### PR TITLE
fix(codex): follow session posture for MCP tool approvals and make Allow Always stick

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -389,9 +389,14 @@ Runtime adapters may normalize this shared registry into the shape their downstr
 
 ### Codex tool approvals
 
-Codex app-server approval-gates tools that have no MCP safety annotations when
-the server uses the default `auto` mode. Interactive turns can approve those
-calls in the Control UI. For a server you trust, set the mode while adding it:
+MCP tool approvals follow the effective Codex session permission posture unless
+you explicitly override the server's approval mode. The default full-permission
+posture does not prompt, including for tools without MCP safety annotations.
+Stricter postures retain approval checks: `workspace` can use automatic review,
+while `guarded` and `read-only` can prompt the operator for unannotated tools.
+Interactive turns can approve those calls in the Control UI.
+
+For a server you trust, set the mode while adding it:
 
 ```bash
 openclaw mcp add memory \
@@ -407,11 +412,22 @@ For an existing saved server, update only its approval mode:
 openclaw mcp configure memory --approval approve
 ```
 
-The flag writes `codex.defaultToolsApprovalMode`, which accepts `auto`,
-`prompt`, or `approve`. `approve` bypasses per-call approval for every tool on
-that server, so use it only for trusted servers. `mcp probe` and `mcp doctor
---probe` warn when a server remains in `auto` mode and none of its tools has
-safety annotations.
+The flag writes `codex.defaultToolsApprovalMode`. An explicit
+`openclaw mcp configure <server> --approval approve|prompt|auto` overrides the
+posture-derived default for that server: `approve` bypasses per-call approval,
+`prompt` asks for every call, and `auto` uses the tool's safety annotations.
+Use `approve` only for trusted servers. `mcp probe` and `mcp doctor --probe`
+warn when a server uses `auto` and none of its tools has safety annotations;
+that warning describes calls under prompting postures.
+
+When offered, **Allow Always** approves the tool, not just the current arguments.
+For servers configured through OpenClaw, the choice currently lasts for the
+current Codex session. Codex can persist it across sessions when the server is
+also saved in its native config. A request that permits only session persistence
+cannot grant a durable approval, and explicit `prompt` mode keeps asking.
+
+For approval delivery through Slack buttons, see
+[Native approvals in Slack](/channels/slack#native-approvals-in-slack).
 
 The optional `codex` block is OpenClaw projection metadata for Codex app-server
 threads only; it does not change ACP sessions, generic Codex harness config, or
@@ -620,7 +636,7 @@ Read commands report invalid config, unknown servers, and disabled named probes 
           "launch": "streamable-http https://mcp.example.com/mcp",
           "tools": 2,
           "codexApprovalMode": "auto",
-          "approvalHint": "tools have no safety annotations; calls will require interactive approval",
+          "approvalHint": "tools have no safety annotations; calls require approval in prompting session postures",
           "resources": true,
           "listChanged": {
             "tools": true,
@@ -634,7 +650,7 @@ Read commands report invalid config, unknown servers, and disabled named probes 
     }
     ```
 
-    `probe --json` opens a live MCP client session and prints its result directly; unlike `status`/`doctor`, the output has no top-level `path` field. Each server includes its effective `codexApprovalMode`; `approvalHint` appears when that mode is `auto` and the discovered tools have no safety annotations. `resources` and `prompts` keys are present only when the server actually advertises that capability (a server without prompts omits the `prompts` key rather than reporting `false`). The command prints the complete result before exiting nonzero when diagnostics are present or a selected enabled server did not connect, so automation can inspect partial successes. Use `probe` for reachability and capability proof, not for static config audits.
+    `probe --json` opens a live MCP client session and prints its result directly; unlike `status`/`doctor`, the output has no top-level `path` field. Each server includes its effective `codexApprovalMode`; `approvalHint` appears when that mode is `auto` and the discovered tools have no safety annotations. The hint describes approval requirements under prompting postures, not the default full-permission posture. `resources` and `prompts` keys are present only when the server actually advertises that capability (a server without prompts omits the `prompts` key rather than reporting `false`). The command prints the complete result before exiting nonzero when diagnostics are present or a selected enabled server did not connect, so automation can inspect partial successes. Use `probe` for reachability and capability proof, not for static config audits.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -93,6 +93,10 @@ The same `docs` server, written straight into config:
 
 An enabled server needs either a command (stdio) or a URL (SSE or Streamable HTTP). The exact server name `__proto__` is reserved; choose a different name. Setting `enabled: false` keeps the definition around without connecting it. Keep credentials out of config literals — store sensitive headers and environment values through the supported secret mechanisms.
 
+## Approvals
+
+Codex MCP tool approvals follow the session permission posture: the default full-permission posture does not prompt, while stricter modes check tools without safety annotations (`workspace` can use automatic review; `guarded` and `read-only` can prompt the operator). When offered, **Allow Always** remembers the tool, even when its arguments change. For servers configured through OpenClaw, this lasts for the current Codex session; Codex can persist the choice across sessions when the server is also saved in its native config. Override a server with `openclaw mcp configure <server> --approval approve|prompt|auto`; an explicit mode takes precedence over the posture-derived default. See [Codex tool approvals](/cli/mcp#codex-tool-approvals) for details and [Native approvals in Slack](/channels/slack#native-approvals-in-slack) for Slack button delivery.
+
 ## Troubleshooting
 
 ### The server appears in Settings but exposes no tools

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -3249,14 +3249,14 @@ describe("Codex app-server approval bridge", () => {
     await requestPluginApproval({
       hostCapabilities: createParams().hostCapabilities,
       title: `${"t".repeat(76)}😀tail`,
-      description: `${"d".repeat(252)}😀tail`,
+      description: `${"d".repeat(508)}😀tail`,
       severity: "warning",
       toolName: "codex_utf16_test",
     });
 
     const payload = gatewayRequestPayload();
     expect(payload.title).toBe(`${"t".repeat(76)}...`);
-    expect(payload.description).toBe(`${"d".repeat(252)}...`);
+    expect(payload.description).toBe(`${"d".repeat(508)}...`);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -37,6 +37,7 @@ import {
 import { startCodexComputerUseHealthMonitor } from "./computer-use-health.js";
 import { ensureCodexComputerUse } from "./computer-use.js";
 import {
+  hasCodexMcpToolApprovalOverrides,
   withMcpElicitationsApprovalPolicy,
   type CodexAppServerRuntimeOptions,
   type CodexPluginConfig,
@@ -226,9 +227,16 @@ export async function startCodexAttemptThread(params: {
           resolvedPluginPolicy,
           enabledPluginConfigKeys,
         } = pluginStartupPolicy;
-        const computerUseMcpElicitationDelegationRequired = params.computerUseConfig.enabled;
         const mcpElicitationDelegationRequired =
-          resolvedPluginPolicy?.enabled === true || computerUseMcpElicitationDelegationRequired;
+          resolvedPluginPolicy?.enabled === true ||
+          params.computerUseConfig.enabled ||
+          (params.nativeToolSurfaceEnabled &&
+            params.configuredMcpOwnershipVersion !== 1 &&
+            hasCodexMcpToolApprovalOverrides(
+              params.config?.mcp?.servers,
+              params.bundleMcpThreadConfig.userStaticServerNames,
+              params.bundleMcpThreadConfig.configPatch?.mcp_servers,
+            ));
         pluginAppServer = mcpElicitationDelegationRequired
           ? {
               ...params.appServer,

--- a/extensions/codex/src/app-server/config-security.ts
+++ b/extensions/codex/src/app-server/config-security.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { hostname as readHostName } from "node:os";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import type {
   CodexAppServerConnectionClass,
@@ -133,6 +134,29 @@ function stableStringifyJson(value: JsonValue): string {
       .join(",")}}`;
   }
   return JSON.stringify(value);
+}
+
+/** Explicit MCP prompting must bypass Codex's unconditional Never-policy approval. */
+export function hasCodexMcpToolApprovalOverrides(
+  servers: NonNullable<OpenClawConfig["mcp"]>["servers"],
+  serverNames?: readonly string[],
+  projectedMcpServers?: Record<string, Record<string, unknown>>,
+): boolean {
+  const modes = new Map(
+    Object.entries(projectedMcpServers ?? {}).map(([name, server]) => [
+      name,
+      server.default_tools_approval_mode,
+    ]),
+  );
+  for (const name of serverNames ?? Object.keys(servers ?? {})) {
+    const server = servers?.[name];
+    const mode = server?.codex?.defaultToolsApprovalMode;
+    // Prepared names already include session overrides that can re-enable a saved disabled server.
+    if (mode !== undefined && (serverNames !== undefined || server?.enabled !== false)) {
+      modes.set(name, mode);
+    }
+  }
+  return [...modes.values()].some((mode) => mode === "auto" || mode === "prompt");
 }
 
 export function withMcpElicitationsApprovalPolicy(

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -44,6 +44,7 @@ export {
 } from "./config-runtime.js";
 export {
   assertCodexAppServerConnectionSecurity,
+  hasCodexMcpToolApprovalOverrides,
   shouldAutoApproveCodexAppServerApprovals,
   withMcpElicitationsApprovalPolicy,
 } from "./config-security.js";

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -406,14 +406,11 @@ describe("Codex app-server elicitation bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({
-      action: "decline",
-      content: null,
-      _meta: {
-        message: expect.stringContaining(
-          "openclaw mcp configure codex_apps__github --approval approve",
-        ),
-      },
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(gatewayToolArg(0, 2)).toMatchObject({
+      description: expect.stringContaining(
+        "openclaw mcp configure codex_apps__github --approval approve",
+      ),
     });
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
@@ -421,7 +418,7 @@ describe("Codex app-server elicitation bridge", () => {
     ]);
   });
 
-  it("declines timed-out MCP approvals with explanatory metadata", async () => {
+  it("declines timed-out MCP approvals without response meta Codex would drop", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-timeout", status: "accepted" })
       .mockResolvedValueOnce({
@@ -436,15 +433,7 @@ describe("Codex app-server elicitation bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({
-      action: "decline",
-      content: null,
-      _meta: {
-        message: expect.stringContaining(
-          "openclaw mcp configure codex_apps__github --approval approve",
-        ),
-      },
-    });
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
   });
 
   it("does not treat inherited request-time MCP decisions as final", async () => {
@@ -697,6 +686,7 @@ describe("Codex app-server elicitation bridge", () => {
     };
     expect(approvalRequest.title).toBe("Computer Use approval");
     expect(approvalRequest.description).toContain("MCP server: computer-use");
+    expect(approvalRequest.description).not.toContain("openclaw mcp configure");
     expect(approvalRequest.description).not.toContain("\u009b");
   });
 
@@ -1831,7 +1821,7 @@ describe("Codex app-server elicitation bridge", () => {
     expect(typeof approvalRequest.title).toBe("string");
     expect(typeof approvalRequest.description).toBe("string");
     expect(approvalRequest.title.length).toBeLessThanOrEqual(80);
-    expect(approvalRequest.description.length).toBeLessThanOrEqual(256);
+    expect(approvalRequest.description.length).toBeLessThanOrEqual(512);
   });
 
   it("fails closed when the approval route is unavailable", async () => {
@@ -1843,15 +1833,7 @@ describe("Codex app-server elicitation bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({
-      action: "decline",
-      content: null,
-      _meta: {
-        message: expect.stringContaining(
-          "openclaw mcp configure codex_apps__github --approval approve",
-        ),
-      },
-    });
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
   });
 
   it("ignores non-approval elicitation requests", async () => {

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -313,6 +313,7 @@ describe("Codex app-server elicitation bridge", () => {
       ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ apps: [] }),
       computerUseMcpServerName: "computer-use",
+      autoApproveMcpTools: true,
     });
 
     expect(result).toEqual({ action: "accept", content: null, _meta: null });
@@ -343,6 +344,53 @@ describe("Codex app-server elicitation bridge", () => {
     ]);
   });
 
