### PR TITLE
fix(ios): avoid duplicate replies after chat history refresh

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -403,6 +403,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
     private struct OpenClawMetadata: Codable {
         let kind: String?
         let id: String?
+        let runId: String?
         let idempotencyKey: String?
         let truncated: Bool?
         let tokensBefore: Double?
@@ -411,6 +412,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
 
     public var id: UUID = .init()
     public var transcriptMessageID: String?
+    public let transcriptRunID: String?
     public var isTruncated = false
     public let role: String
     public let content: [OpenClawChatMessageContent]
@@ -455,6 +457,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         content: [OpenClawChatMessageContent],
         timestamp: Double?,
         transcriptMessageID: String? = nil,
+        transcriptRunID: String? = nil,
         isTruncated: Bool = false,
         idempotencyKey: String? = nil,
         toolCallId: String? = nil,
@@ -469,6 +472,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
     {
         self.id = id
         self.transcriptMessageID = transcriptMessageID
+        self.transcriptRunID = transcriptRunID
         self.isTruncated = isTruncated
         self.role = role
         self.content = content
@@ -510,6 +514,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
 
         self.role = decodedRole
         self.transcriptMessageID = decodedOpenClaw?.id
+        self.transcriptRunID = decodedOpenClaw?.runId
         self.timestamp = decodedTimestamp
         self.idempotencyKey = decodedIdempotencyKey
         self.toolCallId = decodedToolCallId
@@ -622,11 +627,14 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.role, forKey: .role)
         try container.encodeIfPresent(self.timestamp, forKey: .timestamp)
-        if self.transcriptMessageID != nil || self.isTruncated || self.historyMarker != nil {
+        if self.transcriptMessageID != nil || self.transcriptRunID != nil || self.isTruncated || self
+            .historyMarker != nil
+        {
             try container.encode(
                 OpenClawMetadata(
                     kind: self.historyMarker?.kind,
                     id: self.historyMarker?.id ?? self.transcriptMessageID,
+                    runId: self.transcriptRunID,
                     idempotencyKey: nil,
                     truncated: self.isTruncated ? true : nil,
                     tokensBefore: self.historyMarker?.tokensBefore,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache+RecordShaping.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache+RecordShaping.swift
@@ -36,6 +36,7 @@ extension OpenClawChatSQLiteTranscriptCache {
                 },
                 timestamp: message.timestamp,
                 transcriptMessageID: message.transcriptMessageID,
+                transcriptRunID: message.transcriptRunID,
                 isTruncated: message.isTruncated,
                 idempotencyKey: message.idempotencyKey,
                 toolCallId: message.toolCallId,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -1123,6 +1123,7 @@ extension OpenClawChatView {
                 content: content,
                 timestamp: last.timestamp,
                 transcriptMessageID: last.transcriptMessageID,
+                transcriptRunID: last.transcriptRunID,
                 isTruncated: last.isTruncated,
                 idempotencyKey: last.idempotencyKey,
                 toolCallId: last.toolCallId,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
@@ -48,6 +48,7 @@ extension OpenClawChatViewModel {
             content: sanitizedContent,
             timestamp: message.timestamp,
             transcriptMessageID: message.transcriptMessageID,
+            transcriptRunID: message.transcriptRunID,
             isTruncated: message.isTruncated,
             idempotencyKey: message.idempotencyKey,
             toolCallId: message.toolCallId,
@@ -128,9 +129,26 @@ extension OpenClawChatViewModel {
         return [role, toolCallId, toolName, contentFingerprint].joined(separator: "|")
     }
 
+    private static func isFinalAssistantMessage(_ message: OpenClawChatMessage) -> Bool {
+        // Like src/sessions/transcript-events.ts, exclude intermediate tool rows:
+        // they carry the same run ID but cannot settle the final reply.
+        self.isAssistantMessage(message) &&
+            !["tooluse", "tool_use", "tool_calls"].contains(message.stopReason?.lowercased() ?? "") &&
+            !message.content.contains {
+                ["toolcall", "tool_call", "tooluse", "tool_use", "functioncall"]
+                    .contains($0.type?.lowercased() ?? "")
+            }
+    }
+
+    private static func finalMessageRunID(for message: OpenClawChatMessage) -> String? {
+        guard self.isFinalAssistantMessage(message) else { return nil }
+        // v2026.8.1 projected run correlation through idempotencyKey. Prefer the
+        // current recorded run ID so a foreign run never matches a legacy key.
+        return self.normalizedRunID(message.transcriptRunID) ?? self.normalizedIdempotencyKey(message.idempotencyKey)
+    }
+
     static func finalMessageReconciliationKey(for message: OpenClawChatMessage) -> String? {
-        let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard role == "assistant" else { return nil }
+        guard self.isFinalAssistantMessage(message) else { return nil }
 
         // chat.final and session.message can serialize the same final row with
         // different timestamps/content ids. Reconciliation prefers the durable
@@ -141,7 +159,7 @@ extension OpenClawChatViewModel {
         if contentFingerprint.isEmpty, toolCallId.isEmpty, toolName.isEmpty {
             return nil
         }
-        return [role, toolCallId, toolName, contentFingerprint].joined(separator: "|")
+        return ["assistant", toolCallId, toolName, contentFingerprint].joined(separator: "|")
     }
 
     static func normalizedRunID(_ runId: String?) -> String? {
@@ -171,6 +189,8 @@ extension OpenClawChatViewModel {
                 from: existing.content),
             timestamp: incoming.timestamp ?? existing.timestamp,
             transcriptMessageID: incoming.transcriptMessageID ?? existing.transcriptMessageID,
+            transcriptRunID: incoming.transcriptRunID ?? existing.transcriptRunID,
+            isTruncated: incoming.isTruncated,
             idempotencyKey: incoming.idempotencyKey,
             toolCallId: incoming.toolCallId,
             toolName: incoming.toolName,
@@ -348,10 +368,10 @@ extension OpenClawChatViewModel {
     {
         guard let key = Self.finalMessageReconciliationKey(for: message) else { return false }
         guard self.isCurrentSession(scope.session) else { return false }
-        if let runId = Self.normalizedIdempotencyKey(message.idempotencyKey) {
+        if let runId = Self.finalMessageRunID(for: message) {
             return self.messages.contains { existing in
                 self.provisionalFinalMessagesByID[existing.id] == nil &&
-                    Self.normalizedIdempotencyKey(existing.idempotencyKey) == runId
+                    Self.finalMessageRunID(for: existing) == runId
             }
         }
         let searchRange = Self.messageRange(after: scope.latestUserTurn, in: self.messages)
@@ -359,6 +379,7 @@ extension OpenClawChatViewModel {
 
         return self.messages[searchRange].contains { existing in
             self.provisionalFinalMessagesByID[existing.id] == nil &&
+                Self.normalizedRunID(existing.transcriptRunID) == nil &&
                 Self.finalMessageReconciliationKey(for: existing) == key
         }
     }
@@ -378,8 +399,7 @@ extension OpenClawChatViewModel {
             let exactRunIndex = provisional.runId.flatMap { runId in
                 reconciled.indices.last { index in
                     !claimedIncomingIndices.contains(index) &&
-                        Self.isAssistantMessage(reconciled[index]) &&
-                        Self.normalizedIdempotencyKey(reconciled[index].idempotencyKey) == runId
+                        Self.finalMessageRunID(for: reconciled[index]) == runId
                 }
             }
             let matchingIndex = exactRunIndex ?? {
@@ -389,6 +409,7 @@ extension OpenClawChatViewModel {
                 let range = Self.messageRange(after: provisional.scope.latestUserTurn, in: reconciled)
                 return range.last { index in
                     !claimedIncomingIndices.contains(index) &&
+                        Self.normalizedRunID(reconciled[index].transcriptRunID) == nil &&
                         Self.finalMessageReconciliationKey(for: reconciled[index]) == provisional.reconciliationKey
                 }
             }()
@@ -487,6 +508,7 @@ extension OpenClawChatViewModel {
                 content: existing.content,
                 timestamp: existing.timestamp,
                 transcriptMessageID: existing.transcriptMessageID,
+                transcriptRunID: existing.transcriptRunID,
                 isTruncated: existing.isTruncated,
                 idempotencyKey: remoteKey,
                 toolCallId: existing.toolCallId,
@@ -528,13 +550,12 @@ extension OpenClawChatViewModel {
             return true
         }
         return self.messages.contains { message in
-            Self.isAssistantMessage(message) &&
-                Self.normalizedIdempotencyKey(message.idempotencyKey) == runId
+            Self.finalMessageRunID(for: message) == runId
         }
     }
 
     func adoptProvisionalFinalMessage(incoming: OpenClawChatMessage) -> Bool {
-        let incomingRunId = Self.normalizedIdempotencyKey(incoming.idempotencyKey)
+        let incomingRunId = Self.finalMessageRunID(for: incoming)
         let incomingKey = Self.finalMessageReconciliationKey(for: incoming)
         guard incomingRunId != nil || incomingKey != nil else { return false }
         let canonicalUserTurn = self.currentRunMessageScope().latestUserTurn
@@ -544,7 +565,8 @@ extension OpenClawChatViewModel {
             if let incomingRunId, provisional.runId == incomingRunId {
                 return true
             }
-            return provisional.reconciliationKey == incomingKey &&
+            return Self.normalizedRunID(incoming.transcriptRunID) == nil &&
+                provisional.reconciliationKey == incomingKey &&
                 Self.isSameUserTurnBoundary(provisional.scope.latestUserTurn, canonicalUserTurn)
         }) else {
             return false
@@ -858,19 +880,11 @@ extension OpenClawChatViewModel {
     private func provisionalFinalMessagesMissing(
         from incoming: [OpenClawChatMessage]) -> [OpenClawChatMessage]
     {
-        let incomingRunIds = Set(incoming.compactMap { Self.normalizedIdempotencyKey($0.idempotencyKey) })
+        // Adoption above assigns each canonical row at most one provisional ID.
+        // Re-matching by content here could consume a second, distinct reply.
+        let incomingMessageIDs = Set(incoming.map(\.id))
         return self.messages.filter { message in
-            guard let provisional = provisionalFinalMessagesByID[message.id] else { return false }
-            if let runId = provisional.runId, incomingRunIds.contains(runId) {
-                return false
-            }
-            guard Self.containsUserTurn(provisional.scope.latestUserTurn, in: incoming) else {
-                return true
-            }
-            let searchRange = Self.messageRange(after: provisional.scope.latestUserTurn, in: incoming)
-            return !incoming[searchRange].contains { incomingMessage in
-                Self.finalMessageReconciliationKey(for: incomingMessage) == provisional.reconciliationKey
-            }
+            self.provisionalFinalMessagesByID[message.id] != nil && !incomingMessageIDs.contains(message.id)
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -647,6 +647,7 @@ extension OpenClawChatViewModel {
             content: message.content,
             timestamp: Date().timeIntervalSince1970 * 1000,
             transcriptMessageID: message.transcriptMessageID,
+            transcriptRunID: message.transcriptRunID,
             isTruncated: message.isTruncated,
             idempotencyKey: message.idempotencyKey,
             toolCallId: message.toolCallId,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageVisibleTextTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageVisibleTextTests.swift
@@ -156,17 +156,23 @@ struct ChatMessageVisibleTextTests {
             tokensAfter: 9000))
     }
 
-    @Test func `transcript metadata survives message coding round trip`() throws {
-        let original = OpenClawChatMessage(
-            role: "assistant",
-            content: [textContent("short\n...(truncated)...")],
-            timestamp: 1,
-            transcriptMessageID: "msg-round-trip",
-            isTruncated: true)
+    @Test @MainActor func `transcript metadata survives message coding round trip`() throws {
+        let original = try JSONDecoder().decode(
+            OpenClawChatMessage.self,
+            from: Data(
+                #"{"role":"assistant","content":"short","timestamp":1,"__openclaw":{"id":"msg-round-trip","runId":"run-round-trip","truncated":true}}"#
+                    .utf8))
 
+        let adopted = OpenClawChatViewModel.adoptingCanonicalMessage(
+            original,
+            over: OpenClawChatMessage(role: "assistant", content: [textContent("short")], timestamp: 0))
+        let cacheable = try #require(OpenClawChatSQLiteTranscriptCache.cacheableMessages([adopted]).first)
+        let encoded = try JSONEncoder().encode(cacheable)
         let decoded = try JSONDecoder().decode(
             OpenClawChatMessage.self,
-            from: JSONEncoder().encode(original))
+            from: encoded)
+        let encodedObject = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let encodedMetadata = encodedObject["__openclaw"] as? [String: Any]
         let systemRow = OpenClawChatMessage(
             role: "system",
             content: [],
@@ -184,6 +190,7 @@ struct ChatMessageVisibleTextTests {
             from: JSONEncoder().encode(systemRow))
 
         #expect(decoded.transcriptMessageID == "msg-round-trip")
+        #expect(encodedMetadata?["runId"] as? String == "run-round-trip")
         #expect(decoded.isTruncated)
         #expect(decodedSystemRow.provenance == systemRow.provenance)
         #expect(decodedSystemRow.historyMarker == systemRow.historyMarker)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
@@ -120,21 +120,34 @@ private func replayHistory(
         thinkingLevel: "off")
 }
 
-/// Raw history/event row shaped like the gateway JSON, including the persisted
-/// `__openclaw.idempotencyKey` metadata used for turn correlation.
+/// Raw gateway rows with current run metadata or the older idempotency-key contract.
 private func replayRawMessage(
     role: String,
     text: String,
     timestamp: Double,
-    idempotencyKey: String? = nil) -> AnyCodable
+    idempotencyKey: String? = nil,
+    runId: String? = nil,
+    emptyThinking: Bool = false) -> AnyCodable
 {
+    var content: [[String: Any]] = []
+    if emptyThinking {
+        content.append(["type": "thinking", "thinking": ""])
+    }
+    content.append(["type": "text", "text": text])
     var message: [String: Any] = [
         "role": role,
-        "content": [["type": "text", "text": text]],
+        "content": content,
         "timestamp": timestamp,
     ]
+    var metadata: [String: String] = [:]
     if let idempotencyKey {
-        message["__openclaw"] = ["idempotencyKey": idempotencyKey]
+        metadata["idempotencyKey"] = idempotencyKey
+    }
+    if let runId {
+        metadata["runId"] = runId
+    }
+    if !metadata.isEmpty {
+        message["__openclaw"] = metadata
     }
     return AnyCodable(message)
 }
@@ -143,20 +156,17 @@ private func replayDurableMessage(
     role: String,
     text: String,
     timestamp: Double,
-    idempotencyKey: String? = nil) -> OpenClawChatMessage
+    idempotencyKey: String? = nil,
+    runId: String? = nil,
+    emptyThinking: Bool = false) -> OpenClawChatMessage
 {
-    OpenClawChatMessage(
+    try! ChatPayloadDecoding.decode(replayRawMessage(
         role: role,
-        content: [
-            OpenClawChatMessageContent(
-                type: "text",
-                text: text,
-                mimeType: nil,
-                fileName: nil,
-                content: nil),
-        ],
+        text: text,
         timestamp: timestamp,
-        idempotencyKey: idempotencyKey)
+        idempotencyKey: idempotencyKey,
+        runId: runId,
+        emptyThinking: emptyThinking))
 }
 
 private func replaySessionMessageEvent(
@@ -164,6 +174,8 @@ private func replaySessionMessageEvent(
     timestamp: Double,
     role: String = "assistant",
     idempotencyKey: String? = nil,
+    runId: String? = nil,
+    emptyThinking: Bool = false,
     messageId: String) -> OpenClawChatTransportEvent
 {
     .sessionMessage(
@@ -173,7 +185,9 @@ private func replaySessionMessageEvent(
                 role: role,
                 text: text,
                 timestamp: timestamp,
-                idempotencyKey: idempotencyKey),
+                idempotencyKey: idempotencyKey,
+                runId: runId,
+                emptyThinking: emptyThinking),
             messageId: messageId,
             messageSeq: nil))
 }
@@ -191,8 +205,7 @@ private func replayFinalEvent(
             message: replayRawMessage(
                 role: "assistant",
                 text: text,
-                timestamp: timestamp,
-                idempotencyKey: runId),
+                timestamp: timestamp),
             errorMessage: nil))
 }
 
@@ -463,7 +476,11 @@ struct ChatStreamReplayTests {
         }
     }
 
-    @Test func `provisional final is replaced by durable row without content loss`() async throws {
+    @Test(arguments: [false, true], [false, true])
+    func `provisional final is replaced by durable row without content loss`(
+        legacyRunKey: Bool,
+        emptyThinking: Bool) async throws
+    {
         let now = Date().timeIntervalSince1970 * 1000
         let replyText = "Considered answer with detail."
         let harness = try await StreamReplayHarness.bootstrapped()
@@ -481,11 +498,13 @@ struct ChatStreamReplayTests {
             replaySessionMessageEvent(
                 text: replyText,
                 timestamp: now + 2000,
-                idempotencyKey: runId,
+                idempotencyKey: legacyRunKey ? runId : nil,
+                runId: legacyRunKey ? nil : runId,
+                emptyThinking: emptyThinking,
                 messageId: "durable-final"))
 
-        try await harness.converge("durable row replaces provisional") { vm in
-            vm.replayAssistantRows(text: replyText).first?.timestamp == now + 2000
+        try await harness.converge("durable row arrives") { vm in
+            vm.replayAssistantRows(text: replyText).contains { $0.timestamp == now + 2000 }
         }
 
         await MainActor.run {
@@ -493,13 +512,17 @@ struct ChatStreamReplayTests {
             #expect(rows.count == 1)
             // Row identity survives adoption so SwiftUI does not re-animate the bubble.
             #expect(rows.first?.id == provisionalID)
-            #expect(rows.first?.idempotencyKey == runId)
+            #expect(rows.last?.idempotencyKey == (legacyRunKey ? runId : nil))
             let rowText = rows.first?.content.compactMap(\.text).joined() ?? ""
             #expect(Array(rowText.utf8) == Array(replyText.utf8))
         }
     }
 
-    @Test func `durable row arriving before run completion does not duplicate on final`() async throws {
+    @Test(arguments: [false, true], [false, true])
+    func `durable row arriving before run completion does not duplicate on final`(
+        legacyRunKey: Bool,
+        emptyThinking: Bool) async throws
+    {
         let now = Date().timeIntervalSince1970 * 1000
         let replyText = "Answer persisted before completion."
         let harness = try await StreamReplayHarness.bootstrapped()
@@ -510,7 +533,9 @@ struct ChatStreamReplayTests {
             replaySessionMessageEvent(
                 text: replyText,
                 timestamp: now + 5000,
-                idempotencyKey: runId,
+                idempotencyKey: legacyRunKey ? runId : nil,
+                runId: legacyRunKey ? nil : runId,
+                emptyThinking: emptyThinking,
                 messageId: "durable-early"))
         try await harness.converge("durable visible while run still pending") { vm in
             vm.replayAssistantRows(text: replyText).count == 1 && vm.pendingRunCount == 1
@@ -528,6 +553,115 @@ struct ChatStreamReplayTests {
             // second provisional copy of the same reply.
             #expect(rows.first?.timestamp == now + 5000)
             #expect(harness.vm.streamingAssistantText == nil)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `intermediate tool rows cannot consume a final from the same run`(finalFirst: Bool) async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let text = "Final answer after the tool call."
+        let harness = try await StreamReplayHarness.bootstrapped()
+        let runId = try await harness.send("use a tool")
+        let final = replayFinalEvent(runId: runId, text: text, timestamp: now + 1000)
+        let toolMessage: OpenClawChatMessage = try ChatPayloadDecoding.decode(AnyCodable([
+            "role": "assistant",
+            "content": [
+                ["type": "text", "text": "Checking a tool."],
+                ["type": "toolCall", "id": "tool-1", "name": "read", "arguments": [:]],
+            ],
+            "timestamp": now + 2000,
+            "stopReason": "toolUse",
+            "__openclaw": ["runId": runId],
+        ] as [String: Any]))
+        let toolEvent = OpenClawChatTransportEvent.sessionMessage(OpenClawSessionMessageEventPayload(
+            sessionKey: "main",
+            message: toolMessage,
+            messageId: "intermediate-tool-row",
+            messageSeq: nil))
+
+        harness.transport.emit(finalFirst ? final : toolEvent)
+        harness.transport.emit(finalFirst ? toolEvent : final)
+        try await harness.converge("tool row and completion consumed") { vm in
+            vm.pendingRunCount == 0 && vm.messages.contains { $0.timestamp == now + 2000 }
+        }
+        await MainActor.run {
+            #expect(harness.vm.replayAssistantRows(text: text).count == 1)
+            #expect(harness.vm.replayAssistantRows.count == 2)
+        }
+
+        harness.transport.emit(replaySessionMessageEvent(
+            text: text,
+            timestamp: now + 3000,
+            runId: runId,
+            emptyThinking: true,
+            messageId: "terminal-tool-reply"))
+        try await harness.converge("terminal tool reply arrives") { vm in
+            vm.messages.contains { $0.timestamp == now + 3000 }
+        }
+        await MainActor.run {
+            #expect(harness.vm.replayAssistantRows.count == 2)
+            #expect(harness.vm.replayAssistantRows(text: text).map(\.timestamp) == [now + 3000])
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func `another run cannot replace a same-text provisional final`(matchingLegacyKey: Bool) async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let text = "Same reply, distinct runs."
+        let harness = try await StreamReplayHarness.bootstrapped()
+        let runId = try await harness.send("first turn")
+        harness.transport.emit(replayFinalEvent(runId: runId, text: text, timestamp: now + 1000))
+        try await harness.converge("owned provisional final visible") { vm in
+            vm.pendingRunCount == 0 && vm.replayAssistantRows(text: text).count == 1
+        }
+
+        harness.transport.emit(replaySessionMessageEvent(
+            text: text,
+            timestamp: now + 2000,
+            idempotencyKey: matchingLegacyKey ? runId : nil,
+            runId: "different-run",
+            messageId: "different-durable-final"))
+        try await harness.converge("other run durable row arrives") { vm in
+            vm.replayAssistantRows(text: text).contains { $0.timestamp == now + 2000 }
+        }
+        await MainActor.run {
+            #expect(harness.vm.replayAssistantRows(text: text).map(\.timestamp) == [now + 1000, now + 2000])
+        }
+    }
+
+    @Test func `canonical history adopts a final with different content framing`() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let text = "The same final, with a persisted thinking block."
+        let harness = try await StreamReplayHarness.bootstrapped()
+        let runId = try await harness.send("history refresh")
+        harness.transport.emit(replayFinalEvent(runId: runId, text: text, timestamp: now + 1000))
+        try await harness.converge("provisional reply visible before history") { vm in
+            vm.pendingRunCount == 0 && vm.replayAssistantRows(text: text).count == 1
+        }
+        let provisionalID = try await MainActor.run {
+            try #require(harness.vm.replayAssistantRows(text: text).first?.id)
+        }
+
+        await harness.transport.setHistory(replayHistory(messages: [
+            replayRawMessage(
+                role: "user",
+                text: "history refresh",
+                timestamp: now,
+                idempotencyKey: "\(runId):user"),
+            replayRawMessage(
+                role: "assistant",
+                text: text,
+                timestamp: now + 2000,
+                runId: runId,
+                emptyThinking: true),
+        ]))
+        await MainActor.run { harness.vm.resumeFromForeground() }
+        try await harness.converge("canonical history applied") { vm in
+            vm.replayAssistantRows(text: text).contains { $0.timestamp == now + 2000 }
+        }
+        await MainActor.run {
+            #expect(harness.vm.replayAssistantRows(text: text).count == 1)
+            #expect(harness.vm.replayAssistantRows(text: text).first?.id == provisionalID)
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
@@ -38,9 +38,14 @@ private final class ScriptedChatTransport: @unchecked Sendable, OpenClawChatTran
     private let state: State
     private let stream: AsyncStream<OpenClawChatTransportEvent>
     private let continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation
+    private let beforeHistoryResponse: (@Sendable () async -> Void)?
 
-    init(history: OpenClawChatHistoryPayload) {
+    init(
+        history: OpenClawChatHistoryPayload,
+        beforeHistoryResponse: (@Sendable () async -> Void)? = nil)
+    {
         self.state = State(history: history)
+        self.beforeHistoryResponse = beforeHistoryResponse
         var cont: AsyncStream<OpenClawChatTransportEvent>.Continuation!
         self.stream = AsyncStream { c in
             cont = c
@@ -74,7 +79,9 @@ private final class ScriptedChatTransport: @unchecked Sendable, OpenClawChatTran
     // MARK: OpenClawChatTransport
 
     func requestHistory(sessionKey _: String) async throws -> OpenClawChatHistoryPayload {
-        await self.state.recordHistoryRequest()
+        let payload = await self.state.recordHistoryRequest()
+        await self.beforeHistoryResponse?()
+        return payload
     }
 
     func sendMessage(
@@ -127,6 +134,7 @@ private func replayRawMessage(
     timestamp: Double,
     idempotencyKey: String? = nil,
     runId: String? = nil,
+    messageId: String? = nil,
     emptyThinking: Bool = false) -> AnyCodable
 {
     var content: [[String: Any]] = []
@@ -145,6 +153,9 @@ private func replayRawMessage(
     }
     if let runId {
         metadata["runId"] = runId
+    }
+    if let messageId {
+        metadata["id"] = messageId
     }
     if !metadata.isEmpty {
         message["__openclaw"] = metadata
@@ -243,11 +254,12 @@ private struct StreamReplayHarness {
     let vm: OpenClawChatViewModel
 
     static func bootstrapped(
-        initialHistory: OpenClawChatHistoryPayload = replayHistory()) async throws -> StreamReplayHarness
+        initialHistory: OpenClawChatHistoryPayload = replayHistory(),
+        transcriptCache: (any OpenClawChatTranscriptCache)? = nil) async throws -> StreamReplayHarness
     {
         let transport = ScriptedChatTransport(history: initialHistory)
         let vm = await MainActor.run {
-            OpenClawChatViewModel(sessionKey: "main", transport: transport)
+            OpenClawChatViewModel(sessionKey: "main", transport: transport, transcriptCache: transcriptCache)
         }
         await MainActor.run { vm.load() }
         let harness = StreamReplayHarness(transport: transport, vm: vm)
@@ -663,6 +675,108 @@ struct ChatStreamReplayTests {
             #expect(harness.vm.replayAssistantRows(text: text).count == 1)
             #expect(harness.vm.replayAssistantRows(text: text).first?.id == provisionalID)
         }
+    }
+
+    @Test(arguments: [
+        (Optional("cold-canonical-final"), false),
+        (nil, false),
+        (Optional("cold-canonical-final"), true),
+    ])
+    func `cached final converges after lagging untagged history`(
+        transcriptMessageID: String?,
+        canonicalViaLiveEvent: Bool) async throws
+    {
+        let database = try ClientDatabaseTestSuite()
+        let harness = try await StreamReplayHarness.bootstrapped(transcriptCache: database.store)
+        let runId = try await harness.send("cache refresh")
+        let now = Date().timeIntervalSince1970 * 1000
+        let text = "One reply across the cache boundary."
+        let user = replayRawMessage(
+            role: "user",
+            text: "cache refresh",
+            timestamp: now,
+            idempotencyKey: "\(runId):user")
+        await harness.transport.setHistory(replayHistory(messages: [
+            user,
+            replayRawMessage(
+                role: "assistant", text: text, timestamp: now + 1000, messageId: transcriptMessageID),
+        ]))
+        harness.transport.emit(replayFinalEvent(runId: runId, text: text, timestamp: now + 500))
+        try await harness.converge("untagged history adopted the streamed final") { vm in
+            vm.pendingRunCount == 0 && vm.replayAssistantRows.map(\.timestamp) == [now + 1000]
+        }
+        let originalWrite = await MainActor.run { harness.vm.pendingCacheWriteTask }
+        await originalWrite?.value
+        #expect(await database.store.loadTranscript(sessionKey: "main").count == 2)
+        await database.store.retire()
+        try database.databases.close()
+
+        let reopened = try OpenClawClientDatabases(directoryURL: database.directory)
+        defer { try? reopened.close() }
+        let reopenedStore = reopened.store(gatewayID: "gw-a")
+        let canonicalHistory = replayHistory(messages: [
+            user,
+            replayRawMessage(
+                role: "assistant",
+                text: text,
+                timestamp: now + 2000,
+                runId: runId,
+                messageId: transcriptMessageID,
+                emptyThinking: true),
+        ])
+        let (historyGate, releaseHistory) = AsyncStream<Void>.makeStream()
+        defer { releaseHistory.finish() }
+        let transport = ScriptedChatTransport(history: canonicalHistory, beforeHistoryResponse: {
+            for await _ in historyGate {}
+        })
+        let vm = await MainActor.run {
+            OpenClawChatViewModel(sessionKey: "main", transport: transport, transcriptCache: reopenedStore)
+        }
+        let restored = StreamReplayHarness(transport: transport, vm: vm)
+        await MainActor.run { vm.load() }
+        try await restored.converge("reopened database prepainted before history") { vm in
+            vm.isShowingCachedTranscript && vm.replayAssistantRows.map(\.timestamp) == [now + 1000]
+        }
+        await MainActor.run {
+            #expect(vm.replayAssistantRows.map(\.transcriptMessageID) == [transcriptMessageID])
+        }
+
+        // Cold-open history replaces even an unkeyed cached row. Live Gateway
+        // events share the history entry ID and must pass through the wire codec.
+        if canonicalViaLiveEvent {
+            let messageID = try #require(transcriptMessageID)
+            let frame = EventFrame(type: "event", event: "session.message", payload: AnyCodable([
+                "sessionKey": AnyCodable("main"),
+                "messageId": AnyCodable(messageID),
+                "message": replayRawMessage(
+                    role: "assistant",
+                    text: text,
+                    timestamp: now + 2000,
+                    runId: runId,
+                    emptyThinking: true),
+            ]))
+            let priorMutation = await MainActor.run { vm.historyMutationGeneration }
+            try transport.emit(#require(OpenClawChatGatewayPayloadCodec.event(from: frame)))
+            // A deduped event leaves the visible row unchanged; wait for the
+            // handler's history fence before checking that no bubble was added.
+            try await restored.converge("canonical live reply was consumed") { vm in
+                vm.historyMutationGeneration > priorMutation
+            }
+            await MainActor.run { #expect(vm.replayAssistantRows.count == 1) }
+        }
+        releaseHistory.finish()
+        try await restored.converge("cold-open history completed") { vm in
+            vm.healthOK && !vm.isLoading && !vm.isShowingCachedTranscript
+        }
+        await MainActor.run {
+            #expect(vm.replayAssistantRows.map(\.timestamp) == [now + 2000])
+            #expect(vm.replayAssistantRows.map(\.transcriptRunID) == [runId])
+        }
+        let finalWrite = await MainActor.run { vm.pendingCacheWriteTask }
+        await finalWrite?.value
+        let cached = await reopenedStore.loadTranscript(sessionKey: "main")
+        #expect(cached.filter { $0.role == "assistant" }.map(\.timestamp) == [now + 2000])
+        await reopenedStore.retire()
     }
 
     @Test func `reconnect mid-run converges via history refetch and drains pending run`() async throws {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iPhone Chat could show an old assistant reply twice after several successful turns. The real native app retained seven cached rows while the Gateway had exactly six canonical rows: the extra row was an unmetered provisional copy of the first assistant reply.

## Why This Change Was Made

The Gateway already records `__openclaw.runId`, but the native message DTO discarded it. An empty thinking block in canonical history then made the same reply look different from its text-only streamed completion. Preserve the existing run identity through decoding, immutable copies, and the existing cache payload, and use it at the shared history-reconciliation owner.

Run identity is not row identity: intermediate tool rows must not settle an assistant's final reply. Explicit foreign-run metadata also cannot fall back to a coincidentally matching old key or text. The tagged v2026.8.1 idempotency-key contract remains supported when actual run metadata is absent. The second independent history-retention matcher is removed; retention now reads the UUID adoption already recorded by canonical reconciliation. Canonical adoption also retains the existing truncation flag, preserving the full-message affordance.

This is separate from #135697 and #135765. The history owner was byte-identical before and after #135697; that repair did not introduce the observed duplicate. Exact introducing provenance remains unverified.

## User Impact

Streamed assistant replies become their canonical history rows without an extra stale bubble, including after cache restoration. Identical replies from distinct turns, intermediate tool rows, and full-message expansion remain distinct. No configuration, SQLite schema, migration, query, or retention changes are included.

## Evidence

The regression was observed in the signed native iPhone Simulator app against a real Gateway and provider, then confirmed independently in Gateway history and the app's read-only cache. Focused RED tests reproduced both event arrival orders, foreign-run collisions, same-run intermediate tool messages, lost metadata, and the lost truncation flag. All 411 tests across eight native shared-package suites passed after the repair, including actual history refresh, reused-run steering, concurrent/lagging history, offline cold-open, and cache ownership. SwiftFormat and strict SwiftLint passed on the focused patch. Fresh independent P0-scoped autoreview found no actionable P0 findings; this is not an all-severity review certificate.

The candidate signed iPhone Simulator app passed the identical three-turn live UI replay and saved-pairing relaunch: one XCTest, zero failures, 41.711 seconds. The first new canonical reply again contained the exact original trigger, an empty thinking block followed by text. Before reopening Chat, independent inspection found 12 Gateway rows and exactly 12 rows in each native cache scope, in identical canonical transcript-ID order. All three new replies appeared once, with matching run/message IDs and preserved usage; Control was online after relaunch. The baseline had seven cached rows for six Gateway rows. This is actual native app/Gateway/provider proof, not fixture or demo mode. Existing navigation-only launch arguments select Chat/Control; they do not substitute data or connectivity. No physical Watch reliability claim is made.

Before, the stale first reply remained below later answers:

![Before: stale unmetered assistant reply retained after later turns](https://github.com/user-attachments/assets/57168ae5-28e2-482f-869e-c5993f78f0ae)

After, later answers each appear once with canonical usage metadata:

![After: canonical replies without the stale duplicate](https://github.com/user-attachments/assets/e77a0054-c443-44b2-8164-03c636dbaeba)

The follow-up cache review was checked against real SQLite close/reopen and the actual Gateway event codec. All 424 tests across nine suites pass, including three new cases: keyed cold history, unkeyed cold history, and a keyed live event arriving while cold-open history is pending. Each ends with one canonical assistant row in memory and in the rewritten cache. Cold history replaces cached rows; live events preserve the durable message ID and dedupe by it. The proposed additional duplicate does not reproduce, so production is unchanged by this coverage commit. The three-turn native/provider evidence above remains applicable to the unchanged production code. The test-only follow-up also passed fresh P0-scoped autoreview.

## Scope and Release Note

Production: +49/-24 (net +25); tests: +293/-38 (net +255). Growth carries existing wire metadata through immutable message copies and checks the server's terminal-row contract; the duplicate retention matcher was deleted. The test-only cache follow-up adds +118/-4 using existing transport and real-database fixtures, with no production test hook. Release note: iPhone Chat no longer retains duplicate streamed replies after canonical history refresh, and preserved truncation metadata keeps full-message expansion available.
