### PR TITLE
refactor(agents): simplify failed-turn settlement and Codex fixtures

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test-fixtures.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test-fixtures.ts
@@ -19,7 +19,6 @@ type NativeFixtureThread = {
   thread: Record<string, unknown>;
   loaded: boolean;
   subscribed: boolean;
-  items: unknown[];
 };
 
 /** A synthetic native server, not a client mock: requests still cross the real wire and guards. */
@@ -42,10 +41,8 @@ export function createCodexLifecycleHarness(options: {
       thread: response.thread,
       loaded,
       subscribed,
-      items: [],
     };
     threads.set(response.thread.id, entry);
-    return entry;
   };
   for (const threadId of options.persistedThreads ?? []) {
     remember(nativeThreadStartResult(threadId), false, false);
@@ -122,15 +119,13 @@ export function createCodexLifecycleHarness(options: {
         current.subscribed = true;
         return current.response;
       }
-      const resumed = remember(response, true, true);
-      resumed.items = current.items;
+      remember(response, true, true);
       return response;
     }
     if (request.method === "thread/inject_items") {
       if (!current?.loaded || !current.subscribed) {
         throw new Error(`Synthetic injection requires a loaded subscription: ${threadId}`);
       }
-      current.items.push(...(Array.isArray(params.items) ? params.items : []));
       return {};
     }
     return await options.respond(request.method, request.params);
@@ -265,7 +260,6 @@ export function createCodexLifecycleTurnHarness(
     waitForMethod,
     notify,
     handleServerRequest,
-    waitForServerRequestHandler: async () => handleServerRequest,
     completeTurn: async ({ threadId, turnId }: { threadId: string; turnId: string }) => {
       await notify({
         method: "turn/completed",

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -24,6 +24,7 @@ import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { defaultRuntime } from "../../runtime.js";
+import type { ReplyPayload } from "../types.js";
 import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
 import { buildContextOverflowRecoveryText } from "./agent-runner-context-recovery.js";
 import type { AgentTurnInternalResult, AgentTurnParams } from "./agent-runner-execution.types.js";
@@ -87,6 +88,19 @@ export async function handleAgentExecutionError(params: {
       });
     params.state.pendingLifecycleTerminal = undefined;
     return terminal;
+  };
+  const settleFailure = async (
+    payload: ReplyPayload,
+    terminalMetadata?: { fallbackExhaustedFailure: true },
+  ): Promise<Extract<AgentTurnInternalResult, { kind: "final" }>> => {
+    takePendingLifecycleTerminal().emit("error", err, terminalMetadata);
+    turn.replyOperation?.fail("run_failed", err);
+    await params.modelPatch.fail(err);
+    return {
+      kind: "final",
+      payload: markAgentRunFailureReplyPayload(payload),
+      postCompactionModelFailure,
+    };
   };
   const resolveReplyOperationAbortAction = (abortError: unknown): ErrorAction | undefined => {
     const reason = isAgentRunRestartAbortReason(abortError)
@@ -169,14 +183,7 @@ export async function handleAgentExecutionError(params: {
       isGenericRunnerFailure: externalReply.isGenericRunnerFailure,
       cfg: turn.followupRun.run.config,
     });
-    takePendingLifecycleTerminal().emit("error", err);
-    turn.replyOperation?.fail("run_failed", err);
-    await params.modelPatch.fail(err);
-    return {
-      kind: "final",
-      payload: markAgentRunFailureReplyPayload({ text }),
-      postCompactionModelFailure,
-    };
+    return await settleFailure({ text });
   }
   const failoverFacts = resolveReplyFailoverFacts(err, message);
   const fallbackAttempts = isFailoverError(err) ? err.attempts : undefined;
@@ -245,18 +252,11 @@ export async function handleAgentExecutionError(params: {
   }
   const replayPrevented = findCliTimeoutError(err)?.cliTimeout.observedActivity === true;
   if (providerRequestError) {
-    takePendingLifecycleTerminal().emit("error", err);
-    turn.replyOperation?.fail("run_failed", err);
-    await params.modelPatch.fail(err);
-    return {
-      kind: "final",
-      payload: markAgentRunFailureReplyPayload({
-        // Curated facet copy beats the generic classified summary; see
-        // buildExternalRunFailureReply for the same priority.
-        text: providerRequestError.userMessage,
-      }),
-      postCompactionModelFailure,
-    };
+    return await settleFailure({
+      // Curated facet copy beats the generic classified summary; see
+      // buildExternalRunFailureReply for the same priority.
+      text: providerRequestError.userMessage,
+    });
   }
   defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
   const isPureTransientSummary = Boolean(
@@ -333,17 +333,13 @@ export async function handleAgentExecutionError(params: {
     isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
     cfg: turn.followupRun.run.config,
   });
-  takePendingLifecycleTerminal().emit("error", err, { fallbackExhaustedFailure: true });
-  turn.replyOperation?.fail("run_failed", err);
-  await params.modelPatch.fail(err);
-  return {
-    kind: "final",
-    payload: markAgentRunFailureReplyPayload({
+  return await settleFailure(
+    {
       text: userVisibleFallbackText,
       ...(externalRunFailureReply?.presentation
         ? { presentation: externalRunFailureReply.presentation }
         : {}),
-    }),
-    postCompactionModelFailure,
-  };
+    },
+    { fallbackExhaustedFailure: true },
+  );
 }


### PR DESCRIPTION
Related: [the stale Codex instruction repair](https://github.com/openclaw/openclaw/pull/135577).

## What Problem This Solves

Maintainer-requested cleanup following the Codex instruction repair. Failed-turn maintenance required keeping three equivalent settlement paths aligned, while the native lifecycle fixture retained history state and an accessor that no test consumed.

## Why This Change Was Made

One local, typed helper now owns the shared final-settlement sequence. The fixture drops only unused bookkeeping; its real-client wire, request recording, loaded/subscribed validation, and lifecycle transitions remain intact.

Production **+25/−29 (net −4)**; test support **+1/−7 (net −6)**. No regression tests were removed. A proposed direct throw inside `finally` was discarded rather than suppressing or circumventing `no-unsafe-finally`.

## User Impact

No intended user-visible behavior change. Preflight refusals remain ahead of provider-text classification, visible delivery settles before terminal failure, model-patch failure remains awaited, post-compaction attribution is preserved, and only the existing final fallback branch emits fallback-exhaustion metadata. Policy text, ownership checks, incognito refusal/recovery, persistence, and native protocols are unchanged.

This is not a fix for the separate empty-policy model-adherence limitation described below.

## Evidence

- The same ordered **1,258 tests across 47 files** passed on both unmodified `main` (`c4b8d42bd42cdf4ef447bd48dc96abc1fa33c27f`) and the cleanup candidate in [Blacksmith Testbox run 33580471050](https://github.com/openclaw/openclaw/actions/runs/33580471050). The two retained files are byte-identical to that tested candidate; the discarded `finally` change was restored exactly to `HEAD`. The separately gated native-MCP live suite was explicitly excluded from the hermetic run. Counts overlap and must not be summed.
- The final two-file changed gate passed locally: four typecheck lanes, formatting, lint, dead-export checks, doctor contracts, boundary/schema guards, and import-cycle checks. An abandoned artifact owner and its child claim were inspected and removed only after verifying the associated processes/groups were gone.
- Fresh isolated Codex autoreview of the final two-file diff was **scoped-clean at P0/P1**, with no findings. This review is separate from test execution.
- The branch was rebased onto `82bcef85ffef1010e53cac09b4ea0bcea7b68f72`; both changed files remained byte-identical. [Exact-head PR CI 33585118125](https://github.com/openclaw/openclaw/actions/runs/33585118125) completed successfully at `2b817962e6c75356ea32d1124f6b15b47427f3af`.
- Refreshed-head hook-context/projector/attempt smoke passed **192 tests in three files**. Its first attempt stopped before collection because a local Vitest file was missing; one frozen dependency repair followed by the same command passed.

The final local static command was:

```bash
node scripts/check-changed.mjs --base c4b8d42bd42cdf4ef447bd48dc96abc1fa33c27f -- extensions/codex/src/app-server/thread-lifecycle.test-fixtures.ts src/auto-reply/reply/agent-runner-error-handler.ts
```

The refreshed-head smoke command was:

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.auth-context.test.ts extensions/codex/src/app-server/event-projector.verbose-hooks.test.ts extensions/codex/src/app-server/run-attempt.test.ts
```

The first broad Mac test attempt hit CLI-test timeouts and subsequent preflight call-count failures after multi-minute imports. The clean Linux baseline/candidate comparison retained ordering, assertions, and timeouts; no assertions were weakened and no timeout was increased. No unsupported OS or package-manager root-cause claim is made.

### Live verification qualification

Real OpenClaw hook/admitted-host/lifecycle composition, stock Codex **0.151.0**, and actual `gpt-5.6-luna` inference exercised **12 scenarios and 28 HTTP requests**. The corrected recording relay retained native OpenAI provider semantics and protocol headers, and asserted generic-policy provenance metadata. All native handoff/ownership assertions passed, and all 15 clients and both servers closed.

**The live model-output result was 11/12, not fully green:** one warm empty-policy turn returned the old policy marker even though the request contained empty native configuration and the later explicit withdrawal notice. Replacement, cold withdrawal, incognito refusal/recovery, contention recovery, and compaction checks passed. Earlier custom-provider captures are not treated as default OpenAI proof: stock Codex strips internal metadata for non-OpenAI provider identities.

That finding is recorded for a separate behavioral investigation; this cleanup neither changes the policy producer/carrier nor claims to fix model adherence. The failing canary completed as a successful native attempt, so it did not exercise the changed error-settlement path; the changed fixture bookkeeping is not used by the real native probe. No policy-format change, forced compaction, replay, or history rewrite is introduced here. The task credential stayed in the recording relay and was never passed to the native environment or persisted; the credential window and Testbox lease were closed.

Pinned dependency source personally checked at `78c290807ce710180111df227df3b7a4fe845452`: [generic context versus later-turn differences](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/session/mod.rs#L3675-L3701), [history injection](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/codex_thread.rs#L626-L662), [loaded-resume ownership](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server/src/request_processors/thread_processor.rs#L4133-L4183), and [provider-specific metadata stripping](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/client.rs#L968-L978).
