### PR TITLE
test(diffs): unify plugin registration fixtures

### DIFF
--- a/extensions/diffs/src/browser.runtime.test.ts
+++ b/extensions/diffs/src/browser.runtime.test.ts
@@ -1,6 +1,6 @@
 // Diffs tests cover browser plugin behavior.
 import fs from "node:fs/promises";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -10,6 +10,7 @@ import type {
   PluginBlobStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createMockServerResponse } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, OpenClawPluginApi, OpenClawPluginToolContext } from "../api.js";
@@ -394,21 +395,63 @@ describe("PlaywrightDiffScreenshotter", () => {
   });
 });
 
+function createRegistrationHarness(params: {
+  pluginConfig: Record<string, unknown>;
+  currentConfig: () => OpenClawConfig;
+}) {
+  const registered: {
+    tool?: Parameters<OpenClawPluginApi["registerTool"]>[0];
+    httpHandler?: Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]["handler"];
+  } = {};
+  const on = vi.fn();
+  const blobStore = createMemoryBlobStore();
+  const api = createTestPluginApi({
+    id: "diffs",
+    name: "Diffs",
+    description: "Diffs",
+    source: "test",
+    config: { gateway: { port: 18789, bind: "loopback" } },
+    pluginConfig: params.pluginConfig,
+    runtime: {
+      config: { current: params.currentConfig },
+      state: { openBlobStore: () => blobStore },
+    } as never,
+    registerTool(tool) {
+      registered.tool = tool;
+    },
+    registerHttpRoute(route) {
+      registered.httpHandler = route.handler;
+    },
+    on,
+  });
+  registerDiffsPlugin(api);
+  const registration = expectDefined(registered.tool, "registered diffs tool");
+  const handleRequest = expectDefined(registered.httpHandler, "registered diffs HTTP handler");
+
+  return {
+    on,
+    handleRequest,
+    render: async (context: OpenClawPluginToolContext) => {
+      const tool = expectDefined(
+        typeof registration === "function" ? registration(context) : registration,
+        "diffs tool for context",
+      );
+      if (Array.isArray(tool)) {
+        throw new Error("expected one registered diffs tool");
+      }
+      const result = await tool.execute("tool-1", { before: "one\n", after: "two\n" });
+      const details = expectDefined(asOptionalRecord(result.details), "diffs tool details");
+      const viewerPath = details.viewerPath;
+      if (typeof viewerPath !== "string") {
+        throw new Error("expected a diff viewer path");
+      }
+      return { details, viewerPath };
+    },
+  };
+}
+
 describe("diffs plugin registration", () => {
   it("uses live runtime tool config through the registered tool factory", async () => {
-    type RegisteredTool = {
-      execute?: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
-    };
-    type HttpRouteHandler = (
-      req: IncomingMessage,
-      res: ServerResponse,
-    ) => boolean | Promise<boolean>;
-    type RegisteredHttpRouteParams = Parameters<OpenClawPluginApi["registerHttpRoute"]>[0];
-
-    let registeredToolFactory:
-      | ((ctx: OpenClawPluginToolContext) => RegisteredTool | RegisteredTool[] | null | undefined)
-      | undefined;
-    let registeredHttpRouteHandler: HttpRouteHandler | undefined;
     let configFile: OpenClawConfig = {
       gateway: {
         port: 18789,
@@ -432,20 +475,8 @@ describe("diffs plugin registration", () => {
           },
         },
       },
-    } as OpenClawConfig;
-    const blobStore = createMemoryBlobStore();
-
-    const api = createTestPluginApi({
-      id: "diffs",
-      name: "Diffs",
-      description: "Diffs",
-      source: "test",
-      config: {
-        gateway: {
-          port: 18789,
-          bind: "loopback",
-        },
-      },
+    };
+    const { render, handleRequest } = createRegistrationHarness({
       pluginConfig: {
         viewerBaseUrl: "https://startup.example.com/openclaw",
         defaults: {
@@ -458,22 +489,8 @@ describe("diffs plugin registration", () => {
           lineSpacing: 2,
         },
       },
-      runtime: {
-        config: {
-          current: () => configFile,
-        },
-        state: { openBlobStore: () => blobStore },
-      } as never,
-      registerTool(tool: Parameters<OpenClawPluginApi["registerTool"]>[0]) {
-        registeredToolFactory = typeof tool === "function" ? tool : () => tool;
-      },
-      registerHttpRoute(params: RegisteredHttpRouteParams) {
-        registeredHttpRouteHandler = params.handler as HttpRouteHandler;
-      },
-      on: vi.fn(),
+      currentConfig: () => configFile,
     });
-
-    registerDiffsPlugin(api as unknown as OpenClawPluginApi);
 
     configFile = {
       ...configFile,
@@ -495,22 +512,16 @@ describe("diffs plugin registration", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    };
 
-    const registeredTool = registeredToolFactory?.({
+    const { details, viewerPath } = await render({
       agentId: "main",
       sessionId: "session-456",
       messageChannel: "discord",
       agentAccountId: "default",
-    }) as RegisteredTool | undefined;
-    const result = await registeredTool?.execute?.("tool-1", {
-      before: "one\n",
-      after: "two\n",
     });
-    const details = (result as { details?: Record<string, unknown> } | undefined)?.details;
-    const viewerPath = String(details?.viewerPath);
     const res = createMockServerResponse();
-    const handled = await registeredHttpRouteHandler?.(
+    const handled = await handleRequest(
       localReq({
         method: "GET",
         url: viewerPath,
@@ -519,7 +530,7 @@ describe("diffs plugin registration", () => {
     );
 
     expect(handled).toBe(true);
-    expect(String(details?.viewerUrl)).toContain("https://live.example.com/gateway");
+    expect(String(details.viewerUrl)).toContain("https://live.example.com/gateway");
     expect(res.statusCode).toBe(200);
     expect(String(res.body)).toContain('body data-theme="dark"');
     expect(String(res.body)).toContain('"backgroundEnabled":true');
@@ -530,20 +541,6 @@ describe("diffs plugin registration", () => {
   });
 
   it("uses live runtime viewer-access config through the registered HTTP handler", async () => {
-    type RegisteredTool = {
-      execute?: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
-    };
-    type HttpRouteHandler = (
-      req: IncomingMessage,
-      res: ServerResponse,
-    ) => boolean | Promise<boolean>;
-    type RegisteredHttpRouteParams = Parameters<OpenClawPluginApi["registerHttpRoute"]>[0];
-
-    let registeredToolFactory:
-      | ((ctx: OpenClawPluginToolContext) => RegisteredTool | RegisteredTool[] | null | undefined)
-      | undefined;
-    let registeredHttpRouteHandler: HttpRouteHandler | undefined;
-    const on = vi.fn();
     let configFile: OpenClawConfig = {
       gateway: {
         port: 18789,
@@ -560,20 +557,8 @@ describe("diffs plugin registration", () => {
           },
         },
       },
-    } as OpenClawConfig;
-    const blobStore = createMemoryBlobStore();
-
-    const api = createTestPluginApi({
-      id: "diffs",
-      name: "Diffs",
-      description: "Diffs",
-      source: "test",
-      config: {
-        gateway: {
-          port: 18789,
-          bind: "loopback",
-        },
-      },
+    };
+    const { on, render, handleRequest } = createRegistrationHarness({
       pluginConfig: {
         defaults: {
           mode: "view",
@@ -588,22 +573,8 @@ describe("diffs plugin registration", () => {
           allowRemoteViewer: true,
         },
       },
-      runtime: {
-        config: {
-          current: () => configFile,
-        },
-        state: { openBlobStore: () => blobStore },
-      } as never,
-      registerTool(tool: Parameters<OpenClawPluginApi["registerTool"]>[0]) {
-        registeredToolFactory = typeof tool === "function" ? tool : () => tool;
-      },
-      registerHttpRoute(params: RegisteredHttpRouteParams) {
-        registeredHttpRouteHandler = params.handler as HttpRouteHandler;
-      },
-      on,
+      currentConfig: () => configFile,
     });
-
-    registerDiffsPlugin(api as unknown as OpenClawPluginApi);
 
     expect(on).toHaveBeenCalledTimes(1);
     const [hookName, beforePromptBuild] = firstMockCall(on, "plugin hook registration");
@@ -628,21 +599,14 @@ describe("diffs plugin registration", () => {
     expect(promptResult?.prependSystemContext).not.toMatch(/\bmessage\b|\bcanvas\b/i);
     expect(promptResult?.prependContext).toBeUndefined();
 
-    const registeredTool = registeredToolFactory?.({
+    const { details, viewerPath } = await render({
       agentId: "main",
       sessionId: "session-123",
       messageChannel: "discord",
       agentAccountId: "default",
-    }) as RegisteredTool | undefined;
-    const result = await registeredTool?.execute?.("tool-1", {
-      before: "one\n",
-      after: "two\n",
     });
-    const viewerPath = String(
-      (result as { details?: Record<string, unknown> } | undefined)?.details?.viewerPath,
-    );
     const res = createMockServerResponse();
-    const handled = await registeredHttpRouteHandler?.(
+    const handled = await handleRequest(
       localReq({
         method: "GET",
         url: viewerPath,
@@ -652,14 +616,12 @@ describe("diffs plugin registration", () => {
 
     expect(handled).toBe(true);
     expect(res.statusCode).toBe(200);
-    expect((result as { details?: Record<string, unknown> } | undefined)?.details?.context).toEqual(
-      {
-        agentId: "main",
-        sessionId: "session-123",
-        messageChannel: "discord",
-        agentAccountId: "default",
-      },
-    );
+    expect(details.context).toEqual({
+      agentId: "main",
+      sessionId: "session-123",
+      messageChannel: "discord",
+      agentAccountId: "default",
+    });
 
     configFile = {
       ...configFile,
@@ -674,10 +636,10 @@ describe("diffs plugin registration", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    };
 
     const proxiedRes = createMockServerResponse();
-    const proxiedHandled = await registeredHttpRouteHandler?.(
+    const proxiedHandled = await handleRequest(
       localReq({
         method: "GET",
         url: viewerPath,
@@ -693,19 +655,6 @@ describe("diffs plugin registration", () => {
   });
 
   it("fails closed for remote viewer access when the live diffs plugin entry is removed", async () => {
-    type RegisteredTool = {
-      execute?: (toolCallId: string, params: Record<string, unknown>) => Promise<unknown>;
-    };
-    type HttpRouteHandler = (
-      req: IncomingMessage,
-      res: ServerResponse,
-    ) => boolean | Promise<boolean>;
-    type RegisteredHttpRouteParams = Parameters<OpenClawPluginApi["registerHttpRoute"]>[0];
-
-    let registeredToolFactory:
-      | ((ctx: OpenClawPluginToolContext) => RegisteredTool | RegisteredTool[] | null | undefined)
-      | undefined;
-    let registeredHttpRouteHandler: HttpRouteHandler | undefined;
     let configFile: OpenClawConfig = {
       gateway: {
         port: 18789,
@@ -722,65 +671,32 @@ describe("diffs plugin registration", () => {
           },
         },
       },
-    } as OpenClawConfig;
-    const blobStore = createMemoryBlobStore();
-
-    const api = createTestPluginApi({
-      id: "diffs",
-      name: "Diffs",
-      description: "Diffs",
-      source: "test",
-      config: {
-        gateway: {
-          port: 18789,
-          bind: "loopback",
-        },
-      },
+    };
+    const { render, handleRequest } = createRegistrationHarness({
       pluginConfig: {
         security: {
           allowRemoteViewer: true,
         },
       },
-      runtime: {
-        config: {
-          current: () => configFile,
-        },
-        state: { openBlobStore: () => blobStore },
-      } as never,
-      registerTool(tool: Parameters<OpenClawPluginApi["registerTool"]>[0]) {
-        registeredToolFactory = typeof tool === "function" ? tool : () => tool;
-      },
-      registerHttpRoute(params: RegisteredHttpRouteParams) {
-        registeredHttpRouteHandler = params.handler as HttpRouteHandler;
-      },
-      on: vi.fn(),
+      currentConfig: () => configFile,
     });
 
-    registerDiffsPlugin(api as unknown as OpenClawPluginApi);
-
-    const registeredTool = registeredToolFactory?.({
+    const { viewerPath } = await render({
       agentId: "main",
       sessionId: "session-789",
       messageChannel: "discord",
       agentAccountId: "default",
-    }) as RegisteredTool | undefined;
-    const result = await registeredTool?.execute?.("tool-1", {
-      before: "one\n",
-      after: "two\n",
     });
-    const viewerPath = String(
-      (result as { details?: Record<string, unknown> } | undefined)?.details?.viewerPath,
-    );
 
     configFile = {
       ...configFile,
       plugins: {
         entries: {},
       },
-    } as OpenClawConfig;
+    };
 
     const proxiedRes = createMockServerResponse();
-    const proxiedHandled = await registeredHttpRouteHandler?.(
+    const proxiedHandled = await handleRequest(
       localReq({
         method: "GET",
         url: viewerPath,


### PR DESCRIPTION
Three Diffs registration tests separately rebuilt the same partial plugin API, tool lookup, rendering and HTTP-route plumbing. Consolidate that setup into a fresh per-test registration harness using the existing plugin test API and in-memory blob store. The tests still register the real plugin and execute its real tool and HTTP handler; live configuration mutation remains visible to those registered handlers.

The helper checks required registration/results explicitly before use, removing repeated optional calls and casts. Three partial-runtime casts become one existing fixture boundary. Each case retains independent storage and configuration. All 13 browser cases, 53 existing matcher calls, six configuration snapshots, three startup configurations, three tool contexts and all three render inputs remain; the ten screenshot cases still precede the three registration cases. No production code or runtime behavior changes. Final Git diff: test +83/-167, net -84.

Validation: the four canonical browser/plugin/tool/HTTP files pass 42/42 before and after in private proof, and 42/42 again in the current checkout. The per-file case order is preserved; cross-file scheduling differs and is not claimed identical. These tests retain their existing mocked browser boundary, so this is not a live Chromium claim. No walltime speedup is inferred from those runs. Direct source review covered registration, tool, storage, rendering, HTTP, live configuration, SDK helpers, dependency implementation and the original live-config history. All consequential source/config/package blobs were unchanged at the current base. Independent Codex review and manual lower-priority/deslop review found no actionable issue.

The full changed-file gate passed extension test types, boundaries, all three dead-export scans and the other applicable guards. Its unbound-method lint finding prompted a final refinement: the destructured render function is an arrow callback, making its lack of receiver state explicit. The final 13 browser cases and targeted lint pass; Codex review is clean again. Exact-head CI is required before landing.
