### PR TITLE
fix(doctor): resolve stale workspace setup migration loops

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -277,6 +277,17 @@ the container normally.
 
 `openclaw doctor --fix` is the only owner for persistent file-to-SQLite migrations. It validates and claims each recognized source, writes and verifies canonical rows, records a migration receipt, then removes the retired source. Runtime code does not perform lazy imports or fallback reads.
 
+For legacy workspace setup files, an existing canonical SQLite setup record wins,
+including milestones that are absent in SQLite. Doctor does not replay stale
+milestones over it. Before removing a validated setup file or interrupted claim,
+Doctor preserves its exact bytes beside the original as
+`<source>.migrated.<sha256>.<unique-id>`. The SQLite migration receipt records that archive
+path and one line per differing milestone (`legacy=... canonical=...`), which
+Doctor also prints. With no canonical setup record, Doctor imports the legacy
+milestones normally. A successful repair removes the runtime blocker; the next
+run has no workspace setup migration to repeat. Invalid files and workspace
+identity/version conflicts remain blocked for inspection.
+
 Doctor reports interrupted auth-profile archive recovery even when no new migration remains or you decline another migration. If recovery cannot finish, its warning includes the failure cause and leaves the pending source for recovery; do not delete it to silence the warning.
 
 `doctor --fix` also repairs an inconsistent completed auth migration only when its old receipt has no credential fingerprints, none of the migrated credentials remain in the current canonical store, and the preserved archive still matches the recorded source hash. Doctor reimports through the normal verified migration flow. Completed receipts with fingerprints, surviving migrated credentials, or no archive remain untouched, so removing credentials after a verified migration does not restore them from backup.

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -40,6 +40,7 @@ import {
   recordOpenClawDatabaseQuarantine,
 } from "../state/openclaw-quarantine-store.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { sessionDeliveryRoute } from "../utils/delivery-context.shared.js";
 import * as migrationArtifact from "./doctor-session-sqlite-artifact.js";
 import { createSessionSqliteMigrationFailureIssue } from "./doctor-session-sqlite-failure.js";
@@ -2879,6 +2880,47 @@ describe("runDoctorSessionSqlite", () => {
       expect(fs.readFileSync(externalStorePath, "utf8")).toBe("{}\n");
     },
   );
