### PR TITLE
fix(browser): enforce CDP policy for Chrome MCP argument endpoints

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -519,6 +519,8 @@ See [Plugins](/tools/plugin).
   behind a DevTools HTTP(S) discovery endpoint or direct WS(S) endpoint. In that
   mode OpenClaw passes the endpoint to Chrome MCP instead of using auto-connect;
   `userDataDir` is ignored for Chrome MCP launch arguments.
+  Valid endpoint arguments in `mcpArgs` take precedence over `cdpUrl`; see
+  [Custom Chrome MCP launch](/tools/browser#custom-chrome-mcp-launch).
 - `existing-session` profiles keep the current Chrome MCP route limits:
   snapshot/ref-driven actions instead of CSS-selector targeting, one-file upload
   hooks, no dialog timeout overrides, no `wait --load networkidle`, and no

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -321,8 +321,10 @@ main model can read the screenshot directly.
   config. A profile you declare by hand must set `cdpPort` itself, or `cdpUrl`
   for a remote endpoint: the schema rejects an `openclaw` or `clawd` profile
   that sets neither with `Profile must set cdpPort or cdpUrl`.
-  `existing-session` profiles take the endpoint from `cdpUrl` and ignore
-  `cdpPort`; `extension` profiles own their relay port and reject `cdpUrl`.
+  `existing-session` profiles use `cdpUrl` unless valid endpoint arguments in
+  `mcpArgs` override it; see [Custom Chrome MCP launch](/tools/browser#custom-chrome-mcp-launch).
+  They ignore `cdpPort`; `extension` profiles own their relay port and reject
+  `cdpUrl`.
 - Remote and `attachOnly` CDP reachability, WebSocket handshakes, and local
   managed-Chrome startup use built-in deadlines.
 - Repeated managed Chrome launch/readiness failures are circuit-broken per

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -828,21 +828,33 @@ Override the spawned Chrome DevTools MCP server per profile when the default
 `npx chrome-devtools-mcp@latest` flow is not what you want (offline hosts,
 pinned versions, vendored binaries):
 
-| Field        | What it does                                                                                                               |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `mcpCommand` | Executable to spawn instead of `npx`. Resolved as-is; absolute paths are honored.                                          |
-| `mcpArgs`    | Argument array passed verbatim to `mcpCommand`. Replaces the default `chrome-devtools-mcp@latest --autoConnect` arguments. |
+| Field        | What it does                                                                                                                    |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `mcpCommand` | Executable to spawn instead of `npx`. Resolved as-is; absolute paths are honored.                                               |
+| `mcpArgs`    | Extra arguments passed unchanged to `mcpCommand`. Connection options override the generated endpoint or auto-connect arguments. |
 
-When `cdpUrl` is set on an existing-session profile, OpenClaw skips
-`--autoConnect` and forwards the endpoint to Chrome MCP automatically:
+Using `mcpArgs` does not replace the package prefix: when `mcpCommand` is `npx`,
+OpenClaw still prepends `-y chrome-devtools-mcp@latest`.
+
+When `mcpArgs` does not set a connection option, OpenClaw forwards a configured
+`cdpUrl` to Chrome MCP instead of generating `--autoConnect`:
 
 - `http(s)://...` → `--browserUrl <url>` (DevTools HTTP discovery endpoint).
 - `ws(s)://...` → `--wsEndpoint <url>` (direct CDP WebSocket).
 
-Endpoint flags and `userDataDir` cannot be combined: when `cdpUrl` is set,
-`userDataDir` is ignored for Chrome MCP launch, since Chrome MCP attaches to
-the running browser behind the endpoint rather than opening a profile
-directory.
+Explicit endpoint arguments in `mcpArgs` override `cdpUrl`; adding
+`--autoConnect` alongside an endpoint does not hide it. OpenClaw uses the selected
+endpoint for CDP control and checks Browser CDP policy before starting Chrome MCP.
+A matching `blockedHostnames` entry denies attachment even when private-network
+access is trusted. Unrelated blocklist entries do not prevent attachment, and
+the default strict-policy restrictions still apply.
+
+Invalid, empty, duplicate, or conflicting endpoint arguments fail with an error
+before launch. Supply one valid endpoint, or omit `cdpUrl` and endpoint arguments
+to use host-local attachment.
+
+When an endpoint is selected, `userDataDir` is ignored: Chrome MCP attaches to the
+running browser behind that endpoint rather than opening a profile directory.
 
 <Accordion title="Existing-session feature limitations">
 

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -10,10 +10,12 @@
     "playwright-core": "1.62.1",
     "typebox": "1.3.17",
     "ws": "8.21.3",
+    "yargs-parser": "22.0.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
+    "@types/yargs-parser": "21.0.3",
     "undici": "8.10.0"
   },
   "openclaw": {

--- a/extensions/browser/src/browser/cdp-reachability-policy.blocklist.test.ts
+++ b/extensions/browser/src/browser/cdp-reachability-policy.blocklist.test.ts
@@ -1,28 +1,47 @@
+import type { BrowserConfig, BrowserProfileConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it } from "vitest";
-import { assertChromeMcpCdpTransportAllowed } from "./cdp-reachability-policy.js";
-import type { ResolvedBrowserProfile } from "./config.js";
+import {
+  assertChromeMcpCdpTransportAllowed,
+  resolveCdpReachabilityPolicy,
+} from "./cdp-reachability-policy.js";
+import { resolveBrowserConfig, resolveProfile } from "./config.js";
 
-function createExplicitCdpProfile(): ResolvedBrowserProfile {
-  return {
-    name: "chrome-mcp",
-    cdpPort: 9222,
-    cdpUrl: "http://172.29.128.1:9222",
-    cdpHost: "172.29.128.1",
-    cdpIsLoopback: false,
-    color: "#123456",
-    driver: "existing-session",
-    attachOnly: false,
-    headless: false,
-  };
+const blockedHttpEndpoint = "http://blocked.example:9222";
+const blockedWsEndpoint = "ws://blocked.example:9222/devtools/browser/session";
+const trustedHttpEndpoint = "http://trusted.example:9222";
+const privateAccessWithBlocklist = {
+  dangerouslyAllowPrivateNetwork: true,
+  blockedHostnames: ["blocked.example"],
+};
+
+function assertConfiguredTransportAllowed(
+  endpoint: Pick<BrowserProfileConfig, "cdpUrl" | "mcpArgs">,
+  ssrfPolicy?: BrowserConfig["ssrfPolicy"],
+): void {
+  const config = resolveBrowserConfig({
+    ssrfPolicy,
+    profiles: { "chrome-mcp": { driver: "existing-session", ...endpoint } },
+  });
+  const profile = resolveProfile(config, "chrome-mcp");
+  if (!profile) {
+    throw new Error("Expected resolved Chrome MCP test profile");
+  }
+  assertChromeMcpCdpTransportAllowed(
+    profile,
+    resolveCdpReachabilityPolicy(profile, config.ssrfPolicy),
+  );
 }
 
 describe("assertChromeMcpCdpTransportAllowed blocklist scoping", () => {
   it("keeps a trusted explicit CDP endpoint when the blocklist denies other hosts", () => {
     expect(() =>
-      assertChromeMcpCdpTransportAllowed(createExplicitCdpProfile(), {
-        dangerouslyAllowPrivateNetwork: true,
-        blockedHostnames: ["tracker.example.com", "*.ads.example.com"],
-      }),
+      assertConfiguredTransportAllowed(
+        { cdpUrl: "http://172.29.128.1:9222" },
+        {
+          dangerouslyAllowPrivateNetwork: true,
+          blockedHostnames: ["tracker.example.com", "*.ads.example.com"],
+        },
+      ),
     ).not.toThrow();
   });
 
@@ -30,11 +49,107 @@ describe("assertChromeMcpCdpTransportAllowed blocklist scoping", () => {
     "requires pinned transport when the blocklist denies the CDP host via %s",
     (pattern) => {
       expect(() =>
-        assertChromeMcpCdpTransportAllowed(createExplicitCdpProfile(), {
-          dangerouslyAllowPrivateNetwork: true,
-          blockedHostnames: [pattern],
-        }),
+        assertConfiguredTransportAllowed(
+          { cdpUrl: "http://172.29.128.1:9222" },
+          {
+            dangerouslyAllowPrivateNetwork: true,
+            blockedHostnames: [pattern],
+          },
+        ),
       ).toThrow(/cannot carry that pinned transport/i);
     },
   );
+
+  describe.each([
+    { name: "mcpArgs-only profile", cdpUrl: undefined },
+    { name: "mcpArgs overriding a trusted cdpUrl", cdpUrl: trustedHttpEndpoint },
+  ])("$name", ({ cdpUrl }) => {
+    it.each(
+      [
+        { flag: "--browserUrl", url: blockedHttpEndpoint },
+        { flag: "--browser-url", url: blockedHttpEndpoint },
+        { flag: "-u", url: blockedHttpEndpoint },
+        { flag: "--u", url: blockedHttpEndpoint },
+        { flag: "--wsEndpoint", url: blockedWsEndpoint },
+        { flag: "--ws-endpoint", url: blockedWsEndpoint },
+        { flag: "-w", url: blockedWsEndpoint },
+        { flag: "--w", url: blockedWsEndpoint },
+      ].flatMap(({ flag, url }) => [
+        { name: `${flag} split`, mcpArgs: [flag, url] },
+        { name: `${flag} equals`, mcpArgs: [`${flag}=${url}`] },
+      ]),
+    )("rejects the blocklisted endpoint from $name", ({ mcpArgs }) => {
+      expect(() =>
+        assertConfiguredTransportAllowed({ cdpUrl, mcpArgs }, privateAccessWithBlocklist),
+      ).toThrow(/cannot carry that pinned transport/i);
+    });
+  });
+
+  it.each([
+    { name: "grouped HTTP alias", mcpArgs: ["-xu", blockedHttpEndpoint] },
+    { name: "grouped WebSocket alias", mcpArgs: ["-xw", blockedWsEndpoint] },
+    { name: "grouped inline alias", mcpArgs: [`-xu=${blockedHttpEndpoint}`] },
+    { name: "repeated dash expansion", mcpArgs: ["--browser--url", blockedHttpEndpoint] },
+    { name: "mixed-case dash expansion", mcpArgs: ["--browser-Url", blockedHttpEndpoint] },
+    { name: "profile-normalized whitespace", mcpArgs: [" --browserUrl ", blockedHttpEndpoint] },
+  ])("does not let upstream $name escape endpoint policy", ({ mcpArgs }) => {
+    expect(() => assertConfiguredTransportAllowed({ mcpArgs }, privateAccessWithBlocklist)).toThrow(
+      /cannot carry that pinned transport|Chrome MCP.*(?:endpoint|argument)/i,
+    );
+  });
+
+  it.each([
+    {
+      name: "auto-connect before HTTP endpoint",
+      mcpArgs: ["--autoConnect", "--browserUrl", blockedHttpEndpoint],
+    },
+    {
+      name: "auto-connect after WebSocket endpoint",
+      mcpArgs: [`--wsEndpoint=${blockedWsEndpoint}`, "--auto-connect"],
+    },
+  ])("does not let $name hide a denial", ({ mcpArgs }) => {
+    expect(() => assertConfiguredTransportAllowed({ mcpArgs }, privateAccessWithBlocklist)).toThrow(
+      /cannot carry that pinned transport/i,
+    );
+  });
+
+  it.each([
+    { name: "HTTP", mcpArgs: ["--browserUrl", trustedHttpEndpoint] },
+    {
+      name: "WebSocket",
+      mcpArgs: ["--ws-endpoint=ws://trusted.example:9222/devtools/browser/session"],
+    },
+  ])("allows a trusted $name mcpArgs endpoint to override a denied cdpUrl", ({ mcpArgs }) => {
+    expect(() =>
+      assertConfiguredTransportAllowed(
+        { cdpUrl: blockedHttpEndpoint, mcpArgs },
+        privateAccessWithBlocklist,
+      ),
+    ).not.toThrow();
+  });
+
+  it.each([
+    { name: "default arguments", mcpArgs: undefined },
+    { name: "camel-case auto-connect", mcpArgs: ["--autoConnect"] },
+    { name: "kebab-case auto-connect", mcpArgs: ["--auto-connect"] },
+  ])("preserves host-local attachment with $name", ({ mcpArgs }) => {
+    expect(() =>
+      assertConfiguredTransportAllowed(
+        { mcpArgs },
+        { dangerouslyAllowPrivateNetwork: false, blockedHostnames: ["blocked.example"] },
+      ),
+    ).not.toThrow();
+  });
+
+  it.each([
+    { name: "default policy", ssrfPolicy: undefined },
+    { name: "explicit strict policy", ssrfPolicy: { dangerouslyAllowPrivateNetwork: false } },
+  ])("keeps explicit endpoints guarded under $name", ({ ssrfPolicy }) => {
+    expect(() =>
+      assertConfiguredTransportAllowed(
+        { mcpArgs: ["--browserUrl", trustedHttpEndpoint] },
+        ssrfPolicy,
+      ),
+    ).toThrow(/cannot carry that pinned transport/i);
+  });
 });

--- a/extensions/browser/src/browser/cdp-reachability-policy.ts
+++ b/extensions/browser/src/browser/cdp-reachability-policy.ts
@@ -6,7 +6,6 @@
  */
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { normalizeHostname } from "../sdk-security-runtime.js";
-import { CHROME_MCP_ENDPOINT_FLAGS } from "./chrome-mcp-contracts.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { BrowserProfileUnavailableError } from "./errors.js";
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
@@ -66,13 +65,6 @@ function requiresPinnedChromeMcpCdpTransport(
   );
 }
 
-function hasChromeMcpEndpointArg(args?: string[]): boolean {
-  return (args ?? []).some((arg) => {
-    const [name] = arg.split("=", 1);
-    return CHROME_MCP_ENDPOINT_FLAGS.has(name ?? arg);
-  });
-}
-
 export function resolveCdpReachabilityPolicy(
   profile: ResolvedBrowserProfile,
   ssrfPolicy?: SsrFPolicy,
@@ -97,8 +89,7 @@ export function assertChromeMcpCdpTransportAllowed(
   profile: ResolvedBrowserProfile,
   cdpPolicy?: SsrFPolicy,
 ): void {
-  const hasExplicitEndpoint = Boolean(profile.cdpUrl) || hasChromeMcpEndpointArg(profile.mcpArgs);
-  if (profile.driver !== "existing-session" || !hasExplicitEndpoint) {
+  if (profile.driver !== "existing-session" || !profile.cdpUrl) {
     return;
   }
   if (!requiresPinnedChromeMcpCdpTransport(cdpPolicy, profile.cdpHost)) {

--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -8,7 +8,7 @@ import {
   resolveCdpReachabilityPolicy,
 } from "./cdp-reachability-policy.js";
 import { resolveCdpReachabilityTimeouts } from "./cdp-timeouts.js";
-import type { ResolvedBrowserProfile } from "./config.js";
+import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserProfile } from "./config.js";
 import { assertBrowserNavigationAllowed } from "./navigation-guard.js";
 
 const PROFILE_HTTP_REACHABILITY_TIMEOUT_MS = 300;
@@ -675,19 +675,22 @@ describe("CDP reachability policy", () => {
 
   it.each([
     ["cdpUrl", { cdpUrl: "http://127.0.0.1:9222" }],
-    ["--browserUrl", { cdpUrl: "", mcpArgs: ["--browserUrl", "http://127.0.0.1:9222"] }],
-    ["-u", { cdpUrl: "", mcpArgs: ["-u", "http://127.0.0.1:9222"] }],
-    ["--u", { cdpUrl: "", mcpArgs: ["--u", "http://127.0.0.1:9222"] }],
-    ["--wsEndpoint", { cdpUrl: "", mcpArgs: ["--wsEndpoint=ws://127.0.0.1:9222"] }],
-    ["-w", { cdpUrl: "", mcpArgs: ["-w", "ws://127.0.0.1:9222"] }],
-    ["--w", { cdpUrl: "", mcpArgs: ["--w=ws://127.0.0.1:9222"] }],
+    ["--browserUrl", { mcpArgs: ["--browserUrl", "http://127.0.0.1:9222"] }],
+    ["-u", { mcpArgs: ["-u", "http://127.0.0.1:9222"] }],
+    ["--u", { mcpArgs: ["--u", "http://127.0.0.1:9222"] }],
+    ["--wsEndpoint", { mcpArgs: ["--wsEndpoint=ws://127.0.0.1:9222"] }],
+    ["-w", { mcpArgs: ["-w", "ws://127.0.0.1:9222"] }],
+    ["--w", { mcpArgs: ["--w=ws://127.0.0.1:9222"] }],
   ])("rejects Chrome MCP explicit %s endpoints under the default policy", (_source, endpoint) => {
-    const profile = createProfile({
-      driver: "existing-session",
-      cdpHost: "127.0.0.1",
-      cdpIsLoopback: true,
-      ...endpoint,
-    });
+    const profile = resolveProfile(
+      resolveBrowserConfig({
+        profiles: { chrome: { driver: "existing-session", ...endpoint } },
+      }),
+      "chrome",
+    );
+    if (!profile) {
+      throw new Error("Expected configured Chrome MCP profile");
+    }
 
     expect(() => assertChromeMcpCdpTransportAllowed(profile, {})).toThrow(
       /cannot carry that pinned transport/i,

--- a/extensions/browser/src/browser/chrome-mcp-connect.ts
+++ b/extensions/browser/src/browser/chrome-mcp-connect.ts
@@ -16,7 +16,7 @@ import {
   redactChromeMcpLocalPathForDiagnostic,
   redactChromeMcpProfileLabelForDiagnostic,
 } from "./chrome-mcp-diagnostics.js";
-import { buildChromeMcpArgsFromOptions, normalizeChromeMcpOptions } from "./chrome-mcp-options.js";
+import { normalizeChromeMcpOptions } from "./chrome-mcp-options.js";
 import {
   closeTrackedChromeMcpSession,
   refreshChromeMcpCleanupProcess,
@@ -51,7 +51,7 @@ async function createRealSession(
 ): Promise<ChromeMcpSession> {
   const transport = new StdioClientTransport({
     command: options.command,
-    args: buildChromeMcpArgsFromOptions(options),
+    args: options.args,
     stderr: "pipe",
   });
   const client = new Client(

--- a/extensions/browser/src/browser/chrome-mcp-contracts.ts
+++ b/extensions/browser/src/browser/chrome-mcp-contracts.ts
@@ -96,7 +96,7 @@ export type NormalizedChromeMcpProfileOptions = {
   userDataDir?: string;
   browserUrl?: string;
   command: string;
-  extraArgs: string[];
+  args: string[];
 };
 export type ChromeMcpOptionsInput =
   | string
@@ -166,31 +166,6 @@ export type ChromeMcpProcessCleanupState =
   | { status: "uncertain"; target?: ChromeMcpProcessCleanupTarget }
   | { status: "closed" };
 
-export const DEFAULT_CHROME_MCP_COMMAND = "npx";
-export const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "chrome-devtools-mcp@latest"];
-export const DEFAULT_CHROME_MCP_FEATURE_ARGS = [
-  "--no-usage-statistics",
-  // Direct chrome-devtools-mcp launches do not enable structuredContent by default.
-  "--experimentalStructuredContent",
-  "--experimental-page-id-routing",
-];
-export const CHROME_MCP_USAGE_STATISTICS_FLAG_RE = /^--(?:no-)?usage-?statistics(?:=.*)?$/i;
-export const CHROME_MCP_ENDPOINT_FLAGS = new Set([
-  "--browserUrl",
-  "--browser-url",
-  "-u",
-  "--u",
-  "--wsEndpoint",
-  "--ws-endpoint",
-  "-w",
-  "--w",
-]);
-export const CHROME_MCP_CONNECTION_FLAGS = new Set([
-  "--autoConnect",
-  "--auto-connect",
-  ...CHROME_MCP_ENDPOINT_FLAGS,
-]);
-export const CHROME_MCP_USER_DATA_DIR_FLAGS = new Set(["--userDataDir", "--user-data-dir"]);
 export const CHROME_MCP_NEW_PAGE_TIMEOUT_MS = 5_000;
 export const CHROME_MCP_NAVIGATE_TIMEOUT_MS = 20_000;
 export const CHROME_MCP_HANDSHAKE_TIMEOUT_MS = 30_000;

--- a/extensions/browser/src/browser/chrome-mcp-options.ts
+++ b/extensions/browser/src/browser/chrome-mcp-options.ts
@@ -1,16 +1,22 @@
 // Normalizes Chrome MCP profile options and subprocess arguments.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  CHROME_MCP_CONNECTION_FLAGS,
-  CHROME_MCP_USAGE_STATISTICS_FLAG_RE,
-  CHROME_MCP_USER_DATA_DIR_FLAGS,
-  DEFAULT_CHROME_MCP_COMMAND,
-  DEFAULT_CHROME_MCP_FEATURE_ARGS,
-  DEFAULT_CHROME_MCP_PACKAGE_ARGS,
-  type ChromeMcpOptionsInput,
-  type ChromeMcpProfileOptions,
-  type NormalizedChromeMcpProfileOptions,
+import parseArgs from "yargs-parser";
+import type {
+  ChromeMcpOptionsInput,
+  ChromeMcpProfileOptions,
+  NormalizedChromeMcpProfileOptions,
 } from "./chrome-mcp-contracts.js";
+import { BrowserProfileUnavailableError } from "./errors.js";
+
+const DEFAULT_CHROME_MCP_COMMAND = "npx";
+const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "chrome-devtools-mcp@latest"];
+const DEFAULT_CHROME_MCP_FEATURE_ARGS = [
+  "--no-usage-statistics",
+  // Direct chrome-devtools-mcp launches do not enable structuredContent by default.
+  "--experimentalStructuredContent",
+  "--experimental-page-id-routing",
+];
+const CHROME_MCP_USAGE_STATISTICS_FLAG_RE = /^--(?:no-)?usage-?statistics(?:=.*)?$/i;
 
 function normalizeChromeMcpStringList(values?: string[]): string[] {
   return Array.isArray(values)
@@ -23,52 +29,68 @@ function normalizeChromeMcpStringList(values?: string[]): string[] {
 export function normalizeChromeMcpOptions(
   input?: ChromeMcpOptionsInput,
 ): NormalizedChromeMcpProfileOptions {
-  if (typeof input === "object" && input && "command" in input && "extraArgs" in input) {
+  if (typeof input === "object" && input && "command" in input && "args" in input) {
     return input;
   }
   const options = typeof input === "string" ? { userDataDir: input } : (input ?? {});
   const command = normalizeOptionalString(options.mcpCommand) ?? DEFAULT_CHROME_MCP_COMMAND;
+  const extraArgs = normalizeChromeMcpStringList(options.mcpArgs);
+  // Match Chrome MCP's Yargs grammar, including short groups and camel-case
+  // aliases. Policy and direct CDP operations must use the endpoint it launches.
+  const { argv, error } = parseArgs.detailed(extraArgs, {
+    alias: { browserUrl: "u", wsEndpoint: "w" },
+    string: ["browserUrl", "wsEndpoint", "userDataDir"],
+    boolean: ["autoConnect"],
+    configuration: { "strip-aliased": true, "strip-dashed": true },
+  });
+  const endpoint: unknown = argv.wsEndpoint ?? argv.browserUrl;
+  if (
+    error ||
+    (argv.browserUrl !== undefined && argv.wsEndpoint !== undefined) ||
+    (endpoint !== undefined && (typeof endpoint !== "string" || !URL.canParse(endpoint))) ||
+    (argv.autoConnect !== undefined && typeof argv.autoConnect !== "boolean")
+  ) {
+    throw new BrowserProfileUnavailableError(
+      "Chrome MCP endpoint arguments must select one valid browserUrl or wsEndpoint URL. Remove duplicate, conflicting, or empty endpoint arguments from mcpArgs.",
+    );
+  }
+  if (
+    typeof endpoint === "string" &&
+    !(argv.wsEndpoint !== undefined ? /^wss?:$/ : /^https?:$/).test(new URL(endpoint).protocol)
+  ) {
+    throw new BrowserProfileUnavailableError(
+      "Chrome MCP endpoint arguments require http(s) for browserUrl or ws(s) for wsEndpoint.",
+    );
+  }
+  const overridesConnection = endpoint !== undefined || argv.autoConnect !== undefined;
+  const browserUrl = overridesConnection
+    ? typeof endpoint === "string"
+      ? endpoint
+      : undefined
+    : normalizeOptionalString(options.cdpUrl);
+  const userDataDir = normalizeOptionalString(options.userDataDir);
+  const connectionArgs = overridesConnection
+    ? []
+    : browserUrl
+      ? [/^wss?:\/\//i.test(browserUrl) ? "--wsEndpoint" : "--browserUrl", browserUrl]
+      : ["--autoConnect"];
+  const defaultFeatureArgs = extraArgs.some((arg) => CHROME_MCP_USAGE_STATISTICS_FLAG_RE.test(arg))
+    ? DEFAULT_CHROME_MCP_FEATURE_ARGS.filter((arg) => arg !== "--no-usage-statistics")
+    : DEFAULT_CHROME_MCP_FEATURE_ARGS;
   return {
     command,
-    userDataDir: normalizeOptionalString(options.userDataDir),
-    browserUrl: normalizeOptionalString(options.cdpUrl),
-    extraArgs: normalizeChromeMcpStringList(options.mcpArgs),
+    userDataDir,
+    browserUrl,
+    args: [
+      ...(command === DEFAULT_CHROME_MCP_COMMAND ? DEFAULT_CHROME_MCP_PACKAGE_ARGS : []),
+      ...connectionArgs,
+      ...defaultFeatureArgs,
+      ...(!overridesConnection && !browserUrl && userDataDir && argv.userDataDir === undefined
+        ? ["--userDataDir", userDataDir]
+        : []),
+      ...extraArgs,
+    ],
   };
-}
-
-function hasFlag(args: string[], flags: Set<string>): boolean {
-  return args.some((arg) => {
-    const [name] = arg.split("=", 1);
-    return flags.has(name ?? arg);
-  });
-}
-
-function isChromeMcpWebSocketEndpoint(url: string): boolean {
-  return /^wss?:\/\//i.test(url);
-}
-
-function buildChromeMcpConnectionArgs(options: NormalizedChromeMcpProfileOptions): string[] {
-  if (hasFlag(options.extraArgs, CHROME_MCP_CONNECTION_FLAGS)) {
-    return [];
-  }
-  if (options.browserUrl) {
-    return isChromeMcpWebSocketEndpoint(options.browserUrl)
-      ? ["--wsEndpoint", options.browserUrl]
-      : ["--browserUrl", options.browserUrl];
-  }
-  return ["--autoConnect"];
-}
-
-function buildChromeMcpUserDataDirArgs(options: NormalizedChromeMcpProfileOptions): string[] {
-  if (
-    !options.userDataDir ||
-    options.browserUrl ||
-    hasFlag(options.extraArgs, CHROME_MCP_CONNECTION_FLAGS) ||
-    hasFlag(options.extraArgs, CHROME_MCP_USER_DATA_DIR_FLAGS)
-  ) {
-    return [];
-  }
-  return ["--userDataDir", options.userDataDir];
 }
 
 export function buildChromeMcpSessionCacheKey(
@@ -80,7 +102,7 @@ export function buildChromeMcpSessionCacheKey(
     options.userDataDir ?? "",
     options.browserUrl ?? "",
     options.command,
-    options.extraArgs,
+    options.args,
   ]);
 }
 
@@ -98,23 +120,4 @@ export function cacheKeyMatchesProfileName(cacheKey: string, profileName: string
   } catch {
     return false;
   }
-}
-
-export function buildChromeMcpArgsFromOptions(
-  options: NormalizedChromeMcpProfileOptions,
-): string[] {
-  const commandPrefix =
-    options.command === DEFAULT_CHROME_MCP_COMMAND ? DEFAULT_CHROME_MCP_PACKAGE_ARGS : [];
-  const defaultFeatureArgs = options.extraArgs.some((arg) =>
-    CHROME_MCP_USAGE_STATISTICS_FLAG_RE.test(arg),
-  )
-    ? DEFAULT_CHROME_MCP_FEATURE_ARGS.filter((arg) => arg !== "--no-usage-statistics")
-    : DEFAULT_CHROME_MCP_FEATURE_ARGS;
-  return [
-    ...commandPrefix,
-    ...buildChromeMcpConnectionArgs(options),
-    ...defaultFeatureArgs,
-    ...buildChromeMcpUserDataDirArgs(options),
-    ...options.extraArgs,
-  ];
 }

--- a/extensions/browser/src/browser/chrome-mcp.ownership.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ownership.test.ts
@@ -395,47 +395,69 @@ describe("Chrome MCP durable tab ownership", () => {
     );
   });
 
-  it("closes a failed first-page marker through its captured native target", async () => {
-    const navigateError = new Error("navigation failed");
-    const { session, pages } = createMarkerSession({ existingPage: false, navigateError });
-    setChromeMcpSessionFactoryForTest(async () => session as never);
-    fetchJsonMock.mockImplementation(async (url: string) => {
-      if (url.includes("/json/list")) {
-        return pages.map((page) => ({
-          id: page.nativeTargetId,
-          url: page.url,
-          type: "page",
-        }));
-      }
-      return {
-        webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/BROWSER-ONE",
-      };
-    });
-    fetchOkMock.mockImplementationOnce(async (url: string) => {
-      const nativeTargetId = decodeURIComponent(url.split("/").at(-1) ?? "");
-      const index = pages.findIndex((page) => page.nativeTargetId === nativeTargetId);
-      if (index >= 0) {
-        pages.splice(index, 1);
-      }
-    });
+  it.each([
+    { label: "cdpUrl", profile: { cdpUrl: "http://127.0.0.1:9222" } },
+    { label: "mcpArgs only", profile: { mcpArgs: ["--browserUrl", "http://127.0.0.1:9222"] } },
+    {
+      label: "HTTP mcpArgs override",
+      profile: {
+        cdpUrl: "http://127.0.0.1:9333",
+        mcpArgs: ["--browserUrl", "http://127.0.0.1:9222"],
+      },
+    },
+    {
+      label: "WebSocket mcpArgs override",
+      profile: {
+        cdpUrl: "http://127.0.0.1:9333",
+        mcpArgs: ["--wsEndpoint", "ws://127.0.0.1:9222/devtools/browser/BROWSER-ONE"],
+      },
+    },
+  ])(
+    "closes a failed first-page marker through its captured native target using $label",
+    async ({ profile }) => {
+      const navigateError = new Error("navigation failed");
+      const { session, pages } = createMarkerSession({ existingPage: false, navigateError });
+      setChromeMcpSessionFactoryForTest(async () => session as never);
+      fetchJsonMock.mockImplementation(async (url: string) => {
+        if (url.includes("/json/list")) {
+          return pages.map((page) => ({
+            id: page.nativeTargetId,
+            url: page.url,
+            type: "page",
+          }));
+        }
+        return {
+          webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/BROWSER-ONE",
+        };
+      });
+      fetchOkMock.mockImplementationOnce(async (url: string) => {
+        const nativeTargetId = decodeURIComponent(url.split("/").at(-1) ?? "");
+        const index = pages.findIndex((page) => page.nativeTargetId === nativeTargetId);
+        if (index >= 0) {
+          pages.splice(index, 1);
+        }
+      });
 
-    await expect(
-      openChromeMcpTab("chrome-live", "https://example.com", {
-        cdpUrl: "http://127.0.0.1:9222",
-      }),
-    ).rejects.toBe(navigateError);
-    expect(pages).toEqual([]);
-    expect(fetchOkMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:9222/json/close/NATIVE-1",
-      undefined,
-      undefined,
-      undefined,
-    );
-    const calls = (session.client.callTool as ReturnType<typeof vi.fn>).mock.calls as Array<
-      [ToolCall, ...unknown[]]
-    >;
-    expect(calls.map(([call]) => call.name)).not.toContain("close_page");
-  });
+      await expect(openChromeMcpTab("chrome-live", "https://example.com", profile)).rejects.toBe(
+        navigateError,
+      );
+      expect(pages).toEqual([]);
+      expect(fetchJsonMock.mock.calls.map(([url]) => url)).toEqual([
+        "http://127.0.0.1:9222/json/list",
+        "http://127.0.0.1:9222/json/version",
+      ]);
+      expect(fetchOkMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:9222/json/close/NATIVE-1",
+        undefined,
+        undefined,
+        undefined,
+      );
+      const calls = (session.client.callTool as ReturnType<typeof vi.fn>).mock.calls as Array<
+        [ToolCall, ...unknown[]]
+      >;
+      expect(calls.map(([call]) => call.name)).not.toContain("close_page");
+    },
+  );
 
   it("classifies marker lookup network failures separately from ambiguous matches", async () => {
     const { session } = createMarkerSession();

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -6,7 +6,7 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildChromeMcpArgsFromOptions, normalizeChromeMcpOptions } from "./chrome-mcp-options.js";
+import { normalizeChromeMcpOptions } from "./chrome-mcp-options.js";
 import {
   ChromeMcpDocumentUnavailableError,
   clickChromeMcpCoords,
@@ -245,9 +245,7 @@ describe("chrome MCP page parsing", () => {
   });
 
   it("passes HTTP CDP endpoints to Chrome MCP as browserUrl discovery endpoints", () => {
-    const args = buildChromeMcpArgsFromOptions(
-      normalizeChromeMcpOptions({ cdpUrl: "http://127.0.0.1:9222" }),
-    );
+    const { args } = normalizeChromeMcpOptions({ cdpUrl: "http://127.0.0.1:9222" });
 
     expect(args).toContain("--browserUrl");
     expect(args).toContain("http://127.0.0.1:9222");
@@ -255,13 +253,94 @@ describe("chrome MCP page parsing", () => {
   });
 
   it("passes direct WebSocket CDP endpoints to Chrome MCP as wsEndpoint attachments", () => {
-    const args = buildChromeMcpArgsFromOptions(
-      normalizeChromeMcpOptions({ cdpUrl: "ws://127.0.0.1:9222/devtools/browser/abc" }),
-    );
+    const { args } = normalizeChromeMcpOptions({
+      cdpUrl: "ws://127.0.0.1:9222/devtools/browser/abc",
+    });
 
     expect(args).toContain("--wsEndpoint");
     expect(args).toContain("ws://127.0.0.1:9222/devtools/browser/abc");
     expect(args).not.toContain("--browserUrl");
+  });
+
+  const credentialEndpointUrl = new URL("https://browser.example/?token=fixture-token");
+  credentialEndpointUrl.username = "fixture-user";
+  credentialEndpointUrl.password = "fixture-password";
+  const credentialEndpoint = credentialEndpointUrl.href;
+  it.each([
+    { label: "missing", mcpArgs: ["--browserUrl"] },
+    {
+      label: "invalid",
+      mcpArgs: [
+        "--browserUrl",
+        credentialEndpoint.replace("browser.example", "browser.example:bad"),
+      ],
+    },
+    {
+      label: "duplicate",
+      mcpArgs: ["--browserUrl", "https://browser.example/", "-u", credentialEndpoint],
+    },
+    {
+      label: "conflicting",
+      mcpArgs: [
+        "--browserUrl",
+        credentialEndpoint,
+        "--wsEndpoint",
+        "ws://browser.example/devtools/browser/one",
+      ],
+    },
+    { label: "wrong protocol", mcpArgs: ["--wsEndpoint", credentialEndpoint] },
+    { label: "object-shaped", mcpArgs: ["--browserUrl.host", credentialEndpoint] },
+  ])(
+    "rejects $label endpoint arguments before creating a session without echoing secrets",
+    async ({ mcpArgs }) => {
+      const factory = vi.fn(async () => createFakeSession());
+      setChromeMcpSessionFactoryForTest(factory);
+
+      const attempt = ensureChromeMcpAvailable("chrome-live", { mcpArgs });
+
+      await expect(attempt).rejects.toThrow(/endpoint arguments/);
+      await expect(attempt).rejects.not.toThrow(/fixture-user|fixture-password|fixture-token/);
+      expect(factory).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps endpoint-looking arguments after -- positional", () => {
+    const cdpUrl = "https://configured.example";
+    const positionalArgs = ["--browserUrl", "https://positional.example"];
+    const { args, browserUrl } = normalizeChromeMcpOptions({
+      cdpUrl,
+      mcpArgs: ["--", ...positionalArgs],
+    });
+
+    expect(browserUrl).toBe(cdpUrl);
+    expect(args.slice(0, args.indexOf("--"))).toContain(cdpUrl);
+    expect(args.slice(args.indexOf("--") + 1)).toEqual(positionalArgs);
+  });
+
+  it.each([["--autoConnect=false"], ["--auto-connect", "false"], ["--no-auto-connect"]])(
+    "does not substitute cdpUrl for the explicit local connection choice %s",
+    (...mcpArgs) => {
+      const cdpUrl = "https://configured.example";
+      const { args, browserUrl } = normalizeChromeMcpOptions({ cdpUrl, mcpArgs });
+
+      expect(browserUrl).toBeUndefined();
+      expect(args).not.toContain(cdpUrl);
+      expect(args.slice(-mcpArgs.length)).toEqual(mcpArgs);
+    },
+  );
+
+  it("preserves unrelated custom command arguments verbatim", () => {
+    const mcpArgs = [
+      "--headless=false",
+      "--user-data-dir",
+      "/tmp/chrome profile",
+      "--chrome-arg=--disable-features=One,Two",
+    ];
+    const options = normalizeChromeMcpOptions({ mcpCommand: "custom-chrome-mcp", mcpArgs });
+
+    expect(options.command).toBe("custom-chrome-mcp");
+    expect(options.args.slice(-mcpArgs.length)).toEqual(mcpArgs);
+    expect(options.args).not.toContain("chrome-devtools-mcp@latest");
   });
 
   it("keeps document-bound evaluations on one pinned target and raw snapshot uid", async () => {

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -26,6 +26,7 @@ import {
   deriveDefaultBrowserCdpPortRange,
   deriveDefaultBrowserControlPort,
 } from "../config/port-defaults.js";
+import { normalizeChromeMcpOptions } from "./chrome-mcp-options.js";
 import {
   DEFAULT_AI_SNAPSHOT_MAX_CHARS,
   DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
@@ -543,7 +544,11 @@ export function resolveProfile(
   }
 
   if (driver === "existing-session") {
-    const existingSessionCdp = normalizeExistingSessionCdpUrl(rawProfileUrl, profileName);
+    const mcpArgs = normalizeStringList(profile.mcpArgs) ?? undefined;
+    const existingSessionCdp = normalizeExistingSessionCdpUrl(
+      normalizeChromeMcpOptions({ ...profile, mcpArgs }).browserUrl,
+      profileName,
+    );
     return {
       name: profileName,
       cdpPort: 0,
@@ -552,7 +557,7 @@ export function resolveProfile(
       cdpIsLoopback: existingSessionCdp?.cdpIsLoopback ?? true,
       userDataDir: resolveUserPath(profile.userDataDir?.trim() || "") || undefined,
       mcpCommand: normalizeOptionalString(profile.mcpCommand),
-      mcpArgs: normalizeStringList(profile.mcpArgs) ?? undefined,
+      mcpArgs,
       color: DEFAULT_OPENCLAW_BROWSER_COLOR,
       driver,
       executablePath,

--- a/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
@@ -102,10 +102,8 @@ function rawDataText(data: RawData): string {
 async function openExtensionSocket(
   handle: ExtensionRelayHandle,
   protocols: string | string[],
-  localAddress?: string,
 ): Promise<WebSocket> {
   const ws = new WebSocket(`ws://127.0.0.1:${handle.port}/extension`, protocols, {
-    localAddress,
     origin: "chrome-extension://relay-auth-v2-test",
   });
   ws.on("error", () => {});
@@ -113,11 +111,8 @@ async function openExtensionSocket(
   return ws;
 }
 
-async function authenticateV2Extension(
-  handle: ExtensionRelayHandle,
-  localAddress?: string,
-): Promise<WebSocket> {
-  const ws = await openExtensionSocket(handle, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, localAddress);
+async function authenticateV2Extension(handle: ExtensionRelayHandle): Promise<WebSocket> {
+  const ws = await openExtensionSocket(handle, BROWSER_RELAY_EXTENSION_SUBPROTOCOL);
   const challengeMessage = once(ws, "message");
   ws.send(
     JSON.stringify({
@@ -655,7 +650,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
     }
   });
 
-  it("collapses loopback aliases into one relay authentication source", async () => {
+  it("keeps an active extension at the pending source limit and recovers after release", async () => {
     handle = await startExtensionRelayServer({ port: 0, token: KEY, allowLegacyAuth: true });
     const active = await openExtensionSocket(handle, [
       "openclaw-extension-relay",
@@ -672,9 +667,11 @@ describe.sequential("extension relay HTTP auth v2", () => {
     );
     await vi.waitFor(() => expect(handle?.bridge.extensionConnected).toBe(true));
 
+    // Alias equivalence is covered at the authority boundary in auth-v2.test.ts.
+    // Real sockets use the configured loopback address on every platform.
     const attacker = await Promise.all(
       Array.from({ length: 32 }, () =>
-        openExtensionSocket(handle!, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, "127.0.0.2"),
+        openExtensionSocket(handle!, BROWSER_RELAY_EXTENSION_SUBPROTOCOL),
       ),
     );
     expect(active.readyState).toBe(WebSocket.OPEN);
@@ -683,7 +680,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
     const overflow = new WebSocket(
       `ws://127.0.0.1:${handle.port}/extension`,
       BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
-      { localAddress: "127.0.0.3", origin: "chrome-extension://relay-auth-v2-test" },
+      { origin: "chrome-extension://relay-auth-v2-test" },
     );
     overflow.on("error", () => {});
     const overflowClosed = once(overflow, "close");
@@ -696,7 +693,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
     const released = once(attacker[0]!, "close");
     attacker[0]!.close();
     await released;
-    const promoted = await authenticateV2Extension(handle, "127.0.0.3");
+    const promoted = await authenticateV2Extension(handle);
     promoted.send(
       JSON.stringify({
         type: "hello",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       ws:
         specifier: 8.21.3
         version: 8.21.3
+      yargs-parser:
+        specifier: 22.0.0
+        version: 22.0.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -691,6 +694,9 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
+      '@types/yargs-parser':
+        specifier: 21.0.3
+        version: 21.0.3
       undici:
         specifier: 8.10.0
         version: 8.10.0
@@ -5467,6 +5473,9 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
     engines: {node: '>=16.20.0'}
@@ -9579,6 +9588,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
@@ -12730,6 +12743,8 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.2.0
+
+  '@types/yargs-parser@21.0.3': {}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
     optional: true
@@ -17148,6 +17163,8 @@ snapshots:
       decamelize: 1.2.0
 
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs@15.4.1:
     dependencies:


### PR DESCRIPTION
Closes #135845. Follow-up to the endpoint-selection finding in #135097.

## What Problem This Solves

Fixes an issue where operators using Chrome MCP endpoint arguments could attach to a hostname denied by Browser policy, or have a trusted override incorrectly rejected, because policy still used `cdpUrl`. Tab ownership and failed-open cleanup could also address the stale endpoint.

## Why This Change Was Made

The Browser plugin now prepares the effective connection and subprocess arguments together using the same argument parser as Chrome MCP. Resolved profiles, CDP policy, session identity, and native-tab control consume that endpoint; the duplicate hand-written flag scanners and argument builder are removed.

## User Impact

Hostname denials apply to the selected HTTP or WebSocket endpoint before Chrome MCP starts. Trusted overrides, unrelated hostname denials, and host-local attachment retain their intended behavior. Empty, duplicate, conflicting, and invalid endpoint arguments produce actionable errors without echoing credential-bearing URLs. No new config keys, database changes, protocol changes, or public SDK options.

## Evidence

- Before the repair, 41 focused endpoint-policy regressions failed. The real MCP stdio/Puppeteer probe reached a local HTTP sentinel and WebSocket sentinel through denied argument endpoints, while the direct blocked `cdpUrl` control made no connection.
- After the repair, all eight sentinel cases passed: four denied cases launched zero subprocesses and made zero TCP/HTTP/WebSocket attempts; four allowed controls still reached the sentinel through the actual `chrome-devtools-mcp@1.8.0` package.
- Successful live flow with isolated Chrome 152.0.7977.75: trusted argument override of a denied/stale `cdpUrl` attached, listed tabs, opened and navigated to a local HTML fixture, read its exact DOM through MCP, recorded durable ownership, and closed the owned tab. Tab count returned from 1 to 2 to 1. Denying that same endpoint then produced zero new subprocess or network activity. Fresh temporary profile, loopback-only outbound fence, and complete process cleanup; no operator browser or Gateway state used.
- Direct dependency-contract probe: 86 argument cases, 72 accepted by upstream Chrome MCP, zero effective-endpoint projection mismatches. The plugin declares `yargs-parser@22.0.0`, matching Chrome MCP 1.8.0, with its development types.
- Full Browser suite: **224 files and 3,718 tests passed; 6 files and 29 existing tests skipped**. Both relay authority/network files passed together (47 tests); all original alias assertions remain.
- `pnpm build`, repository-wide typechecks/lint/import-cycle checks through `check:changed`, and docs formatting/MDX validation passed. Focused policy, MCP, profile, ownership/rollback, server, and relay suites passed.
- Final changed-fixture checks passed. The final scoped Codex autoreview reported no findings at its requested P0-only threshold; source, dependency-contract, and sibling-path review also covered the owner boundary.
- CI's initial URI scan flagged the deliberately fake credential-bearing test URL because `browser.example` does not resolve. The fixture now uses the existing sibling test's URL-construction pattern while preserving the same runtime URL and every no-echo assertion; no scanner suppression or allowlist was added. Local TruffleHog 3.97.1 changed from exit 183 to exit 0, all 103 MCP tests passed, and the final fixture checks/review passed. The PR commit was replaced so the literal is not retained in the scanned PR history.
- Production TypeScript: +81/-107, net -26. The only nearby cleanup is a portable relay network fixture: all quota/recovery assertions remain, while existing authority tests retain the 127/8, mapped IPv4, and IPv6 alias contract. No new mocks, skipped assertions, or timeout increases.

The final broad run passed without competing build/typecheck/review work. The first broad cold run hit a 60-second control-server fixture warm-up timeout and a secondary CRUD teardown-state failure; the unchanged file passed all 34 tests on focused rerun. The hook does not cancel its underlying async warm-up on timeout, so late singleton cleanup is a follow-up to investigate if it recurs. This repair does not change that runtime lifecycle or claim an established timing cause.

## Review follow-up

Addressed both Rank-up moves from the **06:11 UTC ClawSweeper review cycle on 5020996**, retained in the [durable review comment](https://github.com/openclaw/openclaw/pull/135857#issuecomment-5505314936):

- [8037dec50d7](https://github.com/openclaw/openclaw/commit/8037dec50d7579b865c6ca09d833cf1006231b25) corrects the general Browser profile reference and gateway configuration reference: valid endpoint arguments in `mcpArgs` override `cdpUrl`; `cdpPort` remains ignored for existing-session profiles. Both point to the detailed custom-MCP documentation. This follow-up changes documentation only. Codex autoreview through P2 found no actionable findings; formatting passed for 739 docs, both changed pages passed MDX validation, and all 7,231 internal links passed.
- Dependency-boundary confirmation under the existing Browser security-owner direction: the acting agent directly inspected the published Chrome MCP 1.8.0 package, its parser and connection owner, and the original native proof artifacts. This is not a claim that the human maintainer personally executed the probes. The review environment's missing package/DNS access does not replace or invalidate that retained evidence.

The exact upstream source is the [Chrome MCP 1.8.0 registry tarball](https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.8.0.tgz), published from [45f187b1e3202c9f32ddba913be5d68751c3caa3](https://github.com/ChromeDevTools/chrome-devtools-mcp/commit/45f187b1e3202c9f32ddba913be5d68751c3caa3). The inspected/executed parser, connection owner and entrypoint were compared byte-for-byte with that tarball. Its SHA-512 integrity is:

```text
sha512-Wrm9z0/5WbVs778apjWgYRkpe9bvYQWjK2zVRwqoPAtz1IHQ5+GvotM07UGXJcfrA0rj6Gt1Pnn5+w/Tf1nU4w==
```

Inspected package locations: `build/src/config/mcp-options.js:20-60` defines endpoint types, aliases and conflicts; `:373-405` constructs Yargs with `strip-aliased` and `strip-dashed`; `build/src/index.js:99-112` passes the parsed endpoint into connection setup; `build/src/browser.js:49-58` prefers the explicit WS/HTTP endpoint before host-local attachment. The upstream lockfile resolves `yargs-parser` to 22.0.0, matching this plugin's declared dependency.

The retained direct-parser probe compares endpoint projections only when upstream accepts the arguments: **86 total cases, 72 accepted, 14 rejected, zero accepted-case projection mismatches**. It does not claim identical acceptance of malformed inputs. Coverage includes long/camel/kebab spellings, short aliases/groups, `=` forms, negation, repeated/conflicting arguments, quoted values, `--`, unrelated arguments and explicit auto-connect. The report SHA-256 is `06efeb79e4f853c7aeb9b816f37646668aaaf27522185058978c233cb5b5f6d6`.

The original native MCP sentinel and Chrome-flow results above were rechecked, not rerun for this docs-only follow-up. The denied cases still record zero subprocess/TCP/HTTP/WS attempts; the allowed Chrome flow records DOM readback and tab ownership/cleanup. The Chrome report SHA-256 is `f5ce5b366446e4f7cd72f4257564d6b0b493826ab7f8231b4a28280d976322dd`. Browser runtime and dependency bytes are unchanged from the previously live-tested head. Future upstream Chrome MCP releases remain outside this proof's version scope.

## Landing and late review

Merged through the native prepare/merge workflow as [81be1909b8d2](https://github.com/openclaw/openclaw/commit/81be1909b8d27356818d6e4247d14f23ba6de20d), from exact prepared head 8037dec50d7579b865c6ca09d833cf1006231b25. [Final CI](https://github.com/openclaw/openclaw/actions/runs/33598530896) passed 206 jobs with 15 skips, including both Windows suites and the required gate. A fresh complete final-head Codex review was scoped-clean at P0; the docs correction also passed through P2. The landed tree equals the independently computed merge of the prepared source into its actual main parent. #135845 is closed.

During final native admission, the durable ClawSweeper comment was refreshed with a **late finding**, reviewed at 06:35 UTC and published at 06:36 UTC: the default `chrome-devtools-mcp@latest` executable can evolve independently of the locally modeled parser. The earlier docs/contract-evidence findings were addressed; this newly raised future-version concern was not dispositioned before the merge completed. It is recorded here rather than treated as resolved by the current-version tests.

Named follow-up: **Manage the default Chrome MCP version alongside the endpoint-parser contract.** Pinning the default to the verified 1.8.0 package is the proposed strategy; that default/version-management decision is pending. No additional runtime bypass in Chrome MCP 1.8.0 has been demonstrated. The exact-version source, parser and native Chrome proofs above remain valid, but they do not guarantee future `@latest` behavior. This merge does not change that existing floating default or silently accept its future-contract risk.
