### PR TITLE
fix(openai): restore OAuth audio transcription

### DIFF
--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -57,22 +57,27 @@ The provider inventory reports the local fallback winner separately from global 
 
 ## OpenAI transcription alongside ChatGPT/Codex OAuth
 
-An OpenAI API key and a ChatGPT/Codex OAuth login are separate credentials even
-though both use the `openai` provider. With OAuth only, automatic OpenAI audio
-selection uses the ChatGPT dictation endpoint. Account access is required. This
-route accepts audio files and a language hint; explicit transcription models,
-custom prompts, endpoints, and request overrides require a Platform API key.
-OpenClaw reports a provider error if the account cannot use dictation and does
-not switch that failed request to Platform billing.
+OpenAI audio uses the standard `/v1/audio/transcriptions` endpoint with the
+selected API-key or ChatGPT/Codex OAuth profile. An OAuth login can transcribe
+when the account permits it; access, quota, and billing remain account-specific.
+The default model is `gpt-4o-transcribe`; configured models, prompts, and language
+hints are sent through the same multipart request for either credential class.
+Custom endpoints and request overrides require an API-key profile.
 
-During automatic selection, an OpenAI route that cannot prepare the configured
-request does not block another available provider or local transcription backend.
-The rejected preparation remains visible in the transcription attempt results.
-Missing credentials simply leave that candidate unavailable.
+Automatic selection can try another provider or local backend when the OpenAI
+plugin rejects authentication or configuration before uploading audio. The
+rejection remains visible in the attempt results; missing credentials simply
+leave that candidate unavailable. Once a provider attempts transcription,
+upload or HTTP failures are reported without automatically sending the recording
+to another provider or switching credential classes. Explicit model lists retain
+their configured fallback order.
 
-To select a particular transcription model while keeping OAuth first for normal
-text and reasoning requests, create a dedicated
-API-key profile and select it only on the audio model entry.
+Unless a profile or OAuth auth mode is explicitly selected, an authored OpenAI
+provider key takes precedence over ambient OAuth for audio.
+To keep audio billing explicitly separate while keeping OAuth first for normal
+text and reasoning, create a dedicated API-key profile and select it only on the
+audio model entry. This is optional; an API key is not required merely to choose
+a transcription model.
 
 Repeat these steps for every agent that can receive audio. For a single-agent
 installation, run them once for that agent.

--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -58,8 +58,20 @@ The provider inventory reports the local fallback winner separately from global 
 ## OpenAI transcription alongside ChatGPT/Codex OAuth
 
 An OpenAI API key and a ChatGPT/Codex OAuth login are separate credentials even
-though both use the `openai` provider. To keep OAuth first for normal text and
-reasoning requests while using an API key for speech-to-text, create a dedicated
+though both use the `openai` provider. With OAuth only, automatic OpenAI audio
+selection uses the ChatGPT dictation endpoint. Account access is required. This
+route accepts audio files and a language hint; explicit transcription models,
+custom prompts, endpoints, and request overrides require a Platform API key.
+OpenClaw reports a provider error if the account cannot use dictation and does
+not switch that failed request to Platform billing.
+
+During automatic selection, an OpenAI route that cannot prepare the configured
+request does not block another available provider or local transcription backend.
+The rejected preparation remains visible in the transcription attempt results.
+Missing credentials simply leave that candidate unavailable.
+
+To select a particular transcription model while keeping OAuth first for normal
+text and reasoning requests, create a dedicated
 API-key profile and select it only on the audio model entry.
 
 Repeat these steps for every agent that can receive audio. For a single-agent

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -1007,25 +1007,24 @@ catalog, API-key auth, and dynamic model resolution.
       </Tab>
       <Tab title="Media understanding">
         Audio providers with their own credential and endpoint contracts can
-        implement `prepareAudioTranscription(context)`. The context carries the
-        agent directory, selected profile, resolved transport settings, and
-        explicitly requested model/prompt. Return an async transcription callback
-        that closes over the prepared credentials; do not upload audio during
-        preparation. The host calls it once per selected attachment and does not
-        reinterpret its credentials as an API key or rotate them.
+        implement `transcribeAudioWithContext(request)`. The host calls it after
+        loading each audio file. The request includes the audio bytes, filename,
+        model, prompt, language, timeout, transport settings, configuration,
+        agent directory, and selected profile. Resolve credentials for that call;
+        do not retain credentials across attachment downloads.
 
-        Automatic selection prepares each candidate once and retains the callback
-        for execution. Missing credentials leave a candidate unavailable. Other
-        preparation errors are recorded in the attempt results; selection continues
-        to another provider or local transcription backend without uploading to
-        the rejected candidate. Explicit entries report the original preparation
-        error through the same attempt results.
+        Return `{ ok: true, value: { text, model } }` after transcription. Return
+        `{ ok: false, error }` only for authentication or configuration rejected
+        **before uploading audio**. The host records that error and automatic
+        selection may try the next provider or local backend. Canonical missing
+        provider auth leaves the automatic candidate unavailable without a failed
+        attempt. Upload and HTTP failures must throw: automatic selection then
+        stops without sending the recording to another provider. Explicit model
+        lists retain their authored fallback order.
 
