### PR TITLE
fix(macos): preserve the Talk overlay through quick toggles

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -24,8 +24,10 @@ final class TalkOverlayController {
     private var window: NSPanel?
     private var hostingView: NSHostingView<TalkOverlayView>?
     private let screenInset: CGFloat = 0
+    @ObservationIgnored private var transitionID = UUID()
 
     func present() {
+        self.transitionID = UUID()
         self.ensureWindow()
         self.hostingView?.rootView = TalkOverlayView(controller: self)
         let target = self.targetFrame()
@@ -42,16 +44,15 @@ final class TalkOverlayController {
     }
 
     func dismiss() {
-        guard let window else {
-            self.model.isVisible = false
-            return
-        }
+        let dismissalID = UUID()
+        self.transitionID = dismissalID
+        self.model.isVisible = false
+        guard let window else { return }
 
-        OverlayPanelFactory.animateDismiss(window: window) {
-            Task { @MainActor in
-                window.orderOut(nil)
-                self.model.isVisible = false
-            }
+        OverlayPanelFactory.animateDismiss(window: window) { [weak self] in
+            // A later present or dismiss owns the panel, even while this fade is completing.
+            guard self?.transitionID == dismissalID else { return }
+            window.orderOut(nil)
         }
     }
 

--- a/apps/macos/Tests/Fixtures/TalkOverlay/Fixture.swift
+++ b/apps/macos/Tests/Fixtures/TalkOverlay/Fixture.swift
@@ -1,0 +1,73 @@
+import AppKit
+import SwiftUI
+
+/// Compile the real controller and factory without loading app state or microphone services.
+enum TalkModePhase: String {
+    case idle, listening, thinking, speaking
+}
+
+struct TalkOverlayView: View {
+    var controller: TalkOverlayController
+    var body: some View {
+        Text("Synthetic Talk overlay proof").padding().background(.blue)
+    }
+}
+
+@MainActor
+private final class FixtureDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_: Notification) {
+        Task { @MainActor in
+            do {
+                var failures = 0
+                for delay in [0, 40, 120] {
+                    let controller = TalkOverlayController()
+                    controller.present()
+                    guard let panel = NSApplication.shared.windows.first(where: {
+                        ($0.contentView as? NSHostingView<TalkOverlayView>)?.rootView.controller === controller
+                    }) else {
+                        print("FAIL missing Talk panel")
+                        exit(2)
+                    }
+                    // Timed end-to-end observations with the normal AppKit run loop, not a completion hook.
+                    try await Task.sleep(for: .milliseconds(240))
+                    controller.dismiss()
+                    if delay > 0 { try await Task.sleep(for: .milliseconds(delay)) }
+                    controller.present()
+                    try await Task.sleep(for: .milliseconds(450))
+                    let shown = controller.model.isVisible && panel.isVisible && panel.alphaValue == 1
+                    print("reopen delay_ms=\(delay) model=\(controller.model.isVisible) " +
+                        "panel=\(panel.isVisible) alpha=\(panel.alphaValue) pass=\(shown)")
+                    if !shown { failures += 1 }
+
+                    controller.dismiss()
+                    try await Task.sleep(for: .milliseconds(250))
+                    let hidden = !controller.model.isVisible && !panel.isVisible
+                    print("dismiss model=\(controller.model.isVisible) panel=\(panel.isVisible) pass=\(hidden)")
+                    if !hidden { failures += 1 }
+                    panel.orderOut(nil)
+                }
+                print("RESULT failures=\(failures)")
+                fflush(stdout)
+                exit(failures == 0 ? 0 : 1)
+            } catch {
+                print("FAIL fixture interrupted: \(error)")
+                exit(2)
+            }
+        }
+    }
+}
+
+@main
+private struct TalkOverlayFixture {
+    @MainActor static func main() {
+        let app = NSApplication.shared
+        guard !NSScreen.screens.isEmpty else {
+            print("FAIL Talk overlay fixture requires a logged-in macOS desktop")
+            exit(2)
+        }
+        app.setActivationPolicy(.accessory)
+        let delegate = FixtureDelegate()
+        app.delegate = delegate
+        withExtendedLifetime(delegate) { app.run() }
+    }
+}

--- a/apps/macos/Tests/Fixtures/TalkOverlay/run.sh
+++ b/apps/macos/Tests/Fixtures/TalkOverlay/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Opt-in, timed AppKit E2E; requires a logged-in macOS desktop and Developer ID.
+# Usage: bash apps/macos/Tests/Fixtures/TalkOverlay/run.sh '<Developer ID identity or SHA>'
+set -euo pipefail
+
+identity="${1:?Pass the matching Developer ID Application signing identity or certificate SHA}"
+fixture_source="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$fixture_source/../../../../.." && pwd)"
+fixture_dir="$(mktemp -d /tmp/openclaw-talk-overlay.XXXXXX)"
+trap 'rm -rf -- "$fixture_dir"' EXIT
+bundle="$fixture_dir/TalkOverlayFixture.app"
+mkdir -p "$bundle/Contents/MacOS"
+cat > "$bundle/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>ai.openclaw.talk-overlay-fixture</string>
+<key>CFBundleExecutable</key><string>TalkOverlayFixture</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+<key>LSUIElement</key><true/>
+</dict></plist>
+PLIST
+
+cd -- "$repo_root"
+sources=(
+  apps/macos/Sources/OpenClaw/TalkOverlay.swift
+  apps/macos/Sources/OpenClaw/OverlayPanelFactory.swift
+  apps/macos/Tests/Fixtures/TalkOverlay/Fixture.swift
+)
+shasum -a 256 "${sources[@]}" apps/macos/Tests/Fixtures/TalkOverlay/run.sh
+binary="$bundle/Contents/MacOS/TalkOverlayFixture"
+xcrun swiftc -swift-version 6 -parse-as-library "${sources[@]}" -o "$binary"
+codesign --force --sign "$identity" --timestamp=none "$bundle"
+codesign --verify --strict "$bundle"
+codesign -dv --verbose=4 "$bundle" 2>&1 | awk '
+  /^Authority=Developer ID Application:/ { found = 1 }
+  END { if (!found) { print "Expected Developer ID Application signature"; exit 1 } }
+'
+printf 'fixture_binary_sha256=%s\n' "$(shasum -a 256 "$binary" | cut -d ' ' -f 1)"
+"$binary"

