### PR TITLE
fix(infra): reject dot segments in sanitized temp file names

### DIFF
--- a/src/infra/temp-download.ts
+++ b/src/infra/temp-download.ts
@@ -3,7 +3,7 @@ import "./fs-safe-defaults.js";
 import crypto from "node:crypto";
 import path from "node:path";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { tempWorkspace, type TempWorkspace } from "./private-temp-workspace.js";
+import { tempWorkspace } from "./private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 
 const logger = createSubsystemLogger("infra:temp-download");
@@ -67,23 +67,6 @@ export function buildRandomTempFilePath(params: {
   );
 }
 
-function buildTempDownloadTarget(
-  workspace: TempWorkspace,
-  fileName: string | undefined,
-): TempDownloadTarget {
-  const file = (nextName?: string) =>
-    workspace.path(sanitizeTempFileName(nextName ?? fileName ?? "download.bin"));
-  return {
-    dir: workspace.dir,
-    path: file(),
-    file,
-    cleanup: async () => {
-      await workspace.cleanup();
-    },
-    [Symbol.asyncDispose]: workspace[Symbol.asyncDispose].bind(workspace),
-  };
-}
-
 export async function createTempDownloadTarget(params: {
   prefix: string;
   fileName?: string;
@@ -93,7 +76,9 @@ export async function createTempDownloadTarget(params: {
     rootDir: resolveTempRoot(params.tmpDir),
     prefix: sanitizeTempPrefix(params.prefix),
   });
-  const target = buildTempDownloadTarget(workspace, params.fileName);
+  const fileName = params.fileName;
+  const file = (nextName?: string) =>
+    workspace.path(sanitizeTempFileName(nextName ?? fileName ?? "download.bin"));
   const cleanup = async () => {
     try {
       await workspace.cleanup();
@@ -102,7 +87,9 @@ export async function createTempDownloadTarget(params: {
     }
   };
   return {
-    ...target,
+    dir: workspace.dir,
+    path: file(),
+    file,
     cleanup,
     [Symbol.asyncDispose]: cleanup,
   };

--- a/src/infra/temp-download.ts
+++ b/src/infra/temp-download.ts
@@ -42,7 +42,9 @@ function sanitizeTempExtension(extension?: string): string {
 export function sanitizeTempFileName(fileName: string): string {
   const base = path.basename(fileName).replace(/[^a-zA-Z0-9._-]+/g, "-");
   const normalized = base.replace(/^-+|-+$/g, "");
-  return normalized || "download.bin";
+  // "." and ".." pass the character class above but are rejected as workspace
+  // leaf names, so returning them hands callers a throw instead of a safe name.
+  return !normalized || normalized === "." || normalized === ".." ? "download.bin" : normalized;
 }
 
 /** Build a stable temp path shape while keeping caller-controlled text filename-safe. */

--- a/src/plugin-sdk/temp-path.test.ts
+++ b/src/plugin-sdk/temp-path.test.ts
@@ -71,6 +71,12 @@ describe("withTempDownloadPath", () => {
       expectCleanup: false,
       expectedBasename: "evil.bin",
     },
+    {
+      name: "falls back to the default name when a fileName sanitizes to a dot segment",
+      input: { prefix: "media", fileName: "../.." },
+      expectCleanup: false,
+      expectedBasename: "download.bin",
+    },
   ])("$name", async ({ input, expectCleanup, expectedBasename }) => {
     let capturedPath = "";
     await withTempDownloadPath(input, async (tmpPath) => {

--- a/src/plugin-sdk/temp-path.test.ts
+++ b/src/plugin-sdk/temp-path.test.ts
@@ -62,28 +62,23 @@ describe("withTempDownloadPath", () => {
     {
       name: "creates a temp path under tmp dir and cleans up the temp directory",
       input: { prefix: "line-media" },
-      expectCleanup: true,
       expectedBasename: undefined,
     },
     {
       name: "sanitizes prefix and fileName",
       input: { prefix: "../../channels/../media", fileName: "../../evil.bin" },
-      expectCleanup: false,
       expectedBasename: "evil.bin",
     },
-    {
-      name: "falls back to the default name when a fileName sanitizes to a dot segment",
-      input: { prefix: "media", fileName: "../.." },
-      expectCleanup: false,
+    ...[".", "..", "../..", "-..-"].map((fileName) => ({
+      name: `falls back to the default name for the dot segment ${fileName}`,
+      input: { prefix: "media", fileName },
       expectedBasename: "download.bin",
-    },
-  ])("$name", async ({ input, expectCleanup, expectedBasename }) => {
+    })),
+  ])("$name", async ({ input, expectedBasename }) => {
     let capturedPath = "";
     await withTempDownloadPath(input, async (tmpPath) => {
       capturedPath = tmpPath;
-      if (expectCleanup) {
-        await fs.writeFile(tmpPath, "ok");
-      }
+      await fs.writeFile(tmpPath, "ok");
     });
 
     expectPathInsideTmpRoot(capturedPath);
@@ -92,14 +87,6 @@ describe("withTempDownloadPath", () => {
     } else {
       expect(capturedPath).toContain(path.join(resolvePreferredOpenClawTmpDir(), "line-media-"));
     }
-    if (expectCleanup) {
-      let statError: NodeJS.ErrnoException | undefined;
-      try {
-        await fs.stat(capturedPath);
-      } catch (error) {
-        statError = error as NodeJS.ErrnoException;
-      }
-      expect(statError?.code).toBe("ENOENT");
-    }
+    await expect(fs.stat(path.dirname(capturedPath))).rejects.toMatchObject({ code: "ENOENT" });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a ClawHub archive download fails when its filename resolves to `.` or `..`. The temporary directory has already been created, but staging throws before returning its cleanup handle.

## Why This Change Was Made

The shared filename sanitizer now returns `download.bin` for bare dot segments, matching the leaf-name contract in `@openclaw/fs-safe` 0.7.0. Temporary download targets now have one cleanup implementation; the helper whose cleanup methods were immediately overwritten has been removed. The default filename remains captured when the target is created.

## User Impact

Downloads with these malformed names stage successfully, and their temporary directories are cleaned up normally. Valid filenames, alternate target filenames, callback errors, and asynchronous disposal retain their behavior.

Original fix and reproduction by @teddytennant.

## Evidence

- An isolated Linux run compared the complete [pre-fix parent](https://github.com/openclaw/openclaw/commit/76352df3930424aac2dbdf55f03ba21f7eabe571), [original PR](https://github.com/openclaw/openclaw/commit/01efd6a332fe850c0071194a461724f1a4813a98), and [final revision](https://github.com/openclaw/openclaw/commit/e50af37def3054934b17d52a9cdb63dac846901a) with identical dependency inputs. The new regression fails against pre-fix production code.
- Real filesystem checks covered `.`, `..`, `../..`, normal and nested names, callback failure, alternate target filenames, and asynchronous disposal. The pre-fix dot cases never reached the callback and left a directory visible before process exit. All eight final-revision cases passed, preserving unrelated sentinel files and removing the temporary workspace before exit.
- The final revision passed **101 tests**, with two macOS-only tests skipped on Linux, across the temporary-path suite and four ClawHub suites. A separate trusted-main macOS run reproduced the same defect with fs-safe 0.7.0.
- The published fs-safe 0.7.0 package was integrity-verified and its leaf validation and cleanup implementation inspected directly. Fresh independent Codex review found no blocking issues. Formatting and whitespace checks pass.
- Final PR delta: **production +10/-21 (net -11)**; **tests +8/-15 (net -7)**. Four dot-segment cases replace the single added case, and every filename case now performs a real write and verifies directory cleanup.

[Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33601175139) passed for the final revision. This corrects invalid filename output in the existing SDK contract; it adds no configuration, schema, or public API surface.
