### PR TITLE
test(plugins): unify E2E child shutdown ownership

### DIFF
--- a/extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
+++ b/extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
@@ -1,6 +1,5 @@
 // Proves the external Prometheus plugin's managed install and trusted runtime boundary.
 import { execFile, spawn, type ChildProcess } from "node:child_process";
-import { once } from "node:events";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
@@ -11,6 +10,7 @@ import {
   tempWorkspace,
   type TempWorkspace,
 } from "openclaw/plugin-sdk/temp-path";
+import { stopChildProcess } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
@@ -21,20 +21,14 @@ const pluginRoot = path.resolve(import.meta.dirname, "..");
 const tempWorkspaces: TempWorkspace[] = [];
 const children: ChildProcess[] = [];
 
-async function stopChild(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
-  const exited = once(child, "exit").then(() => true);
-  child.kill("SIGTERM");
-  if (!(await Promise.race([exited, delay(5_000, false)]))) {
-    child.kill("SIGKILL");
-    await Promise.race([exited, delay(5_000)]);
-  }
-}
-
 afterEach(async () => {
-  await Promise.all(children.splice(0).map(stopChild));
+  const stopped = await Promise.allSettled(
+    children.splice(0).map((child) => stopChildProcess(child, 5_000)),
+  );
+  const errors = stopped.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "failed to stop Prometheus E2E children");
+  }
   await Promise.all(tempWorkspaces.splice(0).map((workspace) => workspace.cleanup()));
 });
 
@@ -104,7 +98,10 @@ async function runCli(args: string[], env: NodeJS.ProcessEnv, build = false): Pr
   return result.stdout;
 }
 
