### PR TITLE
ci: keep split test families in separate jobs

### DIFF
--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -756,22 +756,22 @@ function estimateCompactStripeSeconds(
     : blacksmithSeconds;
 }
 
-// Equal-weight sibling stripes can otherwise land in one bin and recreate the
-// indivisible critical-path floor that striping removes.
-function compactGiantStripeFamily(group: NodeTestShardGroup): string | undefined {
-  if (/^agentic-commands-doctor-sessions-cron(?:-(?:memory|sqlite))?$/u.test(group.shard_name)) {
+// Split siblings must stay in different jobs, including nested children of
+// deliberately separated fixed stripes.
+function compactStripeFamily(group: NodeTestShardGroup): string | undefined {
+  if (
+    /^agentic-commands-doctor-sessions-cron(?:-(?:memory|sqlite))?(?:-hosted-\d+)?$/u.test(
+      group.shard_name,
+    )
+  ) {
     return "agentic-commands-doctor-sessions-cron";
   }
-  const membershipTimedParent =
-    /^(agentic-agents-support|agentic-control-plane-agent-chat)-hosted-\d+$/u.exec(
+  return (
+    /^(agentic-agents-embedded-base|agentic-gateway-core|core-runtime-media-ui|core-unit-src-security)-\d+(?:-hosted-\d+)?$/u.exec(
       group.shard_name,
-    )?.[1];
-  if (membershipTimedParent) {
-    return membershipTimedParent;
-  }
-  return /^(agentic-agents-embedded-base|agentic-gateway-core|core-runtime-media-ui|core-unit-src-security)-\d+$/u.exec(
-    group.shard_name,
-  )?.[1];
+    )?.[1] ??
+    (group.timing_key ? parseCompactSplitTimingKey(group.timing_key)?.selectorKey : undefined)
+  );
 }
 
 function expandCompactGroup(group: NodeTestShardGroup): NodeTestShardGroup[] {
@@ -2618,11 +2618,11 @@ function createCompactNodeTestShardBundles(
           : group.runner.includes("-8vcpu-")
             ? COMPACT_LARGE_NODE_TEST_JOB_SECONDS
             : COMPACT_SMALL_NODE_TEST_JOB_SECONDS;
-      const family = compactGiantStripeFamily(group);
+      const family = compactStripeFamily(group);
       return (
         isExclusiveCompactGroup(candidate[0]) === exclusive &&
         (family === undefined ||
-          candidate.every((entry) => compactGiantStripeFamily(entry) !== family)) &&
+          candidate.every((entry) => compactStripeFamily(entry) !== family)) &&
         candidate.length < COMPACT_NODE_TEST_JOB_GROUPS &&
         estimateBinSeconds([...candidate, group]) <= secondsCap
       );

--- a/scripts/lib/vitest-shard-metadata.mts
+++ b/scripts/lib/vitest-shard-metadata.mts
@@ -107,8 +107,8 @@ export function resolveShardTimingKey(spec: VitestShardTimingSpec): string {
   )}`;
 }
 
-// Advisory per-file wall-clock hints (seconds) for stripe balancing, measured
-// from single-file local runs (M4 Max) and static import-graph size. Packing
+// Advisory per-file cost hints (seconds) for stripe balancing, from file walls,
+// serial case costs, and static import-graph size. Packing
 // only: a stale entry skews stripe balance but never correctness. Unlisted
 // files use the default, which mostly reflects the per-file module-graph
 // re-evaluation cost that dominates these serial suites.
@@ -117,7 +117,6 @@ const STRIPE_FILE_SECONDS_HINTS = new Map<string, number>([
   // Runtime prerequisites are charged once per batch, separately from test work.
   ["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts", 6],
   ["test/scripts/plugin-release-git-lifecycle.test.ts", 35],
-  ["test/scripts/vitest-report-owner.test.ts", 71],
   ["test/scripts/pr-main-refresh.test.ts", 30],
   ["test/plugin-npm-package-manifest.test.ts", 26],
   ["test/scripts/ci-node-test-plan.test.ts", 24],
@@ -223,7 +222,12 @@ const STRIPE_FILE_SECONDS_HINTS = new Map<string, number>([
   // spans; canonical push plans omit this tooling workload.
   ["test/scripts/openclaw-performance-git-lifecycle.test.ts", 136],
   ["test/scripts/ci-linux-git.test.ts", 204],
-  ["test/scripts/pr-merge-outcome.test.ts", 159],
+  // Historical single-file wall from PR run 33576929814; this file has since grown.
+  ["test/scripts/pr-merge-outcome.test.ts", 206],
+  // Relative serial case costs from PR runs 33571672257/33576929814.
+  // These mixed invocations do not report complete file walls.
+  ["test/scripts/vitest-report-owner.test.ts", 203],
+  ["test/scripts/write-plugin-sdk-entry-dts.test.ts", 74],
   ["test/scripts/ci-workflow-guards.test.ts", 38],
   ["test/scripts/crabbox-wrapper.test.ts", 19],
   ["test/scripts/find-reusable-release-validation.test.ts", 8],

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -820,6 +820,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       compact.findIndex((shard) => shard.groups.some((group) => group.shard_name === name));
     expect(jobOf("agentic-agents-core-runner-embedded")).toBeGreaterThanOrEqual(0);
     for (const prefix of [
+      "agentic-agents-embedded-base",
       "agentic-gateway-core",
       "core-runtime-media-ui",
       "core-unit-src-security",
@@ -928,6 +929,10 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         if (groups.length === 0) {
           continue;
         }
+        const jobs = groups.map((group) => plan.findIndex((shard) => shard.groups.includes(group)));
+        expect(new Set(jobs).size, `${owner.shardName}: split children stay separate`).toBe(
+          groups.length,
+        );
         const actual = groups.flatMap((group) => group.includePatterns ?? []);
         expect(new Set(actual).size, owner.shardName).toBe(actual.length);
         if (owner.includePatterns) {
@@ -1198,8 +1203,9 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       "agentic-commands-doctor-sessions-cron-memory",
       "agentic-commands-doctor-sessions-cron-sqlite",
     ];
-    const commandShards = createNodeTestShards({ includeReleaseOnlyPluginShards: false }).filter(
-      (shard) => shard.configs.includes("test/vitest/vitest.commands.config.ts"),
+    const base = createNodeTestShards({ includeReleaseOnlyPluginShards: false });
+    const commandShards = base.filter((shard) =>
+      shard.configs.includes("test/vitest/vitest.commands.config.ts"),
     );
     const owners = new Map(
       commandShards
@@ -1253,6 +1259,69 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
           .filter((group) => ownerNames.includes(group.shard_name))
           .every((group) => group.runner === DEFAULT_NODE_TEST_RUNNER),
       ).toBe(true);
+    }
+
+    const families = [ownerNames, [1, 2, 3].map((part) => `agentic-gateway-core-${part}`)];
+    const fixtureConfigs = new Set(
+      base
+        .filter((shard) => families.some((family) => family.includes(shard.shardName)))
+        .flatMap((shard) => shard.configs),
+    );
+    const originalShards = fullSuiteVitestShards.slice();
+    const fixtureShards = originalShards
+      .map((shard) => ({
+        ...shard,
+        projects: shard.projects.filter((config) => fixtureConfigs.has(config)),
+      }))
+      .filter((shard) => shard.projects.length > 0);
+    fullSuiteVitestShards.splice(0, fullSuiteVitestShards.length, ...fixtureShards);
+    try {
+      // Affordable descendants must also stay apart from their unsplit ancestors'
+      // siblings: an immediate-selector-only rule loses the Doctor/giant boundary.
+      const fixtureTimings = Object.fromEntries(
+        base
+          .filter((shard) => shard.configs.some((config) => fixtureConfigs.has(config)))
+          .map((shard) => [shard.shardName, 1]),
+      );
+      vi.spyOn(testTimings, "readCompactGroupTimings").mockImplementation((profile) => ({
+        ...fixtureTimings,
+        ...Object.fromEntries(
+          families.flatMap((family) =>
+            family.map((name, index) => [
+              name,
+              index === 0 ? (profile === "github" ? 400 : 100) : 10,
+            ]),
+          ),
+        ),
+      }));
+      const nestedPlan = createNodeTestShardBundles({
+        compactMode: "pull-request",
+        includeReleaseOnlyPluginShards: false,
+        runnerBackend: "hybrid",
+      });
+      for (const family of families) {
+        const placements = nestedPlan.flatMap((job, jobIndex) =>
+          job.groups
+            .filter((group) => family.includes(group.shard_name.replace(/-hosted-\d+$/u, "")))
+            .map((group) => ({ group, jobIndex })),
+        );
+        expect(
+          placements.filter(({ group }) => group.shard_name.startsWith(`${family[0]}-hosted-`)),
+        ).toHaveLength(3);
+        expect(new Set(placements.map(({ jobIndex }) => jobIndex)).size, family[0]).toBe(
+          placements.length,
+        );
+        for (const name of family) {
+          const actual = placements
+            .filter(({ group }) => group.shard_name.replace(/-hosted-\d+$/u, "") === name)
+            .flatMap(({ group }) => group.includePatterns ?? []);
+          expect(actual.toSorted(), name).toEqual(
+            base.find((shard) => shard.shardName === name)?.includePatterns?.toSorted(),
+          );
+        }
+      }
+    } finally {
+      fullSuiteVitestShards.splice(0, fullSuiteVitestShards.length, ...originalShards);
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Compact CI can split a long test group and then pack its children back into one serial job. The family rule recognized only two derived parents; other parents and nested children of deliberately separated fixed stripes lost that protection. In [run 33576929814](https://github.com/openclaw/openclaw/actions/runs/33576929814), two tooling jobs each spent about 289–294 seconds running split siblings consecutively, before counting checkout/setup.

## Why This Change Was Made

Use the existing complete-selector identity for every derived split, while preserving the stronger Doctor and fixed-stripe ancestry through nested splits. Remove the two-parent allowlist. Keep the shared packer, original test selection, serial execution, worker limits, deadlines and capacity caps.

Refresh three existing file-cost hints so costly files remain visible when tooling is rebalanced. Merge outcome uses 206 seconds from the preceding 204-case version's measured single-file wrapper; its current 238-case version still needs a new timing observation. Report owner and SDK writer use 203 and 74 as relative serial case costs from matching test sources, not complete file-wall measurements. The main-push timing collector intentionally omits tooling, so these PR observations remain advisory file hints rather than entering that collector.

## User Impact

Internal CI scheduling only. In the captured hybrid plan, merge outcome and report owner each occupy a single-file job and enter the first scheduling wave. The SDK writer is a single-file child paired with a different tooling family under the existing admission budget. Native CI will establish their actual wall times; this does not claim that the five-minute target is met.

Committed-profile core descriptor counts are:

| Backend | Push before → after | PR before → after | Existing cap |
| --- | --- | --- | --- |
| Blacksmith | 41 → 41 | 59 → 59 | 96 |
| GitHub | 81 → 81 | 109 → 111 | 112 |
| Hybrid | 74 → 74 | 93 → 96 | 96 |

The six absent-measurement plans also fit their existing caps. The unchanged 70-row plugin fallback from #135787 remains separate. Existing conservative registration bounds already account for the 96/112 core caps and 78-row fallback bound; no concurrency or capacity limit increases.

## Evidence

- Extended existing tests failed before the fix: a derived group had two children in one job; the nested Doctor family had five groups in two jobs. Both pass after the repair, with nested gateway ancestry and existing cheap-stripe behavior covered.
- All 148 cases passed across `ci-node-test-plan`, `ci-node-pretest-admission` and `ci-test-timings`, without skips. The full changed-file gate passed scripts/root-test typechecks, formatting, lint and applicable repository guards.
- All twelve before/after plans preserve the complete file/config/environment/dist execution multiset, whole-config descriptors and fixed-ancestor file assignments. No split-family collisions remain. Runtime prerequisites stay at four jobs on push and five on PR, with the same three private-QA fallback jobs.
- A strict comparison reported runner-label changes for smaller files entering or leaving the compiler fixture's group. That failed receipt is retained. A separate ownership audit verified every transfer against the unchanged compiler-capacity rule and recomputed group/job prerequisites through the canonical APIs. The compiler remains unique on the larger runner; no protected owner loses capacity. Incidental preparation footprints are recorded rather than claimed identical.
- Independent source review found no concrete P1/P2 issue. Configured Codex review was scoped-clean at P0.

Local owner proof used `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/ci-node-test-plan.test.ts test/scripts/ci-node-pretest-admission.test.ts test/scripts/ci-test-timings.test.ts` with two workers. Changed checks used `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- scripts/lib/ci-node-test-plan.mts scripts/lib/vitest-shard-metadata.mts test/scripts/ci-node-test-plan.test.ts`.

Runtime production delta: 0. CI/tooling: +23/-19; tests: +71/-2. The planner itself is line-neutral; the four net tooling lines add a missing measured file weight and document the evidence limits. No new dependency, configuration, runtime API, test-only production seam or test-coverage reduction.
