### PR TITLE
fix(anthropic-vertex): retain current Sonnet 5 pricing

### DIFF
--- a/docs/plugins/reference/anthropic-vertex.md
+++ b/docs/plugins/reference/anthropic-vertex.md
@@ -33,9 +33,11 @@ endpoint. Sonnet 5 defaults to adaptive thinking at `high` effort and supports
 `/think off` or the native `/think xhigh|max` levels. OpenClaw publishes its
 1,000,000-token context window and 128,000-token output limit automatically.
 
-Catalog pricing follows Vertex's introductory global rate of `$2/$10` per
-million input/output tokens through August 31, 2026, then `$3/$15` from
-September 1. The `us` and `eu` multi-region endpoints use Vertex's documented
-10% premium.
+Catalog pricing follows [Google's current Vertex pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#anthropics-claude-models):
+`$2/$10` per million input/output tokens for `global`, or `$2.20/$11` for
+the `us` and `eu` multi-region endpoints. Cache hits and 5-minute cache writes
+cost `$0.20/$2.50` globally or `$0.22/$2.75` in either multi-region endpoint,
+per million tokens. These USD rates apply at both 200K input tokens or less
+and above 200K input tokens.
 
 <!-- openclaw-plugin-reference:manual-end -->

--- a/extensions/anthropic-vertex/index.test.ts
+++ b/extensions/anthropic-vertex/index.test.ts
@@ -127,15 +127,6 @@ describe("anthropic-vertex provider plugin", () => {
     });
   });
 
