### PR TITLE
improve: build macOS release architectures concurrently

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -21,6 +21,8 @@ const repositoryScriptEntries = [
   "apps/android/scripts/build-release-artifacts.ts!",
   "scripts/bundle-a2ui.mts!",
   "scripts/build-discord-activity-sdk.mts!",
+  // package-mac-app.sh launches the architecture scheduler by path.
+  "scripts/build-mac-swift.mts!",
   "scripts/check-control-ui-performance.mts!",
   "scripts/check-control-ui-precompressed-assets.mts!",
   "scripts/check-live-cache.ts!",

--- a/scripts/build-mac-swift.mts
+++ b/scripts/build-mac-swift.mts
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { availableParallelism } from "node:os";
+import path from "node:path";
+import { runManagedCommand, signalExitCode } from "./lib/managed-child-process.mts";
+
+const [root, configuration, peekabooCommit, skipMlx, resultsRoot, ...architectures] =
+  process.argv.slice(2);
+if (
+  !root ||
+  !configuration ||
+  !peekabooCommit ||
+  !skipMlx ||
+  !resultsRoot ||
+  architectures.length === 0 ||
+  architectures.length > 2 ||
+  new Set(architectures).size !== architectures.length ||
+  architectures.some((arch) => arch !== "arm64" && arch !== "x86_64")
+) {
+  throw new Error(
+    "Expected build root, configuration, source revision, MLX flag, result directory and unique macOS architectures",
+  );
+}
+const concurrency = Math.min(architectures.length, availableParallelism());
+const jobs = Math.max(1, Math.floor(availableParallelism() / concurrency));
+const controller = new AbortController();
+const owned: Array<{ arch: string; lock: string; work: string; treeSafe: boolean }> = [];
+const failures: unknown[] = [];
+let parentSignal: NodeJS.Signals | undefined;
+const signals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
+const signalHandlers = signals.map((signal) => {
+  const handler = () => {
+    parentSignal ??= signal;
+    controller.abort(new Error(`Swift build interrupted by ${signal}`));
+  };
+  process.on(signal, handler);
+  return { signal, handler };
+});
+const worker = path.join(root, "scripts/lib/mac-swift-build.sh");
+const workerArgs = (operation: string, arch: string, work: string) => [
+  worker,
+  operation,
+  root,
+  arch,
+  configuration,
+  String(jobs),
+  peekabooCommit,
+  skipMlx,
+  work,
+];
+
+await mkdir(resultsRoot, { recursive: true });
+try {
+  for (let offset = 0; offset < architectures.length; offset += concurrency) {
+    if (controller.signal.aborted || parentSignal) {
+      break;
+    }
+    await Promise.allSettled(
+      architectures.slice(offset, offset + concurrency).map(async (arch) => {
+        const lock = path.join(root, "apps/macos/.build", `.openclaw-package-${arch}.lock`);
+        const work = path.join(resultsRoot, arch);
+        let ownership: (typeof owned)[number] | undefined;
+        try {
+          await mkdir(path.dirname(lock), { recursive: true });
+          // SwiftPM's lock does not cover our checkout resource patches.
+          await mkdir(lock);
+          ownership = { arch, lock, work, treeSafe: true };
+          owned.push(ownership);
+          await mkdir(work);
+          const code = await runManagedCommand({
+            bin: "/bin/bash",
+            args: workerArgs("build", arch, work),
+            requireProcessTreeExit: true,
+            signal: controller.signal,
+          });
+          if (code !== 0) {
+            throw new Error(`Swift ${arch} build failed with exit code ${code}`);
+          }
+          const compiled = (await readFile(path.join(work, "peekaboo-commit"), "utf8")).trim();
+          if (compiled !== peekabooCommit) {
+            throw new Error(`Swift ${arch} compiled a different Peekaboo source`);
+          }
+        } catch (error) {
+          if (
+            ownership &&
+            error &&
+            typeof error === "object" &&
+            "code" in error &&
+            error.code === "EPROCESSGROUP_CLEANUP_FAILED"
+          ) {
+            ownership.treeSafe = false;
+          }
+          failures.push(error);
+          if (!controller.signal.aborted) {
+            controller.abort(error);
+          }
+        }
+      }),
+    );
+  }
+} finally {
+  // All writers have settled before mounts, patched sources or locks are retired.
+  for (const owner of owned) {
+    if (!owner.treeSafe) {
+      continue;
+    }
+    try {
+      const code = await runManagedCommand({
+        bin: "/bin/bash",
+        args: workerArgs("cleanup", owner.arch, owner.work),
+        requireProcessTreeExit: true,
+      });
+      if (code !== 0) {
+        owner.treeSafe = false;
+        failures.push(new Error(`Swift ${owner.arch} cleanup failed with exit code ${code}`));
+      } else {
+        await rm(owner.lock, { recursive: true });
+      }
+    } catch (error) {
+      owner.treeSafe = false;
+      failures.push(error);
+    }
+  }
+}
+if (owned.every((owner) => owner.treeSafe)) {
+  await writeFile(path.join(resultsRoot, "cleanup-complete"), "verified\n", { flag: "wx" });
+}
+for (const { signal, handler } of signalHandlers) {
+  process.off(signal, handler);
+}
+for (const failure of failures) {
+  console.error(failure);
+}
+if (owned.some((owner) => !owner.treeSafe)) {
+  console.error(
+    `Swift cleanup could not be verified; retained work and ownership locks under ${resultsRoot}`,
+  );
+  process.exitCode = 2;
+} else if (parentSignal) {
+  process.exitCode = signalExitCode(parentSignal);
+} else if (failures.length > 0) {
+  process.exitCode = 1;
+}

--- a/scripts/lib/mac-swift-build.sh
+++ b/scripts/lib/mac-swift-build.sh
@@ -1,0 +1,520 @@
+#!/usr/bin/env bash
+
+build_path_for_arch() {
+  echo "$BUILD_ROOT/$1"
+}
+
+bin_for_arch() {
+  echo "$(build_path_for_arch "$1")/$BUILD_CONFIG/$PRODUCT"
+}
+
+helper_build_path_for_arch() {
+  echo "$MLX_TTS_HELPER_BUILD_ROOT/$1"
+}
+
+helper_products_for_arch() {
+  cat "$SWIFT_BUILD_RESULTS/$1/helper-products"
+}
+
+helper_bin_for_arch() {
+  echo "$(helper_products_for_arch "$1")/$MLX_TTS_HELPER_PRODUCT"
+}
+
+build_mlx_tts_helper() {
+  local arch="$1"
+  shift
+  # Swift 6.3 needs Swift Build for Metal and --show-bin-path for its output directory.
+  swift build --build-system swiftbuild \
+    --package-path "$MLX_TTS_HELPER_ROOT" \
+    -c "$BUILD_CONFIG" \
+    --product "$MLX_TTS_HELPER_PRODUCT" \
+    --build-path "$(helper_build_path_for_arch "$arch")" \
+    --arch "$arch" \
+    --jobs "$SWIFT_BUILD_JOBS" \
+    "$@"
+}
+
+sparkle_framework_for_arch() {
+  echo "$(build_path_for_arch "$1")/$BUILD_CONFIG/Sparkle.framework"
+}
+
+run_with_locked_swift_packages() {
+  local resolved_file="${SWIFT_PACKAGE_ROOT:-$ROOT_DIR/apps/macos}/Package.resolved"
+  local resolved_snapshot
+  local command_status=0
+
+  if [[ ! -f "$resolved_file" ]]; then
+    echo "ERROR: Swift package lockfile not found at $resolved_file" >&2
+    return 1
+  fi
+  resolved_snapshot="$(mktemp)"
+  cp "$resolved_file" "$resolved_snapshot"
+  "$@" || command_status=$?
+  if ! cmp -s "$resolved_snapshot" "$resolved_file"; then
+    cp "$resolved_snapshot" "$resolved_file"
+    rm "$resolved_snapshot"
+    echo "ERROR: Swift package resolution changed Package.resolved; update it in a separate reviewed change" >&2
+    return 1
+  fi
+  rm "$resolved_snapshot"
+  return "$command_status"
+}
+
+compiled_peekaboo_commit() {
+  local checkout_or_build_path="$1" expected="$2"
+  local checkout="$checkout_or_build_path"
+  if [[ ! -d "$checkout/.git" && ! -f "$checkout/.git" ]]; then
+    checkout="$checkout_or_build_path/checkouts/Peekaboo"
+  fi
+  [[ -d "$checkout/.git" || -f "$checkout/.git" ]] || {
+    echo "ERROR: Resolved Peekaboo checkout not found at $checkout" >&2
+    return 1
+  }
+  local commit
+  if ! commit="$(git --no-replace-objects -C "$checkout" rev-parse HEAD)"; then
+    echo "ERROR: Could not inspect compiled Peekaboo checkout revision" >&2
+    return 1
+  fi
+  [[ "$commit" == "$expected" ]] || {
+    echo "ERROR: Compiled Peekaboo checkout '$commit' does not match locked source '$expected'" >&2
+    return 1
+  }
+  if ! /usr/bin/python3 - "$checkout" "$commit" <<'PY'
+import hashlib
+import os
+import stat
+import subprocess
+import sys
+
+checkout = os.fsencode(sys.argv[1])
+commit = os.fsencode(sys.argv[2])
+visited: set[tuple[bytes, bytes]] = set()
+
+def run_git(repository: bytes, *arguments: str) -> bytes:
+    return subprocess.run(
+        ["git", "-c", "core.commitGraph=false", "--no-replace-objects", "-C", os.fsdecode(repository), *arguments],
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+
+def object_format_for(object_id: bytes) -> str:
+    if len(object_id) == 40:
+        return "sha1"
+    if len(object_id) == 64:
+        return "sha256"
+    raise SystemExit(1)
+
+def read_verified_object(repository: bytes, object_type: str, object_id: bytes) -> bytes:
+    try:
+        contents = run_git(repository, "cat-file", object_type, object_id.decode("ascii"))
+    except (OSError, subprocess.CalledProcessError, UnicodeError):
+        raise SystemExit(2) from None
+    digest = hashlib.new(object_format_for(object_id))
+    digest.update(f"{object_type} {len(contents)}\0".encode("ascii"))
+    digest.update(contents)
+    if digest.hexdigest().encode("ascii") != object_id:
+        raise SystemExit(1)
+    return contents
+
+def verify_repository(repository: bytes, expected_commit: bytes) -> None:
+    if not os.path.isdir(repository) or os.path.islink(repository):
+        raise SystemExit(1)
+    identity = (os.path.realpath(repository), expected_commit)
+    if identity in visited:
+        raise SystemExit(1)
+    visited.add(identity)
+
+    try:
+        head = run_git(repository, "rev-parse", "HEAD").strip()
+        run_git(repository, "fsck", "--full", "--strict", "--no-dangling", expected_commit.decode("ascii"))
+    except (OSError, subprocess.CalledProcessError):
+        raise SystemExit(2) from None
+    if head != expected_commit:
+        raise SystemExit(1)
+
+    commit = read_verified_object(repository, "commit", expected_commit)
+    tree_line = commit.split(b"\n", 1)[0]
+    if not tree_line.startswith(b"tree "):
+        raise SystemExit(1)
+    tree_id = tree_line.removeprefix(b"tree ")
+    object_format = object_format_for(tree_id)
+    if object_format != object_format_for(expected_commit):
+        raise SystemExit(1)
+    read_verified_object(repository, "tree", tree_id)
+    try:
+        listing = run_git(repository, "ls-tree", "-rz", tree_id.decode("ascii"))
+    except (OSError, subprocess.CalledProcessError, UnicodeError):
+        raise SystemExit(2) from None
+    expected: dict[bytes, tuple[bytes, bytes]] = {}
+    gitlinks: dict[bytes, bytes] = {}
+    for record in listing.split(b"\0"):
+        if not record:
+            continue
+        metadata, path = record.split(b"\t", 1)
+        mode, object_type, object_id = metadata.split(b" ", 2)
+        if object_type == b"blob":
+            expected[path] = (mode, object_id)
+        elif object_type == b"commit":
+            gitlinks[path] = object_id
+
+    def is_gitlink_path(path: bytes) -> bool:
+        return any(path == gitlink or path.startswith(gitlink + b"/") for gitlink in gitlinks)
+
+    actual: set[bytes] = set()
+    for root, directories, files in os.walk(repository, topdown=True, followlinks=False):
+        relative_root = os.path.relpath(root, repository)
+        relative_root = b"" if relative_root == b"." else relative_root
+        kept_directories: list[bytes] = []
+        for directory in directories:
+            relative = os.path.join(relative_root, directory) if relative_root else directory
+            absolute = os.path.join(root, directory)
+            if relative == b".git" or is_gitlink_path(relative):
+                continue
+            if os.path.islink(absolute):
+                actual.add(relative)
+            else:
+                kept_directories.append(directory)
+        directories[:] = kept_directories
+        for filename in files:
+            relative = os.path.join(relative_root, filename) if relative_root else filename
+            if relative == b".git" or is_gitlink_path(relative):
+                continue
+            actual.add(relative)
+
+    if actual != set(expected):
+        raise SystemExit(1)
+
+    for path, (mode, expected_id) in expected.items():
+        absolute = os.path.join(repository, path)
+        file_stat = os.lstat(absolute)
+        if mode == b"120000":
+            if not stat.S_ISLNK(file_stat.st_mode):
+                raise SystemExit(1)
+            contents = os.fsencode(os.readlink(absolute))
+        else:
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise SystemExit(1)
+            executable = bool(file_stat.st_mode & stat.S_IXUSR)
+            if executable != (mode == b"100755"):
+                raise SystemExit(1)
+            with open(absolute, "rb") as source:
+                contents = source.read()
+        digest = hashlib.new(object_format)
+        digest.update(f"blob {len(contents)}\0".encode("ascii"))
+        digest.update(contents)
+        if digest.hexdigest().encode("ascii") != expected_id:
+            raise SystemExit(1)
+
+    for path, object_id in gitlinks.items():
+        verify_repository(os.path.join(repository, path), object_id)
+
+verify_repository(checkout, commit)
+PY
+  then
+    echo "ERROR: Compiled Peekaboo checkout does not exactly match its committed source" >&2
+    return 1
+  fi
+  printf '%s' "$commit"
+}
+
+PEEKABOO_SNAPSHOT_ROOT=""
+PEEKABOO_SNAPSHOT_IMAGE=""
+PEEKABOO_SNAPSHOT_MOUNT=""
+SWIFT_PACKAGE_CONTAINER=""
+SWIFT_PACKAGE_ROOT=""
+SWIFT_PACKAGE_LOCK_BASELINE=""
+
+prepare_swift_package_root() {
+  SWIFT_PACKAGE_CONTAINER="$SWIFT_WORK_ROOT/package"
+  SWIFT_PACKAGE_ROOT="$SWIFT_PACKAGE_CONTAINER/apps/macos"
+  SWIFT_PACKAGE_LOCK_BASELINE="$SWIFT_PACKAGE_CONTAINER/Package.resolved.committed"
+  mkdir -p "$SWIFT_PACKAGE_ROOT"
+  cp "$ROOT_DIR/apps/macos/Package.swift" "$SWIFT_PACKAGE_ROOT/Package.swift"
+  cp "$ROOT_DIR/apps/macos/Package.resolved" "$SWIFT_PACKAGE_LOCK_BASELINE"
+  cp "$SWIFT_PACKAGE_LOCK_BASELINE" "$SWIFT_PACKAGE_ROOT/Package.resolved"
+  chmod 0400 "$SWIFT_PACKAGE_LOCK_BASELINE"
+  ln -s "$ROOT_DIR/apps/macos/Sources" "$SWIFT_PACKAGE_ROOT/Sources"
+  ln -s "$ROOT_DIR/apps/macos/Tests" "$SWIFT_PACKAGE_ROOT/Tests"
+  ln -s "$ROOT_DIR/apps/shared" "$SWIFT_PACKAGE_CONTAINER/apps/shared"
+  ln -s "$ROOT_DIR/apps/swabble" "$SWIFT_PACKAGE_CONTAINER/apps/swabble"
+  MLX_TTS_HELPER_ROOT="$SWIFT_PACKAGE_CONTAINER/apps/macos-mlx-tts"
+  mkdir -p "$MLX_TTS_HELPER_ROOT"
+  cp "$ROOT_DIR/apps/macos-mlx-tts/Package.swift" "$MLX_TTS_HELPER_ROOT/Package.swift"
+  cp "$ROOT_DIR/apps/macos-mlx-tts/Package.resolved" "$MLX_TTS_HELPER_ROOT/Package.resolved"
+  ln -s "$ROOT_DIR/apps/macos-mlx-tts/Sources" "$MLX_TTS_HELPER_ROOT/Sources"
+  ln -s "$ROOT_DIR/apps/macos-mlx-tts/Tests" "$MLX_TTS_HELPER_ROOT/Tests"
+}
+
+clear_peekaboo_edit() {
+  local build_path="$1"
+  swift package --scratch-path "$build_path" unedit --force Peekaboo >/dev/null 2>&1 || true
+}
+
+edit_peekaboo_from_snapshot() {
+  local build_path="$1"
+  swift package --scratch-path "$build_path" edit Peekaboo --path "$PEEKABOO_SNAPSHOT_MOUNT"
+}
+
+verify_snapshot_swift_lock() {
+  /usr/bin/python3 - \
+    "$SWIFT_PACKAGE_LOCK_BASELINE" \
+    "$SWIFT_PACKAGE_ROOT/Package.resolved" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+committed_path, snapshot_path = map(Path, sys.argv[1:])
+committed = json.loads(committed_path.read_text())
+snapshot = json.loads(snapshot_path.read_text())
+
+def pins(document):
+    values = document.get("pins")
+    if not isinstance(values, list):
+        raise SystemExit(1)
+    result = {}
+    for pin in values:
+        if not isinstance(pin, dict):
+            raise SystemExit(1)
+        identity = pin.get("identity")
+        if not isinstance(identity, str) or not identity or identity in result:
+            raise SystemExit(1)
+        result[identity] = pin
+    return result
+
+if committed.get("version") != snapshot.get("version"):
+    raise SystemExit(1)
+
+committed_pins = pins(committed)
+snapshot_pins = pins(snapshot)
+if "peekaboo" not in committed_pins or "peekaboo" in snapshot_pins:
+    raise SystemExit(1)
+del committed_pins["peekaboo"]
+if committed_pins != snapshot_pins:
+    raise SystemExit(1)
+PY
+}
+
+create_verified_peekaboo_snapshot() {
+  local build_path="$1" expected="$2" source_checkout source_commit snapshot_commit
+  source_checkout="$build_path/checkouts/Peekaboo"
+  source_commit="$(compiled_peekaboo_commit "$source_checkout" "$expected")" || return 1
+  PEEKABOO_SNAPSHOT_ROOT="$SWIFT_WORK_ROOT/snapshot"
+  mkdir -p "$PEEKABOO_SNAPSHOT_ROOT"
+  PEEKABOO_SNAPSHOT_IMAGE="$PEEKABOO_SNAPSHOT_ROOT/Peekaboo.dmg"
+  PEEKABOO_SNAPSHOT_MOUNT="$PEEKABOO_SNAPSHOT_ROOT/mount"
+  mkdir "$PEEKABOO_SNAPSHOT_MOUNT"
+  # -quiet suppresses failure stderr too; discard only routine stdout.
+  hdiutil create -fs APFS -format UDRO \
+    -srcfolder "$source_checkout" \
+    -volname OpenClawPeekabooSnapshot \
+    "$PEEKABOO_SNAPSHOT_IMAGE" >/dev/null
+  hdiutil attach -readonly -nobrowse \
+    -mountpoint "$PEEKABOO_SNAPSHOT_MOUNT" \
+    "$PEEKABOO_SNAPSHOT_IMAGE" >/dev/null
+  snapshot_commit="$(compiled_peekaboo_commit "$PEEKABOO_SNAPSHOT_MOUNT" "$expected")" || return 1
+  [[ "$snapshot_commit" == "$source_commit" ]] || return 1
+}
+
+swiftpm_resource_sources() {
+  local checkout_root="$1/checkouts"
+  printf '%s\n' \
+    "$checkout_root/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift" \
+    "$checkout_root/SwiftMath/Sources/SwiftMath/MathBundle/MathFont.swift" \
+    "$checkout_root/SwiftMath/Sources/SwiftMath/MathRender/MTFont.swift"
+}
+
+restore_swiftpm_resource_sources() {
+  local source_file index=0 backup_file
+  while IFS= read -r source_file; do
+    backup_file="$SWIFT_WORK_ROOT/resource-backups/$index"
+    if [[ -f "$backup_file" ]]; then
+      mv "$backup_file" "$source_file" || return 1
+    fi
+    index=$((index + 1))
+  done < <(swiftpm_resource_sources "$BUILD_PATH")
+}
+
+patch_swiftpm_resource_lookups() {
+  local build_path="$1" source_file index=0
+  local source_files=()
+  mkdir "$SWIFT_WORK_ROOT/resource-backups"
+  while IFS= read -r source_file; do
+    if [[ ! -f "$source_file" ]]; then
+      echo "ERROR: SwiftPM resource source not found at $source_file" >&2
+      return 1
+    fi
+    cp -p "$source_file" "$SWIFT_WORK_ROOT/resource-backups/$index"
+    chmod u+w "$source_file"
+    source_files+=("$source_file")
+    index=$((index + 1))
+  done < <(swiftpm_resource_sources "$build_path")
+
+  /usr/bin/python3 - "${source_files[@]}" <<'PY'
+from pathlib import Path
+import sys
+
+
+def replace_exact(path: Path, old: str, new: str, expected: int = 1) -> str:
+    text = path.read_text()
+    if text.count(old) != expected:
+        raise SystemExit(f"Expected {expected} occurrence(s) in {path}: {old!r}")
+    return text.replace(old, new)
+
+
+keyboard_shortcuts, swift_math_font, swift_math_legacy_font = map(Path, sys.argv[1:])
+
+keyboard_text = replace_exact(
+    keyboard_shortcuts,
+    "NSLocalizedString(self, bundle: .module, comment: self)",
+    "NSLocalizedString(self, bundle: .keyboardShortcutsPackagedResources, comment: self)",
+)
+keyboard_marker = "\n\nextension Data {"
+keyboard_injection = """
+
+private extension Bundle {
+\t// Command-line SwiftPM builds resolve Bundle.module beside the executable, which is
+\t// outside a valid signed .app layout. Prefer the bundle copied into Contents/Resources.
+\tstatic let keyboardShortcutsPackagedResources: Bundle = {
+\t\t#if os(macOS)
+\t\tif let url = Bundle.main.url(
+\t\t\tforResource: \"KeyboardShortcuts_KeyboardShortcuts\",
+\t\t\twithExtension: \"bundle\"),
+\t\t   let bundle = Bundle(url: url)
+\t\t{
+\t\t\treturn bundle
+\t\t}
+\t\t#endif
+\t\treturn .module
+\t}()
+}
+"""
+if keyboard_text.count(keyboard_marker) != 1:
+    raise SystemExit(f"Expected one KeyboardShortcuts insertion marker in {keyboard_shortcuts}")
+keyboard_shortcuts.write_text(keyboard_text.replace(keyboard_marker, keyboard_injection + keyboard_marker))
+
+swift_math_text = replace_exact(
+    swift_math_font,
+    "Bundle.module.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+    "Bundle.swiftMathPackagedResources.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+    expected=2,
+)
+swift_math_marker = "\n#endif\n\n/// Now available for everyone to use"
+swift_math_injection = """
+
+extension Bundle {
+    // Keep SwiftMath's generated resource sidecar inside the signed app Resources directory.
+    static let swiftMathPackagedResources: Bundle = {
+        #if os(macOS)
+        if let url = Bundle.main.url(
+            forResource: \"SwiftMath_SwiftMath\",
+            withExtension: \"bundle\"),
+           let bundle = Bundle(url: url)
+        {
+            return bundle
+        }
+        #endif
+        return .module
+    }()
+}
+"""
+if swift_math_text.count(swift_math_marker) != 1:
+    raise SystemExit(f"Expected one SwiftMath insertion marker in {swift_math_font}")
+swift_math_font.write_text(
+    swift_math_text.replace(swift_math_marker, "\n#endif" + swift_math_injection + "\n/// Now available for everyone to use")
+)
+
+legacy_text = replace_exact(
+    swift_math_legacy_font,
+    "Bundle.module.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+    "Bundle.swiftMathPackagedResources.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
+)
+swift_math_legacy_font.write_text(legacy_text)
+PY
+}
+
+cleanup_swift_architecture() {
+  local cleanup_status=0
+  restore_swiftpm_resource_sources || cleanup_status=1
+  if [[ -d "$SWIFT_PACKAGE_ROOT" ]]; then
+    (cd "$SWIFT_PACKAGE_ROOT" && clear_peekaboo_edit "$BUILD_PATH") || cleanup_status=1
+  fi
+  if [[ -d "$PEEKABOO_SNAPSHOT_MOUNT" ]]; then
+    hdiutil detach -quiet "$PEEKABOO_SNAPSHOT_MOUNT" >/dev/null 2>&1 || {
+      # An unattached directory is safe to remove; a live mount must be retained.
+      local mounts
+      if ! mounts="$(/sbin/mount)"; then
+        cleanup_status=1
+      elif printf '%s\n' "$mounts" | grep -F " on $PEEKABOO_SNAPSHOT_MOUNT (" >/dev/null; then
+        cleanup_status=1
+      fi
+    }
+  fi
+  if [[ "$cleanup_status" == "0" ]]; then
+    rm -rf "$PEEKABOO_SNAPSHOT_ROOT" "$SWIFT_PACKAGE_CONTAINER" "$SWIFT_WORK_ROOT/resource-backups"
+  fi
+  return "$cleanup_status"
+}
+
+build_swift_architecture() {
+  local arch="$1" arch_peekaboo_commit
+  prepare_swift_package_root
+  cd "$SWIFT_PACKAGE_ROOT"
+  BUILD_PATH="$(build_path_for_arch "$arch")"
+  clear_peekaboo_edit "$BUILD_PATH"
+  echo "📦 Resolving Swift packages [$arch]"
+  run_with_locked_swift_packages swift package --scratch-path "$BUILD_PATH" resolve
+  echo "🔒 Freezing authenticated Peekaboo sources in a read-only snapshot [$arch]"
+  create_verified_peekaboo_snapshot "$BUILD_PATH" "$PEEKABOO_LOCKED_SOURCE_COMMIT"
+  edit_peekaboo_from_snapshot "$BUILD_PATH"
+  swift package --scratch-path "$BUILD_PATH" resolve
+  verify_snapshot_swift_lock
+  patch_swiftpm_resource_lookups "$BUILD_PATH"
+  echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [$arch]"
+  verify_snapshot_swift_lock
+  swift build -c "$BUILD_CONFIG" --jobs "$SWIFT_BUILD_JOBS" --product "$PRODUCT" --build-path "$BUILD_PATH" --arch "$arch" -Xlinker -rpath -Xlinker @executable_path/../Frameworks
+  verify_snapshot_swift_lock
+  arch_peekaboo_commit="$(compiled_peekaboo_commit "$PEEKABOO_SNAPSHOT_MOUNT" "$PEEKABOO_LOCKED_SOURCE_COMMIT")"
+  printf '%s\n' "$arch_peekaboo_commit" > "$SWIFT_WORK_ROOT/peekaboo-commit"
+  restore_swiftpm_resource_sources
+  clear_peekaboo_edit "$BUILD_PATH"
+  cd "$ROOT_DIR/apps/macos"
+  if [[ "$SKIP_MLX_TTS" == "1" ]]; then
+    echo "🔇 Skipping $MLX_TTS_HELPER_PRODUCT (OPENCLAW_SKIP_MLX_TTS=1) — app will lack the local MLX voice helper [$arch]"
+  else
+    echo "🔨 Building $MLX_TTS_HELPER_PRODUCT ($BUILD_CONFIG) [$arch]"
+    local helper_lock="$MLX_TTS_HELPER_ROOT/Package.resolved"
+    cp "$helper_lock" "$SWIFT_WORK_ROOT/mlx-lock"
+    build_mlx_tts_helper "$arch"
+    build_mlx_tts_helper "$arch" --show-bin-path > "$SWIFT_WORK_ROOT/helper-products"
+    cmp "$SWIFT_WORK_ROOT/mlx-lock" "$helper_lock" || {
+      echo "ERROR: MLX package resolution changed Package.resolved" >&2
+      return 1
+    }
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  operation="$1"
+  ROOT_DIR="$2"
+  arch="$3"
+  BUILD_CONFIG="$4"
+  SWIFT_BUILD_JOBS="$5"
+  PEEKABOO_LOCKED_SOURCE_COMMIT="$6"
+  SKIP_MLX_TTS="$7"
+  SWIFT_WORK_ROOT="$8"
+  PRODUCT=OpenClaw
+  MLX_TTS_HELPER_PRODUCT=openclaw-mlx-tts
+  BUILD_ROOT="$ROOT_DIR/apps/macos/.build"
+  MLX_TTS_HELPER_BUILD_ROOT="$ROOT_DIR/apps/macos-mlx-tts/.build"
+  BUILD_PATH="$(build_path_for_arch "$arch")"
+  SWIFT_PACKAGE_CONTAINER="$SWIFT_WORK_ROOT/package"
+  SWIFT_PACKAGE_ROOT="$SWIFT_PACKAGE_CONTAINER/apps/macos"
+  PEEKABOO_SNAPSHOT_ROOT="$SWIFT_WORK_ROOT/snapshot"
+  PEEKABOO_SNAPSHOT_MOUNT="$PEEKABOO_SNAPSHOT_ROOT/mount"
+  case "$operation" in
+    build) build_swift_architecture "$arch" ;;
+    cleanup) cleanup_swift_architecture ;;
+    *) echo "Unknown Swift build operation: $operation" >&2; exit 1 ;;
+  esac
+fi

