### PR TITLE
fix(agents): report current failover counters in console logs

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-observation.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.test.ts
@@ -4,11 +4,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { log } from "../logger.js";
 import { createFailoverDecisionLogger } from "./failover-observation.js";
 
-function observeDecision(overrides: Partial<Parameters<typeof createFailoverDecisionLogger>[0]>) {
-  // Keep the base case boring so each test only states the failure dimension
-  // whose log metadata should change.
-  const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
-  const logDecision = createFailoverDecisionLogger({
+type DecisionBase = Parameters<typeof createFailoverDecisionLogger>[0];
+type LogCall = Parameters<typeof log.warn>;
+type LogSpy = { mock: { calls: LogCall[] } };
+
+function createDecisionLogger(overrides: Partial<DecisionBase> = {}) {
+  return createFailoverDecisionLogger({
     stage: "assistant",
     runId: "run:base",
     rawError: "",
@@ -22,44 +23,28 @@ function observeDecision(overrides: Partial<Parameters<typeof createFailoverDeci
     aborted: false,
     ...overrides,
   });
-  logDecision("surface_error");
+}
+
+function observeDecision(overrides: Partial<DecisionBase>) {
+  const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+  createDecisionLogger(overrides)("surface_error");
   return firstWarnDetails(warnSpy);
 }
 
-function firstWarnCall(warnSpy: { mock: { calls: unknown[][] } }): unknown[] {
-  const call = warnSpy.mock.calls[0];
+function firstWarnCall(logSpy: LogSpy): LogCall {
+  const call = logSpy.mock.calls[0];
   if (!call) {
-    throw new Error("Expected warning log");
+    throw new Error("Expected failover decision log");
   }
   return call;
 }
 
-function firstWarnDetails(warnSpy: { mock: { calls: unknown[][] } }): {
-  consoleMessage?: string;
-  failoverReason?: string | null;
-  model?: string;
-  profileFailureReason?: string | null;
-  provider?: string;
-  providerRuntimeFailureKind?: string;
-  rawErrorPreview?: string;
-  sourceModel?: string;
-  sourceProvider?: string;
-  timedOut?: boolean;
-} {
-  // The logger intentionally records structured details separate from the
-  // console message, so assertions can cover both machine and human evidence.
-  return firstWarnCall(warnSpy)[1] as {
-    consoleMessage?: string;
-    failoverReason?: string | null;
-    model?: string;
-    profileFailureReason?: string | null;
-    provider?: string;
-    providerRuntimeFailureKind?: string;
-    rawErrorPreview?: string;
-    sourceModel?: string;
-    sourceProvider?: string;
-    timedOut?: boolean;
-  };
+function firstWarnDetails(logSpy: LogSpy) {
+  const details = firstWarnCall(logSpy)[1];
+  if (!details) {
+    throw new Error("Expected structured failover details");
+  }
+  return details;
 }
 
 afterEach(() => {
@@ -92,23 +77,67 @@ describe("createFailoverDecisionLogger timeout normalization", () => {
   });
 });
 
+describe("createFailoverDecisionLogger counters", () => {
+  it.each([
+    ["retry increment", "retry_same_model", 0, 0, { retryCount: 1, profileRotationCount: 0 }, 1, 0],
+    [
+      "rotation increment",
+      "rotate_profile",
+      0,
+      0,
+      { retryCount: 0, profileRotationCount: 1 },
+      0,
+      1,
+    ],
+    ["explicit zero", "retry_same_model", 3, 2, { retryCount: 0, profileRotationCount: 0 }, 0, 0],
+    ["absent extras", "retry_same_model", 3, 2, undefined, 3, 2],
+    ["absent rotation", "retry_same_model", 3, 2, { retryCount: 1 }, 1, 2],
+    ["absent retry", "rotate_profile", 3, 2, { profileRotationCount: 1 }, 3, 1],
+  ] as const)(
+    "keeps %s identical in structured and console details",
+    (
+      _name,
+      decision,
+      retryCount,
+      profileRotationCount,
+      extra,
+      expectedRetry,
+      expectedRotations,
+    ) => {
+      const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+      createDecisionLogger({
+        failoverReason: "overloaded",
+        retryCount,
+        profileRotationCount,
+      })(decision, extra);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const details = firstWarnDetails(warnSpy);
+      expect(details).toMatchObject({
+        decision,
+        retryCount: expectedRetry,
+        profileRotationCount: expectedRotations,
+      });
+      expect(details.consoleMessage).toContain(
+        `retry=${expectedRetry} rotations=${expectedRotations} `,
+      );
+    },
+  );
+});
+
 describe("createFailoverDecisionLogger", () => {
   it("includes from and to model refs when the source differs from the selected target", () => {
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
-    const logDecision = createFailoverDecisionLogger({
-      stage: "assistant",
+    const logDecision = createDecisionLogger({
       runId: "run:failover",
       rawError: "timeout",
       failoverReason: "timeout",
       profileFailureReason: "timeout",
-      provider: "openai",
       model: "gpt-5.4",
       sourceProvider: "github-copilot",
       sourceModel: "gpt-5.4-mini",
-      profileId: "openai:p1",
       fallbackConfigured: true,
       timedOut: true,
-      aborted: false,
       attemptCount: 4,
       retryCount: 2,
       profileRotationCount: 1,
@@ -135,20 +164,16 @@ describe("createFailoverDecisionLogger", () => {
 
   it("omits to model refs when the source matches the selected target", () => {
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
-    const logDecision = createFailoverDecisionLogger({
-      stage: "assistant",
+    const logDecision = createDecisionLogger({
       runId: "run:same-model",
       rawError: "timeout",
       failoverReason: "timeout",
       profileFailureReason: "timeout",
-      provider: "openai",
       model: "gpt-5.4",
       sourceProvider: "openai",
       sourceModel: "gpt-5.4",
-      profileId: "openai:p1",
       fallbackConfigured: true,
       timedOut: true,
-      aborted: false,
     });
 
     logDecision("surface_error");
@@ -159,20 +184,15 @@ describe("createFailoverDecisionLogger", () => {
 
   it("omits raw HTML auth bodies from consoleMessage for HTML 401 auth failures", () => {
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
-    const logDecision = createFailoverDecisionLogger({
-      stage: "assistant",
+    const logDecision = createDecisionLogger({
       runId: "run:auth-html",
       rawError: "401 <!DOCTYPE html><html><body>Unauthorized</body></html>",
       failoverReason: "auth",
       profileFailureReason: "auth",
-      provider: "openai",
       model: "gpt-5.4",
       sourceProvider: "openai",
       sourceModel: "gpt-5.4",
-      profileId: "openai:p1",
       fallbackConfigured: true,
-      timedOut: false,
-      aborted: false,
     });
 
     logDecision("rotate_profile");
@@ -194,20 +214,15 @@ describe("createFailoverDecisionLogger", () => {
       "403 <!DOCTYPE html><html><head><title>403 Forbidden</title></head>" +
       "<body>Enable JavaScript and cookies to continue." +
       "<p>Please stand by, while we are checking your browser...</p></body></html>";
-    const logDecision = createFailoverDecisionLogger({
-      stage: "assistant",
+    const logDecision = createDecisionLogger({
       runId: "run:cf-challenge",
       rawError: cfChallengeHtml,
       failoverReason: "auth",
       profileFailureReason: "auth",
-      provider: "openai",
       model: "gpt-5.4",
       sourceProvider: "openai",
       sourceModel: "gpt-5.4",
-      profileId: "openai:p1",
       fallbackConfigured: true,
-      timedOut: false,
-      aborted: false,
     });
 
     logDecision("rotate_profile");

--- a/src/agents/embedded-agent-runner/run/failover-observation.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.ts
@@ -90,6 +90,8 @@ export function createFailoverDecisionLogger(
       !shouldSuppressRawErrorConsoleSuffix(observedError.providerRuntimeFailureKind)
         ? ` rawError=${safeRawErrorPreview}`
         : "";
+    const retryCount = extra?.retryCount ?? normalizedBase.retryCount;
+    const profileRotationCount = extra?.profileRotationCount ?? normalizedBase.profileRotationCount;
     log.warn("embedded run failover decision", {
       event: "embedded_run_failover_decision",
       tags: ["error_handling", "failover", normalizedBase.stage, decision],
@@ -107,14 +109,14 @@ export function createFailoverDecisionLogger(
       timedOut: normalizedBase.timedOut,
       aborted: normalizedBase.aborted,
       status: extra?.status,
-      retryCount: extra?.retryCount ?? normalizedBase.retryCount,
-      profileRotationCount: extra?.profileRotationCount ?? normalizedBase.profileRotationCount,
+      retryCount,
+      profileRotationCount,
       attemptCount: normalizedBase.attemptCount,
       ...observedError,
       consoleMessage:
         `embedded run failover decision: runId=${safeRunId} stage=${normalizedBase.stage} decision=${decision} ` +
         `reason=${reasonText} attempt=${normalizedBase.attemptCount ?? "-"} ` +
-        `retry=${normalizedBase.retryCount ?? "-"} rotations=${normalizedBase.profileRotationCount ?? "-"} ` +
+        `retry=${retryCount ?? "-"} rotations=${profileRotationCount ?? "-"} ` +
         `from=${safeSourceProvider}/${safeSourceModel}` +
         `${sourceChanged ? ` to=${safeProvider}/${safeModel}` : ""} profile=${profileText}${rawErrorConsoleSuffix}`,
     });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where operators tracing an embedded-agent retry or profile rotation see stale counters in the console while the structured log records the current values. A retry can show `retry=0` even though the decision record correctly says `retryCount: 1`.

## Why This Change Was Made

The logger captures attempt context before the action, then receives updated counters when the action is selected. Resolve those effective values once at that callback boundary and reuse them in both log projections. This removes the duplicate counter selection without changing retry policy, severity, redaction, or when presentation work happens.

Explicit zero remains zero; omitted overrides retain the original captured values. One emission cannot change the base for later emissions. Nearby tests now share their fixture and derive logger argument types instead of repeating a payload type.

## User Impact

Console and structured diagnostics agree when retries advance or profiles rotate. Both prompt-stage and assistant-stage callers use the same repaired logger. No configuration, provider behavior, persistence, or public API changes.

## Evidence

- Before editing the owner, the proposed regression suite produced 73 passes and exactly five expected console-counter assertion failures across four complete files. With the candidate, all 78 tests passed, with zero unhandled errors in either run. Coverage includes the logger, assistant failover, assistant failure, and prompt failure suites under the canonical embedded-agent-run Vitest configuration.
- A separate native-source run used the real logger, file transport, and Node Console with owned regular-file streams: 33 observations and 37 callbacks per variant. The original reproduced increment and explicit-zero disagreements; the candidate repaired them. All 37 records remained WARN; stdout remained empty. Full native file/stderr bytes matched outside bounded timestamps and the declared counter corrections.
- Two successive emissions verified that an override does not mutate captured counters. Redaction, HTML suppression, timeout normalization, omitted overrides, and unchanged actions remained paired. All task processes and temporary state were closed.
- Independent source review and Codex autoreview; formatting and diff checks. The test file was subsequently formatted without semantic changes. Exact-head CI will verify the submitted bytes.

Production delta: +5/-3 (net +2) for the two shared effective values; tests: +72/-57 (net +15 after formatting and fixture consolidation). This is a correctness repair, with no performance claim. Native logger proof does not claim a forced live-provider failover.
