### PR TITLE
fix(apple): cancel native notifications before side effects

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -2568,6 +2568,7 @@ final class NodeAppModel {
 
         let shouldSpeak = params.speak ?? true
         let status = await notificationAuthorizationStatus()
+        try Task.checkCancellation()
         let notificationsAllowed = Self.isNotificationServingEnabled(status)
         if !notificationsAllowed, !shouldSpeak {
             return BridgeInvokeResponse(
@@ -2599,6 +2600,7 @@ final class NodeAppModel {
         }
 
         if shouldSpeak {
+            try Task.checkCancellation()
             let toSpeak = text
             Task { @MainActor in
                 try? await TalkSystemSpeechSynthesizer.shared.speak(text: toSpeak)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -2601,6 +2601,8 @@ final class NodeAppModel {
 
         if shouldSpeak {
             try Task.checkCancellation()
+            // This synchronous handoff commits speech, like enqueueing a notification;
+            // playback intentionally outlives the command's immediate receipt.
             let toSpeak = text
             Task { @MainActor in
                 try? await TalkSystemSpeechSynthesizer.shared.speak(text: toSpeak)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3216,38 +3216,34 @@ extension NodeAppModel {
                         code: .invalidRequest,
                         message: "INVALID_REQUEST: empty watch notification"))
             }
-            do {
-                let gatewayStableID = currentWatchChatGatewayStableID()
-                self.watchMessageOutbox.recordPromptRoute(
-                    promptID: normalizedParams.promptId,
-                    gatewayStableID: gatewayStableID)
-                let result = try await watchMessagingService.sendNotification(
-                    id: req.id,
-                    params: normalizedParams,
-                    gatewayStableID: gatewayStableID)
-                if result.queuedForDelivery || !result.deliveredImmediately {
-                    let invokeID = req.id
-                    Task { @MainActor in
-                        await WatchPromptNotificationBridge.scheduleMirroredWatchPromptNotificationIfNeeded(
-                            invokeID: invokeID,
-                            params: normalizedParams,
-                            gatewayStableID: gatewayStableID,
-                            sendResult: result)
-                    }
+            let gatewayStableID = currentWatchChatGatewayStableID()
+            self.watchMessageOutbox.recordPromptRoute(
+                promptID: normalizedParams.promptId,
+                gatewayStableID: gatewayStableID)
+            let result = try await watchMessagingService.sendNotification(
+                id: req.id,
+                params: normalizedParams,
+                gatewayStableID: gatewayStableID)
+            try Task.checkCancellation()
+            if result.queuedForDelivery || !result.deliveredImmediately {
+                let invokeID = req.id
+                let notificationCenter = self.notificationCenter
+                // Watch delivery is committed. The accepted best-effort phone mirror
+                // intentionally outlives this invoke's receipt and cancellation owner.
+                Task { @MainActor in
+                    await WatchPromptNotificationBridge.scheduleMirroredWatchPromptNotificationIfNeeded(
+                        invokeID: invokeID,
+                        params: normalizedParams,
+                        gatewayStableID: gatewayStableID,
+                        sendResult: result,
+                        notificationCenter: notificationCenter)
                 }
-                let payload = OpenClawWatchNotifyPayload(
-                    deliveredImmediately: result.deliveredImmediately,
-                    queuedForDelivery: result.queuedForDelivery,
-                    transport: result.transport)
-                return try Self.successfulInvokeResponse(req, payload: payload)
-            } catch {
-                return BridgeInvokeResponse(
-                    id: req.id,
-                    ok: false,
-                    error: OpenClawNodeError(
-                        code: .unavailable,
-                        message: error.localizedDescription))
             }
+            let payload = OpenClawWatchNotifyPayload(
+                deliveredImmediately: result.deliveredImmediately,
+                queuedForDelivery: result.queuedForDelivery,
+                transport: result.transport)
+            return try Self.successfulInvokeResponse(req, payload: payload)
         default:
             return Self.unknownInvokeResponse(req)
         }

--- a/apps/ios/Sources/OpenClawApp.swift
+++ b/apps/ios/Sources/OpenClawApp.swift
@@ -501,14 +501,17 @@ enum WatchPromptNotificationBridge {
         invokeID: String,
         params: OpenClawWatchNotifyParams,
         gatewayStableID: String?,
-        sendResult: WatchNotificationSendResult) async
+        sendResult: WatchNotificationSendResult,
+        notificationCenter: NotificationCentering) async
     {
         guard sendResult.queuedForDelivery || !sendResult.deliveredImmediately else { return }
 
         let title = params.title.trimmingCharacters(in: .whitespacesAndNewlines)
         let body = params.body.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !title.isEmpty || !body.isEmpty else { return }
-        guard await self.isNotificationAuthorizationAllowed() else { return }
+        guard await self.isNotificationAuthorizationAllowed(notificationCenter: notificationCenter),
+              !Task.isCancelled
+        else { return }
 
         let normalizedActions = (params.actions ?? []).compactMap { action -> OpenClawWatchAction? in
             let id = action.id.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -518,7 +521,6 @@ enum WatchPromptNotificationBridge {
         }
         let displayedActions = Array(normalizedActions.prefix(4))
 
-        let center = UNUserNotificationCenter.current()
         var categoryIdentifier = ""
         if !displayedActions.isEmpty {
             let categoryID = "\(categoryPrefix)\(invokeID)"
@@ -527,7 +529,7 @@ enum WatchPromptNotificationBridge {
                 actions: categoryActions(displayedActions),
                 intentIdentifiers: [],
                 options: [])
-            await upsertNotificationCategory(category, center: center)
+            await upsertNotificationCategory(category, center: .current())
             categoryIdentifier = categoryID
         }
 
@@ -580,7 +582,7 @@ enum WatchPromptNotificationBridge {
             identifier: "watch.prompt.\(invokeID)",
             content: content,
             trigger: nil)
-        try? await addNotificationRequest(request, center: center)
+        try? await notificationCenter.add(request)
     }
 
     static func actionIDKey(index: Int) -> String {
@@ -620,31 +622,15 @@ enum WatchPromptNotificationBridge {
         }
     }
 
-    private static func isNotificationAuthorizationAllowed() async -> Bool {
+    private static func isNotificationAuthorizationAllowed(
+        notificationCenter: NotificationCentering) async -> Bool
+    {
         guard NotificationServingPreference.isEnabled() else { return false }
-        let center = UNUserNotificationCenter.current()
-        let status = await notificationAuthorizationStatus(center: center)
-        return self.isAuthorizationStatusAllowed(status)
-    }
-
-    private static func isAuthorizationStatusAllowed(_ status: UNAuthorizationStatus) -> Bool {
-        switch status {
+        switch await notificationCenter.authorizationStatus() {
         case .authorized, .provisional, .ephemeral:
             return true
         case .denied, .notDetermined:
             return false
-        @unknown default:
-            return false
-        }
-    }
-
-    private static func notificationAuthorizationStatus(
-        center: UNUserNotificationCenter) async -> UNAuthorizationStatus
-    {
-        await withCheckedContinuation { continuation in
-            center.getNotificationSettings { settings in
-                continuation.resume(returning: settings.authorizationStatus)
-            }
         }
     }
 
@@ -658,17 +644,6 @@ enum WatchPromptNotificationBridge {
                 updated.update(with: category)
                 center.setNotificationCategories(updated)
                 continuation.resume()
-            }
-        }
-    }
-
-    private static func addNotificationRequest(
-        _ request: UNNotificationRequest,
-        center: UNUserNotificationCenter) async throws
-    {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            center.add(request) { error in
-                ThrowingContinuationSupport.resumeVoid(continuation, error: error)
             }
         }
     }

--- a/apps/ios/Sources/Push/ExecApprovalNotificationBridge.swift
+++ b/apps/ios/Sources/Push/ExecApprovalNotificationBridge.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import OpenClawProtocol
 @preconcurrency import UserNotifications
 

--- a/apps/ios/Sources/Services/NotificationService.swift
+++ b/apps/ios/Sources/Services/NotificationService.swift
@@ -1,82 +1,31 @@
 import Foundation
-import UserNotifications
+import OpenClawKit
 
 /// Keeps notification failures Sendable across the system prompt and timeout tasks.
 struct NotificationCallError: Error {
     let message: String
 }
 
-private final class NotificationInvokeLatch<Value: Sendable>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<Result<Value, NotificationCallError>, Never>?
-    private var resumed = false
-
-    func setContinuation(_ continuation: CheckedContinuation<Result<Value, NotificationCallError>, Never>) {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        self.continuation = continuation
-    }
-
-    func resume(_ result: Result<Value, NotificationCallError>) {
-        self.lock.lock()
-        guard !self.resumed else {
-            self.lock.unlock()
-            return
-        }
-        self.resumed = true
-        let continuation = self.continuation
-        self.continuation = nil
-        self.lock.unlock()
-        continuation?.resume(returning: result)
-    }
-}
-
 @MainActor
 enum NotificationOperationRunner {
-    /// System permission prompts can stall indefinitely; the latch makes the timeout
-    /// and operation race resume exactly once without blocking the app's main actor.
+    /// Permission callbacks may ignore cancellation. The shared race retires their task
+    /// before returning so late callbacks cannot start a notification for a cancelled caller.
     static func run<Value: Sendable>(
         timeoutSeconds: Double,
         operation: @escaping @Sendable () async throws -> Value) async -> Result<Value, NotificationCallError>
     {
-        let latch = NotificationInvokeLatch<Value>()
-        var operationTask: Task<Void, Never>?
-        var timeoutTask: Task<Void, Never>?
-        defer {
-            operationTask?.cancel()
-            timeoutTask?.cancel()
-        }
-        let timeout = max(0, timeoutSeconds)
-        return await withCheckedContinuation { continuation in
-            latch.setContinuation(continuation)
-            operationTask = Task { @MainActor in
-                do {
-                    try await latch.resume(.success(operation()))
-                } catch {
-                    latch.resume(.failure(NotificationCallError(message: error.localizedDescription)))
-                }
-            }
-            timeoutTask = Task.detached {
-                if timeout > 0 {
-                    try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                }
-                latch.resume(.failure(NotificationCallError(message: "notification request timed out")))
-            }
+        do {
+            let value = try await AsyncTimeout.withTimeout(
+                seconds: timeoutSeconds,
+                onTimeout: { NotificationCallError(message: "notification request timed out") },
+                operation: operation)
+            return .success(value)
+        } catch let error as NotificationCallError {
+            return .failure(error)
+        } catch {
+            return .failure(NotificationCallError(message: error.localizedDescription))
         }
     }
-}
-
-struct NotificationSnapshot: @unchecked Sendable {
-    let identifier: String
-    let userInfo: [AnyHashable: Any]
-}
-
-enum NotificationAuthorizationStatus {
-    case notDetermined
-    case denied
-    case authorized
-    case provisional
-    case ephemeral
 }
 
 enum NotificationServingPreference {
@@ -88,74 +37,5 @@ enum NotificationServingPreference {
             return self.defaultEnabled
         }
         return defaults.bool(forKey: self.storageKey)
-    }
-}
-
-protocol NotificationCentering: Sendable {
-    func authorizationStatus() async -> NotificationAuthorizationStatus
-    func add(_ request: UNNotificationRequest) async throws
-    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) async
-    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) async
-    func deliveredNotifications() async -> [NotificationSnapshot]
-}
-
-struct LiveNotificationCenter: NotificationCentering, @unchecked Sendable {
-    private let center: UNUserNotificationCenter
-
-    init(center: UNUserNotificationCenter = .current()) {
-        self.center = center
-    }
-
-    func authorizationStatus() async -> NotificationAuthorizationStatus {
-        let settings = await self.center.notificationSettings()
-        return switch settings.authorizationStatus {
-        case .authorized:
-            .authorized
-        case .provisional:
-            .provisional
-        case .ephemeral:
-            .ephemeral
-        case .denied:
-            .denied
-        case .notDetermined:
-            .notDetermined
-        @unknown default:
-            .denied
-        }
-    }
-
-    func add(_ request: UNNotificationRequest) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            self.center.add(request) { error in
-                if let error {
-                    cont.resume(throwing: error)
-                } else {
-                    cont.resume(returning: ())
-                }
-            }
-        }
-    }
-
-    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) async {
-        guard !identifiers.isEmpty else { return }
-        self.center.removePendingNotificationRequests(withIdentifiers: identifiers)
-    }
-
-    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) async {
-        guard !identifiers.isEmpty else { return }
-        self.center.removeDeliveredNotifications(withIdentifiers: identifiers)
-    }
-
-    func deliveredNotifications() async -> [NotificationSnapshot] {
-        await withCheckedContinuation { continuation in
-            self.center.getDeliveredNotifications { notifications in
-                continuation.resume(
-                    returning: notifications.map { notification in
-                        NotificationSnapshot(
-                            identifier: notification.request.identifier,
-                            userInfo: notification.request.content.userInfo)
-                    })
-            }
-        }
     }
 }

--- a/apps/ios/Sources/Services/WatchConnectivityTransport.swift
+++ b/apps/ios/Sources/Services/WatchConnectivityTransport.swift
@@ -7,6 +7,17 @@ private struct WatchConnectivityTransportCallbacks {
     var inboundEventHandler: (@Sendable (WatchMessagingInboundEvent) -> Void)?
 }
 
