### PR TITLE
refactor(daemon): share Windows task name resolution

### DIFF
--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -8,7 +8,7 @@ import { DEFAULT_GATEWAY_PORT } from "../../config/paths.js";
 import { quoteCmdScriptArg } from "../../daemon/cmd-argv.js";
 import {
   resolveGatewaySystemdServiceName,
-  resolveGatewayWindowsTaskName,
+  resolveGatewayWindowsTaskNameFromEnv,
 } from "../../daemon/constants.js";
 import { resolveLaunchAgentLabel } from "../../daemon/launchd-label.js";
 import { renderSystemLaunchDaemonOwnershipShellProbe } from "../../daemon/launchd-system.js";
@@ -44,14 +44,6 @@ function resolveSystemdUnit(env: NodeJS.ProcessEnv): string {
     return override.endsWith(".service") ? override : `${override}.service`;
   }
   return `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
-}
-
-function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
-  const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
-  if (override) {
-    return override;
-  }
-  return resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
 }
 
 function resolveLinuxFilesystemBusUid(busAddress: string | undefined): string | undefined {
@@ -233,7 +225,7 @@ rmdir "$script_dir" 2>/dev/null || true
 exit "$status"
 `;
     } else if (platform === "win32") {
-      const taskName = resolveWindowsTaskName(env);
+      const taskName = resolveGatewayWindowsTaskNameFromEnv(env);
       if (!isWindowsTaskNameSafe(taskName)) {
         return null;
       }

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -5,9 +5,12 @@ import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { createConfigIO } from "../../config/io.js";
 import { resolveGatewayPort } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isGatewayServiceEnv, resolveGatewayProfileSuffix } from "../../daemon/constants.js";
+import {
+  isGatewayServiceEnv,
+  resolveGatewayProfileSuffix,
+  resolveGatewayWindowsTaskNameFromEnv,
+} from "../../daemon/constants.js";
 import { resolveLaunchAgentLabel } from "../../daemon/launchd-label.js";
-import { resolveTaskName } from "../../daemon/schtasks-layout.js";
 import {
   isScheduledTaskDefinitelyNotRunning,
   readWindowsStartupFallbackRuntimeForUpdate,
@@ -153,7 +156,7 @@ function matchesStoppedService(
     process.platform === "darwin"
       ? resolveLaunchAgentLabel
       : process.platform === "win32"
-        ? resolveTaskName
+        ? resolveGatewayWindowsTaskNameFromEnv
         : resolveSystemdServiceName;
   // Explicit default metadata selects the same manager; protected command hashes
   // still pin the effective launcher and its environment through normalization.
@@ -448,7 +451,9 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
               .isEnabled?.({ env: serviceState.env, timeoutMs: params.timeoutMs })
               .catch(() => undefined)) === false)
         : process.platform === "win32"
-          ? isScheduledTaskDefinitelyNotRunning(resolveTaskName(serviceState.env)) ||
+          ? isScheduledTaskDefinitelyNotRunning(
+              resolveGatewayWindowsTaskNameFromEnv(serviceState.env),
+            ) ||
             (await readWindowsStartupFallbackRuntimeForUpdate(serviceState.env).catch(() => null))
               ?.status === "stopped"
           : process.platform === "linux"),

