### PR TITLE
In ui/src/e2e/chat-flow.streaming.e2e.test.ts:416 replace inline regex with import { formatWebUiIconErrorText } from "..

### DIFF
--- a/ui/src/components/error-presentation.ts
+++ b/ui/src/components/error-presentation.ts
@@ -1,0 +1,3 @@
+export function formatWebUiIconErrorText(text: string): string {
+  return text.replace(/^⚠️\s*/u, "").trim();
+}

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { formatWebUiIconErrorText } from "../components/error-presentation.ts";
 import { CHAT_TRANSCRIPT_END_THRESHOLD_PX } from "../pages/chat/scroll.ts";
 import {
   chatThreadDistanceFromBottom,
@@ -411,7 +412,7 @@ suite.define(() => {
 
         const gatewayErrorText =
           "⚠️ Model login expired on the gateway for openai. Send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth with `openclaw models auth login --provider openai` in a terminal, then try again.";
-        const errorText = gatewayErrorText.replace(/^⚠️\s*/u, "");
+        const errorText = formatWebUiIconErrorText(gatewayErrorText);
         await gateway.emitGatewayEvent("chat", {
           errorMessage: gatewayErrorText,
           message: {


### PR DESCRIPTION
_This draft PR was generated by [Continuum](https://github.com/yaseenshady/Engineering-Automation-PoC) from a learned engineering workflow and has not been reviewed by a human._

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Replacing the inline regex with the shared formatter — checking the current test and module.

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

The change applies a repository-supported maintenance procedure to the requested area.

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

No user-facing impact was stated by the execution agent.

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

- Validation: **skipped** — worktree has no node_modules and must not run pnpm install per AGENTS.md; verified via manual equivalence check that formatWebUiIconErrorText matches inline regex for the test vector while preserving raw transcript assertion
- Changed files: `ui/src/e2e/chat-flow.streaming.e2e.test.ts`, `ui/src/components/error-presentation.ts`

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
