### PR TITLE
fix(codex): keep replies working after sub-plugin changes

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -62,6 +62,12 @@ describe("codex plugin", () => {
     expect(manifest.providers).toBeUndefined();
   });
 
+  it("keeps only Codex sub-plugin policy changes on the live thread-rotation path", () => {
+    expect(plugin.reload).toEqual({
+      noopPrefixes: ["plugins.entries.codex.config.codexPlugins"],
+    });
+  });
+
   it("does not select an agent or open plugin state while registering", () => {
     const openSyncKeyedStore = vi.fn(() => {
       throw new Error("openSyncKeyedStore is only available through the plugin runtime proxy");

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -69,6 +69,9 @@ export default definePluginEntry({
   id: "codex",
   name: "Codex",
   description: "Codex app-server harness and native session supervision.",
+  reload: {
+    noopPrefixes: ["plugins.entries.codex.config.codexPlugins"],
+  },
   register(api) {
     // Bundled modules may execute from a shared dist chunk, so import.meta.url
     // cannot identify the owning plugin package or its pinned dependencies.

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -327,6 +327,7 @@ describe("Codex /codex plugins subcommand", () => {
     });
     expect(io.currentConfig()).not.toHaveProperty("allow_all_plugins");
     expect(result.text).toContain("installed and authorized");
+    expect(result.text).toContain("Takes effect on your next message.");
   });
 
   it("installs remote plugins with their opaque remote identity and preserves exact summary ids", async () => {
@@ -728,6 +729,7 @@ describe("Codex /codex plugins subcommand", () => {
     );
     expect(installed.text).toContain("points to a different plugin identity");
     expect(enabled.text).toContain("enabled in openclaw.json");
+    expect(enabled.text).toContain("Takes effect on your next message.");
     expect(runtime.install).not.toHaveBeenCalled();
     expect(io.current()["security-review@company-tools"]).toEqual({
       enabled: true,

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -55,11 +55,9 @@ type ConfiguredPluginKeyResolution =
   | { status: "mismatched" };
 
 // Plugin lifecycle changes (enable/disable) write to openclaw.json
-// synchronously. The Codex app-server picks up the new policy when the next
-// thread starts; in-flight conversations keep the old policy until /new or
-// /reset. A full gateway restart is NOT needed.
-const POLICY_REFRESH_HINT =
-  "New Codex conversations pick this up automatically. Use /new or /reset to refresh the current one.";
+// synchronously. The next message rotates the native thread onto the new
+// policy; a conversation reset or full gateway restart is not needed.
+const POLICY_REFRESH_HINT = "Takes effect on your next message.";
 
 export async function handleCodexPluginsSubcommand(
   ctx: PluginCommandContext,
@@ -701,6 +699,6 @@ function formatPluginList(
     ...(globalEnabled
       ? []
       : ["Global codexPlugins.enabled is off; configured sub-plugins are inactive.", ""]),
-    "New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.",
+    POLICY_REFRESH_HINT,
   ].join("\n");
 }

--- a/src/gateway/config-diff.ts
+++ b/src/gateway/config-diff.ts
@@ -5,21 +5,36 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPlainObject } from "../utils.js";
 
 /** Return dotted config paths whose values differ between two config snapshots. */
-export function diffConfigPaths(prev: unknown, next: unknown, prefix = ""): string[] {
+export function diffConfigPaths(
+  prev: unknown,
+  next: unknown,
+  prefix = "",
+  refinementPrefixes: readonly string[] = [],
+): string[] {
   if (prev === next) {
     return [];
   }
-  if (isPlainObject(prev) && isPlainObject(next)) {
-    const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  const hasNestedRefinement = refinementPrefixes.some((entry) =>
+    prefix ? entry.startsWith(`${prefix}.`) : true,
+  );
+  // A missing parent normally collapses to one path. Registered boundaries must
+  // survive that collapse so a narrow owner rule can still outrank its fallback.
+  if (
+    (isPlainObject(prev) && isPlainObject(next)) ||
+    (hasNestedRefinement && (isPlainObject(prev) || isPlainObject(next)))
+  ) {
+    const prevRecord = isPlainObject(prev) ? prev : {};
+    const nextRecord = isPlainObject(next) ? next : {};
+    const keys = new Set([...Object.keys(prevRecord), ...Object.keys(nextRecord)]);
     const paths: string[] = [];
     for (const key of keys) {
-      const prevValue = prev[key];
-      const nextValue = next[key];
+      const prevValue = prevRecord[key];
+      const nextValue = nextRecord[key];
       if (prevValue === undefined && nextValue === undefined) {
         continue;
       }
       const childPrefix = prefix ? `${prefix}.${key}` : key;
-      const childPaths = diffConfigPaths(prevValue, nextValue, childPrefix);
+      const childPaths = diffConfigPaths(prevValue, nextValue, childPrefix, refinementPrefixes);
       if (childPaths.length > 0) {
         paths.push(...childPaths);
       }
@@ -62,8 +77,9 @@ function projectGatewayReloadBoundaries(config: OpenClawConfig) {
 export function diffGatewayReloadPaths(
   prevConfig: OpenClawConfig,
   nextConfig: OpenClawConfig,
+  reloadPrefixes: Iterable<string>,
 ): string[] {
-  const changedPaths = diffConfigPaths(prevConfig, nextConfig);
+  const changedPaths = diffConfigPaths(prevConfig, nextConfig, "", [...reloadPrefixes]);
   const boundaryPaths = diffConfigPaths(
     projectGatewayReloadBoundaries(prevConfig),
     projectGatewayReloadBoundaries(nextConfig),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -180,6 +180,7 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
 ];
 
 let cachedReloadRules: ReloadRule[] | null = null;
+let cachedRefinementPrefixes: string[] = [];
 let cachedRegistry: ReturnType<typeof getActivePluginHttpRouteRegistry> | null = null;
 let cachedGatewayRegistryVersion = -1;
 
@@ -191,6 +192,7 @@ function listReloadRules(): ReloadRule[] {
   // version changes; cache them to keep every config diff cheap.
   if (registry !== cachedRegistry || gatewayRegistryVersion !== cachedGatewayRegistryVersion) {
     cachedReloadRules = null;
+    cachedRefinementPrefixes = [];
     cachedRegistry = registry;
     cachedGatewayRegistryVersion = gatewayRegistryVersion;
   }
@@ -275,8 +277,16 @@ function listReloadRules(): ReloadRule[] {
   // Narrow config contracts must override broad owner fallbacks. Sort once per
   // registry snapshot so the hot path can retain first-match semantics.
   rules.sort((a, b) => b.prefix.length - a.prefix.length);
+  cachedRefinementPrefixes = [...pluginReloadRules, ...channelReloadRules].map(
+    (rule) => rule.prefix,
+  );
   cachedReloadRules = rules;
   return rules;
+}
+
+export function listConfigReloadRefinementPrefixes(): string[] {
+  listReloadRules();
+  return cachedRefinementPrefixes;
 }
 
 function matchRule(path: string): ReloadRule | null {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -52,6 +52,7 @@ import {
   buildGatewayReloadPlan,
   type ChannelKind,
   isNoopGatewayReloadPlan,
+  listConfigReloadRefinementPrefixes,
   resolveConfigReloadMetadata,
 } from "./config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "./config-reload-settings.js";
@@ -179,7 +180,7 @@ describe("diffConfigPaths", () => {
     { prev: {}, next: { mcp: { apps: { enabled: true } } } },
     { prev: { mcp: { apps: { enabled: true } } }, next: {} },
   ])("preserves the Apps restart boundary for whole MCP changes", ({ prev, next }) => {
-    const changedPaths = diffGatewayReloadPaths(prev, next);
+    const changedPaths = diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes());
     expect(changedPaths).toEqual(["mcp", "mcp.apps"]);
     expect(buildGatewayReloadPlan(changedPaths).restartReasons).toContain("mcp.apps");
   });
@@ -196,7 +197,11 @@ describe("diffConfigPaths", () => {
       [configure("first"), configure("second"), true],
       [configure("first", "before"), configure("first", "after"), false],
     ] as const) {
-      expect(buildGatewayReloadPlan(diffGatewayReloadPaths(prev, next)).reloadPlugins).toBe(reload);
+      expect(
+        buildGatewayReloadPlan(
+          diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes()),
+        ).reloadPlugins,
+      ).toBe(reload);
     }
   });
 
@@ -262,7 +267,11 @@ describe("diffConfigPaths", () => {
       expectedPaths: ["session.scope", "session.store"],
     },
   ])("preserves hook policy dependencies when it $name", ({ prev, next, expectedPaths }) => {
-    const changedPaths = diffGatewayReloadPaths(prev as OpenClawConfig, next as OpenClawConfig);
+    const changedPaths = diffGatewayReloadPaths(
+      prev as OpenClawConfig,
+      next as OpenClawConfig,
+      listConfigReloadRefinementPrefixes(),
+    );
 
     for (const expectedPath of expectedPaths) {
       expect(changedPaths).toContain(expectedPath);
@@ -345,6 +354,12 @@ describe("buildGatewayReloadPlan", () => {
       pluginId: "canvas",
       pluginName: "Canvas",
       registration: { restartPrefixes: ["plugins.entries.canvas"] },
+      source: "test",
+    },
+    {
+      pluginId: "codex",
+      pluginName: "Codex",
+      registration: { noopPrefixes: ["plugins.entries.codex.config.codexPlugins"] },
       source: "test",
     },
   ];
@@ -593,7 +608,7 @@ describe("buildGatewayReloadPlan", () => {
     [{ agents: { defaults: { mediaMaxMb: 4 } } }, { agents: {} }],
     [{ agents: { defaults: { mediaMaxMb: 4 } } }, { agents: { defaults: { mediaMaxMb: 1 } } }],
   ])("refreshes every channel when the global media limit changes: %j → %j", (prev, next) => {
-    const paths = diffGatewayReloadPaths(prev, next);
+    const paths = diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes());
     expect(paths).toContain("agents.defaults.mediaMaxMb");
     const plan = buildGatewayReloadPlan(paths);
     expect(plan.restartGateway).toBe(false);
@@ -804,6 +819,52 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartReasons).toEqual([path]);
     expect(plan.hotReasons).toStrictEqual([]);
   });
+
+  const codexEntryConfig = (config?: Record<string, unknown>) => ({
+    plugins: {
+      entries: {
+        codex: config ? { config } : {},
+      },
+    },
+  });
+
+  it.each([
+    {
+      name: "creates config on first install",
+      previous: {},
+      next: codexEntryConfig({ codexPlugins: { enabled: true } }),
+      expectedPaths: ["plugins.entries.codex.config.codexPlugins"],
+    },
+    {
+      name: "changes existing sub-plugin policy",
+      previous: codexEntryConfig({ codexPlugins: { enabled: false } }),
+      next: codexEntryConfig({ codexPlugins: { enabled: true } }),
+      expectedPaths: ["plugins.entries.codex.config.codexPlugins.enabled"],
+    },
+    {
+      name: "keeps a mixed first-install write reloadable",
+      previous: {},
+      next: codexEntryConfig({
+        codexPlugins: { enabled: true },
+        appServer: { transport: "websocket" },
+      }),
+      expectedPaths: [
+        "plugins.entries.codex.config.codexPlugins",
+        "plugins.entries.codex.config.appServer",
+      ],
+      reloadPlugins: true,
+    },
+  ])(
+    "classifies Codex config when it $name",
+    ({ previous, next, expectedPaths, reloadPlugins }) => {
+      const paths = diffGatewayReloadPaths(previous, next, listConfigReloadRefinementPrefixes());
+      const plan = buildGatewayReloadPlan(paths);
+
+      expect(paths).toEqual(expectedPaths);
+      expect(plan.reloadPlugins).toBe(reloadPlugins ?? false);
+      expect(isNoopGatewayReloadPlan(plan)).toBe(reloadPlugins !== true);
+    },
+  );
 
   it("uses default reload settings when config is unset", () => {
     expect(resolveGatewayReloadSettings({})).toMatchObject({ mode: "hybrid", debounceMs: 300 });

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -830,6 +830,65 @@ describe("buildGatewayReloadPlan", () => {
 
   it.each([
     {
+      name: "plugin restart",
+      config: { plugins: { entries: { canvas: { enabled: true } } } },
+      paths: ["plugins.entries.canvas"],
+      kind: "restart",
+      channels: [],
+    },
+    {
+      name: "plugin hot",
+      config: { browser: { profiles: { qa: { cdpUrl: "http://127.0.0.1:9222" } } } },
+      paths: ["browser.profiles"],
+      kind: "hot",
+      channels: [],
+    },
+    {
+      name: "plugin none",
+      config: codexEntryConfig({ codexPlugins: { enabled: true } }),
+      paths: ["plugins.entries.codex.config.codexPlugins"],
+      kind: "none",
+      channels: [],
+    },
+    {
+      name: "channel hot",
+      config: { channels: { telegram: { enabled: true } } },
+      paths: ["channels.telegram"],
+      kind: "hot",
+      channels: ["telegram"],
+    },
+    {
+      name: "channel noop",
+      config: { channels: { whatsapp: { replyToMode: "all" } } },
+      paths: ["channels.whatsapp.replyToMode"],
+      kind: "none",
+      channels: [],
+    },
+  ] as const)(
+    "preserves registered $name boundaries through parent creation and removal",
+    ({ config, paths, kind, channels }) => {
+      for (const [previous, next] of [
+        [{}, config],
+        [config, {}],
+      ] as const) {
+        const changedPaths = diffGatewayReloadPaths(
+          previous,
+          next,
+          listConfigReloadRefinementPrefixes(),
+        );
+        const plan = buildGatewayReloadPlan(changedPaths);
+
+        expect(changedPaths).toEqual(paths);
+        expect(changedPaths.map((path) => resolveConfigReloadMetadata(path).kind)).toEqual([kind]);
+        expect(plan.restartGateway).toBe(kind === "restart");
+        expect(plan.restartChannels).toEqual(new Set(channels));
+        expect(plan.noopPaths).toEqual(kind === "none" ? paths : []);
+      }
+    },
+  );
+
+  it.each([
+    {
       name: "creates config on first install",
       previous: {},
       next: codexEntryConfig({ codexPlugins: { enabled: true } }),

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -39,6 +39,7 @@ import { diffConfigPaths, diffGatewayReloadPaths } from "./config-diff.js";
 import {
   buildGatewayReloadPlan,
   isNoopGatewayReloadPlan,
+  listConfigReloadRefinementPrefixes,
   listPluginInstallTimestampMetadataPaths,
   listPluginInstallWholeRecordPaths,
   type GatewayReloadPlan,
@@ -537,7 +538,11 @@ export function startGatewayConfigReloader(opts: {
         appliedRevision.defer(plan, nextConfigRevisionHash);
       },
     };
-    const configChangedPaths = diffGatewayReloadPaths(currentCompareConfig, nextCompareConfig);
+    const configChangedPaths = diffGatewayReloadPaths(
+      currentCompareConfig,
+      nextCompareConfig,
+      listConfigReloadRefinementPrefixes(),
+    );
     const configPluginInstallTimestampNoopPaths = listPluginInstallTimestampMetadataPaths(
       currentCompareConfig,
       nextCompareConfig,


### PR DESCRIPTION
Closes #135618

## What Problem This Solves

Fixes an issue where changing Codex sub-plugin policy during a Codex-backed conversation could retire the plugin generation used by that channel. Later messages from the still-running channel then failed with `agent harness host capability is no longer active` until the Gateway restarted.

The same failure could occur on the first sub-plugin install: when the Codex config parents did not exist yet, the config diff collapsed the entire write to an ancestor path and bypassed the narrow Codex-owned reload rule.

## Why This Change Was Made

The Codex plugin declares only `plugins.entries.codex.config.codexPlugins` as dynamically read configuration. The Gateway now refines collapsed parent-object diffs through registered plugin and channel reload prefixes, preserving the exact owner boundary even when a write creates or removes all parent objects.

This keeps unrelated Codex settings reloadable. If one write creates `codexPlugins` plus another Codex config block, the diff emits both paths and the unrelated path still triggers normal plugin replacement.

Codex remains responsible for applying sub-plugin policy at the native-thread lifecycle boundary. `ThreadStartParams.config` carries configuration into a new thread (`../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:59-99`), while a loaded thread preserves rejoin semantics and ignores mismatched resume overrides unless it can be safely shut down (`../codex/codex-rs/app-server/src/request_processors/thread_processor.rs:3990-4048`). These citations were rechecked against the final PR head. OpenClaw's existing plugin-app fingerprint therefore rotates the exact native thread on the next turn.

## User Impact

Operators can install, enable, update, or remove Codex sub-plugin policy from a conversation without losing later replies or restarting the Gateway. This includes the first install when the nested Codex config objects are created from scratch.

## Evidence

Before the fix:

- The original regression showed `plugin.reload === undefined`, proving Codex had no narrow owner rule.
- After adding the narrow rule, a first-install write still collapsed to `plugins.entries.codex.config`, so the generic `plugins` rule could replace the active generation.
- The fix2 first-install regression fails without collapsed-diff refinement because it expects `plugins.entries.codex.config.codexPlugins` and `reloadPlugins === false` from an initial config with no Codex entry.

After the fix, deterministic isolated Gateway scenarios covered both policy shapes:

- First install, port `19183`: initial config had no `plugins.entries.codex`; the in-turn write created every parent and was detected as exactly `plugins.entries.codex.config.codexPlugins`. Both turns returned `status: ok`, and two `thread/start` requests proved native thread rotation.
- Existing policy, port `19184`: the write was detected as the exact changed `codexPlugins` descendants. Both turns returned `status: ok`, and two native threads were started.
- Mixed first-install negative control, port `19185`: the same write also created `sessionCatalog`; the Gateway detected both paths and logged `config hot reload applied (plugins.entries.codex.config.sessionCatalog)`, proving unrelated Codex config still replaces the plugin generation.
- None of the scenarios logged an inactive host-capability error.

Registered-prefix consumers checked:

- Plugin registrations: Browser (`restart` and nested `hot`), Canvas (`restart`), and Codex (`none`).
- Bundled channel registrations: a2a, buzz, clickclack, discord, feishu, googlechat, imessage, irc, line, matrix, mattermost, msteams, nextcloud-talk, nostr, qa-channel, raft, reef, signal, slack, sms, synology-chat, telegram, tlon, whatsapp, zalo, and zalouser.
- The table-driven contract matrix covers parent creation and removal for plugin `restart`, `hot`, and `none`, plus channel `hot` and `noop`, using Canvas, Browser, Codex, Telegram, and WhatsApp as nominal representatives.
- External plugins consume the same active reload-registration contract, so their registered prefixes use the same refinement path.

Validation:

- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts extensions/codex/index.test.ts extensions/codex/src/app-server/plugin-thread-config.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts` (538 tests passed on final head)
- `node scripts/check-changed.mjs` (passed on final head)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (`scoped-clean` on final head)
- `node scripts/run-vitest.mjs extensions/codex/src/command-plugins-management.test.ts` (42 tests passed)
- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts` (231 tests passed, including the consumer matrix)
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` (`scoped-clean` for the closeout diff)
- Runtime post-build completed all 12 phases and verified 53 plugin control-plane modules using this worktree's built `@openclaw/ai` output. Direct `pnpm build` reached post-build but the linked worktree's shared `node_modules/@openclaw/ai` symlink resolved stale output from the canonical checkout.

Production LOC: +46/-14 (net +32). The generic growth preserves registered owner boundaries through collapsed object creation/removal without broadening any plugin policy; the closeout production change only corrects command guidance. Tests: +132/-4.
