### PR TITLE
[BACKPORT] fix(cron): create jobs with configured Codex app-server auth

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -31,7 +31,10 @@ import {
 } from "./dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import { createCodexTestHostCapabilities } from "./host-capability.test-support.js";
-import { flattenCodexDynamicToolFunctions } from "./protocol.js";
+import {
+  CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
+  flattenCodexDynamicToolFunctions,
+} from "./protocol.js";
 import { createCodexTestModel } from "./test-support.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -1824,11 +1827,26 @@ describe("Codex app-server dynamic tool build", () => {
 
     expect(nativeToolSurfaceEnabled).toBe(false);
     expect(tools.map((tool) => tool.name)).toEqual(["exec", "process", "message", "node_exec"]);
+    expect(
+      tools
+        .filter((tool) => ["exec", "process", "node_exec"].includes(tool.name))
+        .map((tool) => tool.catalogMode),
+    ).toEqual(["direct-only", "direct-only", "direct-only"]);
 
     const bridge = createCodexDynamicToolBridge({
       tools,
       signal: new AbortController().signal,
       loading: "direct",
+    });
+    expect(bridge.specs).toContainEqual({
+      type: "namespace",
+      name: CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
+      description: "",
+      tools: expect.arrayContaining([
+        expect.objectContaining({ name: "exec" }),
+        expect.objectContaining({ name: "process" }),
+        expect.objectContaining({ name: "node_exec" }),
+      ]),
     });
     await bridge.handleToolCall({
       threadId: "restricted-thread",
@@ -1880,6 +1898,11 @@ describe("Codex app-server dynamic tool build", () => {
     });
 
     expect(tools.map((tool) => tool.name)).toEqual(["message", "sandbox_exec", "sandbox_process"]);
+    expect(tools.map((tool) => tool.catalogMode)).toEqual([
+      undefined,
+      "direct-only",
+      "direct-only",
+    ]);
     expect(tools.find((tool) => tool.name === "sandbox_exec")?.description).toContain(
       "Docker container-path bind layout",
     );

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -79,6 +79,15 @@ const CODEX_NATIVE_SANDBOX_TOOL_REQUIREMENTS = [
   "apply_patch",
 ] as const;
 const CODEX_MEMORY_FLUSH_DYNAMIC_TOOL_ALLOW = new Set(["read", "write"]);
+const CODEX_DISABLED_NATIVE_SHELL_DYNAMIC_TOOLS = new Set([
+  "exec",
+  "process",
+  "sandbox_exec",
+  "sandbox_process",
+  CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
+  CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
+  CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
+]);
 
 /** Keeps node filesystem and process ownership on its native exec-server. */
 export function resolveCodexNodePlacementToolConstructionPlan(
@@ -547,9 +556,13 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     ? webSearchPlan.webFetchHostnameAllowlist
     : undefined;
   input.onWebSearchPolicyResolved?.(webSearchAllowed);
-  const exposedTools = webSearchPlan.suppressManagedWebSearch
+  const webSearchFilteredTools = webSearchPlan.suppressManagedWebSearch
     ? normalizedTools.filter((tool) => tool.name !== "web_search")
     : normalizedTools;
+  const exposedTools = placeDisabledNativeShellToolsInDirectNamespace(
+    webSearchFilteredTools,
+    input.nativeToolSurfaceEnabled,
+  );
   if (preNormalizationDiagnostics.length > 0) {
     embeddedAgentLog.warn(
       `codex app-server quarantined ${preNormalizationDiagnostics.length} unsupported runtime tool schema${preNormalizationDiagnostics.length === 1 ? "" : "s"} before dynamic tool registration`,
@@ -945,6 +958,22 @@ function resolveCodexNativeExecutionPolicyForDynamicTools(
     sandboxAvailable: input.sandbox?.enabled,
     readRuntimeSessionEntry: true,
   });
+}
+/** Keeps replacement shell tools direct even when model metadata mandates Codex Code Mode. */
+function placeDisabledNativeShellToolsInDirectNamespace<
+  T extends { name: string; catalogMode?: string },
+>(tools: T[], nativeToolSurfaceEnabled: boolean | undefined): T[] {
+  if (nativeToolSurfaceEnabled !== false) {
+    return tools;
+  }
+  for (const tool of tools) {
+    if (CODEX_DISABLED_NATIVE_SHELL_DYNAMIC_TOOLS.has(normalizeCodexDynamicToolName(tool.name))) {
+      // Runtime tools can carry non-enumerable policy metadata and prototype behavior.
+      // Preserve the prepared object identity while changing only its Codex catalog placement.
+      tool.catalogMode = "direct-only";
+    }
+  }
+  return tools;
 }
 /** Applies a normalized tool allowlist while preserving shell aliases for exec/process. */
 function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(

--- a/extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { assertScheduledCodexAppAuthorityRuntime } from "./scheduled-app-authority.js";
+import {
+  assertScheduledCodexAppAuthorityRuntime,
+  buildScheduledCodexAppServerConnectionIdentity,
+} from "./scheduled-app-authority.js";
 import { canResolveScheduledConfiguredMcpCreatorAuthority } from "./scheduled-configured-mcp-authority.js";
 
 const eligible = {
@@ -81,6 +84,63 @@ describe("assertScheduledCodexAppAuthorityRuntime", () => {
         scheduledRuntimeAuthority: scheduledAuthority,
       }),
     ).not.toThrow();
+  });
+
+  it("admits the exact configured app-server connection", () => {
+    const appServer = {
+      start: {
+        transport: "websocket",
+        homeScope: "agent",
+        command: "codex",
+        args: [] as string[],
+        headers: {},
+        url: "wss://codex.example.com/app-server",
+      },
+      connectionClass: "remote",
+    } as const;
+    const agentDir = "/agent";
+    const connectionIdentity = buildScheduledCodexAppServerConnectionIdentity(appServer);
+    const configuredAuthority = {
+      ...scheduledAuthority,
+      payload: {
+        ...scheduledAuthority.payload,
+        auth: {
+          kind: "configured-app-server",
+          connectionFingerprint: connectionIdentity,
+          managedRequirementsFingerprint: "managed-requirements",
+        },
+      },
+    };
+    expect(
+      buildScheduledCodexAppServerConnectionIdentity({
+        ...appServer,
+        start: {
+          ...appServer.start,
+          authToken: "rotated",
+          headers: { Authorization: "Bearer rotated" },
+        },
+      }),
+    ).toBe(connectionIdentity);
+
+    expect(() =>
+      assertScheduledCodexAppAuthorityRuntime(
+        scheduledConnection({ appServer, agentDir, startupPreparedAuth: undefined }),
+        { trigger: "cron", scheduledRuntimeAuthority: configuredAuthority },
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertScheduledCodexAppAuthorityRuntime(
+        scheduledConnection({
+          appServer: {
+            ...appServer,
+            start: { ...appServer.start, url: "wss://other.example.com" },
+          },
+          agentDir,
+          startupPreparedAuth: undefined,
+        }),
+        { trigger: "cron", scheduledRuntimeAuthority: configuredAuthority },
+      ),
+    ).toThrow("different configured Codex app-server");
   });
 
   it.each([

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -29,6 +29,7 @@ import { emitCodexAppServerEvent } from "./run-attempt-lifecycle.js";
 import type { CodexAttemptRuntime } from "./run-attempt-runtime.js";
 import { resolveCodexDynamicToolDirectNames } from "./run-attempt-tools.js";
 import {
+  buildScheduledCodexAppServerConnectionIdentity,
   captureScheduledCodexAppAuthority,
   resolveScheduledCodexAppCreatorCaptureDecision,
 } from "./scheduled-app-authority.js";
@@ -146,20 +147,28 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     value?: { version: 1; source: "final-executable-surface" };
   } = {};
   const scheduledAppAuthoritySourceRef: {
-    current?: Omit<
-      Parameters<typeof captureScheduledCodexAppAuthority>[0],
-      "profileId" | "accountId"
-    >;
+    current?: Omit<Parameters<typeof captureScheduledCodexAppAuthority>[0], "auth">;
   } = {};
   const preparedChatgptAuth =
     connection.startupPreparedAuth?.kind === "profile" &&
     connection.startupPreparedAuth.snapshot?.loginParams.type === "chatgptAuthTokens" &&
     connection.startupPreparedAuth.snapshot.chatgptAccountId
       ? {
+          kind: "prepared-profile" as const,
           profileId: connection.startupPreparedAuth.profileId,
           accountId: connection.startupPreparedAuth.snapshot.chatgptAccountId,
         }
       : undefined;
+  const configuredAppServerAuth =
+    !preparedChatgptAuth && connection.appServer.start.transport !== "stdio"
+      ? {
+          kind: "configured-app-server" as const,
+          connectionFingerprint: buildScheduledCodexAppServerConnectionIdentity(
+            connection.appServer,
+          ),
+        }
+      : undefined;
+  const scheduledCodexAppAuth = preparedChatgptAuth ?? configuredAppServerAuth;
   const appPolicy = resolveCodexPluginsPolicy(pluginConfig);
   const codexAppsMayBeVisible =
     appPolicy.enabled &&
@@ -170,6 +179,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     usesSupervisionConnection: connection.usesSupervisionConnection,
     homeScope: connection.appServer.start.homeScope,
     hasPreparedAccountIdentity: Boolean(preparedChatgptAuth),
+    hasConfiguredAppServerIdentity: Boolean(configuredAppServerAuth),
   });
   const codexAppAuthorityUnavailableReason = appCreatorCapture.unavailableReason;
   const canResolveScheduledCodexAppAuthority = appCreatorCapture.supported;
@@ -465,11 +475,11 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         }
         const appSource = scheduledAppAuthoritySourceRef.current;
         const runtimeAuthority =
-          canResolveScheduledCodexAppAuthority && preparedChatgptAuth
+          canResolveScheduledCodexAppAuthority && scheduledCodexAppAuth
             ? appSource
               ? await captureScheduledCodexAppAuthority({
                   ...appSource,
-                  ...preparedChatgptAuth,
+                  auth: scheduledCodexAppAuth,
                   signal: options?.signal,
                 })
               : (() => {

--- a/extensions/codex/src/app-server/scheduled-app-authority.test.ts
+++ b/extensions/codex/src/app-server/scheduled-app-authority.test.ts
@@ -14,6 +14,7 @@ import {
   intersectCodexPluginThreadConfigWithScheduledAuthority,
   resolveScheduledCodexAppCreatorCaptureDecision,
 } from "./scheduled-app-authority.js";
+import { readCodexManagedRequirementsFingerprint } from "./thread-requests.js";
 
 function policyContext() {
   return buildPluginAppPolicyContext(
@@ -109,8 +110,11 @@ describe("scheduled Codex app authority", () => {
     { name: "user home", overrides: { homeScope: "user" }, message: "user-home runtime" },
     {
       name: "missing account identity",
-      overrides: { hasPreparedAccountIdentity: false },
-      message: "genuine ChatGPT account identity",
+      overrides: {
+        hasPreparedAccountIdentity: false,
+        hasConfiguredAppServerIdentity: false,
+      },
+      message: "configured app-server identity",
     },
   ])("refuses creator capture for $name before mutation", ({ overrides, message }) => {
     const decision = resolveScheduledCodexAppCreatorCaptureDecision({
@@ -119,6 +123,7 @@ describe("scheduled Codex app authority", () => {
       usesSupervisionConnection: false,
       homeScope: "agent",
       hasPreparedAccountIdentity: true,
+      hasConfiguredAppServerIdentity: false,
       ...overrides,
     });
 
@@ -127,14 +132,18 @@ describe("scheduled Codex app authority", () => {
     expect(decision.unavailableReason).toContain("no automation changes were saved");
   });
 
-  it("supports creator capture only with a prepared exact account identity", () => {
+  it.each([
+    ["prepared profile", true, false],
+    ["configured app-server", false, true],
+  ])("supports creator capture with a %s identity", (_name, prepared, configured) => {
     expect(
       resolveScheduledCodexAppCreatorCaptureDecision({
         appsMayBeVisible: true,
         authenticatedScheduledMode: false,
         usesSupervisionConnection: false,
         homeScope: "agent",
-        hasPreparedAccountIdentity: true,
+        hasPreparedAccountIdentity: prepared,
+        hasConfiguredAppServerIdentity: configured,
       }),
     ).toEqual({ required: true, supported: true });
   });
@@ -157,7 +166,7 @@ describe("scheduled Codex app authority", () => {
             {
               name: "codex_apps",
               tools: {
-                list: { _meta: { connector_id: "calendar" } },
+                list: { title: "List events", _meta: { connector_id: "calendar" } },
                 create: { _meta: { connector_id: "calendar" } },
                 unrelated: { _meta: { connector_id: "other" } },
               },
@@ -168,7 +177,7 @@ describe("scheduled Codex app authority", () => {
       }
       if (method === "config/read") {
         return {
-          config: { apps: { calendar: { tools: { list: { approval_mode: "writes" } } } } },
+          config: { apps: { calendar: { tools: { "List events": { approval_mode: "writes" } } } } },
         };
       }
       throw new Error(`unexpected method ${method}`);
@@ -178,8 +187,11 @@ describe("scheduled Codex app authority", () => {
       client: { request } as never,
       threadId: "thread-final",
       policyContext: policyContext(),
-      profileId: "openai:work",
-      accountId: "acct-1",
+      auth: {
+        kind: "prepared-profile",
+        profileId: "openai:work",
+        accountId: "acct-1",
+      },
       configCwd: "/workspace",
     });
 
@@ -219,8 +231,11 @@ describe("scheduled Codex app authority", () => {
         client: { request } as never,
         threadId: "thread-final",
         policyContext: policyContext(),
-        profileId: "openai:work",
-        accountId: "acct-1",
+        auth: {
+          kind: "prepared-profile",
+          profileId: "openai:work",
+          accountId: "acct-1",
+        },
       }),
     ).resolves.toBeUndefined();
   });
@@ -250,8 +265,11 @@ describe("scheduled Codex app authority", () => {
         client: { request } as never,
         threadId: "thread-final",
         policyContext: policyContext(),
-        profileId: "openai:work",
-        accountId: "acct-1",
+        auth: {
+          kind: "prepared-profile",
+          profileId: "openai:work",
+          accountId: "acct-1",
+        },
         timeoutMs: 100,
       }),
     ).rejects.toThrow(
@@ -282,10 +300,74 @@ describe("scheduled Codex app authority", () => {
         client: { request } as never,
         threadId: "thread-final",
         policyContext: policyContext(),
-        profileId: "openai:work",
-        accountId: "acct-1",
+        auth: {
+          kind: "prepared-profile",
+          profileId: "openai:work",
+          accountId: "acct-1",
+        },
       }),
     ).rejects.toThrow("No automation changes were saved");
+  });
+
+  it("captures configured app-server authority without a prepared ChatGPT account", async () => {
+    const managedRequirements = {
+      hooks: { PreToolUse: [{ matcher: "*", hooks: [{ type: "command" }] }] },
+    };
+    const request = vi.fn(async (method: string) => {
+      if (method === "app/installed") {
+        return { apps: [{ id: "calendar", enabled: true, callable: true }] };
+      }
+      if (method === "mcpServerStatus/list") {
+        return {
+          data: [
+            {
+              name: "codex_apps",
+              tools: { list: { _meta: { connector_id: "calendar" } } },
+            },
+          ],
+          nextCursor: null,
+        };
+      }
+      if (method === "config/read") {
+        return { config: {} };
+      }
+      if (method === "configRequirements/read") {
+        return { requirements: managedRequirements };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    const managedRequirementsFingerprint = await readCodexManagedRequirementsFingerprint({
+      request,
+    } as never);
+
+    await expect(
+      captureScheduledCodexAppAuthority({
+        client: { request } as never,
+        threadId: "thread-final",
+        policyContext: policyContext(),
+        auth: {
+          kind: "configured-app-server",
+          connectionFingerprint: "configured-connection",
+        },
+      }),
+    ).resolves.toEqual(
+      authority({
+        auth: {
+          kind: "configured-app-server",
+          connectionFingerprint: "configured-connection",
+          managedRequirementsFingerprint,
+        },
+        apps: [
+          {
+            id: "calendar",
+            allowDestructiveActions: true,
+            allowOpenWorld: true,
+            destructiveApprovalMode: "allow",
+            tools: { list: "approve" },
+          },
+        ],
+      }),
+    );
   });
 
   it("intersects stored and current app/tool authority without admitting new apps", () => {
@@ -304,7 +386,16 @@ describe("scheduled Codex app authority", () => {
             },
           },
         },
-        toolNamesByApp: new Map([["calendar", new Set(["list", "edit", "newly_added"])]]),
+        toolsByApp: new Map([
+          [
+            "calendar",
+            new Map<string, string | undefined>([
+              ["list", undefined],
+              ["edit", undefined],
+              ["newly_added", undefined],
+            ]),
+          ],
+        ]),
       },
     );
 
@@ -329,9 +420,84 @@ describe("scheduled Codex app authority", () => {
           open_world_enabled: false,
           approvals_reviewer: "user",
           tools: {
-            list: { approval_mode: "prompt" },
-            edit: { approval_mode: "prompt" },
-            newly_added: { approval_mode: "prompt" },
+            list: { enabled: true, approval_mode: "prompt" },
+            edit: { enabled: true, approval_mode: "prompt" },
+            newly_added: { enabled: true, approval_mode: "prompt" },
+          },
+        },
+      },
+    });
+  });
+
+  it.each([
+    {
+      name: "explicit tool disablement",
+      appConfig: {
+        default_tools_enabled: true,
+        tools: { edit: { enabled: false } },
+      },
+      expectedEnabled: false,
+    },
+    {
+      name: "app default disablement",
+      appConfig: { default_tools_enabled: false },
+      expectedEnabled: false,
+    },
+    {
+      name: "explicit tool enablement over app default disablement",
+      appConfig: {
+        default_tools_enabled: false,
+        tools: { edit: { enabled: true } },
+      },
+      expectedEnabled: true,
+    },
+    {
+      name: "title-keyed enablement over app default disablement",
+      appConfig: {
+        default_tools_enabled: false,
+        tools: { "Edit event": { enabled: true } },
+      },
+      expectedEnabled: true,
+    },
+    {
+      name: "title-keyed disablement over app default enablement",
+      appConfig: {
+        default_tools_enabled: true,
+        tools: { "Edit event": { enabled: false } },
+      },
+      expectedEnabled: false,
+    },
+    {
+      name: "full-name disablement over title-keyed enablement",
+      appConfig: {
+        default_tools_enabled: true,
+        tools: { edit: { enabled: false }, "Edit event": { enabled: true } },
+      },
+      expectedEnabled: false,
+    },
+    {
+      name: "full-name entry without enablement over title-keyed enablement",
+      appConfig: {
+        default_tools_enabled: false,
+        tools: { edit: { approval_mode: "prompt" }, "Edit event": { enabled: true } },
+      },
+      expectedEnabled: false,
+    },
+  ])("preserves $name from the current Codex config", ({ appConfig, expectedEnabled }) => {
+    const intersected = intersectCodexPluginThreadConfigWithScheduledAuthority(
+      threadConfig(),
+      authority(),
+      {
+        config: { apps: { calendar: appConfig } },
+        toolsByApp: new Map([["calendar", new Map([["edit", "Edit event"]])]]),
+      },
+    );
+
+    expect(intersected.configPatch).toMatchObject({
+      apps: {
+        calendar: {
+          tools: {
+            edit: { enabled: expectedEnabled },
           },
         },
       },
@@ -344,7 +510,15 @@ describe("scheduled Codex app authority", () => {
       authority(),
       {
         config: {},
-        toolNamesByApp: new Map([["calendar", new Set(["list", "edit"])]]),
+        toolsByApp: new Map([
+          [
+            "calendar",
+            new Map<string, string | undefined>([
+              ["list", undefined],
+              ["edit", undefined],
+            ]),
+          ],
+        ]),
       },
     );
     const narrowed = intersectCodexPluginThreadConfigWithScheduledAuthority(
@@ -352,7 +526,9 @@ describe("scheduled Codex app authority", () => {
       authority(),
       {
         config: {},
-        toolNamesByApp: new Map([["calendar", new Set(["list"])]]),
+        toolsByApp: new Map([
+          ["calendar", new Map<string, string | undefined>([["list", undefined]])],
+        ]),
       },
     );
 
@@ -370,7 +546,7 @@ describe("scheduled Codex app authority", () => {
     expect(() =>
       intersectCodexPluginThreadConfigWithScheduledAuthority(threadConfig(), authority(), {
         config: {},
-        toolNamesByApp: new Map(),
+        toolsByApp: new Map(),
       }),
     ).toThrow("Scheduled Codex apps are unavailable under the current policy or account: calendar");
   });
@@ -406,12 +582,14 @@ describe("scheduled Codex app authority", () => {
       authority(),
       {
         config: {},
-        toolNamesByApp: new Map([["calendar", new Set(["edit"])]]),
+        toolsByApp: new Map([
+          ["calendar", new Map<string, string | undefined>([["edit", undefined]])],
+        ]),
       },
     );
 
     expect(intersected.configPatch).toMatchObject({
-      apps: { calendar: { tools: { edit: { approval_mode: expected } } } },
+      apps: { calendar: { tools: { edit: { enabled: true, approval_mode: expected } } } },
     });
   });
 

--- a/extensions/codex/src/app-server/scheduled-app-authority.ts
+++ b/extensions/codex/src/app-server/scheduled-app-authority.ts
@@ -19,6 +19,7 @@ import {
 } from "./plugin-thread-config.js";
 import { isJsonObject, type v2 } from "./protocol.js";
 import type { CodexAttemptConnection } from "./run-attempt-connection.js";
+import { readCodexManagedRequirementsFingerprint } from "./thread-requests.js";
 import { withAbortableTimeout } from "./timeout.js";
 
 const CODEX_SCHEDULED_APP_AUTHORITY_NAMESPACE = "codex.apps";
@@ -32,8 +33,39 @@ type CronRuntimeAuthority = NonNullable<EmbeddedRunAttemptParams["scheduledRunti
 type CodexAppToolApprovalMode = "auto" | "prompt" | "writes" | "approve";
 export type CurrentCodexScheduledAppPolicy = {
   config: Record<string, unknown>;
-  toolNamesByApp: ReadonlyMap<string, ReadonlySet<string>>;
+  toolsByApp: ReadonlyMap<string, ReadonlyMap<string, string | undefined>>;
 };
+
+export type ScheduledCodexAppCreatorAuth =
+  | { kind: "prepared-profile"; profileId: string; accountId: string }
+  | { kind: "configured-app-server"; connectionFingerprint: string };
+
+/** Hashes stable configured endpoint identity without retaining credentials or endpoint details. */
+export function buildScheduledCodexAppServerConnectionIdentity(
+  appServer: Pick<
+    CodexAttemptConnection["appServer"],
+    "start" | "connectionClass" | "remoteWorkspaceRoot"
+  >,
+): string {
+  const start = appServer.start;
+  return crypto
+    .createHash("sha256")
+    .update("openclaw:codex:scheduled-app-server:v1\0")
+    .update(
+      JSON.stringify({
+        transport: start.transport,
+        command: start.command,
+        commandSource: start.commandSource ?? null,
+        args: start.args,
+        cwd: start.cwd ?? null,
+        url: start.url ?? null,
+        homeScope: start.homeScope ?? null,
+        connectionClass: appServer.connectionClass,
+        remoteWorkspaceRoot: appServer.remoteWorkspaceRoot ?? null,
+      }),
+    )
+    .digest("hex");
+}
 
 export function resolveScheduledCodexAppCreatorCaptureDecision(params: {
   appsMayBeVisible: boolean;
@@ -41,6 +73,7 @@ export function resolveScheduledCodexAppCreatorCaptureDecision(params: {
   usesSupervisionConnection: boolean;
   homeScope: string | undefined;
   hasPreparedAccountIdentity: boolean;
+  hasConfiguredAppServerIdentity: boolean;
 }): { required: boolean; supported: boolean; unavailableReason?: string } {
   if (!params.appsMayBeVisible) {
     return { required: false, supported: false };
@@ -51,8 +84,8 @@ export function resolveScheduledCodexAppCreatorCaptureDecision(params: {
       ? "Codex apps are visible through a supervised connection that cannot capture creator authority. Use an isolated prepared-profile Codex creator turn; no automation changes were saved."
       : params.homeScope === "user"
         ? "Codex apps are visible through a user-home runtime that cannot capture isolated creator authority. Use an agent-scoped prepared-profile Codex creator turn; no automation changes were saved."
-        : !params.hasPreparedAccountIdentity
-          ? "Codex app authority requires a genuine ChatGPT account identity. Reauthenticate the selected Codex profile, then retry; no automation changes were saved."
+        : !params.hasPreparedAccountIdentity && !params.hasConfiguredAppServerIdentity
+          ? "Codex app authority requires either a prepared ChatGPT profile or an isolated configured app-server identity. Reauthenticate the selected Codex profile or configured app-server, then retry; no automation changes were saved."
           : undefined;
   return {
     required: true,
@@ -61,9 +94,23 @@ export function resolveScheduledCodexAppCreatorCaptureDecision(params: {
   };
 }
 
+type ScheduledCodexAppPreparedProfileAuth = {
+  kind?: undefined;
+  profileId: string;
+  accountId: string;
+};
+type ScheduledCodexAppConfiguredServerAuth = {
+  kind: "configured-app-server";
+  connectionFingerprint: string;
+  managedRequirementsFingerprint: string;
+};
+type ScheduledCodexAppAuthorityAuth =
+  | ScheduledCodexAppPreparedProfileAuth
+  | ScheduledCodexAppConfiguredServerAuth;
+
 type ScheduledCodexAppAuthorityPayload = {
   version: 1;
-  auth: { profileId: string; accountId: string };
+  auth: ScheduledCodexAppAuthorityAuth;
   apps: Array<{
     id: string;
     allowDestructiveActions: boolean;
@@ -106,8 +153,24 @@ function parseScheduledCodexAppAuthority(
   const payload = asOptionalRecord(authority.payload);
   const auth = asOptionalRecord(payload?.auth);
   const profileId = normalizeOptionalString(auth?.profileId);
+  const connectionFingerprint = normalizeOptionalString(auth?.connectionFingerprint);
+  const managedRequirementsFingerprint = normalizeOptionalString(
+    auth?.managedRequirementsFingerprint,
+  );
   const accountId = normalizeOptionalString(auth?.accountId);
-  if (payload?.version !== 1 || !profileId || !accountId || !Array.isArray(payload.apps)) {
+  const parsedAuth: ScheduledCodexAppAuthorityAuth | undefined =
+    auth?.kind === "configured-app-server" &&
+    connectionFingerprint &&
+    managedRequirementsFingerprint
+      ? {
+          kind: "configured-app-server",
+          connectionFingerprint,
+          managedRequirementsFingerprint,
+        }
+      : auth?.kind === undefined && profileId && accountId
+        ? { profileId, accountId }
+        : undefined;
+  if (payload?.version !== 1 || !parsedAuth || !Array.isArray(payload.apps)) {
     throw new Error("Stored Codex app authority is invalid; reauthorize this automation.");
   }
   const seen = new Set<string>();
@@ -144,7 +207,7 @@ function parseScheduledCodexAppAuthority(
       tools,
     };
   });
-  return { version: 1, auth: { profileId, accountId }, apps };
+  return { version: 1, auth: parsedAuth, apps };
 }
 
 type CodexScheduledAppPolicyRequest = (
@@ -152,11 +215,11 @@ type CodexScheduledAppPolicyRequest = (
   params: Record<string, unknown>,
 ) => Promise<unknown>;
 
-async function readCodexScheduledAppToolNamesByApp(params: {
+async function readCodexScheduledAppToolsByApp(params: {
   request: CodexScheduledAppPolicyRequest;
   threadId?: string;
-}): Promise<Map<string, Set<string>>> {
-  const toolNamesByApp = new Map<string, Set<string>>();
+}): Promise<Map<string, Map<string, string | undefined>>> {
+  const toolsByApp = new Map<string, Map<string, string | undefined>>();
   const seenCursors = new Set<string>();
   let cursor: string | null | undefined;
   for (let page = 0; page < MCP_STATUS_MAX_PAGES; page += 1) {
@@ -179,9 +242,10 @@ async function readCodexScheduledAppToolNamesByApp(params: {
       for (const [toolName, tool] of Object.entries(status.tools)) {
         const connectorId = readCodexMcpToolConnectorId(tool);
         if (connectorId) {
-          const names = toolNamesByApp.get(connectorId) ?? new Set<string>();
-          names.add(toolName);
-          toolNamesByApp.set(connectorId, names);
+          const tools = toolsByApp.get(connectorId) ?? new Map<string, string | undefined>();
+          const title = asOptionalRecord(tool)?.title;
+          tools.set(toolName, typeof title === "string" ? title : undefined);
+          toolsByApp.set(connectorId, tools);
         }
       }
     }
@@ -194,7 +258,7 @@ async function readCodexScheduledAppToolNamesByApp(params: {
     }
     cursor = response.nextCursor;
     if (!cursor) {
-      return toolNamesByApp;
+      return toolsByApp;
     }
     if (seenCursors.has(cursor)) {
       throw new Error("Codex app connector inventory repeated its pagination cursor");
@@ -204,37 +268,52 @@ async function readCodexScheduledAppToolNamesByApp(params: {
   throw new Error("Codex app connector inventory exceeded its bounded page limit");
 }
 
-/** Reads the current account policy and connector-backed tool names under one caller deadline. */
+/** Reads current account policy and connector-backed tool metadata under one caller deadline. */
 export async function readCurrentCodexScheduledAppPolicy(params: {
   request: CodexScheduledAppPolicyRequest;
   configCwd?: string;
   threadId?: string;
 }): Promise<CurrentCodexScheduledAppPolicy> {
-  const [configResponse, toolNamesByApp] = await Promise.all([
+  const [configResponse, toolsByApp] = await Promise.all([
     params.request("config/read", {
       includeLayers: false,
       ...(params.configCwd ? { cwd: params.configCwd } : {}),
     }),
-    readCodexScheduledAppToolNamesByApp(params),
+    readCodexScheduledAppToolsByApp(params),
   ]);
   if (!isJsonObject(configResponse)) {
     throw new Error("Codex config/read returned an invalid scheduled app policy response");
   }
   return {
     config: isJsonObject(configResponse.config) ? configResponse.config : {},
-    toolNamesByApp,
+    toolsByApp,
   };
 }
 
-function readToolApprovalMode(
+function readCurrentToolPolicy(
   config: Record<string, unknown>,
   appId: string,
   toolName: string,
-  fallback: CodexAppToolApprovalMode = "auto",
-): CodexAppToolApprovalMode {
+  toolTitle: string | undefined,
+  fallbackApprovalMode: CodexAppToolApprovalMode = "auto",
+): { enabled: boolean; approvalMode: CodexAppToolApprovalMode } {
   const app = asOptionalRecord(asOptionalRecord(config.apps)?.[appId]);
-  const tool = asOptionalRecord(asOptionalRecord(app?.tools)?.[toolName]);
-  return normalizeAppToolApprovalMode(tool?.approval_mode) ?? fallback;
+  const tools = asOptionalRecord(app?.tools);
+  // Codex selects the full-name entry before the title entry, not each field
+  // independently. Preserve that precedence for both enablement and approval.
+  const tool = asOptionalRecord(
+    tools?.[toolName] ?? (toolTitle !== undefined ? tools?.[toolTitle] : undefined),
+  );
+  const defaultToolsEnabled = app?.default_tools_enabled;
+  return {
+    enabled:
+      typeof tool?.enabled === "boolean"
+        ? tool.enabled
+        : typeof defaultToolsEnabled === "boolean"
+          ? defaultToolsEnabled
+          : true,
+    approvalMode: normalizeAppToolApprovalMode(tool?.approval_mode) ?? fallbackApprovalMode,
+  };
 }
 
 /** Captures only apps callable on the exact active Codex client/thread. */
@@ -242,8 +321,7 @@ export async function captureScheduledCodexAppAuthority(params: {
   client: Pick<CodexAppServerClient, "request">;
   threadId: string;
   policyContext: PluginAppPolicyContext;
-  profileId: string;
-  accountId: string;
+  auth: ScheduledCodexAppCreatorAuth;
   configCwd?: string;
   signal?: AbortSignal;
   timeoutMs?: number;
@@ -273,8 +351,9 @@ export async function captureScheduledCodexAppAuthority(params: {
   };
   let installed: v2.AppsInstalledResponse;
   let currentPolicy: CurrentCodexScheduledAppPolicy;
+  let managedRequirementsFingerprint: string | undefined;
   try {
-    [installed, currentPolicy] = await withAbortableTimeout({
+    [installed, currentPolicy, managedRequirementsFingerprint] = await withAbortableTimeout({
       promise: Promise.all([
         boundedClient.request("app/installed", {
           threadId: params.threadId,
@@ -286,6 +365,9 @@ export async function captureScheduledCodexAppAuthority(params: {
           threadId: params.threadId,
           configCwd: params.configCwd,
         }),
+        params.auth.kind === "configured-app-server"
+          ? readCodexManagedRequirementsFingerprint(boundedClient, params.signal)
+          : Promise.resolve(undefined),
       ]),
       timeoutMs,
       signal: params.signal,
@@ -309,23 +391,24 @@ export async function captureScheduledCodexAppAuthority(params: {
     installed.apps.filter((app) => app.enabled && app.callable).map((app) => app.id),
   );
   const apps = Object.entries(params.policyContext.apps)
-    .filter(([id]) => callableIds.has(id) && currentPolicy.toolNamesByApp.has(id))
+    .filter(([id]) => callableIds.has(id) && currentPolicy.toolsByApp.has(id))
     .map(([id, policy]) => ({
       id,
       allowDestructiveActions: policy.allowDestructiveActions,
       allowOpenWorld: policy.allowOpenWorld !== false,
       destructiveApprovalMode: defaultApprovalMode(policy),
       tools: Object.fromEntries(
-        [...(currentPolicy.toolNamesByApp.get(id) ?? [])]
+        [...(currentPolicy.toolsByApp.get(id)?.keys() ?? [])]
           .toSorted()
           .map((toolName) => [
             toolName,
-            readToolApprovalMode(
+            readCurrentToolPolicy(
               currentPolicy.config,
               id,
               toolName,
+              currentPolicy.toolsByApp.get(id)?.get(toolName),
               appApprovalCeiling(defaultApprovalMode(policy)),
-            ),
+            ).approvalMode,
           ]),
       ),
     }))
@@ -333,13 +416,27 @@ export async function captureScheduledCodexAppAuthority(params: {
   if (apps.length === 0) {
     return undefined;
   }
+  const auth: ScheduledCodexAppAuthorityAuth =
+    params.auth.kind === "prepared-profile"
+      ? { profileId: params.auth.profileId, accountId: params.auth.accountId }
+      : {
+          kind: "configured-app-server",
+          connectionFingerprint: params.auth.connectionFingerprint,
+          managedRequirementsFingerprint:
+            managedRequirementsFingerprint ??
+            (() => {
+              throw new Error(
+                "Codex configured app-server authority capture omitted managed requirements",
+              );
+            })(),
+        };
   return {
     version: 1,
     runtimeId: "codex",
     namespace: CODEX_SCHEDULED_APP_AUTHORITY_NAMESPACE,
     payload: {
       version: 1,
-      auth: { profileId: params.profileId, accountId: params.accountId },
+      auth,
       apps,
     },
   };
@@ -412,7 +509,7 @@ export function intersectCodexPluginThreadConfigWithScheduledAuthority(
   authority: EmbeddedRunAttemptParams["scheduledRuntimeAuthority"],
   currentPolicy: CurrentCodexScheduledAppPolicy = {
     config: {},
-    toolNamesByApp: new Map(),
+    toolsByApp: new Map(),
   },
 ): CodexPluginThreadConfig {
   const scheduled = parseScheduledCodexAppAuthority(authority);
@@ -422,7 +519,7 @@ export function intersectCodexPluginThreadConfigWithScheduledAuthority(
   const omittedAppIds = scheduled.apps
     .map((app) => app.id)
     .filter((id) => {
-      const currentTools = currentPolicy.toolNamesByApp.get(id);
+      const currentTools = currentPolicy.toolsByApp.get(id);
       return (
         !Object.hasOwn(config.policyContext.apps, id) || !currentTools || currentTools.size === 0
       );
@@ -473,19 +570,24 @@ export function intersectCodexPluginThreadConfigWithScheduledAuthority(
     const currentAppCeiling = appApprovalCeiling(defaultApprovalMode(currentApp));
     // Current inventory owns existence; captured modes only cap tools that
     // still exist (and tools added later within the already-authorized app).
-    const toolNames = currentPolicy.toolNamesByApp.get(appId) ?? new Set<string>();
+    const tools = currentPolicy.toolsByApp.get(appId) ?? new Map<string, string | undefined>();
     appPatch.tools = Object.fromEntries(
-      [...toolNames].toSorted().map((toolName) => {
+      [...tools.keys()].toSorted().map((toolName) => {
         const capturedMode = captured.tools[toolName] ?? storedAppCeiling;
+        const currentToolPolicy = readCurrentToolPolicy(
+          currentPolicy.config,
+          appId,
+          toolName,
+          tools.get(toolName),
+          currentAppCeiling,
+        );
         return [
           toolName,
           {
+            enabled: currentToolPolicy.enabled,
             approval_mode: intersectToolApprovalMode(
               intersectToolApprovalMode(capturedMode, storedAppCeiling),
-              intersectToolApprovalMode(
-                readToolApprovalMode(currentPolicy.config, appId, toolName, currentAppCeiling),
-                currentAppCeiling,
-              ),
+              intersectToolApprovalMode(currentToolPolicy.approvalMode, currentAppCeiling),
             ),
           },
         ];
@@ -520,6 +622,14 @@ function readScheduledCodexAppAuthorityAuth(
   return parseScheduledCodexAppAuthority(authority)?.auth;
 }
 
+/** Returns the managed-requirements identity captured for a configured app-server job. */
+export function readScheduledCodexAppManagedRequirementsFingerprint(
+  authority: EmbeddedRunAttemptParams["scheduledRuntimeAuthority"],
+): string | undefined {
+  const auth = readScheduledCodexAppAuthorityAuth(authority);
+  return auth?.kind === "configured-app-server" ? auth.managedRequirementsFingerprint : undefined;
+}
+
 export function assertScheduledCodexAppAuthorityRuntime(
   connection: Pick<
     CodexAttemptConnection,
@@ -537,8 +647,19 @@ export function assertScheduledCodexAppAuthorityRuntime(
     connection.appServer.start.homeScope === "user"
   ) {
     throw new AgentHarnessPreflightError(
-      "This automation's Codex app authority requires an isolated scheduled prepared-profile runtime. Reauthorize it from a supported Codex creator turn.",
+      "This automation's Codex app authority requires an isolated scheduled runtime. Reauthorize it from a supported Codex creator turn.",
     );
+  }
+  if (scheduledAuth.kind === "configured-app-server") {
+    const connectionFingerprint = buildScheduledCodexAppServerConnectionIdentity(
+      connection.appServer,
+    );
+    if (connectionFingerprint !== scheduledAuth.connectionFingerprint) {
+      throw new AgentHarnessPreflightError(
+        "This automation was authorized for a different configured Codex app-server. Restore that connection or reauthorize the automation from a fresh owner turn.",
+      );
+    }
+    return;
   }
   const prepared = connection.startupPreparedAuth;
   if (

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -59,6 +59,8 @@ import {
 } from "./thread-requests.js";
 import { resumeCodexAppServerThread } from "./thread-resume.js";
 
+const CODEX_APPS_MCP_SERVER_NAME = "codex_apps";
+
 type ResumeThreadContext = CodexThreadRequestContext & {
   binding: CodexAppServerThreadBinding;
   clearCurrentBinding: (operation: string) => Promise<void>;
@@ -212,14 +214,17 @@ export async function resumeExistingCodexThread(
     resumeResponseAccepted = true;
     assertCodexThreadAcceptsDirectInput(response.thread);
     context.assertResumeConfiguration?.();
-    if (resumeBinding.pendingResumeConfiguration) {
-      await attestCodexPluginThreadApps({
-        client: params.client,
-        threadId: response.thread.id,
-        appIds: context.prebuiltPluginThreadConfig?.provisionalAppIds ?? [],
-        signal: params.signal,
-      });
-    }
+    const provisionalAppIds =
+      context.prebuiltPluginThreadConfig?.provisionalAppIds ??
+      (params.pluginThreadConfig?.enabled
+        ? Object.keys(resumeBinding.pluginAppPolicyContext?.apps ?? {})
+        : []);
+    await attestCodexPluginThreadApps({
+      client: params.client,
+      threadId: response.thread.id,
+      appIds: provisionalAppIds,
+      signal: params.signal,
+    });
     if (
       ringZeroActive ||
       isMessageOnlyCodexSourceReply(params.params) ||
@@ -232,6 +237,7 @@ export async function resumeExistingCodexThread(
             response.thread.id,
             resumeParams.config,
             params.signal,
+            provisionalAppIds.length > 0 ? [CODEX_APPS_MCP_SERVER_NAME] : [],
           ),
         );
       } catch (error) {
@@ -535,6 +541,7 @@ export async function startFreshCodexThread(
           response.thread.id,
           startParams.config,
           params.signal,
+          provisionalAppIds?.length ? [CODEX_APPS_MCP_SERVER_NAME] : [],
         ),
       );
     } catch (error) {

--- a/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-preflight.ts
@@ -14,6 +14,7 @@ import { assertCodexNativeHookRelayAllowed } from "./native-hook-relay.js";
 import { resolveCodexNativeSkillIsolation } from "./native-skill-isolation.js";
 import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
 import { flattenCodexDynamicToolFunctions } from "./protocol.js";
+import { readScheduledCodexAppManagedRequirementsFingerprint } from "./scheduled-app-authority.js";
 import { hashCodexAppServerBindingFingerprint } from "./session-binding.js";
 import { buildContextEngineBinding } from "./thread-context-engine.js";
 import {
@@ -119,6 +120,11 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
     ringZeroActive ||
     messageOnlySourceReply ||
     params.params.pluginHarnessToolPolicyRestricted === true;
+  const allowConfiguredManagedHooks =
+    params.params.pluginHarnessToolPolicyRestricted === true &&
+    !ringZeroActive &&
+    !messageOnlySourceReply &&
+    params.params.scheduledRuntimeAuthority === undefined;
   const imageGenerationDenied =
     params.params.pluginHarnessToolPolicySafeDeniedTools?.includes("image_generate") === true;
   if (restrictedToolSurface && params.nativeCodeModeEnabled !== false) {
@@ -136,6 +142,13 @@ export async function prepareCodexThreadLifecyclePreflight(params: CodexStartOrR
         {
           restrictedToolSurface,
           additionalDeniedFeatures: imageGenerationDenied ? ["image_generation"] : undefined,
+          allowedManagedRequirementsFingerprint:
+            readScheduledCodexAppManagedRequirementsFingerprint(
+              params.params.scheduledRuntimeAuthority,
+            ),
+          // Plugin policy restricts model-visible tools, while configured hooks are
+          // administrator policy. Stricter and detached surfaces remain fail closed.
+          allowConfiguredManagedHooks,
         },
         params.signal,
       ),

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -2309,6 +2309,61 @@ describe("Codex app-server thread lifecycle bindings", () => {
     },
   );
 
+  it("admits configured managed hooks for an interactive plugin-policy turn", async () => {
+    const sessionFile = path.join(tempDir, "plugin-policy-session.jsonl");
+    const workspaceDir = path.join(tempDir, "plugin-policy-workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.pluginHarnessToolPolicyRestricted = true;
+    const respond = vi.fn(async (method: string) => {
+      if (method === "config/read") {
+        return { config: {}, layers: [] };
+      }
+      if (method === "configRequirements/read") {
+        return {
+          requirements: {
+            hooks: {
+              PreToolUse: [{ matcher: "*", hooks: [{ type: "command" }] }],
+            },
+            featureRequirements: { hooks: true },
+          },
+        };
+      }
+      if (method === "thread/start") {
+        return threadStartResult("thread-plugin-policy-managed-hooks");
+      }
+      if (method === "mcpServerStatus/list") {
+        return { data: [], nextCursor: null };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond,
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: fixture.client,
+        params,
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        nativeCodeModeEnabled: false,
+        userMcpServersEnabled: false,
+        hostSystemAgentActive: false,
+      }),
+    ).resolves.toMatchObject({
+      threadId: "thread-plugin-policy-managed-hooks",
+      lifecycle: { action: "started" },
+    });
+    expect(fixture.request.mock.calls.map(([method]) => method)).toEqual([
+      "config/read",
+      "configRequirements/read",
+      "thread/start",
+      "mcpServerStatus/list",
+    ]);
+  });
+
   it("fails closed when requirements pin a restricted Codex feature on", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -290,6 +290,30 @@ describe("Codex ring-zero thread config", () => {
     );
   });
 
+  it("accepts the attested app server alongside disabled inherited servers", async () => {
+    const request = vi.fn(async () => ({
+      data: [
+        disabledMcpServerStatus("inherited"),
+        {
+          name: "codex_apps",
+          serverInfo: { name: "codex_apps", version: "1.0.0" },
+          tools: { "calendar.list": {} },
+        },
+      ],
+      nextCursor: null,
+    }));
+
+    await expect(
+      attestCodexRestrictedToolSurfaceMcpServersDisabled(
+        { request } as never,
+        "thread-restricted",
+        { mcp_servers: { inherited: { enabled: false } } },
+        undefined,
+        ["codex_apps"],
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it.each([
     {
       name: "an unexpected server",
@@ -456,6 +480,54 @@ describe("Codex ring-zero thread config", () => {
       config: { project_doc_max_bytes: 64_000 },
     });
     expect(disabled.config?.project_doc_max_bytes).toBe(0);
+  });
+
+  it("keeps scheduled-authority apps enabled inside the restricted tool surface", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    params.pluginHarnessToolPolicyRestricted = true;
+    params.scheduledRuntimeAuthority = {
+      version: 1,
+      runtimeId: "codex",
+      namespace: "codex.apps",
+      payload: { version: 1, auth: {}, apps: [] },
+    };
+    const apps = {
+      _default: { enabled: false },
+      calendar: { enabled: true },
+    };
+
+    const appServer = createAppServerOptions() as never;
+    const options = {
+      appServer,
+      cwd: "/repo",
+      dynamicTools: [],
+      hostSystemAgentActive: false,
+      nativeCodeModeEnabled: false,
+      config: {
+        apps,
+        mcp_servers: {
+          inherited: { command: "inherited-mcp" },
+        },
+      },
+    };
+    const start = buildThreadStartParams(params, options);
+    const resume = buildThreadResumeParams(params, {
+      ...options,
+      threadId: "thread-1",
+    });
+
+    for (const request of [start, resume]) {
+      expect(request.config?.["features.apps"]).toBe(true);
+      expect(request.config?.["orchestrator.mcp.enabled"]).toBe(true);
+      expect(request.config?.apps).toEqual(apps);
+      expect(request.config?.mcp_servers).toEqual({
+        inherited: {
+          command: "inherited-mcp",
+          enabled: false,
+        },
+      });
+      expect(request.config?.["features.multi_agent"]).toBe(false);
+    }
   });
 });
 

--- a/extensions/codex/src/app-server/thread-mcp-attestation.ts
+++ b/extensions/codex/src/app-server/thread-mcp-attestation.ts
@@ -1,0 +1,99 @@
+import type { CodexAppServerClient } from "./client.js";
+import { isJsonObject, type JsonObject } from "./protocol.js";
+
+export async function attestCodexRestrictedToolSurfaceMcpServersDisabled(
+  client: Pick<CodexAppServerClient, "request">,
+  threadId: string,
+  threadConfig: JsonObject | undefined,
+  signal?: AbortSignal,
+  expectedActiveServerNames: readonly string[] = [],
+): Promise<void> {
+  const configuredServers = threadConfig?.mcp_servers;
+  if (configuredServers !== undefined && !isJsonObject(configuredServers)) {
+    throw new Error("Codex restricted-tool-surface thread config has invalid mcp_servers");
+  }
+  // Codex reports configured-but-disabled servers as inactive status rows.
+  // Match those rows to the exact per-thread deny patch instead of requiring an empty inventory.
+  const expectedDisabledServerNames = new Set<string>();
+  for (const [name, serverConfig] of Object.entries(configuredServers ?? {})) {
+    if (!isJsonObject(serverConfig) || serverConfig.enabled !== false) {
+      throw new Error(`Codex restricted-tool-surface MCP server ${name} is not disabled`);
+    }
+    expectedDisabledServerNames.add(name);
+  }
+  const expectedActiveServers = new Set(expectedActiveServerNames);
+  for (const name of expectedActiveServers) {
+    if (expectedDisabledServerNames.has(name)) {
+      throw new Error(`Codex restricted-tool-surface MCP server ${name} has conflicting policy`);
+    }
+  }
+  const response = await client.request(
+    "mcpServerStatus/list",
+    { threadId, detail: "toolsAndAuthOnly" },
+    { signal },
+  );
+  if (!isJsonObject(response) || !Array.isArray(response.data)) {
+    throw new Error(
+      "Codex mcpServerStatus/list returned an invalid restricted-tool-surface attestation",
+    );
+  }
+  const observedServerNames = new Set<string>();
+  for (const status of response.data) {
+    if (!isJsonObject(status) || typeof status.name !== "string" || !isJsonObject(status.tools)) {
+      throw new Error(
+        "Codex mcpServerStatus/list returned an invalid restricted-tool-surface server",
+      );
+    }
+    if (!expectedDisabledServerNames.has(status.name) && !expectedActiveServers.has(status.name)) {
+      throw new Error(
+        `Codex restricted-tool-surface MCP attestation found unexpected server ${status.name}`,
+      );
+    }
+    if (observedServerNames.has(status.name)) {
+      throw new Error(
+        `Codex restricted-tool-surface MCP attestation returned duplicate server ${status.name}`,
+      );
+    }
+    observedServerNames.add(status.name);
+    if (!Object.hasOwn(status, "serverInfo")) {
+      throw new Error(
+        `Codex restricted-tool-surface MCP attestation returned malformed server ${status.name}`,
+      );
+    }
+    if (expectedActiveServers.has(status.name)) {
+      if (status.serverInfo === null || Object.keys(status.tools).length === 0) {
+        throw new Error(
+          `Codex restricted-tool-surface MCP attestation found inactive admitted server ${status.name}`,
+        );
+      }
+      continue;
+    }
+    if (status.serverInfo !== null) {
+      throw new Error(
+        `Codex restricted-tool-surface MCP attestation found active server ${status.name}`,
+      );
+    }
+    if (Object.keys(status.tools).length > 0) {
+      throw new Error(
+        `Codex restricted-tool-surface MCP attestation found tools for server ${status.name}`,
+      );
+    }
+  }
+  for (const expectedName of expectedDisabledServerNames) {
+    if (!observedServerNames.has(expectedName)) {
+      throw new Error(
+        `Codex restricted-tool-surface MCP attestation is missing server ${expectedName}`,
+      );
+    }
+  }
+  for (const expectedName of expectedActiveServers) {
+    if (!observedServerNames.has(expectedName)) {
+      throw new Error(
+        `Codex restricted-tool-surface MCP attestation is missing admitted server ${expectedName}`,
+      );
+    }
+  }
+  if (response.nextCursor !== undefined && response.nextCursor !== null) {
+    throw new Error("Codex mcpServerStatus/list returned an invalid empty-page cursor");
+  }
+}

--- a/extensions/codex/src/app-server/thread-requests.managed-requirements.test.ts
+++ b/extensions/codex/src/app-server/thread-requests.managed-requirements.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertCodexManagedRequirementsDoNotOverrideToolPolicy,
+  readCodexManagedRequirementsFingerprint,
+} from "./thread-requests.js";
+
+const managedRequirements = {
+  hooks: {
+    PreToolUse: [{ matcher: "*", hooks: [{ type: "command", command: "managed-hook" }] }],
+  },
+  featureRequirements: { hooks: true },
+};
+
+describe("configured app-server managed requirements", () => {
+  it("admits managed hooks for an interactive plugin-policy turn", async () => {
+    const request = vi.fn(async () => ({ requirements: managedRequirements }));
+
+    await expect(
+      assertCodexManagedRequirementsDoNotOverrideToolPolicy({ request } as never, {
+        restrictedToolSurface: true,
+        allowConfiguredManagedHooks: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("admits the exact managed requirements captured for a scheduled restricted turn", async () => {
+    const request = vi.fn(async () => ({ requirements: managedRequirements }));
+    const managedRequirementsFingerprint = await readCodexManagedRequirementsFingerprint({
+      request,
+    } as never);
+
+    await expect(
+      assertCodexManagedRequirementsDoNotOverrideToolPolicy({ request } as never, {
+        restrictedToolSurface: true,
+        allowedManagedRequirementsFingerprint: managedRequirementsFingerprint,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails closed when managed requirements change after scheduled authorization", async () => {
+    const request = vi.fn(async () => ({ requirements: managedRequirements }));
+    const allowedManagedRequirementsFingerprint = await readCodexManagedRequirementsFingerprint({
+      request: vi.fn(async () => ({ requirements: { hooks: {} } })),
+    } as never);
+
+    await expect(
+      assertCodexManagedRequirementsDoNotOverrideToolPolicy({ request } as never, {
+        restrictedToolSurface: true,
+        allowedManagedRequirementsFingerprint,
+      }),
+    ).rejects.toThrow("managed requirements changed");
+  });
+});

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import {
   isHostScopedAgentToolActive,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
@@ -25,6 +26,7 @@ import {
   type JsonObject,
   type JsonValue,
 } from "./protocol.js";
+import { fingerprintJsonObject } from "./thread-fingerprints.js";
 import {
   CODEX_NATIVE_PERSONALITY_NONE,
   resolveCodexAppServerModelProvider,
@@ -474,7 +476,10 @@ export function buildCodexRuntimeThreadConfigForRun(
         ? CODEX_DELEGATION_DISABLED_THREAD_CONFIG
         : undefined,
       messageOnlySourceReply || params.pluginHarnessToolPolicyRestricted === true
-        ? buildRestrictedToolConfigPatch(restrictedToolSurfaceMcpServerNames)
+        ? buildRestrictedToolConfigPatch(
+            restrictedToolSurfaceMcpServerNames,
+            Boolean(params.scheduledRuntimeAuthority),
+          )
         : buildCodexRingZeroThreadConfigPatch(
             params,
             options.hostSystemAgentActive,
@@ -510,7 +515,10 @@ export function buildCodexRingZeroThreadConfigPatch(
   };
 }
 
-function buildRestrictedToolConfigPatch(inheritedMcpServerNames: readonly string[]): JsonObject {
+function buildRestrictedToolConfigPatch(
+  inheritedMcpServerNames: readonly string[],
+  scheduledAppAuthorityActive = false,
+): JsonObject {
   // Restricted turns already send environments: [] and disable native code mode.
   // Remove Codex-owned tool sources here; project-document suppression belongs to
   // ring-zero, message-only, and tool-disabled context policy at the caller.
@@ -519,6 +527,12 @@ function buildRestrictedToolConfigPatch(inheritedMcpServerNames: readonly string
   );
   return {
     ...CODEX_RING_ZERO_THREAD_CONFIG,
+    ...(scheduledAppAuthorityActive
+      ? {
+          "features.apps": true,
+          "orchestrator.mcp.enabled": true,
+        }
+      : {}),
     ...(Object.keys(mcpServers).length > 0 ? { mcp_servers: mcpServers } : {}),
   };
 }
@@ -575,6 +589,8 @@ export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
   options: {
     restrictedToolSurface: boolean;
     additionalDeniedFeatures?: readonly string[];
+    allowedManagedRequirementsFingerprint?: string;
+    allowConfiguredManagedHooks?: boolean;
   },
   signal?: AbortSignal,
 ): Promise<void> {
@@ -586,11 +602,24 @@ export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
   if (!isJsonObject(response) || !Object.hasOwn(response, "requirements")) {
     throw new Error("Codex configRequirements/read returned an invalid response");
   }
+  if (response.requirements !== null && !isJsonObject(response.requirements)) {
+    throw new Error("Codex configRequirements/read returned invalid requirements");
+  }
+  const managedRequirementsFingerprint = buildCodexManagedRequirementsFingerprint(
+    response.requirements,
+  );
+  const managedRequirementsMatch =
+    options.allowedManagedRequirementsFingerprint !== undefined &&
+    managedRequirementsFingerprint === options.allowedManagedRequirementsFingerprint;
+  const managedHooksAllowed =
+    managedRequirementsMatch || options.allowConfiguredManagedHooks === true;
+  if (options.allowedManagedRequirementsFingerprint !== undefined && !managedRequirementsMatch) {
+    throw new Error(
+      "Codex managed requirements changed since this automation was authorized; reauthorize the automation from a fresh owner turn",
+    );
+  }
   if (response.requirements === null) {
     return;
-  }
-  if (!isJsonObject(response.requirements)) {
-    throw new Error("Codex configRequirements/read returned invalid requirements");
   }
   if (options.restrictedToolSurface) {
     for (const key of ["hooks", "managedHooks", "managed_hooks"] as const) {
@@ -601,7 +630,7 @@ export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
       if (!isJsonObject(hooks)) {
         throw new Error("Codex configRequirements/read returned invalid managed hooks");
       }
-      if (hasNonEmptyJsonValue(hooks)) {
+      if (hasNonEmptyJsonValue(hooks) && !managedHooksAllowed) {
         throw new Error("Codex restricted tool surface cannot override managed hooks");
       }
     }
@@ -624,6 +653,9 @@ export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
         (options.restrictedToolSurface &&
           CODEX_RING_ZERO_RESTRICTED_FEATURES.has(canonicalFeature)) ||
         additionalDeniedFeatures.has(canonicalFeature);
+      if (canonicalFeature === "hooks" && managedHooksAllowed) {
+        continue;
+      }
       if (enabled && deniedByToolPolicy) {
         throw new Error(`Codex tool policy cannot override required feature ${feature}`);
       }
@@ -631,80 +663,32 @@ export async function assertCodexManagedRequirementsDoNotOverrideToolPolicy(
   }
 }
 
-export async function attestCodexRestrictedToolSurfaceMcpServersDisabled(
+/** Hashes the exact managed requirements without retaining their hook commands or policy details. */
+function buildCodexManagedRequirementsFingerprint(requirements: JsonObject | null): string {
+  const fingerprint = fingerprintJsonObject({ version: 1, requirements });
+  return crypto.createHash("sha256").update(fingerprint).digest("hex");
+}
+
+/** Reads and fingerprints the exact managed requirements active on this app-server. */
+export async function readCodexManagedRequirementsFingerprint(
   client: Pick<CodexAppServerClient, "request">,
-  threadId: string,
-  threadConfig: JsonObject | undefined,
   signal?: AbortSignal,
-): Promise<void> {
-  const configuredServers = threadConfig?.mcp_servers;
-  if (configuredServers !== undefined && !isJsonObject(configuredServers)) {
-    throw new Error("Codex restricted-tool-surface thread config has invalid mcp_servers");
-  }
-  // Codex reports configured-but-disabled servers as inactive status rows.
-  // Match those rows to the exact per-thread deny patch instead of requiring an empty inventory.
-  const expectedDisabledServerNames = new Set<string>();
-  for (const [name, serverConfig] of Object.entries(configuredServers ?? {})) {
-    if (!isJsonObject(serverConfig) || serverConfig.enabled !== false) {
-      throw new Error(`Codex restricted-tool-surface MCP server ${name} is not disabled`);
-    }
-    expectedDisabledServerNames.add(name);
-  }
-  const response = await client.request(
-    "mcpServerStatus/list",
-    { threadId, detail: "toolsAndAuthOnly" },
+): Promise<string> {
+  const response: CodexConfigRequirementsReadResponse = await client.request(
+    "configRequirements/read",
+    undefined,
     { signal },
   );
-  if (!isJsonObject(response) || !Array.isArray(response.data)) {
-    throw new Error(
-      "Codex mcpServerStatus/list returned an invalid restricted-tool-surface attestation",
-    );
+  if (!isJsonObject(response) || !Object.hasOwn(response, "requirements")) {
+    throw new Error("Codex configRequirements/read returned an invalid response");
   }
-  const observedDisabledServerNames = new Set<string>();
-  for (const status of response.data) {
-    if (!isJsonObject(status) || typeof status.name !== "string" || !isJsonObject(status.tools)) {
-      throw new Error(
-        "Codex mcpServerStatus/list returned an invalid restricted-tool-surface server",
-      );
-    }
-    if (!expectedDisabledServerNames.has(status.name)) {
-      throw new Error(
-        `Codex restricted-tool-surface MCP attestation found unexpected server ${status.name}`,
-      );
-    }
-    if (observedDisabledServerNames.has(status.name)) {
-      throw new Error(
-        `Codex restricted-tool-surface MCP attestation returned duplicate server ${status.name}`,
-      );
-    }
-    observedDisabledServerNames.add(status.name);
-    if (!Object.hasOwn(status, "serverInfo")) {
-      throw new Error(
-        `Codex restricted-tool-surface MCP attestation returned malformed server ${status.name}`,
-      );
-    }
-    if (status.serverInfo !== null) {
-      throw new Error(
-        `Codex restricted-tool-surface MCP attestation found active server ${status.name}`,
-      );
-    }
-    if (Object.keys(status.tools).length > 0) {
-      throw new Error(
-        `Codex restricted-tool-surface MCP attestation found tools for server ${status.name}`,
-      );
-    }
+  if (response.requirements !== null && !isJsonObject(response.requirements)) {
+    throw new Error("Codex configRequirements/read returned invalid requirements");
   }
-  for (const expectedName of expectedDisabledServerNames) {
-    if (!observedDisabledServerNames.has(expectedName)) {
-      throw new Error(
-        `Codex restricted-tool-surface MCP attestation is missing server ${expectedName}`,
-      );
-    }
-  }
-  if (response.nextCursor !== undefined && response.nextCursor !== null) {
-    throw new Error("Codex mcpServerStatus/list returned an invalid empty-page cursor");
-  }
+  return buildCodexManagedRequirementsFingerprint(response.requirements);
 }
+
+export { attestCodexRestrictedToolSurfaceMcpServersDisabled } from "./thread-mcp-attestation.js";
 
 function hasNonEmptyJsonValue(value: JsonValue): boolean {
   if (value === null || value === false || value === "") {

--- a/src/cron/service/runtime-store.test.ts
+++ b/src/cron/service/runtime-store.test.ts
@@ -2,14 +2,55 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createDueIsolatedJob,
   noopLogger,
+  setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { saveCronStore } from "../store.js";
+import type { CronStoredJob } from "../types.js";
 import { stop } from "./ops-lifecycle.js";
-import { applyCronRuntimeRowsToState } from "./runtime-store.js";
+import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
 import { createCronServiceState } from "./state.js";
 import { armTimer } from "./timer.js";
 
+const runtimeStoreFixtures = setupCronRegressionFixtures({ prefix: "cron-runtime-store-" });
+
 describe("cron runtime row publication", () => {
   afterEach(() => vi.useRealTimers());
+
+  it("hydrates private runtime authority in runtime row transactions", async () => {
+    const store = runtimeStoreFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:03.000Z");
+    const job: CronStoredJob = createDueIsolatedJob({
+      id: "manual-run-runtime-authority",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    const runtimeAuthority = {
+      version: 1 as const,
+      runtimeId: "codex",
+      namespace: "codex.apps",
+      payload: { auth: { managedRequirementsFingerprint: "f".repeat(64) } },
+    };
+    job.runtimeAuthority = runtimeAuthority;
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const committedJob = commitCronRuntimeRows({
+      state,
+      jobIds: [job.id],
+      operationLabel: "test runtime authority hydration",
+      mutate: ({ jobs }) => ({ value: jobs.get(job.id) }),
+    });
+
+    expect(committedJob?.runtimeAuthority).toEqual(runtimeAuthority);
+  });
 
   it("adds a sibling-imported row to memory before arming its timer", () => {
     vi.useFakeTimers();

--- a/src/cron/service/runtime-store.ts
+++ b/src/cron/service/runtime-store.ts
@@ -8,8 +8,12 @@ import {
   loadCronRows,
   upsertCronJobRow,
 } from "../store/row-codec.js";
+import {
+  loadCronRuntimeAuthorities,
+  repairCronRuntimeAuthorityRows,
+} from "../store/runtime-authority-store.js";
 import type { CronStoreTransactionHooks } from "../store/transaction-hooks.js";
-import type { CronJob } from "../types.js";
+import type { CronJob, CronStoredJob } from "../types.js";
 import type { CronServiceState } from "./state.js";
 import { publishCronRuntimeRows } from "./store.js";
 
@@ -53,7 +57,7 @@ export function commitCronRuntimeRows<T>(params: {
   transactionHooks?: CronStoreTransactionHooks;
   mutate: (context: {
     database: DatabaseSync;
-    jobs: ReadonlyMap<string, CronJob>;
+    jobs: ReadonlyMap<string, CronStoredJob>;
   }) => CronRuntimeMutation<T>;
 }): T {
   const storeKey = cronStoreKey(params.state.deps.storePath);
@@ -62,13 +66,23 @@ export function commitCronRuntimeRows<T>(params: {
     ({ db }) => {
       const rows = loadCronRows(db, storeKey).filter((row) => jobIds.has(row.job_id));
       const rowsByJobId = new Map(rows.map((row) => [row.job_id, row] as const));
-      const jobs = new Map<string, CronJob>();
+      const loadedJobs: CronStoredJob[] = [];
       for (const row of rows) {
         const job = loadedCronStoreFromRows([row]).store.jobs[0];
         if (job) {
-          jobs.set(job.id, job);
+          loadedJobs.push(job);
         }
       }
+      const { repairJobIds } = loadCronRuntimeAuthorities({ db, storeKey, jobs: loadedJobs });
+      if (repairJobIds.length > 0) {
+        repairCronRuntimeAuthorityRows({
+          db,
+          storeKey,
+          jobs: loadedJobs,
+          jobIds: repairJobIds,
+        });
+      }
+      const jobs = new Map(loadedJobs.map((job) => [job.id, job] as const));
       const mutation = params.mutate({ database: db, jobs });
       const upsertJobIds = [...new Set(mutation.upsertJobIds ?? [])].toSorted();
       const deleteJobIds = [...new Set(mutation.deleteJobIds ?? [])].toSorted();


### PR DESCRIPTION
## Why This Change Was Made

Bring the configured Codex app-server cron authentication repair to the 2026.8.1 release line without taking newer main changes. This is a single-commit backport of #134525 at d6402a0c3df1d166de338b5c957dc7c3919d1aba, including the tool-title policy lookup fix.

## What Problem This Solves

Fixes an issue where users with an authenticated configured Codex app-server could not create app-authorized scheduled jobs because creation required a prepared profile. Also preserves current tool enablement when Codex configuration keys a tool by its MCP title instead of its full name.

## User Impact

Scheduled jobs use the configured endpoint's authentication and current app-tool inventory while retaining their stored app and approval ceilings. Jobs remain endpoint-owned, not bound to their creator's ChatGPT account. No manually maintained tool allowlist is required, and explicit tool disablement is preserved.

## Evidence

`pnpm build` passed on backport head `8827ff24383b9e0c4761813f5ee1b70512e2a288` using native macOS ARM64, Node 26.7.0, and pnpm 12.1.0. The complete app build finished in 3m 36.9s, including runtime and plugin bundles, declarations, and the Control UI. Dependencies were installed with `pnpm install --frozen-lockfile --ignore-scripts`; the operator approved the repository's existing pinned-Codex cooldown exemption. No tracked source or lockfile changed during compilation.

The operator explicitly requested compilation only and waived tests and additional review gates for this backport. No tests were run. This is not a claim of live-runtime validation.

The title-keyed policy behavior was checked against `openai/codex` tag `rust-v0.151.0`, `codex-rs/connectors/src/app_tool_policy.rs`: choose the full-name configuration entry first, then the title entry, before reading enablement and approval fields. Existing test cases were extended but not executed.

Release adaptations retain 8.1's native-execution helper, inline thread request types, and resume contexts. Resumed app attestation reads the same prebuilt or persisted policy used for the resume configuration. The assertion-only change in `thread-lifecycle.app-inventory.test.ts` is omitted because that newer test file does not exist on 8.1.

Backport-Of: #134525
Release-Target: sjf_openclaw_2026-09-01
Release-Base: d4b8674110b5fdaceecef1ea9d14e16e70f18a0b
