### PR TITLE
test(memory): join LanceDB fixture work before cleanup

### DIFF
--- a/extensions/memory-lancedb/memory-lancedb.concurrent.test.ts
+++ b/extensions/memory-lancedb/memory-lancedb.concurrent.test.ts
@@ -5,8 +5,20 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
 const tempDirs: string[] = [];
+const pendingWork: Promise<void>[] = [];
+
+function runFixtureWork(body: () => Promise<void>): Promise<void> {
+  const completion = Promise.resolve().then(body);
+  pendingWork.push(completion);
+  return completion;
+}
 
 afterEach(async () => {
+  // Timed-out bodies can still open handles or register children while unwinding.
+  // Keep the shared database until both the whole body and every child have joined.
+  while (pendingWork.length > 0) {
+    await Promise.allSettled(pendingWork.splice(0));
+  }
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
@@ -15,42 +27,58 @@ function initializeInChild(dbPath: string): Promise<void> {
   const source = `
     import { MemoryDB } from ${JSON.stringify(moduleUrl)};
     const db = new MemoryDB(process.argv[1], 4);
-    await db.count("concurrent-test-agent");
+    try {
+      await db.count("concurrent-test-agent");
+    } finally {
+      db.close();
+    }
   `;
 
-  return new Promise((resolve, reject) => {
-    const child = spawn(
-      process.execPath,
-      ["--import", "tsx", "--input-type=module", "--eval", source, dbPath],
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
-    let stderr = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-    child.once("error", reject);
-    child.once("exit", (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      reject(new Error(`memory-lancedb initializer exited ${String(code)}: ${stderr.trim()}`));
-    });
-  });
+  return runFixtureWork(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          ["--import", "tsx", "--input-type=module", "--eval", source, dbPath],
+          { stdio: ["ignore", "pipe", "pipe"] },
+        );
+        let stderr = "";
+        child.stderr.setEncoding("utf8");
+        child.stderr.on("data", (chunk: string) => {
+          stderr += chunk;
+        });
+        child.once("error", reject);
+        child.once("close", (code) => {
+          if (code === 0) {
+            resolve();
+            return;
+          }
+          reject(new Error(`memory-lancedb initializer exited ${String(code)}: ${stderr.trim()}`));
+        });
+      }),
+  );
 }
 
 describe("memory-lancedb concurrent initialization", () => {
-  test("atomically creates the memories table across processes", async () => {
-    const dbPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-lancedb-race-"));
-    tempDirs.push(dbPath);
+  test("atomically creates the memories table across processes", () =>
+    runFixtureWork(async () => {
+      const dbPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-lancedb-race-"));
+      tempDirs.push(dbPath);
 
-    await Promise.all(Array.from({ length: 6 }, () => initializeInChild(dbPath)));
+      await Promise.all(Array.from({ length: 6 }, () => initializeInChild(dbPath)));
 
-    const lancedb = await import("@lancedb/lancedb");
-    const connection = await lancedb.connect(dbPath);
-    await expect(connection.tableNames()).resolves.toEqual(["memories"]);
-    const table = await connection.openTable("memories");
-    await expect(table.countRows()).resolves.toBe(0);
-  });
+      const lancedb = await import("@lancedb/lancedb");
+      const connection = await lancedb.connect(dbPath);
+      try {
+        await expect(connection.tableNames()).resolves.toEqual(["memories"]);
+        const table = await connection.openTable("memories");
+        try {
+          await expect(table.countRows()).resolves.toBe(0);
+        } finally {
+          table.close();
+        }
+      } finally {
+        connection.close();
+      }
+    }));
 });


### PR DESCRIPTION
The concurrent LanceDB test could remove its shared database after the first initializer failed, while sibling processes still used it. Waiting only for those children was also insufficient: an actual Vitest timeout let the parent test resume with open native table/connection handles during teardown. Register the whole async body and each initializer before work begins, drain them before removing the directory, and close native handles in their owning finally blocks. Child completion now waits for close, including stdio drainage.

The six initializers remain concurrent. The original table-name and empty-row assertions, spawn arguments, stderr diagnostics and 120-second normal deadline remain unchanged. The fixture uses a small local owner matching the existing internal test lifetime design without exporting a production SDK seam. Production/schema/configuration delta 0; test lines +61/-33, net +28. Older native sibling cleanup and cancellation of a permanently hung native initializer remain separate follow-ups.

Private real-Vitest probes reached the actual parent countRows result, held its delivery until a 15-second injected framework timeout, and observed real filesystem removal. Both original and child-only drafts removed the database with the parent body unsettled and both native handles open. The final owner waited, then removed it only after the body and handles finished; all variants retained the same timeout failure. That injected deadline is absent from this patch. Separate early-initializer and parent-assertion failures preserve their original Error/AssertionError, and all children finish before removal. The refined normal case passes, as do all five current-checkout native concurrency/store cases. All 36 children and six private runner groups/database roots from the final probe series were joined and removed.

Manual review covered complete test/store/schema/runtime/plugin lifecycle owners, native siblings, fixture helpers, history, LanceDB 0.37.1 eager-close contracts, Node child lifecycle and Vitest 4.1.11 timeout behavior. Final source bytes match the verified refinement. Independent Codex and manual lower-priority/deslop review found no actionable issue. The local installed fs-safe 0.5.6 differs from the lock's 0.7.0; this direct native store path does not use the changed contract, and locked hosted CI is required. No normal-run speedup, unbounded GC leak or general hung-process cancellation guarantee is claimed.

Full changed-file plugin test types, boundary and assertion/max-line guards, three dead-export scans, and lint passed.

Landing review: exact-head CI33580581648 is green. The ClawSweeper dependency-inspection gap was independently filled by reading the installed LanceDB0.37.1 connection/table implementations and types and exercising their real close/isOpen behavior in the native fault probes. Current-main memory/configuration owners remain unchanged from the tested base.
