### PR TITLE
fix(sessions): reject a blank --store instead of selecting the default store

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -34,20 +34,21 @@ session keys.
 
 Flags:
 
-| Flag                 | Description                                                                   |
-| -------------------- | ----------------------------------------------------------------------------- |
-| `--agent <id>`       | One configured agent store (required for multiple explicit agents).           |
-| `--all-agents`       | Aggregate all configured agent stores.                                        |
-| `--store <path>`     | Legacy store selector path (cannot combine with `--agent` or `--all-agents`). |
-| `--active <minutes>` | Only show sessions updated within the past N minutes.                         |
-| `--limit <n\|all>`   | Max rows to output (default `100`; `all` restores full output).               |
-| `--json`             | Machine-readable output.                                                      |
-| `--verbose`          | Verbose logging.                                                              |
+| Flag                 | Description                                                         |
+| -------------------- | ------------------------------------------------------------------- |
+| `--agent <id>`       | One configured agent store (required for multiple explicit agents). |
+| `--all-agents`       | Aggregate all configured agent stores.                              |
+| `--store <path>`     | Legacy store selector path (cannot combine with `--all-agents`).    |
+| `--active <minutes>` | Only show sessions updated within the past N minutes.               |
+| `--limit <n\|all>`   | Max rows to output (default `100`; `all` restores full output).     |
+| `--json`             | Machine-readable output.                                            |
+| `--verbose`          | Verbose logging.                                                    |
 
 `--store` accepts the documented legacy selector form, including `sessions.json`
 and suffixless custom selectors. OpenClaw resolves that selector to its physical
 SQLite target, verifies the target exists and is usable, and reports the physical
-path it actually read.
+path it actually read. Combine it with `--agent <id>` when you must select the
+configured agent that owns the store.
 
 `openclaw sessions` and the Gateway `sessions.list` RPC are bounded by default
 so large long-lived stores cannot monopolize the CLI process or Gateway event

--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -333,6 +333,54 @@ describe("registerStatusHealthSessionsCommands", () => {
     });
   });
 
