### PR TITLE
refactor(anthropic): share model ref parsing

### DIFF
--- a/extensions/anthropic/claude-model-refs.ts
+++ b/extensions/anthropic/claude-model-refs.ts
@@ -53,9 +53,16 @@ function hasAnyRetiredVersionPrefix(normalized: string, prefixes: readonly strin
   return prefixes.some((prefix) => hasRetiredVersionPrefix(normalized, prefix));
 }
 
-function parseProviderModelRef(
+export function normalizeAnthropicProviderId(provider: string): string {
+  const normalized = normalizeLowercaseStringOrEmpty(provider);
+  if (normalized === "bedrock" || normalized === "aws-bedrock") {
+    return "amazon-bedrock";
+  }
+  return normalized;
+}
+
+export function parseAnthropicModelRef(
   raw: string,
-  defaultProvider: string,
 ): { provider: string; model: string; explicitProvider: boolean } | null {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -63,7 +70,7 @@ function parseProviderModelRef(
   }
   const slashIndex = trimmed.indexOf("/");
   if (slashIndex <= 0) {
-    return { provider: defaultProvider, model: trimmed, explicitProvider: false };
+    return { provider: "anthropic", model: trimmed, explicitProvider: false };
   }
   const provider = trimmed.slice(0, slashIndex).trim();
   const model = trimmed.slice(slashIndex + 1).trim();
@@ -71,7 +78,7 @@ function parseProviderModelRef(
     return null;
   }
   return {
-    provider: normalizeLowercaseStringOrEmpty(provider),
+    provider: normalizeAnthropicProviderId(provider),
     model,
     explicitProvider: true,
   };
@@ -176,7 +183,7 @@ function upgradeOldClaudeModelId(normalized: string): string | null {
 export function resolveClaudeCliAnthropicModelRefs(
   raw: string,
 ): ClaudeCliAnthropicModelRefs | null {
-  const parsed = parseProviderModelRef(raw, "anthropic");
+  const parsed = parseAnthropicModelRef(raw);
   if (!parsed) {
     return null;
   }

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -9,6 +9,8 @@ import {
   normalizeLowercaseStringOrEmpty,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  normalizeAnthropicProviderId,
+  parseAnthropicModelRef,
   resolveClaudeCliAnthropicModelRefs,
   resolveKnownAnthropicModelRef,
 } from "./claude-model-refs.js";
@@ -23,14 +25,6 @@ const ANTHROPIC_API_KEY_DEFAULT_ALLOWLIST_REFS = [
   "anthropic/claude-sonnet-5",
   "anthropic/claude-sonnet-4-6",
 ] as const;
-
-function normalizeProviderId(provider: string): string {
-  const normalized = normalizeLowercaseStringOrEmpty(provider);
-  if (normalized === "bedrock" || normalized === "aws-bedrock") {
-    return "amazon-bedrock";
-  }
-  return normalized;
-}
 
 function resolveAnthropicDefaultAuthMode(
   config: OpenClawConfig,
@@ -95,7 +89,8 @@ function resolveAnthropicDefaultAuthMode(
 function usesRetiredClaudeCliProviderEntry(config: OpenClawConfig): boolean {
   return Object.entries(config.models?.providers ?? {}).some(
     ([provider, entry]) =>
-      normalizeProviderId(provider) === "anthropic" && entry.apiKey === CLAUDE_CLI_PROFILE_ID,
+      normalizeAnthropicProviderId(provider) === "anthropic" &&
+      entry.apiKey === CLAUDE_CLI_PROFILE_ID,
   );
 }
 
@@ -112,29 +107,6 @@ function resolveModelPrimaryValue(
   }
   const trimmed = primary.trim();
   return trimmed || undefined;
-}
-
-function parseProviderModelRef(
-  raw: string,
-  defaultProvider: string,
-): { provider: string; model: string } | null {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const slashIndex = trimmed.indexOf("/");
-  if (slashIndex <= 0) {
-    return { provider: defaultProvider, model: trimmed };
-  }
-  const provider = trimmed.slice(0, slashIndex).trim();
-  const model = trimmed.slice(slashIndex + 1).trim();
-  if (!provider || !model) {
-    return null;
-  }
-  return {
-    provider: normalizeProviderId(provider),
-    model,
-  };
 }
 
 function isAnthropicCacheRetentionTarget(
@@ -155,12 +127,12 @@ function usesClaudeCliModelSelection(config: OpenClawConfig): boolean {
       | { primary?: string; fallbacks?: string[] }
       | undefined,
   );
-  const parsedPrimary = primary ? parseProviderModelRef(primary, "anthropic") : null;
+  const parsedPrimary = primary ? parseAnthropicModelRef(primary) : null;
   if (parsedPrimary?.provider === CLAUDE_CLI_BACKEND_ID) {
     return true;
   }
   return Object.entries(config.agents?.defaults?.models ?? {}).some(([key, entry]) => {
-    const parsed = parseProviderModelRef(key, "anthropic");
+    const parsed = parseAnthropicModelRef(key);
     if (parsed?.provider === CLAUDE_CLI_BACKEND_ID) {
       return true;
     }
@@ -277,7 +249,7 @@ function normalizeAnthropicProviderConfig<T extends { api?: string; models?: unk
 export function normalizeAnthropicProviderConfigForProvider<
   T extends { api?: string; models?: unknown[] },
 >(params: { provider: string; providerConfig: T }): T {
-  const provider = normalizeProviderId(params.provider);
+  const provider = normalizeAnthropicProviderId(params.provider);
   if (provider !== "anthropic" && provider !== CLAUDE_CLI_BACKEND_ID) {
     return params.providerConfig;
   }
@@ -326,7 +298,7 @@ export function applyAnthropicConfigDefaults(params: {
     let modelsMutated = false;
 
     for (const [key, entry] of Object.entries(nextModels)) {
-      const parsed = parseProviderModelRef(key, "anthropic");
+      const parsed = parseAnthropicModelRef(key);
       if (!isAnthropicCacheRetentionTarget(parsed)) {
         continue;
       }
@@ -348,7 +320,7 @@ export function applyAnthropicConfigDefaults(params: {
       ),
     );
     if (primary) {
-      const parsedPrimary = parseProviderModelRef(primary, "anthropic");
+      const parsedPrimary = parseAnthropicModelRef(primary);
       if (parsedPrimary && isAnthropicCacheRetentionTarget(parsedPrimary)) {
         const key = `${parsedPrimary.provider}/${parsedPrimary.model}`;
         const entry = nextModels[key];
@@ -365,7 +337,7 @@ export function applyAnthropicConfigDefaults(params: {
     }
 
     const hasAnthropicApiKeyModel = Object.keys(nextModels).some((key) =>
-      isAnthropicCacheRetentionTarget(parseProviderModelRef(key, "anthropic")),
+      isAnthropicCacheRetentionTarget(parseAnthropicModelRef(key)),
     );
     if (hasAnthropicApiKeyModel) {
       for (const ref of ANTHROPIC_API_KEY_DEFAULT_ALLOWLIST_REFS) {

--- a/extensions/anthropic/provider-policy-api.test.ts
+++ b/extensions/anthropic/provider-policy-api.test.ts
@@ -1,6 +1,7 @@
 // Anthropic tests cover provider policy api plugin behavior.
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { describe, expect, it } from "vitest";
+import { parseAnthropicModelRef } from "./claude-model-refs.js";
 import {
   applyConfigDefaults,
   deprecatedProfileIds,
@@ -39,7 +40,28 @@ function levelIds(levels: readonly { id: string }[] | undefined): string[] {
   return (levels ?? []).map((level) => level.id);
 }
 
+const modelRefCases: Array<[string, string | null, string | null, boolean | null]> = [
+  ["", null, null, null],
+  ["claude-test", "anthropic", "claude-test", false],
+  ["/claude-test", "anthropic", "/claude-test", false],
+  ["anthropic/", null, null, null],
+  ["anthropic/team/claude-test", "anthropic", "team/claude-test", true],
+  ["  AnThRoPiC / claude-test  ", "anthropic", "claude-test", true],
+  ["anthropic/claude-test@anthropic:work", "anthropic", "claude-test@anthropic:work", true],
+  ["bedrock/anthropic.claude-test", "amazon-bedrock", "anthropic.claude-test", true],
+  ["AWS-BEDROCK/anthropic.claude-test", "amazon-bedrock", "anthropic.claude-test", true],
+];
+
 describe("anthropic provider policy public artifact", () => {
+  it.each(modelRefCases)(
+    "parses Anthropic model ref %s",
+    (raw, provider, model, explicitProvider) => {
+      expect(parseAnthropicModelRef(raw)).toEqual(
+        provider === null ? null : { provider, model, explicitProvider },
+      );
+    },
+  );
+
   it("publishes native Claude profiles retired from generic auth", () => {
     expect(deprecatedProfileIds).toEqual(["anthropic:claude-cli"]);
   });


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested duplication cleanup: Anthropic model references were parsed and provider IDs were normalized by separate helpers in two adjacent plugin owner files. The copies already differed in returned metadata, so future changes to slash handling, provider aliases, or explicit-provider detection could drift.

## Why This Change Was Made

The Anthropic plugin now owns one canonical `parseAnthropicModelRef` and one canonical `normalizeAnthropicProviderId` in `extensions/anthropic/claude-model-refs.ts`.

The parser keeps bare references on the `anthropic` provider, preserves the existing `explicitProvider` fact, lowercases explicit provider IDs, and maps `bedrock` and `aws-bedrock` to `amazon-bedrock`. `extensions/anthropic/config-defaults.ts` now uses those helpers and removes its local `normalizeProviderId` and `parseProviderModelRef` copies.

This stays plugin-local. No core, Plugin SDK, manifest, package, other-provider, config-schema, or persistence surface changes.

## User Impact

No user-visible behavior changes. Claude alias and retired-ID migration, auth-profile suffix handling, explicit-provider routing, and cache-retention defaulting retain their existing behavior.

## Evidence

Root cause and owner:

- Owner: Anthropic plugin model-ref normalization.
- Canonical fix: one parser and provider normalizer in `extensions/anthropic/claude-model-refs.ts`.
- Removed paths: the duplicate parser and provider normalizer in `extensions/anthropic/config-defaults.ts`.
- Production LOC: `+22/-43`, net `-21`.
- Test LOC: `+22/-0`.

Contracts characterized by one table-driven test:

- empty and bare refs
- leading, trailing, and multiple slashes
- whitespace and provider case
- auth-profile suffix preservation
- `explicitProvider`
- `bedrock` and `aws-bedrock` aliases

Validation:

- Exact reviewed head: `17e0eb4ba71c2d9417eb7a52f88a57ae2493bca9`.
- Exact parent/base cutoff: `6187bd6faff7d71aec9adc7548cf1ec3608bfeb9`.
- `node scripts/run-vitest.mjs extensions/anthropic/cli-migration.test.ts extensions/anthropic/provider-policy-api.test.ts extensions/anthropic/index.test.ts`
  - 3 files passed, 114 tests passed.
- `node scripts/check-changed.mjs --dry-run -- <three files>`
  - selected `extensions` and `extensionTests`.
- `node scripts/check-changed.mjs -- <three files>`
  - passed all selected formatting, typecheck, lint, dead-export, plugin-boundary, database-first, sidecar, and cycle gates on the rebased head.
- `pnpm check:import-cycles`
  - 0 runtime value cycles.
- `git diff --check`
  - passed.
- Autoreview against exact head `17e0eb4ba71c2d9417eb7a52f88a57ae2493bca9`
  - scoped clean, no accepted/actionable findings, score `0.99`.
- Rebase preserved patch ID `5856caedf77d5eeebe811e277be9c690ef9ea0d6`.

Current overlap checks:

- #103723 (`04c5b4dfeb15`) remains open and changes Anthropic catalog, constants, migration tests, and manifest only. It does not change parser semantics or any file in this PR.
- #122846 (`3d5604ed6d9d`) remains open and only adds Claude model expectations in `extensions/anthropic/cli-migration.test.ts` plus unrelated release/runtime work. It does not change parser semantics or any file in this PR.

Codex contract gate:

- Personally inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`.
- Those sections cover CLI subcommands, prompt normalization, completion generation, and test setup; they do not define model-reference behavior.

Limitations:

- `pnpm build` completed TypeScript/package/plugin compilation and the CLI bootstrap guard, then failed in runtime postbuild because the linked shared `@openclaw/ai/diagnostics` artifact does not export `hasRetryableConnectionErrorCode`. The same stale-artifact error affected Anthropic, iMessage, Signal, and Telegram contract loads. No dependency install or reconciliation was performed in the worktree.
- The first extension-test typecheck encountered three tracked `ui/config` files omitted by the sparse profile. Adding those files to the worktree sparse checkout cleared the failure; the final full `check:changed` run passed.

Native Testbox / prepare proof:

- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 135707` completed successfully at `2026-09-03T01:52:31Z`.
- The native gate accepted exact-head hosted CI run https://github.com/openclaw/openclaw/actions/runs/33703409711 for `17e0eb4ba71c2d9417eb7a52f88a57ae2493bca9`.
- Aggregate `openclaw/ci-gate` passed: https://github.com/openclaw/openclaw/actions/runs/33703409711/job/100493160166.
- Gate mode: `hosted_exact_or_recent_parent`, bound to the exact PR head.
- No separate remote Testbox lease was allocated because the successful exact-head hosted run satisfied the native Testbox gate (`REMOTE_GATES_LEASE_ID` and `REMOTE_GATES_RUN_ID` were empty).
