### PR TITLE
improve(release): reduce Docker cache export overhead

### DIFF
--- a/.github/workflows/docker-release-prepare.yml
+++ b/.github/workflows/docker-release-prepare.yml
@@ -166,6 +166,9 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Prepare OCI output directory
         run: mkdir -p "${RUNNER_TEMP}/docker-release/oci"
+      # Keep intermediate stages in the shared builder for the browser build.
+      # Export runtime layers only; archiving build stages dominates preparation.
+      # Separate scopes avoid importing the retired full-stage cache.
       - name: Build default OCI image
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -173,8 +176,8 @@ jobs:
           context: source
           platforms: linux/${{ matrix.architecture }}
           outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/default,tar=false
-          cache-from: type=gha,scope=docker-release-${{ matrix.architecture }}
-          cache-to: type=gha,mode=max,scope=docker-release-${{ matrix.architecture }}
+          cache-from: type=gha,scope=docker-release-min-${{ matrix.architecture }}
+          cache-to: type=gha,mode=min,scope=docker-release-min-${{ matrix.architecture }}
           build-args: |
             GIT_COMMIT=${{ inputs.release_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve.outputs.built_at }}
@@ -195,8 +198,8 @@ jobs:
           context: source
           platforms: linux/${{ matrix.architecture }}
           outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/browser,tar=false
-          cache-from: type=gha,scope=docker-release-browser-${{ matrix.architecture }}
-          cache-to: type=gha,mode=max,scope=docker-release-browser-${{ matrix.architecture }}
+          cache-from: type=gha,scope=docker-release-browser-min-${{ matrix.architecture }}
+          cache-to: type=gha,mode=min,scope=docker-release-browser-min-${{ matrix.architecture }}
           build-args: |
             GIT_COMMIT=${{ inputs.release_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve.outputs.built_at }}

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -323,6 +323,9 @@ targets keep their required channel.
 
 `docker-release-prepare.yml` builds both native architectures, retains OCI
 indexes and their SBOM/provenance, and runs image smoke checks before approval.
+Its GitHub Actions cache exports final image layers with `mode=min`; intermediate
+build stages stay in the shared local builder for the browser variant. This
+avoids compressing and uploading build-only layers on the release critical path.
 The final manifest records `publicationArtifacts.docker`. Preparation has no
 publication secrets or registry-write permission. After approval, `Docker
 Release` verifies the source/tag, producer, artifact hashes, and image digests,


### PR DESCRIPTION
## What Problem This Solves

Docker release preparation spent 10m18s exporting its amd64 build cache in the original 20m55s run. Saving intermediate build stages cost substantially more than exporting the OCI image itself. This follows up on #135639.

## Why This Change Was Made

Use Docker's [minimum cache mode](https://docs.docker.com/build/cache/backends/#cache-mode) for both image variants, with separate architecture/variant scopes to avoid importing old full-stage indexes. The shared local Buildx builder still reuses dependency and application builds for the browser image. The workflow comment and release-validation guide explain this tradeoff.

The owner is the preparation workflow's cache export policy. No Dockerfile, application code, or new cache backend is needed. Native runner placement, concurrency, OCI output, SBOM/provenance, smoke checks, artifact identities, and publication authorization remain enforced.

## User Impact

Release preparation spends less time saving intermediate layers. Later runs can repeat dependency installation because those layers are no longer exported; the measurements include that cost. Runtime image behavior and operator configuration are unchanged.

## Evidence

| Hosted preparation | Full workflow | amd64 default cache export | arm64 default cache export | Browser cached vertices |
| --- | ---: | ---: | ---: | ---: |
| [Original max, cold](https://github.com/openclaw/openclaw/actions/runs/33580479567) | 20m55s | 617.6s | 525.5s | 57 / 57 |
| [Max, warm repeat](https://github.com/openclaw/openclaw/actions/runs/33584617362) | 14m06s | 154.4s | 109.2s | 57 / 57 |
| [Min, fresh builder and cache index](https://github.com/openclaw/openclaw/actions/runs/33585525992) | 10m37s | 21.8s | 35.7s | 57 / 57 |
| [Min, warm repeat on fresh runners](https://github.com/openclaw/openclaw/actions/runs/33586281812) | 10m57s | 38.4s | 24.8s | 57 / 57 |

The candidate's amd64 cache preparation fell from 237.2s cold / 86.0s warm to 0.1s. Its browser cache exports took 20.0s amd64 / 32.2s arm64. All four candidate OCI image verification and smoke checks passed, and the preparation manifest sealed successfully. The full-workflow time includes an amd64 Buildx cleanup deadline warning after successful artifact uploads; that warning did not fail the job or seal.

The warm min repeat passed all four image checks and sealing, finishing 3m09s (22%) faster than warm max. Its default builds had four cached vertices per architecture and still repeated dependency installation; browser builds retained all 57 local hits. Browser cache exports took 44.2s amd64 / 29.2s arm64. Both min runs used tooling `749428788f893a3eef3411fcf3b020dd21cc8f1a`, and cache preparation remained 0.1s on both architectures.

All runs build frozen source `1fa579a1c2d5f0edb01b84edaa2974136b745b9e`, version `v2026.8.1`, with the same selected plugins, BuildKit 0.32.2 and Buildx 0.36.1. Normal per-run timestamps differ. The first min default builds had zero cached vertices; both browser builds retained all 57 local hits. New scopes isolate indexes, while [BuildKit's blob keys remain shared by digest](https://github.com/moby/buildkit/blob/v0.32.2/cache/remotecache/gha/gha.go#L171-L190), so this is not an empty-remote-store benchmark. These are observed runs, not a guarantee for every runner or registry condition.

Workflow validation, changed-file formatting, and all 139 focused Docker artifact/no-push tests passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33585015990) passed on attempt 2: 132 successful jobs, 16 skipped. Codex autoreview found no accepted/actionable P0 finding. Branch preparations validate cache and image behavior; publication still requires trusted main-lineage tooling and the final release tag. No registry image or package was published.

ClawSweeper follow-through: the comparable completed timings, four image checks, local browser reuse, and direct upstream cache contract above address the requested hosted evidence and rank-up move. Both the first min run and fresh-runner warm repeat are complete; no requested evidence remains pending.

CI follow-ups: the first attempt's source-unit shard failed two lease-termination assertions and timed out in the status authored-cap test. Their owners are unchanged by this PR; the unchanged full-shard retry passed. Track heartbeat callback-admission diagnostics and status alias setup loading if they recur. The retry establishes intermittency, not a repair; no test or timeout was changed.

Workflow delta: +7/-4 (four cache-setting replacements and three explanatory comment lines); docs: +3/-0; tests: unchanged. No application production code grows.
