### PR TITLE
refactor(imessage): share GUID normalization

### DIFF
--- a/extensions/imessage/src/approval-polls.ts
+++ b/extensions/imessage/src/approval-polls.ts
@@ -20,9 +20,9 @@ import {
   buildIMessageApprovalConversationKeyForInbound,
   enumerateApprovalTargetKeys,
   normalizeConversationKey,
-  normalizeIMessageGuid,
   type IMessageApprovalConversationKey,
 } from "./approval-target-keys.js";
+import { normalizeIMessageGuid } from "./message-guid.js";
 import type { IMessagePayload, IMessagePoll } from "./monitor/types.js";
 import { getOptionalIMessageRuntime } from "./runtime.js";
 import { normalizeIMessageHandle } from "./targets.js";

--- a/extensions/imessage/src/approval-reaction-poll-targets.ts
+++ b/extensions/imessage/src/approval-reaction-poll-targets.ts
@@ -14,9 +14,9 @@ import {
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   normalizeConversationKey,
-  normalizeIMessageGuid,
   type IMessageApprovalConversationKey,
 } from "./approval-target-keys.js";
+import { normalizeIMessageGuid } from "./message-guid.js";
 import { getOptionalIMessageRuntime } from "./runtime.js";
 
 const PERSISTENT_POLL_TARGET_NAMESPACE = "imessage.approval-reaction-poll-targets";

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -11,6 +11,7 @@ import {
   registerIMessageApprovalReactionTarget,
   type IMessageApprovalConversationKey,
 } from "./approval-reactions.js";
+import { normalizeIMessageGuid } from "./approval-target-keys.js";
 import type { IMessageRpcClient } from "./client.js";
 import type { IMessagePayload } from "./monitor/types.js";
 
@@ -57,16 +58,12 @@ function uniqueChatIds(chatIds: readonly number[]): number[] {
   return [...new Set(chatIds)];
 }
 
