### PR TITLE
refactor(gateway): remove unused node subscription methods

### DIFF
--- a/src/gateway/server-node-subscriptions.ts
+++ b/src/gateway/server-node-subscriptions.ts
@@ -11,8 +11,6 @@ type NodeSendEventFn = (opts: {
   payloadJSON?: SerializedEventPayload | null;
 }) => void | Promise<unknown>;
 
-type NodeListConnectedFn = () => Array<{ nodeId: string; pairingGeneration?: string }>;
-
 type NodeSubscriptionManager = {
   subscribe: (nodeId: string, pairingGeneration: string, sessionKey: string) => void;
   unsubscribe: (nodeId: string, pairingGeneration: string, sessionKey: string) => void;
@@ -34,13 +32,6 @@ type NodeSubscriptionManager = {
     payload: unknown,
     sendEvent?: NodeSendEventFn | null,
   ) => Promise<void>;
-  sendToAllConnected: (
-    event: string,
-    payload: unknown,
-    listConnected?: NodeListConnectedFn | null,
-    sendEvent?: NodeSendEventFn | null,
-  ) => Promise<void>;
-  clear: () => void;
 };
 
 /** Manages node subscriptions to gateway session events. */
@@ -230,39 +221,6 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     );
   };
 
-  const sendToAllConnected = async (
-    event: string,
-    payload: unknown,
-    listConnected?: NodeListConnectedFn | null,
-    sendEvent?: NodeSendEventFn | null,
-  ) => {
-    if (!sendEvent || !listConnected) {
-      return;
-    }
-    const payloadJSON = toPayloadJSON(payload);
-    if (payloadJSON === undefined) {
-      return;
-    }
-    await settleFanout(
-      listConnected().map(
-        (node) => () =>
-          node.pairingGeneration
-            ? sendEvent({
-                nodeId: node.nodeId,
-                pairingGeneration: node.pairingGeneration,
-                event,
-                payloadJSON,
-              })
-            : undefined,
-      ),
-    );
-  };
-
-  const clear = () => {
-    nodeSubscriptions.clear();
-    sessionSubscribers.clear();
-  };
-
   return {
     subscribe,
     unsubscribe,
@@ -270,7 +228,5 @@ export function createNodeSubscriptionManager(): NodeSubscriptionManager {
     updatePairingGeneration,
     sendToSession,
     sendToAllSubscribed,
-    sendToAllConnected,
-    clear,
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

This maintainer-requested cleanup removes two unused private operations from the Gateway node subscription manager. Neither the connected-node fanout method nor the whole-manager clear operation has a current caller.

## Why This Change Was Made

Delete `sendToAllConnected`, `clear`, and their unused type declarations instead of keeping a second, unreachable fanout and cleanup path. The sole production caller keeps the manager private and uses only its six retained methods; their implementations are unchanged.

Session subscriptions still use the existing bidirectional indexes and generation-fenced NodeRegistry sender. Voice-wake fanout remains separate, including its authenticated generation-less path and operator broadcasts. No public SDK export, configuration, dependency, protocol, or persistence contract changes.

Production: **+0/-44 lines (net -44)**. Tests: **unchanged**.

## User Impact

No intended user-visible behavior change. Subscribe, reconnect, unsubscribe, session delivery, and voice-wake behavior retain their existing owners.

## Evidence

- The same **14 existing cases passed on both original and candidate source**: 4 subscription-manager cases, 8 node-session runtime cases, and 2 real Gateway/WebSocket subscription cases. The WebSocket cases cover reconnect, canonical session aliases, unsubscribe, and final/error delivery; agent dispatch is mocked, so this is not a live model or device test.
- All **28 normal configured changed checks passed** in the [candidate proof run](https://github.com/openclaw/openclaw/actions/runs/33578245366). This tested the frozen candidate, not a newly created PR head.
- One normal full build completed **all 16 stages**, including declaration generation, SDK export checks, and the UI build. All stages ran; no build phase was reported as cached or reused. The generated public SDK declarations contain none of the removed manager symbols.
- One managed Codex precommit review returned **scoped-clean at P0**, with no findings. The reviewer did not rerun the reported tests; this is not an all-priority correctness certificate.
- No new method-count or source-string tests were added for dead private code. Existing owner, sibling, and transport coverage remained unchanged.
