### PR TITLE
fix(ui): keep standalone previews off external connections and sibling caches

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1009,8 +1009,28 @@ For a standalone preview with synthetic data, use:
 pnpm dev:ui:mock -- --port 19321
 ```
 
+Open the printed URL in a fresh Chromium profile or isolated browser context,
+without existing service workers or operator credentials. Chat, presence, and
+profile data are synthetic. Add `--fixture attachments` for media examples; the
+printed board fixture URL is also available.
+
 The mock preview selects its own origin for Gateway resources, including
-avatars, so those requests stay on the preview server.
+avatars, before application startup. It supplies synthetic WebSocket responses
+and confines native resource requests to the serving origin and local data/blob
+fixtures, including frames, while preserving same-origin Vite HMR and terminal
+WebAssembly. Unimplemented HTTP API routes return a local JSON 404; external
+fetches are rejected with a standalone-mock diagnostic. New workers, Talk WebRTC,
+popups, and external link/navigation actions are disabled in the mock app.
+External iframe URL assignments are rejected before Chromium can speculatively
+connect. Add a local fixture when a demo needs another response. Each invocation
+owns a separate Vite cache and removes it on graceful shutdown, so concurrent
+previews and attachment fixtures do not invalidate one another.
+
+This is a trusted-fixture development boundary, not a sandbox for hostile HTML,
+browser extensions, or an already-controlling service worker. Browser-level
+navigation outside the app is outside its control. Production connection settings
+and `pnpm ui:dev` behavior are unchanged; use that command when you intentionally
+need a real Gateway or external integration.
 
 ## Blank Control UI page
 

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1,5 +1,7 @@
 // Control Ui Mock Dev script supports OpenClaw repository automation.
 import { createHash } from "node:crypto";
+import { rmSync } from "node:fs";
+import { mkdir, mkdtemp } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import qrcode from "qrcode";
@@ -40,6 +42,7 @@ import {
   buildChannelWizardMocks,
 } from "./control-ui-mock-channels.ts";
 import { buildCronMocks } from "./control-ui-mock-cron.ts";
+import { createStandaloneMockIsolationPlugins } from "./control-ui-mock-isolation.ts";
 import {
   buildPluginCatalogMock,
   buildPluginInspectMock,
@@ -1494,7 +1497,7 @@ async function createChatPickerScenario(
       updatedAtMs: baseTime - 420_000,
     },
   ];
-  const sessionWorkspaceRoot = repoRoot;
+  const sessionWorkspaceRoot = "/mock/workspace";
   const sessionFileContentByPath = new Map([
     [
       "ui/src/ui/views/chat.ts",
@@ -1787,20 +1790,20 @@ async function createChatPickerScenario(
       {
         category: "Research",
         createdActor: MOCK_ACTOR_MIRA,
-        execCwd: "/Users/peter/Projects/clawdbot",
+        execCwd: "/Users/demo/Projects/clawdbot",
         owner: { actor: MOCK_ACTOR_MIRA },
       },
     ),
     sessionRow("agent:main:model-budget", "Model budget review", baseTime - 80_000, {
       category: "Research",
-      execCwd: "/Users/peter/Projects/openclaw",
+      execCwd: "/Users/demo/Projects/openclaw",
       owner: { actor: { type: "human", id: "presence-riley", label: "Riley" } },
       status: "failed",
       lastRunError: "Model out of credits: openai/gpt-5.6",
     }),
     sessionRow("agent:main:work-openclaw", "OpenClaw work checkout", baseTime - 85_000, {
       createdActor: MOCK_ACTOR_PETER,
-      execCwd: "/Users/peter/Work/openclaw",
+      execCwd: "/Users/demo/Work/openclaw",
       lastReadAt: baseTime - 120_000,
       owner: { actor: MOCK_ACTOR_PETER },
       observerDigest: {
@@ -1814,7 +1817,7 @@ async function createChatPickerScenario(
     }),
     mainChildRow,
     sessionRow("agent:main:home-server", "Home server migration", baseTime - 240_000, {
-      execCwd: "/Users/peter/Projects",
+      execCwd: "/Users/demo/Projects",
       execNode: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
       hasAutomation: true,
       pinned: true,
@@ -2320,8 +2323,8 @@ async function createChatPickerScenario(
         ],
       },
       "system.info": {
-        machineName: "Peters-Mac-Studio",
-        hostname: "peters-mac-studio.local",
+        machineName: "Mock-Workstation",
+        hostname: "mock-workstation.invalid",
         platform: "darwin",
         release: "25.0.0",
         arch: "arm64",
@@ -2334,7 +2337,7 @@ async function createChatPickerScenario(
         memoryFreeBytes: 34_359_738_368,
         diskTotalBytes: 1_000_000_000_000,
         diskAvailableBytes: 640_000_000_000,
-        diskPath: "/Users/peter/.openclaw",
+        diskPath: "/Users/demo/.openclaw",
         defaultAgentUtilityModel: {
           status: "auto",
           model: "anthropic/claude-haiku-4-5",
@@ -2343,43 +2346,43 @@ async function createChatPickerScenario(
       "fs.listDir": {
         cases: [
           {
-            match: { path: "/Users/peter/Projects/openclaw" },
+            match: { path: "/Users/demo/Projects/openclaw" },
             response: {
-              path: "/Users/peter/Projects/openclaw",
-              parent: "/Users/peter/Projects",
-              home: "/Users/peter",
+              path: "/Users/demo/Projects/openclaw",
+              parent: "/Users/demo/Projects",
+              home: "/Users/demo",
               entries: [
-                { name: "ui", path: "/Users/peter/Projects/openclaw/ui" },
-                { name: "src", path: "/Users/peter/Projects/openclaw/src" },
-                { name: "docs", path: "/Users/peter/Projects/openclaw/docs" },
-                { name: "packages", path: "/Users/peter/Projects/openclaw/packages" },
+                { name: "ui", path: "/Users/demo/Projects/openclaw/ui" },
+                { name: "src", path: "/Users/demo/Projects/openclaw/src" },
+                { name: "docs", path: "/Users/demo/Projects/openclaw/docs" },
+                { name: "packages", path: "/Users/demo/Projects/openclaw/packages" },
               ],
             },
           },
           {
-            match: { path: "/Users/peter/Projects" },
+            match: { path: "/Users/demo/Projects" },
             response: {
-              path: "/Users/peter/Projects",
-              parent: "/Users/peter",
-              home: "/Users/peter",
+              path: "/Users/demo/Projects",
+              parent: "/Users/demo",
+              home: "/Users/demo",
               entries: [
-                { name: "openclaw", path: "/Users/peter/Projects/openclaw" },
-                { name: "clawdbot", path: "/Users/peter/Projects/clawdbot" },
-                { name: "sweetistics", path: "/Users/peter/Projects/sweetistics" },
-                { name: "Peekaboo", path: "/Users/peter/Projects/Peekaboo" },
+                { name: "openclaw", path: "/Users/demo/Projects/openclaw" },
+                { name: "clawdbot", path: "/Users/demo/Projects/clawdbot" },
+                { name: "sweetistics", path: "/Users/demo/Projects/sweetistics" },
+                { name: "Peekaboo", path: "/Users/demo/Projects/Peekaboo" },
               ],
             },
           },
           {
             match: {},
             response: {
-              path: "/Users/peter",
+              path: "/Users/demo",
               parent: "/Users",
-              home: "/Users/peter",
+              home: "/Users/demo",
               entries: [
-                { name: "Projects", path: "/Users/peter/Projects" },
-                { name: "Downloads", path: "/Users/peter/Downloads" },
-                { name: ".config", path: "/Users/peter/.config", hidden: true },
+                { name: "Projects", path: "/Users/demo/Projects" },
+                { name: "Downloads", path: "/Users/demo/Downloads" },
+                { name: ".config", path: "/Users/demo/.config", hidden: true },
               ],
             },
           },
@@ -2388,9 +2391,9 @@ async function createChatPickerScenario(
       "worktrees.branches": {
         cases: [
           {
-            match: { repoRoot: "/Users/peter/Projects/openclaw" },
+            match: { repoRoot: "/Users/demo/Projects/openclaw" },
             response: {
-              repoRoot: "/Users/peter/Projects/openclaw",
+              repoRoot: "/Users/demo/Projects/openclaw",
               branches: [
                 { kind: "local", name: "main" },
                 { kind: "local", name: "steipete/place-picker" },
@@ -2400,9 +2403,9 @@ async function createChatPickerScenario(
             },
           },
           {
-            match: { repoRoot: "/Users/peter/Projects/clawdbot" },
+            match: { repoRoot: "/Users/demo/Projects/clawdbot" },
             response: {
-              repoRoot: "/Users/peter/Projects/clawdbot",
+              repoRoot: "/Users/demo/Projects/clawdbot",
               branches: [
                 { kind: "local", name: "main" },
                 { kind: "local", name: "steipete/storage-selector-design" },
@@ -2460,8 +2463,8 @@ async function createChatPickerScenario(
                   command: "openclaw export --target production",
                   agentId: "main",
                   sessionKey: "agent:main:production-export",
-                  host: "peters-mac-studio.local",
-                  cwd: "/Users/peter/Projects/openclaw",
+                  host: "mock-workstation.invalid",
+                  cwd: "/Users/demo/Projects/openclaw",
                   security: "full",
                   ask: "on-miss",
                   allowedDecisions: ["allow-once", "allow-always", "deny"],
@@ -2475,7 +2478,7 @@ async function createChatPickerScenario(
                   command: "git -C /mock/workspace clean -nd",
                   agentId: "release",
                   sessionKey: "agent:main:worktree-cleanup",
-                  host: "peters-mac-studio.local",
+                  host: "mock-workstation.invalid",
                   cwd: "/mock/workspace",
                   security: "sandboxed",
                   ask: "always",
@@ -3060,7 +3063,7 @@ async function createChatPickerScenario(
       taxChildRow,
     ],
     sessionKey: fixture === "workboard" ? workboardMocks.sessionKey : "agent:main:main",
-    workspace: "/Users/peter/Projects/openclaw",
+    workspace: "/Users/demo/Projects/openclaw",
     workspaceGit: true,
   };
 }
@@ -3187,58 +3190,71 @@ const scenario = await createChatPickerScenario(options.fixture);
 if (options.operatorScopes) {
   scenario.operatorScopes = options.operatorScopes;
 }
-const server = await createServer({
-  base: "/",
-  cacheDir: path.join(repoRoot, ".artifacts", "control-ui-mock-vite"),
-  clearScreen: false,
-  configFile: path.join(uiRoot, "vite.config.ts"),
-  define: {
-    "globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify({
-      version: "2026.7.10",
-      commit: "0123456789abcdef0123456789abcdef01234567",
-      commitAt: "2026-07-10T11:22:33.000Z",
-      builtAt: "2026-07-10T12:34:56.000Z",
-      branch: null,
-      dirty: null,
-      release: false,
-      buildId: scenario.serverBuildId,
-    }),
-  },
-  logLevel: "error",
-  optimizeDeps: {
-    ...(options.fixture === "board"
-      ? { entries: [path.join(uiRoot, "src", "test-helpers", "board-fixture.ts")] }
-      : {}),
-    include: ["lit/directives/repeat.js"],
-  },
-  plugins: [
-    createMockGatewayPlugin(scenario, options.fixture),
-    createBoardFixturePlugin(),
-    ...(options.fixture === "attachments" ? [createChatAttachmentFixturePlugin()] : []),
-  ],
-  publicDir: path.join(uiRoot, "public"),
-  resolve: {
-    alias: [
-      ...resolveExternalPackageAliasesForVite(),
-      ...resolveSourcePackageAliasesForVite(),
-      ...resolveTsconfigPathAliasesForVite(),
+// Vite replaces its deps cache when fixture plugins or mode change. Concurrent
+// mocks need separate owners so one startup cannot invalidate another's modules.
+const cacheRoot = path.join(repoRoot, ".artifacts", "control-ui-mock-vite");
+await mkdir(cacheRoot, { recursive: true });
+const cacheDir = await mkdtemp(path.join(cacheRoot, "server-"));
+// Vite's SIGTERM handler calls process.exit() after closing, bypassing finally.
+// The process owns this cache, so its exit hook is the single cleanup path.
+process.once("exit", () => rmSync(cacheDir, { recursive: true, force: true }));
+let server: ViteDevServer | undefined;
+try {
+  server = await createServer({
+    base: "/",
+    cacheDir,
+    clearScreen: false,
+    configFile: path.join(uiRoot, "vite.config.ts"),
+    define: {
+      "globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify({
+        version: "2026.7.10",
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        commitAt: "2026-07-10T11:22:33.000Z",
+        builtAt: "2026-07-10T12:34:56.000Z",
+        branch: null,
+        dirty: null,
+        release: false,
+        buildId: scenario.serverBuildId,
+      }),
+    },
+    logLevel: "error",
+    optimizeDeps: {
+      ...(options.fixture === "board"
+        ? { entries: [path.join(uiRoot, "src", "test-helpers", "board-fixture.ts")] }
+        : {}),
+      include: ["lit/directives/repeat.js"],
+    },
+    plugins: [
+      ...createStandaloneMockIsolationPlugins(),
+      createMockGatewayPlugin(scenario, options.fixture),
+      createBoardFixturePlugin(),
+      ...(options.fixture === "attachments" ? [createChatAttachmentFixturePlugin()] : []),
     ],
-  },
-  root: uiRoot,
-  server: {
-    allowedHosts: options.allowedHosts,
-    host: options.host,
-    port: options.port,
-    strictPort: true,
-  },
-});
+    publicDir: path.join(uiRoot, "public"),
+    resolve: {
+      alias: [
+        ...resolveExternalPackageAliasesForVite(),
+        ...resolveSourcePackageAliasesForVite(),
+        ...resolveTsconfigPathAliasesForVite(),
+      ],
+    },
+    root: uiRoot,
+    server: {
+      allowedHosts: options.allowedHosts,
+      host: options.host,
+      port: options.port,
+      strictPort: true,
+    },
+  });
 
-await server.listen();
-console.log(
-  `[control-ui-mock] ${resolveServerUrl(server, options.host, controlUiSessionPath(scenario.sessionKey ?? "agent:main:main"))}`,
-);
-console.log(
-  `[control-ui-mock] board fixture: ${resolveServerUrl(server, options.host, boardFixturePath)}`,
-);
-await waitForShutdown();
-await server.close();
+  await server.listen();
+  console.log(
+    `[control-ui-mock] ${resolveServerUrl(server, options.host, controlUiSessionPath(scenario.sessionKey ?? "agent:main:main"))}`,
+  );
+  console.log(
+    `[control-ui-mock] board fixture: ${resolveServerUrl(server, options.host, boardFixturePath)}`,
+  );
+  await waitForShutdown();
+} finally {
+  await server?.close();
+}

--- a/scripts/control-ui-mock-isolation.ts
+++ b/scripts/control-ui-mock-isolation.ts
@@ -32,33 +32,27 @@ function installStandaloneNetworkBoundary(): void {
   };
   const framePrototype = HTMLIFrameElement.prototype;
   const frameSrc = Object.getOwnPropertyDescriptor(framePrototype, "src");
-  // oxlint-disable-next-line typescript/unbound-method -- Preserve the native setter for call(this, value) below.
-  const setFrameSrc = frameSrc?.set;
-  if (!setFrameSrc) {
+  if (!frameSrc?.set) {
     throw blocked("unsupported iframe implementation");
   }
   Object.defineProperty(framePrototype, "src", {
     ...frameSrc,
     set(value: string) {
       checkFrameUrl(value);
-      setFrameSrc.call(this, value);
+      frameSrc.set!.call(this, value);
     },
   });
-  // oxlint-disable-next-line typescript/unbound-method -- Preserve the native method for call(this, name, value) below.
-  const setAttribute = framePrototype.setAttribute;
   framePrototype.setAttribute = function (name, value) {
     if (name.toLowerCase() === "src") {
       checkFrameUrl(value);
     }
-    setAttribute.call(this, name, value);
+    Element.prototype.setAttribute.call(this, name, value);
   };
-  // oxlint-disable-next-line typescript/unbound-method -- Preserve the native method for the iframe receiver below.
-  const setAttributeNS = framePrototype.setAttributeNS;
   framePrototype.setAttributeNS = function (namespace, name, value) {
     if (!namespace && name.toLowerCase() === "src") {
       checkFrameUrl(value);
     }
-    setAttributeNS.call(this, namespace, name, value);
+    Element.prototype.setAttributeNS.call(this, namespace, name, value);
   };
 
   // CSP covers resource loads, not native RTC or top-level navigation. Keep

--- a/scripts/control-ui-mock-isolation.ts
+++ b/scripts/control-ui-mock-isolation.ts
@@ -1,0 +1,159 @@
+import type { Plugin } from "vite";
+
+/** Runs before preview and app modules; the preview owns Gateway selection. */
+function installStandaloneNetworkBoundary(): void {
+  const nativeFetch = window.fetch.bind(window);
+  const localOrigin = window.location.origin;
+  const isLocalResource = (url: URL) =>
+    url.origin === localOrigin || url.protocol === "data:" || url.protocol === "blob:";
+  const blocked = (capability: string) =>
+    new DOMException(
+      `Standalone mock blocked ${capability}. Add a local fixture or use pnpm ui:dev for a real Gateway.`,
+      "NotSupportedError",
+    );
+
+  window.fetch = async (input, init) => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    if (!isLocalResource(url)) {
+      throw blocked(`fetch to ${url.origin}`);
+    }
+    // A local resource must not redirect an authenticated request off the fixture server.
+    return nativeFetch(request, { redirect: "error" });
+  };
+
+  // Full Chromium preconnects iframe destinations before checking frame-src.
+  // Reject URL writes before navigation starts; CSP still guards frame contents.
+  const checkFrameUrl = (value: string) => {
+    const url = new URL(value, window.location.href);
+    if (!isLocalResource(url) && url.href !== "about:blank") {
+      throw blocked(`iframe to ${url.origin}`);
+    }
+  };
+  const framePrototype = HTMLIFrameElement.prototype;
+  const frameSrc = Object.getOwnPropertyDescriptor(framePrototype, "src");
+  // oxlint-disable-next-line typescript/unbound-method -- Preserve the native setter for call(this, value) below.
+  const setFrameSrc = frameSrc?.set;
+  if (!setFrameSrc) {
+    throw blocked("unsupported iframe implementation");
+  }
+  Object.defineProperty(framePrototype, "src", {
+    ...frameSrc,
+    set(value: string) {
+      checkFrameUrl(value);
+      setFrameSrc.call(this, value);
+    },
+  });
+  // oxlint-disable-next-line typescript/unbound-method -- Preserve the native method for call(this, name, value) below.
+  const setAttribute = framePrototype.setAttribute;
+  framePrototype.setAttribute = function (name, value) {
+    if (name.toLowerCase() === "src") {
+      checkFrameUrl(value);
+    }
+    setAttribute.call(this, name, value);
+  };
+  // oxlint-disable-next-line typescript/unbound-method -- Preserve the native method for the iframe receiver below.
+  const setAttributeNS = framePrototype.setAttributeNS;
+  framePrototype.setAttributeNS = function (namespace, name, value) {
+    if (!namespace && name.toLowerCase() === "src") {
+      checkFrameUrl(value);
+    }
+    setAttributeNS.call(this, namespace, name, value);
+  };
+
+  // CSP covers resource loads, not native RTC or top-level navigation. Keep
+  // these side effects out of standalone demos, including deferred blank popups.
+  for (const capability of ["RTCPeerConnection", "webkitRTCPeerConnection", "WebTransport"]) {
+    function blockedTransport(): never {
+      throw blocked(capability);
+    }
+    Object.defineProperty(window, capability, { value: blockedTransport });
+  }
+  window.open = () => {
+    console.warn(blocked("popup").message);
+    return null;
+  };
+  window.navigation?.addEventListener("navigate", (event) => {
+    if (new URL(event.destination.url).origin !== localOrigin) {
+      event.preventDefault();
+      console.warn(blocked("external navigation").message);
+    }
+  });
+  for (const eventName of ["click", "auxclick"]) {
+    window.addEventListener(
+      eventName,
+      (event) => {
+        const anchor = event.composedPath().find((node) => node instanceof HTMLAnchorElement);
+        const url = anchor ? new URL(anchor.href) : null;
+        const localDownload =
+          anchor?.download && (url?.protocol === "blob:" || url?.protocol === "data:");
+        if (url && url.origin !== localOrigin && !localDownload) {
+          event.preventDefault();
+          console.warn(blocked("external link").message);
+        }
+      },
+      true,
+    );
+  }
+}
+
+export function createStandaloneMockIsolationPlugins(): Plugin[] {
+  // tsx can emit __name calls in serialized functions; keep that helper local
+  // to the injected script, just like the shared Gateway mock initializer.
+  const script = `(() => { const __name = (target) => target; (${installStandaloneNetworkBoundary.toString()})(); })();`;
+  return [
+    {
+      name: "openclaw-control-ui-mock-isolation",
+      enforce: "pre",
+      configureServer(server) {
+        // Install before *all* custom fixture handlers, not only Vite's HTML
+        // handler: frame/attachment documents need the same native boundary.
+        server.middlewares.use((req, res, next) => {
+          const origin = new URL(`http://${req.headers.host}`).origin;
+          res.setHeader(
+            "Content-Security-Policy",
+            [
+              "default-src 'self'",
+              `connect-src 'self' ${origin.replace(/^http:/, "ws:")} blob: data:`,
+              // The bundled terminal compiles local Wasm; JavaScript eval stays disabled.
+              "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' blob: data:",
+              "media-src 'self' blob: data:",
+              "font-src 'self' data:",
+              "frame-src 'self' blob: data:",
+              "worker-src 'none'",
+              "object-src 'none'",
+              "base-uri 'none'",
+              "form-action 'none'",
+              "sandbox allow-scripts allow-same-origin allow-downloads",
+            ].join("; "),
+          );
+          res.setHeader("X-DNS-Prefetch-Control", "off");
+          next();
+        });
+      },
+      transformIndexHtml: {
+        order: "pre",
+        handler: () => [{ tag: "script", children: script, injectTo: "head-prepend" }],
+      },
+    },
+    {
+      name: "openclaw-control-ui-mock-http-misses",
+      enforce: "post",
+      configureServer(server) {
+        // Registered after fixture handlers but before Vite's SPA fallback.
+        server.middlewares.use((req, res, next) => {
+          const pathname = new URL(req.url ?? "/", "http://mock.invalid").pathname;
+          if (!/^\/(?:api|avatar|__openclaw__|__fixtures)\//.test(pathname)) {
+            next();
+            return;
+          }
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: "Standalone mock has no HTTP fixture for this route." }));
+        });
+      },
+    },
+  ];
+}

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -1,5 +1,7 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
 import { once } from "node:events";
