### PR TITLE
test(ios): reuse immutable IPA validator tools

### DIFF
--- a/test/scripts/ios-validate-app-store-ipa.test.ts
+++ b/test/scripts/ios-validate-app-store-ipa.test.ts
@@ -12,7 +12,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 import JSZip from "jszip";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 const SCRIPT = path.join(process.cwd(), "scripts", "ios-validate-app-store-ipa.sh");
 const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
@@ -20,6 +20,7 @@ const BUILD_COMMIT = "0123456789abcdef0123456789abcdef01234567";
 const BUILD_TIMESTAMP = "2026-07-10T12:34:56.000Z";
 
 const tempDirs: string[] = [];
+let toolsDir: string;
 
 function bashArgs(scriptPath: string): string[] {
   return process.platform === "win32" ? [scriptPath] : ["--noprofile", "--norc", scriptPath];
@@ -314,12 +315,9 @@ async function writeValidFixture(
     "utf8",
   );
 
-  const plistBuddy = path.join(binDir, "plistbuddy");
-  writeFakePlistBuddy(plistBuddy);
-  const plutil = path.join(binDir, "plutil");
-  writeFakePlutil(plutil);
-  const unzip = path.join(binDir, "unzip");
-  writeFakeUnzip(unzip);
+  const plistBuddy = path.join(toolsDir, "plistbuddy");
+  const plutil = path.join(toolsDir, "plutil");
+  const unzip = path.join(toolsDir, "unzip");
   const codesign = path.join(binDir, "codesign");
   writeExecutable(
     codesign,
@@ -392,6 +390,20 @@ function runValidator(
 }
 
 describe("scripts/ios-validate-app-store-ipa.sh", () => {
+  beforeAll(() => {
+    // Interpreters read fixture paths from argv; signing inputs remain case-owned.
+    toolsDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-ios-ipa-tools-"));
+    writeFakePlistBuddy(path.join(toolsDir, "plistbuddy"));
+    writeFakePlutil(path.join(toolsDir, "plutil"));
+    writeFakeUnzip(path.join(toolsDir, "unzip"));
+  });
+
+  afterAll(() => {
+    if (toolsDir) {
+      rmSync(toolsDir, { recursive: true, force: true });
+    }
+  });
+
   afterEach(() => {
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
@@ -401,8 +413,7 @@ describe("scripts/ios-validate-app-store-ipa.sh", () => {
   it("fake plutil escapes regex-metacharacter keys before matching", () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-ios-ipa-"));
     tempDirs.push(root);
-    const plutil = path.join(root, "plutil");
-    writeFakePlutil(plutil);
+    const plutil = path.join(toolsDir, "plutil");
     const plistPath = path.join(root, "meta.plist");
     writeFileSync(
       plistPath,


### PR DESCRIPTION
The IPA validator tests rewrote the same PlistBuddy, plutil and unzip programs for every fixture. Give those three immutable interpreters suite lifetime while keeping each IPA, codesign script and security script private to its case. Record the shared directory before writing the programs so afterAll can clean partial setup failures.

This removes 25 script writes and 25 chmods, totaling 33,857 fewer written bytes, at the cost of one suite directory. All nine cases, 21 assertions, nine real Bash-validator invocations and independent signing inputs remain. The emitted plutil metacharacter regression still runs the actual program twice. Production delta zero; tests +20/-9.

The original and candidate private runs both passed 9/9; instrumentation verified program hashes and private fixture paths on every validator invocation. A fault after the first two shared programs were written retained the setup error and removed the incomplete directory. All 22 test roots were removed. The current canonical checkout also passed all nine cases, full changed-file type checks, guards and lint. Independent Codex review and manual source, caller, history, dependency and cleanup review found no actionable issue.

Single-run timing observations are not treated as an end-to-end speedup measurement. This exercises the existing fake signing boundary and real validator; it does not claim Apple signature verification, release publication or App Store acceptance.

Integration validation: rebased onto main containing #135823, which repairs the unrelated dashboard-title timeout found in the earlier CI run. The IPA test file is byte-identical to the reviewed patch. The current canonical runner passes all 94 IPA, dashboard-title, CLI-backend, model-alias and runtime-compatibility cases, including main's newer asynchronous worker-artifact verification and cleanup. Refreshed review found no actionable issue; the final head gets a new CI run.

The earlier automated review's current-main inspection gap is resolved locally: direct source comparison at ef3b44744446c9f7df0d93b842722c451f8709cc verifies all 35 inspected owner and harness paths match the fresh integration-proof base. The validator, Fastlane caller and fixture contracts are unchanged, and the refreshed PR still contains only the one test-file modification. Exact-head CI completion remains the final landing gate.
