### PR TITLE
fix(agents): route utility completions through the selected runtime

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -38,6 +38,8 @@ mechanics in `openclaw.json`.
 OpenClaw auto-loads an owning bundled plugin when model selection or a
 model-scoped `agentRuntime.id` references its backend.
 
+Utility completions for session digests, progress narration, and tool-call titles use the selected model's runtime too: Claude CLI runs a fresh, tool-free completion with its own authentication, including canonical `anthropic/*` refs configured with `agentRuntime.id: "claude-cli"`.
+
 ## Using it as a fallback
 
 Add the CLI backend to your fallback list so it only runs when primary models fail:

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -518,7 +518,7 @@ permissions, and picker behavior.
 - Whole-agent runtime keys are legacy. `agents.defaults.agentRuntime`, `agents.entries.*.agentRuntime`, session runtime pins, and `OPENCLAW_AGENT_RUNTIME` are ignored by runtime selection. Run `openclaw doctor --fix` to remove stale values.
 - Eligible exact official HTTPS OpenAI Responses/ChatGPT routes with no authored request override may use the Codex harness implicitly. Provider/model `agentRuntime.id: "codex"` makes Codex a fail-closed requirement but does not make an incompatible route compatible.
 - For Claude CLI deployments, prefer `model: "anthropic/claude-opus-5"` plus model-scoped `agentRuntime.id: "claude-cli"`. Legacy `claude-cli/<model>` refs still work for compatibility, but new config should keep provider/model selection canonical and put the execution backend in provider/model runtime policy.
-- This only controls text agent-turn execution. Media generation, vision, PDF, music, video, and TTS still use their provider/model settings.
+- This controls text agent turns and tool-free utility completions, including session digests, progress narration, and tool-call titles. Media generation, vision, PDF, music, video, and TTS still use their provider/model settings.
 
 **Built-in alias shorthands** (only apply when the model is in `agents.defaults.models`):
 

