### PR TITLE
fix: requester sessions recover after settle-wake timeout

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2187,6 +2187,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     const ownerContext = { owner: "gateway-a" } as never;
     const resolveGatewayContext = () => ownerContext;
+    const signal = new AbortController().signal;
     const result = await deliverSubagentAnnouncement({
       requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
       targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
@@ -2206,6 +2207,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       bestEffortDeliver: true,
       directIdempotencyKey: "announce-local-dispatch",
       resolveGatewayContext,
+      signal,
     });
 
     expectDeliveryPath(result, "direct");
@@ -2221,6 +2223,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
     const dispatchOptions = mockCallArg(dispatchGatewayMethodInProcess, 0, 2);
     expect(dispatchOptions).toMatchObject({
+      cancelOnDeadline: true,
       expectFinal: true,
       forceSyntheticClient: true,
       operatorRoleActor: { kind: "system" },
@@ -2233,6 +2236,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       },
       timeoutMs: 120_000,
       resolveGatewayContext,
+      signal,
     });
   });
 
@@ -2241,6 +2245,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       runId: "descendant-wake-run",
     });
     const resolveGatewayContext: GatewayContextResolver = () => undefined;
+    const signal = new AbortController().signal;
     const replaceSubagentRunAfterSteer = vi.fn(async () => true);
     testing.setDepsForTest({
       getRuntimeConfig: () => cfg,
@@ -2257,6 +2262,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       hasUsableSessionEntry: (entry): entry is Record<string, unknown> =>
         typeof entry === "object" && entry !== null,
       resolveGatewayContext,
+      signal,
       deps: {
         callGateway: createGatewayMock(),
         dispatchGatewayMethodInProcess,
@@ -2267,7 +2273,9 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expect(woke).toBe(true);
     expect(mockCallArg(dispatchGatewayMethodInProcess, 0, 2)).toMatchObject({
+      cancelOnDeadline: true,
       resolveGatewayContext,
+      signal,
     });
     expect(replaceSubagentRunAfterSteer).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/agents/subagents/announce/subagent-announce-descendant-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce-descendant-wake.ts
@@ -111,7 +111,9 @@ export async function runDescendantWake(params: {
             idempotencyKey: buildAnnounceIdempotencyKey(`${params.announceId}:wake`),
           },
           {
+            cancelOnDeadline: true,
             operatorRoleActor: { kind: "system" },
+            signal: params.signal,
             timeoutMs: announceTimeoutMs,
             resolveGatewayContext: params.resolveGatewayContext,
           },

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -74,16 +74,19 @@ async function runAnnounceAgentCall(params: {
   agentParams: Record<string, unknown>;
   delegatedToolPolicyHandoff?: SubagentCompletionToolHandoffRegistration;
   expectFinal?: boolean;
+  signal?: AbortSignal;
   timeoutMs?: number;
   resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<unknown> {
   return await dispatchSubagentAnnounceAgent(params.agentParams, {
+    cancelOnDeadline: true,
     expectFinal: params.expectFinal,
     forceSyntheticClient: shouldPreserveUserFacingSessionStateForInputProvenance(
       params.agentParams.inputProvenance,
     ),
     operatorRoleActor: { kind: "system" },
     delegatedToolPolicyHandoff: params.delegatedToolPolicyHandoff,
+    signal: params.signal,
     timeoutMs: params.timeoutMs,
     resolveGatewayContext: params.resolveGatewayContext,
   });
@@ -391,6 +394,7 @@ export async function sendSubagentAnnounceDirectly(params: {
                   }
                 : undefined,
             expectFinal: true,
+            signal: params.signal,
             timeoutMs: announceTimeoutMs,
             resolveGatewayContext: params.resolveGatewayContext,
           });

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInternalAgentTurnFacade } from "../../../gateway/agent-turn/internal-facade.js";
+import { registerChatAbortController } from "../../../gateway/chat-abort.js";
+import { createGatewayMethodRegistry } from "../../../gateway/methods/registry.js";
+import { createChatRunState } from "../../../gateway/server-chat-state.js";
+import type { GatewayRequestContext } from "../../../gateway/server-methods/types.js";
+import { dispatchGatewayMethodInProcess } from "../../../gateway/server-plugin-in-process-dispatch.js";
+import { createSyntheticPluginRuntimeClient } from "../../../gateway/server-plugin-runtime-client.js";
+import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
+import { withPluginRuntimeGatewayRequestScope } from "../../../plugins/runtime/gateway-request-scope.js";
+import { enqueueCommandInLane, getCommandLaneSnapshot } from "../../../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../../../process/command-queue.test-support.js";
+import { createEmbeddedRunLaneController } from "../../embedded-agent-runner/run/lane-controller.js";
+import type { RunEmbeddedAgentParams } from "../../embedded-agent-runner/run/params.js";
+import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+
+const startTurn = vi.hoisted(() => vi.fn());
+const deliver = vi.hoisted(() => vi.fn());
+const registryRead = vi.hoisted(() => ({
+  hasDescendantRunAwaitingSettle: vi.fn(() => false),
+  listSubagentRunsForRequester: vi.fn<() => SubagentRunRecord[]>(() => []),
+  getLatestSubagentRunByChildSessionKey: vi.fn(() => undefined),
+}));
+
+vi.mock("../../../gateway/server-methods.js", () => ({
+  authorizeGatewayRequestPreDispatch: async () => ({ error: null }),
+  createRequestGatewayMethodRegistry: () => ({ isControlPlaneWrite: () => false }),
+  runWithGatewayRequestEnvelope: async (
+    _method: string,
+    _client: unknown,
+    run: () => Promise<unknown>,
+  ) => await run(),
+}));
+
+vi.mock("../../../gateway/agent-turn/agent-request-preflight.js", () => ({
+  prepareAgentRequestPreflight: ({ request }: { request: unknown }) => ({ request }),
+}));
+
+vi.mock("../../../gateway/agent-turn/agent-turn-service.js", () => ({
+  createAgentTurnService: () => ({ startTurn, waitForTurn: vi.fn() }),
+}));
+
+vi.mock("../registry/subagent-registry-read.js", () => registryRead);
+vi.mock("../spawn/subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 0,
+}));
+vi.mock("./subagent-announce.js", () => ({ hasUsableSessionEntry: () => true }));
+vi.mock("./subagent-announce-delivery.js", () => ({
+  deliverSubagentAnnouncement: (...args: unknown[]) => deliver(...args),
+  loadRequesterSessionEntry: () => ({
+    canonicalKey: "agent:main:main",
+    entry: { sessionId: "requester-session" },
+  }),
+}));
+
+import {
+  maybeWakeRequesterAfterAllChildrenSettled,
+  type RequesterSettleWakeBatchState,
+} from "./subagent-announce.requester-settle-wake.js";
+
+const REQUESTER_KEY = "agent:main:main";
+const SESSION_LANE = `session:${REQUESTER_KEY}`;
+const GLOBAL_LANE = "subagent-settle-dispatch-proof";
+
+function settledChild(): SubagentRunRecord {
+  return {
+    runId: "settled-child",
+    childSessionKey: "agent:main:subagent:settled-child",
+    requesterSessionKey: REQUESTER_KEY,
+    requesterDisplayKey: "main",
+    requesterAgentId: "main",
+    task: "finish child work",
+    cleanup: "keep",
+    createdAt: 1_000,
+    execution: { status: "terminal", startedAt: 2_000, endedAt: 3_000 },
+    expectsCompletionMessage: true,
+    completion: { required: true, resultText: "child result", capturedAt: 3_000 },
+    delivery: { status: "delivered" },
+    requesterSettleWake: {
+      status: "pending",
+      attemptCount: 0,
+      requesterYieldBatch: true,
+      rearmGeneration: 1,
+    },
+  };
+}
+
+function createContext(): GatewayRequestContext {
+  const chatRunState = createChatRunState();
+  const methodRegistry = createGatewayMethodRegistry([]);
+  const context = Object.assign({} as GatewayRequestContext, {
+    agentRunSeq: new Map(),
+    broadcast: vi.fn(),
+    chatAbortControllers: new Map(),
+    chatRunState,
+    dedupe: new Map(),
+    getRuntimeConfig: () => ({}),
+    getGatewayMethodRegistry: () => methodRegistry,
+    logGateway: { error: vi.fn(), warn: vi.fn() },
+    nodeSendToSession: vi.fn(),
+    removeChatRun: vi.fn(() => undefined),
+  });
+  context.createAgentTurnFacade = (principal) =>
+    createInternalAgentTurnFacade({
+      ...principal,
+      getContext: () => context,
+      getMethodRegistry: () => methodRegistry,
+    });
+  return context;
+}
+
+describe("requester settle dispatch deadline", () => {
+  beforeEach(() => {
+    resetCommandQueueStateForTest();
+    startTurn.mockReset();
+    deliver.mockReset();
+    registryRead.hasDescendantRunAwaitingSettle.mockReset().mockReturnValue(false);
+    registryRead.getLatestSubagentRunByChildSessionKey.mockReset().mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    resetCommandQueueStateForTest();
+    vi.useRealTimers();
+  });
+
+  it("cancels timed-out wake runs before retry and later work enter the requester lane", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const context = createContext();
+    const child = settledChild();
+    registryRead.listSubagentRunsForRequester.mockReturnValue([child]);
+    const executions: string[] = [];
+    const acceptedSignals: AbortSignal[] = [];
+    let releaseGhost!: () => void;
+    const ghostGate = new Promise<void>((resolve) => {
+      releaseGhost = resolve;
+    });
+
+    startTurn.mockImplementation(async ({ preflight, io }) => {
+      const request = preflight.request as { idempotencyKey: string; sessionKey: string };
+      const registration = registerChatAbortController({
+        chatAbortControllers: context.chatAbortControllers,
+        runId: request.idempotencyKey,
+        sessionId: "requester-session",
+        sessionKey: request.sessionKey,
+        timeoutMs: 60_000,
+        kind: "agent",
+      });
+      let lifecycleGeneration = getAgentEventLifecycleGeneration();
+      let params = {
+        abortSignal: registration.controller.signal,
+        lifecycleGeneration,
+        prompt: "requester settle wake",
+        runId: request.idempotencyKey,
+        sessionFile: "/tmp/requester-settle-proof.jsonl",
+        sessionId: "requester-session",
+        sessionKey: request.sessionKey,
+        timeoutMs: 60_000,
+        workspaceDir: "/tmp",
+      } as RunEmbeddedAgentParams & { sessionFile: string };
+      const lane = createEmbeddedRunLaneController({
+        getLifecycleGeneration: () => lifecycleGeneration,
+        getParams: () => params,
+        globalLane: GLOBAL_LANE,
+        initialQueuedLifecycleGeneration: lifecycleGeneration,
+        sessionLane: SESSION_LANE,
+        setLifecycleGeneration: (value) => {
+          lifecycleGeneration = value;
+        },
+        setParams: (value) => {
+          params = value;
+        },
+      });
+      acceptedSignals.push(registration.controller.signal);
+      io.emitAcceptance([true, { runId: request.idempotencyKey, status: "accepted" }], {
+        runId: request.idempotencyKey,
+      });
+      try {
+        await lane.enqueueSession(() =>
+          lane.enqueueGlobal(async () => {
+            executions.push(request.idempotencyKey);
+            await ghostGate;
+            return { meta: { durationMs: 1 } };
+          }),
+        );
+        io.emitFinal([true, { runId: request.idempotencyKey, status: "ok" }]);
+      } finally {
+        registration.cleanup();
+      }
+    });
+
+    deliver.mockImplementation(async (params: { directIdempotencyKey: string }) => {
+      try {
+        await dispatchGatewayMethodInProcess(
+          "agent",
+          {
+            idempotencyKey: params.directIdempotencyKey,
+            message: "all children settled",
+            sessionKey: REQUESTER_KEY,
+          },
+          {
+            cancelOnDeadline: true,
+            expectFinal: true,
+            forceSyntheticClient: true,
+            timeoutMs: 20,
+          },
+        );
+        return { delivered: true, path: "direct" };
+      } catch (error) {
+        return {
+          delivered: false,
+          path: "direct",
+          disposition: "retryable",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+
+    let releaseBlocker!: () => void;
+    const blockerGate = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    const blocker = enqueueCommandInLane(SESSION_LANE, async () => await blockerGate);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getCommandLaneSnapshot(SESSION_LANE)).toMatchObject({ activeCount: 1 });
+
+    const transitionBatch = (_runIds: readonly string[], state: RequesterSettleWakeBatchState) => {
+      child.requesterSettleWake = state;
+    };
+    const wake = () =>
+      withPluginRuntimeGatewayRequestScope(
+        {
+          context,
+          client: createSyntheticPluginRuntimeClient(),
+          isWebchatConnect: () => false,
+        },
+        () =>
+          maybeWakeRequesterAfterAllChildrenSettled({
+            requesterSessionKey: REQUESTER_KEY,
+            settledEntry: child,
+            transitionBatch,
+            completeBatch: () => {},
+          }),
+      );
+
+    let later: Promise<void> | undefined;
+    try {
+      const firstWake = wake();
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(firstWake).resolves.toBe(false);
+      expect(child.requesterSettleWake).toMatchObject({
+        status: "pending",
+        attemptCount: 1,
+      });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      const replay = wake();
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(replay).resolves.toBe(false);
+
+      const deadlineCancelled = acceptedSignals.map((signal) => signal.aborted);
+      releaseBlocker();
+      await blocker;
+      await vi.advanceTimersByTimeAsync(0);
+
+      let laterRan = false;
+      later = enqueueCommandInLane(SESSION_LANE, async () => {
+        laterRan = true;
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const afterLaterDispatch = getCommandLaneSnapshot(SESSION_LANE);
+
+      expect({
+        afterLaterDispatch: {
+          activeCount: afterLaterDispatch.activeCount,
+          queuedCount: afterLaterDispatch.queuedCount,
+        },
+        deadlineCancelled,
+        executions,
+        laterRan,
+      }).toEqual({
+        afterLaterDispatch: { activeCount: 0, queuedCount: 0 },
+        deadlineCancelled: [true, true],
+        executions: [],
+        laterRan: true,
+      });
+    } finally {
+      releaseBlocker();
+      releaseGhost();
+      await Promise.allSettled([blocker, later]);
+    }
+  });
+});

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerChatAbortController } from "../chat-abort.js";
+import { createChatRunState } from "../server-chat-state.js";
 import type { GatewayRequestContext } from "../server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "../server-plugin-runtime-client.js";
 import { createInternalAgentTurnFacade } from "./internal-facade.js";
@@ -28,15 +30,24 @@ vi.mock("./agent-turn-service.js", () => ({
   }),
 }));
 
-function createFacade() {
+function createContext() {
+  return Object.assign({} as GatewayRequestContext, {
+    agentRunSeq: new Map(),
+    broadcast: vi.fn(),
+    chatAbortControllers: new Map(),
+    chatRunState: createChatRunState(),
+    dedupe: new Map(),
+    getRuntimeConfig: () => ({}),
+    logGateway: { error: vi.fn(), warn: vi.fn() },
+    nodeSendToSession: vi.fn(),
+    removeChatRun: vi.fn(() => undefined),
+  });
+}
+
+function createFacade(context = createContext()) {
   return createInternalAgentTurnFacade({
     client: createSyntheticPluginRuntimeClient(),
-    getContext: () =>
-      ({
-        dedupe: new Map(),
-        getRuntimeConfig: () => ({}),
-        logGateway: { error: vi.fn(), warn: vi.fn() },
-      }) as unknown as GatewayRequestContext,
+    getContext: () => context,
   });
 }
 
@@ -136,5 +147,104 @@ describe("createInternalAgentTurnFacade", () => {
       ),
     ).resolves.toMatchObject({ ok: true });
     expect(onExecutionStarted).toHaveBeenCalledOnce();
+  });
+
+  it("cancels only the accepted run when its opted-in dispatch deadline expires", async () => {
+    vi.useFakeTimers();
+    const context = createContext();
+    const unrelated = registerChatAbortController({
+      chatAbortControllers: context.chatAbortControllers,
+      runId: "unrelated-run",
+      sessionId: "unrelated-session",
+      sessionKey: "agent:main:unrelated",
+      timeoutMs: 60_000,
+      kind: "agent",
+    });
+    let accepted: ReturnType<typeof registerChatAbortController> | undefined;
+    startTurn.mockImplementation(async ({ io }) => {
+      const registration = registerChatAbortController({
+        chatAbortControllers: context.chatAbortControllers,
+        runId: "deadline-run",
+        sessionId: "deadline-session",
+        sessionKey: "agent:main:deadline",
+        timeoutMs: 60_000,
+        kind: "agent",
+      });
+      accepted = registration;
+      io.emitAcceptance([true, { runId: "deadline-run", status: "accepted" }, undefined], {
+        runId: "deadline-run",
+      });
+      await new Promise<void>((_resolve, reject) => {
+        registration.controller.signal.addEventListener(
+          "abort",
+          () => reject(new Error("deadline run aborted")),
+          { once: true },
+        );
+      });
+    });
+
+    try {
+      const result = createFacade(context).dispatchRaw(
+        {
+          message: "settle requester",
+          sessionKey: "agent:main:deadline",
+          idempotencyKey: "deadline-run",
+        },
+        { cancelOnDeadline: true, expectFinal: true, timeoutMs: 20 },
+      );
+      const outcome = expect(result).rejects.toThrow("gateway request timeout for agent");
+      await vi.advanceTimersByTimeAsync(20);
+
+      await outcome;
+      expect(accepted?.controller.signal.aborted).toBe(true);
+      expect(unrelated.controller.signal.aborted).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels a run accepted after its opted-in dispatch deadline", async () => {
+    vi.useFakeTimers();
+    const context = createContext();
+    let accept!: () => void;
+    const acceptanceGate = new Promise<void>((resolve) => {
+      accept = resolve;
+    });
+    let accepted: ReturnType<typeof registerChatAbortController> | undefined;
+    startTurn.mockImplementation(async ({ io }) => {
+      await acceptanceGate;
+      accepted = registerChatAbortController({
+        chatAbortControllers: context.chatAbortControllers,
+        runId: "late-run",
+        sessionId: "late-session",
+        sessionKey: "agent:main:late",
+        timeoutMs: 60_000,
+        kind: "agent",
+      });
+      io.emitAcceptance([true, { runId: "late-run", status: "accepted" }, undefined], {
+        runId: "late-run",
+      });
+    });
+
+    try {
+      const result = createFacade(context).dispatchRaw(
+        {
+          message: "settle requester",
+          sessionKey: "agent:main:late",
+          idempotencyKey: "late-run",
+        },
+        { cancelOnDeadline: true, expectFinal: true, timeoutMs: 20 },
+      );
+      const outcome = expect(result).rejects.toThrow("gateway request timeout for agent");
+      await vi.advanceTimersByTimeAsync(20);
+      await outcome;
+
+      accept();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(accepted?.controller.signal.aborted).toBe(true);
+    } finally {
+      accept();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -4,6 +4,7 @@ import {
   validateAgentParams,
   validateAgentWaitParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { abortChatRunById, type ChatAbortControllerEntry } from "../chat-abort.js";
 import type { GatewayMethodRegistry } from "../methods/registry.js";
 import {
   type GatewayMethodDispatchResponse,
@@ -79,6 +80,22 @@ export function createInternalAgentTurnFacade(
     let resolveFinal: ((response: GatewayMethodDispatchResponse) => void) | undefined;
     let rejectFinal: ((error: Error) => void) | undefined;
     let postAcceptanceError: Error | undefined;
+    // Acceptance publishes the abort owner before this callback runs. Retain that exact
+    // entry so a late deadline cannot cancel a same-run-id successor.
+    let acceptedAbortOwner: { entry: ChatAbortControllerEntry; runId: string } | undefined;
+    let pendingCancelReason: "rpc" | "timeout" | undefined;
+    const cancelAcceptedRun = (reason: "rpc" | "timeout") => {
+      pendingCancelReason ??= reason;
+      const owner = acceptedAbortOwner;
+      if (!owner || context.chatAbortControllers.get(owner.runId) !== owner.entry) {
+        return;
+      }
+      abortChatRunById(context, {
+        runId: owner.runId,
+        sessionKey: owner.entry.sessionKey,
+        stopReason: pendingCancelReason,
+      });
+    };
     const acceptancePromise = new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
       resolveAcceptance = resolve;
       rejectAcceptance = reject;
@@ -103,6 +120,15 @@ export function createInternalAgentTurnFacade(
           resolveAcceptance?.(acceptance);
           const acceptedRunId =
             typeof meta?.runId === "string" && meta.runId.trim() ? meta.runId.trim() : undefined;
+          const acceptedEntry = acceptedRunId
+            ? context.chatAbortControllers.get(acceptedRunId)
+            : undefined;
+          if (acceptedRunId && acceptedEntry) {
+            acceptedAbortOwner = { entry: acceptedEntry, runId: acceptedRunId };
+            if (pendingCancelReason) {
+              cancelAcceptedRun(pendingCancelReason);
+            }
+          }
           if (
             meta?.cached === true &&
             acceptedRunId &&
@@ -192,7 +218,15 @@ export function createInternalAgentTurnFacade(
       response,
       dispatchOptions.timeoutMs,
       dispatchOptions.signal,
-      dispatchOptions.onSignalAbort,
+      dispatchOptions.cancelOnDeadline || dispatchOptions.onSignalAbort
+        ? async () => {
+            if (dispatchOptions.cancelOnDeadline) {
+              cancelAcceptedRun("rpc");
+            }
+            await dispatchOptions.onSignalAbort?.();
+          }
+        : undefined,
+      dispatchOptions.cancelOnDeadline ? () => cancelAcceptedRun("timeout") : undefined,
     );
   };
 

--- a/src/gateway/agent-turn/internal-facade.types.ts
+++ b/src/gateway/agent-turn/internal-facade.types.ts
@@ -12,6 +12,7 @@ export type InternalAgentTurnPrincipalOptions = {
 };
 
 export type InternalAgentTurnDispatchOptions = {
+  cancelOnDeadline?: boolean;
   expectFinal?: boolean;
   onAccepted?: (payload: unknown) => void;
   onExecutionStarted?: () => void;

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -78,6 +78,7 @@ async function waitForDispatch<T>(
   deadlineMs?: number,
   signal?: AbortSignal,
   onSignalAbort?: () => Promise<void> | void,
+  onTimeout?: () => void,
 ): Promise<T> {
   let timeout: NodeJS.Timeout | undefined;
   let onAbort: (() => void) | undefined;
@@ -92,6 +93,7 @@ async function waitForDispatch<T>(
     const cancellation = new Promise<never>((_resolve, reject) => {
       if (remainingTimeoutMs !== undefined) {
         timeout = setTimeout(() => {
+          onTimeout?.();
           reject(new Error(`gateway request timeout for ${method}`));
         }, remainingTimeoutMs);
       }
@@ -128,6 +130,7 @@ export async function waitForGatewayDispatch<T>(
   timeoutMs?: number,
   signal?: AbortSignal,
   onSignalAbort?: () => Promise<void> | void,
+  onTimeout?: () => void,
 ): Promise<T> {
   return await waitForDispatch(
     method,
@@ -135,6 +138,7 @@ export async function waitForGatewayDispatch<T>(
     resolveDispatchDeadlineMs(timeoutMs),
     signal,
     onSignalAbort,
+    onTimeout,
   );
 }
 

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -60,6 +60,7 @@ type DispatchGatewayMethodInProcessOptions = {
   allowSyntheticCronRunContinuation?: boolean;
   agentToolCaller?: TrustedAgentToolCaller;
   agentRunTracking?: GatewayAgentRunTaskOwner;
+  cancelOnDeadline?: boolean;
   disableSyntheticClient?: boolean;
   expectFinal?: boolean;
   forceSyntheticClient?: boolean;
@@ -347,6 +348,7 @@ export async function dispatchGatewayMethodInProcess<T>(
       });
       return method === "agent"
         ? await facade.dispatch<T>(params as AgentRunRequest, {
+            cancelOnDeadline: options?.cancelOnDeadline,
             expectFinal: options?.expectFinal,
             onAccepted: options?.onAccepted,
             onSignalAbort: options?.onSignalAbort,


### PR DESCRIPTION
Closes #135231.

Supersedes #135381 with the cancellation fix at the dispatch owner.

Thanks @nikolascostello for the report and ordered production evidence. Thanks @pengzh1 for the initial fix attempt and test investigation.

## What Problem This Solves

Fixes an issue where a subagent settle wake could time out while waiting in a single-concurrency requester session, remain live, and let retries delay later user work.

## Why This Change Was Made

The in-process agent facade now cancels the exact accepted run when an opted-in deadline ends. Direct and descendant subagent wakes use this mode and pass their existing abort signal. Generic in-process Gateway deadlines remain non-cancelling.

The cancellation uses the Gateway's existing run owner, so timeout, late acceptance, session projection, and lane cleanup follow one canonical lifecycle.

## User Impact

Requester sessions no longer execute expired settle-wake turns after the caller has timed out. Later work continues after the legitimate active turn finishes instead of waiting behind stale wake runs.

## Evidence

- Exact current main `8fe71d40ff1d58779e877d7ba89c82651289606e` was red in the ordered settlement harness: two timed-out wakes remained un-aborted, both reached the backend, the session lane stayed at one active and two queued tasks, and later work did not run.
- Exact candidate `bdfe20af1598dcf1b339d61099bfad03bccf1a7e` was green in the same harness: both wakes were cancelled, neither reached the backend, later work ran, and the lane returned to zero active and zero queued tasks.
- `./node_modules/.bin/vitest run src/agents/subagents/announce/subagent-announce.requester-settle-dispatch.test.ts src/agents/subagents/announce/subagent-announce-delivery.test.ts src/agents/subagents/announce/subagent-announce.timeout.test.ts src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts --config test/vitest/vitest.agents-support.config.ts` — 264 passed.
- `./node_modules/.bin/vitest run src/gateway/agent-turn/internal-facade.test.ts --config test/vitest/vitest.gateway-core.config.ts` — 6 passed.
- `./node_modules/.bin/vitest run src/gateway/server-in-process-dispatch.abort.test.ts --config test/vitest/vitest.gateway.config.ts` — 6 passed.
- Type-aware Oxlint, formatting, `git diff --check`, and P0 Autoreview passed. CI owns type-check and build on this host.

Production delta: +48/-1 lines, net +47. Test delta: +416/-7 lines, net +409. The production growth adds the explicit deadline cancellation contract and exact late-acceptance owner fence; no compatibility path or parallel lifecycle was added.
