### PR TITLE
test(google): centralize auth fixture environment cleanup

### DIFF
--- a/extensions/google/cli-backend-auth.test.ts
+++ b/extensions/google/cli-backend-auth.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { CliBackendAuthProfilePreparationError } from "openclaw/plugin-sdk/cli-backend";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { captureEnv, withTempDir } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
 
 type GeminiPrepareContext = Parameters<
@@ -77,15 +77,28 @@ function buildGeminiApiKeyPrepareContext(workspaceDir: string): GeminiPrepareCon
   };
 }
 
-function restoreEnv(name: string, value: string | undefined): void {
-  if (value === undefined) {
-    delete process.env[name];
-    return;
-  }
-  process.env[name] = value;
-}
-
 describe("google gemini cli backend auth bridge", () => {
+  let env: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    // Preparation can fail before a test obtains its per-run cleanup callback.
+    env = captureEnv([
+      "GEMINI_API_KEY",
+      "GEMINI_CLI_HOME",
+      "GEMINI_CLI_SYSTEM_SETTINGS_PATH",
+      "GEMINI_FORCE_ENCRYPTED_FILE_STORAGE",
+      "GOOGLE_API_KEY",
+      "GOOGLE_APPLICATION_CREDENTIALS",
+      "GOOGLE_CLOUD_ACCESS_TOKEN",
+      "GOOGLE_CLOUD_QUOTA_PROJECT",
+      "GOOGLE_GENAI_USE_GCA",
+    ]);
+  });
+
+  afterEach(() => {
+    env.restore();
+  });
+
   it("rejects a selected OAuth profile for isolated completion", async () => {
     await withTempDir("openclaw-test-workspace-", async (workspaceDir) => {
       await expect(
@@ -138,7 +151,6 @@ describe("google gemini cli backend auth bridge", () => {
 
   it("lets a prepared API-key selector override ambient Code Assist flags", async () => {
     await withTempDir("openclaw-test-workspace-", async (workspaceDir) => {
-      const originalUseGca = process.env.GOOGLE_GENAI_USE_GCA;
       process.env.GOOGLE_GENAI_USE_GCA = "true";
       let prepared: GeminiPreparedExecution | null | undefined;
       try {
@@ -152,7 +164,6 @@ describe("google gemini cli backend auth bridge", () => {
         expect(prepared?.env?.GEMINI_API_KEY).toBe("prepared-key");
         expect(prepared?.env?.GOOGLE_GENAI_USE_GCA).toBe("false");
       } finally {
-        restoreEnv("GOOGLE_GENAI_USE_GCA", originalUseGca);
         await prepared?.cleanup?.();
       }
     });
@@ -178,8 +189,6 @@ describe("google gemini cli backend auth bridge", () => {
         path.join(ambientHome, ".env"),
         'GOOGLE_CLOUD_PROJECT="ambient-project"\nANOTHER_SETTING="must-not-cross"\n',
       );
-
-      const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
       process.env.GEMINI_CLI_HOME = ambientHome;
       const prepared = await buildGoogleGeminiCliBackend().prepareExecution?.({
         workspaceDir,
@@ -205,7 +214,6 @@ describe("google gemini cli backend auth bridge", () => {
           telemetry: { logPrompts: false },
         });
       } finally {
-        restoreEnv("GEMINI_CLI_HOME", originalGeminiCliHome);
         await prepared?.cleanup?.();
       }
     });
@@ -222,8 +230,6 @@ describe("google gemini cli backend auth bridge", () => {
         path.join(projectDir, ".gemini", ".env"),
         'GEMINI_API_KEY="project-key"\nUNRELATED_PROJECT_SETTING="must-not-cross"\n',
       );
-
-      const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
       process.env.GEMINI_CLI_HOME = ambientHome;
       const prepared = await buildGoogleGeminiCliBackend().prepareExecution?.({
         workspaceDir: projectDir,
@@ -237,7 +243,6 @@ describe("google gemini cli backend auth bridge", () => {
         await stageGeminiPreparedExecution(prepared);
         expect(prepared?.env?.GEMINI_API_KEY).toBe("home-key");
       } finally {
-        restoreEnv("GEMINI_CLI_HOME", originalGeminiCliHome);
         await prepared?.cleanup?.();
       }
     });
@@ -256,7 +261,6 @@ describe("google gemini cli backend auth bridge", () => {
         'GOOGLE_GENAI_USE_VERTEXAI="true"\nGOOGLE_APPLICATION_CREDENTIALS="./credentials.json"\n',
       );
 
-      const env = captureEnv(["GEMINI_CLI_HOME", "GOOGLE_APPLICATION_CREDENTIALS"]);
       process.env.GEMINI_CLI_HOME = ambientHome;
       // Process credentials override dotenv; this fixture exercises the file-only path.
       delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
@@ -276,7 +280,6 @@ describe("google gemini cli backend auth bridge", () => {
           path.join(workspaceDir, "credentials.json"),
         );
       } finally {
-        env.restore();
         await prepared?.cleanup?.();
       }
     });
@@ -290,8 +293,6 @@ describe("google gemini cli backend auth bridge", () => {
         path.join(ambientHome, ".gemini", "settings.json"),
         `${JSON.stringify({ security: { auth: { selectedType: "vertex-ai" } } })}\n`,
       );
-      const originalGeminiCliHome = process.env.GEMINI_CLI_HOME;
-      const originalApplicationCredentials = process.env.GOOGLE_APPLICATION_CREDENTIALS;
       process.env.GEMINI_CLI_HOME = ambientHome;
       process.env.GOOGLE_APPLICATION_CREDENTIALS = "./credentials.json";
       let prepared: GeminiPreparedExecution | null | undefined;
@@ -309,8 +310,6 @@ describe("google gemini cli backend auth bridge", () => {
         );
         expect(prepared?.clearEnv).toContain("GOOGLE_APPLICATION_CREDENTIALS");
       } finally {
-        restoreEnv("GEMINI_CLI_HOME", originalGeminiCliHome);
-        restoreEnv("GOOGLE_APPLICATION_CREDENTIALS", originalApplicationCredentials);
         await prepared?.cleanup?.();
       }
     });
@@ -790,7 +789,6 @@ describe("google gemini cli backend auth bridge", () => {
   it("inherits process Gemini system settings when no generated settings path is present", async () => {
     const backend = buildGoogleGeminiCliBackend();
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-workspace-"));
-    const originalSystemSettingsPath = process.env.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
     let prepared:
       | Awaited<ReturnType<NonNullable<typeof backend.prepareExecution>>>
       | null
@@ -830,7 +828,6 @@ describe("google gemini cli backend auth bridge", () => {
         },
       });
     } finally {
-      restoreEnv("GEMINI_CLI_SYSTEM_SETTINGS_PATH", originalSystemSettingsPath);
       await prepared?.cleanup?.();
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
@@ -934,13 +931,6 @@ describe("google gemini cli backend auth bridge", () => {
   it("clears inherited Gemini auth credentials when staging selected OAuth credentials", async () => {
     const backend = buildGoogleGeminiCliBackend();
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-workspace-"));
-    const originalUseGca = process.env.GOOGLE_GENAI_USE_GCA;
-    const originalCloudAccessToken = process.env.GOOGLE_CLOUD_ACCESS_TOKEN;
-    const originalGoogleApplicationCredentials = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-    const originalForceEncryptedFileStorage = process.env.GEMINI_FORCE_ENCRYPTED_FILE_STORAGE;
-    const originalGeminiApiKey = process.env.GEMINI_API_KEY;
-    const originalGoogleApiKey = process.env.GOOGLE_API_KEY;
-    const originalQuotaProject = process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
     let prepared:
       | Awaited<ReturnType<NonNullable<typeof backend.prepareExecution>>>
       | null
@@ -977,13 +967,6 @@ describe("google gemini cli backend auth bridge", () => {
         "GEMINI_CLI_SYSTEM_SETTINGS_PATH",
       ]);
     } finally {
-      restoreEnv("GOOGLE_GENAI_USE_GCA", originalUseGca);
-      restoreEnv("GOOGLE_CLOUD_ACCESS_TOKEN", originalCloudAccessToken);
-      restoreEnv("GOOGLE_APPLICATION_CREDENTIALS", originalGoogleApplicationCredentials);
-      restoreEnv("GEMINI_FORCE_ENCRYPTED_FILE_STORAGE", originalForceEncryptedFileStorage);
-      restoreEnv("GEMINI_API_KEY", originalGeminiApiKey);
-      restoreEnv("GOOGLE_API_KEY", originalGoogleApiKey);
-      restoreEnv("GOOGLE_CLOUD_QUOTA_PROJECT", originalQuotaProject);
       await prepared?.cleanup?.();
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Two Gemini auth tests changed GEMINI_CLI_HOME before awaiting preparation, but entered their restoration finally block only after preparation succeeded. A preparation error could leave later tests pointing at a deleted temporary home. Move the nine environment keys mutated by this suite under its existing captureEnv helper and afterEach ownership, and remove the repeated manual snapshots/restoration helper.

This absorbs the earlier special-case Vertex environment repair while retaining the explicit deletion of ambient application credentials. All 29 auth cases, 105 assertion sites, 11 prepared cleanup calls and both reverse-order cleanup arrays remain. The isolated-completion sibling already guards its two mutations correctly. Production delta is zero; tests +22/-39.

Paired private runs exercised both failing preparation paths with GEMINI_CLI_HOME initially absent and initially set: all four original runs leaked the deleted home path, and all four candidate runs restored the exact prior state while preserving the same injected Error. Both full 29-case runs passed, and all 100 observed temporary roots were removed by existing cleanup. The lead also ran the original auth and isolated-completion suites together: 46/46 passed. These are fixture ownership results, not live provider or performance benchmarks.

The final candidate also passes all46 auth and isolated-completion cases with shuffle seed2111 and identical test identities. The full changed-file gate, including plugin test types, all three dead-export scans and lint, passed. Independent Codex review plus complete manual owner, sibling, helper, history and private-probe review found no actionable issue. Local tests use the existing fs-safe0.5.6 installation; the locked0.7.0 source was inspected, and exact-head hosted locked-dependency CI is required before landing.
