### PR TITLE
refactor(qa-lab): share runtime pair normalization

### DIFF
--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -18,6 +18,7 @@ import {
 import type { RuntimeId, RuntimeParityDrift, RuntimeParityResult } from "./runtime-parity.js";
 import {
   isRuntimeParityResultPass,
+  normalizeRuntimePair,
   resolveRuntimeParityUsagePolicy,
   runtimeParityCellStatus,
 } from "./runtime-parity.js";
@@ -269,15 +270,6 @@ function describeLiveUsageFailure(scenarioName: string, scenario: QaRuntimeParit
     return undefined;
   }
   return `${scenarioName} missing live assistant-message usage (${missing.join(", ")}).`;
-}
-
-function normalizeRuntimePair(
-  pair: [RuntimeId, RuntimeId] | null | undefined,
-): [RuntimeId, RuntimeId] {
-  if (pair?.[0] && pair?.[1]) {
-    return pair;
-  }
-  return ["openclaw", "codex"];
 }
 
 function requiredCoverageStatus(

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -36,6 +36,15 @@ type RuntimeParityStatus = "pass" | "fail" | "skip";
 
 const CANONICAL_RUNTIME_IDS = ["openclaw", "codex"] as const satisfies readonly RuntimeId[];
 
+export function normalizeRuntimePair(
+  pair: [RuntimeId, RuntimeId] | null | undefined,
+): [RuntimeId, RuntimeId] {
+  if (pair?.[0] && pair?.[1]) {
+    return pair;
+  }
+  return ["openclaw", "codex"];
+}
+
 export type RuntimeParityToolCall = {
   tool: string;
   argsHash: string;

--- a/extensions/qa-lab/src/token-efficiency-report.ts
+++ b/extensions/qa-lab/src/token-efficiency-report.ts
@@ -1,7 +1,7 @@
 // Qa Lab plugin module implements token efficiency report behavior.
 import type { RuntimeParityCacheMiss } from "./runtime-parity-cache-diagnostics.js";
 import type { RuntimeId, RuntimeParityCell, RuntimeParityResult } from "./runtime-parity.js";
-import { resolveRuntimeParityUsagePolicy } from "./runtime-parity.js";
+import { normalizeRuntimePair, resolveRuntimeParityUsagePolicy } from "./runtime-parity.js";
 
 type ProcessedTokenEvidence = "measured" | "derived" | "unavailable";
 
@@ -99,15 +99,6 @@ const ZERO_AGGREGATE: TokenEfficiencyReport["aggregate"] = {
   flaggedScenarios: [],
   savingsScenarios: [],
 };
-
-function normalizeRuntimePair(
-  pair: [RuntimeId, RuntimeId] | null | undefined,
-): [RuntimeId, RuntimeId] {
-  if (pair?.[0] && pair?.[1]) {
-    return pair;
-  }
-  return ["openclaw", "codex"];
-}
 
 function normalizeTokenCount(value: number): number {
   return Number.isFinite(value) ? Math.max(0, value) : 0;

--- a/extensions/qa-lab/src/tool-coverage-report.ts
+++ b/extensions/qa-lab/src/tool-coverage-report.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   isRuntimeParityCellPassable,
+  normalizeRuntimePair,
   type RuntimeId,
   type RuntimeParityDrift,
   type RuntimeParityResult,
@@ -85,15 +86,6 @@ type ToolFixtureGroup = {
 };
 
 const PASSING_DRIFTS: ReadonlySet<QaToolCoverageDrift> = new Set(["none", "text-only"]);
-
-function normalizeRuntimePair(
-  pair: [RuntimeId, RuntimeId] | null | undefined,
-): [RuntimeId, RuntimeId] {
-  if (pair?.[0] && pair?.[1]) {
-    return pair;
-  }
-  return ["openclaw", "codex"];
-}
 
 function cellStatus(
   cell: RuntimeParityResult["cells"][RuntimeId] | undefined,


### PR DESCRIPTION
## What Problem This Solves

QA Lab maintained the same permissive runtime-pair normalization policy in three report builders. That duplication made the default pair and tuple-preservation behavior easier to drift independently across parity, token-efficiency, and tool-coverage reports.

## Why This Change Was Made

`extensions/qa-lab/src/runtime-parity.ts` already owns `RuntimeId` and canonical runtime ordering, so it now owns the shared `normalizeRuntimePair` helper. The identical local implementations were removed from the agentic parity, token-efficiency, and tool-coverage report builders.

The helper remains deliberately permissive: complete tuples retain identity and order, including reversed pairs, while missing or partial values receive a fresh `["openclaw", "codex"]` tuple. Strict admission normalization in `extensions/qa-lab/src/run-config.ts` and `extensions/qa-lab/src/cli.runtime.ts` remains separate.

Production LOC: +12/-28, net -16. Tests: +0/-0.

## User Impact

No user-visible behavior changes. QA Lab reports keep the same runtime ordering, defaults, serialization, headers, and validation behavior, with one canonical owner for the shared policy.

## Evidence

- Exact refreshed head: `993c68385a1b3b32bf29e3e42dcee3b2d7609724`, signed, parent `a828190b2953483a4a181ff5d23c283e92713d47`.
- Four focused QA Lab suites passed: 109/109 tests (43 agentic parity, 25 runtime parity, 22 token efficiency, 19 tool coverage).
- Routing-owner suites passed: 105/105 tests (33 Control UI E2E ownership, 72 changed-node planning).
- Differential proof: 8,444 inputs and 25,332 comparisons, zero mismatches, including short-circuit property access, thrown getters, tuple identity, and nonmutation.
- `node scripts/check-changed.mjs --dry-run -- <four changed files>` passed and selected the extension production/test lanes.
- The actual changed gate passed all checks through `tsgo:extensions`; that typecheck was unavailable because the only complete local dependency tree does not match this parent lockfile and reports unrelated stale `yargs-parser` and Telegram typings.
- `pnpm tsgo:extensions:test` was likewise unavailable from the lock-mismatched dependency tree; it also exposed sparse-only missing UI config inputs.
- `pnpm check:import-cycles` and `pnpm check:madge-import-cycles` passed with zero cycles.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime` completed bundling, plugin local-dist, and CLI bootstrap checks, then postbuild was unavailable because the lock-mismatched dependency tree lacks current `@openclaw/ai` dist entrypoints.
- `git diff --check` passed.
- Personally inspected Codex CLI source at `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; this refactor has no Codex protocol or runtime dependency.
- Testbox/live proof is N/A for deterministic private report normalization. Exact-head native CI and QA Smoke remain required before landing.
