### PR TITLE
refactor(release): share stable pin grammar

### DIFF
--- a/scripts/lib/android-version.ts
+++ b/scripts/lib/android-version.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { decodeIosAppStoreVersion } from "./ios-release-plan.ts";
 import { encodeIosAppStoreVersion } from "./ios-version.ts";
 import { readMobileVersionManifest } from "./mobile-version.ts";
-import { parseReleaseVersion } from "./release-version.mjs";
+import { parsePinnedReleaseVersion } from "./release-version.mjs";
 
 const ANDROID_VERSION_FILE = "apps/android/version.json";
 const ANDROID_CHANGELOG_FILE = "apps/android/CHANGELOG.md";
@@ -30,14 +30,6 @@ type ResolvedAndroidVersion = {
 
 function normalizeTrailingNewline(value: string): string {
   return value.endsWith("\n") ? value : `${value}\n`;
-}
-
-function parsePinnedReleaseVersion(rawVersion: string): string | null {
-  const parsed = parseReleaseVersion(rawVersion.trim());
-  if (!parsed || parsed.version !== parsed.baseVersion) {
-    return null;
-  }
-  return parsed.baseVersion;
 }
 
 export function normalizePinnedAndroidVersion(rawVersion: string): string {

--- a/scripts/lib/ios-version.ts
+++ b/scripts/lib/ios-version.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { mobileVersionPath, readMobileVersionManifest } from "./mobile-version.ts";
-import { parseReleaseVersion } from "./release-version.mjs";
+import { parsePinnedReleaseVersion, parseReleaseVersion } from "./release-version.mjs";
 
 const IOS_CHANGELOG_FILE = "apps/ios/CHANGELOG.md";
 export const MAX_IOS_APP_STORE_REVISION = 9;
@@ -20,14 +20,6 @@ type ResolvedIosVersion = {
 };
 
 type SyncIosVersioningMode = "check" | "write";
-
-function parsePinnedReleaseVersion(rawVersion: string): string | null {
-  const parsed = parseReleaseVersion(rawVersion.trim());
-  if (!parsed || parsed.version !== parsed.baseVersion) {
-    return null;
-  }
-  return parsed.baseVersion;
-}
 
 export function normalizePinnedIosVersion(rawVersion: string): string {
   const trimmed = rawVersion.trim();

--- a/scripts/lib/mobile-version.ts
+++ b/scripts/lib/mobile-version.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { parseReleaseVersion } from "./release-version.mjs";
+import { parsePinnedReleaseVersion } from "./release-version.mjs";
 
 const MOBILE_VERSION_FILE = "apps/mobile/version.json";
 
@@ -9,14 +9,13 @@ export type MobileVersionManifest = {
 };
 
 export function normalizeMobileVersion(rawVersion: string): string {
-  const trimmed = rawVersion.trim();
-  const parsed = parseReleaseVersion(trimmed);
-  if (!parsed || parsed.version !== parsed.baseVersion) {
+  const version = parsePinnedReleaseVersion(rawVersion);
+  if (!version) {
     throw new Error(
       `Invalid mobile gateway version '${rawVersion}'. Expected a stable release version like 2026.8.1.`,
     );
   }
-  return parsed.baseVersion;
+  return version;
 }
 
 export function mobileVersionPath(rootDir = path.resolve(".")): string {

--- a/scripts/lib/release-version.d.mts
+++ b/scripts/lib/release-version.d.mts
@@ -18,6 +18,7 @@ type ReleaseTrain =
   | "unsupported-extended-stable-correction";
 
 export function parseReleaseVersion(version: string): ParsedReleaseVersion | null;
+export function parsePinnedReleaseVersion(version: string): string | null;
 export function classifyReleaseTrain(parsedVersion: ParsedReleaseVersion): ReleaseTrain;
 export function resolveReleaseTagPackageIdentity(
   releaseTag: string,

--- a/scripts/lib/release-version.mjs
+++ b/scripts/lib/release-version.mjs
@@ -123,6 +123,15 @@ export function parseReleaseVersion(version) {
 }
 
 /**
+ * @param {string} version
+ * @returns {string | null}
+ */
+export function parsePinnedReleaseVersion(version) {
+  const parsed = parseReleaseVersion(version);
+  return parsed && parsed.version === parsed.baseVersion ? parsed.baseVersion : null;
+}
+
+/**
  * Patch 33 and later final releases belong to the trailing-month
  * extended-stable line; correction suffixes are not valid on that line.
  *

--- a/test/release-version.test.ts
+++ b/test/release-version.test.ts
@@ -3,6 +3,7 @@ import {
   classifyReleaseTrain,
   collectReleaseVersionFloorErrors,
   compareReleaseVersions,
+  parsePinnedReleaseVersion,
   parseReleaseVersion,
 } from "../scripts/lib/release-version.mjs";
 
@@ -41,5 +42,36 @@ describe("release version policy", () => {
     expect(compareReleaseVersions("2026.3.29-alpha.2", "2026.3.29-beta.1")).toBe(-1);
     expect(compareReleaseVersions("2026.3.29-beta.1", "2026.3.29")).toBe(-1);
     expect(compareReleaseVersions("2026.3.29-2", "2026.3.29")).toBe(1);
+  });
+
+  it.each([
+    ["2026.1.1", "2026.1.1"],
+    [" 2026.12.33 ", "2026.12.33"],
+    ["9999.12.9007199254740991", "9999.12.9007199254740991"],
+  ])("accepts stable release pin %j", (version, expected) => {
+    expect(parsePinnedReleaseVersion(version)).toBe(expected);
+  });
+
+  it.each([
+    "v2026.8.1",
+    "V2026.8.1",
+    "2026.8.1-alpha.1",
+    "2026.8.1-beta.1",
+    "2026.8.1-1",
+    "2026.8.1+build.1",
+    "latest",
+    "^2026.8.1",
+    "2026.8.x",
+    "https://example.com/2026.8.1",
+    "workspace:*",
+    "file:../package",
+    "git+https://example.com/repo.git",
+    "2026. 8.1",
+    "2026.08.1",
+    "2026.8.01",
+    "2026.13.1",
+    "2026.8.9007199254740992",
+  ])("rejects non-pin release form %j", (version) => {
+    expect(parsePinnedReleaseVersion(version)).toBeNull();
   });
 });

--- a/test/scripts/android-version.test.ts
+++ b/test/scripts/android-version.test.ts
@@ -7,7 +7,6 @@ import {
   canonicalAndroidVersionCode,
   checkAndroidVersioning,
   extractChangelogSection,
-  normalizePinnedAndroidVersion,
   renderAndroidReleaseNotes,
   renderAndroidVersionProperties,
   resolveAndroidVersion,
@@ -156,15 +155,6 @@ describe("resolveAndroidVersion", () => {
     });
 
     expect(() => resolveAndroidVersion(rootDir)).toThrow(
-      "Expected pinned release version like 2026.6.5",
-    );
-  });
-
-  it("rejects impossible pinned release versions", () => {
-    expect(() => normalizePinnedAndroidVersion("2026.13.2")).toThrow(
-      "Expected pinned release version like 2026.6.5",
-    );
-    expect(() => normalizePinnedAndroidVersion("2026.6.9007199254740993")).toThrow(
       "Expected pinned release version like 2026.6.5",
     );
   });

--- a/test/scripts/ios-version.test.ts
+++ b/test/scripts/ios-version.test.ts
@@ -7,7 +7,6 @@ import {
   encodeIosAppStoreVersion,
   extractChangelogSection,
   normalizeIosAppStoreRevision,
-  normalizePinnedIosVersion,
   renderIosReleaseNotes,
   resolveGatewayVersionForIosRelease,
   resolveIosVersion,
@@ -243,15 +242,6 @@ describe("resolveIosVersion", () => {
     });
 
     expect(() => resolveIosVersion(rootDir, { releaseVersion: "2026.4.6-beta.1" })).toThrow(
-      "Expected release version like 2026.6.5",
-    );
-  });
-
-  it("rejects impossible pinned release versions", () => {
-    expect(() => normalizePinnedIosVersion("2026.13.6")).toThrow(
-      "Expected release version like 2026.6.5",
-    );
-    expect(() => normalizePinnedIosVersion("2026.4.9007199254740993")).toThrow(
       "Expected release version like 2026.6.5",
     );
   });


### PR DESCRIPTION
## What Problem This Solves

The mobile, Android, and iOS release tooling independently implemented the same stable release-pin check. That duplicated grammar could drift even though all three paths consume the same mobile release identity.

## Why This Change Was Made

This adds `parsePinnedReleaseVersion()` beside the canonical release parser and reuses it from the three existing owners. The helper accepts only a canonical stable `YYYY.M.PATCH` after outer whitespace is trimmed.

`apps/mobile/version.json` remains the mobile release source of truth. Android version-code policy, iOS App Store revision encoding, caller-specific missing/invalid errors, and the broader release/install/dependency parsers remain separate and unchanged.

## User Impact

No user-visible behavior changes. Mobile release pins now share one grammar, reducing the risk that Android, iOS, and the mobile manifest accept different values.

## Evidence

Exact refreshed candidate:

- Head: `3afa4bb66bb6d0f76d21d6eea12e81cb27356daf`
- Parent/current main at refresh: `3100ba535f1d003d67a6a7536deacf8666367b38`
- Source head: `27fa3e84a8595e0167641e019f30c95853fc4488`
- Source parent: `11c4ff6c0db65c1edddf28f5b967d5d30c2b41fb`
- Aggregate patch ID preserved: `3e9661ac97e5372c8ba00384d7882b3e6e62f685`
- Signed semantic commit: `refactor(release): share stable pin grammar`

Behavior:

- Differential probe compared exact outputs and error strings for `normalizeMobileVersion`, `normalizePinnedAndroidVersion`, and `normalizePinnedIosVersion` across 18,448 generated inputs. Pre-change and post-change JSON was byte-identical.
- Accepted coverage includes outer whitespace, valid months, positive unpadded patches, and safe integers.
- Rejected coverage includes `v`/`V`, alpha/beta/correction/build suffixes, tags, ranges, aliases, URLs, workspace/file/git specs, internal whitespace, padded components, invalid months, and unsafe integers.
- `apps/mobile/version.json` ownership, Android version codes, iOS App Store revision encoding, and all caller-specific errors are preserved.

Validation:

- Focused Vitest: 4 files, 78 tests passed.
- Import-cycle check: 0 runtime value cycles.
- Focused Oxlint: passed for all changed script and test files.
- Oxfmt check: passed for all 8 changed files.
- Script TypeScript erasability: 571 files checked.
- Refresh replay: byte-identical 8-file diff with every per-file patch ID preserved.
- `git diff --check`: passed.
- Source-head independent Codex P1 autoreview: `scoped-clean`, patch correct with confidence 0.96.

On the source head, the canonical changed-file gate passed conflict markers, changelog attribution, doctor registry, extension export guards, duplicate target coverage, dependency pinning, formatting, package patches, temp-file reporting, the core tsgo boundary, and script erasability. It then stopped in `typecheck scripts` because the shared linked dependency tree was missing unrelated Shiki, Discord, Slack, Markdown, phone, and sparse UI modules. Per worktree policy, no `pnpm install` was run inside the Codex worktree.

Native prepare completed at the exact head with `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 135709`. The native gate accepted green exact-head hosted CI run `33711327358` in `hosted_exact_or_recent_parent` mode; no separate Testbox or Crabbox lease was created.

LOC:

- Production: `+0/-0`
- Tooling: `+16/-23` (net `-7`)
- Tests: `+32/-20` (net `+12`)
- Total: `+48/-43` (net `+5`)

Overlap:

- #136366 already established `apps/mobile/version.json` as the independent mobile release owner; this revision builds on that contract instead of restoring root `package.json` ownership.
- #136610 remains open at `33040408b4fcdd01692ac4f608c3a73d34a0db70`, is file-disjoint from this PR, and retains canonical `release/YYYY.M.PATCH-mobile` identity. Re-review is required if it or `main` changes these scoped files or permits prerelease mobile pins.

Codex contract check:

- Personally inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; the CLI subcommand and completion paths are unrelated to this release grammar.

