### PR TITLE
refactor: simplify upgrade and triage tests

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1106,9 +1106,12 @@ describe("update-cli", () => {
     ...overrides,
   });
 
-  const writeNpmPackageInstall = async (argv: string[], packageRoot: string) => {
-    const version =
-      argv.find((arg) => /^openclaw@\d/u.test(arg))?.slice("openclaw@".length) ?? "9999.0.0";
+  const writeNpmPackageInstall = async (
+    argv: string[],
+    packageRoot: string,
+    version = argv.find((arg) => /^openclaw@\d/u.test(arg))?.slice("openclaw@".length) ??
+      "9999.0.0",
+  ) => {
     const stagePrefix = argv.includes("--prefix")
       ? requireValue(argv[argv.indexOf("--prefix") + 1], "staged prefix")
       : undefined;
@@ -1602,6 +1605,56 @@ describe("update-cli", () => {
         }),
     });
     return { updatedRoot, updatedEntrypoint };
+  };
+
+  const setupManagedGitRootRefresh = async () => {
+    const { root, entrypoints } = setupUpdatedRootRefresh();
+    const updatedEntrypoint = requireValue(entrypoints[0], "updated entrypoint");
+    await writeOpenClawPackageFixture(root, "2026.4.27");
+    mockOwnedGitService();
+    mockGitUpdateAfterMutation(
+      makeOkUpdateResult({
+        mode: "git",
+        root,
+        before: { sha: "old-managed-sha", version: "2026.4.26" },
+        after: { sha: "new-managed-sha", version: "2026.4.27" },
+      }),
+    );
+    mockFileBackedPathExists();
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: gatewayFixturePid,
+      state: "running",
+    });
+    serviceStop.mockImplementationOnce(async () => {
+      serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+    });
+    const runFixtureCommand = requireValue(
+      vi.mocked(runCommandWithTimeout).getMockImplementation(),
+      "default command fixture",
+    );
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      const result = await runFixtureCommand(argv, options);
+      if (argv[2] === "gateway" && argv[3] === "install" && result.code === 0) {
+        expect(argv[1]).toBe(updatedEntrypoint);
+        const env = requireValue(
+          typeof options === "number" ? undefined : options.env,
+          "gateway install environment",
+        );
+        primeServiceCommand([argv[0], updatedEntrypoint, "gateway", "run"], env);
+      }
+      return result;
+    });
+    runRestartScript.mockImplementationOnce(async () => {
+      serviceReadRuntime.mockResolvedValue({
+        status: "running",
+        pid: gatewayFixturePid,
+        state: "running",
+      });
+      mockGatewayProbe("2026.4.27", "updated-work");
+    });
+    return updatedEntrypoint;
   };
 
   const mockNpmGlobalRoot = (nodeModules: string) => {
@@ -2344,19 +2397,7 @@ describe("update-cli", () => {
   });
 
   it("keeps stopped owned-service config and plugin state through fresh post-core handoff", async () => {
-    const { root, entrypoints } = setupUpdatedRootRefresh();
-    const updatedEntrypoint = requireValue(entrypoints[0], "updated entrypoint");
-    await writeOpenClawPackageFixture(root, "2026.4.27");
-    mockOwnedGitService();
-    mockGitUpdateAfterMutation(
-      makeOkUpdateResult({
-        mode: "git",
-        root,
-        before: { sha: "old-managed-sha", version: "2026.4.26" },
-        after: { sha: "new-managed-sha", version: "2026.4.27" },
-      }),
-    );
-    mockFileBackedPathExists();
+    const updatedEntrypoint = await setupManagedGitRootRefresh();
     const managedState = profileStateDir("work");
     const personalState = profileStateDir("personal");
     const managedConfig = {
@@ -2377,39 +2418,6 @@ describe("update-cli", () => {
       OPENCLAW_SERVICE_MARKER: "openclaw",
       OPENCLAW_SERVICE_KIND: "gateway",
       [GATEWAY_SERVICE_RUNTIME_PID_ENV]: String(unrelatedGatewayFixturePid),
-    });
-    serviceLoaded.mockResolvedValue(true);
-    serviceReadRuntime.mockResolvedValue({
-      status: "running",
-      pid: gatewayFixturePid,
-      state: "running",
-    });
-    serviceStop.mockImplementationOnce(async () => {
-      serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
-    });
-    const runFixtureCommand = requireValue(
-      vi.mocked(runCommandWithTimeout).getMockImplementation(),
-      "default command fixture",
-    );
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
-      const result = await runFixtureCommand(argv, options);
-      if (argv[2] === "gateway" && argv[3] === "install" && result.code === 0) {
-        expect(argv[1]).toBe(updatedEntrypoint);
-        const env = requireValue(
-          typeof options === "number" ? undefined : options.env,
-          "gateway install environment",
-        );
-        primeServiceCommand([argv[0], updatedEntrypoint, "gateway", "run"], env);
-      }
-      return result;
-    });
-    runRestartScript.mockImplementationOnce(async () => {
-      serviceReadRuntime.mockResolvedValue({
-        status: "running",
-        pid: gatewayFixturePid,
-        state: "running",
-      });
-      mockGatewayProbe("2026.4.27", "updated-work");
     });
     vi.mocked(readConfigFileSnapshot).mockImplementation(async () =>
       process.env.OPENCLAW_PROFILE === "work" ? managedSnapshot : baseSnapshot,
@@ -2511,58 +2519,13 @@ describe("update-cli", () => {
   });
 
   it("keeps forced post-core fallback and fresh validation in the stopped service profile", async () => {
-    const { root, entrypoints } = setupUpdatedRootRefresh();
-    const updatedEntrypoint = requireValue(entrypoints[0], "updated entrypoint");
-    await writeOpenClawPackageFixture(root, "2026.4.27");
-    mockOwnedGitService();
-    mockFileBackedPathExists();
-    mockGitUpdateAfterMutation(
-      makeOkUpdateResult({
-        mode: "git",
-        root,
-        before: { sha: "old-managed-sha", version: "2026.4.26" },
-        after: { sha: "new-managed-sha", version: "2026.4.27" },
-      }),
-    );
+    const updatedEntrypoint = await setupManagedGitRootRefresh();
     const managedState = profileStateDir("work");
     primeServiceCommand(["node", path.join(process.cwd(), "dist", "index.js"), "gateway", "run"], {
       OPENCLAW_PROFILE: "work",
       OPENCLAW_STATE_DIR: managedState,
       OPENCLAW_CONFIG_PATH: path.join(managedState, "openclaw.json"),
       OPENCLAW_GATEWAY_PORT: "19222",
-    });
-    serviceLoaded.mockResolvedValue(true);
-    serviceReadRuntime.mockResolvedValue({
-      status: "running",
-      pid: gatewayFixturePid,
-      state: "running",
-    });
-    serviceStop.mockImplementationOnce(async () => {
-      serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
-    });
-    const runFixtureCommand = requireValue(
-      vi.mocked(runCommandWithTimeout).getMockImplementation(),
-      "default command fixture",
-    );
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
-      const result = await runFixtureCommand(argv, options);
-      if (argv[2] === "gateway" && argv[3] === "install" && result.code === 0) {
-        expect(argv[1]).toBe(updatedEntrypoint);
-        const env = requireValue(
-          typeof options === "number" ? undefined : options.env,
-          "gateway install environment",
-        );
-        primeServiceCommand([argv[0], updatedEntrypoint, "gateway", "run"], env);
-      }
-      return result;
-    });
-    runRestartScript.mockImplementationOnce(async () => {
-      serviceReadRuntime.mockResolvedValue({
-        status: "running",
-        pid: gatewayFixturePid,
-        state: "running",
-      });
-      mockGatewayProbe("2026.4.27", "updated-work");
     });
     // Only the resume attempt misses; Doctor and service refresh resolve the real target.
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(undefined);
@@ -4412,27 +4375,19 @@ describe("update-cli", () => {
     expect(pluginOutcome(jsonOutput)?.message).toContain("Run openclaw update repair");
   });
 
-  it("fails unexpected post-core plugin sync exceptions", async () => {
-    syncPluginsForUpdateChannel.mockRejectedValueOnce(new Error("plugin sync invariant broke"));
+  it.each([
+    ["plugin sync", syncPluginsForUpdateChannel],
+    ["npm update", updateNpmInstalledPlugins],
+  ] as const)("fails unexpected post-core %s exceptions", async (phase, updatePlugins) => {
+    const message = `${phase} invariant broke`;
+    updatePlugins.mockRejectedValueOnce(new Error(message));
 
     await expect(updateCommand({ json: true, restart: false })).rejects.toEqual(new ExitError(1));
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
     expect(lastWriteJsonCall()).toMatchObject({
       status: "error",
       reason: "post-update-failed",
-      steps: [expect.objectContaining({ exitCode: 1, stderrTail: "plugin sync invariant broke" })],
-    });
-  });
-
-  it("fails unexpected post-core npm update exceptions", async () => {
-    updateNpmInstalledPlugins.mockRejectedValueOnce(new Error("npm update invariant broke"));
-
-    await expect(updateCommand({ json: true, restart: false })).rejects.toEqual(new ExitError(1));
-    expect(defaultRuntime.exit).not.toHaveBeenCalled();
-    expect(lastWriteJsonCall()).toMatchObject({
-      status: "error",
-      reason: "post-update-failed",
-      steps: [expect.objectContaining({ exitCode: 1, stderrTail: "npm update invariant broke" })],
+      steps: [expect.objectContaining({ exitCode: 1, stderrTail: message })],
     });
   });
 
@@ -5480,6 +5435,12 @@ describe("update-cli", () => {
     expect(getLogOutput()).toContain("Low disk space near");
   });
 
+  const packageUpdateInGatewayMessage = [
+    "Package updates cannot run from inside the gateway service process.",
+    "That path replaces the active OpenClaw dist tree while the live gateway may still lazy-load old chunks.",
+    "Run `openclaw update` from a shell outside the gateway service, or stop the gateway service first and then update.",
+  ].join("\n");
+
   it("allows package updates from inherited gateway service env when the managed gateway is not running", async () => {
     await mockPackageInstallAtCaseDir();
     serviceReadRuntime.mockResolvedValueOnce({
@@ -5490,13 +5451,7 @@ describe("update-cli", () => {
 
     await runWithGatewayServiceEnv({ yes: true });
 
-    expect(defaultRuntime.error).not.toHaveBeenCalledWith(
-      [
-        "Package updates cannot run from inside the gateway service process.",
-        "That path replaces the active OpenClaw dist tree while the live gateway may still lazy-load old chunks.",
-        "Run `openclaw update` from a shell outside the gateway service, or stop the gateway service first and then update.",
-      ].join("\n"),
-    );
+    expect(defaultRuntime.error).not.toHaveBeenCalledWith(packageUpdateInGatewayMessage);
     expectPackageInstallSpec("openclaw@9999.0.0");
   });
 
@@ -5512,13 +5467,7 @@ describe("update-cli", () => {
       new ExitError(1),
     );
 
-    expect(defaultRuntime.error).toHaveBeenCalledWith(
-      [
-        "Package updates cannot run from inside the gateway service process.",
-        "That path replaces the active OpenClaw dist tree while the live gateway may still lazy-load old chunks.",
-        "Run `openclaw update` from a shell outside the gateway service, or stop the gateway service first and then update.",
-      ].join("\n"),
-    );
+    expect(defaultRuntime.error).toHaveBeenCalledWith(packageUpdateInGatewayMessage);
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
     expectNoSideEffects(serviceStop, runGatewayUpdate);
     expect(packageInstallCommandCall()).toBeUndefined();
@@ -5546,13 +5495,7 @@ describe("update-cli", () => {
 
       await expect(runWithGatewayServiceEnv({ yes: true })).rejects.toEqual(new ExitError(1));
 
-      expect(defaultRuntime.error).toHaveBeenCalledWith(
-        [
-          "Package updates cannot run from inside the gateway service process.",
-          "That path replaces the active OpenClaw dist tree while the live gateway may still lazy-load old chunks.",
-          "Run `openclaw update` from a shell outside the gateway service, or stop the gateway service first and then update.",
-        ].join("\n"),
-      );
+      expect(defaultRuntime.error).toHaveBeenCalledWith(packageUpdateInGatewayMessage);
       expect(defaultRuntime.exit).not.toHaveBeenCalled();
       expectNoSideEffects(serviceStop, runGatewayUpdate);
       expect(packageInstallCommandCall()).toBeUndefined();
@@ -5570,13 +5513,7 @@ describe("update-cli", () => {
 
     await expect(runWithGatewayServiceEnv({ yes: true })).rejects.toEqual(new ExitError(1));
 
-    expect(defaultRuntime.error).toHaveBeenCalledWith(
-      [
-        "Package updates cannot run from inside the gateway service process.",
-        "That path replaces the active OpenClaw dist tree while the live gateway may still lazy-load old chunks.",
-        "Run `openclaw update` from a shell outside the gateway service, or stop the gateway service first and then update.",
-      ].join("\n"),
-    );
+    expect(defaultRuntime.error).toHaveBeenCalledWith(packageUpdateInGatewayMessage);
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
     expectNoSideEffects(serviceStop, runGatewayUpdate);
     expect(packageInstallCommandCall()).toBeUndefined();
@@ -6050,16 +5987,7 @@ describe("update-cli", () => {
     let doctorStarted = false;
     mockNpmGlobalCommands(nodeModules, async (argv, options) => {
       if (argv[0] === "npm" && argv[1] === "i" && argv.includes("--prefix")) {
-        const stagePrefix = requireValue(argv[argv.indexOf("--prefix") + 1], "staged prefix");
-        const stageRoot = path.join(
-          stagePrefix,
-          process.platform === "win32" ? "node_modules" : "lib/node_modules",
-          "openclaw",
-        );
-        await writeOpenClawPackageFixture(stageRoot, "2026.4.21", {
-          entrySource: "export {};\n",
-          inventory: true,
-        });
+        await writeNpmPackageInstall(argv, pkgRoot, "2026.4.21");
       }
       if (argv[1] !== entryPath || argv[2] !== "doctor") {
         return undefined;
@@ -6998,7 +6926,7 @@ describe("update-cli", () => {
     async (runtimeStatus) => {
       const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       const homeSpy = vi.spyOn(os, "homedir").mockReturnValue(fixtureRoot);
-      const { nodeModules, entryPath } = await setupInstalledPackageRoot(
+      const { nodeModules, pkgRoot, entryPath } = await setupInstalledPackageRoot(
         createCaseDir("openclaw-update-stopped-task"),
       );
       primeNpmChannelTag("latest", "2026.4.21");
@@ -7006,12 +6934,7 @@ describe("update-cli", () => {
       readPackageVersion.mockResolvedValue("2026.4.21");
       mockNpmGlobalCommands(nodeModules, async (argv) => {
         if (argv[0] === "npm" && argv[1] === "i" && argv.includes("--prefix")) {
-          const prefix = requireValue(argv[argv.indexOf("--prefix") + 1], "stage prefix");
-          await writeOpenClawPackageFixture(
-            path.join(prefix, "node_modules", "openclaw"),
-            "2026.4.21",
-            { entrySource: "export {};\n", inventory: true },
-          );
+          await writeNpmPackageInstall(argv, pkgRoot, "2026.4.21");
         }
       });
       primeServiceCommand(["node", entryPath, "gateway", "run"], {
@@ -7759,30 +7682,11 @@ describe("update-cli", () => {
     const installArgvs = commandCalls()
       .map(([argv]) => argv)
       .filter((argv) => argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g");
+    const installPrefix = ["npm", "i", "-g", "--allow-scripts=openclaw", "openclaw@9999.0.0"];
+    const installFlags = ["--no-fund", "--no-audit", "--loglevel=error", "--min-release-age=0"];
     expect(installArgvs).toEqual([
-      [
-        "npm",
-        "i",
-        "-g",
-        "--allow-scripts=openclaw",
-        "openclaw@9999.0.0",
-        "--no-fund",
-        "--no-audit",
-        "--loglevel=error",
-        "--min-release-age=0",
-      ],
-      [
-        "npm",
-        "i",
-        "-g",
-        "--allow-scripts=openclaw",
-        "openclaw@9999.0.0",
-        "--omit=optional",
-        "--no-fund",
-        "--no-audit",
-        "--loglevel=error",
-        "--min-release-age=0",
-      ],
+      installPrefix.concat(installFlags),
+      installPrefix.concat("--omit=optional", installFlags),
     ]);
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
@@ -8389,10 +8293,7 @@ describe("update-cli", () => {
 
     await updateCommand({ channel: "beta", yes: true });
 
-    const lastWrite = lastReplaceConfigCall() as
-      | { nextConfig?: { update?: { channel?: string } } }
-      | undefined;
-    expect(lastWrite?.nextConfig?.update?.channel).toBe("beta");
+    expect(lastReplaceConfigCall()?.nextConfig?.update?.channel).toBe("beta");
   });
 
   it("refreshes post-doctor config before post-update plugin sync", async () => {
@@ -8433,15 +8334,8 @@ describe("update-cli", () => {
 
     await updateCommand({ yes: true });
 
-    const syncConfig = syncPluginCall()?.config as
-      | (OpenClawConfig & { meta?: { lastTouchedVersion?: string } })
-      | undefined;
-    const lastWrite = lastReplaceConfigCall() as
-      | {
-          baseHash?: string;
-          nextConfig?: OpenClawConfig & { meta?: { lastTouchedVersion?: string } };
-        }
-      | undefined;
+    const syncConfig = syncPluginCall()?.config;
+    const lastWrite = lastReplaceConfigCall();
     expect(syncConfig?.meta?.lastTouchedVersion).toBe("2026.5.14");
     expect(lastWrite?.baseHash).toBe("post-doctor-hash");
     expect(lastWrite?.nextConfig?.meta?.lastTouchedVersion).toBe("2026.5.14");

--- a/src/commands/triage-recovery.test.ts
+++ b/src/commands/triage-recovery.test.ts
@@ -7,12 +7,12 @@ import { readRestartSentinelReadOnly, writeRestartSentinel } from "../infra/rest
 import type { UpdateRunResult } from "../infra/update-runner-types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { triageCommand } from "./triage.js";
+import { createTriageRuntime, withTriageTerminal } from "./triage.test-support.js";
 
 const mocks = vi.hoisted(() => ({
   collectDoctorFindings: vi.fn(),
   writeDiagnosticSupportExport: vi.fn(),
   resolveExecutablePath: vi.fn(),
-  select: vi.fn(),
   spawn: vi.fn(),
 }));
 
@@ -28,7 +28,6 @@ vi.mock("../infra/executable-path.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/executable-path.js")>()),
   resolveExecutablePath: mocks.resolveExecutablePath,
 }));
-vi.mock("./configure.shared.js", () => ({ select: mocks.select }));
 
 const agents = ["claude", "codex", "opencode", "pi"] as const;
 const printOnlyModes = [
@@ -37,30 +36,6 @@ const printOnlyModes = [
   { mode: "non-TTY", json: false, nonInteractive: false, terminal: false },
 ] as const;
 const secret = "sk-test-triage-recovery-secret-1234567890";
-
-function createRuntime() {
-  return { log: vi.fn(), error: vi.fn(), exit: vi.fn(), writeStdout: vi.fn(), writeJson: vi.fn() };
-}
-
-async function withTerminal(interactive: boolean, run: () => Promise<void>) {
-  const streams = [process.stdin, process.stdout];
-  const descriptors = streams.map((stream) => Object.getOwnPropertyDescriptor(stream, "isTTY"));
-  for (const stream of streams) {
-    Object.defineProperty(stream, "isTTY", { configurable: true, value: interactive });
-  }
-  try {
-    await run();
-  } finally {
-    streams.forEach((stream, index) => {
-      const descriptor = descriptors[index];
-      if (descriptor) {
-        Object.defineProperty(stream, "isTTY", descriptor);
-      } else {
-        Reflect.deleteProperty(stream, "isTTY");
-      }
-    });
-  }
-}
 
 function failedUpdate(root: string): UpdateRunResult {
   return {
@@ -90,7 +65,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.collectDoctorFindings.mockResolvedValue([]);
   mocks.resolveExecutablePath.mockImplementation((agent: string) => `/usr/local/bin/${agent}`);
-  mocks.select.mockResolvedValue({ kind: "print" });
   mocks.spawn.mockImplementation(() => {
     const child = new EventEmitter();
     queueMicrotask(() => child.emit("exit", 0, null));
@@ -101,46 +75,37 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("triage external recovery handoff", () => {
-  it.each(agents)(
-    "starts the first available agent immediately when that agent is %s",
-    async (agent) => {
-      const available = new Set(agents.slice(agents.indexOf(agent)));
-      mocks.resolveExecutablePath.mockImplementation((binary: typeof agent) =>
-        available.has(binary) ? `/usr/local/bin/${binary}` : undefined,
+  it.each(
+    ["first available", "explicit"].flatMap((selection) =>
+      agents.map((agent) => ({ agent, selection })),
+    ),
+  )("starts the $selection agent $agent immediately", async ({ agent, selection }) => {
+    const explicit = selection === "explicit";
+    const available = new Set(explicit ? agents : agents.slice(agents.indexOf(agent)));
+    mocks.resolveExecutablePath.mockImplementation((binary: typeof agent) =>
+      available.has(binary) ? `/usr/local/bin/${binary}` : undefined,
+    );
+    await withOpenClawTestState({ layout: "split" }, async () => {
+      await withTriageTerminal(true, () =>
+        triageCommand(createTriageRuntime(), {
+          noExport: true,
+          agent: explicit ? agent : undefined,
+        }),
       );
-      await withOpenClawTestState({ layout: "split" }, async () => {
-        await withTerminal(true, () => triageCommand(createRuntime(), { noExport: true }));
-      });
-      expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
-        `/usr/local/bin/${agent}`,
-        agent === "opencode" ? ["--prompt", expect.any(String)] : [expect.any(String)],
-        expect.objectContaining({ stdio: "inherit" }),
-      );
-      expect(mocks.select).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each(agents)(
-    "honors explicit --agent %s without selecting another installed agent",
-    async (agent) => {
-      await withOpenClawTestState({ layout: "split" }, async () => {
-        await withTerminal(true, () => triageCommand(createRuntime(), { noExport: true, agent }));
-      });
-      expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
-        `/usr/local/bin/${agent}`,
-        agent === "opencode" ? ["--prompt", expect.any(String)] : [expect.any(String)],
-        expect.objectContaining({ stdio: "inherit" }),
-      );
-      expect(mocks.select).not.toHaveBeenCalled();
-    },
-  );
+    });
+    expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
+      `/usr/local/bin/${agent}`,
+      agent === "opencode" ? ["--prompt", expect.any(String)] : [expect.any(String)],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
 
   it.each(printOnlyModes)(
     "never launches an explicitly selected agent in $mode mode",
     async ({ json, nonInteractive, terminal }) => {
       await withOpenClawTestState({ layout: "split" }, async () => {
-        const runtime = createRuntime();
-        await withTerminal(terminal, () =>
+        const runtime = createTriageRuntime();
+        await withTriageTerminal(terminal, () =>
           triageCommand(runtime, { json, nonInteractive, noExport: true, agent: "opencode" }),
         );
         if (json) {
@@ -156,7 +121,6 @@ describe("triage external recovery handoff", () => {
           );
         }
         expect(mocks.spawn).not.toHaveBeenCalled();
-        expect(mocks.select).not.toHaveBeenCalled();
       });
     },
   );
@@ -166,32 +130,15 @@ describe("triage external recovery handoff", () => {
       agent === "claude" ? "/usr/local/bin/claude" : undefined,
     );
     await withOpenClawTestState({ layout: "split" }, async () => {
-      const runtime = createRuntime();
+      const runtime = createTriageRuntime();
       await expect(
-        withTerminal(true, () => triageCommand(runtime, { noExport: true, agent: "pi" })),
+        withTriageTerminal(true, () => triageCommand(runtime, { noExport: true, agent: "pi" })),
       ).rejects.toMatchObject({ code: 1 });
       expect(runtime.error).toHaveBeenCalledWith(
         expect.stringMatching(/pi.*(?:not found|not installed|unavailable)/iu),
       );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(mocks.spawn).not.toHaveBeenCalled();
-    });
-  });
-
-  it("does not try another provider after the selected agent fails to start", async () => {
-    mocks.spawn.mockImplementation(() => {
-      const child = new EventEmitter();
-      queueMicrotask(() => child.emit("error", new Error("permission denied")));
-      return child;
-    });
-    await withOpenClawTestState({ layout: "split" }, async () => {
-      const runtime = createRuntime();
-      await expect(
-        withTerminal(true, () => triageCommand(runtime, { noExport: true })),
-      ).rejects.toMatchObject({ code: 1 });
-      expect(mocks.spawn).toHaveBeenCalledOnce();
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(runtime.log).toHaveBeenCalledWith(expect.stringMatching(/^Run manually: .*claude /u));
     });
   });
 
@@ -225,8 +172,8 @@ describe("triage external recovery handoff", () => {
           advisory: { kind: "package-post-install-doctor", message: "Recoverable Doctor advice" },
         },
       ];
-      const runtime = createRuntime();
-      await withTerminal(true, () =>
+      const runtime = createTriageRuntime();
+      await withTriageTerminal(true, () =>
         triageCommand(runtime, {
           recovery: { target, cwd: state.workspaceDir, updateFailure: { result: update } },
         }),
@@ -299,9 +246,9 @@ describe("triage external recovery handoff", () => {
           { code: "EACCES" },
         );
         vi.spyOn(fs, operation).mockRejectedValue(artifactError);
-        const runtime = createRuntime();
+        const runtime = createTriageRuntime();
 
-        await withTerminal(true, () =>
+        await withTriageTerminal(true, () =>
           triageCommand(runtime, {
             noExport: true,
             recovery: {
@@ -336,10 +283,10 @@ describe("triage external recovery handoff", () => {
             code: "EACCES",
           }),
         );
-        const runtime = createRuntime();
+        const runtime = createTriageRuntime();
 
         await expect(
-          withTerminal(terminal, () =>
+          withTriageTerminal(terminal, () =>
             triageCommand(runtime, {
               json,
               nonInteractive,
@@ -393,7 +340,7 @@ describe("standalone triage update evidence", () => {
             ],
           },
         });
-        const runtime = createRuntime();
+        const runtime = createTriageRuntime();
         await triageCommand(runtime, { json: true, noExport: true });
         const prompt = await fs.readFile(runtime.writeJson.mock.calls[0]?.[0]?.promptPath, "utf8");
         expect(prompt).toContain(reason);
@@ -426,7 +373,7 @@ describe("standalone triage update evidence", () => {
         ts: 1,
         stats: { reason: "older-pending-failure" },
       });
-      const runtime = createRuntime();
+      const runtime = createTriageRuntime();
       await triageCommand(runtime, {
         json: true,
         noExport: true,
@@ -455,7 +402,7 @@ describe("standalone triage update evidence", () => {
           ts: 1,
           stats: { reason },
         });
-        const runtime = createRuntime();
+        const runtime = createTriageRuntime();
         await triageCommand(runtime, { json: true, noExport: true });
         const prompt = await fs.readFile(runtime.writeJson.mock.calls[0]?.[0]?.promptPath, "utf8");
         expect(prompt).not.toContain(reason);
@@ -467,7 +414,7 @@ describe("standalone triage update evidence", () => {
     await withOpenClawTestState({ layout: "split" }, async (state) => {
       const databasePath = path.join(state.stateDir, "state", "openclaw.sqlite");
       await expect(fs.access(databasePath)).rejects.toMatchObject({ code: "ENOENT" });
-      await triageCommand(createRuntime(), { json: true, noExport: true });
+      await triageCommand(createTriageRuntime(), { json: true, noExport: true });
       await expect(fs.access(databasePath)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });

--- a/src/commands/triage.test-support.ts
+++ b/src/commands/triage.test-support.ts
@@ -1,0 +1,25 @@
+import { vi } from "vitest";
+
+export function createTriageRuntime() {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn(), writeStdout: vi.fn(), writeJson: vi.fn() };
+}
+
+export async function withTriageTerminal(interactive: boolean, run: () => Promise<void>) {
+  const streams = [process.stdin, process.stdout];
+  const descriptors = streams.map((stream) => Object.getOwnPropertyDescriptor(stream, "isTTY"));
+  for (const stream of streams) {
+    Object.defineProperty(stream, "isTTY", { configurable: true, value: interactive });
+  }
+  try {
+    await run();
+  } finally {
+    streams.forEach((stream, index) => {
+      const descriptor = descriptors[index];
+      if (descriptor) {
+        Object.defineProperty(stream, "isTTY", descriptor);
+      } else {
+        Reflect.deleteProperty(stream, "isTTY");
+      }
+    });
+  }
+}

--- a/src/commands/triage.test.ts
+++ b/src/commands/triage.test.ts
@@ -1,5 +1,4 @@
 import { execFile } from "node:child_process";
-// Triage tests protect bounded prompts, sanitized handoffs, and embedded-run gating.
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -10,6 +9,7 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { HealthFinding } from "../flows/health-checks.js";
 import { resolveInstallationTarget } from "../infra/installation-target-context.js";
 import { triageCommand } from "./triage.js";
+import { createTriageRuntime, withTriageTerminal } from "./triage.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -58,36 +58,6 @@ vi.mock("./agent-exec.js", () => ({
   agentExecCommand: mocks.agentExecCommand,
 }));
 
-function createRuntime() {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn(),
-    writeStdout: vi.fn(),
-    writeJson: vi.fn(),
-  };
-}
-
-async function withInteractiveTerminal(run: () => Promise<void>): Promise<void> {
-  const descriptors = [process.stdin, process.stdout].map((stream) =>
-    Object.getOwnPropertyDescriptor(stream, "isTTY"),
-  );
-  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
-  try {
-    await run();
-  } finally {
-    for (const [index, stream] of [process.stdin, process.stdout].entries()) {
-      const descriptor = descriptors[index];
-      if (descriptor) {
-        Object.defineProperty(stream, "isTTY", descriptor);
-      } else {
-        Reflect.deleteProperty(stream, "isTTY");
-      }
-    }
-  }
-}
-
 describe("triageCommand", () => {
   let stateDir: string;
 
@@ -107,6 +77,7 @@ describe("triageCommand", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
   });
 
@@ -117,11 +88,12 @@ describe("triageCommand", () => {
       { checkId: "core/info", severity: "info", message: "detail" },
     ];
     mocks.collectDoctorFindings.mockResolvedValue(findings);
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
     await triageCommand(runtime, { json: true, noExport: true });
 
     const promptPath = runtime.writeJson.mock.calls[0]?.[0]?.promptPath as string;
+    const targetEnv = `env OPENCLAW_STATE_DIR='${stateDir}' OPENCLAW_CONFIG_PATH='${path.join(stateDir, "openclaw.json")}' OPENCLAW_WORKSPACE_DIR='${path.join(stateDir, "workspace")}'`;
     expect(runtime.writeJson).toHaveBeenCalledOnce();
     expect(path.isAbsolute(promptPath)).toBe(true);
     expect(promptPath.startsWith(stateDir)).toBe(true);
@@ -141,11 +113,11 @@ describe("triageCommand", () => {
               expect.stringContaining("& openclaw triage --run"),
             ]
           : [
-              `env OPENCLAW_STATE_DIR='${stateDir}' OPENCLAW_CONFIG_PATH='${path.join(stateDir, "openclaw.json")}' OPENCLAW_WORKSPACE_DIR='${path.join(stateDir, "workspace")}' claude -p < '${promptPath}'`,
-              `env OPENCLAW_STATE_DIR='${stateDir}' OPENCLAW_CONFIG_PATH='${path.join(stateDir, "openclaw.json")}' OPENCLAW_WORKSPACE_DIR='${path.join(stateDir, "workspace")}' codex exec --skip-git-repo-check - < '${promptPath}'`,
-              `env OPENCLAW_STATE_DIR='${stateDir}' OPENCLAW_CONFIG_PATH='${path.join(stateDir, "openclaw.json")}' OPENCLAW_WORKSPACE_DIR='${path.join(stateDir, "workspace")}' opencode run < '${promptPath}'`,
-              `env OPENCLAW_STATE_DIR='${stateDir}' OPENCLAW_CONFIG_PATH='${path.join(stateDir, "openclaw.json")}' OPENCLAW_WORKSPACE_DIR='${path.join(stateDir, "workspace")}' pi --print < '${promptPath}'`,
-              `env OPENCLAW_STATE_DIR='${stateDir}' OPENCLAW_CONFIG_PATH='${path.join(stateDir, "openclaw.json")}' OPENCLAW_WORKSPACE_DIR='${path.join(stateDir, "workspace")}' openclaw triage --run`,
+              `${targetEnv} claude -p < '${promptPath}'`,
+              `${targetEnv} codex exec --skip-git-repo-check - < '${promptPath}'`,
+              `${targetEnv} opencode run < '${promptPath}'`,
+              `${targetEnv} pi --print < '${promptPath}'`,
+              `${targetEnv} openclaw triage --run`,
             ],
     });
     expect(await fs.readFile(promptPath, "utf8")).toContain("[error] core/error: broken");
@@ -185,7 +157,7 @@ describe("triageCommand", () => {
           { mode: 0o700 },
         );
       }
-      const runtime = createRuntime();
+      const runtime = createTriageRuntime();
       await triageCommand(runtime, { json: true, noExport: true });
       const report = runtime.writeJson.mock.calls[0]?.[0] as {
         promptPath: string;
@@ -210,17 +182,11 @@ describe("triageCommand", () => {
     mocks.resolveExecutablePath.mockImplementation((binary: string) =>
       binary === "codex" ? "/usr/local/bin/codex" : undefined,
     );
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
     await triageCommand(runtime, { json: true, noExport: true });
 
     expect(runtime.writeJson.mock.calls[0]?.[0]).toMatchObject({ detectedAgents: ["codex"] });
-    expect(mocks.resolveExecutablePath.mock.calls).toEqual([
-      ["claude"],
-      ["codex"],
-      ["opencode"],
-      ["pi"],
-    ]);
     expect(mocks.verifySetupInference).not.toHaveBeenCalled();
   });
 
@@ -232,7 +198,7 @@ describe("triageCommand", () => {
         `Gateway unreachable: Config: ${stateDir}/openclaw.json; Authorization: Bearer ${secret}`,
       ),
     );
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
     await triageCommand(runtime, { json: true });
 
@@ -261,14 +227,14 @@ describe("triageCommand", () => {
       mocks.writeDiagnosticSupportExport.mockRejectedValue(
         new Error(`Export unavailable token=${secret}`),
       );
-      const runtime = createRuntime();
+      const runtime = createTriageRuntime();
       const updateResult = path.join(stateDir, "failed-update.json");
       await fs.writeFile(
         updateResult,
         JSON.stringify({ error: `Original update failed at ${stateDir}; token=${secret}` }),
       );
 
-      await withInteractiveTerminal(async () => {
+      await withTriageTerminal(true, async () => {
         await triageCommand(runtime, {
           [mode]: true,
           updateResult,
@@ -301,7 +267,7 @@ describe("triageCommand", () => {
       inputPath,
       JSON.stringify({ error: `Original update failed token=${secret}` }),
     );
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
     await triageCommand(runtime, { json: true, noExport: true, updateResult: inputPath });
     const report = runtime.writeJson.mock.calls[0]?.[0] as { suggestedCommands: string[] };
     const savedArgument = report.suggestedCommands
@@ -344,7 +310,7 @@ describe("triageCommand", () => {
         }),
       }),
     );
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
     await triageCommand(runtime, { json: true });
 
@@ -387,7 +353,7 @@ describe("triageCommand", () => {
       expect(await options.readStatusSnapshot()).toBe(status);
       return { path: bundlePath };
     });
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
     await triageCommand(runtime, { json: true });
 
@@ -419,9 +385,9 @@ describe("triageCommand", () => {
       status: "auth",
       error: "The configured model is unavailable",
     });
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
-    await withInteractiveTerminal(async () => {
+    await withTriageTerminal(true, async () => {
       await expect(triageCommand(runtime, { noExport: true, run: true })).rejects.toThrow(
         "Run `openclaw onboard` or use a suggested handoff command.",
       );
@@ -438,9 +404,9 @@ describe("triageCommand", () => {
       latencyMs: 12,
     });
     mocks.agentExecCommand.mockResolvedValue({ exitCode: 0 });
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
-    await withInteractiveTerminal(async () => {
+    await withTriageTerminal(true, async () => {
       await triageCommand(runtime, { noExport: true, run: true });
     });
 
@@ -455,18 +421,12 @@ describe("triageCommand", () => {
   it("passes the in-memory prompt to explicit embedded triage when its artifact cannot be saved", async () => {
     mocks.verifySetupInference.mockResolvedValue({ ok: true });
     mocks.agentExecCommand.mockResolvedValue({ exitCode: 0 });
-    const write = vi
-      .spyOn(fs, "writeFile")
-      .mockRejectedValueOnce(
-        Object.assign(new Error("EACCES: support artifact permission denied"), { code: "EACCES" }),
-      );
-    const runtime = createRuntime();
+    vi.spyOn(fs, "writeFile").mockRejectedValueOnce(
+      Object.assign(new Error("EACCES: support artifact permission denied"), { code: "EACCES" }),
+    );
+    const runtime = createTriageRuntime();
 
-    try {
-      await withInteractiveTerminal(() => triageCommand(runtime, { noExport: true, run: true }));
-    } finally {
-      write.mockRestore();
-    }
+    await withTriageTerminal(true, () => triageCommand(runtime, { noExport: true, run: true }));
 
     expect(mocks.agentExecCommand).toHaveBeenCalledExactlyOnceWith(
       expect.stringContaining("THIS machine's OpenClaw installation"),
@@ -487,27 +447,23 @@ describe("triageCommand", () => {
       mocks.agentExecCommand.mockResolvedValue({ exitCode: 0 });
       let current = true;
       const writeFile = fs.writeFile.bind(fs);
-      const write = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
         await writeFile(...args);
         if (typeof args[0] === "string" && args[0].includes("openclaw-triage-prompt-")) {
           current = false;
         }
       });
-      const runtime = createRuntime();
-      try {
-        await withInteractiveTerminal(() =>
-          triageCommand(runtime, {
-            run,
-            recovery: {
-              target: resolveInstallationTarget(),
-              updateFailure: { error: "Captured update failure" },
-              isCurrent: () => current,
-            },
-          }),
-        );
-      } finally {
-        write.mockRestore();
-      }
+      const runtime = createTriageRuntime();
+      await withTriageTerminal(true, () =>
+        triageCommand(runtime, {
+          run,
+          recovery: {
+            target: resolveInstallationTarget(),
+            updateFailure: { error: "Captured update failure" },
+            isCurrent: () => current,
+          },
+        }),
+      );
       expect(current).toBe(false);
       expect(mocks.spawn).not.toHaveBeenCalled();
       expect(mocks.verifySetupInference).not.toHaveBeenCalled();
@@ -554,20 +510,13 @@ describe("triageCommand", () => {
       ]);
       vi.stubEnv("PATH", binDir);
       vi.stubEnv("PATHEXT", ".EXE;.CMD;.BAT");
-      const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-      const execPath = vi
-        .spyOn(process, "execPath", "get")
-        .mockReturnValue(
-          nodeSource === "current" ? currentNode : path.join(binDir, "openclaw.exe"),
-        );
-      const runtime = createRuntime();
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      vi.spyOn(process, "execPath", "get").mockReturnValue(
+        nodeSource === "current" ? currentNode : path.join(binDir, "openclaw.exe"),
+      );
+      const runtime = createTriageRuntime();
 
-      try {
-        await withInteractiveTerminal(() => triageCommand(runtime, { noExport: true }));
-      } finally {
-        execPath.mockRestore();
-        platform.mockRestore();
-      }
+      await withTriageTerminal(true, () => triageCommand(runtime, { noExport: true }));
 
       expect(mocks.spawn).toHaveBeenCalledOnce();
       const [command, argv, options] = mocks.spawn.mock.calls[0] ?? [];
@@ -594,19 +543,13 @@ describe("triageCommand", () => {
     async ({ agent, executablePath }) => {
       const configPath = path.join(stateDir, "operator's $config`file.json");
       vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
-      const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       mocks.resolveExecutablePath.mockImplementation((binary: string) =>
         binary === agent ? executablePath : undefined,
       );
-      const runtime = createRuntime();
+      const runtime = createTriageRuntime();
 
-      try {
-        await withInteractiveTerminal(async () => {
-          await triageCommand(runtime, { noExport: true });
-        });
-      } finally {
-        platform.mockRestore();
-      }
+      await withTriageTerminal(true, () => triageCommand(runtime, { noExport: true }));
 
       const commands = runtime.log.mock.calls
         .map(([line]) => String(line))
@@ -638,9 +581,9 @@ describe("triageCommand", () => {
       queueMicrotask(() => child.emit("exit", exitCode, null));
       return child;
     });
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
-    await withInteractiveTerminal(async () => {
+    await withTriageTerminal(true, async () => {
       if (exitCode === 0) {
         await triageCommand(runtime, { noExport: true });
       } else {
@@ -650,11 +593,7 @@ describe("triageCommand", () => {
       }
     });
 
-    const promptLog = runtime.log.mock.calls[0]?.[0];
-    if (typeof promptLog !== "string") {
-      throw new Error("Expected triage to log the saved prompt path.");
-    }
-    const promptPath = promptLog.replace("Debugging prompt: ", "");
+    const promptPath = String(runtime.log.mock.calls[0]?.[0]).replace("Debugging prompt: ", "");
     expect(mocks.spawn).toHaveBeenCalledExactlyOnceWith(
       `/usr/local/bin/${agent}`,
       [await fs.readFile(promptPath, "utf8")],
@@ -676,21 +615,20 @@ describe("triageCommand", () => {
     }
   });
 
-  it("prints the selected manual command and exits nonzero when launching an agent fails", async () => {
-    mocks.resolveExecutablePath.mockImplementation((binary: string) =>
-      binary === "claude" ? "/usr/local/bin/claude" : undefined,
-    );
+  it("reports a failed launch without trying another installed agent", async () => {
+    mocks.resolveExecutablePath.mockImplementation((binary: string) => `/usr/local/bin/${binary}`);
     mocks.spawn.mockImplementation(() => {
       const child = new EventEmitter();
       queueMicrotask(() => child.emit("error", new Error("permission denied")));
       return child;
     });
-    const runtime = createRuntime();
+    const runtime = createTriageRuntime();
 
-    await withInteractiveTerminal(async () => {
+    await withTriageTerminal(true, async () => {
       await expect(triageCommand(runtime, { noExport: true })).rejects.toMatchObject({ code: 1 });
     });
 
+    expect(mocks.spawn).toHaveBeenCalledOnce();
     expect(runtime.error).toHaveBeenCalledWith("Failed to launch claude: permission denied");
     expect(runtime.log).toHaveBeenCalledWith(
       expect.stringMatching(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update the branch.

</details>

## What Problem This Solves

The upgrade/recovery work in #134490 left duplicated test fixtures, repeated expected command data, and obsolete picker mocks. This maintainer-requested follow-up reduces that maintenance burden without changing runtime behavior or removing independent regression coverage.

Related: #134490

## Why This Change Was Made

Reuse the existing staged-package fixture and share the duplicated managed-service lifecycle setup. Triage tests share their mock runtime and terminal restoration, remove the retired picker mock, and consolidate one duplicated launch-failure test into the stronger existing case with all alternative agents available.

Keep all 350 update-CLI cases and their assertions/order. Preserve platform, configuration, consent, restart-safety, redaction, nonzero-exit, sentinel, and cleanup coverage; do not introduce a new test framework or production seam.

## User Impact

No user-visible behavior changes. Four test/support files become **196 net lines smaller**: **203 additions / 399 deletions**. Production LOC: **+0/-0**. Tests: **+178/-399**; shared test support: **+25/-0**.

## Evidence

- Before cleanup: 350 update-CLI tests and 48 triage tests passed.
- Final affected/sibling proof: **483 tests passed across 10 files**, including the complete 350-case CLI suite and the retained triage coverage.
- Complete changed-file gate passed, including core test types, formatting, targeted lint, repository guards, and script/production/full-tree dead-export scans. An initial map/spread lint finding was corrected before rerunning the final tests and full gate.
- Fresh independent Codex autoreview of the final patch: **scoped-clean at P0**, no accepted/actionable findings.
- Runtime, package, schema, configuration, and UI behavior are unchanged; no build or new visual/live proof is required for this test-only refactor.

Commands run from the checkout:

```bash
pnpm test src/cli/update-cli.test.ts src/cli/update-cli/update-command-post-core.test.ts src/cli/update-cli/update-command-post-update.test.ts src/cli/update-cli/update-command-fresh-doctor.test.ts src/commands/triage.test.ts src/commands/triage-recovery.test.ts src/commands/triage-prompt.test.ts src/commands/triage-update.test.ts src/commands/triage-target.test.ts src/infra/update-triage.test.ts
```

```bash
pnpm check:changed -- src/cli/update-cli.test.ts src/commands/triage.test.ts src/commands/triage-recovery.test.ts src/commands/triage.test-support.ts
```
