### PR TITLE
test(infra): await Web Push sends before fixture cleanup

### DIFF
--- a/src/infra/push-web.test.ts
+++ b/src/infra/push-web.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import webPush from "web-push";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
   insertOperatorApproval,
   resolveOperatorApproval,
@@ -90,13 +91,47 @@ vi.mock("web-push", () => ({
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "push-web-test-"));
   vi.clearAllMocks();
-  vi.mocked(webPush.sendNotification).mockResolvedValue({ statusCode: 201 } as never);
+  vi.mocked(webPush.sendNotification)
+    .mockReset()
+    .mockResolvedValue({ statusCode: 201 } as never);
 });
 
 afterEach(async () => {
   closeOpenClawStateDatabase();
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
+
+function startExpiredWebPushBroadcast(payload: Parameters<typeof broadcastWebPush>[0]) {
+  const started = createDeferred();
+  const release = createDeferred();
+  vi.mocked(webPush.sendNotification).mockImplementationOnce(async () => {
+    started.resolve();
+    await release.promise;
+    throw Object.assign(new Error("gone"), { statusCode: 410 });
+  });
+  const broadcast = broadcastWebPush(payload, tmpDir);
+  const finish = () => {
+    release.resolve();
+    return broadcast;
+  };
+  return {
+    started: withTestTimeout(
+      Promise.race([
+        started.promise,
+        broadcast.then(() => {
+          throw new Error("Web Push broadcast completed before send started");
+        }),
+      ]),
+      1_000,
+      "Web Push send did not start",
+    ),
+    finish,
+    // Join the send before afterEach removes the real SQLite fixture, even when a case fails.
+    async [Symbol.asyncDispose]() {
+      await finish();
+    },
+  };
+}
 
 describe("resolveVapidKeys", () => {
   it("generates one durable SQLite VAPID identity", async () => {
@@ -772,23 +807,14 @@ describe("sending", () => {
   it("does not delete a subscription re-registered during an expired send", async () => {
     const endpoint = "https://push.example.com/reregistered";
     await registerWebPushSubscription({ endpoint, keys, baseDir: tmpDir });
-    let rejectSend: ((error: unknown) => void) | undefined;
-    vi.mocked(webPush.sendNotification).mockImplementationOnce(
-      () =>
-        new Promise((_, reject) => {
-          rejectSend = reject;
-        }),
-    );
-
-    const broadcast = broadcastWebPush({ title: "Race" }, tmpDir);
-    await vi.waitFor(() => expect(rejectSend).toBeTypeOf("function"));
+    await using broadcast = startExpiredWebPushBroadcast({ title: "Race" });
+    await broadcast.started;
     const replacement = await registerWebPushSubscription({
       endpoint,
       keys: { p256dh: "replacement-p256dh", auth: "replacement-auth" },
       baseDir: tmpDir,
     });
-    rejectSend?.(Object.assign(new Error("gone"), { statusCode: 410 }));
-    await broadcast;
+    await broadcast.finish();
 
     expect(listWebPushSubscriptions(tmpDir)).toEqual([replacement]);
   });
@@ -796,16 +822,8 @@ describe("sending", () => {
   it("does not delete an expired subscription after a legacy claim appears", async () => {
     const endpoint = "https://push.example.com/pending-claim";
     const subscription = await registerWebPushSubscription({ endpoint, keys, baseDir: tmpDir });
-    let rejectSend: ((error: unknown) => void) | undefined;
-    vi.mocked(webPush.sendNotification).mockImplementationOnce(
-      () =>
-        new Promise((_, reject) => {
-          rejectSend = reject;
-        }),
-    );
-
-    const broadcast = broadcastWebPush({ title: "Race" }, tmpDir);
-    await vi.waitFor(() => expect(rejectSend).toBeTypeOf("function"));
+    await using broadcast = startExpiredWebPushBroadcast({ title: "Race" });
+    await broadcast.started;
     const pushDir = path.join(tmpDir, "push");
     await fs.mkdir(pushDir, { recursive: true });
     await fs.writeFile(
@@ -813,9 +831,8 @@ describe("sending", () => {
       "{}",
       "utf8",
     );
-    rejectSend?.(Object.assign(new Error("gone"), { statusCode: 410 }));
 
-    await expect(broadcast).resolves.toEqual([
+    await expect(broadcast.finish()).resolves.toEqual([
       expect.objectContaining({ ok: false, statusCode: 410 }),
     ]);
     expect(listWebPushSubscriptions(tmpDir)).toEqual([subscription]);
@@ -825,23 +842,14 @@ describe("sending", () => {
     const endpoint = "https://push.example.com/expired";
     await registerWebPushSubscription({ endpoint, keys, baseDir: tmpDir });
     await resolveVapidKeys(tmpDir);
-    let rejectSend: ((error: unknown) => void) | undefined;
-    vi.mocked(webPush.sendNotification).mockImplementationOnce(
-      () =>
-        new Promise((_, reject) => {
-          rejectSend = reject;
-        }),
-    );
-
-    const broadcast = broadcastWebPush({ title: "Expired" }, tmpDir);
-    await vi.waitFor(() => expect(rejectSend).toBeTypeOf("function"));
+    await using broadcast = startExpiredWebPushBroadcast({ title: "Expired" });
+    await broadcast.started;
     closeOpenClawStateDatabase();
     const databasePath = path.join(tmpDir, "state", "openclaw.sqlite");
     await fs.rename(databasePath, `${databasePath}.backup`);
     await fs.mkdir(databasePath);
-    rejectSend?.(Object.assign(new Error("gone"), { statusCode: 410 }));
 
-    await expect(broadcast).resolves.toEqual([
+    await expect(broadcast.finish()).resolves.toEqual([
       expect.objectContaining({ ok: false, statusCode: 410 }),
     ]);
   });


### PR DESCRIPTION
Three Web Push race tests polled every 50 ms to discover when their mocked transport had started. If a case failed after that start, its pending send could survive fixture teardown; a controlled late release then reopened the removed SQLite database. Reuse the existing deferred/timeout helpers for an explicit start signal and give the broadcast an async disposer that releases and joins it before afterEach closes the database and removes the directory.

The real SQLite race coverage remains: re-registration protects the replacement row, a newly appeared legacy claim protects its subscription, and cleanup failure preserves the expired-send result. Reset the transport mock between cases so queued one-shot behavior cannot cross fixture boundaries. Production/schema/configuration delta0; test+45/-37. Three polling waits and duplicate transport gates are removed; no normal-runtime ratio is claimed.

All28 cases pass before and after in the private canonical runner, and all28 pass in the current checkout. Actual assertion-failure probes retain the same AssertionError: the original removes its directory with the send pending, then a recorded owned late release recreates the database; the candidate releases and joins before closing/removal and does not recreate it. Normal traces retain SQL mutation-before-release ordering. The63 native database opens/closes balance;58 roots and all eight recorded PIDs/four groups were cleaned. This does not claim general cancellation of permanently hung preparation.

Full changed-file infra test types, guards, boundary, three dead-export scans and lint pass. Independent Codex review and complete manual owner/caller/dependency/history/lower-priority/deslop review found no actionable issue. Reviewed Web Push transport, SQLite store/cache and Gateway callers remain unchanged from the private proof pin. The local fs-safe0.5.6 versus locked0.7.0 dependency difference is disclosed; locked hosted CI is required. No test deadline, production behavior, SQL schema or public API changes.
