### PR TITLE
refactor(scripts): simplify managed command completion

### DIFF
--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -272,15 +272,8 @@ export async function waitForManagedProcessGroupExit(
 
 /** Run a child command while forwarding termination signals to its process group. */
 export async function runManagedCommand({
-  bin,
-  args = [],
-  cwd,
-  env,
   stdio = "inherit",
   platform = process.platform,
-  shell = platform === "win32",
-  windowsVerbatimArguments,
-  comSpec,
   timeoutMs,
   timeoutKillGraceMs,
   timeoutForceKillOnLeaderExit = false,
@@ -290,9 +283,13 @@ export async function runManagedCommand({
   signal,
   abortKillGraceMs,
   onSignal,
+  ...commandOptions
 }: RunManagedCommandOptions) {
   if (platform === "win32" && requireProcessTreeExit) {
-    throw createManagedCommandUnsupportedTreeVerificationError();
+    throw Object.assign(
+      new Error("Strict managed process-tree verification is not supported on Windows"),
+      { code: "EPROCESS_TREE_VERIFICATION_UNSUPPORTED" },
+    );
   }
   signal?.throwIfAborted();
   const managedStdio: StdioOptions =
@@ -316,17 +313,11 @@ export async function runManagedCommand({
     return undefined;
   });
   const spawnSpec = createManagedCommandSpawnSpec({
-    bin,
-    args,
-    cwd,
-    env,
+    ...commandOptions,
     stdio: managedStdio,
-    shell,
-    windowsVerbatimArguments,
     platform,
-    comSpec,
   });
-  const commandEnv = env ?? process.env;
+  const commandEnv = commandOptions.env ?? process.env;
   let releaseClaim = findVitestResourceOwner(
     commandEnv.TMPDIR || commandEnv.TMP || commandEnv.TEMP || tmpdir(),
   )?.claim();
@@ -345,35 +336,36 @@ export async function runManagedCommand({
     throw error;
   }
   let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-  let finalization: Promise<void> | undefined;
-  let cancellation: Promise<ManagedCommandOutcome> | undefined;
-  let resolveCancellation!: (outcome: ManagedCommandOutcome) => void;
-  const canceled = new Promise<ManagedCommandOutcome>((resolve) => {
-    resolveCancellation = resolve;
+  let finalization: Promise<{ type: "failed"; error: unknown } | undefined> | undefined;
+  let cancellation: ManagedCommandOutcome | undefined;
+  let notifyOutcome!: (outcome: ManagedCommandOutcome) => void;
+  const completion = new Promise<ManagedCommandOutcome>((resolve) => {
+    notifyOutcome = resolve;
   });
-  const stop = (
-    outcome: ManagedCommandOutcome,
-    stopSignal: NodeJS.Signals,
+  const finalize = (
+    stopSignal?: NodeJS.Signals,
     forceKillDelayMs?: number,
     forceKillOnLeaderExit = false,
   ) => {
-    if (cancellation) {
-      return cancellation;
-    }
-    clearTimeout(timeoutTimer);
-    finalization ??= finalizeManagedChild(child, stopSignal, {
+    // Observe eager rejection even when cancellation starts inside onReady.
+    // Physical release stays in onTerminated: strict cleanup can release, then fail.
+    return (finalization ??= finalizeManagedChild(child, stopSignal, {
       platform,
       runTaskkill,
       forceKillDelayMs,
       forceKillOnLeaderExit,
       onTerminated: releaseOwnership,
-    });
-    cancellation = finalization.then(
-      () => outcome,
+    }).then(
+      () => undefined,
       (error: unknown) => ({ type: "failed" as const, error }),
-    );
-    void cancellation.then(resolveCancellation);
-    return cancellation;
+    ));
+  };
+  const stop = (outcome: ManagedCommandOutcome, ...termination: Parameters<typeof finalize>) => {
+    cancellation ??= outcome;
+    clearTimeout(timeoutTimer);
+    const joined = finalize(...termination);
+    notifyOutcome(cancellation);
+    return joined;
   };
   const forwardSignal = (received: NodeJS.Signals) => {
     onSignal?.(received);
@@ -384,20 +376,18 @@ export async function runManagedCommand({
   };
   managedChildren.add(forwardSignal);
   try {
-    const completion = new Promise<ManagedCommandOutcome>((resolve) => {
-      child.once("error", (error) => {
-        clearTimeout(timeoutTimer);
-        resolve({ type: "failed", error });
-      });
-      // The wall deadline includes output drainage, but not group verification after close.
-      child.once("close", () => clearTimeout(timeoutTimer));
-      // Strict owners must start cleanup at exit: descendants can hold output
-      // open indefinitely. Finalization still joins the group and output pipes.
-      child.once(requireProcessTreeExit ? "exit" : "close", (status, received) => {
-        resolve({
-          type: "completed",
-          status: received ? signalExitCode(received) : (status ?? 1),
-        });
+    child.once("error", (error) => {
+      clearTimeout(timeoutTimer);
+      notifyOutcome({ type: "failed", error });
+    });
+    // The wall deadline includes output drainage, but not group verification after close.
+    child.once("close", () => clearTimeout(timeoutTimer));
+    // Strict owners must start cleanup at exit: descendants can hold output
+    // open indefinitely. Finalization still joins the group and output pipes.
+    child.once(requireProcessTreeExit ? "exit" : "close", (status, received) => {
+      notifyOutcome({
+        type: "completed",
+        status: received ? signalExitCode(received) : (status ?? 1),
       });
     });
     if (timeoutMs !== undefined) {
@@ -427,27 +417,18 @@ export async function runManagedCommand({
       onReady?.(child);
     } catch (error) {
       const cleanup = await stop({ type: "failed", error }, "SIGTERM");
-      if (cleanup.type === "failed" && cleanup.error !== error) {
+      if (cleanup && cleanup.error !== error) {
         throw createManagedCommandSetupCleanupError(error, cleanup.error);
       }
       throw error;
     }
-    let outcome = await Promise.race([completion, canceled]);
-    if (outcome.type === "completed" && requireProcessTreeExit && !cancellation) {
-      try {
-        await (finalization ??= finalizeManagedChild(child, undefined, {
-          platform,
-          runTaskkill,
-          onTerminated: releaseOwnership,
-        }));
-      } catch (error) {
-        outcome = { type: "failed", error };
-      }
+    let outcome = await completion;
+    if (outcome.type === "completed" && requireProcessTreeExit) {
+      void finalize();
     }
-    // Cancellation owns the result even when it arrives during normal drainage.
-    if (cancellation) {
-      outcome = await cancellation;
-    }
+    // Cleanup failure overrides the first cancellation, including during strict drainage.
+    const cleanup = finalization ? await finalization : undefined;
+    outcome = cleanup ?? cancellation ?? outcome;
     // Preserve the ordinary API's close-based contract. Cancellation and strict
     // commands release only at the finalizer's positive termination boundary.
     if (outcome.type === "completed" && !requireProcessTreeExit && !cancellation) {
@@ -457,7 +438,9 @@ export async function runManagedCommand({
       throw outcome.error;
     }
     if (outcome.type === "timeout") {
-      throw createManagedCommandTimeoutError(timeoutMs);
+      throw Object.assign(new Error(`Managed command timed out after ${timeoutMs}ms`), {
+        code: "ETIMEDOUT",
+      });
     }
     if (outcome.type === "aborted") {
       throw Object.assign(new Error("Managed command aborted"), { code: "ABORT_ERR" });
@@ -562,21 +545,6 @@ async function finalizeManagedChild(
   );
 }
 
-function createManagedCommandTimeoutError(timeoutMs: number | undefined) {
-  return Object.assign(new Error(`Managed command timed out after ${timeoutMs}ms`), {
-    code: "ETIMEDOUT",
-  });
-}
-
-function createManagedCommandUnsupportedTreeVerificationError() {
-  return Object.assign(
-    new Error("Strict managed process-tree verification is not supported on Windows"),
-    {
-      code: "EPROCESS_TREE_VERIFICATION_UNSUPPORTED",
-    },
-  );
-}
-
 function createManagedCommandSetupCleanupError(error: unknown, cleanupError: unknown) {
   return new AggregateError(
     [error, cleanupError],
@@ -633,37 +601,19 @@ function forwardSignalToManagedChildren(signal: NodeJS.Signals) {
   }
 }
 
-export function createManagedCommandSpawnSpec({
-  bin,
-  args = [],
-  cwd,
-  env,
-  stdio = "inherit",
-  platform = process.platform,
-  shell = platform === "win32",
-  windowsVerbatimArguments,
-  comSpec,
-}: ManagedCommandOptions) {
-  const invocation = createManagedCommandInvocation({
-    bin,
-    args,
-    env,
-    shell,
-    windowsVerbatimArguments,
-    platform,
-    comSpec,
-  });
+export function createManagedCommandSpawnSpec(options: ManagedCommandOptions) {
+  const { cwd, env, stdio = "inherit", platform = process.platform } = options;
+  const { args, command, ...invocationOptions } = createManagedCommandInvocation(options);
 
   return {
-    args: invocation.args,
-    command: invocation.command,
+    args,
+    command,
     options: {
       cwd,
       env,
       stdio,
-      shell: invocation.shell,
+      ...invocationOptions,
       detached: platform !== "win32",
-      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
     },
   };
 }

--- a/scripts/vitest-process-group.mts
+++ b/scripts/vitest-process-group.mts
@@ -581,18 +581,15 @@ function waitForChildCompletionEvent(child: ChildProcess, event: "exit" | "close
  * Resolves only after the child completion contract and any owned POSIX group are joined.
  */
 export function createVitestProcessCompletion(params: CompletionParams) {
-  const exitCompletion = waitForChildCompletionEvent(params.child, "exit");
-  const platform = params.platform ?? process.platform;
-  if (!params.detached || !shouldUseDetachedVitestProcessGroup(platform)) {
-    const closeCompletion = waitForChildCompletionEvent(params.child, "close");
-    return Promise.all([exitCompletion, closeCompletion]).then(([result]) => result);
-  }
-
-  const closeCompletion = waitForChildCompletionEvent(params.child, "close");
+  const { child, detached, platform = process.platform } = params;
+  const exitCompletion = waitForChildCompletionEvent(child, "exit");
+  const closeCompletion = waitForChildCompletionEvent(child, "close");
   // `close` drains inherited pipes, while the group join proves pipe-independent
   // descendants are gone before a sequential caller advances.
   const groupCompletion = exitCompletion.then(async (result) => {
-    await joinVitestProcessGroup(params.child, platform, params.kill ?? process.kill.bind(process));
+    if (detached && shouldUseDetachedVitestProcessGroup(platform)) {
+      await joinVitestProcessGroup(child, platform, params.kill ?? process.kill.bind(process));
+    }
     return result;
   });
   return Promise.all([groupCompletion, closeCompletion]).then(([result]) => result);

--- a/test/helpers/fixture-lifetime.ts
+++ b/test/helpers/fixture-lifetime.ts
@@ -32,18 +32,14 @@ export function createFixtureLifetime(ownerRoot?: string) {
     }
   }
 
-  function track<T>(completion: Promise<T>, cleanup = false): Promise<T> {
+  function admit<T>(body: Promise<T> | (() => Promise<T>), cleanup = false): Promise<T> {
+    // Register before scheduling callbacks, and observe late rejection even
+    // when Vitest has already rejected its separate timeout/cancellation promise.
     register();
+    const completion = typeof body === "function" ? Promise.resolve().then(body) : body;
     work.push({ completion, cleanup });
     void completion.catch(() => {});
     return completion;
-  }
-
-  function run<T>(body: () => Promise<T>): Promise<T> {
-    // Register before the callback's first await, and observe late rejection even
-    // when Vitest has already rejected its separate timeout/cancellation promise.
-    register();
-    return track(Promise.resolve().then(body));
   }
 
   async function drain() {
@@ -104,12 +100,9 @@ export function createFixtureLifetime(ownerRoot?: string) {
   }
 
   return {
-    run,
-    track,
-    verifyCleanup: (body: () => Promise<void>) => {
-      register();
-      return track(Promise.resolve().then(body), true);
-    },
+    run: <T>(body: () => Promise<T>) => admit(body),
+    track: <T>(completion: Promise<T>, cleanup = false) => admit(completion, cleanup),
+    verifyCleanup: (body: () => Promise<void>) => admit(body, true),
     createTempDir: (prefix: string, root = ownerRoot) => {
       register(root);
       return makeTempDir(roots, prefix, root);

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -1482,6 +1482,92 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
   });
 
   posixIt.each([
+    { first: "abort", setupFails: false, cleanupFails: false },
+    { first: "signal", setupFails: false, cleanupFails: false },
+    { first: "abort", setupFails: true, cleanupFails: false },
+    { first: "signal", setupFails: true, cleanupFails: false },
+    { first: "abort", setupFails: true, cleanupFails: true },
+    { first: "signal", setupFails: true, cleanupFails: true },
+  ])(
+    "joins reentrant $first cancellation (setup failure: $setupFails, cleanup failure: $cleanupFails)",
+    async ({ first, setupFails, cleanupFails }) => {
+      const dir = createTempDir("openclaw-managed-reentrant-");
+      // Deliberate failed finalization owns a separate namespace; the controller
+      // joins its real child before this fixture is removed.
+      createVitestResourceOwner(dir);
+      const script = path.join(dir, "controller.mjs");
+      fs.writeFileSync(
+        script,
+        `
+import assert from 'node:assert/strict';
+import { runManagedCommand } from ${JSON.stringify(pathToFileURL(path.resolve("scripts/lib/managed-child-process.mts")).href)};
+const controller = new AbortController();
+const setupError = new Error('setup failed');
+const cleanupError = new Error('taskkill failed synchronously');
+const first = ${JSON.stringify(first)};
+const setupFails = ${setupFails};
+const cleanupFails = ${cleanupFails};
+let child, closed;
+let terminations = 0;
+const kill = process.kill.bind(process);
+process.kill = (pid, signal) => {
+  if (signal && pid === -child?.pid) {
+    terminations++;
+  }
+  return kill(pid, signal);
+};
+const outcome = await runManagedCommand({
+  bin: process.execPath,
+  args: ['-e', 'setTimeout(() => process.exit(73), 5000)'],
+  shell: false,
+  stdio: 'ignore',
+  signal: controller.signal,
+  platform: cleanupFails ? 'win32' : process.platform,
+  runTaskkill() {
+    terminations++;
+    child.kill('SIGKILL');
+    throw cleanupError;
+  },
+  onReady(owned) {
+    child = owned;
+    closed = new Promise(resolve => child.once('close', resolve));
+    const cancel = kind => kind === 'abort' ? controller.abort() : process.emit('SIGTERM');
+    cancel(first);
+    assert.equal(terminations, 1, 'cancellation must initiate termination synchronously');
+    cancel(first === 'abort' ? 'signal' : 'abort');
+    assert.equal(terminations, 1, 'reentrant cancellation must reuse finalization');
+    if (setupFails) {
+      throw setupError;
+    }
+  },
+}).catch(error => error);
+await closed;
+assert.throws(() => kill(child.pid, 0));
+assert.equal(terminations, 1, 'setup failure must also join the same finalizer');
+if (cleanupFails) {
+  assert.ok(outcome instanceof AggregateError);
+  assert.deepEqual(outcome.errors, [setupError, cleanupError]);
+  assert.equal(outcome.cause, cleanupError);
+} else if (setupFails) {
+  assert.equal(outcome, setupError);
+} else if (first === 'abort') {
+  assert.equal(outcome.code, 'ABORT_ERR');
+} else {
+  assert.equal(outcome, 143);
+}
+`,
+      );
+      const result = spawnSync(process.execPath, [script], {
+        encoding: "utf8",
+        env: { ...process.env, TMPDIR: dir, TMP: dir, TEMP: dir },
+        timeout: 10_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+    },
+  );
+
+  posixIt.each([
     { runner: "managed", output: "ignore" },
     { runner: "managed", output: "inherit" },
     { runner: "preparation", output: "ignore" },
@@ -1490,6 +1576,8 @@ child.once('message', () => { ${normalExit ? "process.exit(0);" : ""} });
     "rejects and drains descendants left after a successful leader exit through $runner ($output output)",
     async ({ runner, output }) => {
       const dir = createTempDir("openclaw-managed-lingering-");
+      const owner = createVitestResourceOwner(dir);
+      const env = { ...process.env, TMPDIR: dir, TMP: dir, TEMP: dir };
       const descendantPidPath = path.join(dir, "descendant.pid");
       const args = [
         "-e",
@@ -1507,10 +1595,11 @@ child.once("message", () => process.exit(0));
       try {
         const command =
           runner === "preparation"
-            ? runNodeStep("lingering-prep", args, 1_000)
+            ? runNodeStep("lingering-prep", args, 1_000, { env })
             : runManagedCommand({
                 bin: process.execPath,
                 args,
+                env,
                 requireProcessTreeExit: true,
                 shell: false,
                 stdio: output,
@@ -1518,7 +1607,11 @@ child.once("message", () => process.exit(0));
               });
         const failure = await command.catch((error: unknown) => error);
         const descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
-        expect.soft(failure).toMatchObject({ code: "EPROCESSGROUP_CLEANUP_FAILED" });
+        expect.soft(failure).toMatchObject({
+          code: "EPROCESSGROUP_CLEANUP_FAILED",
+          processTreeState: "terminated",
+        });
+        expect(() => owner.assertReleased()).not.toThrow();
         expect
           .soft(
             isProcessAlive(descendantPid),


### PR DESCRIPTION
Related: #135647 — nested Vitest retained-input ownership repair.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Maintainer-requested cleanup after the nested-retention repair. The managed command runner coordinated completion and cancellation through multiple promise relays and repeated command-option lists, making the lifecycle harder to follow and maintain than necessary.

## Why This Change Was Made

The runner now uses one outcome notification and one memoized finalizer. The first cancellation still owns the result, finalization failure still takes precedence, and physical ownership release stays at the verified termination boundary. Command options flow through the existing invocation normalizer rather than being reconstructed at each layer.

Vitest registers exit and close listeners once and composes group completion once. Fixture lifetimes use one admission path that registers ownership before scheduling callbacks, removing duplicate owner discovery. The process inspectors, strict finalizer, receipt protocol, signal-registration policy, and asynchronous cleanup-to-quiescence loop remain unchanged.

## User Impact

No intended behavior change. Test and build commands keep their existing exit codes, error shapes, cancellation precedence, Windows normalization, bounded deadlines, and retained-input guarantees.

**Production/tooling: +61/-114, net -53 LOC.** Test support: +7/-14, net -7. Characterization tests: +95/-2, net +93. No code moved to another file to manufacture the reduction, and no new dependency, configuration, persistence, or public API was added. This follow-up offsets 53 lines of the preceding repair's net +154 tooling delta.

## Evidence

Baseline on Node 24.20.0/macOS: 111 process tests passed (one Linux-only skip), plus 22 focused ownership tests. Before changing production code, the six new reentrant cancellation cases and four strengthened strict-termination cases passed against the original implementation.

After refactoring:

- Process, Vitest group, and run-node-script suites: **117 passed**, one Linux-only skip.
- Focused ownership suite: **22 passed**, including all five real detached-writer modes, corrupt/missing receipts, no-PID failures, refusal before admission, and work admitted during asynchronous removal.
- Complete fixture-lifetime suite: **11 passed**. These selections overlap and are not summed.
- Changed formatting, script/root-test types, lint, erasability and guards passed; `git diff --check` passed.
- An independent parent rerun reproduced **117 passing process tests** and **22 passing ownership tests**. Fresh isolated Codex autoreview, including complete owner/test context, returned scoped-clean at the configured P0 threshold.

The new reentrancy coverage uses isolated controller processes with real children. It checks immediate termination, first-cancellation precedence, repeated cancellation sharing the same finalizer, setup-error identity, and setup/cleanup aggregation. The existing lingering-child cases now assert that strict cleanup can release its claim while still reporting the contract violation with `processTreeState: "terminated"`.

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts test/scripts/vitest-process-group.test.ts test/helpers/run-node-script.test.ts --reporter=verbose
```

```bash
node scripts/run-vitest.mjs test/scripts/run-vitest-state-cleanup.test.ts test/scripts/fixture-lifetime.test.ts --testNamePattern 'positive nested release|resource registration|spawning fails|group verification fails|fresh fixture|unverified .* cleanup|removal failure|nested managed-child retention|asynchronous fixture removal' --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- scripts/lib/managed-child-process.mts scripts/vitest-process-group.mts test/helpers/fixture-lifetime.ts test/scripts/managed-child-process.test.ts
```

### Deliberately retained and excluded

Managed and Vitest joins are not interchangeable: their strict-result policy, Linux evidence, Windows behavior, and grace periods differ. The bounded identity-bound receipt checks remain intact. Signal registration is already covered by [the separate signal-owner refactor](https://github.com/openclaw/openclaw/pull/135344); output tails by [the separate bounded-tail refactor](https://github.com/openclaw/openclaw/pull/135802). Neither is duplicated here. Compiler-completion callback plumbing was rejected because it would add another seam for little deletion.

Native Linux/Windows execution, full repository suites, and package builds are not claimed by the local proof. This changes no import/export or package boundary; exact-head CI and native landing evidence will be recorded separately.
