### PR TITLE
fix(agents): keep large-roster gateway health responsive

### DIFF
--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -6,6 +6,7 @@ import {
   AgentSelectionRequiredError,
   listAgentEntriesWithSource,
   listAgentIds,
+  resolveAgentEntry,
   resolveConfiguredAgentId,
   resolveAgentConfig,
   resolveAgentOperationAgentId,
@@ -17,6 +18,7 @@ import {
   tryResolveAmbientOwnerAgentId,
   tryResolveDefaultAgentId,
   tryResolveSoleAgentId,
+  withAgentRosterFactsBatch,
 } from "./agent-scope-config.js";
 
 vi.unmock("./agent-scope-config.js");
@@ -344,5 +346,47 @@ describe("resolveAgentConfig model policy", () => {
     expect(resolveAgentConfig(cfg, "main")?.modelPolicy).toEqual({
       allow: ["openai/gpt-5.6-sol"],
     });
+  });
+});
+
+describe("batch-scoped roster facts (#135743)", () => {
+  it("projects the roster once per config object inside a batch", () => {
+    const cfg = { agents: { entries: { main: {}, ops: {} } } } as OpenClawConfig;
+
+    withAgentRosterFactsBatch(() => {
+      expect(listAgentIds(cfg)).toEqual(["main", "ops"]);
+      // Repeated lookups inside one batch reuse the memoized roster record.
+      expect(listAgentIds(cfg)).toBe(listAgentIds(cfg));
+      expect(listAgentEntriesWithSource(cfg)).toBe(listAgentEntriesWithSource(cfg));
+      expect(tryResolveSoleAgentId(cfg)).toBeUndefined();
+    });
+
+    // Outside the batch every helper projects a fresh roster record again.
+    expect(listAgentIds(cfg)).not.toBe(listAgentIds(cfg));
+  });
+
+  it("drops memoized facts when the outermost batch exits", () => {
+    const cfg = { agents: { entries: { main: {} } } } as OpenClawConfig;
+
+    withAgentRosterFactsBatch(() => {
+      expect(tryResolveSoleAgentId(cfg)).toBe("main");
+    });
+
+    const roster = (cfg as { agents: { entries: Record<string, unknown> } }).agents.entries;
+    roster.ops = {};
+    withAgentRosterFactsBatch(() => {
+      expect(tryResolveSoleAgentId(cfg)).toBeUndefined();
+    });
+  });
+
+  it("returns fresh keyed-entry clones for point lookups inside a batch", () => {
+    const cfg = { agents: { entries: { main: { name: "Main" } } } } as OpenClawConfig;
+
+    withAgentRosterFactsBatch(() => {
+      const first = resolveAgentEntry(cfg, "main");
+      first!.name = "Mutated";
+      expect(resolveAgentEntry(cfg, "main")).toEqual({ id: "main", name: "Main" });
+    });
+    expect(resolveAgentEntry(cfg, "main")).toEqual({ id: "main", name: "Main" });
   });
 });

--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -6,7 +6,6 @@ import {
   AgentSelectionRequiredError,
   listAgentEntriesWithSource,
   listAgentIds,
-  resolveAgentEntry,
   resolveConfiguredAgentId,
   resolveAgentConfig,
   resolveAgentOperationAgentId,
@@ -18,7 +17,6 @@ import {
   tryResolveAmbientOwnerAgentId,
   tryResolveDefaultAgentId,
   tryResolveSoleAgentId,
-  withAgentRosterFactsBatch,
 } from "./agent-scope-config.js";
 
 vi.unmock("./agent-scope-config.js");
@@ -346,47 +344,5 @@ describe("resolveAgentConfig model policy", () => {
     expect(resolveAgentConfig(cfg, "main")?.modelPolicy).toEqual({
       allow: ["openai/gpt-5.6-sol"],
     });
-  });
-});
-
-describe("batch-scoped roster facts (#135743)", () => {
-  it("projects the roster once per config object inside a batch", () => {
-    const cfg = { agents: { entries: { main: {}, ops: {} } } } as OpenClawConfig;
-
-    withAgentRosterFactsBatch(() => {
-      expect(listAgentIds(cfg)).toEqual(["main", "ops"]);
-      // Repeated lookups inside one batch reuse the memoized roster record.
-      expect(listAgentIds(cfg)).toBe(listAgentIds(cfg));
-      expect(listAgentEntriesWithSource(cfg)).toBe(listAgentEntriesWithSource(cfg));
-      expect(tryResolveSoleAgentId(cfg)).toBeUndefined();
-    });
-
-    // Outside the batch every helper projects a fresh roster record again.
-    expect(listAgentIds(cfg)).not.toBe(listAgentIds(cfg));
-  });
-
-  it("drops memoized facts when the outermost batch exits", () => {
-    const cfg = { agents: { entries: { main: {} } } } as OpenClawConfig;
-
-    withAgentRosterFactsBatch(() => {
-      expect(tryResolveSoleAgentId(cfg)).toBe("main");
-    });
-
-    const roster = (cfg as { agents: { entries: Record<string, unknown> } }).agents.entries;
-    roster.ops = {};
-    withAgentRosterFactsBatch(() => {
-      expect(tryResolveSoleAgentId(cfg)).toBeUndefined();
-    });
-  });
-
-  it("returns fresh keyed-entry clones for point lookups inside a batch", () => {
-    const cfg = { agents: { entries: { main: { name: "Main" } } } } as OpenClawConfig;
-
-    withAgentRosterFactsBatch(() => {
-      const first = resolveAgentEntry(cfg, "main");
-      first!.name = "Mutated";
-      expect(resolveAgentEntry(cfg, "main")).toEqual({ id: "main", name: "Main" });
-    });
-    expect(resolveAgentEntry(cfg, "main")).toEqual({ id: "main", name: "Main" });
   });
 });

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -93,8 +93,77 @@ function stripNullBytes(s: string): string {
   return s.replaceAll("\0", "");
 }
 