+  it.each<{
+    fullPermission: boolean;
+    mode?: "auto" | "prompt" | "approve";
+    projectedMode?: "auto" | "prompt" | "approve";
+    prompts: boolean;
+  }>([
+    { fullPermission: true, mode: undefined, prompts: false },
+    { fullPermission: false, mode: undefined, prompts: true },
+    { fullPermission: true, mode: "prompt" as const, prompts: true },
+    { fullPermission: true, mode: "auto" as const, prompts: true },
+    { fullPermission: false, mode: "approve" as const, prompts: false },
+    { fullPermission: true, projectedMode: "prompt", prompts: true },
+    { fullPermission: true, projectedMode: "auto", prompts: true },
+    { fullPermission: true, mode: "approve", projectedMode: "prompt", prompts: false },
+  ])(
+    "honors MCP posture and server overrides (full=$fullPermission, mode=$mode, projected=$projectedMode)",
+    async ({ fullPermission, mode, projectedMode, prompts }) => {
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: "plugin:posture", status: "accepted" })
+        .mockResolvedValueOnce({ id: "plugin:posture", decision: "allow-once" });
+      const result = await handleCodexAppServerElicitationRequest({
+        requestParams: { ...buildCurrentCodexApprovalElicitation(), serverName: "linear" },
+        paramsForRun: {
+          ...createParams(),
+          config: {
+            mcp: {
+              servers: {
+                linear: {
+                  url: "https://linear.example/mcp",
+                  ...(mode ? { codex: { defaultToolsApprovalMode: mode } } : {}),
+                },
+              },
+            },
+          },
+        },
+        autoApproveMcpTools: fullPermission,
+        projectedMcpServers: projectedMode
+          ? { linear: { default_tools_approval_mode: projectedMode } }
+          : undefined,
+        ...codexTestTurnIds(),
+      });
+
+      expect(result).toEqual({ action: "accept", content: null, _meta: null });
+      expect(mockCallGatewayTool).toHaveBeenCalledTimes(prompts ? 2 : 0);
+    },
+  );
+
   it("does not trust request-time decisions for two-phase MCP approvals", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({
@@ -358,7 +406,15 @@ describe("Codex app-server elicitation bridge", () => {
       ...codexTestTurnIds(),
     });
 
-    expect(result).toEqual({ action: "decline", content: null, _meta: null });
+    expect(result).toEqual({
+      action: "decline",
+      content: null,
+      _meta: {
+        message: expect.stringContaining(
+          "openclaw mcp configure codex_apps__github --approval approve",
+        ),
+      },
+    });
     expect(mockCallGatewayTool.mock.calls.map(([method]) => method)).toEqual([
       "plugin.approval.request",
       "plugin.approval.waitDecision",
@@ -383,7 +439,11 @@ describe("Codex app-server elicitation bridge", () => {
     expect(result).toEqual({
       action: "decline",
       content: null,
-      _meta: { message: "Approval timed out before an operator responded." },
+      _meta: {
+        message: expect.stringContaining(
+          "openclaw mcp configure codex_apps__github --approval approve",
+        ),
+      },
     });
   });
 
@@ -901,6 +961,7 @@ describe("Codex app-server elicitation bridge", () => {
       paramsForRun: createParams(),
       ...codexTestTurnIds(),
       pluginAppPolicyContext: createPluginAppPolicyContext({ allowDestructiveActions: false }),
+      autoApproveMcpTools: true,
     });
 
     expect(result).toEqual({ action: "decline", content: null, _meta: null });
@@ -1617,15 +1678,28 @@ describe("Codex app-server elicitation bridge", () => {
         persist: "always",
       },
     });
+    expect(gatewayToolArg(0, 2)).toMatchObject({
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
   });
 
-  it("maps allow-always decisions onto metadata for current empty-schema approvals", async () => {
+  it.each([
+    { hints: ["session", "always"], persist: "always" },
+    { hints: "session", persist: "session" },
+    { hints: [], persist: undefined },
+  ])("maps only offered MCP persistence ($hints)", async ({ hints, persist }) => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-current-always", status: "accepted" })
       .mockResolvedValueOnce({ id: "plugin:approval-current-always", decision: "allow-always" });
 
     const result = await handleCodexAppServerElicitationRequest({
-      requestParams: buildCurrentCodexApprovalElicitation(),
+      requestParams: {
+        ...buildCurrentCodexApprovalElicitation(),
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          ...(hints.length ? { persist: hints } : {}),
+        },
+      },
       paramsForRun: createParams(),
       ...codexTestTurnIds(),
     });
@@ -1633,11 +1707,48 @@ describe("Codex app-server elicitation bridge", () => {
     expect(result).toEqual({
       action: "accept",
       content: null,
-      _meta: {
-        persist: "always",
-      },
+      _meta: persist ? { persist } : null,
+    });
+    expect(gatewayToolArg(0, 2)).toMatchObject({
+      allowedDecisions: persist ? ["allow-once", "allow-always", "deny"] : ["allow-once", "deny"],
     });
   });
+
+  it.each([
+    { hints: ["session", "always"], choice: "Allow and don't ask me again", persist: "always" },
+    { hints: "session", choice: "Allow for this session", persist: "session" },
+    { hints: [], choice: "Allow", persist: undefined },
+  ])(
+    "matches the MCP approval enum to $persist persistence",
+    async ({ hints, choice, persist }) => {
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: "plugin:enum", status: "accepted" })
+        .mockResolvedValueOnce({ id: "plugin:enum", decision: "allow-always" });
+      const result = await handleCodexAppServerElicitationRequest({
+        requestParams: {
+          ...buildApprovalElicitation(),
+          _meta: { codex_approval_kind: "mcp_tool_call", persist: hints },
+          requestedSchema: {
+            type: "object",
+            properties: {
+              approval: {
+                type: "string",
+                enum: ["Allow", "Allow for this session", "Allow and don't ask me again", "Cancel"],
+              },
+            },
+            required: ["approval"],
+          },
+        },
+        paramsForRun: createParams(),
+        ...codexTestTurnIds(),
+      });
+      expect(result).toEqual({
+        action: "accept",
+        content: { approval: choice },
+        _meta: persist ? { persist } : null,
+      });
+    },
+  );
 
   it("does not inherit persist defaults for one-time approvals", async () => {
     mockCallGatewayTool
@@ -1735,7 +1846,11 @@ describe("Codex app-server elicitation bridge", () => {
     expect(result).toEqual({
       action: "decline",
       content: null,
-      _meta: null,
+      _meta: {
+        message: expect.stringContaining(
+          "openclaw mcp configure codex_apps__github --approval approve",
+        ),
+      },
     });
   });
 

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -1,8 +1,14 @@
 // Codex plugin module implements elicitation bridge behavior.
 import {
   embeddedAgentLog,
+  type CodexBundleMcpThreadConfig,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  formatMcpCodexApprovalRemedy,
+  requiresMcpCodexToolApproval,
+  resolveProjectedMcpCodexToolApprovalMode,
+} from "openclaw/plugin-sdk/codex-mcp-projection";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatCodexDisplayText } from "../command-formatters.js";
 import {
@@ -40,6 +46,7 @@ type BridgeableApprovalElicitation = {
   meta: JsonObject;
   persistHintsMode?: "legacy" | "explicit";
   allowedDecisions?: ExecApprovalDecision[];
+  serverName?: string;
 };
 
 type ElicitationApprovalOutcome = AppServerApprovalOutcome | "timed-out";
@@ -87,6 +94,8 @@ export async function routeCodexAppServerElicitationRequest(params: {
   turnId: string;
   pluginAppPolicyContext?: PluginAppPolicyContext;
   computerUseMcpServerName?: string;
+  autoApproveMcpTools?: boolean;
+  projectedMcpServers?: NonNullable<CodexBundleMcpThreadConfig["configPatch"]>["mcp_servers"];
   signal?: AbortSignal;
 }): Promise<CodexApprovalElicitationResult> {
   const requestParams = isJsonObject(params.requestParams) ? params.requestParams : undefined;
@@ -137,11 +146,30 @@ export async function routeCodexAppServerElicitationRequest(params: {
     );
   }
 
-  const approvalPrompt =
-    readComputerUseApprovalElicitation(requestParams, params.computerUseMcpServerName) ??
-    readBridgeableApprovalElicitation(requestParams);
+  const computerUsePrompt = readComputerUseApprovalElicitation(
+    requestParams,
+    params.computerUseMcpServerName,
+  );
+  const approvalPrompt = computerUsePrompt ?? readBridgeableApprovalElicitation(requestParams);
   if (!approvalPrompt) {
     return handled(createCodexElicitationResponse("decline"));
+  }
+  if (!computerUsePrompt) {
+    // App elicitation delegation changes Codex's policy; custom MCP servers still
+    // follow the original operator posture unless their server config overrides it.
+    const serverName = readNonBlankStringField(requestParams, "serverName");
+    const server = serverName ? params.paramsForRun.config?.mcp?.servers?.[serverName] : undefined;
+    const mode = serverName
+      ? resolveProjectedMcpCodexToolApprovalMode(
+          serverName,
+          server ?? {},
+          params.projectedMcpServers?.[serverName],
+        )
+      : undefined;
+    if (!requiresMcpCodexToolApproval({ mode, fullPermission: params.autoApproveMcpTools })) {
+      params.paramsForRun.hostCapabilities.assertActive();
+      return handled(buildElicitationResponse(approvalPrompt, "approved-once"));
+    }
   }
 
   const outcome = await requestPluginApprovalOutcome({
@@ -336,10 +364,7 @@ async function buildPluginPolicyElicitationResponse(params: {
       allowedDecisions: allowedPluginPolicyApprovalDecisions(mode, approvalPrompt),
       signal: params.signal,
     });
-    return buildElicitationResponse(
-      approvalPrompt,
-      mode === "ask" && outcome === "approved-session" ? "approved-once" : outcome,
-    );
+    return buildElicitationResponse(approvalPrompt, outcome);
   }
   logPluginElicitationDecline("unmappable_schema", params.requestParams);
   return createCodexElicitationResponse("decline");
@@ -406,14 +431,22 @@ function readPluginApprovalElicitation(
 function buildApprovalAllowedDecisions(
   requestedSchema: JsonObject,
   meta: JsonObject,
+  allowSession = false,
 ): ExecApprovalDecision[] {
-  return canMapPersistentApproval(requestedSchema, meta)
+  return canMapPersistentApproval(requestedSchema, meta, allowSession)
     ? ["allow-once", "allow-always", "deny"]
     : ["allow-once", "deny"];
 }
 
-function canMapPersistentApproval(requestedSchema: JsonObject, meta: JsonObject): boolean {
+function canMapPersistentApproval(
+  requestedSchema: JsonObject,
+  meta: JsonObject,
+  allowSession: boolean,
+): boolean {
   const persistHints = readPersistHints(meta, "explicit");
+  if (allowSession) {
+    return choosePersistHint(persistHints) !== undefined;
+  }
   if (persistHints.length > 0) {
     return persistHints.includes("always");
   }
@@ -472,6 +505,9 @@ function readBridgeableApprovalElicitation(
     }),
     requestedSchema,
     meta: requestParams["_meta"],
+    persistHintsMode: "explicit",
+    allowedDecisions: buildApprovalAllowedDecisions(requestedSchema, requestParams["_meta"], true),
+    serverName: readNonBlankStringField(requestParams, "serverName"),
   };
 }
 
@@ -703,7 +739,12 @@ async function requestPluginApprovalOutcome(params: {
     if (approvalResult?.terminalReason === "timeout") {
       return "timed-out";
     }
-    return mapExecDecisionToOutcome(approvalResult?.decision);
+    const decision = approvalResult?.decision;
+    return mapExecDecisionToOutcome(
+      decision === "allow-always" && params.allowedDecisions?.includes("allow-always") === false
+        ? "allow-once"
+        : decision,
+    );
   } catch {
     return params.signal?.aborted ? "cancelled" : "denied";
   }
@@ -712,7 +753,7 @@ async function requestPluginApprovalOutcome(params: {
 function buildElicitationResponse(
   approvalPrompt: Pick<
     BridgeableApprovalElicitation,
-    "requestedSchema" | "meta" | "persistHintsMode"
+    "requestedSchema" | "meta" | "persistHintsMode" | "serverName"
   >,
   outcome: ElicitationApprovalOutcome,
 ): CodexElicitationResponse {
@@ -722,11 +763,19 @@ function buildElicitationResponse(
   }
   if (outcome === "timed-out") {
     return createCodexElicitationResponse("decline", null, {
-      message: codexApprovalTimeoutText("other"),
+      message: codexApprovalTimeoutText("other", approvalPrompt.serverName),
     });
   }
   if (outcome === "denied" || outcome === "unavailable") {
-    return createCodexElicitationResponse("decline");
+    return createCodexElicitationResponse(
+      "decline",
+      null,
+      approvalPrompt.serverName
+        ? {
+            message: `MCP tool approval ${outcome}. ${formatMcpCodexApprovalRemedy(approvalPrompt.serverName)}`,
+          }
+        : null,
+    );
   }
 
   const content = buildAcceptedContent(approvalPrompt, outcome);
@@ -774,7 +823,11 @@ function buildAcceptedContent(
     }
     const property = { name, schema, required: required.has(name) };
     const next =
-      readApprovalFieldValue(property, outcome) ??
+      readApprovalFieldValue(
+        property,
+        outcome,
+        choosePersistHint(readPersistHints(meta, approvalPrompt.persistHintsMode)),
+      ) ??
       readPersistFieldValue(property, meta, outcome, approvalPrompt.persistHintsMode ?? "legacy") ??
       readFallbackFieldValue(property, outcome);
 
@@ -800,6 +853,7 @@ function buildAcceptedContent(
 function readApprovalFieldValue(
   property: ApprovalPropertyContext,
   outcome: AppServerApprovalOutcome,
+  persist: "always" | "session" | undefined,
 ): JsonValue | undefined {
   if (!isApprovalField(property)) {
     return undefined;
@@ -813,12 +867,14 @@ function readApprovalFieldValue(
     return undefined;
   }
 
-  const sessionChoice = options.find((option) => isSessionApprovalOption(option));
   const acceptChoice = options.find((option) => isPositiveApprovalOption(option));
   if (outcome === "approved-session") {
-    return sessionChoice?.value ?? acceptChoice?.value;
+    return (
+      options.find((option) => isPersistentApprovalOption(option, persist))?.value ??
+      acceptChoice?.value
+    );
   }
-  return acceptChoice?.value ?? sessionChoice?.value;
+  return acceptChoice?.value;
 }
 
 function readPersistFieldValue(
@@ -958,11 +1014,16 @@ function isPositiveApprovalOption(option: { value: string; label: string }): boo
   return /\b(allow|approve|accept|yes|continue|proceed|true)\b/.test(haystack);
 }
 
-function isSessionApprovalOption(option: { value: string; label: string }): boolean {
+function isPersistentApprovalOption(
+  option: { value: string; label: string },
+  persist: "always" | "session" | undefined,
+): boolean {
   const haystack = `${option.value} ${option.label}`.toLowerCase();
-  return (
-    /\b(session|always|persistent)\b/.test(haystack) && /\b(allow|approve|accept)\b/.test(haystack)
-  );
+  const scopeMatches =
+    persist === "always"
+      ? /\b(always|persistent)\b|\bdon't ask me again\b/.test(haystack)
+      : persist === "session" && /\bsession\b/.test(haystack);
+  return scopeMatches && /\b(allow|approve|accept)\b/.test(haystack);
 }
 
 function readNonBlankStringField(record: JsonObject | undefined, key: string): string | undefined {

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -17,7 +17,6 @@ import {
 } from "./elicitation-response.js";
 import {
   approvalRequestExplicitlyUnavailable,
-  codexApprovalTimeoutText,
   mapExecDecisionToOutcome,
   requestPluginApproval,
   sanitizeCodexApprovalVisibleText,
@@ -46,7 +45,6 @@ type BridgeableApprovalElicitation = {
   meta: JsonObject;
   persistHintsMode?: "legacy" | "explicit";
   allowedDecisions?: ExecApprovalDecision[];
-  serverName?: string;
 };
 
 type ElicitationApprovalOutcome = AppServerApprovalOutcome | "timed-out";
@@ -495,19 +493,22 @@ function readBridgeableApprovalElicitation(
   const title =
     sanitizeDisplayText(readNonBlankStringField(requestParams, "message") ?? "") ||
     "Codex MCP tool approval";
+  const serverName = readNonBlankStringField(requestParams, "serverName");
   return {
     title,
     description: buildApprovalDescription({
       title,
       meta: requestParams["_meta"],
       requestedSchema,
-      serverName: sanitizeOptionalDisplayText(readNonBlankStringField(requestParams, "serverName")),
+      serverName: sanitizeOptionalDisplayText(serverName),
+      // Only OpenClaw-configured servers have a `mcp configure` remedy; plugin
+      // and computer-use prompts are governed by their own policies.
+      remedy: serverName ? formatMcpCodexApprovalRemedy(serverName) : undefined,
     }),
     requestedSchema,
     meta: requestParams["_meta"],
     persistHintsMode: "explicit",
     allowedDecisions: buildApprovalAllowedDecisions(requestedSchema, requestParams["_meta"], true),
-    serverName: readNonBlankStringField(requestParams, "serverName"),
   };
 }
 
@@ -557,6 +558,7 @@ function buildApprovalDescription(params: {
   meta: JsonObject;
   requestedSchema: JsonObject;
   serverName: string | undefined;
+  remedy?: string;
 }): string {
   const connectorName = sanitizeOptionalDisplayText(
     readNonBlankStringField(params.meta, MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY),
@@ -571,6 +573,9 @@ function buildApprovalDescription(params: {
     connectorName && `App: ${connectorName}`,
     toolTitle && `Tool: ${toolTitle}`,
     params.serverName && `MCP server: ${params.serverName}`,
+    // Before the tool description: card text is truncated at 256 chars and the
+    // remedy is the line the operator must not lose.
+    params.remedy,
     toolDescription,
   ].filter((line): line is string => Boolean(line));
   const paramLines = readDisplayParamLines(params.meta);
@@ -753,7 +758,7 @@ async function requestPluginApprovalOutcome(params: {
 function buildElicitationResponse(
   approvalPrompt: Pick<
     BridgeableApprovalElicitation,
-    "requestedSchema" | "meta" | "persistHintsMode" | "serverName"
+    "requestedSchema" | "meta" | "persistHintsMode"
   >,
   outcome: ElicitationApprovalOutcome,
 ): CodexElicitationResponse {
@@ -761,21 +766,10 @@ function buildElicitationResponse(
   if (outcome === "cancelled") {
     return createCodexElicitationResponse("cancel");
   }
-  if (outcome === "timed-out") {
-    return createCodexElicitationResponse("decline", null, {
-      message: codexApprovalTimeoutText("other", approvalPrompt.serverName),
-    });
-  }
-  if (outcome === "denied" || outcome === "unavailable") {
-    return createCodexElicitationResponse(
-      "decline",
-      null,
-      approvalPrompt.serverName
-        ? {
-            message: `MCP tool approval ${outcome}. ${formatMcpCodexApprovalRemedy(approvalPrompt.serverName)}`,
-          }
-        : null,
-    );
+  // Codex reads no response meta on decline (0.151.0 maps every decline to
+  // "user rejected MCP tool call"), so remedy text belongs on the operator card.
+  if (outcome === "timed-out" || outcome === "denied" || outcome === "unavailable") {
+    return createCodexElicitationResponse("decline");
   }
 
   const content = buildAcceptedContent(approvalPrompt, outcome);

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -198,6 +198,8 @@ export function createCodexNativeHookRelay(params: {
   sessionId: string;
   sessionKey: string | undefined;
   config: EmbeddedRunAttemptParams["config"];
+  autoApproveMcpTools?: boolean;
+  projectedMcpServers?: Parameters<typeof registerNativeHookRelay>[0]["projectedMcpServers"];
   runId: string;
   channelId?: string;
   requester?: NonNullable<PluginHookToolContext["requester"]>;
@@ -247,6 +249,8 @@ export function createCodexNativeHookRelay(params: {
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
     ...(params.config ? { config: params.config } : {}),
+    autoApproveMcpTools: params.autoApproveMcpTools,
+    projectedMcpServers: params.projectedMcpServers,
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
     ...(params.requester ? { requester: params.requester } : {}),

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -3,6 +3,7 @@
  * approval tool and maps gateway decisions back to Codex outcomes.
  */
 import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { formatMcpCodexApprovalRemedy } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { isApprovalNotFoundError, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexGatewayTimeoutWithGraceMs } from "./attempt-timeouts.js";
@@ -39,8 +40,9 @@ const CODEX_APPROVAL_TIMEOUT_SUBJECTS: Record<CodexApprovalKind, string> = {
   other: "Approval",
 };
 
-export function codexApprovalTimeoutText(kind: CodexApprovalKind): string {
-  return `${CODEX_APPROVAL_TIMEOUT_SUBJECTS[kind]} timed out before an operator responded.`;
+export function codexApprovalTimeoutText(kind: CodexApprovalKind, mcpServerName?: string): string {
+  const message = `${CODEX_APPROVAL_TIMEOUT_SUBJECTS[kind]} timed out before an operator responded.`;
+  return mcpServerName ? `${message} ${formatMcpCodexApprovalRemedy(mcpServerName)}` : message;
 }
 
 /** Normalized Codex app-server approval outcome after a gateway decision. */

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -3,7 +3,6 @@
  * approval tool and maps gateway decisions back to Codex outcomes.
  */
 import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { formatMcpCodexApprovalRemedy } from "openclaw/plugin-sdk/codex-mcp-projection";
 import { isApprovalNotFoundError, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexGatewayTimeoutWithGraceMs } from "./attempt-timeouts.js";
@@ -12,7 +11,9 @@ type AgentHarnessHostCapabilities = EmbeddedRunAttemptParams["hostCapabilities"]
 
 const DEFAULT_CODEX_APPROVAL_TIMEOUT_MS = 120_000;
 const MAX_PLUGIN_APPROVAL_TITLE_LENGTH = 80;
-const MAX_PLUGIN_APPROVAL_DESCRIPTION_LENGTH = 256;
+// Matches the gateway protocol's PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH; the card
+// must fit the MCP server line, the operator remedy, and the tool parameters.
+const MAX_PLUGIN_APPROVAL_DESCRIPTION_LENGTH = 512;
 const ANSI_OSC_SEQUENCE_RE = new RegExp(
   String.raw`(?:\u001b]|\u009d)[^\u001b\u009c\u0007]*(?:\u0007|\u001b\\|\u009c)`,
   "g",
@@ -40,9 +41,8 @@ const CODEX_APPROVAL_TIMEOUT_SUBJECTS: Record<CodexApprovalKind, string> = {
   other: "Approval",
 };
 
-export function codexApprovalTimeoutText(kind: CodexApprovalKind, mcpServerName?: string): string {
-  const message = `${CODEX_APPROVAL_TIMEOUT_SUBJECTS[kind]} timed out before an operator responded.`;
-  return mcpServerName ? `${message} ${formatMcpCodexApprovalRemedy(mcpServerName)}` : message;
+export function codexApprovalTimeoutText(kind: CodexApprovalKind): string {
+  return `${CODEX_APPROVAL_TIMEOUT_SUBJECTS[kind]} timed out before an operator responded.`;
 }
 
 /** Normalized Codex app-server approval outcome after a gateway decision. */

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -6,6 +6,7 @@ import {
 import { resolveCodexStartupTimeoutMs } from "./attempt-timeouts.js";
 import { protectCodexAppServerLiveThread } from "./client-runtime.js";
 import type { CodexAppServerClient } from "./client.js";
+import { shouldAutoApproveCodexAppServerApprovals } from "./config.js";
 import { resolveCodexToolAbortTerminalReason } from "./dynamic-tool-execution.js";
 import { CodexAppServerEventProjector } from "./event-projector.js";
 import { buildCodexHookRequester } from "./hook-requester.js";
@@ -253,6 +254,8 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       sessionId: params.sessionId,
       sessionKey: contextSessionKey,
       config: params.config,
+      autoApproveMcpTools: shouldAutoApproveCodexAppServerApprovals(appServer),
+      projectedMcpServers: runtime.bundleMcpThreadConfig.configPatch?.mcp_servers,
       runId: params.runId,
       channelId: hookChannelId,
       ...(requester ? { requester } : {}),

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -51,6 +51,7 @@ export function createCodexAttemptServerRequestController(
   const { runtime, attemptTools } = context;
   const { connection } = runtime;
   const { params, computerUseConfig, runAbortController, appServer, sessionAgentId } = connection;
+  const autoApprove = shouldAutoApproveCodexAppServerApprovals(appServer);
   const {
     compactionPlanState,
     toolBridge,
@@ -108,6 +109,8 @@ export function createCodexAttemptServerRequestController(
           paramsForRun: params,
           threadId: resourceState.thread.threadId,
           turnId,
+          autoApproveMcpTools: autoApprove,
+          projectedMcpServers: runtime.bundleMcpThreadConfig.configPatch?.mcp_servers,
           pluginAppPolicyContext: resourceState.thread.pluginAppPolicyContext,
           ...(computerUseConfig.enabled
             ? { computerUseMcpServerName: computerUseConfig.mcpServerName }
@@ -145,7 +148,7 @@ export function createCodexAttemptServerRequestController(
             threadId: resourceState.thread.threadId,
             turnId,
             nativeHookRelay: resourceState.nativeHookRelay,
-            autoApprove: shouldAutoApproveCodexAppServerApprovals(appServer),
+            autoApprove,
             signal,
             onNativeToolFailureDisposition: (itemId, disposition, approvalKind) =>
               projector?.recordNativeToolApprovalFailure(itemId, disposition, approvalKind),

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -449,7 +449,9 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
         ...params.config!.mcp!.servers,
         unannotated: { url: "https://unannotated.example.test/mcp" },
       };
-      const requestApproval = vi.fn(async () => ({ id: "plugin:mcp-fixture" }));
+      const requestApproval = vi.fn(async (_request: { description?: string }) => ({
+        id: "plugin:mcp-fixture",
+      }));
       const waitForApproval = vi.fn(async () => ({
         decision: "deny" as const,
         terminalReason: "user" as const,
@@ -504,16 +506,16 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
 
       expect(responses).toEqual([
         { action: "accept", content: null, _meta: null },
-        {
-          action: testCase.delegate ? "decline" : "accept",
-          content: null,
-          _meta: testCase.delegate
-            ? { message: expect.stringContaining("openclaw mcp configure") }
-            : null,
-        },
+        { action: testCase.delegate ? "decline" : "accept", content: null, _meta: null },
       ]);
       expect(requestApproval).toHaveBeenCalledTimes(testCase.delegate ? 1 : 0);
       expect(waitForApproval).toHaveBeenCalledTimes(testCase.delegate ? 1 : 0);
+      // Codex drops decline meta, so the remedy must reach the operator via the card.
+      if (testCase.delegate) {
+        expect(requestApproval.mock.calls[0]?.[0]?.description).toContain(
+          `openclaw mcp configure ${testCase.source === "bundle" ? "bundled" : "fake"} --approval approve`,
+        );
+      }
       const expectedApprovalPolicy = testCase.delegate
         ? {
             granular: {

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -49,7 +49,10 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
     ) => {
       const params = args[0] as Record<string, unknown>;
       mcpMocks.threadConfigCalls.push(params);
-      mcpMocks.threadConfigFacade(params);
+      const override = mcpMocks.threadConfigFacade(params);
+      if (override) {
+        return override;
+      }
       const cfg = params.cfg as
         | { mcp?: { servers?: Record<string, Record<string, unknown>> } }
         | undefined;
@@ -396,43 +399,150 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     });
   });
 
-  it("keeps ordinary configured MCP native without probing or stamping its inventory", async () => {
-    const sessionFile = path.join(tempDir, "session-native-mcp-auth-failure.jsonl");
-    const params = createParams(
-      sessionFile,
-      path.join(tempDir, "workspace-native-mcp-auth-failure"),
-    );
-    configureFakeMcp(params);
-
-    const harness = createStartedThreadHarness(async (method) => {
-      if (method === "mcpServerStatus/list") {
-        return {
-          data: [
-            {
-              name: "fake",
-              serverInfo: null,
-              authStatus: "notLoggedIn",
-              tools: {},
+  it.each([
+    { mode: undefined, source: "operator", delegate: false },
+    { mode: "approve", source: "operator", delegate: false },
+    { mode: "auto", source: "operator", delegate: true },
+    { mode: "prompt", source: "operator", delegate: true },
+    { mode: "prompt", source: "bundle", delegate: true },
+    { mode: "approve", source: "operator-over-bundle", delegate: false },
+  ] as const)(
+    "honors $source MCP approval mode $mode at thread and turn startup",
+    async (testCase) => {
+      const sessionFile = path.join(tempDir, "session-native-mcp-auth-failure.jsonl");
+      const params = createParams(
+        sessionFile,
+        path.join(tempDir, "workspace-native-mcp-auth-failure"),
+      );
+      configureFakeMcp(params);
+      params.config!.mcp!.servers!.fake!.codex = { defaultToolsApprovalMode: testCase.mode };
+      if (testCase.source === "bundle") {
+        params.config!.mcp = {};
+        mcpMocks.threadConfigFacade.mockReturnValueOnce({
+          configPatch: {
+            mcp_servers: {
+              bundled: {
+                url: "https://mcp.example.test",
+                default_tools_approval_mode: testCase.mode,
+              },
             },
-          ],
-          nextCursor: null,
-        };
+          },
+          diagnostics: [],
+          evaluated: true,
+          staticServerNames: ["bundled", "unannotated"],
+          userStaticServerNames: ["unannotated"],
+        });
+      } else if (testCase.source === "operator-over-bundle") {
+        mcpMocks.threadConfigFacade.mockReturnValueOnce({
+          configPatch: {
+            mcp_servers: {
+              fake: { url: "https://mcp.example.test", default_tools_approval_mode: "prompt" },
+            },
+          },
+          diagnostics: [],
+          evaluated: true,
+          staticServerNames: ["fake", "unannotated"],
+          userStaticServerNames: ["fake", "unannotated"],
+        });
       }
-      return undefined;
-    });
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await expect(run).resolves.toBeDefined();
+      params.config!.mcp!.servers = {
+        ...params.config!.mcp!.servers,
+        unannotated: { url: "https://unannotated.example.test/mcp" },
+      };
+      const requestApproval = vi.fn(async () => ({ id: "plugin:mcp-fixture" }));
+      const waitForApproval = vi.fn(async () => ({
+        decision: "deny" as const,
+        terminalReason: "user" as const,
+      }));
+      params.hostCapabilities = Object.freeze({
+        ...params.hostCapabilities,
+        requestApproval,
+        waitForApproval,
+      });
 
-    expect(harness.requests.map((request) => request.method)).not.toContain("mcpServerStatus/list");
-    expect(mcpMocks.staticCalls).toHaveLength(0);
-    expect(mcpMocks.requesterParams[0]?.manifestRegistry).toBe(
-      params.preparedModelRuntime?.metadataSnapshot.manifestRegistry,
-    );
-    expect(mcpMocks.captureCalls).toHaveLength(1);
-    expect(mcpMocks.captureCalls[0]!.storedNames).not.toContain("fake__show");
-  });
+      const harness = createStartedThreadHarness(async (method) => {
+        if (method === "mcpServerStatus/list") {
+          return {
+            data: [
+              {
+                name: "fake",
+                serverInfo: null,
+                authStatus: "notLoggedIn",
+                tools: {},
+              },
+            ],
+            nextCursor: null,
+          };
+        }
+        return undefined;
+      });
+      const run = runCodexAppServerAttempt(params, {
+        pluginConfig: {
+          appServer: { approvalPolicy: "never", sandbox: "danger-full-access" },
+        },
+      });
+      await harness.waitForMethod("turn/start");
+      const responses = [];
+      for (const serverName of ["unannotated", testCase.source === "bundle" ? "bundled" : "fake"]) {
+        responses.push(
+          await harness.handleServerRequest({
+            id: `approval-${serverName}`,
+            method: "mcpServer/elicitation/request",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              serverName,
+              mode: "form",
+              _meta: { codex_approval_kind: "mcp_tool_call" },
+              requestedSchema: { type: "object", properties: {} },
+            },
+          }),
+        );
+      }
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await expect(run).resolves.toBeDefined();
+
+      expect(responses).toEqual([
+        { action: "accept", content: null, _meta: null },
+        {
+          action: testCase.delegate ? "decline" : "accept",
+          content: null,
+          _meta: testCase.delegate
+            ? { message: expect.stringContaining("openclaw mcp configure") }
+            : null,
+        },
+      ]);
+      expect(requestApproval).toHaveBeenCalledTimes(testCase.delegate ? 1 : 0);
+      expect(waitForApproval).toHaveBeenCalledTimes(testCase.delegate ? 1 : 0);
+      const expectedApprovalPolicy = testCase.delegate
+        ? {
+            granular: {
+              mcp_elicitations: true,
+              rules: false,
+              sandbox_approval: false,
+              request_permissions: false,
+              skill_approval: false,
+            },
+          }
+        : "never";
+      for (const method of ["thread/start", "turn/start"]) {
+        expect(harness.requests.find((request) => request.method === method)?.params).toMatchObject(
+          {
+            approvalPolicy: expectedApprovalPolicy,
+          },
+        );
+      }
+      expect(harness.requests.map((request) => request.method)).not.toContain(
+        "mcpServerStatus/list",
+      );
+      expect(mcpMocks.staticCalls).toHaveLength(0);
+      expect(mcpMocks.requesterParams[0]?.manifestRegistry).toBe(
+        params.preparedModelRuntime?.metadataSnapshot.manifestRegistry,
+      );
+      expect(mcpMocks.captureCalls).toHaveLength(1);
+      expect(mcpMocks.captureCalls[0]!.storedNames).not.toContain("fake__show");
+    },
+  );
 
   it("captures a restricted ordinary turn without inventing intentionally disabled native MCP", async () => {
     const sessionFile = path.join(tempDir, "session-native-mcp-restricted.jsonl");

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -19,6 +19,10 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveSessionAgentIdsStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
+import {
+  loadCodexBundleMcpApprovalConfig,
+  resolveCodexMcpToolOverridesForAgent,
+} from "openclaw/plugin-sdk/codex-mcp-projection";
 import { loadExecApprovals } from "openclaw/plugin-sdk/exec-approvals-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -42,6 +46,7 @@ import {
 } from "./client.js";
 import {
   canUseCodexModelBackedApprovalsReviewerForModel,
+  hasCodexMcpToolApprovalOverrides,
   isCodexPairedNodeRemoteExecPlacementSandbox,
   isCodexRemoteExecPlacementSandbox,
   isCodexSandboxExecServerEnabled,
@@ -51,6 +56,7 @@ import {
   resolveOpenClawExecPolicyForCodexAppServer,
   resolveCodexModelBackedReviewerPolicyContext,
   shouldAutoApproveCodexAppServerApprovals,
+  withMcpElicitationsApprovalPolicy,
   type CodexAppServerRuntimeOptions,
 } from "./config.js";
 import {
@@ -506,7 +512,22 @@ export async function runCodexAppServerSideQuestion(
   };
 
   try {
-    const approvalPolicy = appServer.approvalPolicy;
+    const autoApproveMcpTools = shouldAutoApproveCodexAppServerApprovals(appServer);
+    const projectedMcpServers = loadCodexBundleMcpApprovalConfig({
+      workspaceDir: agentWorkspaceDir,
+      cfg: params.cfg,
+      toolOverrides: resolveCodexMcpToolOverridesForAgent(params.cfg, {
+        agentId: sessionAgentId,
+        toolOverrides: params.sessionEntry.toolOverrides,
+      }),
+    });
+    const approvalPolicy = hasCodexMcpToolApprovalOverrides(
+      params.cfg?.mcp?.servers,
+      Object.keys(projectedMcpServers),
+      projectedMcpServers,
+    )
+      ? withMcpElicitationsApprovalPolicy(appServer.approvalPolicy)
+      : appServer.approvalPolicy;
     const sandbox = appServer.sandbox;
     const nativeProviderWebSearchSupport =
       resolveCodexWebSearchPlan({
@@ -558,6 +579,8 @@ export async function runCodexAppServerSideQuestion(
             paramsForRun: sideRunParams,
             threadId: childThreadId,
             turnId,
+            autoApproveMcpTools,
+            projectedMcpServers,
             pluginAppPolicyContext: binding.pluginAppPolicyContext,
             signal: runAbortController.signal,
           });
@@ -580,11 +603,7 @@ export async function runCodexAppServerSideQuestion(
             threadId: childThreadId,
             turnId,
             nativeHookRelay,
-            autoApprove: shouldAutoApproveCodexAppServerApprovals({
-              approvalPolicy,
-              networkProxy: appServer.networkProxy,
-              sandbox,
-            }),
+            autoApprove: autoApproveMcpTools,
             signal: runAbortController.signal,
             onNativeToolFailureDisposition: (itemId, disposition) =>
               nativeToolLifecycleProjector?.recordApprovalFailureDisposition(itemId, disposition),
@@ -660,7 +679,7 @@ export async function runCodexAppServerSideQuestion(
     const serviceTier = binding.serviceTier ?? appServer.serviceTier;
     const nativeHookRelayEvents = resolveCodexSideNativeHookRelayEvents({
       configuredEvents: options.nativeHookRelay?.events,
-      approvalPolicy,
+      approvalPolicy: appServer.approvalPolicy,
     });
     nativeHookRelay = options.nativeHookRelay
       ? registerCodexSideNativeHookRelay({
@@ -670,6 +689,8 @@ export async function runCodexAppServerSideQuestion(
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
           config: params.cfg,
+          autoApproveMcpTools,
+          projectedMcpServers,
           runId: sideRunParams.runId,
           channelId: buildAgentHookContextChannelFields({
             sessionKey: params.sessionKey,
@@ -986,6 +1007,8 @@ function registerCodexSideNativeHookRelay(params: {
   sessionId: string;
   sessionKey: string | undefined;
   config: EmbeddedRunAttemptParamsV2["config"];
+  autoApproveMcpTools: boolean;
+  projectedMcpServers: Parameters<typeof registerNativeHookRelay>[0]["projectedMcpServers"];
   runId: string;
   channelId?: string;
   requestTimeoutMs: number;
@@ -1004,6 +1027,8 @@ function registerCodexSideNativeHookRelay(params: {
     sessionId: params.sessionId,
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
     ...(params.config ? { config: params.config } : {}),
+    autoApproveMcpTools: params.autoApproveMcpTools,
+    projectedMcpServers: params.projectedMcpServers,
     runId: params.runId,
     ...(params.channelId ? { channelId: params.channelId } : {}),
     allowedEvents: params.events,

--- a/src/agents/agent-bundle-mcp-harness.test.ts
+++ b/src/agents/agent-bundle-mcp-harness.test.ts
@@ -383,13 +383,12 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
     await result.dispose();
   });
 
-  it("allows prompt-mode app tools only under host-confirmed yolo", async () => {
+  it("allows unannotated app tools under host-confirmed full permission", async () => {
     const runtime = makeRuntime({ sessionId: "scheduled-app-yolo", requesterSenderId: "unused" });
     runtime.sessionKey = "agent:main:main";
     delete runtime.requesterScope;
     const catalog = runtime.peekCatalog()!;
     catalog.servers["user-mail"]!.toolCount = 2;
-    catalog.servers["user-mail"]!.codexApprovalMode = "prompt";
     catalog.tools = [
       {
         serverName: "user-mail",
@@ -503,15 +502,22 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     expect(result.tools).toEqual([]);
     expect(result.diagnosticNotice).toContain("user-mail/inbox");
-    expect(result.diagnosticNotice).toContain('defaultToolsApprovalMode="approve"');
+    expect(result.diagnosticNotice).toContain(
+      "openclaw mcp configure user-mail --approval approve",
+    );
     expect(callTool).not.toHaveBeenCalled();
     await result?.dispose();
   });
 
-  it("bypasses scheduled MCP prompting only for the host-confirmed yolo profile", async () => {
+  it.each([
+    { mode: undefined, allowed: true },
+    { mode: "auto" as const, allowed: false },
+    { mode: "prompt" as const, allowed: false },
+    { mode: "approve" as const, allowed: true },
+  ])("honors explicit $mode in scheduled full-permission sessions", async ({ mode, allowed }) => {
     const runtime = makeRuntime({ sessionId: "scheduled-yolo", requesterSenderId: "unused" });
     delete runtime.requesterScope;
-    runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = "prompt";
+    runtime.peekCatalog()!.servers["user-mail"]!.codexApprovalMode = mode;
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
     const callTool = vi.spyOn(runtime, "callTool");
 
@@ -522,8 +528,14 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
       autoApproveCodexAppServerApprovals: true,
     });
 
-    await expect(result.tools[0]!.execute("call-1", {})).resolves.toBeDefined();
-    expect(callTool).toHaveBeenCalledOnce();
+    if (allowed) {
+      await expect(result.tools[0]!.execute("call-1", {})).resolves.toBeDefined();
+      expect(callTool).toHaveBeenCalledOnce();
+    } else {
+      expect(result.tools).toEqual([]);
+      expect(result.diagnosticNotice).toContain("user-mail/inbox");
+      expect(callTool).not.toHaveBeenCalled();
+    }
     await result.dispose();
   });
 
@@ -566,7 +578,9 @@ describe("materializeStaticMcpToolsForScheduledHarnessRunCore", () => {
 
     expect(result.tools).toEqual([]);
     expect(result.diagnosticNotice).toContain("user-mail/inbox");
-    expect(result.diagnosticNotice).toContain('defaultToolsApprovalMode="approve"');
+    expect(result.diagnosticNotice).toContain(
+      "openclaw mcp configure user-mail --approval approve",
+    );
     expect(callTool).not.toHaveBeenCalled();
     await result?.dispose();
   });

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -23,7 +23,10 @@ import {
 } from "./conversation-capability-profile.js";
 import { applyFinalEffectiveToolPolicy } from "./embedded-agent-runner/effective-tool-policy.js";
 import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
-import { requiresMcpCodexToolApproval } from "./mcp-codex-tool-approval.js";
+import {
+  formatMcpCodexApprovalRemedy,
+  requiresMcpCodexToolApproval,
+} from "./mcp-codex-tool-approval.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type RequesterScopedHarnessMcpTools = {
@@ -59,27 +62,24 @@ function formatScheduledMcpDiagnosticNotice(messages: readonly string[]): string
   );
 }
 
-function isScheduledCodexApprovalAllowed(tool: AnyAgentTool, autoApprove: boolean): boolean {
-  const mcp = getPluginToolMeta(tool)?.mcp;
-  return (
-    mcp?.operation !== "tool" ||
-    autoApprove ||
-    (mcp.codexApproval !== undefined && !requiresMcpCodexToolApproval(mcp.codexApproval))
-  );
-}
-
 function filterScheduledCodexApproval(
   tools: readonly AnyAgentTool[],
   autoApprove: boolean,
   onOmitted?: (message: string) => void,
 ): AnyAgentTool[] {
   return tools.filter((tool) => {
-    if (isScheduledCodexApprovalAllowed(tool, autoApprove)) {
+    const mcp = getPluginToolMeta(tool)?.mcp;
+    if (
+      mcp?.operation !== "tool" ||
+      !requiresMcpCodexToolApproval({
+        ...mcp.codexApproval,
+        fullPermission: autoApprove,
+      })
+    ) {
       return true;
     }
-    const mcp = getPluginToolMeta(tool)?.mcp;
     onOmitted?.(
-      `${mcp?.serverName ?? "configured MCP"}/${mcp?.toolName ?? tool.name}: requires interactive Codex approval (${mcp?.codexApproval?.mode ?? "auto"}); configure codex.defaultToolsApprovalMode="approve" or use the host-confirmed yolo profile`,
+      `${mcp.serverName}/${mcp.toolName}: requires interactive Codex approval (${mcp.codexApproval?.mode ?? "auto"}); ${formatMcpCodexApprovalRemedy(mcp.serverName)}`,
     );
     return false;
   });

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -94,7 +94,7 @@ function buildAppToolPolicyProjections(params: {
         toolName: tool.toolName,
         operation: "tool",
         codexApproval: {
-          mode: server?.codexApprovalMode ?? "auto",
+          mode: server?.codexApprovalMode,
           ...(tool.codexAnnotations ? { annotations: tool.codexAnnotations } : {}),
         },
       },
@@ -337,7 +337,7 @@ export function buildBundleMcpToolsFromCatalog(params: {
           : {}),
         ...(tool.deniedBySession ? { deniedBySession: true } : {}),
         codexApproval: {
-          mode: server?.codexApprovalMode ?? "auto",
+          mode: server?.codexApprovalMode,
           ...(tool.codexAnnotations ? { annotations: tool.codexAnnotations } : {}),
         },
       },

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -46,7 +46,7 @@ import {
 } from "./mcp-client-lifecycle.js";
 import {
   normalizeMcpCodexToolAnnotations,
-  resolveMcpCodexToolApprovalMode,
+  resolveProjectedMcpCodexToolApprovalMode,
 } from "./mcp-codex-tool-approval.js";
 import {
   applyMcpConnectionOverride,
@@ -794,7 +794,10 @@ export function createSessionMcpRuntime(params: {
                   ...(deniedToolNames.size > 0
                     ? { deniedToolNames: [...deniedToolNames].toSorted() }
                     : {}),
-                  codexApprovalMode: resolveMcpCodexToolApprovalMode(serverName, rawServer),
+                  codexApprovalMode: resolveProjectedMcpCodexToolApprovalMode(
+                    serverName,
+                    rawServer,
+                  ),
                 };
                 const toolEntries: McpCatalogTool[] = [];
                 const policyToolEntries: McpCatalogTool[] = [];

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -148,7 +148,9 @@ describe("createBundleMcpToolRuntime", () => {
       "demo__hidden_tool",
       "demo__model_tool",
     ]);
-    expect(getPluginToolMeta(runtime.appTools![0]!)?.mcp?.codexApproval).toEqual({ mode: "auto" });
+    expect(getPluginToolMeta(runtime.appTools![0]!)?.mcp?.codexApproval).toEqual({
+      mode: undefined,
+    });
     expect(
       applyEmbeddedAttemptToolsAllow(runtime.appTools ?? [], ["demo__model_tool"], {
         toolMeta: (tool) => getPluginToolMeta(tool),

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexMcpServersConfig,
+  loadCodexBundleMcpApprovalConfig,
   loadCodexBundleMcpThreadConfigCore,
 } from "./codex-mcp-config.js";
 import { testing as resolverTesting } from "./mcp-connection-resolver.js";
@@ -120,6 +121,7 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
           weather: {
             command: "node",
             env: { PLUGIN_DATA: dataDir },
+            codex: { defaultToolsApprovalMode: "prompt" },
           },
           broken: { command: "node", env: { PLUGIN_DATA: collisionPath } },
         },
@@ -131,6 +133,11 @@ describe("loadCodexBundleMcpThreadConfigCore", () => {
       },
     });
 
+    expect(loadCodexBundleMcpApprovalConfig({ workspaceDir: "/workspace" })).toEqual({
+      weather: { default_tools_approval_mode: "prompt" },
+      broken: { default_tools_approval_mode: undefined },
+    });
+    await expect(fs.stat(dataDir)).rejects.toMatchObject({ code: "ENOENT" });
     const loaded = loadCodexBundleMcpThreadConfigCore({ workspaceDir: "/workspace" });
 
     expect((await fs.stat(dataDir)).isDirectory()).toBe(true);

--- a/src/agents/codex-mcp-config.ts
+++ b/src/agents/codex-mcp-config.ts
@@ -139,6 +139,56 @@ export function buildCodexMcpServersConfig(config: BundleMcpConfig): CodexMcpSer
   );
 }
 
+/** Side questions need bundle policy without provisioning transports or plugin data directories. */
+export function loadCodexBundleMcpApprovalConfig(
+  params: Pick<LoadCodexBundleMcpThreadConfigParams, "workspaceDir" | "cfg" | "toolOverrides">,
+): CodexMcpServersConfig {
+  const { config } = loadEnabledBundleMcpConfig(params);
+  const configuredMcp = normalizeConfiguredMcpServers(params.cfg?.mcp?.servers);
+  const selected = selectCodexBundleMcpConfig(
+    { mcpServers: { ...config.mcpServers, ...configuredMcp } },
+    configuredMcp,
+    params.toolOverrides,
+  );
+  const { staticServers } = partitionMcpServersByConnectionScope(selected.mcpServers);
+  return Object.fromEntries(
+    Object.keys(staticServers).map((name) => [
+      name,
+      {
+        default_tools_approval_mode:
+          resolveProjectedMcpCodexToolApprovalMode(name, configuredMcp[name] ?? {}) ??
+          resolveProjectedMcpCodexToolApprovalMode(name, config.mcpServers[name] ?? {}),
+      },
+    ]),
+  );
+}
+
+function selectCodexBundleMcpConfig(
+  config: BundleMcpConfig,
+  configuredMcp: ReturnType<typeof normalizeConfiguredMcpServers>,
+  toolOverrides: LoadCodexBundleMcpThreadConfigParams["toolOverrides"],
+): BundleMcpConfig {
+  const serverOverrides = toolOverrides?.mcpServers;
+  return {
+    mcpServers: Object.fromEntries(
+      Object.entries(config.mcpServers)
+        .filter(([name]) => {
+          const override =
+            serverOverrides && Object.hasOwn(serverOverrides, name)
+              ? serverOverrides[name]
+              : undefined;
+          return (
+            override !== false && (override === true || configuredMcp[name]?.enabled !== false)
+          );
+        })
+        .map(([name, server]) => [
+          name,
+          applyCodexSessionMcpToolDenials(name, server, toolOverrides),
+        ]),
+    ),
+  };
+}
+
 function stableJsonValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stableJsonValue);
@@ -184,24 +234,11 @@ export function loadCodexBundleMcpThreadConfigCore(
   });
   const configuredMcp = normalizeConfiguredMcpServers(params.cfg?.mcp?.servers);
   const serverOverrides = params.toolOverrides?.mcpServers;
-  const effectiveConfig: BundleMcpConfig = {
-    mcpServers: Object.fromEntries(
-      Object.entries(bundleMcp.config.mcpServers)
-        .filter(([name]) => {
-          const override =
-            serverOverrides && Object.hasOwn(serverOverrides, name)
-              ? serverOverrides[name]
-              : undefined;
-          return (
-            override !== false && (override === true || configuredMcp[name]?.enabled !== false)
-          );
-        })
-        .map(([name, server]) => [
-          name,
-          applyCodexSessionMcpToolDenials(name, server, params.toolOverrides),
-        ]),
-    ),
-  };
+  const effectiveConfig = selectCodexBundleMcpConfig(
+    bundleMcp.config,
+    configuredMcp,
+    params.toolOverrides,
+  );
   const enabledConfiguredMcp = Object.fromEntries(
     Object.entries(configuredMcp).filter(([name, server]) => {
       const override =

--- a/src/agents/harness/native-hook-relay-permissions.ts
+++ b/src/agents/harness/native-hook-relay-permissions.ts
@@ -1,8 +1,5 @@
 import { createHash } from "node:crypto";
-import {
-  asDateTimestampMs,
-  resolveExpiresAtMsFromDurationMs,
-} from "@openclaw/normalization-core/number-coercion";
+import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { toErrorObject } from "../../infra/errors.js";
@@ -19,6 +16,7 @@ import {
   requestDeferredPluginToolApproval,
   type DeferredPluginToolApproval,
 } from "../agent-tools.before-tool-call.js";
+import { formatMcpCodexApprovalRemedy } from "../mcp-codex-tool-approval.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import {
   nativeHookRelayParamsWereRewritten,
@@ -55,8 +53,6 @@ const MAX_APPROVAL_DESCRIPTION_LENGTH = 700;
 const MAX_PERMISSION_APPROVALS_PER_WINDOW = 12;
 const PERMISSION_APPROVAL_WINDOW_MS = 60_000;
 const MAX_PERMISSION_ALLOW_ALWAYS_ENTRIES = 512;
-const MCP_APPROVAL_UNAVAILABLE_REASON =
-  'MCP tool approval timed out (no operator connected). Approve in the Control UI, or set mcp.servers.<id>.codex.defaultToolsApprovalMode:"approve" for trusted servers.';
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 const NATIVE_SHELL_APPROVAL_TOOLS = new Set([
   "bash",
@@ -187,19 +183,28 @@ export async function runNativeHookRelayPermissionRequest(params: {
   invocation: NativeHookRelayInvocation;
   adapter: NativeHookRelayProviderAdapter;
 }): Promise<NativeHookRelayProcessResponse> {
+  const mcpToolName = params.invocation.toolName?.startsWith("mcp__")
+    ? params.invocation.toolName
+    : undefined;
+  // Native MCP names can be hashed or trimmed. Only Codex knows the exact server;
+  // defer so full posture cannot bypass plugin-app policy before elicitation.
+  if (mcpToolName && params.registration.deferMcpToolApprovals) {
+    return params.adapter.renderNoopResponse(params.invocation.event);
+  }
   const request: NativeHookRelayPermissionApprovalRequest = {
     provider: params.registration.provider,
     ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
     sessionId: params.registration.sessionId,
     ...(params.registration.sessionKey ? { sessionKey: params.registration.sessionKey } : {}),
     runId: params.registration.runId,
-    toolName: normalizeNativeHookToolName(params.invocation.toolName),
+    toolName: mcpToolName ?? normalizeNativeHookToolName(params.invocation.toolName),
     ...(params.invocation.toolUseId ? { toolCallId: params.invocation.toolUseId } : {}),
     ...(params.invocation.cwd ? { cwd: params.invocation.cwd } : {}),
     ...(params.invocation.model ? { model: params.invocation.model } : {}),
     toolInput: params.adapter.readToolInput(params.invocation.rawPayload),
     ...(params.registration.signal ? { signal: params.registration.signal } : {}),
   };
+  const mcpServerName = /^mcp__(.+?)__/.exec(request.toolName)?.[1];
   const mutableFileBinding = await prepareNativeHookMutableFileBinding(request);
   if (!mutableFileBinding.ok) {
     return params.adapter.renderPermissionDecisionResponse("deny", mutableFileBinding.message);
@@ -253,16 +258,18 @@ export async function runNativeHookRelayPermissionRequest(params: {
       return params.adapter.renderPermissionDecisionResponse("allow");
     }
     if (decision === "allow-always") {
-      rememberNativeHookRelayPermissionAllowAlways(allowAlwaysKey);
+      rememberNativeHookRelayPermissionAllowAlways({
+        key: allowAlwaysKey,
+        relayId: params.registration.relayId,
+        mcpTool: mcpToolName !== undefined,
+      });
       return params.adapter.renderPermissionDecisionResponse("allow");
     }
-    if (decision === "deny") {
-      return params.adapter.renderPermissionDecisionResponse("deny", "Denied by user");
-    }
-    if (decision === "timed-out" && request.toolName.startsWith("mcp__")) {
+    if (decision === "deny" || (decision === "timed-out" && mcpToolName)) {
+      const reason = decision === "deny" ? "Denied by user" : "MCP tool approval timed out";
       return params.adapter.renderPermissionDecisionResponse(
         "deny",
-        MCP_APPROVAL_UNAVAILABLE_REASON,
+        mcpToolName ? `${reason}. ${formatMcpCodexApprovalRemedy(mcpServerName)}` : reason,
       );
     }
   } catch (error) {
@@ -345,23 +352,22 @@ function nativeHookRelayPermissionAllowAlwaysKey(params: {
   request: NativeHookRelayPermissionApprovalRequest;
   binding?: SystemRunMutableFileBinding;
 }): string {
-  const hash = createHash("sha256");
-  hash.update("openclaw:native-hook-relay:permission-allow-always:v2");
-  hash.update("\0");
-  hash.update(params.registration.relayId);
-  hash.update("\0");
-  hash.update(params.request.provider);
-  hash.update("\0");
-  hash.update(params.request.agentId ?? "");
-  hash.update("\0");
-  hash.update(params.request.sessionKey ?? params.request.sessionId);
-  hash.update("\0");
-  hash.update(permissionRequestContentFingerprint(params.request));
-  hash.update("\0");
-  hash.update(
-    params.binding ? permissionRequestBindingFingerprint(params.binding) : "no-file-binding",
-  );
-  return hash.digest("hex");
+  // MCP consent covers the tool; executable/file grants must remain input- and
+  // content-bound so approving one invocation cannot authorize another program.
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        params.registration.relayId,
+        params.request.provider,
+        params.request.agentId,
+        params.request.sessionKey ?? params.request.sessionId,
+        params.request.toolName.startsWith("mcp__")
+          ? params.request.toolName
+          : permissionRequestContentFingerprint(params.request),
+        params.binding ? permissionRequestBindingFingerprint(params.binding) : undefined,
+      ]),
+    )
+    .digest("hex");
 }
 
 function permissionRequestFallbackKey(request: NativeHookRelayPermissionApprovalRequest): string {
@@ -508,42 +514,36 @@ function consumeNativeHookRelayPermissionBudget(relayId: string, now = Date.now(
 }
 
 function hasNativeHookRelayPermissionAllowAlways(key: string, now = Date.now()): boolean {
-  const validNow = asDateTimestampMs(now);
-  if (validNow === undefined) {
-    return false;
-  }
   const entry = permissionAllowAlwaysApprovals.get(key);
   if (!entry) {
     return false;
   }
-  const expiresAtMs = asDateTimestampMs(entry.expiresAtMs);
-  if (expiresAtMs === undefined || expiresAtMs <= validNow) {
+  if (entry.expiresAtMs !== undefined && entry.expiresAtMs <= now) {
     permissionAllowAlwaysApprovals.delete(key);
     return false;
   }
   return true;
 }
 
-function rememberNativeHookRelayPermissionAllowAlways(key: string, now = Date.now()): void {
+function rememberNativeHookRelayPermissionAllowAlways(
+  params: { key: string; relayId: string; mcpTool: boolean },
+  now = Date.now(),
+): void {
   pruneNativeHookRelayPermissionAllowAlways(now);
-  const expiresAtMs = resolveExpiresAtMsFromDurationMs(PERMISSION_ALLOW_ALWAYS_TTL_MS, {
-    nowMs: now,
-  });
-  if (expiresAtMs === undefined) {
+  // MCP grants end with their relay registration, not a wall-clock timeout.
+  const expiresAtMs = params.mcpTool
+    ? undefined
+    : resolveExpiresAtMsFromDurationMs(PERMISSION_ALLOW_ALWAYS_TTL_MS, { nowMs: now });
+  if (!params.mcpTool && expiresAtMs === undefined) {
     return;
   }
-  permissionAllowAlwaysApprovals.set(key, { expiresAtMs });
+  permissionAllowAlwaysApprovals.set(params.key, { relayId: params.relayId, expiresAtMs });
   pruneMapToMaxSize(permissionAllowAlwaysApprovals, MAX_PERMISSION_ALLOW_ALWAYS_ENTRIES);
 }
 
 export function pruneNativeHookRelayPermissionAllowAlways(now = Date.now()): void {
-  const validNow = asDateTimestampMs(now);
-  if (validNow === undefined) {
-    return;
-  }
   for (const [key, entry] of permissionAllowAlwaysApprovals) {
-    const expiresAtMs = asDateTimestampMs(entry.expiresAtMs);
-    if (expiresAtMs === undefined || expiresAtMs <= validNow) {
+    if (entry.expiresAtMs !== undefined && entry.expiresAtMs <= now) {
       permissionAllowAlwaysApprovals.delete(key);
     }
   }
@@ -551,6 +551,11 @@ export function pruneNativeHookRelayPermissionAllowAlways(now = Date.now()): voi
 
 export function removeNativeHookRelayPermissionState(relayId: string): void {
   permissionApprovalWindows.delete(relayId);
+  for (const [key, entry] of permissionAllowAlwaysApprovals) {
+    if (entry.relayId === relayId) {
+      permissionAllowAlwaysApprovals.delete(key);
+    }
+  }
   for (const key of pendingPermissionApprovals.keys()) {
     if (key.startsWith(`${relayId}:`)) {
       pendingPermissionApprovals.delete(key);

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -6,6 +6,7 @@ import type {
   DeferredPluginToolApproval,
   HookContext,
 } from "../agent-tools.before-tool-call.js";
+import type { CodexMcpServersConfig } from "../codex-mcp-config.types.js";
 import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
 
 type NativeHookRelayApprovalContext = Pick<
@@ -76,6 +77,7 @@ export type NativeHookRelayRegistration = {
   sessionId: string;
   sessionKey?: string;
   config?: OpenClawConfig;
+  deferMcpToolApprovals?: boolean;
   runId: string;
   channelId?: string;
   requester?: PluginHookToolRequesterContext;
@@ -116,6 +118,8 @@ export type RegisterNativeHookRelayParams = {
   sessionId: string;
   sessionKey?: string;
   config?: OpenClawConfig;
+  autoApproveMcpTools?: boolean;
+  projectedMcpServers?: CodexMcpServersConfig;
   runId: string;
   channelId?: string;
   requester?: PluginHookToolRequesterContext;
@@ -258,5 +262,5 @@ export type NativeHookRelaySharedState = {
   pendingPermissionApprovals: Map<string, Promise<NativeHookRelayPermissionApprovalResult>>;
   pendingPreToolUseApprovals: Map<string, NativeHookRelayPreToolUseApproval>;
   permissionApprovalWindows: Map<string, number[]>;
-  permissionAllowAlwaysApprovals: Map<string, { expiresAtMs: number }>;
+  permissionAllowAlwaysApprovals: Map<string, { relayId: string; expiresAtMs?: number }>;
 };

--- a/src/agents/harness/native-hook-relay.approval-wait.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-wait.test.ts
@@ -15,10 +15,110 @@ afterEach(() => {
 });
 
 describe("native hook relay approval wait handling", () => {
-  it("explains how to unblock an MCP tool when approval times out", async () => {
+  it.each(
+    [
+      { fullPermission: true, mode: undefined, decision: "defer" },
+      { fullPermission: false, mode: undefined, decision: "deny" },
+      { fullPermission: true, mode: "auto" as const, decision: "defer" },
+      { fullPermission: true, mode: "prompt" as const, decision: "defer" },
+      { fullPermission: false, mode: "approve" as const, decision: "defer" },
+      {
+        fullPermission: true,
+        mode: "prompt" as const,
+        serverName: "linear-team",
+        nativeServerName: "linear_team",
+        decision: "defer",
+      },
+      { fullPermission: true, mode: "prompt" as const, serverName: "Linear", decision: "defer" },
+      {
+        fullPermission: true,
+        mode: "prompt" as const,
+        serverName: "team__linear",
+        nativeServerName: "team__linear",
+        decision: "defer",
+      },
+      {
+        fullPermission: true,
+        mode: undefined,
+        projectedMode: "prompt" as const,
+        decision: "defer",
+      },
+      {
+        fullPermission: true,
+        mode: "approve" as const,
+        projectedMode: "prompt" as const,
+        decision: "defer",
+      },
+      {
+        fullPermission: false,
+        mode: "prompt" as const,
+        nativeServerName: "linear_abc12345",
+        decision: "defer",
+      },
+      { fullPermission: false, mode: "prompt" as const, serverName: "linear_", decision: "defer" },
+      {
+        fullPermission: false,
+        mode: "prompt" as const,
+        nativeServerName: "Linear",
+        decision: "defer",
+      },
+      { fullPermission: true, mode: undefined, nativeServerName: "codex_apps", decision: "defer" },
+    ].map((scenario) => ({
+      serverName: scenario.serverName ?? "linear",
+      nativeServerName: scenario.nativeServerName ?? "linear",
+      projectedMode: "projectedMode" in scenario ? scenario.projectedMode : undefined,
+      fullPermission: scenario.fullPermission,
+      mode: scenario.mode,
+      decision: scenario.decision,
+    })),
+  )(
+    "uses full=$fullPermission with server $serverName mode=$mode projected=$projectedMode for MCP approval",
+    async ({ fullPermission, mode, decision, serverName, nativeServerName, projectedMode }) => {
+      mockCallGatewayTool.mockResolvedValue({ id: "approval-1", decision: "deny" });
+      const registration = {
+        provider: "codex" as const,
+        sessionId: "session-1",
+        runId: "run-1",
+        autoApproveMcpTools: fullPermission,
+        projectedMcpServers: projectedMode
+          ? { [serverName]: { default_tools_approval_mode: projectedMode } }
+          : undefined,
+        config: {
+          mcp: {
+            servers: {
+              [serverName]: {
+                url: "https://mcp.example.test",
+                codex: { defaultToolsApprovalMode: mode },
+              },
+            },
+          },
+        },
+      };
+      const relay = registerNativeHookRelay(registration);
+      const result = await invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: `mcp__${nativeServerName}__list_issues`,
+          tool_input: { query: "first" },
+        },
+      });
+
+      if (decision === "defer") {
+        expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+      } else {
+        expect(JSON.parse(result.stdout).hookSpecificOutput.decision.behavior).toBe(decision);
+      }
+      expect(mockCallGatewayTool).toHaveBeenCalledTimes(decision === "defer" ? 0 : 1);
+    },
+  );
+
+  it.each([null, "deny"])("explains how to unblock an MCP tool after %s", async (decision) => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "plugin:approval-timeout", status: "accepted" })
-      .mockResolvedValueOnce({ id: "plugin:approval-timeout", decision: null });
+      .mockResolvedValueOnce({ id: "plugin:approval-timeout", decision });
     const relay = registerNativeHookRelay({
       provider: "codex",
       sessionId: "session-1",
@@ -36,8 +136,93 @@ describe("native hook relay approval wait handling", () => {
       },
     });
 
-    expect(result.stdout).toContain("MCP tool approval timed out");
-    expect(result.stdout).toContain("mcp.servers.<id>.codex.defaultToolsApprovalMode");
+    expect(result.stdout).toContain(
+      decision === null ? "MCP tool approval timed out" : "Denied by user",
+    );
+    expect(result.stdout).toContain("openclaw mcp configure memory --approval approve");
+  });
+
+  it.each(["arguments", "cwd", "elapsed time", "shortened name", "tool", "server", "case"])(
+    "scopes MCP allow-always after changed %s",
+    async (change) => {
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: "approval-1", decision: "allow-always" })
+        .mockResolvedValueOnce({ id: "approval-2", decision: "deny" });
+      const now = Date.now();
+      const relay = registerNativeHookRelay({
+        provider: "codex",
+        sessionId: "session-1",
+        runId: "run-1",
+        ttlMs: 60 * 60_000,
+      });
+      const invoke = (cwd: string, query: string, toolName = "mcp__linear__list_issues") =>
+        invokeNativeHookRelay({
+          provider: "codex",
+          relayId: relay.relayId,
+          event: "permission_request",
+          rawPayload: {
+            hook_event_name: "PermissionRequest",
+            cwd,
+            tool_name: toolName,
+            tool_input: { query },
+          },
+        });
+      const initialToolName = change === "shortened name" ? "mcp__list_issues" : undefined;
+      await invoke("/repo", "first", initialToolName);
+      if (change === "elapsed time" || change === "shortened name") {
+        vi.spyOn(Date, "now").mockReturnValue(now + 31 * 60_000);
+      }
+      const result = await invoke(
+        change === "cwd" ? "/other-repo" : "/repo",
+        change === "arguments" ? "second" : "first",
+        change === "tool"
+          ? "mcp__linear__get_issue"
+          : change === "case"
+            ? "mcp__linear__List_Issues"
+            : change === "server"
+              ? "mcp__other__list_issues"
+              : initialToolName,
+      );
+
+      const sameTool = change !== "tool" && change !== "server" && change !== "case";
+      expect(JSON.parse(result.stdout).hookSpecificOutput.decision.behavior).toBe(
+        sameTool ? "allow" : "deny",
+      );
+      expect(mockCallGatewayTool).toHaveBeenCalledTimes(sameTool ? 1 : 2);
+    },
+  );
+
+  it.each(["unregister", "replace"])("forgets MCP allow-always on relay %s", async (disposal) => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "approval-1", decision: "allow-always" })
+      .mockResolvedValueOnce({ id: "approval-2", decision: "deny" });
+    const registration = {
+      provider: "codex" as const,
+      relayId: "mcp-approval-lifetime",
+      sessionId: "session-1",
+      runId: "run-1",
+    };
+    const relay = registerNativeHookRelay(registration);
+    const invoke = () =>
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "permission_request",
+        rawPayload: {
+          hook_event_name: "PermissionRequest",
+          tool_name: "mcp__linear__list_issues",
+          tool_input: { query: "first" },
+        },
+      });
+    await invoke();
+    if (disposal === "unregister") {
+      relay.unregister();
+    }
+    registerNativeHookRelay({ ...registration, runId: "run-2" });
+    const result = await invoke();
+
+    expect(JSON.parse(result.stdout).hookSpecificOutput.decision.behavior).toBe("deny");
+    expect(mockCallGatewayTool).toHaveBeenCalledTimes(2);
   });
 
   it("defers an MCP tool when no approval id is created", async () => {

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -3917,13 +3917,6 @@ describe("native hook relay registry", () => {
         tool_input: { command: "git status" },
       },
     });
-    relay.unregister();
-    registerNativeHookRelay({
-      provider: "codex",
-      relayId: "codex-stable-permission-cache",
-      sessionId: "session-1",
-      runId: "run-2",
-    });
     const second = await invokeNativeHookRelay({
       provider: "codex",
       relayId: relay.relayId,

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -6,6 +6,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { resolveProjectedMcpCodexToolApprovalMode } from "../mcp-codex-tool-approval.js";
 import { retainBeforeToolCallForNativeHookRelay } from "./host-capability.js";
 import {
   clearNativeHookRelayBridgesForTests,
@@ -199,6 +200,16 @@ function registerNativeHookRelayInternal(
       sessionId: params.sessionId,
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       ...(params.config ? { config: params.config } : {}),
+      deferMcpToolApprovals:
+        params.autoApproveMcpTools === true ||
+        Object.keys({ ...params.projectedMcpServers, ...params.config?.mcp?.servers }).some(
+          (serverName) =>
+            resolveProjectedMcpCodexToolApprovalMode(
+              serverName,
+              params.config?.mcp?.servers?.[serverName] ?? {},
+              params.projectedMcpServers?.[serverName],
+            ) !== undefined,
+        ),
       runId: params.runId,
       ...(params.channelId ? { channelId: params.channelId } : {}),
       ...(params.requester ? { requester: params.requester } : {}),

--- a/src/agents/mcp-codex-tool-approval.test.ts
+++ b/src/agents/mcp-codex-tool-approval.test.ts
@@ -1,21 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatMcpCodexApprovalRemedy,
   normalizeMcpCodexToolAnnotations,
   requiresMcpCodexToolApproval,
-  resolveMcpCodexToolApprovalMode,
   resolveProjectedMcpCodexToolApprovalMode,
 } from "./mcp-codex-tool-approval.js";
 
 describe("Codex MCP tool approval projection", () => {
+  it.each([
+    { kind: "oversized", serverName: "a".repeat(129) },
+    { kind: "option-shaped", serverName: "--help" },
+  ])("keeps $kind server names out of executable approval hints", ({ serverName }) => {
+    expect(formatMcpCodexApprovalRemedy(serverName)).toContain(
+      "openclaw mcp configure <server> --approval approve",
+    );
+  });
+
   it("keeps native projection optional while scheduled enforcement defaults to auto", () => {
     const server = { command: "example-mcp" };
     expect(resolveProjectedMcpCodexToolApprovalMode("example", server)).toBeUndefined();
-    expect(resolveMcpCodexToolApprovalMode("example", server)).toBe("auto");
+    expect(requiresMcpCodexToolApproval({ mode: undefined })).toBe(true);
   });
 
   it("preserves explicit modes and the loopback OpenClaw approval exception", () => {
     expect(
-      resolveMcpCodexToolApprovalMode("example", {
+      resolveProjectedMcpCodexToolApprovalMode("example", {
         command: "example-mcp",
         codex: { defaultToolsApprovalMode: "prompt" },
       }),
@@ -52,5 +61,15 @@ describe("Codex MCP tool approval projection", () => {
         extra: true,
       }),
     ).toEqual({ readOnlyHint: true, idempotentHint: false });
+  });
+
+  it.each([
+    { mode: undefined, fullPermission: true, expected: false },
+    { mode: undefined, fullPermission: false, expected: true },
+    { mode: "auto" as const, fullPermission: true, expected: true },
+    { mode: "prompt" as const, fullPermission: true, expected: true },
+    { mode: "approve" as const, fullPermission: false, expected: false },
+  ])("honors $mode with full permission $fullPermission", ({ expected, ...policy }) => {
+    expect(requiresMcpCodexToolApproval(policy)).toBe(expected);
   });
 });

--- a/src/agents/mcp-codex-tool-approval.ts
+++ b/src/agents/mcp-codex-tool-approval.ts
@@ -27,6 +27,7 @@ function isOpenClawLoopbackServer(name: string, server: McpServerConfig): boolea
 export function resolveProjectedMcpCodexToolApprovalMode(
   serverName: string,
   server: McpServerConfig,
+  projectedServer?: Record<string, unknown>,
 ): McpCodexToolApprovalMode | undefined {
   const codex =
     server.codex && typeof server.codex === "object" && !Array.isArray(server.codex)
@@ -35,15 +36,9 @@ export function resolveProjectedMcpCodexToolApprovalMode(
   return (
     normalizeApprovalMode(codex.defaultToolsApprovalMode) ??
     normalizeApprovalMode(codex.default_tools_approval_mode) ??
+    normalizeApprovalMode(projectedServer?.default_tools_approval_mode) ??
     (isOpenClawLoopbackServer(serverName, server) ? "approve" : undefined)
   );
-}
-
-export function resolveMcpCodexToolApprovalMode(
-  serverName: string,
-  server: McpServerConfig,
-): McpCodexToolApprovalMode {
-  return resolveProjectedMcpCodexToolApprovalMode(serverName, server) ?? "auto";
 }
 
 export function normalizeMcpCodexToolAnnotations(value: unknown): McpCodexToolAnnotations {
@@ -65,15 +60,17 @@ export function normalizeMcpCodexToolAnnotations(value: unknown): McpCodexToolAn
   return result;
 }
 
-/** Mirrors Codex `auto` approval semantics for unattended dynamic execution. */
+/** Explicit server policy outranks the prepared session posture. */
 export function requiresMcpCodexToolApproval(params: {
-  mode: McpCodexToolApprovalMode;
+  mode?: McpCodexToolApprovalMode;
+  fullPermission?: boolean;
   annotations?: McpCodexToolAnnotations;
 }): boolean {
-  if (params.mode === "approve") {
+  const mode = params.mode ?? (params.fullPermission ? "approve" : "auto");
+  if (mode === "approve") {
     return false;
   }
-  if (params.mode === "prompt") {
+  if (mode === "prompt") {
     return true;
   }
   const annotations = params.annotations ?? {};
@@ -84,4 +81,10 @@ export function requiresMcpCodexToolApproval(params: {
     return false;
   }
   return annotations.destructiveHint !== false || annotations.openWorldHint !== false;
+}
+
+export function formatMcpCodexApprovalRemedy(serverName?: string): string {
+  // Config keys are unbounded; keep model-visible hints short and never emit a CLI option as a name.
+  const server = serverName && /^[\w.][\w.-]{0,127}$/.test(serverName) ? serverName : "<server>";
+  return `Run openclaw mcp configure ${server} --approval approve for a trusted server, or change the session permission mode.`;
 }

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -1036,13 +1036,13 @@ describe("mcp cli", () => {
       mockLog.mockClear();
       await runMcpCommand(["mcp", "probe", "memory"]);
       expect(mockLog.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
-        "tools have no safety annotations; calls will require interactive approval",
+        "tools have no safety annotations; calls require approval in prompting session postures",
       );
 
       mockLog.mockClear();
       await runMcpCommand(["mcp", "doctor", "memory", "--probe"]);
       expect(mockLog.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
-        "tools have no safety annotations; calls will require interactive approval",
+        "tools have no safety annotations; calls require approval in prompting session postures",
       );
     });
   });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -192,7 +192,7 @@ type McpDoctorServerResult = {
 
 const MCP_DOCTOR_CONCURRENCY = 4;
 const MCP_CODEX_APPROVAL_ANNOTATION_HINT =
-  "tools have no safety annotations; calls will require interactive approval";
+  "tools have no safety annotations; calls require approval in prompting session postures";
 
 const SENSITIVE_HEADER_NAMES = new Set([
   "authorization",

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -17,6 +17,12 @@ import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 
 export { pinExecToolTarget };
 export { resolveBootstrapFilesForPreparation } from "../agents/bootstrap-files.js";
+export { loadCodexBundleMcpApprovalConfig } from "../agents/codex-mcp-config.js";
+export {
+  formatMcpCodexApprovalRemedy,
+  requiresMcpCodexToolApproval,
+  resolveProjectedMcpCodexToolApprovalMode,
+} from "../agents/mcp-codex-tool-approval.js";
 export type CodexScheduledToolProjectionFactory = AgentHarnessScheduledToolProjectionFactory;
 export type CodexTtsProvenanceTransfer = AgentHarnessTtsProvenanceTransfer;
 

--- a/src/plugins/tool-metadata.ts
+++ b/src/plugins/tool-metadata.ts
@@ -14,7 +14,7 @@ export type PluginToolMcpMeta = {
   excludedFromOpenClawCatalog?: true;
   deniedBySession?: true;
   codexApproval?: {
-    mode: McpCodexToolApprovalMode;
+    mode?: McpCodexToolApprovalMode;
     annotations?: McpCodexToolAnnotations;
   };
   node?: {


### PR DESCRIPTION
## What Problem This Solves

Operators on OpenClaw 2.0 report that a Slack-driven agent "asks permission for almost everything, even basic things like Linear reads" through an MCP server, and that clicking **Allow Always** does not stop the prompts (reported by @linuz90 on X).

OpenClaw's default posture is full permission: a fresh gateway runs `tools.exec` security `full` / ask `off`, and the Codex plugin's default `policyMode` (`yolo`) projects `approvalPolicy: "never"` + `sandbox: "danger-full-access"`. MCP tool calls prompting under that default contradicts the product default.

Root causes (Codex harness, `@openai/codex` 0.151.0; upstream contract verified against `rust-v0.151.0`):

1. **The full-permission posture is lost at the MCP delegation boundary.** When native Codex plugins or computer use are enabled, `withMcpElicitationsApprovalPolicy` (`extensions/codex/src/app-server/config-security.ts`) rewrites `never` into a granular policy with `mcp_elicitations: true`. Upstream's full-access shortcut (`codex-rs/codex-mcp/src/mcp/mod.rs` `mcp_permission_prompt_is_auto_approved`, which requires the exact `Never` enum plus `PermissionProfile::Disabled`) no longer fires, so every tool without MCP safety annotations — most hosted servers, Linear included — reaches the operator on every call. The generic elicitation branch (`elicitation-bridge.ts`) and the hook-relay permission path (`src/agents/harness/native-hook-relay-permissions.ts`) then prompted without knowing the original posture.
2. **"Allow Always" was functionally "allow once" for MCP tools.** The hook relay remembered allow-always under a key hashing tool name, cwd, and the **entire tool input**, in-process with a 30-minute TTL; a Linear read with different arguments re-prompted, and registration cleanup never removed the grants. The elicitation bridge offered persistence without honoring the request's `_meta.persist` hints and selected the "session" enum option while attaching `persist: "always"` meta.
3. **Unspecified server approval mode was collapsed to `"auto"`** in catalog metadata, so gating could not distinguish "operator chose `auto`" from "operator chose nothing"; the scheduled-run bypass also ignored explicit per-server overrides.

## Why This Change Was Made

Approval friction must follow the operator's chosen posture, not a posture-independent fail-closed default.

- One owner decision (`requiresMcpCodexToolApproval` in `src/agents/mcp-codex-tool-approval.ts`): unspecified mode under the full posture never prompts; an explicit per-server `defaultToolsApprovalMode` of `auto`/`prompt` still outranks posture; `approve` never prompts. The prepared original posture is carried into the elicitation bridge, the hook-relay registration, side questions, and the scheduled-run tool filter (`agent-bundle-mcp-harness.ts`), replacing the duplicate gating branches.
- Explicit `auto`/`prompt` server modes now delegate to Codex's native MCP gate (`hasCodexMcpToolApprovalOverrides` → `withMcpElicitationsApprovalPolicy`) so Codex's `never` policy cannot swallow the operator's explicit choice; the hook relay defers `mcp__*` requests to Codex in those cases because native MCP tool names can be hashed/trimmed and only Codex knows the exact server.
- "Allow Always" on an MCP tool is tool-scoped for the relay registration's lifetime (no TTL) and removed exactly on registration cleanup or replacement; non-MCP grants keep exact input/cwd/file-content keying (approving one invocation must not authorize another program). The bridge offers Allow Always only when Codex advertises persistence in `_meta.persist`, aligns the enum choice ("Allow and don't ask me again" vs "Allow for this session") with the persist meta, and hands the decision to Codex's own approval memory (`ApprovedForSession` / `ApprovedMcpPolicyAmendment`).
- The operator approval card for an OpenClaw-configured MCP server now names the remedy (`openclaw mcp configure <server> --approval approve`, or a different session permission mode) — the operator is the one who can stop the prompts. Hook-relay denials carry the same remedy in the decision reason. The bridge no longer attaches remedy text to elicitation *declines*: live proof showed Codex 0.151.0 maps every decline to the fixed `user rejected MCP tool call` and reads no response meta (`codex-rs/core/src/mcp_tool_call.rs`, `parse_mcp_tool_approval_elicitation_response`), so that text — including the pre-existing timeout message — was dead. The plugin's card-description cap moves from 256 to the gateway protocol's 512 (`PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH`) so the remedy does not displace the tool parameters. The `mcp probe` hint no longer claims every default call prompts.

Decided against: seeding a Codex `config.toml` in the agent's codex-home so upstream could persist per-tool approvals for OpenClaw-configured servers — two owners of a server definition is drift bait. Durable cross-session memory for those servers is a named follow-up.

## User Impact

- Default (full-permission) sessions: MCP tool calls no longer prompt, including with native Codex plugins or computer use enabled. Scheduled runs keep unannotated tools under the default posture; an explicit per-server `auto`/`prompt` is still honored (and now also on scheduled runs).
- Stricter sessions (`workspace`, `guarded`, `read-only`, explicit `prompt`): **Allow Always** on an MCP tool covers the tool for the rest of the Codex session / relay registration regardless of arguments; Codex can persist it across sessions for servers saved in its own native config.
- Denied/timed-out MCP approvals explain how to unblock.
- Docs: `docs/cli/mcp.md` §Codex tool approvals rewritten; new §Approvals in `docs/tools/mcp.md`; Slack native-approvals cross-link.

Follow-ups (not in this PR): durable cross-session memory for servers configured only in OpenClaw (needs a writable Codex config owner or an OpenClaw-side per-tool store — design decision); the standalone ACP debug client still classifies unknown MCP tools as prompt-only (`src/acp/approval-classifier.ts`).

## Evidence

- Regression tests written first and failing on pre-fix code for the intended reasons: `src/agents/mcp-codex-tool-approval.test.ts` (posture/explicit-mode matrix), `src/agents/agent-bundle-mcp-harness.test.ts` (scheduled full posture + explicit override matrix), `src/agents/harness/native-hook-relay.approval-wait.test.ts` (deferral, tool-scoped grants across changed args/cwd/31 min, forgotten on unregister/replace, remedies), `extensions/codex/src/app-server/elicitation-bridge.test.ts` (posture, hints → allowed decisions, enum/meta alignment, plugin/CUA isolation), `extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts` (native thread/turn override matrix at the host approval boundary).
- Post-rebase scoped run on the PR head: `pnpm test` over 14 files (the above plus `codex-mcp-config`, `agent-bundle-mcp-tools.materialize`, `native-hook-relay`, `mcp-cli`, `run-attempt.turn-watches`, `sandbox-exec-server-node-relay`, `sandbox-exec-server.lifecycle`, `attempt-startup`, `attempt-startup-retry`) — 566 passed, 0 failed.
- On the final head (`3e1e313`, a test-only commit aligning the configured-MCP integration test with the card-side remedy after exact-head CI caught the stale expectation): `pnpm test` over all 10 test files changed by this PR — 454 passed, 0 failed.
- `pnpm check:changed` on every pushed head (typecheck lanes incl. core tests and extensions, changed-file lint/format, SDK budget, runtime import cycles = 0, sidecar-loader/webhook/pairing guards) — passed, exit 0.
- `pnpm build` on the pre-rebase head: passed, zero `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- Codex-backed autoreview on the change: scoped-clean, no accepted findings.
- Upstream contract inspected directly at `rust-v0.151.0`: `codex-rs/core/src/mcp_tool_call.rs` (`maybe_request_mcp_tool_approval`, `requires_mcp_tool_approval_for_mode`, persist parsing, `normalize_approval_decision_for_mode`, `maybe_persist_mcp_tool_approval`), `codex-rs/codex-mcp/src/mcp/mod.rs:89`, `codex-rs/protocol/src/mcp_approval_meta.rs`, `codex-rs/protocol/src/models.rs` (`DangerFullAccess` → `PermissionProfile::Disabled`).
- Production LOC: +328/-134 (net +194) across both commits; tests +505/-78; docs +30/-10. This is a positive production delta for a bug fix, so naming it: the growth is the typed original-posture propagation across the main-run, side-question, SDK-facade, and relay-registration owners (the fact has to reach every place that prompts), the explicit-override delegation gate (`hasCodexMcpToolApprovalOverrides`) that keeps an operator's `auto`/`prompt` from being swallowed by Codex's `never` policy, the read-only bundle-policy loader side questions need (`loadCodexBundleMcpApprovalConfig`, sharing the extracted `selectCodexBundleMcpConfig` with the main path instead of duplicating it), and the honest persist-hint handling in the bridge. Deleted: the default-to-`auto` resolver, both materialization fallbacks, the separate scheduled bypass predicate, the plugin-only decision downgrade, the stale config-path timeout constant, and the timestamp coercion in the relay. A worker refactor of `attempt-startup.ts` that upstream had already landed was dropped before rebase.
- **Live real-session proof** on the PR head (isolated dev gateway, real Codex app-server 0.151.0, real `openai/gpt-5.6-sol` turn on the Codex harness, unannotated stdio MCP fixture; details in the PR comment): (A) default full-permission posture — the unannotated tool executed with **zero** approval requests across 513 approval-queue polls; (B) explicit `--approval prompt` — a real plugin approval blocked the call, the MCP server never received it, denial was enforced. The live run also exposed that remedy text on elicitation declines never reaches anyone (Codex maps every decline to a fixed denial) — fixed in the follow-up commit by moving the remedy onto the operator card.
- CI note: on head `3e1e313` the `checks-node-compact-small-30` shard failed once in `src/infra/ssh-tunnel.test.ts` ("rejects with the spawn error when ssh binary is missing", `vi.getTimerCount()` expected 0 got 1). That test is not in this PR — it landed on `main` in `0ac750ff76a` after this branch's rebase and runs here only via the merge commit; `main`'s own CI is green on it and it passes locally 3/3 on this branch's files and 5/5 with `main`'s version of `ssh-tunnel.ts`/`ssh-tunnel.test.ts` checked out. Treated as a flaky timer-count assertion; failed jobs rerun rather than the branch re-pushed. Follow-up to make that assertion deterministic is queued separately.
- Remaining gap: no Slack-rendered card was captured (approval text/payloads were observed via the gateway API and CLI); Slack delivery is unchanged and covered by the existing Slack approval tests.