+func updateWatchSnapshotApplicationContext(_ payload: [String: Any], with session: WCSession, lock: NSLock) throws {
+    try lock.withLock {
+        let context = WatchMessagingPayloadCodec.encodeSnapshotApplicationContext(
+            payload,
+            merging: session.applicationContext)
+        // The caller may retire while another snapshot holds this lock.
+        try Task.checkCancellation()
+        try session.updateApplicationContext(context)
+    }
+}
+
 final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     private nonisolated static let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "watch.messaging")
 
@@ -87,12 +98,10 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
             enqueue: { session in
                 if isSnapshot {
                     do {
-                        try self.snapshotContextLock.withLock {
-                            let context = WatchMessagingPayloadCodec.encodeSnapshotApplicationContext(
-                                payload,
-                                merging: session.applicationContext)
-                            try session.updateApplicationContext(context)
-                        }
+                        try updateWatchSnapshotApplicationContext(
+                            payload,
+                            with: session,
+                            lock: self.snapshotContextLock)
                         return "applicationContext"
                     } catch {
                         Self.logger.error(

--- a/apps/ios/Sources/Services/WatchConnectivityTransport.swift
+++ b/apps/ios/Sources/Services/WatchConnectivityTransport.swift
@@ -63,63 +63,72 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     }
 
     func sendPayload(_ payload: [String: Any]) async throws -> WatchNotificationSendResult {
-        try await self.ensureActivated()
-        let session = try self.requireReadySession()
-        if session.isReachable {
-            do {
-                try await sendReachableWatchMessage(payload, with: session)
-                return WatchNotificationSendResult(
-                    deliveredImmediately: true,
-                    queuedForDelivery: false,
-                    transport: "sendMessage")
-            } catch {
-                Self.logger.error("watch sendMessage failed: \(error.localizedDescription, privacy: .public)")
-            }
-        }
-
-        _ = session.transferUserInfo(payload)
-        return WatchNotificationSendResult(
-            deliveredImmediately: false,
-            queuedForDelivery: true,
-            transport: "transferUserInfo")
+        try await self.sendPayload(payload, isSnapshot: false)
     }
 
     func sendSnapshotPayload(_ payload: [String: Any]) async throws -> WatchNotificationSendResult {
-        try await self.ensureActivated()
-        let session = try self.requireReadySession()
-        if session.isReachable {
-            do {
+        try await self.sendPayload(payload, isSnapshot: true)
+    }
+
+    private func sendPayload(
+        _ payload: [String: Any],
+        isSnapshot: Bool) async throws -> WatchNotificationSendResult
+    {
+        try await Self.deliverPayload(
+            prepareSession: {
+                try await self.ensureActivated()
+                return try self.requireReadySession()
+            },
+            sendImmediately: { session in
+                guard session.isReachable else { return false }
                 try await sendReachableWatchMessage(payload, with: session)
+                return true
+            },
+            enqueue: { session in
+                if isSnapshot {
+                    do {
+                        try self.snapshotContextLock.withLock {
+                            let context = WatchMessagingPayloadCodec.encodeSnapshotApplicationContext(
+                                payload,
+                                merging: session.applicationContext)
+                            try session.updateApplicationContext(context)
+                        }
+                        return "applicationContext"
+                    } catch {
+                        Self.logger.error(
+                            "watch updateApplicationContext failed: \(error.localizedDescription, privacy: .public)")
+                    }
+                }
+                try Task.checkCancellation()
+                _ = session.transferUserInfo(payload)
+                return "transferUserInfo"
+            })
+    }
+
+    static func deliverPayload<Session>(
+        prepareSession: () async throws -> Session,
+        sendImmediately: (Session) async throws -> Bool,
+        enqueue: (Session) throws -> String) async throws -> WatchNotificationSendResult
+    {
+        let session = try await prepareSession()
+        // Activation may outlive its caller; only a live request may start a transfer.
+        try Task.checkCancellation()
+        do {
+            if try await sendImmediately(session) {
                 return WatchNotificationSendResult(
                     deliveredImmediately: true,
                     queuedForDelivery: false,
                     transport: "sendMessage")
-            } catch {
-                Self.logger.error(
-                    "watch snapshot sendMessage failed: \(error.localizedDescription, privacy: .public)")
             }
-        }
-
-        do {
-            try self.snapshotContextLock.withLock {
-                let context = WatchMessagingPayloadCodec.encodeSnapshotApplicationContext(
-                    payload,
-                    merging: session.applicationContext)
-                try session.updateApplicationContext(context)
-            }
-            return WatchNotificationSendResult(
-                deliveredImmediately: false,
-                queuedForDelivery: true,
-                transport: "applicationContext")
         } catch {
-            Self.logger.error(
-                "watch updateApplicationContext failed: \(error.localizedDescription, privacy: .public)")
-            _ = session.transferUserInfo(payload)
-            return WatchNotificationSendResult(
-                deliveredImmediately: false,
-                queuedForDelivery: true,
-                transport: "transferUserInfo")
+            Self.logger.error("watch sendMessage failed: \(error.localizedDescription, privacy: .public)")
         }
+        // A failed interactive attempt has not admitted a new background transfer.
+        try Task.checkCancellation()
+        return try WatchNotificationSendResult(
+            deliveredImmediately: false,
+            queuedForDelivery: true,
+            transport: enqueue(session))
     }
 
     private func updateCallbacks(_ update: (inout WatchConnectivityTransportCallbacks) -> Void) {

--- a/apps/ios/Sources/Services/WatchSessionActivationGate.swift
+++ b/apps/ios/Sources/Services/WatchSessionActivationGate.swift
@@ -44,7 +44,12 @@ final class WatchMessageSendCompletion: @unchecked Sendable {
 func sendReachableWatchMessage(_ payload: [String: Any], with session: WCSession) async throws {
     // WatchConnectivity callbacks use their own executor and can race despite their
     // documented exactly-once contract; only the first callback owns this continuation.
-    try await withCheckedThrowingContinuation(isolation: nil) { continuation in
+    try await withCheckedThrowingContinuation(isolation: nil) { (continuation: CheckedContinuation<Void, any Error>) in
+        // An executor hop can retire the caller before this SDK enqueue begins.
+        guard !Task.isCancelled else {
+            continuation.resume(throwing: CancellationError())
+            return
+        }
         let completion = WatchMessageSendCompletion(continuation)
         session.sendMessage(
             payload,

--- a/apps/ios/Tests/ExecApprovalNotificationBridgeTests.swift
+++ b/apps/ios/Tests/ExecApprovalNotificationBridgeTests.swift
@@ -3,6 +3,7 @@ import OpenClawProtocol
 import Testing
 import UserNotifications
 @testable import OpenClaw
+@testable import OpenClawKit
 
 private final class MockNotificationCenter: NotificationCentering, @unchecked Sendable {
     var authorization: NotificationAuthorizationStatus = .authorized

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -1,11 +1,11 @@
 import Foundation
-import OpenClawKit
 import OpenClawProtocol
 import Testing
 import UIKit
 import UserNotifications
 @testable import OpenClaw
 @testable import OpenClawChatUI
+@testable import OpenClawKit
 
 @MainActor
 private final class MockVoiceNoteAudioCapture: VoiceNoteAudioCapture {
@@ -7012,6 +7012,32 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
 
         #expect(res.ok)
         #expect(center.addCalls == 1)
+    }
+
+    @Test @MainActor func `cancelled chat push cannot continue as speech after authorization`() async throws {
+        let (center, appModel) = makeNotificationModel(status: .denied)
+        let authorizationGate = NotificationAuthorizationGate()
+        center.authorizationStatusHandler = { await authorizationGate.wait() }
+        let request = try makeInvokeRequest(
+            id: "cancelled-chat-push",
+            command: OpenClawChatCommand.push.rawValue,
+            params: OpenClawChatPushParams(text: "Cancelled notification test", speak: true))
+        let invocation = Task { @MainActor in await appModel.handleInvoke(request) }
+        let deadline = ContinuousClock().now.advanced(by: .seconds(2))
+        while await !(authorizationGate.hasStarted()), ContinuousClock().now < deadline {
+            await Task.yield()
+        }
+        let authorizationStarted = await authorizationGate.hasStarted()
+        invocation.cancel()
+        await authorizationGate.resume(returning: .denied)
+        let response = await invocation.value
+        await Task.yield()
+        TalkSystemSpeechSynthesizer.shared.stop()
+
+        #expect(authorizationStarted)
+        #expect(!response.ok)
+        #expect(response.error?.message == "node invoke cancelled")
+        #expect(center.addCalls == 0)
     }
 
     @Test @MainActor func `handle invoke rejects invalid screen format`() async {

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -673,6 +673,7 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
         queuedForDelivery: false,
         transport: "sendMessage")
     var sendError: Error?
+    var sendNotificationHandler: (() async throws -> WatchNotificationSendResult)?
     var lastSent: (id: String, params: OpenClawWatchNotifyParams, gatewayStableID: String?)?
     var lastDirectNodeSetupCode: String?
     var lastSentExecApprovalPrompt: OpenClawWatchExecApprovalPromptMessage?
@@ -733,6 +734,9 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
         gatewayStableID: String?) async throws -> WatchNotificationSendResult
     {
         self.lastSent = (id: id, params: params, gatewayStableID: gatewayStableID)
+        if let sendNotificationHandler {
+            return try await sendNotificationHandler()
+        }
         if let sendError {
             throw sendError
         }
@@ -7145,6 +7149,76 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
         #expect(payload.deliveredImmediately == false)
         #expect(payload.queuedForDelivery == true)
         #expect(payload.transport == "transferUserInfo")
+    }
+
+    @Test @MainActor func `cancelled watch notification preserves cancellation after transport`() async throws {
+        let restorePreference = overrideNotificationServingPreference(false)
+        defer { restorePreference() }
+        let (watchService, appModel) = makeWatchModel()
+        let transportGate = WatchSnapshotSendGate()
+        watchService.sendNotificationHandler = {
+            await transportGate.wait()
+            return WatchNotificationSendResult(
+                deliveredImmediately: false,
+                queuedForDelivery: true,
+                transport: "transferUserInfo")
+        }
+        let request = try makeInvokeRequest(
+            id: "cancelled-watch-notify",
+            command: OpenClawWatchCommand.notify.rawValue,
+            params: OpenClawWatchNotifyParams(title: "OpenClaw", body: "Cancelled mirror test"))
+        let invocation = Task { @MainActor in await appModel.handleInvoke(request) }
+        let deadline = ContinuousClock().now.advanced(by: .seconds(2))
+        while await !(transportGate.hasStarted()), ContinuousClock().now < deadline {
+            await Task.yield()
+        }
+        let transportStarted = await transportGate.hasStarted()
+        invocation.cancel()
+        await transportGate.resume()
+        let response = await invocation.value
+
+        #expect(transportStarted)
+        #expect(!response.ok)
+        #expect(response.error?.message == "node invoke cancelled")
+    }
+
+    @Test @MainActor func `watch notification receipt accepts an independent phone mirror`() async throws {
+        let restorePreference = overrideNotificationServingPreference(true)
+        defer { restorePreference() }
+        let center = MockBootstrapNotificationCenter()
+        let (watchService, appModel) = makeWatchModel(notificationCenter: center)
+        let mirrorGate = WatchSnapshotSendGate()
+        center.authorizationStatusHandler = {
+            await mirrorGate.wait()
+            return .authorized
+        }
+        watchService.nextSendResult = WatchNotificationSendResult(
+            deliveredImmediately: false,
+            queuedForDelivery: true,
+            transport: "transferUserInfo")
+        let request = try makeInvokeRequest(
+            id: "accepted-watch-mirror",
+            command: OpenClawWatchCommand.notify.rawValue,
+            params: OpenClawWatchNotifyParams(title: "OpenClaw", body: "Accepted mirror test"))
+        var response: BridgeInvokeResponse?
+        let invocation = Task { @MainActor in
+            response = await appModel.handleInvoke(request)
+        }
+        let deadline = ContinuousClock().now.advanced(by: .seconds(2))
+        while await !(mirrorGate.hasStarted()), ContinuousClock().now < deadline {
+            await Task.yield()
+        }
+        let mirrorStarted = await mirrorGate.hasStarted()
+        await waitForMainActorWork { response != nil }
+        let responseBeforeMirror = response
+        invocation.cancel()
+        await mirrorGate.resume()
+        await invocation.value
+        await waitForMainActorWork { center.addCalls == 1 }
+
+        #expect(mirrorStarted)
+        #expect(responseBeforeMirror?.ok == true)
+        #expect(center.addCalls == 1)
     }
 
     @Test @MainActor func `watch reply codec preserves prompt gateway owner`() throws {

--- a/apps/ios/Tests/NotificationServingPreferenceTests.swift
+++ b/apps/ios/Tests/NotificationServingPreferenceTests.swift
@@ -1,5 +1,8 @@
 import Foundation
+import OpenClawKit
 import Testing
+import UserNotifications
+import XCTest
 @testable import OpenClaw
 
 private enum NotificationOperationProbeError: LocalizedError {
@@ -7,6 +10,25 @@ private enum NotificationOperationProbeError: LocalizedError {
 
     var errorDescription: String? {
         "expected notification failure"
+    }
+}
+
+private actor NotificationOperationPause {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait(entered: XCTestExpectation) async {
+        guard !self.released else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            entered.fulfill()
+        }
+    }
+
+    func release() {
+        self.released = true
+        self.continuation?.resume()
+        self.continuation = nil
     }
 }
 
@@ -67,6 +89,92 @@ struct NotificationServingPreferenceTests {
         case let .failure(error):
             #expect(error.message == "notification request timed out")
         }
+    }
+
+    @Test @MainActor func `caller cancellation retires a suspended notification operation`() async {
+        let pause = NotificationOperationPause()
+        let entered = XCTestExpectation(description: "notification operation suspended")
+        let callerFinished = XCTestExpectation(description: "cancelled caller returned")
+        let (cancellation, recordCancellation) = AsyncStream<Bool>.makeStream()
+        let caller = Task { @MainActor in
+            let result = await NotificationOperationRunner.run(timeoutSeconds: 30) {
+                await pause.wait(entered: entered)
+                recordCancellation.yield(Task.isCancelled)
+                recordCancellation.finish()
+                return 42
+            }
+            callerFinished.fulfill()
+            return result
+        }
+        let ready = await XCTWaiter.fulfillment(of: [entered], timeout: 5)
+        caller.cancel()
+        let finished = await XCTWaiter.fulfillment(of: [callerFinished], timeout: 2)
+        await pause.release()
+        #expect(ready == .completed)
+        #expect(finished == .completed, "Cancellation must return without waiting for the permission callback")
+        for await cancelled in cancellation {
+            #expect(cancelled, "The suspended operation must inherit cancellation before it resumes")
+        }
+        if case .success = await caller.value {
+            Issue.record("The cancelled notification operation unexpectedly succeeded")
+        }
+    }
+
+    @Test @MainActor func `already cancelled callers cannot start a notification operation`() async {
+        let caller = Task { @MainActor in
+            await NotificationOperationRunner.run(timeoutSeconds: 1) {
+                Issue.record("The cancelled caller started a notification operation")
+                return 42
+            }
+        }
+        caller.cancel()
+        if case .success = await caller.value {
+            Issue.record("The cancelled notification operation unexpectedly succeeded")
+        }
+    }
+
+    @Test @MainActor func `cancellation after authorization cannot schedule a native notification`() async {
+        let center = UNUserNotificationCenter.current()
+        let adapter = LiveNotificationCenter(center: center)
+        let identifier = "notification-cancellation-test-\(UUID().uuidString)"
+        let authorized = XCTestExpectation(description: "native authorization settings returned")
+        let (pause, release) = AsyncStream<Void>.makeStream()
+        let operation = Task { @MainActor in
+            defer { center.removePendingNotificationRequests(withIdentifiers: [identifier]) }
+            _ = await adapter.authorizationStatus()
+            authorized.fulfill()
+            for await _ in pause {}
+            let content = UNMutableNotificationContent()
+            content.title = "OpenClaw cancellation test"
+            let request = UNNotificationRequest(
+                identifier: identifier,
+                content: content,
+                trigger: UNTimeIntervalNotificationTrigger(timeInterval: 3600, repeats: false))
+            let outcome: Result<Void, any Error>
+            do {
+                try await adapter.add(request)
+                outcome = .success(())
+            } catch {
+                outcome = .failure(error)
+            }
+            let pending = await center.pendingNotificationRequests()
+            return (outcome, pending.contains { $0.identifier == identifier })
+        }
+        let ready = await XCTWaiter.fulfillment(of: [authorized], timeout: 5)
+        operation.cancel()
+        release.finish()
+        guard ready == .completed else {
+            Issue.record("Native notification settings did not return")
+            return
+        }
+        let (outcome, scheduled) = await operation.value
+        switch outcome {
+        case .success:
+            Issue.record("The native notification adapter accepted a cancelled request")
+        case let .failure(error):
+            #expect(error is CancellationError, "Expected cancellation before scheduling, received \(error)")
+        }
+        #expect(!scheduled)
     }
 
     private func makeDefaults() throws -> (String, UserDefaults) {

--- a/apps/ios/Tests/NotificationServingPreferenceTests.swift
+++ b/apps/ios/Tests/NotificationServingPreferenceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawKit
+import Synchronization
 import Testing
 import UserNotifications
 import XCTest
@@ -95,19 +96,26 @@ struct NotificationServingPreferenceTests {
         let pause = NotificationOperationPause()
         let entered = XCTestExpectation(description: "notification operation suspended")
         let callerFinished = XCTestExpectation(description: "cancelled caller returned")
+        let operationCancelled = Mutex(false)
         let (cancellation, recordCancellation) = AsyncStream<Bool>.makeStream()
         let caller = Task { @MainActor in
             let result = await NotificationOperationRunner.run(timeoutSeconds: 30) {
-                await pause.wait(entered: entered)
-                recordCancellation.yield(Task.isCancelled)
-                recordCancellation.finish()
-                return 42
+                await withTaskCancellationHandler {
+                    await pause.wait(entered: entered)
+                    recordCancellation.yield(Task.isCancelled)
+                    recordCancellation.finish()
+                    return 42
+                } onCancel: {
+                    operationCancelled.withLock { $0 = true }
+                }
             }
             callerFinished.fulfill()
             return result
         }
         let ready = await XCTWaiter.fulfillment(of: [entered], timeout: 5)
         caller.cancel()
+        let cancelledWhenCallReturned = operationCancelled.withLock { $0 }
+        #expect(cancelledWhenCallReturned, "Cancellation must reach the operation before cancel() returns")
         let finished = await XCTWaiter.fulfillment(of: [callerFinished], timeout: 2)
         await pause.release()
         #expect(ready == .completed)

--- a/apps/ios/Tests/WatchSessionActivationGateTests.swift
+++ b/apps/ios/Tests/WatchSessionActivationGateTests.swift
@@ -140,6 +140,94 @@ struct WatchSessionActivationGateTests {
         .enabled(
             if: ProcessInfo.processInfo.environment["OPENCLAW_LIVE_TEST"] == "1",
             "Requires an isolated, unpaired iPhone Simulator; run with OPENCLAW_LIVE_TEST=1."),
+        .serialized,
+        arguments: [false, true])
+    func `native watch snapshot cancellation fences a contended context lock`(
+        cancelBeforeAdmission: Bool) async throws
+    {
+        let session = WCSession.default
+        try #require(!session.isPaired, "Do not probe a paired Watch session")
+        try #require(!session.isReachable, "Do not probe a reachable Watch session")
+        let marker = "openclaw.test.cancelled-snapshot-admission"
+        let originalContext = session.applicationContext
+        defer {
+            if session.applicationContext["type"] as? String == marker {
+                do {
+                    try session.updateApplicationContext(originalContext)
+                } catch {
+                    Issue.record("Could not remove an unexpectedly admitted snapshot probe")
+                }
+            }
+        }
+        let snapshotLock = NSLock()
+        let releaseLock = DispatchSemaphore(value: 0)
+        let holderEntered = XCTestExpectation(description: "snapshot lock held")
+        let holderFinished = XCTestExpectation(description: "snapshot lock released")
+        let holderWasSignalled = Mutex<Bool?>(nil)
+        DispatchQueue(label: "openclaw.test.snapshot-lock-holder").async {
+            snapshotLock.withLock {
+                holderEntered.fulfill()
+                let signalled = releaseLock.wait(timeout: .now() + 15) == .success
+                holderWasSignalled.withLock { $0 = signalled }
+            }
+            holderFinished.fulfill()
+        }
+        defer { releaseLock.signal() }
+        let held = await XCTWaiter.fulfillment(of: [holderEntered], timeout: 5)
+        try #require(held == .completed, "Infrastructure failure: lock holder did not start")
+
+        let senderEntered = XCTestExpectation(description: "outer cancellation fence passed")
+        let senderFinished = XCTestExpectation(description: "snapshot sender completed")
+        // A contended synchronous lock must not occupy the actor running the test driver.
+        let sender = Task.detached { () -> Result<Void, any Error> in
+            defer { senderFinished.fulfill() }
+            do {
+                let session = WCSession.default
+                try Task.checkCancellation()
+                senderEntered.fulfill()
+                try updateWatchSnapshotApplicationContext(
+                    ["type": marker],
+                    with: session,
+                    lock: snapshotLock)
+                return .success(())
+            } catch {
+                let nativeError = error as NSError
+                print("watch snapshot SDK admission: cancelled=\(cancelBeforeAdmission) "
+                    + "domain=\(nativeError.domain) code=\(nativeError.code)")
+                return .failure(error)
+            }
+        }
+        defer { sender.cancel() }
+        let entered = await XCTWaiter.fulfillment(of: [senderEntered], timeout: 5)
+        try #require(entered == .completed, "Infrastructure failure: sender did not reach the locked boundary")
+        try #require(holderWasSignalled.withLock { $0 } == nil, "Infrastructure failure: lock holder expired")
+        if cancelBeforeAdmission {
+            sender.cancel()
+        }
+        releaseLock.signal()
+        let finished = await XCTWaiter.fulfillment(of: [senderFinished, holderFinished], timeout: 5)
+        try #require(finished == .completed, "Infrastructure failure: local snapshot probe did not finish")
+        try #require(
+            holderWasSignalled.withLock { $0 } == true,
+            "Infrastructure failure: lock release was not signalled")
+        let outcome = await sender.value
+        guard case let .failure(error) = outcome else {
+            Issue.record("The unpaired/unreachable SDK snapshot probe unexpectedly succeeded")
+            return
+        }
+        if cancelBeforeAdmission {
+            #expect(error is CancellationError, "Cancellation must win after acquiring the context lock")
+        } else {
+            let nativeError = error as NSError
+            #expect(nativeError.domain == WCErrorDomain)
+            #expect([7002, 7003, 7004, 7005, 7006, 7007, 7016].contains(nativeError.code))
+        }
+    }
+
+    @Test(
+        .enabled(
+            if: ProcessInfo.processInfo.environment["OPENCLAW_LIVE_TEST"] == "1",
+            "Requires an isolated, unpaired iPhone Simulator; run with OPENCLAW_LIVE_TEST=1."),
         arguments: [false, true])
     @MainActor
     func `native watch sender rejects cancellation before SDK admission`(cancelBeforeStart: Bool) async throws {

--- a/apps/ios/Tests/WatchSessionActivationGateTests.swift
+++ b/apps/ios/Tests/WatchSessionActivationGateTests.swift
@@ -1,7 +1,9 @@
 import Foundation
 import OpenClawKit
+import Synchronization
 import Testing
 @preconcurrency import WatchConnectivity
+import XCTest
 @testable import OpenClaw
 
 struct WatchSessionActivationGateTests {
@@ -67,6 +69,124 @@ struct WatchSessionActivationGateTests {
             Issue.record("Unexpected watch message failure: \(error)")
         }
     }
+
+    private enum DeliverySuspension: CaseIterable {
+        case activation
+        case interactiveFailure
+        case acceptedInteractiveReply
+    }
+
+    @Test(arguments: DeliverySuspension.allCases, [false, true])
+    private func `watch delivery cancellation fences new transfers but preserves accepted replies`(
+        suspension: DeliverySuspension,
+        cancelBeforeRelease: Bool) async throws
+    {
+        let gate = WatchSessionActivationGate(timeoutNanoseconds: 10_000_000_000)
+        #expect(gate.beginActivation())
+        let entered = XCTestExpectation(description: "watch delivery suspended")
+        let effects = Mutex<[String]>([])
+        let sender = Task {
+            try await WatchConnectivityTransport.deliverPayload(
+                prepareSession: {
+                    if suspension == .activation {
+                        entered.fulfill()
+                        try await gate.waitUntilActivated()
+                    }
+                },
+                sendImmediately: { _ in
+                    guard suspension != .activation else { return false }
+                    effects.withLock { $0.append("interactive") }
+                    entered.fulfill()
+                    try await gate.waitUntilActivated()
+                    if suspension == .interactiveFailure {
+                        throw URLError(.networkConnectionLost)
+                    }
+                    return true
+                },
+                enqueue: { _ in
+                    effects.withLock { $0.append("background") }
+                    return "transferUserInfo"
+                })
+        }
+        defer {
+            sender.cancel()
+            gate.complete(activated: false, errorDescription: "test cleanup")
+        }
+        let ready = await XCTWaiter.fulfillment(of: [entered], timeout: 5)
+        try #require(ready == .completed)
+        if cancelBeforeRelease {
+            sender.cancel()
+        }
+        gate.complete(activated: true, errorDescription: nil)
+
+        let acceptedReply = suspension == .acceptedInteractiveReply
+        if cancelBeforeRelease, !acceptedReply {
+            await #expect(throws: CancellationError.self) { try await sender.value }
+        } else {
+            let result = try await sender.value
+            #expect(result.deliveredImmediately == acceptedReply)
+            #expect(result.queuedForDelivery == !acceptedReply)
+            #expect(result.transport == (acceptedReply ? "sendMessage" : "transferUserInfo"))
+        }
+        var expectedEffects = suspension == .activation ? [] : ["interactive"]
+        if !cancelBeforeRelease, !acceptedReply {
+            expectedEffects.append("background")
+        }
+        #expect(effects.withLock { $0 } == expectedEffects)
+    }
+
+    #if targetEnvironment(simulator)
+    @Test(
+        .enabled(
+            if: ProcessInfo.processInfo.environment["OPENCLAW_LIVE_TEST"] == "1",
+            "Requires an isolated, unpaired iPhone Simulator; run with OPENCLAW_LIVE_TEST=1."),
+        arguments: [false, true])
+    @MainActor
+    func `native watch sender rejects cancellation before SDK admission`(cancelBeforeStart: Bool) async throws {
+        let session = WCSession.default
+        try #require(!session.isPaired, "Do not probe a paired Watch session")
+        try #require(!session.isReachable, "Do not probe a reachable Watch session")
+        let finished = XCTestExpectation(description: "native Watch send completed")
+        let sender = Task { @MainActor () -> Result<Void, any Error> in
+            defer { finished.fulfill() }
+            #expect(Task.isCancelled == cancelBeforeStart)
+            do {
+                try await sendReachableWatchMessage(
+                    ["type": "openclaw.test.cancelled-delivery-admission"],
+                    with: session)
+                return .success(())
+            } catch {
+                let nativeError = error as NSError
+                print("watch SDK admission: cancelled=\(cancelBeforeStart) "
+                    + "domain=\(nativeError.domain) code=\(nativeError.code)")
+                return .failure(error)
+            }
+        }
+        defer { sender.cancel() }
+        // The child inherits this actor and cannot enter the helper before this cancellation.
+        if cancelBeforeStart {
+            sender.cancel()
+        }
+        let completion = await XCTWaiter.fulfillment(of: [finished], timeout: 5)
+        try #require(
+            completion == .completed,
+            "Infrastructure failure: the local WCSession rejection callback did not finish")
+        let outcome = await sender.value
+        guard case let .failure(error) = outcome else {
+            Issue.record("The unpaired/unreachable SDK probe unexpectedly succeeded")
+            return
+        }
+        if cancelBeforeStart {
+            #expect(error is CancellationError, "Cancellation must win before the SDK accepts a send")
+        } else {
+            let nativeError = error as NSError
+            #expect(nativeError.domain == WCErrorDomain)
+            // WCError.h: unsupported, missing delegate, inactive/unactivated, unpaired,
+            // app missing, or unreachable are all local, non-delivery rejections.
+            #expect([7002, 7003, 7004, 7005, 7006, 7007, 7016].contains(nativeError.code))
+        }
+    }
+    #endif
 
     @Test func `startup event buffering is ordered and bounded`() {
         var buffer = WatchMessagingStartupBuffer<String>(maxCount: 3)

--- a/apps/ios/WatchApp/Sources/WatchDirectNode.swift
+++ b/apps/ios/WatchApp/Sources/WatchDirectNode.swift
@@ -101,6 +101,7 @@ final class WatchDirectNode {
 
     private let networkMetrics: WatchURLSessionMetrics
     private let urlSession: URLSession
+    private let notificationCenter = LiveNotificationCenter()
     private var configuration: PersistedConfiguration?
     private var connectTask: Task<Void, Never>?
     private var activeSession: ActiveSession?
@@ -443,15 +444,14 @@ final class WatchDirectNode {
             method: "GET",
             token: nil)
         let challenge = try JSONDecoder().decode(ChallengeResponse.self, from: challengeData)
-        let notificationSettings = await UNUserNotificationCenter.current().notificationSettings()
+        let notificationStatus = await self.notificationCenter.authorizationStatus()
         let params = try connectParams(
             identity: identity,
             nonce: challenge.nonce,
             // Older watch-node Gateways omitted ts; retain their original local-clock behavior.
             signedAtMs: challenge.ts ?? Int64(Date().timeIntervalSince1970 * 1000),
             credential: credential,
-            notificationsAuthorized: notificationSettings.authorizationStatus == .authorized
-                || notificationSettings.authorizationStatus == .provisional)
+            notificationsAuthorized: notificationStatus == .authorized || notificationStatus == .provisional)
         let connectData = try await request(
             baseURL: baseURL,
             path: "connect",
@@ -642,9 +642,8 @@ final class WatchDirectNode {
                 code: .invalidRequest,
                 message: "INVALID_REQUEST: empty notification")
         }
-        let center = UNUserNotificationCenter.current()
-        let settings = await center.notificationSettings()
-        guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+        let status = await self.notificationCenter.authorizationStatus()
+        guard status == .authorized || status == .provisional else {
             return Self.errorResponse(
                 id: request.id,
                 code: .unavailable,
@@ -664,7 +663,7 @@ final class WatchDirectNode {
         }
         let sound = params.sound?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         content.sound = sound.map { ["none", "silent", "off"].contains($0) } == true ? nil : .default
-        try await center.add(UNNotificationRequest(
+        try await self.notificationCenter.add(UNNotificationRequest(
             identifier: UUID().uuidString,
             content: content,
             trigger: nil))

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -804,20 +804,7 @@ extension MacNodeRuntime {
         let delivery = params.delivery.flatMap { NotificationDelivery(rawValue: $0.rawValue) } ?? .system
         let manager = NotificationManager()
 
-        switch delivery {
-        case .system:
-            let ok = await manager.send(
-                title: title,
-                body: body,
-                sound: params.sound,
-                priority: priority)
-            return ok
-                ? BridgeInvokeResponse(id: req.id, ok: true)
-                : Self.errorResponse(req, code: .unavailable, message: "NOT_AUTHORIZED: notifications")
-        case .overlay:
-            await NotifyOverlayController.shared.present(title: title, body: body)
-            return BridgeInvokeResponse(id: req.id, ok: true)
-        case .auto:
+        if delivery != .overlay {
             let ok = await manager.send(
                 title: title,
                 body: body,
@@ -826,9 +813,16 @@ extension MacNodeRuntime {
             if ok {
                 return BridgeInvokeResponse(id: req.id, ok: true)
             }
-            await NotifyOverlayController.shared.present(title: title, body: body)
-            return BridgeInvokeResponse(id: req.id, ok: true)
+            try Task.checkCancellation()
+            if delivery == .system {
+                return Self.errorResponse(req, code: .unavailable, message: "NOT_AUTHORIZED: notifications")
+            }
         }
+        try await MainActor.run {
+            try Task.checkCancellation()
+            NotifyOverlayController.shared.present(title: title, body: body)
+        }
+        return BridgeInvokeResponse(id: req.id, ok: true)
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/NotificationManager.swift
+++ b/apps/macos/Sources/OpenClaw/NotificationManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawIPC
+import OpenClawKit
 import Security
 import UserNotifications
 
@@ -21,8 +22,10 @@ struct NotificationManager {
         }
         let center = UNUserNotificationCenter.current()
         let status = await center.notificationSettings()
+        guard !Task.isCancelled else { return false }
         if status.authorizationStatus == .notDetermined {
             let granted = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
+            guard !Task.isCancelled else { return false }
             if granted != true {
                 self.logger.warning("notification permission denied (request)")
                 return false
@@ -59,7 +62,7 @@ struct NotificationManager {
 
         let req = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
         do {
-            try await center.add(req)
+            try await LiveNotificationCenter(center: center).add(req)
             self.logger.debug("notification queued")
             return true
         } catch {

--- a/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AsyncTimeoutTests.swift
@@ -210,10 +210,11 @@ struct AsyncTimeoutTests {
         }
 
         task.cancel()
+        let cancelledWhenCallReturned = cancellation.cancelled()
+        #expect(cancelledWhenCallReturned, "Cancellation must reach the operation before cancel() returns")
         await #expect(throws: CancellationError.self) {
             try await task.value
         }
-        #expect(cancellation.cancelled())
         #expect(await !operation.finished())
 
         await operation.release()

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -502,6 +502,29 @@ struct MacNodeRuntimeTests {
         #expect(response.ok == false)
     }
 
+    @Test @MainActor func `cancelled notification cannot present an overlay`() async throws {
+        let overlay = NotifyOverlayController.shared
+        try #require(!overlay.model.isVisible)
+        defer { overlay.dismiss() }
+        let runtime = MacNodeRuntime()
+        let params = OpenClawSystemNotifyParams(
+            title: "Cancelled notification test",
+            body: "This overlay must not appear.",
+            delivery: .overlay)
+        let request = Task { @MainActor in
+            try await self.invoke(
+                runtime,
+                "cancelled-overlay",
+                OpenClawSystemCommand.notify.rawValue,
+                params: params)
+        }
+        request.cancel()
+        let response = try await request.value
+
+        #expect(!response.ok)
+        #expect(!overlay.model.isVisible)
+    }
+
     @Test func `handle invoke camera list requires enabled camera`() async {
         await TestIsolation.withUserDefaultsValues([cameraEnabledKey: false]) {
             let runtime = MacNodeRuntime()

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/AsyncTimeout.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/AsyncTimeout.swift
@@ -1,62 +1,90 @@
-import Foundation
+import Synchronization
 
-private actor AsyncTimeoutRace<T: Sendable> {
-    private enum Outcome {
-        case success(T)
-        case failure(any Error)
+private final class AsyncTimeoutRace<T: Sendable>: Sendable {
+    private enum State {
+        case pending
+        case cancelledBeforeStart
+        case running(CheckedContinuation<T, any Error>, [Task<Void, Never>])
+        case resolved([Task<Void, Never>])
     }
 
-    private var outcome: Outcome?
-    private var continuation: CheckedContinuation<T, any Error>?
-    private var tasks: [Task<Void, Never>] = []
+    private let state = Mutex<State>(.pending)
 
-    func wait(for tasks: [Task<Void, Never>]) async throws -> T {
-        if let outcome {
-            tasks.forEach { $0.cancel() }
-            return try self.value(from: outcome)
+    func wait(
+        seconds: Double,
+        onTimeout: @escaping @Sendable () -> Error,
+        operation: @escaping @Sendable () async throws -> T) async throws -> T
+    {
+        try await withCheckedThrowingContinuation { continuation in
+            let cancelled = self.state.withLock { state in
+                switch state {
+                case .cancelledBeforeStart:
+                    return true
+                case .running, .resolved:
+                    preconditionFailure("A timeout race has only one waiter")
+                case .pending:
+                    // Admission and handle installation share cancellation's lock.
+                    // A cancelled caller cannot leave an unregistered operation running.
+                    let operationTask = Task {
+                        do {
+                            let value = try await operation()
+                            self.resolve(.success(value))
+                        } catch {
+                            self.resolveFailure(error)
+                        }
+                    }
+                    var tasks = [operationTask]
+                    if seconds > 0 {
+                        tasks.append(Task {
+                            do {
+                                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                                self.resolveFailure(onTimeout())
+                            } catch is CancellationError {
+                                // The operation or caller resolved the race first.
+                            } catch {
+                                self.resolveFailure(error)
+                            }
+                        })
+                    }
+                    state = .running(continuation, tasks)
+                    return false
+                }
+            }
+            if cancelled {
+                continuation.resume(throwing: CancellationError())
+            }
         }
-        self.tasks = tasks
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
-        }
     }
 
-    private func resolve(_ outcome: @autoclosure () -> Outcome) {
-        // Timeout factories can log; only evaluate the winner's outcome.
-        guard self.outcome == nil else { return }
-        let outcome = outcome()
-        self.outcome = outcome
-        self.tasks.forEach { $0.cancel() }
-        self.tasks.removeAll()
-        if let continuation {
-            self.continuation = nil
-            self.resume(continuation, with: outcome)
-        }
-    }
-
-    func resolveSuccess(_ value: T) {
-        self.resolve(.success(value))
-    }
-
-    func resolveFailure(_ error: @autoclosure @Sendable () -> any Error) {
+    func resolveFailure(_ error: @autoclosure () -> any Error) {
         self.resolve(.failure(error()))
     }
 
-    private func resume(_ continuation: CheckedContinuation<T, any Error>, with outcome: Outcome) {
-        switch outcome {
-        case let .success(value):
-            continuation.resume(returning: value)
-        case let .failure(error):
-            continuation.resume(throwing: error)
-        }
-    }
-
-    private func value(from outcome: Outcome) throws -> T {
-        switch outcome {
-        case let .success(value):
-            return value
-        case let .failure(error):
-            throw error
+    private func resolve(_ outcome: @autoclosure () -> Result<T, any Error>) {
+        let (continuation, tasks): (CheckedContinuation<T, any Error>?, [Task<Void, Never>]) =
+            self.state.withLock { state in
+                switch state {
+                case .pending:
+                    // Only caller cancellation can precede atomic racer installation.
+                    state = .cancelledBeforeStart
+                    return (nil, [])
+                case .cancelledBeforeStart:
+                    return (nil, [])
+                case let .running(continuation, tasks):
+                    state = .resolved(tasks)
+                    return (continuation, tasks)
+                case let .resolved(tasks):
+                    return (nil, tasks)
+                }
+            }
+        guard !tasks.isEmpty else { return }
+        // Handlers may reenter the race. Keep handles visible until cancellation is applied,
+        // but cancel and resume outside the lock to avoid Swift runtime lock inversion.
+        tasks.forEach { $0.cancel() }
+        self.state.withLock { $0 = .resolved([]) }
+        if let continuation {
+            // Only the winner consumes its factory; it may log or call back into a caller.
+            continuation.resume(with: outcome())
         }
     }
 }
@@ -67,43 +95,13 @@ public enum AsyncTimeout {
         onTimeout: @escaping @Sendable () -> Error,
         operation: @escaping @Sendable () async throws -> T) async throws -> T
     {
-        let clamped = max(0, seconds)
-        // Unstructured racers let the caller return without awaiting a cancellation-ignoring loser.
-        // The actor resumes once and cancels every racer; noncooperative work may still finish later,
-        // so callers must own resource cleanup and stale-result safety.
+        // Unstructured racers avoid joining a cancellation-ignoring loser. Cancellation
+        // marks every racer synchronously; callers still own cleanup and stale-result safety.
         let race = AsyncTimeoutRace<T>()
         return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-
-            let operationTask = Task {
-                do {
-                    let value = try await operation()
-                    await race.resolveSuccess(value)
-                } catch {
-                    await race.resolveFailure(error)
-                }
-            }
-            var tasks = [operationTask]
-            if clamped > 0 {
-                let timeoutTask = Task {
-                    do {
-                        try await Task.sleep(nanoseconds: UInt64(clamped * 1_000_000_000))
-                        await race.resolveFailure(onTimeout())
-                    } catch is CancellationError {
-                        // The operation or caller resolved the race first.
-                    } catch {
-                        await race.resolveFailure(error)
-                    }
-                }
-                tasks.append(timeoutTask)
-            }
-            if Task.isCancelled {
-                tasks.forEach { $0.cancel() }
-                throw CancellationError()
-            }
-            return try await race.wait(for: tasks)
+            try await race.wait(seconds: max(0, seconds), onTimeout: onTimeout, operation: operation)
         } onCancel: {
-            Task { await race.resolveFailure(CancellationError()) }
+            race.resolveFailure(CancellationError())
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeInvocationRegistry.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeInvocationRegistry.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Synchronous invocation ownership, isolated by the containing GatewayNodeSession actor.
+struct GatewayNodeInvocationRegistry {
+    typealias Cleanup = (id: UUID, task: Task<BridgeInvokeResponse, Never>)
+
+    private struct Invocation {
+        enum State {
+            case pending
+            case cancelled
+            case running(Task<BridgeInvokeResponse, Never>)
+        }
+
+        let requestID: String
+        let admissionGeneration: UInt64
+        let waitsForRouteTeardown: Bool
+        var state: State = .pending
+
+        var task: Task<BridgeInvokeResponse, Never>? {
+            if case let .running(task) = self.state {
+                task
+            } else { nil }
+        }
+
+        mutating func cancel() {
+            switch self.state {
+            case .pending: self.state = .cancelled
+            case let .running(task): task.cancel()
+            case .cancelled: break
+            }
+        }
+    }
+
+    private var invocations: [UUID: Invocation] = [:]
+
+    mutating func register(requestID: String, command: String, admissionGeneration: UInt64) -> UUID? {
+        let waitsForRouteTeardown = command == OpenClawComputerCommand.act.rawValue ||
+            command == OpenClawCameraCommand.ptzControl.rawValue ||
+            OpenClawTalkCommand(rawValue: command) != nil
+        guard waitsForRouteTeardown || command == OpenClawSystemCommand.notify.rawValue ||
+            command == OpenClawChatCommand.push.rawValue
+        else { return nil }
+        let id = UUID()
+        self.invocations[id] = Invocation(
+            requestID: requestID,
+            admissionGeneration: admissionGeneration,
+            waitsForRouteTeardown: waitsForRouteTeardown)
+        return id
+    }
+
+    /// The synchronous factory retains the session's actor isolation when creating
+    /// its task; cancellation cannot interleave between admission and registration.
+    mutating func start(
+        id: UUID,
+        makeTask: () -> Task<BridgeInvokeResponse, Never>) -> Task<BridgeInvokeResponse, Never>?
+    {
+        guard !Task.isCancelled, case .pending? = self.invocations[id]?.state else { return nil }
+        let task = makeTask()
+        self.invocations[id]?.state = .running(task)
+        return task
+    }
+
+    mutating func finish(_ id: UUID) {
+        self.invocations.removeValue(forKey: id)
+    }
+
+    mutating func discardPending(_ id: UUID?) {
+        // A joined computer receipt never starts another operation. Its pending
+        // admission ends here; running operations retain cleanup ownership.
+        if let id, self.invocations[id]?.task == nil {
+            self.finish(id)
+        }
+    }
+
+    mutating func cancel(admissionGeneration: UInt64) -> [Cleanup] {
+        var cleanup: [Cleanup] = []
+        for (id, var invoke) in self.invocations where invoke.admissionGeneration == admissionGeneration {
+            invoke.cancel()
+            if invoke.waitsForRouteTeardown, let task = invoke.task {
+                self.invocations[id] = invoke
+                cleanup.append((id, task))
+            } else {
+                // Notification permission callbacks can ignore cancellation. Fence
+                // their effect, but never make them hold replacement routes open.
+                self.finish(id)
+            }
+        }
+        return cleanup
+    }
+
+    mutating func cancel(requestID: String, admissionGeneration: UInt64) {
+        for (id, invoke) in self.invocations
+            where invoke.requestID == requestID && invoke.admissionGeneration == admissionGeneration
+        {
+            self.invocations[id]?.cancel()
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeInvocationRegistry.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeInvocationRegistry.swift
@@ -38,7 +38,7 @@ struct GatewayNodeInvocationRegistry {
             command == OpenClawCameraCommand.ptzControl.rawValue ||
             OpenClawTalkCommand(rawValue: command) != nil
         guard waitsForRouteTeardown || command == OpenClawSystemCommand.notify.rawValue ||
-            command == OpenClawChatCommand.push.rawValue
+            command == OpenClawChatCommand.push.rawValue || command == OpenClawWatchCommand.notify.rawValue
         else { return nil }
         let id = UUID()
         self.invocations[id] = Invocation(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -83,33 +83,6 @@ public actor GatewayNodeSession {
         }
     }
 
-    private struct ActiveInvoke {
-        enum State {
-            case pending
-            case cancelled
-            case running(Task<BridgeInvokeResponse, Never>)
-        }
-
-        let requestID: String
-        let admissionGeneration: UInt64
-        let waitsForRouteTeardown: Bool
-        var state: State = .pending
-
-        var task: Task<BridgeInvokeResponse, Never>? {
-            if case let .running(task) = self.state {
-                task
-            } else { nil }
-        }
-
-        mutating func cancel() {
-            switch self.state {
-            case .pending: self.state = .cancelled
-            case let .running(task): task.cancel()
-            case .cancelled: break
-            }
-        }
-    }
-
     private struct LifecycleCallbackBarrier {
         let id: UUID
         let task: Task<Void, Never>
@@ -136,7 +109,7 @@ public actor GatewayNodeSession {
     private var routeTeardownBarrier: Task<Void, Never>?
     private var lifecycleCallbackBarrier: LifecycleCallbackBarrier?
     private var executingLifecycleCallbackIDs: Set<UUID> = []
-    private var activeInvokes: [UUID: ActiveInvoke] = [:]
+    private var activeInvokes = GatewayNodeInvocationRegistry()
     private var connectOptions: GatewayConnectOptions?
     private var onConnected: (@Sendable () async -> Void)?
     private var onDisconnected: (@Sendable (String) async -> Void)?
@@ -445,7 +418,7 @@ public actor GatewayNodeSession {
         let isLifecycleReentry = self.isExecutingLifecycleCallback()
         let previous = self.routeTeardownBarrier
         let lifecycleCallback = self.lifecycleCallbackBarrier
-        let activeInvokes = self.cancelActiveInvokes(admissionGeneration: admissionGeneration)
+        let activeInvokes = self.activeInvokes.cancel(admissionGeneration: admissionGeneration)
         let invalidationCallbackID = UUID()
         self.executingLifecycleCallbackIDs.insert(invalidationCallbackID)
         // Stop the detached transport concurrently with owner cleanup. Input release
@@ -967,7 +940,7 @@ extension GatewayNodeSession {
         // invoke leases before runtime cleanup; new events receive the fresh epoch.
         let invalidatedAdmissionGeneration = self.admissionGeneration
         self.admissionGeneration &+= 1
-        let activeInvokes = self.cancelActiveInvokes(
+        let activeInvokes = self.activeInvokes.cancel(
             admissionGeneration: invalidatedAdmissionGeneration)
         let onRouteInvalidated = self.onRouteInvalidated
         let onDisconnected = self.onDisconnected
@@ -1152,7 +1125,7 @@ extension GatewayNodeSession {
             guard let payload = evt.payload else { return }
             do {
                 let cancel: NodeInvokeCancelPayload = try self.decodeEventPayload(from: payload)
-                self.cancelActiveInvoke(
+                self.activeInvokes.cancel(
                     requestID: cancel.invokeId,
                     admissionGeneration: admissionGeneration)
                 await self.onInvokeCancel?(cancel.invokeId)
@@ -1179,24 +1152,12 @@ extension GatewayNodeSession {
                 admissionGeneration: admissionGeneration,
                 socketGeneration: socketGeneration)
             let receiptScope = self.computerInvokeReceiptScope()
-            let waitsForRouteTeardown = request.command == OpenClawComputerCommand.act.rawValue ||
-                request.command == OpenClawCameraCommand.ptzControl.rawValue ||
-                OpenClawTalkCommand(rawValue: request.command) != nil
-            let invokeID: UUID?
-            if waitsForRouteTeardown || request.command == OpenClawSystemCommand.notify.rawValue ||
-                request.command == OpenClawChatCommand.push.rawValue
-            {
-                let id = UUID()
-                // Register before returning to receive: a following cancel must retire
-                // this request even while its detached timeout/receipt work is queued.
-                self.activeInvokes[id] = ActiveInvoke(
-                    requestID: request.id,
-                    admissionGeneration: admissionGeneration,
-                    waitsForRouteTeardown: waitsForRouteTeardown)
-                invokeID = id
-            } else {
-                invokeID = nil
-            }
+            // Register before returning to receive: a following cancel must retire
+            // this request even while its detached timeout/receipt work is queued.
+            let invokeID = self.activeInvokes.register(
+                requestID: request.id,
+                command: request.command,
+                admissionGeneration: admissionGeneration)
             // GatewayChannel waits for push handling before it rearms receive. Run device work
             // separately so a long invoke cannot starve heartbeats or later node requests.
             Task.detached { [weak self] in
@@ -1224,11 +1185,7 @@ extension GatewayNodeSession {
         socketGeneration: UInt64) async
     {
         defer {
-            // A joined computer receipt never starts another operation. Its pending
-            // admission ends here; running operations retain cleanup ownership.
-            if let invokeID, self.activeInvokes[invokeID]?.task == nil {
-                self.activeInvokes.removeValue(forKey: invokeID)
-            }
+            self.activeInvokes.discardPending(invokeID)
         }
         guard self.isCurrentRoute(route),
               self.channel === channel
@@ -1301,20 +1258,20 @@ extension GatewayNodeSession {
         guard let invokeID else {
             return await onInvoke(request)
         }
-        guard !Task.isCancelled, case .pending? = self.activeInvokes[invokeID]?.state else {
+        guard let task = self.activeInvokes.start(id: invokeID, makeTask: {
+            Task { await onInvoke(request) }
+        }) else {
             return BridgeInvokeResponse(
                 id: request.id,
                 ok: false,
                 error: OpenClawNodeError(code: .unavailable, message: "node invoke cancelled"))
         }
-        let task = Task { await onInvoke(request) }
-        self.activeInvokes[invokeID]?.state = .running(task)
         let response = await withTaskCancellationHandler {
             await task.value
         } onCancel: {
             task.cancel()
         }
-        self.activeInvokes.removeValue(forKey: invokeID)
+        self.activeInvokes.finish(invokeID)
         return response
     }
 
@@ -1413,38 +1370,10 @@ extension GatewayNodeSession {
 
     #endif
 
-    private func cancelActiveInvokes(
-        admissionGeneration: UInt64) -> [(id: UUID, task: Task<BridgeInvokeResponse, Never>)]
-    {
-        var cleanup: [(id: UUID, task: Task<BridgeInvokeResponse, Never>)] = []
-        for (id, var invoke) in self.activeInvokes where invoke.admissionGeneration == admissionGeneration {
-            invoke.cancel()
-            if invoke.waitsForRouteTeardown, let task = invoke.task {
-                self.activeInvokes[id] = invoke
-                cleanup.append((id, task))
-            } else {
-                // Notification permission callbacks can ignore cancellation. Fence
-                // their effect, but never make them hold replacement routes open.
-                self.activeInvokes.removeValue(forKey: id)
-            }
-        }
-        return cleanup
-    }
-
-    private func cancelActiveInvoke(requestID: String, admissionGeneration: UInt64) {
-        for (id, invoke) in self.activeInvokes
-            where invoke.requestID == requestID && invoke.admissionGeneration == admissionGeneration
-        {
-            self.activeInvokes[id]?.cancel()
-        }
-    }
-
-    private func awaitActiveInvokes(
-        _ invokes: [(id: UUID, task: Task<BridgeInvokeResponse, Never>)]) async
-    {
+    private func awaitActiveInvokes(_ invokes: [GatewayNodeInvocationRegistry.Cleanup]) async {
         for invoke in invokes {
             _ = await invoke.task.value
-            self.activeInvokes.removeValue(forKey: invoke.id)
+            self.activeInvokes.finish(invoke.id)
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -84,9 +84,30 @@ public actor GatewayNodeSession {
     }
 
     private struct ActiveInvoke {
+        enum State {
+            case pending
+            case cancelled
+            case running(Task<BridgeInvokeResponse, Never>)
+        }
+
         let requestID: String
         let admissionGeneration: UInt64
-        let task: Task<BridgeInvokeResponse, Never>
+        let waitsForRouteTeardown: Bool
+        var state: State = .pending
+
+        var task: Task<BridgeInvokeResponse, Never>? {
+            if case let .running(task) = self.state {
+                task
+            } else { nil }
+        }
+
+        mutating func cancel() {
+            switch self.state {
+            case .pending: self.state = .cancelled
+            case let .running(task): task.cancel()
+            case .cancelled: break
+            }
+        }
     }
 
     private struct LifecycleCallbackBarrier {
@@ -1158,11 +1179,30 @@ extension GatewayNodeSession {
                 admissionGeneration: admissionGeneration,
                 socketGeneration: socketGeneration)
             let receiptScope = self.computerInvokeReceiptScope()
+            let waitsForRouteTeardown = request.command == OpenClawComputerCommand.act.rawValue ||
+                request.command == OpenClawCameraCommand.ptzControl.rawValue ||
+                OpenClawTalkCommand(rawValue: request.command) != nil
+            let invokeID: UUID?
+            if waitsForRouteTeardown || request.command == OpenClawSystemCommand.notify.rawValue ||
+                request.command == OpenClawChatCommand.push.rawValue
+            {
+                let id = UUID()
+                // Register before returning to receive: a following cancel must retire
+                // this request even while its detached timeout/receipt work is queued.
+                self.activeInvokes[id] = ActiveInvoke(
+                    requestID: request.id,
+                    admissionGeneration: admissionGeneration,
+                    waitsForRouteTeardown: waitsForRouteTeardown)
+                invokeID = id
+            } else {
+                invokeID = nil
+            }
             // GatewayChannel waits for push handling before it rearms receive. Run device work
             // separately so a long invoke cannot starve heartbeats or later node requests.
             Task.detached { [weak self] in
                 await self?.handleInvokeRequest(
                     request: request,
+                    invokeID: invokeID,
                     onInvoke: onInvoke,
                     route: route,
                     receiptScope: receiptScope,
@@ -1176,12 +1216,20 @@ extension GatewayNodeSession {
 
     private func handleInvokeRequest(
         request: NodeInvokeRequestPayload,
+        invokeID: UUID?,
         onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse,
         route: GatewayNodeSessionRoute,
         receiptScope: String,
         channel: GatewayChannelActor,
         socketGeneration: UInt64) async
     {
+        defer {
+            // A joined computer receipt never starts another operation. Its pending
+            // admission ends here; running operations retain cleanup ownership.
+            if let invokeID, self.activeInvokes[invokeID]?.task == nil {
+                self.activeInvokes.removeValue(forKey: invokeID)
+            }
+        }
         guard self.isCurrentRoute(route),
               self.channel === channel
         else { return }
@@ -1216,6 +1264,7 @@ extension GatewayNodeSession {
             }
             return await self.invokeIfCurrentRoute(
                 req,
+                invokeID: invokeID,
                 expectedRoute: route,
                 onInvoke: onInvoke)
         }
@@ -1239,8 +1288,9 @@ extension GatewayNodeSession {
             socketGeneration: socketGeneration)
     }
 
-    func invokeIfCurrentRoute(
+    private func invokeIfCurrentRoute(
         _ request: BridgeInvokeRequest,
+        invokeID: UUID?,
         expectedRoute: GatewayNodeSessionRoute,
         onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse) async
         -> BridgeInvokeResponse
@@ -1248,20 +1298,17 @@ extension GatewayNodeSession {
         guard self.isCurrentRoute(expectedRoute),
               self.channel != nil
         else { return Self.staleRouteInvokeResponse(requestId: request.id) }
-        let requiresRouteScopedCancellation = request.command == "computer.act" ||
-            request.command == OpenClawCameraCommand.ptzControl.rawValue ||
-            OpenClawTalkCommand(rawValue: request.command) != nil
-        guard requiresRouteScopedCancellation else {
+        guard let invokeID else {
             return await onInvoke(request)
         }
-        // These side-effecting commands own explicit cancellation cleanup. Route
-        // teardown waits for it so a replacement cannot inherit input ownership.
-        let invokeID = UUID()
+        guard !Task.isCancelled, case .pending? = self.activeInvokes[invokeID]?.state else {
+            return BridgeInvokeResponse(
+                id: request.id,
+                ok: false,
+                error: OpenClawNodeError(code: .unavailable, message: "node invoke cancelled"))
+        }
         let task = Task { await onInvoke(request) }
-        self.activeInvokes[invokeID] = ActiveInvoke(
-            requestID: request.id,
-            admissionGeneration: expectedRoute.admissionGeneration,
-            task: task)
+        self.activeInvokes[invokeID]?.state = .running(task)
         let response = await withTaskCancellationHandler {
             await task.value
         } onCancel: {
@@ -1369,22 +1416,26 @@ extension GatewayNodeSession {
     private func cancelActiveInvokes(
         admissionGeneration: UInt64) -> [(id: UUID, task: Task<BridgeInvokeResponse, Never>)]
     {
-        let matches = self.activeInvokes.compactMap { id, invoke in
-            invoke.admissionGeneration == admissionGeneration
-                ? (id: id, task: invoke.task)
-                : nil
+        var cleanup: [(id: UUID, task: Task<BridgeInvokeResponse, Never>)] = []
+        for (id, var invoke) in self.activeInvokes where invoke.admissionGeneration == admissionGeneration {
+            invoke.cancel()
+            if invoke.waitsForRouteTeardown, let task = invoke.task {
+                self.activeInvokes[id] = invoke
+                cleanup.append((id, task))
+            } else {
+                // Notification permission callbacks can ignore cancellation. Fence
+                // their effect, but never make them hold replacement routes open.
+                self.activeInvokes.removeValue(forKey: id)
+            }
         }
-        for match in matches {
-            match.task.cancel()
-        }
-        return matches
+        return cleanup
     }
 
     private func cancelActiveInvoke(requestID: String, admissionGeneration: UInt64) {
-        for invoke in self.activeInvokes.values
+        for (id, invoke) in self.activeInvokes
             where invoke.requestID == requestID && invoke.admissionGeneration == admissionGeneration
         {
-            invoke.task.cancel()
+            self.activeInvokes[id]?.cancel()
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/NotificationCenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/NotificationCenter.swift
@@ -1,0 +1,91 @@
+import Foundation
+import UserNotifications
+
+public struct NotificationSnapshot: @unchecked Sendable {
+    public let identifier: String
+    public let userInfo: [AnyHashable: Any]
+}
+
+public enum NotificationAuthorizationStatus: Sendable {
+    case notDetermined
+    case denied
+    case authorized
+    case provisional
+    case ephemeral
+}
+
+public protocol NotificationCentering: Sendable {
+    func authorizationStatus() async -> NotificationAuthorizationStatus
+    func add(_ request: UNNotificationRequest) async throws
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) async
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) async
+    func deliveredNotifications() async -> [NotificationSnapshot]
+}
+
+public struct LiveNotificationCenter: NotificationCentering, @unchecked Sendable {
+    private let center: UNUserNotificationCenter
+
+    public init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    public func authorizationStatus() async -> NotificationAuthorizationStatus {
+        let settings = await self.center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized:
+            return .authorized
+        case .provisional:
+            return .provisional
+        #if os(iOS)
+        case .ephemeral:
+            return .ephemeral
+        #endif
+        case .denied:
+            return .denied
+        case .notDetermined:
+            return .notDetermined
+        @unknown default:
+            return .denied
+        }
+    }
+
+    public func add(_ request: UNNotificationRequest) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            // Permission reads do not cancel with their caller; retire its effect before enqueueing.
+            guard !Task.isCancelled else {
+                cont.resume(throwing: CancellationError())
+                return
+            }
+            self.center.add(request) { error in
+                if let error {
+                    cont.resume(throwing: error)
+                } else {
+                    cont.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    public func removePendingNotificationRequests(withIdentifiers identifiers: [String]) async {
+        guard !identifiers.isEmpty else { return }
+        self.center.removePendingNotificationRequests(withIdentifiers: identifiers)
+    }
+
+    public func removeDeliveredNotifications(withIdentifiers identifiers: [String]) async {
+        guard !identifiers.isEmpty else { return }
+        self.center.removeDeliveredNotifications(withIdentifiers: identifiers)
+    }
+
+    public func deliveredNotifications() async -> [NotificationSnapshot] {
+        await withCheckedContinuation { continuation in
+            self.center.getDeliveredNotifications { notifications in
+                continuation.resume(
+                    returning: notifications.map { notification in
+                        NotificationSnapshot(
+                            identifier: notification.request.identifier,
+                            userInfo: notification.request.content.userInfo)
+                    })
+            }
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
@@ -37,6 +37,8 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
     {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        // A cancelled caller must not retire the utterance already playing.
+        guard !Task.isCancelled else { throw SpeakError.canceled }
 
         self.stop()
         let token = UUID()

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ThrowingContinuationSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ThrowingContinuationSupport.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public enum ThrowingContinuationSupport {
-    public static func resumeVoid(_ continuation: CheckedContinuation<Void, Error>, error: Error?) {
+enum ThrowingContinuationSupport {
+    static func resumeVoid(_ continuation: CheckedContinuation<Void, Error>, error: Error?) {
         if let error {
             continuation.resume(throwing: error)
         } else {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -388,6 +388,16 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         self.emitInbound(.success(.data(data)))
     }
 
+    func emitInvokeCancel(id: String) {
+        let frame: [String: Any] = [
+            "type": "event",
+            "event": "node.invoke.cancel",
+            "payload": ["invokeId": id, "nodeId": "test-node"],
+        ]
+        let data = (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
+        self.emitInbound(.success(.data(data)))
+    }
+
     private func emitInbound(_ result: ReceiveResult) {
         let handler = self.lock.withLock { () -> (@Sendable (ReceiveResult) -> Void)? in
             guard let handler = self.pendingReceiveHandler else {
@@ -1416,7 +1426,7 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
-    func `stale old invoke is rejected before onInvoke after route switch`() async throws {
+    func `route switch rejects a decoded invoke before detached admission`() async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()
         let invocations = DisconnectProbe()
@@ -1426,25 +1436,38 @@ struct GatewayNodeSessionTests {
             clientId: "openclaw-macos",
             clientDisplayName: "macOS Test")
 
-        try await gateway.connectForTest(testURL("ws://first.example.invalid"), options: options, session: session)
-        let oldRoute = try #require(await gateway.currentRoute())
+        let onInvoke: @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse = { request in
+            await invocations.record(request.id)
+            return BridgeInvokeResponse(id: request.id, ok: true)
+        }
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
+            onInvoke: onInvoke)
+        let oldSocket = try #require(session.latestTask())
+
+        func retireBeforeDetachedAdmission(to gateway: isolated GatewayNodeSession) async {
+            await gateway._test_handlePush(
+                nodeInvokePush(id: "stale-computer", command: OpenClawComputerCommand.act.rawValue),
+                socketGeneration: 1)
+            await gateway.disconnect()
+        }
+        await retireBeforeDetachedAdmission(to: gateway)
 
         try await gateway.connectForTest(
             testURL("ws://replacement.example.invalid"),
             options: options,
-            session: session)
+            session: session,
+            onInvoke: onInvoke)
+        let replacementSocket = try #require(session.latestTask())
+        replacementSocket.emitInvokeRequest(id: "current-computer", command: OpenClawComputerCommand.act.rawValue)
+        try await waitUntil("replacement invoke completed") {
+            replacementSocket.sentRequestCount(method: "node.invoke.result") == 1
+        }
 
-        let response = await gateway.invokeIfCurrentRoute(
-            BridgeInvokeRequest(id: "stale-computer", command: "computer.act", paramsJSON: "{}"),
-            expectedRoute: oldRoute,
-            onInvoke: { request in
-                await invocations.record(request.id)
-                return BridgeInvokeResponse(id: request.id, ok: true, payloadJSON: nil, error: nil)
-            })
-
-        #expect(response.ok == false)
-        #expect(response.error?.code == .unavailable)
-        #expect(await invocations.values() == [])
+        #expect(await invocations.values() == ["current-computer"])
+        #expect(oldSocket.sentRequestCount(method: "node.invoke.result") == 0)
         await gateway.disconnect()
     }
 
@@ -1508,80 +1531,35 @@ struct GatewayNodeSessionTests {
         await gateway.disconnect()
     }
 
-    @Test
-    func `route switch cancels an in flight push to talk start`() async throws {
-        let session = FakeGatewayWebSocketSession()
-        let gateway = GatewayNodeSession()
-        let invokeStarted = AsyncGate()
-        let cancellations = DisconnectProbe()
-        let options = nodeConnectOptions(caps: ["talk"], commands: ["talk.ptt.start"], clientId: "openclaw-ios")
-
-        try await gateway.connectForTest(testURL("ws://first.example.invalid"), options: options, session: session)
-        let route = try #require(await gateway.currentRoute())
-        let invoking = Task {
-            await gateway.invokeIfCurrentRoute(
-                BridgeInvokeRequest(id: "stale-ptt", command: "talk.ptt.start", paramsJSON: nil),
-                expectedRoute: route,
-                onInvoke: { request in
-                    await invokeStarted.wait()
-                    do {
-                        try await Task.sleep(nanoseconds: 60 * 1_000_000_000)
-                    } catch {
-                        await cancellations.record(request.id)
-                    }
-                    return BridgeInvokeResponse(
-                        id: request.id,
-                        ok: false,
-                        error: OpenClawNodeError(code: .unavailable, message: "UNAVAILABLE: route changed"))
-                })
-        }
-        try await waitUntil("push to talk invoke started") {
-            await invokeStarted.hasStarted()
-        }
-        await invokeStarted.release()
-
-        try await gateway.connectForTest(
-            testURL("ws://replacement.example.invalid"),
-            options: options,
-            session: session)
-
-        #expect(await (invoking.value).ok == false)
-        #expect(await cancellations.values() == ["stale-ptt"])
-        await gateway.disconnect()
-    }
-
-    @Test
-    func `route switch cancels queued PTZ control and waits for invoke cleanup`() async throws {
+    @Test(arguments: [
+        OpenClawComputerCommand.act.rawValue,
+        OpenClawCameraCommand.ptzControl.rawValue,
+        OpenClawTalkCommand.pttStart.rawValue,
+    ])
+    func `route switch cancels queued device work and waits for invoke cleanup`(command: String) async throws {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()
         let invokeGate = AsyncGate()
         let cancellations = DisconnectProbe()
-        let options = nodeConnectOptions(
-            caps: ["camera"],
-            commands: [OpenClawCameraCommand.ptzControl.rawValue],
-            clientId: "openclaw-macos")
+        let options = nodeConnectOptions(commands: [command], clientId: "openclaw-macos")
 
-        try await gateway.connectForTest(testURL("ws://first.example.invalid"), options: options, session: session)
-        let route = try #require(await gateway.currentRoute())
-        let invoking = Task {
-            await gateway.invokeIfCurrentRoute(
-                BridgeInvokeRequest(
-                    id: "queued-ptz",
-                    command: OpenClawCameraCommand.ptzControl.rawValue,
-                    paramsJSON: nil),
-                expectedRoute: route,
-                onInvoke: { request in
-                    await invokeGate.wait()
-                    if Task.isCancelled {
-                        await cancellations.record(request.id)
-                    }
-                    return BridgeInvokeResponse(
-                        id: request.id,
-                        ok: false,
-                        error: OpenClawNodeError(code: .unavailable, message: "UNAVAILABLE: route changed"))
-                })
-        }
-        try await waitUntil("PTZ invoke queued before hardware admission") {
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
+            onInvoke: { request in
+                await invokeGate.wait()
+                if Task.isCancelled {
+                    await cancellations.record(request.id)
+                }
+                return BridgeInvokeResponse(
+                    id: request.id,
+                    ok: false,
+                    error: OpenClawNodeError(code: .unavailable, message: "UNAVAILABLE: route changed"))
+            })
+        let socket = try #require(session.latestTask())
+        socket.emitInvokeRequest(id: "queued-device-work", command: command)
+        try await waitUntil("invoke queued before device admission") {
             await invokeGate.hasStarted()
         }
 
@@ -1591,76 +1569,175 @@ struct GatewayNodeSessionTests {
                 options: options,
                 session: session)
         }
-        try await waitUntil("replacement detached old PTZ route") {
+        try await waitUntil("replacement detached old device route") {
             await gateway.currentRoute() == nil
         }
         #expect(session.snapshotMakeCount() == 1)
 
         await invokeGate.release()
-        #expect(await (invoking.value).ok == false)
         try await replacement.value
-        #expect(await cancellations.values() == ["queued-ptz"])
+        #expect(await cancellations.values() == ["queued-device-work"])
         #expect(session.snapshotMakeCount() == 2)
         await gateway.disconnect()
     }
 
-    @Test
-    func `node invoke cancel cancels queued PTZ control and preserves callback`() async throws {
+    @Test(arguments: [
+        OpenClawComputerCommand.act.rawValue,
+        OpenClawCameraCommand.ptzControl.rawValue,
+        OpenClawTalkCommand.pttStart.rawValue,
+        OpenClawSystemCommand.notify.rawValue,
+        OpenClawChatCommand.push.rawValue,
+    ])
+    func `node invoke cancellation retires suspended side effects and preserves callbacks`(
+        command: String) async throws
+    {
         let session = FakeGatewayWebSocketSession()
         let gateway = GatewayNodeSession()
         let invokeGate = AsyncGate()
         let taskCancellations = DisconnectProbe()
         let admissions = DisconnectProbe()
         let callback = NodeInvokeControlProbe()
-        let options = nodeConnectOptions(
-            caps: ["camera"],
-            commands: [OpenClawCameraCommand.ptzControl.rawValue],
-            clientId: "openclaw-macos")
+        let options = nodeConnectOptions(commands: [command], clientId: "openclaw-macos")
 
         try await gateway.connectForTest(
             testURL("ws://gateway.example.invalid"),
             options: options,
             session: session,
+            onInvoke: { request in
+                await invokeGate.wait()
+                if Task.isCancelled {
+                    await taskCancellations.record(request.id)
+                    return BridgeInvokeResponse(
+                        id: request.id,
+                        ok: false,
+                        error: OpenClawNodeError(code: .unavailable, message: "UNAVAILABLE: canceled"))
+                }
+                await admissions.record(request.id)
+                return BridgeInvokeResponse(id: request.id, ok: true)
+            },
             onInvokeCancel: { invokeID in await callback.recordCancellation(invokeID) })
-        let route = try #require(await gateway.currentRoute())
-        let invoking = Task {
-            await gateway.invokeIfCurrentRoute(
-                BridgeInvokeRequest(
-                    id: "queued-ptz",
-                    command: OpenClawCameraCommand.ptzControl.rawValue,
-                    paramsJSON: nil),
-                expectedRoute: route,
-                onInvoke: { request in
-                    await invokeGate.wait()
-                    if Task.isCancelled {
-                        await taskCancellations.record(request.id)
-                        return BridgeInvokeResponse(
-                            id: request.id,
-                            ok: false,
-                            error: OpenClawNodeError(code: .unavailable, message: "UNAVAILABLE: canceled"))
-                    }
-                    await admissions.record(request.id)
-                    return BridgeInvokeResponse(id: request.id, ok: true)
-                })
-        }
-        try await waitUntil("PTZ invoke queued before explicit cancellation") {
+        let socket = try #require(session.latestTask())
+        socket.emitInvokeRequest(id: "suspended-effect", command: command)
+        try await waitUntil("invoke suspended before explicit cancellation") {
             await invokeGate.hasStarted()
         }
-
-        await gateway._test_handlePush(
-            .event(EventFrame(
-                type: "event",
-                event: "node.invoke.cancel",
-                payload: AnyCodable(["invokeId": AnyCodable("queued-ptz")]),
-                seq: nil,
-                stateversion: nil)),
-            socketGeneration: 1)
+        socket.emitInvokeCancel(id: "suspended-effect")
+        try await waitUntil("wire cancellation delivered") {
+            await (callback.values()).1 == ["suspended-effect"]
+        }
         await invokeGate.release()
+        try await waitUntil("cancelled invoke result returned") {
+            socket.sentRequestCount(method: "node.invoke.result") == 1
+        }
 
-        #expect(await (invoking.value).ok == false)
-        #expect(await taskCancellations.values() == ["queued-ptz"])
+        let result = try #require(socket.sentRequests(method: "node.invoke.result").first)
+        let params = try #require(result["params"] as? [String: Any])
+        #expect(params["id"] as? String == "suspended-effect")
+        #expect(params["ok"] as? Bool == false)
+        #expect(await taskCancellations.values() == ["suspended-effect"])
         #expect(await admissions.values() == [])
-        #expect(await (callback.values()).1 == ["queued-ptz"])
+        #expect(await (callback.values()).1 == ["suspended-effect"])
+        await gateway.disconnect()
+    }
+
+    @Test
+    func `node invoke cancellation before detached admission prevents the side effect`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let cancellation = InvokeCancellationFlag()
+        let admissions = DisconnectProbe()
+        let command = OpenClawCameraCommand.ptzControl.rawValue
+        try await gateway.connectForTest(
+            testURL("ws://gateway.example.invalid"),
+            options: nodeConnectOptions(commands: [command], clientId: "openclaw-macos"),
+            session: session,
+            onInvoke: { request in
+                #expect(cancellation.isCancelled(), "The cancel event must precede native admission")
+                guard !Task.isCancelled else {
+                    return BridgeInvokeResponse(id: request.id, ok: false)
+                }
+                await admissions.record(request.id)
+                return BridgeInvokeResponse(id: request.id, ok: true)
+            },
+            onInvokeCancel: { _ in cancellation.markCancelled() })
+
+        /// Both decoded frames arrive in one actor turn: detached work cannot
+        /// register between them. The socket tests above exercise wire decoding.
+        func deliverBeforeDetachedAdmission(to gateway: isolated GatewayNodeSession) async {
+            await gateway._test_handlePush(
+                nodeInvokePush(id: "cancel-before-admission", command: command),
+                socketGeneration: 1)
+            await gateway._test_handlePush(
+                .event(EventFrame(
+                    type: "event",
+                    event: "node.invoke.cancel",
+                    payload: AnyCodable(["invokeId": AnyCodable("cancel-before-admission")]),
+                    seq: nil,
+                    stateversion: nil)),
+                socketGeneration: 1)
+        }
+        await deliverBeforeDetachedAdmission(to: gateway)
+        let socket = try #require(session.latestTask())
+        try await waitUntil("early-cancel invoke settled") {
+            socket.sentRequestCount(method: "node.invoke.result") == 1
+        }
+
+        #expect(cancellation.isCancelled())
+        #expect(await admissions.values() == [])
+        let result = try #require(socket.sentRequests(method: "node.invoke.result").first)
+        let params = try #require(result["params"] as? [String: Any])
+        #expect(params["ok"] as? Bool == false)
+        await gateway.disconnect()
+    }
+
+    @Test(arguments: [OpenClawSystemCommand.notify.rawValue, OpenClawChatCommand.push.rawValue])
+    func `route replacement cancels notification work without awaiting its permission callback`(
+        command: String) async throws
+    {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let permission = AsyncGate()
+        let settled = DisconnectProbe()
+        let cancellation = InvokeCancellationFlag()
+        let options = nodeConnectOptions(commands: [command], clientId: "openclaw-ios")
+        try await gateway.connectForTest(
+            testURL("ws://first.example.invalid"),
+            options: options,
+            session: session,
+            onInvoke: { request in
+                await permission.wait()
+                if Task.isCancelled {
+                    cancellation.markCancelled()
+                }
+                await settled.record(request.id)
+                return BridgeInvokeResponse(id: request.id, ok: !Task.isCancelled)
+            })
+        let firstSocket = try #require(session.latestTask())
+        firstSocket.emitInvokeRequest(id: "pending-permission", command: command)
+        try await waitUntil("permission callback suspended") { await permission.hasStarted() }
+
+        let replacement = Task {
+            try await gateway.connectForTest(
+                testURL("ws://replacement.example.invalid"),
+                options: options,
+                session: session)
+        }
+        do {
+            try await waitUntil("replacement can connect before permission returns", timeoutSeconds: 2) {
+                session.snapshotMakeCount() == 2
+            }
+        } catch {
+            await permission.release()
+            _ = try? await replacement.value
+            await gateway.disconnect()
+            throw error
+        }
+        try await replacement.value
+        #expect(await settled.values().isEmpty)
+        await permission.release()
+        try await waitUntil("retired permission callback returned") { await !settled.values().isEmpty }
+        #expect(cancellation.isCancelled())
+        #expect(firstSocket.sentRequestCount(method: "node.invoke.result") == 0)
         await gateway.disconnect()
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -1587,6 +1587,7 @@ struct GatewayNodeSessionTests {
         OpenClawTalkCommand.pttStart.rawValue,
         OpenClawSystemCommand.notify.rawValue,
         OpenClawChatCommand.push.rawValue,
+        OpenClawWatchCommand.notify.rawValue,
     ])
     func `node invoke cancellation retires suspended side effects and preserves callbacks`(
         command: String) async throws
@@ -1690,7 +1691,11 @@ struct GatewayNodeSessionTests {
         await gateway.disconnect()
     }
 
-    @Test(arguments: [OpenClawSystemCommand.notify.rawValue, OpenClawChatCommand.push.rawValue])
+    @Test(arguments: [
+        OpenClawSystemCommand.notify.rawValue,
+        OpenClawChatCommand.push.rawValue,
+        OpenClawWatchCommand.notify.rawValue,
+    ])
     func `route replacement cancels notification work without awaiting its permission callback`(
         command: String) async throws
     {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkSystemSpeechSynthesizerTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkSystemSpeechSynthesizerTests.swift
@@ -22,6 +22,38 @@ final class TalkSystemSpeechSynthesizerTests: XCTestCase {
         try await self.assertCanceled(first)
     }
 
+    func testLivePreCancelledSpeechDoesNotReplaceCurrentUtterance() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["OPENCLAW_LIVE_TEST"] == "1",
+            "Requires working native speech/audio services; run with OPENCLAW_LIVE_TEST=1.")
+        let speaker = TalkSystemSpeechSynthesizer.shared
+        defer { speaker.stop() }
+        let current = await self.startSpeech()
+        defer { current.cancel() }
+
+        let currentFinished = self.expectation(description: "current utterance must keep playing")
+        currentFinished.isInverted = true
+        let observer = Task { @MainActor in
+            _ = await current.result
+            guard !Task.isCancelled else { return }
+            currentFinished.fulfill()
+        }
+        defer { observer.cancel() }
+
+        var successorStarts = 0
+        let successor = Task { @MainActor in
+            XCTAssertTrue(Task.isCancelled)
+            try await speaker.speak(
+                text: "Cancelled successor speech.", language: "en-US",
+                onStart: { successorStarts += 1 })
+        }
+        successor.cancel()
+        try await self.assertCanceled(successor)
+
+        await self.fulfillment(of: [currentFinished], timeout: 0.25)
+        XCTAssertEqual(successorStarts, 0)
+    }
+
     private func startSpeech() async -> Task<Void, Error> {
         let started = self.expectation(description: "utterance started")
         let speech = Task { @MainActor in

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -258,6 +258,12 @@ deletes the bootstrap credential. Direct mode covers only the commands below.
 Chat, Talk, approvals, and the existing `watch.*` notification flow remain
 iPhone-relay features and still require the paired iPhone.
 
+A `watch.notify` receipt reports Watch transport delivery or queuing, not
+completion of the best-effort iPhone notification mirror. Cancellation is
+checked before starting a new Watch transfer or phone mirror; it cannot recall
+work already handed to WatchConnectivity. Once the phone mirror is handed off,
+it proceeds independently of the invoke.
+
 Direct watchOS node commands:
 
 | Surface       | Commands                       | Notes                                                   |


### PR DESCRIPTION
## What Problem This Solves

Cancelled notification work could survive a delayed authorization callback, enqueue a new Watch transfer, or start speech/overlays after its owner had retired. Immediate Gateway request/cancel pairs could also miss registration.

## Why This Change Was Made

`GatewayNodeInvocationRegistry` reserves cancellation ownership before dispatch and distinguishes cleanup that must drain from notification work that must not strand a replacement route. `AsyncTimeout` now registers its racers under one synchronous owner and cancels the owned child tasks before its cancellation handler returns. Continuation resolution happens outside the lock; it does not join a noncooperative loser. The shared native notification adapter checks cancellation at OS admission, replacing the duplicate iOS latch and timeout implementation.

The Watch transport now has one activation/send/fallback owner for messages and snapshots. It checks cancellation after activation and before new SDK/background admission. `watch.notify` participates in invocation cancellation, and the iPhone caller checks before handing off its best-effort mirror. An accepted Watch acknowledgment remains a truthful transport receipt; an already-accepted phone mirror intentionally continues independently. Neither is a promise to retract work Apple already accepted.

The Mac notification caller checks at permission and MainActor overlay boundaries while preserving its normal overlay fallback. The shared speech adapter rejects a pre-cancelled request before stopping an existing utterance. Accepted asynchronous chat speech keeps its existing lifetime.

## User Impact

Cancelling or replacing an Apple node request prevents still-pending work from starting a new notification, Watch transfer, speech utterance, or overlay. Successful accepted work retains its documented lifetime.

## Evidence

Current revision: `24f03969ed99710df58b7e46a04a16188395a8b2`. It adds the verified snapshot-lock cancellation repair below, after the modifier-only `7a04ea2b4aa9f607de868e8cdea54f017dafda00` follow-up.

Tested parent revision: `7623891fa3488b8db69025a3d90d7ff1427612a0`, rebased onto `7ab7eb8aab504be5a0a3081882e2d3fd5e537f11`. Its five commits are patch-identical after rebase; no touched file had competing upstream changes. Managed Codex P0 review and independent all-severity source review found no actionable cancellation-owner findings. At that revision: production +438/-403 (net +35), tests +603/-128 (net +475), docs +6. Growth represents explicit invocation ownership; duplicate notification/timeout paths are removed. No configuration, dependency, schema, or protocol changes.

A subsequent Periphery check reported `redundantPublicAccessibility` on two declarations, not an unused function. The visibility follow-up removes only those two redundant `public` modifiers from the shared checked-continuation helper (`ThrowingContinuationSupport`) and its method; their bodies and callers are unchanged. Swift 6 type-checking of the helper and transport, repository formatting, and a managed Codex P2-scoped review passed. That head passed shared Periphery and [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33632743261/attempts/2); its first preflight checkout failure remains retained. It was not merged because the later snapshot-lock finding below still required repair. The older signed app/Mac results remain source-specific to their tested parent.

### Snapshot-lock follow-up on the current revision

The latest ClawSweeper finding exposed an additional suspension boundary: the common cancellation check ran before a synchronous snapshot lock. A cancelled caller could wait for another snapshot, acquire the lock, then publish retained application-context state. The existing private lock still owns context read/merge/write; its sole SDK call is now in a phone-only helper that checks cancellation inside the lock immediately before that call. There is no post-success cancellation check, new transport path, or changed fallback policy.

A compiled copy of the exact original lock block first reproduced the forbidden admission with recording SDK/codec boundaries. After mechanical extraction, the permanent regression ran against the **actual WatchConnectivity SDK** on an isolated unpaired iPhone Simulator: the uncancelled and cancelled cases both reached Apple and returned WCError7005, producing **24 passed / 1 failed case**. Adding the fence made the same native selection pass **25/25 cases, 18 methods across four suites, zero skips**. The uncancelled control still returned WCError7005; the cancelled case returned `CancellationError`. Each run preserved all631 captured source facts. No paired-Watch delivery or full public snapshot-path success is inferred from this local SDK-boundary proof.

The real lock is held by a bounded worker; the sending task passes its outer fence before cancellation and lock release. Unexpected SDK acceptance fails the test and restores the synthetic marked context. The regression preserves existing accepted-reply and independent-mirror checks. Managed Codex P0–P2 and independent all-severity reviews found no actionable issues. This addresses the latest snapshot-admission finding and its regression-test rank-up request. The follow-up is production+15/-6 (net+9), tests+88/-0: a small extraction of the existing SDK admission owner, not a session mock or exposed private lock.

### Signed current-head verification

A fresh signed Simulator run on exact clean commit `24f03969ed99710df58b7e46a04a16188395a8b2` passed **25 case executions / 18 methods across four suites**, with no failures or skips, in 18.102 seconds. All 631 captured source facts and HEAD stayed unchanged. Strict deep signature verification passed on the tested app. This is current-head native SDK/owner proof; the normal phone/Gateway and matching Developer-ID Mac results below remain tied to their earlier source revisions.

The normal Simulator app was then restored with one install and no erase, uninstall, or launch. Only the known XCTest plug-in was removed from a copy; all executable code bytes remained identical except the 32-byte signature field. Strict installed-signature verification passed, the tested original product remained intact, and app-data/Keychain metadata continuity was checked. This is cleanup and metadata-continuity evidence, not another UI or login run.

Full current PR delta: production +449/-405 (net +44), tests +691/-128 (net +563), docs +6. There are no configuration, dependency, schema, or protocol changes.

### Fresh proof on the tested parent revision

| Surface | Observed result |
| --- | --- |
| Normally signed iPhone Simulator app and Watch SDK admission | 17 methods in four suites, 23 case executions, zero failures/skips. All 631 captured source records remained unchanged. Covers actual unpaired Watch SDK admission, both cancellation suspension points, accepted replies, independent mirror ownership, activation, callback-once, and inbound transport siblings. |
| Real iOS `UNUserNotificationCenter` | One native XCTest passed using the freshly compiled production owners. Actual authorization was provisional. The OS accepted one scheduled positive control; directly cancelled and runner-cancelled requests both returned `CancellationError` and were absent from pending/delivered notifications. The operation observed cancellation before `cancel()` returned, and the runner returned before the suspended callback was released. Exact-ID cleanup left no test requests pending or delivered. |
| Normal iPhone Simulator UI and full Gateway RPC | One actual UI XCTest passed in 123.309 seconds through ordinary onboarding. The normally built app then received a real `system.notify` invocation from the full isolated Gateway, which returned `ok: true`. Authentication used an explicitly public synthetic fixture on loopback, not the initial private Gateway token. No provider credentials or operator state were used. |
| Exact-marker native notification inspection | One native XCTest passed and found zero matching pending or delivered notifications. This verifies the inspection/cleanup result, not a visible notification banner. |
| Matching Developer-ID-signed Mac components | All three focused native checks passed: health-view rendering/isolation, replacement-overlay positive control, and rejection of a cancelled overlay. |
| Signed Mac `AsyncTimeoutTests` | All six methods passed, including seven case executions and both zero-timeout/unbounded and bounded cancellation cases. |
| Optional broader signed Mac owner suite | 32 of 33 selected methods passed; one existing injected screen-recording fixture failed with two issues. Its attempt to save a temporary recording was denied by the proof sandbox. This optional group remains failed; it is not reported as 39 passing methods or evidence of a cancellation-production regression. |

The iOS OS proof uses a temporary driver with an explicit suspension after a real authorization read, not a replacement notification API. The scheduled positive control proves OS admission, not banner delivery. Source and original app products remained unchanged through that run.

The normal UI/RPC proof used native revision `7623891fa3488b8db69025a3d90d7ff1427612a0` and Gateway source `4fc24e6e0f81121cef0fb4395db29fb87700e7f6`. Device-role approval and the separate node-capability approval were each reviewed for the exact pending request. An under-scoped CLI approval was rejected before mutation; the authorized admin approval then succeeded. The proof refused to dispatch while node capabilities were still pending. This was a real app/Gateway connection and RPC, not a mocked notification transport or a provider conversation.

For the parent-revision proof, both temporary UI-test runner apps were uninstalled. The ordinary signed app was restored without temporary proof plug-ins, and its signature and recorded hashes were reverified without deleting app data. Both task Gateways were stopped. Their temporary state, configuration, credentials and a retained `.last-good` credential backup found during cleanup were removed. A recorded scan of 92 retained proof files found zero matches for the initial private task token.

The Mac build captured 957 unchanged source-file facts and exact equality for all 16 dependency manifests before cloning, after cloning, and after compilation. The staged archive was verified, all 66 packaged binaries were verified under the matching Developer ID, and their hashes still matched after testing. The sandbox and its denial checks were retained. The broader Mac selector excludes only the cancelled-overlay case already exercised in its own process; its screen-recording fixture failure was not hidden by relaxing the sandbox or rerunning with an extra exclusion.

### Retained regression and historical evidence

The byte-original Watch SDK helper returned the real device-not-paired error even for a pre-cancelled request; the repaired helper returns cancellation before calling it. The dispatch-policy RED used a reviewed extraction of the old policy, not a byte-original transport, and failed both forbidden background-transfer cases. Both REDs and the compiler/formatting failed attempts are retained; no gate was weakened.

The shared session suite passed all 79 methods on the latest shared-owner repair, including explicit cancellation and route replacement for Watch notifications. Prior native speech regressions proved rejection before stopping existing playback. Those retained results are source-specific, not substitutes for the fresh signed runs of the tested parent above.

The first fresh Mac build compiled successfully but its recorder rejected copied dependency permission differences before staging. A separate attempt preserved copy metadata and required strict dependency equality before compilation and afterward; the failed record remains intact. An initial archive-extraction attempt also stopped because its Python interpreter lacked the required safe-extraction API; the correct interpreter was used without removing the safety filter. Earlier signed OS/Gateway proofs at `13538457d02313e1b380940eb1cb52e3258081ee` remain historical and are not represented as runs of this head.

The previously discovered Android scheduler/outbox repairs landed separately, including #135961 and #136161. This PR contains no Android changes. The original individual CI interleaving was not captured, so those repairs are not asserted to explain that specific failure.

## CI and Limits

- [Parent-head CI run 33624108983, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33624108983/attempts/2) succeeded for `7623891fa3488b8db69025a3d90d7ff1427612a0`, including [the aggregate CI gate](https://github.com/openclaw/openclaw/actions/runs/33624108983/job/100251216915). The earlier dependency-fetch failure is retained as an unsuccessful prior attempt, not a remaining failure of that parent run.
- The visibility follow-up at `7a04ea2b4aa9f607de868e8cdea54f017dafda00` passed shared Periphery and all selected CI lanes on its controlled retry (22successful jobs,18skipped). The first preflight checkout failure is retained. Current-head [CI 33639328042, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33639328042/attempts/2) succeeded for `24f03969ed99710df58b7e46a04a16188395a8b2`: 22 successful jobs and 18 intentionally skipped jobs, including [the required CI gate](https://github.com/openclaw/openclaw/actions/runs/33639328042/job/100300273602). Successful earlier jobs were retained; the failed lanes were rerun. All selected native checks are green.
- The optional broader signed Mac suite remains 32/33 passed with its disclosed sandbox-denied recording fixture. The three required focused Mac checks and seven timeout case executions passed independently.

No physical Watch delivery, notification banner/pixel observation, full Mac Gateway-to-overlay call, or wire-level mobile cancellation is claimed. The signed native checks prove their stated component and OS-admission boundaries, not those untested flows.

Current-head shared Periphery passed all four jobs in [run 33639328460](https://github.com/openclaw/openclaw/actions/runs/33639328460). The separate [OpenGrep diff scan, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33639327902/attempts/2) also passed, with its actual scan job running on Blacksmith. This is successful diff-scoped scan execution, not a repository-wide finding-count claim. No global runner setting changed. The latest durable ClawSweeper review has no actionable source finding; its request for current-head native CI is now satisfied.

Retained first-attempt failures: security-fast, both Android unit-test flavors, and the separate OpenGrep scan recorded **self-hosted runner lost communication** in their exact annotations, with no reported steps. One attempted security-log retrieval returned BlobNotFound. The underlying runner cause remains unknown; these failures were not security/test findings. The main workflow was recovered only after verifying that no useful job remained executing; failed or cancelled unfinished lanes were rerun, not the successful work.

## Compatibility and Release Note

The Gateway still emits ordinary non-stream cancellation only to its supported node-host/Mac node clients. This PR handles cancellation actually received, local deadlines, and route retirement; it does not add ordinary early-abort delivery to legacy mobile clients. That requires a separately reviewed support/receiver contract, not a broadened host-identity predicate.

Release note: Apple notification requests respect local and received cancellation before new Watch, notification, speech, or overlay delivery, including cancellation before native dispatch; accepted asynchronous work keeps its documented lifetime.