+import { writeFile } from "node:fs/promises";
+import { createServer as createHttpServer } from "node:http";
 import { type AddressInfo, createServer } from "node:net";
 import path from "node:path";
 import type { Readable } from "node:stream";
@@ -8,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ApplicationRuntime } from "../app/bootstrap.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   resolvePlaywrightChromiumExecutablePath,
@@ -44,19 +47,20 @@ async function reservePort(): Promise<number> {
   return port;
 }
 
-async function startFixtureServer(): Promise<FixtureServer> {
+async function startFixtureServer(fixture?: "attachments"): Promise<FixtureServer> {
   const port = await reservePort();
   const url = `http://127.0.0.1:${port}/__fixtures/board/`;
   const child = spawn(
     process.execPath,
     [
       "--import",
-      "tsx",
+      "./scripts/tsx.mjs",
       "scripts/control-ui-mock-dev.ts",
       "--host",
       "127.0.0.1",
       "--port",
       String(port),
+      ...(fixture ? ["--fixture", fixture] : []),
     ],
     {
       cwd: repoRoot,
@@ -73,6 +77,7 @@ async function startFixtureServer(): Promise<FixtureServer> {
   child.stderr.on("data", (chunk: string) => {
     output += chunk;
   });
+  const mockServer = { child, url, output: () => output };
 
   for (let attempt = 0; attempt < 100; attempt += 1) {
     if (child.exitCode !== null || child.signalCode !== null) {
@@ -81,13 +86,13 @@ async function startFixtureServer(): Promise<FixtureServer> {
     try {
       const response = await fetch(url);
       if (response.ok) {
-        return { child, url, output: () => output };
+        return mockServer;
       }
     } catch {}
     await delay(100);
   }
 
-  child.kill("SIGTERM");
+  await stopFixtureServer(mockServer);
   throw new Error(`timed out waiting for Control UI mock server\n${output}`);
 }
 
@@ -355,6 +360,327 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
       }
     } finally {
       await context.close();
+    }
+  });
+
+  it("keeps profile and presence HTTP inside the standalone mock", async () => {
+    const artifacts = createControlUiE2eArtifactDir("standalone-network-isolation");
+    const context = await browser.newContext({
+      serviceWorkers: "block",
+      viewport: { width: 1440, height: 1000 },
+      recordVideo: { dir: artifacts },
+    });
+    const origin = new URL(fixtureServer.url).origin;
+    const escaped: string[] = [];
+    const requests: string[] = [];
+    // A pre-fix tripwire protects the operator, but every rejected escape still fails the test.
+    await context.route("**/*", (route) => {
+      const url = route.request().url();
+      requests.push(url);
+      if (new URL(url).origin !== origin) {
+        escaped.push(url);
+        return route.abort("blockedbyclient");
+      }
+      return route.continue();
+    });
+    const page = await context.newPage();
+    try {
+      await page.goto(`${origin}/chat`, { waitUntil: "networkidle" });
+      await page.getByText("OpenClaw work checkout", { exact: true }).click();
+      await page.getByRole("button", { name: "Write a message to send." }).waitFor();
+      await page.screenshot({ path: path.join(artifacts, "chat.png") });
+      await page.goto(`${origin}/profile`, { waitUntil: "networkidle" });
+      await expect
+        .poll(() => page.getByRole("textbox", { name: "Display name", exact: true }).inputValue())
+        .toBe("Riley");
+      await page.screenshot({ path: path.join(artifacts, "profile.png") });
+      await page.goto(`${origin}/focus/terminal`, { waitUntil: "networkidle" });
+      const terminal = page.locator("openclaw-terminal-panel");
+      await terminal.locator(".tabstrip-tab.is-live").waitFor();
+      await terminal.locator(".tp-host canvas").waitFor({ state: "visible" });
+      await page.screenshot({ path: path.join(artifacts, "terminal.png") });
+      expect(escaped, "standalone mock must not attempt Gateway HTTP or external requests").toEqual(
+        [],
+      );
+    } finally {
+      await writeFile(
+        path.join(artifacts, "network.json"),
+        JSON.stringify({ origin, escaped, requests }, null, 2),
+      );
+      await context.close();
+    }
+  });
+
+  it("blocks native egress before connecting while preserving local HMR and frame resources", async () => {
+    const artifacts = createControlUiE2eArtifactDir("standalone-network-probes");
+    const received: string[] = [];
+    let connections = 0;
+    const sink = createHttpServer((req, res) => {
+      received.push(req.url ?? "/");
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.end("unexpected egress");
+    });
+    sink.on("connection", () => {
+      connections += 1;
+    });
+    await new Promise<void>((resolve) => {
+      sink.listen(0, "127.0.0.1", resolve);
+    });
+    const sinkUrl = `http://127.0.0.1:${(sink.address() as AddressInfo).port}`;
+    const origin = new URL(fixtureServer.url).origin;
+    const context = await browser.newContext({ serviceWorkers: "block" });
+    const escaped: string[] = [];
+    // Allow the synthetic sink through: the browser/server boundary, not the
+    // test router, must prevent TCP connections. Still protect other origins.
+    await context.route("**/*", (route) => {
+      const target = new URL(route.request().url()).origin;
+      if (target === origin || target === sinkUrl) {
+        return route.continue();
+      }
+      escaped.push(route.request().url());
+      return route.abort("blockedbyclient");
+    });
+    const page = await context.newPage();
+    const hmr: string[] = [];
+    page.on("websocket", (socket) => {
+      socket.on("framereceived", ({ payload }) => {
+        if (String(payload).includes('"type":"connected"')) {
+          hmr.push(new URL(socket.url()).origin);
+        }
+      });
+    });
+    const outcomes: Record<string, unknown> = {};
+    try {
+      const response = await page.goto(fixtureServer.url, { waitUntil: "networkidle" });
+      expect(response?.headers()["content-security-policy"]).toContain("worker-src 'none'");
+      await expect.poll(() => hmr.length).toBeGreaterThan(0);
+      expect(hmr.every((url) => new URL(url).host === new URL(origin).host)).toBe(true);
+      outcomes.hmr = hmr;
+
+      outcomes.top = await page.evaluate(async (sinkOrigin) => {
+        const results: Record<string, string> = {};
+        const rejected = async (name: string, run: () => unknown) => {
+          try {
+            await run();
+            results[name] = "allowed";
+          } catch {
+            results[name] = "blocked";
+          }
+        };
+        await rejected("fetch", () => fetch(`${sinkOrigin}/fetch`));
+        await rejected("rtc", () => new RTCPeerConnection());
+        const workerUrl = URL.createObjectURL(
+          new Blob(["postMessage('escaped')"], { type: "text/javascript" }),
+        );
+        const worker = new Worker(workerUrl);
+        await rejected(
+          "worker",
+          () =>
+            new Promise((resolve, reject) => {
+              worker.addEventListener("message", resolve, { once: true });
+              worker.addEventListener("error", reject, { once: true });
+            }),
+        );
+        worker.terminate();
+        URL.revokeObjectURL(workerUrl);
+        results.popup = window.open(`${sinkOrigin}/popup`) === null ? "blocked" : "allowed";
+
+        // Each native attempt completes at the browser's policy event; no sleep
+        // or request interception can make a missing boundary pass this proof.
+        const policy = async (name: string, directive: string, run: () => void) => {
+          await new Promise<void>((resolve) => {
+            const listener = (event: SecurityPolicyViolationEvent) => {
+              if (
+                event.effectiveDirective !== directive ||
+                !event.blockedURI.startsWith(sinkOrigin)
+              ) {
+                return;
+              }
+              document.removeEventListener("securitypolicyviolation", listener);
+              resolve();
+            };
+            document.addEventListener("securitypolicyviolation", listener);
+            run();
+          });
+          results[name] = "blocked";
+        };
+        await policy("xhr", "connect-src", () => {
+          const xhr = new XMLHttpRequest();
+          xhr.open("GET", `${sinkOrigin}/xhr`);
+          xhr.send();
+        });
+        let events: EventSource;
+        await policy("eventSource", "connect-src", () => {
+          events = new EventSource(`${sinkOrigin}/events`);
+        });
+        events!.close();
+        await policy("beacon", "connect-src", () => {
+          navigator.sendBeacon(`${sinkOrigin}/beacon`, "probe");
+        });
+        await policy("image", "img-src", () => {
+          const image = new Image();
+          image.src = `${sinkOrigin}/image`;
+          document.body.append(image);
+        });
+        await policy("media", "media-src", () => {
+          const audio = document.createElement("audio");
+          audio.preload = "auto";
+          audio.src = `${sinkOrigin}/media`;
+          document.body.append(audio);
+          audio.load();
+        });
+        for (const setter of ["property", "attribute", "namespaced", "empty-namespace"] as const) {
+          await rejected(`iframe:${setter}`, () => {
+            const frame = document.createElement("iframe");
+            const url = `${sinkOrigin}/frame`;
+            if (setter === "property") {
+              frame.src = url;
+            } else if (setter === "attribute") {
+              frame.setAttribute("src", url);
+            } else {
+              const namespace = setter === "namespaced" ? null : "";
+              frame.setAttributeNS(namespace, "src", url);
+            }
+            document.body.append(frame);
+          });
+        }
+        await policy("script", "script-src-elem", () => {
+          const script = document.createElement("script");
+          script.src = `${sinkOrigin}/script`;
+          document.head.append(script);
+        });
+        await policy("style", "style-src-elem", () => {
+          const link = document.createElement("link");
+          link.rel = "stylesheet";
+          link.href = `${sinkOrigin}/style`;
+          document.head.append(link);
+        });
+        await rejected("font", () => new FontFace("sink-probe", `url(${sinkOrigin}/font)`).load());
+        const forgedHmr = new WebSocket(
+          `${sinkOrigin.replace("http:", "ws:")}/forged-hmr`,
+          "vite-hmr",
+        );
+        await new Promise<void>((resolve) => {
+          forgedHmr.addEventListener("error", () => resolve(), { once: true });
+        });
+        forgedHmr.close();
+        results.forgedHmr = "blocked";
+        const beforeNavigation = location.href;
+        location.assign(`${sinkOrigin}/navigation`);
+        results.navigation = location.href === beforeNavigation ? "blocked" : "allowed";
+        // Same-origin completion sentinel proves the document is still live.
+        const sentinel = await fetch("/control-ui-config.json");
+        results.sentinel = sentinel.ok ? "local" : "failed";
+        return results;
+      }, sinkUrl);
+      expect(outcomes.top).toEqual({
+        fetch: "blocked",
+        rtc: "blocked",
+        worker: "blocked",
+        popup: "blocked",
+        xhr: "blocked",
+        eventSource: "blocked",
+        beacon: "blocked",
+        image: "blocked",
+        media: "blocked",
+        "iframe:property": "blocked",
+        "iframe:attribute": "blocked",
+        "iframe:namespaced": "blocked",
+        "iframe:empty-namespace": "blocked",
+        script: "blocked",
+        style: "blocked",
+        font: "blocked",
+        forgedHmr: "blocked",
+        navigation: "blocked",
+        sentinel: "local",
+      });
+      expect(new URL(page.url()).origin).toBe(origin);
+
+      await expect
+        .poll(() => page.frames().some((frame) => frame.url().startsWith("data:text/html")))
+        .toBe(true);
+      const widgetFrame = page.frames().find((frame) => frame.url().startsWith("data:text/html"))!;
+      outcomes.frame = await widgetFrame.evaluate(async (sinkOrigin) => {
+        try {
+          await fetch(`${sinkOrigin}/frame-native-fetch`);
+          return "allowed";
+        } catch {
+          return "blocked";
+        }
+      }, sinkUrl);
+      expect(outcomes.frame).toBe("blocked");
+      const missing = await page.evaluate(async () => {
+        const apiResponse = await fetch("/api/unimplemented-mock-probe");
+        return { status: apiResponse.status, body: await apiResponse.json() };
+      });
+      expect(missing).toEqual({
+        status: 404,
+        body: { error: "Standalone mock has no HTTP fixture for this route." },
+      });
+      outcomes.missing = missing;
+      await page.screenshot({ path: path.join(artifacts, "board.png") });
+      expect(escaped).toEqual([]);
+      expect(received).toEqual([]);
+      expect(connections).toBe(0);
+    } finally {
+      await context.close();
+      sink.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        sink.close((error) => (error ? reject(error) : resolve()));
+      });
+      await writeFile(
+        path.join(artifacts, "probes.json"),
+        JSON.stringify(
+          { origin, sinkOrigin: sinkUrl, connections, received, escaped, outcomes },
+          null,
+          2,
+        ),
+      );
+    }
+  });
+
+  it("serves attachment fixtures and blob previews under the same isolation policy", async () => {
+    const attachments = await startFixtureServer("attachments");
+    const artifacts = createControlUiE2eArtifactDir("standalone-isolated-attachments");
+    const context = await browser.newContext({ serviceWorkers: "block" });
+    const origin = new URL(attachments.url).origin;
+    const escaped: string[] = [];
+    await context.route("**/*", (route) => {
+      if (new URL(route.request().url()).origin === origin) {
+        return route.continue();
+      }
+      escaped.push(route.request().url());
+      return route.abort("blockedbyclient");
+    });
+    try {
+      const page = await context.newPage();
+      await page.goto(`${origin}/chat`, { waitUntil: "networkidle" });
+      const result = await page.evaluate(async () => {
+        const response = await fetch("/__fixtures/chat-attachments/sample-image.svg");
+        const blob = await response.blob();
+        const image = new Image();
+        image.src = URL.createObjectURL(blob);
+        document.body.append(image);
+        await image.decode();
+        URL.revokeObjectURL(image.src);
+        return {
+          type: blob.type,
+          width: image.naturalWidth,
+          policy: response.headers.get("content-security-policy"),
+        };
+      });
+      expect(result.type).toBe("image/svg+xml");
+      expect(result.width).toBe(640);
+      expect(result.policy).toContain("worker-src 'none'");
+      await page.screenshot({ path: path.join(artifacts, "attachments.png") });
+      expect(escaped).toEqual([]);
+      await writeFile(
+        path.join(artifacts, "network.json"),
+        JSON.stringify({ origin, escaped, result }, null, 2),
+      );
+    } finally {
+      await context.close();
+      await stopFixtureServer(attachments);
     }
   });
 

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -198,24 +198,20 @@ suite.define(() => {
       await expect.poll(() => trigger.isEnabled()).toBe(true);
       expect(await trigger.textContent()).toContain("Default");
 
-      const remoteChange = {
-        ...session,
-        permissionMode: "read-only",
-        reason: "patch",
-        sessionKey: session.key,
+      const publishRemoteChange = async (permissionModePending: boolean, updatedAt: number) => {
+        const row = { ...session, permissionMode: "read-only", permissionModePending, updatedAt };
+        // Event-triggered roster refreshes must describe the same remote change.
+        await gateway.setMethodResponse("sessions.list", chatSessionListResponse([row]));
+        await gateway.emitGatewayEvent("sessions.changed", {
+          ...row,
+          reason: "patch",
+          sessionKey: session.key,
+        });
       };
-      await gateway.emitGatewayEvent("sessions.changed", {
-        ...remoteChange,
-        permissionModePending: true,
-        updatedAt: 5,
-      });
+      await publishRemoteChange(true, 5);
       await expect.poll(() => trigger.textContent()).toContain("Applying permissions");
       expect(await trigger.isEnabled()).toBe(false);
-      await gateway.emitGatewayEvent("sessions.changed", {
-        ...remoteChange,
-        permissionModePending: false,
-        updatedAt: 6,
-      });
+      await publishRemoteChange(false, 6);
       await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("read-only");
       await expect.poll(() => trigger.isEnabled()).toBe(true);
       expect(await trigger.textContent()).toContain(


### PR DESCRIPTION
## What Problem This Solves

Closes #135691.

Fixes an issue where developers running standalone Control UI previews could make unintended native browser connections or invalidate a concurrently running preview. The previews mocked Gateway WebSockets but did not own every native browser connection. CSP alone was insufficient: full Chrome for Testing made a speculative TCP connection to an external iframe destination before rejecting the frame. Concurrent default, attachment, and board previews also shared a Vite dependency cache that Vite can delete or replace when the configuration changes.

This complements #134686, which already fixed preview-origin selection for avatars. It preserves that fix and #134836's canonical request-handler/session-transcript flow; there is no avatar fetch interception or production settings change.

## Why This Change Was Made

The standalone development server owns both boundaries. Early middleware gives all fixture documents a serving-origin CSP, preserves exact-origin HMR and terminal WebAssembly without JavaScript `unsafe-eval`, and returns local JSON 404s for missing fixture/API routes. The early browser initializer rejects off-origin fetches/redirects and unsupported native transports, workers, popups, and navigation. It intercepts iframe URL assignments before Chromium can preconnect.

Each server invocation now owns a unique Vite cache directory. A single synchronous process-exit cleanup hook removes only that invocation's cache, including Vite's graceful signal path, which calls `process.exit()` after closing the server. SIGKILL cleanup is not promised. Existing shared cache parents are not deleted.

The integration preserves current main's additional browser cases and replaces machine/workspace fixture values with synthetic values. Alternatives rejected: fixing production avatar consumers would put dev-only policy in the wrong owner; CSP alone demonstrably permits speculative iframe connections; a shared cache remains vulnerable to Vite's replacement contract.

## User Impact

Standalone previews remain useful for chat, profile, board, terminal, and attachment demos without contacting an operator Gateway or external services through the covered app paths. Add local fixtures for missing responses, or use `pnpm ui:dev` for intentional real integrations.

This is a trusted-fixture development boundary, not a hostile-HTML sandbox. Browser extensions, an already-controlling service worker, and browser-level navigation outside the app are out of scope. Use a fresh Chromium profile or isolated context. Production runtime, settings, authentication, and normal `ui:dev` behavior are unchanged.

Runtime production LOC: **0**. Development tooling: **+259 / -90 (net +169)**, needed for the previously absent native request boundary and invocation-owned cache lifecycle. Tests: **+341 / -19 (net +322)**. Docs: **+21 / -1**. No new dependency, persistent configuration, protocol, or database surface.

## Evidence

- Historical before proof: the initial avatar tripwire aborted nine attempted off-origin requests; that default-avatar defect is now fixed separately on main by #134686. The remaining native iframe probe recorded **1 TCP connection / 0 HTTP requests** with CSP alone.
- Integrated browser suite: **16/16 passed on Google Chrome for Testing 151.0.7922.34**, with an explicit preflight proving the selected executable equals `chromium.executablePath()` (not the default headless shell). The independent loopback sink remained reachable through the test router and recorded **0 TCP connections / 0 HTTP requests / 0 escaped routed requests**. Profile/chat/terminal, local avatars across reloads, attachment/blob decoding, and the original preview after concurrent attachment shutdown all passed. Graceful teardown left **zero invocation-owned cache directories**. The tested files matched the staged candidate byte-for-byte. [Blacksmith Testbox host workflow](https://github.com/openclaw/openclaw/actions/runs/33575094013), lease `tbx_01m1fqyf7mhcv6zs03n8sat34h`; the delegated command exited 0, independently of the host workflow being cancelled during lease cleanup.
- Follow-up CI repairs: the new suppression directives were removed by invoking the unchanged native `Element` methods; the fixed suppression inventory then passed **4/4 tests** without baseline edits. An existing permission E2E fixture emitted remote state while later list responses still described the old state; it now publishes the canonical snapshot before each event, preserving every assertion and timeout. No production permission code changed.
- Fresh repaired-candidate browser proof: **29/29 passed** (16 standalone + 13 model/reasoning cases) on explicitly verified **Chrome for Testing 151.0.7922.34**, again with **0 TCP / 0 HTTP / 0 escaped requests** and **0 owned caches after graceful shutdown**. [Testbox host workflow](https://github.com/openclaw/openclaw/actions/runs/33576855479), lease `tbx_01m1fse30qrb8xwfhhhknccwje`; the delegated command exited 0 and the tested files matched the candidate byte-for-byte. The host lifecycle is separate from the test result.
- Integrated settings/avatar tests: **90 passed across 5 files**. Follow-up UI typecheck and scoped script/UI lint also passed.
- Fresh Codex-backed autoreview: scoped-clean at the required P0 threshold. Direct Vite cache replacement/signal shutdown and Playwright executable-selection contracts were inspected.
- Integration base: `759e127777b54426c922e8ab4c228523ddac04e9`.

Validation recovery: a successful frozen-lockfile install supplied the missing Mermaid dependency. Local browser attempts then encountered standalone-server startup failures; those runs are retained and are not described as green. Testbox first lacked Playwright FFmpeg, which was installed normally. A subsequent **16/16 system Chromium** run was retained as sibling-browser evidence, then the strict repository installer supplied managed Chrome for Testing for the final **16/16** run above. The Testbox recovery made no source changes and used no larger timeouts, environment-forced assertions, or skipped tests.

Scoped changed-file checks: **passed, exit 0**, including formatting, core-test and script typechecks, core/script lint, i18n, all three dead-export scans, dependency/patch, coercion, suppression, Docker E2E boundary, and HTTP/2 import guards. Command: `node scripts/check-changed.mjs --staged -- docs/web/control-ui.md scripts/control-ui-mock-dev.ts scripts/control-ui-mock-isolation.ts ui/src/e2e/board-fixture.e2e.test.ts`.

ClawSweeper follow-through ([review](https://github.com/openclaw/openclaw/pull/135724#issuecomment-5502651065)): the compact-check failure is repaired without baseline edits. The Vite source gap is closed by direct inspection of Vite 8.2.2 `dist/node/chunks/node.js`: cache deletion/replacement at 32147–32175 and 32241–32269, cache location at 32467–32480, hash inputs at 32684–32712, and close-then-exit at 26571–26579. The rank-up request is complete: [exact-head CI run 33577264641](https://github.com/openclaw/openclaw/actions/runs/33577264641) finished successfully for `ecd2f70a35963cf356018dc4ce117f0f3a1f02cd`, including the required `openclaw/ci-gate`, with zero pending or failed active checks. The fresh review is under 12 hours old, and the follow-up addresses CI diagnostics without expanding behavior.

Reproduction command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-fixture.e2e.test.ts`.

The inspected synthetic screenshots below show UI continuity, not the network measurements. The stale pinned tile is intentional fixture content. Before: CSP-only probe still made one speculative TCP connection. After: the final repaired-candidate native probe made none. The attachment screenshot is not presented as evidence of visible image rendering.

![Standalone board before](https://github.com/user-attachments/assets/08afa627-e73a-4259-bb1f-92a66d5f6f21)

![Standalone board after](https://github.com/user-attachments/assets/3544043d-cffa-4521-a665-5d594fb027a8)
