### PR TITLE
fix(doctor): bind package repair diagnostics to installed roots

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -208,7 +208,9 @@ or a reported missing runtime entry;
 an empty directory is not a successful installation. Rollback removes empty
 managed npm projects after staged files are cleaned up. Doctor preserves external
 companion packages and their install records even when a source checkout also
-contains a bundled-discovery copy of the same plugin.
+contains a bundled-discovery copy of the same plugin. Repair diagnostics must identify the recorded
+package root; a broken same-ID source copy does not trigger replacement of a
+healthy managed package.
 
 With `--json`, stdout contains one JSON document. Doctor panels and other
 diagnostics go to stderr, so stdout can be parsed directly. Failed doctor or

--- a/src/commands/doctor-plugin-registry.test.ts
+++ b/src/commands/doctor-plugin-registry.test.ts
@@ -437,6 +437,7 @@ describe("maybeRepairPluginRegistryState", () => {
       packageName: "@openclaw/google-meet",
       bundledDist: undefined,
       missingEntry: false,
+      missingSourceEntry: false,
     },
     {
       name: "source-external",
@@ -444,6 +445,7 @@ describe("maybeRepairPluginRegistryState", () => {
       packageName: "@openclaw/external-demo",
       bundledDist: false,
       missingEntry: false,
+      missingSourceEntry: false,
     },
     {
       name: "partial catalog-owned external",
@@ -451,10 +453,19 @@ describe("maybeRepairPluginRegistryState", () => {
       packageName: "@openclaw/google-meet",
       bundledDist: undefined,
       missingEntry: true,
+      missingSourceEntry: false,
+    },
+    {
+      name: "healthy catalog-owned external beside a broken source copy",
+      pluginId: "google-meet",
+      packageName: "@openclaw/google-meet",
+      bundledDist: undefined,
+      missingEntry: false,
+      missingSourceEntry: true,
     },
   ])(
     "preserves installed $name plugin payload and records across repeated doctor repairs",
-    async ({ pluginId, packageName, bundledDist, missingEntry }) => {
+    async ({ pluginId, packageName, bundledDist, missingEntry, missingSourceEntry }) => {
       const stateDir = makeTempDir();
       const version = "2026.5.2";
       const bundledDir = path.join(stateDir, "source", "extensions", pluginId);
@@ -481,6 +492,12 @@ describe("maybeRepairPluginRegistryState", () => {
         version: "2026.5.3",
         bundledDist,
       });
+      if (missingSourceEntry) {
+        const manifestPath = path.join(bundledDir, "package.json");
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+        manifest.openclaw = { ...manifest.openclaw, extensions: ["./missing.js"] };
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+      }
       const config: OpenClawConfig = {
         plugins: { allow: [pluginId], entries: { [pluginId]: { enabled: true } } },
       };

--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -60,15 +60,6 @@ export type BundledPluginPackageDescriptor = {
   packageName?: string;
 };
 
-function resolvePluginPathIdentity(
-  value: string,
-  env: NodeJS.ProcessEnv,
-  realpathCache: Map<string, string>,
-): string {
-  const resolved = path.resolve(resolveUserPath(value, env));
-  return safeRealpathSync(resolved, realpathCache) ?? resolved;
-}
-
 /** Keep doctor diagnostics and actual package repair on the same discovery snapshot. */
 export async function resolveConfiguredPluginInstallContext(params: {
   cfg: OpenClawConfig;
@@ -78,6 +69,11 @@ export async function resolveConfiguredPluginInstallContext(params: {
   blockedPluginIds?: ReadonlySet<string>;
   baselineRecords?: Record<string, PluginInstallRecord>;
 }) {
+  const realpathCache = new Map<string, string>();
+  const resolvePathIdentity = (value: string): string => {
+    const resolved = path.resolve(resolveUserPath(value, params.env));
+    return safeRealpathSync(resolved, realpathCache) ?? resolved;
+  };
   const snapshot = loadManifestMetadataSnapshot({ config: params.cfg, env: params.env });
   const currentBundledPlugins = loadInstalledPluginIndex({
     config: params.cfg,
@@ -115,6 +111,7 @@ export async function resolveConfiguredPluginInstallContext(params: {
     collectInstalledPluginIdsWithRepairablePackageDiagnostics({
       snapshot,
       installRecords: records,
+      resolvePathIdentity,
     });
   const installedPluginIdsWithStaleVersionBoundRuntimePackages =
     collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages({
@@ -138,21 +135,18 @@ export async function resolveConfiguredPluginInstallContext(params: {
       blockedPluginIds: params.blockedPluginIds,
     }).keys(),
   );
-  const realpathCache = new Map<string, string>();
   const configuredLoadPathIdentities = new Set(
     snapshot.discovery?.candidates
       .filter((candidate) => candidate.configSelected)
       .flatMap((candidate) => [candidate.rootDir, candidate.source])
-      .map((value) => resolvePluginPathIdentity(value, params.env, realpathCache)),
+      .map(resolvePathIdentity),
   );
   const configuredLoadPathPluginsById = new Map<string, string>();
   for (const plugin of snapshot.plugins) {
     if (
       plugin.origin === "config" ||
       [plugin.rootDir, plugin.source].some((value) =>
-        configuredLoadPathIdentities.has(
-          resolvePluginPathIdentity(value, params.env, realpathCache),
-        ),
+        configuredLoadPathIdentities.has(resolvePathIdentity(value)),
       )
     ) {
       configuredLoadPathPluginsById.set(plugin.id, plugin.rootDir);
@@ -170,17 +164,10 @@ export async function resolveConfiguredPluginInstallContext(params: {
     if (!configPluginRoot || record.source !== "path" || recordedPaths.length === 0) {
       continue;
     }
-    const configRootIdentity = resolvePluginPathIdentity(
-      configPluginRoot,
-      params.env,
-      realpathCache,
-    );
+    const configRootIdentity = resolvePathIdentity(configPluginRoot);
     if (
       isInstalledRecordMissingOnDisk(record, params.env) &&
-      recordedPaths.every(
-        (value) =>
-          resolvePluginPathIdentity(value, params.env, realpathCache) !== configRootIdentity,
-      )
+      recordedPaths.every((value) => resolvePathIdentity(value) !== configRootIdentity)
     ) {
       stalePathInstallPluginIds.add(pluginId);
     }
@@ -505,6 +492,7 @@ function collectConfiguredPluginIdsWithMissingChannelConfigDescriptors(params: {
 function collectInstalledPluginIdsWithRepairablePackageDiagnostics(params: {
   snapshot: PluginMetadataSnapshot;
   installRecords: Record<string, PluginInstallRecord>;
+  resolvePathIdentity: (value: string) => string;
 }): Set<string> {
   const pluginIds = new Set<string>();
   for (const diagnostic of params.snapshot.diagnostics) {
@@ -512,7 +500,12 @@ function collectInstalledPluginIdsWithRepairablePackageDiagnostics(params: {
     if (!pluginId || !Object.hasOwn(params.installRecords, pluginId)) {
       continue;
     }
+    const installPath = params.installRecords[pluginId]?.installPath;
+    // A same-id source copy must never authorize replacing the recorded package.
     if (
+      installPath &&
+      diagnostic.source &&
+      params.resolvePathIdentity(diagnostic.source) === params.resolvePathIdentity(installPath) &&
       REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS.some((marker) =>
         diagnostic.message.includes(marker),
       )

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test-helpers.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test-helpers.ts
@@ -133,13 +133,18 @@ export function successfulUpdate(
   };
 }
 
-export function brokenPluginSnapshot(pluginId: string, expectedEntry = "./dist/index.js") {
+export function brokenPluginSnapshot(
+  pluginId: string,
+  source: string,
+  expectedEntry = "./dist/index.js",
+) {
   return {
     plugins: [],
     diagnostics: [
       {
         level: "error",
         pluginId,
+        source,
         message: `installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ${expectedEntry}.`,
       },
     ],

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -230,7 +230,7 @@ function mockBrokenBraveInstall(
     ...recordOverrides,
   });
   mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-  mocks.loadPluginMetadataSnapshot.mockReturnValue(brokenPluginSnapshot("brave"));
+  mocks.loadPluginMetadataSnapshot.mockReturnValue(brokenPluginSnapshot("brave", installDir));
   mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
     officialWebSearchPluginEntry({
       id: "brave",
@@ -408,7 +408,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         plugins: [{ id: "codex", packageVersion: "2026.5.6", channels: ["codex"] }],
         diagnostics:
           previousState === "damaged"
-            ? brokenPluginSnapshot("codex").diagnostics
+            ? brokenPluginSnapshot("codex", installDir).diagnostics
             : previousState === "stale-descriptor"
               ? [{ level: "error", pluginId: "codex", message: "without channelConfigs metadata" }]
               : [],
@@ -2801,8 +2801,8 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     mocks.loadPluginMetadataSnapshot.mockReturnValue({
       plugins: [],
       diagnostics: [
-        ...brokenPluginSnapshot("brave").diagnostics,
-        ...brokenPluginSnapshot("discord").diagnostics,
+        ...brokenPluginSnapshot("brave", records.brave.installPath).diagnostics,
+        ...brokenPluginSnapshot("discord", records.discord.installPath).diagnostics,
       ],
     });
     mocks.updateNpmInstalledPlugins.mockResolvedValue({
@@ -3972,6 +3972,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         {
           level: "error",
           pluginId: "demo",
+          source: records.demo.installPath,
           message: "extension entry escapes package directory: ./index.ts",
         },
       ],
@@ -4386,7 +4387,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       clawhubUrl: "https://clawhub.ai",
     });
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-    mocks.loadPluginMetadataSnapshot.mockReturnValue(brokenPluginSnapshot(pluginId));
+    mocks.loadPluginMetadataSnapshot.mockReturnValue(brokenPluginSnapshot(pluginId, installDir));
     if (catalogKind === "provider") {
       mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
         officialWebSearchPluginEntry({

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -770,19 +770,32 @@ describe("loadPluginManifestRegistry", () => {
     writeManifest(globalDir, manifest);
     writeManifest(configDir, manifest);
 
-    const registry = loadRegistry([
-      createPluginCandidate({
-        idHint: "external-chat",
-        rootDir: globalDir,
-        origin: "global",
-      }),
-      createPluginCandidate({
-        idHint: "external-chat",
-        rootDir: configDir,
-        origin: "config",
-      }),
-    ]);
+    const registry = loadPluginManifestRegistryCore({
+      candidates: [
+        createPluginCandidate({
+          idHint: "external-chat",
+          rootDir: globalDir,
+          origin: "global",
+        }),
+        createPluginCandidate({
+          idHint: "external-chat",
+          rootDir: configDir,
+          origin: "config",
+        }),
+      ],
+      diagnostics: [globalDir, configDir, globalDir].map((source) => ({
+        level: "warn" as const,
+        pluginId: "external-chat",
+        source,
+        message: "extension entry unreadable (I/O error): ./index.js",
+      })),
+    });
 
+    expect(
+      registry.diagnostics
+        .filter((diagnostic) => diagnostic.message.includes("extension entry unreadable"))
+        .map((diagnostic) => diagnostic.source),
+    ).toEqual([globalDir, configDir]);
     const channelConfigWarnings = registry.diagnostics.filter((diagnostic) =>
       diagnostic.message.includes("without channelConfigs metadata"),
     );

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -626,16 +626,21 @@ function pushManifestCompatibilityDiagnostics(params: {
   pushNonBundledChannelConfigDescriptorDiagnostic(params);
 }
 
-function dedupePluginDiagnostics(diagnostics: PluginDiagnostic[]): PluginDiagnostic[] {
+function dedupePluginDiagnostics(
+  diagnostics: PluginDiagnostic[],
+  discoveryDiagnostics: ReadonlySet<PluginDiagnostic>,
+): PluginDiagnostic[] {
   const seen = new Set<string>();
   const deduped: PluginDiagnostic[] = [];
   for (const diagnostic of diagnostics) {
-    // Errors belong to their failed source; equivalent compatibility warnings remain owner-deduped.
+    // Discovery diagnostics belong to package roots; generated compatibility warnings belong to ids.
     const key = JSON.stringify([
       diagnostic.level,
       diagnostic.pluginId ?? "",
       diagnostic.message,
-      diagnostic.level === "error" ? (diagnostic.source ?? "") : "",
+      diagnostic.level === "error" || discoveryDiagnostics.has(diagnostic)
+        ? (diagnostic.source ?? "")
+        : "",
     ]);
     if (seen.has(key)) {
       continue;
@@ -880,7 +885,8 @@ export function loadPluginManifestRegistryCore(
         env,
         installRecords: getInstallRecords(),
       }));
-  const diagnostics: PluginDiagnostic[] = [...discovery.diagnostics];
+  const discovered = new Set(discovery.diagnostics);
+  const diagnostics: PluginDiagnostic[] = [...discovered];
   const candidates: PluginCandidate[] = discovery.candidates;
   const records: PluginManifestRecord[] = [];
   const seenIds = new Map<string, SeenIdEntry>();
@@ -1133,7 +1139,7 @@ export function loadPluginManifestRegistryCore(
   }
 
   const plugins = rejectCaseFoldedIdCollisions(records, diagnostics);
-  const registry = { plugins, diagnostics: dedupePluginDiagnostics(diagnostics) };
+  const registry = { plugins, diagnostics: dedupePluginDiagnostics(diagnostics, discovered) };
   return registry;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #135791 and its late ClawSweeper finding. The original retirement/rollback fix is landed, but Doctor could select a healthy managed package for repair when a broken source-checkout copy shared its plugin ID. Reinstalling the managed package cannot repair the source copy and can repeat on every Doctor run.

## Why This Change Was Made

Package-entry diagnostics already carry the scanned package root. Doctor now requires that root to match the recorded install root after environment-aware path and realpath normalization, for all package-entry repair markers. It does not fall back to `record.sourcePath`, use containment guesses, or accept a missing diagnostic source.

The existing path-identity helper is now a context-local closure shared by load-path and diagnostic matching. This removes repeated argument plumbing rather than adding a parallel repair policy.

Discovery warnings also retain source identity through final registry deduplication. The registry distinguishes discovery-owned diagnostics by their original object identity; registry-generated compatibility warnings retain their existing owner-level deduplication. This preserves warnings from both roots without introducing another message classifier or weakening the compatibility-warning contract.

## User Impact

A broken same-ID source copy no longer triggers replacement of a healthy managed package. An actual missing managed entry still repairs successfully, and repeated Doctor runs preserve the external payload and record. Source-specific discovery warnings remain available to select the correct repair owner.

No config, environment, schema, public SDK type, or baseline changes. Production delta is +27/-28 (net -1). The update CLI docs describe package-root ownership for repair.

Separate named follow-up: missing-channel-descriptor diagnostics use manifest-file paths and a different collector (`collectConfiguredPluginIdsWithMissingChannelConfigDescriptors`). Attribution of a stale explicitly configured local descriptor to a healthy same-ID npm record needs its own reproduction and contract review; this change is scoped to package-entry diagnostics and does not claim to fix that separate path.

## Evidence

Failing-before proof on the landed #135791 tree:

- Real Doctor order: registry cleanup followed by health detection selected a healthy recorded package because the broken source copy shared its ID. `doctor-plugin-registry.test.ts` expected no repair issues but received `repairable-installed-plugin` for the managed package.
- Registry source preservation: two discovery warnings with the same ID/message but distinct roots collapsed to one. The existing compatibility-deduplication test expected both roots and received only the first.

Passing-after proof: `pnpm test src/commands/doctor-plugin-registry.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/manifest-registry.test.ts` — 246 tests passed. The real Doctor-order case executes both retirement/repair passes twice; the warning case verifies distinct-root preservation, same-root deduplication, and unchanged compatibility-warning deduplication together.

Uncommitted Codex autoreview exited 0: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`.

The requested `pnpm plugin-sdk:api:gen` command has been removed from current main. Its documented replacement, `pnpm plugin-sdk:api:diff --base b2f747df3dd2e723eea5a71e09ed0f310aa5d977 --head d1684c2360e0986e46bd9aa9b0255dd6103a4508`, reports no Plugin SDK API changes. Full changed-file checks passed. Exact-head CI passed for d1684c2360e0986e46bd9aa9b0255dd6103a4508: https://github.com/openclaw/openclaw/actions/runs/33585164024 . No baseline is being recreated or edited.

Final branch autoreview exited 0 with the same scoped-clean result.

`node scripts/check-changed.mjs -- <all seven changed files>` passed, including typechecks, lint, dead exports and repository guards. SDK API comparison completed with exit 0 and no API changes.
