### PR TITLE
refactor(gateway): speed up Control UI asset retention

### DIFF
--- a/src/gateway/control-ui-asset-retention.ts
+++ b/src/gateway/control-ui-asset-retention.ts
@@ -268,6 +268,7 @@ async function publishGeneration(params: {
   await fs.mkdir(staging, { recursive: false, mode: 0o700 });
   try {
     const rootRealPath = await fs.realpath(params.root);
+    let preparedDirectory: string | undefined;
     for (const entry of params.manifest.assets) {
       throwIfCancelled(params.operation);
       const contents = await readVerifiedAsset({
@@ -278,7 +279,12 @@ async function publishGeneration(params: {
       });
       const destination = path.join(staging, entry.path);
       throwIfCancelled(params.operation);
-      await fs.mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+      const directory = path.dirname(destination);
+      // This preparer owns staging; adjacent assets can reuse its last created directory.
+      if (directory !== preparedDirectory) {
+        await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+        preparedDirectory = directory;
+      }
       throwIfCancelled(params.operation);
       await fs.writeFile(destination, contents, {
         mode: 0o600,


### PR DESCRIPTION
## What Problem This Solves

Retaining a Control UI build for already-open dashboard documents repeats directory creation for every asset, even when adjacent assets share a parent. Large builds pay for that redundant filesystem work during background retention.

## Why This Change Was Made

The publication owner now remembers its last successfully created directory within the fresh private staging directory. Adjacent assets reuse it; changing parent creates the new directory normally. This is a single local string, not a process cache or persistent index. Every new publication and failed-attempt retry starts fresh.

Source verification, cancellation checkpoints, file writes, manifest publication, collision readback, pruning and cleanup remain unchanged. Production LOC: +7/-1 (net +6); tests: unchanged. The small increase keeps the reuse state at its existing lifecycle owner without another abstraction or growing collection.

## User Impact

Control UI asset retention completes faster for the measured multi-file builds. This runs after Gateway readiness; no Gateway startup, model-turn latency, or universal speedup is claimed. There is no visual, API, configuration, schema or persistence-contract change.

## Evidence

A fixed native experiment measured the complete real factory plus awaited prepare settlement, including failure settlement. It used Node 26.8.1 on macOS ARM64, six workloads, and four serial hosts in before/candidate/candidate/before order. The latter pair reversed workload order. Each row retained one first call, two warmups and nine measured calls per host: 288 whole operations, with no discarded samples.

| Workload | Forward median, before → after | Reverse median, before → after | Median change, forward / reverse |
| --- | --- | --- | --- |
| Fresh 128-file bundle | 34.782 → 33.153 ms | 34.754 → 31.961 ms | -4.68% / -8.04% |
| Fresh 1,215-file build (31.9 MB) | 349.383 → 336.864 ms | 365.520 → 332.395 ms | -3.58% / -9.06% |
| Nested 64-file bundle | 18.481 → 17.036 ms | 18.455 → 18.205 ms | -7.82% / -1.35% |
| Single file | 1.077 → 1.261 ms | 1.184 → 1.124 ms | +17.10% / -5.02% |
| Already retained build | 64.937 → 66.066 ms | 66.007 → 65.092 ms | +1.74% / -1.39% |
| Corrupt final asset, rejected | 31.852 → 29.822 ms | 32.244 → 29.696 ms | -6.37% / -7.90% |

The predeclared checks passed: both primary workloads improved at least 3% in both orders; no control slowed more than 3% in both orders; native peak RSS stayed within its 10% guard. RSS was 619.1 → 586.7 MB and 608.6 → 602.7 MB; this is a guard result, not a memory-improvement claim. Slower first calls remain recorded: nested forward +2.19%, retained reverse +7.11%, corrupt forward +1.67% and corrupt reverse +27.73%. Single-file forward and retained forward are the two slower medians above.

Before timing, both versions passed native full-output proof, including nested traversal returning to an earlier parent and retrying the same owner after repairing a corrupt asset. All timed returned/cache content was then checked against those full proof outputs. The existing cancellation, integrity, publication, retention and asset-manifest suites passed all 61 tests in each version, with identical complete test membership and no skips. Formatting passes. Codex autoreview is scoped-clean with no actionable findings. Independent source, proof and final raw measurement audits passed; every sample and complete output byte was verified.

Baseline: bd24c98c330e692bf6cc9e28d2813b934275a607. Full local raw samples, file bytes, source identities, lifecycle receipts and failed/rejected campaign experiments are retained. No mkdir syscall-count measurement or end-to-end speedup is inferred from source counts.
