### PR TITLE
fix(plugins): load typed JSX channel state checkers

### DIFF
--- a/src/channels/plugins/module-loader.test.ts
+++ b/src/channels/plugins/module-loader.test.ts
@@ -27,14 +27,17 @@ function normalizeModuleLoaderTarget(target: string): string {
 }
 
 describe("channel plugin module loader helpers", () => {
-  it("resolves extensionless plugin module specifiers to the first existing extension", () => {
-    const rootDir = tempDirs.make("openclaw-channel-module-loader-");
-    const expectedPath = path.join(rootDir, "src", "checker.mts");
-    fs.mkdirSync(path.dirname(expectedPath), { recursive: true });
-    fs.writeFileSync(expectedPath, "export const ok = true;\n", "utf8");
+  it.each(["mts", "mtsx", "ctsx"])(
+    "resolves extensionless plugin module specifiers to %s",
+    (extension) => {
+      const rootDir = tempDirs.make("openclaw-channel-module-loader-");
+      const expectedPath = path.join(rootDir, "src", `checker.${extension}`);
+      fs.mkdirSync(path.dirname(expectedPath), { recursive: true });
+      fs.writeFileSync(expectedPath, "export const ok = true;\n", "utf8");
 
-    expect(resolveExistingPluginModulePath(rootDir, "./src/checker")).toBe(expectedPath);
-  });
+      expect(resolveExistingPluginModulePath(rootDir, "./src/checker")).toBe(expectedPath);
+    },
+  );
 
   it("preserves explicit JavaScript plugin module specifiers", () => {
     const rootDir = tempDirs.make("openclaw-channel-module-loader-");

--- a/src/channels/plugins/module-loader.ts
+++ b/src/channels/plugins/module-loader.ts
@@ -8,7 +8,10 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { describeRootFileOpenFailure, openRootFileSync } from "../../infra/boundary-file-read.js";
 import { hasErrnoCode } from "../../infra/errno.js";
-import { isJavaScriptModulePath } from "../../plugins/native-module-require.js";
+import {
+  isJavaScriptModulePath,
+  PLUGIN_SOURCE_MODULE_EXTENSIONS,
+} from "../../plugins/native-module-require.js";
 import { getPluginCacheRoot, getPluginCacheSource } from "../../plugins/plugin-cache.js";
 import {
   getCachedPluginModuleLoader,
@@ -16,20 +19,6 @@ import {
 } from "../../plugins/plugin-module-loader-cache.js";
 
 const nodeRequire = createRequire(import.meta.url);
-const SOURCE_MODULE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
-const SOURCE_MODULE_RESOLUTION_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"] as const;
-
-function hasNativeSourceRequireHook(modulePath: string): boolean {
-  const extension = path.extname(modulePath).toLowerCase();
-  return (
-    SOURCE_MODULE_EXTENSIONS.has(extension) &&
-    typeof nodeRequire.extensions?.[extension] === "function"
-  );
-}
-
-function isSourceModulePath(modulePath: string): boolean {
-  return SOURCE_MODULE_EXTENSIONS.has(path.extname(modulePath).toLowerCase());
-}
 
 function loadModuleWithJiti(modulePath: string, rootDir: string): unknown {
   const loadWithJiti = getCachedPluginModuleLoader({
@@ -44,8 +33,13 @@ function loadModuleWithJiti(modulePath: string, rootDir: string): unknown {
 }
 
 function loadModule(modulePath: string, rootDir: string): unknown {
-  if (!isJavaScriptModulePath(modulePath) && !hasNativeSourceRequireHook(modulePath)) {
-    if (isSourceModulePath(modulePath)) {
+  const extension = path.extname(modulePath).toLowerCase();
+  const isSource = PLUGIN_SOURCE_MODULE_EXTENSIONS.includes(extension);
+  if (
+    !isJavaScriptModulePath(modulePath) &&
+    !(isSource && typeof nodeRequire.extensions?.[extension] === "function")
+  ) {
+    if (isSource) {
       // Local source plugins need the TS loader unless the current runtime has
       // installed a native source require hook for that extension.
       return loadModuleWithJiti(modulePath, rootDir);
@@ -55,7 +49,7 @@ function loadModule(modulePath: string, rootDir: string): unknown {
   try {
     return nodeRequire(modulePath);
   } catch (error) {
-    if (isSourceModulePath(modulePath)) {
+    if (isSource) {
       // Native source hooks can still fail on ESM/TS edge cases; fall back to
       // the cached loader before surfacing the error.
       return loadModuleWithJiti(modulePath, rootDir);
@@ -72,7 +66,7 @@ function resolveSourceModuleCandidates(rootDir: string, specifier: string): stri
   if (path.extname(resolvedPath)) {
     return [];
   }
-  return SOURCE_MODULE_RESOLUTION_EXTENSIONS.map((extension) => `${resolvedPath}${extension}`);
+  return PLUGIN_SOURCE_MODULE_EXTENSIONS.map((extension) => `${resolvedPath}${extension}`);
 }
 
 /**

--- a/src/channels/plugins/package-state-probes.test.ts
+++ b/src/channels/plugins/package-state-probes.test.ts
@@ -238,50 +238,57 @@ describe("channel package-state probes", () => {
     ).toBe(true);
   });
 
-  it("preserves source overlay precedence over packaged package-state probes", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-state-overlay-"));
-    tempDirs.push(root);
-    const sourceRoot = path.join(root, "extensions", "matrix");
-    const builtRoot = path.join(root, "dist", "extensions", "matrix");
-    fs.mkdirSync(sourceRoot, { recursive: true });
-    fs.mkdirSync(builtRoot, { recursive: true });
-    fs.writeFileSync(
-      path.join(sourceRoot, "auth-presence.js"),
-      "module.exports.hasAnyMatrixAuth = () => true;\n",
-      "utf8",
-    );
-    fs.writeFileSync(
-      path.join(builtRoot, "auth-presence.js"),
-      "module.exports.hasAnyMatrixAuth = () => false;\n",
-      "utf8",
-    );
-    isBundledSourceOverlayPathMock.mockImplementation(
-      ({ sourcePath }: { sourcePath: string }) => path.resolve(sourcePath) === sourceRoot,
-    );
+  it.each(["js", "mtsx", "ctsx"])(
+    "preserves %s source overlay precedence over packaged package-state probes",
+    (extension) => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-state-overlay-"));
+      tempDirs.push(root);
+      const sourceRoot = path.join(root, "extensions", "matrix");
+      const builtRoot = path.join(root, "dist", "extensions", "matrix");
+      fs.mkdirSync(sourceRoot, { recursive: true });
+      fs.mkdirSync(builtRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(sourceRoot, `auth-presence.${extension}`),
+        extension === "js"
+          ? "module.exports.hasAnyMatrixAuth = () => true;\n"
+          : "export const hasAnyMatrixAuth = (): boolean => true;\n",
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(builtRoot, "auth-presence.js"),
+        "module.exports.hasAnyMatrixAuth = () => false;\n",
+        "utf8",
+      );
+      isBundledSourceOverlayPathMock.mockImplementation(
+        ({ sourcePath }: { sourcePath: string }) => path.resolve(sourcePath) === sourceRoot,
+      );
 
-    listChannelCatalogEntriesMock.mockReturnValue([
-      {
-        pluginId: "matrix",
-        origin: "bundled",
-        rootDir: sourceRoot,
-        channel: {
-          id: "matrix",
-          persistedAuthState: {
-            specifier: "./auth-presence",
-            exportName: "hasAnyMatrixAuth",
+      listChannelCatalogEntriesMock.mockReturnValue([
+        {
+          pluginId: "matrix",
+          origin: "bundled",
+          rootDir: sourceRoot,
+          channel: {
+            id: "matrix",
+            configuredState: {
+              specifier: `./auth-presence.${extension}`,
+              exportName: "hasAnyMatrixAuth",
+            },
+            persistedAuthState: {
+              specifier: `./auth-presence.${extension}`,
+              exportName: "hasAnyMatrixAuth",
+            },
           },
-        },
-      } satisfies PluginChannelCatalogEntry,
-    ]);
+        } satisfies PluginChannelCatalogEntry,
+      ]);
 
-    expect(
-      hasBundledChannelPackageState({
-        metadataKey: "persistedAuthState",
-        channelId: "matrix",
-        cfg: {},
-      }),
-    ).toBe(true);
-  });
+      for (const metadataKey of ["configuredState", "persistedAuthState"] as const) {
+        expect(hasBundledChannelPackageState({ metadataKey, channelId: "matrix", cfg: {} })).toBe(
+          true,
+        );
+      }
+    },
+  );
 
   it("preserves parent-mounted source overlay precedence over packaged package-state probes", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-state-parent-overlay-"));

--- a/src/channels/plugins/package-state-probes.ts
+++ b/src/channels/plugins/package-state-probes.ts
@@ -15,6 +15,7 @@ import {
   type PluginChannelCatalogEntry,
 } from "../../plugins/channel-catalog-registry.js";
 import type { PluginDiscoveryResult } from "../../plugins/discovery.js";
+import { isPluginSourceModulePath } from "../../plugins/native-module-require.js";
 import { pluginCacheExistsSync } from "../../plugins/plugin-cache-files.js";
 import { isSafeChannelEnvVarTriggerName } from "../../secrets/channel-env-var-names.js";
 import { loadChannelPluginModule, resolveExistingPluginModulePath } from "./module-loader.js";
@@ -51,10 +52,6 @@ type ChannelPackageStateModuleLocation = {
   modulePath: string;
   rootDir: string;
 };
-
-function isSourceModulePath(modulePath: string): boolean {
-  return /\.(?:c|m)?tsx?$/iu.test(modulePath);
-}
 
 function hasNonEmptyEnvValue(env: NodeJS.ProcessEnv | undefined, key: string): boolean {
   if (!env || !isSafeChannelEnvVarTriggerName(key)) {
@@ -112,7 +109,7 @@ function listBuiltBundledPackageStateModules(params: {
     path.join(sourceRoot.packageRoot, "dist-runtime", "extensions", sourceRoot.dirName),
   ]) {
     const modulePath = resolveExistingPluginModulePath(rootDir, params.specifier);
-    if (pluginCacheExistsSync(modulePath) && !isSourceModulePath(modulePath)) {
+    if (pluginCacheExistsSync(modulePath) && !isPluginSourceModulePath(modulePath)) {
       locations.push({ modulePath, rootDir });
     }
   }

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -6,6 +6,20 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { isPathInside } from "../infra/path-guards.js";
 
 const nodeRequire = createRequire(import.meta.url);
+// Resolution and Jiti must accept the same source family, including typed JSX variants.
+export const PLUGIN_SOURCE_MODULE_EXTENSIONS: readonly string[] = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".mtsx",
+  ".ctsx",
+];
+
+export function isPluginSourceModulePath(modulePath: string): boolean {
+  return PLUGIN_SOURCE_MODULE_EXTENSIONS.includes(path.extname(modulePath).toLowerCase());
+}
+
 // Failed ESM jobs survive require-cache eviction. Preserve an observed terminal error
 // if a retry hits that job, rather than transforming its rejected graph through Jiti.
 const nativeModuleLoadFailures = new Map<string, unknown>();
@@ -90,7 +104,7 @@ export function tryNativeRequireModule(
   }
   const modulePath = toNativeRequirePath(moduleSpecifier);
   if (
-    /\.[cm]?tsx?$/iu.test(modulePath) &&
+    isPluginSourceModulePath(modulePath) &&
     !process.features.typescript &&
     typeof nodeRequire.extensions?.[path.extname(modulePath)] !== "function"
   ) {

--- a/src/plugins/plugin-module-loader-cache.test.ts
+++ b/src/plugins/plugin-module-loader-cache.test.ts
@@ -614,9 +614,8 @@ describe("getCachedPluginModuleLoader", () => {
       ok: true as const,
       moduleExport: { loadedFrom: target },
     }));
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: (p: string) =>
-        p.endsWith(".js") || p.endsWith(".mjs") || p.endsWith(".cjs"),
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } =
@@ -657,9 +656,8 @@ describe("getCachedPluginModuleLoader", () => {
       ok: true as const,
       moduleExport: { loadedFrom: target },
     }));
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: (p: string) =>
-        p.endsWith(".js") || p.endsWith(".mjs") || p.endsWith(".cjs"),
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } =
@@ -709,8 +707,8 @@ describe("getCachedPluginModuleLoader", () => {
       ok: true as const,
       moduleExport,
     }));
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } =
@@ -790,8 +788,8 @@ describe("getCachedPluginModuleLoader", () => {
     const nativeStub = vi.fn(() => {
       throw missingDependency;
     });
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } =
@@ -824,8 +822,8 @@ describe("getCachedPluginModuleLoader", () => {
   it("falls back to source transform when the native-require helper declines", async () => {
     const fromSourceTransformer = vi.fn(() => ({ fromSourceTransform: true }));
     const createJiti = vi.fn(() => fromSourceTransformer);
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: () => ({ ok: false }),
     }));
     const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } =
@@ -870,8 +868,8 @@ describe("getCachedPluginModuleLoader", () => {
     const fromSourceTransformer = vi.fn(() => ({ fromSourceTransform: true }));
     const createJiti = vi.fn(() => fromSourceTransformer);
     const nativeStub = vi.fn(() => ({ ok: true, moduleExport: { fromNative: true } }));
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginSourceModuleLoader } = await importPluginModuleLoader(
@@ -900,8 +898,8 @@ describe("getCachedPluginModuleLoader", () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const fromSourceTransformer = vi.fn(() => ({ fromSourceTransform: true }));
     const createJiti = vi.fn(() => fromSourceTransformer);
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: () => ({ ok: false }),
     }));
     const { getCachedPluginModuleLoader } = await importPluginModuleLoader(
@@ -936,8 +934,8 @@ describe("getCachedPluginModuleLoader", () => {
     const fromSourceTransformer = vi.fn(() => ({ fromSourceTransform: true }));
     const createJiti = vi.fn(() => fromSourceTransformer);
     const nativeStub = vi.fn(() => ({ ok: true, moduleExport: { fromNative: true } }));
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } =
@@ -982,8 +980,8 @@ describe("getCachedPluginModuleLoader", () => {
     const fromSourceTransformer = vi.fn(() => moduleExport);
     const createJiti = vi.fn(() => fromSourceTransformer);
     const nativeStub = vi.fn(() => ({ ok: true, moduleExport: { fromNative: true } }));
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginModuleLoader, getPluginModuleLoaderStats } =
@@ -1020,8 +1018,8 @@ describe("getCachedPluginModuleLoader", () => {
     const fromSourceTransformer = vi.fn(() => ({ fromSourceTransform: true }));
     const createJiti = vi.fn(() => fromSourceTransformer);
     const nativeStub = vi.fn(() => ({ ok: true, moduleExport: { fromNative: true } }));
-    vi.doMock("./native-module-require.js", () => ({
-      isJavaScriptModulePath: () => true,
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
       tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginModuleLoader } = await importPluginModuleLoader(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -9,6 +9,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { resolveOpenClawDevSourceRoot } from "./dev-source-root.js";
+import { PLUGIN_SOURCE_MODULE_EXTENSIONS } from "./native-module-require.js";
 import {
   parsePluginCacheJson,
   pluginCacheExistsSync,
@@ -1554,7 +1555,7 @@ export function buildPluginLoaderJitiOptions(
     // When jiti must transform a plugin entry, keep OpenClaw's own package
     // chunks on the native module graph instead of re-evaluating them in jiti.
     nativeModules: resolvePluginLoaderJitiNativeModules(),
-    extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+    extensions: [...PLUGIN_SOURCE_MODULE_EXTENSIONS, ".js", ".mjs", ".cjs", ".json"],
     ...(hasAliases
       ? {
           alias: jitiAliasMap,


### PR DESCRIPTION
Closes #135819

Follow-up to #135396. This repairs the confirmed source-checker regression only; there is no native receipt change.

<details>
<summary>Additional instructions</summary>

This is a same-repository task branch, available for direct maintainer pushes and takeover. GitHub reports its fork-oriented maintainerCanModify flag as false; the CLI mutation guard does not support changing that field on an existing PR, and no guard was bypassed.

</details>

## What Problem This Solves

Fixes an issue where source-plugin developers would get a false configured/persisted-state result when their lightweight checker uses an explicit `.mtsx` or `.ctsx` path. The package-state consolidation in #135396 removed the second Jiti loader, but the remaining channel loader rejected these extensions before Jiti could load them.

## Why This Change Was Made

The existing native-module owner now provides one typed-source extension list/predicate shared by channel resolution/classification, Jiti options, native eligibility, and package-state filtering. This removes divergent definitions without bringing back a second loader. Jiti's extension order and values remain unchanged.

Explicit typed-JSX checker loading is the introduced regression. Extensionless resolution for those extensions was already missing before #135396; using the same canonical list closes that adjacent inconsistency too. Native SDK singleton ownership, transformed plugin dependency reload, source-overlay precedence, root containment, and health admission policy remain intact. No configuration, dependency, schema, persistent cache, protocol, or receipt policy changes.

Production **+32/-26 (net +6)**; tests **+79/-71 (net +8)**. The six net production lines centralize an existing contract across four consumers while deleting divergent lists/helpers. A local extension-only patch would leave the definitions drifting; restoring the fallback would recreate duplicate loader ownership.

## User Impact

Supported typed-JSX source checkers can again report configured or persisted state correctly. JavaScript and other TypeScript module handling keep their existing behavior. Release-note context: source-plugin state detection no longer silently reports absent state for supported typed-JSX checker files. This is source-checkout proof, not a claim that the fix is already on main or in a stable release.

## Evidence

Candidate: `4c4413637e252b74381165ff39dd5d44672e0b52`, base `04b3fe6659b02a12e6d8e0d95d1a27ed51c1ae22`, tree `76b8714960062e238618b72e680ae10f99d3836a`. The commit tree exactly matches the reviewed working-tree candidate; patch SHA256 `60e9a3ca009bb3c311c26e529fa7f638116e97a1a43fed4593ca910bbe7707a8`.

- **Before/after:** real package-state boundary with synthetic plugins: both `.mtsx`/`.ctsx` and both configured/persisted metadata keys returned `historical=true, delivered=false`. Historical owner bytes came from `105ab9a4b187d6d8f4163b39d2d02fefc02c8b43` with current common dependencies, not a whole historical checkout. Tiny typed checkers avoid the historical SDK alias difference. Raw parent/header and the `b66f194583a6bcd1c0704d27ce56dee6659ab817` parent-relative patch establish the removed fallback.
- **Dependency contract:** directly inspected installed Jiti 2.7.0 types (`lib/types.d.ts:179–183`), `jitiRequire`, `eval_evalModule`, and virtualModules ordering. Both actual typed fixtures load; the implementation recognizes the typed-JSX extension family and enables TypeScript transformation. Installed runtime SHA256: `a0b3b8d5e06a0519c66b62179e29200533057920f6f11370546e979dacd24c49`.
- **Regression RED:** delivered code failed the two new explicit-checker cases and the two extensionless resolver cases for the intended reasons; existing controls passed.
- **Final focused proof:** **156 passed, 1 intentional skip**, Node 24.20.0, six files through the repository router. Includes real checker loading, SDK/native identity, transformed reload, force-transform, public surfaces, and containment. Existing test tables were extended. JavaScript cases retain built-false/source-true overlay precedence; typed explicit cases prove checker loading.
- **Changed gate:** full canonical seven-path gate on the fixed base exited 0, including core/plugin and test typechecks, lint, format, dead exports and resolved architecture guards. Its launcher used Node 24.20.0; some canonical pnpm children used host Node 26.8.1, so this is not an all-Node-24 claim.
- **Fresh full build:** canonical full `scripts/build-all.mts` owner, Node 24 selected for descendants, exited 0 in 6m18s. Runtime/native plugin loading, declarations, SDK exports, UI and performance checks passed. No new dependency install, baseline adjustment or skip override.
- **Review:** fresh isolated complete-candidate Codex P0 autoreview exited 0, scoped-clean, three complete bounded evidence passes, zero findings. Requested P0 scope is not a broader severity certificate. Parent personally reviewed all seven changed files and accepted the proof.

Focused command:

```sh
node scripts/run-vitest.mjs \
  src/channels/plugins/module-loader.test.ts \
  src/channels/plugins/package-state-probes.test.ts \
  src/plugins/native-module-require.test.ts \
  src/plugins/plugin-module-loader-cache.test.ts \
  src/plugins/sdk-alias.test.ts \
  src/plugins/public-surface-loader.test.ts
```

Changed gate:

```sh
node scripts/check-changed.mjs --base 04b3fe6659b02a12e6d8e0d95d1a27ed51c1ae22 -- \
  src/channels/plugins/module-loader.ts \
  src/channels/plugins/module-loader.test.ts \
  src/channels/plugins/package-state-probes.ts \
  src/channels/plugins/package-state-probes.test.ts \
  src/plugins/native-module-require.ts \
  src/plugins/sdk-alias.ts \
  src/plugins/plugin-module-loader-cache.test.ts
```

Failure history: the first six-file run failed six cases because old whole-module mocks omitted the new shared export; the channel shard did not run. Existing mocks were changed to preserve real exports while stubbing only the native operation; **only the final retry is green**. No assertions or timeouts were weakened. The first autoreview preparation stopped before a model call because the complete minified dependency exceeded a per-file cap; two lossless parts plus hashes retained all dependency bytes under the unchanged validator. The later completed review is the passing result.

No operator state, live provider call, or real native receipt was used as a fixture. Exact-head hosted CI is green; native preparation has completed successfully. Final fresh full-review inspection and merge remain maintainer-owned.


### Current CI and review disposition

[Exact-head CI33583763502](https://github.com/openclaw/openclaw/actions/runs/33583763502) completed successfully on `4c4413637e252b74381165ff39dd5d44672e0b52`; all218jobs are terminal, with no failure/timed-out/cancelled jobs, and required `openclaw/ci-gate` is SUCCESS. The canonical exact-head watcher exited0 GREEN using supported `--completion ci-run`. The initial draft run33583722238 was skipped and is not proof.

The full [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135820#issuecomment-5503554368) was read with `Cache-Control: max-age=0`: reviewed `2026-09-02T02:44:25.612Z`, exact head4c441, source revision `683ac25108822e0b0d13d63b971bca2146a3fb381c94d066fb04d1ab75e30765`. It found no concrete correctness/security defect. Its remaining checklist items are dispositioned as follows:

1. **Net+6 production lines:** accepted. The parent reviewed the complete delta and chose the shared existing contract; the review itself agrees that this avoids duplicated classification. No cosmetic line-count workaround or second loader is warranted.
2. **Jiti unavailable in the review checkout:** the direct installed dependency evidence above closes the investigation gap. Parent and acting investigator inspected actual Jiti2.7.0 runtime/types and virtualModules ordering, executed both typed files and the real package-state boundary, and verified the runtime hash. The full dependency implementation was also included losslessly in the isolated P0 evidence bundle. This is not a claim that the remote reviewer installed or executed Jiti.
3. **Do not duplicate the repair:** this PR is the single bounded repair for #135819. No new lane or duplicated fallback was started.

No separate Rank-up moves list was emitted. No code changed after review; no manual re-review request was needed. Native preparation has completed; no merge has been attempted for this PR.


### Native preparation complete — merge remains maintainer-owned

From the independent owning clone, `scripts/pr review-init 135820`, `review-checkout-main`, `review-checkout-pr`, `review-artifacts-init`, and final `review-validate-artifacts` all exited0 with fresh exact-head stamps. After the green CI and full review disposition above, `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 135820` exited0. Prepared and remote head remain `4c4413637e252b74381165ff39dd5d44672e0b52`; source base remains04b3, no rebase or source edit. Native hosted-gate target is that exact head, verified at `2026-09-02T02:49:18Z`; the remote already matched, so the actual push was skipped. The prepared worktree and artifacts are preserved.

**Stopping at preparation.** No merge command was invoked. Final fresh full-review inspection, live mergeability/rules checks, and actual merge belong to the parent maintainer. The issue remains open and this is not claimed fixed on main. Original135396 outcome/worktree and all older receipt bookkeeping remain untouched.
