### PR TITLE
feat(macos): render Mermaid diagrams in native chat

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -2194,7 +2194,7 @@
     {"id":"native.apple.1035cc63963063c2","source":"Copy cookies from a Chrome-family profile into an isolated managed profile.","surface":"apple","sites":[{"kind":"ui-named-argument","path":"apps/macos/Sources/OpenClaw/GeneralSettings.swift"}]},
     {"id":"native.apple.3cdced3b67c32382","source":"Copy device","surface":"apple","sites":[{"kind":"ui-named-argument","path":"apps/ios/Sources/Design/AgentProNodesDestination.swift"}]},
     {"id":"native.apple.97976994d906bdf8","source":"Copy diagnostics","surface":"apple","sites":[{"kind":"ui-call","path":"apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift"}]},
-    {"id":"native.apple.f587edea5b005eee","source":"Copy diagram source","surface":"apple","sites":[{"kind":"ui-modifier","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift"}]},
+    {"id":"native.apple.f587edea5b005eee","source":"Copy diagram source","surface":"apple","sites":[{"kind":"ui-call","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift"},{"kind":"ui-modifier","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift"}]},
     {"id":"native.apple.908f6d2c89a40243","source":"Copy error","surface":"apple","sites":[{"kind":"ui-call","path":"apps/macos/Sources/OpenClaw/OnboardingAISetupView.swift"}]},
     {"id":"native.apple.5ad5b8ff04df6234","source":"Copy full ID","surface":"apple","sites":[{"kind":"ui-modifier","path":"apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift"}]},
     {"id":"native.apple.203aca2c602f831c","source":"Copy full commit hash","surface":"apple","sites":[{"kind":"ui-call","path":"apps/ios/Sources/Design/SettingsProTabSupport.swift"},{"kind":"ui-call","path":"apps/macos/Sources/OpenClaw/AboutSettings.swift"}]},

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -72,7 +72,7 @@ private final class QuickChatRecentMenuTarget: NSObject {
 
 @MainActor
 @Observable
-final class QuickChatController: NSObject, NSWindowDelegate {
+final class QuickChatController: NSObject {
     typealias GlobalMonitorInstaller = (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> Any?
     typealias LocalMonitorInstaller = (NSEvent.EventTypeMask, @escaping (NSEvent) -> NSEvent?) -> Any?
     typealias MonitorClearer = (inout Any?) -> Void
@@ -284,26 +284,6 @@ final class QuickChatController: NSObject, NSWindowDelegate {
 
     func dismiss() {
         self.dismiss(immediate: false)
-    }
-
-    func windowDidResignKey(_: Notification) {
-        guard self.canDismissForOutsideInteraction else { return }
-        let transitionID = self.transitionID
-        // Let AppKit finish handing key status to the destination before checking its owner.
-        // A queued check must not close a later presentation.
-        DispatchQueue.main.async { [weak self] in
-            guard let self, self.transitionID == transitionID else { return }
-            self.dismissIfFocusWasLost()
-        }
-    }
-
-    @objc
-    private func childWindowDidResignKey(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow,
-              window !== self.panel,
-              self.ownsWindow(window)
-        else { return }
-        self.windowDidResignKey(notification)
     }
 
     private func dismiss(immediate: Bool) {
@@ -968,4 +948,26 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         self.handleSendAccepted(openChat: openChat)
     }
     #endif
+}
+
+extension QuickChatController: NSWindowDelegate {
+    func windowDidResignKey(_: Notification) {
+        guard self.canDismissForOutsideInteraction else { return }
+        let transitionID = self.transitionID
+        // Let AppKit finish handing key status to the destination before checking its owner.
+        // A queued check must not close a later presentation.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.transitionID == transitionID else { return }
+            self.dismissIfFocusWasLost()
+        }
+    }
+
+    @objc
+    private func childWindowDidResignKey(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              window !== self.panel,
+              self.ownsWindow(window)
+        else { return }
+        self.windowDidResignKey(notification)
+    }
 }

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -681,7 +681,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         var current = window
         while let window = current {
             if window === panel { return true }
-            current = window.sheetParent ?? window.parentWindow
+            current = window.sheetParent ?? window.parent
         }
         return false
     }

--- a/apps/macos/Sources/OpenClaw/QuickChatController.swift
+++ b/apps/macos/Sources/OpenClaw/QuickChatController.swift
@@ -229,6 +229,7 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         self.recentSessionsTask?.cancel()
         self.recentSessionsTask = nil
         self.replyBinding.clear()
+        NotificationCenter.default.removeObserver(self, name: NSWindow.didResignKeyNotification, object: nil)
         self.panel?.delegate = nil
         self.panel = nil
         self.hostingView = nil
@@ -286,16 +287,23 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     }
 
     func windowDidResignKey(_: Notification) {
-        guard self.isVisible else { return }
-        // System permission dialogs steal key focus mid-grant; the bar must survive that flow.
-        guard !self.model.isGrantingPermissions,
-              !self.model.isStartingDictation,
-              !self.model.isCapturingTextContext,
-              !self.replyBinding.isPastingReply,
-              self.windowPicker?.isInteractionActive != true,
-              !self.isMenuActive
+        guard self.canDismissForOutsideInteraction else { return }
+        let transitionID = self.transitionID
+        // Let AppKit finish handing key status to the destination before checking its owner.
+        // A queued check must not close a later presentation.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.transitionID == transitionID else { return }
+            self.dismissIfFocusWasLost()
+        }
+    }
+
+    @objc
+    private func childWindowDidResignKey(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              window !== self.panel,
+              self.ownsWindow(window)
         else { return }
-        self.dismiss()
+        self.windowDidResignKey(notification)
     }
 
     private func dismiss(immediate: Bool) {
@@ -363,6 +371,12 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         panel.contentView = host
         self.panel = panel
         self.hostingView = host
+        // Sheets retain SwiftUI's delegate; observe their focus loss without replacing it.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.childWindowDidResignKey(_:)),
+            name: NSWindow.didResignKeyNotification,
+            object: nil)
     }
 
     private func makeView() -> QuickChatView {
@@ -447,11 +461,16 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     }
 
     private func focusEditor() {
-        guard self.isVisible, let panel = self.panel, let textView = self.textView else { return }
+        guard self.isVisible, let panel = self.panel, panel.attachedSheet == nil,
+              let textView = self.textView
+        else { return }
         panel.makeKeyAndOrderFront(nil)
         panel.makeFirstResponder(textView)
+        let transitionID = self.transitionID
         DispatchQueue.main.async { [weak self, weak panel, weak textView] in
-            guard let self, self.isVisible, let panel, let textView else { return }
+            guard let self, self.isVisible, self.transitionID == transitionID,
+                  let panel, panel.attachedSheet == nil, let textView
+            else { return }
             panel.makeFirstResponder(textView)
         }
     }