+/**
+ * Roster facts memoized for the duration of a read-only batch (#135743).
+ *
+ * Runtime collection walks every configured agent × model ref, and each
+ * reference re-derived the full roster projection plus its derived owner
+ * resolvers, making startup O(agents² × models) on large fleets — long enough
+ * to block the event loop after the HTTP server has already bound. Inside an
+ * explicit batch scope, roster-derived facts are computed once per config
+ * object and reused for the whole batch.
+ */
+type AgentRosterFacts = {
+  entriesWithSource?: ListedAgentEntry[];
+  agentIds?: string[];
+  soleAgentId?: { value: string | undefined };
+  rawLegacyDefaultAgentId?: { value: string | undefined };
+  compatibilityAgentId?: { value: string | undefined };
+  entryByNormalizedId?: Map<string, { clone: boolean; entry: AgentEntry }>;
+};
+
+let agentRosterFactsDepth = 0;
+let agentRosterFactsByConfig = new WeakMap<object, AgentRosterFacts>();
+
+/**
+ * Runs a read-only callback with batch-scoped roster memoization.
+ *
+ * While the outermost batch is active, roster-derived facts (agent entries,
+ * ids, sole/default/compatibility owners, and point lookups) are cached per
+ * config object. The cache is dropped when the batch exits, so config changes
+ * between batches are always observed. The callback must not mutate the agent
+ * roster, agent defaults, or retained legacy owner state while it runs, and
+ * values returned from roster helpers inside the batch must be treated as
+ * immutable shared snapshots.
+ */
+export function withAgentRosterFactsBatch<T>(callback: () => T): T {
+  agentRosterFactsDepth += 1;
+  try {
+    return callback();
+  } finally {
+    agentRosterFactsDepth -= 1;
+    if (agentRosterFactsDepth === 0) {
+      agentRosterFactsByConfig = new WeakMap();
+    }
+  }
+}
+
+function readAgentRosterFacts(cfg: OpenClawConfig): AgentRosterFacts | undefined {
+  if (agentRosterFactsDepth === 0 || !cfg || typeof cfg !== "object") {
+    return undefined;
+  }
+  let facts = agentRosterFactsByConfig.get(cfg);
+  if (!facts) {
+    facts = {};
+    agentRosterFactsByConfig.set(cfg, facts);
+  }
+  return facts;
+}
+
 /** Lists valid configured agent entries from config. */
 export function listAgentEntriesWithSource(cfg: OpenClawConfig): ListedAgentEntry[] {
+  const facts = readAgentRosterFacts(cfg);
+  if (facts?.entriesWithSource) {
+    return facts.entriesWithSource;
+  }
+  const projected = projectAgentEntriesWithSource(cfg);
+  if (facts) {
+    facts.entriesWithSource = projected;
+  }
+  return projected;
+}
+
+function projectAgentEntriesWithSource(cfg: OpenClawConfig): ListedAgentEntry[] {
   const roster = readAgentRosterProperty(cfg);
   if (roster?.kind === "entries" && isRecord(roster.value)) {
     return Object.entries(roster.value).flatMap(([id, entry]) =>
@@ -160,6 +229,18 @@ export function hasAgentRosterProperty(raw: unknown): boolean {
 
 /** Lists unique configured agent ids. */
 export function listAgentIds(cfg: OpenClawConfig): string[] {
+  const facts = readAgentRosterFacts(cfg);
+  if (facts?.agentIds) {
+    return facts.agentIds;
+  }
+  const ids = projectAgentIds(cfg);
+  if (facts) {
+    facts.agentIds = ids;
+  }
+  return ids;
+}
+
+function projectAgentIds(cfg: OpenClawConfig): string[] {
   const agents = listAgentEntries(cfg);
   if (agents.length === 0 && !hasAgentRosterProperty(cfg)) {
     // Match resolveDefaultAgentId's Plugin SDK compatibility for raw pre-roster configs.
@@ -191,6 +272,18 @@ export function resolveConfiguredAgentId(cfg: OpenClawConfig, agentId: string): 
 }
 
 export function tryResolveSoleAgentId(cfg: OpenClawConfig): string | undefined {
+  const facts = readAgentRosterFacts(cfg);
+  if (facts?.soleAgentId) {
+    return facts.soleAgentId.value;
+  }
+  const value = projectSoleAgentId(cfg);
+  if (facts) {
+    facts.soleAgentId = { value };
+  }
+  return value;
+}
+
+function projectSoleAgentId(cfg: OpenClawConfig): string | undefined {
   const agents = listAgentEntries(cfg);
   if (agents.length === 0) {
     if (!hasAgentRosterProperty(cfg)) {
@@ -214,6 +307,18 @@ export function resolveSoleAgentId(cfg: OpenClawConfig, context?: AgentSelection
 }
 
 function tryResolveRawLegacyDefaultAgentId(cfg: OpenClawConfig): string | undefined {
+  const facts = readAgentRosterFacts(cfg);
+  if (facts?.rawLegacyDefaultAgentId) {
+    return facts.rawLegacyDefaultAgentId.value;
+  }
+  const value = projectRawLegacyDefaultAgentId(cfg);
+  if (facts) {
+    facts.rawLegacyDefaultAgentId = { value };
+  }
+  return value;
+}
+
+function projectRawLegacyDefaultAgentId(cfg: OpenClawConfig): string | undefined {
   if (cfg.agents?.ownership === "explicit") {
     return undefined;
   }
@@ -223,6 +328,18 @@ function tryResolveRawLegacyDefaultAgentId(cfg: OpenClawConfig): string | undefi
 
 /** Resolves sole/raw legacy owners plus the retained in-process migration owner. */
 export function tryResolveLegacyCompatibilityAgentId(cfg: OpenClawConfig): string | undefined {
+  const facts = readAgentRosterFacts(cfg);
+  if (facts?.compatibilityAgentId) {
+    return facts.compatibilityAgentId.value;
+  }
+  const value = projectLegacyCompatibilityAgentId(cfg);
+  if (facts) {
+    facts.compatibilityAgentId = { value };
+  }
+  return value;
+}
+
+function projectLegacyCompatibilityAgentId(cfg: OpenClawConfig): string | undefined {
   const retainedAgentId = getRetainedLegacyDefaultAgentId(cfg);
   return retainedAgentId && listAgentIds(cfg).includes(retainedAgentId)
     ? retainedAgentId
@@ -291,6 +408,14 @@ export function tryResolveDefaultAgentId(cfg: OpenClawConfig): string | undefine
 
 export function resolveAgentEntry(cfg: OpenClawConfig, agentId: string): AgentEntry | undefined {
   const id = normalizeAgentId(agentId);
+  const facts = readAgentRosterFacts(cfg);
+  if (facts) {
+    // Point lookups inside a batch reuse one first-match index instead of
+    // re-traversing the roster per model ref (#135743).
+    const byId = (facts.entryByNormalizedId ??= buildAgentEntryIndex(cfg));
+    const found = byId.get(id);
+    return found ? (found.clone ? { ...found.entry } : found.entry) : undefined;
+  }
   // Point lookups are hot; the public list helper must clone every keyed entry.
   // Traverse the roster directly so a match does not project unrelated agents.
   const roster = readAgentRosterProperty(cfg);
@@ -313,6 +438,26 @@ export function resolveAgentEntry(cfg: OpenClawConfig, agentId: string): AgentEn
     );
   }
   return undefined;
+}
+
+/**
+ * First-match index over the projected roster for batch point lookups.
+ *
+ * Keyed entries must stay clone-on-read (callers may mutate the returned
+ * entry); list entries keep the original object, matching the direct
+ * traversal semantics of `resolveAgentEntry` outside a batch.
+ */
+function buildAgentEntryIndex(
+  cfg: OpenClawConfig,
+): Map<string, { clone: boolean; entry: AgentEntry }> {
+  const index = new Map<string, { clone: boolean; entry: AgentEntry }>();
+  for (const { entry, source } of listAgentEntriesWithSource(cfg)) {
+    const normalizedId = normalizeAgentId(entry?.id);
+    if (!index.has(normalizedId)) {
+      index.set(normalizedId, { clone: source.kind === "entries", entry });
+    }
+  }
+  return index;
 }
 
 /** Resolves the authored entry object for in-place canonical config mutations. */

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -93,77 +93,43 @@ function stripNullBytes(s: string): string {
   return s.replaceAll("\0", "");
 }
 
-/**
- * Roster facts memoized for the duration of a read-only batch (#135743).
- *
- * Runtime collection walks every configured agent × model ref, and each
- * reference re-derived the full roster projection plus its derived owner
- * resolvers, making startup O(agents² × models) on large fleets — long enough
- * to block the event loop after the HTTP server has already bound. Inside an
- * explicit batch scope, roster-derived facts are computed once per config
- * object and reused for the whole batch.
- */
 type AgentRosterFacts = {
-  entriesWithSource?: ListedAgentEntry[];
-  agentIds?: string[];
-  soleAgentId?: { value: string | undefined };
-  rawLegacyDefaultAgentId?: { value: string | undefined };
   compatibilityAgentId?: { value: string | undefined };
   entryByNormalizedId?: Map<string, { clone: boolean; entry: AgentEntry }>;
 };
 
-let agentRosterFactsDepth = 0;
-let agentRosterFactsByConfig = new WeakMap<object, AgentRosterFacts>();
+type AgentRosterFactsBatch = {
+  config: OpenClawConfig;
+  facts: AgentRosterFacts;
+};
+
+let activeAgentRosterFactsBatch: AgentRosterFactsBatch | undefined;
 
 /**
  * Runs a read-only callback with batch-scoped roster memoization.
  *
- * While the outermost batch is active, roster-derived facts (agent entries,
- * ids, sole/default/compatibility owners, and point lookups) are cached per
- * config object. The cache is dropped when the batch exits, so config changes
- * between batches are always observed. The callback must not mutate the agent
- * roster, agent defaults, or retained legacy owner state while it runs, and
- * values returned from roster helpers inside the batch must be treated as
- * immutable shared snapshots.
+ * Runtime discovery calls the owner helpers for every configured model. Keep
+ * their derived facts on this exact config and discard them before returning,
+ * so later config mutations cannot observe a stale process cache.
  */
-export function withAgentRosterFactsBatch<T>(callback: () => T): T {
-  agentRosterFactsDepth += 1;
+export function withAgentRosterFactsBatch<T>(config: OpenClawConfig, callback: () => T): T {
+  const parent = activeAgentRosterFactsBatch;
+  activeAgentRosterFactsBatch = parent?.config === config ? parent : { config, facts: {} };
   try {
     return callback();
   } finally {
-    agentRosterFactsDepth -= 1;
-    if (agentRosterFactsDepth === 0) {
-      agentRosterFactsByConfig = new WeakMap();
-    }
+    activeAgentRosterFactsBatch = parent;
   }
 }
 
 function readAgentRosterFacts(cfg: OpenClawConfig): AgentRosterFacts | undefined {
-  if (agentRosterFactsDepth === 0 || !cfg || typeof cfg !== "object") {
-    return undefined;
-  }
-  let facts = agentRosterFactsByConfig.get(cfg);
-  if (!facts) {
-    facts = {};
-    agentRosterFactsByConfig.set(cfg, facts);
-  }
-  return facts;
+  return activeAgentRosterFactsBatch?.config === cfg
+    ? activeAgentRosterFactsBatch.facts
+    : undefined;
 }
 
 /** Lists valid configured agent entries from config. */
 export function listAgentEntriesWithSource(cfg: OpenClawConfig): ListedAgentEntry[] {
-  const facts = readAgentRosterFacts(cfg);
-  if (facts?.entriesWithSource) {
-    return facts.entriesWithSource;
-  }
-  const projected = projectAgentEntriesWithSource(cfg);
-  if (facts) {
-    facts.entriesWithSource = projected;
-  }
-  return projected;
-}
-
-function projectAgentEntriesWithSource(cfg: OpenClawConfig): ListedAgentEntry[] {
   const roster = readAgentRosterProperty(cfg);
   if (roster?.kind === "entries" && isRecord(roster.value)) {
     return Object.entries(roster.value).flatMap(([id, entry]) =>
@@ -229,18 +195,6 @@ export function hasAgentRosterProperty(raw: unknown): boolean {
 
 /** Lists unique configured agent ids. */
 export function listAgentIds(cfg: OpenClawConfig): string[] {
-  const facts = readAgentRosterFacts(cfg);
-  if (facts?.agentIds) {
-    return facts.agentIds;
-  }
-  const ids = projectAgentIds(cfg);
-  if (facts) {
-    facts.agentIds = ids;
-  }
-  return ids;
-}
-
-function projectAgentIds(cfg: OpenClawConfig): string[] {
   const agents = listAgentEntries(cfg);
   if (agents.length === 0 && !hasAgentRosterProperty(cfg)) {
     // Match resolveDefaultAgentId's Plugin SDK compatibility for raw pre-roster configs.
@@ -272,18 +226,6 @@ export function resolveConfiguredAgentId(cfg: OpenClawConfig, agentId: string): 
 }
 
 export function tryResolveSoleAgentId(cfg: OpenClawConfig): string | undefined {
-  const facts = readAgentRosterFacts(cfg);
-  if (facts?.soleAgentId) {
-    return facts.soleAgentId.value;
-  }
-  const value = projectSoleAgentId(cfg);
-  if (facts) {
-    facts.soleAgentId = { value };
-  }
-  return value;
-}
-
-function projectSoleAgentId(cfg: OpenClawConfig): string | undefined {
   const agents = listAgentEntries(cfg);
   if (agents.length === 0) {
     if (!hasAgentRosterProperty(cfg)) {
@@ -307,18 +249,6 @@ export function resolveSoleAgentId(cfg: OpenClawConfig, context?: AgentSelection
 }
 
 function tryResolveRawLegacyDefaultAgentId(cfg: OpenClawConfig): string | undefined {
-  const facts = readAgentRosterFacts(cfg);
-  if (facts?.rawLegacyDefaultAgentId) {
-    return facts.rawLegacyDefaultAgentId.value;
-  }
-  const value = projectRawLegacyDefaultAgentId(cfg);
-  if (facts) {
-    facts.rawLegacyDefaultAgentId = { value };
-  }
-  return value;
-}
-
-function projectRawLegacyDefaultAgentId(cfg: OpenClawConfig): string | undefined {
   if (cfg.agents?.ownership === "explicit") {
     return undefined;
   }
@@ -332,18 +262,15 @@ export function tryResolveLegacyCompatibilityAgentId(cfg: OpenClawConfig): strin
   if (facts?.compatibilityAgentId) {
     return facts.compatibilityAgentId.value;
   }
-  const value = projectLegacyCompatibilityAgentId(cfg);
+  const retainedAgentId = getRetainedLegacyDefaultAgentId(cfg);
+  const value =
+    retainedAgentId && listAgentIds(cfg).includes(retainedAgentId)
+      ? retainedAgentId
+      : tryResolveDefaultAgentId(cfg);
   if (facts) {
     facts.compatibilityAgentId = { value };
   }
   return value;
-}
-
-function projectLegacyCompatibilityAgentId(cfg: OpenClawConfig): string | undefined {
-  const retainedAgentId = getRetainedLegacyDefaultAgentId(cfg);
-  return retainedAgentId && listAgentIds(cfg).includes(retainedAgentId)
-    ? retainedAgentId
-    : tryResolveDefaultAgentId(cfg);
 }
 
 /** Resolves the owner for ambient system work and explicit requests. */

--- a/src/agents/harness-runtimes.test.ts
+++ b/src/agents/harness-runtimes.test.ts
@@ -4,6 +4,22 @@ import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { collectConfiguredAgentHarnessRuntimes as collectConfiguredAgentHarnessRuntimesBase } from "./harness-runtimes.js";
 
+/** Wraps `agents.entries` in a counting getter (test-local instrumentation). */
+function countRosterReads(config: OpenClawConfig): () => number {
+  const agents = (config as { agents: Record<string, unknown> }).agents;
+  const entries = agents.entries;
+  let reads = 0;
+  Object.defineProperty(agents, "entries", {
+    enumerable: true,
+    configurable: true,
+    get: () => {
+      reads += 1;
+      return entries;
+    },
+  });
+  return () => reads;
+}
+
 function collectConfiguredAgentHarnessRuntimes(
   config: OpenClawConfig,
   options?: Parameters<typeof collectConfiguredAgentHarnessRuntimesBase>[1],
@@ -146,5 +162,51 @@ describe("collectConfiguredAgentHarnessRuntimes", () => {
     } as unknown as OpenClawConfig;
 
     expect(collectConfiguredAgentHarnessRuntimes(config)).toEqual(["claude"]);
+  });
+
+  it("bounds roster reads per collection batch on large fleets (#135743)", () => {
+    // 300 agents × 40 model refs each previously re-projected the full roster
+    // for every reference (O(agents² × models)), blocking the event loop long
+    // after the HTTP server had bound. A collection batch must read the roster
+    // a bounded number of times instead of once per model reference.
+    const agentCount = 300;
+    const modelsPerAgent = 40;
+    const entries: Record<string, { models: Record<string, Record<string, never>> }> = {};
+    for (let i = 0; i < agentCount; i++) {
+      const models: Record<string, Record<string, never>> = {};
+      for (let m = 0; m < modelsPerAgent; m++) {
+        models[`openai/gpt-${m}`] = {};
+      }
+      entries[`agent-${i}`] = { models };
+    }
+    const config = {
+      agents: {
+        entries,
+        defaults: {
+          models: { "anthropic/claude-opus-4-7": {} } as Record<string, Record<string, never>>,
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const migrated = migratePersistedImplicitMainRoster(config).config as OpenClawConfig;
+    const rosterReads = countRosterReads(migrated);
+
+    const runtimes = collectConfiguredAgentHarnessRuntimesBase(migrated);
+
+    expect(runtimes).toEqual(["codex"]);
+    // Bounded by a small constant per batch, not by agents × model refs
+    // (the unfixed path performs ~hundreds of thousands of reads here).
+    expect(rosterReads()).toBeLessThanOrEqual(16);
+  });
+
+  it("observes roster mutations made between collection batches (#135743)", () => {
+    const config = { agents: { entries: { main: {} } } } as unknown as OpenClawConfig;
+    const migrated = migratePersistedImplicitMainRoster(config).config as OpenClawConfig;
+
+    expect(collectConfiguredAgentHarnessRuntimesBase(migrated)).toEqual([]);
+
+    const roster = (migrated as { agents: { entries: Record<string, unknown> } }).agents.entries;
+    roster.worker = { models: { "openai/gpt-5.5": {} } };
+
+    expect(collectConfiguredAgentHarnessRuntimesBase(migrated)).toEqual(["codex"]);
   });
 });

--- a/src/agents/harness-runtimes.test.ts
+++ b/src/agents/harness-runtimes.test.ts
@@ -4,7 +4,6 @@ import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { collectConfiguredAgentHarnessRuntimes as collectConfiguredAgentHarnessRuntimesBase } from "./harness-runtimes.js";
 
-/** Wraps `agents.entries` in a counting getter (test-local instrumentation). */
 function countRosterReads(config: OpenClawConfig): () => number {
   const agents = (config as { agents: Record<string, unknown> }).agents;
   const entries = agents.entries;
@@ -165,17 +164,14 @@ describe("collectConfiguredAgentHarnessRuntimes", () => {
   });
 
   it("bounds roster reads per collection batch on large fleets (#135743)", () => {
-    // 300 agents × 40 model refs each previously re-projected the full roster
-    // for every reference (O(agents² × models)), blocking the event loop long
-    // after the HTTP server had bound. A collection batch must read the roster
-    // a bounded number of times instead of once per model reference.
+    // The collector must not multiply full-roster reads by model-reference count.
     const agentCount = 300;
     const modelsPerAgent = 40;
     const entries: Record<string, { models: Record<string, Record<string, never>> }> = {};
     for (let i = 0; i < agentCount; i++) {
       const models: Record<string, Record<string, never>> = {};
       for (let m = 0; m < modelsPerAgent; m++) {
-        models[`openai/gpt-${m}`] = {};
+        models[`openai/proof-model-${m}`] = {};
       }
       entries[`agent-${i}`] = { models };
     }
@@ -193,8 +189,6 @@ describe("collectConfiguredAgentHarnessRuntimes", () => {
     const runtimes = collectConfiguredAgentHarnessRuntimesBase(migrated);
 
     expect(runtimes).toEqual(["codex"]);
-    // Bounded by a small constant per batch, not by agents × model refs
-    // (the unfixed path performs ~hundreds of thousands of reads here).
     expect(rosterReads()).toBeLessThanOrEqual(16);
   });
 

--- a/src/agents/harness-runtimes.ts
+++ b/src/agents/harness-runtimes.ts
@@ -10,7 +10,7 @@ import {
   isDefaultAgentRuntimeId,
   normalizeOptionalAgentRuntimeId,
 } from "./agent-runtime-id.js";
-import { listAgentEntries } from "./agent-scope-config.js";
+import { listAgentEntries, withAgentRosterFactsBatch } from "./agent-scope-config.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 
 // Harness runtime discovery feeds plugin preloading/setup. Only plugin runtimes
@@ -146,11 +146,17 @@ export function collectConfiguredAgentHarnessRuntimes(
   config: OpenClawConfig,
   options: ConfiguredAgentHarnessRuntimeOptions = {},
 ): string[] {
-  const runtimes = new Set<string>();
-  const includeImplicitRuntimePreferences = options.includeImplicitRuntimePreferences ?? true;
+  // Roster facts are memoized for the whole batch: per-reference policy
+  // resolution otherwise re-projects the roster O(agents × models) times,
+  // which blocks the event loop on large fleets (#135743). The batch is a
+  // pure read of config.
+  return withAgentRosterFactsBatch(() => {
+    const runtimes = new Set<string>();
+    const includeImplicitRuntimePreferences = options.includeImplicitRuntimePreferences ?? true;
 
-  pushConfiguredModelRuntimeIds(config, runtimes);
-  pushConfiguredAgentModelRuntimeIds(config, runtimes, includeImplicitRuntimePreferences);
+    pushConfiguredModelRuntimeIds(config, runtimes);
+    pushConfiguredAgentModelRuntimeIds(config, runtimes, includeImplicitRuntimePreferences);
 
-  return [...runtimes].toSorted((left, right) => left.localeCompare(right));
+    return [...runtimes].toSorted((left, right) => left.localeCompare(right));
+  });
 }

--- a/src/agents/harness-runtimes.ts
+++ b/src/agents/harness-runtimes.ts
@@ -150,7 +150,7 @@ export function collectConfiguredAgentHarnessRuntimes(
   // resolution otherwise re-projects the roster O(agents × models) times,
   // which blocks the event loop on large fleets (#135743). The batch is a
   // pure read of config.
-  return withAgentRosterFactsBatch(() => {
+  return withAgentRosterFactsBatch(config, () => {
     const runtimes = new Set<string>();
     const includeImplicitRuntimePreferences = options.includeImplicitRuntimePreferences ?? true;
 

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -105,9 +105,12 @@ function resolveSelectedMemoryPluginIds(params: {
 export function resolveAgentRuntimePluginSelections(
   config: OpenClawConfig | undefined,
   selections: readonly AgentHarnessPluginSelection[],
+  configuredHarnessRuntimes: readonly string[] = collectConfiguredAgentHarnessRuntimes(
+    config ?? {},
+  ),
 ): AgentHarnessPluginSelection[] {
   return [
-    ...collectConfiguredAgentHarnessRuntimes(config ?? {}).map((runtime) => ({
+    ...configuredHarnessRuntimes.map((runtime) => ({
       runtime,
       provider: "",
       modelId: "",

--- a/src/agents/model-runtime-policy.ts
+++ b/src/agents/model-runtime-policy.ts
@@ -11,8 +11,8 @@ import type { AgentModelEntryConfig } from "../config/types.agent-defaults.js";
 import type { AgentRuntimePolicyConfig } from "../config/types.agents-shared.js";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizeAgentId } from "../routing/session-key.js";
-import { listAgentEntries, resolveSessionAgentIds } from "./agent-scope.js";
+import { resolveAgentEntry } from "./agent-scope-config.js";
+import { resolveSessionAgentIds } from "./agent-scope.js";
 
 /** Config surface that supplied a resolved model runtime policy. */
 type ModelRuntimePolicySource = "model" | "provider";
@@ -162,9 +162,10 @@ function resolveAgentModelEntryRuntimePolicy(params: {
         sessionKey: params.sessionKey,
       }).sessionAgentId
     : tryResolveLegacyCompatibilityAgentId(params.config);
-  const agentEntry = sessionAgentId
-    ? listAgentEntries(params.config).find((entry) => normalizeAgentId(entry.id) === sessionAgentId)
-    : undefined;
+  // Point lookup: projecting the whole roster per model ref made runtime
+  // collection O(agents² × models) on large fleets (#135743).
+  const agentEntry =
+    sessionAgentId && params.config ? resolveAgentEntry(params.config, sessionAgentId) : undefined;
   const modelMaps: Array<Record<string, AgentModelEntryConfig> | undefined> = [
     agentEntry?.models,
     params.config.agents?.defaults?.models,

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -3,11 +3,13 @@ import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import pLimit from "p-limit";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runAbortableTimeout } from "../node-host/with-timeout.js";
 import { prepareModelCatalogThinkingPolicies } from "../plugins/provider-thinking.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
 import { getPreparedRuntimeAuthMaterializations } from "./auth-profiles/runtime-materializations.js";
+import { collectConfiguredAgentHarnessRuntimes } from "./harness-runtimes.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   createPreparedModelCatalogWorker,
@@ -352,6 +354,9 @@ async function buildSnapshotBatch(
     return prepared;
   };
   const loadInboundPluginRegistry = createPreparedInboundRegistryLoader();
+  // Config objects can change between publications. Share this projection only
+  // inside the current build batch so every later publication reads fresh config.
+  const configuredHarnessRuntimesByConfig = new Map<OpenClawConfig, readonly string[]>();
   let runtimePluginMs = 0;
   let pluginMetadataMs = 0;
   let staticProviderCatalogMs = 0;
@@ -370,12 +375,19 @@ async function buildSnapshotBatch(
     );
     const preferBuiltPluginArtifacts =
       pluginGeneration?.preferBuiltPluginArtifacts ?? prepareInboundPluginRegistry;
+    const config = groupCandidates[0]!.input.config;
+    let configuredHarnessRuntimes = configuredHarnessRuntimesByConfig.get(config);
+    if (!configuredHarnessRuntimes) {
+      configuredHarnessRuntimes = collectConfiguredAgentHarnessRuntimes(config);
+      configuredHarnessRuntimesByConfig.set(config, configuredHarnessRuntimes);
+    }
     const prepared = await prepareWorkspaceBuildGroup(
       groupCandidates.map(({ input }) => input),
       catalogMode,
       {
         preferBuiltPluginArtifacts,
         includeCredentialProviders,
+        configuredHarnessRuntimes,
       },
       prepareInboundPluginRegistry ? loadInboundPluginRegistry : undefined,
       pluginGeneration,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -26,6 +26,7 @@ import {
   discoverAuthStorageFacts,
   discoverModelsFromCapturedSources,
 } from "./agent-model-discovery.js";
+import { withAgentRosterFactsBatch } from "./agent-scope-config.js";
 import {
   getPreparedRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreCredentialsRevision,
@@ -162,6 +163,7 @@ export async function prepareWorkspaceBuildGroup(
     providerDiscoveryProviderIds?: readonly string[];
     preferBuiltPluginArtifacts?: boolean;
     includeCredentialProviders?: boolean;
+    configuredHarnessRuntimes?: readonly string[];
   } = {},
   loadInboundPluginRegistry?: PreparedInboundRegistryLoader,
   reusablePluginGeneration?: PreparedModelRuntimePluginGeneration,
@@ -202,6 +204,7 @@ export async function prepareWorkspaceBuildGroup(
     loadInboundPluginRegistry,
     preferBuiltPluginArtifacts,
     reusablePluginGeneration,
+    options.configuredHarnessRuntimes,
   );
   const reuseRuntimeFacts =
     reusablePluginGeneration && runtimePluginRegistry === reusablePluginGeneration.pluginRegistry;
@@ -252,16 +255,18 @@ export async function prepareWorkspaceBuildGroup(
     };
     const configuredProviderIds = [
       ...new Set([
-        ...inputs.flatMap(({ config, agentId }) => [
-          ...collectPreparedModelRuntimeProviderIds(
-            config,
-            {},
-            false,
-            collectPreparedModelRuntimeConfiguredRefs(config, agentId),
-            agentId,
-          ),
-          ...parseConfiguredModelVisibilityEntries({ cfg: config, agentId }).providerWildcards,
-        ]),
+        ...inputs.flatMap(({ config, agentId }) =>
+          withAgentRosterFactsBatch(config, () => [
+            ...collectPreparedModelRuntimeProviderIds(
+              config,
+              {},
+              false,
+              collectPreparedModelRuntimeConfiguredRefs(config, agentId),
+              agentId,
+            ),
+            ...parseConfiguredModelVisibilityEntries({ cfg: config, agentId }).providerWildcards,
+          ]),
+        ),
         ...(options.providerDiscoveryProviderIds ?? []).map(normalizeProviderId).filter(Boolean),
       ]),
     ].toSorted((left, right) => left.localeCompare(right));
@@ -348,12 +353,14 @@ export async function prepareWorkspaceBuildGroup(
     const ambientCredentialsMs = performance.now() - ambientCredentialsStartedAt;
     const agentFactsStartedAt = performance.now();
     const agentBaseFacts = inputs.map((candidate) =>
-      prepareAgentFacts(
-        candidate,
-        catalogMode,
-        ambientCredentials,
-        options.providerDiscoveryProviderIds,
-        options.includeCredentialProviders,
+      withAgentRosterFactsBatch(candidate.config, () =>
+        prepareAgentFacts(
+          candidate,
+          catalogMode,
+          ambientCredentials,
+          options.providerDiscoveryProviderIds,
+          options.includeCredentialProviders,
+        ),
       ),
     );
     const agentFactsMs = performance.now() - agentFactsStartedAt;

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -26,6 +26,7 @@ type PreparedInboundRegistryInput = Pick<
 export type PreparedInboundRegistryLoader = (
   input: PreparedInboundRegistryInput,
   metadataSnapshot: PluginMetadataSnapshot,
+  configuredHarnessRuntimes?: readonly string[],
 ) => PluginRegistry;
 
 function inboundRegistryIdentity(input: PreparedInboundRegistryInput): string {
@@ -59,6 +60,7 @@ export function preparedModelRuntimeWorkspaceFactsKey(input: PreparedModelRuntim
 export function loadPreparedInboundPluginRegistry(
   input: PreparedInboundRegistryInput,
   metadataSnapshot = prepareOwnedPluginLoadContext(input, input.env ?? process.env, undefined),
+  configuredHarnessRuntimes?: readonly string[],
 ): PluginRegistry {
   const activeRegistry = getActivePluginRegistry();
   // Identity is the generation authority. Manifest equivalence alone could let a
@@ -90,6 +92,7 @@ export function loadPreparedInboundPluginRegistry(
       ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
       metadataSnapshot,
       preferBuiltPluginArtifacts: true,
+      configuredHarnessRuntimes,
     });
   prepareOwnedPluginLoadContext(input, input.env ?? process.env, registry, metadataSnapshot, true);
   return registry;
@@ -101,13 +104,17 @@ export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLo
     string,
     { metadataSnapshot: PluginMetadataSnapshot; registry: PluginRegistry }
   >();
-  return (input, metadataSnapshot) => {
+  return (input, metadataSnapshot, configuredHarnessRuntimes) => {
     const key = inboundRegistryIdentity(input);
     const existing = registries.get(key);
     if (existing?.metadataSnapshot === metadataSnapshot) {
       return existing.registry;
     }
-    const registry = loadPreparedInboundPluginRegistry(input, metadataSnapshot);
+    const registry = loadPreparedInboundPluginRegistry(
+      input,
+      metadataSnapshot,
+      configuredHarnessRuntimes,
+    );
     registries.set(key, { metadataSnapshot, registry });
     return registry;
   };
@@ -120,6 +127,7 @@ export function prepareWorkspacePluginRegistries(
   loadInboundRegistry?: PreparedInboundRegistryLoader,
   preferBuiltPluginArtifacts = false,
   reusableGeneration?: PreparedModelRuntimePluginGeneration,
+  configuredHarnessRuntimes?: readonly string[],
 ): {
   runtimePluginRegistry?: PluginRegistry;
   inboundPluginRegistry?: PluginRegistry;
@@ -131,7 +139,8 @@ export function prepareWorkspacePluginRegistries(
   }
   const inboundPluginRegistry = input.readOnly
     ? undefined
-    : (reusableGeneration?.inboundPluginRegistry ?? loadInboundRegistry?.(input, metadataSnapshot));
+    : (reusableGeneration?.inboundPluginRegistry ??
+      loadInboundRegistry?.(input, metadataSnapshot, configuredHarnessRuntimes));
   const baseRegistry = reusableGeneration?.pluginRegistry ?? inboundPluginRegistry;
   const runtimePluginRegistry =
     input.runtimePluginSelections || !baseRegistry
@@ -151,6 +160,7 @@ export function prepareWorkspacePluginRegistries(
           metadataSnapshot,
           ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
           selections: input.runtimePluginSelections,
+          configuredHarnessRuntimes,
         })
       : baseRegistry;
   return {

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -720,6 +720,11 @@ describe("prepared model runtime owner selection", () => {
 
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
     expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(4);
+    expect(
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.map(
+        ([params]) => params.configuredHarnessRuntimes,
+      ),
+    ).toEqual([["codex"], ["codex"], ["codex"], ["codex"]]);
     expect(mocks.resolveAmbientCredentials).toHaveBeenCalledTimes(2);
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledTimes(2);
     expect(mocks.resolveStaticCatalogModel).toHaveBeenCalledTimes(2);

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -269,6 +269,7 @@ describe("prepared model runtime snapshots", () => {
 
     expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledWith({
       config: {},
+      configuredHarnessRuntimes: [],
       env: process.env,
       metadataSnapshot: mocks.pluginMetadataSnapshot,
       workspaceDir: "/tmp/prepared-model-runtime-plugin-workspace",

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -137,6 +137,22 @@ describe("agent runtime plugin registries", () => {
     );
   });
 
+  it("uses harness runtimes prepared by the lifecycle batch", () => {
+    const configuredHarnessRuntimes = ["codex"];
+
+    loadAgentRuntimePluginRegistryHandle({
+      config: {},
+      configuredHarnessRuntimes,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(hoisted.resolveAgentRuntimePluginSelections).toHaveBeenCalledWith(
+      {},
+      [],
+      configuredHarnessRuntimes,
+    );
+  });
+
   it.each([true, false])("reuses only an imported selected owner (imported=%s)", (imported) => {
     const base = createEmptyPluginRegistry();
     base.plugins.push(

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -37,6 +37,8 @@ type AgentRuntimePluginRegistryParams = {
   /** Exact registry from the supplied lifecycle metadata generation. */
   reusableRegistry?: PluginRegistry;
   selections?: readonly AgentHarnessPluginSelection[];
+  /** Config-wide harness runtimes carried by a prepared lifecycle batch. */
+  configuredHarnessRuntimes?: readonly string[];
   /** Lifecycle-owned selection; standalone/direct generations stay source-default. */
   preferBuiltPluginArtifacts?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
@@ -81,7 +83,11 @@ function resolveAgentRuntimePluginRegistryLoad(
     config: params.config,
     workspaceDir: workspaceDir ?? process.cwd(),
     basePluginIds: startupPluginIds,
-    selections: resolveAgentRuntimePluginSelections(params.config, params.selections ?? []),
+    selections: resolveAgentRuntimePluginSelections(
+      params.config,
+      params.selections ?? [],
+      params.configuredHarnessRuntimes,
+    ),
     metadataSnapshot,
   });
   return {


### PR DESCRIPTION
Fixes #135743.

## What Problem This Solves

Fixes an issue where a Gateway with a large agent roster could report that its HTTP server was listening, then stop answering health requests while startup rebuilt the full roster for each configured model reference and workspace.

## Why This Change Was Made

Configured harness discovery now derives roster facts once for one synchronous config read, drops them before returning, and carries the resulting harness runtimes across the prepared-runtime build batch. Point lookups use the existing direct agent-entry resolver. Later config mutations start a fresh batch, so this adds no stale process-wide config cache.

The overlapping approach in #135783 keeps a permanent config-identity cache and does not remove the repeated prepared-workspace scans, so this PR keeps the repair at the lifecycle batch that owns the work.

## User Impact

Large configured fleets can complete startup and answer real HTTP health requests after the Gateway reports listening. Small configurations keep the same runtime-selection results.

## Evidence

- Exact-main red at `a8fdaeaa455178bb99a3a8afa9e113c5cc241200`: a generated 300-agent × 40-model-reference Gateway reported listening, then both a 2-second `/healthz` request and a second 120-second request timed out. The process used 124.81 CPU seconds during 129.74 wall seconds after listen. Inspector sampling captured `listAgentEntriesWithSource` under configured harness discovery.
- Exact-head green at `4c3ea108ca96aa499b0f046adc256ac292cb15c3`: the same built Gateway returned `/healthz` HTTP 200 after 20.22 seconds. Post-listen work used 26.54 CPU seconds during 29.98 wall seconds.
- Restart variation: a generated 240-agent × 37-model-reference Gateway returned `/healthz` HTTP 200 after 6.92 seconds.
- Regression red/green: exact main performed 108,006 roster reads and failed the new batch boundary. This head stays within 16 reads and observes roster mutations on the next batch.
- Performance samples: the focused 300 × 40 collector median fell from 5.214 seconds to 0.775 seconds, an 85.1% reduction.
- Focused tests: 208 tests passed across configured harness discovery, model policy, agent roster ownership, prepared runtime publication, runtime-plugin loading, and harness-plugin selection.
- Checks: targeted Oxfmt, Oxlint, conflict-marker, max-lines, assertion-safety, and P0 Autoreview gates passed. `pnpm build qaRuntime` passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/33592776640.

Original implementation and report-driven direction by @LiuwqGit and @609NFT.
