### PR TITLE
refactor(anthropic): share catalog home resolution

### DIFF
--- a/extensions/anthropic/session-catalog-continue.ts
+++ b/extensions/anthropic/session-catalog-continue.ts
@@ -9,6 +9,7 @@ import {
 } from "./session-catalog-adoption.js";
 import { type CatalogRecord, listClaudeSessions } from "./session-catalog-discovery.js";
 import { importClaudeHistory } from "./session-catalog-history.js";
+import { resolveClaudeCatalogHomeDir } from "./session-catalog-home.js";
 import {
   readBoundedClaudeHistory,
   readClaudeSessionTranscript,
@@ -19,7 +20,7 @@ import {
   listBoundClaudeSessions,
   resolveClaudeCliRoutedModelId,
 } from "./session-catalog-runtime.js";
-import { currentHomeDir, gatewayClaudeScanOptions } from "./session-catalog-scan.js";
+import { gatewayClaudeScanOptions } from "./session-catalog-scan.js";
 import {
   CLAUDE_CLI_NODE_RUN_COMMAND,
   CLAUDE_SESSION_READ_COMMAND,
@@ -50,7 +51,7 @@ export async function continueClaudeSession(
       hostId,
       threadId,
       ...(history ? { history } : {}),
-      listLocalSessions: () => listClaudeSessions(currentHomeDir(), scanOptions),
+      listLocalSessions: () => listClaudeSessions(resolveClaudeCatalogHomeDir(), scanOptions),
       readRemote: async () =>
         (
           await readClaudeSessionTranscript({
@@ -74,7 +75,7 @@ export async function continueClaudeSession(
       let nodeId: string | undefined;
       let record: ClaudeSessionCatalogSession | undefined;
       if (hostId === CLAUDE_LOCAL_SESSION_HOST_ID) {
-        record = (await listClaudeSessions(currentHomeDir(), scanOptions)).find(
+        record = (await listClaudeSessions(resolveClaudeCatalogHomeDir(), scanOptions)).find(
           (candidate) => candidate.threadId === threadId,
         );
         if (!record || !isResumableClaudeSource(record.source)) {

--- a/extensions/anthropic/session-catalog-discovery.ts
+++ b/extensions/anthropic/session-catalog-discovery.ts
@@ -13,11 +13,11 @@ import {
   MAX_STRING_LENGTH,
   readDesktopOverlay,
 } from "./session-catalog-desktop.js";
+import { resolveClaudeCatalogHomeDir } from "./session-catalog-home.js";
 import {
   CLAUDE_CATALOG_IO_CONCURRENCY,
   CLAUDE_PARTIAL_SCAN_TTL_MS,
   CLAUDE_SESSION_SCAN_HARD_TTL_MS,
-  currentHomeDir,
   type ClaudeProjectsTreeSnapshot,
   type ClaudeSessionScanContext,
   projectsDir,
@@ -528,7 +528,7 @@ async function readCliScan(
 }
 
 export async function listClaudeSessions(
-  homeDir = currentHomeDir(),
+  homeDir = resolveClaudeCatalogHomeDir(),
   options: { forceRefresh?: boolean; configDir?: string; includeDesktop?: boolean } = {},
 ): Promise<CatalogRecord[]> {
   const [cli, desktop] = await Promise.all([

--- a/extensions/anthropic/session-catalog-executable.ts
+++ b/extensions/anthropic/session-catalog-executable.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { resolveNodeHostExecutable } from "openclaw/plugin-sdk/node-host";
+import { resolveClaudeCatalogHomeDir } from "./session-catalog-home.js";
 
 const BROKEN_NPM_SHIM_MARKER = "Error: claude native binary not installed.";
 const BROKEN_NPM_INSTALL_HINT = "node_modules/@anthropic-ai/claude-code/install.cjs";
@@ -10,10 +10,6 @@ const CLAUDE_PACKAGE_SHIM_TARGET =
 const MAX_SHIM_PROBE_BYTES = 4096;
 
 let cachedNativeReplacement: { key: string; executable: string | null } | undefined;
-
-function currentHomeDir(env: NodeJS.ProcessEnv): string {
-  return env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
-}
 
 function readSmallExecutableSource(executable: string):
   | {
@@ -116,7 +112,7 @@ function resolveClaudeDesktopExecutable(
 }
 
 function resolveNativeReplacement(env: NodeJS.ProcessEnv): string | undefined {
-  const homeDir = currentHomeDir(env);
+  const homeDir = resolveClaudeCatalogHomeDir(env);
   const cacheKey = `${process.platform}\0${homeDir}`;
   if (cachedNativeReplacement?.key === cacheKey) {
     return cachedNativeReplacement.executable ?? undefined;

--- a/extensions/anthropic/session-catalog-home.test.ts
+++ b/extensions/anthropic/session-catalog-home.test.ts
@@ -1,0 +1,46 @@
+import os from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveClaudeCatalogHomeDir } from "./session-catalog-home.js";
+
+describe("resolveClaudeCatalogHomeDir", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      name: "prefers and trims HOME",
+      env: { HOME: " /home/primary ", USERPROFILE: " /home/secondary " },
+      expected: "/home/primary",
+    },
+    {
+      name: "falls through a blank HOME",
+      env: { HOME: " ", USERPROFILE: " /home/secondary " },
+      expected: "/home/secondary",
+    },
+    {
+      name: "trims USERPROFILE",
+      env: { USERPROFILE: " C:\\Users\\claude " },
+      expected: "C:\\Users\\claude",
+    },
+  ])("$name", ({ env, expected }) => {
+    expect(resolveClaudeCatalogHomeDir(env)).toBe(expected);
+  });
+
+  it("evaluates the fallback at call time when both variables are absent or blank", () => {
+    vi.spyOn(os, "homedir").mockReturnValueOnce("/home/first").mockReturnValueOnce("/home/second");
+
+    expect(resolveClaudeCatalogHomeDir({})).toBe("/home/first");
+    expect(resolveClaudeCatalogHomeDir({ HOME: "", USERPROFILE: " " })).toBe("/home/second");
+  });
+
+  it("does not evaluate the fallback when an explicit home is available", () => {
+    const homedir = vi.spyOn(os, "homedir");
+
+    expect(resolveClaudeCatalogHomeDir({ HOME: " /home/explicit " })).toBe("/home/explicit");
+    expect(resolveClaudeCatalogHomeDir({ HOME: " ", USERPROFILE: " C:\\Users\\explicit " })).toBe(
+      "C:\\Users\\explicit",
+    );
+    expect(homedir).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/anthropic/session-catalog-home.ts
+++ b/extensions/anthropic/session-catalog-home.ts
@@ -1,0 +1,5 @@
+import os from "node:os";
+
+export function resolveClaudeCatalogHomeDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+}

--- a/extensions/anthropic/session-catalog-listing.ts
+++ b/extensions/anthropic/session-catalog-listing.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { CLAUDE_LOCAL_SESSION_HOST_ID } from "./session-catalog-adoption.js";
 import { listClaudeSessions } from "./session-catalog-discovery.js";
+import { resolveClaudeCatalogHomeDir } from "./session-catalog-home.js";
 import { createNodeListFailedError, resolveNodeLabel } from "./session-catalog-node-helpers.js";
 import {
   decodeOffset,
@@ -23,11 +24,7 @@ import {
   readTranscriptParams,
   unwrapNodePayload,
 } from "./session-catalog-parsing.js";
-import {
-  configuredClaudeConfigDir,
-  currentHomeDir,
-  gatewayClaudeScanOptions,
-} from "./session-catalog-scan.js";
+import { configuredClaudeConfigDir, gatewayClaudeScanOptions } from "./session-catalog-scan.js";
 import {
   CLAUDE_CLI_NODE_RUN_COMMAND,
   CLAUDE_SESSION_READ_COMMAND,
@@ -59,7 +56,7 @@ export async function listLocalClaudeSessionPage(
   homeDir?: string,
   scanOptions?: { configDir?: string; includeDesktop?: boolean },
 ): Promise<ClaudeSessionCatalogPage> {
-  const resolvedHome = homeDir ?? currentHomeDir();
+  const resolvedHome = homeDir ?? resolveClaudeCatalogHomeDir();
   const resolvedScanOptions =
     scanOptions ?? (homeDir === undefined ? gatewayClaudeScanOptions(true) : {});
   const params = readListParams(value);
@@ -88,7 +85,7 @@ export async function readLocalClaudeTranscriptPage(
   homeDir?: string,
   scanOptions?: { configDir?: string; includeDesktop?: boolean },
 ): Promise<Omit<ClaudeSessionTranscriptPage, "hostId" | "label">> {
-  const resolvedHome = homeDir ?? currentHomeDir();
+  const resolvedHome = homeDir ?? resolveClaudeCatalogHomeDir();
   const resolvedScanOptions =
     scanOptions ?? (homeDir === undefined ? gatewayClaudeScanOptions(true) : {});
   const params = readTranscriptParams(value);
@@ -235,7 +232,7 @@ export async function listClaudeSessionCatalog(params: {
                       ? { cursor: query.cursors[CLAUDE_LOCAL_SESSION_HOST_ID] }
                       : {}),
                   },
-                  currentHomeDir(),
+                  resolveClaudeCatalogHomeDir(),
                   scanOptions,
                 )),
               };
@@ -383,7 +380,7 @@ export async function readClaudeSessionTranscript(params: {
           limit: params.limit,
           ...(cursor !== undefined ? { cursor } : {}),
         },
-        currentHomeDir(),
+        resolveClaudeCatalogHomeDir(),
         gatewayClaudeScanOptions(params.allowProcessHomeFallback),
       )),
     };

--- a/extensions/anthropic/session-catalog-registration.ts
+++ b/extensions/anthropic/session-catalog-registration.ts
@@ -1,5 +1,4 @@
 import { statSync } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -14,6 +13,7 @@ import type {
 import type { SessionCatalogProvider } from "openclaw/plugin-sdk/session-catalog";
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_ROUTE_PROBE_MODEL_IDS } from "./cli-constants.js";
 import { resolveClaudeTerminalExecutable } from "./session-catalog-executable.js";
+import { resolveClaudeCatalogHomeDir } from "./session-catalog-home.js";
 import {
   CLAUDE_CLI_NODE_RUN_COMMAND,
   CLAUDE_SESSION_READ_COMMAND,
@@ -42,7 +42,7 @@ function isClaudeSessionCatalogEnabled(pluginConfig: unknown): boolean {
 // Node declarations expose catalog commands only when this machine owns a
 // Claude session store; otherwise the gateway must skip the node capability.
 function claudeProjectsAvailable(env: NodeJS.ProcessEnv): boolean {
-  const homeDir = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
+  const homeDir = resolveClaudeCatalogHomeDir(env);
   const configDir = env.CLAUDE_CONFIG_DIR?.trim();
   try {
     return statSync(

--- a/extensions/anthropic/session-catalog-scan.ts
+++ b/extensions/anthropic/session-catalog-scan.ts
@@ -1,5 +1,4 @@
 import fs, { type FileHandle } from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
@@ -405,10 +404,6 @@ export async function readProjectsTreeSnapshot(
 
 export function desktopSessionsDir(homeDir: string): string {
   return path.join(homeDir, "Library", "Application Support", "Claude", "claude-code-sessions");
-}
-
-export function currentHomeDir(env: NodeJS.ProcessEnv = process.env): string {
-  return env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
 }
 
 export function configuredClaudeConfigDir(

--- a/extensions/anthropic/session-catalog.ts
+++ b/extensions/anthropic/session-catalog.ts
@@ -11,6 +11,7 @@ import { adoptedSourceKey, CLAUDE_LOCAL_SESSION_HOST_ID } from "./session-catalo
 import { continueClaudeSession } from "./session-catalog-continue.js";
 import { isExactClaudeSessionCursor } from "./session-catalog-cursor.js";
 import { listClaudeSessions } from "./session-catalog-discovery.js";
+import { resolveClaudeCatalogHomeDir } from "./session-catalog-home.js";
 import {
   assertClaudeLocalAccess,
   listClaudeSessionCatalog,
@@ -19,11 +20,7 @@ import {
 } from "./session-catalog-listing.js";
 import { MAX_TRANSCRIPT_LIMIT, readTranscriptParams } from "./session-catalog-parsing.js";
 import { listBoundClaudeSessions } from "./session-catalog-runtime.js";
-import {
-  configuredClaudeConfigDir,
-  currentHomeDir,
-  gatewayClaudeScanOptions,
-} from "./session-catalog-scan.js";
+import { configuredClaudeConfigDir, gatewayClaudeScanOptions } from "./session-catalog-scan.js";
 import { ClaudeCatalogParamsError } from "./session-catalog-shared.js";
 import * as catalogTerminal from "./session-catalog-terminal.js";
 import { collectTranscriptText, type ClaudeTranscriptItem } from "./session-catalog-transcript.js";
@@ -265,7 +262,7 @@ export function createClaudeSessionCatalogRuntime(
         ...request,
         listClaudeSessions: () =>
           listClaudeSessions(
-            currentHomeDir(),
+            resolveClaudeCatalogHomeDir(),
             gatewayClaudeScanOptions(request.allowProcessHomeFallback),
           ),
         resolveNodeClaudeRecord,


### PR DESCRIPTION
## What Problem This Solves

Claude session catalog code independently resolved the process home in executable discovery, node capability registration, and catalog scanning. Those copies could drift on whitespace handling, environment precedence, or fallback timing.

## Why This Change Was Made

The Anthropic plugin now owns that policy in `extensions/anthropic/session-catalog-home.ts`. Catalog consumers import the leaf directly, while the previous implementations and their `node:os` imports are removed. The resolver preserves trimmed `HOME`, then trimmed `USERPROFILE`, then call-time `os.homedir()`.

The rebase conflict in `extensions/anthropic/session-catalog-discovery.ts` was resolved from current `main`, preserving #136222's Desktop overlay, project-tree snapshot, TTL, cache, and watcher behavior. The only behavioral edit there is the default home resolver. The `session-catalog-scan.ts` removal auto-merged.

No scan-module re-export, compatibility alias, core change, config surface, or Plugin SDK surface was added.

## User Impact

No intended user-visible behavior change. Claude catalog discovery, terminal resolution, continuation, listing, and node capability checks now share one home-directory policy.

## Evidence

- Reviewed head: `8c214be49a87c8e078ad28dadf79bcb88a27983b`, one signed commit by the original author.
- Rebase base: `7ab7eb8aab504be5a0a3081882e2d3fd5e537f11`. Current `main` later advanced without changing any of the nine reviewed files; the merge simulation remained conflict-free.
- Exact scope: nine files. Production LOC: +24/-33, net -9. Tests: +46/-0.
- Blacksmith Testbox (`provider=blacksmith-testbox`, `tbx_01m1gy04ceb3t214k6tgde5yx0`): [run 33624720557](https://github.com/openclaw/openclaw/actions/runs/33624720557), completed and lease released.
- Testbox source proof: synced tree `cfacb5fa4e4ef810aa9bdaa7197ee646e736425b` matched `8c214be49a87c8e078ad28dadf79bcb88a27983b^{tree}`.
- Focused suites:
  `node scripts/run-vitest.mjs extensions/anthropic/session-catalog-home.test.ts extensions/anthropic/session-catalog.test.ts extensions/anthropic/session-catalog-tree-watch.test.ts extensions/anthropic/lazy-import.test.ts`
  passed 81/81.
- Full plugin suite: `pnpm test:extension anthropic` passed 534/534.
- Changed gate:
  `node scripts/check-changed.mjs --timed -- extensions/anthropic/session-catalog-continue.ts extensions/anthropic/session-catalog-discovery.ts extensions/anthropic/session-catalog-executable.ts extensions/anthropic/session-catalog-home.test.ts extensions/anthropic/session-catalog-home.ts extensions/anthropic/session-catalog-listing.ts extensions/anthropic/session-catalog-registration.ts extensions/anthropic/session-catalog-scan.ts extensions/anthropic/session-catalog.ts`
  passed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm build`: passed.
- `git diff --check`: passed.
- Exact autoreview:
  `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking high --codex-bin /opt/homebrew/Caskroom/codex/0.149.0/bin/codex --base origin/main`
  returned scoped clean at 0.99 confidence.
- Independent exact-head read-only Codex review: no findings, `VERIFIED`; it separately confirmed scope, LOC, signature, helper semantics, import boundaries, test value, and preservation of #136222.

Sibling coverage includes executable lookup, node registration, local listing and transcript reads, discovery defaults, continuation, terminal opening, scan caching, Desktop overlays, tree watchers, and lazy imports.

Codex hard gate checked against sibling Codex SHA `5f49aba876922d6f2f55caa153bbb0ed1b46feba`: `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`. Those CLI declaration and prompt/completion paths do not intersect this plugin-local resolver.
