### PR TITLE
refactor(e2e): share OpenClaw state path resolution

### DIFF
--- a/scripts/e2e/lib/codex-install-utils.mjs
+++ b/scripts/e2e/lib/codex-install-utils.mjs
@@ -2,17 +2,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { readJson } from "./fixtures/common.mjs";
+import {
+  resolveOpenClawConfigPath as configPath,
+  resolveOpenClawStateDir as stateDir,
+} from "./openclaw-state-paths.mjs";
 import { readPluginInstallRecords } from "./plugin-index-sqlite.mjs";
 
-export { readJson };
-
-export function stateDir() {
-  return process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME, ".openclaw");
-}
-
-export function configPath() {
-  return process.env.OPENCLAW_CONFIG_PATH || path.join(stateDir(), "openclaw.json");
-}
+export { configPath, readJson, stateDir };
 
 export function managedNpmRoot() {
   return path.join(stateDir(), "npm");

--- a/scripts/e2e/lib/live-plugin-tool/assertions.mjs
+++ b/scripts/e2e/lib/live-plugin-tool/assertions.mjs
@@ -5,6 +5,10 @@ import { DatabaseSync } from "node:sqlite";
 import { isRecord } from "../../../lib/record-shared.mjs";
 import { extractAgentReplyTexts } from "../agent-turn-output.mjs";
 import { readPositiveIntEnv } from "../env-limits.mjs";
+import {
+  resolveOpenClawConfigPath as configPath,
+  resolveOpenClawStateDir as stateDir,
+} from "../openclaw-state-paths.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
 import { readTextFileTail, tailText } from "../text-file-utils.mjs";
 
@@ -36,14 +40,6 @@ function requireEnv(name) {
     throw new Error(`missing ${name}`);
   }
   return value;
-}
-
-function stateDir() {
-  return process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME, ".openclaw");
-}
-
-function configPath() {
-  return process.env.OPENCLAW_CONFIG_PATH || path.join(stateDir(), "openclaw.json");
 }
 
 function agentOutputPath() {

--- a/scripts/e2e/lib/openclaw-state-paths.mjs
+++ b/scripts/e2e/lib/openclaw-state-paths.mjs
@@ -1,0 +1,9 @@
+import path from "node:path";
+
+export function resolveOpenClawStateDir() {
+  return process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME, ".openclaw");
+}
+
+export function resolveOpenClawConfigPath() {
+  return process.env.OPENCLAW_CONFIG_PATH || path.join(resolveOpenClawStateDir(), "openclaw.json");
+}

--- a/scripts/e2e/lib/plugin-index-sqlite.mjs
+++ b/scripts/e2e/lib/plugin-index-sqlite.mjs
@@ -3,6 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { readPositiveIntEnv } from "./env-limits.mjs";
+import {
+  resolveOpenClawConfigPath as configPath,
+  resolveOpenClawStateDir as stateDir,
+} from "./openclaw-state-paths.mjs";
 import { readTextFileBounded } from "./text-file-utils.mjs";
 
 const STATE_KEY = "plugins.installedIndex";
@@ -12,14 +16,6 @@ const JSON_ARTIFACT_MAX_BYTES = readPositiveIntEnv(
   "OPENCLAW_PLUGIN_INDEX_JSON_MAX_BYTES",
   1024 * 1024,
 );
