### PR TITLE
refactor(feishu): share provider prefix stripping

### DIFF
--- a/extensions/feishu/src/subagent-hooks.ts
+++ b/extensions/feishu/src/subagent-hooks.ts
@@ -4,12 +4,8 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { buildFeishuConversationId, parseFeishuConversationId } from "./conversation-id.js";
-import { normalizeFeishuTarget } from "./targets.js";
+import { normalizeFeishuTarget, stripFeishuProviderPrefix } from "./targets.js";
 import { getFeishuThreadBindingManager } from "./thread-bindings.js";
-
-function stripProviderPrefix(raw: string): string {
-  return raw.replace(/^(feishu|lark):/i, "").trim();
-}
 
 function resolveFeishuRequesterConversation(params: {
   accountId?: string;
@@ -26,7 +22,7 @@ function resolveFeishuRequesterConversation(params: {
     return null;
   }
   const rawTo = params.to?.trim();
-  const withoutProviderPrefix = rawTo ? stripProviderPrefix(rawTo) : "";
+  const withoutProviderPrefix = rawTo ? stripFeishuProviderPrefix(rawTo) : "";
   const normalizedTarget = rawTo ? normalizeFeishuTarget(rawTo) : null;
   const threadId =
     params.threadId != null && params.threadId !== "" ? String(params.threadId).trim() : "";

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -6,7 +6,7 @@ const CHAT_ID_PREFIX = "oc_";
 const OPEN_ID_PREFIX = "ou_";
 const USER_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 
-function stripProviderPrefix(raw: string): string {
+export function stripFeishuProviderPrefix(raw: string): string {
   return raw.replace(/^(feishu|lark):/i, "").trim();
 }
 
@@ -30,7 +30,7 @@ export function normalizeFeishuTarget(raw: string): string | null {
     return null;
   }
 
-  const withoutProvider = stripProviderPrefix(trimmed);
+  const withoutProvider = stripFeishuProviderPrefix(trimmed);
   const lowered = normalizeLowercaseStringOrEmpty(withoutProvider);
   if (lowered.startsWith("chat:")) {
     return withoutProvider.slice("chat:".length).trim() || null;
@@ -81,7 +81,7 @@ export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "user_
 }
 
 export function looksLikeFeishuId(raw: string): boolean {
-  const trimmed = stripProviderPrefix(raw.trim());
+  const trimmed = stripFeishuProviderPrefix(raw.trim());
   if (!trimmed) {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

Feishu provider-prefix normalization had two identical private implementations. Keeping the same policy in both target parsing and subagent routing made future behavior drift more likely.

## Why This Change Was Made

This keeps the existing implementation in the Feishu target owner, exports it as `stripFeishuProviderPrefix`, and reuses it from subagent routing. The helper body and all call ordering remain unchanged: one leading `feishu:` or `lark:` prefix is stripped case-insensitively, surrounding whitespace is trimmed, remaining case and empty outcomes are preserved, and target classification behavior is unchanged.

The change is intentionally owner-internal: no Plugin SDK, barrel, manifest, config, dependency, documentation, or test surface changes.

## User Impact

No user-visible behavior changes. Feishu target and subagent routing now share one canonical provider-prefix policy.

## Evidence

- Scope: exactly `extensions/feishu/src/targets.ts` and `extensions/feishu/src/subagent-hooks.ts`
- Replayed head: `0790dc9159fc6a7447596410d7cf51bdadcbf60a`
- Replayed tree: `c2a6f4b305e1acacda99625986b98660999fd783`
- Current-main parent: `29f388fb80cd77ca9702afad8fc1eb0e33215e1b`
- Replay verification: one validly signed commit; `git range-diff` reports exact equality with the original change; patch SHA-256 `1dbc0546208f02cf60c925b8334c6ca423ff08382745d06601136b6a57403b81`
- Production delta: +5/-9, net -4; tests +0/-0
- Exact scope: only `extensions/feishu/src/subagent-hooks.ts` and `extensions/feishu/src/targets.ts`
- Current-main target blobs matched the original parent before replay; no Feishu conflict or semantic drift
- Post-replay focused Feishu proof: 3 files, 265/265 tests passed
- Post-replay full Feishu extension lane: 101 files, 1,969/1,969 tests passed
- Changed-file formatting, lint, exact-scope, and `git diff --check` proof passed
- Fresh Autoreview: scoped clean, no accepted findings, patch correct with 0.99 confidence
- Native frozen-head review: `READY FOR /prepare-pr`, findings 0, artifacts validated
- ClawSweeper rank-up move completed: the requested maintainer review is recorded in the validated native review artifacts
- The broad local extension-test typecheck encountered a missing `yargs-parser` dependency in the unrelated Browser plugin's shared worktree dependency tree; exact-head hosted CI passed
- Exact-head CI run `33686457463` attempt 1 failed only in unrelated jobs `100435230281` (`checks-ui (3/3)`, Chromium session timeout after 293 files passed) and `100435234488` (`checks-node-core-tooling-12`, one deadline-retention assertion after 1,429 tests passed), plus the aggregate gate
- Repository-native failed-only retry attempt 2 passed on unchanged head: replacements `100442723851` and `100442744642`, with aggregate `openclaw/ci-gate` job `100444772415` green
- Codex hard-gate inspection: `openai/codex` `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`
- Live overlap recheck found no other open PR touching either changed file
