### PR TITLE
fix: harden release upgrade and installation boundaries

### DIFF
--- a/src/cli/hook-install-persistence.ts
+++ b/src/cli/hook-install-persistence.ts
@@ -1,8 +1,11 @@
 // CLI persistence for hook-pack installs.
 import { replaceConfigFile } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { type HookInstallUpdate, recordHookInstall } from "../hooks/installs.js";
+import { stageHookInstall } from "../hooks/install-record-transaction.js";
+import type { HookInstallUpdate } from "../hooks/installs.js";
+import type { PackageDirInstallTransaction } from "../infra/install-package-dir.js";
 import type { ConfigSnapshotForInstallPersist } from "../plugins/install-persistence.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { enableInternalHookEntries, logHookPackRestartHint } from "./plugins-command-helpers.js";
 
@@ -13,20 +16,45 @@ export async function persistHookPackInstall(params: {
   install: Omit<HookInstallUpdate, "hookId" | "hooks">;
   successMessage?: string;
   runtime?: RuntimeEnv;
+  beforePersistentApply?: () => void;
+  payloadTransaction?: PackageDirInstallTransaction;
 }): Promise<OpenClawConfig> {
   const runtime = params.runtime ?? defaultRuntime;
-  let next = enableInternalHookEntries(params.snapshot.config, params.hooks);
-  next = recordHookInstall(next, {
-    hookId: params.hookPackId,
-    hooks: params.hooks,
-    ...params.install,
+  return await withPluginLifecycleLease({}, async (lease) => {
+    const assertPersistentApply = () => {
+      lease.assertOwned();
+      params.snapshot.writeOptions.assertConfigPathForWrite?.();
+      params.beforePersistentApply?.();
+    };
+    const next = enableInternalHookEntries(params.snapshot.config, params.hooks);
+    const transaction = await stageHookInstall({
+      update: { hookId: params.hookPackId, hooks: params.hooks, ...params.install },
+      payloadTransaction: params.payloadTransaction,
+      lease,
+      beforePersistentApply: assertPersistentApply,
+    });
+    try {
+      await replaceConfigFile({
+        nextConfig: next,
+        baseHash: params.snapshot.baseHash,
+        writeOptions: {
+          ...params.snapshot.writeOptions,
+          assertConfigPathForWrite: assertPersistentApply,
+        },
+      });
+    } catch (error) {
+      try {
+        await transaction.rollback();
+      } catch (rollbackError) {
+        throw new AggregateError([error, rollbackError], "Hook install config rollback failed", {
+          cause: rollbackError,
+        });
+      }
+      throw error;
+    }
+    await transaction.commit();
+    runtime.log(params.successMessage ?? `Installed hook pack: ${params.hookPackId}`);
+    logHookPackRestartHint(runtime);
+    return next;
   });
-  await replaceConfigFile({
-    nextConfig: next,
-    baseHash: params.snapshot.baseHash,
-    writeOptions: params.snapshot.writeOptions,
-  });
-  runtime.log(params.successMessage ?? `Installed hook pack: ${params.hookPackId}`);
-  logHookPackRestartHint(runtime);
-  return next;
 }

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -792,19 +792,17 @@ vi.mock("../hooks/install.js", () => ({
   resolveHookInstallDir: (hookId: string) => `/tmp/hooks/${hookId}`,
 }));
 
-vi.mock("../hooks/installs.js", () => ({
-  readHookInstalls: () => structuredClone(mockHookInstallRecords),
-  recordHookInstall: ((
-    ...args: Parameters<(typeof import("../hooks/installs.js"))["recordHookInstall"]>
-  ) =>
-    invokeMock<
-      Parameters<(typeof import("../hooks/installs.js"))["recordHookInstall"]>,
-      ReturnType<(typeof import("../hooks/installs.js"))["recordHookInstall"]>
-    >(
-      recordHookInstallMock,
-      ...args,
-    )) as (typeof import("../hooks/installs.js"))["recordHookInstall"],
-}));
+vi.mock("../hooks/installs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../hooks/installs.js")>();
+  return {
+    ...actual,
+    readHookInstalls: () => structuredClone(mockHookInstallRecords),
+    recordHookInstall: (...args: Parameters<typeof actual.recordHookInstall>) => {
+      recordHookInstallMock(...args);
+      return actual.recordHookInstall(...args);
+    },
+  };
+});
 
 vi.mock("../plugins/clawhub.js", () => ({
   CLAWHUB_INSTALL_ERROR_CODE: {
@@ -1125,8 +1123,5 @@ export function resetPluginsCliTestState() {
     ok: false,
     error: "hook npm install disabled in test",
   });
-  recordHookInstallMock.mockImplementation(
-    ((cfg: OpenClawConfig) => cfg) as (...args: unknown[]) => unknown,
-  );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -6,18 +6,20 @@ import { installedPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { hashConfigIncludeRaw } from "../config/includes.js";
+import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import { recordPluginManifestInstallOwner } from "../plugins/manifest-install-owner.js";
+import * as officialInstallTrust from "../plugins/official-external-install-trust.js";
 import {
   listOfficialExternalPluginCatalogEntries,
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
 } from "../plugins/official-external-plugin-catalog.js";
+import * as slotSelection from "../plugins/slot-selection.js";
 import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { VERSION } from "../version.js";
 import {
   applyExclusiveSlotSelectionMock,
-  buildPluginSnapshotReportMock,
   clearPluginRegistryLoadCacheMock,
   enablePluginInConfigMock,
   findBundledPluginSourceMock,
@@ -46,6 +48,7 @@ import {
   configWriteMock,
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
 } from "./plugins-cli-test-helpers.js";
+import { runPluginInstallCommand } from "./plugins-install-command.js";
 
 // Default-selector assertions describe a stable build; beta cases set their own identity.
 const coreVersion = vi.hoisted(() => ({ value: "2026.8.1" }));
@@ -283,35 +286,17 @@ function primeSuccessfulClawHubPluginInstall(
   return result;
 }
 
-function createPathHookPackInstalledConfig(tmpRoot: string): OpenClawConfig {
+function createEnabledHookConfig(): OpenClawConfig {
   return {
     hooks: {
       internal: {
-        installs: {
-          "demo-hooks": {
-            source: "path",
-            sourcePath: tmpRoot,
-            installPath: tmpRoot,
-          },
+        enabled: true,
+        entries: {
+          "command-audit": { enabled: true },
         },
       },
     },
-  } as OpenClawConfig;
-}
-
-function createNpmHookPackInstalledConfig(): OpenClawConfig {
-  return {
-    hooks: {
-      internal: {
-        installs: {
-          "demo-hooks": {
-            source: "npm",
-            spec: "@acme/demo-hooks@1.2.3",
-          },
-        },
-      },
-    },
-  } as OpenClawConfig;
+  };
 }
 
 function createHookPackInstallResult(targetDir: string): {
@@ -334,7 +319,7 @@ function createHookPackInstallResult(targetDir: string): {
 
 function primeHookPackNpmFallback() {
   const cfg = {} as OpenClawConfig;
-  const installedCfg = createNpmHookPackInstalledConfig();
+  const installedCfg = createEnabledHookConfig();
 
   pluginCliConfigMock.mockReturnValue(cfg);
   mockClawHubPackageNotFound("@acme/demo-hooks");
@@ -351,26 +336,16 @@ function primeHookPackNpmFallback() {
       integrity: "sha256-demo",
     },
   });
-  recordHookInstallMock.mockReturnValue(installedCfg);
-
   return { cfg, installedCfg };
 }
 
-function primeHookPackPathFallback(params: {
-  tmpRoot: string;
-  pluginInstallError: string;
-}): OpenClawConfig {
-  const installedCfg = createPathHookPackInstalledConfig(params.tmpRoot);
-
+function primeHookPackPathFallback(params: { tmpRoot: string; pluginInstallError: string }): void {
   pluginCliConfigMock.mockReturnValue({} as OpenClawConfig);
   installPluginFromPathMock.mockResolvedValueOnce({
     ok: false,
     error: params.pluginInstallError,
   });
   installHooksFromPathMock.mockResolvedValueOnce(createHookPackInstallResult(params.tmpRoot));
-  recordHookInstallMock.mockReturnValue(installedCfg);
-
-  return installedCfg;
 }
 
 type MockWithCalls = {
@@ -471,7 +446,7 @@ function replaceConfigCall(callIndex = 0): { baseHash?: string; nextConfig?: Ope
 }
 
 function recordHookInstallCall(callIndex = 0): PersistedInstallRecord {
-  return mockCallArg(recordHookInstallMock, callIndex, 1) as PersistedInstallRecord;
+  return mockCallArg(recordHookInstallMock, callIndex) as PersistedInstallRecord;
 }
 
 function runtimeLogsContain(fragment: string): boolean {
@@ -681,6 +656,109 @@ describe("plugins cli install", () => {
     expect(configWriteMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { source: "npm", pluginId: "demo", raw: "npm:demo" },
+    { source: "official", pluginId: "brave", raw: "brave" },
+    { source: "official primary ClawHub", pluginId: "demo", raw: "demo" },
+    { source: "official secondary ClawHub", pluginId: "matrix", raw: "matrix" },
+    { source: "bundled", pluginId: "demo", raw: "demo" },
+    { source: "bundled fallback", pluginId: "demo", raw: "demo" },
+    { source: "hook fallback", pluginId: "demo", raw: "npm:demo" },
+  ])(
+    "rejects a cancelled $source install without recording or enabling it",
+    async ({ source, pluginId, raw }) => {
+      primeSuccessfulPluginPersistence(pluginId);
+      findBundledPluginSourceMock.mockImplementation((input) => {
+        const { lookup } = input as Parameters<
+          typeof import("../plugins/bundled-sources.js").findBundledPluginSource
+        >[0];
+        return source === "bundled" || (source === "bundled fallback" && lookup.kind === "npmSpec")
+          ? { pluginId, localPath: cliInstallPath(pluginId) }
+          : undefined;
+      });
+      installPluginFromNpmSpecMock.mockResolvedValue(
+        source === "official secondary ClawHub" ||
+          source === "bundled fallback" ||
+          source === "hook fallback"
+          ? { ok: false, error: "npm error E404 package not found", code: "npm_package_not_found" }
+          : createNpmPluginInstallResult(pluginId),
+      );
+      const usesClawHub =
+        source === "official primary ClawHub" || source === "official secondary ClawHub";
+      const clawHubPackage =
+        source === "official secondary ClawHub" ? "@openclaw/matrix" : pluginId;
+      const clawHubSpec = `clawhub:${clawHubPackage}`;
+      if (usesClawHub) {
+        parseClawHubPluginSpecMock.mockReturnValue({ name: clawHubPackage });
+        installPluginFromClawHubMock.mockResolvedValue(
+          createClawHubInstallResult({
+            pluginId,
+            packageName: clawHubPackage,
+            version: "1.2.3",
+            channel: "latest",
+          }),
+        );
+      }
+      installHooksFromNpmSpecMock.mockResolvedValue(createHookPackInstallResult("/tmp/hooks/demo"));
+      const readSnapshot = readConfigFileSnapshotForWriteMock.getMockImplementation();
+      if (!readSnapshot) {
+        throw new Error("missing config snapshot fixture");
+      }
+      let active = true;
+      readConfigFileSnapshotForWriteMock.mockImplementation(async (...args) => {
+        const snapshot = await readSnapshot(...args);
+        active = false;
+        return snapshot;
+      });
+      replaceConfigFileMock.mockImplementation(async (input) => {
+        const params = input as Parameters<
+          typeof import("../config/config.js").replaceConfigFile
+        >[0];
+        params.writeOptions?.assertConfigPathForWrite?.();
+        await configWriteMock(params.nextConfig);
+      });
+      const officialPlanSpy =
+        source === "official primary ClawHub"
+          ? vi
+              .spyOn(officialInstallTrust, "resolveCatalogOfficialExternalInstallPlan")
+              .mockReturnValue({
+                pluginId,
+                spec: clawHubSpec,
+                installSources: [{ source: "clawhub", spec: clawHubSpec }],
+              })
+          : undefined;
+
+      try {
+        await expect(
+          runPluginInstallCommand({
+            raw,
+            opts: { force: true, acceptCapabilities: true },
+            allowInstallPolicyWarningPrompt: false,
+            beforePersistentApply: () => {
+              if (!active) {
+                throw new Error("installation authority closed");
+              }
+            },
+          }),
+        ).rejects.toThrow("installation authority closed");
+      } finally {
+        officialPlanSpy?.mockRestore();
+      }
+
+      if (usesClawHub) {
+        expect(clawHubInstallCall().spec).toBe(clawHubSpec);
+        expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(
+          source === "official secondary ClawHub" ? 1 : 0,
+        );
+        expect(installHooksFromNpmSpecMock).not.toHaveBeenCalled();
+      }
+      expect(configWriteMock).not.toHaveBeenCalled();
+      expect(recordHookInstallMock).not.toHaveBeenCalled();
+      expect(await loadInstalledPluginIndexInstallRecords()).toEqual({});
+      expect(runtimeLogsContain("Installed")).toBe(false);
+    },
+  );
+
   it.each(["@acme/demo-plugin", "npm:@acme/demo-plugin"])(
     "fails closed before installing blocked ambiguous npm plugin spec %s",
     async (spec) => {
@@ -705,18 +783,7 @@ describe("plugins cli install", () => {
   );
 
   it("installs a positively identified npm hook pack without probing plugin installation", async () => {
-    const installedCfg = {
-      hooks: {
-        internal: {
-          installs: {
-            "demo-hooks": {
-              source: "npm",
-              spec: "@acme/demo-hooks@1.2.3",
-            },
-          },
-        },
-      },
-    } as OpenClawConfig;
+    const installedCfg = createEnabledHookConfig();
     primeBlockedPluginConfigMutation();
     installHooksFromNpmSpecMock.mockResolvedValue({
       ok: true,
@@ -732,8 +799,6 @@ describe("plugins cli install", () => {
         integrity: "sha256-demo",
       },
     });
-    recordHookInstallMock.mockReturnValue(installedCfg);
-
     await runAcknowledgedPluginsInstallCommand(["plugins", "install", "@acme/demo-hooks"]);
 
     expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
@@ -850,18 +915,7 @@ describe("plugins cli install", () => {
     "preserves local hook-pack precedence for prefix-shaped paths",
     async () => {
       const localPath = path.join(process.cwd(), `clawhub:demo-hooks-${process.pid}`);
-      const installedCfg = {
-        hooks: {
-          internal: {
-            installs: {
-              "demo-hooks": {
-                source: "path",
-                sourcePath: localPath,
-              },
-            },
-          },
-        },
-      } as OpenClawConfig;
+      const installedCfg = createEnabledHookConfig();
       fs.mkdirSync(localPath);
       primeBlockedPluginConfigMutation();
       parseClawHubPluginSpecMock.mockReturnValue({ name: "demo-hooks" });
@@ -871,7 +925,6 @@ describe("plugins cli install", () => {
         code: "missing_openclaw_extensions",
       });
       installHooksFromPathMock.mockResolvedValue(createHookPackInstallResult(localPath));
-      recordHookInstallMock.mockReturnValue(installedCfg);
 
       try {
         await runAcknowledgedPluginsInstallCommand([
@@ -1274,80 +1327,88 @@ describe("plugins cli install", () => {
     expect(configWriteMock).not.toHaveBeenCalled();
   });
 
-  it("installs marketplace plugins and persists plugin index", async () => {
-    const cfg = {
-      plugins: {
-        entries: {},
-      },
-    } as OpenClawConfig;
-    const enabledCfg = {
-      plugins: {
-        entries: {
-          alpha: {
-            enabled: true,
+  it("persists marketplace installs and reports slot-selection warnings", async () => {
+    await withTempDir("openclaw-marketplace-install-", async (alphaRoot) => {
+      const fixture = createColdPluginFixture({
+        rootDir: alphaRoot,
+        pluginId: "alpha",
+        packageVersion: "1.2.3",
+        manifest: { kind: "memory" },
+      });
+      const cfg: OpenClawConfig = {
+        plugins: {
+          entries: {},
+        },
+      };
+      const enabledCfg: OpenClawConfig = {
+        plugins: {
+          ...cfg.plugins,
+          entries: {
+            alpha: {
+              enabled: true,
+            },
           },
         },
-      },
-    } as OpenClawConfig;
-    pluginCliConfigMock.mockReturnValue(cfg);
-    installPluginFromMarketplaceMock.mockResolvedValue({
-      ok: true,
-      pluginId: "alpha",
-      targetDir: cliInstallPath("alpha"),
-      extensions: ["index.js"],
-      version: "1.2.3",
-      marketplaceName: "Claude",
-      marketplaceSource: "local/repo",
-      marketplacePlugin: "alpha",
-    });
-    enablePluginInConfigMock.mockReturnValue({ config: enabledCfg, enabled: true });
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [{ id: "alpha", kind: "provider" }],
-      diagnostics: [],
-    });
-    const alphaRoot = cliInstallPath("alpha");
-    loadPluginManifestRegistryMock.mockReturnValue({
-      plugins: [
-        recordPluginManifestInstallOwner(
-          {
-            id: "alpha",
-            kind: "memory",
-            origin: "global",
-            channels: [],
-            providers: [],
-            cliBackends: [],
-            skills: [],
-            hooks: [],
-            rootDir: alphaRoot,
-            source: `${alphaRoot}/index.js`,
-            manifestPath: `${alphaRoot}/openclaw.plugin.json`,
-          },
+      };
+      pluginCliConfigMock.mockReturnValue(cfg);
+      installPluginFromMarketplaceMock.mockResolvedValue({
+        ok: true,
+        pluginId: "alpha",
+        targetDir: alphaRoot,
+        extensions: ["index.cjs"],
+        version: "1.2.3",
+        marketplaceName: "Claude",
+        marketplaceSource: "local/repo",
+        marketplacePlugin: "alpha",
+      });
+      enablePluginInConfigMock.mockReturnValue({ config: enabledCfg, enabled: true });
+      loadPluginManifestRegistryMock.mockReturnValue({
+        plugins: [
+          recordPluginManifestInstallOwner(
+            {
+              id: "alpha",
+              kind: "memory",
+              origin: "global",
+              channels: [],
+              providers: [],
+              cliBackends: [],
+              skills: [],
+              hooks: [],
+              rootDir: alphaRoot,
+              source: fixture.runtimeSource,
+              manifestPath: `${alphaRoot}/openclaw.plugin.json`,
+            },
+            "alpha",
+          ),
+        ],
+        diagnostics: [],
+      });
+      // The CLI reports the slot owner's result; first-install discovery is a separate flow.
+      const selectSlot = vi.spyOn(slotSelection, "applySlotSelectionForPlugin").mockReturnValue({
+        config: enabledCfg,
+        warnings: ["slot adjusted"],
+      });
+      try {
+        await runAcknowledgedPluginsInstallCommand([
+          "plugins",
+          "install",
           "alpha",
-        ),
-      ],
-      diagnostics: [],
-    });
-    applyExclusiveSlotSelectionMock.mockReturnValue({
-      config: enabledCfg,
-      warnings: ["slot adjusted"],
-    });
+          "--marketplace",
+          "local/repo",
+        ]);
+      } finally {
+        selectSlot.mockRestore();
+      }
 
-    await runAcknowledgedPluginsInstallCommand([
-      "plugins",
-      "install",
-      "alpha",
-      "--marketplace",
-      "local/repo",
-    ]);
-
-    expect(persistedInstallRecord("alpha").source).toBe("marketplace");
-    expect(persistedInstallRecord("alpha").installPath).toBe(cliInstallPath("alpha"));
-    expect(configWriteMock).toHaveBeenCalledWith(enabledCfg);
-    expect(replaceConfigCall().baseHash).toBe("mock");
-    expect(replaceConfigCall().nextConfig).toBe(enabledCfg);
-    expect(runtimeLogsContain("slot adjusted")).toBe(true);
-    expect(runtimeLogsContain("Installed plugin: alpha")).toBe(true);
-    expect(clearPluginRegistryLoadCacheMock).not.toHaveBeenCalled();
+      expect(persistedInstallRecord("alpha").source).toBe("marketplace");
+      expect(persistedInstallRecord("alpha").installPath).toBe(alphaRoot);
+      expect(configWriteMock).toHaveBeenCalledWith(enabledCfg);
+      expect(replaceConfigCall().baseHash).toBe("mock");
+      expect(replaceConfigCall().nextConfig).toBe(enabledCfg);
+      expect(runtimeLogsContain("slot adjusted")).toBe(true);
+      expect(runtimeLogsContain("Installed plugin: alpha")).toBe(true);
+      expect(clearPluginRegistryLoadCacheMock).not.toHaveBeenCalled();
+    });
   });
 
   it("passes force through as overwrite mode for marketplace installs", async () => {
@@ -2978,8 +3039,6 @@ describe("plugins cli install", () => {
       targetDir: "/tmp/hooks/demo-hooks",
       version: "1.2.3",
     });
-    recordHookInstallMock.mockReturnValue(createPathHookPackInstalledConfig(localHookDir));
-
     try {
       await runAcknowledgedPluginsInstallCommand([
         "plugins",

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -475,16 +475,20 @@ describe("plugins cli update", () => {
       },
     });
     primePluginUpdate(cfg);
-    updateNpmInstalledHookPacksMock.mockResolvedValue({
-      config: nextConfig,
-      changed: true,
-      outcomes: [
-        {
-          hookId: "demo-hooks",
-          status: "updated",
-          message: 'Updated hook pack "demo-hooks": 1.0.0 -> 1.1.0.',
-        },
-      ],
+    const transaction = { commit: vi.fn(async () => {}), rollback: vi.fn(async () => {}) };
+    updateNpmInstalledHookPacksMock.mockImplementation(async (params) => {
+      resolvePluginInstallTransactionSink(params)?.push(transaction);
+      return {
+        config: nextConfig,
+        changed: true,
+        outcomes: [
+          {
+            hookId: "demo-hooks",
+            status: "updated",
+            message: 'Updated hook pack "demo-hooks": 1.0.0 -> 1.1.0.',
+          },
+        ],
+      };
     });
 
     await runPluginsCommand(["plugins", "update", target, "--dangerously-force-unsafe-install"]);
@@ -502,7 +506,51 @@ describe("plugins cli update", () => {
       expect.objectContaining({ nextConfig, baseHash: "update-config" }),
     );
     expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
+    expect(transaction.commit).toHaveBeenCalledOnce();
+    expect(transaction.rollback).not.toHaveBeenCalled();
     expectRestartNoticeLogged();
+  });
+
+  it.each([
+    { failure: "later hook install", settlement: "rollback" },
+    { failure: "config write", settlement: "rollback" },
+    { failure: "backup cleanup", settlement: "commit" },
+  ])("settles hook updates when $failure fails", async ({ failure, settlement }) => {
+    primeUpdateConfigSnapshot({ config: {} });
+    setHookInstallRecords({
+      "demo-hooks": { source: "npm", spec: "@acme/demo-hooks@1.0.0" },
+    });
+    const events: string[] = [];
+    updateNpmInstalledHookPacksMock.mockImplementation(async (params) => {
+      resolvePluginInstallTransactionSink(params)?.push({
+        commit: async () => {
+          events.push("commit");
+          if (failure === "backup cleanup") {
+            throw new Error(failure);
+          }
+        },
+        rollback: async () => {
+          events.push("rollback");
+        },
+      });
+      if (failure === "later hook install") {
+        throw new Error(failure);
+      }
+      return { config: params.config, changed: true, outcomes: [] };
+    });
+    if (failure === "config write") {
+      replaceConfigFileMock.mockRejectedValueOnce(new Error(failure));
+    }
+
+    const update = runPluginsCommand(["plugins", "update", "demo-hooks"]);
+    if (settlement === "commit") {
+      await update;
+      expectRestartNoticeLogged();
+    } else {
+      await expect(update).rejects.toThrow(failure);
+    }
+
+    expect(events).toEqual([settlement]);
   });
 
   it("uses the mutation-start snapshot for updater input and hook selection", async () => {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -62,7 +62,17 @@ export async function runPluginInstallCommand(params: RunPluginInstallCommandPar
   }
   return await withPluginLifecycleLease(
     {},
-    async () => await runPluginInstallCommandUnlocked(params, preflight),
+    async (lease) =>
+      await runPluginInstallCommandUnlocked(
+        {
+          ...params,
+          beforePersistentApply: () => {
+            lease.assertOwned();
+            params.beforePersistentApply?.();
+          },
+        },
+        preflight,
+      ),
   );
 }
 
@@ -73,10 +83,6 @@ async function runPluginInstallCommandUnlocked(
   assertConfigWriteAllowedInCurrentMode();
 
   const runtime = params.runtime ?? defaultRuntime;
-  const persistentApplyOptions = params.beforePersistentApply
-    ? { beforePersistentApply: params.beforePersistentApply }
-    : {};
-  const invalidateRuntimeCache = params.invalidateRuntimeCache ?? true;
   const { raw, opts, installMode, request } = preflight;
   if (opts.dangerouslyForceUnsafeInstall) {
     runtime.log(theme.warn(DEPRECATED_DANGEROUS_FORCE_UNSAFE_INSTALL_WARNING));
@@ -88,6 +94,12 @@ async function runPluginInstallCommandUnlocked(
   if (!snapshot) {
     return runtime.exit(1);
   }
+  const installContext = {
+    snapshot,
+    runtime,
+    invalidateRuntimeCache: params.invalidateRuntimeCache ?? true,
+    beforePersistentApply: params.beforePersistentApply,
+  };
   const safetyOverrides = resolveInstallSafetyOverrides({
     ...opts,
     config: snapshot.config,
@@ -126,13 +138,10 @@ async function runPluginInstallCommandUnlocked(
         plugin: raw,
         mode: installMode,
       },
-      snapshot,
+      ...installContext,
       ...capabilityConsent,
       safetyOverrides,
       logger: createPluginInstallLogger(runtime),
-      invalidateRuntimeCache,
-      runtime,
-      ...persistentApplyOptions,
     });
     if (!result.ok) {
       if (!isClawHubBlockedCliFailure(result)) {
@@ -179,13 +188,12 @@ async function runPluginInstallCommandUnlocked(
             return runtime.exit(1);
           }
           const hookFallback = await tryInstallHookPackFromLocalPath({
-            snapshot,
+            ...installContext,
             installMode,
             resolvedPath: resolved,
             safetyOverrides,
             ...(opts.link ? { link: true } : {}),
             expectedPackageKind: "hook-only",
-            runtime,
           });
           if (hookFallback.ok) {
             return;
@@ -201,13 +209,10 @@ async function runPluginInstallCommandUnlocked(
 
       const result = await installManagedPluginSource({
         request: sourceRequest,
-        snapshot,
+        ...installContext,
         ...capabilityConsent,
         safetyOverrides,
         logger: createPluginInstallLogger(runtime),
-        invalidateRuntimeCache,
-        runtime,
-        ...persistentApplyOptions,
       });
       if (result.ok) {
         return;
@@ -217,12 +222,11 @@ async function runPluginInstallCommandUnlocked(
         return runtime.exit(1);
       }
       const hookFallback = await tryInstallHookPackFromLocalPath({
-        snapshot,
+        ...installContext,
         installMode,
         resolvedPath: resolved,
         safetyOverrides,
         ...(sourceRequest.link ? { link: true } : {}),
-        runtime,
       });
       if (hookFallback.ok) {
         return;
@@ -236,13 +240,10 @@ async function runPluginInstallCommandUnlocked(
     case "git": {
       const result = await installManagedPluginSource({
         request: sourceRequest,
-        snapshot,
+        ...installContext,
         ...capabilityConsent,
         safetyOverrides,
         logger: createPluginInstallLogger(runtime),
-        invalidateRuntimeCache,
-        runtime,
-        ...persistentApplyOptions,
       });
       if (!result.ok) {
         runtime.error(result.error);
@@ -257,10 +258,7 @@ async function runPluginInstallCommandUnlocked(
         () =>
           installManagedPluginSource({
             request: sourceRequest,
-            snapshot,
-            invalidateRuntimeCache,
-            runtime,
-            ...persistentApplyOptions,
+            ...installContext,
           }),
         {
           command: "install",
@@ -280,12 +278,10 @@ async function runPluginInstallCommandUnlocked(
       if (primary?.source === "clawhub") {
         const result = await installManagedPluginSource({
           request: sourceRequest,
-          snapshot,
+          ...installContext,
           ...capabilityConsent,
           safetyOverrides,
           logger: createPluginInstallLogger(runtime),
-          invalidateRuntimeCache,
-          runtime,
         });
         if (!result.ok) {
           runtime.error(result.error);
@@ -294,7 +290,7 @@ async function runPluginInstallCommandUnlocked(
         return;
       }
       const result = await tryInstallPluginOrHookPackFromNpmSpec({
-        snapshot,
+        ...installContext,
         installMode,
         spec: sourceRequest.spec,
         pin: sourceRequest.pin,
@@ -305,8 +301,6 @@ async function runPluginInstallCommandUnlocked(
         expectedIntegrity: primary?.expectedIntegrity ?? sourceRequest.expectedIntegrity,
         trustedSourceLinkedOfficialInstall: true,
         officialRequest: sourceRequest,
-        invalidateRuntimeCache,
-        runtime,
       });
       if (!result.ok) {
         return runtime.exit(1);
@@ -320,6 +314,7 @@ async function runPluginInstallCommandUnlocked(
         installSafetyOverrides = safetyOverrides,
       ) => {
         const result = await installManagedPluginSource({
+          ...installContext,
           request: {
             ...sourceRequest,
             ...(opts.expectedIntegrity ? { expectedIntegrity: opts.expectedIntegrity } : {}),
@@ -330,9 +325,6 @@ async function runPluginInstallCommandUnlocked(
           ...capabilityConsent,
           safetyOverrides: installSafetyOverrides,
           logger: createPluginInstallLogger(runtime),
-          invalidateRuntimeCache,
-          runtime,
-          ...persistentApplyOptions,
         });
         if (!result.ok) {
           if (!isClawHubBlockedCliFailure(result)) {
@@ -386,18 +378,16 @@ async function runPluginInstallCommandUnlocked(
 
     case "npm": {
       const result = await tryInstallPluginOrHookPackFromNpmSpec({
-        snapshot,
+        ...installContext,
         installMode,
         spec: sourceRequest.spec,
         pin: sourceRequest.pin,
         safetyOverrides,
         capabilityConsent,
         allowBundledFallback: sourceRequest.allowBundledFallback ?? false,
-        invalidateRuntimeCache,
         expectedPluginId: sourceRequest.expectedPluginId,
         expectedIntegrity: sourceRequest.expectedIntegrity,
         trustedSourceLinkedOfficialInstall: sourceRequest.trustedSourceLinkedOfficialInstall,
-        runtime,
       });
       if (!result.ok) {
         return runtime.exit(1);

--- a/src/cli/plugins-install-hook-fallback.ts
+++ b/src/cli/plugins-install-hook-fallback.ts
@@ -9,6 +9,10 @@ import {
 } from "../hooks/install.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import {
+  requestDeferredPackageDirInstall,
+  resolvePackageDirInstallTransaction,
+} from "../infra/install-package-dir.js";
 import { findBundledPluginSource } from "../plugins/bundled-sources.js";
 import type { InstallSafetyOverrides } from "../plugins/install-security-scan.js";
 import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
@@ -79,6 +83,7 @@ export async function tryInstallHookPackFromLocalPath(params: {
   link?: boolean;
   expectedPackageKind?: "hook-only";
   runtime?: RuntimeEnv;
+  beforePersistentApply?: () => void;
 }): Promise<{ ok: true } | Extract<InstallHooksResult, { ok: false }>> {
   if (params.snapshot.hookMutation.mode === "blocked") {
     return { ok: false, error: params.snapshot.hookMutation.reason };
@@ -129,17 +134,21 @@ export async function tryInstallHookPackFromLocalPath(params: {
       },
       successMessage: `Linked hook pack path: ${shortenHomePath(params.resolvedPath)}`,
       runtime: params.runtime,
+      beforePersistentApply: params.beforePersistentApply,
     });
     return { ok: true };
   }
 
-  const result = await installHooksFromPath({
-    ...resolveInstallSafetyOverrides(params.safetyOverrides ?? {}),
-    path: params.resolvedPath,
-    mode: params.installMode,
-    ...(params.expectedPackageKind ? { expectedPackageKind: params.expectedPackageKind } : {}),
-    logger: createHookPackInstallLogger(params.runtime),
-  });
+  const result = await installHooksFromPath(
+    requestDeferredPackageDirInstall({
+      ...resolveInstallSafetyOverrides(params.safetyOverrides ?? {}),
+      path: params.resolvedPath,
+      mode: params.installMode,
+      ...(params.expectedPackageKind ? { expectedPackageKind: params.expectedPackageKind } : {}),
+      logger: createHookPackInstallLogger(params.runtime),
+      beforePersistentApply: params.beforePersistentApply,
+    }),
+  );
   if (!result.ok) {
     return result;
   }
@@ -156,6 +165,8 @@ export async function tryInstallHookPackFromLocalPath(params: {
       version: result.version,
     },
     runtime: params.runtime,
+    beforePersistentApply: params.beforePersistentApply,
+    payloadTransaction: resolvePackageDirInstallTransaction(result),
   });
   return { ok: true };
 }
@@ -169,30 +180,35 @@ async function tryInstallHookPackFromNpmSpec(params: {
   expectedIntegrity?: string;
   expectedPackageKind?: "hook-only";
   runtime?: RuntimeEnv;
+  beforePersistentApply?: () => void;
 }): Promise<{ ok: true } | Extract<InstallHooksResult, { ok: false }>> {
   if (params.snapshot.hookMutation.mode === "blocked") {
     return { ok: false, error: params.snapshot.hookMutation.reason };
   }
-  const result = await installHooksFromNpmSpec({
-    ...resolveInstallSafetyOverrides(params.safetyOverrides ?? {}),
-    config: params.snapshot.config,
-    spec: params.spec,
-    mode: params.installMode,
-    ...(params.expectedIntegrity ? { expectedIntegrity: params.expectedIntegrity } : {}),
-    ...(params.expectedPackageKind ? { expectedPackageKind: params.expectedPackageKind } : {}),
-    logger: createHookPackInstallLogger(params.runtime),
-  });
+  const result = await installHooksFromNpmSpec(
+    requestDeferredPackageDirInstall({
+      ...resolveInstallSafetyOverrides(params.safetyOverrides ?? {}),
+      config: params.snapshot.config,
+      spec: params.spec,
+      mode: params.installMode,
+      ...(params.expectedIntegrity ? { expectedIntegrity: params.expectedIntegrity } : {}),
+      ...(params.expectedPackageKind ? { expectedPackageKind: params.expectedPackageKind } : {}),
+      logger: createHookPackInstallLogger(params.runtime),
+      beforePersistentApply: params.beforePersistentApply,
+    }),
+  );
   if (!result.ok) {
     return result;
   }
 
+  const pinMessages: string[] = [];
   const installRecord = resolvePinnedNpmInstallRecordForCli(
     params.spec,
     Boolean(params.pin),
     result.targetDir,
     result.version,
     result.npmResolution,
-    params.runtime?.log ?? defaultRuntime.log,
+    (message) => pinMessages.push(message),
     theme.warn,
   );
   await persistHookPackInstall({
@@ -201,7 +217,13 @@ async function tryInstallHookPackFromNpmSpec(params: {
     hooks: result.hooks,
     install: installRecord,
     runtime: params.runtime,
+    beforePersistentApply: params.beforePersistentApply,
+    payloadTransaction: resolvePackageDirInstallTransaction(result),
   });
+  // Pinning notices follow the commit so output failures cannot strand an owned payload.
+  for (const message of pinMessages) {
+    (params.runtime ?? defaultRuntime).log(message);
+  }
   return { ok: true };
 }
 
@@ -220,8 +242,15 @@ export async function tryInstallPluginOrHookPackFromNpmSpec(params: {
   officialRequest?: Extract<ManagedPluginSourceInstallRequest, { source: "official" }>;
   invalidateRuntimeCache?: boolean;
   runtime?: RuntimeEnv;
+  beforePersistentApply?: () => void;
 }): Promise<{ ok: true } | { ok: false }> {
   const runtime = params.runtime ?? defaultRuntime;
+  const installContext = {
+    snapshot: params.snapshot,
+    runtime,
+    invalidateRuntimeCache: params.invalidateRuntimeCache,
+    beforePersistentApply: params.beforePersistentApply,
+  };
   const fullyBlockedReason = resolveFullyBlockedConfigMutationReason(params.snapshot);
   if (fullyBlockedReason) {
     runtime.error(fullyBlockedReason);
@@ -246,14 +275,13 @@ export async function tryInstallPluginOrHookPackFromNpmSpec(params: {
         return { ok: false };
       }
       const hookFallback = await tryInstallHookPackFromNpmSpec({
-        snapshot: params.snapshot,
+        ...installContext,
         installMode: params.installMode,
         spec: params.spec,
         safetyOverrides: params.safetyOverrides,
         pin: params.pin,
         expectedIntegrity: hookProbe.npmResolution?.integrity ?? params.expectedIntegrity,
         expectedPackageKind: "hook-only",
-        runtime: params.runtime,
       });
       if (hookFallback.ok) {
         return { ok: true };
@@ -279,12 +307,10 @@ export async function tryInstallPluginOrHookPackFromNpmSpec(params: {
         ? { trustedSourceLinkedOfficialInstall: true }
         : {}),
     },
-    snapshot: params.snapshot,
+    ...installContext,
     ...params.capabilityConsent,
     safetyOverrides: params.safetyOverrides,
     logger: createPluginInstallLogger(params.runtime),
-    invalidateRuntimeCache: params.invalidateRuntimeCache,
-    runtime: params.runtime,
   });
   if (!result.ok) {
     // A declared secondary may have been selected by the install owner. Hook-pack
@@ -312,9 +338,7 @@ export async function tryInstallPluginOrHookPackFromNpmSpec(params: {
             bundledSource: bundledFallbackPlan.bundledSource,
             warning: bundledFallbackPlan.warning,
           },
-          snapshot: params.snapshot,
-          invalidateRuntimeCache: params.invalidateRuntimeCache,
-          runtime: params.runtime,
+          ...installContext,
         });
         if (!bundledResult.ok) {
           runtime.error(bundledResult.error);
@@ -324,13 +348,12 @@ export async function tryInstallPluginOrHookPackFromNpmSpec(params: {
       }
     }
     const hookFallback = await tryInstallHookPackFromNpmSpec({
-      snapshot: params.snapshot,
+      ...installContext,
       installMode: params.installMode,
       spec: params.spec,
       safetyOverrides: params.safetyOverrides,
       pin: params.pin,
       expectedIntegrity: params.expectedIntegrity,
-      runtime: params.runtime,
     });
     if (hookFallback.ok) {
       return { ok: true };

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -43,7 +43,10 @@ import {
 import { loadInstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { resolveInstalledPluginLifecycleOwnership } from "../plugins/installed-plugin-package-ownership.js";
 import { configReferencesNpmInstallPath } from "../plugins/installs.js";
-import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import {
+  withPluginLifecycleLease,
+  type PluginLifecycleLeaseContext,
+} from "../plugins/plugin-lifecycle-lease.js";
 import {
   capturePluginPackageUpdateSnapshot,
   pluginPackageUpdateMayMutateConfig,
@@ -196,20 +199,32 @@ export async function runPluginUpdateCommand(params: RunPluginUpdateCommandParam
   assertConfigWriteAllowedInCurrentMode();
   return await withPluginLifecycleLease(
     {},
-    async () => await runPluginUpdateCommandUnlocked(params),
+    async (lease) => await runPluginUpdateCommandUnlocked(params, lease),
   );
 }
 
-async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandParams) {
+async function runPluginUpdateCommandUnlocked(
+  params: RunPluginUpdateCommandParams,
+  lease?: PluginLifecycleLeaseContext,
+) {
   if (!params.opts.dryRun) {
     assertConfigWriteAllowedInCurrentMode();
   }
 
   const sourceSnapshotPromise = readConfigFileSnapshotForWrite()
-    .then((prepared) => ({
-      ...prepared,
-      writeOptions: selectInstallMutationWriteOptions(prepared.writeOptions),
-    }))
+    .then((prepared) => {
+      const writeOptions = selectInstallMutationWriteOptions(prepared.writeOptions);
+      return {
+        ...prepared,
+        writeOptions: {
+          ...writeOptions,
+          assertConfigPathForWrite: () => {
+            lease?.assertOwned();
+            writeOptions.assertConfigPathForWrite?.();
+          },
+        },
+      };
+    })
     .catch(() => null);
   const mutationSnapshot = params.opts.dryRun ? null : await sourceSnapshotPromise;
   if (!params.opts.dryRun && !mutationSnapshot) {
@@ -403,7 +418,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
     dangerouslyForceUnsafeInstall: params.opts.dangerouslyForceUnsafeInstall,
     allowPrompt: !params.opts.dryRun,
   });
-  const deferredPluginTransactions: PluginInstallTransaction[] = [];
+  const deferredInstallTransactions: PluginInstallTransaction[] = [];
   let pluginResult;
   try {
     pluginResult =
@@ -444,12 +459,12 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
                   );
                 },
               },
-              deferredPluginTransactions,
+              deferredInstallTransactions,
             ),
           )
         : { config: cfgWithPluginInstallRecords, changed: false, outcomes: [] };
   } catch (error) {
-    await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
+    await settlePluginInstallTransactions(deferredInstallTransactions, "rollback");
     throw error;
   }
   let packageUpdatePersisted = false;
@@ -468,7 +483,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
         installOwnerMigrations: resolvePluginInstallOwnerMigrations(pluginResult),
       });
       if (!reconciled.ok) {
-        await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
+        await settlePluginInstallTransactions(deferredInstallTransactions, "rollback");
         defaultRuntime.error(reconciled.error);
         return defaultRuntime.exit(1);
       }
@@ -476,30 +491,37 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
     }
     const hookResult =
       hookSelection.hookIds.length > 0
-        ? await updateNpmInstalledHookPacks({
-            config: pluginResult.config,
-            hookIds: hookSelection.hookIds,
-            specOverrides: hookSelection.specOverrides,
-            dryRun: params.opts.dryRun,
-            ...installPolicyWarningAcknowledgement,
-            logger,
-            onIntegrityDrift: async (drift) => {
-              const specLabel = drift.resolvedSpec ?? drift.spec;
-              defaultRuntime.log(
-                theme.warn(
-                  `Integrity drift detected for hook pack "${drift.hookId}" (${specLabel})` +
-                    `\nExpected: ${drift.expectedIntegrity}` +
-                    `\nActual:   ${drift.actualIntegrity}`,
-                ),
-              );
-              if (drift.dryRun) {
-                return true;
-              }
-              return await promptYesNo(
-                `Continue updating hook pack "${drift.hookId}" with this artifact?`,
-              );
-            },
-          })
+        ? await updateNpmInstalledHookPacks(
+            requestDeferredPluginInstall(
+              {
+                config: pluginResult.config,
+                lease,
+                beforePersistentApply: mutationSnapshot?.writeOptions.assertConfigPathForWrite,
+                hookIds: hookSelection.hookIds,
+                specOverrides: hookSelection.specOverrides,
+                dryRun: params.opts.dryRun,
+                ...installPolicyWarningAcknowledgement,
+                logger,
+                onIntegrityDrift: async (drift) => {
+                  const specLabel = drift.resolvedSpec ?? drift.spec;
+                  defaultRuntime.log(
+                    theme.warn(
+                      `Integrity drift detected for hook pack "${drift.hookId}" (${specLabel})` +
+                        `\nExpected: ${drift.expectedIntegrity}` +
+                        `\nActual:   ${drift.actualIntegrity}`,
+                    ),
+                  );
+                  if (drift.dryRun) {
+                    return true;
+                  }
+                  return await promptYesNo(
+                    `Continue updating hook pack "${drift.hookId}" with this artifact?`,
+                  );
+                },
+              },
+              deferredInstallTransactions,
+            ),
+          )
         : { config: pluginResult.config, changed: false, outcomes: [] };
 
     if (!params.opts.dryRun && (pluginResult.changed || hookResult.changed)) {
@@ -515,7 +537,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
           !currentSnapshot.ok ||
           !isDeepStrictEqual([...currentSnapshot.value], [...packageUpdateSnapshot])
         ) {
-          await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
+          await settlePluginInstallTransactions(deferredInstallTransactions, "rollback");
           defaultRuntime.error(
             currentSnapshot.ok
               ? "Plugin package ownership changed during update; no config or index changes were committed. Refresh the plugin registry and retry."
@@ -575,7 +597,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
         });
       }
       packageUpdatePersisted = true;
-      await settlePluginInstallTransactions(deferredPluginTransactions, "commit").catch(() =>
+      await settlePluginInstallTransactions(deferredInstallTransactions, "commit").catch(() =>
         logger.warn("Plugin update committed, but cleanup failed. Restart is required."),
       );
       if (pluginResult.changed) {
@@ -603,7 +625,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
     }
   } catch (error) {
     if (!packageUpdatePersisted) {
-      await settlePluginInstallTransactions(deferredPluginTransactions, "rollback");
+      await settlePluginInstallTransactions(deferredInstallTransactions, "rollback");
     }
     throw error;
   }

--- a/src/commands/doctor-model-catalog-credentials.test.ts
+++ b/src/commands/doctor-model-catalog-credentials.test.ts
@@ -12,6 +12,7 @@ import {
   writePersistedAuthProfileStoreRaw,
 } from "../agents/auth-profiles/sqlite.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import {
   encodePluginModelCatalogRelativePath,
   loadPersistedPluginModelCatalogsReadOnly,
@@ -23,7 +24,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { maybeMigrateModelCatalogCredentials } from "./doctor-model-catalog-credentials.js";
-import type { DoctorPrompter } from "./doctor-prompter.js";
+import { createDoctorPrompter, type DoctorPrompter } from "./doctor-prompter.js";
 
 const note = vi.hoisted(() => vi.fn());
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
@@ -170,6 +171,62 @@ describe("doctor model catalog credential migration", () => {
     expect(repaired).toEqual({ detected: 0, migrated: 0, removed: 2, warnings: [] });
     expect(loadPersistedSharedAuthProfileStore(state.env)).toEqual({ version: 1, profiles: {} });
   });
+
+  it.each(["main", "helper"])(
+    "preserves a %s credential replaced while the repair prompt is pending",
+    async (agentId) => {
+      const state = createState();
+      const agentDir = path.join(state.stateDir, "agents", agentId, "agent");
+      fs.mkdirSync(agentDir, { recursive: true });
+      const cfg: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "main" } },
+          entries: { main: { agentDir: state.agentDir }, [agentId]: { agentDir } },
+        },
+        models: { providers: { custom: provider("${CUSTOM_PROVIDER_KEY}") } },
+      };
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "custom:default": { type: "api_key", provider: "custom", key: "CUSTOM_PROVIDER_KEY" },
+          "custom:models-json": {
+            type: "api_key",
+            provider: "custom",
+            key: "$CUSTOM_PROVIDER_KEY",
+          },
+        },
+        order: { custom: ["custom:default", "custom:models-json"] },
+        lastGood: { custom: "custom:default" },
+        usageStats: { "custom:default": { lastUsed: 123, errorCount: 0 } },
+      };
+      saveAuthProfileStore(store, agentDir);
+      const params = migrationParams(state, cfg);
+      params.prompter = {
+        ...createDoctorPrompter({ runtime: params.runtime, options: {} }),
+        confirmAutoFix: async () => {
+          store.profiles["custom:default"] = {
+            type: "api_key",
+            provider: "custom",
+            key: "replacement-secret",
+          };
+          saveAuthProfileStore(store, agentDir);
+          return true;
+        },
+      };
+
+      const result = await maybeMigrateModelCatalogCredentials(params);
+
+      expect(result).toEqual({ detected: 0, migrated: 0, removed: 1, warnings: [] });
+      expect(loadPersistedAuthProfileStore(agentDir)).toEqual({
+        version: 1,
+        profiles: { "custom:default": store.profiles["custom:default"] },
+        order: { custom: ["custom:default"] },
+        lastGood: store.lastGood,
+        usageStats: store.usageStats,
+      });
+    },
+  );
 
   it("does not copy a stale generated credential over an explicit provider SecretRef", async () => {
     const state = createState();

--- a/src/commands/doctor-model-catalog-credentials.ts
+++ b/src/commands/doctor-model-catalog-credentials.ts
@@ -1,6 +1,7 @@
 /** Doctor-owned migration of plaintext model-catalog credentials into agent SQLite. */
 import fs from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
@@ -69,14 +70,13 @@ function matchesProviderEnvRefMarker(
   return candidate === id || candidate === `$${id}` || candidate === `\${${id}}`;
 }
 
-function findProviderSecretRefProfileIds(store: AuthProfileStore, cfg: OpenClawConfig): string[] {
-  return Object.entries(store.profiles).flatMap(([profileId, credential]) => {
-    return credential.type === "api_key" &&
+function findProviderSecretRefProfiles(store: AuthProfileStore, cfg: OpenClawConfig) {
+  return Object.entries(store.profiles).filter(
+    ([, credential]) =>
+      credential.type === "api_key" &&
       credential.key &&
-      matchesProviderEnvRefMarker(cfg, credential.provider, credential.key)
-      ? [profileId]
-      : [];
-  });
+      matchesProviderEnvRefMarker(cfg, credential.provider, credential.key),
+  );
 }
 
 function collectCredentials(
@@ -164,35 +164,36 @@ async function persistCredentials(params: {
   blockedStores?: readonly AuthProfileStore[];
   credentials: readonly PlaintextCredential[];
   inheritedStore?: AuthProfileStore;
-  invalidProfileIds?: readonly string[];
+  invalidProfiles: ReadonlyArray<[string, AuthProfileCredential]>;
   stateDir: string;
 }): Promise<{ migrated: number; removed: number }> {
   const credentials = uniqueCredentials(params.credentials);
-  const invalidProfileIds = new Set(params.invalidProfileIds ?? []);
-  if (credentials.length === 0 && invalidProfileIds.size === 0) {
+  const { invalidProfiles } = params;
+  if (credentials.length === 0 && invalidProfiles.length === 0) {
     return { migrated: 0, removed: 0 };
   }
   const blockedStores = params.blockedStores ?? [];
   const profileIds = new Map<string, PlaintextCredential>();
   let added = 0;
-  let removed = 0;
+  let removedProfiles: [string, AuthProfileCredential][] = [];
   const updated = await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
     stateDir: params.stateDir,
     saveOptions: { filterExternalAuthProfiles: false, syncExternalCli: false },
     updater: (localStore) => {
-      const existingInvalidProfileIds = new Set(
-        [...invalidProfileIds].filter((profileId) => localStore.profiles[profileId] !== undefined),
+      // Confirmation can pause while another writer replaces a marker. Only remove
+      // the exact credential observed before prompting, including its references.
+      removedProfiles = invalidProfiles.filter(([profileId, credential]) =>
+        isDeepStrictEqual(localStore.profiles[profileId], credential),
       );
-      if (existingInvalidProfileIds.size > 0) {
+      if (removedProfiles.length > 0) {
         Object.assign(
           localStore,
           removeRuntimeExternalProfileReferences({
             store: localStore,
-            profileIds: existingInvalidProfileIds,
+            profileIds: new Set(removedProfiles.map(([profileId]) => profileId)),
           }),
         );
-        removed = existingInvalidProfileIds.size;
       }
       const effectiveStore = params.inheritedStore
         ? mergeAuthProfileStores(params.inheritedStore, localStore)
@@ -213,7 +214,7 @@ async function persistCredentials(params: {
         effectiveStore.profiles[profileId] = localStore.profiles[profileId];
         added += 1;
       }
-      return added > 0 || removed > 0;
+      return added > 0 || removedProfiles.length > 0;
     },
   });
   if (!updated) {
@@ -228,8 +229,8 @@ async function persistCredentials(params: {
   const effectivePersisted = params.inheritedStore
     ? mergeAuthProfileStores(params.inheritedStore, persisted ?? emptyStore())
     : persisted;
-  for (const profileId of invalidProfileIds) {
-    if (persisted?.profiles[profileId] !== undefined) {
+  for (const [profileId, credential] of removedProfiles) {
+    if (isDeepStrictEqual(persisted?.profiles[profileId], credential)) {
       throw new Error(`credential cleanup verification failed for profile "${profileId}"`);
     }
   }
@@ -238,7 +239,7 @@ async function persistCredentials(params: {
       throw new Error(`credential verification failed for provider "${credential.provider}"`);
     }
   }
-  return { migrated: added, removed };
+  return { migrated: added, removed: removedProfiles.length };
 }
 
 function collectAgentCatalogs(agentDir: string, warnings: string[]): AgentCatalogs {
@@ -321,17 +322,17 @@ export async function maybeMigrateModelCatalogCredentials(params: {
       ),
     ),
   );
-  const invalidMainProfileIds = findProviderSecretRefProfileIds(mainStore, params.cfg);
-  const invalidCatalogProfileIds = catalogs.map((catalog) =>
+  const invalidMainProfiles = findProviderSecretRefProfiles(mainStore, params.cfg);
+  const invalidCatalogProfiles = catalogs.map((catalog) =>
     catalog.agentDir === mainAgentDir
       ? []
-      : findProviderSecretRefProfileIds(catalog.localStore, params.cfg),
+      : findProviderSecretRefProfiles(catalog.localStore, params.cfg),
   );
   const detected =
     configCredentials.length + catalogCredentials.reduce((sum, entries) => sum + entries.length, 0);
   const removable =
-    invalidMainProfileIds.length +
-    invalidCatalogProfileIds.reduce((sum, profileIds) => sum + profileIds.length, 0);
+    invalidMainProfiles.length +
+    invalidCatalogProfiles.reduce((sum, profiles) => sum + profiles.length, 0);
 
   for (const warning of warnings) {
     params.runtime.error(warning);
@@ -368,7 +369,7 @@ export async function maybeMigrateModelCatalogCredentials(params: {
     const result = await persistCredentials({
       blockedStores: childStores,
       credentials: configCredentials,
-      invalidProfileIds: invalidMainProfileIds,
+      invalidProfiles: invalidMainProfiles,
       stateDir,
     });
     migrated += result.migrated;
@@ -385,7 +386,7 @@ export async function maybeMigrateModelCatalogCredentials(params: {
       const result = await persistCredentials({
         ...(catalog.agentDir === mainAgentDir ? {} : { agentDir: catalog.agentDir }),
         credentials: catalogCredentials[index] ?? [],
-        invalidProfileIds: invalidCatalogProfileIds[index] ?? [],
+        invalidProfiles: invalidCatalogProfiles[index] ?? [],
         ...(catalog.agentDir === mainAgentDir ? {} : { inheritedStore: migratedMainStore }),
         stateDir,
       });

--- a/src/hooks/install-policy-warning.test.ts
+++ b/src/hooks/install-policy-warning.test.ts
@@ -1,10 +1,20 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  requestDeferredPackageDirInstall,
+  resolvePackageDirInstallTransaction,
+} from "../infra/install-package-dir.js";
+import { packToArchive } from "../plugins/test-helpers/archive-fixtures.js";
 
 const scanPackageInstallSourceMock = vi.fn();
 const scanInstalledPackageDependencyTreeMock = vi.fn();
+const runCommandWithTimeoutMock = vi.fn();
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+}));
 
 vi.mock("../plugins/install-security-scan.js", () => ({
   scanPackageInstallSource: (...args: unknown[]) => scanPackageInstallSourceMock(...args),
@@ -12,10 +22,35 @@ vi.mock("../plugins/install-security-scan.js", () => ({
     scanInstalledPackageDependencyTreeMock(...args),
 }));
 
-const { installHooksFromPath } = await import("./install.js");
+const { installHooksFromPath, installHooksFromNpmSpec } = await import("./install.js");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function makeHookInstallFixture() {
+  const root = tempDirs.make("openclaw-hook-policy-");
+  const pkgDir = path.join(root, "source");
+  const hookDir = path.join(pkgDir, "hooks", "one-hook");
+  const hooksDir = path.join(root, "hooks");
+  fs.mkdirSync(hookDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, "package.json"),
+    JSON.stringify({
+      name: "@acme/canonical-hooks",
+      version: "1.0.0",
+      openclaw: { hooks: ["./hooks/one-hook"] },
+    }),
+  );
+  fs.writeFileSync(path.join(hookDir, "HOOK.md"), "---\nname: one-hook\n---\n");
+  fs.writeFileSync(path.join(hookDir, "handler.ts"), "export default async () => {};\n");
+  return { root, pkgDir, hookDir, hooksDir };
+}
+
 describe("hook install policy warnings", () => {
+  beforeEach(() => {
+    scanPackageInstallSourceMock.mockReset();
+    scanInstalledPackageDependencyTreeMock.mockReset();
+    runCommandWithTimeoutMock.mockReset();
+  });
+
   it("passes acknowledgement through both scan stages", async () => {
     const root = tempDirs.make("openclaw-hook-policy-");
     const source = path.join(root, "source");
@@ -33,5 +68,97 @@ describe("hook install policy warnings", () => {
     for (const scan of [scanPackageInstallSourceMock, scanInstalledPackageDependencyTreeMock]) {
       expect(scan).toHaveBeenCalledWith(expect.objectContaining({ onInstallPolicyWarning }));
     }
+  });
+
+  it.each(["package", "single hook"] as const)(
+    "does not publish a %s after its authority closes during staged preparation",
+    async (source) => {
+      const { pkgDir, hookDir, hooksDir } = makeHookInstallFixture();
+      let authorityActive = true;
+      scanInstalledPackageDependencyTreeMock.mockImplementationOnce(async () => {
+        authorityActive = false;
+      });
+      const result = await installHooksFromPath({
+        path: source === "package" ? pkgDir : hookDir,
+        hooksDir,
+        beforePersistentApply: () => {
+          if (!authorityActive) {
+            throw new Error("hook installation authority closed");
+          }
+        },
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("hook installation authority closed"),
+      });
+      expect(scanInstalledPackageDependencyTreeMock).toHaveBeenCalledOnce();
+      const hookPackId = source === "package" ? "canonical-hooks" : "one-hook";
+      expect(fs.existsSync(path.join(hooksDir, hookPackId))).toBe(false);
+    },
+  );
+
+  it.each(
+    (["package", "single hook", "archive", "npm"] as const).flatMap((source) =>
+      (["install", "update"] as const).map((mode) => ({ source, mode })),
+    ),
+  )("rolls back a deferred $source $mode payload", async ({ source, mode }) => {
+    const { root, pkgDir, hookDir, hooksDir } = makeHookInstallFixture();
+    const hookPackId = source === "single hook" ? "one-hook" : "canonical-hooks";
+    const targetDir = path.join(hooksDir, hookPackId);
+    const previousMarker = path.join(targetDir, "previous.txt");
+    if (mode === "update") {
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(previousMarker, "previous payload");
+    }
+    let sourcePath = source === "single hook" ? hookDir : pkgDir;
+    if (source === "archive" || source === "npm") {
+      sourcePath = await packToArchive({ pkgDir, outDir: root, outName: "hooks.tgz" });
+    }
+    if (source === "npm") {
+      runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
+        if (argv[0] !== "npm" || argv[1] !== "pack" || !options.cwd) {
+          throw new Error("unexpected npm fixture command");
+        }
+        fs.copyFileSync(sourcePath, path.join(options.cwd, "hooks.tgz"));
+        return {
+          code: 0,
+          stdout: JSON.stringify([
+            { name: "@acme/canonical-hooks", version: "1.0.0", filename: "hooks.tgz" },
+          ]),
+          stderr: "",
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
+      });
+    }
+    const result = await (source === "npm"
+      ? installHooksFromNpmSpec(
+          requestDeferredPackageDirInstall({
+            spec: "@acme/canonical-hooks@1.0.0",
+            hooksDir,
+            mode,
+          }),
+        )
+      : installHooksFromPath(
+          requestDeferredPackageDirInstall({ path: sourcePath, hooksDir, mode }),
+        ));
+
+    expect(result.ok).toBe(true);
+    const transaction = result.ok ? resolvePackageDirInstallTransaction(result) : undefined;
+    if (!transaction) {
+      throw new Error("expected deferred hook payload transaction");
+    }
+    const installedHook =
+      source === "single hook" ? targetDir : path.join(targetDir, "hooks", "one-hook");
+    expect(fs.existsSync(path.join(installedHook, "handler.ts"))).toBe(true);
+    await transaction.rollback();
+    if (mode === "update") {
+      expect(fs.readFileSync(previousMarker, "utf8")).toBe("previous payload");
+    } else {
+      expect(fs.existsSync(targetDir)).toBe(false);
+    }
+    expect(fs.existsSync(path.join(hookDir, "handler.ts"))).toBe(true);
   });
 });

--- a/src/hooks/install-record-transaction.ts
+++ b/src/hooks/install-record-transaction.ts
@@ -1,0 +1,76 @@
+import type { PackageDirInstallTransaction } from "../infra/install-package-dir.js";
+import type { PluginInstallTransaction } from "../plugins/install-transaction.js";
+import type { PluginLifecycleLeaseContext } from "../plugins/plugin-lifecycle-lease.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import {
+  recordHookInstall,
+  restoreHookInstallIfCurrent,
+  type HookInstallUpdate,
+  type HookInstallWriteReceipt,
+} from "./installs.js";
+
+/** Retain hook record and payload compensation until their config owner commits. */
+export async function stageHookInstall(params: {
+  update: HookInstallUpdate;
+  payloadTransaction?: PackageDirInstallTransaction;
+  lease: PluginLifecycleLeaseContext;
+  beforePersistentApply?: () => void;
+}): Promise<PluginInstallTransaction> {
+  const { lease, payloadTransaction } = params;
+  const storeOptions = { path: lease.databasePath };
+  let receipt: HookInstallWriteReceipt;
+  try {
+    receipt = runOpenClawStateWriteTransaction((database) => {
+      lease.assertOwnedInTransaction(database.db);
+      params.beforePersistentApply?.();
+      return recordHookInstall(params.update, { database });
+    }, storeOptions);
+  } catch (error) {
+    if (payloadTransaction) {
+      try {
+        lease.assertOwned();
+        await payloadTransaction.rollback();
+      } catch (rollbackError) {
+        throw new AggregateError([error, rollbackError], "Hook install payload rollback failed", {
+          cause: rollbackError,
+        });
+      }
+    }
+    throw error;
+  }
+
+  let settled = false;
+  return {
+    async commit() {
+      if (settled) {
+        return;
+      }
+      // Config is durable. Cleanup or output failures must never undo the committed install.
+      settled = true;
+      try {
+        lease.assertOwned();
+        await payloadTransaction?.commit();
+      } catch (error) {
+        throw new Error("Hook install committed, but payload backup cleanup failed", {
+          cause: error,
+        });
+      }
+    },
+    async rollback() {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      const restored = runOpenClawStateWriteTransaction((database) => {
+        // Compensation uses retained lifecycle ownership, not the now-revoked install authority.
+        lease.assertOwnedInTransaction(database.db);
+        return restoreHookInstallIfCurrent(receipt, { database });
+      }, storeOptions);
+      if (!restored) {
+        throw new Error("Hook install changed before rollback; newer record and payload retained");
+      }
+      lease.assertOwned();
+      await payloadTransaction?.rollback();
+    },
+  };
+}

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -3,6 +3,7 @@
 import path from "node:path";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
+import { copyPackageDirInstallTransactionRequest } from "../infra/install-package-dir.js";
 import { resolveSafeInstallDir, unscopedPackageName } from "../infra/install-safe-path.js";
 import type { NpmIntegrityDrift, NpmSpecResolution } from "../infra/install-source-utils.js";
 import { readRegularFile } from "../infra/regular-file.js";
@@ -79,6 +80,7 @@ type HookInstallForwardParams = InstallSafetyOverrides & {
   expectedHookPackId?: string;
   expectedPackageKind?: "hook-only";
   inspection?: "package-kind";
+  beforePersistentApply?: () => void;
   installPolicyRequest?: {
     kind: "plugin-archive" | "plugin-dir" | "plugin-npm";
     requestedSpecifier: string;
@@ -91,7 +93,7 @@ type HookArchiveInstallParams = { archivePath: string } & HookInstallForwardPara
 type HookPathInstallParams = { path: string } & HookInstallForwardParams;
 
 function buildHookInstallForwardParams(params: HookInstallForwardParams): HookInstallForwardParams {
-  return {
+  return copyPackageDirInstallTransactionRequest(params, {
     config: params.config,
     dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
@@ -104,8 +106,9 @@ function buildHookInstallForwardParams(params: HookInstallForwardParams): HookIn
     expectedHookPackId: params.expectedHookPackId,
     expectedPackageKind: params.expectedPackageKind,
     inspection: params.inspection,
+    beforePersistentApply: params.beforePersistentApply,
     installPolicyRequest: params.installPolicyRequest,
-  };
+  });
 }
 
 function localHookInstallPolicySource(kind: "plugin-archive" | "plugin-dir"): InstallPolicySource {
@@ -517,32 +520,35 @@ async function installHookPackageFromDir(
     };
   }
 
-  const installRes = await runtime.installPackageDirWithManifestDeps({
-    sourceDir: params.packageDir,
-    targetDir,
-    mode: effectiveMode,
-    timeoutMs,
-    logger,
-    copyErrorPrefix: "failed to copy hook pack",
-    depsLogMessage: "Installing hook pack dependencies…",
-    manifestDependencies: manifest.dependencies,
-    afterInstall: async (installedDir) => {
-      const dependencyPolicyFailure = await runHookInstalledDependencyPolicy({
-        hookPackId,
-        installedDir,
-        forward: params,
-        logger,
-        mode: effectiveMode,
-      });
-      return dependencyPolicyFailure ?? { ok: true };
-    },
-  });
+  const installRes = await runtime.installPackageDirWithManifestDeps(
+    copyPackageDirInstallTransactionRequest(params, {
+      sourceDir: params.packageDir,
+      targetDir,
+      mode: effectiveMode,
+      timeoutMs,
+      logger,
+      copyErrorPrefix: "failed to copy hook pack",
+      depsLogMessage: "Installing hook pack dependencies…",
+      manifestDependencies: manifest.dependencies,
+      beforePersistentApply: params.beforePersistentApply,
+      afterInstall: async (installedDir) => {
+        const dependencyPolicyFailure = await runHookInstalledDependencyPolicy({
+          hookPackId,
+          installedDir,
+          forward: params,
+          logger,
+          mode: effectiveMode,
+        });
+        return dependencyPolicyFailure ?? { ok: true };
+      },
+    }),
+  );
   if (!installRes.ok) {
     return installRes;
   }
 
   return {
-    ok: true,
+    ...installRes,
     hookPackId,
     hooks: hookNames,
     packageKind,
@@ -628,32 +634,35 @@ async function installHookFromDir(
     };
   }
 
-  const installRes = await runtime.installPackageDir({
-    sourceDir: params.hookDir,
-    targetDir,
-    mode: effectiveMode,
-    timeoutMs: 120_000,
-    logger,
-    copyErrorPrefix: "failed to copy hook",
-    hasDeps: false,
-    depsLogMessage: "Installing hook dependencies…",
-    afterInstall: async (installedDir) => {
-      const stagedPolicyFailure = await runHookInstalledDependencyPolicy({
-        hookPackId: hookName,
-        installedDir,
-        forward: params,
-        logger,
-        mode: effectiveMode,
-      });
-      return stagedPolicyFailure ?? { ok: true };
-    },
-  });
+  const installRes = await runtime.installPackageDir(
+    copyPackageDirInstallTransactionRequest(params, {
+      sourceDir: params.hookDir,
+      targetDir,
+      mode: effectiveMode,
+      timeoutMs: 120_000,
+      logger,
+      copyErrorPrefix: "failed to copy hook",
+      hasDeps: false,
+      depsLogMessage: "Installing hook dependencies…",
+      beforePersistentApply: params.beforePersistentApply,
+      afterInstall: async (installedDir) => {
+        const stagedPolicyFailure = await runHookInstalledDependencyPolicy({
+          hookPackId: hookName,
+          installedDir,
+          forward: params,
+          logger,
+          mode: effectiveMode,
+        });
+        return stagedPolicyFailure ?? { ok: true };
+      },
+    }),
+  );
   if (!installRes.ok) {
     return installRes;
   }
 
   return {
-    ok: true,
+    ...installRes,
     hookPackId: hookName,
     hooks: [hookName],
     packageKind,
@@ -709,6 +718,7 @@ export async function installHooksFromNpmSpec(
     expectedHookPackId?: string;
     expectedPackageKind?: "hook-only";
     inspection?: "package-kind";
+    beforePersistentApply?: () => void;
     expectedIntegrity?: string;
     onIntegrityDrift?: (params: HookNpmIntegrityDriftParams) => boolean | Promise<boolean>;
   } & InstallSafetyOverrides,

--- a/src/hooks/installs.test.ts
+++ b/src/hooks/installs.test.ts
@@ -1,9 +1,22 @@
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import fs from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { persistHookPackInstall } from "../cli/hook-install-persistence.js";
+import { readConfigFileSnapshotForWrite } from "../config/config.js";
+import {
+  installPackageDir,
+  requestDeferredPackageDirInstall,
+  resolvePackageDirInstallTransaction,
+} from "../infra/install-package-dir.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { readConfigMachineState, writeConfigMachineState } from "../state/config-machine-state.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { stageHookInstall } from "./install-record-transaction.js";
 import { readHookInstalls, recordHookInstall } from "./installs.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
@@ -11,15 +24,246 @@ afterEach(() => {
 
 describe("hook install machine state", () => {
   it("merges independently recorded hook packs", () => {
-    const stateDir = mkdtempSync(join(tmpdir(), "openclaw-hook-installs-"));
+    const stateDir = tempDirs.make("openclaw-hook-installs-");
     const options = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
 
-    recordHookInstall({}, { hookId: "alpha", source: "npm" }, options);
-    recordHookInstall({}, { hookId: "beta", source: "path" }, options);
+    recordHookInstall({ hookId: "alpha", source: "npm" }, options);
+    recordHookInstall({ hookId: "beta", source: "path" }, options);
 
     expect(readHookInstalls(options)).toMatchObject({
       alpha: { source: "npm" },
       beta: { source: "path" },
     });
   });
+});
+
+async function withHookInstallFixture(
+  mode: "install" | "update" | "link",
+  run: (fixture: {
+    configPath: string;
+    sourceDir: string;
+    targetDir: string;
+    payloadTransaction: ReturnType<typeof resolvePackageDirInstallTransaction>;
+  }) => Promise<void>,
+) {
+  const root = tempDirs.make("openclaw-hook-commit-");
+  const stateDir = join(root, "state");
+  const configPath = join(stateDir, "openclaw.json");
+  const sourceDir = join(root, "source");
+  const targetDir = mode === "link" ? sourceDir : join(stateDir, "hooks", "alpha");
+  fs.mkdirSync(sourceDir, { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(join(sourceDir, "payload.txt"), "candidate");
+  fs.writeFileSync(configPath, "{}\n");
+  await withEnvAsync(
+    { OPENCLAW_HOME: root, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath },
+    async () => {
+      await withPluginLifecycleLease({}, async () => {
+        if (mode === "update") {
+          fs.mkdirSync(targetDir, { recursive: true });
+          fs.writeFileSync(join(targetDir, "payload.txt"), "previous");
+          writeConfigMachineState("hooks.internal.installs", {
+            alpha: { source: "path", installPath: targetDir, version: "1.0.0" },
+          });
+        }
+        const result =
+          mode === "link"
+            ? undefined
+            : await installPackageDir(
+                requestDeferredPackageDirInstall({
+                  sourceDir,
+                  targetDir,
+                  mode,
+                  timeoutMs: 30_000,
+                  copyErrorPrefix: "fixture copy failed",
+                  hasDeps: false,
+                  depsLogMessage: "unused",
+                }),
+              );
+        if (result && !result.ok) {
+          throw new Error(result.error);
+        }
+        await run({
+          configPath,
+          sourceDir,
+          targetDir,
+          payloadTransaction: result ? resolvePackageDirInstallTransaction(result) : undefined,
+        });
+      });
+    },
+  );
+}
+
+describe("hook install commit ownership", () => {
+  it.each(
+    (["install", "update", "link"] as const).flatMap((mode) =>
+      (["before record", "after record", "after config"] as const).map((phase) => ({
+        mode,
+        phase,
+      })),
+    ),
+  )(
+    "compensates $mode cancellation $phase without touching its source",
+    async ({ mode, phase }) => {
+      await withHookInstallFixture(
+        mode,
+        async ({ configPath, sourceDir, targetDir, payloadTransaction }) => {
+          const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+          const previousRecords = readConfigMachineState("hooks.internal.installs");
+          const previousConfig = fs.readFileSync(configPath, "utf8");
+          let closed = phase === "before record";
+
+          await expect(
+            persistHookPackInstall({
+              snapshot: {
+                config: snapshot.config,
+                baseHash: snapshot.hash ?? undefined,
+                writeOptions,
+              },
+              hookPackId: "alpha",
+              hooks: ["command-audit"],
+              // Missing optional fields must compare equal to their persisted JSON representation.
+              install: { source: "path", installPath: targetDir, version: undefined },
+              payloadTransaction,
+              beforePersistentApply() {
+                if (phase === "after config") {
+                  closed = Boolean(
+                    JSON.parse(fs.readFileSync(configPath, "utf8")).hooks?.internal?.entries?.[
+                      "command-audit"
+                    ]?.enabled,
+                  );
+                }
+                if (closed) {
+                  throw new Error("hook authority closed");
+                }
+                if (phase === "after record") {
+                  queueMicrotask(() => {
+                    closed = true;
+                  });
+                }
+              },
+            }),
+          ).rejects.toThrow("hook authority closed");
+
+          expect(readConfigMachineState("hooks.internal.installs")).toEqual(previousRecords);
+          expect(fs.readFileSync(configPath, "utf8")).toBe(previousConfig);
+          expect(fs.readFileSync(join(sourceDir, "payload.txt"), "utf8")).toBe("candidate");
+          if (mode === "install") {
+            expect(fs.existsSync(targetDir)).toBe(false);
+          } else {
+            expect(fs.readFileSync(join(targetDir, "payload.txt"), "utf8")).toBe(
+              mode === "update" ? "previous" : "candidate",
+            );
+          }
+        },
+      );
+    },
+  );
+
+  it("refuses compensation after its lifecycle lease has been replaced", async () => {
+    const root = tempDirs.make("openclaw-hook-lease-");
+    const payload = join(root, "payload.txt");
+    fs.writeFileSync(payload, "successor payload");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: join(root, "state") }, async () => {
+      const transaction = await withPluginLifecycleLease({}, async (lease) => {
+        return await stageHookInstall({
+          update: { hookId: "alpha", source: "path", installPath: root },
+          lease,
+          payloadTransaction: {
+            async commit() {},
+            async rollback() {
+              fs.unlinkSync(payload);
+            },
+          },
+        });
+      });
+      await withPluginLifecycleLease({}, async () => {
+        const successor = readHookInstalls();
+        await expect(transaction.rollback()).rejects.toThrow("lost");
+        expect(readHookInstalls()).toEqual(successor);
+        expect(fs.readFileSync(payload, "utf8")).toBe("successor payload");
+      });
+    });
+  });
+
+  it.each(["unrelated", "replacement"] as const)(
+    "preserves a %s record written before compensation",
+    async (writer) => {
+      await withHookInstallFixture("install", async ({ targetDir, payloadTransaction }) => {
+        await withPluginLifecycleLease({}, async (lease) => {
+          const transaction = await stageHookInstall({
+            update: { hookId: "alpha", source: "path", installPath: targetDir, version: undefined },
+            payloadTransaction,
+            lease,
+          });
+          const hookId = writer === "replacement" ? "alpha" : "beta";
+          recordHookInstall({ hookId, source: "npm", version: "2.0.0" });
+
+          if (writer === "replacement") {
+            await expect(transaction.rollback()).rejects.toThrow(
+              "newer record and payload retained",
+            );
+            expect(fs.existsSync(targetDir)).toBe(true);
+          } else {
+            await transaction.rollback();
+            expect(fs.existsSync(targetDir)).toBe(false);
+            expect(readHookInstalls().alpha).toBeUndefined();
+          }
+          expect(readHookInstalls()[hookId]).toMatchObject({ source: "npm", version: "2.0.0" });
+        });
+      });
+    },
+  );
+
+  it.each(["logging", "cleanup"] as const)(
+    "keeps committed state after a %s failure",
+    async (failure) => {
+      await withHookInstallFixture(
+        "update",
+        async ({ configPath, targetDir, payloadTransaction }) => {
+          if (!payloadTransaction) {
+            throw new Error("expected payload transaction");
+          }
+          const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+          await expect(
+            persistHookPackInstall({
+              snapshot: {
+                config: snapshot.config,
+                baseHash: snapshot.hash ?? undefined,
+                writeOptions,
+              },
+              hookPackId: "alpha",
+              hooks: ["command-audit"],
+              install: { source: "path", installPath: targetDir, version: "2.0.0" },
+              payloadTransaction: {
+                ...payloadTransaction,
+                async commit() {
+                  await payloadTransaction.commit();
+                  if (failure === "cleanup") {
+                    throw new Error("cleanup unavailable");
+                  }
+                },
+              },
+              runtime: {
+                log() {
+                  throw new Error("logging unavailable");
+                },
+                error() {},
+                exit() {
+                  throw new Error("unexpected exit");
+                },
+              },
+            }),
+          ).rejects.toThrow(failure === "cleanup" ? "committed" : "logging unavailable");
+
+          expect(readHookInstalls().alpha).toMatchObject({ version: "2.0.0" });
+          expect(fs.readFileSync(join(targetDir, "payload.txt"), "utf8")).toBe("candidate");
+          expect(
+            JSON.parse(fs.readFileSync(configPath, "utf8")).hooks.internal.entries["command-audit"]
+              .enabled,
+          ).toBe(true);
+        },
+      );
+    },
+  );
 });

--- a/src/hooks/installs.ts
+++ b/src/hooks/installs.ts
@@ -1,12 +1,18 @@
 import { expectDefined } from "@openclaw/normalization-core";
 // Hook install record helpers read and write installed hook metadata.
 import type { HookInstallRecord } from "../config/types.hooks.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readConfigMachineState, updateConfigMachineState } from "../state/config-machine-state.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 
-/** Install record plus the hook pack id being updated in config. */
+/** Install record plus its canonical hook pack id. */
 export type HookInstallUpdate = HookInstallRecord & { hookId: string };
+
+export type HookInstallWriteReceipt = {
+  hookId: string;
+  previous?: HookInstallRecord;
+  writtenJson: string;
+  bucketExisted: boolean;
+};
 
 /** Read canonical hook install records from machine state. */
 export function readHookInstalls(
@@ -20,26 +26,60 @@ export function readHookInstalls(
 
 /** Persist one hook install record in machine state. */
 export function recordHookInstall(
-  cfg: OpenClawConfig,
   update: HookInstallUpdate,
   options: OpenClawStateDatabaseOptions = {},
-): OpenClawConfig {
+): HookInstallWriteReceipt {
   const { hookId, ...record } = update;
+  let receipt: HookInstallWriteReceipt | undefined;
   updateConfigMachineState<Record<string, HookInstallRecord>>(
     "hooks.internal.installs",
     (current) => {
-      const installs = {
-        ...current,
-        [hookId]: {
-          ...current?.[hookId],
-          ...record,
-          installedAt: record.installedAt ?? new Date().toISOString(),
-        },
+      const previous = current && Object.hasOwn(current, hookId) ? current[hookId] : undefined;
+      const written = {
+        ...previous,
+        ...record,
+        installedAt: record.installedAt ?? new Date().toISOString(),
       };
-      installs[hookId] = expectDefined(installs[hookId], "installs entry at hook id");
-      return installs;
+      receipt = {
+        hookId,
+        previous,
+        // Compare the persisted shape: optional undefined fields disappear in SQLite JSON.
+        writtenJson: JSON.stringify(written),
+        bucketExisted: current !== undefined,
+      };
+      return { ...current, [hookId]: written };
     },
     options,
   );
-  return cfg;
+  return expectDefined(receipt, "hook install write receipt");
+}
+
+/** Undo only this install's record, preserving unrelated or newer writers. */
+export function restoreHookInstallIfCurrent(
+  receipt: HookInstallWriteReceipt,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  let restored = false;
+  updateConfigMachineState<Record<string, HookInstallRecord>>(
+    "hooks.internal.installs",
+    (current) => {
+      if (
+        !current ||
+        !Object.hasOwn(current, receipt.hookId) ||
+        JSON.stringify(current[receipt.hookId]) !== receipt.writtenJson
+      ) {
+        return current;
+      }
+      const next = { ...current };
+      if (receipt.previous) {
+        next[receipt.hookId] = receipt.previous;
+      } else {
+        delete next[receipt.hookId];
+      }
+      restored = true;
+      return !receipt.bucketExisted && Object.keys(next).length === 0 ? undefined : next;
+    },
+    options,
+  );
+  return restored;
 }

--- a/src/hooks/update.test.ts
+++ b/src/hooks/update.test.ts
@@ -2,36 +2,56 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { HookInstallRecord } from "../config/types.hooks.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  copyPackageDirInstallTransactionRequest,
+  installPackageDir,
+} from "../infra/install-package-dir.js";
+import {
+  requestDeferredPluginInstall,
+  settlePluginInstallTransactions,
+  type PluginInstallTransaction,
+} from "../plugins/install-transaction.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
-import type { HookNpmIntegrityDriftParams } from "./install.js";
+import type { HookNpmIntegrityDriftParams, installHooksFromNpmSpec } from "./install.js";
+import { readHookInstalls, recordHookInstall } from "./installs.js";
 
 const installHooksFromNpmSpecMock = vi.fn();
-let hookInstalls: Record<string, HookInstallRecord> = {};
 
 vi.mock("./install.js", () => ({
   installHooksFromNpmSpec: (...args: unknown[]) => installHooksFromNpmSpecMock(...args),
   resolveHookInstallDir: (hookId: string) => `/tmp/hooks/${hookId}`,
 }));
 
-vi.mock("./installs.js", () => ({
-  readHookInstalls: () => hookInstalls,
-  recordHookInstall: (cfg: OpenClawConfig, update: HookInstallRecord & { hookId: string }) => {
-    const { hookId, ...record } = update;
-    hookInstalls = {
-      ...hookInstalls,
-      [hookId]: {
-        ...hookInstalls[hookId],
-        ...record,
-        installedAt: record.installedAt ?? "2026-05-11T20:00:00.000Z",
-      },
-    };
-    return cfg;
-  },
-}));
-
 const { updateNpmInstalledHookPacks } = await import("./update.js");
+
+async function runHookUpdate(
+  params: Parameters<typeof updateNpmInstalledHookPacks>[0],
+  action: "commit" | "rollback" = "commit",
+) {
+  if (params.dryRun) {
+    return await updateNpmInstalledHookPacks(params);
+  }
+  return await withPluginLifecycleLease({}, async (lease) => {
+    const transactions: PluginInstallTransaction[] = [];
+    try {
+      const result = await updateNpmInstalledHookPacks(
+        requestDeferredPluginInstall({ ...params, lease }, transactions),
+      );
+      await settlePluginInstallTransactions(transactions, action);
+      return result;
+    } catch (error) {
+      await settlePluginInstallTransactions(transactions, "rollback");
+      throw error;
+    }
+  });
+}
 
 function createHookInstallConfig(params: {
   hookId: string;
@@ -39,14 +59,13 @@ function createHookInstallConfig(params: {
   integrity?: string;
   installPath?: string;
 }): OpenClawConfig {
-  hookInstalls = {
-    [params.hookId]: {
-      source: "npm",
-      spec: params.spec,
-      installPath: params.installPath ?? `/tmp/hooks/${params.hookId}`,
-      ...(params.integrity ? { integrity: params.integrity } : {}),
-    },
-  };
+  recordHookInstall({
+    hookId: params.hookId,
+    source: "npm",
+    spec: params.spec,
+    installPath: params.installPath ?? `/tmp/hooks/${params.hookId}`,
+    ...(params.integrity ? { integrity: params.integrity } : {}),
+  });
   return {};
 }
 
@@ -62,13 +81,30 @@ async function createInstalledHookPackDir(version: string): Promise<string> {
 }
 
 describe("updateNpmInstalledHookPacks", () => {
-  beforeEach(() => {
+  let state: OpenClawTestState;
+
+  beforeEach(async () => {
     installHooksFromNpmSpecMock.mockReset();
-    hookInstalls = {};
+    state = await createOpenClawTestState({ label: "hook-update" });
   });
 
   afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await state.cleanup();
     await tempDirs.cleanup();
+  });
+
+  it("refuses mutation without both the retained lease and compensation sink", async () => {
+    const config = createHookInstallConfig({ hookId: "demo-hooks", spec: "@openclaw/demo-hooks" });
+    await expect(updateNpmInstalledHookPacks({ config })).rejects.toThrow(
+      "hook update lifecycle lease",
+    );
+    await withPluginLifecycleLease({}, async (lease) => {
+      await expect(updateNpmInstalledHookPacks({ config, lease })).rejects.toThrow(
+        "hook update transaction sink",
+      );
+    });
+    expect(installHooksFromNpmSpecMock).not.toHaveBeenCalled();
   });
 
   it("aborts exact pinned hook pack updates on integrity drift by default", async () => {
@@ -109,7 +145,7 @@ describe("updateNpmInstalledHookPacks", () => {
       spec: "@openclaw/demo-hooks@1.0.0",
       integrity: "sha512-old",
     });
-    const result = await updateNpmInstalledHookPacks({
+    const result = await runHookUpdate({
       config,
       hookIds: ["demo-hooks"],
       logger: { warn },
@@ -151,7 +187,7 @@ describe("updateNpmInstalledHookPacks", () => {
       hookId: "demo-hooks",
       spec: "@openclaw/demo-hooks",
     });
-    const result = await updateNpmInstalledHookPacks({
+    const result = await runHookUpdate({
       config,
       hookIds: ["demo-hooks"],
     });
@@ -164,7 +200,7 @@ describe("updateNpmInstalledHookPacks", () => {
       }),
     );
     expect(result.changed).toBe(true);
-    expect(hookInstalls["demo-hooks"]).toEqual({
+    expect(readHookInstalls()["demo-hooks"]).toEqual({
       source: "npm",
       spec: "@openclaw/demo-hooks",
       installPath: "/tmp/hooks/demo-hooks",
@@ -176,7 +212,7 @@ describe("updateNpmInstalledHookPacks", () => {
       shasum: "abc123",
       resolvedAt: "2026-05-11T20:00:00.000Z",
       hooks: ["demo"],
-      installedAt: "2026-05-11T20:00:00.000Z",
+      installedAt: expect.any(String),
     });
   });
 
@@ -200,7 +236,7 @@ describe("updateNpmInstalledHookPacks", () => {
         spec: "@openclaw/demo-hooks",
         installPath,
       });
-      const result = await updateNpmInstalledHookPacks({ config, hookIds: ["demo-hooks"], dryRun });
+      const result = await runHookUpdate({ config, hookIds: ["demo-hooks"], dryRun });
 
       expect(result.outcomes).toEqual([
         {
@@ -213,4 +249,47 @@ describe("updateNpmInstalledHookPacks", () => {
       ]);
     },
   );
+
+  it("restores the payload and record when the caller rolls back its config update", async () => {
+    const installPath = await createInstalledHookPackDir("1.0.0");
+    const sourceDir = await createInstalledHookPackDir("2.0.0");
+    const config = createHookInstallConfig({
+      hookId: "demo-hooks",
+      spec: "@openclaw/demo-hooks",
+      installPath,
+    });
+    const previousInstalls = readHookInstalls();
+    installHooksFromNpmSpecMock.mockImplementation(
+      async (params: Parameters<typeof installHooksFromNpmSpec>[0]) => {
+        const result = await installPackageDir(
+          copyPackageDirInstallTransactionRequest(params, {
+            sourceDir,
+            targetDir: installPath,
+            mode: "update",
+            timeoutMs: 30_000,
+            copyErrorPrefix: "hook fixture install failed",
+            hasDeps: false,
+            depsLogMessage: "",
+            beforePersistentApply: params.beforePersistentApply,
+          }),
+        );
+        return result.ok
+          ? {
+              ...result,
+              hookPackId: "demo-hooks",
+              hooks: ["demo"],
+              targetDir: installPath,
+              version: "2.0.0",
+            }
+          : result;
+      },
+    );
+
+    await runHookUpdate({ config, hookIds: ["demo-hooks"] }, "rollback");
+
+    expect(
+      JSON.parse(await fs.readFile(path.join(installPath, "package.json"), "utf8")),
+    ).toMatchObject({ version: "1.0.0" });
+    expect(readHookInstalls()).toEqual(previousInstalls);
+  });
 });

--- a/src/hooks/update.ts
+++ b/src/hooks/update.ts
@@ -1,5 +1,10 @@
 // Hook update helpers refresh installed hook records and config references.
+import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  requestDeferredPackageDirInstall,
+  resolvePackageDirInstallTransaction,
+} from "../infra/install-package-dir.js";
 import { buildNpmResolutionFields } from "../infra/install-source-utils.js";
 import {
   expectedIntegrityForUpdate,
@@ -7,12 +12,15 @@ import {
   readInstalledPackageVersion,
 } from "../infra/package-update-utils.js";
 import type { InstallSafetyOverrides } from "../plugins/install-security-scan.types.js";
+import { resolvePluginInstallTransactionSink } from "../plugins/install-transaction.js";
+import type { PluginLifecycleLeaseContext } from "../plugins/plugin-lifecycle-lease.js";
+import { stageHookInstall } from "./install-record-transaction.js";
 import {
   installHooksFromNpmSpec,
   type HookNpmIntegrityDriftParams,
   resolveHookInstallDir,
 } from "./install.js";
-import { readHookInstalls, recordHookInstall } from "./installs.js";
+import { readHookInstalls } from "./installs.js";
 
 /** Logger contract for hook pack update operations. */
 type HookPackUpdateLogger = {
@@ -82,14 +90,32 @@ export async function updateNpmInstalledHookPacks(params: {
   logger?: HookPackUpdateLogger;
   hookIds?: string[];
   dryRun?: boolean;
+  lease?: PluginLifecycleLeaseContext;
+  beforePersistentApply?: () => void;
   specOverrides?: Record<string, string>;
   onIntegrityDrift?: (params: HookPackUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
 }): Promise<HookPackUpdateSummary> {
   const logger = params.logger ?? {};
-  const installs = readHookInstalls();
+  // The caller owns the config commit and settles every staged payload/record together.
+  const persistence = params.dryRun
+    ? undefined
+    : {
+        lease: expectDefined(params.lease, "hook update lifecycle lease"),
+        transactions: expectDefined(
+          resolvePluginInstallTransactionSink(params),
+          "hook update transaction sink",
+        ),
+      };
+  const beforePersistentApply = () => {
+    persistence?.lease.assertOwned();
+    params.beforePersistentApply?.();
+  };
+  if (persistence) {
+    beforePersistentApply();
+  }
+  const installs = readHookInstalls(persistence ? { path: persistence.lease.databasePath } : {});
   const targets = params.hookIds?.length ? params.hookIds : Object.keys(installs);
   const outcomes: HookPackUpdateOutcome[] = [];
-  let next = params.config;
   let changed = false;
 
   for (const hookId of targets) {
@@ -139,23 +165,26 @@ export async function updateNpmInstalledHookPacks(params: {
       continue;
     }
     const currentVersion = await readInstalledPackageVersion(installPath);
-    const result = await installHooksFromNpmSpec({
-      config: params.config,
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-      onInstallPolicyWarning: params.onInstallPolicyWarning,
-      spec: effectiveSpec,
-      mode: "update",
-      dryRun: params.dryRun,
-      expectedHookPackId: hookId,
-      expectedIntegrity,
-      onIntegrityDrift: createHookPackUpdateIntegrityDriftHandler({
-        hookId,
-        dryRun: Boolean(params.dryRun),
+    const result = await installHooksFromNpmSpec(
+      requestDeferredPackageDirInstall({
+        config: params.config,
+        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
+        onInstallPolicyWarning: params.onInstallPolicyWarning,
+        spec: effectiveSpec,
+        mode: "update",
+        dryRun: params.dryRun,
+        beforePersistentApply,
+        expectedHookPackId: hookId,
+        expectedIntegrity,
+        onIntegrityDrift: createHookPackUpdateIntegrityDriftHandler({
+          hookId,
+          dryRun: Boolean(params.dryRun),
+          logger,
+          onIntegrityDrift: params.onIntegrityDrift,
+        }),
         logger,
-        onIntegrityDrift: params.onIntegrityDrift,
       }),
-      logger,
-    });
+    );
 
     if (!result.ok) {
       outcomes.push({
@@ -173,7 +202,7 @@ export async function updateNpmInstalledHookPacks(params: {
       currentVersion && nextVersion && currentVersion === nextVersion ? "unchanged" : "updated";
     const downgraded = isPackageVersionDowngrade(currentVersion, nextVersion);
 
-    if (params.dryRun) {
+    if (!persistence) {
       outcomes.push({
         hookId,
         status,
@@ -187,15 +216,22 @@ export async function updateNpmInstalledHookPacks(params: {
       continue;
     }
 
-    next = recordHookInstall(next, {
-      hookId,
-      source: "npm",
-      spec: effectiveSpec,
-      installPath: result.targetDir,
-      version: nextVersion,
-      ...buildNpmResolutionFields(result.npmResolution),
-      hooks: result.hooks,
-    });
+    persistence.transactions.push(
+      await stageHookInstall({
+        update: {
+          hookId,
+          source: "npm",
+          spec: effectiveSpec,
+          installPath: result.targetDir,
+          version: nextVersion,
+          ...buildNpmResolutionFields(result.npmResolution),
+          hooks: result.hooks,
+        },
+        payloadTransaction: resolvePackageDirInstallTransaction(result),
+        lease: persistence.lease,
+        beforePersistentApply,
+      }),
+    );
     changed = true;
 
     outcomes.push({
@@ -210,5 +246,5 @@ export async function updateNpmInstalledHookPacks(params: {
     });
   }
 
-  return { config: next, changed, outcomes };
+  return { config: params.config, changed, outcomes };
 }

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -251,6 +251,36 @@ describe("installPackageDir", () => {
     ).resolves.toHaveLength(0);
   });
 
+  it("checks update authority before displacing the existing install", async () => {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("case");
+    const { sourceDir, targetDir } = await createExistingInstallFixture(fixtureRoot);
+    let backupReached = false;
+    const result = await installPackageDir({
+      sourceDir,
+      targetDir,
+      mode: "update",
+      timeoutMs: 1_000,
+      copyErrorPrefix: "failed to copy plugin",
+      hasDeps: false,
+      depsLogMessage: "unused",
+      beforePersistentApply() {
+        throw new Error("update authority closed");
+      },
+      async afterBackup() {
+        backupReached = true;
+        return { ok: true };
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "failed to copy plugin: Error: update authority closed",
+    });
+    expect(backupReached).toBe(false);
+    await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
+  });
+
   it("restores edits detected after the existing install moves to backup", async () => {
     await fixtureRootTracker.setup();
     const fixtureRoot = await fixtureRootTracker.make("case");

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -153,7 +153,7 @@ async function resolveInstallPublishTarget(params: {
   };
 }
 
-type PackageDirInstallTransaction = {
+export type PackageDirInstallTransaction = {
   commit(): Promise<void>;
   rollback(): Promise<void>;
 };
@@ -170,6 +170,15 @@ export function requestDeferredPackageDirInstall<T extends object>(params: T): T
     value: true,
   });
   return params;
+}
+
+export function copyPackageDirInstallTransactionRequest<T extends object>(
+  source: object,
+  target: T,
+): T {
+  return isPackageDirInstallCommitDeferred(source)
+    ? requestDeferredPackageDirInstall(target)
+    : target;
 }
 
 function isPackageDirInstallCommitDeferred(params: object): boolean {
@@ -361,17 +370,20 @@ export async function installPackageDir<
 
   if (params.mode === "update" && (await pathExists(canonicalTargetDir))) {
     const backupRoot = path.join(installBaseRealPath, ".openclaw-install-backups");
-    backupDir = path.join(backupRoot, `${path.basename(canonicalTargetDir)}-${Date.now()}`);
+    const backupPath = path.join(backupRoot, `${path.basename(canonicalTargetDir)}-${Date.now()}`);
     try {
       await fs.mkdir(backupRoot, { recursive: true });
       await assertInstallBoundaryPaths({
         installBaseDir: installBaseRealPath,
-        candidatePaths: [backupDir],
+        candidatePaths: [backupPath],
       });
       await assertInstallBaseStable({
         installBaseDir,
         expectedRealPath: installBaseRealPath,
       });
+      // Moving the current install is a mutation too; do not displace it after ownership closes.
+      params.beforePersistentApply?.();
+      backupDir = backupPath;
       await movePathWithCopyFallback({
         from: canonicalTargetDir,
         sourceHardlinks,

--- a/src/plugins/bundled-install.ts
+++ b/src/plugins/bundled-install.ts
@@ -67,6 +67,7 @@ export async function installBundledPluginSource(params: {
   warning?: string;
   invalidateRuntimeCache?: boolean;
   runtime?: RuntimeEnv;
+  beforePersistentApply?: () => void;
 }): Promise<{ pluginId: string; warnings: string[] }> {
   // Bundled plugins with required config are recorded but not enabled until config validates.
   const existingEntry = params.snapshot.config.plugins?.entries?.[params.bundledSource.pluginId];
@@ -90,6 +91,7 @@ export async function installBundledPluginSource(params: {
     Boolean(warning),
   );
   await persistPluginInstall({
+    ...params,
     snapshot: {
       ...params.snapshot,
       config: configBase,
@@ -102,9 +104,7 @@ export async function installBundledPluginSource(params: {
       installPath: params.bundledSource.localPath,
     },
     enable: shouldEnable,
-    invalidateRuntimeCache: params.invalidateRuntimeCache,
     ...(warnings.length > 0 ? { warningMessage: warnings.join("\n") } : {}),
-    runtime: params.runtime,
   });
   return { pluginId: params.bundledSource.pluginId, warnings };
 }

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -50,7 +50,8 @@ vi.mock("../infra/clawhub-artifacts.js", async () => {
   };
 });
 
-vi.mock("../version.js", () => ({
+vi.mock("../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../version.js")>()),
   resolveCompatibilityHostVersion: (...args: unknown[]) =>
     resolveCompatibilityHostVersionMock(...args),
 }));
@@ -484,6 +485,49 @@ describe("installPluginFromClawHub", () => {
       expect.stringContaining("ClawHub   https://clawhub.ai/plugins/demo"),
     );
     expect(logger.warn).not.toHaveBeenCalled();
+    expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not publish a ClawHub plugin after authority closes during artifact review", async () => {
+    const archive = await mockClawHubFallbackArchive({
+      entries: {
+        "package.json": JSON.stringify({
+          name: "demo",
+          version: "2026.3.22",
+          openclaw: { extensions: ["./index.js"] },
+        }),
+        "openclaw.plugin.json": JSON.stringify({
+          id: "demo",
+          configSchema: { type: "object" },
+        }),
+        "index.js": "export default { register() {} };\n",
+      },
+    });
+    const extensionsDir = path.join(path.dirname(archive.archivePath), "extensions");
+    const { installPluginFromArchive } = await import("./install-package.js");
+    installPluginFromArchiveMock.mockImplementationOnce(installPluginFromArchive);
+    let authorityActive = true;
+    const result = await installPluginFromClawHub({
+      spec: "clawhub:demo",
+      extensionsDir,
+      onBeforePluginArtifactCommit: async () => {
+        authorityActive = false;
+      },
+      beforePersistentApply: () => {
+        if (!authorityActive) {
+          throw new Error("plugin installation authority closed");
+        }
+      },
+    });
+
+    expect(authorityActive).toBe(false);
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("plugin installation authority closed"),
+    });
+    await expect(fs.stat(path.join(extensionsDir, "demo"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -1224,6 +1224,7 @@ export async function installPluginFromClawHub(
     env?: RuntimeVersionEnv;
     confirmInstall?: () => boolean | Promise<boolean>;
     onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
+    beforePersistentApply?: () => void;
   },
 ): Promise<
   | ({
@@ -1460,6 +1461,7 @@ export async function installPluginFromClawHub(
         timeoutMs: params.timeoutMs,
         dryRun: params.dryRun,
         expectedPluginId: runtimeIdResolution.expectedPluginId,
+        beforePersistentApply: params.beforePersistentApply,
         onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit
           ? (artifact) =>
               params.onBeforePluginArtifactCommit!({

--- a/src/plugins/install-package.ts
+++ b/src/plugins/install-package.ts
@@ -408,6 +408,7 @@ export async function installPluginFromArchive(
             requirePluginManifest: true,
             installPolicyRequest,
             onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
+            beforePersistentApply: params.beforePersistentApply,
             onEffectiveMode: (resolvedMode) => {
               effectiveMode = resolvedMode;
             },

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -29,6 +29,7 @@ import {
   recordPluginInstallInRecords,
   withoutPluginInstallRecords,
 } from "./installed-plugin-index-records.js";
+import { loadInstalledPluginIndex } from "./installed-plugin-index.js";
 import { reconcileNpmPluginLoadPath, type PluginInstallUpdate } from "./installs.js";
 import {
   isPluginManifestInstallOwnerAmbiguous,
@@ -37,6 +38,7 @@ import {
 import { loadPluginManifestRegistryCore, type PluginManifestRecord } from "./manifest-registry.js";
 import { safeRealpathSync } from "./path-safety.js";
 import { tracePluginLifecyclePhaseAsync } from "./plugin-lifecycle-trace.js";
+import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
 import { validatePluginSchemaValue } from "./schema-validator.js";
 import { applySlotSelectionForPlugin } from "./slot-selection.js";
@@ -605,10 +607,27 @@ export async function persistPluginInstall(params: {
     }
   }
   const slotWarnings: string[] = [];
+  // Select from this install's candidate before its record reaches the durable index.
+  const slotMetadata = enabledPluginIds.length
+    ? loadPluginMetadataSnapshot({
+        allowCurrent: false,
+        config: next,
+        index: loadInstalledPluginIndex({
+          config: next,
+          candidates: installedCandidates,
+          diagnostics: installedDiscovery.diagnostics,
+          installRecords: nextInstallRecords,
+        }),
+      })
+    : undefined;
   for (const pluginId of enabledPluginIds) {
     const slotResult = await tracePluginLifecyclePhaseAsync(
       "slot selection",
-      async () => applySlotSelectionForPlugin(next, pluginId),
+      async () => {
+        // Legacy kind inspection executes plugin code; every entry follows an awaited boundary.
+        params.beforePersistentApply?.();
+        return applySlotSelectionForPlugin(next, pluginId, slotMetadata);
+      },
       { command: "install", pluginId },
     );
     next = slotResult.config;

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -25,6 +25,7 @@ import { enablePluginInConfig } from "./enable.js";
 import { commitPluginInstallRecordsWithConfig } from "./install-record-commit.js";
 import type { PluginInstallLogger } from "./install-types.js";
 import {
+  clearLoadInstalledPluginIndexInstallRecordsCache,
   loadInstalledPluginIndexInstallRecords,
   recordPluginInstallInRecords,
   withoutPluginInstallRecords,
@@ -37,6 +38,7 @@ import {
 } from "./manifest-install-owner.js";
 import { loadPluginManifestRegistryCore, type PluginManifestRecord } from "./manifest-registry.js";
 import { safeRealpathSync } from "./path-safety.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import { tracePluginLifecyclePhaseAsync } from "./plugin-lifecycle-trace.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { refreshPluginRegistryAfterConfigMutation } from "./registry-refresh.js";
@@ -480,7 +482,7 @@ function resolvePluginConfigEnablement(params: {
   return { mode: "invalid", error: result.errors[0]?.text ?? "invalid plugin config" };
 }
 
-export async function persistPluginInstall(params: {
+type PersistPluginInstallParams = {
   snapshot: ConfigSnapshotForInstallPersist;
   pluginId: string;
   install: Omit<PluginInstallUpdate, "pluginId">;
@@ -492,18 +494,38 @@ export async function persistPluginInstall(params: {
   persistenceLogger?: PluginInstallLogger;
   onCommitted?: () => void;
   beforePersistentApply?: () => void;
-}): Promise<OpenClawConfig> {
+};
+
+export async function persistPluginInstall(
+  params: PersistPluginInstallParams,
+): Promise<OpenClawConfig> {
+  const installRecords = await tracePluginLifecyclePhaseAsync(
+    "install records load",
+    () => loadInstalledPluginIndexInstallRecords(),
+    { command: "install" },
+  );
+  // Keep the prior ledger for replacement cleanup, but validate published package bytes
+  // in a new generation so schema checks and slot selection cannot reuse pre-update facts.
+  try {
+    return await withPluginCache(createPluginCache(), () =>
+      persistPublishedPluginInstall(params, installRecords),
+    );
+  } finally {
+    // Enclosing batch operations must reread the ledger after this isolated mutation.
+    clearLoadInstalledPluginIndexInstallRecordsCache();
+  }
+}
+
+async function persistPublishedPluginInstall(
+  params: PersistPluginInstallParams,
+  installRecords: Record<string, PluginInstallRecord>,
+): Promise<OpenClawConfig> {
   const runtime = params.runtime ?? defaultRuntime;
   // Terminal diagnostics may contain paths/errors; management receives only producer-authored summaries.
   const warn = (message: string, managementMessage: string): void => {
     params.persistenceLogger?.warn?.(managementMessage);
     runtime.log(theme.warn(message));
   };
-  const installRecords = await tracePluginLifecyclePhaseAsync(
-    "install records load",
-    () => loadInstalledPluginIndexInstallRecords(),
-    { command: "install" },
-  );
   const previousInstall = installRecords[params.pluginId];
   const replacedInstallRemoval = resolveReplacedManagedInstallRemoval({
     pluginId: params.pluginId,

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -482,7 +482,7 @@ function resolvePluginConfigEnablement(params: {
   return { mode: "invalid", error: result.errors[0]?.text ?? "invalid plugin config" };
 }
 
-type PersistPluginInstallParams = {
+export async function persistPluginInstall(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   pluginId: string;
   install: Omit<PluginInstallUpdate, "pluginId">;
@@ -494,11 +494,7 @@ type PersistPluginInstallParams = {
   persistenceLogger?: PluginInstallLogger;
   onCommitted?: () => void;
   beforePersistentApply?: () => void;
-};
-
-export async function persistPluginInstall(
-  params: PersistPluginInstallParams,
-): Promise<OpenClawConfig> {
+}): Promise<OpenClawConfig> {
   const installRecords = await tracePluginLifecyclePhaseAsync(
     "install records load",
     () => loadInstalledPluginIndexInstallRecords(),
@@ -507,245 +503,238 @@ export async function persistPluginInstall(
   // Keep the prior ledger for replacement cleanup, but validate published package bytes
   // in a new generation so schema checks and slot selection cannot reuse pre-update facts.
   try {
-    return await withPluginCache(createPluginCache(), () =>
-      persistPublishedPluginInstall(params, installRecords),
-    );
+    return await withPluginCache(createPluginCache(), async () => {
+      const runtime = params.runtime ?? defaultRuntime;
+      // Terminal diagnostics may contain paths/errors; management receives only producer-authored summaries.
+      const warn = (message: string, managementMessage: string): void => {
+        params.persistenceLogger?.warn?.(managementMessage);
+        runtime.log(theme.warn(message));
+      };
+      const previousInstall = installRecords[params.pluginId];
+      const replacedInstallRemoval = resolveReplacedManagedInstallRemoval({
+        pluginId: params.pluginId,
+        previousInstall,
+        nextInstall: params.install,
+      });
+      const nextInstallRecords = recordPluginInstallInRecords(installRecords, {
+        pluginId: params.pluginId,
+        ...params.install,
+      });
+      const reconciledConfig = reconcileNpmPluginLoadPath({
+        config: params.snapshot.config,
+        previousInstall,
+        nextInstall: params.install,
+      });
+      const installedDiscovery = discoverOpenClawPlugins({ installRecords: nextInstallRecords });
+      const realpathCache = new Map<string, string>();
+      const targetPathKeys = new Set(
+        [params.install.installPath, params.install.sourcePath]
+          .filter((candidate): candidate is string => Boolean(candidate?.trim()))
+          .map((candidate) => {
+            const resolved = resolveUserPath(candidate, process.env);
+            return safeRealpathSync(resolved, realpathCache) ?? path.resolve(resolved);
+          }),
+      );
+      const installedCandidates = installedDiscovery.candidates.filter((candidate) => {
+        if (resolvePluginCandidateInstallOwner(candidate) === params.pluginId) {
+          return true;
+        }
+        const candidatePath = candidate.packageDir ?? candidate.rootDir;
+        const resolved = resolveUserPath(candidatePath, process.env);
+        const pathKey = safeRealpathSync(resolved, realpathCache) ?? path.resolve(resolved);
+        return targetPathKeys.has(pathKey);
+      });
+      if (installedCandidates.some(isPluginCandidateInstallOwnerAmbiguous)) {
+        throw new Error(
+          `Plugin package "${params.pluginId}" has ambiguous install ownership. Refresh the plugin registry or reinstall the package before retrying.`,
+        );
+      }
+      const installedRegistry = loadPluginManifestRegistryCore({
+        config: reconciledConfig,
+        candidates: installedCandidates,
+        diagnostics: installedDiscovery.diagnostics,
+        installRecords: nextInstallRecords,
+      });
+      if (installedRegistry.plugins.some(isPluginManifestInstallOwnerAmbiguous)) {
+        throw new Error(
+          `Plugin package "${params.pluginId}" has ambiguous install ownership. Refresh the plugin registry or reinstall the package before retrying.`,
+        );
+      }
+      const manifests = installedRegistry.plugins.filter(
+        (plugin) => resolvePluginManifestInstallOwner(plugin) === params.pluginId,
+      );
+      if (manifests.length === 0) {
+        throw new Error(
+          `Plugin package "${params.pluginId}" has no authoritative runtime child list. Refresh the plugin registry, then reinstall the package or run openclaw doctor before retrying.`,
+        );
+      }
+      const ownedPluginIds = manifests.map((plugin) => plugin.id).toSorted();
+      const manifestByPluginId = new Map(manifests.map((plugin) => [plugin.id, plugin]));
+      const enablementByPluginId = new Map(
+        ownedPluginIds.map((pluginId) => [
+          pluginId,
+          resolvePluginConfigEnablement({
+            config: reconciledConfig,
+            pluginId,
+            manifest: manifestByPluginId.get(pluginId),
+          }),
+        ]),
+      );
+      for (const [pluginId, configEnablement] of enablementByPluginId) {
+        if (configEnablement.mode === "invalid") {
+          throw new Error(
+            `Plugin "${pluginId}" has invalid configured settings: ${configEnablement.error}. Fix plugins.entries.${pluginId}.config, then rerun the install.`,
+          );
+        }
+      }
+
+      let next = reconciledConfig;
+      const enabledPluginIds: string[] = [];
+      for (const pluginId of ownedPluginIds) {
+        const configEnablement = enablementByPluginId.get(pluginId) ?? { mode: "ready" as const };
+        const explicitlyDisabled = reconciledConfig.plugins?.entries?.[pluginId]?.enabled === false;
+        if (configEnablement.mode === "missing") {
+          next = prepareConfigForDisabledInstall(next, pluginId);
+        }
+        if (params.enable === false) {
+          continue;
+        }
+        next = removeInstalledPluginFromDenylist(
+          addInstalledPluginToAllowlist(next, pluginId),
+          pluginId,
+        );
+        if (configEnablement.mode !== "ready" || explicitlyDisabled) {
+          continue;
+        }
+        const enabled = enablePluginInConfig(next, pluginId, { updateChannelConfig: false });
+        next = enabled.config;
+        if (enabled.enabled) {
+          enabledPluginIds.push(pluginId);
+        }
+      }
+      const slotWarnings: string[] = [];
+      // Select from this install's candidate before its record reaches the durable index.
+      const slotMetadata = enabledPluginIds.length
+        ? loadPluginMetadataSnapshot({
+            allowCurrent: false,
+            config: next,
+            index: loadInstalledPluginIndex({
+              config: next,
+              candidates: installedCandidates,
+              diagnostics: installedDiscovery.diagnostics,
+              installRecords: nextInstallRecords,
+            }),
+          })
+        : undefined;
+      for (const pluginId of enabledPluginIds) {
+        const slotResult = await tracePluginLifecyclePhaseAsync(
+          "slot selection",
+          async () => {
+            // Legacy kind inspection executes plugin code; every entry follows an awaited boundary.
+            params.beforePersistentApply?.();
+            return applySlotSelectionForPlugin(next, pluginId, slotMetadata);
+          },
+          { command: "install", pluginId },
+        );
+        next = slotResult.config;
+        slotWarnings.push(...slotResult.warnings);
+      }
+      next = withoutPluginInstallRecords(next);
+      await tracePluginLifecyclePhaseAsync(
+        "config mutation",
+        () =>
+          commitPluginInstallRecordsWithConfig({
+            previousInstallRecords: installRecords,
+            nextInstallRecords,
+            nextConfig: next,
+            baseHash: params.snapshot.baseHash,
+            writeOptions: {
+              ...params.snapshot.writeOptions,
+              afterWrite: { mode: "restart", reason: "plugin source changed" },
+              ...(params.beforePersistentApply
+                ? {
+                    assertConfigPathForWrite: () => {
+                      params.snapshot.writeOptions.assertConfigPathForWrite?.();
+                      params.beforePersistentApply?.();
+                    },
+                  }
+                : {}),
+            },
+          }),
+        { command: "install" },
+      );
+      // The source transaction must survive later cleanup or registry-refresh failures.
+      params.onCommitted?.();
+      if (replacedInstallRemoval) {
+        const removalResult = await tracePluginLifecyclePhaseAsync(
+          "replaced install cleanup",
+          () => applyPluginUninstallDirectoryRemoval(replacedInstallRemoval),
+          { command: "install", pluginId: params.pluginId },
+        );
+        for (const warning of removalResult.warnings) {
+          warn(
+            warning,
+            "A previous plugin installation could not be fully cleaned up. Run `openclaw plugins doctor`.",
+          );
+        }
+        if (removalResult.directoryRemoved) {
+          runtime.log(
+            theme.muted(
+              `Removed previous plugin install directory: ${shortenHomePath(replacedInstallRemoval.target)}`,
+            ),
+          );
+        }
+      }
+      await refreshPluginRegistryAfterConfigMutation({
+        config: next,
+        reason: "source-changed",
+        installRecords: nextInstallRecords,
+        invalidateRuntimeCache: params.invalidateRuntimeCache,
+        traceCommand: "install",
+        logger: {
+          warn: (message) =>
+            warn(
+              message,
+              "Plugin registry refresh or runtime cache invalidation failed. Restart the gateway.",
+            ),
+        },
+      });
+      for (const warning of slotWarnings) {
+        warn(warning, warning);
+      }
+      const configurationRequiredPluginIds = [...enablementByPluginId]
+        .filter(([, state]) => state.mode === "missing")
+        .map(([pluginId]) => pluginId);
+      const configWarning =
+        params.enable !== false && configurationRequiredPluginIds.length > 0
+          ? configurationRequiredPluginIds.length === 1
+            ? `Installed plugin "${configurationRequiredPluginIds[0]}" without enabling it because it requires configuration first. Configure it, then run \`openclaw plugins enable ${configurationRequiredPluginIds[0]}\`.`
+            : `Installed plugin entries ${configurationRequiredPluginIds.join(", ")} without enabling them because they require configuration first. Configure each entry, then run \`openclaw plugins enable <plugin-id>\`.`
+          : undefined;
+      const warningMessage = [params.warningMessage, configWarning].filter(Boolean).join("\n");
+      if (warningMessage) {
+        warn(
+          warningMessage,
+          configWarning ?? "Plugin installation reported a warning. Run `openclaw plugins doctor`.",
+        );
+      }
+      runtime.log(
+        params.successMessage ??
+          (ownedPluginIds.length > 1
+            ? `Installed plugin package ${params.pluginId}: ${ownedPluginIds.join(", ")}`
+            : `Installed plugin: ${params.pluginId}`),
+      );
+      logShadowedNpmInstallWarning({
+        config: next,
+        pluginId: params.pluginId,
+        install: params.install,
+        warn,
+      });
+      runtime.log("Restart the gateway to load plugins.");
+      return next;
+    });
   } finally {
     // Enclosing batch operations must reread the ledger after this isolated mutation.
     clearLoadInstalledPluginIndexInstallRecordsCache();
   }
-}
-
-async function persistPublishedPluginInstall(
-  params: PersistPluginInstallParams,
-  installRecords: Record<string, PluginInstallRecord>,
-): Promise<OpenClawConfig> {
-  const runtime = params.runtime ?? defaultRuntime;
-  // Terminal diagnostics may contain paths/errors; management receives only producer-authored summaries.
-  const warn = (message: string, managementMessage: string): void => {
-    params.persistenceLogger?.warn?.(managementMessage);
-    runtime.log(theme.warn(message));
-  };
-  const previousInstall = installRecords[params.pluginId];
-  const replacedInstallRemoval = resolveReplacedManagedInstallRemoval({
-    pluginId: params.pluginId,
-    previousInstall,
-    nextInstall: params.install,
-  });
-  const nextInstallRecords = recordPluginInstallInRecords(installRecords, {
-    pluginId: params.pluginId,
-    ...params.install,
-  });
-  const reconciledConfig = reconcileNpmPluginLoadPath({
-    config: params.snapshot.config,
-    previousInstall,
-    nextInstall: params.install,
-  });
-  const installedDiscovery = discoverOpenClawPlugins({ installRecords: nextInstallRecords });
-  const realpathCache = new Map<string, string>();
-  const targetPathKeys = new Set(
-    [params.install.installPath, params.install.sourcePath]
-      .filter((candidate): candidate is string => Boolean(candidate?.trim()))
-      .map((candidate) => {
-        const resolved = resolveUserPath(candidate, process.env);
-        return safeRealpathSync(resolved, realpathCache) ?? path.resolve(resolved);
-      }),
-  );
-  const installedCandidates = installedDiscovery.candidates.filter((candidate) => {
-    if (resolvePluginCandidateInstallOwner(candidate) === params.pluginId) {
-      return true;
-    }
-    const candidatePath = candidate.packageDir ?? candidate.rootDir;
-    const resolved = resolveUserPath(candidatePath, process.env);
-    const pathKey = safeRealpathSync(resolved, realpathCache) ?? path.resolve(resolved);
-    return targetPathKeys.has(pathKey);
-  });
-  if (installedCandidates.some(isPluginCandidateInstallOwnerAmbiguous)) {
-    throw new Error(
-      `Plugin package "${params.pluginId}" has ambiguous install ownership. Refresh the plugin registry or reinstall the package before retrying.`,
-    );
-  }
-  const installedRegistry = loadPluginManifestRegistryCore({
-    config: reconciledConfig,
-    candidates: installedCandidates,
-    diagnostics: installedDiscovery.diagnostics,
-    installRecords: nextInstallRecords,
-  });
-  if (installedRegistry.plugins.some(isPluginManifestInstallOwnerAmbiguous)) {
-    throw new Error(
-      `Plugin package "${params.pluginId}" has ambiguous install ownership. Refresh the plugin registry or reinstall the package before retrying.`,
-    );
-  }
-  const manifests = installedRegistry.plugins.filter(
-    (plugin) => resolvePluginManifestInstallOwner(plugin) === params.pluginId,
-  );
-  if (manifests.length === 0) {
-    throw new Error(
-      `Plugin package "${params.pluginId}" has no authoritative runtime child list. Refresh the plugin registry, then reinstall the package or run openclaw doctor before retrying.`,
-    );
-  }
-  const ownedPluginIds = manifests.map((plugin) => plugin.id).toSorted();
-  const manifestByPluginId = new Map(manifests.map((plugin) => [plugin.id, plugin]));
-  const enablementByPluginId = new Map(
-    ownedPluginIds.map((pluginId) => [
-      pluginId,
-      resolvePluginConfigEnablement({
-        config: reconciledConfig,
-        pluginId,
-        manifest: manifestByPluginId.get(pluginId),
-      }),
-    ]),
-  );
-  for (const [pluginId, configEnablement] of enablementByPluginId) {
-    if (configEnablement.mode === "invalid") {
-      throw new Error(
-        `Plugin "${pluginId}" has invalid configured settings: ${configEnablement.error}. Fix plugins.entries.${pluginId}.config, then rerun the install.`,
-      );
-    }
-  }
-
-  let next = reconciledConfig;
-  const enabledPluginIds: string[] = [];
-  for (const pluginId of ownedPluginIds) {
-    const configEnablement = enablementByPluginId.get(pluginId) ?? { mode: "ready" as const };
-    const explicitlyDisabled = reconciledConfig.plugins?.entries?.[pluginId]?.enabled === false;
-    if (configEnablement.mode === "missing") {
-      next = prepareConfigForDisabledInstall(next, pluginId);
-    }
-    if (params.enable === false) {
-      continue;
-    }
-    next = removeInstalledPluginFromDenylist(
-      addInstalledPluginToAllowlist(next, pluginId),
-      pluginId,
-    );
-    if (configEnablement.mode !== "ready" || explicitlyDisabled) {
-      continue;
-    }
-    const enabled = enablePluginInConfig(next, pluginId, { updateChannelConfig: false });
-    next = enabled.config;
-    if (enabled.enabled) {
-      enabledPluginIds.push(pluginId);
-    }
-  }
-  const slotWarnings: string[] = [];
-  // Select from this install's candidate before its record reaches the durable index.
-  const slotMetadata = enabledPluginIds.length
-    ? loadPluginMetadataSnapshot({
-        allowCurrent: false,
-        config: next,
-        index: loadInstalledPluginIndex({
-          config: next,
-          candidates: installedCandidates,
-          diagnostics: installedDiscovery.diagnostics,
-          installRecords: nextInstallRecords,
-        }),
-      })
-    : undefined;
-  for (const pluginId of enabledPluginIds) {
-    const slotResult = await tracePluginLifecyclePhaseAsync(
-      "slot selection",
-      async () => {
-        // Legacy kind inspection executes plugin code; every entry follows an awaited boundary.
-        params.beforePersistentApply?.();
-        return applySlotSelectionForPlugin(next, pluginId, slotMetadata);
-      },
-      { command: "install", pluginId },
-    );
-    next = slotResult.config;
-    slotWarnings.push(...slotResult.warnings);
-  }
-  next = withoutPluginInstallRecords(next);
-  await tracePluginLifecyclePhaseAsync(
-    "config mutation",
-    () =>
-      commitPluginInstallRecordsWithConfig({
-        previousInstallRecords: installRecords,
-        nextInstallRecords,
-        nextConfig: next,
-        baseHash: params.snapshot.baseHash,
-        writeOptions: {
-          ...params.snapshot.writeOptions,
-          afterWrite: { mode: "restart", reason: "plugin source changed" },
-          ...(params.beforePersistentApply
-            ? {
-                assertConfigPathForWrite: () => {
-                  params.snapshot.writeOptions.assertConfigPathForWrite?.();
-                  params.beforePersistentApply?.();
-                },
-              }
-            : {}),
-        },
-      }),
-    { command: "install" },
-  );
-  // The source transaction must survive later cleanup or registry-refresh failures.
-  params.onCommitted?.();
-  if (replacedInstallRemoval) {
-    const removalResult = await tracePluginLifecyclePhaseAsync(
-      "replaced install cleanup",
-      () => applyPluginUninstallDirectoryRemoval(replacedInstallRemoval),
-      { command: "install", pluginId: params.pluginId },
-    );
-    for (const warning of removalResult.warnings) {
-      warn(
-        warning,
-        "A previous plugin installation could not be fully cleaned up. Run `openclaw plugins doctor`.",
-      );
-    }
-    if (removalResult.directoryRemoved) {
-      runtime.log(
-        theme.muted(
-          `Removed previous plugin install directory: ${shortenHomePath(replacedInstallRemoval.target)}`,
-        ),
-      );
-    }
-  }
-  await refreshPluginRegistryAfterConfigMutation({
-    config: next,
-    reason: "source-changed",
-    installRecords: nextInstallRecords,
-    invalidateRuntimeCache: params.invalidateRuntimeCache,
-    traceCommand: "install",
-    logger: {
-      warn: (message) =>
-        warn(
-          message,
-          "Plugin registry refresh or runtime cache invalidation failed. Restart the gateway.",
-        ),
-    },
-  });
-  for (const warning of slotWarnings) {
-    warn(warning, warning);
-  }
-  const configurationRequiredPluginIds = [...enablementByPluginId]
-    .filter(([, state]) => state.mode === "missing")
-    .map(([pluginId]) => pluginId);
-  const configWarning =
-    params.enable !== false && configurationRequiredPluginIds.length > 0
-      ? configurationRequiredPluginIds.length === 1
-        ? `Installed plugin "${configurationRequiredPluginIds[0]}" without enabling it because it requires configuration first. Configure it, then run \`openclaw plugins enable ${configurationRequiredPluginIds[0]}\`.`
-        : `Installed plugin entries ${configurationRequiredPluginIds.join(", ")} without enabling them because they require configuration first. Configure each entry, then run \`openclaw plugins enable <plugin-id>\`.`
-      : undefined;
-  const warningMessage = [params.warningMessage, configWarning].filter(Boolean).join("\n");
-  if (warningMessage) {
-    warn(
-      warningMessage,
-      configWarning ?? "Plugin installation reported a warning. Run `openclaw plugins doctor`.",
-    );
-  }
-  runtime.log(
-    params.successMessage ??
-      (ownedPluginIds.length > 1
-        ? `Installed plugin package ${params.pluginId}: ${ownedPluginIds.join(", ")}`
-        : `Installed plugin: ${params.pluginId}`),
-  );
-  logShadowedNpmInstallWarning({
-    config: next,
-    pluginId: params.pluginId,
-    install: params.install,
-    warn,
-  });
-  runtime.log("Restart the gateway to load plugins.");
-  return next;
 }

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -1,47 +1,24 @@
 // Exercises npm-spec plugin install behavior through the CLI path.
-import { execFile, execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
-import http from "node:http";
+import type http from "node:http";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePluginNpmProjectDir } from "./install-paths.js";
 import { installPluginFromNpmSpec, PLUGIN_INSTALL_ERROR_CODE } from "./install.js";
-
-type PackedVersion = {
-  archive: Buffer;
-  dependencies?: Record<string, string>;
-  integrity: string;
-  openclaw?: Record<string, unknown>;
-  optionalDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
-  shasum: string;
-  tarballName: string;
-  version: string;
-};
-
-type PackPluginParams = {
-  dependencies?: Record<string, string>;
-  indexJs?: string;
-  openclaw?: Record<string, unknown>;
-  optionalDependencies?: Record<string, string>;
-  packageName: string;
-  peerDependencies?: Record<string, string>;
-  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
-  pluginId?: string;
-  rootDir: string;
-  version?: string;
-};
-
-type RegistryPackage = {
-  latest: string;
-  packageName: string;
-  versions: PackedVersion[];
-};
+import {
+  packPlugin,
+  registryPackage,
+  startStaticRegistry,
+  startMutableRegistry,
+  type RegistryPackage,
+} from "./test-helpers/npm-registry-fixtures.js";
 
 const tempDirs = createTempDirTracker();
 const servers: http.Server[] = [];
@@ -131,174 +108,8 @@ function pluginNpmProjectRoot(npmRoot: string, packageName: string): string {
   return resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
 }
 
-async function packPlugin(params: PackPluginParams): Promise<PackedVersion> {
-  const version = params.version ?? "1.0.0";
-  const packageDir = path.join(params.rootDir, `package-${params.packageName}-${version}`);
-  const peerDependenciesMeta = params.peerDependencies
-    ? (params.peerDependenciesMeta ??
-      Object.fromEntries(
-        Object.keys(params.peerDependencies).map((name) => [name, { optional: true }]),
-      ))
-    : undefined;
-  await fs.mkdir(path.join(packageDir, "dist"), { recursive: true });
-  await fs.writeFile(
-    path.join(packageDir, "package.json"),
-    `${JSON.stringify(
-      {
-        name: params.packageName,
-        version,
-        type: "module",
-        openclaw: params.openclaw ?? { extensions: ["./dist/index.js"] },
-        ...(params.dependencies ? { dependencies: params.dependencies } : {}),
-        ...(params.optionalDependencies
-          ? { optionalDependencies: params.optionalDependencies }
-          : {}),
-        ...(params.peerDependencies
-          ? {
-              peerDependencies: params.peerDependencies,
-              ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
-            }
-          : {}),
-      },
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
-  await fs.writeFile(
-    path.join(packageDir, "openclaw.plugin.json"),
-    `${JSON.stringify(
-      {
-        id: params.pluginId ?? params.packageName,
-        name: params.pluginId ?? params.packageName,
-        configSchema: { type: "object" },
-      },
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
-  await fs.writeFile(
-    path.join(packageDir, "dist", "index.js"),
-    params.indexJs ?? "export {};\n",
-    "utf8",
-  );
-
-  const packOutput = execFileSync(
-    "npm",
-    ["pack", "--json", "--ignore-scripts", "--pack-destination", params.rootDir],
-    { cwd: packageDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const parsed = JSON.parse(packOutput) as Array<{ filename: string }>;
-  const tarballName = parsed[0]?.filename;
-  if (!tarballName) {
-    throw new Error(`npm pack did not return a tarball for ${params.packageName}`);
-  }
-  const archive = await fs.readFile(path.join(params.rootDir, tarballName));
-  return {
-    archive,
-    ...(params.dependencies ? { dependencies: params.dependencies } : {}),
-    integrity: `sha512-${crypto.createHash("sha512").update(archive).digest("base64")}`,
-    ...(params.openclaw ? { openclaw: params.openclaw } : {}),
-    ...(params.optionalDependencies ? { optionalDependencies: params.optionalDependencies } : {}),
-    ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
-    ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
-    shasum: crypto.createHash("sha1").update(archive).digest("hex"),
-    tarballName,
-    version,
-  };
-}
-
-async function registryPackage(
-  params: PackPluginParams & { latest?: string },
-): Promise<RegistryPackage> {
-  const version = params.version ?? "1.0.0";
-  return {
-    packageName: params.packageName,
-    latest: params.latest ?? version,
-    versions: [await packPlugin({ ...params, version })],
-  };
-}
-
-async function startStaticRegistry(packages: RegistryPackage[]): Promise<string> {
-  const packageEntries = packages.map((pkg) => ({
-    ...pkg,
-    encodedPackageName: encodeURIComponent(pkg.packageName).replace("%40", "@"),
-    versionsByVersion: new Map(pkg.versions.map((entry) => [entry.version, entry])),
-  }));
-  const server = http.createServer((request, response) => {
-    const url = new URL(request.url ?? "/", "http://127.0.0.1");
-    const baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
-    if (request.method !== "GET") {
-      response.writeHead(405, { "content-type": "text/plain" });
-      response.end("method not allowed");
-      return;
-    }
-
-    for (const pkg of packageEntries) {
-      if (url.pathname === `/${pkg.encodedPackageName}`) {
-        response.writeHead(200, { "content-type": "application/json" });
-        response.end(
-          `${JSON.stringify({
-            name: pkg.packageName,
-            "dist-tags": { latest: pkg.latest },
-            versions: Object.fromEntries(
-              [...pkg.versionsByVersion.entries()].map(([version, entry]) => [
-                version,
-                {
-                  name: pkg.packageName,
-                  version,
-                  ...(entry.openclaw ? { openclaw: entry.openclaw } : {}),
-                  ...(entry.dependencies ? { dependencies: entry.dependencies } : {}),
-                  ...(entry.optionalDependencies
-                    ? { optionalDependencies: entry.optionalDependencies }
-                    : {}),
-                  ...(entry.peerDependencies ? { peerDependencies: entry.peerDependencies } : {}),
-                  ...(entry.peerDependenciesMeta
-                    ? { peerDependenciesMeta: entry.peerDependenciesMeta }
-                    : {}),
-                  dist: {
-                    integrity: entry.integrity,
-                    shasum: entry.shasum,
-                    tarball: `${baseUrl}/${pkg.encodedPackageName}/-/${entry.tarballName}`,
-                  },
-                },
-              ]),
-            ),
-          })}\n`,
-        );
-        return;
-      }
-
-      const tarballPrefix = `/${pkg.encodedPackageName}/-/`;
-      if (url.pathname.startsWith(tarballPrefix)) {
-        const entry = [...pkg.versionsByVersion.values()].find((candidate) =>
-          url.pathname.endsWith(`/${candidate.tarballName}`),
-        );
-        if (entry) {
-          response.writeHead(200, {
-            "content-length": String(entry.archive.length),
-            "content-type": "application/octet-stream",
-          });
-          response.end(entry.archive);
-          return;
-        }
-      }
-    }
-
-    response.writeHead(404, { "content-type": "text/plain" });
-    response.end(`not found: ${url.pathname}`);
-  });
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  servers.push(server);
-  return `http://127.0.0.1:${(server.address() as { port: number }).port}`;
-}
-
 async function useStaticRegistry(packages: RegistryPackage[]): Promise<string> {
-  const registry = await startStaticRegistry(packages);
+  const registry = await startStaticRegistry(packages, servers);
   useRegistry(registry);
   return registry;
 }
@@ -348,88 +159,182 @@ async function installProjectDependencies(
   );
 }
 
-async function startMutableRegistry(params: {
-  packageName: string;
-  initialLatest: string;
-  laterLatest: string;
-  versions: PackedVersion[];
-}): Promise<string> {
-  let latestVersion = params.initialLatest;
-  let metadataRequests = 0;
-  const versions = new Map(params.versions.map((entry) => [entry.version, entry]));
-  const encodedPackageName = encodeURIComponent(params.packageName).replace("%40", "@");
-
-  const server = http.createServer((request, response) => {
-    const url = new URL(request.url ?? "/", "http://127.0.0.1");
-    const baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
-    if (request.method !== "GET") {
-      response.writeHead(405, { "content-type": "text/plain" });
-      response.end("method not allowed");
-      return;
-    }
-
-    if (url.pathname === `/${encodedPackageName}`) {
-      metadataRequests += 1;
-      const metadataLatest = latestVersion;
-      if (metadataRequests === 1) {
-        latestVersion = params.laterLatest;
-      }
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(
-        `${JSON.stringify({
-          name: params.packageName,
-          "dist-tags": { latest: metadataLatest },
-          versions: Object.fromEntries(
-            [...versions.entries()].map(([version, entry]) => [
-              version,
-              {
-                name: params.packageName,
-                version,
-                ...(entry.openclaw ? { openclaw: entry.openclaw } : {}),
-                ...(entry.peerDependencies ? { peerDependencies: entry.peerDependencies } : {}),
-                ...(entry.peerDependenciesMeta
-                  ? { peerDependenciesMeta: entry.peerDependenciesMeta }
-                  : {}),
-                dist: {
-                  integrity: entry.integrity,
-                  shasum: entry.shasum,
-                  tarball: `${baseUrl}/${encodedPackageName}/-/${entry.tarballName}`,
-                },
-              },
-            ]),
-          ),
-        })}\n`,
-      );
-      return;
-    }
-
-    const tarballPrefix = `/${encodedPackageName}/-/`;
-    if (url.pathname.startsWith(tarballPrefix)) {
-      const entry = [...versions.values()].find((candidate) =>
-        url.pathname.endsWith(`/${candidate.tarballName}`),
-      );
-      if (entry) {
-        response.writeHead(200, {
-          "content-length": String(entry.archive.length),
-          "content-type": "application/octet-stream",
-        });
-        response.end(entry.archive);
-        return;
-      }
-    }
-
-    response.writeHead(404, { "content-type": "text/plain" });
-    response.end(`not found: ${url.pathname}`);
-  });
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  servers.push(server);
-  return `http://127.0.0.1:${(server.address() as { port: number }).port}`;
-}
-
 describe("installPluginFromNpmSpec e2e", () => {
+  it.each(["plugin", "hook pack"] as const)(
+    "does not persist an npm %s when delegated authority closes during download",
+    { timeout: 180_000 },
+    async (kind) => {
+      const { rootDir } = await makeInstallFixture("npm-delegated-install-e2e");
+      const packageName = uniquePackageName("delegated-install");
+      const downloadBarrier = { requested: createDeferred(), released: createDeferred() };
+      const registry = await startStaticRegistry(
+        [
+          await registryPackage({
+            packageName,
+            rootDir,
+            ...(kind === "hook pack" ? { hookName: "cancel-test-hook" } : {}),
+          }),
+        ],
+        servers,
+        downloadBarrier,
+      );
+      const stateDir = path.join(rootDir, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const reportPath = path.join(rootDir, "install-result.json");
+      const npmConfigPath = path.join(rootDir, "empty.npmrc");
+      const npmGlobalConfigPath = path.join(rootDir, "global.npmrc");
+      await fs.writeFile(npmConfigPath, "");
+      await fs.writeFile(npmGlobalConfigPath, "");
+      // Import in a fresh process so the hook payload owner resolves this isolated state root.
+      const script = `
+        import { existsSync } from "node:fs";
+        import fs from "node:fs/promises";
+        import path from "node:path";
+        import { randomUUID } from "node:crypto";
+        import { runPluginInstallCommand } from ${JSON.stringify(new URL("../cli/plugins-install-command.ts", import.meta.url).href)};
+        import { writeConfigFile } from ${JSON.stringify(new URL("../config/config.ts", import.meta.url).href)};
+        import { readHookInstalls } from ${JSON.stringify(new URL("../hooks/installs.ts", import.meta.url).href)};
+        import { readPersistedInstalledPluginIndexInstallRecords } from ${JSON.stringify(new URL("./installed-plugin-index-records.ts", import.meta.url).href)};
+        import {
+          claimAgentRunDelegatedAuthority,
+          releaseAgentRunDelegatedAuthority,
+          validateAgentRunDelegatedAuthority,
+        } from ${JSON.stringify(new URL("../infra/agent-run-registry.ts", import.meta.url).href)};
+        const [packageName, registry, reportPath] = JSON.parse(process.argv[1]);
+        await writeConfigFile({});
+        const configBefore = await fs.readFile(process.env.OPENCLAW_CONFIG_PATH, "utf8");
+        const observations = {};
+        for (const stage of ["cancelled", "active"]) {
+          const authority = claimAgentRunDelegatedAuthority(Object.freeze({
+            instanceId: randomUUID(), runId: randomUUID(),
+          }));
+          const errors = [];
+          let exitCode = 0;
+          let authorityClosed = false;
+          const cancellationAbort = new AbortController();
+          const cancellation = stage === "cancelled"
+            ? (async () => {
+                await fetch(registry + "/-/test/authority-close", {
+                  signal: cancellationAbort.signal,
+                }).then((response) => response.text());
+                authorityClosed = releaseAgentRunDelegatedAuthority(authority)
+                  && !validateAgentRunDelegatedAuthority(authority);
+                if (!authorityClosed) throw new Error("Failed to close delegated authority");
+                await fetch(registry + "/-/test/authority-closed").then((response) => response.text());
+              })().catch((error) => errors.push(String(error)))
+            : Promise.resolve();
+          try {
+            await runPluginInstallCommand({
+              raw: "npm:" + packageName + "@1.0.0",
+              opts: { force: true, acceptCapabilities: true },
+              allowInstallPolicyWarningPrompt: false,
+              beforePersistentApply: () => {
+                if (!validateAgentRunDelegatedAuthority(authority)) {
+                  throw new Error("Delegated install authority closed");
+                }
+              },
+              runtime: {
+                log() {},
+                error: (...args) => errors.push(args.join(" ")),
+                exit: (code) => { exitCode = code; },
+              },
+            });
+          } catch (error) {
+            exitCode = 1;
+            errors.push(String(error));
+          }
+          cancellationAbort.abort();
+          await cancellation;
+          const npmEntries = await fs.readdir(path.join(process.env.OPENCLAW_STATE_DIR, "npm"), {
+            recursive: true,
+          }).catch((error) => {
+            if (error.code === "ENOENT") return [];
+            throw error;
+          });
+          observations[stage] = {
+            exitCode, authorityClosed, error: errors.join("\\n"),
+            configUnchanged: configBefore === await fs.readFile(process.env.OPENCLAW_CONFIG_PATH, "utf8"),
+            pluginInstalls: await readPersistedInstalledPluginIndexInstallRecords() ?? {},
+            hookInstalls: readHookInstalls(),
+            npmPayloads: npmEntries.filter((entry) => entry.endsWith(path.join("node_modules", packageName))),
+            hookPayload: existsSync(path.join(process.env.OPENCLAW_STATE_DIR, "hooks", packageName)),
+          };
+          releaseAgentRunDelegatedAuthority(authority);
+        }
+        await fs.writeFile(reportPath, JSON.stringify(observations));
+      `;
+      try {
+        const result = await runNodeScript(
+          [
+            "--import",
+            "tsx",
+            "--input-type=module",
+            "--eval",
+            script,
+            JSON.stringify([packageName, registry, reportPath]),
+          ],
+          {
+            ...process.env,
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_HOME: rootDir,
+            OPENCLAW_AGENT_DIR: undefined,
+            NPM_CONFIG_REGISTRY: registry,
+            npm_config_registry: registry,
+            NPM_CONFIG_CACHE: path.join(rootDir, "npm-cache"),
+            npm_config_cache: path.join(rootDir, "npm-cache"),
+            NPM_CONFIG_USERCONFIG: npmConfigPath,
+            npm_config_userconfig: npmConfigPath,
+            NPM_CONFIG_GLOBALCONFIG: npmGlobalConfigPath,
+            npm_config_globalconfig: npmGlobalConfigPath,
+          },
+          150_000,
+          { maxBuffer: 64 * 1024, requireProcessTreeExit: true },
+        );
+        expect(result.error, result.stderr).toBeUndefined();
+        expect(result.status, result.stderr).toBe(0);
+        const observations = await readJson<
+          Record<
+            "cancelled" | "active",
+            {
+              exitCode: number;
+              authorityClosed: boolean;
+              error: string;
+              configUnchanged: boolean;
+              pluginInstalls: Record<string, unknown>;
+              hookInstalls: Record<string, unknown>;
+              npmPayloads: string[];
+              hookPayload: boolean;
+            }
+          >
+        >(reportPath);
+        expect(observations.cancelled.error).toContain("Delegated install authority closed");
+        expect(observations.cancelled).toMatchObject({
+          exitCode: 1,
+          authorityClosed: true,
+          configUnchanged: true,
+          npmPayloads: [],
+          hookPayload: false,
+        });
+        expect(observations.cancelled.pluginInstalls).toEqual({});
+        expect(observations.cancelled.hookInstalls).toEqual({});
+        // The same artifact still installs under a fresh live claim; rejection is not a broken fixture.
+        expect(observations.active.exitCode, observations.active.error).toBe(0);
+        expect(observations.active.configUnchanged).toBe(false);
+        if (kind === "plugin") {
+          expect(Object.keys(observations.active.pluginInstalls)).toEqual([packageName]);
+          expect(observations.active.npmPayloads).toHaveLength(1);
+        } else {
+          expect(Object.keys(observations.active.hookInstalls)).toEqual([packageName]);
+          expect(observations.active.hookPayload).toBe(true);
+        }
+      } finally {
+        downloadBarrier.requested.resolve();
+        downloadBarrier.released.resolve();
+      }
+    },
+  );
+
   it("installs the newest compatible stable package when npm latest requires a newer plugin API", async () => {
     const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-compatible-version-e2e");
     const packageName = uniquePackageName("compatible-plugin");
@@ -981,12 +886,15 @@ describe("installPluginFromNpmSpec e2e", () => {
       await packPlugin({ packageName, version: "1.0.0", rootDir }),
       await packPlugin({ packageName, version: "2.0.0", rootDir }),
     ];
-    const registry = await startMutableRegistry({
-      packageName,
-      initialLatest: "1.0.0",
-      laterLatest: "2.0.0",
-      versions,
-    });
+    const registry = await startMutableRegistry(
+      {
+        packageName,
+        initialLatest: "1.0.0",
+        laterLatest: "2.0.0",
+        versions,
+      },
+      servers,
+    );
     useRegistry(registry);
 
     const result = await installNpmPlugin({

--- a/src/plugins/install.path.test.ts
+++ b/src/plugins/install.path.test.ts
@@ -98,6 +98,42 @@ beforeEach(() => {
 });
 
 describe("installPluginFromPath", () => {
+  it.each(["native plugin", "bundle"] as const)(
+    "does not publish an archived %s after authority closes during artifact review",
+    async (kind) => {
+      const { pluginDir, extensionsDir } =
+        kind === "native plugin"
+          ? setupNativePluginInstallFixture()
+          : setupBundleInstallFixture({ bundleFormat: "claude", name: "Guarded Bundle" });
+      const pluginId = kind === "native plugin" ? "symlink-plugin" : "guarded-bundle";
+      const archivePath = await packToArchive({
+        pkgDir: pluginDir,
+        outDir: suiteTempRootTracker.makeTempDir(),
+        outName: "guarded-plugin.tgz",
+      });
+      let authorityActive = true;
+      const result = await installPluginFromPath({
+        path: archivePath,
+        extensionsDir,
+        onBeforePluginArtifactCommit: async () => {
+          authorityActive = false;
+        },
+        beforePersistentApply: () => {
+          if (!authorityActive) {
+            throw new Error("plugin installation authority closed");
+          }
+        },
+      });
+
+      expect(authorityActive).toBe(false);
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("plugin installation authority closed"),
+      });
+      expect(fs.existsSync(path.join(extensionsDir, pluginId))).toBe(false);
+    },
+  );
+
   it("rejects managed plain file plugin installs through path install", async () => {
     const baseDir = suiteTempRootTracker.makeTempDir();
     const extensionsDir = path.join(baseDir, "extensions");

--- a/src/plugins/management-service.install-compensation.test.ts
+++ b/src/plugins/management-service.install-compensation.test.ts
@@ -61,7 +61,8 @@ describe("managed plugin install transactions", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it.each(requests)("settles $source payloads at the config commit boundary", async (request) => {
-    for (const failure of ["before-commit", "after-commit", "none"] as const) {
+    for (const failure of ["authority-closed", "before-commit", "after-commit", "none"] as const) {
+      mocks.persist.mockClear();
       const home = await fs.realpath(tempDirs.make("openclaw-managed-upgrade-"));
       const sourceDir = path.join(home, "incoming");
       const targetDir = path.join(home, "extensions", "demo");
@@ -77,10 +78,12 @@ describe("managed plugin install transactions", () => {
       await fs.writeFile(path.join(sourceDir, "version"), "2.0.0");
       await fs.writeFile(path.join(targetDir, "version"), "1.0.0");
       const conflict = new Error(failure);
+      let active = true;
       mocks.persist.mockImplementation(
         async (
           params: Parameters<typeof import("./install-persistence.js").persistPluginInstall>[0],
         ) => {
+          params.beforePersistentApply?.();
           expect(params.install.acceptedSurface?.tools).toEqual(["demo.write"]);
           if (request.source === "marketplace") {
             expect(params.install).toMatchObject({
@@ -100,7 +103,10 @@ describe("managed plugin install transactions", () => {
         },
       );
       mocks.install.mockImplementation(
-        async (params: { onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler }) => {
+        async (params: {
+          onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
+          beforePersistentApply?: () => void;
+        }) => {
           const copy = {
             sourceDir,
             targetDir,
@@ -109,6 +115,7 @@ describe("managed plugin install transactions", () => {
             copyErrorPrefix: "copy failed",
             hasDeps: false,
             depsLogMessage: "",
+            beforePersistentApply: params.beforePersistentApply,
             afterInstall: async (stagedArtifactDir: string) => {
               await params.onBeforePluginArtifactCommit?.({
                 pluginId: "demo",
@@ -149,6 +156,7 @@ describe("managed plugin install transactions", () => {
       );
       const onCapabilityConsent = vi.fn<PluginCapabilityConsentHandler>(async (review) => {
         expect(await fs.readFile(path.join(targetDir, "version"), "utf8")).toBe("1.0.0");
+        active = failure !== "authority-closed";
         return await acceptCapabilities(review);
       });
       const installed = installManagedPluginSource({
@@ -156,15 +164,23 @@ describe("managed plugin install transactions", () => {
         snapshot,
         env: { HOME: home, OPENCLAW_STATE_DIR: path.join(home, "state") },
         onCapabilityConsent,
+        beforePersistentApply: () => {
+          if (!active) {
+            throw conflict;
+          }
+        },
       });
       if (failure === "none") {
         await expect(installed).resolves.toMatchObject({ ok: true });
+      } else if (failure === "authority-closed") {
+        await expect(installed).rejects.toThrow("authority-closed");
+        expect(mocks.persist).not.toHaveBeenCalled();
       } else {
         await expect(installed).rejects.toBe(conflict);
       }
       expect(onCapabilityConsent).toHaveBeenCalledOnce();
       expect(await fs.readFile(path.join(targetDir, "version"), "utf8"), failure).toBe(
-        failure === "before-commit" ? "1.0.0" : "2.0.0",
+        failure === "before-commit" || failure === "authority-closed" ? "1.0.0" : "2.0.0",
       );
       expect(await fs.readdir(path.join(home, "extensions", ".openclaw-install-backups"))).toEqual(
         [],

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -1562,12 +1562,10 @@ async function installResolvedManagedPluginSource(
   const extensionsDir = resolveDefaultPluginExtensionsDir(env);
   if (request.source === "bundled") {
     const result = await installBundledPluginSource({
-      snapshot: params.snapshot,
+      ...params,
       rawSpec: request.rawSpec,
       bundledSource: request.bundledSource,
       warning: request.warning,
-      invalidateRuntimeCache: params.invalidateRuntimeCache,
-      runtime: params.runtime,
     });
     return {
       ok: true,
@@ -1606,6 +1604,7 @@ async function installResolvedManagedPluginSource(
     config: params.snapshot.config,
     extensionsDir,
     logger: params.logger,
+    beforePersistentApply: params.beforePersistentApply,
     ...(capabilityConsent
       ? { onBeforePluginArtifactCommit: capabilityConsent.onBeforePluginArtifactCommit }
       : {}),

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -10,6 +10,7 @@ import {
   cleanupTrackedTempDirsAsync,
   makeTrackedTempDirAsync,
 } from "./test-helpers/fs-fixtures.js";
+import { createBundleInstallFixtureFactory } from "./test-helpers/install-fixtures.js";
 
 const installPluginFromPathMock = vi.fn();
 const fetchWithSsrFGuardMock = vi.hoisted(() =>
@@ -545,6 +546,44 @@ describe("marketplace plugins", () => {
 
       expect(installPluginInput().path).toBe(pluginDir);
       expect(installPluginInput().onInstallPolicyWarning).toBe(onInstallPolicyWarning);
+    });
+  });
+
+  it("does not publish a marketplace plugin after authority closes during artifact review", async () => {
+    await withTempDir("openclaw-marketplace-guard-", async (rootDir) => {
+      const { pluginDir, extensionsDir } = createBundleInstallFixtureFactory(() => rootDir)({
+        bundleFormat: "claude",
+        name: "Guarded Bundle",
+      });
+      const manifestPath = await writeMarketplaceManifest(rootDir, {
+        plugins: [{ name: "guarded-bundle", source: "./plugin-src" }],
+      });
+      const { installPluginFromPath } = await import("./install-package.js");
+      installPluginFromPathMock.mockImplementationOnce(installPluginFromPath);
+      let authorityActive = true;
+      const result = await installPluginFromMarketplace({
+        marketplace: manifestPath,
+        plugin: "guarded-bundle",
+        extensionsDir,
+        onBeforePluginArtifactCommit: async () => {
+          authorityActive = false;
+        },
+        beforePersistentApply: () => {
+          if (!authorityActive) {
+            throw new Error("plugin installation authority closed");
+          }
+        },
+      });
+
+      expect(authorityActive).toBe(false);
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("plugin installation authority closed"),
+      });
+      await expect(fs.stat(path.join(extensionsDir, "guarded-bundle"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.stat(pluginDir)).resolves.toBeDefined();
     });
   });
 

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -1289,6 +1289,7 @@ export async function installPluginFromMarketplace(
     dryRun?: boolean;
     expectedPluginId?: string;
     onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
+    beforePersistentApply?: () => void;
   },
 ): Promise<MarketplaceInstallResult> {
   const loaded = await loadMarketplace({
@@ -1340,6 +1341,7 @@ export async function installPluginFromMarketplace(
         dryRun: params.dryRun,
         expectedPluginId: params.expectedPluginId,
         onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
+        beforePersistentApply: params.beforePersistentApply,
         installPolicyRequest: {
           kind: marketplaceInstallPolicyRequestKind({
             marketplaceOrigin: loaded.marketplace.origin,

--- a/src/plugins/plugin-lifecycle-lease.ts
+++ b/src/plugins/plugin-lifecycle-lease.ts
@@ -14,7 +14,7 @@ const PLUGIN_LIFECYCLE_LEASE_KEY = "global";
 const DEFAULT_PLUGIN_LIFECYCLE_LEASE_MS = 5 * 60_000;
 const DEFAULT_PLUGIN_LIFECYCLE_WAIT_MS = 10 * 60_000;
 
-type PluginLifecycleLeaseContext = OpenClawStateLeaseContext & {
+export type PluginLifecycleLeaseContext = OpenClawStateLeaseContext & {
   databasePath: string;
 };
 

--- a/src/plugins/status.runtime-inspection.test.ts
+++ b/src/plugins/status.runtime-inspection.test.ts
@@ -1,9 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
-import { withEnv } from "../test-utils/env.js";
+import { readConfigFileSnapshotForWrite, writeConfigFile } from "../config/config.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { setGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { getGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
+import { persistPluginInstall } from "./install-persistence.js";
+import { readPersistedInstalledPluginIndexInstallRecords } from "./installed-plugin-index-records.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makePluginLoaderTempDir,
@@ -11,6 +15,7 @@ import {
   useNoBundledPlugins,
   writePlugin,
 } from "./loader.test-fixtures.js";
+import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { getActivePluginRegistry } from "./runtime.js";
@@ -21,6 +26,7 @@ describe("plugin runtime inspection", () => {
   afterEach(() => {
     clearPluginMetadataLifecycleCaches();
     resetPluginLoaderTestStateForTest();
+    closeOpenClawStateDatabaseForTest();
   });
 
   afterAll(() => {
@@ -53,6 +59,180 @@ describe("plugin runtime inspection", () => {
       expect(getGatewayPluginMetadataSnapshot()).toBe(boot);
       expect(getActivePluginRegistry()).toBe(activeRegistry);
     });
+  });
+
+  it.each([
+    { source: "npm", kind: "memory", mode: "ready", slots: ["memory"] },
+    { source: "marketplace", kind: "memory", mode: "ready", slots: ["memory"] },
+    { source: "npm", kind: "context-engine", mode: "ready", slots: ["contextEngine"] },
+    {
+      source: "npm",
+      kind: ["memory", "context-engine"],
+      mode: "ready",
+      slots: ["memory", "contextEngine"],
+    },
+    { source: "npm", kind: undefined, mode: "ready", slots: ["memory"] },
+    { source: "npm", kind: "memory", mode: "disabled", slots: [] },
+    { source: "npm", kind: "memory", mode: "requires-config", slots: [] },
+  ] as const)("persists first-install slots for $source ($kind, $mode)", async (testCase) => {
+    const stateDir = makePluginLoaderTempDir();
+    const configPath = path.join(stateDir, "openclaw.json");
+    await withEnvAsync(
+      {
+        OPENCLAW_HOME: stateDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+      async () => {
+        useNoBundledPlugins();
+        await writeConfigFile({});
+        await withPluginLifecycleLease({}, async () => {
+          const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+          // Warm the same empty operation inventory that precedes installer publication.
+          loadPluginMetadataSnapshot({ allowCurrent: false, config: snapshot.config });
+          const pluginId = "first-slot-candidate";
+          const pluginDir =
+            testCase.source === "npm"
+              ? path.join(stateDir, "npm", "projects", pluginId, "node_modules", pluginId)
+              : path.join(stateDir, "extensions", pluginId);
+          fs.mkdirSync(pluginDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(pluginDir, "package.json"),
+            JSON.stringify({
+              name: pluginId,
+              version: "1.0.0",
+              openclaw: { extensions: ["./index.cjs"] },
+            }),
+          );
+          fs.writeFileSync(
+            path.join(pluginDir, "openclaw.plugin.json"),
+            JSON.stringify({
+              id: pluginId,
+              kind: testCase.kind,
+              configSchema:
+                testCase.mode === "requires-config"
+                  ? {
+                      type: "object",
+                      properties: { apiKey: { type: "string" } },
+                      required: ["apiKey"],
+                    }
+                  : { type: "object", additionalProperties: false, properties: {} },
+            }),
+          );
+          fs.writeFileSync(
+            path.join(pluginDir, "index.cjs"),
+            `module.exports = { id: ${JSON.stringify(pluginId)}, kind: ${JSON.stringify(testCase.kind ?? "memory")}, register() {} };\n`,
+          );
+
+          const next = await persistPluginInstall({
+            snapshot: {
+              config: snapshot.config,
+              baseHash: snapshot.hash ?? undefined,
+              writeOptions,
+            },
+            pluginId,
+            install: { source: testCase.source, installPath: pluginDir, version: "1.0.0" },
+            enable: testCase.mode !== "disabled",
+          });
+
+          const expectedSlots = testCase.slots.length
+            ? Object.fromEntries(testCase.slots.map((slot) => [slot, pluginId]))
+            : undefined;
+          expect(next.plugins?.slots).toEqual(expectedSlots);
+          const persisted = JSON.parse(fs.readFileSync(configPath, "utf8"));
+          expect(persisted.plugins?.slots).toEqual(expectedSlots);
+          expect(persisted.plugins?.load?.paths).toBeUndefined();
+          expect(
+            (await readPersistedInstalledPluginIndexInstallRecords())?.[pluginId],
+          ).toMatchObject({
+            source: testCase.source,
+            installPath: pluginDir,
+          });
+        });
+      },
+    );
+  });
+
+  it("rechecks install authority before inspecting each legacy package entry", async () => {
+    const stateDir = makePluginLoaderTempDir();
+    const configPath = path.join(stateDir, "openclaw.json");
+    await withEnvAsync(
+      {
+        OPENCLAW_HOME: stateDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+      },
+      async () => {
+        useNoBundledPlugins();
+        await writeConfigFile({});
+        await withPluginLifecycleLease({}, async () => {
+          const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+          const previousConfig = fs.readFileSync(configPath, "utf8");
+          loadPluginMetadataSnapshot({ allowCurrent: false, config: snapshot.config });
+          const pluginId = "slot-authority-candidate";
+          const pluginDir = path.join(
+            stateDir,
+            "npm",
+            "projects",
+            pluginId,
+            "node_modules",
+            pluginId,
+          );
+          fs.mkdirSync(pluginDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(pluginDir, "package.json"),
+            JSON.stringify({
+              name: pluginId,
+              version: "1.0.0",
+              openclaw: { extensions: ["./first.cjs", "./second.cjs"] },
+            }),
+          );
+          fs.writeFileSync(
+            path.join(pluginDir, "openclaw.plugin.json"),
+            JSON.stringify({ id: pluginId, configSchema: { type: "object" } }),
+          );
+          for (const [entry, kind] of [
+            ["first", "memory"],
+            ["second", "context-engine"],
+          ]) {
+            fs.writeFileSync(
+              path.join(pluginDir, `${entry}.cjs`),
+              `require("node:fs").writeFileSync(${JSON.stringify(path.join(stateDir, `${entry}.txt`))}, "imported");
+module.exports = { id: ${JSON.stringify(`${pluginId}/${entry}`)}, kind: ${JSON.stringify(kind)}, register() {} };
+`,
+            );
+          }
+          let authorityActive = true;
+
+          await expect(
+            persistPluginInstall({
+              snapshot: {
+                config: snapshot.config,
+                baseHash: snapshot.hash ?? undefined,
+                writeOptions,
+              },
+              pluginId,
+              install: { source: "npm", installPath: pluginDir, version: "1.0.0" },
+              beforePersistentApply() {
+                if (!authorityActive) {
+                  throw new Error("install authority closed");
+                }
+                queueMicrotask(() => {
+                  authorityActive = false;
+                });
+              },
+            }),
+          ).rejects.toThrow("install authority closed");
+
+          expect(fs.existsSync(path.join(stateDir, "first.txt"))).toBe(true);
+          expect(fs.existsSync(path.join(stateDir, "second.txt"))).toBe(false);
+          expect(fs.readFileSync(configPath, "utf8")).toBe(previousConfig);
+          expect(
+            (await readPersistedInstalledPluginIndexInstallRecords())?.[pluginId],
+          ).toBeUndefined();
+        });
+      },
+    );
   });
 
   it("captures full registrations through the non-activating inspection mode", () => {

--- a/src/plugins/status.runtime-inspection.test.ts
+++ b/src/plugins/status.runtime-inspection.test.ts
@@ -6,8 +6,9 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { setGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { getGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
-import { persistPluginInstall } from "./install-persistence.js";
+import { persistPluginInstall, selectInstallMutationWriteOptions } from "./install-persistence.js";
 import { readPersistedInstalledPluginIndexInstallRecords } from "./installed-plugin-index-records.js";
+import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makePluginLoaderTempDir,
@@ -152,6 +153,99 @@ describe("plugin runtime inspection", () => {
       },
     );
   });
+
+  it.each([false, true])(
+    "uses replaced package metadata while preserving its old snapshot (requires config: %s)",
+    async (requiresConfig) => {
+      const stateDir = makePluginLoaderTempDir();
+      const configPath = path.join(stateDir, "openclaw.json");
+      const pluginId = "same-path-candidate";
+      const pluginDir = path.join(stateDir, "extensions", pluginId);
+      const writeVersion = (version: "1.0.0" | "2.0.0") => {
+        fs.mkdirSync(pluginDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(pluginDir, "package.json"),
+          JSON.stringify({ name: pluginId, version, openclaw: { extensions: ["./index.cjs"] } }),
+        );
+        fs.writeFileSync(
+          path.join(pluginDir, "openclaw.plugin.json"),
+          JSON.stringify({
+            id: pluginId,
+            version,
+            kind: version === "1.0.0" ? "context-engine" : ["context-engine", "memory"],
+            configSchema:
+              version === "2.0.0" && requiresConfig
+                ? { type: "object", properties: { token: { type: "string" } }, required: ["token"] }
+                : { type: "object" },
+          }),
+        );
+        fs.writeFileSync(
+          path.join(pluginDir, "index.cjs"),
+          "module.exports = { register() {} };\n",
+        );
+      };
+      const persistVersion = (
+        version: string,
+        { snapshot, writeOptions }: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>,
+      ) =>
+        persistPluginInstall({
+          snapshot: {
+            config: snapshot.sourceConfig,
+            baseHash: snapshot.hash ?? undefined,
+            writeOptions: selectInstallMutationWriteOptions(writeOptions),
+          },
+          pluginId,
+          install: { source: "path", installPath: pluginDir, version },
+        });
+
+      await withEnvAsync(
+        { OPENCLAW_HOME: stateDir, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath },
+        async () => {
+          useNoBundledPlugins();
+          await writeConfigFile({});
+          writeVersion("1.0.0");
+          await withPluginLifecycleLease({}, async () => {
+            await persistVersion("1.0.0", await readConfigFileSnapshotForWrite());
+          });
+          const before = await withPluginLifecycleLease({}, async () => {
+            const prepared = await readConfigFileSnapshotForWrite();
+            const retainedSnapshot = loadPluginMetadataSnapshot({
+              allowCurrent: false,
+              config: prepared.snapshot.sourceConfig,
+            });
+            expect(prepared.snapshot.sourceConfig.plugins?.slots?.contextEngine).toBe(pluginId);
+
+            // The installer replaces this path after the operation has inspected v1.
+            writeVersion("2.0.0");
+            await persistVersion("2.0.0", prepared);
+            return retainedSnapshot;
+          });
+          const persisted = JSON.parse(fs.readFileSync(configPath, "utf8"));
+          expect(persisted.plugins.entries[pluginId].enabled).toBe(!requiresConfig);
+          if (requiresConfig) {
+            expect(persisted.plugins.slots?.memory).toBeUndefined();
+          } else {
+            expect(persisted.plugins.slots).toEqual({ contextEngine: pluginId, memory: pluginId });
+          }
+          const index = await readPersistedInstalledPluginIndex();
+          expect(index?.installRecords[pluginId]).toMatchObject({
+            installPath: pluginDir,
+            version: "2.0.0",
+          });
+          expect(index?.plugins.find((plugin) => plugin.pluginId === pluginId)).toMatchObject({
+            packageVersion: "2.0.0",
+            enabled: !requiresConfig,
+            startup: { memory: true },
+          });
+          expect(before.byPluginId.get(pluginId)).toMatchObject({
+            version: "1.0.0",
+            kind: "context-engine",
+          });
+          expect(before.byPluginId.get(pluginId)?.configSchema).toEqual({ type: "object" });
+        },
+      );
+    },
+  );
 
   it("rechecks install authority before inspecting each legacy package entry", async () => {
     const stateDir = makePluginLoaderTempDir();

--- a/src/plugins/test-helpers/npm-registry-fixtures.ts
+++ b/src/plugins/test-helpers/npm-registry-fixtures.ts
@@ -1,0 +1,326 @@
+// Real npm package and loopback registry fixtures for plugin install tests.
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { resolveNpmJsonEntries } from "../../infra/npm-registry-spec.js";
+import type { Deferred } from "../../shared/deferred.js";
+
+type PackedVersion = {
+  archive: Buffer;
+  dependencies?: Record<string, string>;
+  integrity: string;
+  openclaw?: Record<string, unknown>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  shasum: string;
+  tarballName: string;
+  version: string;
+};
+
+type PackPluginParams = {
+  dependencies?: Record<string, string>;
+  hookName?: string;
+  indexJs?: string;
+  openclaw?: Record<string, unknown>;
+  optionalDependencies?: Record<string, string>;
+  packageName: string;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  pluginId?: string;
+  rootDir: string;
+  version?: string;
+};
+
+export type RegistryPackage = {
+  latest: string;
+  packageName: string;
+  versions: PackedVersion[];
+};
+
+export async function packPlugin(params: PackPluginParams): Promise<PackedVersion> {
+  const version = params.version ?? "1.0.0";
+  const packageDir = path.join(params.rootDir, `package-${params.packageName}-${version}`);
+  const peerDependenciesMeta = params.peerDependencies
+    ? (params.peerDependenciesMeta ??
+      Object.fromEntries(
+        Object.keys(params.peerDependencies).map((name) => [name, { optional: true }]),
+      ))
+    : undefined;
+  await fs.mkdir(path.join(packageDir, "dist"), { recursive: true });
+  await fs.writeFile(
+    path.join(packageDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: params.packageName,
+        version,
+        type: "module",
+        openclaw:
+          params.openclaw ??
+          (params.hookName
+            ? { hooks: [`./hooks/${params.hookName}`] }
+            : { extensions: ["./dist/index.js"] }),
+        ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+        ...(params.optionalDependencies
+          ? { optionalDependencies: params.optionalDependencies }
+          : {}),
+        ...(params.peerDependencies
+          ? {
+              peerDependencies: params.peerDependencies,
+              ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
+            }
+          : {}),
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  if (params.hookName) {
+    const hookDir = path.join(packageDir, "hooks", params.hookName);
+    await fs.mkdir(hookDir, { recursive: true });
+    await fs.writeFile(
+      path.join(hookDir, "HOOK.md"),
+      `---\nname: ${params.hookName}\ndescription: Install cancellation fixture\nmetadata: {"openclaw":{"events":["command:new"]}}\n---\n`,
+    );
+    await fs.writeFile(path.join(hookDir, "handler.js"), "export default async () => {};\n");
+  } else {
+    await fs.writeFile(
+      path.join(packageDir, "openclaw.plugin.json"),
+      `${JSON.stringify(
+        {
+          id: params.pluginId ?? params.packageName,
+          name: params.pluginId ?? params.packageName,
+          configSchema: { type: "object" },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+  }
+  await fs.writeFile(
+    path.join(packageDir, "dist", "index.js"),
+    params.indexJs ?? "export {};\n",
+    "utf8",
+  );
+
+  const packOutput = execFileSync(
+    "npm",
+    ["pack", "--json", "--ignore-scripts", "--pack-destination", params.rootDir],
+    { cwd: packageDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const parsed = resolveNpmJsonEntries(JSON.parse(packOutput)) as Array<{ filename: string }>;
+  const tarballName = parsed[0]?.filename;
+  if (!tarballName) {
+    throw new Error(`npm pack did not return a tarball for ${params.packageName}`);
+  }
+  const archive = await fs.readFile(path.join(params.rootDir, tarballName));
+  return {
+    archive,
+    ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+    integrity: `sha512-${crypto.createHash("sha512").update(archive).digest("base64")}`,
+    ...(params.openclaw ? { openclaw: params.openclaw } : {}),
+    ...(params.optionalDependencies ? { optionalDependencies: params.optionalDependencies } : {}),
+    ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
+    ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
+    shasum: crypto.createHash("sha1").update(archive).digest("hex"),
+    tarballName,
+    version,
+  };
+}
+
+export async function registryPackage(
+  params: PackPluginParams & { latest?: string },
+): Promise<RegistryPackage> {
+  const version = params.version ?? "1.0.0";
+  return {
+    packageName: params.packageName,
+    latest: params.latest ?? version,
+    versions: [await packPlugin({ ...params, version })],
+  };
+}
+
+export async function startStaticRegistry(
+  packages: RegistryPackage[],
+  servers: http.Server[],
+  downloadBarrier?: { requested: Deferred; released: Deferred },
+): Promise<string> {
+  const packageEntries = packages.map((pkg) => ({
+    ...pkg,
+    encodedPackageName: encodeURIComponent(pkg.packageName).replace("%40", "@"),
+    versionsByVersion: new Map(pkg.versions.map((entry) => [entry.version, entry])),
+  }));
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    const baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    if (request.method !== "GET") {
+      response.writeHead(405, { "content-type": "text/plain" });
+      response.end("method not allowed");
+      return;
+    }
+    if (downloadBarrier && url.pathname === "/-/test/authority-close") {
+      void downloadBarrier.requested.promise.then(() => response.end("close"));
+      return;
+    }
+    if (downloadBarrier && url.pathname === "/-/test/authority-closed") {
+      downloadBarrier.released.resolve();
+      response.end("closed");
+      return;
+    }
+
+    for (const pkg of packageEntries) {
+      if (url.pathname === `/${pkg.encodedPackageName}`) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          `${JSON.stringify({
+            name: pkg.packageName,
+            "dist-tags": { latest: pkg.latest },
+            versions: Object.fromEntries(
+              [...pkg.versionsByVersion.entries()].map(([version, entry]) => [
+                version,
+                {
+                  name: pkg.packageName,
+                  version,
+                  ...(entry.openclaw ? { openclaw: entry.openclaw } : {}),
+                  ...(entry.dependencies ? { dependencies: entry.dependencies } : {}),
+                  ...(entry.optionalDependencies
+                    ? { optionalDependencies: entry.optionalDependencies }
+                    : {}),
+                  ...(entry.peerDependencies ? { peerDependencies: entry.peerDependencies } : {}),
+                  ...(entry.peerDependenciesMeta
+                    ? { peerDependenciesMeta: entry.peerDependenciesMeta }
+                    : {}),
+                  dist: {
+                    integrity: entry.integrity,
+                    shasum: entry.shasum,
+                    tarball: `${baseUrl}/${pkg.encodedPackageName}/-/${entry.tarballName}`,
+                  },
+                },
+              ]),
+            ),
+          })}\n`,
+        );
+        return;
+      }
+
+      const tarballPrefix = `/${pkg.encodedPackageName}/-/`;
+      if (url.pathname.startsWith(tarballPrefix)) {
+        const entry = [...pkg.versionsByVersion.values()].find((candidate) =>
+          url.pathname.endsWith(`/${candidate.tarballName}`),
+        );
+        if (entry) {
+          const sendArchive = () => {
+            response.writeHead(200, {
+              "content-length": String(entry.archive.length),
+              "content-type": "application/octet-stream",
+            });
+            response.end(entry.archive);
+          };
+          if (downloadBarrier) {
+            downloadBarrier.requested.resolve();
+            void downloadBarrier.released.promise.then(sendArchive);
+          } else {
+            sendArchive();
+          }
+          return;
+        }
+      }
+    }
+
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end(`not found: ${url.pathname}`);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  servers.push(server);
+  return `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+}
+
+export async function startMutableRegistry(
+  params: {
+    packageName: string;
+    initialLatest: string;
+    laterLatest: string;
+    versions: PackedVersion[];
+  },
+  servers: http.Server[],
+): Promise<string> {
+  let latestVersion = params.initialLatest;
+  let metadataRequests = 0;
+  const versions = new Map(params.versions.map((entry) => [entry.version, entry]));
+  const encodedPackageName = encodeURIComponent(params.packageName).replace("%40", "@");
+
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    const baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+    if (request.method !== "GET") {
+      response.writeHead(405, { "content-type": "text/plain" });
+      response.end("method not allowed");
+      return;
+    }
+
+    if (url.pathname === `/${encodedPackageName}`) {
+      metadataRequests += 1;
+      const metadataLatest = latestVersion;
+      if (metadataRequests === 1) {
+        latestVersion = params.laterLatest;
+      }
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        `${JSON.stringify({
+          name: params.packageName,
+          "dist-tags": { latest: metadataLatest },
+          versions: Object.fromEntries(
+            [...versions.entries()].map(([version, entry]) => [
+              version,
+              {
+                name: params.packageName,
+                version,
+                ...(entry.openclaw ? { openclaw: entry.openclaw } : {}),
+                ...(entry.peerDependencies ? { peerDependencies: entry.peerDependencies } : {}),
+                ...(entry.peerDependenciesMeta
+                  ? { peerDependenciesMeta: entry.peerDependenciesMeta }
+                  : {}),
+                dist: {
+                  integrity: entry.integrity,
+                  shasum: entry.shasum,
+                  tarball: `${baseUrl}/${encodedPackageName}/-/${entry.tarballName}`,
+                },
+              },
+            ]),
+          ),
+        })}\n`,
+      );
+      return;
+    }
+
+    const tarballPrefix = `/${encodedPackageName}/-/`;
+    if (url.pathname.startsWith(tarballPrefix)) {
+      const entry = [...versions.values()].find((candidate) =>
+        url.pathname.endsWith(`/${candidate.tarballName}`),
+      );
+      if (entry) {
+        response.writeHead(200, {
+          "content-length": String(entry.archive.length),
+          "content-type": "application/octet-stream",
+        });
+        response.end(entry.archive);
+        return;
+      }
+    }
+
+    response.writeHead(404, { "content-type": "text/plain" });
+    response.end(`not found: ${url.pathname}`);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  servers.push(server);
+  return `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+}

--- a/src/state/openclaw-state-db-schema-v13-widerow.ts
+++ b/src/state/openclaw-state-db-schema-v13-widerow.ts
@@ -47,12 +47,6 @@ function reprojectLegacyCronJson(db: DatabaseSync): void {
       continue;
     }
     let changed = false;
-    if (typeof job.enabled !== "boolean") {
-      // Early cron rows kept the effective flag only in this retained projection.
-      // Fold it into canonical JSON before schema v13 removes the other projections.
-      job.enabled = row.enabled !== 0;
-      changed = true;
-    }
     const delivery = asNullableRecord(job.delivery);
     const destination = asNullableRecord(delivery?.failureDestination);
     if (
@@ -73,6 +67,12 @@ function reprojectLegacyCronJson(db: DatabaseSync): void {
         nextDelivery.failureDestination = nextDestination;
         job.delivery = nextDelivery;
       }
+    }
+    if (typeof job.enabled !== "boolean") {
+      // Early cron rows kept this flag only in the retained projection.
+      // Restore it after delivery so its change flag cannot create a delivery object.
+      job.enabled = row.enabled !== 0;
+      changed = true;
     }
     const hasLegacyStatus = Object.hasOwn(state, "lastStatus");
     if (

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -8,6 +8,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { gunzipSync } from "node:zlib";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { resolveCronDeliveryPlan } from "../cron/delivery-plan.js";
 import { saveCronStore } from "../cron/store.js";
 import { loadedCronStoreFromRows, loadCronRows } from "../cron/store/row-codec.js";
 import type { CronStoredJob } from "../cron/types.js";
@@ -2476,6 +2477,68 @@ describe("openclaw state database", () => {
       ).toEqual([]);
       expect(migrated.db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
       expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([]);
+    },
+  );
+
+  it.each(["runtime open", "doctor repair"] as const)(
+    "preserves cron delivery when recovering v12 enabled state through %s",
+    (migrationPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const legacy = new DatabaseSync(databasePath);
+      legacy.exec(STATE_SCHEMA_13_TO_12_DOWNGRADE_SQL);
+      const storeKey = path.join(stateDir, "cron", "jobs.json");
+      const cases: Array<{ enabled: boolean; delivery?: { mode: "none" } }> = [
+        { enabled: true },
+        { enabled: false },
+        { enabled: true, delivery: { mode: "none" } },
+      ];
+      const jobs: CronStoredJob[] = cases.map(({ enabled, delivery }, index) => ({
+        id: `legacy-main-${index}`,
+        name: "Legacy main job",
+        enabled,
+        createdAtMs: 100,
+        updatedAtMs: 250,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "tick" },
+        ...(delivery ? { delivery } : {}),
+        state: {},
+      }));
+      const insert = legacy.prepare(
+        `INSERT INTO cron_jobs (
+           store_key, job_id, name, enabled, created_at_ms, schedule_kind, every_ms,
+           session_target, wake_mode, payload_kind, payload_message, job_json, state_json,
+           sort_order, updated_at
+         ) VALUES (?, ?, ?, ?, 100, 'every', 60000, 'main', 'now', 'systemEvent',
+                   'tick', ?, ?, ?, 250)`,
+      );
+      for (const [index, job] of jobs.entries()) {
+        const { enabled, state, ...legacyJob } = job;
+        insert.run(
+          storeKey,
+          job.id,
+          job.name,
+          Number(enabled),
+          JSON.stringify(legacyJob),
+          JSON.stringify(state),
+          index,
+        );
+      }
+      legacy.close();
+
+      if (migrationPath === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      }
+      const migrated = openOpenClawStateDatabase(options);
+      const loaded = loadedCronStoreFromRows(loadCronRows(migrated.db, storeKey)).store.jobs;
+      expect(loaded).toEqual(jobs);
+      for (const job of loaded) {
+        expect(resolveCronDeliveryPlan(job)).toMatchObject({ mode: "none", requested: false });
+      }
     },
   );
 

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2505,7 +2505,7 @@ describe("openclaw state database", () => {
         sessionTarget: "main",
         wakeMode: "now",
         payload: { kind: "systemEvent", text: "tick" },
-        ...(delivery ? { delivery } : {}),
+        delivery,
         state: {},
       }));
       const insert = legacy.prepare(


### PR DESCRIPTION
Closes #135634
Closes #135635
Closes #135637
Closes #135656

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Four release-audit findings affect existing operator flows:

- Doctor can delete a valid credential that another writer replaces while its cleanup confirmation is open.
- Upgrading older cron state can introduce announce delivery when the job did not request it.
- An installation can outlive its delegated run, and a rejected hook install or update can leave payload or registry changes behind after the config write fails.
- A newly installed memory plugin can miss exclusive-slot selection because it is not yet visible in the persisted plugin index. A same-path update can also retain the old manifest, missing newly advertised kinds and newly required plugin configuration.

## Why This Change Was Made

Doctor now compares the credential it inspected with the current credential inside the existing locked store update, deleting only the unchanged invalid value. The legacy cron migration restores the effective enabled flag after delivery projection, so that unrelated normalization cannot manufacture delivery settings.

Install routes carry the same live-authority guard through their source adapters and persistence owners. Integration preserves the upstream official-source plan and carries cancellation checks into both primary and secondary ClawHub routes. Hooks also retain the existing deferred package-directory transaction through path, archive, and npm installation. The config owner coordinates that payload transaction with a receipt from the canonical hook-record store, under the existing lifecycle lease. A rejected install or update restores its own record and payload; compensation does not require the already-closed delegated run to become active again. Conditional record restoration refuses to overwrite a newer same-key record and preserves the payload when ownership is no longer established. Linked source paths never become installer-owned payloads.

The update path uses this same transaction owner and defers settlement until the config decision. Authority is checked before displacing a live update into its backup. Once config is committed, a later backup-cleanup or logging failure cannot roll back committed state. This repairs lifecycle and cancellation handling; it does not introduce a separate storage framework or claim an unauthenticated installation exploit.

Memory-slot selection now consumes metadata prepared from the install owner's candidate index and pending install records. It no longer rediscovers the candidate through the old persisted index. The selection loop revalidates authority for each entry before legacy native kind inspection can import plugin code. There is no synthetic load-path entry or provider-specific exception.

Post-publication discovery, schema validation, slot selection, and config commit run in a fresh operation cache so same-path replacement cannot reuse the previous package bytes. The prior install ledger remains available for replacement cleanup, and the enclosing operation's ledger cache is invalidated after this isolated mutation. This preserves batch-install readback and rollback while leaving the running Gateway's frozen metadata unchanged.

## User Impact

Concurrent credential refreshes survive Doctor cleanup; older cron upgrades preserve delivery intent; failed or cancelled hook changes recover their owned state without erasing a competing writer; and first-time npm and marketplace memory installs select the intended slot and report the change. Same-path updates use the new manifest and leave plugins disabled with an actionable warning when their new configuration requirements are unmet.

There are no new configuration keys, defaults, schema versions, tables, protocol changes, or migration versions. Hook compensation deliberately changes recovery behavior while retaining the existing SQLite store, lifecycle lease, and package transaction machinery. No `CHANGELOG.md` edit is included; release notes remain release-owned.

Diff accounting includes the new files and separates test support from production. Added/removed counts below exclude whitespace-only movement; raw production counts are +721/-449 with the same net +272:

| Scope | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 423 | 151 | +272 |
| Tests | 1,427 | 403 | +1,024 |
| Test support | 336 | 15 | +321 |

Production growth chiefly establishes the previously missing hook record/payload/config ownership boundary for both install and update. It reuses existing transaction and lease primitives, removes the record writer's config-return responsibility, and shares one compensation owner. The additional cache-phase owner separates pre-publication record ownership from post-publication metadata without adding a fallback or a new cache system. The test-support increase includes extracted npm registry fixtures; that movement is not new production behavior or equivalent new test coverage.

## Evidence

Completed:

- Final integrated owner and npm E2E suite: **19 files, 788 passed, 1 existing skip**, covering CLI install/update, Doctor, cron migration, hook records/payloads, plugin persistence, source adapters, and Claw batch package installation/removal.
- The original **17 regression cases** were demonstrated failing before the repair and passing after it. **11 additional regression cases** were demonstrated failing on their pre-fix owners; the complete owner run above includes their fixed results. Source-adapter regressions also failed before guard forwarding was repaired.
- Real CLI Doctor cleanup with a credential replaced during confirmation, plus a real schema-12-to-15 cron upgrade through the runtime/Doctor flow.
- Actual npm E2E coverage in the final integrated run: **14 passed**, including plugin and hook fallback cancellation while registry responses are held, with fresh active-claim success controls.
- Two real delegated-claim closures at different hook publication boundaries, rerun on the integrated PR production tree: rejected CLI operation, unchanged config, empty hook records, and no installed payload after compensation.
- Fresh npm and marketplace memory installs through the real CLI, rerun on the integrated PR production tree: selected memory slot, persisted install, and emitted slot-change warning without added load paths.
- Legacy native-kind inspection marker probe: a revoked captured guard prevented plugin import, record persistence, and slot selection; an active guard allowed all three. This probe used the real import path and a captured guard, not a real delegated claim. The additional two-entry regression failed before the per-entry check and passes after it. An earlier focused run passed **25 tests across 2 files**.
- Primary and secondary ClawHub cancellation rows added after integration with the upstream source plan. Removing only the primary-route guard reproduced the regression: the CLI incorrectly resolved the cancelled install. Both cancellation routes pass in the final integrated suite.
- Real npm hook update with a concurrent config conflict, rerun on the integrated PR production tree: **13 registry HTTP requests** across the scenario; the rejected update restored the old record and payload while preserving concurrent config, then a fresh retry successfully installed the new version.
- Same-path update through two cold real CLI-owner processes: v1 context-engine installation followed by v2 context-engine/memory replacement at the same path. The v2 record, both slots, and the slot-change message agree. A second live case adds a required plugin setting in v2 and proves the installed plugin remains disabled with the configuration warning. Both corresponding regression cases failed on the pre-fix owner and pass now.
- Two real CLI installs under one outer lifecycle lease retain both records, payloads, and slots. A separate second-install config conflict restores only the second installation, preserves the first plugin and concurrent config edit, and reports `ConfigMutationConflictError`. Config and cached/persisted record readback remain valid inside and after the lease.
- Latest focused native inspection owner run: **12 passed**, including the seven existing first-install rows, both same-path regressions, and legacy-kind authority coverage. Fresh npm and marketplace first-install probes also pass after the final cache/ledger adjustment.
- Final-head [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/33580166581/job/100092729701) passed for d3483bf; final CI also passed.

CI initially flagged a conditional object spread inside the cron regression fixture. The test-only cleanup assigns the optional field directly; JSON still omits undefined delivery, and both existing runtime/Doctor migration cases pass with unchanged assertions. An intermediate cache implementation failed seven existing install-record readback cases; the final implementation also invalidates the enclosing ledger cache, and the full suite plus real batch success/rollback proofs now pass. The next CI pass caught the module exceeding its existing file-size limit. Inlining the one-use cache helper and parameter type restored compliance without changing persistence logic, assertions, or lint limits. Scoped lint, all 788 tests, all five live probe groups, and fresh autoreview passed again after that simplification.

Validation before landing:

- [x] Final integrated affected-owner tests after the latest guards and upstream integration.
- [x] Final changed-file checks, including lint, formatting, boundaries, core/core-test typechecks, dead-code scans, schema and security guards.
- [x] Independent Codex autoreview of the integrated candidate and fresh review of the final cache/ledger follow-up: no actionable P0 findings or suspected credentials. These were scoped P0 reviews, not a claim that all lower-priority defects are excluded.
- [x] Actual npm E2E rerun after the final production changes.
- [x] Completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135736#issuecomment-5502807275) of cache/ledger behavior at 89b4c06: no actionable findings. The only later commit, d3483bf, inlines the same body and cache cleanup for lint compliance. Its rank-up move—complete exact-head checks before merge—is retained.
- [x] [Exact-head PR CI](https://github.com/openclaw/openclaw/actions/runs/33580166581), including final build coverage and the required `openclaw/ci-gate`, passed for d3483bf. No PR checks remain pending.
