### PR TITLE
fix(ui): display wildcard tool policies correctly

### DIFF
--- a/ui/src/e2e/agent-config-save.e2e.test.ts
+++ b/ui/src/e2e/agent-config-save.e2e.test.ts
@@ -95,7 +95,28 @@ suite.define(() => {
     );
   });
 
-  it("submits keyed entries and surfaces Gateway validation failures", async () => {
+  it.each([
+    {
+      name: "profile allow",
+      toolId: "read",
+      groupId: "fs",
+      groupLabel: "Files",
+      description: "Read files",
+      profileLabel: "Full",
+      tools: { profile: "full" },
+      expectedTools: { profile: "full", deny: ["read"] },
+    },
+    {
+      name: "wildcard alsoAllow",
+      toolId: "web_fetch",
+      groupId: "web",
+      groupLabel: "Web",
+      description: "Fetch web content",
+      profileLabel: "Minimal",
+      tools: { profile: "minimal", alsoAllow: ["web_*"] },
+      expectedTools: { profile: "minimal", alsoAllow: ["web_*"], deny: ["web_fetch"] },
+    },
+  ])("submits keyed entries and surfaces Gateway validation failures ($name)", async (scenario) => {
     await suite.withPage(
       {
         locale: "en-US",
@@ -108,7 +129,7 @@ suite.define(() => {
             entries: {
               main: {
                 default: true,
-                tools: { profile: "full" },
+                tools: scenario.tools,
               },
             },
           },
@@ -134,17 +155,17 @@ suite.define(() => {
             },
             "tools.catalog": {
               agentId: "main",
-              profiles: [{ id: "full", label: "Full" }],
+              profiles: [{ id: scenario.tools.profile, label: scenario.profileLabel }],
               groups: [
                 {
-                  id: "fs",
-                  label: "Files",
+                  id: scenario.groupId,
+                  label: scenario.groupLabel,
                   source: "core",
                   tools: [
                     {
-                      id: "read",
-                      label: "read",
-                      description: "Read files",
+                      id: scenario.toolId,
+                      label: scenario.toolId,
+                      description: scenario.description,
                       source: "core",
                       defaultProfiles: ["full"],
                     },
@@ -154,7 +175,7 @@ suite.define(() => {
             },
             "tools.effective": {
               agentId: "main",
-              profile: "full",
+              profile: scenario.tools.profile,
               groups: [],
               notices: [],
             },
@@ -169,11 +190,17 @@ suite.define(() => {
 
         await page
           .locator(".agent-tools-group")
-          .filter({ hasText: "Files" })
+          .filter({ hasText: scenario.groupLabel })
           .locator(".agent-tools-group__summary")
           .click();
+        const toggle = page.locator(`#agent-tool-${scenario.toolId} wa-switch`);
+        await expect
+          .poll(() =>
+            toggle.evaluate((element) => (element as HTMLElement & { checked: boolean }).checked),
+          )
+          .toBe(true);
         await gateway.deferNext("config.set");
-        await page.locator("#agent-tool-read wa-switch").click();
+        await toggle.click();
 
         const request = await gateway.waitForRequest("config.set");
         const params = requireRecord(request.params);
@@ -183,7 +210,7 @@ suite.define(() => {
             entries: {
               main: {
                 default: true,
-                tools: { profile: "full", deny: ["read"] },
+                tools: scenario.expectedTools,
               },
             },
           },

--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -671,6 +671,79 @@ describe("agents tools panel (browser)", () => {
       container.remove();
     }
   });
+
+  it.each([
+    {
+      name: "prefix wildcard",
+      tools: { allow: ["web_*"] },
+      expected: { web_fetch: true, web_: true, read: false },
+    },
+    {
+      name: "suffix wildcard",
+      tools: { allow: ["*fetch"] },
+      expected: { web_fetch: true, read: false },
+    },
+    {
+      name: "literal dots in wildcard",
+      tools: { allow: ["mcp.server.*"] },
+      expected: { "mcp.server.tool": true, mcpXserverXtool: false },
+    },
+    {
+      name: "base exec alias and direct deny",
+      tools: { allow: [" BASH "], deny: ["exec"] },
+      expected: { exec: false, apply_patch: true, write: false },
+    },
+    {
+      name: "override exec deny",
+      tools: { profile: "full", deny: ["exec"] },
+      expected: { exec: false, apply_patch: false, write: true },
+    },
+    {
+      name: "group expansion and direct deny",
+      tools: { allow: ["group:fs"], deny: ["write"] },
+      expected: { read: true, write: false, apply_patch: true },
+    },
+  ])("renders policy-controlled switches: $name", async ({ tools, expected }) => {
+    const container = document.createElement("div");
+    render(
+      renderAgentTools(
+        createBaseParams({
+          configForm: {
+            agents: { entries: { main: { default: true, tools } } },
+          },
+          toolsCatalogResult: {
+            agentId: "main",
+            profiles: [{ id: "full", label: "Full" }],
+            groups: [
+              {
+                id: "policy",
+                label: "Policy",
+                source: "core",
+                tools: Object.keys(expected).map((id) => ({
+                  id,
+                  label: id,
+                  description: id,
+                  source: "core" as const,
+                  defaultProfiles: [],
+                })),
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(
+      Object.fromEntries(
+        Array.from(container.querySelectorAll(".agent-tool-card"), (card) => [
+          card.querySelector(".agent-tool-title")?.textContent?.trim(),
+          card.querySelector<HTMLElement & { checked: boolean }>("wa-switch")?.checked,
+        ]),
+      ),
+    ).toEqual(expected);
+  });
 });
 
 describe("agents skills panel (browser)", () => {

--- a/ui/src/pages/agents/tool-policy.ts
+++ b/ui/src/pages/agents/tool-policy.ts
@@ -1,6 +1,10 @@
 // Keep catalog-backed policy evaluation behind the Agents page's lazy boundary;
 // importing it from shared agent display helpers loads tool descriptions at startup.
 import {
+  compileGlobPatterns,
+  matchesAnyGlobPattern as matchesAny,
+} from "../../../../src/agents/glob-pattern.js";
+import {
   expandToolGroups,
   normalizeToolPolicyName,
 } from "../../../../src/agents/tool-policy-shared.js";
@@ -10,50 +14,14 @@ type ToolPolicy = {
   deny?: string[];
 };
 
-type CompiledPattern =
-  | { kind: "all" }
-  | { kind: "exact"; value: string }
-  | { kind: "regex"; value: RegExp };
-
-function compilePattern(pattern: string): CompiledPattern {
-  const normalized = normalizeToolPolicyName(pattern);
-  if (!normalized) {
-    return { kind: "exact", value: "" };
-  }
-  if (normalized === "*") {
-    return { kind: "all" };
-  }
-  if (!normalized.includes("*")) {
-    return { kind: "exact", value: normalized };
-  }
-  const escaped = normalized.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
-  return { kind: "regex", value: new RegExp(`^${escaped.replaceAll("\\*", ".*")}$`) };
-}
-
-function compilePatterns(patterns?: string[]): CompiledPattern[] {
+function compilePatterns(patterns?: string[]) {
   if (!Array.isArray(patterns)) {
     return [];
   }
-  return expandToolGroups(patterns)
-    .map(compilePattern)
-    .filter((pattern) => {
-      return pattern.kind !== "exact" || pattern.value.length > 0;
-    });
-}
-
-function matchesAny(name: string, patterns: CompiledPattern[]) {
-  for (const pattern of patterns) {
-    if (pattern.kind === "all") {
-      return true;
-    }
-    if (pattern.kind === "exact" && name === pattern.value) {
-      return true;
-    }
-    if (pattern.kind === "regex" && pattern.value.test(name)) {
-      return true;
-    }
-  }
-  return false;
+  return compileGlobPatterns({
+    raw: expandToolGroups(patterns),
+    normalize: normalizeToolPolicyName,
+  });
 }
 
 export function isAllowedByPolicy(name: string, policy?: ToolPolicy) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users viewing an agent's Tools panel would see incorrect enabled states when tool policies contained wildcards. For example, `web_*` did not match `web_fetch`; a leading wildcard such as `*fetch` could also interrupt rendering, and punctuation inside wildcard patterns was not treated literally.

## Why This Change Was Made

Use the existing agent-policy glob compiler and matcher instead of the Control UI's duplicate implementation. The UI keeps its own catalog normalization, group expansion, deny precedence, and existing `apply_patch` → `exec` display relationship. Runtime policy's separate `apply_patch` → `write` relationship is unchanged: this is a glob-mechanics fix, not a claim that all UI and runtime policy decisions are equivalent.

The compiler remains in the lazy Agents page. No configuration, dependency, protocol, or persistence surface is added.

Production: **+9/-41, net -32 lines**. Tests: **+112/-12, net +100 lines**.

Related earlier reports: #123213 and #44378, both closed without merging. This change replaces the compiler/matcher duplicate; their separate session-label escaping changes are not included.

## User Impact

Wildcard policies now display the expected catalog-tool state, including literal punctuation, without the leading-wildcard render failure. Existing group, deny, and UI alias behavior is preserved.

## Evidence

- Original source: 16 browser cases, 3 config E2E cases, and 26 core cases passed.
- Expanded tests against original production: three browser failures and one config-flow failure reproduced the defects. With the candidate, all **22 browser + 4 config E2E + 26 core cases passed**.
- The config E2E exercises the actual Agents page and config callback, including wildcard selection, saving the keyed agent configuration, and a visible rejected-save result.
- All **20 normal configured changed checks passed**, including both type graphs, formatting, lint, i18n, and dead-export checks. The [configured proof run](https://github.com/openclaw/openclaw/actions/runs/33576730523) used the exact three-file candidate over its tested base; this is not yet the new PR head's CI.
- A supported production build passed. Actual emitted source maps place the UI policy and shared compiler owners in the lazy Agents chunk, outside the eight-chunk static startup graph. The maintained performance report has no violations; the largest CSS asset exactly meets its existing ceiling. No budget or baseline changed.
- One normal managed Codex precommit review returned scoped-clean at the P0 threshold with no findings. This is not an all-priority review certificate; the reviewer did not rerun the reported tests.

### Before and after

The same isolated synthetic fixture uses a minimal-profile agent with `alsoAllow: ["web_*"]` and a `web_fetch` catalog entry. The original shows **0/1 enabled**, with the switch off; the candidate shows **1/1 enabled**, with it on.

![Before: wildcard catalog tool is incorrectly disabled](https://github.com/user-attachments/assets/bdbb8e61-91e1-4097-be88-6603f01987a6)

![After: wildcard catalog tool is enabled](https://github.com/user-attachments/assets/683dca7c-2dc9-4c51-be6a-b300027631d8)

Both images come from the real rendered Control UI with the existing mock Gateway harness, not replacement HTML. The fixture intentionally has no live session tools, so these pictures prove the catalog policy display, not real Gateway tool availability. No external provider was used. Historical E2E bundle bytes were removed by normal teardown; no old/new bundle-byte equivalence is claimed.

