### PR TITLE
test(irc): observe socket and ingress completion events

### DIFF
--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -1,4 +1,6 @@
 // Irc tests cover client plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { withTimeout } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it } from "vitest";
 import { connectIrcClient } from "./client.js";
 import { onIrcTestLine, startIrcTestServer } from "./irc-server.test-support.js";
@@ -6,6 +8,7 @@ import { onIrcTestLine, startIrcTestServer } from "./irc-server.test-support.js"
 type LoopbackIrcServer = {
   port: number;
   lines: string[];
+  quitReceived: Promise<void>;
   close(): Promise<void>;
 };
 
@@ -13,6 +16,7 @@ type HangingIrcServer = {
   port: number;
   acceptedCount: number;
   closedCount: number;
+  socketClosed: Promise<void>;
   openSocketCount(): number;
   close(): Promise<void>;
 };
@@ -21,10 +25,14 @@ async function startLoopbackIrcServer(options?: {
   rejectInitialNick?: boolean;
 }): Promise<LoopbackIrcServer> {
   const lines: string[] = [];
+  const quitReceived = createDeferred<void>();
   const server = await startIrcTestServer((socket) => {
     let awaitingFallbackNick = false;
     onIrcTestLine(socket, (line) => {
       lines.push(line);
+      if (line.startsWith("QUIT :")) {
+        quitReceived.resolve();
+      }
       if (line.startsWith("USER ")) {
         if (options?.rejectInitialNick) {
           awaitingFallbackNick = true;
@@ -38,12 +46,11 @@ async function startLoopbackIrcServer(options?: {
       }
     });
   });
-  return { ...server, lines };
+  return { ...server, lines, quitReceived: quitReceived.promise };
 }
 
 async function connectAndCollectRegistration(params: {
   nickserv: NonNullable<Parameters<typeof connectIrcClient>[0]["nickserv"]>;
-  done: (lines: string[], errors: Error[]) => boolean;
 }): Promise<{ lines: string[]; errors: Error[] }> {
   const server = await startLoopbackIrcServer();
   const errors: Error[] = [];
@@ -59,10 +66,9 @@ async function connectAndCollectRegistration(params: {
       nickserv: params.nickserv,
       onError: (error) => errors.push(error),
     });
-    await waitForIrcCondition(
-      () => params.done(server.lines, errors),
-      "expected IRC registration outcome",
-    );
+    // QUIT follows all registration writes on the same stream; wait for peer receipt.
+    client.quit("test complete");
+    await withTimeout(server.quitReceived, 1000, "IRC registration output");
     return { lines: [...server.lines], errors };
   } finally {
     client?.close();
@@ -91,34 +97,21 @@ async function connectAfterNickCollision(nick: string): Promise<string> {
   }
 }
 
-async function waitForIrcCondition(
-  predicate: () => boolean,
-  message: string,
-  timeoutMs = 1000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() >= deadline) {
-      throw new Error(message);
-    }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 10);
-    });
-  }
-}
-
 async function startHangingIrcServer(): Promise<HangingIrcServer> {
   let acceptedCount = 0;
   let closedCount = 0;
+  const socketClosed = createDeferred<void>();
   const server = await startIrcTestServer((socket) => {
     acceptedCount += 1;
     socket.on("data", () => {});
     socket.on("close", () => {
       closedCount += 1;
+      socketClosed.resolve();
     });
   });
   return {
     ...server,
+    socketClosed: socketClosed.promise,
     get acceptedCount() {
       return acceptedCount;
     },
@@ -132,7 +125,6 @@ describe("irc client nickserv", () => {
   it("sends IDENTIFY when a password is configured", async () => {
     const result = await connectAndCollectRegistration({
       nickserv: { password: "secret" },
-      done: (lines) => lines.includes("PRIVMSG NickServ :IDENTIFY secret"),
     });
 
     expect(result.lines).toContain("PRIVMSG NickServ :IDENTIFY secret");
@@ -145,7 +137,6 @@ describe("irc client nickserv", () => {
         register: true,
         registerEmail: "bot@example.com",
       },
-      done: (lines) => lines.some((line) => line.startsWith("PRIVMSG NickServ :REGISTER ")),
     });
 
     expect(result.lines.filter((line) => line.startsWith("PRIVMSG NickServ :"))).toEqual([
@@ -160,7 +151,6 @@ describe("irc client nickserv", () => {
         password: "secret",
         register: true,
       },
-      done: (_lines, errors) => errors.length > 0,
     });
 
     expect(result.errors[0]?.message).toMatch(/registerEmail/);
@@ -172,7 +162,6 @@ describe("irc client nickserv", () => {
         service: "NickServ\n",
         password: "secret\r\nJOIN #bad",
       },
-      done: (lines) => lines.some((line) => line.startsWith("PRIVMSG NickServ :IDENTIFY")),
     });
 
     expect(result.lines).toContain("PRIVMSG NickServ :IDENTIFY secret JOIN #bad");
@@ -195,11 +184,10 @@ describe("irc client readiness timeout", () => {
         }),
       ).rejects.toThrow(/IRC connect/);
 
+      await withTimeout(server.socketClosed, 1000, "timed-out IRC socket close");
       expect(server.acceptedCount).toBeGreaterThanOrEqual(1);
-      await waitForIrcCondition(
-        () => server.closedCount >= 1 && server.openSocketCount() === 0,
-        `expected timed-out IRC connect socket to close; accepted=${server.acceptedCount} closed=${server.closedCount} open=${server.openSocketCount()}`,
-      );
+      expect(server.closedCount).toBeGreaterThanOrEqual(1);
+      expect(server.openSocketCount()).toBe(0);
     } finally {
       await server.close();
     }
@@ -250,22 +238,16 @@ async function collectPrivmsgBodies(
     connectTimeoutMs: 5000,
     messageChunkMaxChars,
   });
-  const receivedBodies = () =>
-    server.lines
-      .filter((line) => line.startsWith("PRIVMSG #general :"))
-      .map((line) => line.slice("PRIVMSG #general :".length));
   try {
     client.sendPrivmsg("#general", text);
-    const deadline = Date.now() + 5000;
-    while (receivedBodies().join("").length < text.length && Date.now() < deadline) {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10);
-      });
-    }
+    client.quit("test complete");
+    await withTimeout(server.quitReceived, 5000, "IRC PRIVMSG output");
+    return server.lines
+      .filter((line) => line.startsWith("PRIVMSG #general :"))
+      .map((line) => line.slice("PRIVMSG #general :".length));
   } finally {
     client.close();
   }
