### PR TITLE
docs: add release contribution counts

### DIFF
--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -20,7 +20,7 @@ This update touches every part of OpenClaw, including installation, messaging, m
 
 The sections below describe the user-facing result, with the complete PR and commit record available inside each subsection when someone wants to dig into it.
 
-**Release scale:** 16,977 pull requests, 698 direct commits, and 987 human contributors.
+**Release scale:** 16,977 pull requests, 698 direct commits, and 987 contributors.
 
 ## Installation and Onboarding
 

--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -20,7 +20,7 @@ This update touches every part of OpenClaw, including installation, messaging, m
 
 The sections below describe the user-facing result, with the complete PR and commit record available inside each subsection when someone wants to dig into it.
 
-**Release scale:** 16,977 pull requests, 698 direct commits, and 994 human contributors.
+**Release scale:** 16,977 pull requests, 698 direct commits, and 987 human contributors.
 
 ## Installation and Onboarding
 

--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -20,6 +20,8 @@ This update touches every part of OpenClaw, including installation, messaging, m
 
 The sections below describe the user-facing result, with the complete PR and commit record available inside each subsection when someone wants to dig into it.
 
+**Release scale:** 16,977 pull requests, 698 direct commits, and 994 human contributors.
+
 ## Installation and Onboarding
 
 <Warning>

--- a/docs/releases/2026.8.2.md
+++ b/docs/releases/2026.8.2.md
@@ -12,7 +12,7 @@ keywords:
 
 v2026.8.2 adds a Home button to the Control UI that opens your personal Home agent beside whatever you are working on, instead of making you leave it to start another conversation. It also brings a Linux desktop companion, background sessions you can start without switching pages, browser control that can stay available without a running Gateway, four new looks for the Control UI, and a long tail of fixes for replies, voice, updates, and recovery.
 
-**Release scale:** 784 pull requests, 10 direct commits, and 134 human contributors.
+**Release scale:** 784 pull requests, 10 direct commits, and 134 contributors.
 
 ## Installation and Onboarding
 

--- a/docs/releases/2026.8.2.md
+++ b/docs/releases/2026.8.2.md
@@ -12,7 +12,7 @@ keywords:
 
 v2026.8.2 adds a Home button to the Control UI that opens your personal Home agent beside whatever you are working on, instead of making you leave it to start another conversation. It also brings a Linux desktop companion, background sessions you can start without switching pages, browser control that can stay available without a running Gateway, four new looks for the Control UI, and a long tail of fixes for replies, voice, updates, and recovery.
 
-**Release scale:** 784 pull requests, 10 direct commits, and 135 human contributors.
+**Release scale:** 784 pull requests, 10 direct commits, and 134 human contributors.
 
 ## Installation and Onboarding
 

--- a/docs/releases/2026.8.2.md
+++ b/docs/releases/2026.8.2.md
@@ -12,6 +12,8 @@ keywords:
 
 v2026.8.2 adds a Home button to the Control UI that opens your personal Home agent beside whatever you are working on, instead of making you leave it to start another conversation. It also brings a Linux desktop companion, background sessions you can start without switching pages, browser control that can stay available without a running Gateway, four new looks for the Control UI, and a long tail of fixes for replies, voice, updates, and recovery.
 
+**Release scale:** 784 pull requests, 10 direct commits, and 135 human contributors.
+
 ## Installation and Onboarding
 
 Installation and first-run setup now do a better job of preserving the system and model choices people already made. Linux and macOS recovery paths fail more clearly, guided setup keeps the selected agent and model through reconnects, and required runtime plugins can be reviewed, installed, and verified without sending people to Terminal.


### PR DESCRIPTION
## What Problem This Solves

The v2026.8.1 and v2026.8.2 release pages describe their changes in detail but do not give readers a quick sense of the size of each release or how many people contributed.

## Why This Change Was Made

This adds one compact Release scale line near the top of each page using frozen release evidence. The counts include pull requests, direct commits, and contributors under the established verified-credit methodology, including co-authors and additional verified human credit.

## User Impact

Readers can understand the scale and community participation behind each release without opening the complete source accordions.

## Evidence

- v2026.8.1 frozen manifest: 16,977 pull requests and 698 direct commits
- v2026.8.1 established verified-credit contributor count: 987
- v2026.8.2 frozen manifest: 784 pull requests and 10 direct commits
- v2026.8.2 established verified-credit contributor count: 134
- pnpm docs:list
- pnpm docs:check-mdx
- pnpm docs:check-links
- pnpm docs:check-i18n-glossary
- git diff --check
