### PR TITLE
refactor(signal): share delivered conversation key

### DIFF
--- a/extensions/signal/src/aliases.test.ts
+++ b/extensions/signal/src/aliases.test.ts
@@ -1,7 +1,11 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Signal tests cover alias target resolution behavior.
 import { describe, expect, it } from "vitest";
-import { listSignalAliasDirectoryEntries, resolveSignalTarget } from "./aliases.js";
+import {
+  listSignalAliasDirectoryEntries,
+  resolveSignalDeliveredConversationKey,
+  resolveSignalTarget,
+} from "./aliases.js";
 
 describe("resolveSignalTarget aliases", () => {
   it("resolves top-level DM aliases to canonical targets", () => {
@@ -48,6 +52,13 @@ describe("resolveSignalTarget aliases", () => {
       source: "alias",
     });
     expect(resolveSignalTarget({ cfg, accountId: "work", input: "home" })?.to).toBe("+15551234567");
+    expect(
+      resolveSignalDeliveredConversationKey({
+        cfg,
+        accountId: "work",
+        to: "ops",
+      }),
+    ).toBe("group:VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=");
   });
 
   it("rejects recursive aliases before delivery", () => {
@@ -65,6 +76,12 @@ describe("resolveSignalTarget aliases", () => {
     expect(() => resolveSignalTarget({ cfg, input: "home" })).toThrow(
       'Signal alias "home" resolves recursively through "home".',
     );
+    expect(
+      resolveSignalDeliveredConversationKey({
+        cfg,
+        to: "signal:home",
+      }),
+    ).toBe("home");
   });
 
   it("rejects aliases whose final value is not a Signal target", () => {

--- a/extensions/signal/src/aliases.ts
+++ b/extensions/signal/src/aliases.ts
@@ -142,6 +142,28 @@ export function resolveSignalTarget(params: {
   return null;
 }
 
+export function resolveSignalDeliveredConversationKey(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  to: string;
+}): string | null {
+  // Delivery already succeeded, so conversation-key recovery is fail-soft.
+  // Approval route revalidation stays fail-closed in approval-reaction-routes.ts.
+  try {
+    return (
+      resolveSignalTarget({
+        cfg: params.cfg,
+        accountId: params.accountId,
+        input: params.to,
+      })?.to ??
+      normalizeSignalMessagingTarget(params.to) ??
+      null
+    );
+  } catch {
+    return normalizeSignalMessagingTarget(params.to) ?? null;
+  }
+}
+
 export function listSignalAliasDirectoryEntries(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -25,7 +25,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
-import { resolveSignalTarget } from "./aliases.js";
+import { resolveSignalDeliveredConversationKey } from "./aliases.js";
 import { getSignalApprovalApprovers, signalApprovalAuth } from "./approval-auth.js";
 import {
   buildTargetRoute,
@@ -90,24 +90,6 @@ const signalApprovalReactionTargets =
 
 export function resolveSignalApprovalConversationKey(to: string): string | null {
   return normalizeSignalMessagingTarget(to) ?? null;
-}
-
-function resolveSignalApprovalConversationKeyForDeliveredTarget(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  to: string;
-}): string | null {
-  try {
-    return (
-      resolveSignalTarget({
-        cfg: params.cfg,
-        accountId: params.accountId,
-        input: params.to,
-      })?.to ?? resolveSignalApprovalConversationKey(params.to)
-    );
-  } catch {
-    return resolveSignalApprovalConversationKey(params.to);
-  }
 }
 
 function normalizeSignalApprovalTargetAuthorKey(value: string): string | null {
@@ -385,7 +367,7 @@ export function registerSignalApprovalReactionTargetForDeliveredPayload(params: 
   ) {
     return false;
   }
-  const conversationKey = resolveSignalApprovalConversationKeyForDeliveredTarget({
+  const conversationKey = resolveSignalDeliveredConversationKey({
     cfg: params.cfg,
     accountId: params.target.accountId,
     to: params.target.to,

--- a/extensions/signal/src/question-reactions.ts
+++ b/extensions/signal/src/question-reactions.ts
@@ -7,11 +7,8 @@ import {
 } from "openclaw/plugin-sdk/question-gateway-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
-import { resolveSignalTarget } from "./aliases.js";
-import {
-  resolveSignalApprovalConversationKey,
-  resolveSignalApprovalTargetAuthorKeys,
-} from "./approval-reactions.js";
+import { resolveSignalDeliveredConversationKey } from "./aliases.js";
+import { resolveSignalApprovalTargetAuthorKeys } from "./approval-reactions.js";
 
 type SignalQuestionReactionIdentity = {
   accountId: string;
@@ -39,24 +36,6 @@ const questionReactionTargets = createQuestionReactionTargetStore<
   resolveReaction: questionGatewayRuntime.resolveReaction,
 });
 
-function resolveConversationKey(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  to: string;
-}): string | null {
-  try {
-    return (
-      resolveSignalTarget({
-        cfg: params.cfg,
-        accountId: params.accountId,
-        input: params.to,
-      })?.to ?? resolveSignalApprovalConversationKey(params.to)
-    );
-  } catch {
-    return resolveSignalApprovalConversationKey(params.to);
-  }
-}
-
 export function registerSignalQuestionReactionTargetForDeliveredPayload(params: {
   cfg: OpenClawConfig;
   target: { channel: string; to: string; accountId?: string | null };
@@ -69,7 +48,10 @@ export function registerSignalQuestionReactionTargetForDeliveredPayload(params: 
   if (params.target.channel !== "signal" || !binding) {
     return false;
   }
-  const conversationKey = resolveConversationKey({ cfg: params.cfg, ...params.target });
+  const conversationKey = resolveSignalDeliveredConversationKey({
+    cfg: params.cfg,
+    ...params.target,
+  });
   const targetAuthorKeys = resolveSignalApprovalTargetAuthorKeys(params);
   if (!conversationKey || targetAuthorKeys.length === 0) {
     return false;


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested duplication cleanup: Signal question reactions and approval reactions independently recovered the same canonical conversation key after a successful delivery. Keeping the same fail-soft policy in two transport paths made account-scoped alias handling and fallback behavior vulnerable to drift.

## Why This Change Was Made

The Signal alias owner now exposes one internal `resolveSignalDeliveredConversationKey` helper. Both delivered reaction-registration paths use it, and the duplicate `resolveConversationKey` and `resolveSignalApprovalConversationKeyForDeliveredTarget` implementations are removed.

The owner boundary is intentional: delivery already succeeded, so conversation-key recovery falls back to the normalized delivered target when alias or account resolution throws. Approval route revalidation remains fail-closed in `approval-reaction-routes.ts`. No SDK, core, new module, configuration, store, persistence, or public contract changed.

## User Impact

No user-visible behavior changes. Signal ask-user and approval reactions retain the same account-scoped alias resolution, store keys, message filtering, author matching, and target normalization.

## Evidence

- Root cause: two byte-equivalent delivered-target recovery policies lived in separate reaction modules.
- Architectural owner: `extensions/signal/src/aliases.ts`, beside `resolveSignalTarget`.
- Removed paths: local recovery helpers in `question-reactions.ts` and `approval-reactions.ts`.
- Production LOC: `+30/-44`, net `-14`.
- Test LOC: `+18/-1`, net `+17`.
- Focused Signal proof, before and after the final rebase: 6 files and 47 tests passed in each run.
- `pnpm check:import-cycles`: 0 runtime value cycles, before and after rebase.
- `git diff --check`: passed.
- Exact autoreview command passed before and after rebase; score `0.98`, no accepted/actionable findings.
- `check:changed` passed formatting, boundaries, contract tests, production extension typecheck, and all preceding guards. Its extension-test typecheck is blocked by the sparse worktree omitting unrelated Control UI config modules: `ui/config/control-ui-locales.ts`, `control-ui-chunking.ts`, and `control-ui-hover-guard.ts`.
- `pnpm build` completed compilation, package builds, external plugin local dist, and CLI bootstrap checks. Runtime postbuild is blocked by the shared install's stale `@openclaw/ai/diagnostics`, which lacks `hasRetryableConnectionErrorCode`.
- Overlap rechecked immediately before push: #130223 remains open at `7395b9e923ccb874dad72dff3d59471ad0c39016`; #123075 remains open at `8300e46d4a5db58c4f847d60d94bde644bad6fe9`. Their reviewed heads did not move. The former still deletes the question-reaction surface; the latter remains outside imports and conversation-key logic.
- Rebasing once onto `b060c7a1105dc7a51b80c129a20eb4c6e0967fdd` preserved the patch ID. Four later `main` commits were checked before push and touch no Signal files.
- Codex gate inspected directly at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI/completion paths are unrelated.
- No Crabbox run: this is deterministic plugin-internal code motion with focused transport-boundary coverage and no external API or user-visible behavior change.
