### PR TITLE
test(gateway): close fixture peers after failed assertions

### DIFF
--- a/test/scripts/gateway-ws-client.test.ts
+++ b/test/scripts/gateway-ws-client.test.ts
@@ -1,4 +1,3 @@
-// Gateway Ws Client tests cover gateway ws client script behavior.
 import { createServer, type Server } from "node:http";
 import type { Duplex } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
@@ -9,6 +8,10 @@ let server: Server | undefined;
 let wss: WebSocketServer | undefined;
 
 afterEach(async () => {
+  // A failed assertion can skip client.close(); wss.close() waits for those peers.
+  for (const client of wss?.clients ?? []) {
+    client.terminate();
+  }
   await new Promise<void>((resolve) => {
     wss?.close(() => resolve());
     if (!wss) {


### PR DESCRIPTION
When an existing WebSocket error assertion fails before client.close(), the test server still owns an open peer and its close callback cannot finish. Teardown now terminates every owned server peer before awaiting WebSocket and HTTP server closure, matching the repository's existing minimal Gateway fixture. Remove the redundant file-header comment.

All six owner cases and their assertions remain unchanged, along with the real RPC, open and handshake timeouts. Ten owner/sibling cases passed before and after in their original order. Paired real-socket failure probes reproduced blocked old teardown with an open peer/TCP/HTTP listener after252ms; the candidate joined server resources in under1ms while preserving the deliberately failed assertion. Both full-order probes reported five passes and that one intentional failure. Every probe process/socket/root was cleaned.

This is a failure-path lifecycle fix, not a normal-run timing claim. The probe's observer released the old fixture after252ms; no full hook-timeout duration was measured. The patch joins the server side; client-side close propagation remains asynchronous. Production delta is zero; tests+4/-1. Root source, caller, sibling, history, ws dependency and raw probe review found no broader runtime change.

Validation also passed root test types, repository guards, scripts and targeted lint. Independent Codex review and manual lower-priority/deslop review found no actionable issue. Exact-head CI run33576088468 passed. The latest ClawSweeper rank-up move (finish exact-head CI) is satisfied. Its dependency-inspection gap is covered by direct review of installed ws8.21.3: WebSocketServer.close waits on its tracked clients; terminate destroys the peer socket, and the socket-close handler removes that client and schedules server closure when it is last. The real-socket probes exercise this contract. Normal maintainer acceptance is authorized for this batch.
