### PR TITLE
refactor(scripts): share report CLI parse options

### DIFF
--- a/scripts/dependency-changes-report.mts
+++ b/scripts/dependency-changes-report.mts
@@ -6,7 +6,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
-import { writeReportArtifact } from "./lib/report-cli-helpers.mts";
+import { REPORT_CLI_PARSE_OPTIONS, writeReportArtifact } from "./lib/report-cli-helpers.mts";
 import {
   collectAllResolvedPackagesFromLockfile,
   createBulkAdvisoryPayload,
@@ -280,12 +280,7 @@ export function parseArgs(argv: string[]) {
         rejectShortOptions: true,
       }),
     ),
-    {
-      duplicateOptionMessage: (flag) => `${flag} was provided more than once.`,
-      onUnhandledArg(arg) {
-        throw new Error(`Unsupported argument: ${arg}`);
-      },
-    },
+    REPORT_CLI_PARSE_OPTIONS,
   );
   const { baseRef, baseLockfile } = options;
   if (baseRef && baseLockfile) {

--- a/scripts/generate-dependency-release-evidence.mts
+++ b/scripts/generate-dependency-release-evidence.mts
@@ -12,6 +12,7 @@ import {
   RELEASE_DEPENDENCY_RISK_LOCKFILES,
   resolveReleaseDependencyRiskAcceptance,
 } from "./lib/release-dependency-risk-acceptance.mts";
+import { REPORT_CLI_PARSE_OPTIONS } from "./lib/report-cli-helpers.mts";
 
 /**
  * Dependency evidence reports generated for release artifacts.
@@ -570,12 +571,7 @@ export function parseArgs(argv: string[]): EvidenceCliOptions {
         rejectShortOptions: true,
       }),
     ),
-    {
-      duplicateOptionMessage: (flag) => `${flag} was provided more than once.`,
-      onUnhandledArg(arg) {
-        throw new Error(`Unsupported argument: ${arg}`);
-      },
-    },
+    REPORT_CLI_PARSE_OPTIONS,
   );
   return helpIndex === -1 ? parsed : { ...parsed, help: true };
 }

--- a/scripts/lib/report-cli-helpers.mts
+++ b/scripts/lib/report-cli-helpers.mts
@@ -5,6 +5,13 @@ import { parseFlagArgs, stringFlag } from "./arg-utils.mts";
 
 type ReportCliArgs = { jsonPath: string | null; markdownPath: string | null; rootDir: string };
 
+export const REPORT_CLI_PARSE_OPTIONS = {
+  duplicateOptionMessage: (flag: string) => `${flag} was provided more than once.`,
+  onUnhandledArg(arg: string) {
+    throw new Error(`Unsupported argument: ${arg}`);
+  },
+};
+
 export function parseReportCliArgs(argv: string[]) {
   const options: ReportCliArgs = {
     rootDir: process.cwd(),
@@ -23,12 +30,7 @@ export function parseReportCliArgs(argv: string[]) {
       rejectShortOptions: true,
     }),
   );
-  return parseFlagArgs(argv, options, flagSpecs, {
-    duplicateOptionMessage: (flag: string) => `${flag} was provided more than once.`,
-    onUnhandledArg(arg: string) {
-      throw new Error(`Unsupported argument: ${arg}`);
-    },
-  });
+  return parseFlagArgs(argv, options, flagSpecs, REPORT_CLI_PARSE_OPTIONS);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Report-oriented scripts repeated the same duplicate-option and unsupported-argument policy at each `parseFlagArgs` call. Keeping byte-identical copies in separate release tooling paths made their CLI diagnostics easier to drift.

## Why This Change Was Made

`scripts/lib/report-cli-helpers.mts` now owns the internal `REPORT_CLI_PARSE_OPTIONS` constant, and the dependency changes and dependency release evidence CLIs reuse it directly.

The consolidation deliberately excludes `scripts/verify-pr-hosted-gates.mts`, whose double-dash handling, error wording, and trust-anchor closure differ, and `scripts/dependency-ownership-surface-report.mts`, whose optional `--json` grammar differs. It does not change `parseFlagArgs` defaults, release trust closures, help slicing, missing-value handling, conflict validation, or throw timing.

The branch was manually replayed onto current `main` after #136681 merged. Its trusted-tooling changes remain intact; no old PR commit was rebased or cherry-picked.

## User Impact

No user-visible behavior changes. Existing report CLI error messages and parsing behavior remain byte-equivalent while their shared policy has one owner.

Tooling LOC: `+12/-19`, net `-7`. Tests, generated files, snapshots, and lockfiles: unchanged.

## Evidence

Published head: `05407a7fd5dd93c74b52f53b11a9399a82632c0c`

- `node scripts/run-vitest.mjs test/scripts/report-cli-helpers.test.ts test/scripts/dependency-changes-report.test.ts test/scripts/generate-dependency-release-evidence.test.ts`
  - Passed: 3 files, 25 tests.
- `pnpm lint:scripts`
  - Passed.
- `pnpm check:import-cycles`
  - Passed: 0 runtime value cycles.
- `pnpm check:script-erasability`
  - Passed: 571 TypeScript implementation files checked.
- `node scripts/check-changed.mjs --dry-run -- scripts/lib/report-cli-helpers.mts scripts/dependency-changes-report.mts scripts/generate-dependency-release-evidence.mts`
  - Selected the scripts/tooling lane and exact three files.
- `node_modules/.bin/oxfmt --check scripts/lib/report-cli-helpers.mts scripts/dependency-changes-report.mts scripts/generate-dependency-release-evidence.mts`
  - Passed.
- `git diff HEAD^ --check`
  - Passed.
- Commit signature verified as valid.
- Exact commit autoreview passed at 0.99 with no accepted/actionable findings.
- Independent frozen-head review passed at 0.99 with 25/25 independent tests.
- Codex hard gate inspected:
  - `../codex/codex-rs/cli/src/main.rs:220-245`
  - `../codex/codex-rs/cli/src/main.rs:2840-2870`
  - These CLI dispatch, prompt normalization, completion, and test boundaries are unrelated.

- Exact-head CI run 33693254461 passed: https://github.com/openclaw/openclaw/actions/runs/33693254461
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 135859` completed in `hosted_exact_or_recent_parent` mode, reusing the exact-head hosted gate without creating a separate Testbox lease.
- Fresh ClawSweeper review completed on the exact head with no actionable correctness or security finding.
- Native squash merge landed as `94edd0f0d5fc0f124c21a2a6f7b4e4f25c847489`; GitHub reports its signature present and verified.
