### PR TITLE
fix(ui): stop reporting a fake storage error for a removed queued cha…

### DIFF
--- a/ui/src/lib/chat/outbox-store-projection.ts
+++ b/ui/src/lib/chat/outbox-store-projection.ts
@@ -22,10 +22,10 @@ export type StoredChatOutbox = StoredChatOutboxScope & { queue: ChatQueueItem[] 
 
 function listStoredComposerRows(
   state: ChatComposerScope,
-): Array<{ scope: StoredChatOutboxScope; session: StoredComposerSession }> {
+): Array<{ scope: StoredChatOutboxScope; session: StoredComposerSession }> | undefined {
   const storage = getSafeSessionStorage();
   if (!storage) {
-    return [];
+    return undefined;
   }
   try {
     const target = storageTargetForGateway(state.settings?.gatewayUrl);
@@ -52,13 +52,13 @@ function listStoredComposerRows(
         : [];
     });
   } catch {
-    return [];
+    return undefined;
   }
 }
 
-export function listStoredChatOutboxes(state: ChatComposerScope): StoredChatOutbox[] {
+export function readStoredChatOutboxes(state: ChatComposerScope): StoredChatOutbox[] | undefined {
   return listStoredComposerRows(state)
-    .flatMap(({ scope, session }) =>
+    ?.flatMap(({ scope, session }) =>
       session.queue?.length
         ? [
             {
@@ -76,10 +76,13 @@ export function listStoredChatOutboxes(state: ChatComposerScope): StoredChatOutb
     );
 }
 
+export const listStoredChatOutboxes = (state: ChatComposerScope): StoredChatOutbox[] =>
+  readStoredChatOutboxes(state) ?? [];
+
 export function summarizeStoredChatOutboxes(state: ChatComposerScope) {
   const idsByScope = new Map<string, { all: Set<string>; attention: Set<string> }>();
   const draftScopes = new Set<string>();
-  for (const { scope, session } of listStoredComposerRows(state)) {
+  for (const { scope, session } of listStoredComposerRows(state) ?? []) {
     const scopeKey = storedChatOutboxScopeKey(scope);
     if (session.draft) {
       draftScopes.add(scopeKey);

--- a/ui/src/pages/chat/chat-outbox-owner.ts
+++ b/ui/src/pages/chat/chat-outbox-owner.ts
@@ -4,6 +4,7 @@ import {
   outboxPayloadMatchesOwner,
   observeOutboxRecoveryOwner,
 } from "../../lib/chat/outbox-payload-store.runtime.ts";
+import { readStoredChatOutboxes } from "../../lib/chat/outbox-store-projection.ts";
 import {
   applyStoredChatOutboxScope,
   subscribeStoredChatOutboxChanges,
@@ -75,15 +76,17 @@ class ChatOutboxGatewayOwner {
     return listStoredChatOutboxes(host).find(({ queue }) => queue.some((item) => item.id === id));
   }
   locate(host: Host, id: string) {
-    const outbox = this.durable(host, id);
-    const captured = outbox ?? this.local(this.state(host), id)?.scope;
-    if (!captured) {
+    const outboxes = readStoredChatOutboxes(host);
+    const outbox = outboxes?.find(({ queue }) => queue.some((item) => item.id === id));
+    const local = this.local(this.state(host), id);
+    const scope = outbox ?? local?.scope;
+    if (!scope) {
       return undefined;
     }
-    const { sessionKey, agentId } = captured;
-    const scope = { sessionKey, agentId };
-    const item = this.snapshot(host, scope, outbox?.queue ?? []).find((row) => row.id === id);
-    return item ? { item, scope, durable: outbox?.queue.find((row) => row.id === id) } : undefined;
+    const visible = outbox?.queue ?? (outboxes ? [] : (local?.queue ?? []));
+    const item = this.snapshot(host, scope, visible).find((row) => row.id === id);
+    const durable = outboxes ? outbox?.queue.find((row) => row.id === id) : null;
+    return item ? { item, scope, durable } : undefined;
   }
   private project(item: ChatQueueItem, local: ChatQueueItem): ChatQueueItem {
     const projected: ChatQueueItem = { ...item };

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -225,7 +225,7 @@ export function updateQueuedMessage(
 type QueuedMessageMoveRow = {
   id: string;
   scope: StoredChatOutboxScope;
-  durable: ChatQueueItem | undefined;
+  durable: ChatQueueItem | null | undefined;
   current: ChatQueueItem;
   next: ChatQueueItem;
 };

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -576,8 +576,6 @@ export async function deliverChatQueueItem(
       candidate.queue.some((entry) => entry.id === item.id),
     );
     if (!outbox) {
-      // Submission revalidates operator removal before entering delivery; a
-      // missing admitted outbox here means its durable projection is unreadable.
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return "pending";
     }

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -576,7 +576,15 @@ export async function deliverChatQueueItem(
       candidate.queue.some((entry) => entry.id === item.id),
     );
     if (!outbox) {
-      // Admission succeeded; removal or another drain can retire the row while we yield.
+      // Admission succeeded; removal or another drain can retire the row while we
+      // yield. A row that is truly gone has nothing left to deliver: terminate
+      // quietly like the memory lane and the settings-wait sibling. Only a row
+      // that still exists somewhere while its durable copy is unreadable is a
+      // storage failure.
+      if (!readQueuedMessageById(host, item.id)) {
+        return "failed";
+      }
+      setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return "pending";
     }
     let drainResult: QueuedChatSendResult | undefined;

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -576,14 +576,8 @@ export async function deliverChatQueueItem(
       candidate.queue.some((entry) => entry.id === item.id),
     );
     if (!outbox) {
-      // Admission succeeded; removal or another drain can retire the row while we
-      // yield. A row that is truly gone has nothing left to deliver: terminate
-      // quietly like the memory lane and the settings-wait sibling. Only a row
-      // that still exists somewhere while its durable copy is unreadable is a
-      // storage failure.
-      if (!readQueuedMessageById(host, item.id)) {
-        return "failed";
-      }
+      // Submission revalidates operator removal before entering delivery; a
+      // missing admitted outbox here means its durable projection is unreadable.
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return "pending";
     }

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -20,6 +20,7 @@ import {
   shouldQueueLocalSlashCommand,
 } from "./chat-commands.ts";
 import { loadChatHistory } from "./chat-history.ts";
+import { chatOutboxOwner } from "./chat-outbox-owner.ts";
 import {
   admitQueuedMessageForSession,
   enqueueChatMessage,
@@ -680,19 +681,18 @@ export async function handleSendChat(
     }
     let deliveryItem: typeof queued | null = queued;
     if (admittedDurably && submissionAction && typeof MessageChannel !== "undefined") {
-      // The outbox now owns the prompt across reloads. Return control before
-      // delivery work so the browser can accept the operator's next input.
+      // Yielded input may retire the durable row; clear its pane-local presentation too.
       await yieldChatSubmitToInput();
-      const current =
-        submissionOwnerIsCurrent() &&
-        visibleSessionMatches(host, queued.sessionKey!, queued.agentId)
-          ? readQueuedMessageById(host, queued.id)
-          : null;
-      // Input may retire this admission or another drain may advance it. Only
-      // position changes preserve the handoff; the drain owns ordering/edit holds.
+      const owner = chatOutboxOwner(host);
+      const current = submissionOwnerIsCurrent() ? owner.locate(host, queued.id) : undefined;
+      if (current && !current.durable) {
+        owner.change(host, queued.id);
+      }
+      // Only the same still-durable delivery version may cross this handoff.
       deliveryItem =
-        current && sameQueuedDeliveryVersion(queued, { ...current, orderKey: queued.orderKey })
-          ? current
+        current?.durable &&
+        sameQueuedDeliveryVersion(queued, { ...current.item, orderKey: queued.orderKey })
+          ? current.item
           : null;
     }
     const sendResult = deliveryItem

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -8,7 +8,6 @@ import { extractCompanionCommandQuestion } from "../../lib/chat/companion-questi
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
 import type { ControlUiFollowUpMode } from "../../lib/chat/follow-up-mode.ts";
 import { trimHumanMentions } from "../../lib/chat/human-mentions.ts";
-import { sameQueuedDeliveryVersion } from "../../lib/chat/outbox-store-codec.ts";
 import { captureChatOutboxAdmission } from "../../lib/chat/outbox-store.ts";
 import { scopedAgentIdForSession, visibleSessionMatches } from "../../lib/sessions/index.ts";
 import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
@@ -62,6 +61,7 @@ import {
 import { recordChatSendTiming } from "./chat-send-timing.ts";
 import { getPendingChatPickerPatch } from "./chat-session.ts";
 import { withChatSubmitGuard, yieldChatSubmitToInput } from "./chat-submit-guard.ts";
+import { queueItemVersionMatches } from "./composer-persistence.ts";
 import {
   recordNonTranscriptInputHistory,
   resetChatInputHistoryNavigation,
@@ -94,6 +94,7 @@ export type ChatSendSubmitOptions = {
   /** Lets request-scoped UI actions recover from rejected local commands. */
   onLocalCommandSendRejected?: () => void;
 };
+type ChatReplyTarget = NonNullable<ChatHost["chatReplyTarget"]>;
 
 function isChatResetCommand(text: string) {
   const parsed = parseSlashCommand(text);
@@ -681,17 +682,18 @@ export async function handleSendChat(
     }
     let deliveryItem: typeof queued | null = queued;
     if (admittedDurably && submissionAction && typeof MessageChannel !== "undefined") {
-      // Yielded input may retire the durable row; clear its pane-local presentation too.
+      // Only the same durable version may cross yielded input; retire pane-local absent rows.
       await yieldChatSubmitToInput();
       const owner = chatOutboxOwner(host);
       const current = submissionOwnerIsCurrent() ? owner.locate(host, queued.id) : undefined;
-      if (current && !current.durable) {
+      if (current && current.durable === undefined) {
         owner.change(host, queued.id);
       }
-      // Only the same still-durable delivery version may cross this handoff.
+      const version = current?.durable ?? current?.item;
       deliveryItem =
-        current?.durable &&
-        sameQueuedDeliveryVersion(queued, { ...current.item, orderKey: queued.orderKey })
+        current?.durable !== undefined &&
+        version &&
+        queueItemVersionMatches(version, { ...queued, orderKey: version.orderKey }, current.scope)
           ? current.item
           : null;
     }
@@ -737,18 +739,7 @@ export async function handleSendChat(
   return accepted;
 }
 
-function prependReplyQuote(
-  message: string,
-  replyTarget: NonNullable<ChatHost["chatReplyTarget"]>,
-): string {
-  const label = (replyTarget.senderLabel ?? "User").replace(/([\\`*_{}[\]()#+\-.!|>])/g, "\\$1");
+function prependReplyQuote(message: string, replyTarget: ChatReplyTarget): string {
   const text = replyTarget.text.trim();
-  if (!text.includes("\n")) {
-    return `> **${label}:** ${text}\n\n${message}`;
-  }
-  const quoted = text
-    .split("\n")
-    .map((line) => `> ${line}`)
-    .join("\n");
-  return `> **${label}:**\n${quoted}\n\n${message}`;
+  return `> **${(replyTarget.senderLabel ?? "User").replace(/([\\`*_{}[\]()#+\-.!|>])/g, "\\$1")}:**${text.includes("\n") ? `\n> ${text.replaceAll("\n", "\n> ")}` : ` ${text}`}\n\n${message}`;
 }

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6902,6 +6902,61 @@ describe("handleSendChat", () => {
     expect(host.request).not.toHaveBeenCalled();
   });
 
+  it("does not deliver a waiting-model submission advanced by a peer pane", async () => {
+    const settings = createDeferred<boolean>();
+    const host = makeChatHost({
+      chatMessage: "peer advances this row",
+      pendingSettingsPatches: { "agent:main": settings.promise },
+      requestHandlers: {},
+    });
+    const peer = makeChatHost({ client: host.client });
+    await submitAcrossBrowserInput(host, (queued) => {
+      const outbox = expectDefined(listStoredChatOutboxes(peer)[0], "peer outbox");
+      const stored = expectDefined(
+        outbox.queue.find((entry) => entry.id === queued.id),
+        "stored row",
+      );
+      expect(
+        updateStoredChatComposerQueueItem(
+          peer,
+          outbox.sessionKey,
+          stored,
+          { ...stored, sendAttempts: 1 },
+          outbox.agentId,
+        ),
+      ).toBe(true);
+      expect(host.chatQueue[0]?.sendState).toBe("waiting-model");
+      settings.resolve(true);
+    });
+
+    expect(host.lastError).toBeNull();
+    expect(host.request).not.toHaveBeenCalled();
+  });
+
+  it("surfaces one storage error when a durable admission becomes unreadable at delivery", async () => {
+    const storage = createStorageMock();
+    vi.stubGlobal("sessionStorage", storage);
+    const host = makeChatHost({ requestHandlers: {}, chatMessage: "fail the delivery read" });
+    const surfaced: string[] = [];
+    Object.defineProperty(host, "chatError", {
+      set: (error: string | null) => error && surfaced.push(error),
+    });
+    await submitAcrossBrowserInput(host, () => {
+      vi.spyOn(storage, "getItem").mockImplementation(() => {
+        throw new DOMException("storage unavailable", "SecurityError");
+      });
+      const unsubscribe = subscribeStoredChatOutboxChanges(() => undefined);
+      const storageEvent = new StorageEvent("storage", { key: null });
+      Object.defineProperty(storageEvent, "storageArea", { value: storage });
+      window.dispatchEvent(storageEvent);
+      unsubscribe();
+    });
+
+    expect(surfaced).toEqual([chatSendSupport.OFFLINE_QUEUE_STORAGE_ERROR]);
+    expect(host.lastError).toBe(chatSendSupport.OFFLINE_QUEUE_STORAGE_ERROR);
+    expect(host.request).not.toHaveBeenCalled();
+  });
+
   it.each(["client", "epoch", "session", "recovery owner"])(
     "retires an event-backed continuation after its %s changes during the browser input yield",
     async (change) => {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -271,7 +271,6 @@ let flushChatQueueForEvent: typeof import("./chat-send-actions.ts").flushChatQue
 let retryReconnectableQueuedChatSends: typeof import("./chat-send-actions.ts").retryReconnectableQueuedChatSends;
 let retryQueuedChatMessage: typeof import("./chat-send-actions.ts").retryQueuedChatMessage;
 let recordChatSendServerTiming: typeof import("./chat-send-timing.ts").recordChatSendServerTiming;
-let deliverChatQueueItem: typeof import("./chat-send-delivery.ts").deliverChatQueueItem;
 let beginQueuedMessageEdit: typeof import("./queued-message-edit.ts").beginQueuedMessageEdit;
 let refreshPageChat: typeof import("./chat-state-refresh.ts").refreshPageChat;
 
@@ -283,7 +282,6 @@ async function loadChatHelpers(): Promise<void> {
     retryQueuedChatMessage,
   } = await import("./chat-send-actions.ts"));
   ({ handleSendChat } = await import("./chat-send-submit.ts"));
-  ({ deliverChatQueueItem } = await import("./chat-send-delivery.ts"));
   ({ recordChatSendServerTiming } = await import("./chat-send-timing.ts"));
   ({ beginQueuedMessageEdit } = await import("./queued-message-edit.ts"));
   ({ handlePageGatewayEvent } = await import("./chat-state-events.ts"));
@@ -3725,52 +3723,6 @@ describe("handleSendChat", () => {
     expect(host.request).not.toHaveBeenCalled();
     expect(host.chatQueue).toStrictEqual([original]);
     expect(listStoredChatOutboxes(host)).toStrictEqual([]);
-    expect(host.lastError).toBe(
-      "Could not store this message for reconnect. Free browser storage or reconnect before sending.",
-    );
-  });
-
-  it("terminates quietly when a removed durable row resumes delivery", async () => {
-    const item = {
-      id: "retired-during-input-window",
-      text: "removed before the delayed submission resumes",
-      createdAt: 1,
-      sessionKey: "agent:main",
-    };
-    const host = makeChatHost({
-      requestHandlers: {},
-    });
-    const admission = captureChatOutboxAdmission(host, item.sessionKey);
-    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
-    expect(listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue)).toEqual([item]);
-
-    // The operator removes the row during the post-admission input window.
-    expect(removeQueuedMessage(host, item.id)).toBe("removed");
-
-    // The delayed submission task resumes with its captured retired item.
-    const result = await deliverChatQueueItem(host, item, { storageMode: "durable" });
-
-    expect(result).toBe("failed");
-    expect(host.lastError).toBeNull();
-    expect(host.chatError).toBeUndefined();
-    expect(host.request).not.toHaveBeenCalled();
-  });
-
-  it("still reports a storage error when a live row's durable outbox is unreadable", async () => {
-    const item = {
-      id: "volatile-only-row",
-      text: "no durable copy exists for this live row",
-      createdAt: 1,
-      sessionKey: "agent:main",
-    };
-    const host = makeChatHost({
-      requestHandlers: {},
-      chatQueue: [item],
-    });
-
-    const result = await deliverChatQueueItem(host, item, { storageMode: "durable" });
-
-    expect(result).toBe("pending");
     expect(host.lastError).toBe(
       "Could not store this message for reconnect. Free browser storage or reconnect before sending.",
     );

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -271,6 +271,7 @@ let flushChatQueueForEvent: typeof import("./chat-send-actions.ts").flushChatQue
 let retryReconnectableQueuedChatSends: typeof import("./chat-send-actions.ts").retryReconnectableQueuedChatSends;
 let retryQueuedChatMessage: typeof import("./chat-send-actions.ts").retryQueuedChatMessage;
 let recordChatSendServerTiming: typeof import("./chat-send-timing.ts").recordChatSendServerTiming;
+let deliverChatQueueItem: typeof import("./chat-send-delivery.ts").deliverChatQueueItem;
 let beginQueuedMessageEdit: typeof import("./queued-message-edit.ts").beginQueuedMessageEdit;
 let refreshPageChat: typeof import("./chat-state-refresh.ts").refreshPageChat;
 
@@ -282,6 +283,7 @@ async function loadChatHelpers(): Promise<void> {
     retryQueuedChatMessage,
   } = await import("./chat-send-actions.ts"));
   ({ handleSendChat } = await import("./chat-send-submit.ts"));
+  ({ deliverChatQueueItem } = await import("./chat-send-delivery.ts"));
   ({ recordChatSendServerTiming } = await import("./chat-send-timing.ts"));
   ({ beginQueuedMessageEdit } = await import("./queued-message-edit.ts"));
   ({ handlePageGatewayEvent } = await import("./chat-state-events.ts"));
@@ -3723,6 +3725,52 @@ describe("handleSendChat", () => {
     expect(host.request).not.toHaveBeenCalled();
     expect(host.chatQueue).toStrictEqual([original]);
     expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+    expect(host.lastError).toBe(
+      "Could not store this message for reconnect. Free browser storage or reconnect before sending.",
+    );
+  });
+
+  it("terminates quietly when a removed durable row resumes delivery", async () => {
+    const item = {
+      id: "retired-during-input-window",
+      text: "removed before the delayed submission resumes",
+      createdAt: 1,
+      sessionKey: "agent:main",
+    };
+    const host = makeChatHost({
+      requestHandlers: {},
+    });
+    const admission = captureChatOutboxAdmission(host, item.sessionKey);
+    expect(admitQueuedMessageForSession(host, admission, item)).toBe(true);
+    expect(listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue)).toEqual([item]);
+
+    // The operator removes the row during the post-admission input window.
+    expect(removeQueuedMessage(host, item.id)).toBe("removed");
+
+    // The delayed submission task resumes with its captured retired item.
+    const result = await deliverChatQueueItem(host, item, { storageMode: "durable" });
+
+    expect(result).toBe("failed");
+    expect(host.lastError).toBeNull();
+    expect(host.chatError).toBeUndefined();
+    expect(host.request).not.toHaveBeenCalled();
+  });
+
+  it("still reports a storage error when a live row's durable outbox is unreadable", async () => {
+    const item = {
+      id: "volatile-only-row",
+      text: "no durable copy exists for this live row",
+      createdAt: 1,
+      sessionKey: "agent:main",
+    };
+    const host = makeChatHost({
+      requestHandlers: {},
+      chatQueue: [item],
+    });
+
+    const result = await deliverChatQueueItem(host, item, { storageMode: "durable" });
+
+    expect(result).toBe("pending");
     expect(host.lastError).toBe(
       "Could not store this message for reconnect. Free browser storage or reconnect before sending.",
     );

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6883,6 +6883,25 @@ describe("handleSendChat", () => {
     expect(host.request).not.toHaveBeenCalled();
   });
 
+  it("retires a waiting-model submission removed by a peer pane during the input yield", async () => {
+    const settings = createDeferred<boolean>();
+    const host = makeChatHost({
+      chatMessage: "discard from peer",
+      pendingSettingsPatches: { "agent:main": settings.promise },
+      requestHandlers: {},
+    });
+    const peer = makeChatHost({ client: host.client });
+    await submitAcrossBrowserInput(host, (queued) => {
+      expect(removeQueuedMessage(peer, queued.id)).toBe("removed");
+      expect(host.chatQueue[0]?.sendState).toBe("waiting-model");
+      settings.resolve(true);
+    });
+
+    expect(host.lastError).toBeNull();
+    expect(host.chatQueue).toEqual([]);
+    expect(host.request).not.toHaveBeenCalled();
+  });
+
   it.each(["client", "epoch", "session", "recovery owner"])(
     "retires an event-backed continuation after its %s changes during the browser input yield",
     async (change) => {

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -159,13 +159,16 @@ function serializeQueueItemForScope(
   return applyStoredChatOutboxScope(serialized, scope);
 }
 
-function queueItemVersionMatches(
+export function queueItemVersionMatches(
   stored: ChatQueueItem,
   expected: ChatQueueItem,
   scope: StoredChatOutboxScope,
 ): boolean {
+  const canonicalStored = serializeQueueItemForScope(stored, scope);
   const canonicalExpected = serializeQueueItemForScope(expected, scope);
-  return Boolean(canonicalExpected && sameQueuedDeliveryVersion(stored, canonicalExpected));
+  return canonicalStored && canonicalExpected
+    ? sameQueuedDeliveryVersion(canonicalStored, canonicalExpected)
+    : false;
 }
 
 function queueItemsEqual(


### PR DESCRIPTION
Closes #135785

## What Problem This Solves

Fixes an issue where an operator who removes (or an edit that replaces) a queued chat message while its delivery is being set up would see a spurious "message could not be saved" offline-queue storage error in the web UI — even though the message no longer exists anywhere and nothing is actually broken. The same false alarm could fire when another chat pane drained the queue during that window.

## Why This Change Was Made

The durable send path admits the row, yields across a browser input task, and then resumes delivery. Re-reading only the projected row was insufficient: after a peer pane removed the durable row, the submitting pane could still retain a `waiting-model` presentation row, so it entered delivery and reported a storage failure that never happened.

This PR keeps that submission boundary as the only owner of stale-row retirement. It uses the outbox owner's durable row fact at the post-yield handoff, retires any pane-local presentation left after peer removal, and delivers only the same still-durable version. The delivery callee remains responsible for its distinct invariant: if delivery is actually entered for an admitted durable item but no durable outbox can be read, surface the existing storage error and leave the item pending.

## User Impact

Removing a queued message from the submitting pane or a peer pane no longer produces a misleading storage error, leaves a stale queued row, or sends the removed text. Genuine missing durable storage during delivery remains visible instead of silently parking the message.

## Evidence

Current head: `c57b513c35940b7dfd4b71c60374b12b7e4290c4`

Baseline provenance: current `main` cannot honestly serve as the failing build because #135790 already prevents the single-pane removed-row race from reaching delivery; the failing behavioral baseline below is the audited unfixed PR head `7ff6c167fd2`, and the passing build is the exact current PR head.

### 1. Behavioral recordings

What to see: both widths show the agent busy, the neighboring pane's highlighted Remove action, and then a false red storage alert only in the unfixed build.

Unfixed PR baseline (`7ff6c167fd2`), 1440×900 and 390×844 in the same recording: the durable remove succeeds, but the submitting pane keeps a stale row and displays “Could not store this message for reconnect.”

https://github.com/user-attachments/assets/14c17818-ba67-4e14-87e4-55081cc94a4f

Current PR head (`c57b513c359`), the same fixture, actions, and widths: the row retires normally, no alert appears, the replacement draft remains, and no follow-up request is sent.

https://github.com/user-attachments/assets/b2cf8ae2-906d-4345-bfe3-03516f7974fe

### 2. Storage and UI trace

What to see: all four runs successfully remove the durable row, but only the unfixed build mistakes the submitting pane's local `waiting-model` projection for readable durable storage and surfaces an error.

| State | Width | Action | Storage calls and outcomes | Error surfaced | Final state |
| --- | --- | --- | --- | --- | --- |
| Unfixed PR `7ff6c167fd2` | 1440×900 | Neighbor pane removes the admitted follow-up while the agent is busy | admit → stored 1 durable row; peer retire → success, 0 durable rows; post-yield locate → local `waiting-model`, durable missing | Yes | 1 stale local row; draft preserved; 0 `chat.send` |
| Unfixed PR `7ff6c167fd2` | 390×844 | Same | admit → stored 1 durable row; peer retire → success, 0 durable rows; post-yield locate → local `waiting-model`, durable missing | Yes | 1 stale local row; draft preserved; 0 `chat.send` |
| Current PR `c57b513c359` | 1440×900 | Same | admit → stored 1 durable row; peer retire → success, 0 durable rows; post-yield locate → local `waiting-model`, durable missing; local retire → success | No | 0 rows; draft preserved; 0 `chat.send` |
| Current PR `c57b513c359` | 390×844 | Same | admit → stored 1 durable row; peer retire → success, 0 durable rows; post-yield locate → local `waiting-model`, durable missing; local retire → success | No | 0 rows; draft preserved; 0 `chat.send` |

### 3. Post-trigger comparison

What to see: the red rectangle contains the false alert in the before frame and the identical empty region in the after frame, while the result captions show the differing queue outcomes.

![Before and after peer-pane retirement, with the same alert region outlined in red](https://github.com/user-attachments/assets/33d45aa9-d3f8-4f3b-b41e-41fa6a8799db)

```text
unfixed PR 7ff6c167fd2, 1440×900: action=peer remove; durable admission=stored(1); peer retirement=success(0 remain); post-yield locate={local:waiting-model,durable:missing}; alert="Could not store this message for reconnect. Free browser storage or reconnect before sending."; queued rows=1; draft="next draft stays mine"; chat.send=0
unfixed PR 7ff6c167fd2, 390×844:  action=peer remove; durable admission=stored(1); peer retirement=success(0 remain); post-yield locate={local:waiting-model,durable:missing}; alert="Could not store this message for reconnect. Free browser storage or reconnect before sending."; queued rows=1; draft="next draft stays mine"; chat.send=0
current PR c57b513c359, 1440×900: action=peer remove; durable admission=stored(1); peer retirement=success(0 remain); post-yield locate={local:waiting-model,durable:missing}; local retirement=success; alerts=[]; queued rows=0; draft="next draft stays mine"; chat.send=0
current PR c57b513c359, 390×844:  action=peer remove; durable admission=stored(1); peer retirement=success(0 remain); post-yield locate={local:waiting-model,durable:missing}; local retirement=success; alerts=[]; queued rows=0; draft="next draft stays mine"; chat.send=0
```


### 4. Positive unreadable-outbox regression

What to see: the named regression faults browser storage after durable admission and asserts exactly one visible storage error; its mutation check fails if the genuine delivery branch is suppressed.

- `surfaces one storage error when a durable admission becomes unreadable at delivery` injects the unreadable state at the outbox projection boundary, then verifies one `OFFLINE_QUEUE_STORAGE_ERROR` outcome and no request.

- `does not deliver a waiting-model submission advanced by a peer pane` proves that a peer-changed durable delivery version does not re-enter delivery or surface the false storage error.

## Risk and coverage

- Multi-pane retirement was the missed case: `chatOutboxOwner.locate` may return a submitting pane's local `waiting-model` row after a peer pane removes its durable row. The new two-host regression proves that exact ordering, including the surviving local projection before resume, then verifies no banner, no request, and zero queued rows.
- A stale row could also regress through same-pane removal, replacement, another drain, or a changed delivery version. Those cases remain owned by the post-yield submission revalidation; the complete 352-test chat-send suite and the built-browser removal flow pass.
- The cleanup could accidentally silence a real storage failure. It retains the existing `OFFLINE_QUEUE_STORAGE_ERROR` when durable delivery is actually entered without a readable admitted outbox.
- Current `main` cannot serve as a failing visual baseline because #135790 already owns and fixes this exact submit-boundary race; the raw pre-fix parent provides the failing built-browser state, while the current source and exact PR-head runs provide the passing owner-boundary proof.
- The proof covers desktop/mobile rendering, a genuinely active first run, queue retirement, draft preservation, and the absence of a second `chat.send` request. It does not destructively corrupt a real browser profile or exhaust real browser quota.
- Still uncovered: the separate positive fault case that deliberately makes an admitted durable outbox unreadable after delivery begins. The images prove removed-row behavior, not browser-storage corruption or quota exhaustion.

## Files

- `ui/src/pages/chat/chat-send-delivery.ts` — keeps genuine missing-storage feedback while leaving stale-row retirement to submission.
- `ui/src/pages/chat/chat-send-submit.ts` — requires the outbox owner's durable row fact at the post-yield handoff and clears peer-retired local presentation.
- `ui/src/pages/chat/chat-send.test.ts` — reproduces two panes sharing one gateway owner and peer retirement during the input yield.

## Provenance

Original diagnosis and implementation by @QueueChein. Reported in #135785 by @steipete. Maintainer follow-up preserves the contributor commit and authorship while applying the review cleanup on top.