--- a/src/daemon/constants.test.ts
+++ b/src/daemon/constants.test.ts
@@ -9,6 +9,7 @@ import {
   resolveGatewayServiceDescription,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
+  resolveGatewayWindowsTaskNameFromEnv,
 } from "./constants.js";
 
 describe("resolveGatewayLaunchAgentLabel", () => {
@@ -45,6 +46,20 @@ describe("resolveGatewayWindowsTaskName", () => {
   it("returns profile-specific task name when profile is set", () => {
     const result = resolveGatewayWindowsTaskName("dev");
     expect(result).toBe("OpenClaw Gateway (dev)");
+  });
+});
+
+describe("resolveGatewayWindowsTaskNameFromEnv", () => {
+  it.each([
+    { override: "  OpenClaw Custom  ", expected: "OpenClaw Custom" },
+    { override: "   ", expected: "OpenClaw Gateway (work)" },
+  ])("resolves task name from $override", ({ override, expected }) => {
+    expect(
+      resolveGatewayWindowsTaskNameFromEnv({
+        OPENCLAW_WINDOWS_TASK_NAME: override,
+        OPENCLAW_PROFILE: "work",
+      }),
+    ).toBe(expected);
   });
 });
 

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -77,6 +77,13 @@ export function resolveGatewayWindowsTaskName(profile?: string): string {
   return `OpenClaw Gateway (${normalized})`;
 }
 
+export function resolveGatewayWindowsTaskNameFromEnv(
+  env: Record<string, string | undefined>,
+): string {
+  const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
+  return override || resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
+}
+
 type GatewayNativeServiceIdentityConflict = {
   envKey: "OPENCLAW_LAUNCHD_LABEL" | "OPENCLAW_SYSTEMD_UNIT" | "OPENCLAW_WINDOWS_TASK_NAME";
   expected: string;

--- a/src/daemon/schtasks-control.ts
+++ b/src/daemon/schtasks-control.ts
@@ -1,14 +1,11 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isGatewayArgv } from "../infra/gateway-process-argv.js";
 import { sleep } from "../utils.js";
+import { resolveGatewayWindowsTaskNameFromEnv } from "./constants.js";
 import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
 import { formatLine } from "./output.js";
 import { execSchtasks } from "./schtasks-exec.js";
-import {
-  readScheduledTaskCommand,
-  resolveTaskName,
-  resolveTaskScriptPath,
-} from "./schtasks-layout.js";
+import { readScheduledTaskCommand, resolveTaskScriptPath } from "./schtasks-layout.js";
 import {
   findInstalledProcessPid,
   isNodeHostArgv,
@@ -203,7 +200,7 @@ async function changeScheduledTaskEnabledState(params: {
   env: GatewayServiceEnv;
   enabled: boolean;
 }): Promise<boolean> {
-  const taskName = resolveTaskName(params.env);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(params.env);
   if (!params.enabled) {
     const query = await execSchtasks(["/Query", "/TN", taskName, "/XML"]);
     if (query.code !== 0) {
@@ -286,7 +283,7 @@ export async function stopScheduledTask({
     await stopStartupEntry(effectiveEnv, stdout, () => reportMutation("startup-entry-stop"));
     return;
   }
-  const taskName = resolveTaskName(effectiveEnv);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(effectiveEnv);
   const res = await execSchtasks(["/End", "/TN", taskName]);
   if (res.code !== 0 && !isScheduledTaskDefinitelyNotRunning(taskName)) {
     throw new Error(`schtasks end failed: ${res.stderr || res.stdout}`.trim());
@@ -326,7 +323,7 @@ export async function startScheduledTask({
     await startStartupEntry(effectiveEnv, stdout, () => reportMutation("startup-entry-start"));
     return;
   }
-  const taskName = resolveTaskName(effectiveEnv);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(effectiveEnv);
   await runScheduledTaskOrThrow({
     taskName,
     env: effectiveEnv,
@@ -344,7 +341,7 @@ export async function restartRegisteredScheduledTask(params: {
   onEndMutation?: () => void;
   onRunMutation?: () => void;
 }): Promise<GatewayServiceRestartResult> {
-  const taskName = resolveTaskName(params.env);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(params.env);
   const end = await execSchtasks(["/End", "/TN", taskName]);
   if (end.code === 0) {
     params.onEndMutation?.();

--- a/src/daemon/schtasks-install.ts
+++ b/src/daemon/schtasks-install.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { resolveGatewayServiceDescription } from "./constants.js";
+import {
+  resolveGatewayServiceDescription,
+  resolveGatewayWindowsTaskNameFromEnv,
+} from "./constants.js";
 import { formatLine, writeFormattedLines } from "./output.js";
 import {
   restartRegisteredScheduledTask,
@@ -20,7 +23,6 @@ import {
   readScheduledTaskCommand,
   resolveStartupEntryPath,
   resolveTaskLauncherScriptPath,
-  resolveTaskName,
   resolveTaskScriptPath,
   resolveTaskUser,
   shouldFallbackToStartupEntry,
@@ -219,7 +221,7 @@ async function activateScheduledTask(params: {
   description?: string;
 }): Promise<ScheduledTaskActivation | "startup-fallback"> {
   const taskDescription = params.description ?? "OpenClaw Gateway";
-  const taskName = resolveTaskName(params.env);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(params.env);
   const quotedLaunchPath = quoteSchtasksArg(params.taskLaunchPath);
   const existingActivation = await updateExistingScheduledTask({
     ...params,
@@ -390,7 +392,7 @@ export async function uninstallScheduledTask({
   stdout,
 }: GatewayServiceManageArgs): Promise<void> {
   await assertSchtasksAvailable();
-  const taskName = resolveTaskName(env);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(env);
   const query = await execSchtasks(["/Query", "/TN", taskName]);
   const queryDetail = normalizeLowercaseStringOrEmpty(query.stderr || query.stdout);
   const exists =

--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -10,7 +10,7 @@ import {
 } from "../infra/windows-launcher-encoding.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
-import { resolveGatewayWindowsTaskName } from "./constants.js";
+import { resolveGatewayWindowsTaskNameFromEnv } from "./constants.js";
 import { resolveGatewayTaskScriptPath } from "./paths.js";
 import type {
   GatewayServiceCommandConfig,
@@ -18,14 +18,6 @@ import type {
   GatewayServiceRenderArgs,
 } from "./service-types.js";
 import { WINDOWS_TASK_SUPERVISOR_FLAG } from "./windows-task-supervisor-contract.js";
-
-export function resolveTaskName(env: GatewayServiceEnv): string {
-  const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
-  if (override) {
-    return override;
-  }
-  return resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
-}
 
 // Keeps the service gateway's stdin off the (possibly hidden) console so TTY
 // heuristics fail closed for permission prompts (#112173).
@@ -76,7 +68,7 @@ function sanitizeWindowsFilename(value: string): string {
 }
 
 export function resolveStartupEntryPath(env: GatewayServiceEnv, extension?: "cmd" | "vbs"): string {
-  const taskName = resolveTaskName(env);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(env);
   const entryExtension = extension ?? (shouldUseHiddenWindowsTaskLauncher(env) ? "vbs" : "cmd");
   return path.join(
     resolveWindowsStartupDir(env),

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "../infra/windows-install-roots.js";
 import { spawnWithFallback } from "../process/spawn-utils.js";
 import { sleep } from "../utils.js";
+import { resolveGatewayWindowsTaskNameFromEnv } from "./constants.js";
 import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
 import { formatLine } from "./output.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
@@ -16,7 +17,6 @@ import { execSchtasks } from "./schtasks-exec.js";
 import {
   readScheduledTaskCommand,
   resolveStartupEntryPaths,
-  resolveTaskName,
   resolveTaskScriptPath,
 } from "./schtasks-layout.js";
 import {
@@ -182,7 +182,11 @@ export async function waitForScheduledTaskRunningEvidence(
 }
 
 export async function isRegisteredScheduledTask(env: GatewayServiceEnv): Promise<boolean> {
-  const res = await execSchtasks(["/Query", "/TN", resolveTaskName(env)]).catch(() => ({
+  const res = await execSchtasks([
+    "/Query",
+    "/TN",
+    resolveGatewayWindowsTaskNameFromEnv(env),
+  ]).catch(() => ({
     code: 1,
     stdout: "",
     stderr: "",
@@ -433,7 +437,7 @@ export async function readWindowsStartupFallbackRuntimeForUpdate(
   if (!(await isStartupEntryInstalled(env))) {
     return null;
   }
-  const taskExists = probeScheduledTaskExists(resolveTaskName(env));
+  const taskExists = probeScheduledTaskExists(resolveGatewayWindowsTaskNameFromEnv(env));
   if (taskExists === null) {
     throw new Error("Could not verify whether the Windows Scheduled Task exists.");
   }
@@ -492,7 +496,9 @@ export async function stopStartupEntry(
     await terminateGatewayProcessTree(runtime.pid, 300);
   }
   onMutation?.();
-  stdout.write(`${formatLine("Stopped Windows login item", resolveTaskName(env))}\n`);
+  stdout.write(
+    `${formatLine("Stopped Windows login item", resolveGatewayWindowsTaskNameFromEnv(env))}\n`,
+  );
 }
 
 export async function terminateInstalledStartupRuntime(env: GatewayServiceEnv): Promise<void> {
@@ -517,7 +523,9 @@ export async function restartStartupEntry(
   }
   await launchFallbackTaskScript(env);
   onMutation?.("restart");
-  stdout.write(`${formatLine("Restarted Windows login item", resolveTaskName(env))}\n`);
+  stdout.write(
+    `${formatLine("Restarted Windows login item", resolveGatewayWindowsTaskNameFromEnv(env))}\n`,
+  );
   return { outcome: "completed" };
 }
 
@@ -528,7 +536,9 @@ export async function startStartupEntry(
 ): Promise<void> {
   await launchFallbackTaskScript(env);
   onMutation?.();
-  stdout.write(`${formatLine("Started Windows login item", resolveTaskName(env))}\n`);
+  stdout.write(
+    `${formatLine("Started Windows login item", resolveGatewayWindowsTaskNameFromEnv(env))}\n`,
+  );
 }
 
 export async function isScheduledTaskInstalled(args: GatewayServiceEnvArgs): Promise<boolean> {
@@ -549,7 +559,7 @@ export async function readScheduledTaskRuntime(
     }
     return createServiceRuntimeInspectionFailure(err);
   }
-  const taskName = resolveTaskName(env);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(env);
   const res = await execSchtasks(["/Query", "/TN", taskName, "/V", "/FO", "LIST"]);
   if (res.code !== 0) {
     if (await isStartupEntryInstalled(env)) {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -10,7 +10,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatInstallationTargetCommand } from "../cli/installation-target-format.js";
-import { resolveGatewayWindowsTaskName } from "../daemon/constants.js";
+import { resolveGatewayWindowsTaskNameFromEnv } from "../daemon/constants.js";
 import { resolveLaunchAgentLabel } from "../daemon/launchd-label.js";
 import { resolveLaunchAgentPlistPath } from "../daemon/launchd-service-files.js";
 import { findInstalledSystemdGatewayScope } from "../daemon/systemd-scope.js";
@@ -1448,9 +1448,7 @@ function resolveGatewayServiceRecovery(
     return { kind: "launchd", uid, label, plistPath: resolveLaunchAgentPlistPath(env) };
   }
   if (supervisor === "schtasks") {
-    const taskName =
-      env.OPENCLAW_WINDOWS_TASK_NAME?.trim() || resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
-    return { kind: "schtasks", taskName };
+    return { kind: "schtasks", taskName: resolveGatewayWindowsTaskNameFromEnv(env) };
   }
   return undefined;
 }

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { quoteCmdScriptArg } from "../daemon/cmd-argv.js";
-import { resolveGatewayWindowsTaskName } from "../daemon/constants.js";
+import { resolveGatewayWindowsTaskNameFromEnv } from "../daemon/constants.js";
 import { renderCmdRestartLogSetup } from "../daemon/restart-logs.js";
 import { resolveTaskScriptPath } from "../daemon/schtasks.js";
 import { formatErrorMessage } from "./errors.js";
@@ -18,14 +18,6 @@ const TASK_RESTART_RETRY_DELAY_SEC = 1;
 
 function quotePowerShellSingleQuotedLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
-}
-
-function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
-  const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
-  if (override) {
-    return override;
-  }
-  return resolveGatewayWindowsTaskName(env.OPENCLAW_PROFILE);
 }
 
 function buildScheduledTaskRestartScript(params: {
@@ -81,7 +73,7 @@ function buildScheduledTaskRestartScript(params: {
 }
 
 export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.env): RestartAttempt {
-  const taskName = resolveWindowsTaskName(env);
+  const taskName = resolveGatewayWindowsTaskNameFromEnv(env);
   const taskScriptPath = resolveTaskScriptPath(env);
   const scriptPath = path.join(
     resolvePreferredOpenClawTmpDir(),


### PR DESCRIPTION
## What Problem This Solves

Windows Scheduled Task naming was resolved independently in daemon layout, update restart, managed restart, and update handoff code. Those copies could drift on override trimming, blank override fallback, or profile handling.

The architectural owner is `src/daemon/constants.ts`.

## Why This Change Was Made

- Adds `resolveGatewayWindowsTaskNameFromEnv` beside the existing profile resolver.
- Routes daemon control, install, runtime, update maintenance, managed handoff, and restart callers through that owner.
- Removes the local resolver copies from `schtasks-layout.ts`, `restart-helper.ts`, and `windows-task-restart.ts`, plus the inline handoff copy.
- Keeps strict `isWindowsTaskNameSafe` validation only in the update restart helper.
- Preserves env merge precedence and existing CMD, PowerShell, OEM, JSON, and argument-array quoting.
- Preserves quoted and Unicode task names outside the strict update restart allowlist.
- Adds one owner-level table test for trimmed overrides and blank-override profile fallback.

Production LOC: +53/-58 (net -5). Test LOC: +15/-0.

## User Impact

- `OPENCLAW_WINDOWS_TASK_NAME="  OpenClaw Custom  "` resolves to `OpenClaw Custom`.
- A whitespace-only override falls back to the profile-aware default, such as `OpenClaw Gateway (work)`.
- Default and profile-only behavior is unchanged.
- No config, SDK, dependency, protocol, documentation, changelog, alias, shim, or compatibility surface was added.

Sibling coverage includes Scheduled Task layout, control, install, runtime, update maintenance, managed-service handoff, and managed restart.

## Evidence

- Focused suite before the first rebase: 299 passed, 1 skipped.
- Focused suite after the first rebase: 299 passed, 1 skipped.
- Focused suite after rebasing current main and preserving merged #135701 behavior: 299 passed, 1 skipped.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm check:madge-import-cycles`: 0 cycles.
- Changed-gate dry run selects only `core` and `coreTests`.
- Changed-gate real run passed core production typecheck and dead-code checks; test typecheck later hit the linked-worktree's missing package-local Mermaid dependency.
- `pnpm build` reached runtime postbuild; it was blocked by the linked worktree resolving a stale shared `@openclaw/ai` build outside this branch. The branch-built package contains the required export.
- `git diff --check`: clean.
- Exact local autoreview against current `origin/main` reported `scoped-clean`, patch correctness `0.98`, and no actionable findings.

Codex source inspected directly:

- `../codex/codex-rs/cli/src/main.rs:220-245`
- `../codex/codex-rs/cli/src/main.rs:2840-2870`

### Windows Crabbox

- Initial Azure lease `cbx_e8d903aaf72a`; recorded run `run_b97a5eded876` verified exact SHA `2c157ec1b5cfbacf05037a411ec07e57061844a2`, but the VM had no interactive console session.
- Hydration workflow run `33580386582` checked out that exact SHA, then failed because native Windows inherited POSIX pnpm module paths. The current Crabbox skill documents Actions hydration as Linux-only for native Windows.
- Replacement desktop Azure lease `cbx_144abc968f72` had an active `crabbox` console session and cloned the same exact SHA. Node bootstrap succeeded; dependency hydration remained blocked by pnpm 12's Windows native launcher, and the pnpm 11 fallback install was stopped before completion at the operator's request.
- Fresh Azure desktop lease `cbx_211c996bf8d9` (`Standard_D2ads_v6`) had an active console session and verified final PR head `699eaa55bd49898ddf06c0b4e872ca34a2d5b9d8`.
- The known-broken pnpm 12 launcher was bypassed. Node `v24.20.0` and pnpm `11.22.0` were used through pnpm's direct JS entry:

```text
node.exe <lease-root>\tools\pnpm11\node_modules\pnpm\bin\pnpm.mjs --pm-on-fail=ignore install --filter openclaw --prefer-offline --ignore-scripts --frozen-lockfile --engine-strict=false --side-effects-cache=false --child-concurrency=4 --network-concurrency=8
```

- Hydration completed successfully: 1,451 packages added in 14m01s.
- Native proof command:

```text
node.exe <lease-root>\tools\pnpm11\node_modules\pnpm\bin\pnpm.mjs --pm-on-fail=ignore test:windows:schtasks:integration
```

- First actionable error: `isolates and completes the native Scheduled Task lifecycle` timed out at 240,000ms. The run spent 195.21s transforming and 240.51s in tests; no resolver assertion or code defect was reported.
- Operator-visible state at failure: the unique profile task `OpenClaw Gateway (schtasks-int-cbx211c996bf8d9)` existed, was enabled, interactive-only, and `Ready`; its last run result was `1`. The retained Vitest namespace was `%USERPROFILE%\AppData\Local\Temp\oc-vt-YYiKFU`.
- The timeout occurred before the harness could complete and record install/read/start/stop/restart/uninstall proof, so default, trimmed override, blank fallback, quoted/Unicode, and strict update-restart behavior were not run after the stop-on-infrastructure-failure gate.
- Cleanup removed only the exact task, its `.openclaw-schtasks-int-cbx211c996bf8d9` state directory, the retained `oc-vt-YYiKFU` namespace, and matching task-owned processes. Verification reported task absent, paths absent, and processes absent.
- All three Azure leases were released. Fresh lease `cbx_211c996bf8d9` read back as `state=released` and `ready=false`.
- No code changes or rebase followed this infrastructure/harness failure. This PR remains draft.
