### PR TITLE
fix(doctor): doctor --lint --json can emit terminal notes that break JSON parsing

### DIFF
--- a/src/commands/doctor-lint.notes.test.ts
+++ b/src/commands/doctor-lint.notes.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { note } from "../../packages/terminal-core/src/note.js";
+import { clearHealthChecksForTest, registerHealthCheck } from "../flows/health-check-registry.js";
+import { runDoctorLintCli } from "./doctor-lint.js";
+
+const mocks = vi.hoisted(() => ({
+  readConfigFileSnapshot: vi.fn(),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+  };
+});
+
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+describe("runDoctorLintCli note output", () => {
+  let previousStateDir: string | undefined;
+  let stateDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearHealthChecksForTest();
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-lint-notes-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      path: path.join(stateDir, "openclaw.json"),
+    });
+  });
+
+  afterEach(() => {
+    clearHealthChecksForTest();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("keeps legacy health-check notes out of JSON stdout", async () => {
+    registerHealthCheck({
+      id: "test/json-note-leak",
+      kind: "plugin",
+      description: "test legacy note suppression",
+      async detect() {
+        note("legacy diagnostic", "Doctor warnings");
+        return [];
+      },
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        onlyIds: ["test/json-note-leak"],
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toHaveBeenCalledTimes(1);
+      const output = String(stdout.mock.calls[0]?.[0]);
+      expect(output).not.toContain("legacy diagnostic");
+      expect(JSON.parse(output)).toMatchObject({
+        ok: true,
+        checksRun: 1,
+        findings: [],
+      });
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+});

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { withSuppressedNotes } from "../../packages/terminal-core/src/note.js";
 import { resolveAgentWorkspaceDir, tryResolveDefaultAgentId } from "../agents/agent-scope.js";
 import { createConfigIO, readConfigFileSnapshot } from "../config/config.js";
 import { maybeLoadDotEnvForConfig } from "../config/io.read-helpers.js";
@@ -93,7 +94,11 @@ export async function runDoctorLintCli(
   runtime: RuntimeEnv,
   opts: DoctorLintCliOptions,
 ): Promise<number> {
-  const execution = await prepareDoctorLintExecution(runtime, opts);
+  // JSON mode owns stdout: health checks reached from preparation still emit terminal
+  // notes there, and any stray note makes the payload unparseable for automated consumers.
+  const prepare = async () => await prepareDoctorLintExecution(runtime, opts);
+  const execution =
+    detectMode(opts) === "json" ? await withSuppressedNotes(prepare) : await prepare();
   execution.writeOutput();
   return execution.exitCode;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators and automation running `openclaw doctor --lint --json` (or piping `openclaw doctor --lint` into another tool) could get a stdout stream that is not valid JSON. Doctor lint writes exactly one JSON document to stdout, but any health check reached while the lint run is being prepared can also write a human-readable terminal note to that same stream. The consumer then fails to parse the report, and the failure looks like a broken Doctor rather than interleaved output.

`doctor` is registered with `configGuard: "skip"` (`src/cli/command-catalog.ts:453-461`), so the CLI's existing machine-output note suppression (`src/cli/command-startup-policy.ts:34`, applied in `src/cli/program/config-guard.ts:274-277`) never covers this command. The lint action itself ran with notes fully enabled.

## Why This Change Was Made

The JSON stdout contract is owned by `runDoctorLintCli`, which is the only place that decides between human and JSON output (`detectMode`) and the only place that writes the payload. The fix applies the repo's existing `withSuppressedNotes` scope around lint preparation whenever that decision is JSON, so the same policy the CLI already uses for machine output now also covers the command's own execution window. Interactive/human mode is unchanged and still prints notes.

This is not hypothetical: `note` is exported to plugin authors through the Plugin SDK (`src/plugin-sdk/cli-runtime.ts:19`) and plugins register Doctor health checks that run inside this preparation phase, so a single plugin note corrupts the Doctor JSON of every operator who installs it.

## User Impact

`openclaw doctor --lint --json` and `openclaw doctor --lint | <parser>` now emit exactly the JSON report on stdout, so scripts, CI steps, and agents can parse it reliably. Human-readable `doctor --lint` output is unchanged.

## Evidence

**Regression test fails before the fix, passes after** (`src/commands/doctor-lint.notes.test.ts`, registers a health check whose `detect` calls `note()` and asserts JSON mode makes exactly one stdout write):

Before (on `main`, test only):

```
node scripts/run-vitest.mjs run src/commands/doctor-lint.notes.test.ts
 × |commands| src/commands/doctor-lint.notes.test.ts > runDoctorLintCli note output > keeps legacy health-check notes out of JSON stdout
   → expected "Mock" to be called 1 times, but got 2 times
 Test Files  1 failed (1)
```

After (with the fix):

```
node scripts/run-vitest.mjs run src/commands/doctor-lint.notes.test.ts
 ✓ |commands| ... > keeps legacy health-check notes out of JSON stdout
 Test Files  1 passed (1)
```

**Whole doctor-lint suite** (`node scripts/run-vitest.mjs run src/commands/doctor-lint`): 3 files, 27 tests passed — `doctor-lint.test.ts`, `doctor-lint.state-isolation.test.ts`, `doctor-lint.notes.test.ts`.

**Real CLI run** against a throwaway state dir (`pnpm build`, then `OPENCLAW_STATE_DIR=$(mktemp -d) node scripts/run-node.mjs doctor --lint --json`): stdout parses cleanly.

```
node -e 'JSON.parse(require("fs").readFileSync(0,"utf8")); console.log("valid json")'
valid json
{"ok":false,"checksRun":30,"checksSkipped":29,"findings":[{"checkId":"core/doctor/gateway-auth", ...
```

**Gates**: `pnpm build` exit 0; `node scripts/check-changed.mjs` exit 0 (all lanes, including `format changed files`, `tsgo:core`, `tsgo:core:test`, oxlint, import cycles).

**Autoreview**: `autoreview --mode uncommitted` (codex / `gpt-5.6-sol`, thinking high) — `autoreview scoped-clean: no accepted/actionable findings`, verdict "patch is correct (0.99)".

**LOC delta**: production +5/-1 (`src/commands/doctor-lint.ts`); tests +86 (new `src/commands/doctor-lint.notes.test.ts`). The growth is one import plus the JSON-mode scope; there is no smaller absorbing refactor because the human/JSON decision and the stdout write already live in this one function.

**Proof gap**: not exercised behind a real Cloudflare-style plugin that emits notes; the regression test stands in for that producer by registering a health check that calls `note()` directly.