--- a/apps/macos/Tests/OpenClawIPCTests/TalkOverlayTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkOverlayTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import QuartzCore
 import SwiftUI
 import Testing
 @testable import OpenClaw
@@ -16,10 +17,18 @@ struct TalkOverlayTests {
         })
         defer { window.orderOut(nil) }
 
-        controller.dismiss()
-        controller.present()
-        if dismissAgain { controller.dismiss() }
-        try await Task.sleep(for: .milliseconds(400))
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            NSAnimationContext.runAnimationGroup { _ in
+                controller.dismiss()
+                controller.present()
+                if dismissAgain { controller.dismiss() }
+            } completionHandler: {
+                // The factory queues its dismissal completion on MainActor after AppKit finishes.
+                Task { @MainActor in continuation.resume() }
+            }
+            // Commit animations without relying on the test runner's next run-loop iteration.
+            CATransaction.flush()
+        }
 
         #expect(controller.model.isVisible == !dismissAgain)
         #expect(window.isVisible == !dismissAgain)

--- a/apps/macos/Tests/OpenClawIPCTests/TalkOverlayTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkOverlayTests.swift
@@ -1,5 +1,4 @@
 import AppKit
-import QuartzCore
 import SwiftUI
 import Testing
 @testable import OpenClaw
@@ -7,8 +6,8 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct TalkOverlayTests {
-    @Test(arguments: [false, true])
-    func `latest presentation intent survives an interrupted dismissal`(dismissAgain: Bool) async throws {
+    @Test
+    func `visibility intent changes before animations complete`() throws {
         _ = NSApplication.shared
         let controller = TalkOverlayController()
         controller.present()
@@ -17,21 +16,12 @@ struct TalkOverlayTests {
         })
         defer { window.orderOut(nil) }
 
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            NSAnimationContext.runAnimationGroup { _ in
-                controller.dismiss()
-                controller.present()
-                if dismissAgain { controller.dismiss() }
-            } completionHandler: {
-                // The factory queues its dismissal completion on MainActor after AppKit finishes.
-                Task { @MainActor in continuation.resume() }
-            }
-            // Commit animations without relying on the test runner's next run-loop iteration.
-            CATransaction.flush()
-        }
-
-        #expect(controller.model.isVisible == !dismissAgain)
-        #expect(window.isVisible == !dismissAgain)
-        #expect(window.alphaValue == (dismissAgain ? 0 : 1))
+        #expect(controller.model.isVisible)
+        controller.dismiss()
+        #expect(!controller.model.isVisible)
+        controller.present()
+        #expect(controller.model.isVisible)
+        controller.dismiss()
+        #expect(!controller.model.isVisible)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/TalkOverlayTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkOverlayTests.swift
@@ -1,0 +1,28 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct TalkOverlayTests {
+    @Test(arguments: [false, true])
+    func `latest presentation intent survives an interrupted dismissal`(dismissAgain: Bool) async throws {
+        _ = NSApplication.shared
+        let controller = TalkOverlayController()
+        controller.present()
+        let window = try #require(NSApplication.shared.windows.first {
+            ($0.contentView as? NSHostingView<TalkOverlayView>)?.rootView.controller === controller
+        })
+        defer { window.orderOut(nil) }
+
+        controller.dismiss()
+        controller.present()
+        if dismissAgain { controller.dismiss() }
+        try await Task.sleep(for: .milliseconds(400))
+
+        #expect(controller.model.isVisible == !dismissAgain)
+        #expect(window.isVisible == !dismissAgain)
+        #expect(window.alphaValue == (dismissAgain ? 0 : 1))
+    }
+}


