### PR TITLE
fix(plugins): preserve external payloads during doctor repair

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -201,7 +201,8 @@ Registry verification and any required capability review finish before the
 repaired install record is published.
 
 When a bundled plugin moves to an external package, failed relocation reports
-that the replacement payload is missing and points to `openclaw update repair`.
+that the replacement payload was not installed and preserves the underlying error.
+Resolve that error before retrying with `openclaw update repair`.
 Doctor and update repair reinstall configured payloads with missing package files
 or a reported missing runtime entry;
 an empty directory is not a successful installation. Rollback removes empty

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -200,6 +200,15 @@ preserves the existing payload and does not publish a new install record.
 Registry verification and any required capability review finish before the
 repaired install record is published.
 
+When a bundled plugin moves to an external package, failed relocation reports
+that the replacement payload is missing and points to `openclaw update repair`.
+Doctor and update repair reinstall configured payloads with missing package files
+or a reported missing runtime entry;
+an empty directory is not a successful installation. Rollback removes empty
+managed npm projects after staged files are cleaned up. Doctor preserves external
+companion packages and their install records even when a source checkout also
+contains a bundled-discovery copy of the same plugin.
+
 With `--json`, stdout contains one JSON document. Doctor panels and other
 diagnostics go to stderr, so stdout can be parsed directly. Failed doctor or
 plugin finalization steps still exit non-zero.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4079,7 +4079,7 @@ describe("update-cli", () => {
       ]);
       if (source === "bridge") {
         expect(jsonOutput?.postUpdate?.plugins?.sync.errors).toEqual([
-          "Failed to update consent-fixture: Operator review token changed.",
+          'Failed to update consent-fixture: Operator review token changed.\nBundled relocation did not install the replacement plugin payload; resolve the error above, then run "openclaw update repair".',
         ]);
       }
       expect(defaultRuntime.exit).not.toHaveBeenCalled();

--- a/src/commands/doctor-plugin-registry.test-support.ts
+++ b/src/commands/doctor-plugin-registry.test-support.ts
@@ -1,0 +1,271 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect } from "vitest";
+import type { PluginCandidate } from "../plugins/discovery.js";
+import { resolvePluginNpmProjectDir } from "../plugins/install-paths.js";
+import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
+
+export async function readRequiredPersistedInstalledPluginIndex(
+  stateDir: string,
+): Promise<InstalledPluginIndex> {
+  const persisted = await readPersistedInstalledPluginIndex({ stateDir });
+  if (!persisted) {
+    throw new Error("Expected persisted installed plugin index");
+  }
+  return persisted;
+}
+
+export function hermeticEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+    OPENCLAW_VERSION: "2026.4.25",
+    VITEST: "true",
+    ...overrides,
+  };
+}
+
+export function createCandidate(rootDir: string, id = "demo"): PluginCandidate {
+  fs.writeFileSync(
+    path.join(rootDir, "index.ts"),
+    "throw new Error('runtime entry should not load during doctor registry repair');\n",
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id,
+      name: id,
+      configSchema: { type: "object" },
+      providers: [id],
+    }),
+    "utf8",
+  );
+  return {
+    idHint: id,
+    source: path.join(rootDir, "index.ts"),
+    rootDir,
+    origin: "global",
+  };
+}
+
+export function createBundledCandidate(params: {
+  rootDir: string;
+  id: string;
+  packageName: string;
+  version: string;
+  bundledDist?: boolean;
+}): PluginCandidate {
+  const packageManifest =
+    params.bundledDist === undefined ? undefined : { build: { bundledDist: params.bundledDist } };
+  fs.writeFileSync(
+    path.join(params.rootDir, "index.ts"),
+    "throw new Error('runtime entry should not load during doctor registry repair');\n",
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(params.rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: params.id,
+      name: params.id,
+      configSchema: { type: "object" },
+      providers: [params.id],
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(params.rootDir, "package.json"),
+    JSON.stringify({
+      name: params.packageName,
+      version: params.version,
+      ...(packageManifest ? { openclaw: packageManifest } : {}),
+    }),
+    "utf8",
+  );
+  return {
+    idHint: params.id,
+    source: path.join(params.rootDir, "index.ts"),
+    rootDir: params.rootDir,
+    origin: "bundled",
+    packageName: params.packageName,
+    packageVersion: params.version,
+    ...(packageManifest ? { packageManifest } : {}),
+  };
+}
+
+export function createManagedNpmPlugin(params: {
+  stateDir: string;
+  id: string;
+  packageName: string;
+  version: string;
+  peerDependencies?: Record<string, string>;
+  packageLock?: boolean;
+}) {
+  const npmBaseDir = path.join(params.stateDir, "npm");
+  const npmRoot = resolvePluginNpmProjectDir({
+    npmDir: npmBaseDir,
+    packageName: params.packageName,
+  });
+  const packageDir = path.join(npmRoot, "node_modules", ...params.packageName.split("/"));
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(npmRoot, "package.json"),
+    JSON.stringify({
+      dependencies: {
+        [params.packageName]: params.version,
+      },
+    }),
+    "utf8",
+  );
+  if (params.packageLock) {
+    fs.writeFileSync(
+      path.join(npmRoot, "package-lock.json"),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          "": {
+            dependencies: {
+              [params.packageName]: params.version,
+              "other-plugin": "1.0.0",
+            },
+          },
+          [`node_modules/${params.packageName}`]: {
+            version: params.version,
+          },
+          "node_modules/other-plugin": {
+            version: "1.0.0",
+          },
+        },
+        dependencies: {
+          [params.packageName]: {
+            version: params.version,
+          },
+          "other-plugin": {
+            version: "1.0.0",
+          },
+        },
+      }),
+      "utf8",
+    );
+  }
+  fs.writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: params.packageName,
+      version: params.version,
+      ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
+      openclaw: {
+        extensions: ["."],
+      },
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(packageDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: params.id,
+      name: params.id,
+      configSchema: {
+        type: "object",
+      },
+    }),
+    "utf8",
+  );
+  return { npmRoot, packageDir };
+}
+
+export function createCurrentIndex(): InstalledPluginIndex {
+  return {
+    version: 1,
+    hostContractVersion: "2026.4.25",
+    compatRegistryVersion: "compat-v1",
+    migrationVersion: 1,
+    policyHash: "policy-v1",
+    generatedAtMs: 1777118400000,
+    installRecords: {},
+    plugins: [],
+    diagnostics: [],
+  };
+}
+
+export function createCurrentIndexWithNpmRecord(params: {
+  pluginId: string;
+  packageName: string;
+  packageDir: string;
+  version: string;
+}): InstalledPluginIndex {
+  return {
+    ...createCurrentIndex(),
+    installRecords: {
+      [params.pluginId]: {
+        source: "npm",
+        spec: `${params.packageName}@${params.version}`,
+        installPath: params.packageDir,
+        version: params.version,
+        resolvedName: params.packageName,
+        resolvedVersion: params.version,
+        resolvedSpec: `${params.packageName}@${params.version}`,
+      },
+    },
+  };
+}
+
+export function createCurrentIndexWithPathRecord(params: {
+  pluginId: string;
+  installPath: string;
+  version?: string;
+}): InstalledPluginIndex {
+  return {
+    ...createCurrentIndex(),
+    installRecords: {
+      [params.pluginId]: {
+        source: "path",
+        installPath: params.installPath,
+        ...(params.version ? { version: params.version } : {}),
+      },
+    },
+  };
+}
+
+export function expectedPluginIndexRecord(params: {
+  rootDir: string;
+  pluginId: string;
+  origin: "bundled" | "global";
+  packageName?: string;
+  packageVersion?: string;
+}) {
+  return {
+    pluginId: params.pluginId,
+    ...(params.packageName ? { packageName: params.packageName } : {}),
+    ...(params.packageVersion ? { packageVersion: params.packageVersion } : {}),
+    manifestPath: path.join(params.rootDir, "openclaw.plugin.json"),
+    manifestHash: expect.any(String),
+    manifestFile: {
+      size: expect.any(Number),
+      mtimeMs: expect.any(Number),
+      ctimeMs: expect.any(Number),
+    },
+    source: path.join(params.rootDir, "index.ts"),
+    rootDir: params.rootDir,
+    origin: params.origin,
+    enabled: true,
+    startup: {
+      sidecar: false,
+      memory: false,
+      configPaths: [],
+      agentHarnesses: [],
+    },
+    contributions: {
+      channels: [],
+      channelConfigs: [],
+      providers: [params.pluginId],
+      modelCatalogProviders: [],
+      modelSupportPrefixes: [],
+      modelSupportPatterns: [],
+      autoEnableProviderIds: [],
+      commandAliases: [],
+      contracts: {},
+    },
+    compat: [],
+  };
+}

--- a/src/commands/doctor-plugin-registry.test.ts
+++ b/src/commands/doctor-plugin-registry.test.ts
@@ -1,17 +1,13 @@
 // Doctor plugin registry tests cover plugin registry checks and repair diagnostics.
 import fs from "node:fs";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../packages/terminal-core/src/note.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginCandidate } from "../plugins/discovery.js";