-
-function stateDir() {
-  return process.env.OPENCLAW_STATE_DIR || path.join(process.env.HOME, ".openclaw");
-}
-
-function configPath() {
-  return process.env.OPENCLAW_CONFIG_PATH || path.join(stateDir(), "openclaw.json");
-}
 
 function readJsonMaybe(file) {
   let text;

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -239,6 +239,7 @@ function copySurvivorCaptureClosure(workDir: string) {
   const library = join(workDir, "lib");
   mkdirSync(join(library, "upgrade-survivor"), { recursive: true });
   for (const name of [
+    "openclaw-state-paths.mjs",
     "plugin-index-sqlite.mjs",
     "env-limits.mjs",
     "text-file-utils.mjs",

--- a/test/scripts/openclaw-state-paths.test.ts
+++ b/test/scripts/openclaw-state-paths.test.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  resolveOpenClawConfigPath as resolveConfig,
+  resolveOpenClawStateDir as resolveState,
+} from "../../scripts/e2e/lib/openclaw-state-paths.mjs";
+import { withEnv } from "../../src/test-utils/env.js";
+
+const home = path.join(path.sep, "tmp", "openclaw-home");
+const state = path.join(path.sep, "tmp", "openclaw-state");
+const rawState = `${state}/../raw `;
+const rawConfig = " ./raw config.json ";
+
+describe("OpenClaw E2E state paths", () => {
+  it.each([
+    ["returns raw state path bytes", resolveState, [home, undefined, rawState], rawState],
+    ["preserves whitespace state overrides", resolveState, [home, undefined, " \t "], " \t "],
+    [
+      "falls back from an empty state override",
+      resolveState,
+      [home, undefined, ""],
+      path.join(home, ".openclaw"),
+    ],
+    [
+      "returns a config override without resolving HOME",
+      resolveConfig,
+      [undefined, rawConfig, undefined],
+      rawConfig,
+    ],
+    [
+      "falls back from an empty config override via state",
+      resolveConfig,
+      [undefined, "", state],
+      path.join(state, "openclaw.json"),
+    ],
+  ])("%s", (_name, resolve, [HOME, OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR], expected) => {
+    withEnv({ HOME, OPENCLAW_CONFIG_PATH, OPENCLAW_STATE_DIR }, () =>
+      expect(resolve()).toBe(expected),
+    );
+  });
+
+  it.each([
+    ["state", resolveState],
+    ["config", resolveConfig],
+  ])("rejects missing HOME for the default %s path", (_name, resolve) => {
+    withEnv(
+      { HOME: undefined, OPENCLAW_CONFIG_PATH: undefined, OPENCLAW_STATE_DIR: undefined },
+      () => expect(resolve).toThrow(TypeError),
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Private E2E harnesses repeated the same OpenClaw state and config path resolution in three places. Keeping the same environment precedence in separate helpers made raw override handling, empty-value fallback, and missing-`HOME` behavior vulnerable to drift.

## Why This Change Was Made

The private E2E harness now owns one leaf module, `scripts/e2e/lib/openclaw-state-paths.mjs`, for the shared path policy. Codex install utilities preserve their existing `stateDir` and `configPath` exports, while the live plugin and plugin-index harnesses import the same implementation under their existing local names.

Removed paths:

- local resolver pair in `scripts/e2e/lib/codex-install-utils.mjs`
- local resolver pair in `scripts/e2e/lib/live-plugin-tool/assertions.mjs`
- local resolver pair in `scripts/e2e/lib/plugin-index-sqlite.mjs`

The release marketplace resolver remains local and unchanged because its `HOME ?? ""` behavior intentionally resolves a missing home differently. No core, plugin, SDK, config, or public API surface was added.

## User Impact

No user-visible behavior changes. E2E harnesses resolve the same state and config paths through one private owner.

## Evidence

Exact tested base: `54a9f3481d87916617414315cdde3e1cc42330e3`

Exact signed head: `d3168a24d805e6059851a9585d0c0e3b0155c19b`

The rebase preserved the original stable patch ID `364af6eb4d3ea5d9e88e768fc18cb4bc5737d416`; `git range-diff` reported the original and rebased commits as identical.

Semantic matrix:

| Input | Preserved result |
| --- | --- |
| truthy state override | returned byte-for-byte |
| whitespace state override | returned byte-for-byte |
| empty state override | falls back to `HOME/.openclaw` |
| truthy config override | returned byte-for-byte without evaluating state or `HOME` |
| empty config override | falls through to the resolved state directory |
| missing `HOME` without an override | preserves the existing `TypeError` |

Focused proof:

```text
81 tests passed:
- 7 shared path semantic cases
- 70 caller/owner tests
- 4 isolated copied-closure tests
```

Exact-head gates:

- `node scripts/check-changed.mjs --dry-run -- <six changed files>` selected `testRoot` and `tooling`
- `node scripts/check-changed.mjs -- <six changed files>` passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- `pnpm check:madge-import-cycles`: 0 cycles
- `git diff --check`: passed
- autoreview with `gpt-5.6-sol` at high reasoning: scoped-clean, `0.99`

Open-PR overlap was rechecked on September 2, 2026. The earlier audit found twelve hunk-disjoint changes in `test/scripts/docker-build-helper.test.ts`; four other PRs remain open now: #135671, #134785, #134454, and #134047. Their hunks are in unrelated test regions. No open PR touches the resolver/helper files or the semantic path test.

LOC:

- production runtime: `0`
- tooling: `+22/-25`, net `-3`
- tests and test support: `+52/-0`

Testbox and Crabbox were not used. The local changed gate passed on the exact head; hosted exact-head CI is still required before landing.

Codex contract check: `codex-rs/cli/src/main.rs:220-245` owns CLI command declarations, and `codex-rs/cli/src/main.rs:2840-2870` owns prompt normalization and completion generation. Neither path owns OpenClaw E2E state/config resolution.
