### PR TITLE
test(ui): reuse notice runtime and stabilize capability navigation

### DIFF
--- a/ui/src/app/update-success-notice.test.ts
+++ b/ui/src/app/update-success-notice.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../test-helpers/storage.ts";
 
 const { getSafeSessionStorageMock, reloadControlUiIfStaleMock, showToastMock } = vi.hoisted(() => ({
@@ -20,16 +20,21 @@ vi.mock("../local-storage.ts", () => ({
 }));
 
 describe("update success notice", () => {
-  beforeEach(() => {
+  let createUpdateNoticeSession: typeof import("./update-success-notice.ts").createUpdateNoticeSession;
+
+  beforeAll(async () => {
+    // Discard any owner import that predates this suite's mocked boundaries.
     vi.resetModules();
+    ({ createUpdateNoticeSession } = await import("./update-success-notice.ts"));
+  });
+
+  beforeEach(() => {
     vi.clearAllMocks();
     getSafeSessionStorageMock.mockReturnValue(null);
     reloadControlUiIfStaleMock.mockReturnValue(false);
   });
 
-  it("announces a non-reloading success when session storage is unavailable", async () => {
-    const { createUpdateNoticeSession } = await import("./update-success-notice.ts");
-
+  it("announces a non-reloading success when session storage is unavailable", () => {
     createUpdateNoticeSession("ws://gateway.test").announceVerifiedInstall(
       { version: "2026.8.11", sha: "abcdef1234567890" },
       { gateway: "ws://gateway.test", profileId: null },
@@ -42,8 +47,7 @@ describe("update success notice", () => {
 
   it.each(["handoff", "verified"] as const)(
     "hydrates the previous bundle's flat %s notice on upgrade",
-    async (kind) => {
-      const { createUpdateNoticeSession } = await import("./update-success-notice.ts");
+    (kind) => {
       const storage = createStorageMock();
       getSafeSessionStorageMock.mockReturnValue(storage);
       const scope = { gateway: "ws://gateway.test", profileId: "operator" };
@@ -82,8 +86,7 @@ describe("update success notice", () => {
     "quota exceeded",
     "invalid receipts",
     "oversized history",
-  ])("does not consume triage or erase history when storage is %s", async (failure) => {
-    const { createUpdateNoticeSession } = await import("./update-success-notice.ts");
+  ])("does not consume triage or erase history when storage is %s", (failure) => {
     const storage = createStorageMock();
     getSafeSessionStorageMock.mockReturnValue(storage);
     const scope = { gateway: "ws://gateway.test", profileId: null };
@@ -127,8 +130,7 @@ describe("update success notice", () => {
     expect(storage.getItem("openclaw:control-ui:update:v1")).toBe(previous);
   });
 
-  it("preserves consumed identities when another receipt exceeds the size limit", async () => {
-    const { createUpdateNoticeSession } = await import("./update-success-notice.ts");
+  it("preserves consumed identities when another receipt exceeds the size limit", () => {
     const storage = createStorageMock();
     getSafeSessionStorageMock.mockReturnValue(storage);
     const scope = { gateway: "ws://gateway.test", profileId: null };
@@ -143,8 +145,7 @@ describe("update success notice", () => {
     expect(createUpdateNoticeSession(scope.gateway).hasTriaged(scope, "previous")).toBe(true);
   });
 
-  it("retains the latest 32 consumed identities independently of pending and success notices", async () => {
-    const { createUpdateNoticeSession } = await import("./update-success-notice.ts");
+  it("retains the latest 32 consumed identities independently of pending and success notices", () => {
     getSafeSessionStorageMock.mockReturnValue(createStorageMock());
     const scope = { gateway: "ws://gateway.test", profileId: null };
     const session = createUpdateNoticeSession(scope.gateway);

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -601,7 +601,11 @@ suite.define(() => {
       const docs = menu.getByRole("menuitem", { name: /^Docs/ });
       await expect.poll(() => docs.isDisabled()).toBe(true);
       await expect.poll(() => tooltipTitleText(docs)).toContain("operator.admin access");
+      // Leave disabled-row hints before the next click's hit test. Returning to
+      // the root can put Web search under the pointer that clicked Back.
+      await composer.locator("textarea").hover();
       await menu.getByRole("menuitem", { name: "Back" }).click();
+      await composer.locator("textarea").hover();
       await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
       await expect
         .poll(() => menu.getByRole("menuitem", { name: /^github/ }).isDisabled())


### PR DESCRIPTION
The update-notice suite rebuilt the same module for each of ten cases even though mutable notice, receipt and storage state belongs to each createUpdateNoticeSession call. Keep the historical initial reset in beforeAll, retain that one imported factory, and remove repeated dynamic imports and unnecessary async test callbacks. Per-case mock defaults and fresh session/storage creation remain.

All ten cases and24 assertion sites remain; production delta is zero, tests+14/-13. The structural saving is ten explicit resets/imports becoming one. No wall-time or memory reduction is claimed.

Validation:80 owner, continuity and triage cases passed before and after through the canonical runner. A separate private warm-module run loaded the real unmocked owner before test collection, proved that exact factory was still cached before the suite hook, then observed one distinct retained factory across all ten shuffled cases. All ten passed. Removing only the retained initial reset failed all ten original assertions plus the factory-identity guard, confirming that the historical mock boundary must remain. All private process groups and run-owned roots were cleaned.

Manual review covered the full notice owner, factory callers, storage/toast/UUID boundaries, overlay lifecycle, sibling tests, relevant history and installed Vitest setup/reset/hook ordering. Cross-file ordering alone was not used as warm-cache proof because the repository runner clears evaluated exports after each file. Runtime UI and visuals are unchanged.

Repository guards, i18n verification, all three dead-export scans and targeted lint passed. The selected local UI type graph is blocked by the checkout's missing mermaid dependency at packages/mermaid-renderer/src/renderer.ts; hosted exact-head typecheck is required before landing.

Independent Codex review and manual lower-priority/deslop review found no actionable issue.

Also repair the capability-menu E2E interaction found by this PR's CI. Returning from Skills can put disabled Web search under the stationary pointer, opening its permission tooltip over Connectors. Playwright checks the hit target before moving the mouse, so a normal click waits behind that hint. Hover the visible composer field before Back and before Connectors to make pointer departure explicit; preserve normal click actionability and every permission assertion.

The exact CI interception was reproduced in real Chromium with the current Web search anchor still connected and hovered. Pointer departure closed the hint through its existing lifecycle; the same adverse flow then passed. The complete final menu file passed all10 cases and retained all68 assertion expressions. Root reviewed the complete menu, tooltip/title owners, suite and sibling tests, the installed Playwright pointer-action implementation, raw states and local screenshots. This test-only repair changes no UI visuals, timeout or retry behavior, and makes no measured flake-rate claim. Combined production delta0; tests+18/-13. The new head requires a fresh hosted CI run.
