### PR TITLE
fix: allow degraded gateway startup for migration warnings

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -429,7 +429,7 @@ That stages grounded durable candidates into the short-term dreaming store while
 
     Legacy session-file import and repair belong to explicit Doctor runs. Gateway and local CLI startup use SQLite; they do not import, restore, or rewrite session JSON/JSONL files. When startup finds a legacy session store, it refuses readiness and prints the Doctor command for the active profile instead of serving empty history. Stop the Gateway, back up its state, and run `openclaw doctor --fix` before restarting it to upgrade old session history. The [targeted migration sequence](/cli/doctor#session-sqlite-migration) provides inspection and validation evidence. Current SQLite maintenance does not require legacy files to remain on disk.
 
-    Doctor reports individual channel migration-plan failures while continuing plans for unrelated sources, including those from the same plugin. Plans sharing the failed source are deferred, and source cleanup waits for its last consumer to finish without reported failures or incomplete imports. A startup migration warning still blocks Gateway readiness; resolve the reported failure and run `openclaw doctor --fix` before retrying startup.
+    Doctor reports individual channel migration-plan failures while continuing plans for unrelated sources, including those from the same plugin. Plans sharing the failed source are deferred, and source cleanup waits for its last consumer to finish without reported failures or incomplete imports. Advisory startup migration warnings allow the Gateway to start degraded. Startup logs the warnings once with the exact repair command; `openclaw status` and `openclaw doctor` show the running Gateway's warning report. Run `openclaw doctor --fix` against the same state/config, then restart the Gateway. Warning-bearing work is not marked complete and is retried on a later startup. Migration errors that leave required state unsafe to read, including failed shared-schema repair, still refuse startup.
 
     Doctor emits warnings when migrations leave legacy folders behind as backups. WhatsApp auth is intentionally only migrated via `openclaw doctor`. Talk provider/provider-map normalization compares by structural equality, so key-order-only diffs no longer trigger repeat no-op `doctor --fix` changes.
 
@@ -600,7 +600,7 @@ That stages grounded durable candidates into the short-term dreaming store while
 
     Use `openclaw memory status --deep` to verify embedding readiness at runtime.
 
-    Embedding-provider readiness is a health check, not a state migration. Gateway startup does not initialize memory embedding providers during migration preflight, so auth-profile SecretRefs can activate afterward. If embeddings remain unavailable, memory sync preserves an existing semantic index rather than replacing it with FTS-only data. Genuine migration warnings still block Gateway readiness.
+    Embedding-provider readiness is a health check, not a state migration. Gateway startup does not initialize memory embedding providers during migration preflight, so auth-profile SecretRefs can activate afterward. If embeddings remain unavailable, memory sync preserves an existing semantic index rather than replacing it with FTS-only data. Migration warnings allow degraded startup; errors that leave required state unsafe to read still block Gateway readiness.
 
   </Accordion>
   <Accordion title="14. Channel status warnings">

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -53,6 +53,12 @@ See [Database schemas](/reference/database-schemas) for downgrade precautions.
 
 ## Graceful restarts drain first
 
+Startup migration warnings do not prevent the Gateway from starting. It logs the
+warnings once and starts degraded; `openclaw status` and `openclaw doctor` show the
+running Gateway's warning report. Run `openclaw doctor --fix` against the same
+state/config, then restart the Gateway. Unfinished migrations remain pending for
+a later startup. Errors that leave required state unsafe to read still stop startup.
+
 A requested restart (`openclaw gateway restart`, a config change that requires
 a restart, or a gateway update) does not kill in-flight work immediately. The
 gateway stops accepting new work, then waits for active agent turns and

--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -55,7 +55,9 @@ See [Database schemas](/reference/database-schemas) for downgrade precautions.
 
 Startup migration warnings do not prevent the Gateway from starting. It logs the
 warnings once and starts degraded; `openclaw status` and `openclaw doctor` show the
-running Gateway's warning report. Run `openclaw doctor --fix` against the same
+running Gateway's warning report. Read-only operators receive the repair hint;
+warning details are restricted to administrators and startup logs.
+Run `openclaw doctor --fix` against the same
 state/config, then restart the Gateway. Unfinished migrations remain pending for
 a later startup. Errors that leave required state unsafe to read still stop startup.
 

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -1,3 +1,4 @@
+import { note } from "../../packages/terminal-core/src/note.js";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
 import type { ConfigFileSnapshot } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -5,6 +6,11 @@ import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
 } from "../infra/startup-migration-checkpoint.js";
+import {
+  formatStartupMigrationFailure,
+  recordStartupMigrationWarnings,
+} from "../infra/state-migrations.messages.js";
+import type { MigrationMessages } from "../infra/state-migrations.types.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import {
   migrationCheckpointIdentitiesMatch,
@@ -17,7 +23,6 @@ import {
   runStartupUpgradeConvergence,
 } from "./doctor-config-preflight-plugin-verification.js";
 import {
-  formatStartupMigrationFailure,
   throwStartupMigrationIdentityChanged,
   throwStartupMigrationRefusal,
 } from "./doctor-startup-migration-refusal.js";
@@ -80,20 +85,11 @@ export async function completeStartupMigrationPreflight(params: {
     });
   }
   if (params.gatewayStartupCheckpointRequired) {
-    if (params.startupMigrationWarnings.length > 0) {
-      throwStartupMigrationRefusal(
-        formatStartupMigrationFailure({
-          warnings: [...params.startupMigrationWarnings],
-          blockers: [],
-        }),
-      );
-    }
     if (params.shouldRecordStartupCheckpoint && !params.snapshot.valid) {
       throwStartupMigrationRefusal(
-        formatStartupMigrationFailure({
-          warnings: [],
-          blockers: ['OpenClaw config is invalid; run "openclaw doctor --fix" before startup.'],
-        }),
+        formatStartupMigrationFailure([
+          'OpenClaw config is invalid; run "openclaw doctor --fix" before startup.',
+        ]),
       );
     }
     setActiveDegradedPlugins([]);
@@ -133,8 +129,10 @@ export async function completeStartupMigrationPreflight(params: {
         }
       }
     }
+    recordStartupMigrationWarnings(params.startupMigrationWarnings);
   }
