### PR TITLE
test(gateway): register title runtime backend in fixtures

### DIFF
--- a/src/gateway/dashboard-session-title.test.ts
+++ b/src/gateway/dashboard-session-title.test.ts
@@ -17,6 +17,7 @@ vi.mock("../config/sessions/session-accessor.js", () => ({
 }));
 vi.mock("./session-transcript-title-reader.js", () => ({ readSessionTitleFieldsFromTranscript }));
 
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createDeferredCore } from "../shared/deferred.js";
@@ -59,6 +60,17 @@ function mockSessionUpdate(current: SessionEntry): void {
 
 describe("maybeGenerateDashboardSessionTitle", () => {
   beforeEach(() => {
+    // Exercise runtime compatibility with a registered backend; setup loading has its own tests.
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+        },
+      ],
+    });
     generateConversationLabelWithFallback.mockReset();
     resolveUtilityModelRefForAgent.mockReset();
     updateSessionEntry.mockReset();
@@ -73,7 +85,10 @@ describe("maybeGenerateDashboardSessionTitle", () => {
     mockSessionUpdate(baseEntry);
   });
 
-  afterEach(() => vi.useRealTimers());
+  afterEach(() => {
+    cliBackendsTesting.resetDepsForTest();
+    vi.useRealTimers();
+  });
 
   it("generates and persists a dashboard display name", async () => {
     await expect(maybeGenerateDashboardSessionTitle(titleParams())).resolves.toBe(true);


### PR DESCRIPTION
## Summary

The dashboard title test for a compatible session runtime override starts with an empty runtime CLI registry. Resolving its configured backend therefore loads and transforms the Anthropic setup entry point. This case exceeded its 120-second test budget in CI run 33580802586 (136.7 seconds).

Provide the minimal registered backend through the existing CLI-backend test dependency seam, and reset that seam after each case. The real title, runtime-compatibility, alias, and binding resolution still run. All 34 cases, 55 assertion sites, prompts, configuration inputs, and per-file order are preserved. Production delta: 0; tests +16/-1. No timeout increase or production change.

## Validation

- Original IPA-head and current-main private runs each pass all 34 title cases. Instrumentation observes one targeted Anthropic setup load taking 27.35 and 26.18 seconds respectively; it does not show whole-registry loading.
- With the registration fixture, the trace shows zero setup/module-loader calls. The uninstrumented compatible-runtime case took 87.7ms locally. These are individual local observations, not a controlled throughput benchmark or a breakdown of the CI timeout.
- Canonical runner: all 85 title, CLI-backend, model-alias, and runtime-compatibility cases pass, both in the private source copy and the working checkout.
- Failure probe: change the fixture provider and suppress setup fallback; the original compatible-runtime assertion fails while the other 33 cases pass. After-all inspection confirms the real binding list is empty on both success and failure paths.
- Six private proof runners joined; temporary source, links, and caches removed. Full source/history/dependency review, independent fixture audit, deslop pass, and Codex review completed.
- Local changed-file checks pass except the broader gateway test type graph cannot resolve this checkout's missing mermaid package. Remaining guards, dead-export scan, and target lint are run separately. Locked-dependency exact-head CI is required before landing.

## Scope

Test-only; documentation and changelog are not needed. Setup fallback behavior remains covered by the existing CLI-backend tests. No new helper, cast, test export, configuration, dependency, or production path is introduced.