+  it.each([
+    { name: "bare sessions", args: ["sessions", "--store", ""], owner: sessionsCommand },
+    { name: "list leaf", args: ["sessions", "list", "--store", ""], owner: sessionsCommand },
+    { name: "list parent", args: ["sessions", "--store", "", "list"], owner: sessionsCommand },
+    {
+      name: "cleanup leaf",
+      args: ["sessions", "cleanup", "--store", ""],
+      owner: sessionsCleanupCommand,
+    },
+    {
+      name: "cleanup parent",
+      args: ["sessions", "--store", "", "cleanup"],
+      owner: sessionsCleanupCommand,
+    },
+    { name: "tail leaf", args: ["sessions", "tail", "--store", ""], owner: sessionsTailCommand },
+    { name: "tail parent", args: ["sessions", "--store", "", "tail"], owner: sessionsTailCommand },
+    {
+      name: "trajectory export leaf",
+      args: ["sessions", "export-trajectory", "--store", ""],
+      owner: exportTrajectoryCommand,
+    },
+    {
+      name: "trajectory export parent",
+      args: ["sessions", "--store", "", "export-trajectory"],
+      owner: exportTrajectoryCommand,
+    },
+  ])("preserves an explicit blank store at the $name boundary", async ({ args, owner }) => {
+    await runCli(args);
+
+    expectCommandOptions(owner, { store: "" });
+  });
+
+  it.each([
+    { name: "bare sessions", args: ["sessions"], owner: sessionsCommand },
+    { name: "list", args: ["sessions", "list"], owner: sessionsCommand },
+    { name: "cleanup", args: ["sessions", "cleanup"], owner: sessionsCleanupCommand },
+    { name: "tail", args: ["sessions", "tail"], owner: sessionsTailCommand },
+    {
+      name: "trajectory export",
+      args: ["sessions", "export-trajectory"],
+      owner: exportTrajectoryCommand,
+    },
+  ])("preserves omitted store at the $name boundary", async ({ args, owner }) => {
+    await runCli(args);
+
+    expectCommandOptions(owner, { store: undefined });
+  });
+
   it("dispatches sessions list as an alias for bare sessions (regression for #81139)", async () => {
     await runCli(["sessions", "list"]);
 

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -63,7 +63,7 @@ function addSessionsListOptions(command: Command): Command {
   return command
     .option("--json", "Output as JSON", false)
     .option("--verbose", "Verbose logging", false)
-    .option("--store <path>", "Path to physical .sqlite session store")
+    .option("--store <path>", "Legacy session store selector path")
     .option("--agent <id>", "Agent id to inspect (required for multiple explicit agents)")
     .option("--all-agents", "Aggregate sessions across all configured agents", false)
     .option("--active <minutes>", "Only show sessions updated within the past N minutes")
@@ -327,7 +327,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
   sessionsCmd
     .command("cleanup")
     .description("Run session-store maintenance now")
-    .option("--store <path>", "Path to physical .sqlite session store")
+    .option("--store <path>", "Legacy session store selector path")
     .option("--agent <id>", "Agent id to maintain (required for multiple explicit agents)")
     .option("--all-agents", "Run maintenance across all configured agents", false)
     .option("--dry-run", "Preview maintenance actions without writing", false)
@@ -399,7 +399,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--session-key <key>", "Session key to tail (default: active sessions or latest)")
     .option("--tail <count>", "Number of existing trajectory events to show", "80")
     .option("--follow", "Continue following for new trajectory events", false)
-    .option("--store <path>", "Path to physical .sqlite session store")
+    .option("--store <path>", "Legacy session store selector path")
     .option("--agent <id>", "Agent id to inspect (required for multiple explicit agents)")
     .option("--all-agents", "Aggregate sessions across all configured agents", false)
     .action(async (opts, command) => {
@@ -432,7 +432,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--session-key <key>", "Session key to export")
     .option("--output <path>", "Output directory name inside .openclaw/trajectory-exports")
     .option("--workspace <path>", "Workspace root for the export (default: current directory)")
-    .option("--store <path>", "Path to physical .sqlite session store")
+    .option("--store <path>", "Legacy session store selector path")
     .option("--agent <id>", "Agent id for resolving the default session store")
     .option("--request-json-base64 <payload>", "Base64url-encoded export request")
     .option("--json", "Output JSON", false)

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -309,6 +309,13 @@ describe("program routes", () => {
     await expectRunFalse(["sessions"], routeArgv("sessions --store"));
   });
 
+  it.each([
+    ["separate empty value", ["node", "openclaw", "sessions", "--store", ""]],
+    ["empty assigned value", routeArgv("sessions --store=")],
+  ])("falls back to Commander for a sessions --store $0", async (_name, argv) => {
+    await expectRunFalse(["sessions"], argv);
+  });
+
   it("returns false for sessions route when --active value is missing", async () => {
     await expectRunFalse(["sessions"], routeArgv("sessions --active"));
   });

--- a/src/commands/export-trajectory.test.ts
+++ b/src/commands/export-trajectory.test.ts
@@ -202,6 +202,22 @@ describe("exportTrajectoryCommand", () => {
     expect(mocks.exportTrajectoryForCommand).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("rejects an %s explicit store before resolving one", async (_label, store) => {
+    const runtime = createRuntime();
+
+    await expectTrajectoryFailure(
+      exportTrajectoryCommand({ sessionKey: "agent:main:telegram:direct:123", store }, runtime),
+      runtime,
+      "--store must not be blank",
+    );
+    expect(mocks.resolveStorePath).not.toHaveBeenCalled();
+    expect(mocks.loadSessionEntryReadOnly).not.toHaveBeenCalled();
+    expect(mocks.exportTrajectoryForCommand).not.toHaveBeenCalled();
+  });
+
   it("routes invalid explicit stores through the command failure owner", async () => {
     const runtime = createRuntime();
     mocks.resolveStorePath.mockReturnValue("/tmp/missing.sqlite");

--- a/src/commands/export-trajectory.test.ts
+++ b/src/commands/export-trajectory.test.ts
@@ -218,6 +218,53 @@ describe("exportTrajectoryCommand", () => {
     expect(mocks.exportTrajectoryForCommand).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["empty", "agent", "", "--agent must not be blank"],
+    ["whitespace-only", "agent", "   ", "--agent must not be blank"],
+    ["empty", "store", "", "--store must not be blank"],
+    ["whitespace-only", "store", "   ", "--store must not be blank"],
+  ])("rejects an %s encoded %s before reading a session", async (_label, field, value, message) => {
+    const runtime = createRuntime();
+    const requestJsonBase64 = Buffer.from(
+      JSON.stringify({ sessionKey: "agent:main:telegram:direct:123", [field]: value }),
+      "utf8",
+    ).toString("base64url");
+
+    await expectTrajectoryFailure(
+      exportTrajectoryCommand({ requestJsonBase64 }, runtime),
+      runtime,
+      message,
+    );
+    expect(mocks.resolveStorePath).not.toHaveBeenCalled();
+    expect(mocks.loadSessionEntryReadOnly).not.toHaveBeenCalled();
+    expect(mocks.exportTrajectoryForCommand).not.toHaveBeenCalled();
+  });
+
+  it("honours a non-blank encoded store and agent", async () => {
+    const runtime = createRuntime();
+    mocks.getRuntimeConfig.mockReturnValue({ agents: { list: [{ id: "main" }, { id: "work" }] } });
+    mocks.resolveStorePath.mockReturnValue("/tmp/encoded-store.json");
+    const requestJsonBase64 = Buffer.from(
+      JSON.stringify({
+        sessionKey: "agent:main:telegram:direct:123",
+        store: "/tmp/encoded-store.json",
+        agent: "work",
+      }),
+      "utf8",
+    ).toString("base64url");
+
+    await exportTrajectoryCommand({ requestJsonBase64 }, runtime);
+
+    expect(mocks.resolveStorePath).toHaveBeenCalledWith("/tmp/encoded-store.json", {
+      agentId: "work",
+    });
+    expect(mocks.loadSessionEntryReadOnly).toHaveBeenCalledWith({
+      agentId: "work",
+      sessionKey: "agent:main:telegram:direct:123",
+      storePath: "/tmp/encoded-store.json",
+    });
+  });
+
   it("routes invalid explicit stores through the command failure owner", async () => {
     const runtime = createRuntime();
     mocks.resolveStorePath.mockReturnValue("/tmp/missing.sqlite");

--- a/src/commands/export-trajectory.ts
+++ b/src/commands/export-trajectory.ts
@@ -122,6 +122,11 @@ export async function exportTrajectoryCommand(
   if (resolvedOpts.agent !== undefined && !requestedAgent) {
     throwTrajectoryExportError("--agent must not be blank");
   }
+  // Same contract as --agent above; a blank value here reaches the configured
+  // default store instead of the one the caller named.
+  if (resolvedOpts.store !== undefined && !resolvedOpts.store.trim()) {
+    throwTrajectoryExportError("--store must not be blank");
+  }
   let targetAgentId: string;
   try {
     targetAgentId = requestedAgent

--- a/src/commands/export-trajectory.ts
+++ b/src/commands/export-trajectory.ts
@@ -1,6 +1,6 @@
 /** CLI command for exporting a session transcript as a trajectory artifact. */
 import path from "node:path";
-import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
+import { readNonBlankString, readStringValue } from "@openclaw/normalization-core/string-coerce";
 import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { ExpectedCliError } from "../cli/failure-output.js";
@@ -67,11 +67,13 @@ function decodeExportTrajectoryRequest(encoded: string): Partial<ExportTrajector
   if (output !== undefined) {
     opts.output = output;
   }
-  const store = readNonBlankString(request.store);
+  // Keep a present-but-blank store or agent so exportTrajectoryCommand rejects it
+  // the way it rejects a blank flag, instead of silently selecting the default.
+  const store = readStringValue(request.store);
   if (store !== undefined) {
     opts.store = store;
   }
-  const agent = readNonBlankString(request.agent);
+  const agent = readStringValue(request.agent);
   if (agent !== undefined) {
     opts.agent = agent;
   }

--- a/src/commands/export-trajectory.ts
+++ b/src/commands/export-trajectory.ts
@@ -124,8 +124,6 @@ export async function exportTrajectoryCommand(
   if (resolvedOpts.agent !== undefined && !requestedAgent) {
     throwTrajectoryExportError("--agent must not be blank");
   }
-  // Same contract as --agent above; a blank value here reaches the configured
-  // default store instead of the one the caller named.
   if (resolvedOpts.store !== undefined && !resolvedOpts.store.trim()) {
     throwTrajectoryExportError("--store must not be blank");
   }

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -70,6 +70,26 @@ function gatewayTransportError(kind: "closed" | "timeout", code?: number): Gatew
   });
 }
 
+function gatewayCleanupResult(storePath: string) {
+  return {
+    agentId: "main",
+    storePath,
+    mode: "enforce",
+    dryRun: false,
+    beforeCount: 3,
+    afterCount: 1,
+    missing: 0,
+    dmScopeRetired: 0,
+    modelRunPruned: 0,
+    pruned: 2,
+    capped: 0,
+    diskBudget: null,
+    wouldMutate: true,
+    applied: true,
+    appliedCount: 1,
+  } as const;
+}
+
 describe("sessionsCleanupCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -111,40 +131,18 @@ describe("sessionsCleanupCommand", () => {
     });
   });
 
-  it.each([
-    ["empty", ""],
-    ["whitespace-only", "   "],
-  ])(
-    "keeps an %s explicit store local instead of delegating default cleanup to the gateway",
-    async (_label, store) => {
-      // Resolve a full result so a regression that delegates fails on the
-      // gateway assertion below instead of throwing on the beforeEach null.
-      mocks.callGateway.mockResolvedValue({
-        agentId: "main",
-        storePath: "/gateway/sessions.json",
-        mode: "enforce",
-        dryRun: false,
-        beforeCount: 3,
-        afterCount: 1,
-        missing: 0,
-        dmScopeRetired: 0,
-        modelRunPruned: 0,
-        pruned: 2,
-        capped: 0,
-        diskBudget: null,
-        wouldMutate: true,
-        applied: true,
-        appliedCount: 1,
-      });
-      const { runtime } = makeRuntime();
-      await sessionsCleanupCommand({ store, enforce: true }, runtime);
+  it("keeps an empty explicit store local instead of delegating default cleanup to the gateway", async () => {
+    // Resolve a full result so a regression that delegates fails on the
+    // gateway assertion below instead of throwing on the beforeEach null.
+    mocks.callGateway.mockResolvedValue(gatewayCleanupResult("/gateway/sessions.json"));
+    const { runtime } = makeRuntime();
+    await sessionsCleanupCommand({ store: "", enforce: true }, runtime);
 
-      expect(mocks.callGateway).not.toHaveBeenCalled();
-      expect(mocks.resolveSessionStoreTargetsOrExit).toHaveBeenCalledWith(
-        expect.objectContaining({ opts: expect.objectContaining({ store }) }),
-      );
-    },
-  );
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.resolveSessionStoreTargetsOrExit).toHaveBeenCalledWith(
+      expect.objectContaining({ opts: expect.objectContaining({ store: "" }) }),
+    );
+  });
 
   it("emits a single JSON object for non-dry runs and applies maintenance", async () => {
     mocks.callGateway.mockRejectedValue(gatewayTransportError("closed"));
@@ -260,23 +258,7 @@ describe("sessionsCleanupCommand", () => {
 
   it("delegates non-store enforcing cleanup through the Gateway writer when reachable", async () => {
     const remoteStorePath = "C:\\Users\\gateway\\.openclaw\\agents\\main\\sessions\\sessions.json";
-    mocks.callGateway.mockResolvedValue({
-      agentId: "main",
-      storePath: remoteStorePath,
-      mode: "enforce",
-      dryRun: false,
-      beforeCount: 3,
-      afterCount: 1,
-      missing: 0,
-      dmScopeRetired: 0,
-      modelRunPruned: 0,
-      pruned: 2,
-      capped: 0,
-      diskBudget: null,
-      wouldMutate: true,
-      applied: true,
-      appliedCount: 1,
-    });
+    mocks.callGateway.mockResolvedValue(gatewayCleanupResult(remoteStorePath));
 
     const { runtime, logs } = makeRuntime();
     await sessionsCleanupCommand(
@@ -376,23 +358,7 @@ describe("sessionsCleanupCommand", () => {
 
   it("preserves a Gateway-owned store path in human output", async () => {
     const remoteStorePath = "C:\\Users\\gateway\\.openclaw\\openclaw-agent.sqlite";
-    mocks.callGateway.mockResolvedValue({
-      agentId: "main",
-      storePath: remoteStorePath,
-      mode: "enforce",
-      dryRun: false,
-      beforeCount: 3,
-      afterCount: 1,
-      missing: 0,
-      dmScopeRetired: 0,
-      modelRunPruned: 0,
-      pruned: 2,
-      capped: 0,
-      diskBudget: null,
-      wouldMutate: true,
-      applied: true,
-      appliedCount: 1,
-    });
+    mocks.callGateway.mockResolvedValue(gatewayCleanupResult(remoteStorePath));
 
     const { runtime, logs } = makeRuntime();
     await sessionsCleanupCommand({ enforce: true }, runtime);

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -117,6 +117,25 @@ describe("sessionsCleanupCommand", () => {
   ])(
     "keeps an %s explicit store local instead of delegating default cleanup to the gateway",
     async (_label, store) => {
+      // Resolve a full result so a regression that delegates fails on the
+      // gateway assertion below instead of throwing on the beforeEach null.
+      mocks.callGateway.mockResolvedValue({
+        agentId: "main",
+        storePath: "/gateway/sessions.json",
+        mode: "enforce",
+        dryRun: false,
+        beforeCount: 3,
+        afterCount: 1,
+        missing: 0,
+        dmScopeRetired: 0,
+        modelRunPruned: 0,
+        pruned: 2,
+        capped: 0,
+        diskBudget: null,
+        wouldMutate: true,
+        applied: true,
+        appliedCount: 1,
+      });
       const { runtime } = makeRuntime();
       await sessionsCleanupCommand({ store, enforce: true }, runtime);
 

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -111,6 +111,22 @@ describe("sessionsCleanupCommand", () => {
     });
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])(
+    "keeps an %s explicit store local instead of delegating default cleanup to the gateway",
+    async (_label, store) => {
+      const { runtime } = makeRuntime();
+      await sessionsCleanupCommand({ store, enforce: true }, runtime);
+
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+      expect(mocks.resolveSessionStoreTargetsOrExit).toHaveBeenCalledWith(
+        expect.objectContaining({ opts: expect.objectContaining({ store }) }),
+      );
+    },
+  );
+
   it("emits a single JSON object for non-dry runs and applies maintenance", async () => {
     mocks.callGateway.mockRejectedValue(gatewayTransportError("closed"));
     mocks.runSessionsCleanup.mockResolvedValue({

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -249,9 +249,11 @@ function renderAppliedSummaries(params: {
 async function maybeRunGatewayCleanup(
   opts: SessionsCleanupOptions,
 ): Promise<{ delegated: true; result: SessionsCleanupResult } | { delegated: false }> {
-  if (opts.store || opts.dryRun) {
+  if (opts.store !== undefined || opts.dryRun) {
     // Explicit store paths and dry-runs must stay local; the gateway only owns
-    // live in-process cleanup for default stores.
+    // live in-process cleanup for default stores. A blank --store counts as
+    // explicit: delegating it would clean the default store the caller was
+    // trying to override, before local validation can reject it.
     return { delegated: false };
   }
   try {

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -250,10 +250,8 @@ async function maybeRunGatewayCleanup(
   opts: SessionsCleanupOptions,
 ): Promise<{ delegated: true; result: SessionsCleanupResult } | { delegated: false }> {
   if (opts.store !== undefined || opts.dryRun) {
-    // Explicit store paths and dry-runs must stay local; the gateway only owns
-    // live in-process cleanup for default stores. A blank --store counts as
-    // explicit: delegating it would clean the default store the caller was
-    // trying to override, before local validation can reject it.
+    // Explicit store paths and dry-runs stay local; sessions.cleanup takes no store param.
+    // A blank --store is explicit too: delegating it would clean the default store.
     return { delegated: false };
   }
   try {

--- a/src/config/sessions/targets.selection.test.ts
+++ b/src/config/sessions/targets.selection.test.ts
@@ -7,4 +7,11 @@ describe("session store target selection", () => {
       "--agent must not be blank",
     );
   });
+
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("rejects an %s store instead of selecting the default store", (_label, store) => {
+    expect(() => resolveSessionStoreTargets({}, { store })).toThrow("--store must not be blank");
+  });
 });

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -663,7 +663,6 @@ export function resolveSessionStoreTargets(
   if (opts.agent !== undefined && !requestedAgent) {
     throw new Error("--agent must not be blank");
   }
-  // An explicitly blank --store is not "no store": it would select the default one.
   if (opts.store !== undefined && !opts.store.trim()) {
     throw new Error("--store must not be blank");
   }

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -663,6 +663,10 @@ export function resolveSessionStoreTargets(
   if (opts.agent !== undefined && !requestedAgent) {
     throw new Error("--agent must not be blank");
   }
+  // An explicitly blank --store is not "no store": it would select the default one.
+  if (opts.store !== undefined && !opts.store.trim()) {
+    throw new Error("--store must not be blank");
+  }
   const hasAgent = requestedAgent !== undefined;
   const allAgents = opts.allAgents === true;
   if (hasAgent && allAgents) {


### PR DESCRIPTION
## What Problem This Solves

An explicitly present but blank `sessions --store` value was treated like an omitted option. A shell-expanded empty variable could therefore list, clean, tail, or export from the configured default session store instead of the named store.

## Why This Change Was Made

The shared session selector now rejects a present blank store before default resolution. Cleanup also treats store presence as local work before any Gateway call. Trajectory export preserves blank direct and encoded values until the command-level guard rejects them.

Omission remains the default-store path. No compatibility alias or fallback was added.

The CLI help and sessions guide now describe `--store` as a legacy selector and document its valid use with a matching `--agent`.

## User Impact

- `--store ""`, `--store "   "`, and `--store=` fail with `--store must not be blank`.
- Omitting `--store` keeps the existing configured or default store behavior.
- Nonblank selectors keep the existing legacy-to-SQLite resolution and validation behavior.

## Evidence

Current `main` at `87ecc61b1dde2a511347469bfde2055be22af9fd` reproduced the defect through the real TypeScript CLI entry point. Empty direct, leaf, inherited-parent, and encoded store values reached the same default paths as omission. A nonblank missing selector reached explicit-store validation, which confirmed the test did not bypass selector handling.

The repaired tree passed:

- 161 focused tests across session target resolution, cleanup routing, trajectory export, Commander registration, and fast routing.
- A real CLI matrix for bare `sessions`, `sessions list`, cleanup, tail, direct export, encoded export, parent/leaf placement, omission, empty input, whitespace input, `--store=`, and a nonblank control.
- `pnpm check:changed`.
- `pnpm docs:check-mdx`.
- `pnpm docs:check-links` with zero broken links.

All runs used isolated session state. The cleanup proof used `--dry-run`; it did not touch an operator store.
