### PR TITLE
refactor(scripts): share response reader cancellation

### DIFF
--- a/scripts/e2e/lib/openai-chat-tools/client.mjs
+++ b/scripts/e2e/lib/openai-chat-tools/client.mjs
@@ -1,4 +1,5 @@
 // Gateway client for OpenAI chat tools E2E scenarios.
+import { cancelResponseReaderSoon } from "../../../lib/bounded-response.mjs";
 import { readPositiveIntEnv, readTcpPortEnv } from "../env-limits.mjs";
 
 const portText = process.env.PORT;
@@ -19,12 +20,6 @@ if (!Number.isFinite(maxBodyBytes) || maxBodyBytes <= 0) {
   throw new Error(`invalid OPENCLAW_OPENAI_CHAT_TOOLS_MAX_BODY_BYTES: ${maxBodyBytes}`);
 }
 
-function cancelReaderSoon(reader) {
-  void Promise.resolve()
-    .then(() => reader.cancel())
-    .catch(() => undefined);
-}
-
 async function readResponseChunk(reader, timeoutPromise, markCanceled) {
   const readPromise = reader.read();
   if (!timeoutPromise) {
@@ -35,7 +30,7 @@ async function readResponseChunk(reader, timeoutPromise, markCanceled) {
   const timeoutReadPromise = timeoutPromise.catch((error) => {
     if (waitingForRead) {
       markCanceled();
-      cancelReaderSoon(reader);
+      cancelResponseReaderSoon(reader);
     }
     throw error;
   });

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import { readSecretFileSync } from "@openclaw/fs-safe/secret";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { truncateUtf16Safe } from "../packages/normalization-core/src/utf16-slice.js";
-import { readBoundedResponseText } from "./lib/bounded-response.mjs";
+import { cancelResponseReaderSoon, readBoundedResponseText } from "./lib/bounded-response.mjs";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
 import {
   normalizeGitHubRepo as normalizeRepo,
@@ -187,12 +187,6 @@ async function withGitHubFetchTimeout<T>(
   }
 }
 
-function cancelReaderSoon(reader: ReadableStreamDefaultReader<Uint8Array>): void {
-  void Promise.resolve()
-    .then(() => reader.cancel())
-    .catch(() => undefined);
-}
-
 async function readGitHubErrorChunk(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   timeoutPromise: Promise<never> | undefined,
@@ -206,7 +200,7 @@ async function readGitHubErrorChunk(
     read,
     timeoutPromise.catch((error: unknown) => {
       markCanceled();
-      cancelReaderSoon(reader);
+      cancelResponseReaderSoon(reader);
       throw error;
     }),
   ]);

--- a/scripts/lib/bounded-response.mjs
+++ b/scripts/lib/bounded-response.mjs
@@ -21,7 +21,9 @@ export function createBoundedResponseTooLargeError(message) {
   return Object.assign(new Error(message), { code: "ETOOBIG" });
 }
 
-function cancelReaderSoon(reader) {
+// Defer cancellation so timeout/abort rejection wins the pending read.
+// Swallow cleanup rejection so it cannot surface as an unhandled rejection.
+export function cancelResponseReaderSoon(reader) {
   void Promise.resolve()
     .then(() => reader.cancel())
     .catch(() => undefined);
@@ -65,7 +67,7 @@ async function readResponseChunk(reader, label, signal, markCanceled) {
           "Non-Error rejection",
         ),
       );
-      cancelReaderSoon(reader);
+      cancelResponseReaderSoon(reader);
     };
     signal.addEventListener("abort", onAbort, { once: true });
     removeAbortListener = () => signal.removeEventListener("abort", onAbort);
@@ -88,7 +90,7 @@ async function readResponseChunkWithTimeout(reader, label, signal, timeoutPromis
   const timeoutReadPromise = timeoutPromise.catch((error) => {
     if (waitingForRead) {
       markCanceled();
-      cancelReaderSoon(reader);
+      cancelResponseReaderSoon(reader);
     }
     throw toLintErrorObject(error, `${label} response body read timed out`);
   });

--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -7,7 +7,10 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 // This zero-install hook runs on Node 22.22.3+, where native TypeScript stripping is enabled.
 import { truncateUtf16Safe } from "../../packages/normalization-core/src/utf16-slice.ts";
-import { readBoundedResponseText as readBoundedResponseTextWithLimit } from "../lib/bounded-response.mjs";
+import {
+  cancelResponseReaderSoon,
+  readBoundedResponseText as readBoundedResponseTextWithLimit,
+} from "../lib/bounded-response.mjs";
 import { pnpmLockfileDocuments } from "../lib/pnpm-lockfile-documents.mjs";
 
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
@@ -796,9 +799,7 @@ export async function readBoundedBulkAdvisoryErrorText(
             read,
             options.timeoutPromise.catch((error) => {
               canceled = true;
-              void Promise.resolve()
-                .then(() => reader.cancel())
-                .catch(() => undefined);
+              cancelResponseReaderSoon(reader);
               throw error;
             }),
           ])

--- a/scripts/update-clawtributors.ts
+++ b/scripts/update-clawtributors.ts
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import pMap, { pMapSkip } from "p-map";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
+import { cancelResponseReaderSoon } from "./lib/bounded-response.mjs";
 import { execPlainGh } from "./lib/plain-gh.mjs";
 import type { ApiContributor, Entry, MapConfig, User } from "./update-clawtributors.types.js";
 
@@ -601,12 +602,6 @@ async function withAvatarProbeTimeout<T>(
   }
 }
 
-function cancelAvatarProbeReaderSoon(reader: ReadableStreamDefaultReader<Uint8Array>): void {
-  void Promise.resolve()
-    .then(() => reader.cancel())
-    .catch(() => undefined);
-}
-
 function toAvatarProbeError(value: unknown, fallbackMessage: string): Error {
   if (value instanceof Error) {
     return value;
@@ -631,7 +626,7 @@ async function readAvatarProbeChunkWithTimeout(
   const timeoutReadPromise = timeoutPromise.catch((error: unknown) => {
     if (waitingForRead) {
       markCanceled();
-      cancelAvatarProbeReaderSoon(reader);
+      cancelResponseReaderSoon(reader);
     }
     throw toAvatarProbeError(error, "avatar probe response body read timed out");
   });


### PR DESCRIPTION
## What Problem This Solves

Response-reader timeout cleanup used the same deferred cancellation policy in several script call paths, but each path owned a local copy. That duplication made observable timeout/abort error precedence vulnerable to drift.

## Why This Change Was Made

`scripts/lib/bounded-response.mjs` now owns and exports `cancelResponseReaderSoon`. GitHub reads, clawtributor avatar probes, npm advisory reads, and the OpenAI chat-tools E2E client reuse that exact implementation.

The canonical helper preserves the existing `Promise.resolve().then(reader.cancel).catch` behavior: cancellation remains deferred so timeout/abort rejection wins the pending read, and cleanup rejection remains swallowed. No SDK/plugin seam, dependency, test, docs, changelog, or surrounding reader-flow change was added.

Removed duplicate paths:

- local `cancelReaderSoon` implementations in `scripts/gh-read.ts` and the chat-tools client
- local `cancelAvatarProbeReaderSoon` in `scripts/update-clawtributors.ts`
- the inline cancellation Promise chain in `scripts/pre-commit/pnpm-audit-prod.mjs`

## User Impact

No user-visible behavior changes. Script timeout and abort handling keeps the same error precedence and best-effort stream cleanup, with one tooling-owned implementation.

## Evidence

- Root cause: four sibling script paths duplicated the same non-obvious cancellation scheduling invariant.
- Architectural owner: `scripts/lib/bounded-response.mjs`.
- Canonical fix: one exported tooling helper reused by all in-scope script callers.
- LOC: tooling production `+14/-22` (net `-8`); E2E test support `+2/-7` (net `-5`); tests `0`; total `+16/-29` (net `-13`).
- Sibling coverage: GitHub error reads, avatar probes, npm advisory error reads, bounded response abort/timeout reads, and the bare Docker chat-tools client. The extension-local QA fixture remains local to avoid a plugin-to-`scripts/**` dependency or new SDK seam.
- Focused script tests: 59 passed across the current `unit-fast` and `tooling` owner shards.
- Docker helper contract: 1 passed, proving bare Docker E2E scripts mount root helper modules.
- Chat-tools process E2E: 18 passed with `OPENCLAW_E2E_SKIP_BUILD=1`.
- The exact unit-config commands were also attempted; current `vitest.unit.config.ts` excludes `test/**`, so both exited before collection with "No test files found". The repository's current `scripts/test-projects.mts` owner routing ran the same requested files successfully.
- The unmodified E2E command attempted its stale-dist prerequisite first and stopped on an unrelated shared-install export mismatch for `hasRetryableConnectionErrorCode`; skipping only that prerequisite ran all 18 selected E2E tests successfully.
- `pnpm check:changed --dry-run` and `pnpm check:changed` passed after materializing the tracked `ui/config/**` inputs omitted by the core sparse profile.
- `git diff --check` passed.
- Autoreview: scoped-clean, patch correct at `0.97`.
- Crabbox was not run: this dependency-free tooling refactor has direct unit, Docker packaging-boundary, process-level E2E, script typecheck, lint, and changed-lane proof; it does not alter a live provider or channel flow.
- Codex source check: `../codex/codex-rs/cli/src/main.rs:220-245` covers CLI subcommand/completion declarations, while `:2840-2870` covers prompt newline normalization, config overrides, and completion output. Neither participates in Fetch response-body reads or cancellation.
- Overlap: https://github.com/openclaw/openclaw/pull/126237 also touches `scripts/lib/bounded-response.mjs`, but only the separate `toLintErrorObject` implementation and tests; it does not overlap this helper or its call sites.
