### PR TITLE
refactor(ui): simplify transcript composition and placement

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4004,9 +4004,9 @@ ui/src/pages/chat/chat-session-companion.ts	5
 ui/src/pages/chat/chat-state-events.ts	6
 ui/src/pages/chat/chat-state-page.ts	5
 ui/src/pages/chat/chat-state-route.ts	1
-ui/src/pages/chat/chat-thread-build.ts	2
+ui/src/pages/chat/chat-thread-build.ts	1
 ui/src/pages/chat/chat-thread-grouping.ts	2
-ui/src/pages/chat/chat-thread-items.ts	4
+ui/src/pages/chat/chat-thread-items.ts	3
 ui/src/pages/chat/components/chat-audio-player.ts	1
 ui/src/pages/chat/components/chat-composer-plus-menu.ts	1
 ui/src/pages/chat/components/chat-composer-slash-menu.ts	1

--- a/ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
+++ b/ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
@@ -83,8 +83,11 @@ suite.define(() => {
         );
       });
 
-      await composer.press("Meta+Enter");
-      await gateway.waitForRequest("chat.send");
+      // A chord fires the one-shot listener on its modifier before submission.
+      // Arm the next-input task from the actual submit key instead.
+      await composer.press("Enter");
+      const request = await gateway.waitForRequest("chat.send");
+      expect(request.params).toMatchObject({ message: "first prompt" });
       await expect
         .poll(() => composer.getAttribute("data-submit-task-order"))
         .toBe(JSON.stringify(["next-input-task", "transport:second prompt"]));

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -37,15 +37,15 @@ import {
 import { groupMessages } from "./chat-thread-grouping.ts";
 import {
   appendCanvasBlockToAssistantMessage,
-  buildMessageKeys,
+  buildMessageItems,
   canvasPreviewBaseIdentity,
   createCanvasAssistantMessage,
   extractChatMessagePreview,
   findCanvasInsertionIndex,
-  findNearestAssistantMessageIndex,
+  findNearestAssistantMessage,
   hasRenderableNormalizedMessage,
   insertionIndexesForBounds,
-  messageKey,
+  type ChatProjection,
   messageMatchesSearchQuery,
   queuedSendThreadMessage,
   rawMessageTimestamp,
@@ -60,7 +60,8 @@ import {
 import {
   applyPersistedToolInvocationBounds,
   findCurrentTurnBounds,
-  findRunTurnBounds,
+  createRunTurnLookup,
+  createToolCallLookup,
   isKeyedAssistantStreamFallbackMessage,
   optionalBoundaryIdentity,
   optionalRunIdentity,
@@ -71,7 +72,6 @@ import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
 import { selectChatInputDisplay } from "./history-merge.ts";
 import { resolveSystemNoticeKind } from "./system-notice-kinds.ts";
 import { isLiveTerminalForRun } from "./terminal-message-identity.ts";
-import { buildToolStreamIdentity } from "./tool-stream-identity.ts";
 
 export type BuildChatItemsProps = {
   paneId: string;
@@ -103,7 +103,18 @@ export type BuildChatItemsProps = {
 
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   let items: ChatItem[] = [];
-  const tools = props.toolMessages.filter((message) => asRecord(message) !== null);
+  const tools = props.toolMessages.filter(
+    (message): message is Record<string, unknown> => asRecord(message) !== null,
+  );
+  const toolItems = buildMessageItems(tools).map((item) => {
+    const projection: ChatProjection<typeof item> = { item };
+    return {
+      projection,
+      runId: normalizeOptionalString(item.message.runId),
+      callId: normalizeOptionalString(item.message.toolCallId),
+      preview: extractChatMessagePreview(item.message),
+    };
+  });
   const history = composeTranscriptDisplay(
     props.messages.filter(
       (message) =>
@@ -111,17 +122,12 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         (props.persistCommentary !== false || !isKeyedAssistantStreamFallbackMessage(message)),
     ),
   );
-  const historyKeys = buildMessageKeys(history);
-  const toolKeys = buildMessageKeys(tools, history.length);
-  const liftedCanvasSources = tools.flatMap((message, index) => {
-    const source = extractChatMessagePreview(message);
-    return source ? [{ ...source, message, index }] : [];
-  });
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
-  for (let i = 0; i < history.length; i++) {
-    const msg = projectContextCompactionActivity(history[i]);
-    const itemKey = historyKeys[i] ?? messageKey(msg, i);
+  for (const [i, item] of buildMessageItems(history).entries()) {
+    const msg = projectContextCompactionActivity(item.message);
+    item.message = msg;
+    const itemKey = item.key;
     const normalized = safeNormalizeMessage(msg);
     if (!normalized) {
       continue;
@@ -207,11 +213,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       continue;
     }
 
-    items.push({
-      kind: "message",
-      key: itemKey,
-      message: msg,
-    });
+    items.push(item);
   }
   const queuedSends = props.queue ?? [];
   const { queue: threadQueuedSends, pendingInputs } = selectChatInputDisplay(
@@ -237,10 +239,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   // Transient projections merge into stable history + queued-send rows by timestamp.
   // Stable rows keep their relative order despite client and Gateway clock skew.
-  const timestampedProjectionItems: ChatItem[] = buildPendingInputItems(
+  const projections: ChatProjection[] = buildPendingInputItems(
     pendingInputs,
     props.searchOpen ? props.searchQuery : undefined,
-  );
+  ).map((item) => ({ item }));
   const appendQueuedSend = (queued: ChatQueueItem) => {
     if (!shouldRenderQueuedSendInThread(queued)) {
       return;
@@ -273,7 +275,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     });
     items.splice(insertionIndex < 0 ? items.length : insertionIndex, 0, {
       kind: "message",
-      key: queued.sendRunId ? buildMessageKeys([message])[0]! : `pending-send:${queued.id}`,
+      key: queued.sendRunId ? buildMessageItems([message])[0]!.key : `pending-send:${queued.id}`,
       message,
     });
   };
@@ -281,15 +283,18 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     appendQueuedSend(queued);
   }
   const currentTurnBounds = findCurrentTurnBounds(items);
-  for (const liftedCanvasSource of liftedCanvasSources) {
-    const baseIdentity = canvasPreviewBaseIdentity(liftedCanvasSource.message, liftedCanvasSource);
+  const canvasRunBounds = createRunTurnLookup(items);
+  for (const { projection, preview } of toolItems) {
+    if (!preview) {
+      continue;
+    }
+    const baseIdentity = canvasPreviewBaseIdentity(projection.item.message, preview);
     if (baseIdentity && persistedCanvasIdentities.has(baseIdentity)) {
       continue;
     }
-    const sourceRunId = asRecord(liftedCanvasSource.message)?.runId;
     const canvasBounds = resolveRunInsertionBounds(
-      items,
-      sourceRunId,
+      canvasRunBounds,
+      projection.item.message.runId,
       props.runId,
       currentTurnBounds,
     );
@@ -297,60 +302,53 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       items,
       canvasBounds ?? undefined,
     );
-    const assistantIndex = findNearestAssistantMessageIndex(
+    const assistant = findNearestAssistantMessage(
       items,
-      liftedCanvasSource.timestamp,
+      preview.timestamp,
       canvasMinimumIndex,
       canvasMaximumIndex,
     );
-    if (assistantIndex == null) {
-      if (searchFiltering) {
-        continue;
-      }
-      const insertionIndex = findCanvasInsertionIndex(
-        items,
-        liftedCanvasSource.timestamp,
-        canvasMinimumIndex,
-        canvasMaximumIndex,
-      );
-      const nextItem = items[insertionIndex];
-      const nextTimestamp =
-        nextItem?.kind === "message" ? rawMessageTimestamp(nextItem.message) : null;
-      const boundaryTimestamp =
-        nextTimestamp == null
-          ? futureQueuedTimestamp
-          : futureQueuedTimestamp == null
-            ? nextTimestamp
-            : Math.min(nextTimestamp, futureQueuedTimestamp);
-      const timestamp =
-        liftedCanvasSource.timestamp != null && boundaryTimestamp != null
-          ? Math.min(liftedCanvasSource.timestamp, boundaryTimestamp)
-          : liftedCanvasSource.timestamp;
-      // Canvas previews are positioned relative to the queued-send tail that
-      // existed when they were lifted, so they stay in the stable row order
-      // rather than being re-sorted with live stream/tool cards.
-      items.splice(insertionIndex, 0, {
-        kind: "message",
-        key: `${
-          toolKeys[liftedCanvasSource.index] ??
-          messageKey(liftedCanvasSource.message, liftedCanvasSource.index + history.length)
-        }:canvas`,
-        message: createCanvasAssistantMessage(liftedCanvasSource, timestamp),
-      });
+    if (assistant) {
+      items[assistant.index] = {
+        ...assistant.item,
+        message: appendCanvasBlockToAssistantMessage(
+          assistant.item.message,
+          preview.preview,
+          preview.text,
+        ),
+      };
       continue;
     }
-    const item = items[assistantIndex];
-    if (!item || item.kind !== "message") {
+    if (searchFiltering) {
       continue;
     }
-    items[assistantIndex] = {
-      ...item,
-      message: appendCanvasBlockToAssistantMessage(
-        item.message as Record<string, unknown>,
-        liftedCanvasSource.preview,
-        liftedCanvasSource.text,
-      ),
-    };
+    const insertionIndex = findCanvasInsertionIndex(
+      items,
+      preview.timestamp,
+      canvasMinimumIndex,
+      canvasMaximumIndex,
+    );
+    const nextItem = items[insertionIndex];
+    const nextTimestamp =
+      nextItem?.kind === "message" ? rawMessageTimestamp(nextItem.message) : null;
+    const boundaryTimestamp =
+      nextTimestamp == null
+        ? futureQueuedTimestamp
+        : futureQueuedTimestamp == null
+          ? nextTimestamp
+          : Math.min(nextTimestamp, futureQueuedTimestamp);
+    const timestamp =
+      preview.timestamp != null && boundaryTimestamp != null
+        ? Math.min(preview.timestamp, boundaryTimestamp)
+        : preview.timestamp;
+    // Canvas previews are positioned relative to the queued-send tail that
+    // existed when they were lifted, so they stay in the stable row order
+    // rather than being re-sorted with live stream/tool cards.
+    items.splice(insertionIndex, 0, {
+      kind: "message",
+      key: `${projection.item.key}:canvas`,
+      message: createCanvasAssistantMessage(preview, timestamp),
+    });
   }
   items = items.filter(
     (item) => item.kind !== "message" || hasRenderableNormalizedMessage(item.message),
@@ -370,107 +368,80 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   const indexedSegments = segments.filter(
     (segment) => !streamSegmentHasItemId(segment) && segment.boundaryMarker !== true,
   );
-  const toolItems = tools.map((message, index) => ({
-    key: toolKeys[index] ?? messageKey(message, index + history.length),
-    message,
-  }));
-  const toolKeysByIdentity = new Map<string, string>();
-  const uniqueToolKeysByCallId = new Map<string, string | null>();
-  const addUniqueBareValue = (
-    values: Map<string, string | null>,
-    toolCallId: string,
-    value: string,
-  ) => values.set(toolCallId, values.has(toolCallId) ? null : value);
+  const toolLookup = createToolCallLookup<ChatProjection>();
   for (const tool of toolItems) {
-    const toolRecord = asRecord(tool.message);
-    const toolCallId = normalizeOptionalString(toolRecord?.toolCallId);
-    if (typeof toolCallId === "string" && toolCallId.trim()) {
-      const runId = normalizeOptionalString(toolRecord?.runId);
-      if (runId) {
-        toolKeysByIdentity.set(buildToolStreamIdentity(runId, toolCallId), tool.key);
-      }
-      addUniqueBareValue(uniqueToolKeysByCallId, toolCallId, tool.key);
-    }
+    toolLookup.add(tool.runId, tool.callId, tool.projection);
   }
-  const maxLen = Math.max(indexedSegments.length, tools.length);
-  let previousAccumulatedStreamText: string | null = null;
-  const toolStreamPredecessors = new Map<string, string>();
-  const projectionInsertionBounds = new Map<string, TurnInsertionBounds>();
-  const applyRunBounds = (
-    key: string,
+  // Empty user rows may have disappeared since canvas placement. Preserve the
+  // earlier current-turn fallback, but resolve exact bounds over rendered rows.
+  const projectionRunBounds = createRunTurnLookup(items);
+  const resolveProjectionBounds = (
     runId: unknown,
     boundaryRunId?: string,
     afterBoundaryRunId?: string,
-  ) => {
-    const bounds = resolveRunInsertionBounds(items, runId, props.runId, currentTurnBounds);
-    const boundaryKey = boundaryRunId
-      ? findRunTurnBounds(items, boundaryRunId)?.afterKey
+  ): TurnInsertionBounds | undefined => {
+    const bounds = resolveRunInsertionBounds(
+      projectionRunBounds,
+      runId,
+      props.runId,
+      currentTurnBounds,
+    );
+    const boundaryKey = boundaryRunId ? projectionRunBounds(boundaryRunId)?.afterKey : undefined;
+    const afterBounds = afterBoundaryRunId ? projectionRunBounds(afterBoundaryRunId) : undefined;
+    return bounds || boundaryKey || afterBounds
+      ? {
+          ...bounds,
+          ...(afterBounds?.afterKey ? { afterKey: afterBounds.afterKey } : {}),
+          ...(afterBounds?.beforeKey ? { beforeKey: afterBounds.beforeKey } : {}),
+          ...(boundaryKey ? { beforeKey: boundaryKey } : {}),
+        }
       : undefined;
-    const afterBounds = afterBoundaryRunId
-      ? findRunTurnBounds(items, afterBoundaryRunId)
-      : undefined;
-    if (bounds || boundaryKey || afterBounds) {
-      projectionInsertionBounds.set(key, {
-        ...bounds,
-        ...(afterBounds?.afterKey ? { afterKey: afterBounds.afterKey } : {}),
-        ...(afterBounds?.beforeKey ? { beforeKey: afterBounds.beforeKey } : {}),
-        ...(boundaryKey ? { beforeKey: boundaryKey } : {}),
-      });
-    }
   };
   if (!searchFiltering) {
     if (props.archiveNotice) {
-      timestampedProjectionItems.push(props.archiveNotice);
+      projections.push({ item: props.archiveNotice });
     }
     for (const notice of props.guardianNotices ?? []) {
-      const item = buildGuardianNoticeItem(notice);
-      timestampedProjectionItems.push(item);
-      applyRunBounds(item.key, notice.runId);
+      projections.push({
+        item: buildGuardianNoticeItem(notice),
+        bounds: resolveProjectionBounds(notice.runId),
+      });
     }
   }
-  const toolBoundariesByIdentity = new Map<string, string>();
-  const uniqueToolBoundariesByCallId = new Map<string, string | null>();
-  const toolAfterBoundariesByIdentity = new Map<string, string>();
-  const uniqueToolAfterBoundariesByCallId = new Map<string, string | null>();
+  const toolBeforeBoundaries = createToolCallLookup<string>();
+  const toolAfterBoundaries = createToolCallLookup<string>();
   for (const segment of indexedSegments) {
-    const toolCallId = normalizeOptionalString(segment.toolCallId);
+    const callId = normalizeOptionalString(segment.toolCallId);
+    const runId = normalizeOptionalString(segment.runId);
     const boundaryRunId = normalizeOptionalString(segment.boundaryRunId);
     const afterBoundaryRunId = afterBoundaryBySegment.get(segment);
-    if (!toolCallId) {
-      continue;
-    }
-    const runId = normalizeOptionalString(segment.runId);
-    if (runId && boundaryRunId) {
-      toolBoundariesByIdentity.set(buildToolStreamIdentity(runId, toolCallId), boundaryRunId);
-    }
     if (boundaryRunId) {
-      addUniqueBareValue(uniqueToolBoundariesByCallId, toolCallId, boundaryRunId);
-    }
-    if (runId && afterBoundaryRunId) {
-      toolAfterBoundariesByIdentity.set(
-        buildToolStreamIdentity(runId, toolCallId),
-        afterBoundaryRunId,
-      );
+      toolBeforeBoundaries.add(runId, callId, boundaryRunId);
     }
     if (afterBoundaryRunId) {
-      addUniqueBareValue(uniqueToolAfterBoundariesByCallId, toolCallId, afterBoundaryRunId);
+      toolAfterBoundaries.add(runId, callId, afterBoundaryRunId);
     }
   }
-  const resolveScopedValue = (
-    exact: ReadonlyMap<string, string>,
-    bare: ReadonlyMap<string, string | null>,
-    runId: string | undefined,
-    toolCallId: string,
-  ) =>
-    (runId ? exact.get(buildToolStreamIdentity(runId, toolCallId)) : undefined) ??
-    bare.get(toolCallId) ??
-    undefined;
+  const appendStreamSegment = (segment: ChatStreamSegment, key: string, text: string) => {
+    const afterBoundaryRunId = afterBoundaryBySegment.get(segment);
+    projections.push({
+      item: {
+        kind: "stream",
+        key,
+        text,
+        startedAt: segment.ts,
+        isStreaming: false,
+        ...optionalRunIdentity(segment.runId),
+        ...optionalBoundaryIdentity(afterBoundaryRunId ?? segment.runId),
+      },
+      bounds: resolveProjectionBounds(segment.runId, segment.boundaryRunId, afterBoundaryRunId),
+    });
+  };
+  let previousAccumulatedStreamText: string | null = null;
+  const maxLen = Math.max(indexedSegments.length, toolItems.length);
   for (let i = 0; i < maxLen; i++) {
-    if (i < indexedSegments.length) {
-      const segment = indexedSegments[i];
-      if (!segment) {
-        continue;
-      }
+    const segment = indexedSegments[i];
+    if (segment) {
       const text = sanitizeStreamText(segment.text);
       const usesAccumulatedText = streamSegmentUsesAccumulatedText(segment);
       const visibleText = usesAccumulatedText
@@ -484,92 +455,33 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       }
       if (visibleText.length > 0 && segment.persisted !== true) {
         const streamKey = `stream-seg:${props.sessionKey}:${i}`;
-        const streamItem: ChatItem = {
-          kind: "stream",
-          key: streamKey,
-          text: visibleText,
-          startedAt: segment.ts,
-          isStreaming: false,
-          ...optionalRunIdentity(segment.runId),
-          ...optionalBoundaryIdentity(afterBoundaryBySegment.get(segment) ?? segment.runId),
-        };
-        timestampedProjectionItems.push(streamItem);
-        applyRunBounds(
-          streamItem.key,
-          segment.runId,
-          segment.boundaryRunId,
-          afterBoundaryBySegment.get(segment),
+        appendStreamSegment(segment, streamKey, visibleText);
+        const tool = toolLookup.get(
+          normalizeOptionalString(segment.runId),
+          segment.toolCallId?.trim(),
         );
-        const toolCallId = segment.toolCallId?.trim();
-        const toolKey = toolCallId
-          ? resolveScopedValue(
-              toolKeysByIdentity,
-              uniqueToolKeysByCallId,
-              normalizeOptionalString(segment.runId),
-              toolCallId,
-            )
-          : undefined;
-        if (toolKey) {
+        if (tool) {
           // Gateway and browser clocks can disagree. Keep the assistant text that
           // introduced a tool causally before its card even when timestamps do not.
-          toolStreamPredecessors.set(toolKey, streamKey);
+          tool.predecessorKey = streamKey;
         }
       }
     }
     const tool = toolItems[i];
     if (tool && props.showToolCalls) {
-      const toolItem: ChatItem = {
-        kind: "message",
-        key: tool.key,
-        message: tool.message,
-      };
-      timestampedProjectionItems.push(toolItem);
-      const toolRecord = asRecord(tool.message);
-      const toolCallId = normalizeOptionalString(toolRecord?.toolCallId);
-      const toolRunId = normalizeOptionalString(toolRecord?.runId);
-      applyRunBounds(
-        toolItem.key,
-        toolRunId,
-        toolCallId
-          ? resolveScopedValue(
-              toolBoundariesByIdentity,
-              uniqueToolBoundariesByCallId,
-              toolRunId,
-              toolCallId,
-            )
-          : undefined,
-        toolCallId
-          ? resolveScopedValue(
-              toolAfterBoundariesByIdentity,
-              uniqueToolAfterBoundariesByCallId,
-              toolRunId,
-              toolCallId,
-            )
-          : undefined,
-      );
+      const before = toolBeforeBoundaries.get(tool.runId, tool.callId);
+      const after = toolAfterBoundaries.get(tool.runId, tool.callId);
+      tool.projection.bounds = resolveProjectionBounds(tool.runId, before, after);
+      projections.push(tool.projection);
     }
   }
+  // Keyed commentary does not advance cumulative text and follows the indexed
+  // stream/tool pairs on timestamp ties.
   for (const segment of keyedSegments) {
     const text = sanitizeStreamText(segment.text);
-    if (text.length === 0) {
-      continue;
+    if (text.length > 0) {
+      appendStreamSegment(segment, `stream-seg:${props.sessionKey}:${segment.itemId}`, text);
     }
-    const commentaryItem: ChatItem = {
-      kind: "stream",
-      key: `stream-seg:${props.sessionKey}:${segment.itemId}`,
-      text,
-      startedAt: segment.ts,
-      isStreaming: false,
-      ...optionalRunIdentity(segment.runId),
-      ...optionalBoundaryIdentity(afterBoundaryBySegment.get(segment) ?? segment.runId),
-    };
-    timestampedProjectionItems.push(commentaryItem);
-    applyRunBounds(
-      commentaryItem.key,
-      segment.runId,
-      segment.boundaryRunId,
-      afterBoundaryBySegment.get(segment),
-    );
   }
 
   for (const prompt of props.questionPrompts ?? []) {
@@ -588,21 +500,19 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       questionId: prompt.id,
       startedAt: prompt.createdAtMs,
     };
-    timestampedProjectionItems.push(questionItem);
-    if (prompt.runId) {
-      applyRunBounds(questionItem.key, prompt.runId);
-    }
+    projections.push({
+      item: questionItem,
+      bounds: prompt.runId ? resolveProjectionBounds(prompt.runId) : undefined,
+    });
   }
 
   // Unowned projections keep their user-turn floor despite clock skew;
   // identified live tools stay in the canonical invocation's interval.
-  applyPersistedToolInvocationBounds(items, toolItems, projectionInsertionBounds);
-  insertChatItemsByTimestamp(
+  applyPersistedToolInvocationBounds(
     items,
-    timestampedProjectionItems,
-    projectionInsertionBounds,
-    toolStreamPredecessors,
+    toolItems.map((tool) => tool.projection),
   );
+  insertChatItemsByTimestamp(items, projections);
 
   // The active claw is telemetry, not a placeholder: it stays through visible
   // assistant text and tool cards until the run settles. The initial-load
@@ -649,7 +559,8 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         ...optionalBoundaryIdentity(latestBoundaryRunId ?? liveRunId),
       };
       const liveTurnRunId = latestBoundaryRunId ?? normalizeOptionalString(props.runId);
-      const liveTurnBounds = liveTurnRunId ? findRunTurnBounds(items, liveTurnRunId) : null;
+      // Pending-custody user rows now participate in the live tail's ceiling.
+      const liveTurnBounds = liveTurnRunId ? createRunTurnLookup(items)(liveTurnRunId) : null;
       if (liveTurnBounds) {
         const { maximum } = insertionIndexesForBounds(items, liveTurnBounds);
         items.splice(maximum, 0, liveStreamItem);

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -13,8 +13,6 @@ import { prepareMessagesForGrouping } from "./chat-thread-duplicates.ts";
 import { userTurnRunId } from "./chat-thread-items.ts";
 import {
   isKeyedAssistantStreamFallbackMessage,
-  streamPartBoundaryId,
-  streamPartRunId,
   transcriptRunId,
 } from "./chat-thread-run-identity.ts";
 import {
@@ -152,7 +150,7 @@ export type StreamRunRenderItem = {
   key: string;
   runId?: string;
   boundaryId?: string;
-  parts: Array<Extract<ChatItem, { kind: "stream" | "reading-indicator" | "question" }>>;
+  parts: Array<Extract<ChatItem, { kind: "stream" | "reading-indicator" }>>;
 };
 export function coalesceStreamRuns(
   items: RenderChatItem[],
@@ -162,8 +160,7 @@ export function coalesceStreamRuns(
   const flush = () => {
     const [first] = run;
     if (first) {
-      const runId = streamPartRunId(first);
-      const boundaryId = streamPartBoundaryId(first);
+      const { runId, boundaryId } = first;
       result.push({
         kind: "stream-run",
         key: `stream-run:${first.key}`,
@@ -177,10 +174,7 @@ export function coalesceStreamRuns(
   for (const item of items) {
     if (item.kind === "stream" || item.kind === "reading-indicator") {
       const first = run[0];
-      if (
-        first &&
-        (streamPartRunId(first) !== item.runId || streamPartBoundaryId(first) !== item.boundaryId)
-      ) {
+      if (first && (first.runId !== item.runId || first.boundaryId !== item.boundaryId)) {
         flush();
       }
       run.push(item);

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -176,12 +176,12 @@ export function transcriptPositionTimestamp(
   return next;
 }
 
-export function findNearestAssistantMessageIndex(
+export function findNearestAssistantMessage(
   items: ChatItem[],
   toolTimestamp: number | null,
   minimumIndex = 0,
   maximumIndex = items.length,
-): number | null {
+) {
   let currentTurnStart = minimumIndex;
   let currentTurnEnd = maximumIndex;
   for (let index = minimumIndex; index < maximumIndex; index += 1) {
@@ -201,47 +201,34 @@ export function findNearestAssistantMessageIndex(
     }
     currentTurnStart = index + 1;
   }
-  const assistantEntries = items
-    .map((item, index) => {
-      if (index < currentTurnStart || index >= currentTurnEnd || item.kind !== "message") {
-        return null;
-      }
-      const message = asRecord(item.message);
-      const role = typeof message?.role === "string" ? message.role.toLowerCase() : "";
-      if (role !== "assistant") {
-        return null;
-      }
-      return {
-        index,
-        timestamp: safeNormalizeMessage(item.message)?.timestamp ?? null,
-      };
-    })
-    .filter(Boolean) as Array<{ index: number; timestamp: number | null }>;
-  if (assistantEntries.length === 0) {
-    return null;
-  }
-  if (toolTimestamp == null) {
-    return assistantEntries[assistantEntries.length - 1]?.index ?? null;
-  }
-  let previous: { index: number; timestamp: number } | null = null;
-  let next: { index: number; timestamp: number } | null = null;
-  for (const entry of assistantEntries) {
-    if (entry.timestamp == null) {
+  type Anchor = { index: number; item: Extract<ChatItem, { kind: "message" }> };
+  let last: Anchor | null = null;
+  let previous: { anchor: Anchor; timestamp: number } | null = null;
+  // Keep stable traversal order: last preceding / first following assistant,
+  // not a timestamp sort that could cross an existing reply.
+  for (let index = currentTurnStart; index < currentTurnEnd; index++) {
+    const item = items[index];
+    if (item?.kind !== "message") {
       continue;
     }
-    if (entry.timestamp <= toolTimestamp) {
-      previous = { index: entry.index, timestamp: entry.timestamp };
+    const message = asRecord(item.message);
+    if (typeof message?.role !== "string" || message.role.toLowerCase() !== "assistant") {
       continue;
     }
-    next = { index: entry.index, timestamp: entry.timestamp };
-    break;
+    last = { index, item };
+    const timestamp = safeNormalizeMessage(item.message)?.timestamp;
+    if (toolTimestamp == null || timestamp == null) {
+      continue;
+    }
+    if (timestamp <= toolTimestamp) {
+      previous = { anchor: last, timestamp };
+      continue;
+    }
+    return previous && toolTimestamp - previous.timestamp <= timestamp - toolTimestamp
+      ? previous.anchor
+      : last;
   }
-  if (previous && next) {
-    const previousDelta = toolTimestamp - previous.timestamp;
-    const nextDelta = next.timestamp - toolTimestamp;
-    return nextDelta < previousDelta ? next.index : previous.index;
-  }
-  return previous?.index ?? next?.index ?? assistantEntries.at(-1)?.index ?? null;
+  return previous?.anchor ?? last;
 }
 
 export function findCanvasInsertionIndex(
@@ -378,7 +365,9 @@ function messageProjectionDigest(message: unknown): string {
   return digest;
 }
 
-export function buildMessageKeys(messages: unknown[], indexOffset = 0): string[] {
+export function buildMessageItems<Message>(
+  messages: Message[],
+): Array<Extract<ChatItem, { kind: "message" }> & { message: Message }> {
   const sourceKeys = messages.map(transcriptMessageSourceKey);
   const sourceCounts = new Map<string, number>();
   for (const sourceKey of sourceKeys) {
@@ -395,7 +384,15 @@ export function buildMessageKeys(messages: unknown[], indexOffset = 0): string[]
       : (sourceKey ?? "legacy");
     const occurrence = projectionOccurrences.get(projectionKey) ?? 0;
     projectionOccurrences.set(projectionKey, occurrence + 1);
-    return messageKey(message, index + indexOffset, `${projectionKey}:${occurrence}`);
+    const record = asRecord(message);
+    const callId = typeof record?.toolCallId === "string" ? record.toolCallId : "";
+    const role = typeof record?.role === "string" ? record.role : "unknown";
+    const transcriptKey = `${projectionKey}:${occurrence}`;
+    return {
+      kind: "message",
+      key: callId ? `tool:${role}:${callId}:${transcriptKey}` : `msg:${transcriptKey}`,
+      message,
+    };
   });
 }
 
@@ -478,6 +475,12 @@ export function timestampAfterVisibleItems(items: ChatItem[], desiredTimestamp: 
 // assistant replies when their timestamps come from different clocks (#112943).
 export type TurnInsertionBounds = { afterKey?: string; beforeKey?: string };
 
+export type ChatProjection<Item extends ChatItem = ChatItem> = {
+  item: Item;
+  bounds?: TurnInsertionBounds;
+  predecessorKey?: string;
+};
+
 export function insertionIndexesForBounds(
   items: ChatItem[],
   bounds: TurnInsertionBounds | undefined,
@@ -494,26 +497,32 @@ export function insertionIndexesForBounds(
   };
 }
 
-export function insertChatItemsByTimestamp(
-  items: ChatItem[],
-  inserts: ChatItem[],
-  insertionBoundsByKey: ReadonlyMap<string, TurnInsertionBounds>,
-  toolStreamPredecessors: ReadonlyMap<string, string>,
-): void {
+export function insertChatItemsByTimestamp(items: ChatItem[], inserts: ChatProjection[]): void {
   const timestampsByKey = new Map<string, number>();
-  for (const item of inserts) {
+  const placementsByKey = new Map<string, Pick<ChatProjection, "bounds" | "predecessorKey">>();
+  for (const { item, bounds, predecessorKey } of inserts) {
     const timestamp = chatItemTimestamp(item);
     if (timestamp != null) {
       timestampsByKey.set(item.key, timestamp);
     }
+    // Repeated logical keys share the last supplied fact for each field;
+    // an unbounded projection must not erase an earlier causal constraint.
+    const placement = placementsByKey.get(item.key) ?? {};
+    if (bounds) {
+      placement.bounds = bounds;
+    }
+    if (predecessorKey) {
+      placement.predecessorKey = predecessorKey;
+    }
+    placementsByKey.set(item.key, placement);
   }
   // Sort inserts among themselves by timestamp, preserving the original index
   // order for ties and honoring predecessor relationships so a stream segment
   // stays before the tool card it introduced.
   const sortedInserts = inserts
-    .map((item, index) => {
+    .map(({ item }, index) => {
       const rawTimestamp = chatItemTimestamp(item);
-      const predecessorKey = toolStreamPredecessors.get(item.key);
+      const predecessorKey = placementsByKey.get(item.key)?.predecessorKey;
       const predecessorTimestamp = predecessorKey ? timestampsByKey.get(predecessorKey) : null;
       return {
         item,
@@ -550,7 +559,7 @@ export function insertChatItemsByTimestamp(
   for (const { item, effectiveTimestamp } of sortedInserts) {
     const { minimum, maximum } = insertionIndexesForBounds(
       items,
-      insertionBoundsByKey.get(item.key),
+      placementsByKey.get(item.key)?.bounds,
     );
     if (effectiveTimestamp == null) {
       items.splice(maximum, 0, item);
@@ -574,26 +583,4 @@ export function insertChatItemsByTimestamp(
       items.splice(insertionIndex, 0, item);
     }
   }
-}
-
-export function messageKey(message: unknown, index: number, transcriptKey?: string): string {
-  const m = asRecord(message) ?? {};
-  const toolCallId = typeof m.toolCallId === "string" ? m.toolCallId : "";
-  const role = typeof m.role === "string" ? m.role : "unknown";
-  const id = typeof m.id === "string" && m.id ? m.id : null;
-  const messageId = typeof m.messageId === "string" && m.messageId ? m.messageId : null;
-  const identity = id ?? messageId;
-  const timestamp = typeof m.timestamp === "number" ? m.timestamp : null;
-  if (toolCallId) {
-    const suffix =
-      transcriptKey ?? identity ?? (timestamp == null ? index : `${timestamp}:${index}`);
-    return `tool:${role}:${toolCallId}:${suffix}`;
-  }
-  if (transcriptKey) {
-    return `msg:${transcriptKey}`;
-  }
-  if (identity) {
-    return `msg:${identity}`;
-  }
-  return timestamp == null ? `msg:${role}:${index}` : `msg:${role}:${timestamp}:${index}`;
 }

--- a/ui/src/pages/chat/chat-thread-run-identity.ts
+++ b/ui/src/pages/chat/chat-thread-run-identity.ts
@@ -6,7 +6,11 @@ import { asNullableRecord as asRecord } from "@openclaw/normalization-core/recor
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ChatItem } from "../../lib/chat/chat-types.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
-import { userTurnRunId, type TurnInsertionBounds } from "./chat-thread-items.ts";
+import {
+  userTurnRunId,
+  type ChatProjection,
+  type TurnInsertionBounds,
+} from "./chat-thread-items.ts";
 import { chatItemStartsUserTurn, safeNormalizeMessage } from "./chat-turn-boundary.ts";
 import { readLiveTerminalRunId } from "./terminal-message-identity.ts";
 import { buildToolStreamIdentity, extractToolMessageRefs } from "./tool-stream-identity.ts";
@@ -38,19 +42,32 @@ export function optionalBoundaryIdentity(value: unknown): { boundaryId: string }
   return runId ? { boundaryId: `send:${runId}` } : undefined;
 }
 
-export function streamPartRunId(
-  part: Extract<ChatItem, { kind: "stream" | "reading-indicator" | "question" }>,
-): string | undefined {
-  return part.kind === "question" ? undefined : part.runId;
+export function createToolCallLookup<Value>() {
+  const exact = new Map<string, Value>();
+  const unique = new Map<string, Value | null>();
+  return {
+    add(runId: string | undefined, callId: string | undefined, value: Value) {
+      if (!callId) {
+        return;
+      }
+      if (runId) {
+        exact.set(buildToolStreamIdentity(runId, callId), value);
+      }
+      // Ambiguity belongs to each fact, not the whole call. Even equal values
+      // from two occurrences cannot identify an unscoped owner.
+      unique.set(callId, unique.has(callId) ? null : value);
+    },
+    get(runId: string | undefined, callId: string | undefined): Value | undefined {
+      return callId
+        ? ((runId ? exact.get(buildToolStreamIdentity(runId, callId)) : undefined) ??
+            unique.get(callId) ??
+            undefined)
+        : undefined;
+    },
+  };
 }
 
-export function streamPartBoundaryId(
-  part: Extract<ChatItem, { kind: "stream" | "reading-indicator" | "question" }>,
-): string | undefined {
-  return part.kind === "question" ? undefined : part.boundaryId;
-}
-
-function isUserChatItem(item: ChatItem): boolean {
+function isUserChatItem(item: ChatItem): item is Extract<ChatItem, { kind: "message" }> {
   if (item.kind !== "message") {
     return false;
   }
@@ -59,26 +76,39 @@ function isUserChatItem(item: ChatItem): boolean {
 }
 
 export function findCurrentTurnBounds(items: ChatItem[]): TurnInsertionBounds | null {
-  const index = items.findLastIndex(isUserChatItem);
-  const item = items[index];
-  return index >= 0 && item ? { afterKey: item.key } : null;
+  const item = items.findLast(isUserChatItem);
+  return item ? { afterKey: item.key } : null;
 }
 
-export function findRunTurnBounds(items: ChatItem[], runId: string): TurnInsertionBounds | null {
-  const index = items.findIndex(
-    (item) =>
-      item.kind === "message" && isUserChatItem(item) && userTurnRunId(item.message) === runId,
-  );
-  const item = items[index];
-  if (index < 0 || !item) {
-    return null;
-  }
-  const nextUser = items.slice(index + 1).find(isUserChatItem);
-  return { afterKey: item.key, ...(nextUser ? { beforeKey: nextUser.key } : {}) };
+export function createRunTurnLookup(items: ChatItem[]) {
+  let bounds: Map<string, TurnInsertionBounds> | undefined;
+  return (runId: string): TurnInsertionBounds | null => {
+    if (!bounds) {
+      bounds = new Map();
+      let nextUserKey: string | undefined;
+      // Keys survive canvas splices. Rebuild after user rows are filtered or
+      // inserted; the earliest user for a run owns its next-user ceiling.
+      for (let index = items.length - 1; index >= 0; index--) {
+        const item = items[index]!;
+        if (!isUserChatItem(item)) {
+          continue;
+        }
+        const owner = userTurnRunId(item.message);
+        if (owner !== null) {
+          bounds.set(owner, {
+            afterKey: item.key,
+            ...(nextUserKey ? { beforeKey: nextUserKey } : {}),
+          });
+        }
+        nextUserKey = item.key;
+      }
+    }
+    return bounds.get(runId) ?? null;
+  };
 }
 
 export function resolveRunInsertionBounds(
-  items: ChatItem[],
+  findRunBounds: ReturnType<typeof createRunTurnLookup>,
   runId: unknown,
   currentRunId: string | null | undefined,
   currentTurnBounds: TurnInsertionBounds | null,
@@ -86,7 +116,7 @@ export function resolveRunInsertionBounds(
   if (typeof runId !== "string" || !runId.trim()) {
     return currentRunId != null ? currentTurnBounds : null;
   }
-  const runBounds = findRunTurnBounds(items, runId);
+  const runBounds = findRunBounds(runId);
   if (runId === currentRunId) {
     // Active runs can span steers: the original prompt is a floor, not a ceiling.
     return runBounds ? { afterKey: runBounds.afterKey } : currentTurnBounds;
@@ -102,9 +132,11 @@ export function resolveRunInsertionBounds(
 /** A persisted invocation owns its live echo's interval even without a user send key. */
 export function applyPersistedToolInvocationBounds(
   items: ChatItem[],
-  tools: Array<{ key: string; message: unknown }>,
-  insertionBounds: Map<string, TurnInsertionBounds>,
+  tools: Array<ChatProjection<Extract<ChatItem, { kind: "message" }>>>,
 ): void {
+  if (tools.length === 0) {
+    return;
+  }
   const invocations = new Map<string, TurnInsertionBounds | null>();
   let bounds: TurnInsertionBounds = {};
   for (const item of items) {
@@ -129,13 +161,13 @@ export function applyPersistedToolInvocationBounds(
     }
   }
   for (const tool of tools) {
-    const refs = extractToolMessageRefs(tool.message);
+    const refs = extractToolMessageRefs(tool.item.message);
     const matching = refs.map((ref) =>
       ref.runId ? invocations.get(buildToolStreamIdentity(ref.runId, ref.id)) : undefined,
     );
     const [first] = matching;
     if (first && matching.every((candidate) => candidate === first)) {
-      insertionBounds.set(tool.key, first);
+      tool.bounds = first;
     }
   }
 }

--- a/ui/src/pages/chat/chat-thread.question.test.ts
+++ b/ui/src/pages/chat/chat-thread.question.test.ts
@@ -144,10 +144,25 @@ describe("question chat items", () => {
     expect(container.innerHTML).not.toContain("fake-secret-never-render");
   });
 
-  it("omits questions belonging to another session", () => {
-    const other = prompt("pending");
-    other.sessionKey = "agent:other:main";
+  it.each(["pending", "answered", "expired", "cancelled"] as const)(
+    "scopes %s questions to the selected session and its equivalent alias",
+    (status) => {
+      const question = prompt(status);
+      const expected =
+        status === "pending"
+          ? []
+          : [
+              {
+                kind: "question",
+                key: "question:question-1",
+                questionId: "question-1",
+                startedAt: 1_000,
+              },
+            ];
 
-    expect(items(other, false)).toEqual([]);
-  });
+      expect(items(question, false)).toEqual(expected);
+      expect(items({ ...question, sessionKey: "main" }, false)).toEqual(expected);
+      expect(items({ ...question, sessionKey: "agent:other:main" }, false)).toEqual([]);
+    },
+  );
 });

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -314,6 +314,75 @@ describe("assistant commentary grouping", () => {
     expect(runBToolIndex).toBeLessThan(steerBIndex);
   });
 
+  it.each(
+    [
+      {
+        name: "independently unique boundaries",
+        boundaries: [{ afterBoundaryRunId: "a" }, { boundaryRunId: "c" }],
+        timestamp: 1_000,
+        orders: ["A B tool C", "A B tool C", "A B tool C"],
+      },
+      {
+        name: "ambiguous after boundary",
+        boundaries: [{ afterBoundaryRunId: "a", boundaryRunId: "c" }, { afterBoundaryRunId: "b" }],
+        timestamp: 0,
+        orders: ["tool A B C", "A tool B C", "A B tool C"],
+      },
+      {
+        name: "ambiguous before boundary",
+        boundaries: [{ boundaryRunId: "b" }, { afterBoundaryRunId: "a", boundaryRunId: "c" }],
+        timestamp: 1_000,
+        orders: ["A tool B C", "A tool B C", "A B tool C"],
+      },
+      {
+        name: "repeated equal boundaries remain ambiguous",
+        boundaries: [
+          { afterBoundaryRunId: "unloaded", boundaryRunId: "c" },
+          { afterBoundaryRunId: "unloaded", boundaryRunId: "c" },
+        ],
+        timestamp: 1_000,
+        orders: ["A B C tool", "A B tool C", "A B tool C"],
+      },
+    ].flatMap(({ name, boundaries, timestamp, orders }) =>
+      [undefined, "run-1", "run-2"].map((runId, index) => ({
+        name,
+        boundaries,
+        timestamp,
+        runId,
+        expectedOrder: orders[index]!.split(" "),
+      })),
+    ),
+  )(
+    "resolves $name independently for tool owner $runId",
+    ({ boundaries, timestamp, runId, expectedOrder }) => {
+      const paneId = `independent-tool-boundaries:${JSON.stringify([boundaries, runId])}`;
+      try {
+        const groups = messageGroups({
+          paneId,
+          messages: [
+            userMessage("A", 100, { __openclaw: { idempotencyKey: "a:user" } }),
+            userMessage("B", 200, { __openclaw: { idempotencyKey: "b:user" } }),
+            userMessage("C", 300, { __openclaw: { idempotencyKey: "c:user" } }),
+          ],
+          streamSegments: boundaries.map((boundary, index) => ({
+            text: "",
+            ts: 10,
+            runId: `run-${index + 1}`,
+            toolCallId: "shared-call",
+            ...boundary,
+          })),
+          toolMessages: [toolResultMessage("shared-call", "read", "output", timestamp, { runId })],
+        });
+
+        expect(
+          groups.map((group) => (group.role === "tool" ? "tool" : messageRecord(group).content)),
+        ).toEqual(expectedOrder);
+      } finally {
+        resetChatThreadState(paneId);
+      }
+    },
+  );
+
   it("keeps a post-steer tool segment and card after a textless steer", () => {
     const toolCallId = "call-after-steer";
     const items = buildCachedChatItems(
@@ -3569,14 +3638,22 @@ describe("buildCachedChatItems", () => {
     ]);
   });
 
-  it("keeps an unkeyed preamble from corrupting the accumulated prefix tracker", () => {
-    // A standalone (itemId-less) preamble whose text is not part of the
-    // cumulative run text must not become the prefix baseline — pre-fix the
-    // next cumulative snapshot re-rendered every earlier segment's text.
-    const items = buildCachedChatItems(
-      createProps({
+  it.each([false, true])(
+    "keeps cumulative text around an unkeyed preamble with persisted prefix=%s",
+    (persistedPrefix) => {
+      // A durable prefix hides only its row; an unrelated unkeyed preamble must
+      // neither replace that baseline nor revive it on later cumulative updates.
+      const paneId = `persisted-prefix:${persistedPrefix}`;
+      const input = createProps({
+        paneId,
+        messages: persistedPrefix ? [assistantMessage("First thought.", 1)] : [],
         streamSegments: [
-          { text: "First thought.", ts: 1, toolCallId: "call-1" },
+          {
+            text: "First thought.",
+            ts: 1,
+            toolCallId: "call-1",
+            ...(persistedPrefix ? { persisted: true } : {}),
+          },
           { text: "Standalone preamble", ts: 2 },
           { text: "First thought. After tool.", ts: 3, toolCallId: "call-2" },
         ],
@@ -3584,15 +3661,31 @@ describe("buildCachedChatItems", () => {
           chatMessage("toolResult", "Tool one", 2),
           chatMessage("toolResult", "Tool two", 4),
         ],
-      }),
-    );
-
-    expect(items.filter((item) => item.kind === "stream")).toMatchObject([
-      { text: "First thought." },
-      { text: "Standalone preamble" },
-      { text: "After tool." },
-    ]);
-  });
+        stream: "First thought. After tool. Continued.",
+        streamStartedAt: 5,
+      });
+      const streamTexts = (items: ReturnType<typeof buildCachedChatItems>) =>
+        items.flatMap((item) => (item.kind === "stream" ? [item.text] : []));
+      const precedingTexts = [
+        ...(persistedPrefix ? [] : ["First thought."]),
+        "Standalone preamble",
+        "After tool.",
+      ];
+      try {
+        const initial = buildCachedChatItems(input);
+        expect(streamTexts(initial)).toEqual([...precedingTexts, "Continued."]);
+        const next = { ...input, stream: "First thought. After tool. Continued. Again." };
+        const cached = buildCachedChatItems(next);
+        expect(cached).toBe(initial);
+        expect(streamTexts(cached)).toEqual([...precedingTexts, "Continued. Again."]);
+        expect(
+          streamTexts(buildCachedChatItems({ ...next, messages: [...next.messages] })),
+        ).toEqual([...precedingTexts, "Continued. Again."]);
+      } finally {
+        resetChatThreadState(paneId);
+      }
+    },
+  );
 
   it("deduplicates accumulated stream snapshots around tool cards", () => {
     const items = buildCachedChatItems(
@@ -3733,26 +3826,43 @@ describe("buildCachedChatItems", () => {
     ).toBe(true);
   });
 
-  it("keeps same-millisecond stream segments interleaved with their matching tool cards", () => {
-    const items = buildCachedChatItems(
-      createProps({
-        streamSegments: [
-          { text: "First tool.", ts: 2_000, toolCallId: "call-read" },
-          { text: "First tool. Second tool.", ts: 2_000, toolCallId: "call-list" },
-        ],
-        toolMessages: [
-          toolResultMessage("call-read", "read", "file contents", 1_000),
-          toolResultMessage("call-list", "list", "file list", 1_000),
-        ],
-      }),
-    );
+  it.each([false, true])(
+    "keeps same-millisecond segments interleaved with tools and mixed preambles=%s",
+    (mixedPreambles) => {
+      const items = buildCachedChatItems(
+        createProps({
+          streamSegments: [
+            { text: "First tool.", ts: 2_000, toolCallId: "call-read" },
+            { text: "First tool. Second tool.", ts: 2_000, toolCallId: "call-list" },
+            ...(mixedPreambles
+              ? [
+                  { text: "Unmatched preamble", ts: 2_000 },
+                  { text: "Keyed preamble", ts: 2_000, itemId: "keyed-preamble" },
+                ]
+              : []),
+          ],
+          toolMessages: [
+            toolResultMessage("call-read", "read", "file contents", 1_000),
+            toolResultMessage("call-list", "list", "file list", 1_000),
+          ],
+        }),
+      );
 
-    expect(items).toHaveLength(4);
-    expect(items[0]).toMatchObject({ kind: "stream", text: "First tool." });
-    expect(messageRecord(requireGroup(items[1])).toolCallId).toBe("call-read");
-    expect(items[2]).toMatchObject({ kind: "stream", text: "Second tool." });
-    expect(messageRecord(requireGroup(items[3])).toolCallId).toBe("call-list");
-  });
+      expect(items).toHaveLength(mixedPreambles ? 6 : 4);
+      expect(items[0]).toMatchObject({ kind: "stream", text: "First tool." });
+      expect(messageRecord(requireGroup(items[1])).toolCallId).toBe("call-read");
+      expect(items[2]).toMatchObject({ kind: "stream", text: "Second tool." });
+      expect(messageRecord(requireGroup(items[3])).toolCallId).toBe("call-list");
+      expect(items.slice(4)).toEqual(
+        mixedPreambles
+          ? [
+              expect.objectContaining({ kind: "stream", text: "Unmatched preamble" }),
+              expect.objectContaining({ kind: "stream", text: "Keyed preamble" }),
+            ]
+          : [],
+      );
+    },
+  );
 
   it("keeps a live tool card after its stream segment when an unkeyed preamble shifts indexes", () => {
     const items = buildCachedChatItems(

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -364,13 +364,14 @@ describe("chat transcript controller", () => {
   });
 
   it.each([
-    { behavior: "auto", resizeBefore: true, deltaY: -100 },
-    { behavior: "smooth", resizeBefore: true, deltaY: -100 },
-    { behavior: "smooth", resizeBefore: false, deltaY: -100 },
-    { behavior: "smooth", resizeBefore: true, deltaY: 100 },
+    { behavior: "auto", resizeBefore: true, deltaY: -100, observerLate: false },
+    { behavior: "smooth", resizeBefore: true, deltaY: -100, observerLate: false },
+    { behavior: "smooth", resizeBefore: false, deltaY: -100, observerLate: false },
+    { behavior: "smooth", resizeBefore: true, deltaY: 100, observerLate: false },
+    { behavior: "smooth", resizeBefore: true, deltaY: -100, observerLate: true },
   ] as const)(
-    "recovers $behavior measurements with resizeBeforeInterruption=$resizeBefore and wheel=$deltaY",
-    async ({ behavior, resizeBefore, deltaY }) => {
+    "recovers $behavior measurements with resizeBeforeInterruption=$resizeBefore, wheel=$deltaY, and late offset=$observerLate",
+    async ({ behavior, resizeBefore, deltaY, observerLate }) => {
       const flushFrames = stubAnimationFrames();
       transcriptDomState.measuredRowHeight = 120;
       const rows: TestContentRow[] = Array.from({ length: 40 }, (_, index) => ({
@@ -379,10 +380,15 @@ describe("chat transcript controller", () => {
         content: html`<div>row ${index}</div>`,
       }));
       const { container, renderRows, transcript } = await mountTestTranscript(
-        `pane-${behavior}-${resizeBefore}-resize`,
+        `pane-${behavior}-${resizeBefore}-${deltaY}-${observerLate}-resize`,
         rows,
       );
       try {
+        container.scrollTo = (options?: ScrollToOptions | number) => {
+          if (typeof options === "object" && options.behavior !== "smooth") {
+            container.scrollTop = options.top ?? container.scrollTop;
+          }
+        };
         Object.defineProperties(container, {
           clientHeight: { configurable: true, value: 600 },
           scrollHeight: { configurable: true, value: 4000 },
@@ -409,12 +415,23 @@ describe("chat transcript controller", () => {
           }
         };
         transcript.scrollToEnd({ behavior });
+        if (observerLate) {
+          container.scrollTop = 135;
+          container.dispatchEvent(new Event("scroll"));
+        }
         if (resizeBefore) {
           resize();
         }
+        if (observerLate) {
+          // Native wheel movement can precede both input delivery and the
+          // offset observer. Remeasurement must use this viewport, not 135.
+          container.scrollTop = 0;
+        }
         container.dispatchEvent(new WheelEvent("wheel", { deltaY }));
-        container.scrollTop = 0;
-        container.dispatchEvent(new Event("scroll"));
+        if (!observerLate) {
+          container.scrollTop = 0;
+          container.dispatchEvent(new Event("scroll"));
+        }
         if (!resizeBefore) {
           resize();
         }
@@ -422,6 +439,12 @@ describe("chat transcript controller", () => {
         renderRows(rows);
         expect(transcriptSize(container)).toBe(initialSize + 80);
         expect(container.scrollTop).toBe(0);
+        if (observerLate) {
+          container.dispatchEvent(new Event("scroll"));
+          flushFrames();
+          renderRows(rows);
+          expect(container.scrollTop).toBe(0);
+        }
       } finally {
         transcript.hostDisconnected();
       }

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -246,7 +246,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
       observeElementOffset: (instance, callback) => {
         const element = this.scrollElement;
         const interrupt = (event: Event) => {
-          if (element !== this.scrollElement || instance.scrollElement !== element) {
+          if (!element || element !== this.scrollElement || instance.scrollElement !== element) {
             return;
           }
           if (
@@ -260,6 +260,12 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
           }
           this.pendingInteractionAnchor = null;
           this.cancelScroll();
+          // Native input can move the viewport before its scroll event. Publish
+          // that offset before queued remeasurement compensates against a stale fold.
+          const offset = element.scrollTop;
+          if (offset !== instance.scrollOffset) {
+            callback(offset, instance.isScrolling);
+          }
           this.callbacks.onReaderScroll?.();
         };
         for (const type of ["wheel", "touchstart", "keydown", "pointerdown"]) {
@@ -488,7 +494,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     const element = this.scrollElement;
     if (element) {
       // Cancellation is one instant target replacement, never the multi-frame
-      // restoration API. Reconcile committed rows after core's offset listener.
+      // restoration API.
       this.virtualizerController
         .getVirtualizer()
         .scrollToOffset(element.scrollTop, { behavior: "instant" });


### PR DESCRIPTION
Related: #135568 (queued prompts before saved replies), #135507 (original ordering report, already fixed).

## What Problem This Solves

This is the maintainer-requested follow-up refactor to the queued-prompt ordering repair. Control UI transcript composition mixed stable rows, canvas lifting, live tools, commentary, and queued input placement in one large builder. Repeated run-boundary scans and separately managed identity/placement maps made ordering-sensitive changes unnecessarily difficult to audit and made tool-heavy rebuilds expensive.

## Why This Change Was Made

Prepare keyed rows and live-tool identity/preview facts once, carry placement bounds and predecessors with each transient projection, and reuse one exact-run/occurrence-unique lookup policy. Run-bound indexes stay local to the three distinct observation points: canvas placement before empty-row filtering, closed projections after filtering, and the live tail after pending-custody users are inserted. The earlier current-turn fallback remains separately captured; invocation intervals keep their notice/reset semantics.

The refactor also removes unreachable key fallbacks, duplicate stream construction, nullable canvas-entry casts, and impossible question branches in stream-run grouping. Indexed cumulative-prefix behavior, keyed commentary, strict canonical reply anchors, stable history order, current/future queue phases, and cache identity remain unchanged. No queue-custody, persistence, protocol, config, provider, dependency, or public SDK change; no cross-build normalization cache.

Production: **+281 / -351 (net -70)**. Tests: **+203 / -52 (net +151)**. Two assertion-baseline counts decrease because their casts were removed; no budget was raised.

## User Impact

The composition refactor preserves presentation and ordering. Queued prompts remain before their owned replies, including reconnect and settled-run cases, and tool/stream/canvas rows retain their causal placement. Maintainers get a smaller composition pipeline and explicit placement ownership. The accompanying CI repair also prevents manual scroll interruption from being pulled back by row measurement using a stale viewport offset.

A supplemental local benchmark forced full rebuilds of 401 history rows, with 10 warmups and 20 measured samples per case (Node 24.20.0):

| Tool cards | Before median | After median |
| --- | ---: | ---: |
| 0 | 1.746 ms | 1.880 ms |
| 25 | 9.635 ms | 3.092 ms |
| 100 | 30.490 ms | 6.064 ms |

The tool-heavy case is about five times faster in this fixture. These are local measurements, not an SLA or a universal speedup; the no-tool distributions overlap.

## CI repair found during validation

The first [PR CI run](https://github.com/openclaw/openclaw/actions/runs/33577282844) failed the native-wheel disclosure test at an unchanged `scrollTop === 0` assertion (64 px). An [earlier main run](https://github.com/openclaw/openclaw/actions/runs/33576097060/job/100080416908) had independently failed the same case (132 px). This was investigated rather than retried away.

The browser can move the viewport before delivering its scroll observer. A source-attested Linux trace showed native offset 0 while the attached virtualizer still cached 135. Cancelling smooth movement queues row remeasurement; if that runs first, it compensates against the stale offset. A deterministic boundary regression captured the original order and failed before the fix at **215 px instead of 0**. The existing explicit-input owner now publishes a changed native offset through the supplied observer callback before that queued measurement. It adds no backward-scroll inference, passive-listener change, timeout, dependency patch, or private-field mutation. This restores the [documented manual-scroll behavior](https://docs.openclaw.ai/web/control-ui#what-it-can-do-today).

Validation of the integrated candidate:

- **560 unit tests / 10 files passed**, including all 79 controller/page-scroll tests for restoration, idle, stationary/downward input, typing, reveal, resize and delayed native offset delivery.
- **36 real-Chromium mock-Gateway E2Es / 5 files passed**, including all eight disclosure/measurement cases and the original four composition/recovery suites.
- **121 tests / 26 files passed** in the original Linux two-worker `5/13` workload, with CI's system Chromium and no temporary diagnostic observer. Provider: Blacksmith Testbox; lease `tbx_01m1fwvby1njnphfavceazth0y`; [run](https://github.com/openclaw/openclaw/actions/runs/33580823039); delegated command exit 0. Lease stopped after proof. The linked Actions run can show cleanup cancellation; the delegated command result is authoritative.
- The complete changed gate, focused lint, UI production/test types and `pnpm ui:build` passed. Fresh isolated Codex autoreview of the complete integrated candidate returned scoped-clean at the requested P0 threshold. The [second exact-head hosted run](https://github.com/openclaw/openclaw/actions/runs/33582991371) failed a different submit-responsiveness E2E assertion in shard `10/14`; the test-only repair is described below. **[Final exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33584937810) is green** on `6c78c98fbe1567b951616575fa1f5fd49c6ef032`. The [landing verification](https://github.com/openclaw/openclaw/pull/135738#issuecomment-5503664674) records exact commands and confirms the inspected virtualizer source matches the published package.

The branch was rebased once onto the exact first parent of the historical failing CI merge, and its pre-repair tree was verified identical to that merge. The four composition production files remain byte-identical to the originally reviewed refactor. The frozen temporal oracle and composition screenshots below are retained evidence for that refactor, not a claim that they exercise the new scroll repair.

Inspected synthetic browser proof after the scroll repair (these are mock-Gateway flows, not live-provider tests):

![Recovered assistant text remains separate from the following messages after interruption and return](https://github.com/user-attachments/assets/449478df-cb16-4e5b-be66-4ac806dd693e)

https://github.com/user-attachments/assets/de4334eb-5d52-4ebe-8ae6-a5f21bd10314

The separate reduced-motion capture showed one blank transcript video frame during an instantaneous jump away; bottom messages returned on the next frame. Durable geometry and all assertions passed. A named follow-up records the exact frame for baseline comparison; regression provenance is not established, and this PR does not claim to fix that brief flash.

## Submit fixture repair

The second hosted failure exposed a race in the responsiveness fixture rather than lost operator input. Its unfiltered one-shot `keydown` listener runs on the Meta portion of `Meta+Enter`, so the synthetic next-input task can replace the draft before Enter actually submits it. A deterministic native Meta-down → next-input task → Enter reproduction produced the same failure as CI: the request contained `second prompt` and the submitted draft was empty. The fixture repair uses the default Enter submission event, retains the task-order and next-draft assertions, and adds an exact assertion that the request contains `first prompt`. Modifier shortcuts remain covered by the composer action tests. The corrected browser E2E and all **55 keyboard sibling tests** pass; its payload assertion now checks the unknown RPC parameters as an object rather than accessing an unchecked property. Fresh isolated Codex review is scoped-clean. No additional production change is needed.

## Refactor evidence

- **480 unit tests passed** across transcript construction/grouping, nested activity, agent-run frames, questions, event-to-renderer state, in-flight history, and stream reconciliation.
- **28 real-Chromium mock-Gateway E2E tests passed** across active-turn reconnect recovery, two-pane session placement, agent-run transcripts, and stream reconciliation. This is deterministic browser/Gateway-contract proof, not a claim of authenticated provider/channel testing.
- **37 scenarios / 85 temporal checkpoints exactly match** a separately executed pre-edit baseline. Comparison covers complete ordered output, nested content, keys, timestamps, run/boundary IDs, and within-process array/message identity survival. The recipe is frozen and both captures attest 466 source hashes; earlier checkpoints are serialized immediately so later cache mutations cannot rewrite the oracle.
- Before/after browser recordings use the same unchanged recorder and original event sequence. All five stage reports match in both panes: pre-send, streaming, early durable output, completion, reload. No page errors. Captures were inspected and contain synthetic data only.
- UI production/core test typechecks, ratchets, formatting, i18n, dependency/coercion checks, and all three unused-export scans passed. The full changed-gate run then found one test-fixture lint error; after removing the unused copied fields, focused core lint, a 253-test rerun, UI test types, and the remaining style/script lint checks passed. `pnpm ui:build` passed.
- Diff-scoped deslop completed; independent isolated Codex autoreview returned **scoped-clean at the requested P0 threshold**, with no accepted/actionable findings.

Before and after the refactor, at the early durable-reply boundary (unchanged ordering is intentional):

| Before | After |
| --- | --- |
| ![Before refactor: both panes keep the pending prompt above the saved reply](https://github.com/user-attachments/assets/77b4ef8e-6b7f-4b2f-a62a-3058ce43fc6c) | ![After refactor: both panes preserve the same ordering](https://github.com/user-attachments/assets/a31d9419-df7f-438f-b40f-f8e749a0c704) |

Final candidate flow:

https://github.com/user-attachments/assets/23ec4fa5-cd91-4c8b-abb5-efae321e977d

Characterization coverage was added before production edits for independent before/after ambiguity (including repeated equal values), mixed equal-time streams/tools/keyed preambles, persisted cumulative prefixes through warm-cache updates, and terminal-question session scope. Initial validation required decreasing the assertion baseline after cast removal; the earlier browser capture also waited for cold Vite optimization before the unchanged recorder succeeded. No timing/assertion relaxation or product workaround was used.

Deferred: tightening the fixture-oriented live-tool host fallback belongs to lifecycle reconciliation, not render-local composition. Existing pending internal-system notice work in #134278 is a separate presentation/provenance change; its files do not overlap this refactor. The original queue-order issue remains fixed/closed by #135568.
