### PR TITLE
fix(feishu): apply group binding changes without restart

### DIFF
--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -143,7 +143,11 @@ describe("broadcast dispatch", () => {
     path: "/tmp/inbound-clip.mp4",
     contentType: "video/mp4",
   });
+  let currentRuntimeConfig = {} as ClawdbotConfig;
   const runtimeStub = {
+    config: {
+      current: vi.fn(() => currentRuntimeConfig),
+    },
     system: {
       enqueueSystemEvent: vi.fn(),
     },
@@ -245,6 +249,11 @@ describe("broadcast dispatch", () => {
     };
   }
 
+  async function dispatchMessage(params: Parameters<typeof handleFeishuMessage>[0]) {
+    currentRuntimeConfig = params.cfg;
+    await handleFeishuMessage(params);
+  }
+
   function createBroadcastEvent(options: {
     messageId: string;
     text: string;
@@ -331,7 +340,7 @@ describe("broadcast dispatch", () => {
       botMentioned: true,
     });
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       botOpenId: "bot-open-id",
@@ -416,7 +425,7 @@ describe("broadcast dispatch", () => {
       ensureNoVisibleReplyFallback: vi.fn(),
     });
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg: createBroadcastConfig(),
       event: createBroadcastEvent({
         messageId: "msg-broadcast-observer-isolation",
@@ -460,7 +469,7 @@ describe("broadcast dispatch", () => {
       botMentioned: true,
     });
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       botOpenId: "bot-open-id",
@@ -494,7 +503,7 @@ describe("broadcast dispatch", () => {
       botMentioned: true,
     });
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       botOpenId: "bot-open-id",
@@ -529,7 +538,7 @@ describe("broadcast dispatch", () => {
       botMentioned: true,
     });
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       botOpenId: "bot-open-id",
@@ -546,7 +555,7 @@ describe("broadcast dispatch", () => {
       text: "hello everyone",
     });
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       botOpenId: "ou_known_bot",
@@ -565,7 +574,7 @@ describe("broadcast dispatch", () => {
       text: "hello everyone",
     });
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       runtime: createRuntimeEnv(),
@@ -602,7 +611,7 @@ describe("broadcast dispatch", () => {
       },
     };
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       runtime: createRuntimeEnv(),
@@ -647,7 +656,7 @@ describe("broadcast dispatch", () => {
       },
     };
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       runtime: createRuntimeEnv(),
@@ -659,7 +668,7 @@ describe("broadcast dispatch", () => {
     mockGetChatInfo.mockClear();
     builtInboundContextCalls.length = 0;
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       runtime: createRuntimeEnv(),
@@ -712,7 +721,7 @@ describe("broadcast dispatch", () => {
     (cfg.broadcast as Record<string, unknown>).strategy = "sequential";
 
     await expect(
-      handleFeishuMessage({
+      dispatchMessage({
         cfg,
         event,
         botOpenId: "bot-open-id",
@@ -733,7 +742,7 @@ describe("broadcast dispatch", () => {
 
     mockDispatchReply.mockClear();
     const retryTransport = createIngressLifecycle();
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       botOpenId: "bot-open-id",
@@ -784,7 +793,7 @@ describe("broadcast dispatch", () => {
     const transport = createIngressLifecycle();
 
     await expect(
-      handleFeishuMessage({
+      dispatchMessage({
         cfg: createBroadcastConfig(),
         event: createBroadcastEvent({
           messageId: "msg-broadcast-fallback-failure",
@@ -829,7 +838,7 @@ describe("broadcast dispatch", () => {
     const transport = createIngressLifecycle();
 
     await expect(
-      handleFeishuMessage({
+      dispatchMessage({
         cfg,
         event: createBroadcastEvent({
           messageId: "msg-broadcast-setup-failure",
@@ -869,7 +878,7 @@ describe("broadcast dispatch", () => {
     );
     const transport = createIngressLifecycle();
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg: createBroadcastConfig(),
       event: createBroadcastEvent({
         messageId: "msg-broadcast-undispatched",
@@ -910,7 +919,7 @@ describe("broadcast dispatch", () => {
     });
     transport.calls.adopted.mockImplementationOnce(async () => await adoptionGate);
 
-    const handling = handleFeishuMessage({
+    const handling = dispatchMessage({
       cfg: createBroadcastConfig(),
       event: createBroadcastEvent({
         messageId: "msg-broadcast-adoption-order",
@@ -967,7 +976,7 @@ describe("broadcast dispatch", () => {
     });
     const transport = createIngressLifecycle();
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg: createBroadcastConfig(),
       event: createBroadcastEvent({
         messageId: "msg-broadcast-deferred",
@@ -1022,7 +1031,7 @@ describe("broadcast dispatch", () => {
       },
     };
 
-    await handleFeishuMessage({
+    await dispatchMessage({
       cfg,
       event,
       runtime: createRuntimeEnv(),

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -7,7 +7,7 @@ import type {
   resolveConfiguredBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
-import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveAgentRoute, type ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveGroupSessionKey } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
@@ -1274,6 +1274,95 @@ describe("handleFeishuMessage command authorization", () => {
     expect(dynamicAgentRequest.accountId).toBe("default");
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({ cfg: refreshedCfg }),
+    );
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: refreshedCfg }),
+    );
+  });
+
+  it("routes a gateway-received group message with bindings reloaded after handler startup", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg = createFeishuTestConfig(
+      { groupPolicy: "open", requireMention: false },
+      { agents: { list: [{ id: "main" }, { id: "sales" }] } },
+    );
+    const refreshedCfg = createFeishuTestConfig(
+      { groupPolicy: "open", requireMention: false },
+      {
+        agents: { list: [{ id: "main" }, { id: "sales" }] },
+        bindings: [
+          {
+            agentId: "sales",
+            match: {
+              channel: "feishu",
+              accountId: "default",
+              peer: { kind: "group", id: "oc-refreshed-binding" },
+            },
+          },
+        ],
+      },
+    );
+    currentRuntimeConfig = cfg;
+    const pluginRuntime = createFeishuBotRuntime();
+    const channelRuntime = {
+      ...pluginRuntime.channel,
+      routing: {
+        ...pluginRuntime.channel.routing,
+        resolveAgentRoute,
+      },
+      commands: {
+        ...pluginRuntime.channel.commands,
+        isControlCommandMessage: vi.fn(() => false),
+      },
+      debounce: {
+        resolveInboundDebounceMs: vi.fn(() => 0),
+        createInboundDebouncer: vi.fn(
+          (options: {
+            onFlush: (
+              entries: Array<{ event: FeishuMessageEvent }>,
+              createFlush: typeof createTestInboundDebounceFlush,
+            ) => { completion: Promise<void> };
+          }) => ({
+            enqueue: async (entry: { event: FeishuMessageEvent }) => {
+              await options.onFlush([entry], createTestInboundDebounceFlush).completion;
+            },
+            flushKey: async () => {},
+            cancelKey: () => false,
+            drain: async () => {},
+          }),
+        ),
+      },
+    } as unknown as PluginRuntime["channel"];
+    setFeishuRuntime(pluginRuntime);
+    const receive = createFeishuMessageReceiveHandler({
+      cfg,
+      channelRuntime,
+      accountId: "default",
+      runtime: createRuntimeEnv(),
+      chatHistories: new Map(),
+      handleMessage: handleFeishuMessage,
+      resolveDebounceText: ({ event }) =>
+        (JSON.parse(event.message.content) as { text: string }).text,
+      hasProcessedMessage: vi.fn(async () => false),
+    });
+
+    // Simulate the gateway config reload after this long-lived receive handler
+    // has already captured its startup config.
+    currentRuntimeConfig = refreshedCfg;
+    await receive(
+      createFeishuTestEvent({
+        messageId: "msg-refreshed-group-binding",
+        senderOpenId: "ou-sender",
+        chatId: "oc-refreshed-binding",
+        chatType: "group",
+      }),
+    );
+
+    expect(pluginRuntime.config.current).toHaveBeenCalled();
+    expect(mockResolveAgentRoute).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: refreshedCfg, agentId: "sales" }),
     );
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledWith(
       expect.objectContaining({ cfg: refreshedCfg }),

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -784,16 +784,16 @@ export async function handleFeishuMessage(params: {
     let effectiveDmIngress = dmIngress;
     let effectiveShouldComputeCommandAuthorized =
       directAuthorization?.shouldComputeCommandAuthorized ?? shouldComputeCommandAuthorized;
-    let effectiveCfg = cfg;
+    // Route every inbound turn against the latest bindings. Direct chats also
+    // reauthorize when that runtime snapshot changed after initial admission.
+    let effectiveCfg = getFeishuRuntime().config.current() as ClawdbotConfig;
     if (isDirect) {
-      const currentCfg = getFeishuRuntime().config.current() as ClawdbotConfig;
-      if (currentCfg !== effectiveCfg) {
-        const currentAuthorization = await resolveDirectAuthorization(currentCfg, true);
+      if (effectiveCfg !== cfg) {
+        const currentAuthorization = await resolveDirectAuthorization(effectiveCfg, true);
         if (currentAuthorization.ingress.ingress.admission !== "dispatch") {
           await rejectDirectAuthorization(currentAuthorization);
           return;
         }
-        effectiveCfg = currentCfg;
         effectiveDmPolicy = currentAuthorization.dmPolicy;
         effectiveConfigAllowFrom = currentAuthorization.configAllowFrom;
         effectiveDmIngress = currentAuthorization.ingress;


### PR DESCRIPTION
Closes #133757

## What Problem This Solves

Feishu group messages continued routing with stale bindings after configuration reloads, so operators had to restart the Gateway before updated group-to-agent bindings took effect.

## Why This Change Was Made

Each inbound turn now resolves its route from the mandatory current runtime configuration. Direct messages retain the existing reauthorization behavior when the runtime snapshot changes.

The regression test crosses the receive boundary: it creates a long-lived Feishu message handler with the startup configuration, swaps `PluginRuntime.config.current()` to a reloaded configuration, delivers a group event through that existing handler, and uses the real core `resolveAgentRoute` to verify that the new exact group binding selects the `sales` agent.

## User Impact

Operators can update Feishu group-to-agent bindings and have subsequent group messages use the new route immediately, without restarting the Gateway.

## Evidence

- `pnpm exec vitest run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/bot.test.ts -t "routes a gateway-received group message" --reporter=verbose` — boundary proof passed and selected `sales` through the real route resolver
- `pnpm exec vitest run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.broadcast.test.ts --reporter=dot` — 119 passed
- Full Feishu extension run: 100 test files / 1917 tests passed; the only local Windows failures were 13 pre-existing `doctor.test.ts` temp-directory cleanup `EPERM` errors
- `pnpm exec oxfmt --check extensions/feishu/src/bot.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.broadcast.test.ts`
- `pnpm exec oxlint extensions/feishu/src/bot.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.broadcast.test.ts`
- `git diff --check`
<!-- feishu-live-proof-2026-09-02 -->
### Real Feishu Gateway proof (2026-09-02)

Validated with a published self-built Feishu app over the real WebSocket transport, a real Feishu group, and OpenClaw `2026.8.1` built from this PR head (`9ec9067`). Identifiers and credentials are redacted.

The same Gateway process remained alive throughout (PID unchanged, listener continuously active):

```text
17:53:36 gateway listening; Feishu WebSocket client ready

17:57:22 received real group message in oc_[redacted]
17:57:22 route bindings=1
17:57:22 matchedBy=binding.channel agentId=main
17:57:23 dispatching session=agent:main:feishu:group:oc_[redacted]
17:57:26 session turn created agentId=main channel=feishu

17:58:47 config change detected; evaluating reload (bindings)
             exact binding added: oc_[redacted] -> sales
             Gateway was not restarted; same PID and listener verified

18:00:56 received next real group message in the same oc_[redacted]
18:00:56 route bindings=2
18:00:56 binding agentId=sales account=default peer=group:oc_[redacted]
18:00:56 matchedBy=binding.peer agentId=sales
18:00:56 dispatching session=agent:sales:feishu:group:oc_[redacted]
18:00:57 session turn created agentId=sales channel=feishu
```

The Feishu client displayed bot reply cards labeled first `Agent: PR Proof Main`, then `Agent: PR Proof Sales`. The configured test model credential was stale and returned HTTP 401, but that occurred after routing and does not affect this proof: both real inbound events were accepted, the second event used the refreshed binding in the existing handler/Gateway process, the corresponding agent run was created, and Feishu received the outbound cards.