### PR TITLE
refactor(agents): share delivery string array check

### DIFF
--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -1,7 +1,6 @@
 /**
  * Normalizes and delivers agent command results to outbound channels.
  */
-import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -55,6 +54,7 @@ import type { OutboundSessionContext } from "../../infra/outbound/session-contex
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { hasAnyNonEmptyString as hasNonEmptyStringArray } from "../delivery-evidence-values.js";
 import type { MessagingToolSend } from "../embedded-agent-messaging.types.js";
 import type { EmbeddedAgentRunMeta } from "../embedded-agent-runner/types.js";
 import { isNestedAgentLane } from "../lanes.js";
@@ -196,10 +196,6 @@ function logNestedOutput(
     }
     runtime.log(`${prefix} ${line}`);
   }
-}
-
-function hasNonEmptyStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.some(hasNonEmptyString);
 }
 
 function hasNonEmptyArray<T>(value: T[] | undefined): value is T[] {

--- a/src/agents/delivery-evidence-values.test.ts
+++ b/src/agents/delivery-evidence-values.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { hasAnyNonEmptyString } from "./delivery-evidence-values.js";
+
+describe("hasAnyNonEmptyString", () => {
+  it.each([
+    { name: "undefined", value: undefined, expected: false },
+    { name: "scalar text", value: "ready", expected: false },
+    { name: "empty array", value: [], expected: false },
+    { name: "blank strings", value: ["", " \n "], expected: false },
+    { name: "mixed values without text", value: [null, 1, {}, []], expected: false },
+    { name: "nested text", value: [["ready"]], expected: false },
+    { name: "non-empty text", value: ["", " ready "], expected: true },
+    { name: "mixed values with text", value: [null, "ready", 1], expected: true },
+  ])("returns $expected for $name", ({ value, expected }) => {
+    expect(hasAnyNonEmptyString(value)).toBe(expected);
+  });
+
+  it("does not mutate mixed delivery evidence", () => {
+    const value: unknown[] = ["", { text: "nested" }, " ready ", null];
+    const before = value.slice();
+
+    expect(hasAnyNonEmptyString(value)).toBe(true);
+    expect(value).toEqual(before);
+  });
+});

--- a/src/agents/delivery-evidence-values.ts
+++ b/src/agents/delivery-evidence-values.ts
@@ -1,0 +1,5 @@
+import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
+
+export function hasAnyNonEmptyString(value: unknown): boolean {
+  return Array.isArray(value) && value.some(hasNonEmptyString);
+}

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -1,6 +1,7 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeMediaReferenceForComparison } from "../../media/media-reference-comparison.js";
+import { hasAnyNonEmptyString as hasNonEmptyStringArray } from "../delivery-evidence-values.js";
 /**
  * Extracts visible delivery evidence from embedded-agent run results.
  */