### PR DESCRIPTION
Related: #132565 (macOS Talk overlay dismissal race). Closes #127645 (Talk panel disappears after rapid toggling).

## What Problem This Solves

The macOS Talk panel can disappear when Talk is re-enabled during its previous fade-out: the old dismissal completion hides the newly presented panel.

## Why This Change Was Made

The overlay controller now records desired visibility immediately and gives each presentation or dismissal a new token. A dismissal completion hides the panel only while it still owns that token. The existing animation factory remains unchanged, and the redundant nested task is removed. No new helper, production test hook, dependency, configuration, protocol, or storage surface is added.

This is a maintainer rewrite of Huzaifa Iftikhar's (@HuzaifaChaudary) work in #132565 and the selected canonical replacement for that overlapping proposal. The original will be closed only after this repair is verified on main. The controller repair is production +10/-9 (net +1), compared with the original PR's +35 production lines. A 27-line unit regression is supplemented by a 73-line native fixture and 40-line opt-in runner.

## User Impact

Quick off/on transitions leave the Talk panel visible. Ordinary dismissal still hides it.

## Evidence

A Developer ID-signed isolated AppKit application ran the actual controller and panel factory with an inert synthetic view. Present → dismiss → present failed on the baseline at 0, 40, and 120 ms, then passed at every timing with this repair. Normal dismissal also passed. These actual animation checks remain separate from the checked-in synchronous regression.

The final Swift Testing regression checks immediate desired visibility through present → dismiss → present → dismiss. Against the original controller it fails both immediate-dismiss assertions; against the repaired controller it passes. The local proof uses the native SwiftPM backend, Swift 6 language mode, and the actual overlay and waveform views, with inert application-state/control dependencies. It ran on Swift 6.4/Testing 2077; a local Swift 6.3.3 build could not import the missing Testing module, so no local Swift 6.3 runtime proof is claimed. Scoped SwiftFormat 0.63.0, SwiftLint 0.65.1, and whitespace checks pass.

CI history matters here: the first full run failed the original 400 ms test on post-animation alpha/visibility assertions. The next completion-wait version reached the job's 20-minute timeout; TalkOverlayTests and three unrelated suites remained unfinished. The exact hang cause was not reproduced locally, including with the native backend and actual views. The final test does not await an AppKit animation completion or claim to prove final rendered state; the separate signed AppKit proof covers that behavior. [CI run 33582520467](https://github.com/openclaw/openclaw/actions/runs/33582520467) passed on the controller-and-unit-test head `27ae3f1a016d73b8882cdc6df0768e1aff6ddf4b`, including macOS Swift tests, the release build, all three macOS Node jobs, and the final CI gate.

This is not a full operator OpenClaw session or microphone test. Both complete before/after captures were inspected and contain only synthetic data. Both attached images are publicly accessible: downloaded PNG bytes match the inspected originals exactly. No alternate image host was used.

Adjacent Notify and Voice Wake overlay completions need separate reproduction; this PR does not claim to repair them.

### Rerunnable native regression

