### PR TITLE
fix(heartbeat): show first-alert preamble once for isolated routes

### DIFF
--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -14,7 +14,7 @@ import {
   patchSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import { resolveMirroredTranscriptText } from "../config/sessions/transcript-mirror.js";
-import type { SessionEntry } from "../config/sessions/types.js";
+import { mergeSessionEntry, type SessionEntry } from "../config/sessions/types.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { formatErrorMessage } from "./errors.js";
 import {
@@ -287,8 +287,11 @@ export async function finalizeHeartbeatOutcome(params: {
   outboundIdentity: ReturnType<typeof resolveAgentOutboundIdentity>;
 }): Promise<HeartbeatRunResult> {
   const { cfg, agentId, scheduledTasks, startedAt, wakeSource } = params.wake;
-  const { delivery, entry, previousUpdatedAt } = params.prepared;
+  const { delivery, previousUpdatedAt } = params.prepared;
   const { runSessionKey, sessionKey, storePath, visibility } = params.prepared;
+  // Delivery markers belong to the policy session, not a rotating isolated run or recipient.
+  const stateKey = params.prepared.outboundPolicySessionKey ?? sessionKey;
+  const stateEntry = loadExactSessionEntryReadOnly({ storePath, sessionKey: stateKey })?.entry;
   const outcome = params.outcome;
   const recordOutcome = (response: HeartbeatToolResponse) =>
     persistHeartbeatOutcome({
@@ -430,10 +433,8 @@ export async function finalizeHeartbeatOutcome(params: {
   const { hasStructuredReplyContent, mediaUrls, normalized, replyPayload } = outcome;
   // Suppress duplicate heartbeats (same payload) within a short window.
   // This prevents "nagging" when nothing changed but the model repeats the same items.
-  const prevHeartbeatText =
-    typeof entry?.lastHeartbeatText === "string" ? entry.lastHeartbeatText : "";
-  const prevHeartbeatAt =
-    typeof entry?.lastHeartbeatSentAt === "number" ? entry.lastHeartbeatSentAt : undefined;
+  const prevHeartbeatText = stateEntry?.lastHeartbeatText ?? "";
+  const prevHeartbeatAt = stateEntry?.lastHeartbeatSentAt;
   const isDuplicateMain =
     !mediaUrls.length &&
     !hasStructuredReplyContent &&
@@ -565,12 +566,10 @@ export async function finalizeHeartbeatOutcome(params: {
   const visibleSendSucceeded = send.status === "sent";
   if (visibleSendSucceeded) {
     const hasHeartbeatText = Boolean(deliveryText.trim());
+    const fallbackEntry = mergeSessionEntry(undefined, { updatedAt: startedAt });
     await patchSessionEntryCore(
-      { storePath, sessionKey },
-      (current, context) => {
-        if (!context.existingEntry) {
-          return null;
-        }
+      { storePath, sessionKey: stateKey },
+      (current) => {
         // Visible structured-only sends satisfy their own pending final too;
         // preserve old text dedupe markers and another run's recovery state.
         const ownsPendingFinalDelivery = heartbeatRunOwnsPendingFinalDelivery(current, startedAt);
@@ -584,7 +583,7 @@ export async function finalizeHeartbeatOutcome(params: {
           ...(ownsPendingFinalDelivery ? CLEARED_PENDING_FINAL_DELIVERY_FIELDS : {}),
         };
       },
-      { preserveActivity: true },
+      { fallbackEntry, preserveActivity: true },
     );
   }
 

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -33,7 +33,11 @@ import {
   resolveHeartbeatSummaryForAgent,
   runHeartbeatOnce,
 } from "./heartbeat-runner.js";
-import { seedHeartbeatScratchForTest, seedSessionStore } from "./heartbeat-runner.test-utils.js";
+import {
+  readSessionStoreForTest,
+  seedHeartbeatScratchForTest,
+  seedSessionStore,
+} from "./heartbeat-runner.test-utils.js";
 import {
   resolveHeartbeatDeliveryTarget,
   resolveHeartbeatDeliveryTargetWithSessionRoute,
@@ -1137,19 +1141,23 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
-  it("prepends the first heartbeat alert only once for the implicit owner default", async () => {
+  it("persists implicit first-alert state when an isolated heartbeat starts without a base row", async () => {
     const tmpDir = await createCaseDir("hb-owner-preamble");
     const storePath = path.join(tmpDir, "sessions.json");
     const cfg: OpenClawConfig = {
-      agents: { defaults: { workspace: tmpDir, heartbeat: { every: "5m" } } },
+      agents: {
+        defaults: { workspace: tmpDir, heartbeat: { every: "5m", isolatedSession: true } },
+      },
       commands: { ownerAllowFrom: ["+15555550166"] },
       channels: { whatsapp: { allowFrom: ["+15555550166"] } },
       session: { store: storePath },
     };
-    await seedWhatsAppSession(storePath, resolveMainSessionKey(cfg));
+    const sessionKey = resolveMainSessionKey(cfg);
+    const isolatedSessionKey = `${sessionKey}:heartbeat`;
     const replySpy = vi
       .fn()
       .mockResolvedValueOnce({ text: "First alert" })
+      .mockResolvedValueOnce({ text: "Second alert" })
       .mockResolvedValueOnce({ text: "Second alert" });
     const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "m1", toJid: "jid" });
 
@@ -1157,11 +1165,26 @@ describe("runHeartbeatOnce", () => {
       cfg,
       deps: createHeartbeatDeps(sendWhatsApp, { nowMs: 1, getReplyFromConfig: replySpy }),
     });
+    let store = readSessionStoreForTest(storePath);
+    expect(store[sessionKey]).toMatchObject({
+      lastHeartbeatText: "First alert",
+      lastHeartbeatSentAt: 1,
+    });
+    expectReplyCall(replySpy, 0, {
+      SessionKey: isolatedSessionKey,
+    });
+    expect(store[isolatedSessionKey]?.lastHeartbeatText).toBeUndefined();
+
     await runHeartbeatOnce({
       cfg,
       deps: createHeartbeatDeps(sendWhatsApp, { nowMs: 2, getReplyFromConfig: replySpy }),
     });
+    await runHeartbeatOnce({
+      cfg,
+      deps: createHeartbeatDeps(sendWhatsApp, { nowMs: 3, getReplyFromConfig: replySpy }),
+    });
 
+    expect(sendWhatsApp).toHaveBeenCalledTimes(2);
     expectWhatsAppSendCall(sendWhatsApp, 0, {
       to: "+15555550166",
       text: 'First heartbeat alert: your bot runs periodic background checks and messages you only when something needs attention. Set agents.defaults.heartbeat.target: "none" to keep these internal.\nFirst alert',
@@ -1170,6 +1193,12 @@ describe("runHeartbeatOnce", () => {
       to: "+15555550166",
       text: "Second alert",
     });
+    store = readSessionStoreForTest(storePath);
+    expect(store[sessionKey]).toMatchObject({
+      lastHeartbeatText: "Second alert",
+      lastHeartbeatSentAt: 2,
+    });
+    expect(store[isolatedSessionKey]?.lastHeartbeatText).toBeUndefined();
   });
 
   it("uses per-agent heartbeat overrides and session keys", async () => {


### PR DESCRIPTION
Closes #135205

Supersedes #135225 with a clean current-main branch. This keeps @rwinkelman's repair intent and commit credit without its unrelated Gateway change.

## What Problem This Solves

Fixes an issue where implicit owner-route heartbeats with `isolatedSession: true` repeated the first-heartbeat preamble on every distinct Telegram delivery when no base session existed yet.

## Why This Change Was Made

Successful heartbeat delivery now reads and writes dedupe and first-alert markers on the prepared policy session. It creates that policy row when the first visible delivery has no existing row, while the rotating isolated run and exact recipient remain marker-free.

The existing identical-text dedupe predicate is unchanged.

## User Impact

Operators see the first-heartbeat explanation once. Later heartbeat alerts contain only their current content.

## Evidence

Baseline `b2f747df3dd2e723eea5a71e09ed0f310aa5d977` on Telegram's Test Server:

- Two real implicit-route heartbeat deliveries used distinct model responses.
- Both direct messages repeated the first-heartbeat preamble.
- SQLite contained only the rotating `agent:main:main:heartbeat` row after each send.
- The base policy row and its `lastHeartbeatSentAt` marker were absent.
- The mock provider recorded exactly two requests.

Exact head `fc1fd84703732f8116c7f63cb937539e26f2e619` on Telegram's Test Server:

- The first direct message included the preamble and `BASELINE_FIRST_HEARTBEAT_135205`.
- The second direct message contained only `BASELINE_SECOND_HEARTBEAT_135205`.
- After the first send, the base policy row held the first body and timestamp.
- After the second send, the same base row held the second body and timestamp.
- Both isolated rows had `heartbeatIsolatedBaseSessionKey` and no heartbeat markers.
- The mock provider recorded exactly two requests.

Live command shape, with ports and artifact paths omitted:

```sh
node .agents/skills/telegram-e2e-userbot/scripts/run-mock-sut-user-e2e.mjs \
  --source-gateway --dm --scenario <scenario.json> \
  --record <events.ndjson> --output <summary.json>
```

Focused regression proof:

```text
Pre-fix with the new test: 1 failed, 56 passed.
Exact head: 64 passed across the owner and isolated-session sibling suites.
```

Production delta: `-1` line. Test delta: `+29` lines.

Landing gates:

- Exact-head Autoreview passed with no accepted or actionable P0 findings.
- Exact-head CI run `33586427589` completed green, including production and test type checks.
- The latest ClawSweeper comment is a review-started placeholder and contains no findings or `Rank-up moves`; there are no published moves to apply or skip.