-async function packPlugin(outputDir: string): Promise<{
+async function packPlugin(
+  outputDir: string,
+  version: string,
+): Promise<{
   files: string[];
   tarballPath: string;
 }> {
@@ -122,7 +119,7 @@ async function packPlugin(outputDir: string): Promise<{
     maxBuffer: 2 * 1024 * 1024,
     timeout: 60_000,
   });
-  const result = await execFileAsync(
+  await execFileAsync(
     process.execPath,
     [
       "scripts/lib/plugin-npm-package-manifest.mjs",
@@ -131,7 +128,6 @@ async function packPlugin(outputDir: string): Promise<{
       "--",
       "npm",
       "pack",
-      "--json",
       "--ignore-scripts",
       "--pack-destination",
       outputDir,
@@ -146,20 +142,21 @@ async function packPlugin(outputDir: string): Promise<{
       timeout: 60_000,
     },
   );
-  const entries = JSON.parse(result.stdout) as Array<{
-    filename?: string;
-    files?: Array<{ path?: string }>;
-  }>;
-  const entry = entries[0];
-  const filename = entry?.filename;
-  if (!filename) {
-    throw new Error("npm pack did not report the diagnostics-prometheus tarball");
-  }
+  const tarballPath = path.join(
+    outputDir,
+    `${packageName.replace(/^@/, "").replace("/", "-")}-${version}.tgz`,
+  );
+  expect((await fs.stat(tarballPath)).isFile()).toBe(true);
+  const entries = await execFileAsync("tar", ["-tzf", tarballPath], {
+    maxBuffer: 2 * 1024 * 1024,
+    timeout: 60_000,
+  });
   return {
-    files: (entry.files ?? []).flatMap((file) =>
-      typeof file.path === "string" ? [file.path] : [],
-    ),
-    tarballPath: path.join(outputDir, filename),
+    files: entries.stdout
+      .trim()
+      .split(/\r?\n/u)
+      .map((file) => file.replace(/^package\//u, "")),
+    tarballPath,
   };
 }
 
@@ -291,7 +288,7 @@ describe("diagnostics-prometheus managed install runtime", () => {
     );
 
     const pluginVersion = await readPluginVersion();
-    const packedPlugin = await packPlugin(root);
+    const packedPlugin = await packPlugin(root, pluginVersion);
     expect(packedPlugin.files.some((file) => /^dist\/index\.(?:js|mjs|cjs)$/u.test(file))).toBe(
       true,
     );

--- a/extensions/ollama/src/node-inference.paired-node.e2e.test.ts
+++ b/extensions/ollama/src/node-inference.paired-node.e2e.test.ts
@@ -1,7 +1,6 @@
 // Proves local Ollama inference crosses a real Gateway and paired node socket.
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { once } from "node:events";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
@@ -9,6 +8,7 @@ import { performance } from "node:perf_hooks";
 import { setTimeout as delay } from "node:timers/promises";
 import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 import type { OpenClawPluginNodeHostCommand } from "openclaw/plugin-sdk/plugin-entry";
+import { stopChildProcess } from "openclaw/plugin-sdk/test-env";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { describe, expect, it, vi } from "vitest";
 import { createOllamaNodeHostCommands } from "./node-inference.js";
@@ -270,10 +270,17 @@ describe("Ollama paired-node Gateway inference", () => {
           ...(node ? [node.stopAndWait({ timeoutMs: 1000 })] : []),
           ...(operator ? [operator.stopAndWait({ timeoutMs: 1000 })] : []),
         ]);
-        if (gateway) {
-          await stopGatewayProcess(gateway);
+        try {
+          if (gateway) {
+            await stopChildProcess(gateway, 2_000).catch((error: unknown) => {
+              // Keep live-child state for diagnosis without leaking this fixture's process environment.
+              state.restoreEnv();
+              throw error;
+            });
+          }
+        } finally {
+          await Promise.allSettled([nodeOllama.close(), gatewayOllama.close()]);
         }
-        await Promise.allSettled([nodeOllama.close(), gatewayOllama.close()]);
         await state.cleanup();
       }
     },
@@ -638,17 +645,4 @@ async function handleFakeOllamaRequest(
   }
   response.statusCode = 404;
   response.end(JSON.stringify({ error: "not found" }));
-}
-
-async function stopGatewayProcess(child: ChildProcessWithoutNullStreams): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
-  const exited = once(child, "exit").then(() => true);
-  child.kill("SIGTERM");
-  if (await Promise.race([exited, delay(2_000).then(() => false)])) {
-    return;
-  }
-  child.kill("SIGKILL");
-  await Promise.race([exited, delay(2_000)]);
 }

--- a/src/plugin-sdk/test-env.ts
+++ b/src/plugin-sdk/test-env.ts
@@ -9,6 +9,7 @@ export { withFetchPreconnect, type FetchMock } from "../test-utils/fetch-mock.js
 export { createMockServerResponse } from "../test-utils/mock-http-response.js";
 export { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
 export { withTempDir } from "../test-utils/temp-dir.js";
+export { stopChildProcess } from "../../test/helpers/stop-child-process.js";
 export { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 export { useFrozenTime, useRealTime } from "../test-utils/frozen-time.js";
 export { withServer } from "./test-helpers/http-test-server.js";

--- a/test/helpers/stop-child-process.ts
+++ b/test/helpers/stop-child-process.ts
@@ -1,0 +1,32 @@
+import type { ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { withTimeout } from "@openclaw/fs-safe/advanced";
+
+export async function stopChildProcess(child: ChildProcess, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  const exitWait = new AbortController();
+  const exited = once(child, "exit", { signal: exitWait.signal });
+  try {
+    for (const signal of ["SIGTERM", "SIGKILL"] as const) {
+      const timeoutError = new Error(
+        `child ${String(child.pid)} did not exit within ${timeoutMs}ms after ${signal}`,
+      );
+      child.kill(signal);
+      try {
+        await withTimeout(exited, timeoutMs, { createError: () => timeoutError });
+        return;
+      } catch (error) {
+        // Only the grace deadline escalates; child errors and the final deadline remain failures.
+        if (error !== timeoutError || signal === "SIGKILL") {
+          throw error;
+        }
+      }
+    }
+  } finally {
+    // Remove once's exit/error listeners even if kill throws or the final wait times out.
+    exitWait.abort();
+    await exited.catch(() => undefined);
+  }
+}


### PR DESCRIPTION
The Prometheus and paired-node Ollama E2Es duplicated shutdown helpers that left losing timeout timers scheduled after child exit. Both helpers also returned success when the final SIGKILL deadline expired without observing exit, allowing live-child state to be removed. Share a small direct-child exit helper through the existing private test-env facade. Cancel its deadline/listeners on every outcome, escalate only the grace timeout, and preserve child errors and final shutdown failures.

Prometheus now joins every registered stop result before removing workspaces. Ollama closes both HTTP fixtures and restores its exact prior environment when stopping fails, retaining state for diagnosis. The helper intentionally preserves direct-child exit semantics; it does not claim pipe or process-group joining. The 5000/2000-ms phase budgets, startup/inference budgets and all 22 existing assertions remain unchanged. Test/test-support +72/-48; application production 0. The SDK facade remains private, nonproduction and excluded from published exports.

Running the complete fixture also exposed an npm 12 packaging defect: the old array parser rejected keyed JSON even though the archive existed. Remove that parser and derive the canonical tarball filename from the fixed package name and validated version; assert the actual file and list its real tar entries. Native tar was already required by the registry. This keeps the real package build/install/provenance/runtime/metrics checks and adds one archive-file assertion, without changing dependencies or using a source-directory substitute.

Private canonical E2Es with fresh frozen pnpm 12.1, Node 24.19, npm 12.0.2 and fs-safe 0.7 pass 2/2 after normal complete runtime/AI generation. Baseline Ollama passed; baseline Prometheus reproduced the keyed-JSON failure. In a later real-flow fault after all ten Ollama oracles, suppressing delivery through the exact owned child kill method makes the original falsely pass with state removed and child alive. The candidate reports its final shutdown deadline, restores all seven applied environment keys, closes both HTTP fixtures and retains state until the saved native kill rescue joins it. Ten native helper cases separately cover normal exit, escalation, exact child-error identity, synchronous kill error and final deadline with zero residual timers/listeners. All 31 recorded process IDs/groups and six state roots from full-flow proof were cleaned.

Current-main source review found only upstream-registry changes among the relevant owners. Both recorded full-run environments omit upstream controls; the current local-package branch returns identical metadata with one immediate async await, and tarball/startup/lifetime behavior is unchanged. The older 2/2 result carries to that local-only path by source/environment proof; this is not a fresh current-head E2E or validation of upstream merging. No walltime speedup or cross-platform E2E claim is made.

Current-checkout boundary tests pass 10/10. Independent Codex and complete manual source/dependency/history/lower-priority/deslop review found no actionable issue. Core types and SDK export/surface/boundary checks pass; the wider local core-test type run reaches the known missing Mermaid dependency in an unrelated graph. The remaining plugin/root test types, all lint suites, dependency/boundary/dead-export guards and applicable ratchets pass. Exact-head locked CI remains required before landing. Separate followups remain whole Prometheus async-body/execFile ownership across framework timeout, Ollama partial acquisition before try/finally, and process-wait close/deadline ownership. These are not claimed fixed by this bounded stopper refactor.

Lint identified a direct rethrow in the original outer finally. The final refinement awaits the same stopper rejection callback before the unchanged HTTP finally. An additional 10/10 paired native-process probes execute the exact before/after cleanup blocks: normal TERM, original assertion failure, real TERM-to-KILL escalation, exact thrown-kill Error identity and the final deadline. All outcomes, state retention and environment restoration match; all ten children/groups and twenty real HTTP servers close. State lifecycle methods are exact source with recording database/config callbacks in this narrow probe; it supplements the earlier full E2E run.
