### PR TITLE
fix(watch): explain when a spoken reply times out

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -3780,6 +3780,7 @@
     {"id":"native.apple.94ceefa933744b07","source":"Speech error: %@","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/ios/Sources/Voice/TalkModeManager.swift"}]},
     {"id":"native.apple.d33742884171fcb6","source":"Speech recognition","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/ios/Sources/Voice/TalkModeManager.swift"},{"kind":"ui-localized-call","path":"apps/ios/Sources/Voice/VoiceWakeManager.swift"}]},
     {"id":"native.apple.aed8b232944118ee","source":"Speech recognizer unavailable","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/ios/Sources/Voice/VoiceWakeManager.swift"}]},
+    {"id":"native.apple.9cd3d02a42d41ca0","source":"Spoken reply timed out. Check Chat on iPhone.","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/ios/WatchApp/Sources/WatchVoiceTurnTracker.swift"}]},
     {"id":"native.apple.875f9991a9ec5b8b","source":"Stable","surface":"apple","sites":[{"kind":"conditional-branch","path":"apps/macos/Sources/OpenClaw/CLIInstaller.swift"}]},
     {"id":"native.apple.e743425f84b8c003","source":"Stagger (milliseconds)","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/ios/Sources/Design/AgentAutomationDetailScreen.swift"}]},
     {"id":"native.apple.44c771ed7cd80202","source":"Stagger must be a non-negative number of milliseconds.","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/ios/Sources/Design/AgentAutomationModels.swift"}]},

