### PR TITLE
fix(sandbox): restore guest coding in private workspaces

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -305,11 +305,11 @@ For the full prerequisites, configuration reference, workspace-mode comparison, 
 
 `agents.defaults.sandbox.workspaceAccess` controls what the sandbox can see:
 
-| Value            | Behavior                                                                                  |
-| ---------------- | ----------------------------------------------------------------------------------------- |
-| `none` (default) | Tools see an isolated sandbox workspace under `~/.openclaw/sandboxes`.                    |
-| `ro`             | Mounts the agent workspace read-only at `/agent` (disables `write`/`edit`/`apply_patch`). |
-| `rw`             | Mounts the agent workspace read/write at `/workspace`.                                    |
+| Value            | Behavior                                                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `none` (default) | Tools can read and write an isolated sandbox workspace under `~/.openclaw/sandboxes`; the agent workspace is not exposed. |
+| `ro`             | Mounts the agent workspace read-only at `/agent` (disables `write`/`edit`/`apply_patch`).                                 |
+| `rw`             | Mounts the agent workspace read/write at `/workspace`.                                                                    |
 
 For a role-required sandbox, OpenClaw caps configured `rw` workspace access at
 `ro` and logs an `agent/sandbox` warning. The guest keeps a separate sandbox
@@ -318,12 +318,17 @@ mount. This prevents guests from sharing the writable agent workspace; `none`
 and `ro` remain unchanged. Sessions without a role-required sandbox retain their
 configured workspace access.
 
-With the OpenShell backend, `mirror` mode still uses the local workspace as the canonical source between exec turns, `remote` mode uses the remote OpenShell workspace as canonical after the initial seed, and `workspaceAccess: "ro"`/`"none"` still restrict write behavior the same way.
+With the OpenShell backend, `mirror` mode still uses the local workspace as the canonical source between exec turns, and `remote` mode uses the remote OpenShell workspace as canonical after the initial seed. The same access rules apply: `none` permits private workspace writes, while `ro` disables writes.
 
 Inbound media is copied into the active sandbox workspace (`media/inbound/*`).
 
 <Note>
-**Skills**: the `read` tool is sandbox-rooted. With `workspaceAccess: "none"`, OpenClaw mirrors eligible skills into the sandbox workspace (`.../skills`) so they can be read. With `"rw"`, workspace skills are readable from `/workspace/skills`, and eligible managed, bundled, or plugin skills are materialized into the generated read-only path `/workspace/.openclaw/sandbox-skills/skills`.
+**Skills**: the `read` tool is sandbox-rooted. With `workspaceAccess: "none"`, OpenClaw mirrors eligible skills into the sandbox workspace (`.../skills`) as read-only instruction roots; other private workspace files remain writable. With `"rw"`, workspace skills are readable from `/workspace/skills`, and eligible managed, bundled, or plugin skills are materialized into the generated read-only path `/workspace/.openclaw/sandbox-skills/skills`.
+
+Local container mounts and sandbox file tools enforce these read-only roots.
+SSH and OpenShell shell execution relies on the remote host or OpenShell policy
+for filesystem restrictions; `workspaceAccess` alone does not make remote shell
+paths read-only.
 </Note>
 
 ## Multiple folders for one agent
@@ -370,12 +375,12 @@ This example gives the `research` agent a writable primary workspace, read-only 
 
 `workspaceAccess` and bind modes are independent:
 
-| Setting                          | Controls                                                                    |
-| -------------------------------- | --------------------------------------------------------------------------- |
-| `workspaceAccess: "none"`        | Uses an isolated sandbox workspace; does not expose the agent workspace.    |
-| `workspaceAccess: "ro"`          | Mounts the agent workspace read-only at `/agent`.                           |
-| `workspaceAccess: "rw"`          | Mounts the agent workspace read/write at `/workspace`.                      |
-| `docker.binds` entry `:ro`/`:rw` | Controls only that additional host folder at its configured container path. |
+| Setting                          | Controls                                                                         |
+| -------------------------------- | -------------------------------------------------------------------------------- |
+| `workspaceAccess: "none"`        | Uses a writable isolated sandbox workspace; does not expose the agent workspace. |
+| `workspaceAccess: "ro"`          | Mounts the agent workspace read-only at `/agent`.                                |
+| `workspaceAccess: "rw"`          | Mounts the agent workspace read/write at `/workspace`.                           |
+| `docker.binds` entry `:ro`/`:rw` | Controls only that additional host folder at its configured container path.      |
 
 Changing `workspaceAccess` does not change an additional bind from `ro` to `rw`, or vice versa. Global and per-agent `docker.binds` are merged. Keep `scope: "agent"` or `"session"` for per-agent binds; `scope: "shared"` ignores all per-agent Docker overrides and uses only global binds.
 
@@ -510,11 +515,12 @@ By default, local container sandboxes run with **no network**. Override with `ag
 The default-off [secret egress proxy](/gateway/secrets#secret-egress-proxy) is Gateway-loopback only. Sandbox exec receives neither its proxy/CA environment nor protected sentinels. Sandbox/container proxy reachability is not implemented; do not enable sandbox networking expecting secret substitution to work in this release.
 
 <Note>
-Package installation and certificate-store changes are image provisioning, not
-normal sandbox-turn behavior. The defaults deliberately combine no network,
-a read-only root filesystem, and a non-root image user, so an in-turn package
-install should fail. Prefer a custom image that already contains packages and
-private certificate roots. If a Node process needs a private CA, also configure
+System package installation and certificate-store changes are image provisioning,
+not normal sandbox-turn behavior. The defaults deliberately combine no network,
+a read-only root filesystem, and a non-root image user, so an in-turn system package
+install should fail. Project-local dependencies can be installed in a writable
+workspace when the operator enables network egress. Prefer a custom image that
+already contains system packages and private certificate roots. If a Node process needs a private CA, also configure
 the CA path for Node, for example with `NODE_EXTRA_CA_CERTS`, through the custom
 image or `sandbox.docker.env`.
 </Note>

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -301,7 +301,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/tool-payload` | Private-local after July 2026; Extract normalized payloads from tool result objects |
     | `plugin-sdk/tool-results` | Typed text and JSON agent tool result builders |
     | `plugin-sdk/tool-send` | Extract canonical send target fields from tool args |
-    | `plugin-sdk/sandbox` | Private-local after July 2026; Sandbox backend types and SSH/OpenShell command helpers, including fail-fast exec command preflight |
+    | `plugin-sdk/sandbox` | Private-local after July 2026; Sandbox backend types and SSH/OpenShell command helpers, including fail-fast exec command preflight and `resolveReadOnlyWorkspaceSkillMounts` for canonical read-only skill overlays in writable workspaces |
     | `plugin-sdk/temp-path` | Shared temp-download path helpers and private secure temp workspaces |
     | `plugin-sdk/logging-core` | Subsystem logger and redaction helpers |
     | `plugin-sdk/markdown-table-runtime` | Private-local after July 2026; Markdown table mode and conversion helpers |

