### PR TITLE
fix(secrets): publish the durable auth order on a running gateway refresh

### DIFF
--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -572,6 +572,10 @@ export function getRuntimeAuthProfileStoreCredentialsRevision(): number {
   return runtimeAuthStoreCredentialsRevision;
 }
 
+export function getRuntimeAuthProfileStoreSnapshotsRevision(): number {
+  return runtimeAuthStoreSnapshotsRevision;
+}
+
 /** Process-local generation for one exact runtime snapshot rollback owner. */
 export function getRuntimeAuthProfileStoreSnapshotRevision(agentDir?: string): number {
   return getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(resolveRuntimeStoreKey(agentDir));

--- a/src/agents/auth-profiles/store-state-owner.test.ts
+++ b/src/agents/auth-profiles/store-state-owner.test.ts
@@ -14,6 +14,7 @@ import { resolveSharedAuthStorePath } from "./path-resolve.js";
 import { loadPersistedAuthProfileStore, loadPersistedSharedAuthProfileStore } from "./persisted.js";
 import {
   getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   listOwnedRuntimeAuthProfileStoreSnapshots,
   prepareRuntimeAuthProfileStoreSnapshots,
   replaceOwnedRuntimeAuthProfileStoreSnapshots,
@@ -324,6 +325,7 @@ describe("explicit auth state ownership", () => {
             config: {},
             authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores),
             authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+            authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
             warnings: [],
             webTools: {
               search: { providerSource: "none", diagnostics: [] },

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -22,7 +22,10 @@ import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-reque
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
 import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { getRuntimeAuthProfileStoreCredentialsRevision } from "./auth-profiles/runtime-snapshots.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
+} from "./auth-profiles/runtime-snapshots.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
@@ -751,6 +754,7 @@ describe("createOpenClawTools browser plugin integration", () => {
       config: staleRuntimeConfig,
       authStores: [],
       authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
       warnings: [],
       webTools: {
         search: {

--- a/src/commands/agent.runtime-config.test.ts
+++ b/src/commands/agent.runtime-config.test.ts
@@ -111,6 +111,7 @@ const prepareSecretsRuntimeSnapshotMock = vi.hoisted(() =>
       config: params.assignmentConfig,
       authStores: [],
       authStoreCredentialsRevision: 0,
+      authStoreSnapshotsRevision: 0,
       warnings: [],
       webTools: {},
     }),

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -22,6 +22,7 @@ vi.mock("../secrets/store/secret-store.js", () => {
 });
 import {
   getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   getRuntimeAuthProfileStoreSnapshotCore,
   setRuntimeAuthProfileStoreSnapshot,
 } from "../agents/auth-profiles/runtime-snapshots.js";
@@ -88,6 +89,7 @@ function createSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapshot 
     config,
     authStores: [],
     authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+    authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
     warnings: [],
     webTools: {
       search: { providerSource: "none", diagnostics: [] },

--- a/src/gateway/server-methods/question.test.ts
+++ b/src/gateway/server-methods/question.test.ts
@@ -58,6 +58,7 @@ function mockReferencedStoreSnapshot() {
     config: {},
     authStores: [],
     authStoreCredentialsRevision: 0,
+    authStoreSnapshotsRevision: 0,
     warnings: [],
     webTools: {
       search: { providerSource: "none", diagnostics: [] },

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -5,7 +5,10 @@
  * lifecycle instead of individual config writers.
  */
 import { describe, expect, it, vi } from "vitest";
-import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
+} from "../agents/auth-profiles/runtime-snapshots.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
 import { startManagedGatewayConfigReloader } from "./server-reload-handlers.js";
@@ -112,6 +115,7 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
         config,
         authStores: [],
         authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+        authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
         warnings: [],
         webTools: {},
       })) as never,

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -10,6 +10,7 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   prepareRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import { addSession, markBackgrounded, markExited } from "../agents/bash-process-registry.js";
@@ -489,6 +490,7 @@ function makePreparedSecretsSnapshot(
     sourceConfig: config,
     config,
     authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+    authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
     ...overrides,

--- a/src/gateway/server-shared-auth-generation.test.ts
+++ b/src/gateway/server-shared-auth-generation.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
+} from "../agents/auth-profiles/runtime-snapshots.js";
 import { createEmptyRuntimeWebToolsMetadata } from "../secrets/runtime-fast-path.js";
 import {
   activateSecretsRuntimeSnapshot,
@@ -46,6 +49,7 @@ describe("shared gateway generation publication", () => {
       config: {},
       authStores: [],
       authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
       warnings: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
     };

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -9,6 +9,7 @@ import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-prof
 import {
   getRuntimeAuthProfileStoreCredentialsRevision,
   getRuntimeAuthProfileStoreSnapshotCore,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   prepareRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
 } from "../agents/auth-profiles/runtime-snapshots.js";
@@ -112,6 +113,7 @@ function preparedSnapshot(config: OpenClawConfig): PreparedSecretsRuntimeSnapsho
     config,
     authStores: [],
     authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+    authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
     warnings: [],
     webTools: {
       search: {

--- a/src/secrets/runtime-command-secrets.test.ts
+++ b/src/secrets/runtime-command-secrets.test.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
+} from "../agents/auth-profiles/runtime-snapshots.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveCommandSecretsFromActiveRuntimeSnapshot } from "./runtime-command-secrets.js";
 import { createEmptyRuntimeWebToolsMetadata } from "./runtime-fast-path.js";
@@ -73,6 +76,7 @@ function activateMinimalSecretsRuntimeSnapshot(params: {
     config: structuredClone(params.resolvedConfig ?? params.config),
     authStores: [],
     authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+    authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
     warnings: [],
     webTools: createEmptyRuntimeWebToolsMetadata(),
   };

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -5,6 +5,7 @@ import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
 import { resolveSharedAuthStorePath } from "../agents/auth-profiles/path-resolve.js";
 import {
   getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   prepareRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
@@ -222,6 +223,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
 } | null {
   const runtimeEnv = mergeSecretsRuntimeEnv(params.env);
   const authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
+  const authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
   const sourceConfig = cloneConfigWithResolutionFacts(params.config);
   const resolvedConfig = cloneConfigWithResolutionFacts(params.config);
   const includeAuthStoreRefs = params.includeAuthStoreRefs ?? true;
@@ -262,6 +264,7 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
     config: resolvedConfig,
     authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores, runtimeEnv),
     authStoreCredentialsRevision,
+    authStoreSnapshotsRevision,
     warnings: [],
     degradedOwners: [],
     secretOwners: [],

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -223,6 +223,8 @@ export function prepareSecretsRuntimeFastPathSnapshot(params: {
 } | null {
   const runtimeEnv = mergeSecretsRuntimeEnv(params.env);
   const authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
+  // Capture before store reads. A live mutation during preparation must advance past
+  // this watermark, or activation could overwrite it with the prepared candidate.
   const authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
   const sourceConfig = cloneConfigWithResolutionFacts(params.config);
   const resolvedConfig = cloneConfigWithResolutionFacts(params.config);

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -421,6 +421,7 @@ describe("secrets runtime state", () => {
       {
         version: 1,
         profiles: { "openai:default": credential },
+        order: { openai: ["openai:default"] },
         usageStats: { "openai:default": { lastUsed: 1 } },
       },
       agentDir,
@@ -433,6 +434,7 @@ describe("secrets runtime state", () => {
           store: {
             version: 1,
             profiles: { "openai:default": credential },
+            order: { openai: [] },
             usageStats: { "openai:default": { lastUsed: 1 } },
           },
         },
@@ -442,6 +444,8 @@ describe("secrets runtime state", () => {
       {
         version: 1,
         profiles: { "openai:default": credential },
+        order: { openai: ["openai:default"] },
+        lastGood: { openai: "openai:default" },
         usageStats: {
           "openai:default": { lastUsed: 2, cooldownUntil: Date.now() + 60_000 },
         },
@@ -454,6 +458,12 @@ describe("secrets runtime state", () => {
     expect(
       getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.usageStats?.["openai:default"],
     ).toMatchObject({ lastUsed: 2, cooldownUntil: expect.any(Number) });
+    expect(getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.order?.openai).toEqual([
+      "openai:default",
+    ]);
+    expect(getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.lastGood?.openai).toBe(
+      "openai:default",
+    );
   });
 
   it("removes candidate-only auth profiles when rolling config back", () => {
@@ -491,7 +501,7 @@ describe("secrets runtime state", () => {
     ).toBeUndefined();
   });
 
-  it("publishes a durable order loaded after a separate-process write", () => {
+  it("publishes prepared bookkeeping when the live snapshot is unchanged", () => {
     const agentDir = "/tmp/openclaw-auth-order-durable-refresh";
     const profiles = {
       "openai:a": { type: "api_key" as const, provider: "openai", key: "sk-a" },
@@ -511,31 +521,6 @@ describe("secrets runtime state", () => {
       "openai:b",
       "openai:a",
     ]);
-  });
-
-  it("keeps live bookkeeping mutated after the candidate was loaded", () => {
-    const agentDir = "/tmp/openclaw-auth-order-concurrent-mutation";
-    const profiles = {
-      "openai:a": { type: "api_key" as const, provider: "openai", key: "sk-a" },
-      "openai:b": { type: "api_key" as const, provider: "openai", key: "sk-b" },
-    };
-    const snapshot = (order: string[]) =>
-      preparedSnapshot({
-        authStores: [{ agentDir, store: { version: 1, profiles, order: { openai: order } } }],
-      });
-    activateSnapshot(snapshot(["openai:a", "openai:b"]));
-    const previousRevision = getActiveSecretsRuntimeSnapshotRevisionState();
-    const candidate = snapshot(["openai:b", "openai:a"]);
-
-    const live = getRuntimeAuthProfileStoreSnapshotCore(agentDir)!;
-    live.order = { openai: ["openai:a"] };
-    live.lastGood = { openai: "openai:a" };
-    setRuntimeAuthProfileStoreSnapshot(live, agentDir);
-    expect(activateSnapshotIfCurrent(candidate, { expectedRevision: previousRevision })).toBe(true);
-
-    const published = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
-    expect(published?.order?.openai).toEqual(["openai:a"]);
-    expect(published?.lastGood?.openai).toBe("openai:a");
   });
 
   it("rolls back candidate credentials against the activation-time auth baseline", () => {
@@ -620,24 +605,25 @@ describe("secrets runtime state", () => {
     });
   });
 
-  it("preserves an auth rotation captured by the candidate", () => {
+  it("preserves an auth rotation and order captured by the candidate", () => {
     const finalKey = "sk-candidate";
     const agentDir = "/tmp/openclaw-auth-rollback-sk-candidate";
-    const snapshot = (key: string, port: number) =>
+    const snapshot = (key: string, port: number, order: string[] = []) =>
       preparedGatewayAuthSnapshot(agentDir, port, {
         version: 1,
         profiles: {
           "openai:default": { type: "api_key", provider: "openai", key },
         },
+        order: { openai: order },
       });
     activateSnapshot(snapshot("sk-old", 19_001));
     const previous = getActiveSecretsRuntimeSnapshotState()!;
     const previousRevision = getActiveSecretsRuntimeSnapshotRevisionState();
     setRuntimeAuthProfileStoreSnapshot(
-      snapshot("sk-candidate", 19_002).authStores[0]!.store,
+      snapshot("sk-candidate", 19_002, ["openai:default"]).authStores[0]!.store,
       agentDir,
     );
-    const candidate = snapshot("sk-candidate", 19_002);
+    const candidate = snapshot("sk-candidate", 19_002, ["openai:default"]);
     candidate.authStores[0]!.store.profiles["anthropic:candidate"] = {
       type: "api_key",
       provider: "anthropic",
@@ -651,6 +637,9 @@ describe("secrets runtime state", () => {
     ).toMatchObject({
       key: finalKey,
     });
+    expect(getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.order?.openai).toEqual([
+      "openai:default",
+    ]);
     expect(
       getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.profiles["anthropic:candidate"],
     ).toBeUndefined();

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -7,6 +7,7 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   getRuntimeAuthProfileStoreCredentialsRevision,
   getRuntimeAuthProfileStoreSnapshotCore,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   noteRuntimeAuthProfileStorePersistedMutation,
   prepareRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
@@ -95,6 +96,7 @@ function preparedSnapshot(
     sourceConfig: {},
     config: {},
     authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+    authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
     warnings: [],
     webTools: {
       search: { providerSource: "none", diagnostics: [] },
@@ -487,6 +489,53 @@ describe("secrets runtime state", () => {
     expect(
       getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.profiles["anthropic:candidate"],
     ).toBeUndefined();
+  });
+
+  it("publishes a durable order loaded after a separate-process write", () => {
+    const agentDir = "/tmp/openclaw-auth-order-durable-refresh";
+    const profiles = {
+      "openai:a": { type: "api_key" as const, provider: "openai", key: "sk-a" },
+      "openai:b": { type: "api_key" as const, provider: "openai", key: "sk-b" },
+    };
+    const snapshot = (order: string[]) =>
+      preparedSnapshot({
+        authStores: [{ agentDir, store: { version: 1, profiles, order: { openai: order } } }],
+      });
+    activateSnapshot(snapshot(["openai:a", "openai:b"]));
+    const previousRevision = getActiveSecretsRuntimeSnapshotRevisionState();
+
+    const refreshed = snapshot(["openai:b", "openai:a"]);
+    expect(activateSnapshotIfCurrent(refreshed, { expectedRevision: previousRevision })).toBe(true);
+
+    expect(getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.order?.openai).toEqual([
+      "openai:b",
+      "openai:a",
+    ]);
+  });
+
+  it("keeps live bookkeeping mutated after the candidate was loaded", () => {
+    const agentDir = "/tmp/openclaw-auth-order-concurrent-mutation";
+    const profiles = {
+      "openai:a": { type: "api_key" as const, provider: "openai", key: "sk-a" },
+      "openai:b": { type: "api_key" as const, provider: "openai", key: "sk-b" },
+    };
+    const snapshot = (order: string[]) =>
+      preparedSnapshot({
+        authStores: [{ agentDir, store: { version: 1, profiles, order: { openai: order } } }],
+      });
+    activateSnapshot(snapshot(["openai:a", "openai:b"]));
+    const previousRevision = getActiveSecretsRuntimeSnapshotRevisionState();
+    const candidate = snapshot(["openai:b", "openai:a"]);
+
+    const live = getRuntimeAuthProfileStoreSnapshotCore(agentDir)!;
+    live.order = { openai: ["openai:a"] };
+    live.lastGood = { openai: "openai:a" };
+    setRuntimeAuthProfileStoreSnapshot(live, agentDir);
+    expect(activateSnapshotIfCurrent(candidate, { expectedRevision: previousRevision })).toBe(true);
+
+    const published = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
+    expect(published?.order?.openai).toEqual(["openai:a"]);
+    expect(published?.lastGood?.openai).toBe("openai:a");
   });
 
   it("rolls back candidate credentials against the activation-time auth baseline", () => {

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -12,6 +12,8 @@ import { loadRuntimeAuthProfileOwnerSnapshot } from "../agents/auth-profiles/run
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   listOwnedRuntimeAuthProfileStoreSnapshots,
   replaceOwnedRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
@@ -56,6 +58,7 @@ export type PreparedSecretsRuntimeSnapshot = {
   config: OpenClawConfig;
   authStores: OwnedRuntimeAuthProfileStoreSnapshotEntry[];
   authStoreCredentialsRevision: number;
+  authStoreSnapshotsRevision?: number;
   warnings: SecretResolverWarning[];
   degradedOwners?: DegradedSecretOwner[];
   secretOwners?: SecretOwnerRefState[];
@@ -247,6 +250,7 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
     config: cloneConfigWithResolutionFacts(snapshot.config),
     authStores: structuredClone(snapshot.authStores),
     authStoreCredentialsRevision: snapshot.authStoreCredentialsRevision,
+    authStoreSnapshotsRevision: snapshot.authStoreSnapshotsRevision,
     warnings: snapshot.warnings.map((warning) => ({ ...warning })),
     degradedOwners: (snapshot.degradedOwners ?? []).map(cloneDegradedSecretOwner),
     secretOwners: (snapshot.secretOwners ?? []).map(cloneSecretOwnerRefState),
@@ -257,6 +261,7 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
 function mergeLiveAuthStoreBookkeeping(
   authStores: PreparedSecretsRuntimeSnapshot["authStores"],
   degradedOwners: readonly DegradedSecretOwner[] = [],
+  preparedSnapshotsRevision?: number,
 ): PreparedSecretsRuntimeSnapshot["authStores"] {
   const liveEntries = new Map(
     listOwnedRuntimeAuthProfileStoreSnapshots().map((entry) => [entry.databasePath, entry]),
@@ -268,6 +273,13 @@ function mergeLiveAuthStoreBookkeeping(
     }
     let bookkeeping = entry.store;
     if (isDeepStrictEqual(snapshotMutationOwner(entry), snapshotMutationOwner(live))) {
+      if (
+        preparedSnapshotsRevision !== undefined &&
+        getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(entry.databasePath) <=
+          preparedSnapshotsRevision
+      ) {
+        return entry;
+      }
       bookkeeping = live.store;
     } else if (entry.owner.kind === "resolved" && live.owner.kind === "resolved") {
       // Effective state cannot separate old inherited values from local overrides or clears.
@@ -927,6 +939,7 @@ export function graftActiveSecretsRuntimeAuthState(snapshot: PreparedSecretsRunt
   }
   snapshot.authStores = getLiveSecretsRuntimeAuthStores();
   snapshot.authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
+  snapshot.authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
   setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, activeRefreshContext);
 }
 
@@ -964,7 +977,11 @@ export function activateSecretsRuntimeSnapshotState(params: {
   }
   const next = cloneSnapshot(params.snapshot);
   if (params.mergeLiveAuthBookkeeping !== false) {
-    next.authStores = mergeLiveAuthStoreBookkeeping(next.authStores, next.degradedOwners);
+    next.authStores = mergeLiveAuthStoreBookkeeping(
+      next.authStores,
+      next.degradedOwners,
+      next.authStoreSnapshotsRevision,
+    );
   }
   const activationAuthStores = listOwnedRuntimeAuthProfileStoreSnapshots();
   const previousLineageAuthStores = activeSnapshotLineageAuthStores;
@@ -979,6 +996,7 @@ export function activateSecretsRuntimeSnapshotState(params: {
   setRuntimeConfigSnapshot(next.config, params.runtimeSourceConfig ?? next.sourceConfig);
   replaceOwnedRuntimeAuthProfileStoreSnapshots(next.authStores);
   next.authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
+  next.authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
   const previousLineageStartRevision = activeSnapshotLineageStartRevision;
   activeSnapshot = next;
   activeSnapshotRevision += 1;
@@ -1110,8 +1128,10 @@ export function restoreSecretsRuntimeSnapshotStateIfCurrent(
           ...independentEntries,
         ],
         params.snapshot.degradedOwners,
+        params.snapshot.authStoreSnapshotsRevision,
       ).toSorted((left, right) => left.agentDir.localeCompare(right.agentDir)),
       authStoreCredentialsRevision: currentCredentialsRevision,
+      authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
     },
     mergeLiveAuthBookkeeping: false,
     preserveActivationLineage: false,
@@ -1129,6 +1149,7 @@ export function getActiveSecretsRuntimeSnapshotState(): PreparedSecretsRuntimeSn
   const snapshot = cloneSnapshot(activeSnapshot);
   snapshot.authStores = listOwnedRuntimeAuthProfileStoreSnapshots();
   snapshot.authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
+  snapshot.authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
   if (activeRefreshContext) {
     preparedSnapshotRefreshContext.set(
       snapshot,

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -58,7 +58,7 @@ export type PreparedSecretsRuntimeSnapshot = {
   config: OpenClawConfig;
   authStores: OwnedRuntimeAuthProfileStoreSnapshotEntry[];
   authStoreCredentialsRevision: number;
-  authStoreSnapshotsRevision?: number;
+  authStoreSnapshotsRevision: number;
   warnings: SecretResolverWarning[];
   degradedOwners?: DegradedSecretOwner[];
   secretOwners?: SecretOwnerRefState[];
@@ -260,8 +260,8 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
 
 function mergeLiveAuthStoreBookkeeping(
   authStores: PreparedSecretsRuntimeSnapshot["authStores"],
+  preparedSnapshotsRevision: number,
   degradedOwners: readonly DegradedSecretOwner[] = [],
-  preparedSnapshotsRevision?: number,
 ): PreparedSecretsRuntimeSnapshot["authStores"] {
   const liveEntries = new Map(
     listOwnedRuntimeAuthProfileStoreSnapshots().map((entry) => [entry.databasePath, entry]),
@@ -274,9 +274,8 @@ function mergeLiveAuthStoreBookkeeping(
     let bookkeeping = entry.store;
     if (isDeepStrictEqual(snapshotMutationOwner(entry), snapshotMutationOwner(live))) {
       if (
-        preparedSnapshotsRevision !== undefined &&
         getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(entry.databasePath) <=
-          preparedSnapshotsRevision
+        preparedSnapshotsRevision
       ) {
         return entry;
       }
@@ -979,8 +978,8 @@ export function activateSecretsRuntimeSnapshotState(params: {
   if (params.mergeLiveAuthBookkeeping !== false) {
     next.authStores = mergeLiveAuthStoreBookkeeping(
       next.authStores,
-      next.degradedOwners,
       next.authStoreSnapshotsRevision,
+      next.degradedOwners,
     );
   }
   const activationAuthStores = listOwnedRuntimeAuthProfileStoreSnapshots();
@@ -1127,8 +1126,8 @@ export function restoreSecretsRuntimeSnapshotStateIfCurrent(
           ),
           ...independentEntries,
         ],
-        params.snapshot.degradedOwners,
         params.snapshot.authStoreSnapshotsRevision,
+        params.snapshot.degradedOwners,
       ).toSorted((left, right) => left.agentDir.localeCompare(right.agentDir)),
       authStoreCredentialsRevision: currentCredentialsRevision,
       authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -296,6 +296,7 @@ function activateRuntimeWebToolsResult(
       config: result.resolvedConfig,
       authStores: [],
       authStoreCredentialsRevision: 0,
+      authStoreSnapshotsRevision: 0,
       warnings: result.context.warnings,
       degradedOwners: result.degradedOwners,
       secretOwners: result.secretOwners,

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "../agents/auth-profiles/legacy-source-diagnostic.js";
 import {
   getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   prepareRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
@@ -189,6 +190,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
 }): Promise<PreparedSecretsRuntimeSnapshot> {
   const runtimeEnv = mergeSecretsRuntimeEnv(params.env);
   const authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
+  const authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
   const sourceConfig = cloneConfigWithResolutionFacts(params.config);
   const assignmentSourceConfig = cloneConfigWithResolutionFacts(
     params.assignmentConfig ?? params.config,
@@ -224,6 +226,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       config: resolvedConfig,
       authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores, runtimeEnv),
       authStoreCredentialsRevision,
+      authStoreSnapshotsRevision,
       warnings: [],
       degradedOwners: migrationDegradedOwners,
       secretOwners: [],
@@ -341,6 +344,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
     config: resolvedConfig,
     authStores: prepareRuntimeAuthProfileStoreSnapshots(authStores, runtimeEnv),
     authStoreCredentialsRevision,
+    authStoreSnapshotsRevision,
     warnings: context.warnings,
     degradedOwners: [
       ...migrationDegradedOwners,
@@ -489,6 +493,7 @@ export async function refreshActiveSecretsRuntimeSnapshotForConfig(
       candidate.snapshot.authStores = getLiveSecretsRuntimeAuthStores();
       candidate.snapshot.authStoreCredentialsRevision =
         getRuntimeAuthProfileStoreCredentialsRevision();
+      candidate.snapshot.authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
       setPreparedSecretsRuntimeSnapshotRefreshContext(candidate.snapshot, activeRefreshContext);
     }
     if (activateSecretsRuntimeSnapshotIfCurrent(candidate.snapshot, candidate.expectedRevision)) {
@@ -673,6 +678,7 @@ export async function refreshActiveProviderAuthRuntimeSnapshot(): Promise<boolea
       config,
       authStores: candidate.snapshot.authStores,
       authStoreCredentialsRevision: candidate.snapshot.authStoreCredentialsRevision,
+      authStoreSnapshotsRevision: candidate.snapshot.authStoreSnapshotsRevision,
       warnings: mergeProviderAuthRuntimeWarnings(
         activeSnapshot.warnings,
         candidate.snapshot.warnings,

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -190,6 +190,8 @@ export async function prepareSecretsRuntimeSnapshot(params: {
 }): Promise<PreparedSecretsRuntimeSnapshot> {
   const runtimeEnv = mergeSecretsRuntimeEnv(params.env);
   const authStoreCredentialsRevision = getRuntimeAuthProfileStoreCredentialsRevision();
+  // Capture before store reads. A live mutation during preparation must advance past
+  // this watermark, or activation could overwrite it with the prepared candidate.
   const authStoreSnapshotsRevision = getRuntimeAuthProfileStoreSnapshotsRevision();
   const sourceConfig = cloneConfigWithResolutionFacts(params.config);
   const assignmentSourceConfig = cloneConfigWithResolutionFacts(

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   getRuntimeAuthProfileStoreCredentialsRevision,
+  getRuntimeAuthProfileStoreSnapshotsRevision,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
@@ -585,6 +586,7 @@ describe("web search runtime", () => {
       config: resolvedConfig,
       authStores: [],
       authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
       warnings: [],
       webTools: {
         search: {
@@ -762,6 +764,7 @@ describe("web search runtime", () => {
       config: {},
       authStores: [],
       authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
       warnings: [],
       webTools: {
         search: {
@@ -804,6 +807,7 @@ describe("web search runtime", () => {
       config: {},
       authStores: [],
       authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
       warnings: [],
       webTools: {
         search: {
@@ -849,6 +853,7 @@ describe("web search runtime", () => {
       config: structuredClone(config),
       authStores: [],
       authStoreCredentialsRevision: getRuntimeAuthProfileStoreCredentialsRevision(),
+      authStoreSnapshotsRevision: getRuntimeAuthProfileStoreSnapshotsRevision(),
       warnings: [],
       webTools: {
         search: {


### PR DESCRIPTION
## What Problem This Solves

`openclaw models auth order set` persists the requested order and asks a running Gateway to refresh through `models.authStatus { refresh: true }`. Before this fix, the refresh could report success while the Gateway kept routing with its old in-memory order until restart.

Fixes #135734.

## Why This Change Was Made

### Root cause

`mergeLiveAuthStoreBookkeeping` always preferred same-owner live bookkeeping during activation. A separate CLI process cannot update the Gateway's process-local snapshot, so this rule replaced the freshly loaded SQLite order with the stale live order.

The faulty merge came from #105289. #119946 later connected auth-order writes to the refresh path and made the stale merge user-visible on this command.

### Fix

Prepared secrets snapshots now record the process-local auth snapshot generation before reading auth stores. Activation publishes the prepared order, last-good pointer, usage data, and inheritance state when that exact store did not change after preparation. A later in-process mutation advances the store generation and still wins.

The generation receipt is required for every internal snapshot. There is no fallback to the stale merge behavior. Rollback uses the same generation rule, so it retains durable bookkeeping loaded by the candidate and any newer live mutation.

## User Impact

Operators can change provider profile priority while the Gateway is running. A successful refresh now makes routing use the durable order without a restart, while a real concurrent in-process update still wins.

## Evidence

- Current-main red at `07cac7a3b6644e3dadef56cf3f4dc08372e330d9`: a real separate CLI changed durable order from `a,b` to `b,a`; both the CLI-triggered refresh and an explicit real Gateway refresh succeeded; live order stayed `a,b`.
- Exact-head green at `4ff38d7dc8da7d8e5e753ca59fcfac2bbfe194f3`: the same real CLI and running-Gateway path changed durable and live order to `b,a`; a second explicit refresh kept them aligned.
- Regression test: fails on current main for the stale live-order mismatch and passes on the repaired head.
- `node scripts/run-vitest.mjs src/secrets/runtime-state.test.ts`: 63 passed.
- All 13 changed test files: 579 passed.
- Owner and sibling refresh tests: 141 passed.
- Targeted Oxlint, Oxfmt, conflict-marker, max-lines, assertion-safety, test-temp, coercion, deprecated-API, and import-cycle checks passed.
- Local typecheck and build were not run because this host forbids them; exact-head CI owns those checks.

## Test audit

- The regression protects prepared bookkeeping when live state did not change.
- Existing concurrency coverage now checks order and last-good state as well as usage data.
- Rollback coverage proves that candidate-loaded order survives a rejected config activation.
- Tests use the production activation boundary and add no test-only production seam.

## Risk

Production grows by 37 net lines. The added state is one lifecycle generation receipt required to distinguish stale live state from a real concurrent live mutation. It does not add configuration, schema, protocol, or fallback behavior.
