### PR TITLE
refactor(scripts): share bounded output tail

### DIFF
--- a/scripts/check-extension-package-tsc-boundary.mts
+++ b/scripts/check-extension-package-tsc-boundary.mts
@@ -12,6 +12,7 @@ import {
   MAX_TIMER_TIMEOUT_MS,
   resolveTimerTimeoutMs,
 } from "../packages/normalization-core/src/number-coercion.ts";
+import { appendBoundedTail } from "./lib/bounded-output-tail.mjs";
 import {
   portableRelativePath,
   readArtifactRecord,
@@ -147,22 +148,6 @@ function formatFailureFooter(params: StepFailureParams = {}) {
 
 function createStepOutputCapture(): StepOutputCapture {
   return { text: "", truncatedChars: 0 };
-}
-
-/**
- * Appends child-process output while preserving only the diagnostic tail.
- */
-export function appendBoundedStepOutput(
-  buffer: StepOutputCapture,
-  chunk: unknown,
-  maxChars = STEP_OUTPUT_MAX_CHARS,
-) {
-  const nextText = buffer.text + String(chunk);
-  if (nextText.length <= maxChars) {
-    return { text: nextText, truncatedChars: buffer.truncatedChars };
-  }
-  const truncatedChars = buffer.truncatedChars + nextText.length - maxChars;
-  return { text: nextText.slice(-maxChars), truncatedChars };
 }
 
 function formatCapturedStepOutput(buffer: StepOutputCapture) {
@@ -352,10 +337,10 @@ export async function runNodeStepAsync(
         child.stdout!.setEncoding("utf8");
         child.stderr!.setEncoding("utf8");
         child.stdout!.on("data", (chunk) => {
-          stdout = appendBoundedStepOutput(stdout, chunk);
+          stdout = appendBoundedTail(stdout, chunk, STEP_OUTPUT_MAX_CHARS);
         });
         child.stderr!.on("data", (chunk) => {
-          stderr = appendBoundedStepOutput(stderr, chunk);
+          stderr = appendBoundedTail(stderr, chunk, STEP_OUTPUT_MAX_CHARS);
         });
       },
     });

--- a/scripts/e2e/kitchen-sink-rpc-walk.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mts
@@ -14,6 +14,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { asRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
+import { appendBoundedTail } from "../lib/bounded-output-tail.mjs";
 import {
   createBoundedResponseTooLargeError,
   readBoundedResponseText,
@@ -462,20 +463,6 @@ function readJson(file: string): unknown {
   return JSON.parse(fs.readFileSync(file, "utf8"));
 }
 
-export function appendBoundedOutput(
-  buffer: CapturedOutput,
-  chunk: string | Uint8Array,
-  maxChars = resolveKitchenSinkRpcConfig().outputCaptureChars,
-) {
-  const text = String(chunk);
-  const combined = `${buffer.text}${text}`;
-  const overflowChars = Math.max(0, combined.length - maxChars);
-  return {
-    text: overflowChars > 0 ? combined.slice(overflowChars) : combined,
-    truncatedChars: buffer.truncatedChars + overflowChars,
-  };
-}
-
 function formatCapturedOutput(label: string, buffer: CapturedOutput) {
   return buffer.truncatedChars > 0
     ? `[${label} truncated ${buffer.truncatedChars} chars]\n${buffer.text}`
@@ -583,10 +570,10 @@ export function runCommand(
       forceKillTimer.unref();
     }, resolvedTimeoutMs);
     child.stdout?.on("data", (chunk) => {
-      stdout = appendBoundedOutput(stdout, chunk, outputCaptureChars);
+      stdout = appendBoundedTail(stdout, chunk, outputCaptureChars);
     });
     child.stderr?.on("data", (chunk) => {
-      stderr = appendBoundedOutput(stderr, chunk, outputCaptureChars);
+      stderr = appendBoundedTail(stderr, chunk, outputCaptureChars);
     });
     child.on("error", (error) => {
       clearTimeout(timer);

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import { appendBoundedTail } from "../../../lib/bounded-output-tail.mjs";
 import {
   createBoundedResponseTooLargeError,
   readBoundedResponseText,
@@ -378,15 +379,6 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-export function appendBoundedOutput(buffer, chunk, maxChars = OUTPUT_CAPTURE_CHARS) {
-  const nextText = buffer.text + String(chunk);
-  if (nextText.length <= maxChars) {
-    return { text: nextText, truncatedChars: buffer.truncatedChars };
-  }
-  const truncatedChars = buffer.truncatedChars + nextText.length - maxChars;
-  return { text: nextText.slice(-maxChars), truncatedChars };
-}
-
 function formatCapturedOutput(label, buffer) {
   if (!buffer.text) {
     return "";
@@ -453,10 +445,10 @@ export function runCommand(command, args, options = {}) {
     let timedOut = false;
     let settled = false;
     child.stdout?.on("data", (chunk) => {
-      stdout = appendBoundedOutput(stdout, chunk);
+      stdout = appendBoundedTail(stdout, chunk, OUTPUT_CAPTURE_CHARS);
     });
     child.stderr?.on("data", (chunk) => {
-      stderr = appendBoundedOutput(stderr, chunk);
+      stderr = appendBoundedTail(stderr, chunk, OUTPUT_CAPTURE_CHARS);
     });
     const clearCommandTimer = timeoutMs
       ? setTimeout(() => {

--- a/scripts/lib/bounded-output-tail.mjs
+++ b/scripts/lib/bounded-output-tail.mjs
@@ -1,0 +1,18 @@
+/**
+ * @typedef {{ text: string, truncatedChars: number }} BoundedTail
+ */
+
+/**
+ * @param {BoundedTail} state
+ * @param {unknown} chunk
+ * @param {number} maxChars
+ * @returns {BoundedTail}
+ */
+export function appendBoundedTail(state, chunk, maxChars) {
+  const nextText = state.text + String(chunk);
+  const droppedChars = Math.max(0, nextText.length - maxChars);
+  return {
+    text: droppedChars > 0 ? nextText.slice(droppedChars) : nextText,
+    truncatedChars: state.truncatedChars + droppedChars,
+  };
+}

--- a/scripts/lib/extension-boundary-inputs.mts
+++ b/scripts/lib/extension-boundary-inputs.mts
@@ -30,6 +30,7 @@ const GENERATOR_INPUTS = [
   "scripts/lib/extension-boundary-inputs.mts",
   "scripts/lib/compiler-input-snapshot.mts",
   "scripts/lib/build-artifact-cache.mts",
+  "scripts/lib/bounded-output-tail.mjs",
   "scripts/lib/local-check-runtime.mts",
   "scripts/lib/managed-child-process.mts",
   "scripts/lib/vitest-resource-ownership.mts",

--- a/scripts/profile-extension-memory.mts
+++ b/scripts/profile-extension-memory.mts
@@ -19,6 +19,7 @@ import {
   findBuiltExtensionMemoryEntries,
 } from "./ensure-extension-memory-build.mts";
 import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mts";
+import { appendBoundedTail } from "./lib/bounded-output-tail.mjs";
 import { formatErrorMessage } from "./lib/error-format.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 
@@ -173,21 +174,6 @@ function createOutputCapture(): OutputCapture {
   return { text: "", truncatedChars: 0 };
 }
 
-function appendBoundedOutput(
-  capture: OutputCapture,
-  chunk: unknown,
-  maxChars = OUTPUT_CAPTURE_MAX_CHARS,
-): OutputCapture {
-  const nextText = capture.text + String(chunk);
-  if (nextText.length <= maxChars) {
-    return capture.truncatedChars === 0
-      ? { text: nextText, truncatedChars: 0 }
-      : { text: nextText, truncatedChars: capture.truncatedChars };
-  }
-  const truncatedChars = capture.truncatedChars + nextText.length - maxChars;
-  return { text: nextText.slice(-maxChars), truncatedChars };
-}
-
 function formatCapturedOutput(capture: OutputCapture): string {
   if (capture.truncatedChars === 0) {
     return capture.text;
@@ -280,13 +266,13 @@ export async function runCase({
     }
 
     child.stdout.on("data", (chunk) => {
-      stdout = appendBoundedOutput(stdout, chunk);
+      stdout = appendBoundedTail(stdout, chunk, OUTPUT_CAPTURE_MAX_CHARS);
     });
     child.stderr.on("data", (chunk) => {
       const rssScan = scanMaxRssMb(stderrRssTail, chunk, maxRssMb);
       stderrRssTail = rssScan.tail;
       maxRssMb = rssScan.maxRssMb;
-      stderr = appendBoundedOutput(stderr, chunk);
+      stderr = appendBoundedTail(stderr, chunk, OUTPUT_CAPTURE_MAX_CHARS);
     });
     child.on("error", (error) => {
       const stderrText = formatCapturedOutput(stderr);

--- a/scripts/resolve-openclaw-package-candidate.mts
+++ b/scripts/resolve-openclaw-package-candidate.mts
@@ -19,6 +19,7 @@ import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import { isRecord as isJsonRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { booleanFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
+import { appendBoundedTail } from "./lib/bounded-output-tail.mjs";
 import { toErrorObject } from "./lib/error-format.mts";
 import { terminateManagedChild } from "./lib/managed-child-process.mts";
 import { resolveNpmJsonEntries } from "./lib/npm-json-output.mts";
@@ -385,10 +386,10 @@ function run(command: string, args: readonly string[], options: RunOptions = {})
     let stderr = { text: "", truncatedChars: 0 };
     if (options.capture) {
       child.stdout?.on("data", (chunk: Buffer) => {
-        stdout = appendBoundedCommandOutput(stdout, chunk, COMMAND_STDOUT_CAPTURE_MAX_CHARS);
+        stdout = appendBoundedTail(stdout, chunk, COMMAND_STDOUT_CAPTURE_MAX_CHARS);
       });
       child.stderr?.on("data", (chunk: Buffer) => {
-        stderr = appendBoundedCommandOutput(stderr, chunk, COMMAND_STDERR_CAPTURE_MAX_CHARS);
+        stderr = appendBoundedTail(stderr, chunk, COMMAND_STDERR_CAPTURE_MAX_CHARS);
       });
     }
     child.on("error", (error: Error) => {
@@ -512,19 +513,6 @@ async function waitForProcessTreeExit(
     });
   }
   return !processTreeIsAlive(child, useProcessGroup);
-}
-
-function appendBoundedCommandOutput(
-  buffer: CommandOutputBuffer,
-  chunk: string | Uint8Array,
-  maxChars: number,
-) {
-  const nextText = buffer.text + String(chunk);
-  if (nextText.length <= maxChars) {
-    return { text: nextText, truncatedChars: buffer.truncatedChars };
-  }
-  const truncatedChars = buffer.truncatedChars + nextText.length - maxChars;
-  return { text: nextText.slice(-maxChars), truncatedChars };
 }
 
 function formatCapturedCommandOutput(buffer: CommandOutputBuffer) {

--- a/test/scripts/bounded-output-tail.test.ts
+++ b/test/scripts/bounded-output-tail.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { appendBoundedTail } from "../../scripts/lib/bounded-output-tail.mjs";
+
+describe("appendBoundedTail", () => {
+  it("preserves raw UTF-16 tail semantics and cumulative truncation", () => {
+    expect(appendBoundedTail({ text: "ab", truncatedChars: 0 }, "cd", 4)).toEqual({
+      text: "abcd",
+      truncatedChars: 0,
+    });
+
+    const prior = appendBoundedTail({ text: "abc", truncatedChars: 2 }, "def", 4);
+    expect(prior).toEqual({ text: "cdef", truncatedChars: 4 });
+
+    expect(appendBoundedTail({ text: "", truncatedChars: 0 }, new Uint8Array([65, 66]), 8)).toEqual(
+      {
+        text: "65,66",
+        truncatedChars: 0,
+      },
+    );
+
+    const splitSurrogate = appendBoundedTail({ text: "\ud83d", truncatedChars: 0 }, "\ude00b", 2);
+    expect(splitSurrogate).toEqual({ text: "\ude00b", truncatedChars: 1 });
+    expect(splitSurrogate.text.charCodeAt(0)).toBe(0xde00);
+  });
+});

--- a/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
+++ b/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
@@ -291,14 +291,22 @@ describe("bundled plugin install/uninstall probe", () => {
     expect(sweep).not.toContain('cat "$uninstall_log"');
   });
 
-  it("keeps runtime command output capture bounded", async () => {
-    const runtimeSmoke = await import(pathToFileURL(runtimeSmokePath).href);
+  it("uses the runtime output limit for command capture", async () => {
+    const runtimeSmoke = await importRuntimeSmokeWithEnv({
+      OPENCLAW_BUNDLED_PLUGIN_RUNTIME_OUTPUT_CHARS: "5",
+    });
 
-    const first = runtimeSmoke.appendBoundedOutput({ text: "", truncatedChars: 0 }, "abcdef", 5);
-    expect(first).toEqual({ text: "bcdef", truncatedChars: 1 });
-
-    const second = runtimeSmoke.appendBoundedOutput(first, "ghij", 5);
-    expect(second).toEqual({ text: "fghij", truncatedChars: 5 });
+    await expect(
+      runtimeSmoke.runCommand(process.execPath, [
+        "-e",
+        "process.stdout.write('abcdef'); process.stderr.write('UVWXYZ');",
+      ]),
+    ).resolves.toEqual({
+      stdout: "bcdef",
+      stderr: "VWXYZ",
+      stdoutTruncatedChars: 1,
+      stderrTruncatedChars: 1,
+    });
   });
 
   it("preserves explicit nullish runtime RPC result fields", async () => {

--- a/test/scripts/check-extension-package-tsc-boundary.test.ts
+++ b/test/scripts/check-extension-package-tsc-boundary.test.ts
@@ -7,7 +7,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  appendBoundedStepOutput,
   cleanupCanaryArtifactsForExtensions,
   formatBoundaryCheckSuccessSummary,
   formatSlowCompileSummary,
@@ -140,14 +139,6 @@ describe("check-extension-package-tsc-boundary", () => {
       ),
     ).rejects.toMatchObject({ kind: "timeout", fullOutput: expect.stringContaining(diagnostic) });
   });
-  it("keeps a bounded tail of captured step output", () => {
-    const first = appendBoundedStepOutput({ text: "", truncatedChars: 0 }, "abcdef", 5);
-    const second = appendBoundedStepOutput(first, "ghij", 5);
-
-    expect(first).toEqual({ text: "bcdef", truncatedChars: 1 });
-    expect(second).toEqual({ text: "fghij", truncatedChars: 5 });
-  });
-
   it("removes stale canary artifacts across extensions", () => {
     const { rootDir } = createTempExtensionRoot();
     const { canaryPath, tsconfigPath } = writeCanaryArtifacts(rootDir);

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -16,7 +16,6 @@ import { setTimeout as delay } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  appendBoundedOutput,
   assertChannelAccountRunning,
   assertCommandResourceCeiling,
   assertCreatedKitchenSinkSession,
@@ -697,14 +696,6 @@ describe("kitchen-sink RPC gateway readiness logs", () => {
 });
 
 describe("kitchen-sink RPC command output capture", () => {
-  it("keeps a bounded tail and tracks truncated output", () => {
-    const first = appendBoundedOutput({ text: "", truncatedChars: 0 }, "abcdef", 5);
-    expect(first).toEqual({ text: "bcdef", truncatedChars: 1 });
-
-    const second = appendBoundedOutput(first, "ghij", 5);
-    expect(second).toEqual({ text: "fghij", truncatedChars: 5 });
-  });
-
   it("honors the resolved command output capture limit", async () => {
     const result = await runCommand(
       process.execPath,


### PR DESCRIPTION
## What Problem This Solves

Five script and E2E command runners independently maintained the same bounded diagnostic-tail logic. The copies had already diverged in syntax and test exposure, making raw UTF-16 truncation, cumulative drop accounting, and output-limit wiring easier to change inconsistently.

## Why This Change Was Made

The private scripts layer now owns one `appendBoundedTail` implementation in `scripts/lib/bounded-output-tail.mjs`. The package candidate resolver, extension boundary compiler, bundled-plugin runtime smoke, extension memory profiler, and kitchen-sink RPC walk use it with their existing explicit limits.

The local implementations and test-only exports were removed. The shared function preserves `String(chunk)` coercion, UTF-16 code-unit slicing, cumulative `truncatedChars`, fresh result objects, and `{ text, truncatedChars }` key order.

Intentionally excluded:

- Control UI's surrogate-safe tail
- cross-OS byte/decoder capture
- Parallels raw-byte capture
- text-only and other non-state tails

Tooling production: +34/-77, net -43. Tests: +40/-25, net +15. Overall: +74/-102, net -28.

## User Impact

No user-visible behavior changes. Script failures and E2E diagnostics retain the same bounded tails and truncation counts, with one canonical implementation.

## Evidence

Root cause: identical raw UTF-16 bounded-tail policy was duplicated across five private script owners.

Architectural owner: `scripts/lib/bounded-output-tail.mjs`.

Canonical fix and removed paths:

- Added one dependency-free `.mjs` helper for plain Node and TypeScript script closures.
- Removed five local appenders and their default-argument variants.
- Removed direct implementation tests from the extension boundary and kitchen-sink owners.
- Replaced the bundled-plugin test-only export check with a real `runCommand` test proving environment-driven output-limit wiring.
- Added the helper to extension boundary generator inputs.

Sibling coverage:

- The canonical test covers no truncation, prior truncation, `String(Uint8Array)`, and an intentional dangling-surrogate result.
- Existing owner tests continue to prove package failure tails, truncation rejection, RSS scanning, command result counts, compiler diagnostics, and subprocess cleanup.
- Docker boundary proof confirms bare E2E scripts receive the complete `scripts/lib` tree.
- Byte-aware decoder and raw-buffer siblings remain separate because their contracts differ.

Fresh replay proof at exact head `e0237b5fb728d71166696cea1bcc5040e9cb846a`:

- Replayed onto main `868aae3c56db67af6d7fdcabc1dd26739a7f6c5e` with a signed commit.
- The old and replayed binary patches have identical SHA-256 `3d1ee6ad90859ce964eebca0197c2867ec663d817abc0b742cc8169cf10d2c53`.
- Current main had no intervening changes in any of the 11 touched paths; a synthetic merge is conflict-free.
- Focused owner/consumer Vitest proof: 266 tests passed across the shared helper, boundary compiler, package resolver, memory profiler, bundled-plugin runtime, and kitchen-sink command capture.
- Touched-file formatting and `git diff --check`: passed.
- Changed-scope script and root-test TypeScript graphs: passed.
- Scripts/test Oxlint, coercion-helper, Docker E2E boundary, raw-http2, conflict-marker, changelog, doctor-registry, wildcard, duplicate-coverage, dependency-pin, patch, temp-report, core-tsgo-boundary, and script-erasability checks: passed.
- Two fresh independent reviews of the replayed branch and frozen commit: scoped clean, 0.98 each.
- Live keyword search and current open-PR file scan found no overlapping bounded-tail change; the prior exhaustive 11-file census remains applicable because the patch and all touched base blobs are unchanged.

The first exact-head CI run, https://github.com/openclaw/openclaw/actions/runs/33684358383, failed only in untouched `ui/src/styles/corner-shape.browser.test.ts` because Chromium serialized circular corners as `superellipse(1)` instead of `round`. That stale baseline was fixed on main by #136402 before this replay. Fresh exact-head CI and native Testbox prepare proof remain the final landing gates.

ClawSweeper's stored-data warning is not applicable: `scripts/e2e/kitchen-sink-rpc-walk.mts` is an ephemeral command runner, and this patch changes only in-memory output-tail implementation. It adds no schema, migration, persistence, serialized representation, or upgrade contract.

Codex check: `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870` cover CLI declarations, prompt newline normalization, overrides, and completion generation. They do not own subprocess diagnostic-tail or packaging behavior.