@@ -642,8 +661,29 @@ final class QuickChatController: NSObject, NSWindowDelegate {
     }
 
     private func dismissIfFocusWasLost() {
-        guard self.isVisible, self.panel?.isKeyWindow != true else { return }
+        guard self.canDismissForOutsideInteraction, !self.ownsWindow(NSApp?.keyWindow) else { return }
         self.dismiss()
+    }
+
+    /// These flows intentionally move focus outside the bar without ending its presentation.
+    private var canDismissForOutsideInteraction: Bool {
+        self.isVisible &&
+            !self.model.isGrantingPermissions &&
+            !self.model.isStartingDictation &&
+            !self.model.isCapturingTextContext &&
+            !self.replyBinding.isPastingReply &&
+            self.windowPicker?.isInteractionActive != true &&
+            !self.isMenuActive
+    }
+
+    private func ownsWindow(_ window: NSWindow?) -> Bool {
+        guard let panel = self.panel else { return false }
+        var current = window
+        while let window = current {
+            if window === panel { return true }
+            current = window.sheetParent ?? window.parentWindow
+        }
+        return false
     }
 
     private func cancelPasteRequest() {
@@ -659,30 +699,19 @@ final class QuickChatController: NSObject, NSWindowDelegate {
         guard self.monitoringEnabled, self.globalMonitor == nil, self.localMonitor == nil else { return }
         let mouseEvents: NSEvent.EventTypeMask = [.leftMouseDown, .rightMouseDown, .otherMouseDown]
         // Global and local monitors are paired because global monitors omit this app's clicks.
+        // AppKit calls both on the main thread; classify the recipient before it can detach.
         self.globalMonitor = self.globalMonitorInstaller(mouseEvents) { [weak self] _ in
-            let point = NSEvent.mouseLocation
-            Task { @MainActor in self?.dismissIfClickOutside(at: point) }
+            MainActor.assumeIsolated { self?.dismissIfClickOutside(window: nil) }
         }
         self.localMonitor = self.localMonitorInstaller(mouseEvents) { [weak self] event in
-            let point = NSEvent.mouseLocation
-            Task { @MainActor in self?.dismissIfClickOutside(at: point) }
+            MainActor.assumeIsolated { self?.dismissIfClickOutside(window: event.window) }
             return event
         }
     }
 
-    private func dismissIfClickOutside(at point: NSPoint) {
-        guard self.isVisible,
-              !self.model.isGrantingPermissions,
-              !self.model.isStartingDictation,
-              !self.model.isCapturingTextContext,
-              !self.replyBinding.isPastingReply,
-              self.windowPicker?.isInteractionActive != true,
-              !self.isMenuActive,
-              let panel = self.panel
-        else { return }
-        if !panel.frame.contains(point) {
-            self.dismiss()
-        }
+    private func dismissIfClickOutside(window: NSWindow?) {
+        guard self.canDismissForOutsideInteraction, !self.ownsWindow(window) else { return }
+        self.dismiss()
     }
 
     private func showAgentPicker() {

--- a/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/QuickChatControllerTests.swift
@@ -143,6 +143,31 @@ struct QuickChatControllerTests {
         #expect(clearedMonitorCount == 2)
     }
 
+    @Test func `deferred focus loss cannot dismiss a newer presentation`() async throws {
+        let model = Self.makeModel()
+        let controller = QuickChatController(enableUI: false, model: model, monitoringEnabled: false)
+        defer { controller.stop() }
+        controller.present()
+        let firstPresentation = try #require(model.activePresentationID)
+
+        controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        controller.dismiss()
+        controller.present()
+        let nextPresentation = try #require(model.activePresentationID)
+        #expect(nextPresentation != firstPresentation)
+
+        await Self.drainMainQueue()
+
+        #expect(controller.isVisible)
+        #expect(model.activePresentationID == nextPresentation)
+
+        controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        await Self.drainMainQueue()
+
+        #expect(!controller.isVisible)
+        #expect(model.activePresentationID == nil)
+    }
+
     @Test func `resign key keeps bar visible while granting permissions`() async {
         let latch = GrantLatch()
         let model = QuickChatModel(
@@ -185,6 +210,7 @@ struct QuickChatControllerTests {
             await Task.yield()
         }
         controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        await Self.drainMainQueue()
         #expect(!controller.isVisible)
         controller.stop()
     }
@@ -230,6 +256,7 @@ struct QuickChatControllerTests {
             await Task.yield()
         }
         controller.windowDidResignKey(Notification(name: NSWindow.didResignKeyNotification))
+        await Self.drainMainQueue()
         #expect(!controller.isVisible)
         controller.stop()
     }
@@ -240,6 +267,12 @@ struct QuickChatControllerTests {
         }
         await TestIsolation.withUserDefaultsValues([quickChatEnabledKey: false]) {
             #expect(!AppState(preview: true).quickChatEnabled)
+        }
+    }
+
+    private static func drainMainQueue() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
@@ -101,10 +101,6 @@ private struct ChatMathPlatformView: NSViewRepresentable {
     }
 
     func updateNSView(_ view: MTMathUILabel, context: Context) {
-        self.configure(view)
-    }
-
-    private func configure(_ view: MTMathUILabel) {
         view.displayErrorInline = false
         view.labelMode = .display
         view.textAlignment = .center
@@ -113,6 +109,11 @@ private struct ChatMathPlatformView: NSViewRepresentable {
         if view.latex != self.latex {
             view.latex = self.latex
         }
+    }
+
+    /// SwiftMath reports fittingSize on macOS; SwiftUI's default bridge can collapse it in split views.
+    func sizeThatFits(_ _: ProposedViewSize, nsView: MTMathUILabel, context _: Context) -> CGSize? {
+        nsView.fittingSize
     }
 }
 #else

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
@@ -11,7 +11,7 @@ struct ChatCodeBlockView: View {
     let block: ChatCodeBlock
 
     var body: some View {
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
         if self.block.language == "mermaid", self.block.isComplete {
             ChatMermaidBlockView(source: self.block.code)
         } else {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift
@@ -19,6 +19,10 @@ struct ChatMermaidBlockView: View {
     @State private var token: UUID?
     @State private var generation = UUID()
     @State private var showSource = false
+    #if os(macOS)
+    @State private var isHovered = false
+    @FocusState private var copyIsFocused: Bool
+    #endif
     /// Keep the selected preview stable while rotation re-renders the inline diagram.
     @State private var expanded: PreviewSelection?
 
@@ -36,11 +40,23 @@ struct ChatMermaidBlockView: View {
                     self.copySource()
                 } label: {
                     Image(systemName: "doc.on.doc")
-                        .frame(width: 44, height: 44)
+                        .frame(width: self.controlSize, height: self.controlSize)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Copy diagram source")
+                #if os(macOS)
+                .help("Copy diagram source")
+                .focused(self.$copyIsFocused)
+                .opacity(self.isHovered || self.copyIsFocused ? 1 : 0)
+                #endif
                 Menu {
+                    #if os(macOS)
+                    Button {
+                        self.copySource()
+                    } label: {
+                        Text("Copy diagram source").font(OpenClawChatTypography.body)
+                    }
+                    #endif
                     Button {
                         self.showSource.toggle()
                     } label: {
@@ -65,9 +81,15 @@ struct ChatMermaidBlockView: View {
                     }
                 } label: {
                     Image(systemName: "ellipsis")
-                        .frame(width: 44, height: 44)
+                        .frame(width: self.controlSize, height: self.controlSize)
                 }
                 .accessibilityLabel("Diagram options")
+                #if os(macOS)
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("Diagram options")
+                #endif
             }
             .foregroundStyle(.secondary)
             if self.showSource {
@@ -105,9 +127,18 @@ struct ChatMermaidBlockView: View {
         .onChange(of: self.request, initial: true) { _, _ in self.render() }
         .onDisappear { self.cancel() }
         #if os(macOS)
+        .onHover { self.isHovered = $0 }
         .sheet(item: self.$expanded) { self.preview($0) }
         #else
         .fullScreenCover(item: self.$expanded) { self.preview($0) }
+        #endif
+    }
+
+    private var controlSize: CGFloat {
+        #if os(macOS)
+        28
+        #else
+        44
         #endif
     }
 
@@ -226,6 +257,9 @@ private struct ChatMermaidPreviewView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Close diagram preview")
+                #if os(macOS)
+                .keyboardShortcut(.cancelAction)
+                #endif
             }
             if self.failed {
                 Text("Diagram preview unavailable")

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift
@@ -272,6 +272,8 @@ private struct ChatMermaidPreviewView: View {
         .background(OpenClawChatTheme.assistantBubble)
         #if os(macOS)
         .frame(minWidth: 500, idealWidth: 900, minHeight: 350, idealHeight: 600)
+        // Mac sheets default to a form width; fit both axes so Expand honors the ideal size.
+        .presentationSizing(.fitted)
         #endif
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMermaidBlockView.swift
@@ -271,7 +271,7 @@ private struct ChatMermaidPreviewView: View {
         }
         .background(OpenClawChatTheme.assistantBubble)
         #if os(macOS)
-        .frame(minWidth: 500, minHeight: 350)
+        .frame(minWidth: 500, idealWidth: 900, minHeight: 350, idealHeight: 600)
         #endif
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMathBlockViewTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMathBlockViewTests.swift
@@ -1,0 +1,91 @@
+#if os(macOS)
+import AppKit
+import SwiftMath
+import SwiftUI
+import Testing
+@testable import OpenClawChatUI
+
+@MainActor
+struct ChatMathBlockViewTests {
+    @Test(arguments: [false, true])
+    func `display math retains its typeset bounds in transcript layout`(usesSplitView: Bool) throws {
+        _ = NSApplication.shared
+        let message = OpenClawChatMessage(
+            role: "assistant",
+            content: [OpenClawChatMessageContent(
+                type: "text",
+                text: "Before the equation.\n\n$$E = mc^2$$\n\nAfter the equation.",
+                mimeType: nil,
+                fileName: nil,
+                content: nil)],
+            timestamp: nil)
+        let content = ScrollView {
+            LazyVStack(alignment: .leading) {
+                ChatMessageBubble(
+                    message: message,
+                    style: .standard,
+                    markdownVariant: .standard,
+                    userAccent: nil,
+                    displayOptions: [],
+                    assistantName: "OpenClaw",
+                    assistantAvatarText: "OC",
+                    assistantAvatarTint: nil,
+                    showsAssistantAvatar: usesSplitView,
+                    isClean: true,
+                    contextWindowTokens: nil,
+                    userMessageExpanded: false,
+                    onToggleUserMessageExpanded: {},
+                    inlineWidgetResolverReady: false,
+                    inlineWidgetResourceResolver: { _, _ in nil },
+                    mediaArtifactResolverReady: false,
+                    mediaPlaybackAllowed: { false },
+                    loadMediaArtifact: { _, _, _ in nil })
+            }
+            .frame(maxWidth: .infinity)
+        }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 960, height: 680),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false)
+        let host: NSView
+        if usesSplitView {
+            // Full chat's split-view host can collapse an equation that sizes
+            // correctly in Quick Chat's direct host. Exercise both containers.
+            let controller = NSHostingController(rootView: NavigationSplitView {
+                Text("Sessions")
+                    .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 340)
+            } detail: {
+                content
+            })
+            window.contentViewController = controller
+            controller.sceneBridgingOptions = [.toolbars]
+            host = controller.view
+        } else {
+            host = NSHostingView(rootView: content)
+            window.contentView = host
+        }
+        defer {
+            window.contentViewController = nil
+            window.contentView = nil
+        }
+
+        for layoutWidth in [CGFloat(960), CGFloat(620), CGFloat(960)] {
+            window.setContentSize(NSSize(width: layoutWidth, height: 400))
+            host.layoutSubtreeIfNeeded()
+            let label = try #require(Self.mathLabel(in: host))
+            #expect(label.error == nil)
+            let typesetSize = label.fittingSize
+            #expect(typesetSize.width > 0)
+            #expect(typesetSize.height > 0)
+            #expect(label.bounds.width + 0.5 >= typesetSize.width)
+            #expect(label.bounds.height + 0.5 >= typesetSize.height)
+        }
+    }
+
+    private static func mathLabel(in view: NSView) -> MTMathUILabel? {
+        if let label = view as? MTMathUILabel { return label }
+        return view.subviews.lazy.compactMap { Self.mathLabel(in: $0) }.first
+    }
+}
+#endif

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -18,6 +18,21 @@ The full chat window is a native split view:
 
 The anchored compact chat panel from the menu bar keeps the compact single-column layout with the same model, thinking, verbosity, and Fast controls inline, plus starter prompts, Talk Mode, voice notes, and Listen. Assistant reasoning and tool activity remain hidden in this compact surface.
 
+## Diagrams
+
+Completed fenced blocks labeled `mermaid` render as diagrams in native chat,
+including Quick Chat. Rendering runs locally using bundled assets. A fence is
+complete when its closing delimiter arrives or the response finishes; incomplete
+streaming fences remain code.
+
+Use the small options button at the top right to view or copy the source and
+expand the diagram. The copy button also appears on hover or keyboard focus.
+Click the diagram to open its vector preview, where you can zoom and pan. Close
+the preview with its close button or Escape.
+
+Invalid or oversized diagrams keep their source readable. Temporary rendering
+failures offer **Retry diagram** in the options menu.
+
 ## Session colors
 
 Right-click a session in the sidebar, or open its menu-bar session submenu, and choose **Color**. Select red, blue, green, yellow, purple, orange, pink, or cyan. **Default** clears the color.
@@ -107,7 +122,7 @@ Disable the feature entirely with **Settings → General → Quick Chat**; the s
 - Session groups: `sessions.groups.list`, `sessions.groups.put`, `sessions.groups.rename`, and `sessions.groups.delete` own the path-free group catalog. Write-scoped `sessions.groups.defaults` and `sessions.groups.update` own optional New Session folder/worktree defaults. Membership is the session `category` updated through `sessions.patch` or assigned during `sessions.create`.
 - Unread state: after a session activates and its live history loads successfully, the app clears the unread state it observed. A manual unread marker created while that session is already open remains through refreshes and run completion; leave and reopen the session, or mark it read explicitly, to clear it. Failed history loads do not clear unread state, and a transient patch failure retries on the next activation. During staggered upgrades, an older active app can still send a bare read acknowledgement that clears the marker. Cross-client protection therefore requires every active app to support the acknowledgement contract; update all connected clients before relying on the reminder.
 - Onboarding uses a dedicated session to keep first-run setup separate.
-- Offline cache: the app keeps a small read-only cache of recent chat sessions and transcripts per gateway (`~/Library/Application Support/OpenClaw/chat-cache.sqlite`): cold opens paint the last known transcript immediately and refresh once the Gateway responds, and recent chats stay browsable while disconnected (sending stays disabled until the connection is back).
+- Offline storage: recent sessions and transcripts are cached per Gateway in `~/Library/Application Support/OpenClaw/databases/gateway-cache.sqlite`. Client-owned pending commands and routing state live separately in `client-state.sqlite` in the same directory. Cold opens paint cached transcripts before the connection is ready and refresh once the Gateway responds.
 
 ## Security surface
 

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -28,7 +28,9 @@ streaming fences remain code.
 Use the small options button at the top right to view or copy the source and
 expand the diagram. The copy button also appears on hover or keyboard focus.
 Click the diagram to open its vector preview, where you can zoom and pan. Close
-the preview with its close button or Escape.
+the preview with its close button or Escape. In Quick Chat, closing the preview
+returns to the reply; clicking outside both the bar and its preview dismisses
+Quick Chat.
 
 Invalid or oversized diagrams keep their source readable. Temporary rendering
 failures offer **Retry diagram** in the options menu.


### PR DESCRIPTION
Related: #135293

Follows the landed Android implementation in #135342 and shared Apple/iOS implementation in #135470.

## What Problem This Solves

Mac chat and Quick Chat show Mermaid source instead of the diagrams available in the Control UI and mobile apps. Completed diagrams now render inline with compact controls. This also fixes missing display equations in full chat and Quick Chat conversations disappearing when their expanded preview opens.

## Why This Change Was Made

Mac reuses the shared Apple renderer and pinned offline assets introduced for iOS. A bounded WebKit renderer produces native transcript images; expanded previews display sanitized SVG with JavaScript disabled.

The fixes stay with their owners. Quick Chat recognizes its attached window family and ties deferred focus checks to the presentation that scheduled them. The math bridge reports SwiftMath’s measured size to SwiftUI, preventing a split-view host from allocating an equation zero space. The Mac preview explicitly fits both axes so its existing 900×600 ideal size is honored.

## User Impact

Users can read or copy source and expand a diagram from the small corner menu. Copy also appears on hover or keyboard focus, and clicking the diagram opens the vector preview. Close or Escape returns to the conversation. Invalid diagrams retain readable source, temporary failures offer Retry, and incomplete streaming fences remain code.

The native chat documentation describes these controls and the correct cache locations. No Gateway configuration, permission, persistent store or database migration is added.

## Evidence

**Final source: `9d495af861022b32d6ad63697a81b869763e1118`.** All checks completed: **169 passed, 15 skipped, zero pending or failed**, including the required CI gate, Mac tests/release build, iOS build, iPhone/iPad screenshot tests and all selected Periphery scans. [Main CI](https://github.com/openclaw/openclaw/actions/runs/33591672403), [iOS Periphery](https://github.com/openclaw/openclaw/actions/runs/33591672392), [shared-kit Periphery and intersection](https://github.com/openclaw/openclaw/actions/runs/33591672443).

| Surface | Before | After — final 9d495af8 |
| --- | --- | --- |
| Full chat | ![Mac chat before Mermaid rendering](https://github.com/user-attachments/assets/c5b49620-9375-42bb-9e4d-e59b88063665) | ![Mac chat renders the reference diagram and display equation](https://github.com/user-attachments/assets/c6a53cb9-ede8-4c58-b305-45abb3e28f64) |
| Quick Chat | ![Quick Chat before Mermaid rendering](https://github.com/user-attachments/assets/ce79871c-003e-4a2a-9681-cbfcaa0cc192) | ![Quick Chat renders the diagram and equation with compact controls](https://github.com/user-attachments/assets/cdba59b7-679a-4a56-9243-deee9e4fb619) |

![Expanded Mermaid preview with native Close control](https://github.com/user-attachments/assets/b0c8b990-0648-47f8-a466-cc21e6cab700)

These are unedited app-window captures of synthetic messages, inspected independently before upload. Before uses the older pre-feature build `d903d89736807b10c29ba9e8358535de22fbf363`, rather than the immediate parent. All after images were freshly captured from the final 9d build. Both app builds are signed by OpenClaw Foundation.

- **Final signed build:** the canonical arm64 Debug package passed, including runtime JavaScript, native code, MLX, offline resources, the bundled worker and post-sign worker checks. It uses the supported runtime-only mode that omits SDK declaration emission. The installed app’s commit, executable, five Mermaid resources and Developer ID signature were verified in the isolated Mac VM.
- **Final native interactions:** full chat and Quick Chat render the reference graph and `E = mc²`. Source/view switching, menu expansion and direct-image activation work. Both previews measure 900×600. Mouse Close and Escape return to the conversation. Quick Chat retains its parent while the larger sheet is open, dismisses both on an outside click, reopens as an empty 620×56 bar, and dismisses on a switch to Finder. The same app process remains running. Source Copy matches all 279 bytes; Quick Chat Copy replaced a distinct clipboard marker.
- **Final controller tests:** a fresh build from clean 9d ran all eight Quick Chat tests in the VM: eight passed, none failed or skipped. This includes stale-presentation focus fencing and permission/capture focus behavior. Strict SwiftLint, SwiftFormat, native source-inventory verification and Codex autoreview passed.
- **Regression and stress evidence:** the same math regression fails before the fix and passes after it in direct and split-view hosts resized 960 → 620 → 960 points. The failing host allocated 0×0 despite a measured 63.88×14.28 equation. On signed 398, the native sweep reached all 40 diagrams: 33 rendered initially and seven required explicit Retry. All 40 equations rendered; malformed source remained readable and copied exactly while the following valid graph/math rendered. These stress results retain their original source attribution; their renderer, assets and math owner are unchanged in 9d. The larger-preview resizing check passed on a262, before the final mechanical callback relocation.

An earlier Mac release check caught the strict 800-line type-body limit. Grouping unchanged delegate callbacks in their conformance extension reduced the body from 807 to 791 lines; the final release check passed. Unassigned Apple jobs were recovered through the workflows’ documented hosted retry route, retaining completed successful work. All resulting checks finished successfully.

The latest ClawSweeper review’s rank-up requests are addressed by the final signed native evidence above and completed checks. Physical Mac trackpad pinch remains unverified because the available automation has no supported magnification gesture; WebKit magnification is enabled. The iOS simulator pinch result remains iOS-only evidence.

Recorded follow-up from the live run: preserve paragraph separators in shared native prose. The existing `/help` rendering joins paragraph text such as `[input]More:`; the prose pipeline predates this feature. This is separate from Mermaid presentation.

Measured against the landed iOS parent: production +110/-42 (net +68), tests +124, documentation +18/-1, source inventory +1/-1. The final callback relocation adds two structural lines and changes no callback statements. The production growth enables desktop controls and repairs shared presentation ownership while reusing the existing renderer and resource lifecycle.