-        Prepared callbacks receive the audio bytes, filename, language, timeout,
-        and fetch transport. Return the actual model only when known; the host
-        does not substitute a configured model when the provider omits it.
-        `transcribeAudio` remains available for providers using host-owned
-        API-key resolution and rotation.
+        Return the model when known; otherwise the host retains the requested
+        model in its result. `transcribeAudio` remains available for providers
+        using host-owned API-key resolution and rotation.
 
         ```typescript
         api.registerMediaUnderstandingProvider({

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -1006,6 +1006,27 @@ catalog, API-key auth, and dynamic model resolution.
         lifecycle. Do not infer or enable this mode from a model name alone.
       </Tab>
       <Tab title="Media understanding">
+        Audio providers with their own credential and endpoint contracts can
+        implement `prepareAudioTranscription(context)`. The context carries the
+        agent directory, selected profile, resolved transport settings, and
+        explicitly requested model/prompt. Return an async transcription callback
+        that closes over the prepared credentials; do not upload audio during
+        preparation. The host calls it once per selected attachment and does not
+        reinterpret its credentials as an API key or rotate them.
+
+        Automatic selection prepares each candidate once and retains the callback
+        for execution. Missing credentials leave a candidate unavailable. Other
+        preparation errors are recorded in the attempt results; selection continues
+        to another provider or local transcription backend without uploading to
+        the rejected candidate. Explicit entries report the original preparation
+        error through the same attempt results.
+
+        Prepared callbacks receive the audio bytes, filename, language, timeout,
+        and fetch transport. Return the actual model only when known; the host
+        does not substitute a configured model when the provider omits it.
+        `transcribeAudio` remains available for providers using host-owned
+        API-key resolution and rotation.
+
         ```typescript
         api.registerMediaUnderstandingProvider({
           id: "acme-ai",

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -923,14 +923,14 @@ value into `plugins.entries.openai.config.personality` when that key is unset.
     The bundled `openai` plugin registers batch speech-to-text through
     OpenClaw's media-understanding transcription surface.
 
-    Automatic selection can use an OpenClaw ChatGPT OAuth profile with the
-    account's dictation endpoint when no Platform key is available. This route
-    supports a file and language hint, without promising a particular model.
-    Explicit models, custom prompts, endpoints, or request overrides require a
-    Platform API key. See [Audio and voice notes](/nodes/audio#openai-transcription-alongside-chatgptcodex-oauth)
-    for keeping an audio API-key profile separate from normal OAuth inference.
-
-    With Platform API-key auth:
+    Batch transcription can use the selected OpenAI API-key or ChatGPT OAuth
+    profile on the standard transcription endpoint when the account permits it.
+    Configured models, prompts, and language hints work through the same request
+    path. Access and quota errors are reported without switching credential
+    classes; OAuth support does not imply included or unlimited transcription.
+    Custom endpoints and request overrides require an API-key profile.
+    See [Audio and voice notes](/nodes/audio#openai-transcription-alongside-chatgptcodex-oauth)
+    for selecting a separate audio API-key profile when desired.
 
     - Default model: `gpt-4o-transcribe`
     - Endpoint: OpenAI REST `/v1/audio/transcriptions`

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -923,6 +923,15 @@ value into `plugins.entries.openai.config.personality` when that key is unset.
     The bundled `openai` plugin registers batch speech-to-text through
     OpenClaw's media-understanding transcription surface.
 
+    Automatic selection can use an OpenClaw ChatGPT OAuth profile with the
+    account's dictation endpoint when no Platform key is available. This route
+    supports a file and language hint, without promising a particular model.
+    Explicit models, custom prompts, endpoints, or request overrides require a
+    Platform API key. See [Audio and voice notes](/nodes/audio#openai-transcription-alongside-chatgptcodex-oauth)
+    for keeping an audio API-key profile separate from normal OAuth inference.
+
+    With Platform API-key auth:
+
     - Default model: `gpt-4o-transcribe`
     - Endpoint: OpenAI REST `/v1/audio/transcriptions`
     - Input path: multipart audio file upload

--- a/extensions/openai/audio-transcription.ts
+++ b/extensions/openai/audio-transcription.ts
@@ -6,7 +6,6 @@ import { transcribeOpenAiCompatibleAudio } from "openclaw/plugin-sdk/media-under
 import {
   findNormalizedProviderValue,
   hasConfiguredSecretInput,
-  resolveOpenAICodexAuthIdentity,
 } from "openclaw/plugin-sdk/provider-auth";
 import {
   collectProviderApiKeysForExecution,
@@ -14,20 +13,10 @@ import {
   isProviderAuthError,
   requireApiKey,
   resolveApiKeyForProvider,
-  resolveProviderAuthProfileMetadata,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
-import {
-  assertOkOrThrowHttpError,
-  buildAudioTranscriptionFormData,
-  postTranscriptionRequest,
-  providerOperationRetryConfig,
-  readProviderJsonObjectResponse,
-  requireTranscriptionText,
-} from "openclaw/plugin-sdk/provider-http";
+import { providerOperationRetryConfig } from "openclaw/plugin-sdk/provider-http";
 import { classifyOpenAIBaseUrl, OPENAI_API_BASE_URL } from "./base-url.js";
 import { OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL } from "./default-models.js";
-
-const CHATGPT_TRANSCRIPTION_URL = "https://chatgpt.com/backend-api/transcribe";
 
 export async function transcribeOpenAiAudio(params: AudioTranscriptionRequest) {
   return await transcribeOpenAiCompatibleAudio({
@@ -38,8 +27,8 @@ export async function transcribeOpenAiAudio(params: AudioTranscriptionRequest) {
   });
 }
 
-export const prepareOpenAiAudioTranscription: NonNullable<
-  MediaUnderstandingProvider["prepareAudioTranscription"]
+export const transcribeOpenAiAudioWithContext: NonNullable<
+  MediaUnderstandingProvider["transcribeAudioWithContext"]
 > = async (context) => {
   const providerConfig = findNormalizedProviderValue(context.cfg.models?.providers, "openai");
   const hasConfiguredKey = hasConfiguredSecretInput(
@@ -77,115 +66,60 @@ export const prepareOpenAiAudioTranscription: NonNullable<
     lockedProfile: Boolean(context.profile),
   };
   const explicitSubscription = providerConfig?.auth === "oauth" || providerConfig?.auth === "token";
-  const auth = await resolveApiKeyForProvider({
-    ...params,
-    modelApi: context.profile || explicitSubscription ? undefined : "openai-audio-transcriptions",
-  }).catch((error: unknown) => {
-    if (
-      context.profile ||
-      hasConfiguredKey ||
-      !nativeEndpoint ||
-      !isProviderAuthError(error, "missing-provider-auth")
-    ) {
-      throw error;
-    }
-    // Missing Platform credentials may select the subscription route; failed credentials
-    // never trigger a switch to another account or billing surface.
-    return resolveApiKeyForProvider(params);
-  });
-  const credential = requireApiKey(auth, "openai");
-  if (auth.mode === "api-key") {
-    const apiKeys = collectProviderApiKeysForExecution({
-      provider: "openai",
-      primaryApiKey: credential,
+  let auth: Awaited<ReturnType<typeof resolveApiKeyForProvider>>;
+  let credential: string;
+  try {
+    auth = await resolveApiKeyForProvider({
+      ...params,
+      modelApi: context.profile || explicitSubscription ? undefined : "openai-audio-transcriptions",
+    }).catch((error: unknown) => {
+      if (
+        context.profile ||
+        hasConfiguredKey ||
+        !nativeEndpoint ||
+        !isProviderAuthError(error, "missing-provider-auth")
+      ) {
+        throw error;
+      }
+      // Only absent API-key credentials allow subscription selection. Failed credentials
+      // and rejected uploads never switch accounts or credential classes.
+      return resolveApiKeyForProvider(params);
     });
-    return async (input) =>
-      await executeWithApiKeyRotation({
-        provider: "openai",
-        apiKeys,
-        transientRetry: providerOperationRetryConfig("read"),
-        execute: async (apiKey) =>
-          transcribeOpenAiAudio({
-            ...input,
-            // The inherited provider URL can target ChatGPT text inference. Audio's
-            // resolved credential class owns the official endpoint and billing surface.
-            baseUrl: nativeEndpoint ? OPENAI_API_BASE_URL : context.baseUrl,
-            headers: context.headers,
-            request: context.request,
-            apiKey,
-            auth: { kind: "api-key", apiKey },
+    credential = requireApiKey(auth, "openai");
+    if (auth.mode !== "api-key") {
+      if (auth.mode !== "oauth" && auth.mode !== "token") {
+        throw new Error("OpenAI audio transcription requires an API key or OAuth profile.");
+      }
+      if (!nativeEndpoint || context.headers || context.request) {
+        throw new Error(
+          "OpenAI OAuth audio transcription requires the official endpoint without custom request overrides. Remove the overrides or select an OpenAI API-key profile.",
+        );
+      }
+    }
+  } catch (error) {
+    // This result is exclusively a rejection before uploading audio. HTTP failures
+    // below must throw so automatic selection cannot send the file to another provider.
+    return { ok: false, error };
+  }
+  const transcribe = (apiKey: string) =>
+    transcribeOpenAiAudio({
+      ...context,
+      // Official text-inference bases do not select the batch-audio endpoint.
+      baseUrl: nativeEndpoint ? OPENAI_API_BASE_URL : context.baseUrl,
+      apiKey,
+      ...(auth.mode === "api-key" ? { auth: { kind: "api-key" as const, apiKey } } : {}),
+    });
+  const value =
+    auth.mode === "api-key"
+      ? await executeWithApiKeyRotation({
+          provider: "openai",
+          apiKeys: collectProviderApiKeysForExecution({
+            provider: "openai",
+            primaryApiKey: credential,
           }),
-      });
-  }
-  if (auth.mode !== "oauth" && auth.mode !== "token") {
-    throw new Error(
-      "OpenAI audio transcription requires an API key or ChatGPT subscription profile.",
-    );
-  }
-  if (!nativeEndpoint) {
-    throw new Error(
-      "ChatGPT audio transcription cannot use a custom endpoint. Select an OpenAI API-key profile for this audio model.",
-    );
-  }
-  if (context.requestedModel?.trim() || context.prompt?.trim()) {
-    throw new Error(
-      "OpenClaw's ChatGPT audio integration uses the service defaults. Model and prompt overrides require an OpenAI API-key profile; remove the audio overrides or select that profile.",
-    );
-  }
-  if (context.headers || context.request) {
-    throw new Error(
-      "ChatGPT audio transcription does not support custom request overrides. Remove the audio overrides or select an OpenAI API-key profile.",
-    );
-  }
-  const metadata = auth.profileId
-    ? resolveProviderAuthProfileMetadata({
-        provider: "openai",
-        cfg: context.cfg,
-        agentDir: context.agentDir,
-        profileId: auth.profileId,
-      })
-    : undefined;
-  const accountId = resolveOpenAICodexAuthIdentity({
-    access: credential,
-    accountId: metadata?.accountId,
-  }).accountId;
-  if (!accountId) {
-    throw new Error(
-      "The selected ChatGPT audio profile is missing its account id. Sign in to OpenAI again.",
-    );
-  }
-  return async (input) => {
-    const { response, release } = await postTranscriptionRequest({
-      url: CHATGPT_TRANSCRIPTION_URL,
-      headers: new Headers({
-        authorization: `Bearer ${credential}`,
-        "ChatGPT-Account-ID": accountId,
-      }),
-      body: buildAudioTranscriptionFormData({
-        buffer: input.buffer,
-        fileName: input.fileName,
-        mime: input.mime,
-        fields: { language: input.language },
-      }),
-      timeoutMs: input.timeoutMs,
-      signal: input.signal,
-      fetchFn: input.fetchFn ?? fetch,
-      pinDns: false,
-    });
-    try {
-      await assertOkOrThrowHttpError(response, "ChatGPT audio transcription failed");
-      const payload = await readProviderJsonObjectResponse(
-        response,
-        "ChatGPT audio transcription failed",
-      );
-      return {
-        text: requireTranscriptionText(
-          typeof payload.text === "string" ? payload.text : undefined,
-          "ChatGPT audio transcription response missing text",
-        ),
-      };
-    } finally {
-      await release();
-    }
-  };
+          transientRetry: providerOperationRetryConfig("read"),
+          execute: transcribe,
+        })
+      : await transcribe(credential);
+  return { ok: true, value };
 };

--- a/extensions/openai/audio-transcription.ts
+++ b/extensions/openai/audio-transcription.ts
@@ -1,0 +1,191 @@
+import type {
+  AudioTranscriptionRequest,
+  MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+import { transcribeOpenAiCompatibleAudio } from "openclaw/plugin-sdk/media-understanding";
+import {
+  findNormalizedProviderValue,
+  hasConfiguredSecretInput,
+  resolveOpenAICodexAuthIdentity,
+} from "openclaw/plugin-sdk/provider-auth";
+import {
+  collectProviderApiKeysForExecution,
+  executeWithApiKeyRotation,
+  isProviderAuthError,
+  requireApiKey,
+  resolveApiKeyForProvider,
+  resolveProviderAuthProfileMetadata,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  assertOkOrThrowHttpError,
+  buildAudioTranscriptionFormData,
+  postTranscriptionRequest,
+  providerOperationRetryConfig,
+  readProviderJsonObjectResponse,
+  requireTranscriptionText,
+} from "openclaw/plugin-sdk/provider-http";
+import { classifyOpenAIBaseUrl, OPENAI_API_BASE_URL } from "./base-url.js";
+import { OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL } from "./default-models.js";
+
+const CHATGPT_TRANSCRIPTION_URL = "https://chatgpt.com/backend-api/transcribe";
+
+export async function transcribeOpenAiAudio(params: AudioTranscriptionRequest) {
+  return await transcribeOpenAiCompatibleAudio({
+    ...params,
+    provider: "openai",
+    defaultBaseUrl: OPENAI_API_BASE_URL,
+    defaultModel: OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
+  });
+}
+
+export const prepareOpenAiAudioTranscription: NonNullable<
+  MediaUnderstandingProvider["prepareAudioTranscription"]
+> = async (context) => {
+  const providerConfig = findNormalizedProviderValue(context.cfg.models?.providers, "openai");
+  const hasConfiguredKey = hasConfiguredSecretInput(
+    providerConfig?.apiKey,
+    context.cfg.secrets?.defaults,
+  );
+  const endpointKind = classifyOpenAIBaseUrl(context.baseUrl);
+  const nativeEndpoint =
+    endpointKind === "unresolved" || endpointKind === "platform" || endpointKind === "chatgpt";
+  // Audio's authored provider key owns billing before ambient profiles. This request-local
+  // projection preserves that order without changing the agent's text-inference configuration.
+  const cfg =
+    !context.profile &&
+    providerConfig &&
+    hasConfiguredKey &&
+    (!providerConfig.auth || providerConfig.auth === "api-key")
+      ? {
+          ...context.cfg,
+          models: {
+            ...context.cfg.models,
+            providers: {
+              ...context.cfg.models?.providers,
+              openai: { ...providerConfig, auth: "api-key" as const },
+            },
+          },
+        }
+      : context.cfg;
+  const params = {
+    provider: "openai",
+    cfg,
+    agentDir: context.agentDir,
+    workspaceDir: context.workspaceDir,
+    profileId: context.profile,
+    preferredProfile: context.preferredProfile,
+    lockedProfile: Boolean(context.profile),
+  };
+  const explicitSubscription = providerConfig?.auth === "oauth" || providerConfig?.auth === "token";
+  const auth = await resolveApiKeyForProvider({
+    ...params,
+    modelApi: context.profile || explicitSubscription ? undefined : "openai-audio-transcriptions",
+  }).catch((error: unknown) => {
+    if (
+      context.profile ||
+      hasConfiguredKey ||
+      !nativeEndpoint ||
+      !isProviderAuthError(error, "missing-provider-auth")
+    ) {
+      throw error;
+    }
+    // Missing Platform credentials may select the subscription route; failed credentials
+    // never trigger a switch to another account or billing surface.
+    return resolveApiKeyForProvider(params);
+  });
+  const credential = requireApiKey(auth, "openai");
+  if (auth.mode === "api-key") {
+    const apiKeys = collectProviderApiKeysForExecution({
+      provider: "openai",
+      primaryApiKey: credential,
+    });
+    return async (input) =>
+      await executeWithApiKeyRotation({
+        provider: "openai",
+        apiKeys,
+        transientRetry: providerOperationRetryConfig("read"),
+        execute: async (apiKey) =>
+          transcribeOpenAiAudio({
+            ...input,
+            // The inherited provider URL can target ChatGPT text inference. Audio's
+            // resolved credential class owns the official endpoint and billing surface.
+            baseUrl: nativeEndpoint ? OPENAI_API_BASE_URL : context.baseUrl,
+            headers: context.headers,
+            request: context.request,
+            apiKey,
+            auth: { kind: "api-key", apiKey },
+          }),
+      });
+  }
+  if (auth.mode !== "oauth" && auth.mode !== "token") {
+    throw new Error(
+      "OpenAI audio transcription requires an API key or ChatGPT subscription profile.",
+    );
+  }
+  if (!nativeEndpoint) {
+    throw new Error(
+      "ChatGPT audio transcription cannot use a custom endpoint. Select an OpenAI API-key profile for this audio model.",
+    );
+  }
+  if (context.requestedModel?.trim() || context.prompt?.trim()) {
+    throw new Error(
+      "OpenClaw's ChatGPT audio integration uses the service defaults. Model and prompt overrides require an OpenAI API-key profile; remove the audio overrides or select that profile.",
+    );
+  }
+  if (context.headers || context.request) {
+    throw new Error(
+      "ChatGPT audio transcription does not support custom request overrides. Remove the audio overrides or select an OpenAI API-key profile.",
+    );
+  }
+  const metadata = auth.profileId
+    ? resolveProviderAuthProfileMetadata({
+        provider: "openai",
+        cfg: context.cfg,
+        agentDir: context.agentDir,
+        profileId: auth.profileId,
+      })
+    : undefined;
+  const accountId = resolveOpenAICodexAuthIdentity({
+    access: credential,
+    accountId: metadata?.accountId,
+  }).accountId;
+  if (!accountId) {
+    throw new Error(
+      "The selected ChatGPT audio profile is missing its account id. Sign in to OpenAI again.",
+    );
+  }
+  return async (input) => {
+    const { response, release } = await postTranscriptionRequest({
+      url: CHATGPT_TRANSCRIPTION_URL,
+      headers: new Headers({
+        authorization: `Bearer ${credential}`,
+        "ChatGPT-Account-ID": accountId,
+      }),
+      body: buildAudioTranscriptionFormData({
+        buffer: input.buffer,
+        fileName: input.fileName,
+        mime: input.mime,
+        fields: { language: input.language },
+      }),
+      timeoutMs: input.timeoutMs,
+      signal: input.signal,
+      fetchFn: input.fetchFn ?? fetch,
+      pinDns: false,
+    });
+    try {
+      await assertOkOrThrowHttpError(response, "ChatGPT audio transcription failed");
+      const payload = await readProviderJsonObjectResponse(
+        response,
+        "ChatGPT audio transcription failed",
+      );
+      return {
+        text: requireTranscriptionText(
+          typeof payload.text === "string" ? payload.text : undefined,
+          "ChatGPT audio transcription response missing text",
+        ),
+      };
+    } finally {
+      await release();
+    }
+  };
+};

--- a/extensions/openai/media-understanding-provider.test.ts
+++ b/extensions/openai/media-understanding-provider.test.ts
@@ -1,4 +1,6 @@
 // Openai tests cover media understanding provider plugin behavior.
+import { inspect } from "node:util";
+import { expectDefined } from "@openclaw/normalization-core";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import {
   createAuthCaptureJsonFetch,
@@ -8,18 +10,16 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { openaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
 
-const authMocks = vi.hoisted(() => ({ resolve: vi.fn(), metadata: vi.fn() }));
+const authMocks = vi.hoisted(() => ({ resolve: vi.fn() }));
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth-runtime")>()),
   resolveApiKeyForProvider: authMocks.resolve,
-  resolveProviderAuthProfileMetadata: authMocks.metadata,
 }));
 
 installPinnedHostnameTestHooks();
 
 beforeEach(() => {
   authMocks.resolve.mockReset();
-  authMocks.metadata.mockReset().mockReturnValue({});
 });
 
 describe("openaiMediaUnderstandingProvider", () => {
@@ -34,12 +34,8 @@ describe("openaiMediaUnderstandingProvider", () => {
   });
 });
 
-describe("provider-prepared audio transcription", () => {
-  const token = `fixture.${Buffer.from(
-    JSON.stringify({
-      "https://api.openai.com/auth": { chatgpt_account_id: "fixture-account" },
-    }),
-  ).toString("base64url")}.signature`;
+describe("provider-owned audio transcription", () => {
+  const token = "fixture-oauth-token";
 
   function useOAuth() {
     authMocks.resolve.mockResolvedValue({
@@ -49,32 +45,41 @@ describe("provider-prepared audio transcription", () => {
     });
   }
 
-  it.each([undefined, "https://api.openai.com", "https://chatgpt.com/backend-api/codex"])(
-    "routes subscription audio from official base %s to the fixed ChatGPT endpoint",
-    async (baseUrl) => {
+  it.each([
+    [undefined, undefined],
+    [undefined, "gpt-4o-mini-transcribe"],
+    ["https://api.openai.com", "gpt-4o-mini-transcribe"],
+    ["https://chatgpt.com/backend-api/codex", "gpt-4o-mini-transcribe"],
+  ])(
+    "routes subscription audio from official base %s with model %s to the standard transcription endpoint",
+    async (baseUrl, model) => {
       useOAuth();
       const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "Hallo" });
-      const transcribe = await openaiMediaUnderstandingProvider.prepareAudioTranscription!({
+      const result = await openaiMediaUnderstandingProvider.transcribeAudioWithContext!({
         cfg: {},
         agentDir: "/fixture/agents/audio",
         profile: "openai:audio",
         baseUrl,
-      });
-      const result = await transcribe({
         buffer: Buffer.from("audio"),
         fileName: "voice.wav",
         language: "de",
+        model,
+        prompt: "Names: Ada",
         timeoutMs: 1000,
         fetchFn,
       });
       const { url, init } = getRequest();
-      expect(url).toBe("https://chatgpt.com/backend-api/transcribe");
+      expect(url).toBe("https://api.openai.com/v1/audio/transcriptions");
       expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${token}`);
-      expect(new Headers(init?.headers).get("ChatGPT-Account-ID")).toBe("fixture-account");
-      expect((init?.body as FormData).get("language")).toBe("de");
-      expect((init?.body as FormData).has("model")).toBe(false);
-      expect(result).toEqual({ text: "Hallo" });
-      expect(authMocks.metadata).not.toHaveBeenCalled();
+      expect(new Headers(init?.headers).has("ChatGPT-Account-ID")).toBe(false);
+      const body = expectDefined(init?.body, "transcription request body") as FormData;
+      expect(body.get("language")).toBe("de");
+      expect(body.get("model")).toBe(model ?? "gpt-4o-transcribe");
+      expect(body.get("prompt")).toBe("Names: Ada");
+      expect(result).toEqual({
+        ok: true,
+        value: { text: "Hallo", model: model ?? "gpt-4o-transcribe" },
+      });
       expect(authMocks.resolve).toHaveBeenCalledWith(
         expect.objectContaining({
           agentDir: "/fixture/agents/audio",
@@ -82,42 +87,6 @@ describe("provider-prepared audio transcription", () => {
           lockedProfile: true,
         }),
       );
-    },
-  );
-
-  it.each(["first", "second"])(
-    "uses only the selected %s account metadata for an opaque OAuth token",
-    async (selected) => {
-      const profileId = `openai:${selected}`;
-      authMocks.resolve.mockResolvedValue({
-        apiKey: "opaque-fixture-access",
-        mode: "oauth",
-        profileId,
-        source: `profile:${profileId}`,
-      });
-      authMocks.metadata.mockImplementation((params: { profileId?: string }) => ({
-        accountId: params.profileId === "openai:second" ? "second-account" : "first-account",
-      }));
-      const transcribe = await openaiMediaUnderstandingProvider.prepareAudioTranscription!({
-        cfg: {},
-        agentDir: "/fixture/agents/worker",
-      });
-      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "account transcript" });
-      await transcribe({
-        buffer: Buffer.from("audio"),
-        fileName: "voice.wav",
-        timeoutMs: 1000,
-        fetchFn,
-      });
-      expect(new Headers(getRequest().init?.headers).get("ChatGPT-Account-ID")).toBe(
-        `${selected}-account`,
-      );
-      expect(authMocks.metadata).toHaveBeenCalledExactlyOnceWith({
-        provider: "openai",
-        cfg: {},
-        agentDir: "/fixture/agents/worker",
-        profileId,
-      });
     },
   );
 
@@ -168,18 +137,22 @@ describe("provider-prepared audio transcription", () => {
             const provider = registry.registry.mediaUnderstandingProviders.find(
               (entry) => entry.provider.id === "openai",
             )?.provider;
-            if (!provider?.prepareAudioTranscription) {
-              throw new Error("OpenAI audio preparation registration missing");
+            if (!provider?.transcribeAudioWithContext) {
+              throw new Error("OpenAI audio transcription registration missing");
             }
-            const transcribe = await provider.prepareAudioTranscription({ cfg });
             const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "subscription" });
-            await transcribe({
+            const result = await provider.transcribeAudioWithContext({
+              cfg,
               buffer: Buffer.from("audio"),
               fileName: "voice.wav",
               timeoutMs: 1000,
               fetchFn,
             });
-            expect(getRequest().url).toBe("https://chatgpt.com/backend-api/transcribe");
+            expect(result.ok).toBe(true);
+            expect(getRequest().url).toBe("https://api.openai.com/v1/audio/transcriptions");
+            expect(new Headers(getRequest().init?.headers).get("authorization")).toBe(
+              `Bearer ${token}`,
+            );
             expect(authMocks.resolve).toHaveBeenCalledTimes(2);
           });
         } finally {
@@ -213,12 +186,10 @@ describe("provider-prepared audio transcription", () => {
         },
       };
       const original = structuredClone(cfg);
-      const transcribe = await openaiMediaUnderstandingProvider.prepareAudioTranscription!({
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+      await openaiMediaUnderstandingProvider.transcribeAudioWithContext!({
         cfg,
         baseUrl,
-      });
-      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
-      await transcribe({
         buffer: Buffer.from("audio"),
         fileName: "voice.wav",
         model: "gpt-4o-mini-transcribe",
@@ -238,8 +209,9 @@ describe("provider-prepared audio transcription", () => {
       );
       const { url, init } = getRequest();
       expect(url).toBe(expectedUrl);
-      expect((init?.body as FormData).get("model")).toBe("gpt-4o-mini-transcribe");
-      expect((init?.body as FormData).get("prompt")).toBe("Names: Ada");
+      const body = expectDefined(init?.body, "transcription request body") as FormData;
+      expect(body.get("model")).toBe("gpt-4o-mini-transcribe");
+      expect(body.get("prompt")).toBe("Names: Ada");
     },
   );
 
@@ -248,27 +220,74 @@ describe("provider-prepared audio transcription", () => {
     { baseUrl: "https://api.openai.com:8443/v1" },
     { baseUrl: "https://api.openai.com/v1?alternate=true" },
     { headers: { authorization: "Bearer other" } },
-    { prompt: "Translate to French" },
-    { requestedModel: "gpt-4o-mini-transcribe" },
   ])("rejects unsupported subscription request settings before upload: %j", async (settings) => {
     useOAuth();
     await expect(
-      openaiMediaUnderstandingProvider.prepareAudioTranscription!({
+      openaiMediaUnderstandingProvider.transcribeAudioWithContext!({
         cfg: {},
+        buffer: Buffer.from("audio"),
+        fileName: "voice.wav",
+        timeoutMs: 1000,
         profile: "openai:audio",
         ...settings,
       }),
-    ).rejects.toThrow(/API-key profile/);
+    ).resolves.toEqual({
+      ok: false,
+      error: expect.objectContaining({ message: expect.stringMatching(/API-key profile/) }),
+    });
   });
 
   it("does not switch billing routes after an authored credential failure", async () => {
     const failure = new Error("selected profile could not refresh");
     authMocks.resolve.mockRejectedValue(failure);
     await expect(
-      openaiMediaUnderstandingProvider.prepareAudioTranscription!({ cfg: {} }),
-    ).rejects.toBe(failure);
+      openaiMediaUnderstandingProvider.transcribeAudioWithContext!({
+        cfg: {},
+        buffer: Buffer.from("audio"),
+        fileName: "voice.wav",
+        timeoutMs: 1000,
+      }),
+    ).resolves.toEqual({ ok: false, error: failure });
     expect(authMocks.resolve).toHaveBeenCalledTimes(1);
   });
+
+  it.each([400, 200])(
+    "redacts reflected request credentials from HTTP %s diagnostics",
+    async (status) => {
+      const credential = "synthetic-only";
+      authMocks.resolve.mockResolvedValue({
+        apiKey: credential,
+        mode: "oauth",
+        profileId: "openai:fixture",
+        source: "profile:openai:fixture",
+      });
+      const fetchFn = vi.fn<typeof fetch>().mockImplementationOnce(async (_url, init) => {
+        expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${credential}`);
+        return new Response(
+          status === 400
+            ? JSON.stringify({ error: { message: `Rejected ${credential}`, code: credential } })
+            : credential,
+          { status, headers: { "x-request-id": credential } },
+        );
+      });
+      const error = await openaiMediaUnderstandingProvider.transcribeAudioWithContext!({
+        cfg: {},
+        buffer: Buffer.from("audio"),
+        fileName: "voice.wav",
+        timeoutMs: 1000,
+        fetchFn,
+      }).catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        message:
+          status === 400
+            ? "Audio transcription failed (HTTP 400): Rejected *** [code=***] [request_id=***]"
+            : "Audio transcription failed: malformed JSON response",
+      });
+      expect(inspect(error)).not.toContain(credential);
+      expect(authMocks.resolve).toHaveBeenCalledTimes(1);
+    },
+  );
 });
 
 describe("transcribeOpenAiAudio", () => {

--- a/extensions/openai/media-understanding-provider.test.ts
+++ b/extensions/openai/media-understanding-provider.test.ts
@@ -1,13 +1,26 @@
 // Openai tests cover media understanding provider plugin behavior.
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import {
   createAuthCaptureJsonFetch,
   createRequestCaptureJsonFetch,
   installPinnedHostnameTestHooks,
 } from "openclaw/plugin-sdk/test-media-understanding";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { openaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
 
+const authMocks = vi.hoisted(() => ({ resolve: vi.fn(), metadata: vi.fn() }));
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth-runtime")>()),
+  resolveApiKeyForProvider: authMocks.resolve,
+  resolveProviderAuthProfileMetadata: authMocks.metadata,
+}));
+
 installPinnedHostnameTestHooks();
+
+beforeEach(() => {
+  authMocks.resolve.mockReset();
+  authMocks.metadata.mockReset().mockReturnValue({});
+});
 
 describe("openaiMediaUnderstandingProvider", () => {
   it("declares audio support with the transcription default", () => {
@@ -18,6 +31,243 @@ describe("openaiMediaUnderstandingProvider", () => {
     });
     expect(openaiMediaUnderstandingProvider.autoPriority).toEqual({ image: 20, audio: 20 });
     expect(openaiMediaUnderstandingProvider.transcribeAudio).toBeTypeOf("function");
+  });
+});
+
+describe("provider-prepared audio transcription", () => {
+  const token = `fixture.${Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": { chatgpt_account_id: "fixture-account" },
+    }),
+  ).toString("base64url")}.signature`;
+
+  function useOAuth() {
+    authMocks.resolve.mockResolvedValue({
+      apiKey: token,
+      mode: "oauth",
+      source: "profile:openai:audio",
+    });
+  }
+
+  it.each([undefined, "https://api.openai.com", "https://chatgpt.com/backend-api/codex"])(
+    "routes subscription audio from official base %s to the fixed ChatGPT endpoint",
+    async (baseUrl) => {
+      useOAuth();
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "Hallo" });
+      const transcribe = await openaiMediaUnderstandingProvider.prepareAudioTranscription!({
+        cfg: {},
+        agentDir: "/fixture/agents/audio",
+        profile: "openai:audio",
+        baseUrl,
+      });
+      const result = await transcribe({
+        buffer: Buffer.from("audio"),
+        fileName: "voice.wav",
+        language: "de",
+        timeoutMs: 1000,
+        fetchFn,
+      });
+      const { url, init } = getRequest();
+      expect(url).toBe("https://chatgpt.com/backend-api/transcribe");
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Bearer ${token}`);
+      expect(new Headers(init?.headers).get("ChatGPT-Account-ID")).toBe("fixture-account");
+      expect((init?.body as FormData).get("language")).toBe("de");
+      expect((init?.body as FormData).has("model")).toBe(false);
+      expect(result).toEqual({ text: "Hallo" });
+      expect(authMocks.metadata).not.toHaveBeenCalled();
+      expect(authMocks.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentDir: "/fixture/agents/audio",
+          profileId: "openai:audio",
+          lockedProfile: true,
+        }),
+      );
+    },
+  );
+
+  it.each(["first", "second"])(
+    "uses only the selected %s account metadata for an opaque OAuth token",
+    async (selected) => {
+      const profileId = `openai:${selected}`;
+      authMocks.resolve.mockResolvedValue({
+        apiKey: "opaque-fixture-access",
+        mode: "oauth",
+        profileId,
+        source: `profile:${profileId}`,
+      });
+      authMocks.metadata.mockImplementation((params: { profileId?: string }) => ({
+        accountId: params.profileId === "openai:second" ? "second-account" : "first-account",
+      }));
+      const transcribe = await openaiMediaUnderstandingProvider.prepareAudioTranscription!({
+        cfg: {},
+        agentDir: "/fixture/agents/worker",
+      });
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "account transcript" });
+      await transcribe({
+        buffer: Buffer.from("audio"),
+        fileName: "voice.wav",
+        timeoutMs: 1000,
+        fetchFn,
+      });
+      expect(new Headers(getRequest().init?.headers).get("ChatGPT-Account-ID")).toBe(
+        `${selected}-account`,
+      );
+      expect(authMocks.metadata).toHaveBeenCalledExactlyOnceWith({
+        provider: "openai",
+        cfg: {},
+        agentDir: "/fixture/agents/worker",
+        profileId,
+      });
+    },
+  );
+
+  it.each([undefined, "", " \t "])(
+    "resolves subscription auth through the real resolver with absent key %j",
+    async (apiKey) =>
+      withEnvAsync({ OPENAI_API_KEY: undefined }, async () => {
+        const [
+          { createPluginRegistryFixture },
+          { createPluginRecord },
+          { withPluginRuntimeRegistryScope },
+          { default: plugin },
+        ] = await Promise.all([
+          import("openclaw/plugin-sdk/plugin-test-contracts"),
+          import("openclaw/plugin-sdk/plugin-test-runtime"),
+          import("openclaw/plugin-sdk/channel-test-helpers"),
+          import("./index.js"),
+        ]);
+        const cfg = {
+          auth: { order: { openai: ["openai:fixture-subscription"] } },
+          models: {
+            providers: {
+              openai: { apiKey, baseUrl: "https://api.openai.com/v1", models: [] },
+            },
+          },
+        };
+        const { registry } = createPluginRegistryFixture(cfg);
+        const record = createPluginRecord({ id: "openai" });
+        registry.registry.plugins.push(record);
+        // Capability discovery registers the provider before its media callback runs.
+        plugin.register(registry.createApi(record, { config: cfg, registrationMode: "discovery" }));
+        const realAuth = await vi.importActual<
+          typeof import("openclaw/plugin-sdk/provider-auth-runtime")
+        >("openclaw/plugin-sdk/provider-auth-runtime");
+        authMocks.resolve.mockImplementation((params) =>
+          realAuth.resolveApiKeyForProvider({
+            ...params,
+            store: {
+              version: 1,
+              profiles: {
+                "openai:fixture-subscription": { type: "token", provider: "openai", token },
+              },
+            },
+          }),
+        );
+        try {
+          await withPluginRuntimeRegistryScope(registry.registry, async () => {
+            const provider = registry.registry.mediaUnderstandingProviders.find(
+              (entry) => entry.provider.id === "openai",
+            )?.provider;
+            if (!provider?.prepareAudioTranscription) {
+              throw new Error("OpenAI audio preparation registration missing");
+            }
+            const transcribe = await provider.prepareAudioTranscription({ cfg });
+            const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "subscription" });
+            await transcribe({
+              buffer: Buffer.from("audio"),
+              fileName: "voice.wav",
+              timeoutMs: 1000,
+              fetchFn,
+            });
+            expect(getRequest().url).toBe("https://chatgpt.com/backend-api/transcribe");
+            expect(authMocks.resolve).toHaveBeenCalledTimes(2);
+          });
+        } finally {
+          registry.rollbackPluginGlobalSideEffects(record.id, record);
+        }
+      }),
+  );
+
+  it.each([
+    ["https://api.openai.com/v1", "https://api.openai.com/v1/audio/transcriptions"],
+    ["https://chatgpt.com/backend-api/codex", "https://api.openai.com/v1/audio/transcriptions"],
+    ["https://custom.example/v1", "https://custom.example/v1/audio/transcriptions"],
+  ])(
+    "keeps an authored API key ahead of OAuth with provider base %s",
+    async (baseUrl, expectedUrl) => {
+      authMocks.resolve.mockResolvedValue({
+        apiKey: "fixture-platform-key",
+        mode: "api-key",
+        source: "models.json",
+      });
+      const cfg = {
+        auth: { order: { openai: ["openai:chatgpt", "openai:audio"] } },
+        models: {
+          providers: {
+            openai: {
+              baseUrl,
+              apiKey: "fixture-platform-key",
+              models: [],
+            },
+          },
+        },
+      };
+      const original = structuredClone(cfg);
+      const transcribe = await openaiMediaUnderstandingProvider.prepareAudioTranscription!({
+        cfg,
+        baseUrl,
+      });
+      const { fetchFn, getRequest } = createRequestCaptureJsonFetch({ text: "hello" });
+      await transcribe({
+        buffer: Buffer.from("audio"),
+        fileName: "voice.wav",
+        model: "gpt-4o-mini-transcribe",
+        prompt: "Names: Ada",
+        timeoutMs: 1000,
+        fetchFn,
+      });
+      expect(cfg).toEqual(original);
+      expect(authMocks.resolve).toHaveBeenCalledTimes(1);
+      expect(authMocks.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelApi: "openai-audio-transcriptions",
+          cfg: expect.objectContaining({
+            models: { providers: { openai: { ...cfg.models.providers.openai, auth: "api-key" } } },
+          }),
+        }),
+      );
+      const { url, init } = getRequest();
+      expect(url).toBe(expectedUrl);
+      expect((init?.body as FormData).get("model")).toBe("gpt-4o-mini-transcribe");
+      expect((init?.body as FormData).get("prompt")).toBe("Names: Ada");
+    },
+  );
+
+  it.each([
+    { baseUrl: "https://custom.example/v1" },
+    { baseUrl: "https://api.openai.com:8443/v1" },
+    { baseUrl: "https://api.openai.com/v1?alternate=true" },
+    { headers: { authorization: "Bearer other" } },
+    { prompt: "Translate to French" },
+    { requestedModel: "gpt-4o-mini-transcribe" },
+  ])("rejects unsupported subscription request settings before upload: %j", async (settings) => {
+    useOAuth();
+    await expect(
+      openaiMediaUnderstandingProvider.prepareAudioTranscription!({
+        cfg: {},
+        profile: "openai:audio",
+        ...settings,
+      }),
+    ).rejects.toThrow(/API-key profile/);
+  });
+
+  it("does not switch billing routes after an authored credential failure", async () => {
+    const failure = new Error("selected profile could not refresh");
+    authMocks.resolve.mockRejectedValue(failure);
+    await expect(
+      openaiMediaUnderstandingProvider.prepareAudioTranscription!({ cfg: {} }),
+    ).rejects.toBe(failure);
+    expect(authMocks.resolve).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extensions/openai/media-understanding-provider.ts
+++ b/extensions/openai/media-understanding-provider.ts
@@ -4,7 +4,7 @@ import {
   describeImagesWithModel,
   type MediaUnderstandingProvider,
 } from "openclaw/plugin-sdk/media-understanding";
-import { prepareOpenAiAudioTranscription, transcribeOpenAiAudio } from "./audio-transcription.js";
+import { transcribeOpenAiAudioWithContext, transcribeOpenAiAudio } from "./audio-transcription.js";
 import { OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL } from "./default-models.js";
 
 export const openaiMediaUnderstandingProvider: MediaUnderstandingProvider = {
@@ -15,5 +15,5 @@ export const openaiMediaUnderstandingProvider: MediaUnderstandingProvider = {
   describeImage: describeImageWithModel,
   describeImages: describeImagesWithModel,
   transcribeAudio: transcribeOpenAiAudio,
-  prepareAudioTranscription: prepareOpenAiAudioTranscription,
+  transcribeAudioWithContext: transcribeOpenAiAudioWithContext,
 };

--- a/extensions/openai/media-understanding-provider.ts
+++ b/extensions/openai/media-understanding-provider.ts
@@ -2,22 +2,10 @@
 import {
   describeImageWithModel,
   describeImagesWithModel,
-  transcribeOpenAiCompatibleAudio,
-  type AudioTranscriptionRequest,
   type MediaUnderstandingProvider,
 } from "openclaw/plugin-sdk/media-understanding";
+import { prepareOpenAiAudioTranscription, transcribeOpenAiAudio } from "./audio-transcription.js";
 import { OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL } from "./default-models.js";
-
-const DEFAULT_OPENAI_AUDIO_BASE_URL = "https://api.openai.com/v1";
-
-async function transcribeOpenAiAudio(params: AudioTranscriptionRequest) {
-  return await transcribeOpenAiCompatibleAudio({
-    ...params,
-    provider: "openai",
-    defaultBaseUrl: DEFAULT_OPENAI_AUDIO_BASE_URL,
-    defaultModel: OPENAI_DEFAULT_AUDIO_TRANSCRIPTION_MODEL,
-  });
-}
 
 export const openaiMediaUnderstandingProvider: MediaUnderstandingProvider = {
   id: "openai",
@@ -27,4 +15,5 @@ export const openaiMediaUnderstandingProvider: MediaUnderstandingProvider = {
   describeImage: describeImageWithModel,
   describeImages: describeImagesWithModel,
   transcribeAudio: transcribeOpenAiAudio,
+  prepareAudioTranscription: prepareOpenAiAudioTranscription,
 };

--- a/packages/media-understanding-common/src/provider-supports.ts
+++ b/packages/media-understanding-common/src/provider-supports.ts
@@ -3,7 +3,7 @@ import type { MediaUnderstandingCapability } from "./types.js";
 
 type MediaCapabilityProvider = {
   transcribeAudio?: unknown;
-  prepareAudioTranscription?: unknown;
+  transcribeAudioWithContext?: unknown;
   describeImage?: unknown;
   describeVideo?: unknown;
 };
@@ -19,7 +19,7 @@ export function providerSupportsCapability(
     return false;
   }
   if (capability === "audio") {
-    return Boolean(provider.prepareAudioTranscription || provider.transcribeAudio);
+    return Boolean(provider.transcribeAudioWithContext || provider.transcribeAudio);
   }
   if (capability === "image") {
     return Boolean(provider.describeImage);

--- a/packages/media-understanding-common/src/provider-supports.ts
+++ b/packages/media-understanding-common/src/provider-supports.ts
@@ -3,6 +3,7 @@ import type { MediaUnderstandingCapability } from "./types.js";
 
 type MediaCapabilityProvider = {
   transcribeAudio?: unknown;
+  prepareAudioTranscription?: unknown;
   describeImage?: unknown;
   describeVideo?: unknown;
 };
@@ -18,7 +19,7 @@ export function providerSupportsCapability(
     return false;
   }
   if (capability === "audio") {
-    return Boolean(provider.transcribeAudio);
+    return Boolean(provider.prepareAudioTranscription || provider.transcribeAudio);
   }
   if (capability === "image") {
     return Boolean(provider.describeImage);

--- a/src/media-understanding/openai-audio-api.ts
+++ b/src/media-understanding/openai-audio-api.ts
@@ -4,7 +4,7 @@ import type { MediaUnderstandingCapability } from "./types.js";
 export const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
 
 // Shipped transcribeAudio descriptors receive host-resolved API-key auth.
-// Provider-prepared audio owns its credential contract and does not use this path.
+// Context-owning audio providers own their credential contract and do not use this path.
 export function resolveOpenAiAudioAuthModelApi(params: {
   capability: MediaUnderstandingCapability;
   providerId: string;

--- a/src/media-understanding/openai-audio-api.ts
+++ b/src/media-understanding/openai-audio-api.ts
@@ -3,12 +3,13 @@ import type { MediaUnderstandingCapability } from "./types.js";
 // Shared API contract id for OpenAI-compatible /audio/transcriptions requests.
 export const OPENAI_AUDIO_TRANSCRIPTIONS_API = "openai-audio-transcriptions";
 
+// Shipped transcribeAudio descriptors receive host-resolved API-key auth.
+// Provider-prepared audio owns its credential contract and does not use this path.
 export function resolveOpenAiAudioAuthModelApi(params: {
   capability: MediaUnderstandingCapability;
   providerId: string;
 }): string | undefined {
-  if (params.capability === "audio" && params.providerId.trim().toLowerCase() === "openai") {
-    return OPENAI_AUDIO_TRANSCRIPTIONS_API;
-  }
-  return undefined;
+  return params.capability === "audio" && params.providerId.trim().toLowerCase() === "openai"
+    ? OPENAI_AUDIO_TRANSCRIPTIONS_API
+    : undefined;
 }

--- a/src/media-understanding/openai-compatible-audio.test.ts
+++ b/src/media-understanding/openai-compatible-audio.test.ts
@@ -1,5 +1,6 @@
 // OpenAI-compatible audio tests cover attribution headers, auth selection,
 // filename normalization, and stable malformed-response errors.
+import { inspect } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import { CUSTOM_LOCAL_AUTH_MARKER } from "../agents/model-auth-markers.js";
 import { VERSION } from "../version.js";
@@ -141,22 +142,42 @@ describe("transcribeOpenAiCompatibleAudio", () => {
     expect(headers.get("authorization")).toBe("Bearer typed-key");
   });
 
-  it("wraps malformed transcription JSON with a stable provider error", async () => {
-    const fetchFn = vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("{ nope"));
+  it.each([400, 200])(
+    "redacts reflected request credentials from HTTP %s diagnostics",
+    async (status) => {
+      const credential = "synthetic-only";
+      const fetchFn = vi.fn<typeof fetch>().mockImplementationOnce(async (_url, init) => {
+        const authorization = new Headers(init?.headers).get("authorization");
+        expect(authorization).toBe(`Bearer ${credential}`);
+        return new Response(
+          status === 400
+            ? JSON.stringify({ error: { message: `Rejected ${credential}`, code: credential } })
+            : credential,
+          { status, headers: { "x-request-id": credential } },
+        );
+      });
 
-    await expect(
-      transcribeOpenAiCompatibleAudio({
+      const error = await transcribeOpenAiCompatibleAudio({
         buffer: Buffer.from("audio"),
         fileName: "note.mp3",
-        apiKey: "test-key",
+        apiKey: "unused-fixture-key",
+        headers: { authorization: `Bearer ${credential}` },
         timeoutMs: 1000,
         fetchFn,
         provider: "openai",
         defaultBaseUrl: "https://api.openai.com/v1",
         defaultModel: "gpt-4o-transcribe",
-      }),
-    ).rejects.toThrow("Audio transcription failed: malformed JSON response");
-  });
+      }).catch((cause: unknown) => cause);
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toMatchObject({
+        message:
+          status === 400
+            ? "Audio transcription failed (HTTP 400): Rejected *** [code=***] [request_id=***]"
+            : "Audio transcription failed: malformed JSON response",
+      });
+      expect(inspect(error)).not.toContain(credential);
+    },
+  );
 
   it("rejects non-object successful transcription JSON with a stable provider error", async () => {
     const fetchFn = vi.fn<typeof fetch>().mockResolvedValueOnce(new Response(JSON.stringify([])));

--- a/src/media-understanding/openai-compatible-audio.ts
+++ b/src/media-understanding/openai-compatible-audio.ts
@@ -76,9 +76,11 @@ export async function transcribeOpenAiCompatibleAudio(
   });
 
   try {
-    await assertOkOrThrowHttpError(res, "Audio transcription failed");
+    await assertOkOrThrowHttpError(res, "Audio transcription failed", { requestHeaders: headers });
 
-    const payload = await readProviderJsonObjectResponse(res, "Audio transcription failed");
+    const payload = await readProviderJsonObjectResponse(res, "Audio transcription failed", {
+      requestHeaders: headers,
+    });
     const text = requireTranscriptionText(
       typeof payload.text === "string" ? payload.text : undefined,
       "Audio transcription response missing text",

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -21,20 +21,11 @@ import {
 } from "./defaults.constants.js";
 import { resolveEffectiveMediaEntryCapabilities } from "./entry-capabilities.js";
 import { normalizeMediaUnderstandingChatType, resolveMediaUnderstandingScope } from "./scope.js";
-import type { MediaUnderstandingCapability, MediaUnderstandingProvider } from "./types.js";
+import type { MediaUnderstandingCapability } from "./types.js";
 
 export type ResolvedMediaModelEntry = {
   entry: MediaUnderstandingModelConfig;
-  requestedModel?: string;
   secretOwnerId?: string;
-  audioPreparation?:
-    | {
-        status: "ready";
-        transcribe: Awaited<
-          ReturnType<NonNullable<MediaUnderstandingProvider["prepareAudioTranscription"]>>
-        >;
-      }
-    | { status: "failed"; error: unknown };
 };
 
 /** Default per-provider media-understanding runtime timeout in milliseconds. */
@@ -157,7 +148,7 @@ export function resolveModelEntries(params: {
       }
       return caps.includes(capability);
     })
-    .map(({ entry, secretOwnerId }) => ({ entry, requestedModel: entry.model, secretOwnerId }))
+    .map(({ entry, secretOwnerId }) => ({ entry, secretOwnerId }))
     .toSorted((left, right) => {
       const preferred = config?.preferredModel?.trim();
       if (!preferred) {

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -21,11 +21,20 @@ import {
 } from "./defaults.constants.js";
 import { resolveEffectiveMediaEntryCapabilities } from "./entry-capabilities.js";
 import { normalizeMediaUnderstandingChatType, resolveMediaUnderstandingScope } from "./scope.js";
-import type { MediaUnderstandingCapability } from "./types.js";
+import type { MediaUnderstandingCapability, MediaUnderstandingProvider } from "./types.js";
 
 export type ResolvedMediaModelEntry = {
   entry: MediaUnderstandingModelConfig;
+  requestedModel?: string;
   secretOwnerId?: string;
+  audioPreparation?:
+    | {
+        status: "ready";
+        transcribe: Awaited<
+          ReturnType<NonNullable<MediaUnderstandingProvider["prepareAudioTranscription"]>>
+        >;
+      }
+    | { status: "failed"; error: unknown };
 };
 
 /** Default per-provider media-understanding runtime timeout in milliseconds. */
@@ -148,7 +157,7 @@ export function resolveModelEntries(params: {
       }
       return caps.includes(capability);
     })
-    .map(({ entry, secretOwnerId }) => ({ entry, secretOwnerId }))
+    .map(({ entry, secretOwnerId }) => ({ entry, requestedModel: entry.model, secretOwnerId }))
     .toSorted((left, right) => {
       const preferred = config?.preferredModel?.trim();
       if (!preferred) {

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -112,15 +112,46 @@ function requireCapabilityOutput(result: CapabilityResult, index: number) {
 }
 
 describe("runCapability auto audio entries", () => {
-  it("auto-selects provider-prepared audio with subscription auth without pinning a model", async () => {
+  it("resolves audio credentials after loading each attachment", async () => {
+    await withAudioFixture("openclaw-audio-late-auth", async ({ ctx, media, cache }) => {
+      let currentCredential = "before-download";
+      const getBuffer = cache.getBuffer.bind(cache);
+      vi.spyOn(cache, "getBuffer").mockImplementation(async (params) => {
+        const audio = await getBuffer(params);
+        currentCredential = "after-download";
+        return audio;
+      });
+      const result = await runCapability({
+        capability: "audio",
+        cfg: createOpenAiAudioCfg(),
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry: createProviderRegistry({
+          openai: {
+            id: "openai",
+            capabilities: ["audio"],
+            transcribeAudioWithContext: async () => ({
+              ok: true,
+              value: { text: currentCredential },
+            }),
+          },
+        }),
+      });
+      expect(result.decision.outcome).toBe("success");
+      expect(result.outputs[0]?.text).toBe("after-download");
+    });
+  });
+
+  it("auto-selects provider-owned audio with subscription auth and its audio default", async () => {
     const modelAuth = await import("../agents/model-auth.js");
     const hasAuth = vi.mocked(modelAuth.hasAvailableAuthForProvider);
     hasAuth.mockImplementation(
       async (params) => params.provider === "openai" && params.modelApi === undefined,
     );
-    const prepareAudioTranscription = vi.fn(async (context: { requestedModel?: string }) => {
-      expect(context.requestedModel).toBeUndefined();
-      return async () => ({ text: "subscription transcript" });
+    const transcribeAudioWithContext = vi.fn(async (context: { model?: string }) => {
+      expect(context.model).toBe("transcription-default");
+      return { ok: true as const, value: { text: "subscription transcript" } };
     });
     try {
       await withAudioFixture("openclaw-auto-prepared-audio", async ({ ctx, media, cache }) => {
@@ -136,14 +167,14 @@ describe("runCapability auto audio entries", () => {
               id: "openai",
               capabilities: ["audio"],
               defaultModels: { audio: "transcription-default" },
-              prepareAudioTranscription,
+              transcribeAudioWithContext,
             },
           }),
         });
         expect(result.decision.outcome).toBe("success");
         expect(result.outputs[0]?.text).toBe("subscription transcript");
-        expect(result.outputs[0]?.model).toBeUndefined();
-        expect(prepareAudioTranscription).toHaveBeenCalledTimes(1);
+        expect(result.outputs[0]?.model).toBe("transcription-default");
+        expect(transcribeAudioWithContext).toHaveBeenCalledTimes(1);
       });
     } finally {
       hasAuth.mockReset().mockResolvedValue(true);
@@ -163,6 +194,67 @@ describe("runCapability auto audio entries", () => {
     expect(result.decision.outcome).toBe("success");
   });
 
+  it.each([false, true])(
+    "retries a failed upload on another provider only for an explicit fallback list: %s",
+    async (explicit) => {
+      const modelAuth = await import("../agents/model-auth.js");
+      const hasAuth = vi.mocked(modelAuth.hasAvailableAuthForProvider);
+      hasAuth.mockClear();
+      const rejected = new Error("Audio transcription failed (HTTP 403)");
+      const transcribeAudio = vi.fn(async () => ({ text: "authored fallback transcript" }));
+      await withAudioFixture("openclaw-audio-upload-fallback", async ({ ctx, media, cache }) => {
+        const result = await runCapability({
+          capability: "audio",
+          cfg: {
+            models: {
+              providers: {
+                openai: { baseUrl: "https://api.openai.com/v1", models: [] },
+                mistral: { baseUrl: "https://api.mistral.ai/v1", models: [] },
+              },
+            },
+            ...(explicit
+              ? {
+                  tools: {
+                    media: {
+                      models: [
+                        { provider: "openai", capabilities: ["audio" as const] },
+                        { provider: "mistral", capabilities: ["audio" as const] },
+                      ],
+                    },
+                  },
+                }
+              : {}),
+          },
+          ctx,
+          attachments: cache,
+          media,
+          activeModel: { provider: "openai", model: "chat-model" },
+          providerRegistry: createProviderRegistry({
+            openai: {
+              id: "openai",
+              capabilities: ["audio"],
+              transcribeAudioWithContext: async () => {
+                throw rejected;
+              },
+            },
+            mistral: { id: "mistral", capabilities: ["audio"], transcribeAudio },
+          }),
+        });
+        expect(result.decision.outcome).toBe(explicit ? "success" : "failed");
+        expect(result.decision.attachments[0]?.attempts[0]).toMatchObject({
+          provider: "openai",
+          outcome: "failed",
+          reason: String(rejected),
+        });
+        expect(transcribeAudio).toHaveBeenCalledTimes(explicit ? 1 : 0);
+        if (!explicit) {
+          expect(result.outputs).toEqual([]);
+          expect(hasAuth).not.toHaveBeenCalled();
+        }
+      });
+    },
+  );
+
   it.each(["provider", "local"] as const)(
     "continues to the next %s when automatic subscription preparation rejects the request",
     async (fallback) => {
@@ -170,11 +262,11 @@ describe("runCapability auto audio entries", () => {
       const rejected = new Error(
         "This subscription route cannot use the configured endpoint or prompt.",
       );
-      const prepareAudioTranscription = vi.fn(
+      const transcribeAudioWithContext = vi.fn(
         async (context: { baseUrl?: string; prompt?: string }) => {
           expect(context.baseUrl).toBe("https://custom.example/v1");
           expect(context.prompt).toBe("Preserve names.");
-          throw rejected;
+          return { ok: false as const, error: rejected };
         },
       );
       const transcribeAudio = vi.fn(async () => ({ text: "second-provider transcript" }));
@@ -191,7 +283,9 @@ describe("runCapability auto audio entries", () => {
                   models: {
                     providers: {
                       openai: { baseUrl: "https://custom.example/v1", models: [] },
-                      ...(fallback === "provider" ? { mistral: { models: [] } } : {}),
+                      ...(fallback === "provider"
+                        ? { mistral: { baseUrl: "https://api.mistral.ai/v1", models: [] } }
+                        : {}),
                     },
                   },
                   tools: { media: { audio: { prompt: "Preserve names." } } },
@@ -201,7 +295,7 @@ describe("runCapability auto audio entries", () => {
                 media,
                 activeModel: { provider: "openai", model: "chat-model" },
                 providerRegistry: createProviderRegistry({
-                  openai: { id: "openai", capabilities: ["audio"], prepareAudioTranscription },
+                  openai: { id: "openai", capabilities: ["audio"], transcribeAudioWithContext },
                   ...(fallback === "provider"
                     ? {
                         mistral: {
@@ -224,7 +318,7 @@ describe("runCapability auto audio entries", () => {
                   reason: String(rejected),
                 }),
               );
-              expect(prepareAudioTranscription).toHaveBeenCalledTimes(1);
+              expect(transcribeAudioWithContext).toHaveBeenCalledTimes(1);
             },
           );
         });
@@ -235,11 +329,12 @@ describe("runCapability auto audio entries", () => {
     },
   );
 
-  it("keeps missing prepared-provider credentials unavailable without recording a failed attempt", async () => {
+  it("keeps missing provider credentials unavailable without recording a failed attempt", async () => {
     const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auto-prepare-no-auth-"));
-    const prepareAudioTranscription = vi.fn(async () => {
-      throw new ProviderAuthError("missing-provider-auth", "openai", "No configured credentials");
-    });
+    const transcribeAudioWithContext = vi.fn(async () => ({
+      ok: false as const,
+      error: new ProviderAuthError("missing-provider-auth", "openai", "No configured credentials"),
+    }));
     try {
       clearMediaUnderstandingBinaryCacheForTests();
       await withEnvAsync(
@@ -257,13 +352,13 @@ describe("runCapability auto audio entries", () => {
                   id: "openai",
                   capabilities: ["audio"],
                   autoPriority: { audio: 20 },
-                  prepareAudioTranscription,
+                  transcribeAudioWithContext,
                 },
               }),
             });
             expect(result.decision.outcome).toBe("skipped");
             expect(result.decision.attachments[0]?.attempts).toEqual([]);
-            expect(prepareAudioTranscription).toHaveBeenCalledTimes(1);
+            expect(transcribeAudioWithContext).toHaveBeenCalledTimes(1);
           });
         },
       );

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { ProviderAuthError } from "../agents/model-auth-runtime-shared.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { MediaUnderstandingConfig } from "../config/types.tools.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -56,9 +57,24 @@ function createOpenAiAudioCfg(extra?: Partial<OpenClawConfig>): OpenClawConfig {
   } as unknown as OpenClawConfig;
 }
 
-async function createMockExecutable(dir: string, name: string) {
-  const executablePath = path.join(dir, name);
-  await fs.writeFile(executablePath, "#!/bin/sh\necho mocked-local-whisper\n", { mode: 0o755 });
+async function createWhisperExecutable(dir: string) {
+  const executablePath = path.join(dir, "whisper");
+  await fs.writeFile(
+    executablePath,
+    [
+      "#!/bin/sh",
+      'while [ "$#" -gt 0 ]; do',
+      '  case "$1" in',
+      '    --output_dir) output_dir="$2"; shift 2 ;;',
+      '    *) audio_path="$1"; shift ;;',
+      "  esac",
+      "done",
+      'audio_name="${audio_path##*/}"',
+      'printf "%s\\n" mocked-local-whisper > "$output_dir/${audio_name%.*}.txt"',
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
   return executablePath;
 }
 
@@ -96,6 +112,44 @@ function requireCapabilityOutput(result: CapabilityResult, index: number) {
 }
 
 describe("runCapability auto audio entries", () => {
+  it("auto-selects provider-prepared audio with subscription auth without pinning a model", async () => {
+    const modelAuth = await import("../agents/model-auth.js");
+    const hasAuth = vi.mocked(modelAuth.hasAvailableAuthForProvider);
+    hasAuth.mockImplementation(
+      async (params) => params.provider === "openai" && params.modelApi === undefined,
+    );
+    const prepareAudioTranscription = vi.fn(async (context: { requestedModel?: string }) => {
+      expect(context.requestedModel).toBeUndefined();
+      return async () => ({ text: "subscription transcript" });
+    });
+    try {
+      await withAudioFixture("openclaw-auto-prepared-audio", async ({ ctx, media, cache }) => {
+        const result = await runCapability({
+          capability: "audio",
+          cfg: {},
+          ctx,
+          attachments: cache,
+          media,
+          activeModel: { provider: "openai", model: "chat-model" },
+          providerRegistry: createProviderRegistry({
+            openai: {
+              id: "openai",
+              capabilities: ["audio"],
+              defaultModels: { audio: "transcription-default" },
+              prepareAudioTranscription,
+            },
+          }),
+        });
+        expect(result.decision.outcome).toBe("success");
+        expect(result.outputs[0]?.text).toBe("subscription transcript");
+        expect(result.outputs[0]?.model).toBeUndefined();
+        expect(prepareAudioTranscription).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      hasAuth.mockReset().mockResolvedValue(true);
+    }
+  });
+
   it("uses provider keys to auto-enable audio transcription", async () => {
     let seenModel: string | undefined;
     const result = await runAutoAudioCase({
@@ -107,6 +161,116 @@ describe("runCapability auto audio entries", () => {
     expect(requireCapabilityOutput(result, 0).text).toBe("ok");
     expect(seenModel).toBe("gpt-4o-transcribe");
     expect(result.decision.outcome).toBe("success");
+  });
+
+  it.each(["provider", "local"] as const)(
+    "continues to the next %s when automatic subscription preparation rejects the request",
+    async (fallback) => {
+      const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auto-prepare-fallback-"));
+      const rejected = new Error(
+        "This subscription route cannot use the configured endpoint or prompt.",
+      );
+      const prepareAudioTranscription = vi.fn(
+        async (context: { baseUrl?: string; prompt?: string }) => {
+          expect(context.baseUrl).toBe("https://custom.example/v1");
+          expect(context.prompt).toBe("Preserve names.");
+          throw rejected;
+        },
+      );
+      const transcribeAudio = vi.fn(async () => ({ text: "second-provider transcript" }));
+      try {
+        await createWhisperExecutable(binDir);
+        clearMediaUnderstandingBinaryCacheForTests();
+        await withAudioFixture("openclaw-auto-prepare-fallback", async ({ ctx, media, cache }) => {
+          await withEnvAsync(
+            { PATH: binDir, SHERPA_ONNX_MODEL_DIR: undefined, WHISPER_CPP_MODEL: undefined },
+            async () => {
+              const result = await runCapability({
+                capability: "audio",
+                cfg: {
+                  models: {
+                    providers: {
+                      openai: { baseUrl: "https://custom.example/v1", models: [] },
+                      ...(fallback === "provider" ? { mistral: { models: [] } } : {}),
+                    },
+                  },
+                  tools: { media: { audio: { prompt: "Preserve names." } } },
+                },
+                ctx,
+                attachments: cache,
+                media,
+                activeModel: { provider: "openai", model: "chat-model" },
+                providerRegistry: createProviderRegistry({
+                  openai: { id: "openai", capabilities: ["audio"], prepareAudioTranscription },
+                  ...(fallback === "provider"
+                    ? {
+                        mistral: {
+                          id: "mistral",
+                          capabilities: ["audio" as const],
+                          transcribeAudio,
+                        },
+                      }
+                    : {}),
+                }),
+              });
+              expect(result.decision.outcome).toBe("success");
+              expect(result.outputs[0]?.text).toBe(
+                fallback === "provider" ? "second-provider transcript" : "mocked-local-whisper",
+              );
+              expect(result.decision.attachments[0]?.attempts).toContainEqual(
+                expect.objectContaining({
+                  provider: "openai",
+                  outcome: "failed",
+                  reason: String(rejected),
+                }),
+              );
+              expect(prepareAudioTranscription).toHaveBeenCalledTimes(1);
+            },
+          );
+        });
+      } finally {
+        clearMediaUnderstandingBinaryCacheForTests();
+        await fs.rm(binDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("keeps missing prepared-provider credentials unavailable without recording a failed attempt", async () => {
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auto-prepare-no-auth-"));
+    const prepareAudioTranscription = vi.fn(async () => {
+      throw new ProviderAuthError("missing-provider-auth", "openai", "No configured credentials");
+    });
+    try {
+      clearMediaUnderstandingBinaryCacheForTests();
+      await withEnvAsync(
+        { PATH: binDir, SHERPA_ONNX_MODEL_DIR: undefined, WHISPER_CPP_MODEL: undefined },
+        async () => {
+          await withAudioFixture("openclaw-auto-prepare-no-auth", async ({ ctx, media, cache }) => {
+            const result = await runCapability({
+              capability: "audio",
+              cfg: {},
+              ctx,
+              attachments: cache,
+              media,
+              providerRegistry: createProviderRegistry({
+                openai: {
+                  id: "openai",
+                  capabilities: ["audio"],
+                  autoPriority: { audio: 20 },
+                  prepareAudioTranscription,
+                },
+              }),
+            });
+            expect(result.decision.outcome).toBe("skipped");
+            expect(result.decision.attachments[0]?.attempts).toEqual([]);
+            expect(prepareAudioTranscription).toHaveBeenCalledTimes(1);
+          });
+        },
+      );
+    } finally {
+      clearMediaUnderstandingBinaryCacheForTests();
+      await fs.rm(binDir, { recursive: true, force: true });
+    }
   });
 
   it("skips OpenAI audio auto-selection when only ChatGPT OAuth is available", async () => {
@@ -343,28 +507,29 @@ describe("runCapability auto audio entries", () => {
   it("prefers provider keys over auto-detected local whisper", async () => {
     const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auto-audio-bin-"));
     try {
-      await createMockExecutable(binDir, "whisper");
+      await createWhisperExecutable(binDir);
       clearMediaUnderstandingBinaryCacheForTests();
       let seenModel: string | undefined;
-      const result = await withEnvAsync(
-        {
-          PATH: binDir,
-          SHERPA_ONNX_MODEL_DIR: undefined,
-          WHISPER_CPP_MODEL: undefined,
-          GEMINI_API_KEY: undefined,
-        },
-        async () =>
-          await runAutoAudioCase({
-            transcribeAudio: async (req) => {
-              seenModel = req.model;
-              return { text: "provider transcription", model: req.model ?? "unknown" };
-            },
-          }),
-      );
-
-      const output = requireCapabilityOutput(result, 0);
-      expect(output.provider).toBe("openai");
-      expect(output.text).toBe("provider transcription");
+      await withAudioFixture("openclaw-auto-audio-priority", async ({ ctx, media, cache }) => {
+        const result = await withEnvAsync(
+          { PATH: binDir, SHERPA_ONNX_MODEL_DIR: undefined, WHISPER_CPP_MODEL: undefined },
+          async () =>
+            runCapability({
+              capability: "audio",
+              cfg: createOpenAiAudioCfg(),
+              ctx,
+              attachments: cache,
+              media,
+              providerRegistry: createOpenAiAudioProvider(async (req) => {
+                seenModel = req.model;
+                return { text: "provider transcription", model: req.model ?? "unknown" };
+              }),
+            }),
+        );
+        const output = requireCapabilityOutput(result, 0);
+        expect(output.provider).toBe("openai");
+        expect(output.text).toBe("provider transcription");
+      });
       expect(seenModel).toBe("gpt-4o-transcribe");
     } finally {
       clearMediaUnderstandingBinaryCacheForTests();

--- a/src/media-understanding/runner.auto-selection.test.ts
+++ b/src/media-understanding/runner.auto-selection.test.ts
@@ -105,10 +105,8 @@ describe("automatic media selection", () => {
   );
 
   it.each(["provider-transcription", undefined])(
-    "key-selected audio ignores the chat model with provider default %s",
+    "configured audio ignores the chat model with provider default %s",
     async (model) => {
-      let attempts = 0;
-      selection.auth.mockImplementation(async () => ++attempts > 1);
       const seenModels: Array<string | undefined> = [];
       const provider: MediaUnderstandingProvider = {
         id: "selection-audio",
@@ -122,25 +120,33 @@ describe("automatic media selection", () => {
       await withAudioFixture("media-selection-key-audio", async ({ ctx, media, cache }) => {
         const result = await runCapability({
           capability: "audio",
-          cfg: {},
+          cfg: {
+            models: {
+              providers: {
+                [provider.id]: { baseUrl: "https://audio.example/v1", models: [] },
+              },
+            },
+          },
           ctx,
           media,
           attachments: cache,
           providerRegistry: new Map([[provider.id, provider]]),
-          activeModel: { provider: provider.id, model: "chat-only-model" },
+          activeModel: { provider: "chat-only", model: "chat-only-model" },
         });
         expect(result.decision.outcome).toBe("success");
         expect(seenModels).toEqual([model]);
-        expect(attempts).toBe(2);
+        expect(selection.auth).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ provider: provider.id }),
+        );
       });
     },
   );
 
-  it("retains the final key-provider pass after unavailable local audio", async () => {
+  it("checks audio providers once in priority order until auth is available", async () => {
     const calls: string[] = [];
     selection.auth.mockImplementation(async ({ provider }) => {
       calls.push(provider);
-      return calls.length === 4;
+      return provider === "second";
     });
     const providers = ["first", "second"].map(
       (id, priority): MediaUnderstandingProvider => ({
@@ -151,7 +157,7 @@ describe("automatic media selection", () => {
         transcribeAudio: async ({ model }) => ({ text: id, model }),
       }),
     );
-    await withAudioFixture("media-selection-second-pass", async ({ ctx, media, cache }) => {
+    await withAudioFixture("media-selection-provider-order", async ({ ctx, media, cache }) => {
       const result = await runCapability({
         capability: "audio",
         cfg: {},
@@ -160,7 +166,7 @@ describe("automatic media selection", () => {
         attachments: cache,
         providerRegistry: new Map(providers.map((provider) => [provider.id, provider])),
       });
-      expect(calls).toEqual(["first", "second", "first", "second"]);
+      expect(calls).toEqual(["first", "second"]);
       expect(result.outputs).toEqual([
         {
           kind: "audio.transcription",

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import { expectDefined } from "@openclaw/normalization-core";
+import { ok, type Result } from "@openclaw/normalization-core/result";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
@@ -613,36 +614,6 @@ function resolveProviderRequestContext(params: {
   return { baseUrl, headers, request };
 }
 
-/** Prepares auth and routing before an automatic audio candidate becomes the winner. */
-export async function prepareProviderAudioTranscription(params: {
-  prepare: NonNullable<MediaUnderstandingProvider["prepareAudioTranscription"]>;
-  providerId: string;
-  entry: MediaUnderstandingModelConfig;
-  cfg: OpenClawConfig;
-  config?: MediaUnderstandingConfig;
-  requestedModel?: string;
-  agentDir?: string;
-  workspaceDir?: string;
-}) {
-  assertRuntimeMediaRequestSecretOwnerAvailable({ capability: "audio", entry: params.entry });
-  const { prompt, hasConfiguredPrompt } = resolveEntryRunOptions({
-    ...params,
-    capability: "audio",
-  });
-  return params.prepare({
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-    profile: params.entry.profile,
-    preferredProfile: params.entry.preferredProfile,
-    requestedModel: params.requestedModel,
-    prompt:
-      resolveMediaRequestOverrides(params.config).prompt ??
-      (hasConfiguredPrompt ? prompt : undefined),
-    ...resolveProviderRequestContext(params),
-  });
-}
-
 /** Formats a compact operator-facing summary of a media-understanding decision. */
 export function formatDecisionSummary(decision: MediaUnderstandingDecision): string {
   const attachments = Array.isArray(decision.attachments) ? decision.attachments : [];
@@ -779,12 +750,8 @@ export async function runProviderEntry(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   config?: MediaUnderstandingConfig;
-  requestedModel?: string;
   secretOwnerId?: string;
-  preparedAudioTranscription?: Awaited<
-    ReturnType<NonNullable<MediaUnderstandingProvider["prepareAudioTranscription"]>>
-  >;
-}): Promise<MediaUnderstandingOutput | null> {
+}): Promise<Result<MediaUnderstandingOutput | null, unknown>> {
   const { entry, capability, cfg } = params;
   const providerIdRaw = entry.provider?.trim();
   if (!providerIdRaw) {
@@ -841,13 +808,13 @@ export async function runProviderEntry(params: {
     };
     const describeImage = provider?.describeImage ?? describeImageWithModel;
     const result = await describeImage(imageInput);
-    return {
+    return ok({
       kind: "image.description",
       attachmentIndex: params.attachmentIndex,
       text: trimOutput(result.text, maxChars),
       provider: requestProviderId,
       model: result.model ?? modelId,
-    };
+    });
   }
 
   const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
@@ -862,7 +829,7 @@ export async function runProviderEntry(params: {
   const fetchFn = resolveProxyFetchFromEnv();
 
   if (capability === "audio") {
-    if (!provider.transcribeAudio && !provider.prepareAudioTranscription) {
+    if (!provider.transcribeAudio && !provider.transcribeAudioWithContext) {
       throw new Error(`Audio transcription provider "${providerId}" not available.`);
     }
     const requestOverrides = resolveMediaRequestOverrides(params.config);
@@ -913,15 +880,19 @@ export async function runProviderEntry(params: {
       fetchFn,
     };
     let result: AudioTranscriptionResult;
-    if (provider.prepareAudioTranscription) {
-      const transcribe =
-        params.preparedAudioTranscription ??
-        (await prepareProviderAudioTranscription({
-          ...params,
-          providerId,
-          prepare: provider.prepareAudioTranscription,
-        }));
-      result = await transcribe(input);
+    if (provider.transcribeAudioWithContext) {
+      const attempt = await provider.transcribeAudioWithContext({
+        ...input,
+        cfg,
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
+        profile: entry.profile,
+        preferredProfile: entry.preferredProfile,
+      });
+      if (!attempt.ok) {
+        return attempt;
+      }
+      result = attempt.value;
     } else {
       const transcribeAudio = expectDefined(
         provider.transcribeAudio,
@@ -956,13 +927,13 @@ export async function runProviderEntry(params: {
             })
           : await transcribeAudio(buildRequest({ kind: "none" }));
     }
-    return {
+    return ok({
       kind: "audio.transcription",
       attachmentIndex: params.attachmentIndex,
       text: trimOutput(result.text, maxChars),
       provider: providerId,
-      model: provider.prepareAudioTranscription ? result.model : (result.model ?? model),
-    };
+      model: result.model ?? model,
+    });
   }
 
   if (!provider.describeVideo) {
@@ -1034,13 +1005,13 @@ export async function runProviderEntry(params: {
           execute: (apiKey) => describeVideo(buildRequest({ kind: "api-key", apiKey })),
         })
       : await describeVideo(buildRequest({ kind: "none" }));
-  return {
+  return ok({
     kind: "video.description",
     attachmentIndex: params.attachmentIndex,
     text: trimOutput(result.text, maxChars),
     provider: providerId,
     model: result.model ?? model,
-  };
+  });
 }
 
 /** Executes one CLI-backed media-understanding entry for one attachment. */

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -2,6 +2,7 @@
 // rotation, output extraction, and decision summaries.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -29,7 +30,7 @@ import {
 import type { RuntimeMsgContext as MsgContext, TemplateContext } from "../auto-reply/templating.js";
 import { applyTemplate } from "../auto-reply/templating.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import type { ModelProviderConfig, OpenClawConfig } from "../config/types.js";
+import type { OpenClawConfig } from "../config/types.js";
 import type {
   MediaUnderstandingConfig,
   MediaUnderstandingModelConfig,
@@ -66,6 +67,7 @@ import { resolveOpenAiAudioAuthModelApi } from "./openai-audio-api.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./provider-registry.js";
 import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
 import type {
+  AudioTranscriptionResult,
   MediaAttachment,
   MediaUnderstandingCapability,
   MediaUnderstandingDecision,
@@ -473,20 +475,11 @@ type ProviderExecutionAuth =
       kind: "api-key";
       apiKeys: string[];
       source?: string;
-      providerConfig?: ModelProviderConfig;
     }
   | {
       kind: "none";
       source: string;
-      providerConfig?: ModelProviderConfig;
     };
-
-function resolveProviderExecutionAuthModelApi(params: {
-  capability: MediaUnderstandingCapability;
-  providerId: string;
-}): string | undefined {
-  return resolveOpenAiAudioAuthModelApi(params);
-}
 
 async function resolveProviderExecutionAuth(params: {
   capability: MediaUnderstandingCapability;
@@ -497,11 +490,10 @@ async function resolveProviderExecutionAuth(params: {
   agentDir?: string;
   workspaceDir?: string;
 }): Promise<ProviderExecutionAuth> {
-  const providerConfig = params.cfg.models?.providers?.[params.providerId];
-  const modelApi = resolveProviderExecutionAuthModelApi({
-    capability: params.capability,
-    providerId: params.providerId,
-  });
+  const providerConfig = findNormalizedProviderValue(
+    params.cfg.models?.providers,
+    params.providerId,
+  );
   const literalApiKey = resolveLiteralProviderApiKey({
     cfg: params.cfg,
     providerId: params.providerId,
@@ -514,7 +506,6 @@ async function resolveProviderExecutionAuth(params: {
         primaryApiKey: literalApiKey,
       }),
       source: `models.providers.${params.providerId}.apiKey`,
-      providerConfig,
     };
   }
   const resolveMediaProviderAuth = (): ProviderExecutionAuth | undefined => {
@@ -536,7 +527,6 @@ async function resolveProviderExecutionAuth(params: {
               primaryApiKey: syntheticApiKey,
             }),
             source: syntheticSource,
-            providerConfig,
           }
         : undefined;
     }
@@ -544,7 +534,6 @@ async function resolveProviderExecutionAuth(params: {
       return {
         kind: "none",
         source: providerAuth.source,
-        providerConfig,
       };
     }
     const apiKey = providerAuth.apiKey.trim();
@@ -558,7 +547,6 @@ async function resolveProviderExecutionAuth(params: {
         primaryApiKey: apiKey,
       }),
       source: providerAuth.source,
-      providerConfig,
     };
   };
   const { isProviderAuthError, requireApiKey, resolveApiKeyForProviderCore } =
@@ -571,7 +559,10 @@ async function resolveProviderExecutionAuth(params: {
       preferredProfile: params.entry.preferredProfile,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
-      modelApi,
+      modelApi: resolveOpenAiAudioAuthModelApi({
+        capability: params.capability,
+        providerId: params.providerId,
+      }),
     });
     const apiKey = requireApiKey(auth, params.providerId);
     return {
@@ -581,7 +572,6 @@ async function resolveProviderExecutionAuth(params: {
         primaryApiKey: apiKey,
       }),
       source: auth.source,
-      providerConfig,
     };
   } catch (err) {
     if (
@@ -598,26 +588,16 @@ async function resolveProviderExecutionAuth(params: {
   }
 }
 
-async function resolveProviderExecutionContext(params: {
-  capability: MediaUnderstandingCapability;
+function resolveProviderRequestContext(params: {
   providerId: string;
-  provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
   entry: MediaUnderstandingModelConfig;
   config?: MediaUnderstandingConfig;
-  agentDir?: string;
-  workspaceDir?: string;
 }) {
-  const auth = await resolveProviderExecutionAuth({
-    capability: params.capability,
-    providerId: params.providerId,
-    provider: params.provider,
-    cfg: params.cfg,
-    entry: params.entry,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-  });
-  const providerConfig = auth.providerConfig;
+  const providerConfig = findNormalizedProviderValue(
+    params.cfg.models?.providers,
+    params.providerId,
+  );
   const baseUrl = params.entry.baseUrl ?? params.config?.baseUrl ?? providerConfig?.baseUrl;
   const mergedHeaders = {
     ...sanitizeProviderHeaders(providerConfig?.headers as Record<string, unknown> | undefined),
@@ -630,7 +610,37 @@ async function resolveProviderExecutionContext(params: {
     sanitizeConfiguredProviderRequest(params.config?.request),
     sanitizeConfiguredProviderRequest(params.entry.request),
   );
-  return { auth, baseUrl, headers, request };
+  return { baseUrl, headers, request };
+}
+
+/** Prepares auth and routing before an automatic audio candidate becomes the winner. */
+export async function prepareProviderAudioTranscription(params: {
+  prepare: NonNullable<MediaUnderstandingProvider["prepareAudioTranscription"]>;
+  providerId: string;
+  entry: MediaUnderstandingModelConfig;
+  cfg: OpenClawConfig;
+  config?: MediaUnderstandingConfig;
+  requestedModel?: string;
+  agentDir?: string;
+  workspaceDir?: string;
+}) {
+  assertRuntimeMediaRequestSecretOwnerAvailable({ capability: "audio", entry: params.entry });
+  const { prompt, hasConfiguredPrompt } = resolveEntryRunOptions({
+    ...params,
+    capability: "audio",
+  });
+  return params.prepare({
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    profile: params.entry.profile,
+    preferredProfile: params.entry.preferredProfile,
+    requestedModel: params.requestedModel,
+    prompt:
+      resolveMediaRequestOverrides(params.config).prompt ??
+      (hasConfiguredPrompt ? prompt : undefined),
+    ...resolveProviderRequestContext(params),
+  });
 }
 
 /** Formats a compact operator-facing summary of a media-understanding decision. */
@@ -769,7 +779,11 @@ export async function runProviderEntry(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   config?: MediaUnderstandingConfig;
+  requestedModel?: string;
   secretOwnerId?: string;
+  preparedAudioTranscription?: Awaited<
+    ReturnType<NonNullable<MediaUnderstandingProvider["prepareAudioTranscription"]>>
+  >;
 }): Promise<MediaUnderstandingOutput | null> {
   const { entry, capability, cfg } = params;
   const providerIdRaw = entry.provider?.trim();
@@ -848,10 +862,9 @@ export async function runProviderEntry(params: {
   const fetchFn = resolveProxyFetchFromEnv();
 
   if (capability === "audio") {
-    if (!provider.transcribeAudio) {
+    if (!provider.transcribeAudio && !provider.prepareAudioTranscription) {
       throw new Error(`Audio transcription provider "${providerId}" not available.`);
     }
-    const transcribeAudio = provider.transcribeAudio;
     const requestOverrides = resolveMediaRequestOverrides(params.config);
     const media = await params.cache.getBuffer({
       attachmentIndex: params.attachmentIndex,
@@ -867,15 +880,11 @@ export async function runProviderEntry(params: {
         hasConfiguredPrompt,
         language: audioLanguage,
       });
-    const { auth, baseUrl, headers, request } = await resolveProviderExecutionContext({
-      capability,
+    const transport = resolveProviderRequestContext({
       providerId,
-      provider,
       cfg,
       entry,
       config: params.config,
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
     });
     const providerQuery = resolveProviderQuery({
       providerId,
@@ -891,41 +900,68 @@ export async function runProviderEntry(params: {
         workspaceDir: params.workspaceDir,
       }) ||
       entry.model;
-    const authSource = auth.source ?? `provider:${providerId}`;
-    const buildRequest = (requestAuth: { kind: "api-key"; apiKey: string } | { kind: "none" }) => ({
+    const input = {
       buffer: media.buffer,
       fileName: media.fileName,
       mime: media.mime,
-      apiKey: requestAuth.kind === "api-key" ? requestAuth.apiKey : CUSTOM_LOCAL_AUTH_MARKER,
-      auth:
-        requestAuth.kind === "api-key"
-          ? { kind: "api-key" as const, apiKey: requestAuth.apiKey, source: auth.source }
-          : { kind: "none" as const, source: authSource },
-      baseUrl,
-      headers,
-      request,
+      ...transport,
       model,
       language: audioLanguage,
       prompt: audioPrompt,
       query: providerQuery,
       timeoutMs,
       fetchFn,
-    });
-    const result =
-      auth.kind === "api-key"
-        ? await executeWithApiKeyRotation({
-            provider: providerId,
-            apiKeys: auth.apiKeys,
-            transientRetry: providerOperationRetryConfig("read"),
-            execute: async (apiKey) => transcribeAudio(buildRequest({ kind: "api-key", apiKey })),
-          })
-        : await transcribeAudio(buildRequest({ kind: "none" }));
+    };
+    let result: AudioTranscriptionResult;
+    if (provider.prepareAudioTranscription) {
+      const transcribe =
+        params.preparedAudioTranscription ??
+        (await prepareProviderAudioTranscription({
+          ...params,
+          providerId,
+          prepare: provider.prepareAudioTranscription,
+        }));
+      result = await transcribe(input);
+    } else {
+      const transcribeAudio = expectDefined(
+        provider.transcribeAudio,
+        "audio transcription callback",
+      );
+      const auth = await resolveProviderExecutionAuth({
+        capability,
+        providerId,
+        provider,
+        cfg,
+        entry,
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
+      });
+      const buildRequest = (
+        requestAuth: { kind: "api-key"; apiKey: string } | { kind: "none" },
+      ) => ({
+        ...input,
+        apiKey: requestAuth.kind === "api-key" ? requestAuth.apiKey : CUSTOM_LOCAL_AUTH_MARKER,
+        auth:
+          requestAuth.kind === "api-key"
+            ? { kind: "api-key" as const, apiKey: requestAuth.apiKey, source: auth.source }
+            : { kind: "none" as const, source: auth.source ?? `provider:${providerId}` },
+      });
+      result =
+        auth.kind === "api-key"
+          ? await executeWithApiKeyRotation({
+              provider: providerId,
+              apiKeys: auth.apiKeys,
+              transientRetry: providerOperationRetryConfig("read"),
+              execute: async (apiKey) => transcribeAudio(buildRequest({ kind: "api-key", apiKey })),
+            })
+          : await transcribeAudio(buildRequest({ kind: "none" }));
+    }
     return {
       kind: "audio.transcription",
       attachmentIndex: params.attachmentIndex,
       text: trimOutput(result.text, maxChars),
       provider: providerId,
-      model: result.model ?? model,
+      model: provider.prepareAudioTranscription ? result.model : (result.model ?? model),
     };
   }
 
@@ -946,15 +982,20 @@ export async function runProviderEntry(params: {
       `Video attachment ${params.attachmentIndex + 1} base64 payload ${estimatedBase64Bytes} exceeds ${maxBase64Bytes}`,
     );
   }
-  const { auth, baseUrl, headers, request } = await resolveProviderExecutionContext({
+  const auth = await resolveProviderExecutionAuth({
     capability,
     providerId,
     provider,
     cfg,
     entry,
-    config: params.config,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
+  });
+  const { baseUrl, headers, request } = resolveProviderRequestContext({
+    providerId,
+    cfg,
+    entry,
+    config: params.config,
   });
   const authSource = auth.source ?? `provider:${providerId}`;
   const model =

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -163,26 +163,26 @@ function createVideoCfg(params: { provider: string; model: string }): OpenClawCo
 }
 
 describe("runCapability local no-auth audio providers", () => {
-  it("runs provider-prepared audio without resolving an unrelated API key", async () => {
+  it("runs provider-owned audio without resolving an unrelated API key", async () => {
     modelAuthTestControl.forceMissingProvider = true;
     await withIsolatedAgentDir(async (agentDir) => {
       await withAudioFixture("openclaw-prepared-audio", async ({ ctx, media, cache }) => {
         const provider = {
           id: "prepared-audio",
           capabilities: ["audio" as const],
-          prepareAudioTranscription: async (context: {
+          transcribeAudioWithContext: async (context: {
             agentDir?: string;
             profile?: string;
-            requestedModel?: string;
+            model?: string;
+            buffer: Buffer;
+            language?: string;
           }) => {
             expect(context.agentDir).toBe(agentDir);
             expect(context.profile).toBe("prepared-audio:account");
-            expect(context.requestedModel).toBe("prepared-model");
-            return async (request: { buffer: Buffer; language?: string }) => {
-              expect(request.buffer.byteLength).toBeGreaterThan(1024);
-              expect(request.language).toBe("de");
-              return { text: "prepared transcript" };
-            };
+            expect(context.model).toBe("prepared-model");
+            expect(context.buffer.byteLength).toBeGreaterThan(1024);
+            expect(context.language).toBe("de");
+            return { ok: true as const, value: { text: "prepared transcript" } };
           },
         };
         const result = await runCapability({
@@ -201,8 +201,8 @@ describe("runCapability local no-auth audio providers", () => {
 
         expect(result.decision.outcome).toBe("success");
         expect(result.outputs[0]?.text).toBe("prepared transcript");
-        expect(result.outputs[0]?.model).toBeUndefined();
-        expect(result.decision.attachments[0]?.chosen?.model).toBeUndefined();
+        expect(result.outputs[0]?.model).toBe("prepared-model");
+        expect(result.decision.attachments[0]?.chosen?.model).toBe("prepared-model");
       });
     });
   });

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -163,6 +163,50 @@ function createVideoCfg(params: { provider: string; model: string }): OpenClawCo
 }
 
 describe("runCapability local no-auth audio providers", () => {
+  it("runs provider-prepared audio without resolving an unrelated API key", async () => {
+    modelAuthTestControl.forceMissingProvider = true;
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withAudioFixture("openclaw-prepared-audio", async ({ ctx, media, cache }) => {
+        const provider = {
+          id: "prepared-audio",
+          capabilities: ["audio" as const],
+          prepareAudioTranscription: async (context: {
+            agentDir?: string;
+            profile?: string;
+            requestedModel?: string;
+          }) => {
+            expect(context.agentDir).toBe(agentDir);
+            expect(context.profile).toBe("prepared-audio:account");
+            expect(context.requestedModel).toBe("prepared-model");
+            return async (request: { buffer: Buffer; language?: string }) => {
+              expect(request.buffer.byteLength).toBeGreaterThan(1024);
+              expect(request.language).toBe("de");
+              return { text: "prepared transcript" };
+            };
+          },
+        };
+        const result = await runCapability({
+          capability: "audio",
+          cfg: createAudioCfg({
+            provider: provider.id,
+            model: "prepared-model",
+            entry: { profile: "prepared-audio:account", language: "de" },
+          }),
+          ctx,
+          attachments: cache,
+          media,
+          agentDir,
+          providerRegistry: buildProviderRegistry({ [provider.id]: provider }),
+        });
+
+        expect(result.decision.outcome).toBe("success");
+        expect(result.outputs[0]?.text).toBe("prepared transcript");
+        expect(result.outputs[0]?.model).toBeUndefined();
+        expect(result.decision.attachments[0]?.chosen?.model).toBeUndefined();
+      });
+    });
+  });
+
   it("allows a local no-auth audio provider when configured as a local models provider", async () => {
     await withIsolatedAgentDir(async (agentDir) => {
       await withEnvAsync(AUTH_ENV, async () => {

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -3,6 +3,7 @@
 import path from "node:path";
 import { mergeInboundPathRoots } from "@openclaw/media-core/inbound-path-policy";
 import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
+import { ok } from "@openclaw/normalization-core/result";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeNullableString,
@@ -64,7 +65,6 @@ import {
 import {
   buildModelDecision,
   formatDecisionSummary,
-  prepareProviderAudioTranscription,
   runCliEntry,
   runProviderEntry,
 } from "./runner.entries.js";
@@ -478,6 +478,33 @@ async function activeModelSupportsNativeVision(params: {
   return modelSupportsVision(entry);
 }
 
+async function* resolveAutoAudioEntries(
+  params: Parameters<typeof resolveAutoEntries>[0],
+): AsyncGenerator<ResolvedMediaModelEntry> {
+  const activeProvider = normalizeMediaExecutionProviderId(
+    params.activeModel?.provider?.trim() ?? "",
+  );
+  const providers = uniqueStrings([
+    ...(activeProvider ? [activeProvider] : []),
+    ...resolveConfiguredKeyProviderOrder({
+      ...params,
+      fallbackProviders: resolveAutoMediaKeyProvidersFromRegistry(params),
+    }),
+  ]);
+  // Advance lazily: unused providers must not refresh credentials, and an upload
+  // failure must not silently disclose the same recording to another provider.
+  for (const providerId of providers) {
+    const entry = await resolveAutoProviderModelEntry(params, providerId, () => undefined);
+    if (entry) {
+      yield { entry };
+    }
+  }
+  const localAudio = await inspectLocalAudioSelection();
+  for (const entry of localAudio.entries) {
+    yield { entry };
+  }
+}
+
 async function resolveAutoEntries(params: {
   cfg: OpenClawConfig;
   agentId?: string;
@@ -489,47 +516,6 @@ async function resolveAutoEntries(params: {
   nativeVisionActive: boolean;
   config?: MediaUnderstandingConfig;
 }): Promise<ResolvedMediaModelEntry[]> {
-  if (params.capability === "audio") {
-    const rejected: ResolvedMediaModelEntry[] = [];
-    const activeProvider = normalizeMediaExecutionProviderId(
-      params.activeModel?.provider?.trim() ?? "",
-    );
-    const providers = uniqueStrings([
-      ...(activeProvider ? [activeProvider] : []),
-      ...resolveConfiguredKeyProviderOrder({
-        ...params,
-        fallbackProviders: resolveAutoMediaKeyProvidersFromRegistry(params),
-      }),
-    ]);
-    for (const providerId of providers) {
-      const entry = await resolveAutoProviderModelEntry(params, providerId, () => undefined);
-      if (!entry) {
-        continue;
-      }
-      const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
-      if (!provider?.prepareAudioTranscription) {
-        return [...rejected, { entry }];
-      }
-      try {
-        const transcribe = await prepareProviderAudioTranscription({
-          ...params,
-          entry,
-          providerId,
-          prepare: provider.prepareAudioTranscription,
-        });
-        return [...rejected, { entry, audioPreparation: { status: "ready", transcribe } }];
-      } catch (error) {
-        if (isProviderAuthError(error, "missing-provider-auth")) {
-          continue;
-        }
-        // Preserve the rejected route for the same attempt reporting used by execution.
-        // The next candidate may be usable without uploading audio to this one.
-        rejected.push({ entry, audioPreparation: { status: "failed", error } });
-      }
-    }
-    const localAudio = await inspectLocalAudioSelection();
-    return [...rejected, ...localAudio.entries.map((entry) => ({ entry }))];
-  }
   if (params.capability === "image" && !params.nativeVisionActive) {
     const imageModelEntries = resolveImageModelFromAgentDefaults({
       cfg: params.cfg,
@@ -614,7 +600,7 @@ async function resolveAutoProviderModelEntry(
     return null;
   }
   if (
-    !(params.capability === "audio" && provider?.prepareAudioTranscription) &&
+    !(params.capability === "audio" && provider?.transcribeAudioWithContext) &&
     !(await hasProviderAuthAvailable({
       capability: params.capability,
       provider: providerId,
@@ -673,7 +659,8 @@ async function runAttachmentEntries(params: {
   workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   cache: MediaAttachmentCache;
-  entries: ResolvedMediaModelEntry[];
+  entries: Iterable<ResolvedMediaModelEntry> | AsyncIterable<ResolvedMediaModelEntry>;
+  automaticAudio: boolean;
   config?: MediaUnderstandingConfig;
 }): Promise<{
   output: MediaUnderstandingOutput | null;
@@ -682,24 +669,23 @@ async function runAttachmentEntries(params: {
   const { entries, capability } = params;
   const attachmentIndex = params.attachment.index;
   const attempts: MediaUnderstandingModelDecision[] = [];
-  for (const candidate of entries) {
+  for await (const candidate of entries) {
     const { entry } = candidate;
     const entryType = entry.type ?? (entry.command ? "cli" : "provider");
     try {
-      if (candidate.audioPreparation?.status === "failed") {
-        throw candidate.audioPreparation.error;
-      }
-      const result =
+      const attempt =
         entryType === "cli"
-          ? await runCliEntry({
-              capability,
-              entry,
-              cfg: params.cfg,
-              ctx: params.ctx,
-              attachment: params.attachment,
-              cache: params.cache,
-              config: params.config,
-            })
+          ? ok(
+              await runCliEntry({
+                capability,
+                entry,
+                cfg: params.cfg,
+                ctx: params.ctx,
+                attachment: params.attachment,
+                cache: params.cache,
+                config: params.config,
+              }),
+            )
           : await runProviderEntry({
               capability,
               entry,
@@ -712,10 +698,24 @@ async function runAttachmentEntries(params: {
               workspaceDir: params.workspaceDir,
               providerRegistry: params.providerRegistry,
               config: params.config,
-              requestedModel: candidate.requestedModel,
               secretOwnerId: candidate.secretOwnerId,
-              preparedAudioTranscription: candidate.audioPreparation?.transcribe,
             });
+      if (!attempt.ok) {
+        if (
+          !(params.automaticAudio && isProviderAuthError(attempt.error, "missing-provider-auth"))
+        ) {
+          attempts.push(
+            buildModelDecision({
+              entry,
+              entryType,
+              outcome: "failed",
+              reason: String(attempt.error),
+            }),
+          );
+        }
+        continue;
+      }
+      const result = attempt.value;
       if (result?.text) {
         const decision = buildModelDecision({ entry, entryType, outcome: "success" });
         if (result.provider) {
@@ -747,19 +747,22 @@ async function runAttachmentEntries(params: {
         if (shouldLogVerbose()) {
           logVerbose(`Skipping ${capability} model due to ${err.reason}: ${err.message}`);
         }
-        continue;
+      } else {
+        attempts.push(
+          buildModelDecision({
+            entry,
+            entryType,
+            outcome: "failed",
+            reason: String(err),
+          }),
+        );
+        if (shouldLogVerbose()) {
+          logVerbose(`${capability} understanding failed: ${String(err)}`);
+        }
       }
-      attempts.push(
-        buildModelDecision({
-          entry,
-          entryType,
-          outcome: "failed",
-          reason: String(err),
-        }),
-      );
-      if (shouldLogVerbose()) {
-        logVerbose(`${capability} understanding failed: ${String(err)}`);
-      }
+    }
+    if (params.automaticAudio && entryType === "provider") {
+      break;
     }
   }
 
@@ -946,8 +949,9 @@ export async function runCapability(params: {
     config,
     providerRegistry: params.providerRegistry,
   });
+  const automaticAudio = capability === "audio" && entries.length === 0;
   let resolvedEntries: ResolvedMediaModelEntry[] = entries;
-  if (resolvedEntries.length === 0) {
+  if (!automaticAudio && resolvedEntries.length === 0) {
     resolvedEntries = await resolveAutoEntries({
       cfg,
       agentId: params.agentId,
@@ -960,7 +964,7 @@ export async function runCapability(params: {
       nativeVisionActive: capability === "image" && (await resolveNativeVisionFlag()) === true,
     });
   }
-  if (resolvedEntries.length === 0) {
+  if (!automaticAudio && resolvedEntries.length === 0) {
     return {
       outputs: [],
       decision: await buildDecision(
@@ -988,13 +992,29 @@ export async function runCapability(params: {
       workspaceDir: params.workspaceDir,
       providerRegistry: params.providerRegistry,
       cache: params.attachments,
-      entries: resolvedEntries,
+      entries: automaticAudio
+        ? resolveAutoAudioEntries({
+            cfg,
+            agentId: params.agentId,
+            agentDir: params.agentDir,
+            workspaceDir: params.workspaceDir,
+            providerRegistry: params.providerRegistry,
+            capability,
+            activeModel: params.activeModel,
+            nativeVisionActive: false,
+          })
+        : resolvedEntries,
+      automaticAudio,
       config,
     });
     if (output) {
       outputs.push(output);
     }
-    attachmentDispositions[attachment.index] = output ? { kind: "handled" } : { kind: "failed" };
+    attachmentDispositions[attachment.index] = output
+      ? { kind: "handled" }
+      : attempts.length > 0
+        ? { kind: "failed" }
+        : { kind: "no-model" };
     attachmentDecisions.push({
       attachmentIndex: attachment.index,
       attempts,

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -17,6 +17,7 @@ import {
 } from "../../packages/media-understanding-common/src/provider-id.js";
 import { providerSupportsCapability } from "../../packages/media-understanding-common/src/provider-supports.js";
 import { isMinimaxVlmModel, isMinimaxVlmProvider } from "../agents/minimax-vlm.js";
+import { isProviderAuthError } from "../agents/model-auth-runtime-shared.js";
 import {
   buildModelAliasIndex,
   inferUniqueProviderFromConfiguredModels,
@@ -63,6 +64,7 @@ import {
 import {
   buildModelDecision,
   formatDecisionSummary,
+  prepareProviderAudioTranscription,
   runCliEntry,
   runProviderEntry,
 } from "./runner.entries.js";
@@ -485,33 +487,65 @@ async function resolveAutoEntries(params: {
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
   nativeVisionActive: boolean;
-}): Promise<MediaUnderstandingModelConfig[]> {
+  config?: MediaUnderstandingConfig;
+}): Promise<ResolvedMediaModelEntry[]> {
+  if (params.capability === "audio") {
+    const rejected: ResolvedMediaModelEntry[] = [];
+    const activeProvider = normalizeMediaExecutionProviderId(
+      params.activeModel?.provider?.trim() ?? "",
+    );
+    const providers = uniqueStrings([
+      ...(activeProvider ? [activeProvider] : []),
+      ...resolveConfiguredKeyProviderOrder({
+        ...params,
+        fallbackProviders: resolveAutoMediaKeyProvidersFromRegistry(params),
+      }),
+    ]);
+    for (const providerId of providers) {
+      const entry = await resolveAutoProviderModelEntry(params, providerId, () => undefined);
+      if (!entry) {
+        continue;
+      }
+      const provider = getMediaUnderstandingProvider(providerId, params.providerRegistry);
+      if (!provider?.prepareAudioTranscription) {
+        return [...rejected, { entry }];
+      }
+      try {
+        const transcribe = await prepareProviderAudioTranscription({
+          ...params,
+          entry,
+          providerId,
+          prepare: provider.prepareAudioTranscription,
+        });
+        return [...rejected, { entry, audioPreparation: { status: "ready", transcribe } }];
+      } catch (error) {
+        if (isProviderAuthError(error, "missing-provider-auth")) {
+          continue;
+        }
+        // Preserve the rejected route for the same attempt reporting used by execution.
+        // The next candidate may be usable without uploading audio to this one.
+        rejected.push({ entry, audioPreparation: { status: "failed", error } });
+      }
+    }
+    const localAudio = await inspectLocalAudioSelection();
+    return [...rejected, ...localAudio.entries.map((entry) => ({ entry }))];
+  }
   if (params.capability === "image" && !params.nativeVisionActive) {
     const imageModelEntries = resolveImageModelFromAgentDefaults({
       cfg: params.cfg,
       agentId: params.agentId,
     });
     if (imageModelEntries.length > 0) {
-      return imageModelEntries;
+      return imageModelEntries.map((entry) => ({ entry }));
     }
   }
   const activeEntry = await resolveActiveModelEntry(params);
   if (activeEntry) {
-    return [activeEntry];
-  }
-  if (params.capability === "audio") {
-    const keyEntry = await resolveKeyEntry(params);
-    if (keyEntry) {
-      return [keyEntry];
-    }
-    const localAudio = await inspectLocalAudioSelection();
-    if (localAudio.entries.length > 0) {
-      return localAudio.entries;
-    }
+    return [{ entry: activeEntry }];
   }
   const keys = await resolveKeyEntry(params);
   if (keys) {
-    return [keys];
+    return [{ entry: keys }];
   }
   return [];
 }
@@ -530,7 +564,7 @@ export async function resolveAutoImageModel(params: {
     capability: "image",
     nativeVisionActive: false,
   });
-  for (const entry of entries) {
+  for (const { entry } of entries) {
     if (entry.type === "cli") {
       continue;
     }
@@ -579,14 +613,16 @@ async function resolveAutoProviderModelEntry(
   if (!providerSupportsCapability(provider, params.capability)) {
     return null;
   }
-  const hasAuth = await hasProviderAuthAvailable({
-    capability: params.capability,
-    provider: providerId,
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-  });
-  if (!hasAuth) {
+  if (
+    !(params.capability === "audio" && provider?.prepareAudioTranscription) &&
+    !(await hasProviderAuthAvailable({
+      capability: params.capability,
+      provider: providerId,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+    }))
+  ) {
     return null;
   }
   // Active selection reads its model after auth; key selection captures it before auth.
@@ -650,6 +686,9 @@ async function runAttachmentEntries(params: {
     const { entry } = candidate;
     const entryType = entry.type ?? (entry.command ? "cli" : "provider");
     try {
+      if (candidate.audioPreparation?.status === "failed") {
+        throw candidate.audioPreparation.error;
+      }
       const result =
         entryType === "cli"
           ? await runCliEntry({
@@ -673,16 +712,16 @@ async function runAttachmentEntries(params: {
               workspaceDir: params.workspaceDir,
               providerRegistry: params.providerRegistry,
               config: params.config,
+              requestedModel: candidate.requestedModel,
               secretOwnerId: candidate.secretOwnerId,
+              preparedAudioTranscription: candidate.audioPreparation?.transcribe,
             });
       if (result?.text) {
         const decision = buildModelDecision({ entry, entryType, outcome: "success" });
         if (result.provider) {
           decision.provider = result.provider;
         }
-        if (result.model) {
-          decision.model = result.model;
-        }
+        decision.model = result.model;
         if (result.requestedBackend) {
           decision.requestedBackend = result.requestedBackend;
         }
@@ -909,18 +948,17 @@ export async function runCapability(params: {
   });
   let resolvedEntries: ResolvedMediaModelEntry[] = entries;
   if (resolvedEntries.length === 0) {
-    resolvedEntries = (
-      await resolveAutoEntries({
-        cfg,
-        agentId: params.agentId,
-        agentDir: params.agentDir,
-        workspaceDir: params.workspaceDir,
-        providerRegistry: params.providerRegistry,
-        capability,
-        activeModel: params.activeModel,
-        nativeVisionActive: capability === "image" && (await resolveNativeVisionFlag()) === true,
-      })
-    ).map((entry) => ({ entry }));
+    resolvedEntries = await resolveAutoEntries({
+      cfg,
+      agentId: params.agentId,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      providerRegistry: params.providerRegistry,
+      capability,
+      activeModel: params.activeModel,
+      config,
+      nativeVisionActive: capability === "image" && (await resolveNativeVisionFlag()) === true,
+    });
   }
   if (resolvedEntries.length === 0) {
     return {

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -1,5 +1,6 @@
 // Shared media-understanding types for attachments, provider hooks, request
 // auth, decisions, and structured extraction inputs.
+import type { Result } from "@openclaw/normalization-core/result";
 import type { MediaUnderstandingCapability } from "../../packages/media-understanding-common/src/types.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { ModelProviderConfig } from "../config/types.js";
@@ -120,21 +121,12 @@ export type AudioTranscriptionResult = {
   model?: string;
 };
 
-export type AudioTranscriptionInput = Omit<AudioTranscriptionRequest, "apiKey" | "auth">;
-
-export type AudioTranscriptionContext = Pick<
-  AudioTranscriptionRequest,
-  "baseUrl" | "headers" | "request"
-> & {
+type AudioTranscriptionContext = Omit<AudioTranscriptionRequest, "apiKey" | "auth"> & {
   cfg: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
   profile?: string;
   preferredProfile?: string;
-  /** Explicit model selection; automatic provider defaults leave this absent. */
-  requestedModel?: string;
-  /** An operator-authored prompt, excluding the host's default transcription prompt. */
-  prompt?: string;
 };
 
 export type VideoDescriptionRequest = {
@@ -291,10 +283,11 @@ export type MediaUnderstandingProvider = {
     ctx: MediaUnderstandingProviderAuthContext,
   ) => MediaUnderstandingProviderSyntheticAuthResult | null | undefined;
   transcribeAudio?: (req: AudioTranscriptionRequest) => Promise<AudioTranscriptionResult>;
-  /** Resolves provider-owned routing/auth once, without uploading audio during preparation. */
-  prepareAudioTranscription?: (
-    ctx: AudioTranscriptionContext,
-  ) => Promise<(req: AudioTranscriptionInput) => Promise<AudioTranscriptionResult>>;
+  /** Called after file loading. Result.error is only a rejection before audio upload;
+   * upload/HTTP failures must throw and stop automatic provider selection. */
+  transcribeAudioWithContext?: (
+    req: AudioTranscriptionContext,
+  ) => Promise<Result<AudioTranscriptionResult, unknown>>;
   describeVideo?: (req: VideoDescriptionRequest) => Promise<VideoDescriptionResult>;
   describeImage?: (req: ImageDescriptionRequest) => Promise<ImageDescriptionResult>;
   describeImages?: (req: ImagesDescriptionRequest) => Promise<ImagesDescriptionResult>;

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -120,6 +120,23 @@ export type AudioTranscriptionResult = {
   model?: string;
 };
 
+export type AudioTranscriptionInput = Omit<AudioTranscriptionRequest, "apiKey" | "auth">;
+
+export type AudioTranscriptionContext = Pick<
+  AudioTranscriptionRequest,
+  "baseUrl" | "headers" | "request"
+> & {
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  profile?: string;
+  preferredProfile?: string;
+  /** Explicit model selection; automatic provider defaults leave this absent. */
+  requestedModel?: string;
+  /** An operator-authored prompt, excluding the host's default transcription prompt. */
+  prompt?: string;
+};
+
 export type VideoDescriptionRequest = {
   buffer: Buffer;
   fileName: string;
@@ -274,6 +291,10 @@ export type MediaUnderstandingProvider = {
     ctx: MediaUnderstandingProviderAuthContext,
   ) => MediaUnderstandingProviderSyntheticAuthResult | null | undefined;
   transcribeAudio?: (req: AudioTranscriptionRequest) => Promise<AudioTranscriptionResult>;
+  /** Resolves provider-owned routing/auth once, without uploading audio during preparation. */
+  prepareAudioTranscription?: (
+    ctx: AudioTranscriptionContext,
+  ) => Promise<(req: AudioTranscriptionInput) => Promise<AudioTranscriptionResult>>;
   describeVideo?: (req: VideoDescriptionRequest) => Promise<VideoDescriptionResult>;
   describeImage?: (req: ImageDescriptionRequest) => Promise<ImageDescriptionResult>;
   describeImages?: (req: ImagesDescriptionRequest) => Promise<ImagesDescriptionResult>;

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -20,6 +20,7 @@ export {
 } from "../agents/api-key-rotation.js";
 export { NON_ENV_SECRETREF_MARKER } from "../agents/model-auth-markers.js";
 export {
+  isProviderAuthError,
   requireApiKey,
   resolveAwsSdkEnvVarName,
   type ResolvedProviderAuth,


### PR DESCRIPTION
Fixes #96135. Supersedes #97280, with credit to @yungchentang (Yung-Chen Tang).

## What Problem This Solves

An existing OpenAI login could not transcribe an inbound voice note because the host's API-key-only audio filter rejected OAuth before the OpenAI plugin could make a request. The standard transcription endpoint accepts the existing login tested here. Operators should not need to add an API key merely to get past that local filter; account access and quota remain authoritative.

## Why This Change Was Made

The OpenAI plugin now resolves audio credentials after each attachment loads and sends both supported credential classes through the existing `/v1/audio/transcriptions` adapter. Models, prompts, language hints, multipart construction, timeouts and error redaction have one implementation. No credentials are captured across downloads, no separate ChatGPT batch endpoint or account-metadata lookup is involved, and global text-inference auth policy is unchanged.

The additive `transcribeAudioWithContext` hook lets the provider own that decision while preserving the shipped `transcribeAudio` contract for existing plugins. Only authentication/configuration rejection before upload returns `Result.error`. Automatic candidates are visited lazily; an actual upload failure or empty provider result stops automatic selection, so the same recording is not silently uploaded elsewhere. Explicitly configured fallback lists retain their existing behavior. Only API-key auth enters API-key rotation.

The shared adapter now gives its existing HTTP/JSON error helpers the final request headers, so a provider error that reflects a bearer cannot expose it through its message or cause.

## User Impact

- An existing OpenAI OAuth login can handle default or explicitly configured audio models when that account has access. This does not promise that every subscription includes transcription, or that usage is free or unlimited.
- Explicit profile selection stays locked. An authored API key retains precedence unless the operator explicitly selects a profile or OAuth/token auth mode; failed uploads never switch credential classes.
- OAuth is restricted to the official endpoint without custom request/header overrides. Custom compatible endpoints retain API-key behavior.
- Ordinary missing auth remains an unavailable automatic candidate; real refresh/configuration errors remain visible. Credentials are resolved per file, immediately before the provider request.

## Evidence

The normal built Gateway processed a synthetic WAV through `chat.send`, inbound attachment handling, automatic audio selection, `agent.wait` and `chat.history`. Every row below returned HTTP 200, an exact matching provider transcript and assistant reply, with one observed audio request and confirmed process cleanup:

| Credentials and selection | Observed result |
| --- | --- |
| Existing OAuth login; default `gpt-4o-transcribe` | Pass; no API key or aliases forwarded |
| Existing OAuth login; explicit `gpt-4o-mini-transcribe` | Pass; no API key or aliases forwarded |
| Explicit API-key auth; default model | Pass; request bearer matched the configured key |
| Existing login plus an authored API key | Pass; request bearer matched the configured key |

Credential comparisons stayed in memory; evidence contains only booleans, status and route labels. This is real Gateway/provider proof with synthetic audio, not a browser interaction or proof of every account's entitlement. The first observer assumed HTTP/1 response headers and could not verify the response body; its corrected HTTP/2-aware runs above are the completed proof. No network-route changes, challenge bypass, manual auth-file staging, or alternative-key fallback were used. The tested production bytes match commit `08da32f5402f5c2252cdddf9840475ea71113338`.

Regression failures were captured before the repair for early credential resolution, the incorrect endpoint, and credential reflection in HTTP/JSON errors. Focused provider, selection, local-fallback, legacy-descriptor, endpoint and redaction tests pass. Core/plugin production and test typechecks, SDK boundaries and export budget checks pass. The normal build and fresh Codex reviews passed.

CI on `08da32f` found three old selection fixtures that required duplicate provider probes. The test-only follow-up `c3239944cf8a6777c60b290298ed0e9214100dce` replaces those with stable authentication and preserves the audio-model and ordered-fallback assertions: the three failures reproduced first, then all seven selection cases and exact lint passed. Production bytes are unchanged from the four live runs above. [Required CI passed on this exact head](https://github.com/openclaw/openclaw/actions/runs/33614543709/attempts/2). The first attempt passed the media lane but failed an anonymous Git history fetch before security scanners ran; a failed-jobs-only retry on the workflow's alternate runner passed. The scan-history authentication failure is retained as a separate CI follow-up, not hidden by a scanner skip.

OSS Codex was inspected at `eb10d91e48ccbd0930427461fb392337addb1ac0`, including `codex-rs/core/src/realtime_conversation.rs:1718`, `codex-rs/codex-api/src/endpoint/realtime_websocket/methods_v2.rs:145`, and `codex-rs/codex-api/src/endpoint/realtime_call.rs:61`. Its realtime paths do not establish a batch-transcription entitlement; the successful normal Gateway calls above establish the tested account's batch behavior. This PR does not claim realtime-voice parity.

Maintainer decision: support account-authorized OAuth batch transcription on the official endpoint through the additive contextual provider hook, with API-key precedence, override restrictions, and legacy descriptors preserved. This follows the maintainer's direction to make the existing OpenAI login work and to live-test and land the repair; it does not promise entitlement for every account.

ClawSweeper rank-up follow-through: the 09:48 UTC review of final head `c3239944` accepts the Gateway proof and reports no actionable or security findings. The contract decision is recorded above, and exact-head CI is now green. Additional Telegram Test Server transport proof is unavailable: the proof host has neither an authenticated Convex CLI nor the broker credential pair, and the Telegram E2E skill prohibits installing or signing in during runtime setup. No personal Telegram session was substituted and no Telegram-specific coverage is claimed. Multi-account logout/abort semantics are not broadened; no real account was revoked or reassigned for testing. The captured-bearer path was removed, and post-download credential resolution is covered by the regression. The existing shared media-preprocessing cancellation gap remains a separate follow-up.

Production is **+362/−159 (net +203)**; tests are **+642/−42 (net +600)**; docs are **+50/−4 (net +46)**. Growth supplies the provider-owned OAuth boundary and the pre-upload versus uploaded failure contract without weakening legacy plugin auth. The implementation removes duplicate transport/preparation work and is 89 production lines smaller than the earlier draft. No dependency, configuration, persistence or protocol surface is added.

Contributor attribution is retained:

```text
Co-authored-by: yungchentang <46495124+yungchentang@users.noreply.github.com>
```
