### PR TITLE
test(voice-call): stop auth tunnel after failed assertions

### DIFF
--- a/extensions/voice-call/src/tunnel.process.test.ts
+++ b/extensions/voice-call/src/tunnel.process.test.ts
@@ -1,7 +1,7 @@
-// Voice Call process tests exercise real tunnel child shutdown behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { startTunnel } from "./tunnel.js";
 
@@ -43,57 +43,54 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boole
 
 describe.skipIf(process.platform === "win32")("voice-call tunnel child process", () => {
   it("passes ngrok auth through the environment without exposing it in argv", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ngrok-auth-"));
-    const evidencePath = path.join(tempDir, "ngrok-auth-evidence.json");
-    const ngrokPath = path.join(tempDir, "ngrok");
-    const previousPath = process.env.PATH;
-    const previousEvidencePath = process.env.OPENCLAW_NGROK_AUTH_EVIDENCE_FILE;
+    await withTempDir("openclaw-ngrok-auth-", async (tempDir) => {
+      const evidencePath = path.join(tempDir, "ngrok-auth-evidence.json");
+      const ngrokPath = path.join(tempDir, "ngrok");
 
-    await fs.writeFile(
-      ngrokPath,
-      [
-        "#!/usr/bin/env node",
-        'const fs = require("node:fs");',
-        "const token = process.env.NGROK_AUTHTOKEN;",
-        "fs.writeFileSync(",
-        "  process.env.OPENCLAW_NGROK_AUTH_EVIDENCE_FILE,",
-        "  JSON.stringify({ argvContainsToken: process.argv.includes(token), envHasToken: Boolean(token) }),",
-        ");",
-        'process.stdout.write(JSON.stringify({ msg: "started tunnel", url: "https://auth.ngrok.test" }) + "\\n");',
-        "setInterval(() => {}, 1000);",
-      ].join("\n"),
-      { mode: 0o755 },
-    );
-    process.env.PATH = `${tempDir}${path.delimiter}${previousPath ?? ""}`;
-    process.env.OPENCLAW_NGROK_AUTH_EVIDENCE_FILE = evidencePath;
+      await fs.writeFile(
+        ngrokPath,
+        [
+          "#!/usr/bin/env node",
+          'const fs = require("node:fs");',
+          "const token = process.env.NGROK_AUTHTOKEN;",
+          "fs.writeFileSync(",
+          "  process.env.OPENCLAW_NGROK_AUTH_EVIDENCE_FILE,",
+          "  JSON.stringify({ argvContainsToken: process.argv.includes(token), envHasToken: Boolean(token) }),",
+          ");",
+          'process.stdout.write(JSON.stringify({ msg: "started tunnel", url: "https://auth.ngrok.test" }) + "\\n");',
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+        { mode: 0o755 },
+      );
+      await withEnvAsync(
+        {
+          PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          OPENCLAW_NGROK_AUTH_EVIDENCE_FILE: evidencePath,
+        },
+        async () => {
+          const tunnel = await startTunnel({
+            provider: "ngrok",
+            port: 3334,
+            path: "/voice/webhook",
+            ngrokAuthToken: "synthetic-test-token",
+          });
+          if (!tunnel) {
+            throw new Error("Expected ngrok tunnel to start");
+          }
 
-    try {
-      const tunnel = await startTunnel({
-        provider: "ngrok",
-        port: 3334,
-        path: "/voice/webhook",
-        ngrokAuthToken: "synthetic-test-token",
-      });
-      if (!tunnel) {
-        throw new Error("Expected ngrok tunnel to start");
-      }
-
-      await expect
-        .poll(async () => JSON.parse(await fs.readFile(evidencePath, "utf8")), {
-          timeout: 2_000,
-          interval: 20,
-        })
-        .toEqual({ argvContainsToken: false, envHasToken: true });
-      await tunnel.stop();
-    } finally {
-      process.env.PATH = previousPath;
-      if (previousEvidencePath === undefined) {
-        delete process.env.OPENCLAW_NGROK_AUTH_EVIDENCE_FILE;
-      } else {
-        process.env.OPENCLAW_NGROK_AUTH_EVIDENCE_FILE = previousEvidencePath;
-      }
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
+          try {
+            await expect
+              .poll(async () => JSON.parse(await fs.readFile(evidencePath, "utf8")), {
+                timeout: 2_000,
+                interval: 20,
+              })
+              .toEqual({ argvContainsToken: false, envHasToken: true });
+          } finally {
+            await tunnel.stop();
+          }
+        },
+      );
+    });
   });
 
   it("force-kills ngrok when it ignores graceful shutdown", async () => {


### PR DESCRIPTION
The ngrok auth process test stopped its tunnel only after its auth assertion succeeded. A failure deleted the temporary executable and restored the environment while leaving the real child running. Put the returned tunnel inside a finally-owned stop scope, nested within the established SDK environment and temporary-directory helpers. This removes the duplicated manual environment cleanup and the redundant file header.

All three real process cases and all 16 sibling unit cases remain. Nineteen cases passed before and after, with the candidate shuffled using seed2447. The two shutdown cases, auth assertion, poll intervals and production startup/shutdown deadlines are unchanged.

A paired real-child failure probe changed only the fixture's reported auth evidence while retaining the expected assertion. The original left its child alive after directory deletion; the candidate delivered SIGTERM and observed child closure before removing the directory. Both propagated the exact original AssertionError, and environment values were restored exactly. Both complete three-case process suites also passed; all eight observed children and owned roots were cleaned. These probes use a synthetic executable and token, with no ngrok service or provider credentials.

This is a failure-path resource fix, with no normal-run speed claim. Production delta is zero; tests+49/-52. Complete owner/caller/sibling/helper/history and Node24 close/kill contracts were reviewed. The separate sibling unit-test losing Promise.race timer is an existing follow-up outside this ownership repair.

Validation: focused baseline/candidate tests, changed-file types/guards/lint, independent Codex review and manual deslop. Exact-head hosted CI is required before landing. The checkout's installed fs-safe0.5.6 differs from the locked0.7.0; this process-lifecycle proof does not depend on a changed fs-safe contract, and hosted CI uses the lockfile.
