### PR TITLE
perf(test): preserve exact unit selection for CI

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -60,6 +60,7 @@ import {
 import { isVoiceCallExtensionRoot } from "../test/vitest/vitest.extension-voice-call-paths.mjs";
 import { isWhatsAppExtensionRoot } from "../test/vitest/vitest.extension-whatsapp-paths.mjs";
 import { isZaloExtensionRoot } from "../test/vitest/vitest.extension-zalo-paths.mjs";
+import { narrowIncludePatternsForCli } from "../test/vitest/vitest.pattern-file.ts";
 import { resolveVitestFsModuleCacheRoot } from "../test/vitest/vitest.performance-config.ts";
 import {
   isPluginSdkLightTarget,
@@ -87,6 +88,8 @@ import {
 import {
   isBoundaryTestFile,
   isBundledPluginDependentUnitTestFile,
+  isUnitConfigTestFile,
+  unitTestIncludePatterns,
 } from "../test/vitest/vitest.unit-paths.mjs";
 import {
   detectChangedLanes,
@@ -4017,8 +4020,34 @@ export function buildVitestRunPlans(
     const useWholeConfigTarget = grouped.some((targetArg) =>
       shouldUseWholeConfigTarget(kind, targetArg, cwd),
     );
+    const scopedTargetArgs = useCliTargetArgs ? uniqueOrdered(grouped) : [];
+    const forwardedPlanArgs = [...nonTargetArgs, ...scopedTargetArgs];
+    const unitCliIncludes =
+      kind === "default" &&
+      useCliTargetArgs &&
+      !watchMode &&
+      !options.env?.[INCLUDE_FILE_ENV_KEY]?.trim()
+        ? narrowIncludePatternsForCli(unitTestIncludePatterns, [
+            "node",
+            "vitest",
+            ...forwardedPlanArgs,
+          ])
+        : null;
+    // CI needs explicit selection metadata. Keep the CLI filters too: the unit
+    // config and runner use them for exclude and empty-selection policy.
+    const scopedUnitIncludes =
+      unitCliIncludes?.length &&
+      grouped.every((targetArg) =>
+        unitCliIncludes.includes(toRepoRelativeTarget(targetArg, cwd)),
+      ) &&
+      unitCliIncludes.every(
+        (file) =>
+          !isGlobTarget(file) && isUnitConfigTestFile(file) && isExistingFileTarget(file, cwd),
+      )
+        ? unitCliIncludes
+        : null;
     const includePatterns = useCliTargetArgs
-      ? null
+      ? scopedUnitIncludes
       : useWholeConfigTarget
         ? null
         : uniqueOrdered(
@@ -4027,8 +4056,6 @@ export function buildVitestRunPlans(
               return lightLanePatterns ?? [toScopedIncludePattern(targetArg, cwd)];
             }),
           );
-    const scopedTargetArgs = useCliTargetArgs ? uniqueOrdered(grouped) : [];
-    const forwardedPlanArgs = [...nonTargetArgs, ...scopedTargetArgs];
     const broadToolingScriptPlans = createBroadToolingScriptPlans({
       config,
       cwd,

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -193,6 +193,27 @@ describe("CI changed Node test plan", () => {
     ]);
   });
 
+  it("keeps an exact default-unit change focused while retaining boundary coverage", () => {
+    const target = "src/node-host/node-worker-bundle-installer.test.ts";
+    expect(createChangedNodeTestShards([target])).toEqual([
+      {
+        checkName: "checks-node-changed",
+        configs: [],
+        requiresDist: false,
+        runner: "blacksmith-8vcpu-ubuntu-2404",
+        shardName: "changed",
+        targets: [target],
+      },
+      {
+        checkName: "checks-node-changed-boundary",
+        configs: ["test/vitest/vitest.boundary.config.ts"],
+        requiresDist: false,
+        runner: "blacksmith-8vcpu-ubuntu-2404",
+        shardName: "changed-boundary",
+      },
+    ]);
+  });
+
   it("keeps boundary coverage on test-only diffs without the build-artifacts lane", () => {
     // Test-only diffs skip build-artifacts (which hosts the full boundary
     // gate), so the plan carries its own nondist boundary shard instead.

--- a/test/scripts/test-projects-routing.test.ts
+++ b/test/scripts/test-projects-routing.test.ts
@@ -600,7 +600,7 @@ describe("test-projects args", () => {
         expect(buildVitestRunPlans([file])).toEqual([
           {
             config: plan.config,
-            forwardedArgs: plan.includePatterns ? [] : [file],
+            forwardedArgs: plan.forwardedArgs.includes(file) ? [file] : [],
             includePatterns: plan.includePatterns ? [file] : null,
             watchMode: false,
           },

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -344,6 +344,7 @@ describe("scripts/test-projects changed-target routing", () => {
         expectSingleVitestRunPlan(buildVitestRunPlans([target], cwd), {
           config: "test/vitest/vitest.unit.config.ts",
           forwardedArgs: [`${target}.test.ts`],
+          includePatterns: [`${target}.test.ts`],
         });
         expect(findUnmatchedExplicitTestTargets([target], cwd)).toEqual([]);
 
@@ -1505,6 +1506,79 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
+  it.each(["src/selector/one.test.ts", "./src/selector/one.test.ts"])(
+    "records exact default-unit ownership for %s without removing CLI filters",
+    (target) => {
+      withTinyFileTree({ "src/selector/one.test.ts": "" }, (cwd) => {
+        expectSingleVitestRunPlan(buildVitestRunPlans([target, "--", "-t", "case"], cwd), {
+          config: "test/vitest/vitest.unit.config.ts",
+          forwardedArgs: ["-t", "case", target],
+          includePatterns: ["src/selector/one.test.ts"],
+        });
+      });
+    },
+  );
+
+  it.each([
+    ["src/selector/missing.test.ts"],
+    ["src/selector/one.spec.ts"],
+    ["src/selector/*.test.ts"],
+    ["src/selector/one.test.ts", "src/selector/one.spec.ts"],
+    ["src/selector/one.test.ts", "src/selector/missing.test.ts"],
+    ["src/selector/one.live.test.ts"],
+    ["outside/one.test.ts"],
+  ])("keeps unsupported default-unit targets on the CLI route: %j", (...targets) => {
+    withTinyFileTree(
+      {
+        "src/selector/one.test.ts": "",
+        "src/selector/one.spec.ts": "",
+        "src/selector/one.live.test.ts": "",
+        "outside/one.test.ts": "",
+      },
+      (cwd) => {
+        expectSingleVitestRunPlan(buildVitestRunPlans(targets, cwd), {
+          config: "test/vitest/vitest.unit.config.ts",
+          forwardedArgs: targets,
+        });
+      },
+    );
+  });
+
+  it("preserves absolute and watch default-unit target semantics", () => {
+    const target = "src/selector/one.test.ts";
+    withTinyFileTree({ [target]: "" }, (cwd) => {
+      const absolute = path.join(cwd, target);
+      expectSingleVitestRunPlan(buildVitestRunPlans([absolute], cwd), {
+        config: "test/vitest/vitest.unit.config.ts",
+        forwardedArgs: [absolute],
+      });
+      expectSingleVitestRunPlan(buildVitestRunPlans(["--watch", target], cwd), {
+        config: "test/vitest/vitest.unit.config.ts",
+        forwardedArgs: [target],
+        watchMode: true,
+      });
+    });
+  });
+
+  it("keeps inherited default-unit include files intersected with the CLI target", () => {
+    const target = "src/selector/one.test.ts";
+    withTinyFileTree({ [target]: "", "include.json": JSON.stringify([]) }, (cwd) => {
+      const includeFile = path.join(cwd, "include.json");
+      const [spec] = createVitestRunSpecs([target], {
+        cwd,
+        baseEnv: { OPENCLAW_VITEST_INCLUDE_FILE: includeFile },
+      });
+      expect(spec).toMatchObject({
+        config: "test/vitest/vitest.unit.config.ts",
+        includePatterns: null,
+        includeFilePath: null,
+        env: { OPENCLAW_VITEST_INCLUDE_FILE: includeFile },
+      });
+      expect(spec?.pnpmArgs.at(-1)).toBe(target);
+      expect(fs.readFileSync(includeFile, "utf8")).toBe("[]");
+    });
+  });
+
   it("routes explicit imported source files through import-graph tests", () => {
     let plans: ReturnType<typeof buildVitestRunPlans> = [];
     withTinyGitRepo(
@@ -1521,7 +1595,7 @@ describe("scripts/test-projects changed-target routing", () => {
       {
         config: "test/vitest/vitest.unit.config.ts",
         forwardedArgs: ["src/runtime.consumer.test.ts"],
-        includePatterns: null,
+        includePatterns: ["src/runtime.consumer.test.ts"],
         watchMode: false,
       },
     ]);
@@ -1545,7 +1619,7 @@ describe("scripts/test-projects changed-target routing", () => {
       {
         config: "test/vitest/vitest.unit.config.ts",
         forwardedArgs: ["src/runtime.consumer.test.ts"],
-        includePatterns: null,
+        includePatterns: ["src/runtime.consumer.test.ts"],
         watchMode: false,
       },
     ]);
@@ -1699,7 +1773,7 @@ describe("scripts/test-projects changed-target routing", () => {
       {
         config: "test/vitest/vitest.unit.config.ts",
         forwardedArgs: ["src/runtime.consumer.test.ts"],
-        includePatterns: null,
+        includePatterns: ["src/runtime.consumer.test.ts"],
         watchMode: false,
       },
     ]);
@@ -3100,7 +3174,7 @@ describe("scripts/test-projects changed-target routing", () => {
       {
         config: "test/vitest/vitest.unit.config.ts",
         forwardedArgs: ["packages/sdk/src/index.test.ts"],
-        includePatterns: null,
+        includePatterns: ["packages/sdk/src/index.test.ts"],
         watchMode: false,
       },
     ]);
@@ -3410,7 +3484,7 @@ describe("scripts/test-projects changed-target routing", () => {
       {
         config: "test/vitest/vitest.unit.config.ts",
         forwardedArgs: ["packages/normalization-core/src/string-normalization.test.ts"],
-        includePatterns: null,
+        includePatterns: ["packages/normalization-core/src/string-normalization.test.ts"],
         watchMode: false,
       },
       {
@@ -3691,7 +3765,11 @@ describe("scripts/test-projects changed-target routing", () => {
     expectChangedTargets(fixturePaths, [owner]);
     expectSingleVitestRunPlan(
       buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => fixturePaths),
-      { config: "test/vitest/vitest.unit.config.ts", forwardedArgs: [owner] },
+      {
+        config: "test/vitest/vitest.unit.config.ts",
+        forwardedArgs: [owner],
+        includePatterns: [owner],
+      },
     );
   });
 

--- a/test/vitest-unit-config.test.ts
+++ b/test/vitest-unit-config.test.ts
@@ -1,5 +1,6 @@
 // Vitest unit config tests validate unit test project configuration.
 import { afterEach, describe, expect, it } from "vitest";
+import { buildVitestRunPlans } from "../scripts/test-projects.test-support.mts";
 import { createPatternFileHelper } from "./helpers/pattern-file.js";
 import { normalizeConfigPath, normalizeConfigPaths } from "./helpers/vitest-config-paths.js";
 import {
@@ -87,6 +88,49 @@ describe("unit vitest config", () => {
     expect(testConfig.include).toEqual(["src/media-generation/runtime-shared.test.ts"]);
     expect(testConfig.passWithNoTests).toBeUndefined();
   });
+
+  it.each([false, true])(
+    "keeps routed unit configuration equivalent to CLI discovery with all files excluded=%s",
+    (excludeAll) => {
+      const targets = [
+        "src/node-host/node-worker-bundle-installer.test.ts",
+        "src/media-generation/runtime-shared.test.ts",
+      ];
+      const plans = buildVitestRunPlans([...targets, "--", "--coverage"]);
+      expect(plans).toHaveLength(1);
+      const plan = plans[0];
+      if (!plan) {
+        throw new Error("expected a default unit plan");
+      }
+      expect(plan.includePatterns).toEqual(targets);
+      expect(plan.forwardedArgs).toEqual(["--coverage", ...targets]);
+      const options = { argv: ["node", "vitest", "run", ...plan.forwardedArgs] };
+      const env = excludeAll
+        ? {
+            OPENCLAW_VITEST_EXTRA_EXCLUDE_FILE: patternFiles.writePatternFile(
+              "exclude.json",
+              targets,
+            ),
+          }
+        : {};
+      const cliConfig = requireTestConfig(createUnitVitestConfigWithOptions(env, options));
+      const routedConfig = requireTestConfig(
+        createUnitVitestConfigWithOptions(
+          {
+            ...env,
+            OPENCLAW_VITEST_INCLUDE_FILE: patternFiles.writePatternFile(
+              "include.json",
+              plan.includePatterns,
+            ),
+          },
+          options,
+        ),
+      );
+      expect(routedConfig).toEqual(cliConfig);
+      expect(routedConfig.include).toEqual(targets);
+      expect(routedConfig.passWithNoTests).toBe(excludeAll ? true : undefined);
+    },
+  );
 
   it("lets root Vitest project runs skip unit files owned by excluded projects", () => {
     const unitConfig = createUnitVitestConfigWithOptions(


### PR DESCRIPTION
Exact default-unit test files were already selected through Vitest's CLI and canonical config, but the router reported no finite include list. CI therefore treated those requests as imprecise and selected its compact fallback. Publish the existing canonical file selection at the router after verifying every target is represented by an existing, unit-owned literal. Preserve the original CLI filters so exclusion and explicit-file empty-selection behavior remain unchanged.

Missing, absolute, glob, live/spec, mixed partial, watch and inherited-include requests retain their existing routes. Package/public-SDK, special setup, path/target limits and unsupported-change guards remain unchanged. Targeted CI still includes the full boundary checks and one isolated process per selected file. This changes no workflow, runner capacity, concurrency setting, dependency or application runtime. Test infrastructure +30/-3; tests +150/-7.

The current checkout passed all643 cases across the router, route ownership, CI planner/executor, unit config/path owners and native empty-selection suite. Fourteen new cases preserve CLI/config equivalence and conservative fallbacks; the original implementation fails the five positive selection assertions while the nine conservative cases pass. Actual excluded-file probes retain exit1 by default and exit0 with explicit passWithNoTests, with matching native JSON reports. Full changed-file types, repository guards and lint passed. Independent Codex review and manual source, caller, sibling, history, dependency and deslop review found no actionable issue.

At the separately recorded967a7ead7a20 proof pin, all747 default-unit plans retain identical config/CLI/watch fields while gaining exact metadata; all21 full fallback matrices are unchanged. Three isolated examples (worker bundle, media generation and web search) select the target plus boundary row instead of broad fallback rows. These are local planner comparisons, not measured Actions duration or a claim that every metadata promotion narrows CI. Package-consumer narrowing remains a separate follow-up. The complete prior622-case proof and current643-case run are recorded separately; no baseline whole-suite timing improvement is claimed.

Current-main integration requested by ClawSweeper is complete: the exact published patch applied to2a247c0de589 and passed35 focused canonical cases (full16 unit-config,12 new router/CI and7 changed release-routing cases). The negative control retains five intended failures and nine conservative passes. All747 current default-unit plans preserve config/CLI/watch fields and all45 full fallback matrices remain identical. Eight release-owner sets and their effective CI plans remain unchanged. Docker release/preparation and FRV keep their existing Dockerfile selection with finite local metadata while retaining conservative CI fallback. Latest main ae9ee9679dd3 has identical affected owners. Exact-head CI33580132290 is green; no code refinement or rebase was needed.
