### PR TITLE
fix(android): offer recording when dictation is unavailable

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatDictation.kt
@@ -101,10 +101,6 @@ internal class AndroidChatDictationRecognizer(
     generation += 1
     val operation = generation
     retireRecognizer()
-    if (!isAvailable) {
-      onEvent(ChatDictationRecognitionEvent.Error(SpeechRecognizer.ERROR_SERVER_DISCONNECTED))
-      return
-    }
     val active = SpeechRecognizer.createOnDeviceSpeechRecognizer(appContext)
     active.setRecognitionListener(
       object : RecognitionListener {
@@ -205,8 +201,6 @@ internal class ChatDictationController(
   private val lock = Any()
   private val _state = MutableStateFlow<ChatDictationState>(ChatDictationState.Idle)
   val state: StateFlow<ChatDictationState> = _state.asStateFlow()
-  val isAvailable: Boolean
-    get() = recognizer.isAvailable
 
   private var completion: CompletableDeferred<String?>? = null
   private var ownsMic = false

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -927,6 +927,7 @@ fun ChatScreen(
       voiceNoteLevel = voiceNoteLevel,
       recordVoiceNoteEnabled =
         !talkActive &&
+          !composerOwner.gatewayStableId.isNullOrBlank() &&
           pendingRunCount == 0 &&
           !micCaptureActive &&
           !dictationActive &&

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -940,6 +940,7 @@ fun ChatScreen(
             composerState.cancelMediaAcquisition(mediaAuthorizationId)
             return@launch
           }
+          dictationController.cancel()
           if (voiceNoteRecorder.start(recordingId)) {
             if (
               viewModel.isCurrentChatComposerOwner(ownerSnapshot) &&
@@ -2579,6 +2580,9 @@ private fun ChatComposer(
 
     VoiceNoteRecorderError(voiceNoteState)
     ChatDictationError(dictationState)
+    if (recordVoiceNoteEnabled && (dictationState as? ChatDictationState.Failure)?.reason == ChatDictationFailure.Unavailable) {
+      TextButton(onClick = onStartVoiceNote) { Text(voiceNoteRecordLabel()) }
+    }
 
     if (!healthOk && gatewayOffline) {
       ChatOfflineNotice(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -187,7 +187,7 @@ class ChatComposerLayoutTest {
     val recognitionAvailable = SpeechRecognizer.isOnDeviceRecognitionAvailable(app)
     ShadowSpeechRecognizer.setIsOnDeviceRecognitionAvailable(false)
     try {
-      showChat(viewportWidth = 320.dp)
+      val viewModel = showChat(viewportWidth = 320.dp)
       composeRule.runOnIdle {
         controller.handleGatewayEvent(
           "agent",
@@ -217,6 +217,20 @@ class ChatComposerLayoutTest {
       composeRule.onNodeWithText(nativeString("On-device speech recognition is unavailable.")).assertDoesNotExist()
       composeRule.onNodeWithText(nativeString("Record voice note")).assertDoesNotExist()
       editor.assertTextEquals("Existing draft")
+
+      composeRule.runOnIdle { viewModel.forgetGateway(AndroidScreenshotFixture.gatewayId) }
+      composeRule.waitUntil {
+        viewModel.activeGatewayStableId.value == null &&
+          prefs.gatewayRegistry.entries.value
+            .isEmpty()
+      }
+      assertTrue("Forgetting the last gateway leaves Chat accessible", viewModel.onboardingCompleted.value)
+      editor.performTextReplacement("Draft after forgetting")
+      dictation.performClick()
+      composeRule.onNodeWithText(nativeString("On-device speech recognition is unavailable.")).assertIsDisplayed()
+      composeRule.onNodeWithText(nativeString("Record voice note")).assertDoesNotExist()
+      dictation.assert(SemanticsMatcher.keyNotDefined(SemanticsActions.OnLongClick))
+      editor.assertTextEquals("Draft after forgetting")
     } finally {
       ShadowSpeechRecognizer.setIsOnDeviceRecognitionAvailable(recognitionAvailable)
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -10,12 +10,15 @@ import ai.openclaw.app.NodeRuntimeMode
 import ai.openclaw.app.R
 import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.chat.ChatController
+import ai.openclaw.app.gateway.GatewayRegistryEntry
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.i18n.NativeStringResources
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawTheme
 import android.content.Context
 import android.provider.Settings
+import android.speech.SpeechRecognizer
 import android.view.KeyEvent
 import android.view.inspector.WindowInspector
 import androidx.compose.foundation.background
@@ -79,6 +82,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowSpeechRecognizer
 import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
@@ -168,6 +172,54 @@ class ChatComposerLayoutTest {
     editor.performTextReplacement("")
     assertComposerControlsVisible(primaryAction = "Start Talk")
     composeRule.onNodeWithContentDescription(nativeString("Send")).assertDoesNotExist()
+  }
+
+  @Test
+  fun unavailableDictationOffersExplicitVoiceNoteRecoveryWithoutChangingTheDraft() {
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(
+        stableId = AndroidScreenshotFixture.gatewayId,
+        kind = GatewayRegistryEntryKind.MANUAL,
+        name = "Test gateway",
+      ),
+    )
+    prefs.gatewayRegistry.setActive(AndroidScreenshotFixture.gatewayId)
+    val recognitionAvailable = SpeechRecognizer.isOnDeviceRecognitionAvailable(app)
+    ShadowSpeechRecognizer.setIsOnDeviceRecognitionAvailable(false)
+    try {
+      showChat(viewportWidth = 320.dp)
+      composeRule.runOnIdle {
+        controller.handleGatewayEvent(
+          "agent",
+          """{"sessionKey":"${AndroidScreenshotFixture.mainSessionKey}","runId":"android-screenshot-active-run","seq":1,"stream":"lifecycle","data":{"phase":"end"}}""",
+        )
+      }
+      val editor = composeRule.onNode(hasSetTextAction())
+      editor.performTextReplacement("Existing draft")
+      val dictation =
+        composeRule.onNode(
+          SemanticsMatcher("dictation control") { node ->
+            node.config.getOrNull(SemanticsActions.OnClick)?.label == nativeString("Dictation")
+          },
+        )
+      dictation.performClick()
+
+      composeRule.onNodeWithText(nativeString("On-device speech recognition is unavailable.")).assertIsDisplayed()
+      composeRule.onNodeWithText("Microphone permission is required to record a voice note.").assertDoesNotExist()
+      composeRule.onNodeWithContentDescription(nativeString("Cancel voice note")).assertDoesNotExist()
+      dictation.assertIsDisplayed()
+      editor.assertTextEquals("Existing draft")
+
+      val recovery = composeRule.onNodeWithText(nativeString("Record voice note")).assertIsDisplayed().assertHasClickAction()
+      recovery.performClick()
+
+      composeRule.onNodeWithText("Microphone permission is required to record a voice note.").assertIsDisplayed()
+      composeRule.onNodeWithText(nativeString("On-device speech recognition is unavailable.")).assertDoesNotExist()
+      composeRule.onNodeWithText(nativeString("Record voice note")).assertDoesNotExist()
+      editor.assertTextEquals("Existing draft")
+    } finally {
+      ShadowSpeechRecognizer.setIsOnDeviceRecognitionAvailable(recognitionAvailable)
+    }
   }
 
   @Test

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -342,9 +342,10 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
   transcript into the draft. Long-press the microphone to record a voice-note
   attachment. The UI reports unavailable recognition, missing permission,
   busy/network failures, and no-speech outcomes instead of silently dropping
-  the attempt. If dictation is unavailable, **Record voice note** offers a new
-  recording while keeping the draft. It does not recover speech from the failed
-  dictation attempt or send anything automatically.
+  the attempt. If dictation is unavailable and a gateway is selected,
+  **Record voice note** offers a new recording while keeping the draft. It does
+  not recover speech from the failed dictation attempt or send anything
+  automatically.
 - Start continuous **Talk** from the Chat waveform. Dictation, voice-note
   recording, and Talk are mutually exclusive microphone paths.
 - Talk Mode promotes the existing foreground service from `connectedDevice` to `connectedDevice|microphone` before capture starts, then demotes it when Talk Mode stops. The node service declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` with `CHANGE_NETWORK_STATE`; Android 14+ also requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -342,7 +342,9 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
   transcript into the draft. Long-press the microphone to record a voice-note
   attachment. The UI reports unavailable recognition, missing permission,
   busy/network failures, and no-speech outcomes instead of silently dropping
-  the attempt.
+  the attempt. If dictation is unavailable, **Record voice note** offers a new
+  recording while keeping the draft. It does not recover speech from the failed
+  dictation attempt or send anything automatically.
 - Start continuous **Talk** from the Chat waveform. Dictation, voice-note
   recording, and Talk are mutually exclusive microphone paths.
 - Talk Mode promotes the existing foreground service from `connectedDevice` to `connectedDevice|microphone` before capture starts, then demotes it when Talk Mode stops. The node service declares `FOREGROUND_SERVICE_CONNECTED_DEVICE` with `CHANGE_NETWORK_STATE`; Android 14+ also requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.


### PR DESCRIPTION
Closes #125322

Related: #125323, the original Android voice-note proposal by Ravi Tharuma (@RaviTharuma). This is a credited maintainer replacement; it does not rewrite the contributor's branch.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users tapping **Dictation** in Android Chat see an unavailable-recognition error with no visible recording recovery when on-device speech recognition cannot run. The existing long-press recorder is not surfaced by that error.

## Why This Change Was Made

The composer offers an explicit **Record voice note** action for unavailable dictation and reuses the existing recorder admission, permission, and attachment flow. Choosing it clears the stale dictation failure without changing the draft. Dictation keeps its tap behavior; the UI does not silently switch from transcription to recording.

Review of the refreshed composer found another reachable failure: forgetting the last gateway leaves Chat accessible, but a recording cannot acquire a composer owner. The shared recording eligibility now requires a selected gateway, so both the existing long-press action and the new recovery action agree with media admission. The regression exercises the real `MainViewModel.forgetGateway` path, rather than manufacturing an invalid owner.

The duplicate recognizer availability guard and unused controller availability getter are removed. The controller remains the availability owner; existing ownership checks still fence asynchronous recording results.

## User Impact

Users with a selected gateway can explicitly start a new recording when dictation is unavailable. Their draft stays intact, and finishing a recording still stages an attachment for a separate **Send** action. This does not recover speech from the failed dictation attempt or send anything automatically. The existing permission flow remains in place; no configuration, provider fallback, dependency, or storage change is added.

After the last gateway is forgotten, Chat no longer advertises recording actions that cannot proceed. The Android documentation explains the selected-gateway requirement and the separation between recovery, recording, and sending.

## Evidence

This candidate was refreshed onto `c7935224bdddd88e4e76e8dce129af11b4787cad`, preserving the newer composer layout and its updated test helper. Current local proof uses rebased HEAD `5a74620b8541f4cc29363f18ff9d1753c004444d` plus the reviewed recording-eligibility, regression, and documentation changes. That reviewed source was subsequently committed as `70460590a30`. The combined four-file patch has SHA-256 `1fb4ec97193162b3a54334d2c5235bac3bac5a18483b85b3627a4b4aa872a12c`. Source hashes, APK hashes, and raw test results are retained; this is not a claim that the working-tree repair was already committed or merged when captured.

| Check | Observed result |
| --- | --- |
| Refreshed baseline regression | Failed as expected on the captured c793 production files because **Record voice note** was absent after unavailable dictation. |
| Last-gateway regression before repair | Failed as expected after actual gateway removal: the recovery button remained visible despite having no recording owner. Onboarding was still complete. |
| Focused regression coverage | **49/49 passed:** 16 composer, 12 dictation-controller, 20 recorder-controller, and 1 voice-note attachment test. The extended composer regression then passed again with the final formatted source during the native APK build; that rerun is included in the 49, not added to it. |
| Normal Android builds | BEFORE and AFTER application and instrumentation APK builds passed with normal Mermaid generation. The IME instrumentation APK also built normally. No Gradle task was excluded; the isolated checkout used its own frozen dependencies. |
| Native BEFORE | **1/1 passed:** actual unavailable-recognition result; draft and error visible; no explicit recovery action. |
| Native AFTER | **1/1 passed:** explicit recovery visible and clicked; stale dictation error replaced by the fixture's recording-permission result; draft unchanged. |
| Native AFTER with keyboard | **1/1 passed:** the real editor is focused and the Android keyboard remains visible immediately before both screenshots. Recovery stays visible and clickable. This run reuses the same verified AFTER application APK. |
| Formatting and review | All three changed Kotlin files pass pinned ktlint 1.8.0; documentation formatting and `git diff --check` pass. Fresh independent Codex review of the complete candidate is clean through P2, with source-integrity verification before and after review. |

**[CI 33595970851](https://github.com/openclaw/openclaw/actions/runs/33595970851) passed for the final `70460590a303f100a41457bc50020768402ebfdd` candidate.** The green [run 33582035168](https://github.com/openclaw/openclaw/actions/runs/33582035168) belongs to the earlier `47e3c1ff268a2668a7fc8bd2679560ce943789f7` head. It is historical evidence, not CI coverage of this rebase or the recording-owner repair. Older published screenshots likewise do not establish the refreshed layout.

The native runs use the real `MainActivity` and Compose UI on an isolated Android 14/API 34 ARM64 emulator with synthetic chat data. Android's actual on-device recognition availability check returns false; that native result is not mocked. BEFORE contains the captured c793 production; AFTER contains the reviewed candidate. Temporary instrumentation was removed and all final tracked source hashes were restored exactly after proof.

The permission-required result comes from the screenshot fixture having no ViewModel permission requester. It does **not** demonstrate an OS permission denial, a real permission dialog or grant, successful microphone capture/transcription, attachment delivery, or a live Gateway. Physical-device audio, AEC, and TalkBack were not tested. Recording/staging/Send separation is source-backed; the fixture's outbox is not delivery proof.

### Refreshed before/after pictures


These five fresh captures contain only synthetic chat data. Each full capture was inspected before uploading to GitHub, and anonymous downloads of all five returned PNGs with SHA-256 hashes matching the inspected originals exactly. They show the refreshed c793/candidate layout, rather than the older published screenshots.

| Before: captured c793 composer | After: reviewed candidate |
| --- | --- |
| ![Unavailable dictation has no recording recovery](https://github.com/user-attachments/assets/1ea00f7a-6569-4abe-a5d3-b1a8ef7586ad) | ![Explicit Record voice note recovery preserves the draft](https://github.com/user-attachments/assets/e24b6c46-5ca3-406e-aeab-dd555ff833e9) |

<details>
<summary>Recovery result and real keyboard-visible proof</summary>

![Recovery preserves the draft and reaches the fixture permission-required result](https://github.com/user-attachments/assets/2773c196-3123-4cee-ba08-49a392284379)

| Recovery with keyboard visible | After selecting recovery |
| --- | --- |
| ![Record voice note remains visible above the Android keyboard](https://github.com/user-attachments/assets/b6b1e336-245d-4b73-a9dd-5d7cb732ef1f) | ![Draft, keyboard and fixture permission result remain visible](https://github.com/user-attachments/assets/2eba9284-bd42-4b4e-b46a-6f373cfefcd2) |

</details>

### Scope and follow-ups

| Surface | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 5 | 6 | **−1** |
| Permanent regression test | 66 | 0 | +66 |
| Android documentation | 4 | 1 | +3 |

The selected interaction retains the documented tap-to-dictate and long-press-to-record behavior, then adds a clearly labeled recovery action after an unavailable result. The automatic tap-to-record alternative from #125323 is intentionally omitted because it changes the meaning of an action labeled **Dictation**. This is the explicit-recovery decision requested by review; it adds a visible route to the existing recorder. The requested transition into successful physical-device recording remains outside the observed proof above; the larger Android audio rewrite is not included here.

Two existing follow-ups remain separate: the generic **Speech recognition** error needs clearer retry guidance, and attachment-menu eligibility without a selected gateway needs its own picker-flow proof. Neither is hidden by a new fallback or storage change.

Contributor credit from original commit `b85a04b848fc741023b345f771d11043eed60e24` is preserved:

```text
Co-authored-by: Ravi Tharuma <RaviTharuma@users.noreply.github.com>
```