+
+  it("preserves the typed maintenance cause when import finalization fails", async () => {
+    const store = createLegacyStore();
+    fs.writeFileSync(store.storePath, "{}\n");
+    openOpenClawAgentDatabase({ agentId: "main", env: store.env });
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    const openDatabase = nodeSqlite.openNodeSqliteDatabase;
+    const sharedPath = resolveOpenClawStateSqlitePath(store.env);
+    const spy = vi
+      .spyOn(nodeSqlite, "openNodeSqliteDatabase")
+      .mockImplementation((file, options) => {
+        if (file === sharedPath && !options?.readOnly) {
+          throw Object.assign(new Error("fixture lease storage failure"), { code: "SQLITE_IOERR" });
+        }
+        return openDatabase(file, options);
+      });
+    try {
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+      expect(report.targets[0]?.issues).toContainEqual(
+        expect.objectContaining({
+          code: "sqlite_compact_failed",
+          message: expect.stringContaining("fixture lease storage failure | SQLITE_IOERR"),
+        }),
+      );
+      expect(fs.readFileSync(store.storePath, "utf8")).toBe("{}\n");
+      const failureReportPath = expectDefined(
+        report.migrationRun?.failureReportMarkdownPath,
+        "failure report",
+      );
+      expect(fs.readFileSync(failureReportPath, "utf8")).toContain(
+        "fixture lease storage failure | SQLITE_IOERR",
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
 
   it("refuses compaction while this process owns an open agent database handle", async () => {
     const { sqlitePath, store } = await createImportedStoreForCompaction();

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -1441,7 +1441,7 @@ async function compactSqliteDatabase(
   } catch (err) {
     report.issues.push({
       code: "sqlite_compact_failed",
-      message: `SQLite database compact failed: ${String(err)}`,
+      message: `SQLite database compact failed: ${formatErrorMessage(err)}`,
     });
   }
 }

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
   readSessionArchiveContentSync,
@@ -14,6 +14,8 @@ import {
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import * as nodeSqlite from "./node-sqlite.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
 import {
@@ -33,6 +35,30 @@ afterEach(() => {
 });
 
 describe("legacy media persistence doctor migration", () => {
+  it("preserves the typed maintenance cause when lease acquisition fails", async () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-lease-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const sharedPath = resolveOpenClawStateSqlitePath(env);
+    const openDatabase = nodeSqlite.openNodeSqliteDatabase;
+    const spy = vi
+      .spyOn(nodeSqlite, "openNodeSqliteDatabase")
+      .mockImplementation((file, options) => {
+        if (file === sharedPath) {
+          throw Object.assign(new Error("fixture lease storage failure"), { code: "SQLITE_IOERR" });
+        }
+        return openDatabase(file, options);
+      });
+    try {
+      const result = await migrateLegacyMediaPersistence({ env });
+      expect(result.changes).toEqual([]);
+      expect(result.warnings).toEqual([
+        expect.stringContaining("fixture lease storage failure | SQLITE_IOERR"),
+      ]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("canonicalizes assistant media at the generic transcript append owner", async () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-append-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/infra/state-migrations.media-persistence.ts
+++ b/src/infra/state-migrations.media-persistence.ts
@@ -34,6 +34,7 @@ import { withLegacySessionParticipantsSchema } from "../state/openclaw-agent-par
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
 import { VERSION } from "../version.js";
+import { formatErrorMessage } from "./errors.js";
 import { repairGatewayAgentMediaMigrationStartupFailures } from "./gateway-boot-lifecycle.js";
 import {
   executeSqliteQuerySync,
@@ -715,7 +716,7 @@ export async function migrateLegacyMediaPersistence(
       }
     });
   } catch (error) {
-    warnings.push(`Agent database maintenance deferred: ${String(error)}`);
+    warnings.push(`Agent database maintenance deferred: ${formatErrorMessage(error)}`);
   }
   return { changes, warnings };
 }

--- a/src/infra/state-migrations.workspace-setup-receipts.ts
+++ b/src/infra/state-migrations.workspace-setup-receipts.ts
@@ -1,4 +1,5 @@
 // Receipt lookup and source-removal bookkeeping for legacy workspace migration.
+import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion";
 import {
   readLegacyMigrationReceipt,
   resolveLegacyMigrationSourceKey,
@@ -11,6 +12,7 @@ export type MigrationReceipt = {
   sourceKey: string;
   sha256: string | null;
   removedSource: boolean;
+  archivePath?: string;
 };
 
 export function resolveWorkspaceMigrationSourceKey(source: LegacyWorkspaceStateSource): string {
@@ -26,11 +28,13 @@ export function readReceipt(
   env: NodeJS.ProcessEnv,
 ): MigrationReceipt | null {
   const receipt = readLegacyMigrationReceipt(resolveWorkspaceMigrationSourceKey(source), env);
+  const archivePath = receipt ? safeParseJsonRecord(receipt.reportJson)?.archivePath : undefined;
   return receipt
     ? {
         sourceKey: receipt.sourceKey,
         sha256: receipt.sourceSha256,
         removedSource: receipt.removedSource,
+        ...(typeof archivePath === "string" ? { archivePath } : {}),
       }
     : null;
 }

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -23,7 +23,10 @@ import {
   readLegacyMigrationReceiptFromDatabase,
   recordLegacyMigrationReceipt,
 } from "./state-migrations.receipts.js";
-import { resolveWorkspaceMigrationSourceKey } from "./state-migrations.workspace-setup-receipts.js";
+import {
+  resolveWorkspaceMigrationSourceKey,
+  type MigrationReceipt,
+} from "./state-migrations.workspace-setup-receipts.js";
 import type { LegacyWorkspaceStateSource } from "./state-migrations.workspace-setup.types.js";
 
 const MIGRATION_KIND = WORKSPACE_LEGACY_STATE_MIGRATION_KIND;
@@ -44,6 +47,7 @@ export type SourceSnapshot = {
   sha256: string;
   size: number;
   raw: string;
+  buffer: Buffer;
 };
 
 type ParsedSetup = {
@@ -175,16 +179,16 @@ function canonicalFingerprint(value: unknown): string {
 }
 
 function setupFingerprint(params: {
-  workspacePath: string;
-  bootstrapSeededAt: string | null;
-  setupCompletedAt: string | null;
+  workspace_path: string | null;
+  bootstrap_seeded_at: string | null;
+  setup_completed_at: string | null;
 }): string {
   return canonicalFingerprint({
     kind: "setup",
-    workspacePath: params.workspacePath,
+    workspacePath: params.workspace_path,
     version: WORKSPACE_SETUP_STATE_VERSION,
-    bootstrapSeededAt: params.bootstrapSeededAt,
-    setupCompletedAt: params.setupCompletedAt,
+    bootstrapSeededAt: params.bootstrap_seeded_at,
+    setupCompletedAt: params.setup_completed_at,
   });
 }
 
@@ -268,9 +272,6 @@ export function canonicalCoversParsedSource(params: {
   return runSqliteDeferredTransactionSync(db, () => {
     const kysely = getNodeSqliteKysely<WorkspaceMigrationDatabase>(db);
     if (params.source.kind === "setup" && params.parsed.kind === "setup") {
-      if (!params.source.workspaceDir) {
-        return false;
-      }
       const row = executeSqliteQueryTakeFirstSync(
         db,
         kysely
@@ -278,25 +279,11 @@ export function canonicalCoversParsedSource(params: {
           .selectAll()
           .where("workspace_key", "=", params.source.workspaceKey),
       );
-      if (
-        !row ||
-        row.workspace_path !== params.source.workspaceDir ||
-        row.version !== WORKSPACE_SETUP_STATE_VERSION
-      ) {
-        return false;
-      }
-      const fingerprint = setupFingerprint({
-        workspacePath: row.workspace_path,
-        bootstrapSeededAt: row.bootstrap_seeded_at,
-        setupCompletedAt: row.setup_completed_at,
-      });
-      const sourceBootstrapSeededAt = params.parsed.value.bootstrapSeededAt ?? null;
-      const sourceSetupCompletedAt = params.parsed.value.setupCompletedAt ?? null;
-      const coversSource =
-        (sourceBootstrapSeededAt === null || row.bootstrap_seeded_at === sourceBootstrapSeededAt) &&
-        (sourceSetupCompletedAt === null || row.setup_completed_at === sourceSetupCompletedAt);
-      const authority = findMigrationAuthority({ db, kysely, source: params.source, fingerprint });
-      return coversSource || Boolean(authority && authority.priority <= params.source.priority);
+      // SQLite owns initialized milestones; a matching receipt permits cleanup only.
+      return (
+        row?.version === WORKSPACE_SETUP_STATE_VERSION &&
+        row.workspace_path === params.source.workspaceDir
+      );
     }
     if (params.source.kind !== "attestation" || params.parsed.kind !== "attestation") {
       return false;
@@ -343,8 +330,9 @@ export function importAndRecordReceipt(params: {
   snapshot: SourceSnapshot;
   parsed: ParsedSource;
   env: NodeJS.ProcessEnv;
-  replaceRemovedReceipt?: boolean;
-}): { sourceKey: string; imported: boolean } {
+  previousReceipt?: MigrationReceipt;
+  archivePath?: string;
+}): { sourceKey: string; imported: boolean; differences: string[] } {
   const key = resolveWorkspaceMigrationSourceKey(params.source);
   const runId = `${key}:${params.snapshot.sha256.slice(0, 16)}`;
   const now = Date.now();
@@ -353,23 +341,23 @@ export function importAndRecordReceipt(params: {
       const { db } = database;
       const kysely = getNodeSqliteKysely<WorkspaceMigrationDatabase>(db);
       const existingReceipt = readLegacyMigrationReceiptFromDatabase(db, key);
-      // Only a receipt whose source was fully removed can be replaced by a later generation.
-      if (existingReceipt && (!params.replaceRemovedReceipt || !existingReceipt.removedSource)) {
+      // Revalidate the observed receipt before publishing a new backup or generation.
+      if (
+        existingReceipt &&
+        (existingReceipt.sourceSha256 !== params.previousReceipt?.sha256 ||
+          existingReceipt.removedSource !== params.previousReceipt?.removedSource)
+      ) {
         throw new Error("workspace migration receipt appeared concurrently; retry Doctor");
       }
 
       let imported = false;
+      const differences: string[] = [];
       let resolution: "inserted" | "verified" | "merged" | "replaced" | "superseded";
       let verifiedFingerprint: string;
       if (params.parsed.kind === "setup") {
         if (!params.source.workspaceDir) {
           throw new Error("legacy workspace setup has no workspace path");
         }
-        const incomingFingerprint = setupFingerprint({
-          workspacePath: params.source.workspaceDir,
-          bootstrapSeededAt: params.parsed.value.bootstrapSeededAt ?? null,
-          setupCompletedAt: params.parsed.value.setupCompletedAt ?? null,
-        });
         const existing = executeSqliteQueryTakeFirstSync(
           db,
           kysely
@@ -384,77 +372,22 @@ export function importAndRecordReceipt(params: {
           ) {
             throw new Error("legacy workspace setup conflicts with canonical SQLite state");
           }
-          const existingFingerprint = setupFingerprint({
-            workspacePath: existing.workspace_path,
-            bootstrapSeededAt: existing.bootstrap_seeded_at,
-            setupCompletedAt: existing.setup_completed_at,
-          });
-          const sourceBootstrapSeededAt = params.parsed.value.bootstrapSeededAt ?? null;
-          const sourceSetupCompletedAt = params.parsed.value.setupCompletedAt ?? null;
-          const coversSource =
-            (sourceBootstrapSeededAt === null ||
-              existing.bootstrap_seeded_at === sourceBootstrapSeededAt) &&
-            (sourceSetupCompletedAt === null ||
-              existing.setup_completed_at === sourceSetupCompletedAt);
-          const authority = findMigrationAuthority({
-            db,
-            kysely,
-            source: params.source,
-            fingerprint: existingFingerprint,
-          });
-          if (authority && params.source.priority < authority.priority) {
-            executeSqliteQuerySync(
-              db,
-              kysely
-                .updateTable("workspace_setup_state")
-                .set({
-                  bootstrap_seeded_at: sourceBootstrapSeededAt,
-                  setup_completed_at: sourceSetupCompletedAt,
-                  updated_at: now,
-                })
-                .where("workspace_key", "=", params.source.workspaceKey),
-            );
-            imported = true;
-            resolution = "replaced";
-            verifiedFingerprint = incomingFingerprint;
-          } else if (coversSource) {
-            resolution = "verified";
-            verifiedFingerprint = existingFingerprint;
-          } else if (!authority) {
-            const mergedBootstrapSeededAt = existing.bootstrap_seeded_at ?? sourceBootstrapSeededAt;
-            const mergedSetupCompletedAt = existing.setup_completed_at ?? sourceSetupCompletedAt;
-            const hasConflictingMilestone =
-              (sourceBootstrapSeededAt !== null &&
-                existing.bootstrap_seeded_at !== null &&
-                sourceBootstrapSeededAt !== existing.bootstrap_seeded_at) ||
-              (sourceSetupCompletedAt !== null &&
-                existing.setup_completed_at !== null &&
-                sourceSetupCompletedAt !== existing.setup_completed_at);
-            if (hasConflictingMilestone) {
-              throw new Error("legacy workspace setup conflicts with canonical SQLite state");
+          const existingFingerprint = setupFingerprint(existing);
+          // The canonical record is authoritative even without an import receipt.
+          // Keep legacy differences for inspection instead of replaying old milestones.
+          for (const [milestone, canonical] of [
+            ["bootstrapSeededAt", existing.bootstrap_seeded_at],
+            ["setupCompletedAt", existing.setup_completed_at],
+          ] as const) {
+            const legacy = params.parsed.value[milestone];
+            if (legacy !== undefined && legacy !== canonical) {
+              differences.push(
+                `${milestone} legacy=${JSON.stringify(legacy)} canonical=${JSON.stringify(canonical)}`,
+              );
             }
-            executeSqliteQuerySync(
-              db,
-              kysely
-                .updateTable("workspace_setup_state")
-                .set({
-                  bootstrap_seeded_at: mergedBootstrapSeededAt,
-                  setup_completed_at: mergedSetupCompletedAt,
-                  updated_at: now,
-                })
-                .where("workspace_key", "=", params.source.workspaceKey),
-            );
-            imported = true;
-            resolution = "merged";
-            verifiedFingerprint = setupFingerprint({
-              workspacePath: existing.workspace_path,
-              bootstrapSeededAt: mergedBootstrapSeededAt,
-              setupCompletedAt: mergedSetupCompletedAt,
-            });
-          } else {
-            resolution = "superseded";
-            verifiedFingerprint = existingFingerprint;
           }
+          resolution = differences.length > 0 ? "superseded" : "verified";
+          verifiedFingerprint = existingFingerprint;
         } else {
           // Missing row, or an attestation-only merged row (NULL version) that
           // adopts the legacy setup facts; a differing recorded path conflicts.
@@ -480,7 +413,7 @@ export function importAndRecordReceipt(params: {
           );
           imported = true;
           resolution = existing ? "merged" : "inserted";
-          verifiedFingerprint = incomingFingerprint;
+          verifiedFingerprint = setupFingerprint(setupColumns);
         }
         const verified = executeSqliteQueryTakeFirstSync(
           db,
@@ -492,13 +425,7 @@ export function importAndRecordReceipt(params: {
         // Every setup import branch writes the source path, so a NULL path
         // here is a verification failure, not an attestation-only row.
         const actualFingerprint =
-          verified && verified.workspace_path != null
-            ? setupFingerprint({
-                workspacePath: verified.workspace_path,
-                bootstrapSeededAt: verified.bootstrap_seeded_at,
-                setupCompletedAt: verified.setup_completed_at,
-              })
-            : null;
+          verified && verified.workspace_path != null ? setupFingerprint(verified) : null;
         if (!verified || actualFingerprint !== verifiedFingerprint) {
           throw new Error("SQLite verification failed for workspace setup state");
         }
@@ -695,6 +622,7 @@ export function importAndRecordReceipt(params: {
           receiptPreservesAuthority(existingReceipt, verifiedFingerprint),
         resolution,
         imported,
+        ...(params.archivePath ? { archivePath: params.archivePath, differences } : {}),
       });
       recordLegacyMigrationReceipt(db, {
         sourceKey: key,
@@ -709,7 +637,7 @@ export function importAndRecordReceipt(params: {
         reportJson,
         upsert: existingReceipt !== null,
       });
-      return { sourceKey: key, imported };
+      return { sourceKey: key, imported, differences };
     },
     { env: params.env },
   );

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -824,123 +824,177 @@ describe("legacy workspace Doctor migration", () => {
     ).toBeUndefined();
   });
 
-  it("keeps a conflicting source and preserves canonical SQLite state", async () => {
-    const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const db = openOpenClawStateDatabase({ env: context.env }).db;
-    db.prepare(
-      `INSERT INTO workspace_setup_state (
+  it.each([
+    {
+      bootstrap: "2026-07-16T00:00:00.000Z",
+      completion: "2026-07-16T00:01:00.000Z",
+      label: "both divergent milestones",
+    },
+    {
+      bootstrap: undefined,
+      completion: "2026-07-16T00:01:00.000Z",
+      label: "a legacy-only milestone",
+    },
+  ])(
+    "archives $label, preserves canonical setup, and converges",
+    async ({ bootstrap, completion }) => {
+      const context = setup();
+      const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+      const db = openOpenClawStateDatabase({ env: context.env }).db;
+      const seededAt = "2026-07-15T00:00:00.000Z";
+      const completedAt = bootstrap ? "2026-07-15T00:01:00.000Z" : null;
+      db.prepare(
+        `INSERT INTO workspace_setup_state (
          workspace_key, workspace_path, version, bootstrap_seeded_at, setup_completed_at, updated_at
-       ) VALUES (?, ?, 1, ?, NULL, 1)`,
-    ).run(identity.workspaceKey, identity.workspacePath, "2026-07-15T00:00:00.000Z");
-    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
-    await fsp.writeFile(
-      setupPath,
-      JSON.stringify({ version: 1, bootstrapSeededAt: "2026-07-16T00:00:00.000Z" }),
-      "utf8",
-    );
+       ) VALUES (?, ?, 1, ?, ?, 1)`,
+      ).run(identity.workspaceKey, identity.workspacePath, seededAt, completedAt);
+      const setupPath = path.join(identity.workspacePath, "openclaw-workspace-state.json");
+      const raw = JSON.stringify({
+        version: 1,
+        bootstrapSeededAt: bootstrap,
+        setupCompletedAt: completion,
+      });
+      await fsp.writeFile(setupPath, raw, "utf8");
+      expect(() =>
+        assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
+      ).toThrow(/requires migration/);
 
-    const result = await migrate(context);
+      const result = await migrate(context);
 
-    expect(result.warnings[0]).toContain("conflicts with canonical SQLite state");
-    expect(fs.existsSync(setupPath)).toBe(true);
-    expect(fs.existsSync(`${setupPath}.doctor-importing`)).toBe(false);
-    expect(
-      db
-        .prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
-        .get(identity.workspaceKey),
-    ).toEqual({ bootstrap_seeded_at: "2026-07-15T00:00:00.000Z" });
-  });
+      expect(result.warnings).toEqual([]);
+      expect(fs.existsSync(setupPath)).toBe(false);
+      expect(fs.existsSync(`${setupPath}.doctor-importing`)).toBe(false);
+      expect(readWorkspaceStateSnapshot(context.workspaceDir).setup).toEqual({
+        version: 1,
+        bootstrapSeededAt: seededAt,
+        ...(completedAt ? { setupCompletedAt: completedAt } : {}),
+      });
+      const receipt = db
+        .prepare("SELECT report_json, removed_source FROM migration_sources WHERE source_path = ?")
+        .get(setupPath) as { report_json: string; removed_source: number };
+      const archivePath = JSON.parse(receipt.report_json).archivePath as string;
+      expect(archivePath).toMatch(
+        `${setupPath}.migrated.${createHash("sha256").update(raw).digest("hex")}.`,
+      );
+      await expect(fsp.readFile(archivePath, "utf8")).resolves.toBe(raw);
+      const differences = [
+        ...(bootstrap
+          ? [
+              `bootstrapSeededAt legacy=${JSON.stringify(bootstrap)} canonical=${JSON.stringify(seededAt)}`,
+            ]
+          : []),
+        `setupCompletedAt legacy=${JSON.stringify(completion)} canonical=${JSON.stringify(completedAt)}`,
+      ];
+      expect(JSON.parse(receipt.report_json)).toMatchObject({
+        resolution: "superseded",
+        imported: false,
+        archivePath,
+        differences,
+      });
+      expect(receipt.removed_source).toBe(1);
+      expect(result.notices).toEqual(expect.arrayContaining(differences));
+      expect(() =>
+        assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
+      ).not.toThrow();
+      expect(detect(context).hasLegacy).toBe(false);
+      expect(await migrate(context)).toEqual({ changes: [], warnings: [] });
+      expect(
+        db
+          .prepare(
+            "SELECT report_json, removed_source FROM migration_sources WHERE source_path = ?",
+          )
+          .get(setupPath),
+      ).toEqual(receipt);
+      await expect(fsp.readFile(archivePath, "utf8")).resolves.toBe(raw);
+    },
+  );
 
-  it("merges complementary legacy milestones into unowned SQLite setup state", async () => {
-    const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const seededAt = "2026-07-15T00:00:00.000Z";
-    const completedAt = "2026-07-15T00:01:00.000Z";
-    const db = openOpenClawStateDatabase({ env: context.env }).db;
-    db.prepare(
-      `INSERT INTO workspace_setup_state (
-         workspace_key, workspace_path, version, bootstrap_seeded_at, setup_completed_at, updated_at
-       ) VALUES (?, ?, 1, ?, NULL, 1)`,
-    ).run(identity.workspaceKey, identity.workspacePath, seededAt);
-    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
-    await fsp.writeFile(
-      setupPath,
-      JSON.stringify({ version: 1, setupCompletedAt: completedAt }),
-      "utf8",
-    );
+  it.each(["new", "old", "conflicting"])(
+    "uses receipts for idempotent cleanup-only retries (%s receipt)",
+    async (kind) => {
+      const conflicting = kind === "conflicting";
+      const context = setup();
+      const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+      const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+      const seededAt = "2026-07-15T00:00:00.000Z";
+      const setupSource = JSON.stringify({ version: 1, bootstrapSeededAt: seededAt });
+      const claimPath = `${setupPath}.doctor-importing`;
+      const canonicalSeededAt = conflicting ? "2026-07-14T00:00:00.000Z" : seededAt;
+      if (conflicting) {
+        openOpenClawStateDatabase({ env: context.env })
+          .db.prepare(
+            "INSERT INTO workspace_setup_state (workspace_key, workspace_path, version, bootstrap_seeded_at, updated_at) VALUES (?, ?, 1, ?, 1)",
+          )
+          .run(identity.workspaceKey, identity.workspacePath, canonicalSeededAt);
+      }
+      await fsp.writeFile(setupPath, setupSource, "utf8");
+      const first = await migrateLegacyWorkspaceState({
+        detected: detect(context),
+        env: context.env,
+        stateDir: context.stateDir,
+        removeSource: () => {
+          throw new Error("simulated unlink failure");
+        },
+      });
+      expect(first.warnings[0]).toContain("legacy cleanup failed");
+      expect(first.warnings[0]).toContain(setupPath);
+      expect(fs.existsSync(claimPath)).toBe(true);
+      const db = openOpenClawStateDatabase({ env: context.env }).db;
 
-    const result = await migrate(context);
+      await fsp.writeFile(claimPath, "{invalid", "utf8");
+      const unreadable = await migrate(context);
+      expect(unreadable.warnings[0]).toContain(setupPath);
+      expect(unreadable.warnings[0]).toContain("invalid JSON");
+      expect(await fsp.readFile(claimPath, "utf8")).toBe("{invalid");
 
-    expect(result.warnings).toEqual([]);
-    expect(fs.existsSync(setupPath)).toBe(false);
-    expect(
-      db
-        .prepare(
-          "SELECT bootstrap_seeded_at, setup_completed_at FROM workspace_setup_state WHERE workspace_key = ?",
-        )
-        .get(identity.workspaceKey),
-    ).toEqual({ bootstrap_seeded_at: seededAt, setup_completed_at: completedAt });
-    const receipt = db
-      .prepare("SELECT report_json FROM migration_sources WHERE source_path = ?")
-      .get(path.join(identity.workspacePath, "openclaw-workspace-state.json")) as {
-      report_json: string;
-    };
-    expect(JSON.parse(receipt.report_json)).toMatchObject({
-      authoritative: false,
-      imported: true,
-      resolution: "merged",
-    });
-  });
+      await fsp.writeFile(claimPath, setupSource, "utf8");
+      const archiveReceipt = db
+        .prepare("SELECT report_json FROM migration_sources WHERE source_path = ?")
+        .get(setupPath) as { report_json: string };
+      const archivePath = JSON.parse(archiveReceipt.report_json).archivePath as string;
+      await expect(fsp.readFile(archivePath, "utf8")).resolves.toBe(setupSource);
+      if (kind === "old") {
+        const oldReport = JSON.parse(archiveReceipt.report_json);
+        delete oldReport.archivePath;
+        delete oldReport.differences;
+        db.prepare("UPDATE migration_sources SET report_json = ? WHERE source_path = ?").run(
+          JSON.stringify(oldReport),
+          setupPath,
+        );
+      } else {
+        await fsp.writeFile(archivePath, "partial backup", "utf8");
+        const corruptBackup = await migrate(context);
+        expect(corruptBackup.warnings[0]).toContain("backup differs from the claimed source");
+        expect(fs.existsSync(claimPath)).toBe(true);
+        await fsp.writeFile(archivePath, setupSource, "utf8");
+      }
+      const retry = await migrate(context);
 
-  it("uses receipts for idempotent cleanup-only retries", async () => {
-    const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
-    const seededAt = "2026-07-15T00:00:00.000Z";
-    const setupSource = JSON.stringify({ version: 1, bootstrapSeededAt: seededAt });
-    const claimPath = `${setupPath}.doctor-importing`;
-    await fsp.writeFile(setupPath, setupSource, "utf8");
-    const first = await migrateLegacyWorkspaceState({
-      detected: detect(context),
-      env: context.env,
-      stateDir: context.stateDir,
-      removeSource: () => {
-        throw new Error("simulated unlink failure");
-      },
-    });
-    expect(first.warnings[0]).toContain("legacy cleanup failed");
-    expect(first.warnings[0]).toContain(setupPath);
-    expect(fs.existsSync(claimPath)).toBe(true);
-    const db = openOpenClawStateDatabase({ env: context.env }).db;
-
-    await fsp.writeFile(claimPath, "{invalid", "utf8");
-    const unreadable = await migrate(context);
-    expect(unreadable.warnings[0]).toContain(setupPath);
-    expect(unreadable.warnings[0]).toContain("invalid JSON");
-    expect(await fsp.readFile(claimPath, "utf8")).toBe("{invalid");
-
-    await fsp.writeFile(claimPath, setupSource, "utf8");
-    const retry = await migrate(context);
-
-    expect(retry.warnings).toEqual([]);
-    expect(fs.existsSync(claimPath)).toBe(false);
-    expect(
-      db
-        .prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
-        .get(identity.workspaceKey),
-    ).toEqual({ bootstrap_seeded_at: seededAt });
-    expect(
-      db
-        .prepare(
-          "SELECT source_sha256, removed_source FROM migration_sources WHERE source_path = ?",
-        )
-        .get(path.join(identity.workspacePath, "openclaw-workspace-state.json")),
-    ).toEqual({
-      source_sha256: createHash("sha256").update(setupSource).digest("hex"),
-      removed_source: 1,
-    });
-  });
+      expect(retry.warnings).toEqual([]);
+      const finalReceipt = db
+        .prepare("SELECT report_json FROM migration_sources WHERE source_path = ?")
+        .get(setupPath) as { report_json: string };
+      const finalArchive = JSON.parse(finalReceipt.report_json).archivePath as string;
+      expect(finalArchive === archivePath).toBe(kind !== "old");
+      await expect(fsp.readFile(finalArchive, "utf8")).resolves.toBe(setupSource);
+      expect(fs.existsSync(claimPath)).toBe(false);
+      expect(
+        db
+          .prepare("SELECT bootstrap_seeded_at FROM workspace_setup_state WHERE workspace_key = ?")
+          .get(identity.workspaceKey),
+      ).toEqual({ bootstrap_seeded_at: canonicalSeededAt });
+      expect(
+        db
+          .prepare(
+            "SELECT source_sha256, removed_source FROM migration_sources WHERE source_path = ?",
+          )
+          .get(path.join(identity.workspacePath, "openclaw-workspace-state.json")),
+      ).toEqual({
+        source_sha256: createHash("sha256").update(setupSource).digest("hex"),
+        removed_source: 1,
+      });
+    },
+  );
 
   it("cleans receipt-covered superseded setup markers after an interrupted delete", async () => {
     const context = setup();

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -1,5 +1,5 @@
 // Doctor-only import for retired workspace setup and attestation files.
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -108,10 +108,37 @@ async function readBoundedRegularFile(params: {
       sha256: createHash("sha256").update(buffer).digest("hex"),
       size: after.size,
       raw,
+      buffer,
     };
   } finally {
     await opened[Symbol.asyncDispose]();
   }
+}
+
+async function archiveWorkspaceSetupSource(
+  sourceRoot: Root,
+  source: LegacyWorkspaceStateSource,
+  snapshot: SourceSnapshot,
+  existingArchivePath?: string,
+): Promise<string> {
+  const archivePath =
+    existingArchivePath ?? `${source.sourcePath}.migrated.${snapshot.sha256}.${randomUUID()}`;
+  const relativePath = path.relative(source.rootDir, archivePath);
+  // The receipt publishes only a verified backup. A crash during creation leaves
+  // an unreferenced artifact, so the next attempt can safely use a fresh name.
+  if (!existingArchivePath) {
+    await sourceRoot.create(relativePath, snapshot.buffer, { mode: 0o600 });
+  }
+  const archived = await readBoundedRegularFile({
+    sourceRoot,
+    relativePath,
+    sourcePath: archivePath,
+    maxBytes: SETUP_MAX_BYTES,
+  });
+  if (archived.sha256 !== snapshot.sha256) {
+    throw new Error(`workspace setup backup differs from the claimed source: ${archivePath}`);
+  }
+  return archivePath;
 }
 
 function createLegacySourceClaim(
@@ -342,6 +369,7 @@ function assertConfiguredWorkspaceIdentity(source: LegacyWorkspaceStateSource): 
 }
 
 async function cleanupReceiptSource(params: {
+  sourceRoot: Root;
   sourceClaim: LegacyMigrationSourceClaim<SourceSnapshot>;
   source: LegacyWorkspaceStateSource;
   receipt: MigrationReceipt;
@@ -393,6 +421,30 @@ async function cleanupReceiptSource(params: {
         warnings: ["Workspace state is in SQLite, but the retired source now conflicts."],
       };
     }
+    const notices: string[] = [];
+    if (parsed.kind === "setup") {
+      const archivePath = await archiveWorkspaceSetupSource(
+        params.sourceRoot,
+        params.source,
+        snapshot,
+        params.receipt.archivePath,
+      );
+      if (!params.receipt.archivePath) {
+        // Receipts written before setup backups still need an archive before cleanup.
+        const imported = importAndRecordReceipt({
+          source: params.source,
+          snapshot,
+          parsed,
+          env: params.env,
+          previousReceipt: params.receipt,
+          archivePath,
+        });
+        notices.push(
+          `Archived legacy workspace setup state at ${archivePath}.`,
+          ...imported.differences,
+        );
+      }
+    }
     const unchanged = await sourceClaim.read(true);
     if (!snapshotsMatch(snapshot, unchanged)) {
       if (claimedByThisRun) {
@@ -406,7 +458,10 @@ async function cleanupReceiptSource(params: {
     return {
       changes: [],
       warnings: [],
-      notices: ["Discarded retired workspace state already covered by its SQLite receipt."],
+      notices: [
+        ...notices,
+        "Discarded retired workspace state already covered by its SQLite receipt.",
+      ],
     };
   } catch (error) {
     return {
@@ -425,9 +480,10 @@ async function migrateOneSource(params: {
   removeSource?: (sourcePath: string) => Promise<void> | void;
 }): Promise<MigrationMessages> {
   let sourceClaim: LegacyMigrationSourceClaim<SourceSnapshot>;
+  let sourceRoot: Root;
   try {
     assertConfiguredWorkspaceIdentity(params.source);
-    const sourceRoot = await root(params.source.rootDir, {
+    sourceRoot = await root(params.source.rootDir, {
       hardlinks: "reject",
       symlinks: "reject",
     });
@@ -454,6 +510,7 @@ async function migrateOneSource(params: {
   // already renamed before a crash. Collisions keep the stricter receipt check.
   if (receipt && !(receipt.removedSource && hasSource !== hasClaim)) {
     return cleanupReceiptSource({
+      sourceRoot,
       sourceClaim,
       source: params.source,
       receipt,
@@ -477,6 +534,7 @@ async function migrateOneSource(params: {
   let operation = `reading legacy workspace state at ${params.source.sourcePath}`;
   let claimAttempted = false;
   let imported: ReturnType<typeof importAndRecordReceipt> | undefined;
+  let archivePath: string | undefined;
   try {
     let snapshot = await sourceClaim.read(!hasSource);
     // Empty reserved hashed markers have no importable state. The runtime gate is
@@ -507,13 +565,17 @@ async function migrateOneSource(params: {
     }
 
     if (parsed) {
+      if (parsed.kind === "setup") {
+        archivePath = await archiveWorkspaceSetupSource(sourceRoot, params.source, snapshot);
+      }
       assertConfiguredWorkspaceIdentity(params.source);
       imported = importAndRecordReceipt({
         source: params.source,
         snapshot,
         parsed,
         env: params.env,
-        replaceRemovedReceipt: receipt?.removedSource === true,
+        previousReceipt: receipt ?? undefined,
+        archivePath,
       });
     }
 
@@ -559,7 +621,11 @@ async function migrateOneSource(params: {
       imported.imported ? `Migrated ${label} to SQLite.` : `Verified canonical SQLite ${label}.`,
     ],
     warnings: [],
-    notices: ["Removed retired workspace state after verified SQLite import."],
+    notices: [
+      ...(archivePath ? [`Archived legacy workspace setup state at ${archivePath}.`] : []),
+      ...imported.differences,
+      "Removed retired workspace state after verified SQLite import.",
+    ],
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users upgrading from legacy workspace setup files could run `openclaw doctor --fix` repeatedly without unblocking agent turns. Different setup timestamps in SQLite and the retired file caused Doctor to retain that file indefinitely; runtime then sent every turn back to the same unsuccessful repair.

Fixes #134331. Related: #135395, #135717.

## Why This Change Was Made

Apply the maintainer-approved database-first policy at the workspace setup migration owner: an initialized canonical SQLite setup record wins, including absent milestones. Retired setup files no longer replace or complement that record based on legacy-source priority. An absent setup record still imports normally; attestation precedence and unsafe-file, identity, version, and collision checks remain unchanged.

Before retiring a validated setup source, Doctor exclusively creates a uniquely named backup, verifies its exact bytes, and publishes its path through the existing SQLite migration receipt. The receipt and Doctor notices identify each differing milestone as `legacy=... canonical=...`. Interrupted cleanup verifies the receipt-selected backup; older pending receipts acquire archive metadata before removal. A crash before receipt publication leaves an unreferenced backup, not a poisoned deterministic filename that blocks every retry. No schema, version, configuration, or environment surface is added.

The two maintenance diagnostics also use the existing redacting cause formatter instead of erasing the nested error. Heartbeat timing and Tailscale are outside this change. Thanks to @jjjhenriksen for the milestone-level diagnostic work in #135395; this change carries that diagnostic intent into the canonical-wins repair instead of adding a legacy-acceptance switch.

## User Impact

A valid stale setup file no longer strands Discord or other channel turns in a Doctor loop. Canonical setup facts remain unchanged, the original file bytes remain inspectable in the recorded backup, and subsequent Doctor runs have no setup migration to repeat. Malformed or unsafe files still fail closed.

Maintenance failures now retain their underlying message and error code, helping distinguish the separately tracked lease failures without weakening lease authority.

## Evidence

- Failing-before workspace regression: `pnpm test src/infra/state-migrations.workspace-setup.test.ts -- -t 'archives .*preserves canonical'` failed against untouched production source with `Failed migrating legacy workspace state: legacy workspace setup conflicts with canonical SQLite state`. The legacy-only case also proved the old path had no backup.
- Both nested-cause regressions failed before their respective formatter replacements: the recorded diagnostic contained only `OpenClawStateLeaseError: failed to acquire agent database maintenance lease ...`, omitting `fixture lease storage failure | SQLITE_IOERR`. The fault is injected at SQLite opening; the real maintenance owner supplies the typed wrapper.
- Workspace, recreated-marker, sandbox, and media suites: 72 tests passed. Includes backup bytes, per-milestone receipt content, second-run no-op, new/old/conflicting receipt recovery, corrupt-backup refusal, configured aliases, sandbox ownership, and unchanged attestation precedence.
- `pnpm build qaRuntime`: passed; no ineffective dynamic imports.
- Real disposable-state CLI: ran `pnpm openclaw doctor --fix --non-interactive` twice; both exited 0. First run printed archive and both milestone differences. Direct SQLite inspection confirmed the original canonical timestamps, `resolution=superseded`, `imported=false`, and `removed_source=1`; backup SHA-256 matched the recorded original. Second run reported no workspace setup migration. No operator state or live Gateway was used. This proves the Doctor/runtime migration boundary, not an authenticated Discord roundtrip.

- Focused session checks: `pnpm test src/commands/doctor-session-sqlite.test.ts -- -t 'preserves the typed maintenance cause|refuses compaction|rejects .* before compaction'` passed all 6 selected cases, including persisted failure-report cause text.
- Broader local session run was interrupted after three existing retirement-fixture failures (`unlink`, `unlink-later`, `receipt`) following 57 passing cases. Their six-case original group passed on a fresh focused rerun: `pnpm test src/commands/doctor-session-sqlite.test.ts -- -t 'resumes retirement after a' --bail=1`. A subsequent full rerun in original order, `pnpm test src/commands/doctor-session-sqlite.test.ts -- --bail=1`, passed **all 223 tests** unchanged (652.77s), including the three earlier failures. The transient first-run cause is not established; no lease timeout/heartbeat behavior was altered to get a pass.
- Uncommitted Codex autoreview: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority` (exit 0).
- Production LOC: +122/-123 (net -1). Tests: +236/-114 (net +122). Documentation: +11/-0. No baseline, inventory, snapshot, or changelog edits.

- Changed-file gate passed: `node scripts/check-changed.mjs -- <the nine changed paths>` (format, core/test typechecks, lint, dead exports, migration/schema/boundary guards, import cycles).
- Branch Codex autoreview also exited 0 with `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`.
- Exact-head CI is attached to `6b0c1b20b0d5a2b8cc5412395708cdd5938a0e60`: https://github.com/openclaw/openclaw/actions/runs/33578919318 **green**, watcher exited 0 with `GREEN`. Total owner/sibling coverage is 295 passing tests across the five files, plus the focused reruns. [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135755#issuecomment-5502966085) found no actionable code findings. Its rank-up move (green exact-head CI) is satisfied; [pre-merge proof](https://github.com/openclaw/openclaw/pull/135755#issuecomment-5503014365) records the completed gates.