-function normalizeMessageGuid(value: string): string {
-  return value.trim().replace(/^p:\d+\//iu, "");
-}
-
 function enumerateMessageGuidCandidates(value: string): string[] {
   const trimmed = value.trim();
   if (!trimmed) {
     return [];
   }
-  const normalized = normalizeMessageGuid(trimmed);
+  const normalized = normalizeIMessageGuid(trimmed);
   return [trimmed, normalized].filter(
     (candidate, index, candidates) =>
       candidate.length > 0 && candidates.indexOf(candidate) === index,
@@ -228,7 +225,7 @@ export async function pollPendingIMessageApprovalReactions(params: {
       }
       const target =
         pendingByMessageId.get(targetGuid) ??
-        pendingByMessageId.get(normalizeMessageGuid(targetGuid));
+        pendingByMessageId.get(normalizeIMessageGuid(targetGuid));
       if (!target) {
         continue;
       }

--- a/extensions/imessage/src/approval-reaction-poller.ts
+++ b/extensions/imessage/src/approval-reaction-poller.ts
@@ -11,8 +11,8 @@ import {
   registerIMessageApprovalReactionTarget,
   type IMessageApprovalConversationKey,
 } from "./approval-reactions.js";
-import { normalizeIMessageGuid } from "./approval-target-keys.js";
 import type { IMessageRpcClient } from "./client.js";
+import { normalizeIMessageGuid } from "./message-guid.js";
 import type { IMessagePayload } from "./monitor/types.js";
 
 const RECENT_CHAT_LIMIT = 50;

--- a/extensions/imessage/src/approval-target-keys.ts
+++ b/extensions/imessage/src/approval-target-keys.ts
@@ -13,11 +13,6 @@ export type IMessageApprovalConversationKey = {
   handle?: string;
 };
 
-/** Strip the `p:<n>/` part prefix Messages puts on some GUIDs so keys match. */
-export function normalizeIMessageGuid(value: string): string {
-  return value.trim().replace(/^p:\d+\//iu, "");
-}
-
 function chatIdToKeyValue(chatId: number | string | undefined): string | null {
   if (chatId == null || chatId === "") {
     return null;

--- a/extensions/imessage/src/message-guid.ts
+++ b/extensions/imessage/src/message-guid.ts
@@ -1,0 +1,4 @@
+/** Strip the `p:<n>/` part prefix Messages puts on some GUIDs so keys match. */
+export function normalizeIMessageGuid(value: string): string {
+  return value.trim().replace(/^p:\d+\//iu, "");
+}

--- a/extensions/imessage/src/monitor/poll-comment.test-support.ts
+++ b/extensions/imessage/src/monitor/poll-comment.test-support.ts
@@ -51,6 +51,12 @@ describe("createPollCommentFolder", () => {
     expect(folder.isPollComment("SOME-OTHER-GUID", T0, "+15551110000")).toBe(false);
   });
 
+  it("keeps part-prefixed and raw GUIDs distinct", () => {
+    const folder = createPollCommentFolder();
+    folder.rememberPoll(`p:0/${POLL_GUID}`, T0, "+15551110000");
+    expect(folder.isPollComment(POLL_GUID, T0 + 500, "+15551110000")).toBe(false);
+  });
+
   it("does not fold a non-reply or a reply with no usable timestamp", () => {
     const folder = createPollCommentFolder();
     folder.rememberPoll(POLL_GUID, T0, "+15551110000");

--- a/extensions/imessage/src/monitor/reaction-context.ts
+++ b/extensions/imessage/src/monitor/reaction-context.ts
@@ -1,4 +1,5 @@
 // Imessage plugin module implements reaction context behavior.
+import { normalizeIMessageGuid } from "../approval-target-keys.js";
 import type { IMessagePayload } from "./types.js";
 
 export type IMessageReactionContext = {
@@ -29,9 +30,7 @@ const TAPBACK_TEXT_PATTERNS: Array<{
 ];
 
 function normalizeReactionValue(value: unknown): string | undefined {
-  return typeof value === "string"
-    ? value.trim().replace(/^p:\d+\//iu, "") || undefined
-    : undefined;
+  return typeof value === "string" ? normalizeIMessageGuid(value) || undefined : undefined;
 }
 
 function resolveReactionTargetGuidCandidates(...values: unknown[]): string[] {
@@ -44,7 +43,7 @@ function resolveReactionTargetGuidCandidates(...values: unknown[]): string[] {
     if (!raw) {
       continue;
     }
-    const normalized = raw.replace(/^p:\d+\//iu, "");
+    const normalized = normalizeIMessageGuid(raw);
     for (const candidate of [normalized, raw]) {
       if (candidate && !candidates.includes(candidate)) {
         candidates.push(candidate);

--- a/extensions/imessage/src/monitor/reaction-context.ts
+++ b/extensions/imessage/src/monitor/reaction-context.ts
@@ -1,5 +1,5 @@
 // Imessage plugin module implements reaction context behavior.
-import { normalizeIMessageGuid } from "../approval-target-keys.js";
+import { normalizeIMessageGuid } from "../message-guid.js";
 import type { IMessagePayload } from "./types.js";
 
 export type IMessageReactionContext = {

--- a/extensions/imessage/src/question-reactions.ts
+++ b/extensions/imessage/src/question-reactions.ts
@@ -6,18 +6,15 @@ import {
   questionGatewayRuntime,
 } from "openclaw/plugin-sdk/question-gateway-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { normalizeIMessageGuid } from "./approval-target-keys.js";
 import { resolveIMessageReactionContext } from "./monitor/reaction-context.js";
 import type { IMessagePayload } from "./monitor/types.js";
-
-function normalizeGuid(value: string): string {
-  return value.trim().replace(/^p:\d+\//iu, "");
-}
 
 type IMessageQuestionReactionIdentity = { accountId: string; messageGuid: string };
 
 function buildKey(identity: IMessageQuestionReactionIdentity): string | null {
   const account = identity.accountId.trim();
-  const guid = normalizeGuid(identity.messageGuid);
+  const guid = normalizeIMessageGuid(identity.messageGuid);
   return account && guid ? `${account}:${guid}` : null;
 }
 
@@ -44,7 +41,7 @@ function reactionCandidates(
   const guids = Array.from(
     new Set(
       [...(reaction.targetGuids ?? []), reaction.targetGuid ?? ""]
-        .map(normalizeGuid)
+        .map(normalizeIMessageGuid)
         .filter(Boolean),
     ),
   );
@@ -70,7 +67,7 @@ export function registerIMessageQuestionReactionTargetForDeliveredPayload(params
       typeof result.meta?.imessageMessageGuid === "string"
         ? result.meta.imessageMessageGuid
         : result.messageId;
-    if (/^\d+$/u.test(normalizeGuid(guid))) {
+    if (/^\d+$/u.test(normalizeIMessageGuid(guid))) {
       continue;
     }
     registered =

--- a/extensions/imessage/src/question-reactions.ts
+++ b/extensions/imessage/src/question-reactions.ts
@@ -6,7 +6,7 @@ import {
   questionGatewayRuntime,
 } from "openclaw/plugin-sdk/question-gateway-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { normalizeIMessageGuid } from "./approval-target-keys.js";
+import { normalizeIMessageGuid } from "./message-guid.js";
 import { resolveIMessageReactionContext } from "./monitor/reaction-context.js";
 import type { IMessagePayload } from "./monitor/types.js";
 


### PR DESCRIPTION
## What Problem This Solves

iMessage GUID part-prefix normalization was duplicated across question reactions, approval reaction polling, and reaction context. Keeping multiple local implementations made ordering and empty-value behavior vulnerable to drift.

## Why This Change Was Made

This consolidates the reaction and approval callers on one neutral plugin-owned helper in `extensions/imessage/src/message-guid.ts`. Approval-specific target-key code no longer owns the generic GUID normalizer.

Preserved contracts:

- question reaction identity remains account-scoped and normalized-only, with numeric message IDs excluded;
- approval polling remains raw-then-normalized, persists original IDs, rebinds observed candidates, and retains expiry and lifecycle checks;
- reaction context remains normalized-then-raw and preserves optional and empty handling;
- approval actor, account, conversation, allowlist, resolver, and Gateway authority are unchanged;
- poll-comment matching deliberately remains trim-only because folding `p:0/GUID` into `GUID` could silently discard a legitimate reply.

No dependency, core/SDK seam, config, persistence, protocol, or changelog entry was added.

## User Impact

No intended user-visible behavior change. iMessage reaction GUID handling now has one neutral canonical owner while poll-comment identity remains deliberately stricter.

## Evidence

### Scope and LOC

- Exact signed head: `6e9766e42300d91e9792fd5dbdbc916d2c5a9699`.
- Aggregate patch ID: `1bcc3cd8f7de993e1dbd32508cb5948c08cf5f2b`.
- Revision patch ID: `11c490b06848b8cc9378f81ae4b68240c8e7f00a`.
- Production: `+16/-24` across seven files, net `-8`.
- Test support: `+6/-0` across one file.
- Total: eight files, `+22/-24`.
- The helper moved unchanged to `extensions/imessage/src/message-guid.ts`; exactly five consumers now import it, and the approval-module export was removed.

### Tests and gates

- Focused owner and sibling tests: 64/64 passed.
- Import-cycle, plugin-boundary, changed-gate classification, scoped lint/format, and `git diff --check`: passed.
- Independent frozen-head review: approved at 0.99 confidence with no findings.
- Exact-head CI and native Testbox prepare are pending and will be recorded before merge.

The added poll-comment case protects observable drop/no-drop behavior rather than the helper location.

### Overlap guards

- https://github.com/openclaw/openclaw/pull/123075 remains open and unlanded at `8300e46d4a5db58c4f847d60d94bde644bad6fe9`.
- https://github.com/openclaw/openclaw/pull/130223 remains open and unlanded at `7395b9e923ccb874dad72dff3d59471ad0c39016`.
- Current `main` at `0be787a80c93dd4e71fa71f759b07f812b2fee25` has no drift in the eight affected files; the merge tree is clean.

### Codex source inspection

Personally inspected sibling Codex source at:

- `../codex/codex-rs/cli/src/main.rs:220-245`
- `../codex/codex-rs/cli/src/main.rs:2840-2870`

Those CLI and prompt-normalization paths impose no protocol or runtime contract on this plugin-local refactor.
