### PR TITLE
fix(plugins): match scoped ClawHub specs in uninstall warnings

### DIFF
--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -12,6 +12,7 @@ import {
   buildPluginDiagnosticsReportMock,
   buildPluginSnapshotReportMock,
   createTestInstalledPluginIndex,
+  parseClawHubPluginSpecMock,
   pluginCliConfigMock,
   planPluginUninstallMock,
   PromptInputClosedError,
@@ -317,15 +318,18 @@ describe("plugins cli uninstall", () => {
     expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
   });
 
-  it("warns but proceeds when a shared plugin has an uncertain Claw reference", async () => {
+  it("warns for a versionless scoped ClawHub spec and proceeds", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     process.env.OPENCLAW_STATE_DIR = tempDirs.make("openclaw-claw-plugin-ref-");
     closeOpenClawStateDatabaseForTest();
     try {
+      const { parseClawHubPluginSpec } = await vi.importActual<
+        typeof import("../infra/clawhub-spec.js")
+      >("../infra/clawhub-spec.js");
+      parseClawHubPluginSpecMock.mockImplementation(parseClawHubPluginSpec);
       const installRecord = {
         source: "clawhub" as const,
-        spec: "clawhub:@owner/audit@2.0.1",
-        clawhubPackage: "@owner/audit",
+        spec: "clawhub:@owner/audit",
         version: "2.0.1",
         installPath: ALPHA_INSTALL_PATH,
       };

--- a/src/plugins/uninstall-claw-references.test.ts
+++ b/src/plugins/uninstall-claw-references.test.ts
@@ -52,14 +52,39 @@ describe("collectClawPluginUninstallWarnings", () => {
     );
   });
 
-  it("matches a scoped ClawHub spec recorded without a version", () => {
+  it.each([
+    {
+      label: "matches a scoped spec recorded without a version",
+      record: {
+        source: "clawhub" as const,
+        spec: "clawhub:@owner/audit",
+        version: "2.0.1",
+      },
+      ref: "@owner/audit",
+    },
+    {
+      label: "prefers the canonical package over the raw spec",
+      record: {
+        source: "clawhub" as const,
+        spec: "clawhub:@alias/audit@2.0.1",
+        clawhubPackage: "@owner/audit",
+        version: "2.0.1",
+      },
+      ref: "@owner/audit",
+    },
+    {
+      label: "falls back to the plugin id when the package fields are absent",
+      record: { source: "clawhub" as const, version: "2.0.1" },
+      ref: "audit",
+    },
+  ])("$label", ({ record, ref }) => {
     readClawPackageRefsMock.mockReturnValue([
       {
         kind: "plugin",
         source: "clawhub",
-        ref: "@owner/audit",
+        ref,
         version: "2.0.1",
-        status: "installed",
+        status: "complete",
         clawName: "@owner/audit-claw",
       },
     ]);
@@ -67,11 +92,7 @@ describe("collectClawPluginUninstallWarnings", () => {
     expect(
       collectClawPluginUninstallWarnings({
         pluginId: "audit",
-        installRecord: {
-          source: "clawhub" as const,
-          spec: "clawhub:@owner/audit",
-          version: "2.0.1",
-        },
+        installRecord: record,
       }),
     ).toContain('Warning: plugin "audit" is referenced by Claw: @owner/audit-claw.');
   });

--- a/src/plugins/uninstall-claw-references.test.ts
+++ b/src/plugins/uninstall-claw-references.test.ts
@@ -51,4 +51,28 @@ describe("collectClawPluginUninstallWarnings", () => {
       'Warning: plugin "audit" is referenced by Claw: @owner/audit-claw.',
     );
   });
+
+  it("matches a scoped ClawHub spec recorded without a version", () => {
+    readClawPackageRefsMock.mockReturnValue([
+      {
+        kind: "plugin",
+        source: "clawhub",
+        ref: "@owner/audit",
+        version: "2.0.1",
+        status: "installed",
+        clawName: "@owner/audit-claw",
+      },
+    ]);
+
+    expect(
+      collectClawPluginUninstallWarnings({
+        pluginId: "audit",
+        installRecord: {
+          source: "clawhub" as const,
+          spec: "clawhub:@owner/audit",
+          version: "2.0.1",
+        },
+      }),
+    ).toContain('Warning: plugin "audit" is referenced by Claw: @owner/audit-claw.');
+  });
 });

--- a/src/plugins/uninstall-claw-references.test.ts
+++ b/src/plugins/uninstall-claw-references.test.ts
@@ -54,15 +54,6 @@ describe("collectClawPluginUninstallWarnings", () => {
 
   it.each([
     {
-      label: "matches a scoped spec recorded without a version",
-      record: {
-        source: "clawhub" as const,
-        spec: "clawhub:@owner/audit",
-        version: "2.0.1",
-      },
-      ref: "@owner/audit",
-    },
-    {
       label: "prefers the canonical package over the raw spec",
       record: {
         source: "clawhub" as const,

--- a/src/plugins/uninstall-claw-references.ts
+++ b/src/plugins/uninstall-claw-references.ts
@@ -1,5 +1,6 @@
 import { readClawPackageRefs, type PersistedClawPackageRef } from "../claws/provenance.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 
 function clawPackageRefMatchesPluginInstall(
@@ -10,8 +11,7 @@ function clawPackageRefMatchesPluginInstall(
   if (ref.kind !== "plugin" || ref.source !== "clawhub" || record.source !== "clawhub") {
     return false;
   }
-  const installedRef =
-    record.clawhubPackage ?? record.spec?.replace(/^clawhub:/i, "").replace(/@[^@]+$/, "");
+  const installedRef = record.clawhubPackage ?? parseClawHubPluginSpec(record.spec ?? "")?.name;
   return (installedRef ?? pluginId) === ref.ref;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Uninstalling a plugin installed from ClawHub under a scoped name without a version, such as `clawhub:@owner/audit`, can omit the dependency warning for a persisted Claw reference. The operator can remove the plugin without seeing which Claws still reference it.

## Why This Change Was Made

The warning matcher stripped the version from `record.spec` with a local regular expression. For a versionless scoped spec, that expression removed the entire package name and produced an empty string. The empty string also bypassed the plugin-ID fallback.

The matcher now uses the existing `parseClawHubPluginSpec` parser. This keeps ClawHub install-record parsing in the plugin owner and leaves Claw provenance and external-plugin policy unchanged.

The regression coverage drives the plugin uninstall command with real SQLite Claw provenance and the real canonical parser. Helper coverage also proves the identity order: the canonical `clawhubPackage` wins over the raw spec, and the plugin ID remains the final fallback.

## User Impact

Plugin uninstall previews now warn about persisted Claw references for scoped and unscoped ClawHub specs, with or without version suffixes.

## Evidence

Current main `3c131e60a8abeb673edbee12b6f715e9b9c15409` used production SQLite writers to create a task-local plugin install record and Claw package reference, then ran the real command:

```text
openclaw plugins uninstall audit --dry-run
Plugin: audit
Will remove: install record, directory: …/extensions/audit
Dry run, no changes made.
```

Exact head `c728ee462f7d1d097e15bf8fc0c10e3794fbdd43` ran the same command for all four forms: `clawhub:audit`, `clawhub:audit@2.0.1`, `clawhub:@owner/audit`, and `clawhub:@owner/audit@2.0.1`. Every run printed:

```text
Warning: plugin "audit" is referenced by Claw: @owner/audit-claw.
Uninstalling it may break those Claws until the plugin is reinstalled or the Claws are updated.
```

Focused validation on the exact head:

- uninstall warning owner: 4 passed
- canonical ClawHub parser: 1 passed
- plugin uninstall CLI: 21 passed
- Oxlint, Oxfmt, and `git diff --check`: passed

Production change: +2/-2 lines, net zero. Tests protect the failed scoped case, canonical-package precedence, and the final plugin-ID fallback.