--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -27,11 +27,13 @@ const mocks = vi.hoisted(() => ({
   ensureSelectedAgentHarnessPlugin: vi.fn(async () => {}),
   getRegisteredAgentHarness: vi.fn(),
   ensureAuthProfileStore: vi.fn(),
-  isCliRuntimeAliasForProvider: vi.fn(() => false),
+  isCliRuntimeAliasForProvider: vi.fn<(params: { runtime?: string; provider?: string }) => boolean>(
+    () => false,
+  ),
   prepareSimpleCompletionModel: vi.fn(),
   prepareAgentRuntimeAuth: vi.fn(),
   resolveModelWithRegistry: vi.fn(),
-  resolveCliRuntimeCanonicalProvider: vi.fn(() => undefined),
+  resolveCliRuntimeCanonicalProvider: vi.fn<() => string | undefined>(() => undefined),
   resolveCliBackendConfig: vi.fn<
     () => { config: { command: string; modelAliases?: Record<string, string> } } | undefined
   >(() => ({ config: { command: "test-cli" } })),
@@ -167,6 +169,8 @@ beforeEach(() => {
     release: releaseRuntimeLease,
   });
   mocks.isCliRuntimeAliasForProvider.mockReturnValue(false);
+  mocks.resolveCliRuntimeCanonicalProvider.mockReturnValue(undefined);
+  mocks.resolveEffectiveAgentRuntime.mockReturnValue("codex");
   mocks.resolveCliRuntimeExecutionProvider.mockReturnValue(undefined);
   mocks.resolveEmbeddedCliBackendDispatchEligibility.mockReturnValue(undefined);
   mocks.prepareSimpleCompletionModel.mockResolvedValue({
@@ -200,6 +204,48 @@ function registerHarness(overrides: Partial<AgentHarness>): void {
 }
 
 describe("runIsolatedCompletion", () => {
+  it.each(["claude-cli", "anthropic"])(
+    "keeps the CLI execution owner for a %s utility model without resolving HTTP credentials",
+    async (provider) => {
+      mocks.resolveCliRuntimeCanonicalProvider.mockReturnValue(
+        provider === "claude-cli" ? "anthropic" : undefined,
+      );
+      mocks.resolveEffectiveAgentRuntime.mockReturnValue(
+        provider === "anthropic" ? "claude-cli" : "codex",
+      );
+      mocks.isCliRuntimeAliasForProvider.mockImplementation(
+        ({ runtime, provider: modelProvider }) =>
+          runtime === "claude-cli" && modelProvider === "anthropic",
+      );
+      mocks.prepareSimpleCompletionModel.mockRejectedValue(
+        new Error("native-auth markers must never become HTTP credentials"),
+      );
+      mocks.runCliAgent.mockResolvedValue({ payloads: [{ text: "Utility result" }] });
+
+      await expect(
+        runIsolatedCompletion({
+          ...request(),
+          provider,
+          model: "claude-test",
+          agentHarnessRuntimeOverride: undefined,
+        }),
+      ).resolves.toMatchObject({
+        text: "Utility result",
+        provider: "anthropic",
+        owner: { kind: "cli", id: "claude-cli" },
+      });
+      expect(mocks.prepareSimpleCompletionModel).not.toHaveBeenCalled();
+      expect(mocks.runCliAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "claude-cli",
+          modelProvider: "anthropic",
+          isolatedCompletion: true,
+          cliToolAvailability: { native: [], openClaw: [] },
+        }),
+      );
+    },
+  );
+
   it("hands harness-owned authorization to the V2 owner without resolving a host key", async () => {
     const runIsolatedCompletionV2 = vi.fn(async () => ({
       assistant: assistant([{ type: "text", text: "native result" }]),

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -423,12 +423,15 @@ export async function runIsolatedCompletion(
   const agentId = request.agentId ?? resolveDefaultAgentId(config);
   const agentDir = request.agentDir ?? resolveAgentDir(config, agentId);
   const workspaceDir = request.workspaceDir ?? resolveAgentWorkspaceDir(config, agentId);
-  const provider =
-    resolveCliRuntimeCanonicalProvider({
-      runtime: request.provider,
-      config,
-      includeSetupRegistry: true,
-    }) ?? request.provider;
+  const canonicalProvider = resolveCliRuntimeCanonicalProvider({
+    runtime: request.provider,
+    config,
+    includeSetupRegistry: true,
+  });
+  const provider = canonicalProvider ?? request.provider;
+  // Canonicalizing a CLI model ref must not discard its explicit execution owner.
+  const runtimeOverride =
+    request.agentHarnessRuntimeOverride ?? (canonicalProvider ? request.provider : undefined);
   const lease = await acquireAgentRunPreparedModelRuntime(
     {
       config,
@@ -439,9 +442,7 @@ export async function runIsolatedCompletion(
         {
           provider,
           modelId: request.model,
-          ...(request.agentHarnessRuntimeOverride
-            ? { runtime: request.agentHarnessRuntimeOverride }
-            : {}),
+          ...(runtimeOverride ? { runtime: runtimeOverride } : {}),
           agentId,
         },
       ],
@@ -456,13 +457,13 @@ export async function runIsolatedCompletion(
         modelId: request.model,
         config,
         agentId,
-        agentHarnessId: request.agentHarnessRuntimeOverride,
-        agentHarnessRuntimeOverride: request.agentHarnessRuntimeOverride,
+        agentHarnessId: runtimeOverride,
+        agentHarnessRuntimeOverride: runtimeOverride,
         workspaceDir,
         pluginRegistry,
       });
       const runtime =
-        request.agentHarnessRuntimeOverride ??
+        runtimeOverride ??
         resolveEffectiveAgentRuntime({ cfg: config, provider, modelId: request.model, agentId });
       const cliOwner = resolveCliOwner({
         request,

--- a/src/agents/simple-completion-runtime.selection.test.ts
+++ b/src/agents/simple-completion-runtime.selection.test.ts
@@ -185,7 +185,6 @@ describe("resolveSimpleCompletionSelectionForAgent", () => {
     );
     expect(selection.provider).toBe("openai");
     expect(selection.modelId).toBe("gpt-5.4-mini");
-    expect(selection.runtimeProvider).toBe("openai");
   });
 
   it("falls back to runtime default model when no explicit model is configured", () => {

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -817,7 +817,6 @@ describe("prepareSimpleCompletionModelForAgent", () => {
     expectPreparedModelResult(result);
     expect(result.selection.provider).toBe("openai");
     expect(result.selection.modelId).toBe("gpt-5.5");
-    expect(result.selection.runtimeProvider).toBe("openai");
     expect(result.model).toMatchObject({
       id: "gpt-5.5",
       api: "openai-responses",

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -45,7 +45,6 @@ import {
   fingerprintAuthProfileCredential,
   fingerprintResolvedProviderAuth,
 } from "./execution-auth-binding.js";
-import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import {
   createAgentRuntimeMetadataPluginIdScope,
   type AgentHarnessPluginSelection,
@@ -65,7 +64,7 @@ import {
   resolveModelRefFromString,
 } from "./model-selection.js";
 import { resolveOpenAIModelRoutes, selectOpenAIModelRouteAuth } from "./openai-model-routes.js";
-import { OPENAI_PROVIDER_ID, isOpenAIProvider } from "./openai-routing.js";
+import { isOpenAIProvider } from "./openai-routing.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   type PreparedModelRuntimeSnapshot,
@@ -110,7 +109,7 @@ export type PreparedSimpleCompletionModel =
 type AgentSimpleCompletionSelection = {
   provider: string;
   modelId: string;
-  /** Provider used for auth/transport when runtime policy redirects the logical model ref. */
+  /** Shipped SDK return field; new selections carry canonical identity in provider. */
   runtimeProvider?: string;
   profileId?: string;
   agentDir: string;
@@ -190,17 +189,10 @@ function resolveSimpleCompletionSelectionRequest(
   if (!provider || !modelId) {
     return null;
   }
-  const runtimeProvider =
-    isOpenAIProvider(provider) &&
-    resolveAgentHarnessPolicy({ provider, modelId, config: params.cfg, agentId: params.agentId })
-      .runtime === "codex"
-      ? OPENAI_PROVIDER_ID
-      : undefined;
   return {
     selection: {
       provider,
       modelId,
-      ...(runtimeProvider ? { runtimeProvider } : {}),
       profileId: split?.profile || undefined,
       agentDir: params.agentDir?.trim() || resolveAgentDir(params.cfg, params.agentId),
     },
@@ -569,7 +561,7 @@ export async function prepareSimpleCompletionModelForAgent(params: {
     workspaceDir,
     selections: [
       {
-        provider: tentativeSelection.runtimeProvider ?? tentativeSelection.provider,
+        provider: tentativeSelection.provider,
         modelId: tentativeSelection.modelId,
         agentId: params.agentId,
       },
@@ -599,7 +591,7 @@ export async function prepareSimpleCompletionModelForAgent(params: {
     workspaceDir,
     selections: [
       {
-        provider: selection.runtimeProvider ?? selection.provider,
+        provider: selection.provider,
         modelId: selection.modelId,
         agentId: params.agentId,
       },
@@ -623,20 +615,19 @@ export async function prepareSimpleCompletionModelForAgent(params: {
       return { error: `No model configured for agent ${params.agentId}.` };
     }
   }
-  const selectedProvider = selection.runtimeProvider ?? selection.provider;
   return await withPreparedSimpleCompletionRuntime(
     {
       ...params,
       agentDir: selection.agentDir,
       pluginMetadataSnapshot: metadataSnapshot,
     },
-    [{ provider: selectedProvider, modelId: selection.modelId }],
+    [{ provider: selection.provider, modelId: selection.modelId }],
     async (context) => {
       const prepared = await prepareSimpleCompletionModelCore(
         {
           cfg: params.cfg,
           agentId: params.agentId,
-          provider: selectedProvider,
+          provider: selection.provider,
           modelId: selection.modelId,
           agentDir: selection.agentDir,
           profileId: selection.profileId,

--- a/src/agents/utility-completion.ts
+++ b/src/agents/utility-completion.ts
@@ -1,0 +1,21 @@
+import { resolveSimpleCompletionSelectionForAgent } from "./simple-completion-runtime.js";
+
+/** Capture model identity only; the isolated execution owner resolves its own auth. */
+export async function prepareUtilityCompletionForAgent(
+  params: Parameters<typeof resolveSimpleCompletionSelectionForAgent>[0] & {
+    preferredProfile?: string;
+  },
+) {
+  const selection = resolveSimpleCompletionSelectionForAgent(params);
+  if (!selection) {
+    throw new Error(`No utility model configured for agent ${params.agentId}.`);
+  }
+  return {
+    config: params.cfg,
+    provider: selection.provider,
+    model: selection.modelId,
+    authProfileId: selection.profileId ?? params.preferredProfile,
+    agentId: params.agentId,
+    agentDir: selection.agentDir,
+  };
+}

--- a/src/agents/utility-completion.ts
+++ b/src/agents/utility-completion.ts
@@ -1,6 +1,6 @@
 import { resolveSimpleCompletionSelectionForAgent } from "./simple-completion-runtime.js";
 
-/** Capture model identity only; the isolated execution owner resolves its own auth. */
+/** Keep visible-text retry/fallback in callers; the runtime owns authentication. */
 export async function prepareUtilityCompletionForAgent(
   params: Parameters<typeof resolveSimpleCompletionSelectionForAgent>[0] & {
     preferredProfile?: string;
@@ -15,6 +15,7 @@ export async function prepareUtilityCompletionForAgent(
     provider: selection.provider,
     model: selection.modelId,
     authProfileId: selection.profileId ?? params.preferredProfile,
+    outputTextPolicy: "strict-visible" as const,
     agentId: params.agentId,
     agentDir: selection.agentDir,
   };

--- a/src/auto-reply/reply/progress-narrator-model.test.ts
+++ b/src/auto-reply/reply/progress-narrator-model.test.ts
@@ -14,6 +14,7 @@ const prepared: Parameters<typeof generateNarrationWithUtilityModel>[0]["prepare
   provider: "openai",
   model: "gpt-test",
   authProfileId: undefined,
+  outputTextPolicy: "strict-visible",
   agentId: "main",
   agentDir: "/unused-narration-test",
 };

--- a/src/auto-reply/reply/progress-narrator-model.test.ts
+++ b/src/auto-reply/reply/progress-narrator-model.test.ts
@@ -2,34 +2,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { generateNarrationWithUtilityModel } from "./progress-narrator-model.js";
 
 const complete = vi.hoisted(() => vi.fn());
-vi.mock("../../agents/simple-completion-runtime.js", () => ({
-  completeWithPreparedSimpleCompletionModel: complete,
-  prepareSimpleCompletionModelForAgent: vi.fn(),
+vi.mock("../../agents/isolated-completion.js", () => ({
+  runIsolatedCompletion: complete,
+}));
+vi.mock("../../agents/utility-completion.js", () => ({
+  prepareUtilityCompletionForAgent: vi.fn(),
 }));
 
 const prepared: Parameters<typeof generateNarrationWithUtilityModel>[0]["prepared"] = {
-  selection: { provider: "openai", modelId: "gpt-test", agentDir: "/unused-narration-test" },
-  model: {
-    provider: "openai",
-    id: "gpt-test",
-    name: "Narration test",
-    api: "openai-responses",
-    baseUrl: "https://example.invalid/v1",
-    reasoning: false,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 8192,
-    maxTokens: 4096,
-  },
-  auth: { apiKey: "synthetic", source: "test", mode: "api-key" },
+  config: {},
+  provider: "openai",
+  model: "gpt-test",
+  agentId: "main",
+  agentDir: "/unused-narration-test",
 };
 
 beforeEach(() => {
   vi.useFakeTimers();
   complete.mockReset();
   complete.mockResolvedValue({
-    stopReason: "stop",
-    content: [{ type: "text", text: "Working on the request." }],
+    text: "Working on the request.",
+    provider: "openai",
+    model: "gpt-test",
+    owner: { kind: "harness", id: "openclaw" },
   });
 });
 

--- a/src/auto-reply/reply/progress-narrator-model.test.ts
+++ b/src/auto-reply/reply/progress-narrator-model.test.ts
@@ -13,6 +13,7 @@ const prepared: Parameters<typeof generateNarrationWithUtilityModel>[0]["prepare
   config: {},
   provider: "openai",
   model: "gpt-test",
+  authProfileId: undefined,
   agentId: "main",
   agentDir: "/unused-narration-test",
 };

--- a/src/auto-reply/reply/progress-narrator-model.ts
+++ b/src/auto-reply/reply/progress-narrator-model.ts
@@ -1,11 +1,8 @@
 // Utility-model preparation and completion for progress narration.
-import {
-  completeWithPreparedSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
-} from "../../agents/simple-completion-runtime.js";
+import { runIsolatedCompletion } from "../../agents/isolated-completion.js";
+import { prepareUtilityCompletionForAgent } from "../../agents/utility-completion.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import type { TextContent } from "../../llm/types.js";
 
 const NARRATION_TIMEOUT_MS = 10_000;
 const NOTES_IN_PROMPT = 15;
@@ -28,10 +25,6 @@ export type ProgressNarrationInput = {
   activityNotes: readonly string[];
   previousText: string;
 };
-
-function isTextContentBlock(block: { type: string }): block is TextContent {
-  return block.type === "text";
-}
 
 export function truncateAtWordBoundary(text: string, maxChars: number): string {
   const chars = Array.from(text);
@@ -64,17 +57,11 @@ function buildNarrationUserPrompt(input: ProgressNarrationInput): string {
 
 export async function prepareNarrationModel(params: { cfg: OpenClawConfig; agentId: string }) {
   try {
-    const prepared = await prepareSimpleCompletionModelForAgent({
+    return await prepareUtilityCompletionForAgent({
       cfg: params.cfg,
       agentId: params.agentId,
       useUtilityModel: true,
-      allowMissingApiKeyModes: ["aws-sdk"],
     });
-    if ("error" in prepared) {
-      logVerbose(`progress-narrator: ${prepared.error}`);
-      return null;
-    }
-    return prepared;
   } catch (err) {
     logVerbose(`progress-narrator: model preparation failed: ${String(err)}`);
     return null;
@@ -94,36 +81,19 @@ export async function generateNarrationWithUtilityModel(params: {
     : controller.signal;
   try {
     signal.throwIfAborted();
-    const result = await completeWithPreparedSimpleCompletionModel({
-      model: params.prepared.model,
-      auth: params.prepared.auth,
-      cfg: params.cfg,
-      context: {
-        systemPrompt: NARRATION_SYSTEM_PROMPT,
-        messages: [
-          {
-            role: "user",
-            content: buildNarrationUserPrompt(params.input),
-            timestamp: Date.now(),
-          },
-        ],
-      },
-      options: {
-        maxTokens: Math.min(NARRATION_MAX_TOKENS, Math.floor(params.prepared.model.maxTokens)),
+    const result = await runIsolatedCompletion({
+      ...params.prepared,
+      config: params.cfg,
+      systemPrompt: NARRATION_SYSTEM_PROMPT,
+      prompt: buildNarrationUserPrompt(params.input),
+      timeoutMs: NARRATION_TIMEOUT_MS,
+      abortSignal: signal,
+      streamParams: {
+        maxTokens: NARRATION_MAX_TOKENS,
         temperature: 0.3,
-        signal,
       },
     });
-    if (result.stopReason === "error") {
-      const error = result.errorMessage?.trim() || "unknown error";
-      logVerbose(`progress-narrator: completion failed: ${error}`);
-      return { text: null, error };
-    }
-    const text = result.content
-      .filter(isTextContentBlock)
-      .map((block) => block.text)
-      .join("")
-      .trim();
+    const text = result.text.trim();
     return { text: text || null };
   } catch (err) {
     logVerbose(`progress-narrator: completion failed: ${String(err)}`);

--- a/src/auto-reply/reply/progress-narrator.test.ts
+++ b/src/auto-reply/reply/progress-narrator.test.ts
@@ -10,9 +10,8 @@ import type { ProgressNarrationInput } from "./progress-narrator-model.js";
 const narratorWarnSpy = vi.hoisted(() => vi.fn());
 const narrationModelMocks = vi.hoisted(() => ({
   prepared: {
-    selection: { provider: "openai", modelId: "gpt-5.5-mini" },
-    model: {},
-    auth: {},
+    provider: "openai",
+    model: "gpt-5.5-mini",
   },
   prepare: vi.fn(),
   generate: vi.fn(),

--- a/src/auto-reply/reply/progress-narrator.ts
+++ b/src/auto-reply/reply/progress-narrator.ts
@@ -76,7 +76,7 @@ function createProgressNarrator(params: {
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
   let retryImmediate = false;
   // Each turn owns cancellation; replacing it fences old continuations without
-  // discarding the prepared model shared by queued turns.
+  // discarding the model selection shared by queued turns.
   let turnController = new AbortController();
   let userMessage = params.userMessage ?? "";
 
@@ -143,8 +143,8 @@ function createProgressNarrator(params: {
       disableNarration();
       return null;
     }
-    const { provider, modelId, profileId } = prepared.selection;
-    utilityModelLabel = `${provider}/${modelId}${profileId ? ` via ${profileId}` : ""}`;
+    const { provider, model, authProfileId } = prepared;
+    utilityModelLabel = `${provider}/${model}${authProfileId ? ` via ${authProfileId}` : ""}`;
     return await generateNarrationWithUtilityModel({
       cfg: params.cfg,
       prepared,

--- a/src/gateway/chat-tool-titles.test.ts
+++ b/src/gateway/chat-tool-titles.test.ts
@@ -4,14 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const completeWithPreparedSimpleCompletionModel = vi.hoisted(() => vi.fn());
-const prepareSimpleCompletionModelForAgent = vi.hoisted(() => vi.fn());
+const runIsolatedCompletion = vi.hoisted(() => vi.fn());
+const prepareUtilityCompletionForAgent = vi.hoisted(() => vi.fn());
 const resolveUtilityModelRefForAgent = vi.hoisted(() => vi.fn());
 
-vi.mock("../agents/simple-completion-runtime.js", () => ({
-  completeWithPreparedSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
-}));
+vi.mock("../agents/isolated-completion.js", () => ({ runIsolatedCompletion }));
+vi.mock("../agents/utility-completion.js", () => ({ prepareUtilityCompletionForAgent }));
 
 vi.mock("../agents/utility-model.js", () => ({
   resolveUtilityModelRefForAgent,
@@ -25,17 +23,21 @@ import { generateToolCallTitles } from "./chat-tool-titles.js";
 const AGENT_ID = "main";
 
 function mockPreparedModel(): void {
-  prepareSimpleCompletionModelForAgent.mockResolvedValue({
-    selection: { provider: "openai", modelId: "gpt-test", agentDir: "/tmp/openclaw-agent" },
-    model: { provider: "openai", id: "gpt-test", maxTokens: 8192 },
-    auth: { apiKey: "k", mode: "api-key" },
+  prepareUtilityCompletionForAgent.mockResolvedValue({
+    config: {},
+    provider: "openai",
+    model: "gpt-test",
+    agentId: AGENT_ID,
+    agentDir: "/tmp/openclaw-agent",
   });
 }
 
 function mockCompletionTitles(titles: Record<string, string>): void {
-  completeWithPreparedSimpleCompletionModel.mockResolvedValue({
-    stopReason: "stop",
-    content: [{ type: "text", text: JSON.stringify({ titles }) }],
+  runIsolatedCompletion.mockResolvedValue({
+    text: JSON.stringify({ titles }),
+    provider: "openai",
+    model: "gpt-test",
+    owner: { kind: "harness", id: "openclaw" },
   });
 }
 
@@ -44,8 +46,8 @@ describe("generateToolCallTitles", () => {
   let previousStateDir: string | undefined;
 
   beforeEach(() => {
-    completeWithPreparedSimpleCompletionModel.mockReset();
-    prepareSimpleCompletionModelForAgent.mockReset();
+    runIsolatedCompletion.mockReset();
+    prepareUtilityCompletionForAgent.mockReset();
     resolveUtilityModelRefForAgent.mockReset();
     // Default: canonical utility routing resolves a cheap same-provider model.
     resolveUtilityModelRefForAgent.mockReturnValue("openai/gpt-test");
@@ -83,7 +85,7 @@ describe("generateToolCallTitles", () => {
       "item-1": "Checked repo status",
       "item-2": "Listed source files",
     });
-    expect(completeWithPreparedSimpleCompletionModel).toHaveBeenCalledTimes(1);
+    expect(runIsolatedCompletion).toHaveBeenCalledTimes(1);
   });
 
   it("redacts secret-bearing inputs before they reach the utility model", async () => {
@@ -104,10 +106,10 @@ describe("generateToolCallTitles", () => {
       ],
     });
 
-    const call = completeWithPreparedSimpleCompletionModel.mock.calls[0]?.[0] as {
-      context: { messages: Array<{ content: string }> };
+    const call = runIsolatedCompletion.mock.calls[0]?.[0] as {
+      prompt: string;
     };
-    expect(call.context.messages[0]?.content).not.toContain(token);
+    expect(call.prompt).not.toContain(token);
   });
 
   it("redacts secrets that straddle the prompt truncation boundary", async () => {
@@ -125,10 +127,10 @@ describe("generateToolCallTitles", () => {
       items: [{ id: "item-1", name: "bash", input }],
     });
 
-    const call = completeWithPreparedSimpleCompletionModel.mock.calls[0]?.[0] as {
-      context: { messages: Array<{ content: string }> };
+    const call = runIsolatedCompletion.mock.calls[0]?.[0] as {
+      prompt: string;
     };
-    const content = call.context.messages[0]?.content ?? "";
+    const content = call.prompt ?? "";
     expect(content).not.toContain(token);
     expect(content).not.toContain(token.slice(0, 12));
   });
@@ -143,10 +145,10 @@ describe("generateToolCallTitles", () => {
       items: [{ id: "item-1", name: "bash", input: `${"a".repeat(1_999)}😀tail` }],
     });
 
-    const call = completeWithPreparedSimpleCompletionModel.mock.calls[0]?.[0] as {
-      context: { messages: Array<{ content: string }> };
+    const call = runIsolatedCompletion.mock.calls[0]?.[0] as {
+      prompt: string;
     };
-    const promptPayload = JSON.parse(call.context.messages[0]?.content ?? "{}") as {
+    const promptPayload = JSON.parse(call.prompt ?? "{}") as {
       items?: Array<{ input?: string }>;
     };
     expect(promptPayload.items?.[0]?.input).toBe("a".repeat(1_999));
@@ -166,13 +168,11 @@ describe("generateToolCallTitles", () => {
 
     expect(first).toEqual({ "item-1": "Checked repo status" });
     expect(second).toEqual(first);
-    expect(completeWithPreparedSimpleCompletionModel).toHaveBeenCalledTimes(1);
+    expect(runIsolatedCompletion).toHaveBeenCalledTimes(1);
   });
 
   it("fails closed to an empty result when model preparation errors", async () => {
-    prepareSimpleCompletionModelForAgent.mockResolvedValue({
-      error: 'No API key resolved for provider "openai".',
-    });
+    prepareUtilityCompletionForAgent.mockRejectedValue(new Error("No utility model configured."));
 
     await expect(
       generateToolCallTitles({
@@ -181,7 +181,7 @@ describe("generateToolCallTitles", () => {
         items: [{ id: "item-1", name: "bash", input: "git status --short" }],
       }),
     ).resolves.toEqual({});
-    expect(completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+    expect(runIsolatedCompletion).not.toHaveBeenCalled();
   });
 
   it("prepares the canonical utility model ref", async () => {
@@ -200,12 +200,11 @@ describe("generateToolCallTitles", () => {
       agentId: AGENT_ID,
       primaryProvider: undefined,
     });
-    expect(prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith({
+    expect(prepareUtilityCompletionForAgent).toHaveBeenCalledWith({
       cfg,
       agentId: AGENT_ID,
       modelRef: "openai/gpt-test",
       preferredProfile: undefined,
-      allowMissingApiKeyModes: ["aws-sdk"],
     });
   });
 
@@ -224,7 +223,7 @@ describe("generateToolCallTitles", () => {
       items: [{ id: "item-1", name: "bash", input: "git status --short" }],
     });
 
-    expect(prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+    expect(prepareUtilityCompletionForAgent).toHaveBeenCalledWith(
       expect.objectContaining({ modelRef: "openai/gpt-test@work", preferredProfile: "work" }),
     );
   });
@@ -280,8 +279,8 @@ describe("generateToolCallTitles", () => {
         items: [{ id: "item-1", name: "bash", input: "git status --short" }],
       }),
     ).resolves.toEqual({});
-    expect(prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
-    expect(completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+    expect(prepareUtilityCompletionForAgent).not.toHaveBeenCalled();
+    expect(runIsolatedCompletion).not.toHaveBeenCalled();
   });
 
   it("skips generation when utility routing is disabled or has no default", async () => {
@@ -296,7 +295,7 @@ describe("generateToolCallTitles", () => {
         items: [{ id: "item-1", name: "bash", input: "git status --short" }],
       }),
     ).resolves.toEqual({});
-    expect(prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
-    expect(completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+    expect(prepareUtilityCompletionForAgent).not.toHaveBeenCalled();
+    expect(runIsolatedCompletion).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/chat-tool-titles.test.ts
+++ b/src/gateway/chat-tool-titles.test.ts
@@ -27,6 +27,7 @@ function mockPreparedModel(): void {
     config: {},
     provider: "openai",
     model: "gpt-test",
+    outputTextPolicy: "strict-visible",
     agentId: AGENT_ID,
     agentDir: "/tmp/openclaw-agent",
   });

--- a/src/gateway/chat-tool-titles.ts
+++ b/src/gateway/chat-tool-titles.ts
@@ -18,12 +18,10 @@
 import { createHash } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { runIsolatedCompletion } from "../agents/isolated-completion.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { parseModelRef } from "../agents/model-selection-normalize.js";
-import {
-  completeWithPreparedSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
-} from "../agents/simple-completion-runtime.js";
+import { prepareUtilityCompletionForAgent } from "../agents/utility-completion.js";
 import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logVerbose } from "../globals.js";
@@ -211,65 +209,40 @@ async function generateMissingTitles(params: {
   if (params.items.length === 0) {
     return generated;
   }
-  let prepared: Awaited<ReturnType<typeof prepareSimpleCompletionModelForAgent>>;
+  let prepared: Awaited<ReturnType<typeof prepareUtilityCompletionForAgent>>;
   try {
-    prepared = await prepareSimpleCompletionModelForAgent({
+    prepared = await prepareUtilityCompletionForAgent({
       cfg: params.cfg,
       agentId: params.agentId,
       modelRef: params.modelRef,
       // Profile-isolated sessions must not leak their tool args through the
       // agent/default credential; the session's auth profile wins.
       preferredProfile: params.sessionAuthProfile,
-      allowMissingApiKeyModes: ["aws-sdk"],
     });
   } catch (err) {
     logVerbose(`chat-tool-titles: model preparation failed: ${String(err)}`);
     return generated;
   }
-  if ("error" in prepared) {
-    logVerbose(`chat-tool-titles: ${prepared.error}`);
-    return generated;
-  }
-
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TOOL_TITLES_TIMEOUT_MS);
   try {
-    const result = await completeWithPreparedSimpleCompletionModel({
-      model: prepared.model,
-      auth: prepared.auth,
-      cfg: params.cfg,
-      context: {
-        systemPrompt: TOOL_TITLES_SYSTEM_PROMPT,
-        messages: [
-          {
-            role: "user",
-            content: JSON.stringify({
-              // Caller ids never reach the model: they are unbounded client
-              // input; local batch indexes are remapped on the way out.
-              items: params.items.map((item, index) => ({
-                id: String(index),
-                tool: item.name,
-                input: item.input,
-              })),
-            }),
-            timestamp: Date.now(),
-          },
-        ],
-      },
-      options: {
-        maxTokens: Math.min(TOOL_TITLES_MAX_TOKENS, Math.floor(prepared.model.maxTokens)),
-        signal: controller.signal,
-      },
+    const result = await runIsolatedCompletion({
+      ...prepared,
+      systemPrompt: TOOL_TITLES_SYSTEM_PROMPT,
+      prompt: JSON.stringify({
+        // Caller ids never reach the model: they are unbounded client
+        // input; local batch indexes are remapped on the way out.
+        items: params.items.map((item, index) => ({
+          id: String(index),
+          tool: item.name,
+          input: item.input,
+        })),
+      }),
+      timeoutMs: TOOL_TITLES_TIMEOUT_MS,
+      abortSignal: controller.signal,
+      streamParams: { maxTokens: TOOL_TITLES_MAX_TOKENS },
     });
-    if (result.stopReason === "error") {
-      logVerbose(`chat-tool-titles: completion failed: ${result.errorMessage ?? "unknown error"}`);
-      return generated;
-    }
-    const text = result.content
-      .filter((block): block is { type: "text"; text: string } => block.type === "text")
-      .map((block) => block.text)
-      .join("")
-      .trim();
+    const text = result.text.trim();
     const titles = text ? parseTitlesResponse(text) : null;
     if (!titles) {
       return generated;

--- a/src/gateway/session-observer-completion.ts
+++ b/src/gateway/session-observer-completion.ts
@@ -15,7 +15,6 @@ export function createSessionObserverCompletion(params: {
   getConfig: SessionObserverDeps["getConfig"];
   prepareModel: PrepareModel;
   completeModel: CompleteModel;
-  now: () => number;
   setTimeoutFn: typeof setTimeout;
   clearTimeoutFn: typeof clearTimeout;
   isCurrent: (state: SessionObserverState) => boolean;
@@ -30,12 +29,11 @@ export function createSessionObserverCompletion(params: {
       agentId: state.agentId,
       modelRef,
       useUtilityModel: true,
-      allowMissingApiKeyModes: ["aws-sdk"],
     }));
     let failed = true;
     try {
       const prepared = await preparedPromise;
-      failed = "error" in prepared;
+      failed = false;
       return prepared;
     } finally {
       // Pending and successful preparation remain shared; settled failures do not.
@@ -62,45 +60,23 @@ export function createSessionObserverCompletion(params: {
         if (!params.isCurrent(state) || controller.signal.aborted) {
           throw new Error("session observer state is no longer active");
         }
-        if ("error" in prepared) {
-          throw new Error(prepared.error);
-        }
         for (let attempt = 0; attempt < 2; attempt += 1) {
           if (!params.isCurrent(state) || controller.signal.aborted) {
             throw new Error("session observer state is no longer active");
           }
           const result = await params.completeModel({
-            model: prepared.model,
-            auth: prepared.auth,
-            cfg: params.getConfig(),
-            context: {
-              systemPrompt: SESSION_OBSERVER_SYSTEM_PROMPT,
-              messages: [
-                {
-                  role: "user",
-                  content: buildSessionObserverPrompt(state, notes),
-                  timestamp: params.now(),
-                },
-              ],
-            },
-            options: {
-              maxTokens: Math.min(
-                SESSION_OBSERVER_MODEL_MAX_TOKENS,
-                Math.floor(prepared.model.maxTokens),
-              ),
+            ...prepared,
+            config: params.getConfig(),
+            systemPrompt: SESSION_OBSERVER_SYSTEM_PROMPT,
+            prompt: buildSessionObserverPrompt(state, notes),
+            timeoutMs: MODEL_TIMEOUT_MS,
+            abortSignal: controller.signal,
+            streamParams: {
+              maxTokens: SESSION_OBSERVER_MODEL_MAX_TOKENS,
               temperature: 0.2,
-              signal: controller.signal,
             },
           });
-          if (result.stopReason === "error") {
-            throw new Error(result.errorMessage?.trim() || "session observer completion failed");
-          }
-          const text = result.content
-            .filter((block): block is { type: "text"; text: string } => block.type === "text")
-            .map((block) => block.text)
-            .join("")
-            .trim();
-          const parsed = normalizeSessionObserverModelOutput(text);
+          const parsed = normalizeSessionObserverModelOutput(result.text);
           if (parsed) {
             return parsed;
           }

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -7,14 +7,12 @@ import {
   type SessionObserverPlanProgress,
 } from "../../packages/gateway-protocol/src/schema/sessions.js";
 import { normalizeAgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
+import type { runIsolatedCompletion } from "../agents/isolated-completion.js";
 import {
   terminalHealthFor,
   type SessionActivityNoteState,
 } from "../agents/session-activity-notes.js";
-import type {
-  completeWithPreparedSimpleCompletionModel,
-  prepareSimpleCompletionModelForAgent,
-} from "../agents/simple-completion-runtime.js";
+import type { prepareUtilityCompletionForAgent } from "../agents/utility-completion.js";
 import type { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
 import {
   loadSessionEntryReadOnly,
@@ -46,8 +44,8 @@ export function sessionObserverScopeKey(sessionKey: string, agentId: string): st
     ? sessionKey
     : `agent:${normalizeAgentId(agentId)}:${sessionKey}`;
 }
-type PrepareModel = typeof prepareSimpleCompletionModelForAgent;
-type CompleteModel = typeof completeWithPreparedSimpleCompletionModel;
+type PrepareModel = typeof prepareUtilityCompletionForAgent;
+type CompleteModel = typeof runIsolatedCompletion;
 type PreparedModel = Awaited<ReturnType<PrepareModel>>;
 
 export type SessionObserverState = SessionActivityNoteState & {
@@ -211,21 +209,14 @@ export type SessionObserverDeps = {
   clearTimeoutFn?: typeof clearTimeout;
 };
 
-let completionRuntimePromise:
-  | Promise<typeof import("../agents/simple-completion-runtime.js")>
-  | undefined;
-
-function loadCompletionRuntime() {
-  completionRuntimePromise ??= import("../agents/simple-completion-runtime.js");
-  return completionRuntimePromise;
-}
-
 export async function defaultPrepareModel(params: Parameters<PrepareModel>[0]) {
-  return await (await loadCompletionRuntime()).prepareSimpleCompletionModelForAgent(params);
+  const { prepareUtilityCompletionForAgent } = await import("../agents/utility-completion.js");
+  return await prepareUtilityCompletionForAgent(params);
 }
 
 export async function defaultCompleteModel(params: Parameters<CompleteModel>[0]) {
-  return await (await loadCompletionRuntime()).completeWithPreparedSimpleCompletionModel(params);
+  const { runIsolatedCompletion } = await import("../agents/isolated-completion.js");
+  return await runIsolatedCompletion(params);
 }
 
 export const SESSION_OBSERVER_SYSTEM_PROMPT = [

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -225,7 +225,7 @@ export const SESSION_OBSERVER_SYSTEM_PROMPT = [
   "Do not transcribe the activity log. Summarize what it is doing and how it is going.",
   "Use American English and present tense. Do not use markdown in string values.",
   'Set health to exactly one of "on-track", "grinding", "stuck", "waiting-on-user", "wrapping-up", "done", or "failed".',
-  'Return strict JSON only, for example: {"headline":"Checking the fix","assessment":"Tests are passing.","health":"on-track","planProgress":{"completed":2,"total":3}}. Omit optional fields instead of setting them to null.',
+  'Return one raw JSON object only, without Markdown fences or surrounding text, for example: {"headline":"Checking the fix","assessment":"Tests are passing.","health":"on-track","planProgress":{"completed":2,"total":3}}. Omit optional fields instead of setting them to null.',
 ].join(" ");
 
 const ModelDigestSchema = z

--- a/src/gateway/session-observer-preparation.test.ts
+++ b/src/gateway/session-observer-preparation.test.ts
@@ -11,6 +11,7 @@ import {
 const runtimeMocks = vi.hoisted(() => ({
   prepareDirect: vi.fn(),
   completeDirect: vi.fn(),
+  selectModel: vi.fn(),
   prepareUtility: vi.fn(),
   completeIsolated: vi.fn(),
 }));
@@ -18,6 +19,7 @@ const runtimeMocks = vi.hoisted(() => ({
 vi.mock("../agents/simple-completion-runtime.js", () => ({
   prepareSimpleCompletionModelForAgent: runtimeMocks.prepareDirect,
   completeWithPreparedSimpleCompletionModel: runtimeMocks.completeDirect,
+  resolveSimpleCompletionSelectionForAgent: runtimeMocks.selectModel,
 }));
 vi.mock("../agents/utility-completion.js", () => ({
   prepareUtilityCompletionForAgent: runtimeMocks.prepareUtility,
@@ -34,7 +36,7 @@ afterEach(() => {
 
 describe("session observer model preparation", () => {
   it.each(["claude-cli", "anthropic"])(
-    "publishes a digest from a runtime-owned %s utility completion without API auth",
+    "publishes a digest from a runtime-owned %s utility completion after empty output without API auth",
     async (provider) => {
       vi.useFakeTimers();
       vi.setSystemTime(0);
@@ -61,13 +63,31 @@ describe("session observer model preparation", () => {
       runtimeMocks.completeDirect
         .mockReset()
         .mockRejectedValue(new Error("HTTP 401 invalid credential"));
-      runtimeMocks.prepareUtility.mockResolvedValue(prepared);
-      runtimeMocks.completeIsolated.mockReset().mockResolvedValue({
+      const { prepareUtilityCompletionForAgent } = await vi.importActual<
+        typeof import("../agents/utility-completion.js")
+      >("../agents/utility-completion.js");
+      runtimeMocks.selectModel.mockReturnValue({
+        provider,
+        modelId: prepared.model,
+        agentDir: prepared.agentDir,
+      });
+      runtimeMocks.prepareUtility.mockImplementation(prepareUtilityCompletionForAgent);
+      const completion = {
         text: JSON.stringify({ headline: "Reviewing the implementation", health: "on-track" }),
         provider: "anthropic",
         model: prepared.model,
         owner: { kind: "cli", id: "claude-cli" },
-      });
+      };
+      runtimeMocks.completeIsolated
+        .mockReset()
+        .mockImplementationOnce(async (request) => {
+          // The isolated owner rejects empty output unless its caller owns visible-text recovery.
+          if (request.outputTextPolicy !== "strict-visible") {
+            throw new Error("Isolated completion returned empty output.");
+          }
+          return { ...completion, text: "" };
+        })
+        .mockResolvedValueOnce(completion);
       const harness = createHarness({
         config,
         utilityModelRef: config.agents.defaults.utilityModel,
@@ -80,6 +100,7 @@ describe("session observer model preparation", () => {
       await flushObserver();
 
       expect(runtimeMocks.completeDirect).not.toHaveBeenCalled();
+      expect(runtimeMocks.completeIsolated).toHaveBeenCalledTimes(2);
       expect(runtimeMocks.completeIsolated).toHaveBeenCalledWith(
         expect.objectContaining({
           ...prepared,

--- a/src/gateway/session-observer-preparation.test.ts
+++ b/src/gateway/session-observer-preparation.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultCompleteModel, defaultPrepareModel } from "./session-observer-model.js";
 import {
   createHarness,
   flushObserver,
@@ -7,6 +8,24 @@ import {
   startAndAddToolNotes,
 } from "./session-observer.test-utils.js";
 
+const runtimeMocks = vi.hoisted(() => ({
+  prepareDirect: vi.fn(),
+  completeDirect: vi.fn(),
+  prepareUtility: vi.fn(),
+  completeIsolated: vi.fn(),
+}));
+
+vi.mock("../agents/simple-completion-runtime.js", () => ({
+  prepareSimpleCompletionModelForAgent: runtimeMocks.prepareDirect,
+  completeWithPreparedSimpleCompletionModel: runtimeMocks.completeDirect,
+}));
+vi.mock("../agents/utility-completion.js", () => ({
+  prepareUtilityCompletionForAgent: runtimeMocks.prepareUtility,
+}));
+vi.mock("../agents/isolated-completion.js", () => ({
+  runIsolatedCompletion: runtimeMocks.completeIsolated,
+}));
+
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
@@ -14,6 +33,71 @@ afterEach(() => {
 });
 
 describe("session observer model preparation", () => {
+  it.each(["claude-cli", "anthropic"])(
+    "publishes a digest from a runtime-owned %s utility completion without API auth",
+    async (provider) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      const config = {
+        agents: {
+          defaults: {
+            utilityModel: `${provider}/claude-sonnet-4-6`,
+            models: { "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } } },
+          },
+        },
+      };
+      const prepared = {
+        config,
+        provider,
+        model: "claude-sonnet-4-6",
+        agentId: "main",
+        agentDir: "/tmp/agent",
+      };
+      runtimeMocks.prepareDirect.mockResolvedValue({
+        selection: { provider, modelId: prepared.model, agentDir: prepared.agentDir },
+        model: { provider, id: prepared.model, maxTokens: 8192 },
+        auth: { apiKey: "openclaw:claude-cli-native-auth", mode: "oauth" },
+      });
+      runtimeMocks.completeDirect
+        .mockReset()
+        .mockRejectedValue(new Error("HTTP 401 invalid credential"));
+      runtimeMocks.prepareUtility.mockResolvedValue(prepared);
+      runtimeMocks.completeIsolated.mockReset().mockResolvedValue({
+        text: JSON.stringify({ headline: "Reviewing the implementation", health: "on-track" }),
+        provider: "anthropic",
+        model: prepared.model,
+        owner: { kind: "cli", id: "claude-cli" },
+      });
+      const harness = createHarness({
+        config,
+        utilityModelRef: config.agents.defaults.utilityModel,
+        prepareModel: vi.fn(defaultPrepareModel),
+        completeModel: vi.fn(defaultCompleteModel),
+      });
+      startAndAddToolNotes(harness.observer);
+      await vi.advanceTimersByTimeAsync(12_000);
+      await vi.dynamicImportSettled();
+      await flushObserver();
+
+      expect(runtimeMocks.completeDirect).not.toHaveBeenCalled();
+      expect(runtimeMocks.completeIsolated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...prepared,
+          timeoutMs: 10_000,
+          abortSignal: expect.any(AbortSignal),
+        }),
+      );
+      expect(runtimeMocks.completeIsolated.mock.calls[0]?.[0]).not.toHaveProperty("auth");
+      expect(harness.broadcastToConnIds).toHaveBeenCalledWith(
+        "session.observer",
+        expect.objectContaining({ headline: "Reviewing the implementation", health: "on-track" }),
+        expect.any(Set),
+        expect.anything(),
+      );
+      harness.observer.dispose();
+    },
+  );
+
   it("does not start completion after observation ends during model preparation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -57,21 +141,12 @@ describe("session observer model preparation", () => {
     harness.observer.dispose();
   });
 
-  it.each([
-    {
-      failure: "a rejected promise",
-      firstPreparation: () => Promise.reject(new Error("temporary preparation failure")),
-    },
-    {
-      failure: "a resolved error",
-      firstPreparation: async () => ({ error: "temporary preparation failure" }),
-    },
-  ])("retries after $failure", async ({ firstPreparation }) => {
+  it("retries after a rejected preparation", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const prepareModel = vi
       .fn()
-      .mockImplementationOnce(firstPreparation)
+      .mockRejectedValueOnce(new Error("temporary preparation failure"))
       .mockResolvedValue(preparedModel());
     const harness = createHarness({ prepareModel });
     startAndAddToolNotes(harness.observer);

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -98,8 +98,8 @@ function persistGuard(harness: Harness): (() => boolean) | undefined {
   return harness.persistDigest.mock.calls[0]?.[0]?.stillCurrent as (() => boolean) | undefined;
 }
 
-function completionMessages(harness: Harness, index = 0) {
-  return harness.completeModel.mock.calls[index]?.[0]?.context?.messages ?? [];
+function completionPrompt(harness: Harness, index = 0): string {
+  return harness.completeModel.mock.calls[index]?.[0]?.prompt ?? "";
 }
 
 describe("session observer terminal, persistence, synthesis, and races", () => {
@@ -579,7 +579,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     emitEvent(harness, "assistant", { delta: "ey=super-secret-value-0123456789 attached." });
     await advanceAndFlush(12_000);
     expect(harness.completeModel).toHaveBeenCalledOnce();
-    const prompt = JSON.stringify(completionMessages(harness));
+    const prompt = completionPrompt(harness);
     expect(prompt).toContain("Assistant:");
     expect(prompt).not.toContain("super-secret-value-0123456789");
   });
@@ -612,7 +612,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     emitEvent(harness, "assistant", { text: "Working on the fix and verifying it." });
     await advanceAndFlush(12_000);
     expect(harness.completeModel).toHaveBeenCalledOnce();
-    const prompt = JSON.stringify(completionMessages(harness));
+    const prompt = completionPrompt(harness);
     expect(prompt.match(/Assistant:/gu)).toHaveLength(1);
     expect(prompt).toContain("Working on the fix and verifying it.");
   });
@@ -798,7 +798,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     emitEvent(harness, "assistant", { delta: "private-context-body-must-not-leave" });
     await advanceAndFlush(12_000);
     expect(harness.completeModel).toHaveBeenCalledOnce();
-    const openPrompt = String(completionMessages(harness)[0]?.content);
+    const openPrompt = completionPrompt(harness);
     expect(openPrompt).not.toContain("private-context-body-must-not-leave");
     expect(openPrompt).not.toContain("Assistant:");
 
@@ -808,7 +808,7 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     startAndAddToolNotes(harness.observer, { count: 4 });
     await advanceAndFlush(12_000);
     expect(harness.completeModel).toHaveBeenCalledTimes(2);
-    const closedPrompt = String(completionMessages(harness, 1)[0]?.content);
+    const closedPrompt = completionPrompt(harness, 1);
     expect(closedPrompt).not.toContain("private-context-body-must-not-leave");
     expect(closedPrompt).toContain("visible prose after");
   });

--- a/src/gateway/session-observer.test-utils.ts
+++ b/src/gateway/session-observer.test-utils.ts
@@ -43,16 +43,20 @@ export function event(params: {
 
 export function modelMessage(value: Record<string, unknown>) {
   return {
-    stopReason: "stop",
-    content: [{ type: "text", text: JSON.stringify(value) }],
+    text: JSON.stringify(value),
+    provider: "openai",
+    model: "gpt-test",
+    owner: { kind: "harness", id: "openclaw" },
   };
 }
 
 export function preparedModel() {
   return {
-    selection: { provider: "openai", modelId: "gpt-test", agentDir: "/tmp/agent" },
-    model: { provider: "openai", id: "gpt-test", maxTokens: 8_192 },
-    auth: { apiKey: "test-api-key", mode: "api-key" },
+    config: cfg,
+    provider: "openai",
+    model: "gpt-test",
+    agentId: "main",
+    agentDir: "/tmp/agent",
   };
 }
 

--- a/src/gateway/session-observer.test-utils.ts
+++ b/src/gateway/session-observer.test-utils.ts
@@ -55,6 +55,7 @@ export function preparedModel() {
     config: cfg,
     provider: "openai",
     model: "gpt-test",
+    outputTextPolicy: "strict-visible" as const,
     agentId: "main",
     agentDir: "/tmp/agent",
   };

--- a/src/gateway/session-observer.test.ts
+++ b/src/gateway/session-observer.test.ts
@@ -375,11 +375,11 @@ describe("session observer", () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     let firstCall = true;
-    const completeModel = vi.fn(async (params: { options: { signal: AbortSignal } }) => {
+    const completeModel = vi.fn(async (params: { abortSignal: AbortSignal }) => {
       if (firstCall) {
         firstCall = false;
         return await new Promise<ReturnType<typeof modelMessage>>((_resolve, reject) => {
-          params.options.signal.addEventListener("abort", () => reject(new Error("aborted")), {
+          params.abortSignal.addEventListener("abort", () => reject(new Error("aborted")), {
             once: true,
           });
         });
@@ -502,9 +502,7 @@ describe("session observer", () => {
 
     await vi.advanceTimersByTimeAsync(12_000);
     await flushObserver();
-    const prompt = String(
-      harness.completeModel.mock.calls[0]?.[0]?.context?.messages?.[0]?.content,
-    );
+    const prompt = String(harness.completeModel.mock.calls[0]?.[0]?.prompt);
     expect(prompt).not.toContain("test-token");
     expect(prompt).not.toContain(runtimeDetail);
     expect(prompt).not.toContain(commandOutput);
@@ -820,7 +818,7 @@ describe("session observer", () => {
     vi.setSystemTime(0);
     const completeModel = vi
       .fn()
-      .mockResolvedValueOnce({ stopReason: "stop", content: [{ type: "text", text: "nope" }] })
+      .mockResolvedValueOnce({ ...modelMessage({}), text: "nope" })
       .mockResolvedValueOnce(
         modelMessage({ headline: "Continuing after a retry", health: "on-track" }),
       );

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -12,6 +12,7 @@ import {
 } from "../agents/session-activity-notes.js";
 import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
 import { getAgentRunContext } from "../infra/agent-run-registry.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   createSessionObserverAudience,
@@ -260,7 +261,6 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     getConfig: deps.getConfig,
     prepareModel,
     completeModel,
-    now,
     setTimeoutFn,
     clearTimeoutFn,
     isCurrent: modelStateIsCurrent,
@@ -417,7 +417,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           observerLog.warn("session observer disabled after consecutive failures", {
             sessionKey: state.sessionKey,
             runId: state.runId,
-            error,
+            error: formatErrorMessage(error),
           });
           if (final || state.finalPending || state.terminalHealth) {
             retireTerminalState(state);


### PR DESCRIPTION
## What Problem This Solves

Fixes #135566.

Session-observer digests, progress narration, and tool-call titles bypassed the selected agent runtime and prepared a direct provider HTTP request. On a Claude CLI deployment this could send the non-secret native-auth marker to Anthropic and fail with HTTP 401, even while foreground turns worked. As the reporter clarified, this affects both legacy `claude-cli/*` references and canonical `anthropic/*` models configured with `agentRuntime.id: "claude-cli"`.

## Why This Change Was Made

Route these utility callers through the existing tool-free isolated-completion owner, already used by conversation labels. Preparation now carries model and auth-profile identity, not resolved HTTP credentials; the runtime owns authentication, tools, and execution. Preserve the explicit CLI owner when canonicalizing a legacy model reference. Remove the redundant simple-completion runtime-provider branch and caller-specific message/result handling.

The shared owner still supports direct API-key routes, harness-owned authentication, strict empty-tool CLI execution, profile isolation, token clamping, and cancellation. Observer deadlines, stale-run fencing, structured output retry, and visible digest delivery remain in their existing lifecycle owners. Observer failure logs now record the error message explicitly. Utility requests retain strict visible-text semantics, leaving empty-output retry/fallback with the caller. A live native probe also exposed fenced JSON, so the observer prompt explicitly requests a raw object without fences; its parser and deadline remain unchanged.

## User Impact

Claude CLI-backed utility models produce session digests, progress narration, and tool-call titles through Claude CLI rather than attempting direct Anthropic HTTP authentication. No configuration, environment variable, database schema, or public protocol was added. The CLI backend and runtime configuration docs describe utility completion behavior.

Thanks to @goslingmanagment for the detailed report and canonical-model scope correction.

## Evidence

- Initial before/after regression: `publishes a digest from a runtime-owned %s utility completion without API auth`, for both `claude-cli` and `anthropic`. On the original production tree both failed because direct completion received the synthetic native-auth marker. On the candidate they publish a digest through isolated completion and never invoke the direct completion adapter.
- Before/after regression: `keeps the CLI execution owner for a %s utility model without resolving HTTP credentials`. The legacy reference failed before the fix with `Agent harness codex is unavailable for isolated completion`; both references pass after the fix without host HTTP credential preparation.
- Targeted Testbox run: 203 tests across 13 files and four shards, covering isolated completion, simple-completion selection/preparation, utility-model selection, observer lifecycle, titles, narration, and conversation labels.
- Empty-output regression: both provider forms failed before strict-visible propagation with `expected "vi.fn()" to be called 2 times, but got 1 times`; afterward 76 focused tests passed.
- Native CLI trace and auth-boundary evidence: https://github.com/openclaw/openclaw/pull/135711#issuecomment-5502767534. Both reference forms returned `utility-runtime-ok` through Claude CLI within the unchanged 10-second budget, with zero direct host Anthropic requests. This uses an isolated API-key profile forwarded to native Claude Code 2.1.233, not the operator's subscription login.
- `pnpm check:changed` passed; `git diff --check` passed. Supported `pnpm plugin-sdk:api:diff --base 2cf5cb2a2c5678bb1b09010491037da7b40c8797 --head 27044006304e7a1bfd1ae2f12312c2baa1f13789` reported no Plugin SDK API changes. The requested API baseline generator was intentionally removed by #123036; no baseline was fabricated.
- Initial CI caught a missing undefined `authProfileId` in the narration test fixture (TS2741); fixed in fa9e3e9. Failure and correction: https://github.com/openclaw/openclaw/pull/135711#issuecomment-5502648952.
- Real native observer-digest proof passed for legacy and canonical Sonnet references in 6,053 ms and 4,663 ms, with production JSON validation and zero direct host Anthropic requests: https://github.com/openclaw/openclaw/pull/135711#issuecomment-5502884987.
- Final observer rerun: 36 tests passed. Uncommitted and branch autoreviews both exited 0 with `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority` (default P0 threshold).
- Exact-head CI for ec74dc6ef08d525677175ce313b71c2320305373: https://github.com/openclaw/openclaw/actions/runs/33578694144 (passed; exact-head watcher exited 0 with GREEN). Previous head 5ff350f2170 passed: https://github.com/openclaw/openclaw/actions/runs/33577800653.
- Dependency source inspected directly: Codex `codex-rs/app-server/src/request_processors/thread_processor.rs:1120-1250,1370-1465` and `codex-rs/core/src/tools/spec_plan.rs:126-190,1040-1056`; explicit empty environments/dynamic tools remain owned by the bounded adapter. OpenClaw's Codex V2 host-authorization path remains on its existing prepared direct transport (`extensions/codex/harness.ts:254-263`).

Validation so far:

```text
pnpm test src/agents/isolated-completion.test.ts src/agents/simple-completion-runtime src/agents/utility-model.test.ts src/gateway/session-observer src/gateway/chat-tool-titles.test.ts src/auto-reply/reply/progress-narrator src/auto-reply/reply/conversation-label-generator.test.ts
# 203 passed; 13 files; four shards (Linux Testbox)

autoreview --mode uncommitted --engine codex
# autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
# Default P0 threshold; exit 0.
```

LOC: production +98/-174 (net -76); tests/test support +230/-91 (net +139); docs +3/-1. No baseline, inventory, snapshot, ignore, or budget changes.

Verification limitations/follow-up: the additional local `cli-runner.spawn.test.ts` run reached the host's saved schema-v16 database while this checkout supports v15, and also had fixture failures; it was stopped without modifying user state or weakening the harness. That local harness isolation issue is separate from this patch (no CLI runner production/test edits). The focused candidate tests and clean CI are the regression evidence. The full local build was stopped during lengthy declaration generation; the supported `pnpm build:ci-artifacts` subsequently passed, including runtime/plugin checks and UI performance budgets. No budget/baseline was edited. Native proof uses synthetic input and temporary state; Gateway UI transport/persistence is covered by observer tests, not claimed as live UI proof.

Named follow-up: native Haiku 4.5 can return fenced JSON despite the clarified instruction, exhausting the observer's existing retry/deadline. This is recorded as a non-outcome and is not claimed fixed by this routing repair. Runtime-wide structured-output enforcement deserves a separate capability-level change; strict parsing and deadlines were not weakened. Sonnet native digest proof passed for both reference forms.
