### PR TITLE
fix(agents): memoize agent list rebuild in runtime policy resolution

### DIFF
--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -4,6 +4,7 @@ import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   AgentSelectionRequiredError,
+  listAgentEntries,
   listAgentEntriesWithSource,
   listAgentIds,
   resolveConfiguredAgentId,
@@ -318,6 +319,18 @@ describe("agent roster resolution", () => {
       tools: { allow: ["*"] },
     });
     expect(listedEntry.tools).toBeUndefined();
+  });
+
+  it("memoizes the roster rebuild per config object", () => {
+    const cfg = { agents: { entries: { alpha: {}, beta: {} } } } as OpenClawConfig;
+    // Startup resolves runtime policy per agent per model ref; the roster must
+    // be built once per config identity instead of cloned on every call.
+    expect(listAgentEntriesWithSource(cfg)).toBe(listAgentEntriesWithSource(cfg));
+    expect(listAgentEntries(cfg)).toBe(listAgentEntries(cfg));
+    // A distinct config object is a distinct roster snapshot.
+    expect(
+      listAgentEntriesWithSource({ agents: { entries: { alpha: {}, beta: {} } } } as OpenClawConfig),
+    ).not.toBe(listAgentEntriesWithSource(cfg));
   });
 });
 

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -93,34 +93,44 @@ function stripNullBytes(s: string): string {
   return s.replaceAll("\0", "");
 }
 
-/** Lists valid configured agent entries from config. */
-export function listAgentEntriesWithSource(cfg: OpenClawConfig): ListedAgentEntry[] {
-  const roster = readAgentRosterProperty(cfg);
-  if (roster?.kind === "entries" && isRecord(roster.value)) {
-    return Object.entries(roster.value).flatMap(([id, entry]) =>
-      isRecord(entry)
-        ? [
-            {
-              entry: { ...entry, id },
-              source: { kind: "entries" as const, key: id },
-            },
-          ]
-        : [],
-    );
-  }
-  if (roster?.kind !== "list" || !Array.isArray(roster.value)) {
-    return [];
-  }
-  return roster.value.flatMap((entry, index) =>
-    entry !== null && typeof entry === "object"
-      ? [{ entry: entry as AgentEntry, source: { kind: "list" as const, index } }]
-      : [],
-  );
-}
+// Config objects are immutable snapshots during a process lifetime (mutation
+// flows rebuild the object instead of editing it in place), so the roster can be
+// memoized per config identity. Startup resolves runtime policy per agent per
+// model ref; without this, each call rebuilds and clones the full roster,
+// making startup O(agents^2 * models) on large configs.
+const listedAgentEntriesByConfig = new WeakMap<object, ListedAgentEntry[]>();
 
-/** Lists valid configured agent entries from either supported representation. */
-export function listAgentEntries(cfg: OpenClawConfig): AgentEntry[] {
-  return listAgentEntriesWithSource(cfg).map(({ entry }) => entry);
+/** Lists valid configured agent entries from config, memoized per config object. */
+export function listAgentEntriesWithSource(cfg: OpenClawConfig): ListedAgentEntry[] {
+  const cached = listedAgentEntriesByConfig.get(cfg);
+  if (cached) {
+    return cached;
+  }
+  const roster = readAgentRosterProperty(cfg);
+  const listed: ListedAgentEntry[] =
+    roster?.kind === "entries" &&
+    roster.value &&
+    typeof roster.value === "object" &&
+    !Array.isArray(roster.value)
+      ? Object.entries(roster.value).flatMap(([id, entry]) =>
+          entry !== null && typeof entry === "object" && !Array.isArray(entry)
+            ? [
+                {
+                  entry: { ...(entry as Omit<AgentEntry, "id">), id },
+                  source: { kind: "entries" as const, key: id },
+                },
+              ]
+            : [],
+        )
+      : roster?.kind !== "list" || !Array.isArray(roster.value)
+        ? []
+        : roster.value.flatMap((entry, index) =>
+            entry !== null && typeof entry === "object"
+              ? [{ entry: entry as AgentEntry, source: { kind: "list" as const, index } }]
+              : [],
+          );
+  listedAgentEntriesByConfig.set(cfg, listed);
+  return listed;
 }
 
 /** Converts either supported roster representation into the canonical keyed shape. */


### PR DESCRIPTION
Fixes #135743

## Root cause

Startup's `collectConfiguredAgentHarnessRuntimes` walks every configured agent × every model ref. Each runtime-policy resolution falls through `tryResolveLegacyCompatibilityAgentId` → `tryResolveDefaultAgentId` → `tryResolveSoleAgentId` → `listAgentEntries()`, which rebuilds and clones the **entire** agent roster from config on every call (`listAgentEntriesWithSource` spreads every keyed entry into a fresh object). With 632 `agents.entries` × 57 model refs that is ~36,700 full-roster rebuilds ≈ 23M entry objects constructed synchronously after `http server listening` — the event loop never yields and the gateway never answers `/health`.

## Fix

Memoize `listAgentEntriesWithSource` per config object identity with a `WeakMap` (`listedAgentEntriesByConfig`), the same keying pattern already used for config-carried state in `legacy.default-agent-owner-state.ts`. Config objects are immutable snapshots during a process lifetime — mutation flows (agent create/edit, sticky model selection) rebuild the config object instead of editing it in place, so a per-identity cache is safe and is never poisoned by roster mutation.

Effect: the first call per config object builds the roster once; every subsequent `listAgentEntries`/`listAgentIds` call in the fallback chain (and the per-model-ref `listAgentEntries(...).find(...)` in `resolveAgentModelEntryRuntimePolicy`) is O(1). Startup drops from O(agents² × models) to O(agents × models), behaviour-preserving.

## Tests

Added a regression test in `agent-scope-config.test.ts` asserting the roster is built once per config object (same reference on repeat calls) and that distinct config objects get distinct snapshots.