The late review correctly identified that the synchronous unit test does not execute the stale completion. The opt-in fixture in `apps/macos/Tests/Fixtures/TalkOverlay/` now compiles the actual controller and factory into a separately signed synthetic AppKit app and runs the normal application event loop. It verifies its Developer ID Application signature before launch, reports source and binary hashes, and removes its temporary app. It does not load operator app state, a Gateway, or microphone services.

```sh
bash apps/macos/Tests/Fixtures/TalkOverlay/run.sh '<Developer ID Application identity or certificate SHA>'
```

Removing only the dismissal-token guard makes the same fixture fail the real panel-visibility assertion at all three reopen offsets (0, 40, and 120 ms), while ordinary dismissal still passes. The current controller passes all three reopen and all three ordinary-dismissal checks, including visible alpha for each reopened panel. This is timed end-to-end proof using 240/450/250 ms observation intervals, not deterministic completion control or a formal callback acknowledgment. The fixture is opt-in and separate from automatic Swift Testing. [CI run 33593368734](https://github.com/openclaw/openclaw/actions/runs/33593368734) passed on final head `58b669e60f91ada1955aa3a328c68a3b3605febf`, including macOS Swift tests and the release build. CI does not automatically execute the opt-in fixture.

For the review's rank-up request, the real event-loop fixture supplies durable coverage of the asynchronous outcome. Deterministic unit completion control is intentionally not added: tracing disproved the proposed animation-disable/task-barrier ordering, and exposing a new production hook solely for this test would weaken the implementation. No workaround, swizzle, timeout increase, or production change is included.

The retained signed run occurred before committing `58b669e60f91ada1955aa3a328c68a3b3605febf`; all four input hashes were rechecked after the commit and match its files exactly. It is not a claim that the process was launched after that commit. The runtime log below omits only the temporary app path and signing-status line:

```text
e0cfa5da037ee0194e4dd537a19fcda95e6a00b107f662624342a2a048fc8398  apps/macos/Sources/OpenClaw/TalkOverlay.swift
5c8bc4d76fdfadb469cd8a66164217df7b6f73e0c93c894289732a98b25ac85e  apps/macos/Sources/OpenClaw/OverlayPanelFactory.swift
36569c41a9ce519f195ef2653046ffe5b05bb8d33f13155942e2eba06468f06b  apps/macos/Tests/Fixtures/TalkOverlay/Fixture.swift
3c2c8637738503d26ff409f83d3c136e62192042be1475ca6fd1c9a9d05e17f1  apps/macos/Tests/Fixtures/TalkOverlay/run.sh
fixture_binary_sha256=85965bfb1fca0dd7a73e33f6cbccfc04a8289582d5589e42354210ae52e2cf1d
reopen delay_ms=0 model=true panel=true alpha=1.0 pass=true
dismiss model=false panel=false pass=true
reopen delay_ms=40 model=true panel=true alpha=1.0 pass=true
dismiss model=false panel=false pass=true
reopen delay_ms=120 model=true panel=true alpha=1.0 pass=true
dismiss model=false panel=false pass=true
RESULT failures=0
```

The parent runner exited 0. The preceding negative control, with only the dismissal-token guard removed, exited 1 and reported `RESULT failures=3`: all reopened panels were hidden, while all ordinary dismissals passed. That control's controller hash was `8b469e80fe828f59bb7e4047e01002ec754e2541d1e771470f09dabb9e956728` and its signed binary hash was `4aec244aaa9bda7b9c35792b74a7cff1ba875120a5412122291d69a2dc0cca89`; the other three source hashes were unchanged.

### Before/after pictures

Retained captures of the actual Talk overlay controller and unchanged animation factory in an isolated AppKit fixture with a synthetic view. After present → dismiss → present, the original owner hides the reopened panel; the repaired owner leaves it visible.

| Before | After |
| --- | --- |
| ![Before: the reopened synthetic Talk overlay is hidden](https://github.com/user-attachments/assets/9f28bcca-1a2c-4d7a-bfa5-56120c5ce51e) | ![After: the reopened synthetic Talk overlay remains visible](https://github.com/user-attachments/assets/8024e9f0-84be-4656-b450-f2f2cb1fd10c) |

These pictures cover the owner and animation behavior. They do not establish full-app, microphone, current PR-head, or merged-main execution; immutable identities of the captured binaries were not retained.
