### PR TITLE
test(plugins): cover startup consent convergence

### DIFF
--- a/src/commands/doctor-config-preflight-plugin-verification.test.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.test.ts
@@ -1,5 +1,35 @@
-import { describe, expect, it } from "vitest";
-import { formatStartupPluginVerificationFailure } from "./doctor-config-preflight-plugin-verification.js";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  readPersistedInstalledPluginIndexInstallRecords,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "../plugins/installed-plugin-index-records.js";
+import { listOfficialExternalPluginCatalogEntries } from "../plugins/official-external-plugin-catalog.js";
+import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
+import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import {
+  formatStartupPluginVerificationFailure,
+  runStartupUpgradeConvergence,
+} from "./doctor-config-preflight-plugin-verification.js";
+import { runPostCorePluginConvergence } from "./doctor/shared/post-core-plugin-convergence.js";
+
+const npmInstall = vi.hoisted(() =>
+  vi.fn<typeof import("../plugins/install.js").installPluginFromNpmSpec>(() => {
+    throw new Error("unselected plugin reached package installation");
+  }),
+);
+vi.mock("../plugins/install.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/install.js")>()),
+  installPluginFromNpmSpec: npmInstall,
+}));
+vi.mock("../plugins/clawhub.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/clawhub.js")>()),
+  installPluginFromClawHub: () => {
+    throw new Error("unselected plugin reached ClawHub installation");
+  },
+}));
 
 describe("formatStartupPluginVerificationFailure", () => {
   it("uses install-neutral gateway restart guidance", () => {
@@ -16,4 +46,166 @@ describe("formatStartupPluginVerificationFailure", () => {
       ].join("\n"),
     );
   });
+});
+
+describe.each(["startup", "repair"] as const)("%s consent inventory", (first) => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  afterEach(() => npmInstall.mockReset());
+
+  async function converge(
+    cfg: Parameters<typeof runStartupUpgradeConvergence>[0]["cfg"],
+    env: NodeJS.ProcessEnv,
+  ) {
+    if (first === "startup") {
+      expect(await runStartupUpgradeConvergence({ cfg, env })).toEqual({
+        blockingDiagnostic: null,
+        quarantinedPlugins: [],
+      });
+    } else {
+      expect((await runPostCorePluginConvergence({ cfg, env })).warnings).toEqual([]);
+    }
+  }
+
+  it.each([false, true])(
+    "does not install catalog-only plugins or retained bundled records (retained=%s)",
+    async (retained) => {
+      npmInstall.mockClear();
+      const home = tempDirs.make("openclaw-consent-inventory-");
+      const bundledRoot = path.join(home, "bundled");
+      const pluginId = "bundled-consent-fixture";
+      const packageName = "@openclaw/bundled-consent-fixture";
+      const rootDir = path.join(bundledRoot, pluginId);
+      fs.mkdirSync(rootDir, { recursive: true });
+      const fixture = createColdPluginFixture({ rootDir, pluginId, packageName });
+      const env = {
+        HOME: home,
+        OPENCLAW_STATE_DIR: path.join(home, "state"),
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        VITEST: "true",
+      };
+      const cfg = { plugins: { allow: ["selected-fixture"] } };
+      await withPluginCache(createPluginCache(), async () => {
+        await writePersistedInstalledPluginIndexInstallRecords(
+          retained
+            ? {
+                [pluginId]: {
+                  source: "npm",
+                  spec: packageName,
+                  resolvedName: packageName,
+                  installPath: path.join(home, "missing-payload"),
+                },
+              }
+            : {},
+          { config: cfg, env },
+        );
+      });
+      expect(listOfficialExternalPluginCatalogEntries().length).toBeGreaterThan(0);
+      for (let start = 0; start < 2; start += 1) {
+        await withPluginCache(createPluginCache(), async () => {
+          await converge(cfg, env);
+          const repair = await runPostCorePluginConvergence({ cfg, env });
+          expect(repair.warnings).toEqual([]);
+          expect(repair.installRecords).toEqual({});
+        });
+        // A completed lifecycle changes the next generation, not the invoking snapshot.
+        const persisted = await withPluginCache(createPluginCache(), () =>
+          readPersistedInstalledPluginIndexInstallRecords({ env }),
+        );
+        expect(persisted).toEqual({});
+      }
+      expect(npmInstall).not.toHaveBeenCalled();
+      expect(fs.existsSync(fixture.runtimeMarker)).toBe(false);
+    },
+  );
+
+  it.each([
+    {
+      envVar: "OPENCODE_API_KEY",
+      packages: {
+        opencode: "@openclaw/opencode-provider",
+        "opencode-go": "@openclaw/opencode-go-provider",
+      },
+    },
+    { envVar: "OPENROUTER_API_KEY", packages: { perplexity: "@openclaw/perplexity-plugin" } },
+  ])(
+    "converges verified official packages selected only by $envVar",
+    async ({ envVar, packages }) => {
+      const home = tempDirs.make("openclaw-consent-env-");
+      const bundledRoot = path.join(home, "bundled");
+      fs.mkdirSync(bundledRoot, { recursive: true });
+      const env = {
+        HOME: home,
+        OPENCLAW_STATE_DIR: path.join(home, "state"),
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+        VITEST: "true",
+        [envVar]: "synthetic-credential",
+      };
+      const cfg = { plugins: { allow: ["selected-fixture"] } };
+      const runtimeMarkers: string[] = [];
+      npmInstall.mockClear();
+      npmInstall.mockImplementation(async (params) => {
+        const pluginId = params.expectedPluginId;
+        const packageName = Object.entries(packages).find(([id]) => id === pluginId)?.[1];
+        if (!pluginId || !packageName) {
+          throw new Error(`Unexpected plugin install: ${params.spec}`);
+        }
+        const rootDir = path.join(home, "installed", pluginId);
+        fs.mkdirSync(rootDir, { recursive: true });
+        const fixture = createColdPluginFixture({
+          rootDir,
+          pluginId,
+          packageName,
+          providerId: pluginId,
+          manifest: { channels: [], channelConfigs: {}, providerAuthChoices: [] },
+        });
+        runtimeMarkers.push(fixture.runtimeMarker);
+        const npmResolution = {
+          name: packageName,
+          version: "1.0.0",
+          resolvedSpec: `${packageName}@1.0.0`,
+          integrity: "sha512-synthetic-fixture",
+        };
+        await params.onBeforePluginArtifactCommit?.({
+          pluginId,
+          stagedArtifactDir: rootDir,
+          mode: "install",
+          sourceRecord: {
+            source: "npm",
+            spec: params.spec,
+            resolvedName: packageName,
+            resolvedSpec: npmResolution.resolvedSpec,
+          },
+        });
+        return {
+          ok: true,
+          pluginId,
+          targetDir: rootDir,
+          version: "1.0.0",
+          extensions: ["./index.cjs"],
+          npmResolution,
+        };
+      });
+      await withPluginCache(createPluginCache(), async () => {
+        await converge(cfg, env);
+      });
+      await withPluginCache(createPluginCache(), async () => {
+        const repair = await runPostCorePluginConvergence({ cfg, env });
+        expect(repair.warnings).toEqual([]);
+        expect(Object.keys(repair.installRecords).toSorted()).toEqual(
+          Object.keys(packages).toSorted(),
+        );
+        for (const [pluginId, packageName] of Object.entries(packages)) {
+          expect(repair.installRecords[pluginId]).toMatchObject({
+            source: "npm",
+            resolvedName: packageName,
+          });
+          expect(repair.installRecords[pluginId]?.acceptedSurface).toBeUndefined();
+        }
+      });
+      expect(npmInstall).toHaveBeenCalledTimes(Object.keys(packages).length);
+      expect(runtimeMarkers.some((marker) => fs.existsSync(marker))).toBe(false);
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Protect the startup/update-repair boundary behind #135233 and the stable-release follow-up in #135171. The reports are reproducible on published 2026.8.2, but current main already contains the runtime correction in #134933 (`f54f806b272829fa6b33d45da0f611a70f8f418b`). This PR adds cross-owner regression coverage; it does not introduce another consent policy or remove catalog entries.

Fixes #135233.

## Why This Change Was Made

A catalog entry alone does not select a plugin. The configured-plugin inventory also infers providers from environment credentials: `OPENROUTER_API_KEY` can select Perplexity, and the OpenCode credential selects OpenCode Zen/Go. On 2026.8.2, package staging requests consent before committing the install, so ordinary plugin commands correctly report no installed plugin while startup is blocked waiting for consent. Main now recognizes verified official package provenance at that staging boundary.

The other suspected cause—retained managed install records for packages now bundled—is already retired by the shared convergence owner, including in 2026.8.2. The tests preserve that behavior and prove durable removal across cold cache generations. They run startup-first and repair-first, so one entry point cannot mask a defect in the other.

## User Impact

No new runtime behavior, configuration, storage schema, or dependencies. The existing main-only fix removes the verified official package consent dead end; it is not present in 2026.8.2. Unverified local copies still require consent. Catalog-only plugins remain absent, and stale bundled records converge without executing plugin runtime code.

## Evidence

- `pnpm test src/commands/doctor-config-preflight-plugin-verification.test.ts`: 9 passing cases, including startup-first and repair-first; final run exited 0. Earlier local launchers lingered after Vitest completed and were cleaned up.
- Failing-before proof: temporarily substituted the exact `v2026.8.2` consent owner (`src/plugins/capability-consent.ts`, blob `7b896f0f83b9581216ccbce26831f7db767888ec`) and ran the same file. Four provider cases failed with `requires capability consent`; the five catalog-only/stale-record/formatter cases passed. Restored main byte-for-byte before the passing run. No stash or branch switch.
- Real published-package proof: on isolated Linux, npm `openclaw@2026.8.2` reported commit `0965053`. An empty state without a credential reached Gateway ready. Synthetic OpenRouter/OpenCode credentials independently reproduced startup refusal with the corresponding consent error. `update repair --json --yes --timeout 120` reproduced the warnings. No real credentials or user state were used.
- Uncommitted autoreview: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority` (exit 0).
- `node scripts/check-changed.mjs -- src/commands/doctor-config-preflight-plugin-verification.test.ts`: all guards/typechecks/dead-code scans passed; the final lint step identified two `sort()` calls. Replaced them with `toSorted()` and reran the exact type-aware lint command successfully (exit 0).
- Installed-main proof: built the canonical self-contained package from this worktree on a fresh Linux Testbox, installed it into an isolated prefix, and ran all three repair/Gateway scenarios. Every repair exited 0, every Gateway reached ready, and none emitted a capability-consent error. Inventory verified Perplexity/OpenCode were not bundled in the artifact and were installed as managed npm plugins. Remote source SHA-256 for the consent owner exactly matched this worktree; its sync commit parent was `d9d19fefb4bb1a6b6274356069cc0b32699ee001`. The source artifact's package version label is 2026.8.1; this is not the published 2026.8.1 package.
- Branch autoreview also exited 0 with the same scoped-clean result. Exact-head CI for `33b1fff5860a0d9adda81615c25a4a162bf16c5b` is green: https://github.com/openclaw/openclaw/actions/runs/33575942181. ClawSweeper reported no findings; its only before-merge item was CI completion.

Production delta: +0/-0. Tests: +194/-2 (net +192).

Related observation on the initial pinned tree: older missing-configured-plugin-install fixtures could fall through to the operator home; the local attempt stopped at the SQLite newer-schema guard. New fixtures explicitly isolate HOME/state. While this work ran, #134490 added native process-home isolation in the test launcher; no extra test-home refactor is included here.
