### PR TITLE
fix(logging): read the active file for configured log tails

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -8,7 +8,7 @@ import type {
   RealtimeVoiceSessionHarness,
   RealtimeVoiceToolCallEvent,
 } from "openclaw/plugin-sdk/realtime-voice";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
@@ -145,7 +145,7 @@ function makeHandler(
   };
   const realtimeProvider = deps?.realtimeProvider ?? makeRealtimeProvider(() => makeBridge());
   const providerConfig = deps?.providerConfig ?? { apiKey: "test-key" };
-  return new RealtimeCallHandler(
+  const handler = new RealtimeCallHandler(
     config,
     {
       processEvent: vi.fn(),
@@ -168,6 +168,8 @@ function makeHandler(
     },
     undefined,
   );
+  onTestFinished(() => handler.close());
+  return handler;
 }
 
 const startRealtimeServer = async (

--- a/src/commands/channels.logs.test.ts
+++ b/src/commands/channels.logs.test.ts
@@ -2,8 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setLoggerOverride } from "../logging.js";
+import { getChildLogger, setLoggerOverride } from "../logging.js";
+import { flushLogger } from "../logging/logger.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import { createTestRuntime } from "./test-runtime-config-helpers.js";
@@ -291,23 +293,28 @@ describe("channelsLogsCommand", () => {
     expect(payload.lines.map((line) => line.message)).toEqual(["fallback sent"]);
   });
 
-  it("prefers the configured rolling log when it exists", async () => {
+  it("reads the active writer file instead of a newer stale configured rolling log", async () => {
     const configuredFile = path.join(tempDir, "openclaw-2026-04-26.log");
-    const fallbackFile = path.join(tempDir, "openclaw-2026-04-25.log");
-    setLoggerOverride({ file: configuredFile });
-    await fs.writeFile(
-      fallbackFile,
-      logLine({ module: "gateway/channels/external-chat/send", message: "fallback sent" }),
-    );
+    setLoggerOverride({ file: configuredFile, level: "info" });
+    getChildLogger({ module: "gateway/channels/external-chat/send" }).warn("current sent");
+    await flushLogger();
+
+    const writtenFiles = await fs.readdir(tempDir);
+    expect(writtenFiles).toEqual([expect.stringMatching(/^openclaw-\d{4}-\d{2}-\d{2}\.log$/)]);
+    const activeFile = path.join(tempDir, expectDefined(writtenFiles[0], "active log file"));
+    expect(activeFile).not.toBe(configuredFile);
+
     await fs.writeFile(
       configuredFile,
-      logLine({ module: "gateway/channels/external-chat/send", message: "current sent" }),
+      logLine({ module: "gateway/channels/external-chat/send", message: "stale sent" }),
     );
+    const newerMtime = new Date((await fs.stat(activeFile)).mtimeMs + 60_000);
+    await fs.utimes(configuredFile, newerMtime, newerMtime);
 
     await channelsLogsCommand({ channel: "external-chat", json: true }, runtime);
 
     const payload = readJsonPayload();
-    expect(payload.file).toBe(configuredFile);
+    expect(payload.file).toBe(activeFile);
     expect(payload.lines.map((line) => line.message)).toEqual(["current sent"]);
   });
 

--- a/src/gateway/server.logs-tail.test.ts
+++ b/src/gateway/server.logs-tail.test.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { flushLogger, getChildLogger, setLoggerOverride } from "../logging/logger.js";
+import { installGatewayTestHooks, rpcReq } from "./test-helpers.js";
+import { installConnectedControlUiServerSuite } from "./test-with-server.js";
+
+installGatewayTestHooks({ scope: "suite" });
+let ws: WebSocket;
+installConnectedControlUiServerSuite((started) => {
+  ws = started.ws;
+});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("tails configured rolling placeholders through authenticated Gateway RPC", async () => {
+  const tempDir = tempDirs.make("openclaw-gateway-log-tail-");
+  setLoggerOverride({
+    file: path.join(tempDir, "openclaw-YYYY-MM-DD.log"),
+    level: "info",
+    consoleLevel: "silent",
+  });
+  try {
+    getChildLogger({ module: "log-tail" }).warn({ reason: "disabled" }, "rolling RPC record");
+    await flushLogger();
+
+    const response = await rpcReq<{ file: string; lines: string[] }>(ws, "logs.tail", {
+      limit: 200,
+      maxBytes: 256_000,
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.payload?.lines).toEqual(
+      expect.arrayContaining([expect.stringContaining("rolling RPC record")]),
+    );
+    expect(path.dirname(response.payload?.file ?? "")).toBe(tempDir);
+    expect(path.basename(response.payload?.file ?? "")).toMatch(
+      /^openclaw-\d{4}-\d{2}-\d{2}\.log$/,
+    );
+  } finally {
+    await flushLogger();
+    setLoggerOverride({ level: "silent", consoleLevel: "silent" });
+  }
+});

--- a/src/logging/log-file-path.test.ts
+++ b/src/logging/log-file-path.test.ts
@@ -118,5 +118,6 @@ describe("profile rolling log families", () => {
     expect(isLegacyRollingLogFilePath("openclaw-2026-07-22.log")).toBe(true);
     expect(isLegacyRollingLogFilePath("openclaw-YYYY-MM-DD.log")).toBe(true);
     expect(isLegacyRollingLogFilePath("openclaw-dev-2026-07-22.log")).toBe(false);
+    expect(isLegacyRollingLogFilePath("openclaw-configured.log")).toBe(false);
   });
 });

--- a/src/logging/log-file-path.ts
+++ b/src/logging/log-file-path.ts
@@ -73,9 +73,8 @@ export function isRollingLogFilePath(file: string): boolean {
 export function isLegacyRollingLogFilePath(file: string): boolean {
   const base = path.basename(file);
   return (
-    base.startsWith(`${LOG_PREFIX}-`) &&
-    base.endsWith(LOG_SUFFIX) &&
-    base.length === `${LOG_PREFIX}-YYYY-MM-DD${LOG_SUFFIX}`.length
+    base === `${LOG_PREFIX}-YYYY-MM-DD${LOG_SUFFIX}` ||
+    ROLLING_LOG_FILE_RE.exec(base)?.[1] === LOG_PREFIX
   );
 }
 

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -3,7 +3,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { resetLogger, setLoggerOverride } from "../logging.js";
+import {
+  flushLogger,
+  getChildLogger,
+  getResolvedLoggerSettings,
+  resetLogger,
+  setLoggerOverride,
+} from "./logger.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const metadataBoundaries = [
@@ -51,6 +57,26 @@ describe("readConfiguredLogTail", () => {
     redactSensitiveLinesMock.mockClear();
     resetLogger();
     setLoggerOverride(null);
+  });
+
+  it("tails configured rolling placeholders through the real file logger", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    setLoggerOverride({
+      file: path.join(tempDir, "openclaw-YYYY-MM-DD.log"),
+      level: "info",
+    });
+
+    getChildLogger({ module: "log-tail" }).warn({ reason: "disabled" }, "rolling log record");
+    await flushLogger();
+
+    const result = await readConfiguredLogTail();
+
+    expect(result.lines).toEqual([expect.stringContaining("rolling log record")]);
+    for (const file of [result.file, getResolvedLoggerSettings().file]) {
+      expect(path.dirname(file)).toBe(tempDir);
+      expect(path.basename(file)).toMatch(/^openclaw-\d{4}-\d{2}-\d{2}\.log$/);
+    }
   });
 
   it("applies redaction once per request across all returned lines", async () => {
@@ -183,7 +209,10 @@ describe("readConfiguredLogTail", () => {
     "rethrows $code from the $boundary boundary",
     async ({ boundary, code }) => {
       const tempDir = tempDirs.make("openclaw-log-tail-");
-      const configured = path.join(tempDir, "openclaw-2026-01-22.log");
+      const configured = path.join(
+        tempDir,
+        boundary === "final stat" ? "configured.log" : "openclaw-2026-01-22.log",
+      );
       const candidate = path.join(tempDir, "openclaw-2026-01-21.log");
       const error = Object.assign(new Error(`${code} injected`), { code });
       const realStat = fs.stat.bind(fs);

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -563,9 +563,9 @@ function resolveSettings(): ResolvedRuntimeSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? resolveDefaultActiveLogFile();
-  const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   const rolling = cfg?.file ? isLegacyRollingLogFilePath(cfg.file) : true;
+  const file = resolveActiveLogFileWithMode(cfg?.file ?? resolveDefaultActiveLogFile(), rolling);
+  const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes, rolling };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Gateway and local log tails could return no records when `logging.file` used the supported `openclaw-YYYY-MM-DD.log` placeholder. The logger wrote a dated file while the reader looked for the unresolved placeholder. A configured historical date could likewise make readers prefer stale records over the file being written. This also affected QA checks that rely on structured Gateway logs.

## Why This Change Was Made

Resolve the active file at the shared logger settings owner so the writer, Gateway `logs.tail`, and local readers agree. Keep per-write date rollover and profile-family isolation. Tighten the existing rolling-file classifier using the existing date parser: a fixed filename such as `openclaw-configured.log` must not be redirected merely because its length matches a date.

The repair removes the loose prefix/suffix/length predicate and adds no configuration option, fallback reader, or storage format. Production: +4/-5 (net -1). Tests and test fixtures: +97/-14 (net +83), across seven changed files overall.

## User Impact

CLI and Control UI log tails read records written through configured rolling paths. Explicit fixed filenames remain fixed; dated default-family paths continue rolling, and explicit profile-shaped overrides retain their existing behavior.

## Evidence

Both a real file-logger regression and an authenticated Gateway `logs.tail` RPC regression failed on the missing record before the settings repair and passed afterward. The neighboring suite then caught the fixed-filename classifier bug; its existing expectation was retained. All 50 path/profile, logging/error/redaction, and Gateway cases passed.

[The first CI run](https://github.com/openclaw/openclaw/actions/runs/33579979518) exposed an old channel-log test that expected a stale configured date to win. Its replacement writes through the real logger, discovers the emitted file from disk, creates a newer stale configured file, and requires the channel command to return the writer's file and current record. It failed against the original settings owner and passed with the repair. All 17 channel-log cases passed, including missing rolling-file and fixed custom-file controls.

That CI run also passed all 804 voice-call assertions but reported a console RPC rejection during worker teardown. The logs show two earlier TwiML fixtures leaving their 30-second token watchdogs alive. The existing test factory now registers `handler.close()` with Vitest's awaited `onTestFinished` hook. This clears pending tokens through their lifecycle owner; it adds no timer delay, retry, console suppression, or production path. All 95 tests across the realtime handler, lifecycle, and playback-mark files passed. The rejected RPC payload was not recorded, so the watchdog leak is established without claiming its exact attribution to that rejection; the complete voice-call CI shard passes on the corrected head.

Formatting, targeted core and plugin lint, `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm tsgo:extensions:test`, and diff checks passed. Independent Codex review of the complete seven-file diff is clean at P0–P2. [Hosted CI on head `98c06fba24ee0aae4665baa0178b45e2c216d3b8`](https://github.com/openclaw/openclaw/actions/runs/33582258882) passed: 209 successful jobs and 17 skipped, including both previously failing shards. Repository-native prepare/merge gates remain required before landing.

The latest ClawSweeper review has no code findings. Its remaining CI and Vitest-contract checks are resolved: the installed Vitest 4.1.11 runner registers the callback under the existing hook timeout, awaits it after `afterEach`, and reports hook exceptions as test failures (`@vitest/runner/dist/chunk-artifact.js`, lines 797–802, 2574–2610, and 2977–2988). The local voice tests, extension-test typecheck, and exact-head CI confirm that use.

The filesystem error fixture uses a fixed filename for its final-stat case so date resolution does not redirect the injected error into fallback candidate discovery.

Follow-ups: daemon status renders a configured path for a potentially different service home/config owner and needs its own path review. Separately, the classic media-stream test fixtures omit `MediaStreamHandler.close()` at 19 of 20 HTTP-server cleanup sites; consolidating those fixtures is a distinct cleanup task, not a proven explanation of the token-watchdog warnings above.