--- a/apps/ios/WatchApp/Sources/WatchInboxStore.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxStore.swift
@@ -192,6 +192,7 @@ import WatchKit
     {
         self.defaults = defaults
         self.restorePersistedState()
+        self.expireVoiceTurnIfNeeded(nowMs: Self.nowMs())
         if [self.replyStatus?.code, self.appSnapshotStatus?.code, self.appCommandStatus?.code].contains(.sending) {
             // Attempt ownership never survives app restoration, so interrupted sends must be retryable.
             if self.replyStatus?.code == .sending {
@@ -1420,7 +1421,6 @@ extension WatchInboxStore {
             ?? state.appCommandStatusText.flatMap(
                 WatchAppCommandStatus.decodeLegacyLocalizedText)
         self.voiceTurnState = state.voiceTurnState ?? WatchVoiceTurnState()
-        self.voiceTurnState.expireIfNeeded(nowMs: Self.nowMs())
         self.deferredGatewayPayloads = Array(
             (state.deferredGatewayPayloads ?? []).suffix(Self.maxDeferredGatewayPayloads))
         self.execApprovalTerminalTombstones = state.execApprovalTerminalTombstones ?? []

--- a/apps/ios/WatchApp/Sources/WatchInboxView.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxView.swift
@@ -1326,7 +1326,7 @@ private struct WatchChatTimelineView: View {
         self.voiceReplyTimeout = Task { @MainActor in
             try? await Task.sleep(nanoseconds: delayNanoseconds)
             guard !Task.isCancelled else { return }
-            self.store.cancelVoiceTurn()
+            self.scheduleVoiceReplyTimeout()
         }
     }
 }

--- a/apps/ios/WatchApp/Sources/WatchVoiceTurnTracker.swift
+++ b/apps/ios/WatchApp/Sources/WatchVoiceTurnTracker.swift
@@ -87,15 +87,11 @@ struct WatchVoiceTurnState: Codable, Equatable {
         self.startedAtMs = nil
     }
 
-    mutating func expireIfNeeded(nowMs: Int64) {
-        guard self.tracker.isAwaitingReply,
-              let startedAtMs,
-              nowMs >= startedAtMs,
-              nowMs - startedAtMs >= Self.timeoutMs
-        else {
-            return
-        }
+    @discardableResult
+    mutating func expireIfNeeded(nowMs: Int64) -> Bool {
+        guard self.remainingTimeoutMs(nowMs: nowMs) == 0 else { return false }
         self.cancel()
+        return true
     }
 
     func remainingTimeoutMs(nowMs: Int64) -> Int64? {
@@ -120,8 +116,10 @@ extension WatchInboxStore {
     }
 
     func consume(chatCompletion message: WatchChatCompletionMessage) {
+        let nowMs = WatchVoiceTurnState.nowMs()
+        self.expireVoiceTurnIfNeeded(nowMs: nowMs)
         let previousState = self.voiceTurnState
-        self.voiceTurnState.receive(message, nowMs: WatchVoiceTurnState.nowMs())
+        self.voiceTurnState.receive(message, nowMs: nowMs)
         guard self.voiceTurnState != previousState else { return }
         self.persistVoiceTurnState()
     }
@@ -132,8 +130,10 @@ extension WatchInboxStore {
     }
 
     func takeVoiceReply() -> String? {
+        let nowMs = WatchVoiceTurnState.nowMs()
+        self.expireVoiceTurnIfNeeded(nowMs: nowMs)
         let previousState = self.voiceTurnState
-        let reply = self.voiceTurnState.takeReply(nowMs: WatchVoiceTurnState.nowMs())
+        let reply = self.voiceTurnState.takeReply(nowMs: nowMs)
         if self.voiceTurnState != previousState {
             self.persistVoiceTurnState()
         }
@@ -147,16 +147,20 @@ extension WatchInboxStore {
     }
 
     func voiceReplyTimeoutNanoseconds() -> UInt64? {
-        let previousState = self.voiceTurnState
         let nowMs = WatchVoiceTurnState.nowMs()
-        self.voiceTurnState.expireIfNeeded(nowMs: nowMs)
-        if self.voiceTurnState != previousState {
-            self.persistVoiceTurnState()
-        }
+        self.expireVoiceTurnIfNeeded(nowMs: nowMs)
         guard let remainingMs = self.voiceTurnState.remainingTimeoutMs(nowMs: nowMs) else {
             return nil
         }
         return UInt64(remainingMs) * 1_000_000
+    }
+
+    func expireVoiceTurnIfNeeded(nowMs: Int64) {
+        guard self.voiceTurnState.expireIfNeeded(nowMs: nowMs) else { return }
+        // Only readback expires; the message may already be delivered or still running.
+        self.markAppCommandBlocked(
+            .sendChat,
+            reason: String(localized: "Spoken reply timed out. Check Chat on iPhone."))
     }
 }
 #endif

--- a/apps/ios/WatchTests/WatchInboxStoreOperationTests.swift
+++ b/apps/ios/WatchTests/WatchInboxStoreOperationTests.swift
@@ -252,6 +252,70 @@ struct WatchInboxStoreOperationTests {
         }
     }
 
+    @Test(arguments: ["timer", "readback", "completion", "relaunch"])
+    func `expired spoken replies leave a visible readback timeout without failing delivery`(
+        observation: String) throws
+    {
+        try Self.withStore { store, defaults in
+            store.consume(appSnapshot: Self.snapshot(id: "voice-owner"))
+            let attempt = store.markAppCommandSending(.sendChat)
+            #expect(store.markAppCommandResult(Self.result(.delivered), command: .sendChat, attemptID: attempt))
+            store.voiceTurnState.begin(
+                commandId: "expired-voice-command",
+                nowMs: WatchVoiceTurnState.nowMs() - WatchVoiceTurnState.timeoutMs - 1)
+            store.persistVoiceTurnState()
+
+            let observed: WatchInboxStore
+            switch observation {
+            case "timer":
+                #expect(store.voiceReplyTimeoutNanoseconds() == nil)
+                observed = store
+            case "readback":
+                #expect(store.takeVoiceReply() == nil)
+                observed = store
+            case "completion":
+                store.consume(chatCompletion: WatchChatCompletionMessage(
+                    commandId: "expired-voice-command", replyText: "Late reply"))
+                observed = store
+            default:
+                observed = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            }
+
+            #expect(!observed.isAwaitingVoiceReply)
+            #expect(observed.appCommandStatus?.code != .failed)
+            #expect(observed.appCommandStatusText == String(localized:
+                "Spoken reply timed out. Check Chat on iPhone."))
+            observed.consume(chatCompletion: WatchChatCompletionMessage(
+                commandId: "expired-voice-command", replyText: "Late reply"))
+            #expect(observed.takeVoiceReply() == nil)
+
+            let restored = WatchInboxStore(defaults: defaults, requestNotificationAuthorization: false)
+            #expect(restored.appCommandStatusText == observed.appCommandStatusText)
+            var replacement = Self.snapshot(id: "replacement-session")
+            replacement.sessionKey = "another-session"
+            restored.consume(appSnapshot: replacement)
+            #expect(restored.appCommandStatus == nil)
+        }
+    }
+
+    @Test func `canceling a spoken reply keeps successful delivery and does not report a timeout`() throws {
+        try Self.withStore { store, _ in
+            store.consume(appSnapshot: Self.snapshot(id: "voice-owner"))
+            let attempt = store.markAppCommandSending(.sendChat)
+            #expect(store.markAppCommandResult(Self.result(.delivered), command: .sendChat, attemptID: attempt))
+            let sentStatus = store.appCommandStatusText
+            store.beginVoiceTurn(commandId: "canceled-voice-command")
+
+            store.cancelVoiceTurn()
+            #expect(store.voiceReplyTimeoutNanoseconds() == nil)
+            #expect(store.appCommandStatusText == sentStatus)
+            #expect(store.appCommandStatus?.code == .sent)
+            store.consume(chatCompletion: WatchChatCompletionMessage(
+                commandId: "canceled-voice-command", replyText: "Late reply"))
+            #expect(store.takeVoiceReply() == nil)
+        }
+    }
+
     @Test func `blocked command retires older completions and persists its reason`() throws {
         try Self.withStore { store, defaults in
             store.consume(appSnapshot: Self.snapshot(id: "owner-snapshot"))

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -173,8 +173,9 @@ Gateway or chat on iPhone retires the pending spoken reply and clears the old
 Watch preview. Leaving Watch Chat or backgrounding the app stops playback;
 a reply received while away can be read on return if its wait has not expired.
 
-The spoken-reply wait expires after 90 seconds. Cancelling that wait or stopping
-speech does **not** cancel the Gateway chat run or remove a queued message.
+The spoken-reply wait expires after 90 seconds and shows **Spoken reply timed
+out. Check Chat on iPhone.**, including after reopening the Watch app. Cancelling
+that wait or stopping speech does **not** cancel the Gateway chat run or remove a queued message.
 If no reply is spoken, refresh Chat or check the conversation on iPhone before
 resending. Long runs and interrupted return delivery can still require this
 manual readback. Keep the Gateway updated for reliable reply attribution when


### PR DESCRIPTION
## What Problem This Solves

Apple Watch silently returned to its normal chat controls when a spoken reply took longer than the existing 90-second readback deadline. That looked like the request had disappeared.

## Why This Change Was Made

The voice-turn owner already detects expiry, but previously discarded it as an ordinary cancellation. Expiry now returns a recorded outcome, and the existing Watch status presentation shows “Spoken reply timed out. Check Chat on iPhone.” The timer, late completion, readback, and restoration paths use the same owner. This does not cancel the Gateway run, mark the underlying message undelivered, change the deadline, or add a persisted field. Explicit cancellation remains distinct.

This is the separate timeout follow-up to #135697. Head `391b93cb17795c1a5600da2736e498bfc5e5babf` replaces the draft's temporary parent reference with the actual six-file repair. The prior ClawSweeper no-op finding is addressed by this focused diff.

## User Impact

An expired spoken-reply wait now tells the user where to check the eventual reply, including after reopening the Watch app. No setup or configuration changes are required.

## Verification

The regression failed on the original owner in four native watchOS test executions. The repaired Watch store suite passed all 20 executions (17 test methods), covering normal expiry, restored expired state, a late completion, readback, persistence, and explicit cancellation. These tests execute in the watchOS Simulator; they are not a manual 90-second UI run. SwiftFormat and strict SwiftLint passed. A fresh independent P0-scoped autoreview found no actionable P0 findings; that threshold is not an all-severity approval.

A separate live native Watch-process probe exercised the production store's public begin/timeout APIs with the owner-provided 90-second deadline, a real monotonic clock, and real UserDefaults. After 90.142 seconds, the store stopped waiting and exposed “Spoken reply timed out. Check Chat on iPhone.” without reporting delivery failure. A late completion was ignored: `takeVoiceReply()` returned `nil`. After explicitly stopping the Watch test host, a fresh process restored the same status from UserDefaults and still returned no voice reply. This used no injected clock, copied timer logic, or direct expired-state assignment.

Actual UI proof is still outstanding. Xcode 27 Device Hub has an onscreen simulator window, but both the native automation connector and the signed local Peekaboo path cannot acquire a valid exact-owner snapshot. Local screen recording, accessibility, and event permissions are already granted; those permissions were not changed and no blind input was sent. There is no physical Watch available. The live owner/persistence probe used fixture transport inputs: it is not GUI-rendered evidence, actual WatchConnectivity delivery, or manual/physical-Watch validation.

## Scope and Release Note

Production: +21/-17 (net +4); tests: +64; docs: +3/-2; generated native string catalog: +1. The four production lines retain and present an already-detected terminal outcome instead of introducing another state machine. Release note: Apple Watch now explains when a spoken reply times out and points users to Chat on iPhone.

No standalone voice transport or durable-delivery schema changes are included here.