--- a/scripts/lib/mac-swift-build.sh
+++ b/scripts/lib/mac-swift-build.sh
@@ -442,7 +442,7 @@ cleanup_swift_architecture() {
     hdiutil detach -quiet "$PEEKABOO_SNAPSHOT_MOUNT" >/dev/null 2>&1 || {
       # An unattached directory is safe to remove; a live mount must be retained.
       local mounts
-      if ! mounts="$(/sbin/mount)"; then
+      if ! mounts="$(mount)"; then
         cleanup_status=1
       elif printf '%s\n' "$mounts" | grep -F " on $PEEKABOO_SNAPSHOT_MOUNT (" >/dev/null; then
         cleanup_status=1

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -20,6 +20,8 @@ case "$APP_ROOT" in
 esac
 APP_DESTINATION="$APP_ROOT"
 APP_STAGE_DIR=""
+SWIFT_BUILD_PID=""
+SWIFT_BUILD_RESULTS=""
 BUILD_ROOT="$ROOT_DIR/apps/macos/.build"
 PRODUCT="OpenClaw"
 MLX_TTS_HELPER_PRODUCT="openclaw-mlx-tts"
@@ -136,469 +138,30 @@ sparkle_canonical_build_from_version() {
   (cd "$ROOT_DIR" && node --import tsx "$ROOT_DIR/scripts/sparkle-build.ts" canonical-build "$1")
 }
 
-build_path_for_arch() {
-  echo "$BUILD_ROOT/$1"
-}
-
-bin_for_arch() {
-  echo "$(build_path_for_arch "$1")/$BUILD_CONFIG/$PRODUCT"
-}
-
-helper_build_path_for_arch() {
-  echo "$MLX_TTS_HELPER_BUILD_ROOT/$1"
-}
-
-helper_bin_for_arch() {
-  local products
-  products="$(build_mlx_tts_helper "$1" --show-bin-path)" || return
-  echo "$products/$MLX_TTS_HELPER_PRODUCT"
-}
-
-build_mlx_tts_helper() {
-  local arch="$1"
-  shift
-  # Swift 6.3 needs Swift Build for Metal and --show-bin-path for its output directory.
-  swift build --build-system swiftbuild \
-    --package-path "$MLX_TTS_HELPER_ROOT" \
-    -c "$BUILD_CONFIG" \
-    --product "$MLX_TTS_HELPER_PRODUCT" \
-    --build-path "$(helper_build_path_for_arch "$arch")" \
-    --arch "$arch" \
-    "$@"
-}
-
-sparkle_framework_for_arch() {
-  echo "$(build_path_for_arch "$1")/$BUILD_CONFIG/Sparkle.framework"
-}
-
-run_with_locked_swift_packages() {
-  local resolved_file="${SWIFT_PACKAGE_ROOT:-$ROOT_DIR/apps/macos}/Package.resolved"
-  local resolved_snapshot
-  local command_status=0
-
-  if [[ ! -f "$resolved_file" ]]; then
-    echo "ERROR: Swift package lockfile not found at $resolved_file" >&2
-    return 1
-  fi
-  resolved_snapshot="$(mktemp)"
-  cp "$resolved_file" "$resolved_snapshot"
-  "$@" || command_status=$?
-  if ! cmp -s "$resolved_snapshot" "$resolved_file"; then
-    cp "$resolved_snapshot" "$resolved_file"
-    rm "$resolved_snapshot"
-    echo "ERROR: Swift package resolution changed Package.resolved; update it in a separate reviewed change" >&2
-    return 1
-  fi
-  rm "$resolved_snapshot"
-  return "$command_status"
-}
-
-compiled_peekaboo_commit() {
-  local checkout_or_build_path="$1" expected="$2"
-  local checkout="$checkout_or_build_path"
-  if [[ ! -d "$checkout/.git" && ! -f "$checkout/.git" ]]; then
-    checkout="$checkout_or_build_path/checkouts/Peekaboo"
-  fi
-  [[ -d "$checkout/.git" || -f "$checkout/.git" ]] || {
-    echo "ERROR: Resolved Peekaboo checkout not found at $checkout" >&2
-    return 1
-  }
-  local commit
-  if ! commit="$(git --no-replace-objects -C "$checkout" rev-parse HEAD)"; then
-    echo "ERROR: Could not inspect compiled Peekaboo checkout revision" >&2
-    return 1
-  fi
-  [[ "$commit" == "$expected" ]] || {
-    echo "ERROR: Compiled Peekaboo checkout '$commit' does not match locked source '$expected'" >&2
-    return 1
-  }
-  if ! /usr/bin/python3 - "$checkout" "$commit" <<'PY'
-import hashlib
-import os
-import stat
-import subprocess
-import sys
-
-checkout = os.fsencode(sys.argv[1])
-commit = os.fsencode(sys.argv[2])
-visited: set[tuple[bytes, bytes]] = set()
-
-def run_git(repository: bytes, *arguments: str) -> bytes:
-    return subprocess.run(
-        ["git", "-c", "core.commitGraph=false", "--no-replace-objects", "-C", os.fsdecode(repository), *arguments],
-        check=True,
-        stdout=subprocess.PIPE,
-    ).stdout
-
-def object_format_for(object_id: bytes) -> str:
-    if len(object_id) == 40:
-        return "sha1"
-    if len(object_id) == 64:
-        return "sha256"
-    raise SystemExit(1)
-
-def read_verified_object(repository: bytes, object_type: str, object_id: bytes) -> bytes:
-    try:
-        contents = run_git(repository, "cat-file", object_type, object_id.decode("ascii"))
-    except (OSError, subprocess.CalledProcessError, UnicodeError):
-        raise SystemExit(2) from None
-    digest = hashlib.new(object_format_for(object_id))
-    digest.update(f"{object_type} {len(contents)}\0".encode("ascii"))
-    digest.update(contents)
-    if digest.hexdigest().encode("ascii") != object_id:
-        raise SystemExit(1)
-    return contents
-
-def verify_repository(repository: bytes, expected_commit: bytes) -> None:
-    if not os.path.isdir(repository) or os.path.islink(repository):
-        raise SystemExit(1)
-    identity = (os.path.realpath(repository), expected_commit)
-    if identity in visited:
-        raise SystemExit(1)
-    visited.add(identity)
-
-    try:
-        head = run_git(repository, "rev-parse", "HEAD").strip()
-        run_git(repository, "fsck", "--full", "--strict", "--no-dangling", expected_commit.decode("ascii"))
-    except (OSError, subprocess.CalledProcessError):
-        raise SystemExit(2) from None
-    if head != expected_commit:
-        raise SystemExit(1)
-
-    commit = read_verified_object(repository, "commit", expected_commit)
-    tree_line = commit.split(b"\n", 1)[0]
-    if not tree_line.startswith(b"tree "):
-        raise SystemExit(1)
-    tree_id = tree_line.removeprefix(b"tree ")
-    object_format = object_format_for(tree_id)
-    if object_format != object_format_for(expected_commit):
-        raise SystemExit(1)
-    read_verified_object(repository, "tree", tree_id)
-    try:
-        listing = run_git(repository, "ls-tree", "-rz", tree_id.decode("ascii"))
-    except (OSError, subprocess.CalledProcessError, UnicodeError):
-        raise SystemExit(2) from None
-    expected: dict[bytes, tuple[bytes, bytes]] = {}
-    gitlinks: dict[bytes, bytes] = {}
-    for record in listing.split(b"\0"):
-        if not record:
-            continue
-        metadata, path = record.split(b"\t", 1)
-        mode, object_type, object_id = metadata.split(b" ", 2)
-        if object_type == b"blob":
-            expected[path] = (mode, object_id)
-        elif object_type == b"commit":
-            gitlinks[path] = object_id
-
-    def is_gitlink_path(path: bytes) -> bool:
-        return any(path == gitlink or path.startswith(gitlink + b"/") for gitlink in gitlinks)
-
-    actual: set[bytes] = set()
-    for root, directories, files in os.walk(repository, topdown=True, followlinks=False):
-        relative_root = os.path.relpath(root, repository)
-        relative_root = b"" if relative_root == b"." else relative_root
-        kept_directories: list[bytes] = []
-        for directory in directories:
-            relative = os.path.join(relative_root, directory) if relative_root else directory
-            absolute = os.path.join(root, directory)
-            if relative == b".git" or is_gitlink_path(relative):
-                continue
-            if os.path.islink(absolute):
-                actual.add(relative)
-            else:
-                kept_directories.append(directory)
-        directories[:] = kept_directories
-        for filename in files:
-            relative = os.path.join(relative_root, filename) if relative_root else filename
-            if relative == b".git" or is_gitlink_path(relative):
-                continue
-            actual.add(relative)
-
-    if actual != set(expected):
-        raise SystemExit(1)
-
-    for path, (mode, expected_id) in expected.items():
-        absolute = os.path.join(repository, path)
-        file_stat = os.lstat(absolute)
-        if mode == b"120000":
-            if not stat.S_ISLNK(file_stat.st_mode):
-                raise SystemExit(1)
-            contents = os.fsencode(os.readlink(absolute))
-        else:
-            if not stat.S_ISREG(file_stat.st_mode):
-                raise SystemExit(1)
-            executable = bool(file_stat.st_mode & stat.S_IXUSR)
-            if executable != (mode == b"100755"):
-                raise SystemExit(1)
-            with open(absolute, "rb") as source:
-                contents = source.read()
-        digest = hashlib.new(object_format)
-        digest.update(f"blob {len(contents)}\0".encode("ascii"))
-        digest.update(contents)
-        if digest.hexdigest().encode("ascii") != expected_id:
-            raise SystemExit(1)
-
-    for path, object_id in gitlinks.items():
-        verify_repository(os.path.join(repository, path), object_id)
-
-verify_repository(checkout, commit)
-PY
-  then
-    echo "ERROR: Compiled Peekaboo checkout does not exactly match its committed source" >&2
-    return 1
-  fi
-  printf '%s' "$commit"
-}
-
-PEEKABOO_SNAPSHOT_ROOT=""
-PEEKABOO_SNAPSHOT_IMAGE=""
-PEEKABOO_SNAPSHOT_MOUNT=""
-PEEKABOO_EDIT_BUILD_PATHS=()
-SWIFT_PACKAGE_CONTAINER=""
-SWIFT_PACKAGE_ROOT=""
-SWIFT_PACKAGE_LOCK_BASELINE=""
-
-prepare_swift_package_root() {
-  SWIFT_PACKAGE_CONTAINER="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-macos-package.XXXXXX")"
-  SWIFT_PACKAGE_ROOT="$SWIFT_PACKAGE_CONTAINER/apps/macos"
-  SWIFT_PACKAGE_LOCK_BASELINE="$SWIFT_PACKAGE_CONTAINER/Package.resolved.committed"
-  mkdir -p "$SWIFT_PACKAGE_ROOT"
-  cp "$ROOT_DIR/apps/macos/Package.swift" "$SWIFT_PACKAGE_ROOT/Package.swift"
-  cp "$ROOT_DIR/apps/macos/Package.resolved" "$SWIFT_PACKAGE_LOCK_BASELINE"
-  cp "$SWIFT_PACKAGE_LOCK_BASELINE" "$SWIFT_PACKAGE_ROOT/Package.resolved"
-  chmod 0400 "$SWIFT_PACKAGE_LOCK_BASELINE"
-  ln -s "$ROOT_DIR/apps/macos/Sources" "$SWIFT_PACKAGE_ROOT/Sources"
-  ln -s "$ROOT_DIR/apps/macos/Tests" "$SWIFT_PACKAGE_ROOT/Tests"
-  ln -s "$ROOT_DIR/apps/shared" "$SWIFT_PACKAGE_CONTAINER/apps/shared"
-  ln -s "$ROOT_DIR/apps/swabble" "$SWIFT_PACKAGE_CONTAINER/apps/swabble"
-}
-
-clear_peekaboo_edit() {
-  local build_path="$1"
-  swift package --scratch-path "$build_path" unedit --force Peekaboo >/dev/null 2>&1 || true
-}
-
-edit_peekaboo_from_snapshot() {
-  local build_path="$1"
-  swift package --scratch-path "$build_path" edit Peekaboo --path "$PEEKABOO_SNAPSHOT_MOUNT"
-  PEEKABOO_EDIT_BUILD_PATHS+=("$build_path")
-}
-
-verify_snapshot_swift_lock() {
-  /usr/bin/python3 - \
-    "$SWIFT_PACKAGE_LOCK_BASELINE" \
-    "$SWIFT_PACKAGE_ROOT/Package.resolved" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-committed_path, snapshot_path = map(Path, sys.argv[1:])
-committed = json.loads(committed_path.read_text())
-snapshot = json.loads(snapshot_path.read_text())
-
-def pins(document):
-    values = document.get("pins")
-    if not isinstance(values, list):
-        raise SystemExit(1)
-    result = {}
-    for pin in values:
-        if not isinstance(pin, dict):
-            raise SystemExit(1)
-        identity = pin.get("identity")
-        if not isinstance(identity, str) or not identity or identity in result:
-            raise SystemExit(1)
-        result[identity] = pin
-    return result
-
-if committed.get("version") != snapshot.get("version"):
-    raise SystemExit(1)
-
-committed_pins = pins(committed)
-snapshot_pins = pins(snapshot)
-if "peekaboo" not in committed_pins or "peekaboo" in snapshot_pins:
-    raise SystemExit(1)
-del committed_pins["peekaboo"]
-if committed_pins != snapshot_pins:
-    raise SystemExit(1)
-PY
-}
-
-cleanup_peekaboo_snapshot() {
-  local build_path
-  for build_path in "${PEEKABOO_EDIT_BUILD_PATHS[@]:-}"; do
-    [[ -n "$build_path" ]] || continue
-    clear_peekaboo_edit "$build_path"
-  done
-  PEEKABOO_EDIT_BUILD_PATHS=()
-  if [[ -n "$PEEKABOO_SNAPSHOT_MOUNT" && -d "$PEEKABOO_SNAPSHOT_MOUNT" ]]; then
-    hdiutil detach -quiet "$PEEKABOO_SNAPSHOT_MOUNT" >/dev/null 2>&1 || true
-  fi
-  [[ -z "$PEEKABOO_SNAPSHOT_ROOT" || ! -d "$PEEKABOO_SNAPSHOT_ROOT" ]] ||
-    rm -rf "$PEEKABOO_SNAPSHOT_ROOT"
-  PEEKABOO_SNAPSHOT_ROOT=""
-  PEEKABOO_SNAPSHOT_IMAGE=""
-  PEEKABOO_SNAPSHOT_MOUNT=""
-}
-
-cleanup_swift_package_root() {
-  [[ -z "$SWIFT_PACKAGE_CONTAINER" || ! -d "$SWIFT_PACKAGE_CONTAINER" ]] ||
-    rm -rf "$SWIFT_PACKAGE_CONTAINER"
-  SWIFT_PACKAGE_CONTAINER=""
-  SWIFT_PACKAGE_ROOT=""
-  SWIFT_PACKAGE_LOCK_BASELINE=""
-}
-
-create_verified_peekaboo_snapshot() {
-  local build_path="$1" expected="$2" source_checkout source_commit snapshot_commit
-  source_checkout="$build_path/checkouts/Peekaboo"
-  source_commit="$(compiled_peekaboo_commit "$source_checkout" "$expected")" || return 1
-  cleanup_peekaboo_snapshot
-  PEEKABOO_SNAPSHOT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-peekaboo-snapshot.XXXXXX")"
-  PEEKABOO_SNAPSHOT_IMAGE="$PEEKABOO_SNAPSHOT_ROOT/Peekaboo.dmg"
-  PEEKABOO_SNAPSHOT_MOUNT="$PEEKABOO_SNAPSHOT_ROOT/mount"
-  mkdir "$PEEKABOO_SNAPSHOT_MOUNT"
-  # -quiet suppresses failure stderr too; discard only routine stdout.
-  hdiutil create -fs APFS -format UDRO \
-    -srcfolder "$source_checkout" \
-    -volname OpenClawPeekabooSnapshot \
-    "$PEEKABOO_SNAPSHOT_IMAGE" >/dev/null
-  hdiutil attach -readonly -nobrowse \
-    -mountpoint "$PEEKABOO_SNAPSHOT_MOUNT" \
-    "$PEEKABOO_SNAPSHOT_IMAGE" >/dev/null
-  snapshot_commit="$(compiled_peekaboo_commit "$PEEKABOO_SNAPSHOT_MOUNT" "$expected")" || return 1
-  [[ "$snapshot_commit" == "$source_commit" ]] || return 1
-}
-
-PATCHED_SWIFTPM_RESOURCE_SOURCES=()
-
-restore_swiftpm_resource_sources() {
-  local source_file
-  local backup_file
-  for source_file in "${PATCHED_SWIFTPM_RESOURCE_SOURCES[@]:-}"; do
-    [[ -n "$source_file" ]] || continue
-    backup_file="$source_file.openclaw-original"
-    if [[ -f "$backup_file" ]]; then
-      mv "$backup_file" "$source_file"
-    fi
-  done
-  PATCHED_SWIFTPM_RESOURCE_SOURCES=()
-}
-
-patch_swiftpm_resource_lookups() {
-  local build_path="$1"
-  local checkout_root="$build_path/checkouts"
-  local source_file
-  local source_files=(
-    "$checkout_root/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift"
-    "$checkout_root/SwiftMath/Sources/SwiftMath/MathBundle/MathFont.swift"
-    "$checkout_root/SwiftMath/Sources/SwiftMath/MathRender/MTFont.swift"
-  )
-
-  for source_file in "${source_files[@]}"; do
-    if [[ ! -f "$source_file" ]]; then
-      echo "ERROR: SwiftPM resource source not found at $source_file" >&2
-      return 1
-    fi
-    if [[ -e "$source_file.openclaw-original" ]]; then
-      echo "ERROR: Stale SwiftPM resource source backup at $source_file.openclaw-original" >&2
-      return 1
-    fi
-    cp -p "$source_file" "$source_file.openclaw-original"
-    chmod u+w "$source_file"
-    PATCHED_SWIFTPM_RESOURCE_SOURCES+=("$source_file")
-  done
-
-  /usr/bin/python3 - "${source_files[@]}" <<'PY'
-from pathlib import Path
-import sys
-
-
-def replace_exact(path: Path, old: str, new: str, expected: int = 1) -> str:
-    text = path.read_text()
-    if text.count(old) != expected:
-        raise SystemExit(f"Expected {expected} occurrence(s) in {path}: {old!r}")
-    return text.replace(old, new)
-
-
-keyboard_shortcuts, swift_math_font, swift_math_legacy_font = map(Path, sys.argv[1:])
-
-keyboard_text = replace_exact(
-    keyboard_shortcuts,
-    "NSLocalizedString(self, bundle: .module, comment: self)",
-    "NSLocalizedString(self, bundle: .keyboardShortcutsPackagedResources, comment: self)",
-)
-keyboard_marker = "\n\nextension Data {"
-keyboard_injection = """
-
-private extension Bundle {
-\t// Command-line SwiftPM builds resolve Bundle.module beside the executable, which is
-\t// outside a valid signed .app layout. Prefer the bundle copied into Contents/Resources.
-\tstatic let keyboardShortcutsPackagedResources: Bundle = {
-\t\t#if os(macOS)
-\t\tif let url = Bundle.main.url(
-\t\t\tforResource: \"KeyboardShortcuts_KeyboardShortcuts\",
-\t\t\twithExtension: \"bundle\"),
-\t\t   let bundle = Bundle(url: url)
-\t\t{
-\t\t\treturn bundle
-\t\t}
-\t\t#endif
-\t\treturn .module
-\t}()
-}
-"""
-if keyboard_text.count(keyboard_marker) != 1:
-    raise SystemExit(f"Expected one KeyboardShortcuts insertion marker in {keyboard_shortcuts}")
-keyboard_shortcuts.write_text(keyboard_text.replace(keyboard_marker, keyboard_injection + keyboard_marker))
-
-swift_math_text = replace_exact(
-    swift_math_font,
-    "Bundle.module.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
-    "Bundle.swiftMathPackagedResources.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
-    expected=2,
-)
-swift_math_marker = "\n#endif\n\n/// Now available for everyone to use"
-swift_math_injection = """
-
-extension Bundle {
-    // Keep SwiftMath's generated resource sidecar inside the signed app Resources directory.
-    static let swiftMathPackagedResources: Bundle = {
-        #if os(macOS)
-        if let url = Bundle.main.url(
-            forResource: \"SwiftMath_SwiftMath\",
-            withExtension: \"bundle\"),
-           let bundle = Bundle(url: url)
-        {
-            return bundle
-        }
-        #endif
-        return .module
-    }()
-}
-"""
-if swift_math_text.count(swift_math_marker) != 1:
-    raise SystemExit(f"Expected one SwiftMath insertion marker in {swift_math_font}")
-swift_math_font.write_text(
-    swift_math_text.replace(swift_math_marker, "\n#endif" + swift_math_injection + "\n/// Now available for everyone to use")
-)
-
-legacy_text = replace_exact(
-    swift_math_legacy_font,
-    "Bundle.module.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
-    "Bundle.swiftMathPackagedResources.url(forResource: \"mathFonts\", withExtension: \"bundle\")",
-)
-swift_math_legacy_font.write_text(legacy_text)
-PY
-}
+source "$ROOT_DIR/scripts/lib/mac-swift-build.sh"
 
 cleanup_package_build() {
-  restore_swiftpm_resource_sources
-  cleanup_peekaboo_snapshot
-  cleanup_swift_package_root
+  if [[ -n "$SWIFT_BUILD_RESULTS" && ! -f "$SWIFT_BUILD_RESULTS/cleanup-complete" ]]; then
+    echo "ERROR: Swift cleanup was not verified; retaining $APP_STAGE_DIR for inspection" >&2
+    return
+  fi
   [[ -z "$APP_STAGE_DIR" ]] || rm -rf "$APP_STAGE_DIR"
 }
 
+interrupt_package_build() {
+  local signal="$1" code="$2"
+  if [[ -n "$SWIFT_BUILD_PID" ]]; then
+    kill -"$signal" "$SWIFT_BUILD_PID" 2>/dev/null || true
+    wait "$SWIFT_BUILD_PID" || true
+    SWIFT_BUILD_PID=""
+  fi
+  exit "$code"
+}
+
 trap cleanup_package_build EXIT
+trap 'interrupt_package_build INT 130' INT
+trap 'interrupt_package_build TERM 143' TERM
+trap 'interrupt_package_build HUP 129' HUP
 
 PNPM_CMD=()
 
@@ -687,7 +250,6 @@ merge_framework_machos() {
 
 PEEKABOO_SOURCE_COMMIT="$(resolve_peekaboo_source_commit)"
 PEEKABOO_LOCKED_SOURCE_COMMIT="$PEEKABOO_SOURCE_COMMIT"
-COMPILED_PEEKABOO_SOURCE_COMMIT=""
 
 require_swift_toolchain
 
@@ -739,48 +301,18 @@ APP_STAGE_DIR="$(mktemp -d "$ROOT_DIR/dist/.openclaw-package.XXXXXX")"
 APP_ROOT="$APP_STAGE_DIR/OpenClaw.app"
 
 echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [${BUILD_ARCHS[*]}]"
-for arch in "${BUILD_ARCHS[@]}"; do
-  prepare_swift_package_root
-  cd "$SWIFT_PACKAGE_ROOT"
-  BUILD_PATH="$(build_path_for_arch "$arch")"
-  clear_peekaboo_edit "$BUILD_PATH"
-  echo "📦 Resolving Swift packages [$arch]"
-  run_with_locked_swift_packages swift package --scratch-path "$BUILD_PATH" resolve
-  if [[ -z "$PEEKABOO_SNAPSHOT_MOUNT" ]]; then
-    echo "🔒 Freezing authenticated Peekaboo sources in a read-only snapshot"
-    create_verified_peekaboo_snapshot "$BUILD_PATH" "$PEEKABOO_LOCKED_SOURCE_COMMIT"
-  fi
-  edit_peekaboo_from_snapshot "$BUILD_PATH"
-  swift package --scratch-path "$BUILD_PATH" resolve
-  verify_snapshot_swift_lock
-  patch_swiftpm_resource_lookups "$BUILD_PATH"
-  echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [$arch]"
-  verify_snapshot_swift_lock
-  swift build -c "$BUILD_CONFIG" --product "$PRODUCT" --build-path "$BUILD_PATH" --arch "$arch" -Xlinker -rpath -Xlinker @executable_path/../Frameworks
-  verify_snapshot_swift_lock
-  arch_peekaboo_commit="$(compiled_peekaboo_commit "$PEEKABOO_SNAPSHOT_MOUNT" "$PEEKABOO_LOCKED_SOURCE_COMMIT")"
-  if [[ -n "$COMPILED_PEEKABOO_SOURCE_COMMIT" && "$COMPILED_PEEKABOO_SOURCE_COMMIT" != "$arch_peekaboo_commit" ]]; then
-    echo "ERROR: Peekaboo checkout differs across requested architectures" >&2
-    exit 1
-  fi
-  COMPILED_PEEKABOO_SOURCE_COMMIT="$arch_peekaboo_commit"
-  restore_swiftpm_resource_sources
-  clear_peekaboo_edit "$BUILD_PATH"
-  PEEKABOO_EDIT_BUILD_PATHS=()
-  cd "$ROOT_DIR/apps/macos"
-  cleanup_swift_package_root
-  if [[ "$SKIP_MLX_TTS" == "1" ]]; then
-    echo "🔇 Skipping $MLX_TTS_HELPER_PRODUCT (OPENCLAW_SKIP_MLX_TTS=1) — app will lack the local MLX voice helper [$arch]"
-  else
-    echo "🔨 Building $MLX_TTS_HELPER_PRODUCT ($BUILD_CONFIG) [$arch]"
-    build_mlx_tts_helper "$arch"
-  fi
-done
-[[ -n "$COMPILED_PEEKABOO_SOURCE_COMMIT" ]] || {
-  echo "ERROR: No compiled Peekaboo checkout was verified" >&2
-  exit 1
-}
-PEEKABOO_SOURCE_COMMIT="$COMPILED_PEEKABOO_SOURCE_COMMIT"
+SWIFT_BUILD_RESULTS="$APP_STAGE_DIR/swift-builds"
+node "$ROOT_DIR/scripts/build-mac-swift.mts" "$ROOT_DIR" "$BUILD_CONFIG" \
+  "$PEEKABOO_LOCKED_SOURCE_COMMIT" "$SKIP_MLX_TTS" "$SWIFT_BUILD_RESULTS" "${BUILD_ARCHS[@]}" &
+SWIFT_BUILD_PID=$!
+if wait "$SWIFT_BUILD_PID"; then
+  SWIFT_BUILD_PID=""
+  PEEKABOO_SOURCE_COMMIT="$PEEKABOO_LOCKED_SOURCE_COMMIT"
+else
+  build_status=$?
+  SWIFT_BUILD_PID=""
+  exit "$build_status"
+fi
 
 BIN_PRIMARY="$(bin_for_arch "$PRIMARY_ARCH")"
 echo "pkg: binary $BIN_PRIMARY" >&2
@@ -936,7 +468,7 @@ fi
 echo "📦 Copying SwiftPM resource bundles"
 SWIFTPM_BUILD_PRODUCTS=("$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG")
 if [[ "$SKIP_MLX_TTS" != "1" ]]; then
-  SWIFTPM_BUILD_PRODUCTS+=("$(build_mlx_tts_helper "$PRIMARY_ARCH" --show-bin-path)")
+  SWIFTPM_BUILD_PRODUCTS+=("$(helper_products_for_arch "$PRIMARY_ARCH")")
 fi
 # Main app and helper dependencies share the signed Resources directory.
 # MLX loads its compiled Metal library from its resource bundle there.

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1784,12 +1784,14 @@ describe("package-mac-app plist stamping", () => {
   });
 
   it.each([
-    { operation: "create", exitCode: 1, reason: "No such file or directory" },
-    { operation: "attach", exitCode: 73, reason: "Permission denied" },
-    { operation: "none", exitCode: 0, reason: "" },
+    { operation: "create", exitCode: 1, reason: "No such file or directory", mounts: "empty" },
+    { operation: "attach", exitCode: 73, reason: "Permission denied", mounts: "empty" },
+    { operation: "none", exitCode: 0, reason: "", mounts: "empty" },
+    { operation: "attach", exitCode: 73, reason: "Permission denied", mounts: "mounted" },
+    { operation: "attach", exitCode: 73, reason: "Permission denied", mounts: "failed" },
   ])(
-    "preserves Peekaboo snapshot diagnostics and cleanup: $operation",
-    ({ operation, exitCode, reason }) => {
+    "preserves Peekaboo snapshot diagnostics and cleanup: $operation / $mounts",
+    ({ operation, exitCode, reason, mounts }) => {
       const root = tempDirs.make("openclaw-peekaboo-snapshot-fixture-");
       const buildPath = path.join(root, "build with spaces");
       const checkout = path.join(buildPath, "checkouts", "Peekaboo");
@@ -1830,6 +1832,15 @@ describe("package-mac-app plist stamping", () => {
         `,
       );
       chmodSync(hdiutil, 0o755);
+      const mountCommand = path.join(root, "mount");
+      writeFileSync(
+        mountCommand,
+        `#!/bin/bash
+printf 'mount\\n' >> "$operations"
+${mounts === "failed" ? "exit 1" : mounts === "mounted" ? `printf '/dev/disk9 on %s/work/snapshot/mount (apfs, read-only)\\n' "$fixture_root"` : "exit 0"}
+`,
+      );
+      chmodSync(mountCommand, 0o755);
 
       const result = runHelper(
         `
@@ -1866,13 +1877,19 @@ describe("package-mac-app plist stamping", () => {
       if (operation === "none") {
         expectedOperations.push(`verify:${mount}:${expectedCommit}`, "snapshot-ready");
       }
-      expectedOperations.push(
-        "detach",
-        `remove:-rf ${snapshotRoot}  ${path.join(root, "work/resource-backups")}`,
-      );
-      expect(result.status).toBe(exitCode);
+      expectedOperations.push("detach");
+      if (operation !== "none") {
+        expectedOperations.push("mount");
+      }
+      const retained = mounts !== "empty";
+      if (!retained) {
+        expectedOperations.push(
+          `remove:-rf ${snapshotRoot}  ${path.join(root, "work/resource-backups")}`,
+        );
+      }
+      expect(result.status).toBe(retained ? 1 : exitCode);
       expect(readFileSync(operationsPath, "utf8").trim().split("\n")).toEqual(expectedOperations);
-      expect(existsSync(snapshotRoot)).toBe(false);
+      expect(existsSync(snapshotRoot)).toBe(retained);
       expect(readFileSync(path.join(checkout, "source"), "utf8")).toBe("source preserved\n");
       expect(readFileSync(unrelated, "utf8")).toBe("unrelated snapshot preserved\n");
       const readArgs = (command: string) =>

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1,6 +1,7 @@
 // Package Mac App tests cover package mac app script behavior.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { availableParallelism } from "node:os";
 import path from "node:path";
 import { minimatch } from "minimatch";
 import { afterEach, describe, expect, it } from "vitest";
@@ -8,6 +9,125 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const scriptPath = "scripts/package-mac-app.sh";
+const swiftScriptPath = "scripts/lib/mac-swift-build.sh";
+
+describe.skipIf(process.platform === "win32" || availableParallelism() < 2)(
+  "parallel macOS Swift build ownership",
+  () => {
+    it.each(["success", "failure", "wrong-source", "cancel", "cleanup-failure"])(
+      "joins architecture workers and preserves assembly safety: %s",
+      async (mode) => {
+        const root = tempDirs.make("openclaw-swift-parallel-");
+        const stage = path.join(root, "stage");
+        const scripts = path.join(root, "scripts/lib");
+        mkdirSync(scripts, { recursive: true });
+        mkdirSync(stage);
+        const commit = "b".repeat(40);
+        writeFileSync(
+          path.join(scripts, "mac-swift-build.sh"),
+          `#!/bin/bash
+set -euo pipefail
+exec "${process.execPath}" "${path.join(root, "worker.mjs")}" "$@"
+`,
+        );
+        writeFileSync(
+          path.join(root, "worker.mjs"),
+          `
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+const [operation, root, arch, config, jobs, commit, skip, work] = process.argv.slice(2);
+const mode = ${JSON.stringify(mode)};
+const event = (value) => fs.appendFileSync(path.join(root, 'events'), value + '\\n');
+if (operation === 'cleanup') {
+  event('cleanup:' + arch);
+  process.exit(mode === 'cleanup-failure' ? 55 : 0);
+}
+event('build:' + arch + ':' + jobs);
+const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+fs.writeFileSync(path.join(root, 'pid-' + arch), String(child.pid));
+const exited = new Promise(resolve => child.on('exit', resolve));
+process.on('SIGTERM', async () => { child.kill(); await exited; event('stopped:' + arch); process.exit(143); });
+fs.writeFileSync(path.join(root, 'ready-' + arch), 'ready');
+const deadline = Date.now() + 5000;
+while (!['arm64', 'x86_64'].every(a => fs.existsSync(path.join(root, 'ready-' + a)))) {
+  if (Date.now() > deadline) throw new Error('architecture barrier did not open');
+  await new Promise(resolve => setTimeout(resolve, 10));
+}
+event('barrier:' + arch);
+if (mode === 'cancel' || (mode === 'failure' && arch === 'arm64')) await new Promise(() => {});
+child.kill(); await exited;
+if (mode === 'failure') process.exit(42);
+fs.writeFileSync(path.join(work, 'peekaboo-commit'), mode === 'wrong-source' ? 'wrong' : commit);
+`,
+        );
+        const script = readFileSync(scriptPath, "utf8");
+        const cleanup = script.slice(
+          script.indexOf("cleanup_package_build() {"),
+          script.indexOf("PNPM_CMD=()"),
+        );
+        const build = script.slice(
+          script.indexOf('echo "🔨 Building $PRODUCT'),
+          script.indexOf('BIN_PRIMARY="$(bin_for_arch'),
+        );
+        // Exercise the real parent wait/signal/cleanup flow; only the heavy graph is a fixture.
+        const launcher = `set -euo pipefail
+ROOT_DIR=${JSON.stringify(root)}
+APP_STAGE_DIR=${JSON.stringify(stage)}
+SWIFT_BUILD_RESULTS=""
+SWIFT_BUILD_PID=""
+PRODUCT=OpenClaw
+BUILD_CONFIG=release
+PEEKABOO_LOCKED_SOURCE_COMMIT=${commit}
+SKIP_MLX_TTS=0
+BUILD_ARCHS=(arm64 x86_64)
+node() { exec "${process.execPath}" ${JSON.stringify(path.resolve("scripts/build-mac-swift.mts"))} "\${@:2}"; }
+${cleanup}
+${build}
+touch "$ROOT_DIR/assembled"
+`;
+        const child = spawn("/bin/bash", ["-c", launcher], { stdio: ["ignore", "pipe", "pipe"] });
+        let stderr = "";
+        child.stderr.on("data", (chunk: Buffer) => {
+          stderr += chunk.toString();
+        });
+        child.stdout.resume();
+        const closed = new Promise<number | null>((resolve) => {
+          child.on("close", resolve);
+        });
+        if (mode === "cancel") {
+          await expect
+            .poll(
+              () =>
+                existsSync(path.join(root, "ready-arm64")) &&
+                existsSync(path.join(root, "ready-x86_64")),
+            )
+            .toBe(true);
+          child.kill("SIGTERM");
+        }
+        const code = await closed;
+        expect(code, stderr).toBe(
+          mode === "success" ? 0 : mode === "cancel" ? 143 : mode === "cleanup-failure" ? 2 : 1,
+        );
+        expect(existsSync(path.join(root, "assembled"))).toBe(mode === "success");
+        expect(existsSync(stage)).toBe(mode === "cleanup-failure");
+        const events = readFileSync(path.join(root, "events"), "utf8").trim().split("\n");
+        expect(events.filter((event) => event.startsWith("cleanup:")).toSorted()).toEqual([
+          "cleanup:arm64",
+          "cleanup:x86_64",
+        ]);
+        for (const arch of ["arm64", "x86_64"]) {
+          const pid = Number(readFileSync(path.join(root, `pid-${arch}`), "utf8"));
+          expect(() => process.kill(pid, 0)).toThrow();
+          expect(
+            existsSync(path.join(root, "apps/macos/.build", `.openclaw-package-${arch}.lock`)),
+          ).toBe(mode === "cleanup-failure");
+        }
+      },
+      15_000,
+    );
+  },
+);
 
 describe("packaged worker freshness", () => {
   it.each([
@@ -196,7 +316,7 @@ function runSwiftToolchainHarness(options: {
 function getSparkleBuildHelperBlock(): string {
   const script = readFileSync(scriptPath, "utf8");
   const start = script.indexOf("sparkle_canonical_build_from_version()");
-  const end = script.indexOf("build_path_for_arch()");
+  const end = script.indexOf('source "$ROOT_DIR/scripts/lib/mac-swift-build.sh"');
 
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
@@ -288,7 +408,7 @@ function runSourceProvenanceStampHarness(corruptKey?: string) {
 }
 
 function getMLXTTSHelperBuildBlock(): string {
-  const script = readFileSync(scriptPath, "utf8");
+  const script = readFileSync(swiftScriptPath, "utf8");
   const start = script.indexOf("helper_build_path_for_arch() {");
   const end = script.indexOf("sparkle_framework_for_arch()", start);
 
@@ -299,21 +419,21 @@ function getMLXTTSHelperBuildBlock(): string {
 }
 
 function getSwiftPackageResolutionBlock(): string {
-  const script = readFileSync(scriptPath, "utf8");
+  const script = readFileSync(swiftScriptPath, "utf8");
   const start = script.indexOf("run_with_locked_swift_packages()");
-  const end = script.indexOf("PNPM_CMD=()");
+  const end = script.indexOf("build_swift_architecture() {");
 
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
 
   // The shared EXIT cleanup also needs the packager preamble's unallocated app stage.
-  return `APP_STAGE_DIR=""\n${script.slice(start, end)}`;
+  return `${script.slice(start, end)}\nBUILD_PATH="$ROOT_DIR/build"\nSWIFT_WORK_ROOT="$ROOT_DIR/work"\nmkdir -p "$SWIFT_WORK_ROOT"\n`;
 }
 
 function getCompiledPeekabooHelperBlock(): string {
-  const script = readFileSync(scriptPath, "utf8");
+  const script = readFileSync(swiftScriptPath, "utf8");
   const start = script.indexOf("compiled_peekaboo_commit() {");
-  const end = script.indexOf("PATCHED_SWIFTPM_RESOURCE_SOURCES=()", start);
+  const end = script.indexOf("swiftpm_resource_sources()", start);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
   return script.slice(start, end);
@@ -505,9 +625,9 @@ function getSwiftPMResourceBundleBlock(): string {
 }
 
 function getSwiftPMResourcePatchBlock(): string {
-  const script = readFileSync(scriptPath, "utf8");
-  const start = script.indexOf("PATCHED_SWIFTPM_RESOURCE_SOURCES=()");
-  const end = script.indexOf("cleanup_package_build() {", start);
+  const script = readFileSync(swiftScriptPath, "utf8");
+  const start = script.indexOf("swiftpm_resource_sources()");
+  const end = script.indexOf("cleanup_swift_architecture() {", start);
 
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
@@ -579,8 +699,8 @@ function runSwiftPMResourceBundleHarness(
     helper_build_path_for_arch() {
       echo "$MLX_TTS_HELPER_BUILD_ROOT/$1"
     }
-    build_mlx_tts_helper() {
-      [[ "$#" -eq 2 && "$1" == "$PRIMARY_ARCH" && "$2" == "--show-bin-path" ]] || return 1
+    helper_products_for_arch() {
+      [[ "$#" -eq 1 && "$1" == "$PRIMARY_ARCH" ]] || return 1
       printf '%s\\n' ${JSON.stringify(helperBuildProducts)}
     }
     ${getSwiftPMResourceBundleBlock()}
@@ -589,7 +709,7 @@ function runSwiftPMResourceBundleHarness(
   return { appRoot, result };
 }
 
-function runSwiftPMResourcePatchHarness() {
+function runSwiftPMResourcePatchHarness(failRestore = false) {
   const root = tempDirs.make("openclaw-package-resource-patch-");
   const buildPath = path.join(root, "build");
   const checkoutRoot = path.join(buildPath, "checkouts");
@@ -648,12 +768,17 @@ function runSwiftPMResourcePatchHarness() {
 
   const result = runHelper(`
     set -euo pipefail
+    SWIFT_WORK_ROOT=${JSON.stringify(tempDirs.make("openclaw-resource-backups-"))}
+    BUILD_PATH=${JSON.stringify(buildPath)}
     ${getSwiftPMResourcePatchBlock()}
     patch_swiftpm_resource_lookups ${JSON.stringify(buildPath)}
     grep -q keyboardShortcutsPackagedResources ${JSON.stringify(keyboardShortcuts)}
     test "$(grep -c swiftMathPackagedResources ${JSON.stringify(swiftMathFont)})" -eq 3
     grep -q swiftMathPackagedResources ${JSON.stringify(swiftMathLegacyFont)}
-    restore_swiftpm_resource_sources
+    ${failRestore ? "mv() { return 13; }" : ""}
+    cleanup_status=0
+    restore_swiftpm_resource_sources || cleanup_status=$?
+    exit "$cleanup_status"
   `);
 
   return { fixtures, result };
@@ -886,7 +1011,7 @@ describe("package-mac-app plist stamping", () => {
   it("gates only release packaging on clean matching source and verifies the embedded commit", () => {
     const script = readFileSync(scriptPath, "utf8");
     const sourceCheck = script.indexOf('bash "$ROOT_DIR/scripts/apple-release-source-check.sh"');
-    const build = script.indexOf('cd "$ROOT_DIR/apps/macos"');
+    const build = script.indexOf('node "$ROOT_DIR/scripts/build-mac-swift.mts"');
     const embeddedRead = script.indexOf(
       'plist_print_required "$APP_ROOT/Contents/Info.plist" OpenClawGitCommit',
     );
@@ -1004,10 +1129,7 @@ describe("package-mac-app plist stamping", () => {
 
   it("builds and bundles the MLX TTS helper for every requested architecture", () => {
     const script = readFileSync(scriptPath, "utf8");
-    const buildLoop = script.slice(
-      script.indexOf('for arch in "${BUILD_ARCHS[@]}"; do'),
-      script.indexOf('BIN_PRIMARY="$(bin_for_arch "$PRIMARY_ARCH")"'),
-    );
+    const buildLoop = readFileSync(swiftScriptPath, "utf8");
     const helperCopy = script.slice(
       script.indexOf('echo "🚚 Copying MLX TTS helper"'),
       script.indexOf("SPARKLE_FRAMEWORK_PRIMARY="),
@@ -1108,8 +1230,13 @@ describe("package-mac-app plist stamping", () => {
       MLX_TTS_HELPER_BUILD_ROOT=${JSON.stringify(helperBuildRoot)}
       MLX_TTS_HELPER_PRODUCT=openclaw-mlx-tts
       BUILD_CONFIG=release
+      SWIFT_BUILD_JOBS=2
+      SWIFT_BUILD_RESULTS=${JSON.stringify(tempRoot)}
+      mkdir -p "$SWIFT_BUILD_RESULTS/${arch}"
       ${getMLXTTSHelperBuildBlock()}
       build_mlx_tts_helper ${arch}
+      build_mlx_tts_helper ${arch} --show-bin-path > "$SWIFT_BUILD_RESULTS/${arch}/helper-products"
+      swift() { echo unexpected-build >&2; return 99; }
       cat "$(helper_bin_for_arch ${arch})"
     `);
 
@@ -1129,6 +1256,8 @@ describe("package-mac-app plist stamping", () => {
         path.join(helperBuildRoot, arch),
         "--arch",
         arch,
+        "--jobs",
+        "2",
       ];
       const invocations = readFileSync(invocationPath, "utf8")
         .trim()
@@ -1139,7 +1268,7 @@ describe("package-mac-app plist stamping", () => {
   );
 
   it("skips the MLX TTS helper build and copy when OPENCLAW_SKIP_MLX_TTS=1", () => {
-    const script = readFileSync(scriptPath, "utf8");
+    const script = readFileSync(scriptPath, "utf8") + readFileSync(swiftScriptPath, "utf8");
 
     // Both the per-arch build and the bundle copy are gated on the same flag so
     // a skipped build never tries to copy a helper binary that was not built.
@@ -1583,6 +1712,11 @@ describe("package-mac-app plist stamping", () => {
     }
   });
 
+  it("fails cleanup instead of deleting backups when resource restoration fails", () => {
+    const { result } = runSwiftPMResourcePatchHarness(true);
+    expect(result.status).not.toBe(0);
+  });
+
   it("fails closed when any required SwiftPM resource bundle is missing", () => {
     for (const missingBundle of swiftPMResourceBundles) {
       const { result } = runSwiftPMResourceBundleHarness({ missingBundle });
@@ -1633,45 +1767,20 @@ describe("package-mac-app plist stamping", () => {
     expect(script).toContain('--output "$APP_ROOT/Contents/Resources"');
   });
 
-  it("preserves locked Swift package resolution before building", () => {
-    const script = readFileSync(scriptPath, "utf8");
-    const resolveCall =
-      'run_with_locked_swift_packages swift package --scratch-path "$BUILD_PATH" resolve';
-    const buildCall = 'swift build -c "$BUILD_CONFIG" --product "$PRODUCT"';
-    const prepareCall = 'node "$ROOT_DIR/scripts/prepare-apple-mermaid.mjs"';
-
-    expect(script.indexOf(prepareCall)).toBeGreaterThan(script.indexOf("run_pnpm build"));
-    expect(script.indexOf(prepareCall)).toBeLessThan(script.indexOf(resolveCall));
-
-    expect(script).toContain(
-      'resolved_file="${SWIFT_PACKAGE_ROOT:-$ROOT_DIR/apps/macos}/Package.resolved"',
+  it("preserves locked Swift resolution and verifies source around each native build", () => {
+    const worker = readFileSync(swiftScriptPath, "utf8");
+    const build = worker.indexOf('swift build -c "$BUILD_CONFIG" --jobs');
+    expect(worker).toContain('chmod 0400 "$SWIFT_PACKAGE_LOCK_BASELINE"');
+    expect(worker).toContain('cmp -s "$resolved_snapshot" "$resolved_file"');
+    expect(worker).toContain('cp "$resolved_snapshot" "$resolved_file"');
+    expect(worker).toContain("identity in result");
+    expect(worker.lastIndexOf("verify_snapshot_swift_lock", build)).toBeGreaterThan(
+      worker.indexOf("build_swift_architecture()"),
     );
-    expect(script).toContain(
-      'SWIFT_PACKAGE_LOCK_BASELINE="$SWIFT_PACKAGE_CONTAINER/Package.resolved.committed"',
+    expect(worker.indexOf("verify_snapshot_swift_lock", build)).toBeGreaterThan(build);
+    expect(worker).toContain(
+      'cp "$ROOT_DIR/apps/macos-mlx-tts/Package.resolved" "$MLX_TTS_HELPER_ROOT/Package.resolved"',
     );
-    expect(script).toContain('chmod 0400 "$SWIFT_PACKAGE_LOCK_BASELINE"');
-    expect(script).toContain("identity in result");
-    expect(script).toContain('cmp -s "$resolved_snapshot" "$resolved_file"');
-    expect(script).toContain('cp "$resolved_snapshot" "$resolved_file"');
-    expect(script).toContain("ERROR: Swift package resolution changed Package.resolved");
-    expect(script).toContain(resolveCall);
-    expect(script).toContain(buildCall);
-    expect(
-      script.indexOf(
-        "prepare_swift_package_root",
-        script.indexOf('for arch in "${BUILD_ARCHS[@]}"; do'),
-      ),
-    ).toBeLessThan(script.indexOf(resolveCall));
-    expect(script.indexOf("cleanup_swift_package_root", script.indexOf(buildCall))).toBeGreaterThan(
-      script.indexOf(buildCall),
-    );
-    const buildIndex = script.indexOf(buildCall);
-    expect(script.lastIndexOf("verify_snapshot_swift_lock", buildIndex)).toBeGreaterThan(
-      script.indexOf(resolveCall),
-    );
-    expect(script.indexOf("verify_snapshot_swift_lock", buildIndex)).toBeGreaterThan(buildIndex);
-    expect(script).not.toContain("swift build --disable-automatic-resolution");
-    expect(script.indexOf(resolveCall)).toBeLessThan(script.indexOf(buildCall));
   });
 
   it.each([
@@ -1729,7 +1838,10 @@ describe("package-mac-app plist stamping", () => {
       export operations=${JSON.stringify(operationsPath)}
       export PATH=${JSON.stringify(`${root}:/usr/bin:/bin`)}
       TMPDIR=${JSON.stringify(scratch)}
+      ROOT_DIR=${JSON.stringify(root)}
       ${getSwiftPackageResolutionBlock()}
+      trap cleanup_swift_architecture EXIT
+      BUILD_PATH=${JSON.stringify(buildPath)}
       compiled_peekaboo_commit() {
         printf 'verify:%s:%s\\n' "$1" "$2" >> "$operations"
         printf '%s' "$2"
@@ -1754,7 +1866,10 @@ describe("package-mac-app plist stamping", () => {
       if (operation === "none") {
         expectedOperations.push(`verify:${mount}:${expectedCommit}`, "snapshot-ready");
       }
-      expectedOperations.push("detach", `remove:-rf ${snapshotRoot}`);
+      expectedOperations.push(
+        "detach",
+        `remove:-rf ${snapshotRoot}  ${path.join(root, "work/resource-backups")}`,
+      );
       expect(result.status).toBe(exitCode);
       expect(readFileSync(operationsPath, "utf8").trim().split("\n")).toEqual(expectedOperations);
       expect(existsSync(snapshotRoot)).toBe(false);
@@ -1801,7 +1916,7 @@ describe("package-mac-app plist stamping", () => {
     expect(verifier).toContain('"--no-replace-objects"');
     expect(verifier).toContain('"fsck", "--full", "--strict"');
     expect(verifier).toContain('"cat-file", object_type');
-    expect(readFileSync(scriptPath, "utf8")).toContain(
+    expect(readFileSync(swiftScriptPath, "utf8")).toContain(
       'swift package --scratch-path "$build_path" edit Peekaboo --path "$PEEKABOO_SNAPSHOT_MOUNT"',
     );
     const mismatched = runRealCompiledPeekabooHarness("none", "e".repeat(40));


### PR DESCRIPTION
## What Problem This Solves

Universal macOS packaging builds its arm64 and x86_64 native dependency graphs serially, leaving release time on the table even when the host can build both architectures. This runs the two graphs concurrently while keeping the total Swift compiler job budget bounded by available CPUs.

## Why This Change Was Made

The packaging owner now delegates each architecture to an isolated app and MLX package root, with separate SwiftPM scratch paths, a verified read-only Peekaboo source snapshot, invocation-owned resource backups, and an exclusive architecture lock. The existing managed-child process owner joins workers and descendants before restoring patched sources or detaching snapshots. A failed build cancels its sibling; cleanup failure retains work and ownership locks for diagnosis. Assembly begins only after both builds verify the expected source revision.

The old serial graph loop and shared temporary-package/snapshot cleanup path are removed. The existing shell build logic is extracted into one worker owner, rather than duplicated. Production delta is +197 lines after accounting for the move; the additional code owns concurrent scheduling, cancellation, and verified cleanup. Tests add 132 net lines. No new operator configuration is introduced.

## User Impact

Maintainers can produce universal macOS releases sooner without changing the packaged application's behavior. This is an internal release-tooling change, so no product changelog entry is needed.

## Evidence

- Before: an execution barrier in the original serial graph loop observed only arm64 starting and exited 41 while waiting for the second architecture.
- `node scripts/run-vitest.mjs test/scripts/package-mac-app.test.ts`: 81 tests passed. Executable fixtures cover concurrent success, worker failure, source-revision mismatch, parent cancellation, cleanup failure and retained locks, resource restoration, snapshot verification, and existing packaging behavior.
- Hosted CI caught the missing Knip executable entry and a Linux-incompatible mount path in the snapshot fixture. The canonical entry is now declared and both unused-file scans pass. Five focused snapshot scenarios pass, including retention when the mount is active or listing fails; this expands the owner suite to 83 cases.
- After the final lint edits, the five executable parallel-build scenarios passed again. Bash syntax checks, targeted formatting, and type-aware lint passed. The scoped Codex autoreview found no actionable P0 findings.
- Two real SwiftPM packages sharing source files built arm64 and x86_64 concurrently with separate package/scratch roots and two jobs each: 7.55s and 7.56s worker times, 7.56s total. Both binaries had the requested architecture; package manifests remained unchanged. This proves the SwiftPM isolation contract, not a complete signed application release.
- The complete packager, extracted worker, managed-child lifecycle owner, relevant SwiftPM CLI/source contracts, and focused tests were inspected. A full application rebuild and Apple upload were deliberately not repeated for this post-release follow-up.

Alternative considered: simply backgrounding the original loop would share shell state, package lockfiles and cleanup ownership; architecture-local workers keep those responsibilities explicit. Remaining limitation: no end-to-end signed universal application was rebuilt for this change.