-  return receivedBodies();
 }
 
 const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -7,6 +7,8 @@ import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { withTimeout } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createIrcIngressMonitor } from "./irc-ingress.js";
 import { onIrcTestLine, startIrcTestServer } from "./irc-server.test-support.js";
@@ -18,18 +20,22 @@ type DisconnectingIrcServer = {
   port: number;
   lines: string[];
   connectionCount: number;
+  disconnectFirst(): void;
   close(): Promise<void>;
 };
 
 type InboundIrcServer = {
   port: number;
+  sendInbound(target: string, colonlessBody?: boolean, senderNick?: string): void;
   close(): Promise<void>;
 };
 
 type ReconnectingReplyIrcServer = {
   port: number;
   linesByConnection: string[][];
+  replacementQuitReceived: Promise<void>;
   connectionCount: number;
+  sendInbound(): void;
   disconnectFirst(): void;
   close(): Promise<void>;
 };
@@ -45,51 +51,52 @@ async function withIngressQueue<T>(fn: (queue: IrcIngressQueue) => Promise<T>): 
     accountId: "default",
     stateDir,
   });
+  const complete = queue.complete.bind(queue);
   try {
     return await fn(queue);
   } finally {
+    queue.complete = complete;
     closeOpenClawStateDatabaseForTest();
     await fs.rm(stateDir, { recursive: true, force: true });
   }
 }
 
-async function waitForIrcCondition(
-  predicate: () => boolean,
-  message: string,
-  timeoutMs = 3000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!predicate()) {
-    if (Date.now() >= deadline) {
-      throw new Error(message);
+function observeIngressCompletion(queue: IrcIngressQueue): Promise<string> {
+  const completed = createDeferred<string>();
+  const complete = queue.complete.bind(queue);
+  // An empty pending list also hides active claims; observe the real terminal write.
+  queue.complete = async (idOrClaim, ...args) => {
+    const result = await complete(idOrClaim, ...args);
+    if (result) {
+      completed.resolve(typeof idOrClaim === "string" ? idOrClaim : idOrClaim.id);
     }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 10);
-    });
-  }
+    return result;
+  };
+  return completed.promise;
 }
 
