### PR TITLE
perf(markdown): reduce temporary reply-formatting allocations

### DIFF
--- a/packages/markdown-core/src/render.crossing.test.ts
+++ b/packages/markdown-core/src/render.crossing.test.ts
@@ -43,6 +43,46 @@ describe("renderMarkdownWithMarkers crossing spans", () => {
       }),
     ).toBe(html);
   });
+
+  it("keeps marker callback order and link nesting for unsorted same-start styles", () => {
+    let opened = 0;
+    const marker = (tag: string) => ({
+      open: () => `<${tag} data-open="${++opened}">`,
+      close: `</${tag}>`,
+    });
+
+    expect(
+      renderMarkdownWithMarkers(
+        {
+          text: "abcd 🌍",
+          styles: [
+            { start: 0, end: 2, style: "italic" },
+            { start: 0, end: 7, style: "italic" },
+            { start: 0, end: 7, style: "bold" },
+            { start: 0, end: 2, style: "bold" },
+            { start: 0, end: 7, style: "blockquote" },
+          ],
+          links: [{ start: 0, end: 7, href: "https://example.com" }],
+        },
+        {
+          styleMarkers: {
+            bold: marker("b"),
+            italic: marker("i"),
+            blockquote: marker("blockquote"),
+          },
+          escapeText: (text) => text,
+          buildLink: (link) => ({
+            start: link.start,
+            end: link.end,
+            open: `<a href="${link.href}">`,
+            close: "</a>",
+          }),
+        },
+      ),
+    ).toBe(
+      '<blockquote data-open="1"><a href="https://example.com"><b data-open="2"><i data-open="3"><b data-open="4"><i data-open="5">ab</i></b>cd 🌍</i></b></a></blockquote>',
+    );
+  });
 });
 
 describe("renderMarkdownWithMarkers code content", () => {

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -84,18 +84,6 @@ const STRUCTURAL_STYLES = new Set<MarkdownStyle>([
   "heading_6",
 ]);
 
-function sortStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
-  return [...spans].toSorted((a, b) => {
-    if (a.start !== b.start) {
-      return a.start - b.start;
-    }
-    if (a.end !== b.end) {
-      return b.end - a.end;
-    }
-    return (STYLE_RANK.get(a.style) ?? 0) - (STYLE_RANK.get(b.style) ?? 0);
-  });
-}
-
 type TextRange = { start: number; end: number };
 
 function mergeRanges(ranges: readonly TextRange[]): TextRange[] {
@@ -217,35 +205,32 @@ export function renderMarkdownWithMarkers(
   const annotationBoundaries = [
     ...new Set(annotated.flatMap((span) => [span.start, span.end])),
   ].toSorted((a, b) => a - b);
-  const styled = sortStyleSpans(
-    projected.styles
-      .filter((span) => Boolean(styleMarkers[span.style]))
-      .flatMap((span) => {
-        if (STRUCTURAL_STYLES.has(span.style)) {
-          return [span];
-        }
-        return subtractRanges(span, dominantAnnotationRanges).flatMap((piece) =>
-          splitAtBoundaries(piece, annotationBoundaries),
-        );
-      }),
-  );
-
   const boundaries = new Set<number>();
   boundaries.add(0);
   boundaries.add(text.length);
 
   const startsAt = new Map<number, MarkdownStyleSpan[]>();
-  for (const span of styled) {
-    if (span.start === span.end) {
+  for (const span of projected.styles) {
+    if (!styleMarkers[span.style]) {
       continue;
     }
-    boundaries.add(span.start);
-    boundaries.add(span.end);
-    const bucket = startsAt.get(span.start);
-    if (bucket) {
-      bucket.push(span);
-    } else {
-      startsAt.set(span.start, [span]);
+    const pieces = STRUCTURAL_STYLES.has(span.style)
+      ? [span]
+      : subtractRanges(span, dominantAnnotationRanges).flatMap((piece) =>
+          splitAtBoundaries(piece, annotationBoundaries),
+        );
+    for (const piece of pieces) {
+      if (piece.start === piece.end) {
+        continue;
+      }
+      boundaries.add(piece.start);
+      boundaries.add(piece.end);
+      const bucket = startsAt.get(piece.start);
+      if (bucket) {
+        bucket.push(piece);
+      } else {
+        startsAt.set(piece.start, [piece]);
+      }
     }
   }
   for (const spans of startsAt.values()) {


### PR DESCRIPTION
## What Problem This Solves

Formatting a reply with many styled spans creates a global staging array and sorts every span before the renderer groups and sorts the same spans again.

## Why This Change Was Made

Stream supported, annotation-adjusted style pieces directly into the renderer's existing start buckets. Remove the global style array and `sortStyleSpans`. Keep the per-bucket sort because marker callbacks can observe their invocation order, and keep the mixed-opening sort for structural styles, annotations, links and formatting.

The marker renderer remains the canonical owner. Crossing-span close/reopen behavior, annotation dominance, link provenance, input immutability and channel chunking are preserved. Production: +19/-34, net **-15 lines**. Tests: +40/-0.

## User Impact

Replies retain their formatting and chunk boundaries while the renderer creates fewer temporary arrays and performs fewer sort comparisons. There are no configuration, protocol, dependency or storage changes.

## Evidence

- On current main `0edbcd8efac0599b2ed58f44cd9c84ed7b1027cc`, 219 tests passed across 11 files covering the renderer, annotations, current IR/chunking/fallback callers, tables, Telegram HTML/rich blocks, Slack and Discord.
- A paired source-owner probe produced **4,295 byte-identical observations across 987 inputs**, including shuffled styles, overlapping spans, stateful marker callbacks, annotations, Unicode and links. The independent mixed-span HTML oracle, long Telegram chunks and generic chunks also matched.
- For 200 renders with 256 styles each, measured array-producing method results fell from 53,200 to 52,600; their element positions fell from 358,600 to 205,000. Total sort comparisons fell from 651,000 to 455,400, including increased work in the retained local sorts. These are allocation/work counts, not heap-byte, RSS or whole-Gateway latency claims.
- The new callback-order test passes on both versions and fails when the required local bucket sort is removed. The separate performance gate fails on the redundant global sort and passes after this refactor.
- Linux proof now passes through the actual Gateway, mock OpenAI Responses provider and Crabline Telegram API. Both versions completed the same two-turn scenario with four accepted, byte-identical HTML sends. Parent and independent review checked the canonical provider records, all 96 long-message segments, executed renderer bundles, clean Gateway shutdown, removed state roots and closed ports.
- Full changed-file checks and fresh scoped Codex P0 review passed. Exact-head CI run [33576239576](https://github.com/openclaw/openclaw/actions/runs/33576239576) is green.

<details>
<summary>Gateway/channel proof and limits</summary>

The lease is associated with [Testbox run 33576131088](https://github.com/openclaw/openclaw/actions/runs/33576131088). The successful native command returned exit 0; the suite used `node dist/entry.js qa suite --provider-mode mock-openai --channel-driver crabline --channel telegram --concurrency 1 --scenario markdown-spans-proof` with private repository/output directories. The task-only fixture combines the independent mixed-span oracle with the existing three-chunk long-final fixture.

```json
{
  "provider": "blacksmith-testbox",
  "leaseId": "tbx_01m1frtawqby8c80xx4w4qpksk",
  "sourceBase": "eee230d0b763d30e737aaf0c28c7277aa30adcf9",
  "candidatePatchSha256": "e8f443fd6c5c7fdd0daf6058bccf541e9b69e5f7f49d4863b303ba1712076930",
  "baselineOwnerSha256": "148f0855b596ed274fe3881ab810697863461f348abeb01db920267656e72d22",
  "candidateOwnerSha256": "7af83cd8bcbaa97e11167cf3649f28d077e601528ecacc4c52cb27e9e3125b37",
  "before": {
    "scenariosPassed": 1,
    "failed": 0,
    "skipped": 0,
    "modelHttp200Responses": 2,
    "acceptedHtmlMessages": 4
  },
  "after": {
    "scenariosPassed": 1,
    "failed": 0,
    "skipped": 0,
    "modelHttp200Responses": 2,
    "acceptedHtmlMessages": 4
  },
  "htmlUtf16Lengths": [
    193,
    3948,
    3915,
    552
  ],
  "payloadsByteIdentical": true,
  "longSegmentsInOrder": 96,
  "rendererMainThreadInvocationCounts": [
    4,
    4
  ],
  "gatewayShutdownsClean": true,
  "gatewayRuntimeRootsRemoved": 2,
  "servicePortsClosed": 6,
  "privateTaskRemoved": true
}
```

The archived output contains 58 regular files; all 57 original checksum entries were independently verified. The archive SHA-256 is `f174ec8c30a626fab56d94382b0a3c3e9e505402378ffb909fd2045dd077fb34`. Both original inner receipts report no surviving observed children; retrieval separately rechecked all 151 outer-recorded process identities, both Gateway runtime roots and all six ports. Ten additional short-lived identities present only in the inner receipts were not re-statted by that later retrieval.

This is mock-provider/Crabline channel proof, not real Telegram or vendor API proof. V8 coverage attributes renderer execution to the actual Gateway main thread during each fixture, not to individual sends. The coverage-instrumented QA timing/RSS samples are not used as a performance comparison. The paired Linux run pins `eee230d0`; the exact renderer bytes match this PR, and the current-main 219-test/4,295-observation checks above cover subsequent IR/chunking changes. Native main `967a7ead` has no further Markdown-package drift from that current-main probe.

Earlier attempts stopped at proof setup or transport before this completed pair; their failures remain retained. No production code, assertions, timeouts or access checks were weakened to obtain the successful run.

</details>