-  if (params.shouldRecordStartupCheckpoint) {
+  // Advisory findings allow service, but must not certify unfinished migration work.
+  if (params.shouldRecordStartupCheckpoint && params.startupMigrationWarnings.length === 0) {
     if (!params.migrationCheckpoint) {
       throw new Error("OpenClaw startup migration checkpoint module was not loaded.");
     }
@@ -143,5 +141,13 @@ export async function completeStartupMigrationPreflight(params: {
       identity: params.migrationCheckpointIdentity,
       lease: params.startupMigrationLease,
     });
+  }
+}
+
+export function noteStateMigrationResult(result: MigrationMessages): void {
+  for (const key of ["changes", "notices", "warnings"] as const) {
+    if (result[key]?.length) {
+      note(result[key].map((entry) => `- ${entry}`).join("\n"), `Doctor ${key}`);
+    }
   }
 }

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -396,7 +396,9 @@ describe("gateway startup-migration refusal", () => {
 
     try {
       // Readiness must use the migration fixture without extra hooks or Control UI settings.
-      await instance.state.writeConfig({ gateway: { mode: "local", auth: { mode: "none" } } });
+      await instance.state.writeConfig({
+        gateway: { mode: "local", port, auth: { mode: "none" } },
+      });
       seedPluginStateConflict(stateDir);
       fs.mkdirSync(path.dirname(storePath), { recursive: true });
       const job = {
@@ -432,7 +434,7 @@ describe("gateway startup-migration refusal", () => {
         expect(logs).toContain(STARTUP_RECOVERY);
         expect(logs).not.toContain(STARTUP_REFUSAL);
         const status = await instance.cli(["gateway", "call", "status", "--json"]);
-        expect(status.code, status.stderr).toBe(0);
+        expect(status.code, status.stdout + "\n" + status.stderr).toBe(0);
         expect(JSON.parse(status.stdout).startupMigrationWarning).toContain(warning);
         expect(fs.existsSync(path.join(stateDir, "plugin-state", "state.sqlite"))).toBe(true);
       } finally {

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -435,7 +435,9 @@ describe("gateway startup-migration refusal", () => {
         expect(logs).not.toContain(STARTUP_REFUSAL);
         const status = await instance.cli(["gateway", "call", "status", "--json"]);
         expect(status.code, status.stdout + "\n" + status.stderr).toBe(0);
-        expect(JSON.parse(status.stdout).startupMigrationWarning).toContain(warning);
+        expect(JSON.parse(status.stdout).startupMigrationWarning).toBe(
+          'Startup migrations need attention. Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
+        );
         expect(fs.existsSync(path.join(stateDir, "plugin-state", "state.sqlite"))).toBe(true);
       } finally {
         await instance.stopGateway();

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -366,7 +366,7 @@ describe("doctor invalid config process exit", () => {
 
 // Synchronous CLI probes must not consume neighboring cases' timeout budgets.
 describe("gateway startup-migration refusal", () => {
-  it("quarantines every invalid legacy automation before Gateway readiness", async () => {
+  it("boots with migration warnings while preserving legacy state and quarantining invalid automation", async () => {
     const instance = await createOpenClawTestInstance({
       name: "cron-upgrade-ready",
       startTimeoutMs: 30_000,
@@ -397,6 +397,7 @@ describe("gateway startup-migration refusal", () => {
     try {
       // Readiness must use the migration fixture without extra hooks or Control UI settings.
       await instance.state.writeConfig({ gateway: { mode: "local", auth: { mode: "none" } } });
+      seedPluginStateConflict(stateDir);
       fs.mkdirSync(path.dirname(storePath), { recursive: true });
       const job = {
         name: "Legacy automation",
@@ -425,6 +426,15 @@ describe("gateway startup-migration refusal", () => {
         await instance.startGateway();
         const response = await fetch(`http://127.0.0.1:${port}/readyz`);
         await expect(response.json()).resolves.toMatchObject({ ready: true, failing: [] });
+        const warning = "Left plugin-state sidecar in place";
+        const logs = instance.logs();
+        expect(logs.split(warning)).toHaveLength(2);
+        expect(logs).toContain(STARTUP_RECOVERY);
+        expect(logs).not.toContain(STARTUP_REFUSAL);
+        const status = await instance.cli(["gateway", "call", "status", "--json"]);
+        expect(status.code, status.stderr).toBe(0);
+        expect(JSON.parse(status.stdout).startupMigrationWarning).toContain(warning);
+        expect(fs.existsSync(path.join(stateDir, "plugin-state", "state.sqlite"))).toBe(true);
       } finally {
         await instance.stopGateway();
       }
@@ -448,7 +458,7 @@ describe("gateway startup-migration refusal", () => {
     }
   }, 45_000);
 
-  it("repairs the stable upgrade config and additive state schema before readiness", async () => {
+  it("repairs the stable upgrade config and additive state schema despite advisory warnings", async () => {
     const root = await fs.promises.realpath(tempDirs.make("openclaw-stable-upgrade-ready-"));
     const stateDir = path.join(root, "state");
     const configPath = path.join(root, "openclaw.json");
@@ -477,6 +487,7 @@ describe("gateway startup-migration refusal", () => {
 
     fs.mkdirSync(stateDir, { recursive: true });
     fs.writeFileSync(configPath, JSON.stringify(stableConfig));
+    seedPluginStateConflict(stateDir);
     const preflightUrl = new URL("./doctor-config-preflight.ts", import.meta.url).href;
     const stateDatabaseUrl = new URL("../state/openclaw-state-db.ts", import.meta.url).href;
     const script = `
@@ -528,6 +539,8 @@ describe("gateway startup-migration refusal", () => {
     const resultLine = result.stdout.split("\n").find((line) => line.startsWith("__RESULT__"));
 
     expect(resultLine, output).toBeDefined();
+    expect(output).toContain("Left plugin-state sidecar in place");
+    expect(output).toContain(STARTUP_RECOVERY);
     expect(JSON.parse(resultLine!.slice("__RESULT__".length))).toEqual({
       valid: true,
       hasLastTouchedAt: false,
@@ -539,8 +552,8 @@ describe("gateway startup-migration refusal", () => {
     expect(hasActiveStartupMigrationLease({ env })).toBe(false);
   }, 75_000);
 
-  it("refuses readiness for a schema-only legacy agent database without an owner", () => {
-    const root = fs.realpathSync(tempDirs.make("openclaw-ownerless-agent-refusal-"));
+  it("reaches readiness while preserving a legacy agent database without an owner", () => {
+    const root = fs.realpathSync(tempDirs.make("openclaw-ownerless-agent-ready-"));
     const stateDir = path.join(root, "state");
     const configPath = path.join(root, "openclaw.json");
     const config = {
@@ -593,12 +606,12 @@ describe("gateway startup-migration refusal", () => {
     const output = `${result.stderr}\n${result.stdout}`;
 
     expect(result.error, output).toBeUndefined();
-    expect(result.status, output).toBe(1);
-    expect(result.stdout, output).not.toContain("__READY__");
-    expect(result.stderr, output).toContain("__REFUSED__");
-    expect(result.stderr, output).toContain(STARTUP_REFUSAL);
-    expect(result.stderr, output).toContain(STARTUP_RECOVERY);
-    expect(result.stderr, output).toContain("agent schema owner is missing or blank");
+    expect(result.status, output).toBe(0);
+    expect(result.stdout, output).toContain("__READY__");
+    expect(result.stderr, output).not.toContain("__REFUSED__");
+    expect(output).not.toContain(STARTUP_REFUSAL);
+    expect(output).toContain(STARTUP_RECOVERY);
+    expect(output).toContain("agent schema owner is missing or blank");
     expect(fs.existsSync(databasePath)).toBe(true);
     expect(hasActiveStartupMigrationLease({ env })).toBe(false);
   }, 75_000);
@@ -652,60 +665,6 @@ describe("gateway startup-migration refusal", () => {
     expect(fs.readFileSync(legacyPath, "utf8")).toBe('{"legacy":true}\n');
     expect(hasActiveStartupMigrationLease({ env })).toBe(false);
   }, 75_000);
-
-  it("exits cleanly after reporting the refusal once and releasing its lease", async () => {
-    const temporaryRoot = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-startup-migration-exit-"),
-    );
-    const root = await fs.promises.realpath(temporaryRoot);
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(root, "openclaw.json");
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
-      HOME: root,
-      USERPROFILE: root,
-      OPENCLAW_CONFIG_PATH: configPath,
-      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_TEST_FAST: "1",
-      NO_COLOR: "1",
-    };
-    delete env.NODE_ENV;
-    delete env.OPENCLAW_HOME;
-    delete env.VITEST;
-
-    try {
-      fs.mkdirSync(stateDir, { recursive: true });
-      const originalConfig = JSON.stringify({
-        meta: { lastTouchedAt: "2026-08-01T00:00:00.000Z" },
-        gateway: { mode: "local", auth: { mode: "none" } },
-      });
-      fs.writeFileSync(configPath, originalConfig);
-      seedPluginStateConflict(stateDir);
-      const runtimeRoot = createBuiltRuntime(root);
-
-      const result = runBuiltRuntime(
-        runtimeRoot,
-        env,
-        ["gateway", "run", "--allow-unconfigured"],
-        30_000,
-      );
-      const output = `${result.stderr}\n${result.stdout}`;
-
-      expect(result.error, output).toBeUndefined();
-      expect(result.status, output).toBe(1);
-      expect(result.signal, output).toBeNull();
-      expect(result.stderr).toContain(STARTUP_REFUSAL);
-      expect(result.stderr).toContain(STARTUP_RECOVERY);
-      expect(result.stderr.split(STARTUP_REFUSAL)).toHaveLength(2);
-      expect(result.stderr).not.toContain("[openclaw] Could not start the CLI.");
-      expect(fs.readFileSync(configPath, "utf8")).toBe(originalConfig);
-      expect(fs.existsSync(`${configPath}.bak`)).toBe(false);
-      expect(hasActiveStartupMigrationLease({ env })).toBe(false);
-    } finally {
-      await fs.promises.rm(root, { recursive: true, force: true });
-    }
-  }, 45_000);
 
   it("refuses before relocating legacy state when a live gateway owns the state directory", async () => {
     // Live owner fixture with gateway-shaped argv: on Windows no file-lock start

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
 import type { LegacyConfigIssue } from "../config/types.js";
+import { readStartupMigrationWarning } from "../infra/state-migrations.messages.js";
 import {
   listActiveDegradedPlugins,
   setActiveDegradedPlugins,
@@ -858,6 +859,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(autoMigrateLegacyPluginDoctorState).toHaveBeenCalledWith({
       config: { gateway: { mode: "local", port: 19091 } },
       env: process.env,
+      log: expect.any(Object),
     });
   });
 
@@ -876,24 +878,64 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(autoMigrateLegacyPluginDoctorState).toHaveBeenCalledWith({
       config: { gateway: { mode: "local", port: 19091 } },
       env: process.env,
+      log: expect.any(Object),
       doctorOnlyStateMigrations: true,
     });
   });
 
-  it("blocks gateway readiness when state migration warnings outlive the startup checkpoint", async () => {
-    needsStateMigrationCheckpoint.mockReturnValue(true);
-    needsStartupMigrationCheckpoint.mockReturnValue(false);
+  it.each([false, true])(
+    "allows warning-only startup with checkpoint required=%s",
+    async (required) => {
+      needsStateMigrationCheckpoint.mockReturnValue(true);
+      needsStartupMigrationCheckpoint.mockReturnValue(required);
+      autoMigrateLegacyStateDir.mockResolvedValueOnce({
+        migrated: false,
+        skipped: false,
+        changes: [],
+        warnings: ["Left legacy config health state in place."],
+      });
+
+      await expect(runDoctorConfigPreflight(startupCheckpointOptions)).resolves.toBeDefined();
+
+      expect(readStartupMigrationWarning()).toContain("Left legacy config health state in place.");
+      expect(readStartupMigrationWarning()).toContain(
+        'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
+      );
+      expect(note.mock.calls.filter(([, title]) => title === "Doctor warnings")).toHaveLength(0);
+      expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
+      expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+      expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+      await runDoctorConfigPreflight(startupCheckpointOptions);
+      expect(readStartupMigrationWarning()).toContain("Left legacy config health state in place.");
+    },
+  );
+
+  it("bounds and redacts startup warnings while preserving the Doctor follow-up", async () => {
+    const credential = "sk-" + "syntheticfixture".repeat(4);
     autoMigrateLegacyStateDir.mockResolvedValueOnce({
       migrated: false,
       skipped: false,
       changes: [],
-      warnings: ["Left legacy config health state in place."],
+      warnings: [`Detector token ${credential} ${"details ".repeat(1000)}`],
     });
+    await runDoctorConfigPreflight(startupCheckpointOptions);
+    const warning = readStartupMigrationWarning();
+    expect(warning).not.toContain(credential);
+    expect(warning?.length).toBeLessThan(2200);
+    expect(warning).toContain("… (see startup log)");
+    expect(warning).toContain(
+      'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
+    );
+  });
+
+  it("refuses startup and releases the lease when a migration errors", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    autoMigrateLegacyState.mockRejectedValueOnce(new Error("Canonical state cannot be read"));
 
     await expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
-      "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.",
+      "Canonical state cannot be read",
     );
-
+    expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
     expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -911,6 +911,7 @@ describe("runDoctorConfigPreflight state migration", () => {
   );
 
   it("bounds and redacts startup warnings while preserving the Doctor follow-up", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
     const credential = "sk-" + "syntheticfixture".repeat(4);
     autoMigrateLegacyStateDir.mockResolvedValueOnce({
       migrated: false,

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -35,7 +35,10 @@ import {
   readDoctorConfigPreflightSnapshot,
   type DoctorConfigPreflightPluginSnapshotRead,
 } from "./doctor-config-preflight-plugin-index.js";
-import { completeStartupMigrationPreflight } from "./doctor-config-preflight-startup.js";
+import {
+  completeStartupMigrationPreflight,
+  noteStateMigrationResult,
+} from "./doctor-config-preflight-startup.js";
 import * as cronMigration from "./doctor-config-preflight.cron.js";
 import { maybeRepairPluginOpenClawHostLinks } from "./doctor-plugin-host-links.js";
 import {
@@ -74,23 +77,6 @@ export function shouldSkipPluginValidationForDoctorConfigPreflight(
   return isTruthyEnvValue(env.OPENCLAW_UPDATE_IN_PROGRESS);
 }
 
-function noteStateMigrationResult(result: {
-  changes: string[];
-  warnings: string[];
-  notices?: string[];
-}): void {
-  if (result.changes.length > 0) {
-    note(result.changes.map((entry) => `- ${entry}`).join("\n"), "Doctor changes");
-  }
-  const notices = result.notices ?? [];
-  if (notices.length > 0) {
-    note(notices.map((entry) => `- ${entry}`).join("\n"), "Doctor notices");
-  }
-  if (result.warnings.length > 0) {
-    note(result.warnings.map((entry) => `- ${entry}`).join("\n"), "Doctor warnings");
-  }
-}
-
 /**
  * Runs early doctor config checks before the main config repair flow.
  *
@@ -122,6 +108,8 @@ export async function runDoctorConfigPreflight(
 ): Promise<DoctorConfigPreflightResult> {
   const stateMigrationsRequested = options.migrateState !== false;
   const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
+  // Startup publishes one aggregate report; ordinary Doctor calls keep their per-stage output.
+  const migrationLog = gatewayStartupCheckpointRequired ? { info() {}, warn() {} } : undefined;
   if (gatewayStartupCheckpointRequired) {
     // First preflight operation: state write admission below already quarantines orphaned
     // SQLite sidecars, so the live-owner refusal must precede every mutation-capable step.
@@ -227,7 +215,10 @@ export async function runDoctorConfigPreflight(
     notices?: string[];
   }) => {
     startupMigrationWarnings.push(...result.warnings);
-    noteStateMigrationResult(result);
+    noteStateMigrationResult({
+      ...result,
+      warnings: gatewayStartupCheckpointRequired ? [] : result.warnings,
+    });
   };
   const migrateLegacyConfigIfNeeded = async () => {
     if (legacyConfigMigrationComplete) {
@@ -311,7 +302,7 @@ export async function runDoctorConfigPreflight(
     if (stateDirMigrations && stateMigrationsAllowed) {
       const { autoMigrateLegacyStateDir } = stateDirMigrations;
       const stateDirResult = await measurePreflightStep("state-dir-migrations", () =>
-        autoMigrateLegacyStateDir({ env: process.env }),
+        autoMigrateLegacyStateDir({ env: process.env, log: migrationLog }),
       );
       noteStartupStateMigrationResult(stateDirResult);
     }
@@ -477,6 +468,7 @@ export async function runDoctorConfigPreflight(
                 autoMigrateLegacyPluginDoctorState({
                   config: pluginDoctorOnlyConfig,
                   env: process.env,
+                  log: migrationLog,
                   ...(options.doctorOnlyStateMigrations === true
                     ? { doctorOnlyStateMigrations: true }
                     : {}),
@@ -514,6 +506,7 @@ export async function runDoctorConfigPreflight(
                 cfg: migrationConfig,
                 ...(pluginDoctorConfig ? { pluginDoctorConfig } : {}),
                 env: process.env,
+                log: migrationLog,
                 recoverCorruptTargetStore: options.recoverCorruptTargetStore,
                 doctorOnlyStateMigrations: options.doctorOnlyStateMigrations,
                 ...(gatewayStartupCheckpointRequired
@@ -556,6 +549,7 @@ export async function runDoctorConfigPreflight(
                 autoMigrateLegacyPluginDoctorState({
                   config: pluginDoctorConfig,
                   env: process.env,
+                  log: migrationLog,
                   ...(options.doctorOnlyStateMigrations === true
                     ? { doctorOnlyStateMigrations: true }
                     : {}),
@@ -567,6 +561,7 @@ export async function runDoctorConfigPreflight(
             await measurePreflightStep("task-sidecar-migrations", () =>
               autoMigrateLegacyTaskStateSidecars({
                 env: process.env,
+                log: migrationLog,
               }),
             ),
           );
@@ -576,6 +571,7 @@ export async function runDoctorConfigPreflight(
           await measurePreflightStep("task-sidecar-migrations", () =>
             autoMigrateLegacyTaskStateSidecars({
               env: process.env,
+              log: migrationLog,
             }),
           ),
         );
@@ -597,13 +593,8 @@ export async function runDoctorConfigPreflight(
       );
     }
     // State migrations must consume retired locators before the config write removes them.
-    // Explicit Doctor repair commits after that attempt; startup still requires clean migration.
-    if (
-      automaticConfigRepair &&
-      stateMigrationsAllowed &&
-      freshConfigGuardAllowed &&
-      (activeConfigRepair || startupMigrationWarnings.length === 0)
-    ) {
+    // Unsafe migration failures throw; advisory findings must not strand repairable config.
+    if (automaticConfigRepair && stateMigrationsAllowed && freshConfigGuardAllowed) {
       if (gatewayStartupCheckpointRequired && !startupMigrationLease) {
         throw new Error("Automatic startup config repair requires the startup migration lease.");
       }
@@ -659,7 +650,6 @@ export async function runDoctorConfigPreflight(
       shouldPersistRefreshedPluginIndex &&
       stateMigrationsAllowed &&
       freshConfigGuardAllowed &&
-      startupMigrationWarnings.length === 0 &&
       snapshot.valid
     ) {
       const persistedSnapshotRead = await persistRefreshedPluginIndex({

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -133,6 +133,14 @@ describe("checkGatewayHealth", () => {
     expect(note.mock.calls.map(([, title]) => title)).not.toContain("OpenClaw version mismatch");
   });
 
+  it("reports startup migration warnings without marking the gateway unhealthy", async () => {
+    const startupMigrationWarning = 'Retained legacy state. Run "openclaw doctor --fix".';
+    callGateway.mockResolvedValueOnce({ startupMigrationWarning }).mockResolvedValue({});
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    await expect(checkGatewayHealth({ runtime, cfg })).resolves.toMatchObject({ healthOk: true });
+    expect(note).toHaveBeenCalledWith(startupMigrationWarning, "Startup migration warnings");
+  });
+
   it("renders the shared redacted telemetry exporter summary", async () => {
     callGateway
       .mockResolvedValueOnce({ ok: true })

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -112,6 +112,9 @@ export async function checkGatewayHealth(params: {
     });
     healthOk = true;
     noteCliGatewayVersionSkew(status);
+    if (status.startupMigrationWarning) {
+      note(sanitizeTerminalText(status.startupMigrationWarning), "Startup migration warnings");
+    }
     const secretDegradations = projectDoctorSecretRuntimeDegradations(status);
     if (secretDegradations.length > 0) {
       note(

--- a/src/commands/doctor-startup-migration-refusal.ts
+++ b/src/commands/doctor-startup-migration-refusal.ts
@@ -1,21 +1,6 @@
 // Gateway startup-migration readiness refusals shared by doctor config preflight.
 import { ExitError } from "../runtime.js";
 
-export function formatStartupMigrationFailure(params: {
-  warnings: string[];
-  blockers: string[];
-}): string {
-  const details = [
-    ...params.warnings.map((warning) => `- ${warning}`),
-    ...params.blockers.map((blocker) => `- ${blocker}`),
-  ];
-  return [
-    "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.",
-    ...details,
-    'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.',
-  ].join("\n");
-}
-
 export function throwStartupMigrationRefusal(message: string): never {
   // ExitError bypasses entry.ts's generic failure formatter, so report the owned reason here.
   console.error(message);

--- a/src/commands/status-overview-rows.test.ts
+++ b/src/commands/status-overview-rows.test.ts
@@ -218,6 +218,22 @@ describe("status-overview-rows", () => {
     expect(findRowValue(rows, "Degraded plugins")).toBe("warn(1 configured-unavailable · discord)");
   });
 
+  it.each(["default", "all"])("surfaces startup migration warnings in %s output", (mode) => {
+    const params = createStatusCommandOverviewRowsParams();
+    params.summary.startupMigrationWarning = "Retained legacy state. Run openclaw doctor --fix.";
+    const rows =
+      mode === "default"
+        ? buildStatusCommandOverviewRows(params)
+        : buildStatusAllOverviewRows({
+            ...params,
+            configPath: "/tmp/openclaw.json",
+            secretDiagnosticsCount: 0,
+          });
+    expect(findRowValue(rows, "Startup migrations")).toContain(
+      params.summary.startupMigrationWarning,
+    );
+  });
+
   it("builds status-all overview rows from the shared surface", () => {
     const summary = createStatusCommandOverviewRowsParams().summary;
     const rows = buildStatusAllOverviewRows({

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -33,13 +33,19 @@ import {
 } from "./status.command-sections.js";
 import type { MemoryPluginStatus, MemoryStatusSnapshot } from "./status.scan.shared.js";
 
-type StatusDegradationSummary = Pick<StatusSummary, "degradedSecretOwners" | "degradedPlugins">;
+type StatusDegradationSummary = Pick<
+  StatusSummary,
+  "degradedSecretOwners" | "degradedPlugins" | "startupMigrationWarning"
+>;
 
 function buildStatusDegradationRows(
   summary: StatusDegradationSummary,
   decorate = (value: string) => value,
 ) {
   const rows: Array<{ Item: string; Value: string }> = [];
+  if (summary.startupMigrationWarning) {
+    rows.push({ Item: "Startup migrations", Value: decorate(summary.startupMigrationWarning) });
+  }
   const secretOwners = summary.degradedSecretOwners ?? [];
   if (secretOwners.length > 0) {
     rows.push({

--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -144,7 +144,11 @@ describe("collectStatusScanOverview", () => {
     });
     mocks.callGateway.mockImplementation(async ({ method }: { method?: string }) =>
       method === "status"
-        ? { degradedSecretOwners: [], degradedPlugins: [] }
+        ? {
+            degradedSecretOwners: [],
+            degradedPlugins: [],
+            startupMigrationWarning: "Retained legacy state; run openclaw doctor --fix.",
+          }
         : { channelAccounts: {} },
     );
     mocks.collectChannelStatusIssues.mockReturnValue([{ channel: "quietchat", message: "boom" }]);
@@ -171,6 +175,9 @@ describe("collectStatusScanOverview", () => {
     expect(channelTableCall?.[1]?.showSecrets).toBe(false);
     expect(channelTableCall?.[1]?.sourceConfig).toStrictEqual({ session: { raw: true } });
     expect(result.channelIssues).toEqual([{ channel: "quietchat", message: "boom" }]);
+    expect(result.runtimeDegradation?.startupMigrationWarning).toBe(
+      "Retained legacy state; run openclaw doctor --fix.",
+    );
   });
 
   it("can keep channel overview on metadata-only status paths", async () => {

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -100,7 +100,10 @@ export type StatusScanOverviewResult = {
     | "gatewaySelf"
     | "gatewayCallOverrides"
   >;
-  runtimeDegradation: Pick<StatusSummary, "degradedSecretOwners" | "degradedPlugins"> | null;
+  runtimeDegradation: Pick<
+    StatusSummary,
+    "degradedSecretOwners" | "degradedPlugins" | "startupMigrationWarning"
+  > | null;
   channelsStatus: unknown;
   channelIssues: ReturnType<typeof collectChannelStatusIssuesFn>;
   channels: Awaited<ReturnType<typeof buildChannelsTableFn>>;
@@ -263,6 +266,7 @@ export async function collectStatusScanOverview(params: {
     runtimeDegradation = status && {
       degradedSecretOwners: status.degradedSecretOwners ?? [],
       degradedPlugins: status.degradedPlugins ?? [],
+      startupMigrationWarning: status.startupMigrationWarning,
     };
   }
 

--- a/src/gateway/server-methods/health.owner-routing.test.ts
+++ b/src/gateway/server-methods/health.owner-routing.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { recordStartupMigrationWarnings } from "../../infra/state-migrations.messages.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { healthHandlers } from "./health.js";
@@ -10,7 +11,7 @@ afterEach(() => {
   resetConfigRuntimeState();
 });
 
-async function callStatus(config: OpenClawConfig) {
+async function callStatus(config: OpenClawConfig, scopes = ["operator.read"]) {
   setRuntimeConfigSnapshot(config, config);
   const respond = vi.fn();
   await healthHandlers.status!({
@@ -18,7 +19,7 @@ async function callStatus(config: OpenClawConfig) {
     params: { includeChannelSummary: false },
     respond: respond as never,
     context: {} as never,
-    client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+    client: { connect: { role: "operator", scopes } } as never,
     isWebchatConnect: () => false,
   });
   return respond;
@@ -68,6 +69,31 @@ describe("Gateway status owner routing", () => {
       expect(respond).toHaveBeenCalledTimes(1);
       expect(respond.mock.calls[0]?.[0]).toBe(true);
       expect(respond.mock.calls[0]?.[2]).toBeUndefined();
+    });
+  });
+
+  it("limits startup migration details to admin status while readers retain the repair hint", async () => {
+    await withStateDirEnv("openclaw-gateway-status-warning-", async ({ stateDir }) => {
+      const warning = `EACCES: permission denied, open '${path.join(stateDir, "private-bindings.json")}'`;
+      recordStartupMigrationWarnings([warning]);
+      const config = {
+        agents: { entries: { main: {} } },
+        session: { store: path.join(stateDir, "sessions.json") },
+      };
+      const hint =
+        'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.';
+
+      const reader = await callStatus(config);
+      const readerPayload = reader.mock.calls[0]?.[1];
+      expect(reader.mock.calls[0]?.[0]).toBe(true);
+      expect(readerPayload.startupMigrationWarning).toContain(hint);
+      expect(readerPayload.startupMigrationWarning).not.toContain(stateDir);
+      expect(readerPayload.startupMigrationWarning).not.toContain("EACCES");
+
+      const admin = await callStatus(config, ["operator.admin"]);
+      expect(admin.mock.calls[0]?.[0]).toBe(true);
+      expect(admin.mock.calls[0]?.[1].startupMigrationWarning).toContain(warning);
+      expect(admin.mock.calls[0]?.[1].startupMigrationWarning).toContain(hint);
     });
   });
 });

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -17,7 +17,6 @@ import { migrateLegacyMainSessionKeys } from "../config/sessions/legacy-main-ses
 import { isPerAgentSessionStoreConfig } from "../config/sessions/session-store-config.js";
 import { resolveConfiguredAgentDatabaseTargets } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   collectRelevantDoctorPluginIds,
   listPluginDoctorSessionStoreAgentIds,
@@ -90,7 +89,11 @@ import {
   detectLegacyMeetingTranscripts,
   migrateLegacyMeetingTranscripts,
 } from "./state-migrations.meeting-transcripts.js";
-import { mergeNotices } from "./state-migrations.messages.js";
+import {
+  formatStartupMigrationFailure,
+  logStateMigrationResult,
+  mergeNotices,
+} from "./state-migrations.messages.js";
 import {
   detectLegacyNodeHostConfig,
   migrateLegacyNodeHostConfig,
@@ -1185,6 +1188,10 @@ export async function autoMigrateLegacyState(params: {
       ? repairOpenClawStateDatabaseSchema(stateSchemaOptions)
       : repairOpenClawStateDatabaseSchemaIfNeeded(stateSchemaOptions);
   if (stateSchema.warnings.length > 0) {
+    // A failed canonical schema repair is an error: runtime cannot safely open this store.
+    if (params.doctorOnlyStateMigrations !== true) {
+      throw new Error(formatStartupMigrationFailure(stateSchema.warnings));
+    }
     return {
       migrated: stateDirResult.migrated || stateSchema.changes.length > 0,
       skipped: false,
@@ -1193,6 +1200,12 @@ export async function autoMigrateLegacyState(params: {
       ...(stateDirResult.notices?.length ? { notices: stateDirResult.notices } : {}),
     };
   }
+  // Preserve retired locators before advisory early returns can permit config repair.
+  const pluginDoctorConfig = params.pluginDoctorConfig ?? params.cfg;
+  const configMachineState = migrateLegacyConfigMachineState({
+    config: pluginDoctorConfig,
+    env: { ...env, OPENCLAW_STATE_DIR: stateDir },
+  });
   const agentMigrationOptions = {
     configuredAgentDatabaseTargets: resolveConfiguredAgentDatabaseTargets(params.cfg, { env }),
     env: { ...env, OPENCLAW_STATE_DIR: stateDir },
@@ -1211,12 +1224,14 @@ export async function autoMigrateLegacyState(params: {
       migrated:
         stateDirResult.migrated ||
         stateSchema.changes.length > 0 ||
+        configMachineState.changes.length > 0 ||
         transcriptDirectives.changes.length > 0 ||
         mediaPersistence.changes.length > 0,
       skipped: false,
       changes: [
         ...stateDirResult.changes,
         ...stateSchema.changes,
+        ...configMachineState.changes,
         ...transcriptDirectives.changes,
         ...mediaPersistence.changes,
       ],
@@ -1233,11 +1248,6 @@ export async function autoMigrateLegacyState(params: {
     params.doctorOnlyStateMigrations === true
       ? migrateLegacyProfileWorkspace({ env, homedir })
       : { changes: [], warnings: [] };
-  const pluginDoctorConfig = params.pluginDoctorConfig ?? params.cfg;
-  const configMachineState = migrateLegacyConfigMachineState({
-    config: pluginDoctorConfig,
-    env: { ...env, OPENCLAW_STATE_DIR: stateDir },
-  });
   const pluginSessionStoreAgentIds = listPluginDoctorSessionStoreAgentIds({
     config: pluginDoctorConfig,
     env,
@@ -1275,25 +1285,6 @@ export async function autoMigrateLegacyState(params: {
           legacySessionSurfaces,
         })
       : { changes: [], warnings: [] };
-
-  const logMigrationResults = (changes: string[], warnings: string[], notices: string[]) => {
-    const logger = params.log ?? createSubsystemLogger("state-migrations");
-    if (changes.length > 0) {
-      logger.info(
-        `Auto-migrated legacy state:\n${changes.map((entry) => `- ${entry}`).join("\n")}`,
-      );
-    }
-    if (warnings.length > 0) {
-      logger.warn(
-        `Legacy state migration warnings:\n${warnings.map((entry) => `- ${entry}`).join("\n")}`,
-      );
-    }
-    if (notices.length > 0) {
-      logger.info(
-        `Legacy state migration notes:\n${notices.map((entry) => `- ${entry}`).join("\n")}`,
-      );
-    }
-  };
 
   const detected = await detectLegacyStateMigrations({
     cfg: params.cfg,
@@ -1408,7 +1399,7 @@ export async function autoMigrateLegacyState(params: {
       deviceAuth,
       deviceIdentity,
     ]);
-    logMigrationResults(changes, warnings, notices);
+    logStateMigrationResult({ changes, warnings, notices }, params.log);
     return {
       migrated: stateDirResult.migrated || changes.length > 0,
       skipped: false,
@@ -1447,7 +1438,7 @@ export async function autoMigrateLegacyState(params: {
     meetingTranscripts,
     ...migrations.finalNoticeSources,
   ]);
-  logMigrationResults(changes, warnings, notices);
+  logStateMigrationResult({ changes, warnings, notices }, params.log);
   return {
     // Custom agent roots omit transcript changes from their shared-state report.
     // Preserve the completed migration status without claiming agent ownership.

--- a/src/infra/state-migrations.messages.ts
+++ b/src/infra/state-migrations.messages.ts
@@ -40,8 +40,14 @@ export function recordStartupMigrationWarnings(warnings: readonly string[]): voi
   }
 }
 
-export function readStartupMigrationWarning(): string | undefined {
-  return startupMigrationWarning;
+export function readStartupMigrationWarning(includeSensitive = true): string | undefined {
+  // Migration errors can contain host paths; read-only status keeps only the repair hint.
+  return (
+    startupMigrationWarning &&
+    (includeSensitive
+      ? startupMigrationWarning
+      : `Startup migrations need attention. ${STARTUP_MIGRATION_FOLLOW_UP}`)
+  );
 }
 
 export function mergeNotices(sources: NoticeSource[]): string[] {

--- a/src/infra/state-migrations.messages.ts
+++ b/src/infra/state-migrations.messages.ts
@@ -1,5 +1,64 @@
+import { truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { redactSensitiveText } from "../logging/redact.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { MigrationLogger, MigrationMessages } from "./state-migrations.types.js";
+
 type NoticeSource = { notices?: readonly string[] } | undefined;
+
+const STARTUP_MIGRATION_FOLLOW_UP =
+  'Run "openclaw doctor --fix" against the same state/config, then restart the gateway.';
+
+export function formatStartupMigrationFailure(errors: readonly string[]): string {
+  return [
+    "OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.",
+    ...errors.map((error) => `- ${error}`),
+    STARTUP_MIGRATION_FOLLOW_UP,
+  ].join("\n");
+}
+
+let startupMigrationWarning: string | undefined;
+
+/** The running Gateway owns this boot fact; status and Doctor must not rerun migrations to infer it. */
+export function recordStartupMigrationWarnings(warnings: readonly string[]): void {
+  if (warnings.length === 0) {
+    return;
+  }
+  const details = sanitizeTerminalText(
+    redactSensitiveText([...new Set(warnings)].map((warning) => `- ${warning}`).join("\n"), {
+      mode: "tools",
+    }),
+  );
+  // Keep this boot fact until restart: a repeated preflight can skip already-checked migrations.
+  // Bound model-visible diagnostics; the startup log retains the full redacted report.
+  const summary = `${truncateWithMarker(details, 2000, { marker: "… (see startup log)", reserve: 20, trimEnd: true })}\n${STARTUP_MIGRATION_FOLLOW_UP}`;
+  if (startupMigrationWarning !== summary) {
+    startupMigrationWarning = summary;
+    createSubsystemLogger("state-migrations").warn(
+      `Startup migration warnings; continuing with degraded state.\n${details}\n${STARTUP_MIGRATION_FOLLOW_UP}`,
+    );
+  }
+}
+
+export function readStartupMigrationWarning(): string | undefined {
+  return startupMigrationWarning;
+}
 
 export function mergeNotices(sources: NoticeSource[]): string[] {
   return [...new Set(sources.flatMap((source) => (source?.notices ? [...source.notices] : [])))];
+}
+
+export function logStateMigrationResult(
+  result: MigrationMessages,
+  logger: MigrationLogger = createSubsystemLogger("state-migrations"),
+): void {
+  for (const [key, title, level] of [
+    ["changes", "Auto-migrated legacy state", "info"],
+    ["warnings", "Legacy state migration warnings", "warn"],
+    ["notices", "Legacy state migration notes", "info"],
+  ] as const) {
+    if (result[key]?.length) {
+      logger[level](`${title}:\n${result[key].map((entry) => `- ${entry}`).join("\n")}`);
+    }
+  }
 }

--- a/src/infra/state-migrations.plugin-doctor.ts
+++ b/src/infra/state-migrations.plugin-doctor.ts
@@ -12,6 +12,7 @@ import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { withAgentDatabaseMaintenanceLease } from "../state/openclaw-agent-db.js";
 import { repairOpenClawStateDatabaseSchemaIfNeeded } from "../state/openclaw-state-db.js";
 import { acquireGatewayLock } from "./gateway-lock.js";
+import { formatStartupMigrationFailure } from "./state-migrations.messages.js";
 import { createPluginDoctorStateMigrationContext } from "./state-migrations.plugin-doctor-context.js";
 import { autoMigrateLegacyStateDir } from "./state-migrations.state-dir.js";
 import type {
@@ -335,20 +336,17 @@ export async function autoMigrateLegacyPluginDoctorState(params: {
   const changes = [...stateDirResult.changes, ...stateSchema.changes];
   const warnings = [...stateDirResult.warnings, ...stateSchema.warnings];
   const notices = [...(stateDirResult.notices ?? [])];
-  if (stateSchema.warnings.length > 0) {
-    return {
-      migrated: stateDirResult.migrated || stateSchema.changes.length > 0,
-      skipped: false,
-      changes,
-      warnings,
-      ...(notices.length > 0 ? { notices } : {}),
-    };
+  if (stateSchema.warnings.length > 0 && params.doctorOnlyStateMigrations !== true) {
+    throw new Error(formatStartupMigrationFailure(stateSchema.warnings));
   }
   const input: PluginDoctorInput = { config: params.config, env, stateDir, oauthDir };
-  const plans = await collectPluginDoctorStateMigrationPlans(input, {
-    includeDoctorOnly: params.doctorOnlyStateMigrations === true,
-    warnings,
-  });
+  const plans =
+    stateSchema.warnings.length > 0
+      ? []
+      : await collectPluginDoctorStateMigrationPlans(input, {
+          includeDoctorOnly: params.doctorOnlyStateMigrations === true,
+          warnings,
+        });
   const migrated = await migratePluginDoctorStatePlans(input, plans);
   changes.push(...migrated.changes);
   warnings.push(...migrated.warnings);

--- a/src/infra/state-migrations.state-dir.ts
+++ b/src/infra/state-migrations.state-dir.ts
@@ -4,8 +4,8 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveProfileStateDir } from "../cli/profile-utils.js";
 import { resolveLegacyStateDirs, resolveNewStateDir, resolveStateDir } from "../config/paths.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isWithinDir } from "./path-safety.js";
+import { logStateMigrationResult } from "./state-migrations.messages.js";
 import {
   migrateLegacyInstalledPluginIndex,
   preflightLegacyInstalledPluginIndexMigration,
@@ -412,17 +412,7 @@ export async function autoMigrateLegacyTaskStateSidecars(params: {
 
   const stateDir = resolveStateDir(params.env ?? process.env, params.homedir);
   const result = await migrateLegacyTaskStateSidecars({ stateDir });
-  const logger = params.log ?? createSubsystemLogger("state-migrations");
-  if (result.changes.length > 0) {
-    logger.info(
-      `Auto-migrated legacy state:\n${result.changes.map((entry) => `- ${entry}`).join("\n")}`,
-    );
-  }
-  if (result.warnings.length > 0) {
-    logger.warn(
-      `Legacy state migration warnings:\n${result.warnings.map((entry) => `- ${entry}`).join("\n")}`,
-    );
-  }
+  logStateMigrationResult(result, params.log);
   return {
     migrated: result.changes.length > 0,
     skipped: false,

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1103,10 +1103,11 @@ describe("state migrations", () => {
       database.close();
     }
     const store = path.join(root, "legacy-jobs.json");
-    const result = await autoMigrateLegacyState({
-      cfg: { agents: { ownership: "explicit", entries: { main: {} } }, cron: { store } },
-      env,
-    });
+    const cfg: OpenClawConfig & { cron: { store: string } } = {
+      agents: { ownership: "explicit", entries: { main: {} } },
+      cron: { store },
+    };
+    const result = await autoMigrateLegacyState({ cfg, env });
     expect(result.warnings).toContainEqual(
       expect.stringContaining("invalid historical transcript migration cursor"),
     );

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -1080,6 +1080,40 @@ describe("state migrations", () => {
     );
   });
 
+  it("preserves retired config locators before an advisory transcript migration return", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const databasePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    fsSync.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const database = new DatabaseSync(databasePath);
+    try {
+      ensureOpenClawAgentDatabaseSchema(database, {
+        agentId: "main",
+        env,
+        path: databasePath,
+        register: false,
+      });
+      database
+        .prepare(
+          "INSERT INTO schema_meta(meta_key,role,schema_version,agent_id,app_version,created_at,updated_at) VALUES(?,?,?,?,?,?,?)",
+        )
+        .run("historical-transcript-directives-v1", "agent", 1, "main", "invalid-json", 1, 1);
+    } finally {
+      database.close();
+    }
+    const store = path.join(root, "legacy-jobs.json");
+    const result = await autoMigrateLegacyState({
+      cfg: { agents: { ownership: "explicit", entries: { main: {} } }, cron: { store } },
+      env,
+    });
+    expect(result.warnings).toContainEqual(
+      expect.stringContaining("invalid historical transcript migration cursor"),
+    );
+    expect(readConfigMachineState("cron.store", { env })).toBe(store);
+    expect(result.changes).toContain("Migrated cron.store → shared SQLite state");
+  });
+
   it("ignores a schema-only legacy agent database without selecting an owner", async () => {
     const root = await createTempDir();
     const stateDir = path.join(root, ".openclaw");
@@ -1114,7 +1148,7 @@ describe("state migrations", () => {
   });
 
   it.each([null, "", "   "])(
-    "keeps a schema-only legacy agent database with invalid owner %j blocking",
+    "preserves a schema-only legacy agent database with invalid owner %j as advisory",
     async (agentId) => {
       const root = await createTempDir();
       const stateDir = path.join(root, ".openclaw");
@@ -1125,13 +1159,8 @@ describe("state migrations", () => {
       const databasePath = seedSchemaOnlyLegacyAgentDatabase(stateDir, { agentId });
 
       const automatic = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
-
-      expect(automatic.skipped).toBe(false);
       expect(automatic.warnings).toContainEqual(
         expect.stringContaining("agent schema owner is missing or blank"),
-      );
-      expect(automatic.notices ?? []).not.toContain(
-        "Deferred legacy agent/session migration: select an agent owner",
       );
       expect(fsSync.existsSync(databasePath)).toBe(true);
       expect(fsSync.existsSync(path.join(stateDir, "agents", "main", "agent"))).toBe(false);
@@ -3823,15 +3852,13 @@ describe("state migrations", () => {
       },
     ];
 
-    const result = await autoMigrateLegacyPluginDoctorState({
-      config: cfg,
-      env,
-      homedir: () => root,
-    });
-
-    expect(result.changes).toStrictEqual([]);
-    expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toContain("Failed migrating shared state database schema");
+    await expect(
+      autoMigrateLegacyPluginDoctorState({
+        config: cfg,
+        env,
+        homedir: () => root,
+      }),
+    ).rejects.toThrow("Failed migrating shared state database schema");
     expect(detectLegacyState).not.toHaveBeenCalled();
     expect(migrateLegacyState).not.toHaveBeenCalled();
   });
@@ -3853,13 +3880,9 @@ describe("state migrations", () => {
       db.close();
     }
 
-    const result = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
-
-    expect(result.migrated).toBe(false);
-    expect(result.skipped).toBe(false);
-    expect(result.changes).toStrictEqual([]);
-    expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toContain("Failed migrating shared state database schema");
+    await expect(autoMigrateLegacyState({ cfg, env, homedir: () => root })).rejects.toThrow(
+      "Failed migrating shared state database schema",
+    );
     await expect(fs.readFile(voiceWakePath, "utf8")).resolves.toContain("leave-me");
     await expect(fs.stat(`${voiceWakePath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -525,7 +525,7 @@ export async function getStatusSummary(
     },
     channelSummary,
     queuedSystemEvents,
-    startupMigrationWarning: readStartupMigrationWarning(),
+    startupMigrationWarning: readStartupMigrationWarning(includeSensitive),
     degradedSecretOwners: listActiveDegradedSecretOwners().map(
       ({ ownerKind, ownerId, state, degradationState, paths: ownerPaths, reason }) => {
         const redactedReason: string = redactSecretDegradationReason(reason);

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -25,6 +25,7 @@ import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
 import { resolveHeartbeatSessionKey } from "../infra/heartbeat-runner-session.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
 import { hasResolvableHeartbeatOwnerRoute } from "../infra/outbound/targets.js";
+import { readStartupMigrationWarning } from "../infra/state-migrations.messages.js";
 import { peekSystemEvents } from "../infra/system-events.js";
 import {
   listActiveDegradedPlugins,
@@ -524,6 +525,7 @@ export async function getStatusSummary(
     },
     channelSummary,
     queuedSystemEvents,
+    startupMigrationWarning: readStartupMigrationWarning(),
     degradedSecretOwners: listActiveDegradedSecretOwners().map(
       ({ ownerKind, ownerId, state, degradationState, paths: ownerPaths, reason }) => {
         const redactedReason: string = redactSecretDegradationReason(reason);

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -73,6 +73,7 @@ export type StatusSummary = {
   };
   channelSummary: string[];
   queuedSystemEvents: string[];
+  startupMigrationWarning?: string;
   degradedSecretOwners?: Array<{
     ownerKind: "account" | "capability" | "gateway" | "provider" | "route";
     ownerId: string;


### PR DESCRIPTION
## What Problem This Solves

Fixes #135150. A single advisory migration finding currently exits Gateway startup with code 1, so launchd/systemd repeatedly restarts an otherwise usable Gateway. This implements the maintainer decision to start visibly degraded on migration warnings, without a configuration switch.

## Why This Change Was Made

Startup preflight owned the wrong severity policy: it aggregated detector warnings and passed every nonempty result to the fatal refusal helper. Warnings also prevented otherwise valid automatic config repair and refreshed plugin-index persistence, creating indirect refusals. The preflight now completes those operations, records a bounded/redacted boot diagnostic, logs one aggregate warning with the exact Doctor follow-up, and continues. Unfinished migrations do not receive successful state/startup checkpoints; a later restart retries them. Retired machine-owned config locators are preserved before advisory early returns, so config repair cannot remove their last retained values.

Required-state errors remain fatal at their migration owner: failed canonical shared-schema repair throws before unsafe state can be consumed. Unassigned legacy agent files remain untouched and advisory; active per-agent databases still enforce their own schema/owner validation. Existing config, live-owner, migration-lease, and plugin-verification guards remain intact. Migration output now uses one shared logger instead of duplicate formatting paths. Status (including remote and --all) and Doctor consume the recorded Gateway fact rather than rerunning migration detection. The existing admin-sensitive status projection restricts warning paths/error details to administrators; read-only operators still receive the warning and exact repair hint.

Provenance was checked with replacement objects disabled: raw commit `b81666ca6af25c86cc099983a4358cdc5ea9ced8` (#101881, “Fix container image upgrade migrations before gateway readiness”) records parent `aa27ae9d9f37ee1127f89952e1dfeb9fb8577b99`. The explicit raw-parent diff adds the warning-or-blocker refusal; the parent lacks it. The original change intentionally blocked startup on plugin repair warnings during container upgrades. `ef18fbe56684416136d0111e0c9c4f323bda0ae9` later moved the existing policy into the startup helper, rather than introducing it. The same gate is present in shipped `v2026.8.1`.

The reported Codex producer is already repaired on main by `eefe8bdc16571a952302c571f89cc8c46b5486cc` (#123331). `extensions/codex/src/migration/session-binding-sidecars.ts:128` supplies explicit directory/store ownership; `:427` classifies missing ownership and preserves ambiguous shared-root bindings. This PR verifies that existing repair instead of adding another compatibility shim or guessing an agent from a thread ID. Direct upstream source inspection at `openai/codex` revision `0ae94fdd49b05ee7faa4d984d06a68492cb32b54` checked `codex-rs/protocol/src/thread_id.rs:12` (UUID thread identity), `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1368` and `:1520` (thread/list filters and opaque pagination), and `codex-rs/app-server/src/request_processors/thread_processor.rs:238` (cwd normalization). None provides an OpenClaw agent owner.

## User Impact

A retained sidecar conflict or plugin detection warning no longer causes a supervisor crash loop. The Gateway remains reachable, reports the warning in status/Doctor, and says: `Run "openclaw doctor --fix" against the same state/config, then restart the gateway.` Unsafe required state still refuses startup. No config option, environment variable, schema, migration version, or compatibility route is added. The Doctor and restart-recovery documentation now describe the distinction.

## Evidence

- Before the production change, both `allows warning-only startup with checkpoint required=false/true` failed with `AssertionError: promise rejected "ExitError: OpenClaw startup migrations di… { code: 1 }" instead of resolving`. The migration-error case passed. A direct source preflight reproduction also exited 1 at the old warning refusal. The initial Vitest attempt was interrupted during slow compilation; the retry produced the stated failure summary before its slow teardown was interrupted.
- Focused warning/status/Doctor coverage: 75 tests passed across four files. Checks include default status, remote status propagation, `--all`, warning-only startup with/without checkpoint refresh, migration error refusal, lease release, and retained diagnostics.
- Final focused warning regression: `pnpm test src/commands/doctor-config-preflight.state-migration.test.ts --pool threads -t 'warning-only|bounds and redacts|when a migration errors'` — 4 passed. This includes bounded/redacted diagnostics and the unchanged Doctor follow-up.
- Local selected migration suite: 7 passed (retired locator early-return preservation, advisory unknown legacy owners, canonical shared-schema failures). Command/status/Doctor suites had 58 passing tests; their one new bounds fixture initially did not request migrations, was corrected, and passed the final focused rerun above.
- Blacksmith Testbox `tbx_01m1fs37qhes40p5cbzvs91m5n`: 13 focused core/Codex cases passed; all 5 selected process cases passed after preserving the fixture Gateway port. [Remote run](https://github.com/openclaw/openclaw/actions/runs/33576459600). The real Gateway reached `/readyz`, logged the warning once and the exact hint, returned its warning through the status RPC, retained the conflicting sidecar, and quarantined malformed automation. Upgrade/config repair, ownerless legacy state, and live-owner fencing passed. No timeout changes or auth bypass. Lease stopped and verified completed.
- Remote candidate identity was verified by seven consequential source SHA-256 hashes against local source; the hydrated `.git` banner was not used as candidate proof. The final process fixture differs from its remotely tested form only by formatting.
- Local process proof encountered host-load timeouts (30-second readiness and 60-second source process); the same scenarios passed on isolated Testbox. Initial CI found a test-only retired `cron.store` type error; the fixture now declares its historical shape explicitly. The first remote status probe exposed a fixture port omission (ECONNREFUSED at default 18789), corrected by retaining the allocated port.
- Final Codex ownership regression: `pnpm test extensions/codex/doctor-contract-api.test.ts --pool threads -t 'ambiguous shared-root|fixed-store owner|explicit owner'` — 4 passed, including both missing/absent system-owner cases.
- Final branch autoreview: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`; `overall: patch is correct (0.97)`.
- Exact-head CI: **GREEN**, watcher exit 0, on `3a68a6a8ef0f08967d2de1b80ac646d1856b76b1` in [run 33577099567](https://github.com/openclaw/openclaw/actions/runs/33577099567). This was the pre-privacy-fix head. A late ClawSweeper review correctly found that raw diagnostic paths needed the existing admin/read projection; that finding is being repaired before landing.
- LOC: production +152/-111 (net +41); tests +183/-96 (net +87); docs +10/-2. The new boot diagnostic, bounded/redacted serialization, and remote status/Doctor propagation require the remaining growth; duplicate migration log/note formatting was consolidated within the same owner. No baseline/budget/inventory/snapshot edits.
- Uncommitted autoreview: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`; final result `overall: patch is correct (0.98)`. The subsequent branch review completed cleanly as recorded above.

- Independent ordering reproduction: a synthetic historical-transcript cursor warning previously returned with `cron.store` absent from machine state and exited 1 on the preservation assertion. The identical probe now exits 0 with the warning retained and the exact locator preserved.

- ClawSweeper privacy finding addressed on `30faeccdd1f07eeae98ec685b1d964d987421734`: read-only status gets a generic warning plus the same Doctor hint; admin status retains bounded/redacted detail. `pnpm test src/gateway/server-methods/health.owner-routing.test.ts --pool threads` passed all 3 tests. The new `limits startup migration details to admin status while readers retain the repair hint` case first failed on the prior source because reader status contained the synthetic private state path (exit 1); after the fix, both reader/admin branches pass (exit 0). Uncommitted autoreview: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`; `overall: patch is correct (0.98)`. Exact-head CI and refreshed branch review are pending for this replacement head.

- Follow-up CI caught one stale process-test expectation on the privacy-fix head: read-only status correctly returned the safe summary rather than detailed sidecar text (504 other tests in that shard passed). `43e27fec988bb2cbfe430d621ef156994e835d65` updates that assertion to the exact reader-safe summary and hint, retaining the separate full-log assertion. `pnpm test src/commands/doctor-config-preflight.process.test.ts --pool threads -t 'boots with migration warnings'` now passes locally through the real Gateway (1 passed, exit 0; 6.9s test). The complete privacy changed-file check passed, exit 0. Uncommitted fixture review is scoped-clean, overall patch is correct (0.99). Final-head CI is running.

Final disposition: **GREEN** on `43e27fec988bb2cbfe430d621ef156994e835d65`, watcher exit 0, [CI run 33579856873](https://github.com/openclaw/openclaw/actions/runs/33579856873). Final branch autoreview is scoped-clean, `overall: patch is correct (0.96)`. The latest ClawSweeper review (01:40 UTC) has no findings or security concerns. Its exact-head CI rank-up move is complete. Peter explicitly accepted warning-only degraded startup before implementation; the required-state fatal boundary remains unchanged in intent and verified.
