### PR TITLE
test(hooks): reuse immutable import URL fixtures

### DIFF
--- a/src/hooks/import-url.test.ts
+++ b/src/hooks/import-url.test.ts
@@ -1,63 +1,60 @@
-// Hook import URL tests cover file URL conversion for hook modules.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildImportUrl } from "./import-url.js";
 
 describe("buildImportUrl", () => {
-  let tmpDir: string;
-  let tmpFile: string;
+  const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+  let fixtureRoot: string;
+  let immutableHandlerPath: string;
 
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "import-url-test-"));
-    tmpFile = path.join(tmpDir, "handler.js");
-    fs.writeFileSync(tmpFile, "export default () => {};");
-  });
-
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+  beforeAll(() => {
+    fixtureRoot = tempDirs.make("import-url-test-");
+    immutableHandlerPath = path.join(fixtureRoot, "handler.js");
+    fs.writeFileSync(immutableHandlerPath, "export default () => {};");
   });
 
   it("returns bare URL for bundled hooks (no query string)", () => {
-    const url = buildImportUrl(tmpFile, "openclaw-bundled");
+    const url = buildImportUrl(immutableHandlerPath, "openclaw-bundled");
     expect(url).not.toContain("?t=");
     expect(url).toMatch(/^file:\/\//);
   });
 
   it("appends file-metadata cache buster for workspace hooks", () => {
-    const url = buildImportUrl(tmpFile, "openclaw-workspace");
+    const url = buildImportUrl(immutableHandlerPath, "openclaw-workspace");
     expect(url).toMatch(/\?t=[\d.]+&c=[\d.]+&s=\d+/);
 
-    const { ctimeMs, mtimeMs, size } = fs.statSync(tmpFile);
+    const { ctimeMs, mtimeMs, size } = fs.statSync(immutableHandlerPath);
     expect(url).toContain(`?t=${mtimeMs}`);
     expect(url).toContain(`&c=${ctimeMs}`);
     expect(url).toContain(`&s=${size}`);
   });
 
   it("appends file-metadata cache buster for managed hooks", () => {
-    const url = buildImportUrl(tmpFile, "openclaw-managed");
+    const url = buildImportUrl(immutableHandlerPath, "openclaw-managed");
     expect(url).toMatch(/\?t=[\d.]+&c=[\d.]+&s=\d+/);
   });
 
   it("appends file-metadata cache buster for plugin hooks", () => {
-    const url = buildImportUrl(tmpFile, "openclaw-plugin");
+    const url = buildImportUrl(immutableHandlerPath, "openclaw-plugin");
     expect(url).toMatch(/\?t=[\d.]+&c=[\d.]+&s=\d+/);
   });
 
   it("returns same URL for bundled hooks across calls (cacheable)", () => {
-    const url1 = buildImportUrl(tmpFile, "openclaw-bundled");
-    const url2 = buildImportUrl(tmpFile, "openclaw-bundled");
+    const url1 = buildImportUrl(immutableHandlerPath, "openclaw-bundled");
+    const url2 = buildImportUrl(immutableHandlerPath, "openclaw-bundled");
     expect(url1).toBe(url2);
   });
 
   it("returns same URL for workspace hooks when file is unchanged", () => {
-    const url1 = buildImportUrl(tmpFile, "openclaw-workspace");
-    const url2 = buildImportUrl(tmpFile, "openclaw-workspace");
+    const url1 = buildImportUrl(immutableHandlerPath, "openclaw-workspace");
+    const url2 = buildImportUrl(immutableHandlerPath, "openclaw-workspace");
     expect(url1).toBe(url2);
   });
 
   it("reloads a workspace hook after a same-size edit with restored mtime", async () => {
+    const tmpFile = path.join(fixtureRoot, "reload-handler.js");
     const initialSource = 'export default () => "before";\n';
     const editedSource = 'export default () => "after!";\n';
     expect(Buffer.byteLength(editedSource)).toBe(Buffer.byteLength(initialSource));
@@ -88,7 +85,7 @@ describe("buildImportUrl", () => {
   });
 
   it("falls back to Date.now() when file does not exist", () => {
-    const url = buildImportUrl("/nonexistent/handler.js", "openclaw-workspace");
+    const url = buildImportUrl(path.join(fixtureRoot, "missing-handler.js"), "openclaw-workspace");
     expect(url).toMatch(/\?t=\d+/);
   });
 });


### PR DESCRIPTION
The hook import-URL suite recreated and deleted the same no-op handler for every case. Give its immutable handler one suite-owned temporary root through the canonical cleanup tracker, while the reload case keeps a separate writable handler and the missing-file case uses an uncreated path under that root. This reduces root allocations, standard handler writes and recursive removals from eight to one each.

All eight owner cases remain, including the real dynamic imports before and after a same-size edit with restored mtime, exact metadata URL checks, and bundled/mutable source behavior. The existing ctime polling bound is unchanged. Production delta is zero; tests +20/-23. This is an operation-count reduction; no wall-time or memory ratio is claimed.

Validation: all26 import-URL, module-loader and loader cases passed before and after, with identical identities. The candidate ran shuffled with seed2221; the real reload case preceded later immutable-handler checks. Manual review covered the full owner, loader/callers, sibling tests, tracker, history and Node24 ESM URL cache implementation.

The full changed-file gate passed, including the plugins-platform test type graph, all three dead-export scans and lint. Independent Codex review and manual fixture/state review found no actionable issue.
