### PR TITLE
test: prune Telegram live Docker source mirrors

### DIFF
--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -29,24 +29,17 @@ afterEach(() => {
 });
 
 describe("package Telegram live Docker E2E", () => {
-  it("supports npm-specific Convex credential aliases", () => {
+  it("forwards npm-specific credential aliases through the Docker boundary", () => {
     const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
 
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE");
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE");
-    expect(script).toContain('docker_env+=(-e OPENCLAW_QA_CREDENTIAL_SOURCE="$credential_source")');
-    expect(script).toContain('docker_env+=(-e OPENCLAW_QA_CREDENTIAL_ROLE="$credential_role")');
-  });
-
-  it("defaults CI runs to Convex when broker credentials are present", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-
-    expect(script).toContain(
-      'if [ -n "${CI:-}" ] && [ -n "${OPENCLAW_QA_CONVEX_SITE_URL:-}" ]; then',
-    );
-    expect(script).toContain("OPENCLAW_QA_CONVEX_SECRET_CI");
-    expect(script).toContain("OPENCLAW_QA_CONVEX_SECRET_MAINTAINER");
-    expect(script).toContain('printf "convex"');
+    for (const contract of [
+      "OPENCLAW_NPM_TELEGRAM_CREDENTIAL_SOURCE",
+      "OPENCLAW_NPM_TELEGRAM_CREDENTIAL_ROLE",
+      'docker_env+=(-e OPENCLAW_QA_CREDENTIAL_SOURCE="$credential_source")',
+      'docker_env+=(-e OPENCLAW_QA_CREDENTIAL_ROLE="$credential_role")',
+    ]) {
+      expect(script).toContain(contract);
+    }
   });
 
   it("installs the package candidate before forwarding runtime secrets", () => {
@@ -92,146 +85,6 @@ describe("package Telegram live Docker E2E", () => {
     );
     expect(script).toContain('credential_role="ci"');
     expect(script).toContain('credential_role="maintainer"');
-  });
-
-  it("bounds installed-package hot path OpenClaw commands", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-    const runtimeRunStart = script.indexOf("# Mount the trusted current-source QA harness");
-    const runtimeRun = script.slice(runtimeRunStart);
-
-    expect(runtimeRunStart).toBeGreaterThanOrEqual(0);
-    expect(script).toContain(
-      '-e OPENCLAW_E2E_COMMAND_TIMEOUT="${OPENCLAW_E2E_COMMAND_TIMEOUT:-300s}"',
-    );
-    expect(runtimeRun).toContain("source scripts/lib/openclaw-e2e-instance.sh");
-    expect(runtimeRun).toContain('sut_command="/npm-global/bin/openclaw"');
-    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" --version');
-    expect(runtimeRun).toContain(
-      'openclaw_e2e_run_command "$sut_command" plugins install @openclaw/codex',
-    );
-    expect(runtimeRun).toContain("--accept-capabilities");
-    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" onboard');
-    expect(runtimeRun).toContain(
-      'OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command "$sut_command" onboard',
-    );
-    expect(runtimeRun).not.toContain("export OPENAI_API_KEY=");
-    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" channels add');
-    expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" doctor --fix');
-    expect(runtimeRun).toContain(
-      'openclaw_e2e_run_command "$sut_command" doctor --non-interactive',
-    );
-    expect(runtimeRun).toContain('export OPENCLAW_NPM_TELEGRAM_SUT_COMMAND="$sut_command"');
-    expect(runtimeRun).toContain('openclaw_e2e_print_log "$file"');
-    expect(runtimeRun).not.toContain("sed -n '1,220p'");
-    expect(runtimeRun).not.toMatch(/^\s*openclaw (onboard|channels add|doctor )/mu);
-    expect(
-      runtimeRun.indexOf('openclaw_e2e_run_command "$sut_command" plugins install @openclaw/codex'),
-    ).toBeLessThan(runtimeRun.indexOf('openclaw_e2e_run_command "$sut_command" onboard'));
-  });
-
-  it("isolates onboarding hot-path config from the live suite", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-
-    expect(script).toContain(
-      'runtime_home="$(mktemp -d "/tmp/openclaw-npm-telegram-runtime.XXXXXX")"',
-    );
-    expect(script).toContain(
-      'hotpath_home="$(mktemp -d "/tmp/openclaw-npm-telegram-hotpath.XXXXXX")"',
-    );
-    expect(script).toContain('export HOME="$hotpath_home"');
-    expect(script).toContain('export HOME="$runtime_home"');
-  });
-
-  it("fails fast after the first package Telegram scenario failure", () => {
-    const runner = readFileSync(
-      path.resolve(TEST_DIR, "../../scripts/e2e/npm-telegram-live-runner.ts"),
-      "utf8",
-    );
-
-    expect(runner).toContain("failFast: true");
-  });
-
-  it("can install a resolved package tarball instead of a registry spec", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_PACKAGE_TGZ");
-    expect(script).toContain("OPENCLAW_CURRENT_PACKAGE_TGZ");
-    expect(script).toContain('-e OPENCLAW_QA_PACKAGE_SOURCE="$package_install_source"');
-    expect(script).toContain('-e OPENCLAW_QA_PACKAGE_SOURCE_KIND="$package_source_kind"');
-    expect(script).toContain("OPENCLAW_QA_PACKAGE_SOURCE_SHA");
-    expect(script).toContain(
-      'package_mount_args=(-v "$resolved_package_tgz:$package_install_source:ro")',
-    );
-    expect(script).toContain('validate_openclaw_package_spec "$PACKAGE_SPEC"');
-    expect(script.indexOf('if [ -n "$resolved_package_tgz" ]; then')).toBeLessThan(
-      script.indexOf('validate_openclaw_package_spec "$PACKAGE_SPEC"'),
-    );
-  });
-
-  it("installs prepared root and companion tarballs through an exact local registry", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_PACKAGE_DIR");
-    expect(script).toContain('package_source_kind="prepared-package-set"');
-    expect(script).toContain('package_install_source="openclaw@$(read_package_version');
-    expect(script).toContain('-v "$resolved_package_dir:/package-under-test:ro"');
-    expect(script).toContain(
-      '-v "$ROOT_DIR/scripts/lib/bounded-response.mjs:/tmp/lib/bounded-response.mjs:ro"',
-    );
-    expect(script).toContain(
-      '-v "$ROOT_DIR/scripts/e2e/lib/plugins/npm-registry-server.mjs:/tmp/openclaw-e2e/lib/plugins/npm-registry-server.mjs:ro"',
-    );
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_PACKAGE_SET");
-    expect(script).toContain("node /tmp/openclaw-e2e/lib/plugins/npm-registry-server.mjs");
-    expect(script).toContain(
-      'OPENCLAW_NPM_REGISTRY_UPSTREAM="${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_URL:-https://registry.npmjs.org}"',
-    );
-    expect(script).toContain('export NPM_CONFIG_REGISTRY="$registry_url"');
-  });
-
-  it("serves the verified prerelease registry for installation and recovery", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-    const recoveryRun = script.slice(
-      script.indexOf('run_logged_print_heartbeat "npm-telegram-live-suite"'),
-    );
-
-    expect(script).toContain(
-      'openclaw_prepublish_plugin_registry_configure_docker_args "$resolved_prepublish_plugin_registry_dir"',
-    );
-    expect(recoveryRun).toContain(
-      '${prepublish_registry_mount_args[@]+"${prepublish_registry_mount_args[@]}"}',
-    );
-    expect(
-      script.match(
-        /\$\{prepublish_registry_mount_args\[@\]\+"\$\{prepublish_registry_mount_args\[@\]\}"\}/gu,
-      ),
-    ).toHaveLength(2);
-    expect(recoveryRun).toContain("source scripts/e2e/lib/prepublish-plugin-registry.sh");
-    expect(recoveryRun).toContain("openclaw_prepublish_plugin_registry_start");
-    expect(recoveryRun.indexOf("openclaw_prepublish_plugin_registry_start")).toBeLessThan(
-      recoveryRun.indexOf('echo "Running installed-package onboarding recovery hot path..."'),
-    );
-  });
-
-  it("keeps live Docker artifacts isolated by default", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-
-    expect(script).toContain(
-      'RUN_ID="${OPENCLAW_NPM_TELEGRAM_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"',
-    );
-    expect(script).toContain(
-      'OUTPUT_DIR="${OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR:-.artifacts/qa-e2e/npm-telegram-live/$RUN_ID}"',
-    );
-    expect(script).toContain(
-      'OUTPUT_DIR_CONTAINER_RELATIVE=".artifacts/qa-e2e/npm-telegram-live-output"',
-    );
-    expect(script).toContain('OUTPUT_DIR_CONTAINER="/app/$OUTPUT_DIR_CONTAINER_RELATIVE"');
-    expect(script).toContain(
-      '-e OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR="$OUTPUT_DIR_CONTAINER_RELATIVE"',
-    );
-    expect(script).not.toContain(
-      'OUTPUT_DIR="${OPENCLAW_NPM_TELEGRAM_OUTPUT_DIR:-.artifacts/qa-e2e/npm-telegram-live}"',
-    );
   });
 
   it("uses unique direct-run output dirs by default", () => {
@@ -319,15 +172,6 @@ describe("package Telegram live Docker E2E", () => {
     expect(dockerEnvStart).toBeGreaterThanOrEqual(0);
     expect(dockerEnvEnd).toBeGreaterThan(dockerEnvStart);
     expect(dockerEnv).toContain("-e TMPDIR=/tmp");
-  });
-
-  it("forwards repeated RTT controls to the package Telegram live lane", () => {
-    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
-
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_RTT_SAMPLES");
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_RTT_TIMEOUT_MS");
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_RTT_MAX_FAILURES");
-    expect(script).toContain("OPENCLAW_NPM_TELEGRAM_RTT_CHECKS");
   });
 
   it("forwards destructive downgrade approval only through the explicit env list", () => {


### PR DESCRIPTION
## What Problem This Solves

The package Telegram live test carried a broad inventory of Docker shell source strings in addition to its executable security, trust-boundary, scenario-selection, downgrade, and result-handling tests.

## Why This Change Was Made

Remove the implementation-coupled shell mirrors while retaining 44 focused contracts, including the NPM-specific credential alias selection and Docker environment handoff. Scheduled package Telegram live lanes continue to own end-to-end Docker execution.

## User Impact

No user-visible behavior changes. Telegram package validation and live scripts are unchanged.

## Evidence

- `pnpm check:changed`
- `pnpm test:changed` — 44 passed on current `main`
- Structured autoreview: scoped clean, 0.96 confidence, no accepted/actionable findings