-async function waitForIrcAsyncCondition(
-  predicate: () => Promise<boolean>,
-  message: string,
-  timeoutMs = 3000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!(await predicate())) {
-    if (Date.now() >= deadline) {
-      throw new Error(message);
-    }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 10);
-    });
-  }
+function observeReconnect() {
+  const reconnected = createDeferred<void>();
+  let readyCount = 0;
+  const statusSink = vi.fn<NonNullable<Parameters<typeof monitorIrcProvider>[0]["statusSink"]>>(
+    (patch) => {
+      if (patch.lifecycle === "ready" && ++readyCount === 2) {
+        reconnected.resolve();
+      }
+    },
+  );
+  return { statusSink, reconnected: reconnected.promise };
 }
 
 async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
   const lines: string[] = [];
   let connectionCount = 0;
+  let firstSocket: net.Socket;
   const server = await startIrcTestServer((socket) => {
     const connectionNumber = ++connectionCount;
+    if (connectionNumber === 1) {
+      firstSocket = socket;
+    }
     onIrcTestLine(socket, (line) => {
       lines.push(line);
       if (line.startsWith("USER ")) {
@@ -98,68 +105,65 @@ async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
         } else {
           socket.write(":server 001 bot :welcome\r\n");
         }
-        if (connectionNumber === 1) {
-          setTimeout(() => socket.destroy(), 10);
-        }
       }
     });
   });
   return {
     ...server,
     lines,
+    disconnectFirst: () => firstSocket.destroy(),
     get connectionCount() {
       return connectionCount;
     },
   };
 }
 
