### PR TITLE
fix(ui): avoid false storage errors after removing queued input

### DIFF
--- a/ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
+++ b/ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
@@ -26,6 +26,69 @@ async function withChatPage(run: (page: Page) => Promise<void>): Promise<void> {
 }
 
 suite.define(() => {
+  it("keeps a durably admitted removal retired across the browser input yield", async () => {
+    await withChatPage(async (page) => {
+      const gateway = await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("discard before delivery");
+      await gateway.setOnline(false);
+      await gateway.closeLatest();
+      await composer.evaluate((element) => {
+        const ActualMessageChannel = MessageChannel;
+        window.MessageChannel = class extends ActualMessageChannel {
+          constructor() {
+            super();
+            const post = this.port2.postMessage.bind(this.port2);
+            this.port2.postMessage = () => {
+              window.MessageChannel = ActualMessageChannel;
+              element.setAttribute("data-admission-yielded", "true");
+              document.addEventListener("resume-admitted-send", () => post(undefined), {
+                once: true,
+              });
+            };
+          }
+        };
+      });
+
+      await composer.press("Enter");
+      await expect.poll(() => composer.getAttribute("data-admission-yielded")).toBe("true");
+      const queued = page.locator(".chat-queue__item", { hasText: "discard before delivery" });
+      await queued.waitFor();
+      if (proofDir) {
+        await page.screenshot({ path: path.join(proofDir, "retirement-admitted.png") });
+      }
+      await queued.locator(".chat-queue__remove").evaluate((button: HTMLElement) => button.click());
+      await queued.waitFor({ state: "detached" });
+      await composer.fill("next draft stays mine");
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            document.dispatchEvent(new Event("resume-admitted-send"));
+            const channel = new MessageChannel();
+            channel.port1.addEventListener(
+              "message",
+              () => {
+                channel.port1.close();
+                channel.port2.close();
+                resolve();
+              },
+              { once: true },
+            );
+            channel.port1.start();
+            channel.port2.postMessage(undefined);
+          }),
+      );
+      if (proofDir) {
+        await page.screenshot({ path: path.join(proofDir, "retirement-resumed.png") });
+      }
+      expect(await page.getByRole("alert").allTextContents()).toEqual([]);
+      expect(await composer.inputValue()).toBe("next draft stays mine");
+      expect(await page.locator(".chat-queue__item").count()).toBe(0);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+    });
+  });
+
   it("returns to browser input before starting durable chat delivery", async () => {
     await withChatPage(async (page) => {
       const gateway = await installMockGateway(page);

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -7,6 +7,7 @@ import { parseSlashCommand } from "../../lib/chat/commands.ts";
 import { extractCompanionCommandQuestion } from "../../lib/chat/companion-question.ts";
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
 import type { ControlUiFollowUpMode } from "../../lib/chat/follow-up-mode.ts";
+import { sameQueuedDeliveryVersion } from "../../lib/chat/outbox-store-codec.ts";
 import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import { scopedAgentIdForSession, visibleSessionMatches } from "../../lib/sessions/index.ts";
 import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
@@ -58,7 +59,7 @@ import {
 } from "./chat-send-support.ts";
 import { recordChatSendTiming } from "./chat-send-timing.ts";
 import { getPendingChatPickerPatch } from "./chat-session.ts";
-import { withChatSubmitGuard } from "./chat-submit-guard.ts";
+import { withChatSubmitGuard, yieldChatSubmitToInput } from "./chat-submit-guard.ts";
 import {
   recordNonTranscriptInputHistory,
   resetChatInputHistoryNavigation,
@@ -538,6 +539,12 @@ export async function handleSendChat(
       return;
     }
     const submittedAgentId = scopedAgentIdForSession(host, submittedSessionKey);
+    const submissionOwnerIsCurrent = () =>
+      submittedOwnerIsCurrent() &&
+      host.client === submittedClient &&
+      host.connectionEpoch === submittedEpoch &&
+      host.sessionKey === submittedSessionKey &&
+      visibleSessionMatches(host, submittedSessionKey, submittedAgentId);
     if (!visibleSessionMatches(host, submittedSessionKey, submittedAgentId)) {
       setChatError(host, t("mcpServers.sessionUnavailable"));
       return;
@@ -596,11 +603,7 @@ export async function handleSendChat(
       const payload = await prepareOutboxPayload(host, queued);
       const currentEdit = activeQueuedMessageEdit(host);
       const stillOwnsSubmission =
-        submittedOwnerIsCurrent() &&
-        host.client === submittedClient &&
-        host.connectionEpoch === submittedEpoch &&
-        host.sessionKey === submittedSessionKey &&
-        visibleSessionMatches(host, submittedSessionKey, submittedAgentId) &&
+        submissionOwnerIsCurrent() &&
         (!isInlineEditSubmission ||
           (currentEdit === inlineEdit && currentEdit.revision === submittedInlineEditRevision));
       if (!stillOwnsSubmission) {
@@ -672,38 +675,39 @@ export async function handleSendChat(
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return;
     }
+    let deliveryItem: typeof queued | null = queued;
     if (admittedDurably && submissionAction && typeof MessageChannel !== "undefined") {
       // The outbox now owns the prompt across reloads. Return control before
       // delivery work so the browser can accept the operator's next input.
-      await new Promise<void>((resolve) => {
-        const channel = new MessageChannel();
-        channel.port1.addEventListener(
-          "message",
-          () => {
-            channel.port1.close();
-            channel.port2.close();
-            resolve();
-          },
-          { once: true },
-        );
-        channel.port1.start();
-        channel.port2.postMessage(undefined);
-      });
+      await yieldChatSubmitToInput();
+      const current =
+        submissionOwnerIsCurrent() &&
+        visibleSessionMatches(host, queued.sessionKey!, queued.agentId)
+          ? readQueuedMessageById(host, queued.id)
+          : null;
+      // Input may retire this admission or another drain may advance it. Only
+      // position changes preserve the handoff; the drain owns ordering/edit holds.
+      deliveryItem =
+        current && sameQueuedDeliveryVersion(queued, { ...current, orderKey: queued.orderKey })
+          ? current
+          : null;
     }
-    const sendResult = await deliverChatQueueItem(host, queued, {
-      previousDraft: cleared.previousDraft,
-      previousAttachments: cleared.previousAttachments,
-      ...(intent || (directRunActive && followUpMode !== "queue")
-        ? { allowActiveRunSend: true }
-        : {}),
-      ...(expectedLeafEntryId !== undefined ? { expectedLeafEntryId } : {}),
-      ...(pendingSettings ? { pendingSettings } : {}),
-      restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),
-      restoreDraft: Boolean(messageOverride && opts?.restoreDraft),
-      restoreOnTerminalFailure: Boolean(rawParsedCommand || intent),
-      routingSessionKey: submittedSessionKey,
-      storageMode: canSendFromMemory ? "memory" : "durable",
-    });
+    const sendResult = deliveryItem
+      ? await deliverChatQueueItem(host, deliveryItem, {
+          previousDraft: cleared.previousDraft,
+          previousAttachments: cleared.previousAttachments,
+          ...(intent || (directRunActive && followUpMode !== "queue")
+            ? { allowActiveRunSend: true }
+            : {}),
+          ...(expectedLeafEntryId !== undefined ? { expectedLeafEntryId } : {}),
+          ...(pendingSettings ? { pendingSettings } : {}),
+          restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),
+          restoreDraft: Boolean(messageOverride && opts?.restoreDraft),
+          restoreOnTerminalFailure: Boolean(rawParsedCommand || intent),
+          routingSessionKey: submittedSessionKey,
+          storageMode: canSendFromMemory ? "memory" : "durable",
+        })
+      : "pending";
     const pending = readQueuedMessageById(host, queued.id);
     accepted = sendResult !== "failed";
     const pendingBusySend =
@@ -718,8 +722,8 @@ export async function handleSendChat(
     if (
       (sendResult !== "failed" || pending?.sendState === "failed") &&
       replyTarget &&
-      host.chatReplyTarget?.messageId === replyTarget.messageId &&
-      host.sessionKey === submittedSessionKey
+      host.chatReplyTarget === replyTarget &&
+      submissionOwnerIsCurrent()
     ) {
       // The reconnect queue owns the quote; later offline turns must not reuse it.
       host.chatReplyTarget = null;

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -58,6 +58,7 @@ import { chatOutboxOwner } from "./chat-outbox-owner.ts";
 import { renderChatPaneComposerControls } from "./chat-pane-session-controls.ts";
 import { createTestChatPane } from "./chat-pane.test-support.ts";
 import { getChatPendingInputs } from "./chat-pending-inputs.ts";
+import { moveQueuedChatMessage } from "./chat-send-actions.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import * as chatSendSupport from "./chat-send-support.ts";
 import {
@@ -82,6 +83,7 @@ import { getChatSessionProjection, publishChatSessionProjection } from "./histor
 import { handleChatInputHistoryKey } from "./input-history.ts";
 import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
 import { prepareOutboxPayload } from "./outbox-payloads.ts";
+import { updateQueuedMessageEdit } from "./queued-message-edit.ts";
 import { handleChatScrollTakeover } from "./scroll.ts";
 import {
   cacheChatSessionSnapshot,
@@ -6803,6 +6805,191 @@ describe("handleSendChat", () => {
     sent.resolve({ runId: host.chatQueue[0]?.sendRunId, status: "started" });
     await Promise.all([first, reentry, second]);
   });
+
+  async function submitAcrossBrowserInput(
+    host: TestChatHost,
+    duringYield: (queued: ChatQueueItem) => void | Promise<void>,
+  ): Promise<boolean | undefined> {
+    const channel = new MessageChannel();
+    const resume = channel.port2.postMessage.bind(channel.port2);
+    const yielded = createDeferred();
+    vi.spyOn(channel.port2, "postMessage").mockImplementation(() => yielded.resolve());
+    vi.spyOn(globalThis, "MessageChannel").mockImplementationOnce(function () {
+      return channel;
+    });
+    const submission = handleSendChat(host, undefined, undefined, new Event("submit"));
+    try {
+      await Promise.race([
+        yielded.promise,
+        submission.then(() => {
+          throw new Error("Submission ended without yielding after admission");
+        }),
+      ]);
+      const queued = expectDefined(listStoredChatOutboxes(host)[0]?.queue.at(-1), "admitted row");
+      await duringYield(queued);
+    } finally {
+      resume(undefined);
+      await submission;
+      channel.port1.close();
+      channel.port2.close();
+    }
+    return submission;
+  }
+
+  it("retires an event-backed submission removed during the browser input yield", async () => {
+    const host = makeChatHost({
+      connected: false,
+      requestHandlers: {},
+      chatMessage: "discard before delivery",
+      chatReplyTarget: { messageId: "quoted-message", text: "original quote" },
+    });
+    const accepted = await submitAcrossBrowserInput(host, (queued) => {
+      expect(queued.text).toContain("discard before delivery");
+      expect(removeQueuedMessage(host, queued.id)).toBe("removed");
+      host.chatMessage = "next draft";
+    });
+
+    expect(accepted).toBe(true);
+    expect(host.lastError).toBeNull();
+    expect(host.chatReplyTarget).toBeNull();
+    expect(host.chatMessage).toBe("next draft");
+    expect(listStoredChatOutboxes(host)).toEqual([]);
+    expect(host.chatQueue).toEqual([]);
+    expect(host.request).not.toHaveBeenCalled();
+  });
+
+  it.each(["client", "epoch", "session", "recovery owner"])(
+    "retires an event-backed continuation after its %s changes during the browser input yield",
+    async (change) => {
+      const host = makeChatHost({ requestHandlers: {}, chatMessage: "old owner input" });
+      const newReply = { messageId: "same-message", text: "new owner quote" };
+      host.chatReplyTarget = { messageId: newReply.messageId, text: "old owner quote" };
+      const accepted = await submitAcrossBrowserInput(host, () => {
+        if (change === "client") {
+          host.client = clientWithRequest(host.request);
+        } else if (change === "epoch") {
+          host.connectionEpoch += 1;
+        } else if (change === "session") {
+          host.sessionKey = "agent:main:other";
+        } else {
+          vi.spyOn(
+            expectDefined(host.client, "submission client"),
+            "recoveryScope",
+            "get",
+          ).mockReturnValue("new-owner");
+        }
+        host.chatMessage = "new owner draft";
+        host.chatReplyTarget = newReply;
+      });
+      expect(accepted).toBe(true);
+      expect(host.request).not.toHaveBeenCalled();
+      expect(host.lastError).toBeNull();
+      expect(host.chatMessage).toBe("new owner draft");
+      expect(host.chatReplyTarget).toBe(newReply);
+      const stored = readStoredOutboxStore(
+        sessionStorage,
+        storageTargetForGateway(host.settings.gatewayUrl),
+      );
+      expect(Object.values(stored.sessions).flatMap((scope) => scope.queue ?? [])).toEqual([
+        expect.objectContaining({ sessionKey: "agent:main", sendAttempts: 0 }),
+      ]);
+    },
+  );
+
+  it("keeps a replacement and a newer reply after the browser input yield", async () => {
+    const host = makeChatHost({
+      connected: false,
+      requestHandlers: {},
+      chatMessage: "original text",
+      chatReplyTarget: { messageId: "same-message", text: "original quote" },
+    });
+    const newerReply = { messageId: "same-message", text: "selected again" };
+    const accepted = await submitAcrossBrowserInput(host, async (queued) => {
+      expect(beginQueuedMessageEdit(host, queued.id)).toBe("started");
+      expect(updateQueuedMessageEdit(host, "replacement text")).toBe(true);
+      expect(
+        await handleSendChat(host, "replacement text", { resumeQueuedMessageEditId: queued.id }),
+      ).toBe(true);
+      host.chatMessage = "new draft";
+      host.chatReplyTarget = newerReply;
+    });
+    expect(accepted).toBe(true);
+    expect(host.lastError).toBeNull();
+    expect(host.chatMessage).toBe("new draft");
+    expect(host.chatReplyTarget).toBe(newerReply);
+    expect(listStoredChatOutboxes(host)[0]?.queue).toEqual([
+      expect.objectContaining({ text: "replacement text", sendAttempts: 0 }),
+    ]);
+    expect(host.request).not.toHaveBeenCalled();
+  });
+
+  it.each(["edit hold", "reorder"])(
+    "uses canonical queue arbitration after a browser input %s",
+    async (change) => {
+      const host = makeChatHost({
+        connected: false,
+        requestHandlers: {
+          "chat.history": () => idleChatHistory(),
+          "chat.send": (params: unknown) => ({
+            runId: requireRecord(params, "canonical queued send").idempotencyKey,
+            status: "started",
+          }),
+        },
+        chatMessage: "first input",
+      });
+      const accepted = await submitAcrossBrowserInput(host, async (queued) => {
+        await handleSendChat(host, "second input");
+        if (change === "edit hold") {
+          expect(beginQueuedMessageEdit(host, queued.id)).toBe("started");
+          expect(updateQueuedMessageEdit(host, "correction in progress")).toBe(true);
+        } else {
+          moveQueuedChatMessage(host, queued.id, 1);
+        }
+        host.connected = true;
+      });
+      expect(accepted).toBe(true);
+      expect(host.lastError).toBeNull();
+      const sends = host.request.mock.calls.filter(([method]) => method === "chat.send");
+      if (change === "edit hold") {
+        expect(sends).toEqual([]);
+        expect(host.chatQueuedEdit?.draftText).toBe("correction in progress");
+      } else {
+        expect(sends.map(([, params]) => requireRecord(params, "send").message)).toEqual([
+          "second input",
+        ]);
+      }
+    },
+  );
+
+  it.each(["started", "ok"])(
+    "does not reacquire a %s send advanced by reconnect during the browser input yield",
+    async (ack) => {
+      const host = makeChatHost({
+        connected: false,
+        requestHandlers: {
+          "chat.history": () => idleChatHistory(),
+          "chat.send": (params: unknown) => ({
+            runId: requireRecord(params, "reconnect send").idempotencyKey,
+            status: ack,
+          }),
+        },
+        chatMessage: "one admitted turn",
+      });
+      let queueAfterReconnect: ChatQueueItem[] = [];
+      const accepted = await submitAcrossBrowserInput(host, async () => {
+        host.connected = true;
+        await retryReconnectableQueuedChatSends(host);
+        expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(
+          1,
+        );
+        queueAfterReconnect = [...host.chatQueue];
+      });
+      expect(accepted).toBe(true);
+      expect(host.lastError).toBeNull();
+      expect(host.chatQueue).toEqual(queueAfterReconnect);
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
+    },
+  );
 
   it("keeps an acknowledged live send pending while durable history is briefly stale", async () => {
     let historyRequests = 0;

--- a/ui/src/pages/chat/chat-submit-guard.ts
+++ b/ui/src/pages/chat/chat-submit-guard.ts
@@ -3,6 +3,23 @@ import type { ChatHost } from "./chat-send-contract.ts";
 
 const submissionActionIds = new WeakMap<Event, string>();
 
+export function yieldChatSubmitToInput(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const channel = new MessageChannel();
+    channel.port1.addEventListener(
+      "message",
+      () => {
+        channel.port1.close();
+        channel.port2.close();
+        resolve();
+      },
+      { once: true },
+    );
+    channel.port1.start();
+    channel.port2.postMessage(undefined);
+  });
+}
+
 export async function withChatSubmitGuard<T>(
   host: ChatHost,
   key: string,


### PR DESCRIPTION
Closes #135785 (false storage warning after removing queued input).

Related: #135345 (immediate next-input responsiveness). This is the separate main-CI repair needed before landing #135657 (GitHub preflight diagnostics); no preflight changes are mixed into this branch.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch and remains takeover-ready.

</details>

## What Problem This Solves

Fixes an issue where users quickly removing an offline queued message could see a storage-failure warning after the row was successfully removed. The original main UI E2E encountered the alert after removal; a deterministic Chromium reproduction confirmed the false “Could not store this message for reconnect” warning.

## Why This Change Was Made

After durable admission yields to browser input, the submission now revalidates its original owner and current delivery version before continuing. Removed, replaced, or already-advanced work does not re-enter delivery; surviving work uses the canonical current row, with ordering and active-edit holds still owned by the existing drain. Successful-admission bookkeeping and newer reply/draft ownership are preserved.

The input yield remains and moves into the existing submission lifecycle module, keeping the submit owner below its existing line limit without suppression. The general storage-error path, removal assertion, deadlines, schemas, configuration, dependencies, and protocol remain unchanged.

## User Impact

Removing an admitted queued message stays retired without a false storage warning, restored draft, or stale delivery continuation. Newer drafts/replies and the ability to type the next prompt before transport starts remain intact. Already-started reconnect work is not downgraded by the old submission continuation. Real rejected storage writes still show an error and retain the row.

## Evidence

**Before:** controlled post-admission removal in a real Chromium UI with a mocked Gateway produced the exact false alert:

![Before: removed queued input followed by a false storage warning](https://github.com/user-attachments/assets/286ee919-0683-4945-836a-a339681ce8ff)

**After:** the row stays retired, the newer draft remains, and the alert is absent:

![After: removed input remains retired and the newer draft is preserved](https://github.com/user-attachments/assets/45a7375c-bc7b-4265-bf96-a49764c20b50)

Both full captures were inspected and contain only isolated synthetic fixture data. No operator Gateway, live provider, account, or credentials were used.

Pre-fix proof: **8 of 10 new unit cases failed**; edit-hold/reorder controls passed. The controlled browser removal case failed with the false warning. This explains the unsafe interleaving behind the [main CI failure](https://github.com/openclaw/openclaw/actions/runs/33571549601/job/100067133365); the original job log elides its alert text, so that exact original interleaving is not claimed as observed.

Final focused proof: **27 unit tests and all 8 requested browser cases passed**.

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/chat/chat-send.test.ts -t 'browser input|model-wait|reply|creation-time destination|verified Blob admission|distinct user actions|releases queued attachment payloads once'
```

```bash
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_ARTIFACT_DIR=../queue-yield-browser-owner-final node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner --maxWorkers=1 ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
```

```bash
OPENCLAW_CAPTURE_UI_PROOF=1 OPENCLAW_UI_E2E_ARTIFACT_DIR=../queue-yield-browser-owner-final node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner --maxWorkers=1 ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
```

The original queue-edit file/case order and unchanged next-input-before-transport assertion were preserved. The entire historical 116-test CI shard was not rerun locally; no full-suite claim is made.

```bash
node scripts/check-changed.mjs --base 4f34b7df4dba7550b1a4ba32592489a44ce28b02 -- ui/src/pages/chat/chat-send-submit.ts ui/src/pages/chat/chat-submit-guard.ts ui/src/pages/chat/chat-send.test.ts ui/src/e2e/chat-submit-responsiveness.e2e.test.ts
```

The four-file changed gate passed: formatting, TypeScript, guards, dead-export scans, and scoped lint/style. `git diff --check` passed. Independent protected Codex autoreview was scoped-clean at the P0-only threshold after final edits.

Production: **+57/-36, net +21** (including the existing yield implementation's move). Tests: **+250/-0**. The production growth supplies the missing post-await owner/version boundary and preserves completion bookkeeping; existing owner, version-comparison, and drain helpers are reused rather than adding a new state scheme.

Exact-head CI and native review/prepare/merge validation will be verified before landing.