-  it.each(["global", "us", "eu"])("publishes Sonnet 5 for the %s endpoint", (region) => {
-    const provider = buildAnthropicVertexProvider({
-      env: { GOOGLE_CLOUD_LOCATION: region },
-      nowMs: Date.UTC(2026, 7, 31),
-    });
-
-    expect(provider.models.map((model) => model.id)).toContain("claude-sonnet-5");
-  });
-
   it.each([
     {
       region: "global",
@@ -162,80 +153,88 @@ describe("anthropic-vertex provider plugin", () => {
     });
   });
 
-  it.each([
+  describe.each([
     {
       region: "global",
-      nowMs: Date.UTC(2026, 7, 31),
+      baseUrl: "https://aiplatform.googleapis.com",
       cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+      retiredCost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
     },
     {
       region: "us",
-      nowMs: Date.UTC(2026, 7, 31),
+      baseUrl: "https://aiplatform.us.rep.googleapis.com",
       cost: { input: 2.2, output: 11, cacheRead: 0.22, cacheWrite: 2.75 },
-    },
-    {
-      region: "global",
-      nowMs: Date.UTC(2026, 8, 1),
-      cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+      retiredCost: { input: 3.3, output: 16.5, cacheRead: 0.33, cacheWrite: 4.125 },
     },
     {
       region: "eu",
-      nowMs: Date.UTC(2026, 8, 1),
-      cost: { input: 3.3, output: 16.5, cacheRead: 0.33, cacheWrite: 4.125 },
+      baseUrl: "https://aiplatform.eu.rep.googleapis.com",
+      cost: { input: 2.2, output: 11, cacheRead: 0.22, cacheWrite: 2.75 },
+      retiredCost: { input: 3.3, output: 16.5, cacheRead: 0.33, cacheWrite: 4.125 },
     },
-  ])("uses the documented Sonnet 5 pricing for $region", ({ region, nowMs, cost }) => {
-    const provider = buildAnthropicVertexProvider({
-      env: { GOOGLE_CLOUD_LOCATION: region },
-      nowMs,
-    });
+  ])("Sonnet 5 pricing for $region", ({ region, baseUrl, cost, retiredCost }) => {
+    describe.each([
+      { boundary: "before", nowMs: Date.UTC(2026, 8, 1) - 1 },
+      { boundary: "at", nowMs: Date.UTC(2026, 8, 1) },
+      { boundary: "after", nowMs: Date.UTC(2026, 8, 1) + 1 },
+    ])("$boundary the retired September 1 boundary", ({ nowMs }) => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(nowMs);
+      });
 
-    expect(provider.models.find((model) => model.id === "claude-sonnet-5")).toMatchObject({
-      cost,
-      contextWindow: 1_000_000,
-      maxTokens: 128_000,
-      thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-    });
-  });
+      afterEach(() => {
+        vi.useRealTimers();
+      });
 
-  it("restores missing or stale Sonnet 5 pricing during runtime normalization", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.UTC(2026, 8, 1));
-    try {
-      const provider = await registerSingleProviderPlugin(anthropicVertexPlugin);
-      const model = {
-        id: "claude-sonnet-5",
-        name: "Claude Sonnet 5",
-        api: "anthropic-messages",
-        provider: "anthropic-vertex",
-        baseUrl: "https://aiplatform.us.rep.googleapis.com",
-        reasoning: true,
-        input: ["text", "image"],
-        contextWindow: 1_000_000,
-        contextTokens: 1_000_000,
-        maxTokens: 128_000,
-        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-      };
-      const expectedCost = {
-        input: 3.3,
-        output: 16.5,
-        cacheRead: 0.33,
-        cacheWrite: 4.125,
-      };
+      it("publishes current pricing with or without the shipped nowMs argument", () => {
+        const env = { GOOGLE_CLOUD_LOCATION: region };
+        const providers = [
+          buildAnthropicVertexProvider({ env }),
+          buildAnthropicVertexProvider({ env, nowMs }),
+        ];
+        for (const provider of providers) {
+          expect(provider.models.find((model) => model.id === "claude-sonnet-5")).toMatchObject({
+            cost,
+            contextWindow: 1_000_000,
+            maxTokens: 128_000,
+            thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+          });
+        }
+      });
 
-      for (const cost of [
-        undefined,
-        { input: 2.2, output: 11, cacheRead: 0.22, cacheWrite: 2.75 },
-      ]) {
-        const normalized = provider.normalizeResolvedModel?.({
+      it("repairs missing or retired pricing and leaves current pricing unchanged", async () => {
+        const provider = await registerSingleProviderPlugin(anthropicVertexPlugin);
+        const model = {
+          id: "claude-sonnet-5",
+          name: "Claude Sonnet 5",
+          api: "anthropic-messages",
           provider: "anthropic-vertex",
-          modelId: "claude-sonnet-5",
-          model: { ...model, cost },
-        } as never);
-        expect(normalized?.cost).toEqual(expectedCost);
-      }
-    } finally {
-      vi.useRealTimers();
-    }
+          baseUrl,
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: 1_000_000,
+          contextTokens: 1_000_000,
+          maxTokens: 128_000,
+          thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        };
+        for (const staleCost of [undefined, retiredCost]) {
+          const normalized = provider.normalizeResolvedModel?.({
+            provider: "anthropic-vertex",
+            modelId: model.id,
+            model: { ...model, cost: staleCost },
+          } as never);
+          expect(normalized?.cost).toEqual(cost);
+        }
+        expect(
+          provider.normalizeResolvedModel?.({
+            provider: "anthropic-vertex",
+            modelId: model.id,
+            model: { ...model, cost },
+          } as never),
+        ).toBeUndefined();
+      });
+    });
   });
 
   it("restores missing or stale Opus 5 metadata during runtime normalization", async () => {

--- a/extensions/anthropic-vertex/provider-catalog.ts
+++ b/extensions/anthropic-vertex/provider-catalog.ts
@@ -20,8 +20,6 @@ import { resolveAnthropicVertexClientRegion, resolveAnthropicVertexRegion } from
 export const ANTHROPIC_VERTEX_DEFAULT_MODEL_ID = "claude-sonnet-4-6";
 const ANTHROPIC_VERTEX_DEFAULT_CONTEXT_WINDOW = 1_000_000;
 const ANTHROPIC_VERTEX_CLAUDE_5_MAX_TOKENS = 128_000;
-// Vertex's introductory rate expires at the documented UTC month boundary.
-const SONNET_5_STANDARD_PRICING_START_MS = Date.UTC(2026, 8, 1);
 const CLAUDE_5_SUPPORTED_REGIONS = new Set(["global", "us", "eu"]);
 const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
 
@@ -30,15 +28,11 @@ const OPUS_5_COST = {
   multiRegion: { input: 5.5, output: 27.5, cacheRead: 0.55, cacheWrite: 6.875 },
 } as const;
 
+// Google's current table retains these rates beyond September 1, 2026 (5-minute cache writes).
+// https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#anthropics-claude-models
 const SONNET_5_COST = {
-  promotional: {
-    global: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
-    multiRegion: { input: 2.2, output: 11, cacheRead: 0.22, cacheWrite: 2.75 },
-  },
-  standard: {
-    global: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-    multiRegion: { input: 3.3, output: 16.5, cacheRead: 0.33, cacheWrite: 4.125 },
-  },
+  global: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
+  multiRegion: { input: 2.2, output: 11, cacheRead: 0.22, cacheWrite: 2.75 },
 } as const;
 
 function buildAnthropicVertexModel(params: {
@@ -72,21 +66,15 @@ function resolveOpus5Cost(region: string): ModelDefinitionConfig["cost"] | undef
   return normalizedRegion === "global" ? OPUS_5_COST.global : OPUS_5_COST.multiRegion;
 }
 
-function resolveSonnet5Cost(
-  region: string,
-  nowMs: number = Date.now(),
-): ModelDefinitionConfig["cost"] | undefined {
+function resolveSonnet5Cost(region: string): ModelDefinitionConfig["cost"] | undefined {
   const normalizedRegion = normalizeLowercaseStringOrEmpty(region);
   if (!CLAUDE_5_SUPPORTED_REGIONS.has(normalizedRegion)) {
     return undefined;
   }
-  const pricingPeriod = nowMs >= SONNET_5_STANDARD_PRICING_START_MS ? "standard" : "promotional";
-  return normalizedRegion === "global"
-    ? SONNET_5_COST[pricingPeriod].global
-    : SONNET_5_COST[pricingPeriod].multiRegion;
+  return normalizedRegion === "global" ? SONNET_5_COST.global : SONNET_5_COST.multiRegion;
 }
 
-function buildAnthropicVertexCatalog(region: string, nowMs: number): ModelDefinitionConfig[] {
+function buildAnthropicVertexCatalog(region: string): ModelDefinitionConfig[] {
   const opus5Cost = resolveOpus5Cost(region);
   const opus5 = opus5Cost
     ? [
@@ -104,7 +92,7 @@ function buildAnthropicVertexCatalog(region: string, nowMs: number): ModelDefini
         }),
       ]
     : [];
-  const sonnet5Cost = resolveSonnet5Cost(region, nowMs);
+  const sonnet5Cost = resolveSonnet5Cost(region);
   const sonnet5 = sonnet5Cost
     ? [
         buildAnthropicVertexModel({
@@ -232,6 +220,8 @@ export function normalizeAnthropicVertexResolvedModel(
 /** Build the implicit Anthropic Vertex provider config for the current env. */
 export function buildAnthropicVertexProvider(params?: {
   env?: NodeJS.ProcessEnv;
+  // Ignored: pricing is time-independent. Retained for the v2026.8.1 public API;
+  // remove only in a breaking API release.
   nowMs?: number;
 }): ModelProviderConfig {
   const region = resolveAnthropicVertexRegion(params?.env);
@@ -246,6 +236,6 @@ export function buildAnthropicVertexProvider(params?: {
     baseUrl,
     api: "anthropic-messages",
     apiKey: GCP_VERTEX_CREDENTIALS_MARKER,
-    models: buildAnthropicVertexCatalog(region, params?.nowMs ?? Date.now()),
+    models: buildAnthropicVertexCatalog(region),
   };
 }


### PR DESCRIPTION
Closes #135664 — Vertex Sonnet 5 cost estimates are 50% too high after September 1.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

OpenClaw's `anthropic-vertex/claude-sonnet-5` cost estimates switch to rates 50% above Google's published prices at September 1, 2026. The obsolete schedule affects input, output, cache-hit, and 5-minute cache-write costs on `global`, `us`, and `eu`, both in catalog construction and resolved-model normalization.

## Why This Change Was Made

Replace the provider owner's promotional/standard schedule with one fixed, region-aware current-cost table consumed by both paths. Delete the expiry constant, scheduled higher rates, and internal clock threading instead of compensating in a display or changing unrelated providers.

The public builder's `nowMs` field remains accepted and is explicitly documented as ignored: stable `v2026.8.1` exports `buildAnthropicVertexProvider({ env?, nowMs? })` through `api.ts`. Removal is reserved for a breaking API release. The documentation now describes Google's current rates rather than the retired schedule.

## User Impact

Vertex Sonnet 5 estimates use $2 input / $10 output per million tokens globally, or $2.20 / $11 in US/EU multi-regions, with the cache rates below. The existing normalization hook repairs missing or obsolete higher costs while leaving already-canonical metadata unchanged.

No new configuration or setup is required. This corrects OpenClaw's estimates, not Google's actual billing. Model availability, endpoints, context/output limits, thinking, cache TTL, authentication, other providers, and stored user state are unchanged.

## Evidence

AI-assisted implementation and investigation. Local validation passed for the exact source committed as `88a7388c337a5a4a0123e5712046b50bc9a693ef`, based on refreshed `main` at `9c0ef3b41844ed836625060981e47a1880f38d25`; task-file hashes remained unchanged throughout validation and the commit hook. [Exact-head CI run 33579403831](https://github.com/openclaw/openclaw/actions/runs/33579403831) completed successfully for `88a7388c337a5a4a0123e5712046b50bc9a693ef`, including the required `openclaw/ci-gate`.

### Live Google pricing contract

Direct unauthenticated GETs to [Google's official partner-model pricing table](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#anthropics-claude-models) returned HTTP 200 on **2026-09-01 at 17:47:39, 21:10:21, and 23:38:52 UTC**. The same table was independently re-fetched at **2026-09-02 02:44:47 UTC** to address the review runner's DNS limitation; it again returned HTTP 200 and the same prices. The actual HTML tables were bound to their Global, US Multi-Region, and EU Multi-Region tab labels and show these USD prices per million tokens:

| Endpoint | Input | Output | Cache hit | 5-minute cache write |
| --- | ---: | ---: | ---: | ---: |
| Global | $2.00 | $10.00 | $0.20 | $2.50 |
| US Multi-Region | $2.20 | $11.00 | $0.22 | $2.75 |
| EU Multi-Region | $2.20 | $11.00 | $0.22 | $2.75 |

Both the `<=200K` and `>200K` input columns have the same rates. The removed schedule selected `$3/$15/$0.30/$3.75` globally and `$3.30/$16.50/$0.33/$4.125` in either multi-region.

This is actual Google table evidence, not search snippets or an inference from Anthropic/AWS prices, and not a claim that Google published an explicit cancellation announcement. No authenticated inference or billing call was made; the live evidence is the pricing-page response, while provider behavior is verified at its real registration/catalog/normalization boundaries.

### Before and after

Before production edits, the expanded index regression suite produced **12 intended failures and 26 passes** against the original pricing implementation: catalog construction and normalization failed at/after the retired UTC boundary for all three endpoints; before-boundary and sibling cases passed. The old provider implementation is unchanged between that source base and this PR's refreshed base.

After the fix, the **standard repository wrapper passed all 86 tests in all seven Vertex files**, including the complete before/at/after matrix, builder calls with/without the shipped `nowMs` argument, missing/retired/current-cost normalization, Opus pricing, region routing, auth fixtures, and stream behavior. No test-only production seam, timeout increase, or weaker assertion was added.

Completed local commands:

```bash
pnpm build
```

```bash
node scripts/run-vitest.mjs extensions/anthropic-vertex
```

```bash
node scripts/check-changed.mjs -- docs/plugins/reference/anthropic-vertex.md extensions/anthropic-vertex/index.test.ts extensions/anthropic-vertex/provider-catalog.ts
```

```bash
pnpm plugins:inventory:check
```

```bash
git diff --check
```

Fresh isolated Codex autoreview was **scoped-clean at the default P0 priority**, with no accepted/actionable findings. The reviewer did not run tests; the commands above supply that proof independently.

Earlier attempts on the old base encountered stale installed dependencies, a discovery-import timeout during compiled-worker preparation, and TS7056 during SDK declaration generation. Pinned dependencies were installed, and the task branch was refreshed to include [the existing protocol declaration repair](https://github.com/openclaw/openclaw/pull/135360). The current full build, standard tests, and complete changed gate pass; this PR authors no schema or harness changes.

### Ownership and size

The change stays in `extensions/anthropic-vertex/provider-catalog.ts`, its existing `index.test.ts`, and the preserved manual pricing paragraph in `docs/plugins/reference/anthropic-vertex.md`. Discovery and full-plugin entry points already share the builder; the registered normalization hook calls the same pricing owner. The unchanged manifest delegates to `provider-discovery.ts` and contains no model-cost table to duplicate.

**Production LOC: +11/-21 (net -10). Tests: +70/-71 (net -1). Docs: +6/-4 (net +2).** No new config/env surface, schema, persistence behavior, dependency, lockfile, manifest field, or migration. Anthropic/Mantle pricing and the unrelated node-session PR are untouched.

Docs: [Anthropic Vertex plugin reference](https://docs.openclaw.ai/plugins/reference/anthropic-vertex).