@@ -111,10 +112,6 @@ export function hasCompletedTerminalDeliveryEvidence(
 
 function hasNonEmptyArray(value: unknown): boolean {
   return Array.isArray(value) && value.length > 0;
-}
-
-function hasNonEmptyStringArray(value: unknown): boolean {
-  return Array.isArray(value) && value.some(hasNonEmptyString);
 }
 
 function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {

--- a/src/agents/embedded-agent-runner/message-visibility.ts
+++ b/src/agents/embedded-agent-runner/message-visibility.ts
@@ -9,6 +9,7 @@ import {
   SILENT_REPLY_TOKEN,
 } from "../../auto-reply/tokens.js";
 import { resolveAssistantMessagePhase } from "../../shared/chat-message-content.js";
+import { hasAnyNonEmptyString as hasNonEmptyStringArray } from "../delivery-evidence-values.js";
 
 type AgentPayloadLike = {
   text?: unknown;
@@ -29,10 +30,6 @@ type PayloadVisibilityOptions = {
   includeSilentReplyPayloads?: boolean;
   requireTerminalContent?: boolean;
 };
-
-function hasNonEmptyStringArray(value: unknown): boolean {
-  return Array.isArray(value) && value.some(hasNonEmptyString);
-}
 
 function collectStringValues(value: unknown, output: Set<string>) {
   if (typeof value === "string" && value.trim()) {

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
@@ -139,6 +139,17 @@ describe("attempt trajectory status", () => {
     ).toEqual({ status: "success" });
   });
 
+  it("keeps media-only committed delivery as terminal progress", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          messagingToolSentMediaUrls: ["file:///tmp/render.png"],
+          lastAssistantStopReason: "toolUse",
+        }),
+      ),
+    ).toEqual({ status: "success" });
+  });
+
   it("keeps accepted session spawns as terminal progress", () => {
     expect(
       resolveAttemptTrajectoryTerminal(

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
@@ -5,6 +5,7 @@ import {
   hasAcceptedSessionSpawn,
   type AcceptedSessionSpawn,
 } from "../../accepted-session-spawn.js";
+import { hasAnyNonEmptyString as hasAnyNonBlankString } from "../../delivery-evidence-values.js";
 
 type AttemptTrajectoryTerminalStatus = "success" | "error" | "interrupted";
 
@@ -69,10 +70,6 @@ export function resolveTerminalAssistantTexts(params: {
 
 function hasNonEmptyAssistantText(texts: string[]): boolean {
   return texts.some((text) => text.trim().length > 0);
-}
-
-function hasAnyNonBlankString(values: string[]): boolean {
-  return values.some((value) => value.trim().length > 0);
 }
 
 function hasCommittedMessagingDeliveryEvidence(


### PR DESCRIPTION
## What Problem This Solves

Four agent delivery paths independently checked whether delivery evidence contained any non-empty string. The duplicated predicates could drift across command result projection, delivery evidence, payload visibility, and terminal trajectory classification.

## Why This Change Was Made

The agent runtime now owns one private `hasAnyNonEmptyString(value: unknown): boolean` helper using `Array.isArray` plus the canonical `hasNonEmptyString` predicate. All four callers reuse it under their existing local names, so call-site policy remains unchanged.

This was rebuilt manually from reviewed parent `7a8240b3c6005ee287351d96b00d16200ef3a76e`. It preserves the delivery ownership and finalization logic from #136524 (`b22ab4828071378be0d179f2a40a6f8418fec1cc`) and does not change strict untrusted guards, assistant text, target/route/media policy, SDK or barrel surfaces, config, protocol, persistence, or dependencies.

## User Impact

No intended user-visible behavior change. Mixed arrays and typed string arrays retain their existing non-empty-string semantics, while media-only committed messaging delivery remains terminal progress.

## Evidence

- Added a direct helper matrix covering scalars, empty and blank arrays, mixed values, nested values, positive strings, and nonmutation.
- Added a terminal trajectory regression for media-only committed delivery.
- Seven focused suites passed: `168/168`.
- Deterministic differential against both removed predicate forms:
  - mixed scalars/arrays: `69,921`
  - typed string arrays: `137,257`
  - mismatches: `0`
  - mutations: `0`
- Core test type shards passed on the final code.
- Targeted formatting and lint passed.
- Changed-scope checks passed, including dead exports, coercion guards, plugin boundaries, and core typechecking.
- Import-cycle checks passed: runtime value cycles `0`; Madge cycles `0`.
- Native-state schema, database-first legacy-store, media-download-helper, runtime-sidecar, webhook body-order, and pairing-auth guards passed.
- Production LOC: reviewed metric `+9/-16`, net `-7`; raw Git numstat is `+9/-17`, net `-8`, because the obsolete command-local normalization import is counted as a deletion. Tests: `+36/-0`.
- Codex source was inspected directly at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; those CLI paths impose no protocol or runtime contract on this private OpenClaw predicate.
- No CI dispatch or Testbox run was started. This draft is intentionally frozen after the corrected push for independent review.