--- a/docs/start/teams.md
+++ b/docs/start/teams.md
@@ -99,6 +99,40 @@ Named operator roles bind authenticated profiles to a policy: which sessions the
 
 Assign roles with the `users.setRole` Gateway method; see [Named operator roles](/gateway/operator-scopes#named-operator-roles) for the full policy surface and [Permission modes](/gateway/permission-modes) for per-session tool posture.
 
+### Coding as a guest
+
+A sandbox-required guest can work without an administrator role. With the default
+`workspaceAccess: "none"`, file and shell tools use a writable private workspace,
+not the shared agent workspace. Managed skill instructions stay read-only.
+Child sessions inherit the parent's sandbox requirement, even when the agent's
+default sandbox mode is off.
+
+Local container sandboxes have no network by default. If guests need to clone
+public repositories or install project-local dependencies, explicitly enable
+outbound networking for the coding agent, for example:
+
+```json5
+{
+  agents: {
+    entries: {
+      roboclaw: {
+        sandbox: {
+          workspaceAccess: "none",
+          docker: { network: "bridge" },
+        },
+      },
+    },
+  },
+}
+```
+
+Network access does not grant host execution or inject shared credentials. Use a
+sandbox image with the required runtimes already installed; the read-only root
+filesystem still prevents system package installation. Enabling egress allows
+requests to destinations reachable from the container, so use a restricted
+container network when that access needs tighter controls. See
+[Sandboxing](/gateway/sandboxing#workspace-access) for workspace and network policy.
+
 ## Verify
 
 - Mention the bot in the allowed team channel and confirm it replies there.

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -7,21 +7,25 @@ import type {
   SandboxFsStat,
   SandboxResolvedPath,
 } from "openclaw/plugin-sdk/sandbox";
-import { createWritableRenameTargetResolver } from "openclaw/plugin-sdk/sandbox";
+import {
+  createWritableRenameTargetResolver,
+  resolveReadOnlyWorkspaceSkillMounts,
+} from "openclaw/plugin-sdk/sandbox";
 import { FsSafeError } from "openclaw/plugin-sdk/security-runtime";
 import type { OpenShellFsBridgeContext, OpenShellMirrorBackend } from "./backend.types.js";
-import { resolveOpenShellWorkspaceRoot, type OpenShellWorkspaceRoot } from "./workspace-roots.js";
+import {
+  isOpenShellRemotePathInside,
+  resolveOpenShellWorkspaceRoot,
+  type OpenShellWorkspaceRoot,
+} from "./workspace-roots.js";
 
 type ResolvedMountPath = SandboxResolvedPath & {
   mountHostRoot: string;
   writable: boolean;
-  source: "workspace" | "agent" | "protectedSkill";
 };
 
 type FsSafeRoot = Awaited<ReturnType<typeof fsRoot>>;
 type FsSafeStat = Awaited<ReturnType<FsSafeRoot["stat"]>>;
-
-const MATERIALIZED_SKILLS_CONTAINER_PARTS = [".openclaw", "sandbox-skills", "skills"] as const;
 
 export function createOpenShellFsBridge(params: {
   sandbox: OpenShellFsBridgeContext;
@@ -33,7 +37,7 @@ export function createOpenShellFsBridge(params: {
 class OpenShellFsBridge implements SandboxFsBridge {
   private readonly resolveRenameTargets = createWritableRenameTargetResolver(
     (target) => this.resolveTarget(target),
-    (target, action) => this.ensureWritable(target, action),
+    (target, action) => this.ensureWritable(target, action, true),
   );
 
   constructor(
@@ -178,7 +182,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
   }): Promise<void> {
     const target = this.resolveTarget(params);
     const hostPath = this.requireHostPath(target);
-    this.ensureWritable(target, "remove files");
+    this.ensureWritable(target, "remove files", params.recursive);
     await assertLocalPathSafety({
       target,
       root: target.mountHostRoot,
@@ -256,10 +260,33 @@ class OpenShellFsBridge implements SandboxFsBridge {
     };
   }
 
-  private ensureWritable(target: ResolvedMountPath, action: string) {
-    if (this.sandbox.workspaceAccess !== "rw" || !target.writable) {
+  private ensureWritable(target: ResolvedMountPath, action: string, includeDescendants = false) {
+    if (
+      this.sandbox.workspaceAccess === "ro" ||
+      !target.writable ||
+      (includeDescendants &&
+        this.readOnlyMounts().some((mount) =>
+          isOpenShellRemotePathInside(target.containerPath, mount.containerPath),
+        ))
+    ) {
       throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
     }
+  }
+
+  private readOnlyMounts() {
+    const workdirs = [this.sandbox.containerWorkdir];
+    if (
+      this.sandbox.workspaceAccess !== "none" &&
+      path.resolve(this.sandbox.workspaceDir) !== path.resolve(this.sandbox.agentWorkspaceDir)
+    ) {
+      workdirs.push(this.backend.remoteAgentWorkspaceDir || "/agent");
+    }
+    return [
+      ...workdirs.flatMap((workdir) =>
+        resolveReadOnlyWorkspaceSkillMounts({ ...this.sandbox, workdir }),
+      ),
+      ...(this.sandbox.readOnlyResourceMounts ?? []),
+    ];
   }
 
   private requireHostPath(target: ResolvedMountPath): string {
@@ -280,29 +307,8 @@ class OpenShellFsBridge implements SandboxFsBridge {
       "/",
     );
     const workspaceContainerRoot = this.sandbox.containerWorkdir.replace(/\\/g, "/");
-    const skillsRoot = this.sandbox.skillsWorkspaceDir
-      ? path.resolve(this.sandbox.skillsWorkspaceDir, "skills")
-      : undefined;
-    const skillsContainerRoot = path.posix.join(
-      workspaceContainerRoot,
-      ...MATERIALIZED_SKILLS_CONTAINER_PARTS,
-    );
-    const workspaceSkillsShadowRoot = path.resolve(
-      workspaceRoot,
-      ...MATERIALIZED_SKILLS_CONTAINER_PARTS,
-    );
     const input = params.filePath.trim();
-
-    if (skillsRoot && this.sandbox.workspaceAccess === "rw") {
-      const protectedSkillTarget = resolveProtectedSkillTarget({
-        input,
-        skillsRoot,
-        skillsContainerRoot,
-      });
-      if (protectedSkillTarget) {
-        return protectedSkillTarget;
-      }
-    }
+    const readOnlyMounts = this.readOnlyMounts();
 
     const containerMounts: OpenShellWorkspaceRoot<{
       hostRoot: string;
@@ -313,7 +319,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
         owner: "workspace",
         value: {
           hostRoot: workspaceRoot,
-          writable: this.sandbox.workspaceAccess === "rw",
+          writable: this.sandbox.workspaceAccess !== "ro",
         },
       },
       ...(hasAgentMount
@@ -329,6 +335,14 @@ class OpenShellFsBridge implements SandboxFsBridge {
           ]
         : []),
     ];
+    containerMounts.unshift(
+      ...readOnlyMounts.map((mount) => ({
+        remote: mount.containerPath,
+        owner:
+          resolveOpenShellWorkspaceRoot(containerMounts, mount.containerPath)?.owner ?? "workspace",
+        value: { hostRoot: path.resolve(mount.hostPath), writable: false },
+      })),
+    );
     const resolveContainerTarget = (containerPath: string): ResolvedMountPath | undefined => {
       const containerMount = resolveOpenShellWorkspaceRoot(containerMounts, containerPath);
       if (!containerMount) {
@@ -348,13 +362,12 @@ class OpenShellFsBridge implements SandboxFsBridge {
             ? relative
               ? containerMount.remote + "/" + relative
               : containerMount.remote
-            : relative,
+            : path.posix.relative(workspaceContainerRoot, containerPath),
         containerPath: relative
           ? path.posix.join(containerMount.remote, relative)
           : containerMount.remote,
         mountHostRoot: containerMount.value.hostRoot,
         writable: containerMount.value.writable,
-        source: containerMount.owner,
       };
     };
     const containerCwd = params.cwd?.replace(/\\/g, "/");
@@ -384,15 +397,18 @@ class OpenShellFsBridge implements SandboxFsBridge {
     const cwd = params.cwd ? path.resolve(params.cwd) : workspaceRoot;
     const hostPath = path.isAbsolute(input) ? path.resolve(input) : path.resolve(cwd, input);
 
-    if (skillsRoot && this.sandbox.workspaceAccess === "rw") {
-      const protectedSkillShadowTarget = resolveProtectedSkillShadowTarget({
-        hostPath,
-        workspaceSkillsShadowRoot,
-        skillsRoot,
-        skillsContainerRoot,
-      });
-      if (protectedSkillShadowTarget) {
-        return protectedSkillShadowTarget;
+    // Resolve protected host aliases before the writable workspace that contains
+    // them; virtual mount shadows still resolve through the container table below.
+    for (const mount of readOnlyMounts) {
+      if (isPathInside(mount.hostPath, hostPath)) {
+        const relative = path
+          .relative(mount.hostPath, hostPath)
+          .split(path.sep)
+          .join(path.posix.sep);
+        return expectResolvedContainerTarget(
+          resolveContainerTarget(path.posix.join(mount.containerPath, relative)),
+          input,
+        );
       }
     }
 
@@ -402,22 +418,6 @@ class OpenShellFsBridge implements SandboxFsBridge {
         resolveContainerTarget(path.posix.join(workspaceContainerRoot, relative)),
         input,
       );
-    }
-
-    if (skillsRoot && this.sandbox.workspaceAccess === "rw" && isPathInside(skillsRoot, hostPath)) {
-      const relative = path.relative(skillsRoot, hostPath).split(path.sep).join(path.posix.sep);
-      return {
-        hostPath,
-        relativePath: relative
-          ? path.posix.join(...MATERIALIZED_SKILLS_CONTAINER_PARTS, relative)
-          : path.posix.join(...MATERIALIZED_SKILLS_CONTAINER_PARTS),
-        containerPath: relative
-          ? path.posix.join(skillsContainerRoot, relative)
-          : skillsContainerRoot,
-        mountHostRoot: skillsRoot,
-        writable: false,
-        source: "protectedSkill",
-      };
     }
 
     if (hasAgentMount && isPathInside(agentRoot, hostPath)) {
@@ -596,72 +596,6 @@ function isNotFoundError(err: unknown): boolean {
       "code" in err &&
       (err as { code?: unknown }).code === "ENOENT")
   );
-}
-
-function resolveProtectedSkillTarget(params: {
-  input: string;
-  skillsRoot: string;
-  skillsContainerRoot: string;
-}): ResolvedMountPath | null {
-  const relativeRoot = path.posix.join(...MATERIALIZED_SKILLS_CONTAINER_PARTS);
-  const normalizedInput = path.posix.normalize(params.input.replace(/\\/g, "/"));
-  const isAbsoluteContainer =
-    normalizedInput === params.skillsContainerRoot ||
-    normalizedInput.startsWith(`${params.skillsContainerRoot}/`);
-  const isRelativeContainer =
-    normalizedInput === relativeRoot || normalizedInput.startsWith(`${relativeRoot}/`);
-  if (!isAbsoluteContainer && !isRelativeContainer) {
-    return null;
-  }
-
-  const relative = isAbsoluteContainer
-    ? path.posix.relative(params.skillsContainerRoot, normalizedInput)
-    : path.posix.relative(relativeRoot, normalizedInput);
-  const safeRelative = relative === "." ? "" : relative;
-  const hostPath = safeRelative
-    ? path.resolve(params.skillsRoot, ...safeRelative.split("/"))
-    : params.skillsRoot;
-  return {
-    hostPath,
-    relativePath: safeRelative ? path.posix.join(relativeRoot, safeRelative) : relativeRoot,
-    containerPath: safeRelative
-      ? path.posix.join(params.skillsContainerRoot, safeRelative)
-      : params.skillsContainerRoot,
-    mountHostRoot: params.skillsRoot,
-    writable: false,
-    source: "protectedSkill",
-  };
-}
-
-function resolveProtectedSkillShadowTarget(params: {
-  hostPath: string;
-  workspaceSkillsShadowRoot: string;
-  skillsRoot: string;
-  skillsContainerRoot: string;
-}): ResolvedMountPath | null {
-  if (!isPathInside(params.workspaceSkillsShadowRoot, params.hostPath)) {
-    return null;
-  }
-
-  const relative = path
-    .relative(params.workspaceSkillsShadowRoot, params.hostPath)
-    .split(path.sep)
-    .join(path.posix.sep);
-  const safeRelative = relative === "." ? "" : relative;
-  const hostPath = safeRelative
-    ? path.resolve(params.skillsRoot, ...safeRelative.split("/"))
-    : params.skillsRoot;
-  const relativeRoot = path.posix.join(...MATERIALIZED_SKILLS_CONTAINER_PARTS);
-  return {
-    hostPath,
-    relativePath: safeRelative ? path.posix.join(relativeRoot, safeRelative) : relativeRoot,
-    containerPath: safeRelative
-      ? path.posix.join(params.skillsContainerRoot, safeRelative)
-      : params.skillsContainerRoot,
-    mountHostRoot: params.skillsRoot,
-    writable: false,
-    source: "protectedSkill",
-  };
 }
 
 async function assertLocalPathSafety(params: {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -971,12 +971,14 @@ async function createOpenShellBackendFixture(params: {
 async function createMirrorFsBridgeFixture(
   workspaceDir: string,
   backend: OpenShellMirrorBackend = createMirrorBackendMock(),
+  workspaceAccess: "rw" | "none" | "ro" = "rw",
 ) {
   const sandbox = createSandboxTestContext({
     overrides: {
       backendId: "openshell",
       workspaceDir,
       agentWorkspaceDir: workspaceDir,
+      workspaceAccess,
       containerWorkdir: "/sandbox",
     },
   });
@@ -1156,22 +1158,59 @@ describe("openshell fs bridges", () => {
     },
   );
 
-  it("writes locally and syncs the file to the remote workspace", async () => {
-    await using workspace = await createOpenShellTestWorkspace("fs");
-    const workspaceDir = workspace.dir;
-    const { backend, bridge } = await createMirrorFsBridgeFixture(workspaceDir);
-    await bridge.writeFile({
-      filePath: "nested/file.txt",
-      data: "hello",
-      mkdir: true,
-    });
+  it.each([
+    { workspaceAccess: "rw", mutation: "write" },
+    { workspaceAccess: "none", mutation: "write" },
+    { workspaceAccess: "ro", mutation: "write" },
+    { workspaceAccess: "rw", mutation: "remove" },
+    { workspaceAccess: "none", mutation: "remove" },
+    { workspaceAccess: "rw", mutation: "rename" },
+    { workspaceAccess: "none", mutation: "rename" },
+  ] as const)(
+    "enforces $workspaceAccess workspace writes and protects skills from $mutation",
+    async ({ workspaceAccess, mutation }) => {
+      await using workspace = await createOpenShellTestWorkspace("fs");
+      const workspaceDir = workspace.dir;
+      const { backend, bridge } = await createMirrorFsBridgeFixture(
+        workspaceDir,
+        undefined,
+        workspaceAccess,
+      );
+      if (workspaceAccess === "ro") {
+        await expect(bridge.writeFile({ filePath: "file.txt", data: "blocked" })).rejects.toThrow(
+          "read-only",
+        );
+        expect(backend["syncLocalPathToRemote"]).not.toHaveBeenCalled();
+        return;
+      }
+      await bridge.writeFile({
+        filePath: "nested/file.txt",
+        data: "hello",
+        mkdir: true,
+      });
 
-    expect(await fs.readFile(path.join(workspaceDir, "nested", "file.txt"), "utf8")).toBe("hello");
-    expect(backend["syncLocalPathToRemote"]).toHaveBeenCalledWith(
-      path.join(workspaceDir, "nested", "file.txt"),
-      "/sandbox/nested/file.txt",
-    );
-  });
+      expect(await fs.readFile(path.join(workspaceDir, "nested", "file.txt"), "utf8")).toBe(
+        "hello",
+      );
+      expect(backend["syncLocalPathToRemote"]).toHaveBeenCalledWith(
+        path.join(workspaceDir, "nested", "file.txt"),
+        "/sandbox/nested/file.txt",
+      );
+      const skillRelativePath =
+        mutation === "write" ? "skills/demo/SKILL.md" : ".agents/skills/demo/SKILL.md";
+      const skillPath = path.join(workspaceDir, skillRelativePath);
+      await fs.mkdir(path.dirname(skillPath), { recursive: true });
+      await fs.writeFile(skillPath, "managed instructions");
+      const mutate =
+        mutation === "write"
+          ? bridge.writeFile({ filePath: skillRelativePath, data: "changed" })
+          : mutation === "remove"
+            ? bridge.remove({ filePath: ".agents", recursive: true })
+            : bridge.rename({ from: ".agents", to: "moved-instructions" });
+      await expect(mutate).rejects.toThrow("read-only");
+      await expect(fs.readFile(skillPath, "utf8")).resolves.toBe("managed instructions");
+    },
+  );
 
   it("creates mirror files exclusively before syncing them", async () => {
     await using workspace = await createOpenShellTestWorkspace("fs");
@@ -1562,65 +1601,73 @@ describe("openshell fs bridges", () => {
     );
   });
 
-  it("reads materialized sandbox skills from the protected skills workspace", async () => {
-    await using workspace = await createOpenShellTestWorkspace("fs");
-    const workspaceDir = workspace.dir;
-    await using skillsWorkspace = await createOpenShellTestWorkspace("skills");
-    const skillsWorkspaceDir = skillsWorkspace.dir;
-    const skillFile = path.join(skillsWorkspaceDir, "skills", "demo", "SKILL.md");
-    const shadowFile = path.join(
-      workspaceDir,
-      ".openclaw",
-      "sandbox-skills",
-      "skills",
-      "demo",
-      "SKILL.md",
-    );
-    await fs.mkdir(path.dirname(skillFile), { recursive: true });
-    await fs.mkdir(path.dirname(shadowFile), { recursive: true });
-    await fs.writeFile(skillFile, "# Demo\nmaterialized\n", "utf8");
-    await fs.writeFile(shadowFile, "# Demo\nworkspace shadow\n", "utf8");
-
-    const backend = createMirrorBackendMock();
-    const sandbox = createSandboxTestContext({
-      overrides: {
-        backendId: "openshell",
+  it.each(["external", "nested"] as const)(
+    "reads materialized sandbox skills from a protected %s skills workspace",
+    async (location) => {
+      await using workspace = await createOpenShellTestWorkspace("fs");
+      const workspaceDir = workspace.dir;
+      await using skillsWorkspace = await createOpenShellTestWorkspace("skills");
+      const skillsWorkspaceDir =
+        location === "external" ? skillsWorkspace.dir : path.join(workspaceDir, "materialized");
+      const skillFile = path.join(skillsWorkspaceDir, "skills", "demo", "SKILL.md");
+      const shadowFile = path.join(
         workspaceDir,
-        agentWorkspaceDir: workspaceDir,
-        skillsWorkspaceDir,
-        workspaceAccess: "rw",
-        containerWorkdir: "/sandbox",
-      },
-    });
+        ".openclaw",
+        "sandbox-skills",
+        "skills",
+        "demo",
+        "SKILL.md",
+      );
+      await fs.mkdir(path.dirname(skillFile), { recursive: true });
+      await fs.mkdir(path.dirname(shadowFile), { recursive: true });
+      await fs.writeFile(skillFile, "# Demo\nmaterialized\n", "utf8");
+      await fs.writeFile(shadowFile, "# Demo\nworkspace shadow\n", "utf8");
 
-    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
-    const bridge = createOpenShellFsBridge({ sandbox, backend });
+      const backend = createMirrorBackendMock();
+      const sandbox = createSandboxTestContext({
+        overrides: {
+          backendId: "openshell",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          skillsWorkspaceDir,
+          workspaceAccess: "rw",
+          containerWorkdir: "/sandbox",
+        },
+      });
 
-    await expect(
-      bridge.readFile({
-        filePath: "/sandbox/.openclaw/sandbox-skills/skills/demo/SKILL.md",
-      }),
-    ).resolves.toEqual(Buffer.from("# Demo\nmaterialized\n"));
-    await expect(
-      bridge.readFile({
-        filePath: ".openclaw/sandbox-skills/skills/demo/SKILL.md",
-      }),
-    ).resolves.toEqual(Buffer.from("# Demo\nmaterialized\n"));
-    await expect(
-      bridge.writeFile({
-        filePath: ".openclaw/sandbox-skills/skills/demo/SKILL.md",
-        data: "owned",
-      }),
-    ).rejects.toThrow(/read-only/);
-    await expect(
-      bridge.writeFile({
-        filePath: shadowFile,
-        data: "owned",
-      }),
-    ).rejects.toThrow(/read-only/);
-    expect(await fs.readFile(shadowFile, "utf8")).toContain("workspace shadow");
-    expect(backend["syncLocalPathToRemote"]).not.toHaveBeenCalled();
-  });
+      const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+      const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+      await expect(
+        bridge.readFile({
+          filePath: "/sandbox/.openclaw/sandbox-skills/skills/demo/SKILL.md",
+        }),
+      ).resolves.toEqual(Buffer.from("# Demo\nmaterialized\n"));
+      await expect(
+        bridge.readFile({
+          filePath: ".openclaw/sandbox-skills/skills/demo/SKILL.md",
+        }),
+      ).resolves.toEqual(Buffer.from("# Demo\nmaterialized\n"));
+      await expect(
+        bridge.writeFile({
+          filePath: ".openclaw/sandbox-skills/skills/demo/SKILL.md",
+          data: "owned",
+        }),
+      ).rejects.toThrow(/read-only/);
+      await expect(
+        bridge.writeFile({
+          filePath: shadowFile,
+          data: "owned",
+        }),
+      ).rejects.toThrow(/read-only/);
+      await expect(bridge.writeFile({ filePath: skillFile, data: "owned" })).rejects.toThrow(
+        /read-only/,
+      );
+      await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("materialized");
+      expect(await fs.readFile(shadowFile, "utf8")).toContain("workspace shadow");
+      expect(backend["syncLocalPathToRemote"]).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects reads of a symlinked leaf", async () => {
     await using workspace = await createOpenShellTestWorkspace("fs");

--- a/src/agents/agent-tools.at-prefixed-remote-paths.test.ts
+++ b/src/agents/agent-tools.at-prefixed-remote-paths.test.ts
@@ -1,7 +1,11 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readMemoryArtifactProvenance } from "../memory/memory-artifact-provenance.js";
+import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   createSandboxedEditTool,
   createSandboxedReadTool,
@@ -10,6 +14,8 @@ import {
   wrapToolWorkspaceRootGuardWithOptions,
 } from "./agent-tools.read.js";
 import { createApplyPatchTool } from "./apply-patch.js";
+import { createMemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
+import { resolveSandboxFileIdentity } from "./sandbox/file-mutation-identity.js";
 import { createRemoteShellSandboxFsBridge } from "./sandbox/remote-fs-bridge.js";
 import { createLocalRemoteShellScriptRunner } from "./sandbox/remote-fs-bridge.test-helpers.js";
 import { createSandboxTestContext } from "./sandbox/test-fixtures.js";
@@ -238,6 +244,78 @@ describe.each(["portable", "Linux shell"] as const)("leading-@ remote paths (%s)
       await expect(fs.readFile(path.join(remoteRoot, "replace-present.md"), "utf8")).resolves.toBe(
         "sibling",
       );
+      await withStateDirEnv("openclaw-remote-provenance-", async () => {
+        const relativePath = "memory/quarantine.md";
+        const memoryPath = path.posix.join(containerWorkdir, relativePath);
+        const memoryWriteProvenance = createMemoryWriteProvenanceObserver({
+          mutationRoot: hostRoot,
+          workspaceDir: hostRoot,
+          resolvePath: (filePath) =>
+            resolveSandboxFileIdentity({ bridge, cwd: hostRoot, filePath }),
+          resolveOriginClass: () => "untrusted",
+        });
+        const toolOptions = { root: hostRoot, bridge, memoryWriteProvenance };
+        const memoryWrite = guard(createSandboxedWriteTool(toolOptions));
+        const expectQuarantine = async (content: string) => {
+          await expect(
+            readMemoryArtifactProvenance({ workspaceDir: hostRoot, relativePath }),
+          ).resolves.toMatchObject({
+            originClass: "untrusted",
+            fileHash: createHash("sha256").update(content).digest("hex"),
+          });
+          await expect(fs.readFile(path.join(remoteRoot, relativePath), "utf8")).resolves.toBe(
+            content,
+          );
+        };
+        try {
+          await memoryWrite.execute("remote-memory-write", {
+            path: memoryPath,
+            content: "written",
+          });
+          await expectQuarantine("written");
+          await guard(createSandboxedEditTool(toolOptions)).execute("remote-memory-edit", {
+            path: memoryPath,
+            edits: [{ oldText: "written", newText: "edited" }],
+          });
+          await expectQuarantine("edited");
+          await createApplyPatchTool({
+            cwd: hostRoot,
+            sandbox: { root: hostRoot, bridge },
+            memoryWriteProvenance,
+          }).execute("remote-memory-patch", {
+            input: [
+              "*** Begin Patch",
+              `*** Update File: ${memoryPath}`,
+              "@@",
+              "-edited",
+              "+patched",
+              "*** End Patch",
+            ].join("\n"),
+          });
+          await expectQuarantine("patched");
+          await wrapToolMemoryFlushAppendOnlyWrite(memoryWrite, {
+            root: hostRoot,
+            relativePath,
+            containerWorkdir,
+            sandbox: { root: hostRoot, bridge },
+            memoryWriteProvenance,
+          }).execute("remote-memory-flush", { path: memoryPath, content: "flushed" });
+          await expectQuarantine("patched\nflushed");
+          if (fixture === "Linux shell") {
+            await fs.symlink(
+              path.join(remoteRoot, "memory"),
+              path.join(remoteRoot, "journal-alias"),
+            );
+            await memoryWrite.execute("remote-memory-alias", {
+              path: path.posix.join(containerWorkdir, "journal-alias/quarantine.md"),
+              content: "aliased",
+            });
+            await expectQuarantine("aliased");
+          }
+        } finally {
+          resetPluginStateStoreForTests();
+        }
+      });
       await expect(fs.stat(path.join(hostRoot, "@notes.md"))).rejects.toMatchObject({
         code: "ENOENT",
       });

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -2672,35 +2672,68 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
-  it("records sandbox-backed memory writes before mutation", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-sandbox-taint-"));
-    try {
-      const sandbox = createAgentToolsSandboxContext({
-        workspaceDir,
-        fsBridge: createHostSandboxFsBridge(workspaceDir),
-        workspaceAccess: "rw",
-      });
-      const tools = createOpenClawCodingTools({
-        workspaceDir,
-        sandbox,
-        senderIsOwner: true,
-        isTurnTainted: () => true,
-      });
-      await requireToolExecute(requireTool(tools, "write"))("sandbox-memory", {
-        path: "memory/2026-07-29.md",
-        content: "sandbox network note\n",
-      });
-
-      await expect(
-        readMemoryArtifactProvenance({
+  it.each(["relative", "container"])(
+    "records sandbox-backed %s memory writes before mutation",
+    async (pathKind) => {
+      const workspaceDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-memory-sandbox-taint-"),
+      );
+      const sandboxRoot = path.join(workspaceDir, "private");
+      await fs.mkdir(sandboxRoot);
+      try {
+        const sandbox = createAgentToolsSandboxContext({
+          workspaceDir: sandboxRoot,
+          agentWorkspaceDir: workspaceDir,
+          fsBridge: createContainerWorkspaceSandboxFsBridge(sandboxRoot),
+          workspaceAccess: "none",
+        });
+        const tools = createOpenClawCodingTools({
           workspaceDir,
-          relativePath: "memory/2026-07-29.md",
-        }),
-      ).resolves.toMatchObject({ originClass: "untrusted" });
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
-  });
+          sandbox,
+          senderIsOwner: true,
+          isTurnTainted: () => true,
+        });
+        const filePath = (relative: string) =>
+          pathKind === "container" ? `/workspace/${relative}` : relative;
+        await requireToolExecute(requireTool(tools, "write"))("sandbox-project", {
+          path: filePath("project.txt"),
+          content: "before\n",
+        });
+        await requireToolExecute(requireTool(tools, "edit"))("sandbox-edit", {
+          path: filePath("project.txt"),
+          edits: [{ oldText: "before", newText: "after" }],
+        });
+        await expect(fs.readFile(path.join(sandboxRoot, "project.txt"), "utf8")).resolves.toBe(
+          "after\n",
+        );
+        await requireToolExecute(requireTool(tools, "write"))("sandbox-memory", {
+          path: filePath("memory/2026-07-29.md"),
+          content: "sandbox network note\n",
+        });
+        await requireToolExecute(requireTool(tools, "apply_patch"))("sandbox-patch", {
+          input: `*** Begin Patch\n*** Add File: ${filePath("memory/nested/project.md")}\n+project note\n*** End Patch`,
+        });
+        await expect(
+          readMemoryArtifactProvenance({
+            workspaceDir: sandboxRoot,
+            relativePath: "memory/nested/project.md",
+          }),
+        ).resolves.toMatchObject({ originClass: "untrusted" });
+
+        await expect(
+          readMemoryArtifactProvenance({
+            workspaceDir: sandboxRoot,
+            relativePath: "memory/2026-07-29.md",
+          }),
+        ).resolves.toMatchObject({ originClass: "untrusted" });
+        await expect(
+          readMemoryArtifactProvenance({ workspaceDir, relativePath: "memory/2026-07-29.md" }),
+        ).resolves.toBeUndefined();
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("rejects legacy alias parameters", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-alias-"));

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -795,8 +795,9 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
           sandbox: options.sandbox,
           signal,
         });
-      if (options.memoryWriteProvenance?.classifies(allowedAbsolutePath)) {
-        await options.memoryWriteProvenance.write({
+      const memoryWriteProvenance = options.memoryWriteProvenance;
+      if (memoryWriteProvenance && (await memoryWriteProvenance.classifies(allowedAbsolutePath))) {
+        await memoryWriteProvenance.write({
           absolutePath: allowedAbsolutePath,
           contentBefore,
           contentAfter: `${contentBefore}${separator}${content}`,

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -85,6 +85,7 @@ import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js
 import { createOpenClawTools, filterToolsByClientCaps } from "./openclaw-tools.js";
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
 import type { SandboxContext } from "./sandbox.js";
+import { resolveSandboxFileIdentity } from "./sandbox/file-mutation-identity.js";
 import {
   resolveScheduledToolCallerContext,
   type ScheduledToolPolicyContext,
@@ -548,7 +549,16 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const memoryFlushWriteRoot = sandboxRoot ?? workspaceRoot;
   const memoryWriteProvenance = createMemoryWriteProvenanceObserver({
     mutationRoot: sandboxRoot ?? workspaceRoot,
-    workspaceDir: workspaceRoot,
+    workspaceDir: sandboxRoot ?? workspaceRoot,
+    resolvePath: sandboxFsBridge
+      ? (filePath) =>
+          resolveSandboxFileIdentity({
+            bridge: sandboxFsBridge,
+            filePath,
+            cwd: sandboxRoot,
+            signal: options?.abortSignal,
+          })
+      : undefined,
     resolveOriginClass: () =>
       options?.senderIsOwner === false || options?.isTurnTainted?.() === true
         ? "untrusted"

--- a/src/agents/apply-patch-file-ops.ts
+++ b/src/agents/apply-patch-file-ops.ts
@@ -215,18 +215,19 @@ function withPatchMemoryWriteProvenance(params: {
   operations: PatchFileOps;
   observer: MemoryWriteProvenanceObserver | undefined;
 }): PatchFileOps {
-  const operations = withMemoryWriteProvenance(params.operations, params.observer);
-  if (!params.observer) {
+  const observer = params.observer;
+  const operations = withMemoryWriteProvenance(params.operations, observer);
+  if (!observer) {
     return operations;
   }
   return {
     ...operations,
     createFileExclusive: async (filePath, content) => {
-      if (!params.observer?.classifies(filePath)) {
+      if (!(await observer.classifies(filePath))) {
         return params.operations.createFileExclusive(filePath, content);
       }
       try {
-        await params.observer.write({
+        await observer.write({
           absolutePath: filePath,
           contentBefore: "",
           contentAfter: content,

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -1,6 +1,6 @@
-import { realpathSync } from "node:fs";
 import path from "node:path";
 import { isMissingPathError } from "../infra/errors.js";
+import { canonicalPathFromExistingAncestor } from "../infra/fs-safe.js";
 import { logWarn } from "../logger.js";
 import {
   clearMemoryArtifactProvenance,
@@ -9,7 +9,7 @@ import {
 } from "../memory/memory-artifact-provenance.js";
 
 export type MemoryWriteProvenanceObserver = {
-  classifies: (absolutePath: string) => boolean;
+  classifies: (absolutePath: string) => Promise<boolean>;
   write: (params: {
     absolutePath: string;
     contentBefore: string;
@@ -36,7 +36,7 @@ export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
   return {
     ...operations,
     writeFile: async (absolutePath: string, content: string) => {
-      if (!observer.classifies(absolutePath)) {
+      if (!(await observer.classifies(absolutePath))) {
         await operations.writeFile(absolutePath, content);
         return;
       }
@@ -59,7 +59,7 @@ export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
     ...(remove
       ? {
           remove: async (absolutePath: string) => {
-            const contentBefore = observer.classifies(absolutePath)
+            const contentBefore = (await observer.classifies(absolutePath))
               ? await operations
                   .readFile(absolutePath)
                   .then((value) => (Buffer.isBuffer(value) ? value.toString("utf8") : value))
@@ -79,14 +79,7 @@ export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
 }
 
 function resolveMemoryRelativePath(root: string, absolutePath: string): string | undefined {
-  const canonicalPath = (candidate: string) => {
-    try {
-      return realpathSync.native(candidate);
-    } catch {
-      return path.join(realpathSync.native(path.dirname(candidate)), path.basename(candidate));
-    }
-  };
-  const relativePath = path.relative(canonicalPath(root), canonicalPath(absolutePath));
+  const relativePath = path.relative(root, absolutePath);
   if (
     !relativePath ||
     path.isAbsolute(relativePath) ||
@@ -101,17 +94,27 @@ function resolveMemoryRelativePath(root: string, absolutePath: string): string |
 export function createMemoryWriteProvenanceObserver(params: {
   mutationRoot: string;
   workspaceDir: string;
+  resolvePath?: (filePath: string) => Promise<string>;
   resolveOriginClass: () => "agent" | "untrusted";
   sessionId?: string;
   sessionKey?: string;
   now?: () => number;
 }): MemoryWriteProvenanceObserver {
   const now = params.now ?? Date.now;
+  const resolvePath = params.resolvePath ?? canonicalPathFromExistingAncestor;
+  const resolveRelativePath = async (absolutePath: string) => {
+    // Both paths must be canonicalized by the same filesystem owner: container
+    // paths are not host paths, and aliases must retain memory quarantine.
+    const [root, target] = await Promise.all([
+      resolvePath(params.mutationRoot),
+      resolvePath(absolutePath),
+    ]);
+    return resolveMemoryRelativePath(root, target);
+  };
   return {
-    classifies: (absolutePath) =>
-      resolveMemoryRelativePath(params.mutationRoot, absolutePath) !== undefined,
+    classifies: async (absolutePath) => (await resolveRelativePath(absolutePath)) !== undefined,
     write: async ({ absolutePath, contentBefore, contentAfter, commit }) => {
-      const relativePath = resolveMemoryRelativePath(params.mutationRoot, absolutePath);
+      const relativePath = await resolveRelativePath(absolutePath);
       if (!relativePath) {
         await commit();
         return;
@@ -141,7 +144,7 @@ export function createMemoryWriteProvenanceObserver(params: {
       }
     },
     clearAfterDelete: async (absolutePath, contentBefore) => {
-      const relativePath = resolveMemoryRelativePath(params.mutationRoot, absolutePath);
+      const relativePath = await resolveRelativePath(absolutePath);
       if (!relativePath) {
         return;
       }

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -775,38 +775,28 @@ describe("ensureSandboxBrowser create args", () => {
     expect(latestBridgeResolved().evaluateEnabled).toBe(false);
   });
 
-  it("mounts the main workspace read-only when workspaceAccess is none", async () => {
-    const cfg = buildConfig(false);
-    cfg.workspaceAccess = "none";
+  it.each([
+    { workspaceAccess: "none", flags: "z", rejectedFlags: "ro,z" },
+    { workspaceAccess: "ro", flags: "ro,z", rejectedFlags: "z" },
+    { workspaceAccess: "rw", flags: "z", rejectedFlags: "ro,z" },
+  ] as const)(
+    "uses the main workspace mount permissions for workspaceAccess=$workspaceAccess",
+    async ({ workspaceAccess, flags, rejectedFlags }) => {
+      const cfg = buildConfig(false);
+      cfg.workspaceAccess = workspaceAccess;
 
-    await ensureTestSandboxBrowser({
-      scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
-      cfg,
-    });
+      await ensureTestSandboxBrowser({
+        scopeKey: "session:test",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg,
+      });
 
-    const createArgs = requireDockerCreateArgs();
-
-    expect(createArgs).toContain("/tmp/workspace:/workspace:ro,z");
-  });
-
-  it("keeps the main workspace writable when workspaceAccess is rw", async () => {
-    const cfg = buildConfig(false);
-    cfg.workspaceAccess = "rw";
-
-    await ensureTestSandboxBrowser({
-      scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
-      cfg,
-    });
-
-    const createArgs = requireDockerCreateArgs();
-
-    expect(createArgs).toContain("/tmp/workspace:/workspace:z");
-    expect(createArgs).not.toContain("/tmp/workspace:/workspace:ro,z");
-  });
+      const createArgs = requireDockerCreateArgs();
+      expect(createArgs).toContain(`/tmp/workspace:/workspace:${flags}`);
+      expect(createArgs).not.toContain(`/tmp/workspace:/workspace:${rejectedFlags}`);
+    },
+  );
 
   it("stamps the mount format version label on browser containers", async () => {
     await ensureTestSandboxBrowser({

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -647,9 +647,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
       const cfg = createSandboxConfig([], undefined, workspaceAccess);
 
       spawnState.inspectRunning = false;
-      spawnState.labelHash = "";
       registryMocks.readRegistryEntry.mockResolvedValue(null);
-      registryMocks.updateRegistry.mockResolvedValue(undefined);
 
       const createCall = await ensureSandboxCreateCallForTest({ cfg, workspaceDir });
 

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -414,46 +414,50 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(registryUpdate?.configHash).toBe(newHash);
   });
 
-  it("recreates a cold container when the shared Docker create-args epoch changes", async () => {
-    const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
-    // Keep the create-args epoch as the only hash delta in this scenario.
-    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`], "rw", {});
-    const hashInput = {
-      docker: cfg.docker,
-      dockerEnvPolicyEpoch: resolveDockerEnvPolicyEpoch(cfg.docker.env),
-      workspaceAccess: cfg.workspaceAccess,
-      workspaceDir,
-      agentWorkspaceDir: workspaceDir,
-      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
-      readOnlyWorkspaceSkillMounts: [],
-    };
-    const oldHash = computeSandboxConfigHash({
-      ...hashInput,
-      createArgsEpoch: "pre-init",
-    });
-    const newHash = computeSandboxConfigHash({
-      ...hashInput,
-      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
-    });
+  it.each(["create-args", "private-workspace-mount"] as const)(
+    "recreates a cold container when the %s format changes",
+    async (format) => {
+      const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
+      const cfg = createSandboxConfig([], [], "none", {});
+      const hashInput = {
+        docker: cfg.docker,
+        dockerEnvPolicyEpoch: resolveDockerEnvPolicyEpoch(cfg.docker.env),
+        workspaceAccess: cfg.workspaceAccess,
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+        readOnlyWorkspaceSkillMounts: [],
+      };
+      const oldHash = computeSandboxConfigHash({
+        ...hashInput,
+        createArgsEpoch: format === "create-args" ? "pre-init" : SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
+        mountFormatVersion: format === "private-workspace-mount" ? 3 : SANDBOX_MOUNT_FORMAT_VERSION,
+      });
+      const newHash = computeSandboxConfigHash({
+        ...hashInput,
+        createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
+      });
 
-    spawnState.labelHash = oldHash;
-    registryMocks.readRegistryEntry.mockResolvedValue({
-      containerName: "oc-test-shared",
-      sessionKey: "shared",
-      createdAtMs: 1,
-      lastUsedAtMs: 0,
-      image: cfg.docker.image,
-      configHash: oldHash,
-    });
+      spawnState.labelHash = oldHash;
+      registryMocks.readRegistryEntry.mockResolvedValue({
+        containerName: "oc-test-shared",
+        sessionKey: "shared",
+        createdAtMs: 1,
+        lastUsedAtMs: 0,
+        image: cfg.docker.image,
+        configHash: oldHash,
+      });
 
-    const createCall = await ensureSandboxCreateCallForTest({ cfg, workspaceDir });
-    expect(spawnState.calls.some((call) => call.args[0] === "rm")).toBe(true);
-    expect(createCall.args.filter((arg) => arg === "--init")).toHaveLength(1);
-    expect(createCall.args).toContain(
-      `openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`,
-    );
-    expect(createCall.args).toContain(`openclaw.configHash=${newHash}`);
-  });
+      const createCall = await ensureSandboxCreateCallForTest({ cfg, workspaceDir });
+      expect(spawnState.calls.some((call) => call.args[0] === "rm")).toBe(true);
+      expect(createCall.args.filter((arg) => arg === "--init")).toHaveLength(1);
+      expect(createCall.args).toContain(
+        `openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`,
+      );
+      expect(createCall.args).toContain(`openclaw.configHash=${newHash}`);
+      expect(createCall.args).toContain(`${workspaceDir}:/workspace:z`);
+    },
+  );
 
   it("keeps a hot pre-init container running and emits the recreate hint", async () => {
     const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
@@ -635,7 +639,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
   it.each([
     { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace:z" },
     { workspaceAccess: "ro" as const, expectedMainMount: "/tmp/workspace:/workspace:ro,z" },
-    { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace:ro,z" },
+    { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace:z" },
   ])(
     "uses expected main mount permissions when workspaceAccess=$workspaceAccess",
     async ({ workspaceAccess, expectedMainMount }) => {

--- a/src/agents/sandbox/file-mutation-identity.ts
+++ b/src/agents/sandbox/file-mutation-identity.ts
@@ -17,9 +17,8 @@ function hasSandboxFileIdentity(bridge: SandboxFsBridge): bridge is SandboxFileI
   return SANDBOX_FILE_IDENTITY in bridge;
 }
 
-export async function resolveSandboxFileMutationQueueKey(params: {
+export async function resolveSandboxFileIdentity(params: {
   bridge: SandboxFsBridge;
-  root: string;
   filePath: string;
   cwd?: string;
   signal?: AbortSignal;
@@ -39,5 +38,15 @@ export async function resolveSandboxFileMutationQueueKey(params: {
       ? resolveIdentityPathViaExistingAncestorSync(resolved.hostPath)
       : resolved.containerPath;
   }
-  return `${params.root}\0${identity}`;
+  return identity;
+}
+
+export async function resolveSandboxFileMutationQueueKey(params: {
+  bridge: SandboxFsBridge;
+  root: string;
+  filePath: string;
+  cwd?: string;
+  signal?: AbortSignal;
+}): Promise<string> {
+  return `${params.root}\0${await resolveSandboxFileIdentity(params)}`;
 }

--- a/src/agents/sandbox/fs-bridge-mutation-python.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-python.ts
@@ -9,9 +9,12 @@ import {
 // callers can tell a lost exclusive-create race from a real failure. Any other
 // nonzero exit stays an error.
 export const SANDBOX_CREATE_EXISTS_EXIT_CODE = 17;
+// Preserve missing-read identity across the shell boundary without parsing stderr.
+export const SANDBOX_READ_NOT_FOUND_EXIT_CODE = 2;
 
 export const SANDBOX_PINNED_MUTATION_PYTHON = [
   `SANDBOX_CREATE_EXISTS_EXIT_CODE = ${SANDBOX_CREATE_EXISTS_EXIT_CODE}`,
+  `SANDBOX_READ_NOT_FOUND_EXIT_CODE = ${SANDBOX_READ_NOT_FOUND_EXIT_CODE}`,
   "import ctypes",
   "import errno",
   "import os",
@@ -452,6 +455,8 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "            read_file_bounded(parent_fd, sys.argv[4], int(sys.argv[5]))",
   "        else:",
   "            read_file(parent_fd, sys.argv[4])",
+  "    except FileNotFoundError:",
+  "        sys.exit(SANDBOX_READ_NOT_FOUND_EXIT_CODE)",
   "    finally:",
   "        if parent_fd is not None:",
   "            os.close(parent_fd)",

--- a/src/agents/sandbox/fs-bridge-path-safety.ts
+++ b/src/agents/sandbox/fs-bridge-path-safety.ts
@@ -15,7 +15,7 @@ import {
   relativePathEscapesContainerRoot,
 } from "./path-utils.js";
 
-type BoundaryAllowedType = "file" | "directory";
+type BoundaryAllowedType = "file" | "directory" | "file-or-directory";
 
 function sandboxBoundaryError(action: string, containerPath: string, error: unknown): Error {
   if (error instanceof Error && !(error instanceof FsSafeError && error.code === "not-file")) {
@@ -30,7 +30,7 @@ function sandboxBoundaryError(action: string, containerPath: string, error: unkn
 type PathSafetyOptions = {
   action: string;
   aliasPolicy?: PathAliasPolicy;
-  requireWritable?: boolean;
+  requireWritable?: boolean | "subtree";
   allowedType?: BoundaryAllowedType;
 };
 
@@ -86,11 +86,19 @@ export class SandboxFsPathGuard {
   }
 
   async assertPathSafety(target: SandboxResolvedFsPath, options: PathSafetyOptions) {
+    // fs-safe pins one expected type. Select directory mutations explicitly;
+    // its descriptor/type checks still reject swaps after this observation.
+    const allowedType =
+      options.allowedType === "file-or-directory"
+        ? this.pathIsExistingDirectory(target.hostPath)
+          ? "directory"
+          : "file"
+        : options.allowedType;
     const guarded = await this.openBoundaryWithinRequiredMount(target, options.action, {
       aliasPolicy: options.aliasPolicy,
-      allowedType: options.allowedType,
+      allowedType,
     });
-    await this.assertGuardedPathSafety(target, options, guarded);
+    await this.assertGuardedPathSafety(target, { ...options, allowedType }, guarded);
   }
 
   async openReadableFile(
@@ -139,7 +147,9 @@ export class SandboxFsPathGuard {
     if (!guarded.ok) {
       if (guarded.reason !== "path") {
         const canFallbackToDirectoryStat =
-          options.allowedType === "directory" && this.pathIsExistingDirectory(target.hostPath);
+          guarded.reason === "io" &&
+          options.allowedType === "directory" &&
+          this.pathIsExistingDirectory(target.hostPath);
         if (!canFallbackToDirectoryStat) {
           throw sandboxBoundaryError(options.action, target.containerPath, guarded.error);
         }
@@ -154,7 +164,17 @@ export class SandboxFsPathGuard {
     });
     // Re-check the canonical path against mounts so symlinks cannot escape the sandbox root.
     const canonicalMount = this.resolveRequiredMount(canonicalContainerPath, options.action);
-    if (options.requireWritable && !canonicalMount.writable) {
+    // Removing or moving a parent must not bypass a narrower read-only mount.
+    if (
+      options.requireWritable &&
+      (!canonicalMount.writable ||
+        (options.requireWritable === "subtree" &&
+          this.mountsByContainer.some(
+            (mount) =>
+              !mount.writable &&
+              isPathInsideContainerRoot(canonicalContainerPath, mount.containerRoot),
+          )))
+    ) {
       throw new Error(
         `Sandbox path is read-only; cannot ${options.action}: ${target.containerPath}`,
       );
@@ -166,7 +186,7 @@ export class SandboxFsPathGuard {
     action: string,
     options?: {
       aliasPolicy?: PathAliasPolicy;
-      allowedType?: BoundaryAllowedType;
+      allowedType?: "file" | "directory";
     },
   ): Promise<RootFileOpenResult> {
     const lexicalMount = this.resolveRequiredMount(target.containerPath, action);

--- a/src/agents/sandbox/fs-bridge.backend.e2e.test.ts
+++ b/src/agents/sandbox/fs-bridge.backend.e2e.test.ts
@@ -74,13 +74,26 @@ async function runLocalShellCommand(
 }
 
 describe("sandbox fs bridge local backend e2e", () => {
-  it.runIf(process.platform !== "win32")(
-    "writes through backend shell commands using the pinned mutation helper",
-    async () => {
+  it.runIf(process.platform !== "win32").each([
+    { workspaceAccess: "rw", mutation: "write" },
+    { workspaceAccess: "none", mutation: "write" },
+    { workspaceAccess: "ro", mutation: "write" },
+    { workspaceAccess: "rw", mutation: "remove" },
+    { workspaceAccess: "none", mutation: "remove" },
+    { workspaceAccess: "rw", mutation: "rename" },
+    { workspaceAccess: "none", mutation: "rename" },
+  ] as const)(
+    "enforces $workspaceAccess workspace writes and protects skills from $mutation",
+    async ({ workspaceAccess, mutation }) => {
       const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fsbridge-e2e-"));
       const workspacePath = path.join(stateDir, "workspace");
       await fs.mkdir(workspacePath, { recursive: true });
       const workspaceDir = await fs.realpath(workspacePath);
+      const skillRelativePath =
+        mutation === "write" ? "skills/demo/SKILL.md" : ".agents/skills/demo/SKILL.md";
+      const skillPath = path.join(workspaceDir, skillRelativePath);
+      await fs.mkdir(path.dirname(skillPath), { recursive: true });
+      await fs.writeFile(skillPath, "managed instructions");
       const scripts: string[] = [];
       const backend: SandboxBackendHandle = {
         id: "local-test",
@@ -107,7 +120,9 @@ describe("sandbox fs bridge local backend e2e", () => {
         const sandbox = createSandboxTestContext({
           overrides: {
             workspaceDir,
-            agentWorkspaceDir: workspaceDir,
+            agentWorkspaceDir:
+              workspaceAccess === "none" ? path.join(stateDir, "agent") : workspaceDir,
+            workspaceAccess,
             containerName: "local-backend-fsbridge",
             containerWorkdir: workspaceDir,
             backend,
@@ -115,11 +130,34 @@ describe("sandbox fs bridge local backend e2e", () => {
         });
 
         const bridge = createSandboxFsBridge({ sandbox });
+        if (workspaceAccess === "ro") {
+          await expect(
+            bridge.writeFile({ filePath: "nested/hello.txt", data: "blocked" }),
+          ).rejects.toThrow("read-only");
+          expect(scripts).toEqual([]);
+          return;
+        }
         await bridge.writeFile({ filePath: "nested/hello.txt", data: "from-backend" });
 
         await expect(
           fs.readFile(path.join(workspaceDir, "nested", "hello.txt"), "utf8"),
         ).resolves.toBe("from-backend");
+        await bridge.rename({ from: "nested", to: "renamed" });
+        await expect(
+          fs.readFile(path.join(workspaceDir, "renamed", "hello.txt"), "utf8"),
+        ).resolves.toBe("from-backend");
+        await bridge.remove({ filePath: "renamed", recursive: true });
+        await expect(fs.stat(path.join(workspaceDir, "renamed"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        const mutate =
+          mutation === "write"
+            ? bridge.writeFile({ filePath: skillRelativePath, data: "changed" })
+            : mutation === "remove"
+              ? bridge.remove({ filePath: ".agents", recursive: true })
+              : bridge.rename({ from: ".agents", to: "moved-instructions" });
+        await expect(mutate).rejects.toThrow("read-only");
+        await expect(fs.readFile(skillPath, "utf8")).resolves.toBe("managed instructions");
         expect(scripts.some((script) => script.includes("operation = sys.argv[1]"))).toBe(true);
       } finally {
         await fs.rm(stateDir, { recursive: true, force: true });

--- a/src/agents/sandbox/fs-bridge.boundary.test.ts
+++ b/src/agents/sandbox/fs-bridge.boundary.test.ts
@@ -63,27 +63,37 @@ describe("sandbox fs bridge boundary validation", () => {
     });
   });
 
-  it("rejects pre-existing host symlink escapes before docker exec", async () => {
-    // Host-visible symlink escapes are rejected locally so Docker never follows
-    // them inside a privileged bridge command.
-    await withTempDir("openclaw-fs-bridge-", async (stateDir) => {
-      const { workspaceDir, outsideFile } = await createHostEscapeFixture(stateDir);
-      if (process.platform === "win32") {
-        return;
-      }
-      await fs.symlink(outsideFile, path.join(workspaceDir, "link.txt"));
+  it.each(["file", "directory"] as const)(
+    "rejects pre-existing host %s symlink escapes before docker exec",
+    async (kind) => {
+      // Host-visible symlink escapes are rejected locally so Docker never follows
+      // them inside a privileged bridge command.
+      await withTempDir("openclaw-fs-bridge-", async (stateDir) => {
+        const { workspaceDir, outsideFile } = await createHostEscapeFixture(stateDir);
+        if (process.platform === "win32") {
+          return;
+        }
+        await fs.symlink(
+          kind === "directory" ? path.dirname(outsideFile) : outsideFile,
+          path.join(workspaceDir, "link.txt"),
+        );
 
-      const bridge = createSandboxFsBridge({
-        sandbox: createSandbox({
-          workspaceDir,
-          agentWorkspaceDir: workspaceDir,
-        }),
+        const bridge = createSandboxFsBridge({
+          sandbox: createSandbox({
+            workspaceDir,
+            agentWorkspaceDir: workspaceDir,
+          }),
+        });
+
+        await expect(
+          kind === "directory"
+            ? bridge.mkdirp({ filePath: "link.txt" })
+            : bridge.readFile({ filePath: "link.txt" }),
+        ).rejects.toThrow(/Symlink escapes/);
+        expect(mockedExecDockerRaw).not.toHaveBeenCalled();
       });
-
-      await expect(bridge.readFile({ filePath: "link.txt" })).rejects.toThrow(/Symlink escapes/);
-      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
-    });
-  });
+    },
+  );
 
   it("rejects pre-existing host hardlink escapes before docker exec", async () => {
     // Hardlinks can expose outside files without a symlink marker, so the bridge

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -29,7 +29,6 @@ import {
   resolveSandboxFsPathWithMounts,
   type SandboxResolvedFsPath,
 } from "./fs-paths.js";
-import type { SandboxWorkspaceAccess } from "./types.js";
 
 type RunCommandOptions = {
   args?: string[];
@@ -227,7 +226,8 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       target,
       options: {
         action: "remove files",
-        requireWritable: true,
+        requireWritable: params.recursive ? "subtree" : true,
+        allowedType: "file-or-directory",
       } as const,
     };
     await this.runCheckedCommand({
@@ -255,14 +255,16 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       target: from,
       options: {
         action: "rename files",
-        requireWritable: true,
+        requireWritable: "subtree",
+        allowedType: "file-or-directory",
       } as const,
     };
     const toCheck = {
       target: to,
       options: {
         action: "rename files",
-        requireWritable: true,
+        requireWritable: "subtree",
+        allowedType: "file-or-directory",
       } as const,
     };
     await this.runCheckedCommand({
@@ -382,7 +384,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   }
 
   private ensureWriteAccess(target: SandboxResolvedFsPath, action: string) {
-    if (!allowsWrites(this.sandbox.workspaceAccess) || !target.writable) {
+    if (this.sandbox.workspaceAccess === "ro" || !target.writable) {
       throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
     }
   }
@@ -396,10 +398,6 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       mounts: this.mounts,
     });
   }
-}
-
-function allowsWrites(access: SandboxWorkspaceAccess): boolean {
-  return access === "rw";
 }
 
 function coerceStatType(typeRaw?: string): "file" | "directory" | "other" {

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -75,7 +75,7 @@ export function buildSandboxFsMounts(sandbox: SandboxFsBridgeContext): SandboxFs
     {
       hostRoot: path.resolve(sandbox.workspaceDir),
       containerRoot: normalizeContainerPathCore(sandbox.containerWorkdir),
-      writable: sandbox.workspaceAccess === "rw",
+      writable: sandbox.workspaceAccess !== "ro",
       source: "workspace",
     },
   ];

--- a/src/agents/sandbox/remote-fs-bridge-paths.ts
+++ b/src/agents/sandbox/remote-fs-bridge-paths.ts
@@ -1,10 +1,6 @@
 /** Pure mount and path helpers for the remote sandbox filesystem bridge. */
 import path from "node:path";
 import { normalizeContainerPathCore } from "./path-utils.js";
-import {
-  isExistingWorkspaceSkillMountSource,
-  resolveMaterializedSandboxSkillsWorkspaceDir,
-} from "./workspace-mounts.js";
 
 export type RemoteMountSource = "workspace" | "agent" | "protectedSkill";
 
@@ -14,84 +10,6 @@ export type RemoteMountInfo = {
   writable: boolean;
   source: RemoteMountSource;
 };
-
-export function buildRemoteProtectedSkillMounts(params: {
-  localRoot: string;
-  skillsWorkspaceDir?: string;
-  workspaceContainerRoot: string;
-  agentContainerRoot: string;
-  includeAgentMount: boolean;
-}): RemoteMountInfo[] {
-  const materializedSkillsWorkspaceDir = path.resolve(
-    params.skillsWorkspaceDir ?? resolveMaterializedSandboxSkillsWorkspaceDir(params.localRoot),
-  );
-  const mounts: Array<RemoteMountInfo & { allowedRoot: string }> = [
-    {
-      localRoot: path.join(params.localRoot, "skills"),
-      containerRoot: path.posix.join(params.workspaceContainerRoot, "skills"),
-      writable: false,
-      source: "protectedSkill",
-      allowedRoot: params.localRoot,
-    },
-    {
-      localRoot: path.join(params.localRoot, ".agents", "skills"),
-      containerRoot: path.posix.join(params.workspaceContainerRoot, ".agents", "skills"),
-      writable: false,
-      source: "protectedSkill",
-      allowedRoot: params.localRoot,
-    },
-    {
-      localRoot: path.join(materializedSkillsWorkspaceDir, "skills"),
-      containerRoot: path.posix.join(
-        params.workspaceContainerRoot,
-        ".openclaw",
-        "sandbox-skills",
-        "skills",
-      ),
-      writable: false,
-      source: "protectedSkill",
-      allowedRoot: materializedSkillsWorkspaceDir,
-    },
-  ];
-  if (params.includeAgentMount) {
-    mounts.push(
-      {
-        localRoot: path.join(params.localRoot, "skills"),
-        containerRoot: path.posix.join(params.agentContainerRoot, "skills"),
-        writable: false,
-        source: "protectedSkill",
-        allowedRoot: params.localRoot,
-      },
-      {
-        localRoot: path.join(params.localRoot, ".agents", "skills"),
-        containerRoot: path.posix.join(params.agentContainerRoot, ".agents", "skills"),
-        writable: false,
-        source: "protectedSkill",
-        allowedRoot: params.localRoot,
-      },
-      {
-        localRoot: path.join(materializedSkillsWorkspaceDir, "skills"),
-        containerRoot: path.posix.join(
-          params.agentContainerRoot,
-          ".openclaw",
-          "sandbox-skills",
-          "skills",
-        ),
-        writable: false,
-        source: "protectedSkill",
-        allowedRoot: materializedSkillsWorkspaceDir,
-      },
-    );
-  }
-  return mounts
-    .filter((mount) =>
-      isExistingWorkspaceSkillMountSource({
-        rootDir: mount.allowedRoot,
-        hostPath: mount.localRoot,
-      }),
-    )
-    .map(({ allowedRoot: _allowedRoot, ...mount }) => mount);
-}
 
 export function compareRemoteMountsByContainerPath(a: RemoteMountInfo, b: RemoteMountInfo): number {
   return b.containerRoot.length - a.containerRoot.length || mountPriority(b) - mountPriority(a);

--- a/src/agents/sandbox/remote-fs-bridge.test.ts
+++ b/src/agents/sandbox/remote-fs-bridge.test.ts
@@ -81,9 +81,17 @@ function createWorkspaceReadBridge(workspaceDir: string) {
 }
 
 describe("remote sandbox fs bridge", () => {
-  it.runIf(process.platform !== "win32")(
-    "preserves binary payloads, quoted paths, empty files, and exclusive creates without a host mirror",
-    async () => {
+  it.runIf(process.platform !== "win32").each([
+    { workspaceAccess: "rw", mutation: "write" },
+    { workspaceAccess: "none", mutation: "write" },
+    { workspaceAccess: "ro", mutation: "write" },
+    { workspaceAccess: "rw", mutation: "remove" },
+    { workspaceAccess: "none", mutation: "remove" },
+    { workspaceAccess: "rw", mutation: "rename" },
+    { workspaceAccess: "none", mutation: "rename" },
+  ] as const)(
+    "enforces $workspaceAccess workspace writes and protects remote-only skills from $mutation",
+    async ({ workspaceAccess, mutation }) => {
       await withTempDir("openclaw-remote-fs-payload-", async (stateDir) => {
         const workspaceDir = path.join(await fs.realpath(stateDir), "host-workspace");
         const remoteWorkspaceDir = path.join(await fs.realpath(stateDir), "remote 'workspace'");
@@ -94,12 +102,23 @@ describe("remote sandbox fs bridge", () => {
           remoteAgentWorkspaceDir: remoteWorkspaceDir,
         });
         const bridge = createRemoteShellSandboxFsBridge({
-          sandbox: createSandbox({ workspaceDir, agentWorkspaceDir: workspaceDir }),
+          sandbox: createSandbox({
+            workspaceDir,
+            agentWorkspaceDir: workspaceDir,
+            workspaceAccess,
+          }),
           runtime,
         });
         const filePath = "quoted ' \" $() `literal`.bin";
         const payload = Buffer.from([0, 255, 128, 10, 13, 39, 34, 36, 96]);
         const createFileExclusive = bridge.createFileExclusive!.bind(bridge);
+        if (workspaceAccess === "ro") {
+          await expect(createFileExclusive({ filePath, data: payload })).rejects.toThrow(
+            "read-only",
+          );
+          await expect(fs.readdir(remoteWorkspaceDir)).resolves.toEqual([]);
+          return;
+        }
 
         await expect(createFileExclusive({ filePath, data: payload })).resolves.toBe("created");
         await expect(bridge.readFile({ filePath })).resolves.toEqual(payload);
@@ -118,6 +137,19 @@ describe("remote sandbox fs bridge", () => {
           Buffer.alloc(0),
         );
         await expect(fs.readdir(workspaceDir)).resolves.toEqual([]);
+        const skillRelativePath =
+          mutation === "write" ? "skills/demo/SKILL.md" : ".agents/skills/demo/SKILL.md";
+        const skillPath = path.join(remoteWorkspaceDir, skillRelativePath);
+        await fs.mkdir(path.dirname(skillPath), { recursive: true });
+        await fs.writeFile(skillPath, "managed instructions");
+        const mutate =
+          mutation === "write"
+            ? bridge.writeFile({ filePath: skillRelativePath, data: "changed" })
+            : mutation === "remove"
+              ? bridge.remove({ filePath: ".agents", recursive: true })
+              : bridge.rename({ from: ".agents", to: "moved-instructions" });
+        await expect(mutate).rejects.toThrow("read-only");
+        await expect(fs.readFile(skillPath, "utf8")).resolves.toBe("managed instructions");
       });
     },
   );
@@ -483,6 +515,9 @@ describe.runIf(process.platform === "linux")("remote sandbox fs bridge (GNU shel
       await expect(
         createFileExclusive!({ filePath: "escape/outside.txt", data: "blocked" }),
       ).rejects.toThrow(/escapes allowed mounts/);
+      await expect(bridge.mkdirp({ filePath: "escape/dir" })).rejects.toThrow(
+        /escapes allowed mounts/,
+      );
     });
   });
 

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -11,7 +11,10 @@ import type {
 } from "./backend-handle.types.js";
 import { SANDBOX_FILE_IDENTITY } from "./file-mutation-identity.js";
 import { SANDBOX_PINNED_MUTATION_PYTHON_SHELL_LITERAL } from "./fs-bridge-mutation-helper.js";
-import { SANDBOX_CREATE_EXISTS_EXIT_CODE } from "./fs-bridge-mutation-python.js";
+import {
+  SANDBOX_CREATE_EXISTS_EXIT_CODE,
+  SANDBOX_READ_NOT_FOUND_EXIT_CODE,
+} from "./fs-bridge-mutation-python.js";
 import { createWritableRenameTargetResolver } from "./fs-bridge-rename-targets.js";
 import {
   hasMultipleHardlinks,
@@ -26,7 +29,6 @@ import {
 } from "./remote-fs-bridge-canonical-path.js";
 import {
   buildRemoteProtectedSkillRoots,
-  buildRemoteProtectedSkillMounts,
   compareRemoteMountsByContainerPath,
   compareRemoteMountsByLocalPath,
   normalizeContainerPath,
@@ -34,6 +36,7 @@ import {
   toPosixRelative,
 } from "./remote-fs-bridge-paths.js";
 import type { ResolvedRemotePath, RemoteShellSandboxHandle } from "./remote-fs-bridge.types.js";
+import { resolveReadOnlyWorkspaceSkillMounts } from "./workspace-mounts.js";
 
 export type { RemoteShellSandboxHandle } from "./remote-fs-bridge.types.js";
 
@@ -100,7 +103,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     ) {
       throw new Error(`Invalid sandbox entry target: ${target.containerPath}`);
     }
-    const pinned = await this.resolvePinnedParent({
+    const pinned = await this.resolvePinnedTarget({
       containerPath: target.containerPath,
       mountRootPath: target.mountRootPath,
       action: "read files",
@@ -115,7 +118,18 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
         ...(params.maxBytes === undefined ? [] : [String(params.maxBytes)]),
       ],
       signal: params.signal,
+      allowFailure: true,
     });
+    if (result.code === SANDBOX_READ_NOT_FOUND_EXIT_CODE) {
+      throw Object.assign(new Error(`Sandbox file not found: ${target.containerPath}`), {
+        code: "ENOENT",
+      });
+    }
+    if (result.code !== 0) {
+      throw new Error(
+        `Sandbox read failed (${result.code}): ${result.stderr.toString("utf8").trim()}`,
+      );
+    }
     return result.stdout;
   }
 
@@ -137,13 +151,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       action: "copy files",
       signal: params.signal,
     });
-    const sourcePinned = await this.resolvePinnedParent({
+    const sourcePinned = await this.resolvePinnedTarget({
       containerPath: source.containerPath,
       mountRootPath: source.mountRootPath,
       action: "copy files",
       signal: params.signal,
     });
-    const destinationPinned = await this.resolvePinnedParent({
+    const destinationPinned = await this.resolvePinnedTarget({
       containerPath: destination.containerPath,
       mountRootPath: destination.mountRootPath,
       action: "copy files",
@@ -175,7 +189,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
   }): Promise<void> {
     const target = this.resolveTarget(params);
     await this.ensureRemoteWritable(target, "write files", params.signal);
-    const pinned = await this.resolvePinnedParent({
+    const pinned = await this.resolvePinnedTarget({
       containerPath: target.containerPath,
       mountRootPath: target.mountRootPath,
       action: "write files",
@@ -213,7 +227,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
   }): Promise<"created" | "exists"> {
     const target = this.resolveTarget(params);
     await this.ensureRemoteWritable(target, "create files", params.signal);
-    const pinned = await this.resolvePinnedParent({
+    const pinned = await this.resolvePinnedTarget({
       containerPath: target.containerPath,
       mountRootPath: target.mountRootPath,
       action: "create files",
@@ -258,19 +272,16 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     if (relativePath === "" || relativePath === ".") {
       return;
     }
-    const pinned = await this.resolvePinnedParent({
+    const pinned = await this.resolvePinnedTarget({
       containerPath: target.containerPath,
       mountRootPath: target.mountRootPath,
       action: "create directories",
       requireWritable: true,
+      directory: true,
       signal: params.signal,
     });
     await this.runMutation({
-      args: [
-        "mkdirp",
-        pinned.mountRootPath,
-        path.posix.join(pinned.relativeParentPath, pinned.basename),
-      ],
+      args: ["mkdirp", pinned.mountRootPath, pinned.relativeParentPath],
       signal: params.signal,
     });
   }
@@ -283,7 +294,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal;
   }): Promise<void> {
     const target = this.resolveTarget(params);
-    await this.ensureRemoteWritable(target, "remove files", params.signal);
+    await this.ensureRemoteWritable(target, "remove files", params.signal, params.recursive);
     const exists = await this.remotePathExists(target.containerPath, params.signal);
     if (!exists) {
       if (params.force === false) {
@@ -291,11 +302,12 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       }
       return;
     }
-    const pinned = await this.resolvePinnedParent({
+    const pinned = await this.resolvePinnedTarget({
       containerPath: target.containerPath,
       mountRootPath: target.mountRootPath,
       action: "remove files",
       requireWritable: true,
+      includeDescendants: params.recursive,
       allowFinalSymlinkForUnlink: true,
       signal: params.signal,
     });
@@ -320,21 +332,23 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     signal?: AbortSignal;
   }): Promise<void> {
     const { from, to } = this.resolveRenameTargets(params);
-    await this.ensureRemoteWritable(from, "rename files", params.signal);
-    await this.ensureRemoteWritable(to, "rename files", params.signal);
-    const fromPinned = await this.resolvePinnedParent({
+    await this.ensureRemoteWritable(from, "rename files", params.signal, true);
+    await this.ensureRemoteWritable(to, "rename files", params.signal, true);
+    const fromPinned = await this.resolvePinnedTarget({
       containerPath: from.containerPath,
       mountRootPath: from.mountRootPath,
       action: "rename files",
       requireWritable: true,
+      includeDescendants: true,
       allowFinalSymlinkForUnlink: true,
       signal: params.signal,
     });
-    const toPinned = await this.resolvePinnedParent({
+    const toPinned = await this.resolvePinnedTarget({
       containerPath: to.containerPath,
       mountRootPath: to.mountRootPath,
       action: "rename files",
       requireWritable: true,
+      includeDescendants: true,
       signal: params.signal,
     });
     await this.runMutation({
@@ -392,18 +406,16 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     const agentRoot = path.resolve(this.sandbox.agentWorkspaceDir);
     const workspaceContainerRoot = normalizeContainerPath(this.runtime.remoteWorkspaceDir);
     const agentContainerRoot = normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir);
+    const hasAgentMount = this.sandbox.workspaceAccess !== "none" && agentRoot !== workspaceRoot;
     const mounts: RemoteMountInfo[] = [
       {
         localRoot: workspaceRoot,
         containerRoot: workspaceContainerRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
+        writable: this.sandbox.workspaceAccess !== "ro",
         source: "workspace",
       },
     ];
-    if (
-      this.sandbox.workspaceAccess !== "none" &&
-      path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir)
-    ) {
+    if (hasAgentMount) {
       mounts.push({
         localRoot: agentRoot,
         containerRoot: agentContainerRoot,
@@ -411,19 +423,19 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
         source: "agent",
       });
     }
-    if (this.sandbox.workspaceAccess === "rw") {
-      // Skill directories inside writable remote workspaces stay protected when
-      // the original host mount exists, matching local bridge read-only rules.
+    for (const workdir of [
+      workspaceContainerRoot,
+      ...(hasAgentMount ? [agentContainerRoot] : []),
+    ]) {
       mounts.push(
-        ...buildRemoteProtectedSkillMounts({
-          localRoot: agentRoot,
-          skillsWorkspaceDir: this.sandbox.skillsWorkspaceDir,
-          workspaceContainerRoot,
-          agentContainerRoot,
-          includeAgentMount:
-            path.resolve(this.sandbox.agentWorkspaceDir) !==
-            path.resolve(this.sandbox.workspaceDir),
-        }),
+        ...resolveReadOnlyWorkspaceSkillMounts({ ...this.sandbox, workdir }).map(
+          (mount): RemoteMountInfo => ({
+            localRoot: mount.hostPath,
+            containerRoot: mount.containerPath,
+            writable: false,
+            source: "protectedSkill",
+          }),
+        ),
       );
     }
     for (const resource of this.sandbox.readOnlyResourceMounts ?? []) {
@@ -541,7 +553,7 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
   }
 
   private ensureWritable(target: ResolvedRemotePath, action: string) {
-    if (this.sandbox.workspaceAccess !== "rw" || !target.writable) {
+    if (this.sandbox.workspaceAccess === "ro" || !target.writable) {
       throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
     }
   }
@@ -550,12 +562,14 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     target: ResolvedRemotePath,
     action: string,
     signal?: AbortSignal,
+    includeDescendants = false,
   ): Promise<void> {
     this.ensureWritable(target, action);
     await this.assertRemoteProtectedPathWritable({
       containerPath: target.containerPath,
       action,
       signal,
+      includeDescendants,
     });
   }
 
@@ -564,30 +578,31 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     action: string;
     displayPath?: string;
     signal?: AbortSignal;
+    includeDescendants?: boolean;
   }): Promise<void> {
-    const protectedRoot = this.findRemoteProtectedSkillRoot(params.containerPath);
-    if (protectedRoot && (await this.remotePathExists(protectedRoot, params.signal))) {
-      throw new Error(
-        `Sandbox path is read-only; cannot ${params.action}: ${
-          params.displayPath ?? params.containerPath
-        }`,
-      );
-    }
-  }
-
-  private findRemoteProtectedSkillRoot(containerPath: string): string | null {
-    const roots = buildRemoteProtectedSkillRoots({
-      workspaceContainerRoot: normalizeContainerPath(this.runtime.remoteWorkspaceDir),
-      agentContainerRoot: normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir),
-      includeAgentMount:
-        path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir),
-    }).toSorted((a, b) => b.length - a.length);
+    const roots = new Set([
+      ...this.getMounts()
+        .filter((mount) => !mount.writable)
+        .map((mount) => mount.containerRoot),
+      ...buildRemoteProtectedSkillRoots({
+        workspaceContainerRoot: normalizeContainerPath(this.runtime.remoteWorkspaceDir),
+        agentContainerRoot: normalizeContainerPath(this.runtime.remoteAgentWorkspaceDir),
+        includeAgentMount:
+          this.sandbox.workspaceAccess !== "none" &&
+          path.resolve(this.sandbox.agentWorkspaceDir) !== path.resolve(this.sandbox.workspaceDir),
+      }),
+    ]);
     for (const root of roots) {
-      if (isPathInsideContainerRoot(root, containerPath)) {
-        return root;
+      if (
+        (isPathInsideContainerRoot(root, params.containerPath) ||
+          (params.includeDescendants && isPathInsideContainerRoot(params.containerPath, root))) &&
+        (await this.remotePathExists(root, params.signal))
+      ) {
+        throw new Error(
+          `Sandbox path is read-only; cannot ${params.action}: ${params.displayPath ?? params.containerPath}`,
+        );
       }
     }
-    return null;
   }
 
   private async remotePathExists(containerPath: string, signal?: AbortSignal): Promise<boolean> {
@@ -641,20 +656,26 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     }
   }
 
-  private async resolvePinnedParent(params: {
+  private async resolvePinnedTarget(params: {
     containerPath: string;
     mountRootPath: string;
     action: string;
     requireWritable?: boolean;
+    directory?: boolean;
+    includeDescendants?: boolean;
     allowFinalSymlinkForUnlink?: boolean;
     signal?: AbortSignal;
   }): Promise<{ mountRootPath: string; relativeParentPath: string; basename: string }> {
-    const basename = path.posix.basename(params.containerPath);
-    if (!basename || basename === "." || basename === "/") {
+    const basename = params.directory ? "" : path.posix.basename(params.containerPath);
+    if (!params.directory && (!basename || basename === "." || basename === "/")) {
       throw new Error(`Invalid sandbox entry target: ${params.containerPath}`);
     }
     const { canonicalPath, canonicalMountRoot, logicalPath } = await this.resolveCanonicalPath({
-      containerPath: normalizeContainerPath(path.posix.dirname(params.containerPath)),
+      // mkdirp pins the directory itself; file operations pin its parent and
+      // retain no-follow handling for the final filename.
+      containerPath: normalizeContainerPath(
+        params.directory ? params.containerPath : path.posix.dirname(params.containerPath),
+      ),
       mountRootPath: params.mountRootPath,
       action: params.action,
       allowFinalSymlinkForUnlink: params.allowFinalSymlinkForUnlink,
@@ -673,10 +694,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     }
     if (params.requireWritable) {
       await this.assertRemoteProtectedPathWritable({
-        containerPath: logicalPath,
+        containerPath: path.posix.join(logicalPath, basename),
         action: params.action,
         displayPath: params.containerPath,
         signal: params.signal,
+        includeDescendants: params.includeDescendants,
       });
     }
     // Resolve mount policy in the logical namespace, but pin mutations to the

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -113,10 +113,9 @@ export function sanitizeEnvVars(
 
   const blockedPatterns = [...BLOCKED_ENV_VAR_PATTERNS, ...(options.customBlockedPatterns ?? [])];
   const allowedPatterns = [...ALLOWED_ENV_VAR_PATTERNS, ...(options.customAllowedPatterns ?? [])];
-  // Sandbox launches consume the Gateway-owned metadata snapshot so configured
-  // plugin paths cannot bypass manifest-declared credential scrubbing.
+  // Credential metadata belongs to the host; the candidate container environment
+  // must not redirect discovery to another state directory or plugin inventory.
   const metadataSnapshot = getCurrentPluginMetadataSnapshot({
-    env: envVars,
     allowScopedSnapshot: true,
     allowWorkspaceScopedSnapshot: true,
   });
@@ -129,8 +128,8 @@ export function sanitizeEnvVars(
       }
     : undefined;
   const knownSecretNames = new Set(
-    listKnownSecretEnvVarNames({ env: envVars, metadataSnapshot: activeMetadataSnapshot }).map(
-      (name) => name.trim().toUpperCase(),
+    listKnownSecretEnvVarNames({ metadataSnapshot: activeMetadataSnapshot }).map((name) =>
+      name.trim().toUpperCase(),
     ),
   );
 

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -29,7 +29,7 @@ describe("appendWorkspaceMountArgs", () => {
   it.each([
     { access: "rw" as const, expected: "/tmp/workspace:/workspace:z" },
     { access: "ro" as const, expected: "/tmp/workspace:/workspace:ro,z" },
-    { access: "none" as const, expected: "/tmp/workspace:/workspace:ro,z" },
+    { access: "none" as const, expected: "/tmp/workspace:/workspace:z" },
   ])("sets main mount permissions for workspaceAccess=$access", ({ access, expected }) => {
     const args: string[] = [];
     appendWorkspaceMountArgs({
@@ -54,7 +54,7 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
-    expect(mounts).toEqual(["/tmp/workspace:/workspace:ro,z"]);
+    expect(mounts).toEqual(["/tmp/workspace:/workspace:z"]);
   });
 
   it("omits agent workspace mount when paths are identical", () => {
@@ -231,10 +231,12 @@ describe("appendWorkspaceMountArgs", () => {
     );
   });
 
-  it("does not add a separate synced skill overlay when workspaceAccess is none", () => {
+  it("keeps private workspace skills read-only without exposing the agent workspace", () => {
     const agentWorkspaceDir = makeTempWorkspace();
     const sandboxWorkspaceDir = makeTempWorkspace();
     fs.mkdirSync(path.join(sandboxWorkspaceDir, "skills", "demo"), { recursive: true });
+    fs.mkdirSync(path.join(sandboxWorkspaceDir, ".agents", "skills"), { recursive: true });
+    fs.mkdirSync(path.join(agentWorkspaceDir, "skills", "host-only"), { recursive: true });
 
     const args: string[] = [];
     appendWorkspaceMountArgs({
@@ -249,10 +251,11 @@ describe("appendWorkspaceMountArgs", () => {
       (arg) => arg.startsWith(agentWorkspaceDir) || arg.startsWith(sandboxWorkspaceDir),
     );
 
-    expect(mounts).toEqual([`${sandboxWorkspaceDir}:/workspace:ro,z`]);
-    expect(mounts).not.toContain(
+    expect(mounts).toEqual([
+      `${sandboxWorkspaceDir}:/workspace:z`,
       `${path.join(sandboxWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
-    );
+      `${path.join(sandboxWorkspaceDir, ".agents", "skills")}:/workspace/.agents/skills:ro,z`,
+    ]);
   });
 });
 

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -48,7 +48,7 @@ export function resolveMaterializedSandboxSkillsWorkspaceDir(rootDir: string): s
 }
 
 /** Returns true when a skill mount source exists inside the canonical mount root. */
-export function isExistingWorkspaceSkillMountSource(params: {
+function isExistingWorkspaceSkillMountSource(params: {
   rootDir: string;
   hostPath: string;
 }): boolean {

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -12,10 +12,10 @@ import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
 import { normalizeContainerPathCore } from "./path-utils.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
-export const SANDBOX_MOUNT_FORMAT_VERSION = 3;
+export const SANDBOX_MOUNT_FORMAT_VERSION = 4;
 const MATERIALIZED_SANDBOX_SKILLS_WORKSPACE_PARTS = [".openclaw", "sandbox-skills"] as const;
 
-/** Read-only skill directory mounted from the agent workspace into the sandbox workspace. */
+/** Managed skill directory projected read-only into the sandbox workspace. */
 export type ReadOnlyWorkspaceSkillMount = {
   hostPath: string;
   containerPath: string;
@@ -65,7 +65,7 @@ export function isExistingWorkspaceSkillMountSource(params: {
   return isPathInside(agentRoot, canonicalSource);
 }
 
-/** Finds agent-workspace skill directories that should be mounted read-only in rw workspaces. */
+/** Protects managed skills inside writable shared or private sandbox workspaces. */
 export function resolveReadOnlyWorkspaceSkillMounts(params: {
   workspaceDir: string;
   agentWorkspaceDir: string;
@@ -73,27 +73,30 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
   workdir: string;
   workspaceAccess: SandboxWorkspaceAccess;
 }): ReadOnlyWorkspaceSkillMount[] {
-  if (params.workspaceAccess !== "rw") {
+  if (params.workspaceAccess === "ro") {
     return [];
   }
 
-  // RW workspaces mount the project as writable, but skill sources remain read-only so agent
-  // instructions are visible without letting sandbox commands mutate them.
-  const materializedSkillsWorkspaceDir =
-    params.skillsWorkspaceDir ??
-    resolveMaterializedSandboxSkillsWorkspaceDir(params.agentWorkspaceDir);
+  // Private workspaces protect their own synced instructions, never mount the
+  // shared agent workspace merely to obtain its skill sources.
+  const rootDir =
+    params.workspaceAccess === "none" ? params.workspaceDir : params.agentWorkspaceDir;
   const mounts = [
     {
-      hostPath: path.join(params.agentWorkspaceDir, "skills"),
+      hostPath: path.join(rootDir, "skills"),
       containerPath: containerJoin(params.workdir, "skills"),
-      rootDir: params.agentWorkspaceDir,
+      rootDir,
     },
     {
-      hostPath: path.join(params.agentWorkspaceDir, ".agents", "skills"),
+      hostPath: path.join(rootDir, ".agents", "skills"),
       containerPath: containerJoin(params.workdir, ".agents", "skills"),
-      rootDir: params.agentWorkspaceDir,
+      rootDir,
     },
-    {
+  ];
+  if (params.workspaceAccess === "rw") {
+    const materializedSkillsWorkspaceDir =
+      params.skillsWorkspaceDir ?? resolveMaterializedSandboxSkillsWorkspaceDir(rootDir);
+    mounts.push({
       hostPath: path.join(materializedSkillsWorkspaceDir, "skills"),
       containerPath: containerJoin(
         params.workdir,
@@ -101,8 +104,8 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
         "skills",
       ),
       rootDir: materializedSkillsWorkspaceDir,
-    },
-  ];
+    });
+  }
 
   return mounts
     .filter((mount) =>
@@ -198,7 +201,7 @@ export function appendWorkspaceMountArgs(params: {
     formatManagedWorkspaceBind({
       hostPath: workspaceDir,
       containerPath: workdir,
-      readOnly: workspaceAccess !== "rw",
+      readOnly: workspaceAccess === "ro",
     }),
   );
 

--- a/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-child-plan.ts
@@ -205,14 +205,21 @@ export async function resolveSubagentChildPlan(params: {
     sessionKey: params.requesterInternalKey,
     agentId: params.requesterAgentId,
   });
-  const childRuntime = resolveSandboxRuntimeStatus({
-    cfg: params.cfg,
-    sessionKey: childSessionKey,
-  });
+  const creationPolicy = inheritSessionCreationPolicy(
+    {
+      sandbox: requesterRuntime.sandboxRequired ? "required" : undefined,
+      createdActor: requesterRuntime.createdActor,
+    },
+    { type: "agent", id: params.requesterAgentId },
+  );
+  // A fresh child has no stored row yet; admission must include its inherited isolation.
+  const childRuntimeSandboxed =
+    creationPolicy.sandbox === "required" ||
+    resolveSandboxRuntimeStatus({ cfg: params.cfg, sessionKey: childSessionKey }).sandboxed;
   const sandboxError = resolveSpawnSandboxError({
     backend: "subagent",
     requesterSandboxed: requesterRuntime.sandboxed,
-    childSandboxed: childRuntime.sandboxed,
+    childSandboxed: childRuntimeSandboxed,
     sandbox: params.sandboxMode,
   });
   if (sandboxError) {
@@ -221,7 +228,7 @@ export async function resolveSubagentChildPlan(params: {
   const spawnedWorkspaceCwd = spawnedWorkspaceDir
     ? resolveUserPath(spawnedWorkspaceDir)
     : undefined;
-  if (childRuntime.sandboxed && spawnedCwd && spawnedCwd !== spawnedWorkspaceCwd) {
+  if (childRuntimeSandboxed && spawnedCwd && spawnedCwd !== spawnedWorkspaceCwd) {
     return {
       ok: false,
       result: {
@@ -309,14 +316,8 @@ export async function resolveSubagentChildPlan(params: {
       childSessionOrigin,
       incognito,
       childSessionKey,
-      childRuntimeSandboxed: childRuntime.sandboxed,
-      creationPolicy: inheritSessionCreationPolicy(
-        {
-          sandbox: requesterRuntime.sandboxRequired ? "required" : undefined,
-          createdActor: requesterRuntime.createdActor,
-        },
-        { type: "agent", id: params.requesterAgentId },
-      ),
+      childRuntimeSandboxed,
+      creationPolicy,
       targetAgentDir,
       modelPlan,
       launchAuthorization,

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -4,8 +4,10 @@ import os from "node:os";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ThinkLevel } from "../../../auto-reply/thinking.shared.js";
+import { upsertSessionEntryCore } from "../../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../../../state/openclaw-agent-db.paths.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import { resolveUserPath } from "../../../utils.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { installAcceptedSubagentGatewayMock } from "../../test-helpers/subagent-gateway.js";
@@ -1596,66 +1598,65 @@ describe("spawnSubagentDirect seam flow", () => {
   });
 
   it.each([
-    { required: false, source: "profile" },
-    { required: true, source: "profile" },
-    { required: true, source: "channel" },
-    { required: true, source: "unknown" },
+    { required: false, source: "profile", sandbox: "inherit" },
+    { required: true, source: "profile", sandbox: "inherit" },
+    { required: true, source: "profile", sandbox: "require" },
+    { required: true, source: "channel", sandbox: "inherit" },
+    { required: true, source: "unknown", sandbox: "inherit" },
   ] as const)(
-    "inherits native child $source provenance only from a required parent ($required)",
-    async ({ required, source }) => {
-      const parentSessionKey = "agent:main:main";
-      const actor = { type: "human", source, id: "profile-native-creator" } as const;
-      hoisted.loadSessionStoreMock.mockReturnValue({
-        [parentSessionKey]: {
-          sessionId: "parent-session",
-          updatedAt: 1,
-          createdActor: actor,
-          ...(required ? { sandbox: "required" } : {}),
-        },
-      });
-      hoisted.resolveSandboxRuntimeStatusMock.mockImplementation(({ sessionKey }) => ({
-        sandboxed: true,
-        sandboxRequired: required && sessionKey === parentSessionKey,
-        ...(required && sessionKey === parentSessionKey
-          ? {
-              isolationSubject:
-                source === "profile"
-                  ? { kind: "profile" as const, profileId: actor.id }
-                  : { kind: "session" as const, sessionKey: parentSessionKey },
-              createdActor: actor,
-            }
-          : {}),
-      }));
-      let persistedStore: Record<string, Record<string, unknown>> | undefined;
-      installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
-        onStore: (store) => {
-          persistedStore = store;
-        },
-      });
+    "inherits native child $source provenance from a required parent ($required) with sandbox=$sandbox",
+    async ({ required, source, sandbox }) => {
+      await withOpenClawTestState({ prefix: "openclaw-spawn-required-parent-" }, async (state) => {
+        const storePath = state.statePath("agents", "main", "sessions", "sessions.json");
+        const parentSessionKey = "agent:main:main";
+        const actor = { type: "human", source, id: "profile-native-creator" } as const;
+        const parent = await upsertSessionEntryCore(
+          { agentId: "main", sessionKey: parentSessionKey, storePath },
+          {
+            sessionId: "parent-session",
+            updatedAt: 1,
+            createdVia: "operator",
+            createdActor: actor,
+            ...(required ? { sandbox: "required" } : {}),
+          },
+        );
+        hoisted.loadSessionStoreMock.mockReturnValue({ [parentSessionKey]: parent });
+        hoisted.configOverride = createConfigOverride({
+          session: { store: storePath },
+          agents: {
+            defaults: { sandbox: { mode: "off" } },
+            entries: { main: { workspace: state.workspaceDir } },
+          },
+        });
+        hoisted.resolveSandboxRuntimeStatusMock.mockImplementation(resolveSandboxRuntimeStatus);
+        let persistedStore: Record<string, Record<string, unknown>> | undefined;
+        installSessionStoreCaptureMock(hoisted.updateSessionStoreMock, {
+          onStore: (store) => {
+            persistedStore = store;
+          },
+        });
 
-      const result = await spawnSubagentDirect(
-        { task: "continue under the parent's isolation policy" },
-        { agentSessionKey: parentSessionKey },
-      );
+        const result = await spawnSubagentDirect(
+          { task: "continue under the parent's isolation policy", sandbox },
+          { agentSessionKey: parentSessionKey },
+        );
 
-      expect(result.status).toBe("accepted");
-      const entry = persistedStore?.[result.childSessionKey as string];
-      expect(entry).toMatchObject({
-        createdVia: "spawn",
-        createdActor: required ? actor : { type: "agent", id: "main" },
-        parentSessionKey,
+        expect(result.status).toBe("accepted");
+        const entry = persistedStore?.[result.childSessionKey as string];
+        expect(entry).toMatchObject({
+          createdVia: "spawn",
+          createdActor: required ? actor : { type: "agent", id: "main" },
+          parentSessionKey,
+        });
+        expect(entry?.sandbox).toBe(required ? "required" : undefined);
       });
-      expect(entry?.sandbox).toBe(required ? "required" : undefined);
     },
   );
 
-  it("rejects a required parent spawning an unsandboxed native child before side effects", async () => {
+  it("rejects a configured-sandbox parent spawning an unsandboxed native child before side effects", async () => {
     hoisted.resolveSandboxRuntimeStatusMock.mockImplementation(({ sessionKey }) => ({
       sandboxed: sessionKey === "agent:main:main",
-      sandboxRequired: sessionKey === "agent:main:main",
-      ...(sessionKey === "agent:main:main"
-        ? { isolationSubject: { kind: "profile" as const, profileId: "profile-native-creator" } }
-        : {}),
+      sandboxRequired: false,
     }));
     const result = await spawnSubagentDirect(
       { task: "try an unsandboxed child" },

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -1274,6 +1274,58 @@ describe("sessions_spawn tool", () => {
     expect(callGateway).not.toHaveBeenCalled();
   });
 
+  it.each(["inherit", "require"] as const)(
+    "admits a required parent's visible child with sandbox=%s while agent sandboxing is off",
+    async (sandbox) => {
+      await withTestDir({ prefix: "openclaw-visible-required-parent-" }, async (dir) => {
+        const storePath = path.join(dir, "sessions.json");
+        const parentSessionKey = "agent:main:main";
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey: parentSessionKey, storePath },
+          {
+            sessionId: "required-parent",
+            updatedAt: 1,
+            createdVia: "operator",
+            createdActor: { type: "human", source: "profile", id: "guest-profile" },
+            sandbox: "required",
+          },
+        );
+        hoisted.inProcessCreationMock.mockResolvedValue({
+          key: "agent:main:dashboard:required-child",
+          runStarted: true,
+          runId: "required-visible-run",
+        });
+        const tool = createSessionsSpawnTool({
+          agentSessionKey: parentSessionKey,
+          config: {
+            session: { store: storePath },
+            agents: {
+              defaults: { sandbox: { mode: "off" } },
+              entries: { main: { workspace: dir } },
+            },
+          },
+          countActiveRuns: () => 0,
+        });
+
+        const result = await tool.execute("required-visible-spawn", {
+          task: "inspect the project in an isolated child",
+          visible: true,
+          sandbox,
+        });
+
+        expect(result.details).toMatchObject({
+          status: "accepted",
+          childSessionKey: "agent:main:dashboard:required-child",
+        });
+        expect(hoisted.inProcessCreationMock).toHaveBeenCalledWith(
+          "sessions.create",
+          expect.objectContaining({ parentSessionKey }),
+          expect.objectContaining({ requesterSessionKey: parentSessionKey }),
+        );
+      });
+    },
+  );
+
   it.each(["off", "all"] as const)(
     "uses the global requester sandbox mode %s for visible children",
     async (sandboxMode) => {

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -255,12 +255,15 @@ export async function maybeSpawnVisibleSession(params: {
     sessionKey: requesterKey,
     agentId: requesterAgentId,
   });
-  const childRuntime = resolveSandboxRuntimeStatus({
-    cfg,
-    sessionKey: `agent:${targetAgentId}:dashboard:pending`,
-  });
+  // Gateway creation inherits the exact parent's requirement before admitting a child run.
+  const childRuntimeSandboxed =
+    requesterRuntime.sandboxRequired ||
+    resolveSandboxRuntimeStatus({
+      cfg,
+      sessionKey: `agent:${targetAgentId}:dashboard:pending`,
+    }).sandboxed;
   const requesterSandboxed = params.options?.sandboxed === true || requesterRuntime.sandboxed;
-  if (!childRuntime.sandboxed && (requesterSandboxed || params.sandbox === "require")) {
+  if (!childRuntimeSandboxed && (requesterSandboxed || params.sandbox === "require")) {
     return {
       status: "forbidden",
       error: requesterSandboxed
@@ -277,7 +280,7 @@ export async function maybeSpawnVisibleSession(params: {
     : undefined;
   // Sandbox mounts only the target workspace; cwd must stay within that boundary.
   if (
-    childRuntime.sandboxed &&
+    childRuntimeSandboxed &&
     spawnedCwd &&
     (!spawnedWorkspaceCwd || !isPathInside(spawnedWorkspaceCwd, spawnedCwd))
   ) {

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -264,41 +264,52 @@ describe("sandbox explain command", () => {
     });
   });
 
-  it("reports the generated sandbox workspace for non-rw sessions", async () => {
-    mockCfg = {
-      agents: {
-        defaults: {
-          sandbox: {
-            mode: "all",
-            scope: "agent",
-            workspaceAccess: "none",
-            workspaceRoot: "/tmp/openclaw-sandboxes",
+  it.each([
+    { workspaceAccess: "none", writable: true, agentMounts: [] },
+    {
+      workspaceAccess: "ro",
+      writable: false,
+      agentMounts: [expect.objectContaining({ source: "agent", writable: false })],
+    },
+  ])(
+    "reports the generated sandbox workspace for $workspaceAccess sessions",
+    async ({ workspaceAccess, writable, agentMounts }) => {
+      mockCfg = {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+              scope: "agent",
+              workspaceAccess,
+              workspaceRoot: "/tmp/openclaw-sandboxes",
+            },
           },
+          list: [{ id: "builder", workspace: "/tmp/openclaw-agent-workspace" }],
         },
-        list: [{ id: "builder", workspace: "/tmp/openclaw-agent-workspace" }],
-      },
-      session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
-    };
+        session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+      };
 
-    const logs: string[] = [];
-    await sandboxExplainCommand({ json: true, agent: "builder" }, {
-      log: (msg: string) => logs.push(msg),
-      error: (msg: string) => logs.push(msg),
-      exit: (_code: number) => {},
-    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+      const logs: string[] = [];
+      await sandboxExplainCommand({ json: true, agent: "builder" }, {
+        log: (msg: string) => logs.push(msg),
+        error: (msg: string) => logs.push(msg),
+        exit: (_code: number) => {},
+      } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
 
-    const parsed = JSON.parse(logs.join(""));
-    expect(path.dirname(parsed.sandbox.effectiveHostWorkspaceRoot)).toBe(
-      path.resolve("/tmp/openclaw-sandboxes"),
-    );
-    expect(path.basename(parsed.sandbox.effectiveHostWorkspaceRoot)).toMatch(
-      /^workspace-[a-f0-9]{32}$/,
-    );
-    expect(parsed.sandbox.workspaceSource).toBe("sandbox");
-    expect(parsed.sandbox.workspaceMounts).toEqual([
-      expect.objectContaining({ source: "workspace", writable: false }),
-    ]);
-  });
+      const parsed = JSON.parse(logs.join(""));
+      expect(path.dirname(parsed.sandbox.effectiveHostWorkspaceRoot)).toBe(
+        path.resolve("/tmp/openclaw-sandboxes"),
+      );
+      expect(path.basename(parsed.sandbox.effectiveHostWorkspaceRoot)).toMatch(
+        /^workspace-[a-f0-9]{32}$/,
+      );
+      expect(parsed.sandbox.workspaceSource).toBe("sandbox");
+      expect(parsed.sandbox.workspaceMounts).toEqual([
+        expect.objectContaining({ source: "workspace", writable }),
+        ...agentMounts,
+      ]);
+    },
+  );
 
   it("reports guest-isolated workspaces and the effective writable-access cap", async () => {
     await withOpenClawTestState({ label: "sandbox-explain-guests" }, async (state) => {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -3566,115 +3566,53 @@ test("sessions.create persists declared spawn lineage for spawn-owned creations"
   expect(created.payload?.entry?.spawnDepth).toBe(2);
 });
 
-test("sessions.create atomically persists trusted visible-spawn tool policy", async () => {
-  const { storePath } = await createSessionStoreDir();
-  const parentSessionKey = "agent:main:main";
-  await writeSessionStore({
-    entries: {
-      [parentSessionKey]: sessionStoreEntry("sess-visible-spawn-parent"),
-    },
-  });
-
-  const created = await directSessionReq<{
-    key?: string;
-    entry?: {
-      label?: string;
-      spawnedBy?: string;
-      completionOwnerSessionKey?: string;
-      parentSessionKey?: string;
-      spawnDepth?: number;
-      inheritedToolPolicyVersion?: number;
-      inheritedToolAllow?: string[];
-      inheritedToolDeny?: string[];
-    };
-  }>(
-    "sessions.create",
-    {
-      agentId: "main",
-      label: "Restricted visible child",
-      parentSessionKey,
-      spawnDepth: 1,
-    },
-    {
-      client: {
-        connect: { scopes: ["operator.write"] },
-        internal: {
-          syntheticClient: true,
-          sessionCreation: {
-            via: "spawn",
-            actor: { type: "agent", id: "main" },
-            requesterSessionKey: parentSessionKey,
-            completionOwnerSessionKey: "agent:main:discord:direct:alice",
-            inheritedToolPolicy: {
-              version: 1,
-              allow: ["read", "sessions_spawn"],
-              deny: ["exec"],
-            },
-          },
+test.each([false, true])(
+  "sessions.create atomically persists trusted visible-spawn tool policy with required parent=%s",
+  async (required) => {
+    const { storePath } = await createSessionStoreDir();
+    const parentSessionKey = "agent:main:main";
+    const actor = { type: "human", source: "profile", id: "visible-spawn-creator" } as const;
+    await writeSessionStore({
+      entries: {
+        [parentSessionKey]: {
+          ...sessionStoreEntry("sess-visible-spawn-parent"),
+          createdVia: "operator",
+          createdActor: actor,
+          ...(required ? { sandbox: "required" } : {}),
         },
-      } as never,
-    },
-  );
+      },
+    });
 
-  expect(created.ok, JSON.stringify(created.error)).toBe(true);
-  expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
-  expect(created.payload?.entry).toMatchObject({
-    label: "Restricted visible child",
-    spawnedBy: parentSessionKey,
-    completionOwnerSessionKey: "agent:main:discord:direct:alice",
-    parentSessionKey,
-    spawnDepth: 1,
-    inheritedToolPolicyVersion: 1,
-    inheritedToolAllow: ["read", "sessions_spawn"],
-    inheritedToolDeny: ["exec"],
-  });
-  const key = requireNonEmptyString(created.payload?.key, "visible child key");
-  expect(loadSessionEntry({ agentId: "main", sessionKey: key, storePath })).toMatchObject({
-    spawnedBy: parentSessionKey,
-    completionOwnerSessionKey: "agent:main:discord:direct:alice",
-    inheritedToolPolicyVersion: 1,
-    inheritedToolAllow: ["read", "sessions_spawn"],
-    inheritedToolDeny: ["exec"],
-  });
-});
-
-test("sessions.create accepts a signed agent-runtime visible-spawn policy", async () => {
-  const { storePath } = await createSessionStoreDir();
-  const parentSessionKey = "agent:main:main";
-  await writeSessionStore({
-    entries: {
-      [parentSessionKey]: sessionStoreEntry("sess-runtime-spawn-parent"),
-    },
-  });
-
-  const created = await directSessionReq<{
-    key?: string;
-    entry?: {
-      createdVia?: string;
-      createdActor?: unknown;
-      spawnedBy?: string;
-      completionOwnerSessionKey?: string;
-      inheritedToolAllow?: string[];
-      inheritedToolDeny?: string[];
-    };
-  }>(
-    "sessions.create",
-    {
-      agentId: "main",
-      label: "Runtime visible child",
-      parentSessionKey,
-      spawnDepth: 1,
-    },
-    {
-      client: {
-        connect: { scopes: ["operator.write"] },
-        internal: {
-          agentRuntimeIdentity: {
-            kind: "agentRuntime",
-            agentId: "main",
-            sessionKey: parentSessionKey,
-            sessionSpawnContext: {
-              completionOwnerSessionKey: "agent:main:discord:direct:bob",
+    const created = await directSessionReq<{
+      key?: string;
+      entry?: {
+        label?: string;
+        spawnedBy?: string;
+        completionOwnerSessionKey?: string;
+        parentSessionKey?: string;
+        spawnDepth?: number;
+        inheritedToolPolicyVersion?: number;
+        inheritedToolAllow?: string[];
+        inheritedToolDeny?: string[];
+      };
+    }>(
+      "sessions.create",
+      {
+        agentId: "main",
+        label: "Restricted visible child",
+        parentSessionKey,
+        spawnDepth: 1,
+      },
+      {
+        client: {
+          connect: { scopes: ["operator.write"] },
+          internal: {
+            syntheticClient: true,
+            sessionCreation: {
+              via: "spawn",
+              actor: { type: "agent", id: "main" },
+              requesterSessionKey: parentSessionKey,
+              completionOwnerSessionKey: "agent:main:discord:direct:alice",
               inheritedToolPolicy: {
                 version: 1,
                 allow: ["read", "sessions_spawn"],
@@ -3682,27 +3620,155 @@ test("sessions.create accepts a signed agent-runtime visible-spawn policy", asyn
               },
             },
           },
-        },
-      } as never,
-    },
-  );
+        } as never,
+      },
+    );
 
-  expect(created.ok, JSON.stringify(created.error)).toBe(true);
-  expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
-  expect(created.payload?.entry).toMatchObject({
-    createdVia: "spawn",
-    createdActor: { type: "agent", id: "main" },
-    spawnedBy: parentSessionKey,
-    completionOwnerSessionKey: "agent:main:discord:direct:bob",
-    inheritedToolAllow: ["read", "sessions_spawn"],
-    inheritedToolDeny: ["exec"],
+    expect(created.ok, JSON.stringify(created.error)).toBe(true);
+    expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
+    expect(created.payload?.entry).toMatchObject({
+      label: "Restricted visible child",
+      spawnedBy: parentSessionKey,
+      completionOwnerSessionKey: "agent:main:discord:direct:alice",
+      parentSessionKey,
+      spawnDepth: 1,
+      inheritedToolPolicyVersion: 1,
+      inheritedToolAllow: ["read", "sessions_spawn"],
+      inheritedToolDeny: ["exec"],
+    });
+    const key = requireNonEmptyString(created.payload?.key, "visible child key");
+    const child = loadSessionEntry({ agentId: "main", sessionKey: key, storePath });
+    expect(child).toMatchObject({
+      spawnedBy: parentSessionKey,
+      completionOwnerSessionKey: "agent:main:discord:direct:alice",
+      inheritedToolPolicyVersion: 1,
+      inheritedToolAllow: ["read", "sessions_spawn"],
+      inheritedToolDeny: ["exec"],
+      createdActor: required ? actor : { type: "agent", id: "main" },
+    });
+    expect(child?.sandbox).toBe(required ? "required" : undefined);
+  },
+);
+
+test.each([false, true])(
+  "sessions.create accepts a signed agent-runtime visible-spawn policy with required parent=%s",
+  async (required) => {
+    const { storePath } = await createSessionStoreDir();
+    const parentSessionKey = "agent:main:main";
+    const actor = { type: "human", source: "profile", id: "runtime-spawn-creator" } as const;
+    await writeSessionStore({
+      entries: {
+        [parentSessionKey]: {
+          ...sessionStoreEntry("sess-runtime-spawn-parent"),
+          createdVia: "operator",
+          createdActor: actor,
+          ...(required ? { sandbox: "required" } : {}),
+        },
+      },
+    });
+
+    const created = await directSessionReq<{
+      key?: string;
+      entry?: {
+        createdVia?: string;
+        createdActor?: unknown;
+        spawnedBy?: string;
+        completionOwnerSessionKey?: string;
+        inheritedToolAllow?: string[];
+        inheritedToolDeny?: string[];
+      };
+    }>(
+      "sessions.create",
+      {
+        agentId: "main",
+        label: "Runtime visible child",
+        parentSessionKey,
+        spawnDepth: 1,
+      },
+      {
+        client: {
+          connect: { scopes: ["operator.write"] },
+          internal: {
+            agentRuntimeIdentity: {
+              kind: "agentRuntime",
+              agentId: "main",
+              sessionKey: parentSessionKey,
+              sessionSpawnContext: {
+                completionOwnerSessionKey: "agent:main:discord:direct:bob",
+                inheritedToolPolicy: {
+                  version: 1,
+                  allow: ["read", "sessions_spawn"],
+                  deny: ["exec"],
+                },
+              },
+            },
+          },
+        } as never,
+      },
+    );
+
+    expect(created.ok, JSON.stringify(created.error)).toBe(true);
+    expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
+    expect(created.payload?.entry).toMatchObject({
+      createdVia: "spawn",
+      createdActor: required ? actor : { type: "agent", id: "main" },
+      spawnedBy: parentSessionKey,
+      completionOwnerSessionKey: "agent:main:discord:direct:bob",
+      inheritedToolAllow: ["read", "sessions_spawn"],
+      inheritedToolDeny: ["exec"],
+    });
+    const key = requireNonEmptyString(created.payload?.key, "runtime visible child key");
+    const child = loadSessionEntry({ agentId: "main", sessionKey: key, storePath });
+    expect(child).toMatchObject({
+      spawnedBy: parentSessionKey,
+      completionOwnerSessionKey: "agent:main:discord:direct:bob",
+      inheritedToolPolicyVersion: 1,
+      createdActor: required ? actor : { type: "agent", id: "main" },
+    });
+    expect(child?.sandbox).toBe(required ? "required" : undefined);
+  },
+);
+
+test("sessions.create rejects a replaced required spawn parent before child creation", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const parentSessionKey = "agent:main:main";
+  const childSessionKey = "agent:main:dashboard:replaced-parent-child";
+  const parent = {
+    ...sessionStoreEntry("required-spawn-parent"),
+    lifecycleRevision: "original-parent",
+    createdActor: { type: "human", source: "profile", id: "original-creator" } as const,
+    sandbox: "required" as const,
+  };
+  await writeSessionStore({ entries: { [parentSessionKey]: parent } });
+  const { createGatewaySession } = await import("./session-create-service.js");
+  let replaced = false;
+
+  const created = await createGatewaySession({
+    cfg: getRuntimeConfig(),
+    agentId: "main",
+    key: childSessionKey,
+    parentSessionKey,
+    spawnDepth: 1,
+    commandSource: "test",
+    creation: { via: "spawn", actor: { type: "agent", id: "main" } },
+    commitGuard: () => {
+      if (!replaced) {
+        replaced = true;
+        replaceSessionEntrySync(
+          { agentId: "main", sessionKey: parentSessionKey, storePath },
+          { ...parent, lifecycleRevision: "replacement-parent" },
+        );
+      }
+    },
   });
-  const key = requireNonEmptyString(created.payload?.key, "runtime visible child key");
-  expect(loadSessionEntry({ agentId: "main", sessionKey: key, storePath })).toMatchObject({
-    spawnedBy: parentSessionKey,
-    completionOwnerSessionKey: "agent:main:discord:direct:bob",
-    inheritedToolPolicyVersion: 1,
+
+  expect(created).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST", message: expect.stringContaining("changed before") },
   });
+  expect(
+    loadSessionEntry({ agentId: "main", sessionKey: childSessionKey, storePath }),
+  ).toBeUndefined();
 });
 
 test("sessions.create commits no session after delegated authority closes", async () => {

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -50,6 +50,7 @@ import { createSessionDiffBaselineCaptureClaim } from "../config/sessions/sessio
 import { projectPublicSessionEntry } from "../config/sessions/session-entry-projection.js";
 import {
   buildSessionCreationStamp,
+  inheritSessionCreationPolicy,
   type SessionCreatedActor,
   type SessionCreatedVia,
 } from "../config/sessions/session-entry-provenance.js";
@@ -798,6 +799,11 @@ export async function createGatewaySession(params: {
   let createdNewEntry = false;
   let preparedLifecycle: PreparedGatewaySessionLifecycle | undefined;
   let lifecyclePreparationCommitted = false;
+  const holdParentLifecycle =
+    params.creation?.via === "spawn" ||
+    params.emitCommandHooks === true ||
+    params.fork === true ||
+    params.authorizedPluginId !== undefined;
   const spawnToolPolicy =
     params.spawnToolPolicy && canonicalParentSessionKey
       ? {
@@ -812,13 +818,7 @@ export async function createGatewaySession(params: {
   const createChildSession = async (): Promise<GatewaySessionCommitResult> => {
     params.commitGuard?.();
     let currentParentSessionEntry = parentSessionEntry;
-    if (
-      canonicalParentSessionKey &&
-      parentSessionTarget &&
-      (params.emitCommandHooks === true ||
-        params.fork === true ||
-        params.authorizedPluginId !== undefined)
-    ) {
+    if (canonicalParentSessionKey && parentSessionTarget && holdParentLifecycle) {
       const currentParent = loadGatewaySessionEntryReadOnly(
         canonicalParentSessionKey,
         parentSelectedAgentId ? { agentId: parentSelectedAgentId } : undefined,
@@ -826,13 +826,14 @@ export async function createGatewaySession(params: {
       const currentParentEntry = currentParent.entry;
       if (
         !currentParentEntry?.sessionId ||
-        currentParentEntry.sessionId !== parentSessionEntry?.sessionId
+        currentParentEntry.sessionId !== parentSessionEntry?.sessionId ||
+        currentParentEntry.lifecycleRevision !== parentSessionEntry?.lifecycleRevision
       ) {
         return {
           ok: false,
           error: errorShape(
             ErrorCodes.INVALID_REQUEST,
-            `Parent session ${parentSessionKey} changed before ${params.fork === true ? "fork" : "/new"}; retry.`,
+            `Parent session ${parentSessionKey} changed before child creation; retry.`,
           ),
         };
       }
@@ -906,6 +907,21 @@ export async function createGatewaySession(params: {
       });
     }
 
+    // The locked parent owns delegated isolation, including signed remote callers whose
+    // transport context carries only agent identity and cannot carry creator authority.
+    const creation =
+      params.creation?.via === "spawn"
+        ? {
+            ...params.creation,
+            ...inheritSessionCreationPolicy(
+              {
+                sandbox: currentParentSessionEntry?.sandbox,
+                createdActor: currentParentSessionEntry?.createdActor,
+              },
+              params.creation.actor,
+            ),
+          }
+        : params.creation;
     const target = creationTarget;
     const currentTargetEntry = loadGatewaySessionEntryReadOnly(target.canonicalKey, {
       agentId: target.agentId,
@@ -1199,12 +1215,11 @@ export async function createGatewaySession(params: {
           // Stamp provenance only for genuinely new rows: adopting an existing key
           // must not restamp write-once node facts (this direct store write bypasses
           // the merge-level write-once guard), and legacy rows stay "unknown".
-          ...(params.creation && createdNewEntry
+          ...(creation && createdNewEntry
             ? buildSessionCreationStamp({
-                ...params.creation,
+                ...creation,
                 // Delegated isolation survives changes to the creator's current role.
-                sandbox:
-                  params.creation.sandbox ?? resolveCreatorSandbox(params.cfg, params.creation),
+                sandbox: creation.sandbox ?? resolveCreatorSandbox(params.cfg, creation),
               })
             : {}),
           ...(params.visibility && createdNewEntry ? { visibility: params.visibility } : {}),
@@ -1487,9 +1502,7 @@ export async function createGatewaySession(params: {
     canonicalParentSessionKey &&
     parentSessionEntry?.sessionId &&
     parentSessionTarget &&
-    (params.emitCommandHooks === true ||
-      params.fork === true ||
-      params.authorizedPluginId !== undefined)
+    holdParentLifecycle
   ) {
     lifecycleTargets.push({
       scope: parentSessionTarget.storePath,

--- a/src/plugin-sdk/sandbox.ts
+++ b/src/plugin-sdk/sandbox.ts
@@ -27,6 +27,7 @@ export type {
   SshSandboxSettings,
 } from "../agents/sandbox.js";
 export type { OpenClawConfig } from "../config/config.js";
+export { resolveReadOnlyWorkspaceSkillMounts } from "../agents/sandbox/workspace-mounts.js";
 
 export {
   buildExecRemoteCommand,

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -196,8 +196,8 @@ describe("provider env vars dynamic manifest metadata", () => {
     });
   });
 
-  it("scrubs usage credentials from the active configured plugin snapshot", () => {
-    pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockReturnValue({
+  it("scrubs usage credentials using host metadata rather than the candidate sandbox env", () => {
+    const configuredSnapshot = {
       workspaceDir: "/workspace",
       index: {
         plugins: [
@@ -231,7 +231,11 @@ describe("provider env vars dynamic manifest metadata", () => {
           },
         },
       ],
-    });
+    };
+    pluginRegistryMocks.getCurrentPluginMetadataSnapshot.mockImplementation(
+      (params: { env?: NodeJS.ProcessEnv }) =>
+        !params.env || params.env === process.env ? configuredSnapshot : undefined,
+    );
 
     expect(
       sanitizeEnvVars({


### PR DESCRIPTION
## What Problem This Solves

Closes #37634. A sandbox-required guest could chat but could not do ordinary coding work: the private `workspaceAccess: "none"` workspace was mounted read-only, and both spawn paths rejected children before inheriting the parent's sandbox requirement. The real assembled file tools also treated container paths as host paths during memory-provenance classification.

## Why This Change Was Made

Keep isolation at its owning boundary without turning an isolated workspace into a read-only workspace. `none` now provides writable private storage; explicit `ro` and the shared-workspace boundary remain unchanged. One managed-skill mount projection protects instruction roots across local, remote, and OpenShell file bridges. Mount format v4 replaces stale container layouts.

Child admission now derives immutable creator/sandbox policy from the authoritative parent under its lifecycle lock before checking execution policy. File-tool memory provenance reuses backend-owned canonical file identity, including remote aliases, and records private writes against the private workspace rather than the shared workspace.

The composed tests also exposed directory rename/remove rejection, untyped remote missing-file errors, inconsistent remote directory-alias preparation, and candidate-container environment influencing host plugin metadata discovery. These are repaired at their existing owners; missing files remain distinguishable from permission or transport failures, and canonical directory preparation retains no-follow file opens.

## User Impact

Guests can write, edit, patch, run commands, and delegate inside their private sandbox without administrator access. Public cloning and dependency downloads still require the operator's existing network setting; this PR does not change the global no-network default or expose host credentials. Managed skill files remain read-only. Remote arbitrary shell execution still depends on the remote operator's filesystem policy, not file-bridge checks.

Thanks to @whyuds for the original workspace report. No new config option, schema version, protocol version, dependency, or changelog entry.

## Evidence

- Before-fix live guest reproduction: private workspace writes and public clone failed read-only; hidden and visible children were rejected as unsandboxed. A cold upgrade retained the same session/private workspace and replaced the old container layout; seamless hot replacement was not claimed.
- [Real Gateway/provider matrix](https://crabbox.openclaw.ai/portal/runs/run_889768578346): native and Codex runtimes both passed write/edit/read/patch, public clone, two independently verified child executions, private writable workspace, immutable skills, host-exec rejection, and credential absence. Explicit `ro` passed its negative control. Connections had only `operator.read` and `operator.write`; role policy forced sandboxing with agent sandbox mode off.
- [Linux filesystem regression](https://crabbox.openclaw.ai/portal/runs/run_5cad325df01f): 2 assembled remote scenarios and 28 remote-bridge tests passed, including canonical aliases, memory quarantine, and escape/final-file-symlink rejection.
- Local assembled coding/provenance/patch suite: 213 passed. Gateway creation: 135 passed. Hidden spawn: 84 passed. Visible spawn: 134 passed. OpenShell: 116 passed. Provider-environment metadata: 30 passed. Real filesystem bridge E2E: 8 passed. Filesystem boundaries and container recreation: 106 passed.
- [Runtime-candidate validation](https://crabbox.openclaw.ai/portal/runs/run_9e48877fbba3): all 33 changed-file hashes matched; 178 focused tests and normal `pnpm build:docker` (all 11 invocations and post-build guards) passed. `pnpm tsgo:core` and independent Codex review passed. The first CI run exposed two stale sibling-test expectations, a now-unused internal export, and a test-file line limit; the follow-up corrects these without changing runtime behavior. The cleanup has 110 passing focused tests (wrapper exit 0), passing targeted lint, formatting, and independent Codex review; [final exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33576750643) passed on `3dd9470d47172eaa7e5f436f131241986f513f22`, including both Windows test lanes and the required merge gate. All proof machines were released.
- Production: +312/−371 (**net −59**); tests: +782/−412; docs: +59/−19. Removed duplicate remote/OpenShell policy paths instead of adding a parallel guest implementation.

The provider proof used patch `e3b026d22683c3d5817bbfc29f775b54080184cda001529a6081770a589345e9` over `a9469a2119a6cd4251c7346c896c8d9cae3633a3`. The next change was a stable local observer binding in two call sites to satisfy TypeScript narrowing across `await`; that candidate patch `bf1fe8740a9bc49a493a638c0929117f7b038741b32bc99149f4128fe78e7f8b` passed the separately linked tests/build. The subsequent CI-only cleanup makes one unused helper private and updates/consolidates existing tests; it does not alter runtime behavior. Current head: `3dd9470d47172eaa7e5f436f131241986f513f22`.

Named follow-up: **sandboxed skill-path presentation**. One Codex child attempted a shared-host skill pathname, received correct `/workspace/` guidance from the sandbox boundary, and then completed successfully. Investigate the path's presentation/inheritance separately; do not broaden host filesystem access to compensate.