-import { resolvePluginNpmProjectDir } from "../plugins/install-paths.js";
+import * as pluginInstall from "../plugins/install.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
-import {
-  readPersistedInstalledPluginIndex,
-  resolveInstalledPluginIndexStorePath,
-} from "../plugins/installed-plugin-index-store.js";
-import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
+import { resolveInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store.js";
 import { markRetainedManagedNpmInstall } from "../plugins/managed-npm-retention.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
@@ -21,6 +17,21 @@ import {
   pluginRegistryIssueToHealthFinding,
   pluginRegistryIssueToRepairEffect,
 } from "./doctor-plugin-registry.js";
+import {
+  readRequiredPersistedInstalledPluginIndex,
+  hermeticEnv,
+  createCandidate,
+  createBundledCandidate,
+  createManagedNpmPlugin,
+  createCurrentIndex,
+  createCurrentIndexWithNpmRecord,
+  createCurrentIndexWithPathRecord,
+  expectedPluginIndexRecord,
+} from "./doctor-plugin-registry.test-support.js";
+import {
+  detectConfiguredPluginInstallHealthIssues,
+  repairMissingPluginInstallsForIds,
+} from "./doctor/shared/missing-configured-plugin-install.js";
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: vi.fn(),
@@ -29,271 +40,13 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.mocked(note).mockReset();
   cleanupTrackedTempDirs(tempDirs);
 });
 
 function makeTempDir() {
   return makeTrackedTempDir("openclaw-doctor-plugin-registry", tempDirs);
-}
-
-async function readRequiredPersistedInstalledPluginIndex(
-  stateDir: string,
-): Promise<InstalledPluginIndex> {
-  const persisted = await readPersistedInstalledPluginIndex({ stateDir });
-  if (!persisted) {
-    throw new Error("Expected persisted installed plugin index");
-  }
-  return persisted;
-}
-
-function hermeticEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
-  return {
-    OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
-    OPENCLAW_VERSION: "2026.4.25",
-    VITEST: "true",
-    ...overrides,
-  };
-}
-
-function createCandidate(rootDir: string, id = "demo"): PluginCandidate {
-  fs.writeFileSync(
-    path.join(rootDir, "index.ts"),
-    "throw new Error('runtime entry should not load during doctor registry repair');\n",
-    "utf8",
-  );
-  fs.writeFileSync(
-    path.join(rootDir, "openclaw.plugin.json"),
-    JSON.stringify({
-      id,
-      name: id,
-      configSchema: { type: "object" },
-      providers: [id],
-    }),
-    "utf8",
-  );
-  return {
-    idHint: id,
-    source: path.join(rootDir, "index.ts"),
-    rootDir,
-    origin: "global",
-  };
-}
-
-function createBundledCandidate(params: {
-  rootDir: string;
-  id: string;
-  packageName: string;
-  version: string;
-}): PluginCandidate {
-  fs.writeFileSync(
-    path.join(params.rootDir, "index.ts"),
-    "throw new Error('runtime entry should not load during doctor registry repair');\n",
-    "utf8",
-  );
-  fs.writeFileSync(
-    path.join(params.rootDir, "openclaw.plugin.json"),
-    JSON.stringify({
-      id: params.id,
-      name: params.id,
-      configSchema: { type: "object" },
-      providers: [params.id],
-    }),
-    "utf8",
-  );
-  fs.writeFileSync(
-    path.join(params.rootDir, "package.json"),
-    JSON.stringify({
-      name: params.packageName,
-      version: params.version,
-    }),
-    "utf8",
-  );
-  return {
-    idHint: params.id,
-    source: path.join(params.rootDir, "index.ts"),
-    rootDir: params.rootDir,
-    origin: "bundled",
-    packageName: params.packageName,
-    packageVersion: params.version,
-  };
-}
-
-function createManagedNpmPlugin(params: {
-  stateDir: string;
-  id: string;
-  packageName: string;
-  version: string;
-  peerDependencies?: Record<string, string>;
-  packageLock?: boolean;
-}) {
-  const npmBaseDir = path.join(params.stateDir, "npm");
-  const npmRoot = resolvePluginNpmProjectDir({
-    npmDir: npmBaseDir,
-    packageName: params.packageName,
-  });
-  const packageDir = path.join(npmRoot, "node_modules", ...params.packageName.split("/"));
-  fs.mkdirSync(packageDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(npmRoot, "package.json"),
-    JSON.stringify({
-      dependencies: {
-        [params.packageName]: params.version,
-      },
-    }),
-    "utf8",
-  );
-  if (params.packageLock) {
-    fs.writeFileSync(
-      path.join(npmRoot, "package-lock.json"),
-      JSON.stringify({
-        lockfileVersion: 3,
-        packages: {
-          "": {
-            dependencies: {
-              [params.packageName]: params.version,
-              "other-plugin": "1.0.0",
-            },
-          },
-          [`node_modules/${params.packageName}`]: {
-            version: params.version,
-          },
-          "node_modules/other-plugin": {
-            version: "1.0.0",
-          },
-        },
-        dependencies: {
-          [params.packageName]: {
-            version: params.version,
-          },
-          "other-plugin": {
-            version: "1.0.0",
-          },
-        },
-      }),
-      "utf8",
-    );
-  }
-  fs.writeFileSync(
-    path.join(packageDir, "package.json"),
-    JSON.stringify({
-      name: params.packageName,
-      version: params.version,
-      ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
-      openclaw: {
-        extensions: ["."],
-      },
-    }),
-    "utf8",
-  );
-  fs.writeFileSync(
-    path.join(packageDir, "openclaw.plugin.json"),
-    JSON.stringify({
-      id: params.id,
-      name: params.id,
-      configSchema: {
-        type: "object",
-      },
-    }),
-    "utf8",
-  );
-  return { npmRoot, packageDir };
-}
-
-function createCurrentIndex(): InstalledPluginIndex {
-  return {
-    version: 1,
-    hostContractVersion: "2026.4.25",
-    compatRegistryVersion: "compat-v1",
-    migrationVersion: 1,
-    policyHash: "policy-v1",
-    generatedAtMs: 1777118400000,
-    installRecords: {},
-    plugins: [],
-    diagnostics: [],
-  };
-}
-
-function createCurrentIndexWithNpmRecord(params: {
-  pluginId: string;
-  packageName: string;
-  packageDir: string;
-  version: string;
-}): InstalledPluginIndex {
-  return {
-    ...createCurrentIndex(),
-    installRecords: {
-      [params.pluginId]: {
-        source: "npm",
-        spec: `${params.packageName}@${params.version}`,
-        installPath: params.packageDir,
-        version: params.version,
-        resolvedName: params.packageName,
-        resolvedVersion: params.version,
-        resolvedSpec: `${params.packageName}@${params.version}`,
-      },
-    },
-  };
-}
-
-function createCurrentIndexWithPathRecord(params: {
-  pluginId: string;
-  installPath: string;
-  version?: string;
-}): InstalledPluginIndex {
-  return {
-    ...createCurrentIndex(),
-    installRecords: {
-      [params.pluginId]: {
-        source: "path",
-        installPath: params.installPath,
-        ...(params.version ? { version: params.version } : {}),
-      },
-    },
-  };
-}
-
-function expectedPluginIndexRecord(params: {
-  rootDir: string;
-  pluginId: string;
-  origin: "bundled" | "global";
-  packageName?: string;
-  packageVersion?: string;
-}) {
-  return {
-    pluginId: params.pluginId,
-    ...(params.packageName ? { packageName: params.packageName } : {}),
-    ...(params.packageVersion ? { packageVersion: params.packageVersion } : {}),
-    manifestPath: path.join(params.rootDir, "openclaw.plugin.json"),
-    manifestHash: expect.any(String),
-    manifestFile: {
-      size: expect.any(Number),
-      mtimeMs: expect.any(Number),
-      ctimeMs: expect.any(Number),
-    },
-    source: path.join(params.rootDir, "index.ts"),
-    rootDir: params.rootDir,
-    origin: params.origin,
-    enabled: true,
-    startup: {
-      sidecar: false,
-      memory: false,
-      configPaths: [],
-      agentHarnesses: [],
-    },
-    contributions: {
-      channels: [],
-      channelConfigs: [],
-      providers: [params.pluginId],
-      modelCatalogProviders: [],
-      modelSupportPrefixes: [],
-      modelSupportPatterns: [],
-      autoEnableProviderIds: [],
-      commandAliases: [],
-      contracts: {},
-    },
-    compat: [],
-  };
 }
 
 describe("maybeRepairPluginRegistryState", () => {
@@ -334,12 +87,12 @@ describe("maybeRepairPluginRegistryState", () => {
 
   it("maps stale managed npm bundled plugin shadows to structured findings", async () => {
     const stateDir = makeTempDir();
-    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    const bundledDir = path.join(stateDir, "bundled", "bundled-demo");
     fs.mkdirSync(bundledDir, { recursive: true });
     const managed = createManagedNpmPlugin({
       stateDir,
-      id: "google-meet",
-      packageName: "@openclaw/google-meet",
+      id: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       version: "2026.5.2",
     });
     await writePersistedInstalledPluginIndex(createCurrentIndex(), { stateDir });
@@ -349,17 +102,17 @@ describe("maybeRepairPluginRegistryState", () => {
       candidates: [
         createBundledCandidate({
           rootDir: bundledDir,
-          id: "google-meet",
-          packageName: "@openclaw/google-meet",
+          id: "bundled-demo",
+          packageName: "@openclaw/bundled-demo",
           version: "2026.5.3",
         }),
       ],
       env: hermeticEnv(),
       config: {
         plugins: {
-          allow: ["google-meet"],
+          allow: ["bundled-demo"],
           entries: {
-            "google-meet": {
+            "bundled-demo": {
               enabled: true,
               config: {},
             },
@@ -372,8 +125,8 @@ describe("maybeRepairPluginRegistryState", () => {
     const staleIssue = issues.find((issue) => issue.kind === "stale-managed-npm-bundled-plugin");
     expect(staleIssue).toMatchObject({
       kind: "stale-managed-npm-bundled-plugin",
-      pluginId: "google-meet",
-      packageName: "@openclaw/google-meet",
+      pluginId: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       packageDir: managed.packageDir,
       version: "2026.5.2",
     });
@@ -381,7 +134,7 @@ describe("maybeRepairPluginRegistryState", () => {
       checkId: "core/doctor/plugin-registry",
       severity: "warning",
       path: managed.packageDir,
-      target: "google-meet",
+      target: "bundled-demo",
     });
     expect(pluginRegistryIssueToRepairEffect(staleIssue!)).toEqual({
       kind: "package",
@@ -486,12 +239,12 @@ describe("maybeRepairPluginRegistryState", () => {
 
   it("warns about stale managed npm packages that shadow bundled plugins", async () => {
     const stateDir = makeTempDir();
-    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    const bundledDir = path.join(stateDir, "bundled", "bundled-demo");
     fs.mkdirSync(bundledDir, { recursive: true });
     const managed = createManagedNpmPlugin({
       stateDir,
-      id: "google-meet",
-      packageName: "@openclaw/google-meet",
+      id: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       version: "2026.5.2",
     });
     await writePersistedInstalledPluginIndex(createCurrentIndex(), { stateDir });
@@ -501,17 +254,17 @@ describe("maybeRepairPluginRegistryState", () => {
       candidates: [
         createBundledCandidate({
           rootDir: bundledDir,
-          id: "google-meet",
-          packageName: "@openclaw/google-meet",
+          id: "bundled-demo",
+          packageName: "@openclaw/bundled-demo",
           version: "2026.5.3",
         }),
       ],
       env: hermeticEnv(),
       config: {
         plugins: {
-          allow: ["google-meet"],
+          allow: ["bundled-demo"],
           entries: {
-            "google-meet": {
+            "bundled-demo": {
               enabled: true,
               config: {},
             },
@@ -524,18 +277,18 @@ describe("maybeRepairPluginRegistryState", () => {
     expect(vi.mocked(note).mock.calls.join("\n")).toContain(
       "Managed npm plugin packages shadow bundled plugins",
     );
-    expect(vi.mocked(note).mock.calls.join("\n")).toContain("@openclaw/google-meet@2026.5.2");
+    expect(vi.mocked(note).mock.calls.join("\n")).toContain("@openclaw/bundled-demo@2026.5.2");
     expect(fs.existsSync(managed.packageDir)).toBe(true);
   });
 
   it("does not mutate stale packages when config install records are invalid", async () => {
     const stateDir = makeTempDir();
-    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    const bundledDir = path.join(stateDir, "bundled", "bundled-demo");
     fs.mkdirSync(bundledDir, { recursive: true });
     const managed = createManagedNpmPlugin({
       stateDir,
-      id: "google-meet",
-      packageName: "@openclaw/google-meet",
+      id: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       version: "2026.5.2",
     });
     const config = JSON.parse(
@@ -548,8 +301,8 @@ describe("maybeRepairPluginRegistryState", () => {
         candidates: [
           createBundledCandidate({
             rootDir: bundledDir,
-            id: "google-meet",
-            packageName: "@openclaw/google-meet",
+            id: "bundled-demo",
+            packageName: "@openclaw/bundled-demo",
             version: "2026.5.3",
           }),
         ],
@@ -622,12 +375,12 @@ describe("maybeRepairPluginRegistryState", () => {
 
   it("removes stale managed npm packages that shadow bundled plugins during repair", async () => {
     const stateDir = makeTempDir();
-    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    const bundledDir = path.join(stateDir, "bundled", "bundled-demo");
     fs.mkdirSync(bundledDir, { recursive: true });
     const managed = createManagedNpmPlugin({
       stateDir,
-      id: "google-meet",
-      packageName: "@openclaw/google-meet",
+      id: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       version: "2026.5.2",
     });
     await writePersistedInstalledPluginIndex(createCurrentIndex(), { stateDir });
@@ -637,17 +390,17 @@ describe("maybeRepairPluginRegistryState", () => {
       candidates: [
         createBundledCandidate({
           rootDir: bundledDir,
-          id: "google-meet",
-          packageName: "@openclaw/google-meet",
+          id: "bundled-demo",
+          packageName: "@openclaw/bundled-demo",
           version: "2026.5.3",
         }),
       ],
       env: hermeticEnv(),
       config: {
         plugins: {
-          allow: ["google-meet"],
+          allow: ["bundled-demo"],
           entries: {
-            "google-meet": {
+            "bundled-demo": {
               enabled: true,
               config: {},
             },
@@ -665,10 +418,10 @@ describe("maybeRepairPluginRegistryState", () => {
     expect(persisted.refreshReason).toBe("migration");
     expect(persisted.plugins).toStrictEqual([
       expectedPluginIndexRecord({
-        pluginId: "google-meet",
+        pluginId: "bundled-demo",
         rootDir: bundledDir,
         origin: "bundled",
-        packageName: "@openclaw/google-meet",
+        packageName: "@openclaw/bundled-demo",
         packageVersion: "2026.5.3",
       }),
     ]);
@@ -677,26 +430,158 @@ describe("maybeRepairPluginRegistryState", () => {
     );
   });
 
+  it.each([
+    {
+      name: "catalog-owned external",
+      pluginId: "google-meet",
+      packageName: "@openclaw/google-meet",
+      bundledDist: undefined,
+      missingEntry: false,
+    },
+    {
+      name: "source-external",
+      pluginId: "external-demo",
+      packageName: "@openclaw/external-demo",
+      bundledDist: false,
+      missingEntry: false,
+    },
+    {
+      name: "partial catalog-owned external",
+      pluginId: "google-meet",
+      packageName: "@openclaw/google-meet",
+      bundledDist: undefined,
+      missingEntry: true,
+    },
+  ])(
+    "preserves installed $name plugin payload and records across repeated doctor repairs",
+    async ({ pluginId, packageName, bundledDist, missingEntry }) => {
+      const stateDir = makeTempDir();
+      const version = "2026.5.2";
+      const bundledDir = path.join(stateDir, "source", "extensions", pluginId);
+      fs.mkdirSync(bundledDir, { recursive: true });
+      const managed = createManagedNpmPlugin({ stateDir, id: pluginId, packageName, version });
+      if (!missingEntry) {
+        fs.writeFileSync(path.join(managed.packageDir, "index.js"), "export default {};\n");
+      }
+      fs.writeFileSync(
+        path.join(managed.packageDir, "package.json"),
+        JSON.stringify({ name: packageName, version, openclaw: { extensions: ["./index.js"] } }),
+      );
+      const initialIndex = createCurrentIndexWithNpmRecord({
+        pluginId,
+        packageName,
+        packageDir: managed.packageDir,
+        version,
+      });
+      await writePersistedInstalledPluginIndex(initialIndex, { stateDir });
+      const candidate = createBundledCandidate({
+        rootDir: bundledDir,
+        id: pluginId,
+        packageName,
+        version: "2026.5.3",
+        bundledDist,
+      });
+      const config: OpenClawConfig = {
+        plugins: { allow: [pluginId], entries: { [pluginId]: { enabled: true } } },
+      };
+      const env = hermeticEnv({
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.dirname(bundledDir),
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      });
+      const install = vi
+        .spyOn(pluginInstall, "installPluginFromNpmSpec")
+        .mockImplementation(async (options) => {
+          const npmResolution = {
+            name: packageName,
+            version,
+            resolvedSpec: `${packageName}@${version}`,
+            integrity: "sha512-fixture",
+          };
+          fs.writeFileSync(path.join(managed.packageDir, "index.js"), "export default {};\n");
+          await options.onBeforePluginArtifactCommit?.({
+            pluginId,
+            stagedArtifactDir: managed.packageDir,
+            mode: "update",
+            sourceRecord: { source: "npm", spec: options.spec, ...npmResolution },
+          });
+          return {
+            ok: true,
+            pluginId,
+            targetDir: managed.packageDir,
+            extensions: ["./index.js"],
+            version,
+            npmResolution,
+          };
+        });
+      let expectedRecord = expectDefined(
+        initialIndex.installRecords[pluginId],
+        "fixture install record",
+      );
+
+      for (let pass = 0; pass < 2; pass++) {
+        await maybeRepairPluginRegistryState({
+          stateDir,
+          candidates: [candidate],
+          env,
+          config,
+          prompter: { shouldRepair: true },
+        });
+        const issues = await detectConfiguredPluginInstallHealthIssues({ cfg: config, env });
+        expect(issues).toEqual(
+          missingEntry && pass === 0
+            ? [expect.objectContaining({ kind: "repairable-installed-plugin", pluginId })]
+            : [],
+        );
+        const repaired = await repairMissingPluginInstallsForIds({
+          cfg: config,
+          pluginIds: [pluginId],
+          env,
+        });
+
+        expect(fs.existsSync(path.join(managed.packageDir, "openclaw.plugin.json"))).toBe(true);
+        expect(repaired.changes).toHaveLength(missingEntry && pass === 0 ? 1 : 0);
+        expect(repaired.warnings).toEqual([]);
+        expect(repaired.capabilityConsentRequired).toBeUndefined();
+        if (missingEntry && pass === 0) {
+          expect(repaired.records[pluginId]).toMatchObject(expectedRecord);
+          expectedRecord = expectDefined(repaired.records[pluginId], "repaired install record");
+        }
+        expect(repaired.records[pluginId]).toEqual(expectedRecord);
+        expect(
+          JSON.parse(fs.readFileSync(path.join(managed.npmRoot, "package.json"), "utf8"))
+            .dependencies,
+        ).toEqual({ [packageName]: version });
+        const persisted = await readRequiredPersistedInstalledPluginIndex(stateDir);
+        expect(persisted.installRecords[pluginId]).toEqual(expectedRecord);
+      }
+      expect(install).toHaveBeenCalledTimes(missingEntry ? 1 : 0);
+      expect(vi.mocked(note).mock.calls.join("\n")).not.toContain(
+        "Removed stale managed npm plugin package",
+      );
+    },
+  );
+
   it("does not remove retained managed npm packages during stale bundled repair", async () => {
     const stateDir = makeTempDir();
-    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    const bundledDir = path.join(stateDir, "bundled", "bundled-demo");
     fs.mkdirSync(bundledDir, { recursive: true });
     const managed = createManagedNpmPlugin({
       stateDir,
-      id: "google-meet",
-      packageName: "@openclaw/google-meet",
+      id: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       version: "2026.5.2",
     });
     await markRetainedManagedNpmInstall({
       packageDir: managed.packageDir,
-      pluginId: "google-meet",
+      pluginId: "bundled-demo",
       retainedAt: "2026-04-25T00:00:00.000Z",
       reason: "test-retained-generation",
     });
     await writePersistedInstalledPluginIndex(
       createCurrentIndexWithNpmRecord({
-        pluginId: "google-meet",
-        packageName: "@openclaw/google-meet",
+        pluginId: "bundled-demo",
+        packageName: "@openclaw/bundled-demo",
         packageDir: managed.packageDir,
         version: "2026.5.2",
       }),
@@ -708,17 +593,17 @@ describe("maybeRepairPluginRegistryState", () => {
       candidates: [
         createBundledCandidate({
           rootDir: bundledDir,
-          id: "google-meet",
-          packageName: "@openclaw/google-meet",
+          id: "bundled-demo",
+          packageName: "@openclaw/bundled-demo",
           version: "2026.5.3",
         }),
       ],
       env: hermeticEnv(),
       config: {
         plugins: {
-          allow: ["google-meet"],
+          allow: ["bundled-demo"],
           entries: {
-            "google-meet": {
+            "bundled-demo": {
               enabled: true,
               config: {},
             },
@@ -730,10 +615,10 @@ describe("maybeRepairPluginRegistryState", () => {
 
     expect(fs.existsSync(managed.packageDir)).toBe(true);
     const persisted = await readRequiredPersistedInstalledPluginIndex(stateDir);
-    expect(persisted.installRecords["google-meet"]).toMatchObject({
+    expect(persisted.installRecords["bundled-demo"]).toMatchObject({
       source: "npm",
       installPath: managed.packageDir,
-      resolvedName: "@openclaw/google-meet",
+      resolvedName: "@openclaw/bundled-demo",
       resolvedVersion: "2026.5.2",
     });
     expect(vi.mocked(note).mock.calls.join("\n")).not.toContain(
@@ -743,18 +628,18 @@ describe("maybeRepairPluginRegistryState", () => {
 
   it("removes recovered npm install records when a managed package shadows a bundled plugin", async () => {
     const stateDir = makeTempDir();
-    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    const bundledDir = path.join(stateDir, "bundled", "bundled-demo");
     fs.mkdirSync(bundledDir, { recursive: true });
     const managed = createManagedNpmPlugin({
       stateDir,
-      id: "google-meet",
-      packageName: "@openclaw/google-meet",
+      id: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       version: "2026.5.3",
     });
     await writePersistedInstalledPluginIndex(
       createCurrentIndexWithNpmRecord({
-        pluginId: "google-meet",
-        packageName: "@openclaw/google-meet",
+        pluginId: "bundled-demo",
+        packageName: "@openclaw/bundled-demo",
         packageDir: managed.packageDir,
         version: "2026.5.3",
       }),
@@ -766,17 +651,17 @@ describe("maybeRepairPluginRegistryState", () => {
       candidates: [
         createBundledCandidate({
           rootDir: bundledDir,
-          id: "google-meet",
-          packageName: "@openclaw/google-meet",
+          id: "bundled-demo",
+          packageName: "@openclaw/bundled-demo",
           version: "2026.5.3",
         }),
       ],
       env: hermeticEnv(),
       config: {
         plugins: {
-          allow: ["google-meet"],
+          allow: ["bundled-demo"],
           entries: {
-            "google-meet": {
+            "bundled-demo": {
               enabled: true,
               config: {},
             },
@@ -793,10 +678,10 @@ describe("maybeRepairPluginRegistryState", () => {
     expect(persisted.refreshReason).toBe("migration");
     expect(persisted.plugins).toStrictEqual([
       expectedPluginIndexRecord({
-        pluginId: "google-meet",
+        pluginId: "bundled-demo",
         rootDir: bundledDir,
         origin: "bundled",
-        packageName: "@openclaw/google-meet",
+        packageName: "@openclaw/bundled-demo",
         packageVersion: "2026.5.3",
       }),
     ]);
@@ -912,12 +797,12 @@ describe("maybeRepairPluginRegistryState", () => {
 
   it("removes stale managed npm packages from the package lock during repair", async () => {
     const stateDir = makeTempDir();
-    const bundledDir = path.join(stateDir, "bundled", "google-meet");
+    const bundledDir = path.join(stateDir, "bundled", "bundled-demo");
     fs.mkdirSync(bundledDir, { recursive: true });
     const managed = createManagedNpmPlugin({
       stateDir,
-      id: "google-meet",
-      packageName: "@openclaw/google-meet",
+      id: "bundled-demo",
+      packageName: "@openclaw/bundled-demo",
       version: "2026.5.2",
       packageLock: true,
     });
@@ -928,17 +813,17 @@ describe("maybeRepairPluginRegistryState", () => {
       candidates: [
         createBundledCandidate({
           rootDir: bundledDir,
-          id: "google-meet",
-          packageName: "@openclaw/google-meet",
+          id: "bundled-demo",
+          packageName: "@openclaw/bundled-demo",
           version: "2026.5.3",
         }),
       ],
       env: hermeticEnv(),
       config: {
         plugins: {
-          allow: ["google-meet"],
+          allow: ["bundled-demo"],
           entries: {
-            "google-meet": {
+            "bundled-demo": {
               enabled: true,
               config: {},
             },
@@ -952,8 +837,8 @@ describe("maybeRepairPluginRegistryState", () => {
       fs.readFileSync(path.join(managed.npmRoot, "package-lock.json"), "utf8"),
     );
     expect(packageLock.packages[""].dependencies).toEqual({ "other-plugin": "1.0.0" });
-    expect(packageLock.packages).not.toHaveProperty("node_modules/@openclaw/google-meet");
-    expect(packageLock.dependencies).not.toHaveProperty("@openclaw/google-meet");
+    expect(packageLock.packages).not.toHaveProperty("node_modules/@openclaw/bundled-demo");
+    expect(packageLock.dependencies).not.toHaveProperty("@openclaw/bundled-demo");
     expect(packageLock.dependencies).toHaveProperty("other-plugin");
   });
 

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -20,6 +20,7 @@ import {
 import { loadInstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { hasRetainedManagedNpmInstallMarker } from "../plugins/managed-npm-retention.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
+import { isExternallyDistributedPlugin } from "../plugins/official-external-plugin-catalog.js";
 import { refreshPluginRegistry } from "../plugins/plugin-registry-refresh.js";
 import {
   listStaleLocalBundledPluginInstallRecords,
@@ -157,7 +158,9 @@ function listStaleManagedNpmBundledPlugins(
   const currentBundled = loadInstalledPluginIndex({
     ...params,
     installRecords: {},
-  }).plugins.filter((plugin) => plugin.origin === "bundled" && plugin.packageName);
+  }).plugins.filter(
+    (plugin) => plugin.origin === "bundled" && !isExternallyDistributedPlugin(plugin),
+  );
   const bundledByPackage = new Map(
     currentBundled.map((plugin) => [plugin.packageName, plugin] as const),
   );

--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -22,6 +22,7 @@ import { readLegacyNpmPluginDeclaration } from "../../../plugins/legacy-npm-decl
 import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
 import type { PluginPackageInstall } from "../../../plugins/manifest.js";
 import {
+  isExternallyDistributedPlugin,
   listOfficialExternalPluginCatalogEntries,
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstall,
@@ -94,9 +95,9 @@ export async function resolveConfiguredPluginInstallContext(params: {
     configuredChannelIds: params.configuredChannelIds,
   });
   const bundledPluginsById = new Map<string, BundledPluginPackageDescriptor>(
-    currentBundledPlugins.map(
-      (plugin) => [plugin.pluginId, { packageName: plugin.packageName }] as const,
-    ),
+    currentBundledPlugins
+      .filter((plugin) => !isExternallyDistributedPlugin(plugin))
+      .map((plugin) => [plugin.pluginId, { packageName: plugin.packageName }] as const),
   );
   const configuredPluginIdsWithStaleDescriptors =
     collectConfiguredPluginIdsWithMissingChannelConfigDescriptors({
@@ -206,6 +207,7 @@ export async function resolveConfiguredPluginInstallContext(params: {
 
 const MISSING_CHANNEL_CONFIG_DESCRIPTOR_DIAGNOSTIC = "without channelConfigs metadata";
 const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
+  "extension entry not found",
   "extension entry escapes package directory",
   "extension entry unreadable",
   "requires compiled runtime output",

--- a/src/commands/doctor/shared/missing-configured-plugin-install.records.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.records.ts
@@ -171,31 +171,5 @@ export function recordMatchesBundledPackage(
   bundled: { name?: string; packageName?: string },
 ): boolean {
   const packageName = bundled.packageName?.trim() || bundled.name?.trim();
-  if (!packageName) {
-    return false;
-  }
-  if (record.source === "npm") {
-    return [record.spec, record.resolvedName, record.resolvedSpec].some(
-      (value) => recordNpmPackageName(value) === packageName,
-    );
-  }
-  if (record.source === "clawhub") {
-    return [record.clawhubPackage, record.spec].some(
-      (value) => recordClawHubPackageName(value) === packageName,
-    );
-  }
-  return false;
-}
-
-function recordNpmPackageName(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? parseRegistryNpmSpec(trimmed)?.name : undefined;
-}
-
-function recordClawHubPackageName(value: string | undefined): string | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  return parseClawHubPluginSpec(trimmed)?.name ?? trimmed;
+  return Boolean(packageName && collectInstalledRecordPackageNames(record).has(packageName));
 }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1762,27 +1762,27 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   it("does not download configured channel plugins that are still bundled", async () => {
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {
-        id: "matrix",
-        pluginId: "matrix",
+        id: "bundleddemo",
+        pluginId: "bundleddemo",
         origin: "bundled",
         meta: { label: "Matrix" },
         install: {
-          npmSpec: "@openclaw/matrix",
+          npmSpec: "@openclaw/bundleddemo",
         },
       },
     ]);
     mocks.loadPluginMetadataSnapshot.mockReturnValue({
       plugins: [
         {
-          id: "matrix",
+          id: "bundleddemo",
           origin: "bundled",
-          packageName: "@openclaw/matrix",
-          channels: ["matrix"],
+          packageName: "@openclaw/bundleddemo",
+          channels: ["bundleddemo"],
         },
       ],
       diagnostics: [],
     });
-    mockCurrentBundledPlugin("matrix", "@openclaw/matrix");
+    mockCurrentBundledPlugin("bundleddemo", "@openclaw/bundleddemo");
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -1790,11 +1790,11 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       cfg: {
         plugins: {
           entries: {
-            matrix: { enabled: true },
+            bundleddemo: { enabled: true },
           },
         },
         channels: {
-          matrix: { enabled: true, homeserver: "https://matrix.example.org" },
+          bundleddemo: { enabled: true, homeserver: "https://bundleddemo.example.org" },
         },
       },
       env: testEnv,
@@ -1809,41 +1809,41 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
   it("removes stale managed install records when the configured plugin is bundled", async () => {
     const records = {
-      matrix: {
+      bundleddemo: {
         source: "npm",
-        spec: "@openclaw/matrix",
-        installPath: "/missing/matrix",
+        spec: "@openclaw/bundleddemo",
+        installPath: "/missing/bundleddemo",
       },
     };
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {
-        id: "matrix",
-        pluginId: "matrix",
+        id: "bundleddemo",
+        pluginId: "bundleddemo",
         origin: "bundled",
         meta: { label: "Matrix" },
         install: {
-          npmSpec: "@openclaw/matrix",
+          npmSpec: "@openclaw/bundleddemo",
         },
       },
     ]);
     mocks.loadPluginMetadataSnapshot.mockReturnValue({
       plugins: [
         {
-          id: "matrix",
+          id: "bundleddemo",
           origin: "bundled",
-          packageName: "@openclaw/matrix",
-          channels: ["matrix"],
+          packageName: "@openclaw/bundleddemo",
+          channels: ["bundleddemo"],
         },
       ],
       diagnostics: [
         {
-          pluginId: "matrix",
+          pluginId: "bundleddemo",
           message: "manifest without channelConfigs metadata",
         },
       ],
     });
-    mockCurrentBundledPlugin("matrix", "@openclaw/matrix");
+    mockCurrentBundledPlugin("bundleddemo", "@openclaw/bundleddemo");
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -1851,11 +1851,11 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       cfg: {
         plugins: {
           entries: {
-            matrix: { enabled: true },
+            bundleddemo: { enabled: true },
           },
         },
         channels: {
-          matrix: { enabled: true, homeserver: "https://matrix.example.org" },
+          bundleddemo: { enabled: true, homeserver: "https://bundleddemo.example.org" },
         },
       },
       env: testEnv,
@@ -1872,74 +1872,91 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       },
     );
     expect(result).toEqual({
-      changes: ['Removed stale managed install record for bundled plugin "matrix".'],
+      changes: ['Removed stale managed install record for bundled plugin "bundleddemo".'],
       warnings: [],
       pluginInventoryChanged: true,
       records: {},
     });
   });
 
-  it("uses current bundled discovery to remove records before stale snapshots can reinstall official plugins", async () => {
-    const records = {
-      "google-meet": {
-        source: "npm",
-        spec: "@openclaw/google-meet",
-        resolvedName: "@openclaw/google-meet",
-        installPath: "/missing/google-meet",
-      },
-    };
-    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-    mocks.loadPluginMetadataSnapshot.mockReturnValue({
-      plugins: [
+  it.each(["healthy", "absent", "empty"])(
+    "preserves and repairs %s official external installs in source checkouts",
+    async (payload) => {
+      const root = tempDirs.make("openclaw-external-companion-");
+      const installPath = path.join(root, "payload");
+      const repairedPath = path.join(root, "repaired");
+      fs.mkdirSync(repairedPath);
+      fs.writeFileSync(path.join(repairedPath, "package.json"), '{"name":"@openclaw/google-meet"}');
+      if (payload !== "absent") {
+        fs.mkdirSync(installPath);
+      }
+      if (payload === "healthy") {
+        fs.copyFileSync(
+          path.join(repairedPath, "package.json"),
+          path.join(installPath, "package.json"),
+        );
+      }
+      const records = {
+        "google-meet": {
+          source: "npm",
+          spec: "@openclaw/google-meet",
+          resolvedName: "@openclaw/google-meet",
+          installPath,
+        },
+      };
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      const repairedRecords = {
+        "google-meet": { ...records["google-meet"], installPath: repairedPath },
+      };
+      mocks.updateNpmInstalledPlugins.mockResolvedValue(
+        successfulUpdate("google-meet", repairedRecords),
+      );
+      mocks.loadPluginMetadataSnapshot.mockReturnValue({
+        plugins: [
+          {
+            id: "google-meet",
+            origin: "npm",
+            packageName: "@openclaw/google-meet",
+          },
+        ],
+        diagnostics: [],
+      });
+      mockCurrentBundledPlugin("google-meet", "@openclaw/google-meet");
+      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
         {
           id: "google-meet",
-          origin: "npm",
-          packageName: "@openclaw/google-meet",
-        },
-      ],
-      diagnostics: [],
-    });
-    mockCurrentBundledPlugin("google-meet", "@openclaw/google-meet");
-    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
-      {
-        id: "google-meet",
-        label: "Google Meet",
-        install: { npmSpec: "@openclaw/google-meet" },
-        openclaw: {
-          id: "google-meet",
+          label: "Google Meet",
           install: { npmSpec: "@openclaw/google-meet" },
-        },
-      },
-    ]);
-
-    const { repairMissingConfiguredPluginInstalls } =
-      await import("./missing-configured-plugin-install.js");
-    const result = await repairMissingConfiguredPluginInstalls({
-      cfg: {
-        plugins: {
-          entries: {
-            "google-meet": { enabled: true },
+          openclaw: {
+            id: "google-meet",
+            install: { npmSpec: "@openclaw/google-meet" },
           },
         },
-      },
-      env: testEnv,
-    });
+      ]);
 
-    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
-    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
-      {},
-      {
-        config: expect.any(Object),
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const result = await repairMissingConfiguredPluginInstalls({
+        cfg: {
+          plugins: {
+            entries: {
+              "google-meet": { enabled: true },
+            },
+          },
+        },
         env: testEnv,
-      },
-    );
-    expect(result).toEqual({
-      changes: ['Removed stale managed install record for bundled plugin "google-meet".'],
-      warnings: [],
-      pluginInventoryChanged: true,
-      records: {},
-    });
-  });
+      });
+
+      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+      expect(mocks.updateNpmInstalledPlugins).toHaveBeenCalledTimes(payload === "healthy" ? 0 : 1);
+      expect(result.records).toEqual(payload === "healthy" ? records : repairedRecords);
+      expect(result.changes).toEqual(
+        payload === "healthy" ? [] : ['Repaired missing configured plugin "google-meet".'],
+      );
+      expect(result.warnings).toEqual([]);
+      expect(result.capabilityConsentRequired).toBeUndefined();
+    },
+  );
 
   it("installs an official external plugin when only a stale bundled descriptor remains", async () => {
     mocks.loadPluginMetadataSnapshot.mockReturnValue({
@@ -1993,11 +2010,11 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
   it("removes stale bundled install records even when the plugin is not configured", async () => {
     const records = {
-      "google-meet": {
+      bundleddemo: {
         source: "npm",
-        spec: "@openclaw/google-meet",
-        resolvedName: "@openclaw/google-meet",
-        installPath: "/missing/google-meet",
+        spec: "@openclaw/bundleddemo",
+        resolvedName: "@openclaw/bundleddemo",
+        installPath: "/missing/bundleddemo",
       },
     };
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
@@ -2005,7 +2022,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       plugins: [],
       diagnostics: [],
     });
-    mockCurrentBundledPlugin("google-meet", "@openclaw/google-meet");
+    mockCurrentBundledPlugin("bundleddemo", "@openclaw/bundleddemo");
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
@@ -2023,7 +2040,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       },
     );
     expect(result).toEqual({
-      changes: ['Removed stale managed install record for bundled plugin "google-meet".'],
+      changes: ['Removed stale managed install record for bundled plugin "bundleddemo".'],
       warnings: [],
       pluginInventoryChanged: true,
       records: {},
@@ -2035,54 +2052,54 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       "npm",
       {
         source: "npm",
-        spec: "@openclaw/matrix-fork",
-        resolvedName: "@openclaw/matrix-fork",
-        resolvedSpec: "@openclaw/matrix-fork@1.2.3",
-        installPath: "/missing/matrix-fork",
+        spec: "@openclaw/bundleddemo-fork",
+        resolvedName: "@openclaw/bundleddemo-fork",
+        resolvedSpec: "@openclaw/bundleddemo-fork@1.2.3",
+        installPath: "/missing/bundleddemo-fork",
       },
     ],
     [
       "clawhub",
       {
         source: "clawhub",
-        spec: "clawhub:@openclaw/matrix-fork@stable",
-        clawhubPackage: "@openclaw/matrix-fork",
-        installPath: "/missing/matrix-fork",
+        spec: "clawhub:@openclaw/bundleddemo-fork@stable",
+        clawhubPackage: "@openclaw/bundleddemo-fork",
+        installPath: "/missing/bundleddemo-fork",
       },
     ],
   ])(
     "keeps %s install records whose package names only share a bundled prefix",
     async (_, record) => {
-      const records = { matrix: record };
+      const records = { bundleddemo: record };
       mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
       mocks.listChannelPluginCatalogEntries.mockReturnValue([
         {
-          id: "matrix",
-          pluginId: "matrix",
+          id: "bundleddemo",
+          pluginId: "bundleddemo",
           origin: "bundled",
           meta: { label: "Matrix" },
           install: {
-            npmSpec: "@openclaw/matrix",
+            npmSpec: "@openclaw/bundleddemo",
           },
         },
       ]);
       mocks.loadPluginMetadataSnapshot.mockReturnValue({
         plugins: [
           {
-            id: "matrix",
+            id: "bundleddemo",
             origin: "bundled",
-            packageName: "@openclaw/matrix",
-            channels: ["matrix"],
+            packageName: "@openclaw/bundleddemo",
+            channels: ["bundleddemo"],
           },
         ],
         diagnostics: [
           {
-            pluginId: "matrix",
+            pluginId: "bundleddemo",
             message: "manifest without channelConfigs metadata",
           },
         ],
       });
-      mockCurrentBundledPlugin("matrix", "@openclaw/matrix");
+      mockCurrentBundledPlugin("bundleddemo", "@openclaw/bundleddemo");
 
       const { repairMissingConfiguredPluginInstalls } =
         await import("./missing-configured-plugin-install.js");
@@ -2090,11 +2107,11 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         cfg: {
           plugins: {
             entries: {
-              matrix: { enabled: true },
+              bundleddemo: { enabled: true },
             },
           },
           channels: {
-            matrix: { enabled: true, homeserver: "https://matrix.example.org" },
+            bundleddemo: { enabled: true, homeserver: "https://bundleddemo.example.org" },
           },
         },
         env: testEnv,

--- a/src/commands/doctor/shared/post-core-plugin-convergence.retirement.test.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.retirement.test.ts
@@ -67,7 +67,7 @@ describe("post-core bundled plugin retirement", () => {
     const bundledRoot = tempDirs.make("openclaw-post-core-bundled-");
     const cfg = {
       update: { channel: "beta" as const },
-      plugins: { allow: ["codex"], entries: { codex: { enabled: true } } },
+      plugins: { allow: ["bundleddemo"], entries: { bundleddemo: { enabled: true } } },
     };
     const env = {
       OPENCLAW_STATE_DIR: stateDir,
@@ -75,14 +75,14 @@ describe("post-core bundled plugin retirement", () => {
       OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
       VITEST: "true",
     };
-    const bundledDir = path.join(bundledRoot, "codex");
+    const bundledDir = path.join(bundledRoot, "bundleddemo");
     fs.mkdirSync(bundledDir, { recursive: true });
     fs.writeFileSync(path.join(bundledDir, "index.js"), "export default {};\n", "utf8");
     fs.writeFileSync(
       path.join(bundledDir, "openclaw.plugin.json"),
       JSON.stringify({
-        id: "codex",
-        name: "codex",
+        id: "bundleddemo",
+        name: "bundleddemo",
         version: VERSION,
         configSchema: { type: "object" },
       }),
@@ -90,40 +90,40 @@ describe("post-core bundled plugin retirement", () => {
     );
     fs.writeFileSync(
       path.join(bundledDir, "package.json"),
-      JSON.stringify({ name: "@openclaw/codex", version: VERSION }),
+      JSON.stringify({ name: "@openclaw/bundleddemo", version: VERSION }),
       "utf8",
     );
     const npmRoot = resolvePluginNpmGenerationProjectDir({
       npmDir: path.join(stateDir, "npm"),
-      packageName: "@openclaw/codex",
-      generationKey: "@openclaw/codex@2026.7.2-beta.7",
+      packageName: "@openclaw/bundleddemo",
+      generationKey: "@openclaw/bundleddemo@2026.7.2-beta.7",
     });
-    const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "codex");
+    const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "bundleddemo");
     fs.mkdirSync(packageDir, { recursive: true });
     fs.writeFileSync(
       path.join(npmRoot, "package.json"),
-      JSON.stringify({ dependencies: { "@openclaw/codex": "2026.7.2-beta.7" } }),
+      JSON.stringify({ dependencies: { "@openclaw/bundleddemo": "2026.7.2-beta.7" } }),
       "utf8",
     );
     fs.writeFileSync(
       path.join(packageDir, "package.json"),
-      JSON.stringify({ name: "@openclaw/codex", version: "2026.7.2-beta.7" }),
+      JSON.stringify({ name: "@openclaw/bundleddemo", version: "2026.7.2-beta.7" }),
       "utf8",
     );
     fs.writeFileSync(
       path.join(packageDir, "openclaw.plugin.json"),
-      JSON.stringify({ id: "codex", name: "codex", configSchema: { type: "object" } }),
+      JSON.stringify({ id: "bundleddemo", name: "bundleddemo", configSchema: { type: "object" } }),
       "utf8",
     );
     await writePersistedInstalledPluginIndexInstallRecords(
       {
-        codex: {
+        bundleddemo: {
           source: "npm",
-          spec: "@openclaw/codex@beta",
+          spec: "@openclaw/bundleddemo@beta",
           installPath: packageDir,
           version: "2026.7.2-beta.7",
-          resolvedName: "@openclaw/codex",
-          resolvedSpec: "@openclaw/codex@2026.7.2-beta.7",
+          resolvedName: "@openclaw/bundleddemo",
+          resolvedSpec: "@openclaw/bundleddemo@2026.7.2-beta.7",
           resolvedVersion: "2026.7.2-beta.7",
         },
       },
@@ -140,26 +140,28 @@ describe("post-core bundled plugin retirement", () => {
       const records =
         params.baselineRecords ??
         (await loadInstalledPluginIndexInstallRecords({ env: params.env }));
-      const codexRecord = records.codex;
-      if (codexRecord) {
+      const bundleddemoRecord = records.bundleddemo;
+      if (bundleddemoRecord) {
         installAttempts += 1;
         const retryRoot = resolvePluginNpmGenerationProjectDir({
           npmDir: path.join(stateDir, "npm"),
-          packageName: "@openclaw/codex",
-          generationKey: `@openclaw/codex@retry-${installAttempts}`,
+          packageName: "@openclaw/bundleddemo",
+          generationKey: `@openclaw/bundleddemo@retry-${installAttempts}`,
         });
-        const retryPackageDir = path.join(retryRoot, "node_modules", "@openclaw", "codex");
+        const retryPackageDir = path.join(retryRoot, "node_modules", "@openclaw", "bundleddemo");
         fs.mkdirSync(retryPackageDir, { recursive: true });
         const nextRecords = {
           ...records,
-          codex: { ...codexRecord, installPath: retryPackageDir },
+          bundleddemo: { ...bundleddemoRecord, installPath: retryPackageDir },
         };
         await writePersistedInstalledPluginIndexInstallRecords(nextRecords, {
           config: cfg,
           env: params.env,
         });
         return {
-          changes: ['Refreshed stale configured plugin "codex" from @openclaw/codex@beta.'],
+          changes: [
+            'Refreshed stale configured plugin "bundleddemo" from @openclaw/bundleddemo@beta.',
+          ],
           warnings: [],
           records: nextRecords,
         };
@@ -182,12 +184,12 @@ describe("post-core bundled plugin retirement", () => {
     expect(projectsAfterFirst).toHaveLength(1);
     expect(fs.readdirSync(path.join(stateDir, "npm", "projects"))).toEqual(projectsAfterFirst);
     expect(await readPersistedInstalledPluginIndexInstallRecords({ env })).not.toHaveProperty(
-      "codex",
+      "bundleddemo",
     );
-    expect(first.installRecords).not.toHaveProperty("codex");
-    expect(second.installRecords).not.toHaveProperty("codex");
+    expect(first.installRecords).not.toHaveProperty("bundleddemo");
+    expect(second.installRecords).not.toHaveProperty("bundleddemo");
     expect(first.changes).toContain(
-      'Removed stale managed install record for bundled plugin "codex".',
+      'Removed stale managed install record for bundled plugin "bundleddemo".',
     );
     expect(second.changes).toEqual([]);
   });

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -34,6 +34,7 @@ import {
   listManagedNpmRootPackageNames,
   listNewManagedNpmRootPackageDirs,
   quarantineManagedNpmProjectRebuildArtifacts,
+  removeEmptyDirectoryIfPresent,
   resolveManagedNpmGenerationUseForInstall,
   resolveManagedNpmInstallRoot,
   resolveManagedNpmRootDependencySpecForInstall,
@@ -621,6 +622,10 @@ export async function installPluginFromManagedNpmRoot(
       logger,
     });
     await cleanupManagedNpmPluginInstallRollbackSnapshot({ snapshot: rollbackSnapshot, logger });
+    // Prepared npm-pack archives must be gone before retiring an empty failed project.
+    await removeEmptyDirectoryIfPresent(npmRoot).catch((error: unknown) =>
+      logger.warn?.(`Failed to remove empty managed npm project ${npmRoot}: ${String(error)}`),
+    );
   };
 
   try {

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -11,7 +11,13 @@ import { runNodeScript } from "../../test/helpers/run-node-script.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePluginNpmProjectDir } from "./install-paths.js";
+import { withPluginInstallRoots } from "./install-root-context.js";
 import { installPluginFromNpmSpec, PLUGIN_INSTALL_ERROR_CODE } from "./install.js";
+import {
+  configWithInstalledPackageTreeBlockPolicy,
+  createInstalledPackageTreePolicyExec,
+} from "./install.npm-spec.test-support.js";
+import { runPluginPayloadSmokeCheck } from "./payload-verification.js";
 import {
   packPlugin,
   registryPackage,
@@ -19,6 +25,7 @@ import {
   startMutableRegistry,
   type RegistryPackage,
 } from "./test-helpers/npm-registry-fixtures.js";
+import { syncPluginsForUpdateChannel } from "./update-channel.js";
 
 const tempDirs = createTempDirTracker();
 const servers: http.Server[] = [];
@@ -54,54 +61,6 @@ function uniquePackageName(prefix: string): string {
 
 async function readJson<T>(filePath: string): Promise<T> {
   return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
-}
-
-const installedPackageTreePolicySource = `
-let input = "";
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => { input += chunk; });
-process.stdin.on("end", () => {
-  const request = JSON.parse(input);
-  if (request.sourcePathKind === "directory") {
-    process.stdout.write(JSON.stringify({
-      protocolVersion: 1,
-      decision: "block",
-      reason: "blocked installed package tree",
-    }));
-    return;
-  }
-  process.stdout.write(JSON.stringify({ protocolVersion: 1, decision: "allow" }));
-});
-`;
-
-async function createInstalledPackageTreePolicyExec(rootDir: string) {
-  if (process.platform === "win32") {
-    return { command: process.execPath, args: ["-e", installedPackageTreePolicySource] };
-  }
-  const command = path.join(rootDir, "install-policy.cjs");
-  await fs.writeFile(command, `#!${process.execPath}\n${installedPackageTreePolicySource}`, "utf8");
-  await fs.chmod(command, 0o700);
-  return { command, args: [] };
-}
-
-function configWithInstalledPackageTreeBlockPolicy(exec: {
-  command: string;
-  args: string[];
-}): OpenClawConfig {
-  return {
-    security: {
-      installPolicy: {
-        enabled: true,
-        exec: {
-          source: "exec",
-          command: exec.command,
-          args: exec.args,
-          timeoutMs: 5000,
-          maxOutputBytes: 16 * 1024,
-        },
-      },
-    },
-  };
 }
 
 function pluginNpmProjectRoot(npmRoot: string, packageName: string): string {
@@ -160,6 +119,66 @@ async function installProjectDependencies(
 }
 
 describe("installPluginFromNpmSpec e2e", () => {
+  it("relocates a bundled plugin through real npm only after artifact consent", async () => {
+    const { rootDir, npmRoot } = await makeInstallFixture("relocation-e2e");
+    const packageName = uniquePackageName("relocated-plugin");
+    await useStaticRegistry([await registryPackage({ packageName, rootDir })]);
+    const bundledPath = path.join(rootDir, "old", "extensions", packageName);
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: { [packageName]: { enabled: true } },
+        load: { paths: [bundledPath] },
+        installs: {
+          [packageName]: { source: "path", sourcePath: bundledPath, installPath: bundledPath },
+        },
+      },
+    };
+    const roots = {
+      npmDir: npmRoot,
+      extensionsDir: path.join(rootDir, "extensions"),
+      gitDir: path.join(rootDir, "git"),
+      stateDir: path.join(rootDir, "state"),
+    };
+    const sync = (accept: boolean) =>
+      withPluginInstallRoots(roots, () =>
+        syncPluginsForUpdateChannel({
+          config,
+          channel: "stable",
+          env: { ...process.env, OPENCLAW_STATE_DIR: roots.stateDir },
+          externalizedBundledPluginBridges: [
+            { bundledPluginId: packageName, npmSpec: packageName },
+          ],
+          ...(accept
+            ? {
+                onCapabilityConsent: async (details: { reviewToken: string }) => ({
+                  reviewToken: details.reviewToken,
+                }),
+              }
+            : {}),
+        }),
+      );
+    const refused = await sync(false);
+    expect(refused.config).toEqual(config);
+    expect(refused.summary.errors).toEqual([
+      expect.objectContaining({
+        pluginId: packageName,
+        code: "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
+      }),
+    ]);
+    const projectDir = pluginNpmProjectRoot(npmRoot, packageName);
+    await expect(fs.access(projectDir)).rejects.toHaveProperty("code", "ENOENT");
+    const accepted = await sync(true);
+    expect(accepted.summary.errors).toEqual([]);
+    expect(accepted.config.plugins?.load?.paths).toEqual([]);
+    expect(accepted.config.plugins?.installs?.[packageName]?.source).toBe("npm");
+    expect(
+      await runPluginPayloadSmokeCheck({
+        records: accepted.config.plugins?.installs ?? {},
+        env: process.env,
+      }),
+    ).toEqual({ checked: [packageName], failures: [] });
+  }, 120_000);
+
   it.each(["plugin", "hook pack"] as const)(
     "does not persist an npm %s when delegated authority closes during download",
     { timeout: 180_000 },

--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -165,6 +165,10 @@ describe("installPluginFromNpmSpec e2e", () => {
         code: "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
       }),
     ]);
+    expect(refused.summary.errors[0]?.message).toContain(
+      "did not install the replacement plugin payload",
+    );
+    expect(refused.summary.errors[0]?.message).not.toContain("payload is missing");
     const projectDir = pluginNpmProjectRoot(npmRoot, packageName);
     await expect(fs.access(projectDir)).rejects.toHaveProperty("code", "ENOENT");
     const accepted = await sync(true);

--- a/src/plugins/install.npm-spec.test-support.ts
+++ b/src/plugins/install.npm-spec.test-support.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const installedPackageTreePolicySource = `
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  const request = JSON.parse(input);
+  if (request.sourcePathKind === "directory") {
+    process.stdout.write(JSON.stringify({
+      protocolVersion: 1,
+      decision: "block",
+      reason: "blocked installed package tree",
+    }));
+    return;
+  }
+  process.stdout.write(JSON.stringify({ protocolVersion: 1, decision: "allow" }));
+});
+`;
+
+export async function createInstalledPackageTreePolicyExec(rootDir: string) {
+  if (process.platform === "win32") {
+    return { command: process.execPath, args: ["-e", installedPackageTreePolicySource] };
+  }
+  const command = path.join(rootDir, "install-policy.cjs");
+  await fs.writeFile(command, `#!${process.execPath}\n${installedPackageTreePolicySource}`, "utf8");
+  await fs.chmod(command, 0o700);
+  return { command, args: [] };
+}
+
+export function configWithInstalledPackageTreeBlockPolicy(exec: {
+  command: string;
+  args: string[];
+}): OpenClawConfig {
+  return {
+    security: {
+      installPolicy: {
+        enabled: true,
+        exec: {
+          source: "exec",
+          command: exec.command,
+          args: exec.args,
+          timeoutMs: 5000,
+          maxOutputBytes: 16 * 1024,
+        },
+      },
+    },
+  };
+}

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -2894,12 +2894,7 @@ describe("installPluginFromNpmSpec", () => {
     if (!result.ok) {
       expect(result.error).toContain("registry unavailable");
     }
-    await expect(
-      fs.promises.access(path.join(npmProjectRoot, "package.json")),
-    ).rejects.toHaveProperty("code", "ENOENT");
-    await expect(
-      fs.promises.access(path.join(npmProjectRoot, "node_modules", "openclaw")),
-    ).rejects.toHaveProperty("code", "ENOENT");
+    await expect(fs.promises.access(npmProjectRoot)).rejects.toHaveProperty("code", "ENOENT");
   });
 
   it.each(["npm", "npm-pack"] as const)(
@@ -2946,6 +2941,52 @@ describe("installPluginFromNpmSpec", () => {
       expect(retry).toMatchObject({ ok: true, pluginId });
       await resolvePluginInstallTransaction(retry)?.commit();
       expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(true);
+    },
+  );
+
+  it.each([
+    { source: "npm", initialProject: "absent" },
+    { source: "npm", initialProject: "empty" },
+    { source: "npm-pack", initialProject: "absent" },
+    { source: "npm-pack", initialProject: "empty" },
+  ] as const)(
+    "removes an $initialProject managed project after refused $source relocation and permits retry",
+    async ({ source, initialProject }) => {
+      const stateDir = suiteTempRootTracker.makeTempDir();
+      const npmRoot = path.join(stateDir, "npm");
+      const packageName = "relocation-fixture";
+      const spec = `${packageName}@1.0.0`;
+      const archivePath = path.join(stateDir, "plugin.tgz");
+      fs.writeFileSync(archivePath, "fixture archive", "utf8");
+      const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
+      if (initialProject === "empty") {
+        fs.mkdirSync(npmProjectRoot, { recursive: true });
+      }
+      mockNpmViewAndInstallMany([
+        { spec, packArchivePath: archivePath, packageName, version: "1.0.0", npmRoot },
+      ]);
+      const refused = new Error("artifact consent refused");
+      const onBeforePluginArtifactCommit = vi.fn(async () => {});
+      onBeforePluginArtifactCommit.mockRejectedValueOnce(refused);
+      const install = () => {
+        const params = {
+          npmDir: npmRoot,
+          mode: "update" as const,
+          onBeforePluginArtifactCommit,
+        };
+        return source === "npm"
+          ? installPluginFromNpmSpec({ ...params, spec })
+          : installPluginFromNpmPackArchive({ ...params, archivePath });
+      };
+      await expect(install()).rejects.toBe(refused);
+      expect(fs.existsSync(npmProjectRoot)).toBe(false);
+      const retry = await install();
+      expect(retry).toMatchObject({ ok: true, pluginId: packageName });
+      expect(
+        fs.existsSync(
+          path.join(resolveTestPluginPackageDir(npmRoot, packageName), "dist", "index.js"),
+        ),
+      ).toBe(true);
     },
   );
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -19,6 +19,7 @@ import {
   getOfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogEntryForPackage,
   getOfficialExternalPluginCatalogManifest,
+  isExternallyDistributedPlugin,
   isOfficialExternalPluginId,
   isOfficialExternalPluginCatalogFeed,
   listOfficialExternalChannelEnvVars,
@@ -330,6 +331,23 @@ describe("official external plugin catalog", () => {
     expect(source).not.toMatch(/from ["']\.\.\/infra\/net\/fetch-guard\.js["']/);
     expect(source).toContain('await import("../infra/net/fetch-guard.js")');
   });
+
+  it.each([
+    { pluginId: "google-meet", packageName: "@openclaw/google-meet", external: true },
+    { pluginId: "google-meet", packageName: "@example/google-meet", external: false },
+    { pluginId: "other-plugin", packageName: "@openclaw/google-meet", external: false },
+    {
+      pluginId: "source-external",
+      packageName: "@example/source-external",
+      packageBuild: { bundledDist: false },
+      external: true,
+    },
+  ])(
+    "classifies distribution ownership for $pluginId from $packageName",
+    ({ external, ...plugin }) => {
+      expect(isExternallyDistributedPlugin(plugin)).toBe(external);
+    },
+  );
 
   it("ships the official plugin catalog as a feed-shaped bundled fallback", () => {
     expect(isOfficialExternalPluginCatalogFeed(officialExternalPluginCatalog)).toBe(true);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1618,4 +1618,17 @@ export function getOfficialExternalPluginCatalogEntryForPackage(
     (entry) => normalizeOptionalString(entry.name) === normalized,
   );
 }
+
+/** Source discovery alone does not make an external package part of the core distribution. */
+export function isExternallyDistributedPlugin(plugin: {
+  pluginId: string;
+  packageName?: string;
+  packageBuild?: { bundledDist?: boolean };
+}): boolean {
+  const entry = getOfficialExternalPluginCatalogEntryForPackage(plugin.packageName);
+  return (
+    plugin.packageBuild?.bundledDist === false ||
+    (entry !== undefined && resolveOfficialExternalPluginId(entry) === plugin.pluginId)
+  );
+}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/update-channel.consent.test.ts
+++ b/src/plugins/update-channel.consent.test.ts
@@ -173,7 +173,10 @@ describe("channel migration artifact consent", () => {
         expect(result.summary.errors).toEqual([
           expect.objectContaining({ pluginId, code: PLUGIN_CAPABILITY_CONSENT_REQUIRED }),
         ]);
-        expect(result.summary.errors[0]?.message).toContain("external plugin payload is missing");
+        expect(result.summary.errors[0]?.message).not.toContain("payload is missing");
+        expect(result.summary.errors[0]?.message).toContain(
+          "did not install the replacement plugin payload",
+        );
         expect(result.summary.errors[0]?.message).toContain("openclaw update repair");
         if (source !== "npm") {
           expect(result.summary.errors[0]?.message).toContain(`(ClawHub clawhub:${pluginId}).`);

--- a/src/plugins/update-channel.consent.test.ts
+++ b/src/plugins/update-channel.consent.test.ts
@@ -173,6 +173,8 @@ describe("channel migration artifact consent", () => {
         expect(result.summary.errors).toEqual([
           expect.objectContaining({ pluginId, code: PLUGIN_CAPABILITY_CONSENT_REQUIRED }),
         ]);
+        expect(result.summary.errors[0]?.message).toContain("external plugin payload is missing");
+        expect(result.summary.errors[0]?.message).toContain("openclaw update repair");
         if (source !== "npm") {
           expect(result.summary.errors[0]?.message).toContain(`(ClawHub clawhub:${pluginId}).`);
         }

--- a/src/plugins/update-channel.ts
+++ b/src/plugins/update-channel.ts
@@ -283,7 +283,7 @@ export async function syncPluginsForUpdateChannel(params: {
         if (clawHubTrustWarning) {
           summary.warnings.push(clawHubTrustWarning);
         }
-        const message =
+        const failure =
           installSource === "clawhub"
             ? formatClawHubInstallFailure({
                 pluginId: targetPluginId,
@@ -297,6 +297,7 @@ export async function syncPluginsForUpdateChannel(params: {
                 phase: "update",
                 result,
               });
+        const message = `${failure}\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.`;
         summary.errors.push({ pluginId: targetPluginId, message, code: result.code });
         logger.error?.(message);
         continue;

--- a/src/plugins/update-channel.ts
+++ b/src/plugins/update-channel.ts
@@ -297,7 +297,7 @@ export async function syncPluginsForUpdateChannel(params: {
                 phase: "update",
                 result,
               });
-        const message = `${failure}\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.`;
+        const message = `${failure}\nBundled relocation did not install the replacement plugin payload; resolve the error above, then run "openclaw update repair".`;
         summary.errors.push({ pluginId: targetPluginId, message, code: result.code });
         logger.error?.(message);
         continue;

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -5388,7 +5388,7 @@ describe("syncPluginsForUpdateChannel", () => {
         pluginId: "legacy-chat",
         code: "package_not_found",
         message:
-          'Failed to update legacy-chat: Package not found on ClawHub. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.',
+          'Failed to update legacy-chat: Package not found on ClawHub. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).\nBundled relocation did not install the replacement plugin payload; resolve the error above, then run "openclaw update repair".',
       },
     ]);
   });
@@ -5484,7 +5484,7 @@ describe("syncPluginsForUpdateChannel", () => {
         pluginId: "legacy-chat",
         code: "archive_integrity_mismatch",
         message:
-          'Failed to update legacy-chat: ClawHub ClawPack integrity mismatch. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.',
+          'Failed to update legacy-chat: ClawHub ClawPack integrity mismatch. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).\nBundled relocation did not install the replacement plugin payload; resolve the error above, then run "openclaw update repair".',
       },
     ]);
   });
@@ -5558,7 +5558,7 @@ describe("syncPluginsForUpdateChannel", () => {
       {
         pluginId: "legacy-chat",
         message:
-          'Failed to update legacy-chat: package unavailable\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.',
+          'Failed to update legacy-chat: package unavailable\nBundled relocation did not install the replacement plugin payload; resolve the error above, then run "openclaw update repair".',
       },
     ]);
   });

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -5388,7 +5388,7 @@ describe("syncPluginsForUpdateChannel", () => {
         pluginId: "legacy-chat",
         code: "package_not_found",
         message:
-          "Failed to update legacy-chat: Package not found on ClawHub. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).",
+          'Failed to update legacy-chat: Package not found on ClawHub. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.',
       },
     ]);
   });
@@ -5484,7 +5484,7 @@ describe("syncPluginsForUpdateChannel", () => {
         pluginId: "legacy-chat",
         code: "archive_integrity_mismatch",
         message:
-          "Failed to update legacy-chat: ClawHub ClawPack integrity mismatch. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).",
+          'Failed to update legacy-chat: ClawHub ClawPack integrity mismatch. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.',
       },
     ]);
   });
@@ -5555,7 +5555,11 @@ describe("syncPluginsForUpdateChannel", () => {
     expect(result.changed).toBe(false);
     expect(result.config).toBe(config);
     expect(result.summary.errors).toEqual([
-      { pluginId: "legacy-chat", message: "Failed to update legacy-chat: package unavailable" },
+      {
+        pluginId: "legacy-chat",
+        message:
+          'Failed to update legacy-chat: package unavailable\nThe external plugin payload is missing after bundled relocation; run "openclaw update repair" to retry installation.',
+      },
     ]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #134353.

A failed bundled-to-external relocation could leave an empty managed npm project, while Doctor could delete a valid external companion and its install record merely because a source-full checkout also discovered the plugin as bundled. A partial package with a missing runtime entry could then escape the configured-plugin repair pass.

## Why This Change Was Made

Distribution ownership belongs to the plugin catalog, not discovery origin. Both retirement owners now consume one predicate that recognizes the exact official catalog package plus canonical plugin ID, or an explicit external-distribution build declaration. Core-bundled retirement remains intact; its package matching reuses the existing record parser instead of maintaining a second implementation.

Managed npm cleanup removes an empty project only after prepared npm-pack archives and rollback snapshots have been cleaned. It preserves restored/nonempty projects and the original install failure. Configured-plugin health repair now recognizes the discovery owner's missing-entry diagnostic. Failed relocation reports that the replacement payload was not installed, preserves the underlying error, and directs the operator to resolve it before `openclaw update repair`. It does not claim an existing retained payload is absent or change genuine capability-consent requirements.

## User Impact

Doctor preserves externally distributed companions and their install records in source-full checkouts, including on repeated runs. Missing or empty recorded payloads are reinstalled, and a reported missing runtime entry is repaired. Failed relocations no longer leave a zero-file project directory. The update CLI documentation explains recovery.

No new config, environment, persistence schema, or compatibility surface. Production delta: +30/-32 (net -2); tests/test-support: +831/-514 (includes fixture moves); docs: +10/-0. The removed production lines are duplicate package-record parsing within the same retirement owner.

Registry-unavailable source-copy fallback is not added: selecting a different distribution would require reconciling the active install record and operator intent. A failed fetch remains an explicit error, not a claimed successful recovery. Broader unchanged-version multi-entry/setup validation remains a follow-up in `src/plugins/update-installed.ts`.

## Evidence

Failing-before evidence was captured before each corresponding production fix, without stash:

- Repeated Doctor-order preservation: the catalog-owned and explicitly external fixtures lost their package (`expected false to be true`). The independent record-retirement test observed an empty replacement install-record map.
- `removes an $initialProject managed project after refused $source relocation and permits retry`: all npm/npm-pack × absent/empty cases retained the empty project (`expected true to be false`).
- Partial-package discovery reported a missing runtime entry, but the real configured-plugin health detector returned no repair issue (`[]`).

Passing-after verification and CI details are recorded below before landing. The Doctor-order tests use real registry state, filesystem, and repair orchestration; only the package download/install boundary is substituted. They exercise registry cleanup followed by health detection and record repair twice, including a real artifact-consent callback. The real-npm relocation scenario uses a synthetic local registry and package, not a production account.

Passing local proof:

- `pnpm test src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/doctor-plugin-registry.test.ts src/plugins/official-external-plugin-catalog.test.ts` — 215 tests passed.
- `pnpm test src/plugins/install.npm-spec.test.ts src/plugins/update-channel.consent.test.ts` — 110 tests passed.
- Focused post-core convergence/retirement suites — 33 tests passed.
- `pnpm test src/plugins/update.test.ts src/commands/doctor-plugin-registry.test.ts` — 195 tests passed on the final diff.
- `pnpm test src/plugins/install.npm-spec.e2e.test.ts -t 'relocates a bundled plugin'` — passed using real npm and a local synthetic registry; the test took 6.4 seconds after the full runtime build.
- Uncommitted Codex autoreview: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority` (exit 0, default P0 scope).

The first real-npm attempt failed in fixture setup because npm 12 returns keyed-object `npm pack --json` output. The initial fixture correction was superseded during conflict resolution by the shared npm registry fixture landed in #135736, which already uses the canonical npm JSON parser for both output shapes. Earlier expected-message and synthetic core-bundled fixtures were updated to preserve their original coverage under the corrected external-distribution contract. No budgets, snapshots, or ignore lists were changed.

- `node scripts/check-changed.mjs -- <all 17 changed paths>` — exit 0, including core/test typechecks, lint, dead-export scans, and repository guards. Captured before the mechanical E2E fixture rebase; production code is unchanged by that rebase.
- `pnpm test src/plugins/install.npm-spec.e2e.test.ts` — all 13 pre-rebase scenarios passed, including the moved policy fixtures. All 15 scenarios also passed after rebase, including both newly landed upstream boundary cases.
- File-limit failures were fixed by extracting reusable test fixtures; no limit, baseline, or suppression was changed.

ClawSweeper diagnostic finding addressed: 12 updated assertions failed against the inaccurate missing-payload wording, then all 305 requested focused tests passed after the correction. Consent retention and integrity failures preserve their actual cause and never claim an existing payload is missing. See the review-response comment for details.

Final-head real-npm relocation verification passed with explicit assertions for accurate failure wording, empty-project cleanup, approved retry, and static payload validation. Final branch autoreview exited 0 with no accepted/actionable findings.

CI found two stale exact-message expectations in the update/finalize CLI integration test. Updated the single expectation without weakening consent or restart assertions; `pnpm test src/cli/update-cli.test.ts` passes all 357 tests. The original failing job and correction are linked in the CI follow-up comment.

Final validation: exact-head CI for `90232da008e37d1373b8cb58528ea753bb54a697` completed successfully with zero pending checks: https://github.com/openclaw/openclaw/actions/runs/33583314865 . The latest ClawSweeper review has no actionable findings; its remaining wait-for-CI move is satisfied. Native review artifacts validated and `prepare-run complete for PR #135791` succeeded.