-async function startInboundIrcServer(
-  target?: string,
-  welcomeNick = "bot",
-  colonlessBody = false,
-  senderNick = "alice",
-): Promise<InboundIrcServer> {
-  return await startIrcTestServer((socket) => {
+async function startInboundIrcServer(welcomeNick = "bot"): Promise<InboundIrcServer> {
+  let clientSocket: net.Socket;
+  const server = await startIrcTestServer((socket) => {
+    clientSocket = socket;
     onIrcTestLine(socket, (line) => {
       if (line.startsWith("USER ")) {
         socket.write(`:server 001 ${welcomeNick} :welcome\r\n`);
-        if (target) {
-          setTimeout(() => {
-            const bodySeparator = colonlessBody ? " " : " :";
-            socket.write(
-              `:${senderNick}!ident@example.org PRIVMSG ${target}${bodySeparator}hello\r\n`,
-            );
-          }, 20);
-        }
       }
     });
   });
+  return {
+    ...server,
+    sendInbound: (target, colonlessBody = false, senderNick = "alice") => {
+      const bodySeparator = colonlessBody ? " " : " :";
+      clientSocket.write(
+        `:${senderNick}!ident@example.org PRIVMSG ${target}${bodySeparator}hello\r\n`,
+      );
+    },
+  };
 }
 
 async function startReconnectingReplyIrcServer(): Promise<ReconnectingReplyIrcServer> {
   // Retain closed sockets in order so reconnect assertions keep their original connection index.
   const sockets: net.Socket[] = [];
   const linesByConnection: string[][] = [];
+  const replacementQuitReceived = createDeferred<void>();
   const server = await startIrcTestServer((socket) => {
     const connectionIndex = sockets.length;
     sockets.push(socket);
     linesByConnection[connectionIndex] = [];
     onIrcTestLine(socket, (line) => {
       linesByConnection[connectionIndex]?.push(line);
+      if (connectionIndex === 1 && line.startsWith("QUIT :")) {
+        replacementQuitReceived.resolve();
+      }
       if (line.startsWith("USER ")) {
         const nick = connectionIndex === 0 ? "receipt-bot" : "reconnected-bot";
         socket.write(`:server 001 ${nick} :welcome\r\n`);
-        if (connectionIndex === 0) {
-          setTimeout(() => {
-            socket.write(":alice!ident@example.org PRIVMSG receipt-bot :hello\r\n");
-          }, 20);
-        }
       }
     });
   });
   return {
     ...server,
     linesByConnection,
+    replacementQuitReceived: replacementQuitReceived.promise,
+    sendInbound: () => sockets[0]!.write(":alice!ident@example.org PRIVMSG receipt-bot :hello\r\n"),
     get connectionCount() {
       return sockets.length;
     },
@@ -254,7 +258,7 @@ describe("irc monitor reconnect", () => {
   it("reconnects when an established IRC socket closes", async () => {
     await withIngressQueue(async (ingressQueue) => {
       installMonitorRuntime();
-      const statusSink = vi.fn();
+      const { statusSink, reconnected } = observeReconnect();
       const server = await startDisconnectingIrcServer();
       const config = {
         channels: {
@@ -273,13 +277,11 @@ describe("irc monitor reconnect", () => {
 
       try {
         monitor = await monitorIrcProvider({ config, ingressQueue, statusSink });
-        await waitForIrcCondition(
-          () =>
-            server.connectionCount >= 3 &&
-            server.lines.filter((line) => line === "USER bot 0 * :OpenClaw").length >= 3 &&
-            statusSink.mock.calls.filter(([patch]) => patch.lifecycle).length >= 4,
-          "expected IRC monitor to recover after a failed reconnect attempt",
-        );
+        server.disconnectFirst();
+        await withTimeout(reconnected, 3000, "IRC recovery after a failed reconnect attempt");
+        expect(
+          server.lines.filter((line) => line === "USER bot 0 * :OpenClaw").length,
+        ).toBeGreaterThanOrEqual(3);
         expect(server.connectionCount).toBeGreaterThanOrEqual(3);
         expect(
           statusSink.mock.calls.flatMap(([patch]) =>
@@ -308,19 +310,16 @@ describe("irc monitor reconnect", () => {
 
   it("does not send a delayed private reply through the reconnected client", async () => {
     await withIngressQueue(async (ingressQueue) => {
-      let resolvePairing = (_result: { code: string; created: boolean }) => {};
-      let markPairingStarted = () => {};
-      const pairingStarted = new Promise<void>((resolve) => {
-        markPairingStarted = resolve;
-      });
-      const pairingResult = new Promise<{ code: string; created: boolean }>((resolve) => {
-        resolvePairing = resolve;
-      });
+      const pairingStarted = createDeferred<void>();
+      const pairingResult = createDeferred<{ code: string; created: boolean }>();
+      const completed = observeIngressCompletion(ingressQueue);
+      const { statusSink, reconnected } = observeReconnect();
       installPairingMonitorRuntime(async () => {
-        markPairingStarted();
-        return await pairingResult;
+        pairingStarted.resolve();
+        return await pairingResult.promise;
       });
       const server = await startReconnectingReplyIrcServer();
+      const enqueueSpy = vi.spyOn(ingressQueue, "enqueue");
       let monitor: { stop: () => Promise<void> } | undefined;
       try {
         monitor = await monitorIrcProvider({
@@ -338,20 +337,24 @@ describe("irc monitor reconnect", () => {
             },
           } as CoreConfig,
           ingressQueue,
+          statusSink,
         });
-        await pairingStarted;
+        server.sendInbound();
+        await withTimeout(pairingStarted.promise, 3000, "IRC pairing started");
         server.disconnectFirst();
-        await waitForIrcCondition(
-          () =>
-            server.connectionCount >= 2 &&
-            server.linesByConnection[1]?.some((line) => line.startsWith("USER ")) === true,
-          "expected IRC monitor to establish the replacement connection",
-        );
-        resolvePairing({ code: "CODE", created: true });
-        await waitForIrcAsyncCondition(
-          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
-          "expected the stale private reply to settle",
-        );
+        await withTimeout(reconnected, 3000, "IRC replacement connection ready");
+        expect(server.connectionCount).toBeGreaterThanOrEqual(2);
+        expect(server.linesByConnection[1]?.some((line) => line.startsWith("USER "))).toBe(true);
+        pairingResult.resolve({ code: "CODE", created: true });
+        const completedId = await withTimeout(completed, 3000, "stale private reply completion");
+        expect(enqueueSpy).toHaveBeenCalledOnce();
+        expect(completedId).toBe(enqueueSpy.mock.calls[0]?.[0]);
+        expect(await ingressQueue.listPending({ limit: "all" })).toEqual([]);
+        expect(await ingressQueue.listClaims()).toEqual([]);
+        // Let the delayed send finish before shutdown can suppress it.
+        // Peer-observed QUIT follows any reply bytes queued on the replacement socket.
+        await monitor.stop();
+        await withTimeout(server.replacementQuitReceived, 3000, "replacement IRC QUIT");
         expect(
           server.linesByConnection[0]?.some((line) => line.startsWith("PRIVMSG alice :")),
         ).toBe(false);
@@ -359,10 +362,11 @@ describe("irc monitor reconnect", () => {
           server.linesByConnection[1]?.some((line) => line.startsWith("PRIVMSG alice :")),
         ).toBe(false);
       } finally {
-        resolvePairing({ code: "CODE", created: true });
+        pairingResult.resolve({ code: "CODE", created: true });
         if (monitor) {
           await monitor.stop();
         }
+        enqueueSpy.mockRestore();
         await server.close();
       }
     });
@@ -392,8 +396,9 @@ describe("irc monitor inbound target", () => {
     async ({ serverTarget, colonlessBody, expected }) => {
       await withIngressQueue(async (ingressQueue) => {
         installMonitorRuntime();
-        const server = await startInboundIrcServer(serverTarget, "bot", colonlessBody);
+        const server = await startInboundIrcServer();
         const messages: IrcInboundMessage[] = [];
+        const completed = observeIngressCompletion(ingressQueue);
         let monitor: { stop: () => Promise<void> } | undefined;
         try {
           monitor = await monitorIrcProvider({
@@ -414,11 +419,11 @@ describe("irc monitor inbound target", () => {
               messages.push(message);
             },
           });
-          await waitForIrcCondition(
-            () => messages.length === 1,
-            "expected one inbound IRC message",
-          );
+          server.sendInbound(serverTarget, colonlessBody);
+          const completedId = await withTimeout(completed, 3000, "inbound IRC message completion");
+          expect(messages).toHaveLength(1);
           expect(messages[0]).toMatchObject({
+            messageId: completedId,
             ...expected,
             senderNick: "alice",
             text: "hello",
@@ -450,8 +455,9 @@ describe("irc monitor inbound target", () => {
         },
         { receivedAt, laneKey: "channel:#openclaw" },
       );
-      const server = await startInboundIrcServer(undefined, "reconnected-bot");
+      const server = await startInboundIrcServer("reconnected-bot");
       const onMessage = vi.fn();
+      const completed = observeIngressCompletion(ingressQueue);
       let monitor: { stop: () => Promise<void> } | undefined;
       try {
         monitor = await monitorIrcProvider({
@@ -470,10 +476,9 @@ describe("irc monitor inbound target", () => {
           ingressQueue,
           onMessage,
         });
-        await waitForIrcAsyncCondition(
-          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
-          "expected the replayed self echo to settle",
-        );
+        expect(await withTimeout(completed, 3000, "replayed self echo completion")).toBe(eventId);
+        expect(await ingressQueue.listPending({ limit: "all" })).toEqual([]);
+        expect(await ingressQueue.listClaims()).toEqual([]);
         expect(onMessage).not.toHaveBeenCalled();
       } finally {
         if (monitor) {
@@ -501,8 +506,9 @@ describe("irc monitor inbound target", () => {
         },
         { receivedAt, laneKey: "direct:alice" },
       );
-      const server = await startInboundIrcServer(undefined, "receipt-bot");
+      const server = await startInboundIrcServer("receipt-bot");
       const onMessage = vi.fn();
+      const completed = observeIngressCompletion(ingressQueue);
       let monitor: { stop: () => Promise<void> } | undefined;
       try {
         monitor = await monitorIrcProvider({
@@ -521,10 +527,9 @@ describe("irc monitor inbound target", () => {
           ingressQueue,
           onMessage,
         });
-        await waitForIrcAsyncCondition(
-          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
-          "expected the replayed DM to settle",
-        );
+        expect(await withTimeout(completed, 3000, "replayed DM completion")).toBe(eventId);
+        expect(await ingressQueue.listPending({ limit: "all" })).toEqual([]);
+        expect(await ingressQueue.listClaims()).toEqual([]);
         expect(onMessage).not.toHaveBeenCalled();
       } finally {
         if (monitor) {
@@ -538,9 +543,10 @@ describe("irc monitor inbound target", () => {
   it("does not record receipt-time self echoes as inbound activity", async () => {
     await withIngressQueue(async (ingressQueue) => {
       const activityRecord = installMonitorRuntime();
+      const server = await startInboundIrcServer();
       const enqueueSpy = vi.spyOn(ingressQueue, "enqueue");
-      const server = await startInboundIrcServer("#openclaw", "bot", false, "bot");
       const onMessage = vi.fn();
+      const completed = observeIngressCompletion(ingressQueue);
       let monitor: { stop: () => Promise<void> } | undefined;
       try {
         monitor = await monitorIrcProvider({
@@ -559,21 +565,21 @@ describe("irc monitor inbound target", () => {
           ingressQueue,
           onMessage,
         });
-        await waitForIrcCondition(
-          () => enqueueSpy.mock.calls.length === 1,
-          "expected the receipt-time self echo to enter ingress",
-        );
+        server.sendInbound("#openclaw", false, "bot");
+        const completedId = await withTimeout(completed, 3000, "receipt-time self echo completion");
+        expect(enqueueSpy).toHaveBeenCalledOnce();
         await enqueueSpy.mock.results[0]?.value;
-        await waitForIrcAsyncCondition(
-          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
-          "expected the receipt-time self echo to settle",
-        );
+        expect(completedId).toBe(enqueueSpy.mock.calls[0]?.[0]);
+        expect(await ingressQueue.listPending({ limit: "all" })).toEqual([]);
+        expect(await ingressQueue.listClaims()).toEqual([]);
+        await monitor.stop();
         expect(onMessage).not.toHaveBeenCalled();
         expect(activityRecord).not.toHaveBeenCalled();
       } finally {
         if (monitor) {
           await monitor.stop();
         }
+        enqueueSpy.mockRestore();
         await server.close();
       }
     });


### PR DESCRIPTION
IRC socket tests used repeated 10/20-ms timers to guess when registration, inbound dispatch and reconnection had finished. More seriously, the delayed-private-reply test treated an empty pending queue as completion even though the row could still be claimed. Its cleanup could then stop the client before the missing connection guard became observable.

Use the existing deferred/timeout helpers to observe real socket closure, peer-received QUIT, ready lifecycle events and successful queue completion. The queue observer calls the real method with the same arguments and resolves only after a successful terminal write. It does not replace SQLite behavior. Release the held pairing result and await that write before stopping; peer QUIT then bounds all preceding reply bytes on the same TCP stream. Retain all existing negative reply, routing, nickname and byte-limit assertions, with exact event-ID and empty-claim checks where completion matters.

Private canonical proof passes 33/33 before and after. Deleting only the three-line send-time connection guard makes the old delayed-reply case falsely pass; the improved case fails its retained no-PRIVMSG assertion after observing the forbidden reply on the replacement socket. Native events show real queue completion, then that reply, then QUIT. All 52 listeners, 60 peers and 38 state roots from the four runs were cleaned. Per-file case order is preserved; cross-file scheduling differed, and no matched whole-suite order or walltime ratio is claimed. The actual 50-ms registration deadline and 1000-ms reconnect delays remain unchanged.

The current checkout passes all 33 cases. Complete manual review covers client, monitor, inbound, queue/drain/settlement, SDK helpers, sibling tests, dependency contracts, original connection-guard history and raw fault evidence. Current-main drift only changes canonical outer-runner resource ownership and an unrelated legacy cron migration; the IRC owners remain unchanged. Test diff +134/-146; application production and schema delta zero. No new test seam or dependency is introduced.

All changed-file checks passed except an unbound-method lint report on the saved teardown method. Bind that saved function to its original queue before restoring it; final monitor 9/9 and targeted lint pass, with Codex review clean again. Existing helper/dependency source was inspected directly. Historical and current local runs use installed fs-safe 0.5.6 while the lockfile specifies 0.7.0; exact-head frozen CI remains the dependency validation gate. No Windows/Linux or arbitrary escaped-work cleanup claim is made.
