### PR TITLE
fix(ui): show full effort levels for fallback models

### DIFF
--- a/src/agents/harness/model-catalog.test.ts
+++ b/src/agents/harness/model-catalog.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import type { ModelCatalogSnapshot } from "../model-catalog.types.js";
-import { augmentModelCatalogWithAgentHarness } from "./model-catalog.js";
+import {
+  augmentModelCatalogWithAgentHarnesses,
+  augmentPreparedModelCatalogWithAgentHarnesses,
+} from "./model-catalog.js";
 
 const cfg = {
   agents: {
@@ -94,6 +97,76 @@ function registryWithCatalog(loadModelCatalog: () => Promise<readonly never[]>) 
 }
 
 describe("agent harness model catalog", () => {
+  it("hydrates a fallback when a different primary harness fails", async () => {
+    const loadPrimaryModelCatalog = vi.fn(async () => {
+      throw new Error("primary model catalog unavailable");
+    });
+    const loadModelCatalog = vi.fn(async () => [
+      {
+        provider: "openai",
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol (account)",
+        nativeRuntime: "codex",
+        reasoning: true,
+        compat: {
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+        },
+      },
+    ]);
+    const pluginRegistry = registryWithCatalog(loadModelCatalog as never);
+    pluginRegistry.agentHarnesses.unshift({
+      pluginId: "claude-cli",
+      source: "test",
+      harness: {
+        id: "claude-cli",
+        label: "Claude CLI",
+        supports: () => ({ supported: true }),
+        runAttempt: vi.fn(),
+        loadModelCatalog: loadPrimaryModelCatalog,
+      } as never,
+    });
+    const mixedRuntimeConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-5",
+            fallbacks: ["openai/gpt-5.6-sol"],
+          },
+          models: {
+            "anthropic/claude-opus-5": { agentRuntime: { id: "claude-cli" } },
+            "openai/gpt-5.6-sol": {},
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+
+    const result = await augmentPreparedModelCatalogWithAgentHarnesses({
+      input: {
+        config: mixedRuntimeConfig,
+        agentId: "main",
+        agentDir: "/tmp/main-agent",
+        workspaceDir: "/tmp/workspace",
+        runtimePluginSelections: [
+          { provider: "anthropic", modelId: "claude-opus-5", agentId: "main" },
+          { provider: "openai", modelId: "gpt-5.6-sol", agentId: "main" },
+        ],
+      },
+      snapshot,
+      pluginRegistry,
+    });
+
+    expect(loadPrimaryModelCatalog).toHaveBeenCalledOnce();
+    expect(loadModelCatalog).toHaveBeenCalledOnce();
+    expect(result.entries[0]).toMatchObject({
+      id: "gpt-5.6-sol",
+      compat: {
+        supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+      },
+    });
+  });
+
   it.each([false, true])(
     "does not donate host transport or capabilities to native-owned rows (host sibling: %s)",
     async (includeHostRow) => {
@@ -105,13 +178,12 @@ describe("agent harness model catalog", () => {
         reasoning: true,
       };
       const host = { provider: "openai", id: "gpt-5.6-terra", name: "Host model" };
-      const result = await augmentModelCatalogWithAgentHarness({
+      const result = await augmentModelCatalogWithAgentHarnesses({
         cfg,
         agentId: "main",
         agentDir: "/tmp/main-agent",
         workspaceDir: "/tmp/workspace",
-        defaultProvider: "openai",
-        defaultModel: "openai/gpt-5.6-sol",
+        modelSelections: [{ provider: "openai", modelId: "gpt-5.6-sol", agentId: "main" }],
         snapshot,
         pluginRegistry: registryWithCatalog(
           async () => (includeHostRow ? [native, host] : [native]) as never,
@@ -169,13 +241,12 @@ describe("agent harness model catalog", () => {
       },
     ]);
 
-    const result = await augmentModelCatalogWithAgentHarness({
+    const result = await augmentModelCatalogWithAgentHarnesses({
       cfg,
       agentId: "main",
       agentDir: "/tmp/main-agent",
       workspaceDir: "/tmp/workspace",
-      defaultProvider: "anthropic",
-      defaultModel: "openai/gpt-5.6-sol",
+      modelSelections: [{ provider: "openai", modelId: "gpt-5.6-sol", agentId: "main" }],
       snapshot,
       pluginRegistry: registryWithCatalog(loadModelCatalog as never),
     });
@@ -217,13 +288,12 @@ describe("agent harness model catalog", () => {
 
   it("keeps prepared rows when harness discovery fails", async () => {
     const onError = vi.fn();
-    const result = await augmentModelCatalogWithAgentHarness({
+    const result = await augmentModelCatalogWithAgentHarnesses({
       cfg,
       agentId: "main",
       agentDir: "/tmp/main-agent",
       workspaceDir: "/tmp/workspace",
-      defaultProvider: "anthropic",
-      defaultModel: "openai/gpt-5.6-sol",
+      modelSelections: [{ provider: "openai", modelId: "gpt-5.6-sol", agentId: "main" }],
       snapshot,
       pluginRegistry: registryWithCatalog(async () => {
         throw new Error("model/list unavailable");

--- a/src/agents/harness/model-catalog.ts
+++ b/src/agents/harness/model-catalog.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { dedupeByKey } from "../../shared/dedupe-by-key.js";
+import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import {
   resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
@@ -14,6 +15,11 @@ import { resolveModelCatalogIdentityKey } from "../openai-model-routes.js";
 import type { PreparedModelRuntimeInput } from "../prepared-model-runtime.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../workspace.js";
 import { resolveAgentHarnessPolicy } from "./policy.js";
+import type { AgentHarnessPluginSelection } from "./runtime-plugin-load-plan.js";
+
+type LoadHarnessModelCatalog = NonNullable<
+  PluginRegistry["agentHarnesses"][number]["harness"]["loadModelCatalog"]
+>;
 
 function normalizeRouteBaseUrl(value: string | undefined): string {
   if (!value) {
@@ -104,85 +110,127 @@ function enrichHarnessRows(
   });
 }
 
-export async function augmentModelCatalogWithAgentHarness(params: {
+function resolveHarnessRuntime(params: {
   cfg: OpenClawConfig;
   agentId: string;
-  agentDir: string;
-  workspaceDir: string;
-  defaultProvider: string;
-  defaultModel?: string;
+  selection: AgentHarnessPluginSelection;
   snapshot: ModelCatalogSnapshot;
-  pluginRegistry?: PluginRegistry | null;
-  onError?: (error: unknown) => void;
-}): Promise<ModelCatalogSnapshot> {
-  const rawDefaultModel = params.defaultModel?.trim();
-  if (!rawDefaultModel) {
-    return params.snapshot;
+}): string {
+  const requestedRuntime = normalizeOptionalAgentRuntimeId(params.selection.runtime);
+  if (requestedRuntime && !isDefaultAgentRuntimeId(requestedRuntime)) {
+    return requestedRuntime;
   }
-  const ref = resolveModelRefFromString({
-    cfg: params.cfg,
-    raw: rawDefaultModel,
-    defaultProvider: params.defaultProvider,
-    allowManifestNormalization: true,
-    allowPluginNormalization: true,
-  })?.ref;
-  if (!ref) {
-    return params.snapshot;
-  }
-  const refKey = resolveModelCatalogIdentityKey({ provider: ref.provider, id: ref.model });
+  const refKey = resolveModelCatalogIdentityKey({
+    provider: params.selection.provider,
+    id: params.selection.modelId,
+  });
   const routeEntry = [...params.snapshot.entries, ...(params.snapshot.staticEntries ?? [])].find(
     (entry) => resolveModelCatalogIdentityKey(entry) === refKey,
   );
-  const runtime = resolveAgentHarnessPolicy({
-    provider: ref.provider,
-    modelId: ref.model,
+  return resolveAgentHarnessPolicy({
+    provider: params.selection.provider,
+    modelId: params.selection.modelId,
     modelApi: routeEntry?.api,
     modelBaseUrl: routeEntry?.baseUrl,
     config: params.cfg,
     agentId: params.agentId,
   }).runtime;
-  if (runtime === "auto" || runtime === "openclaw") {
-    return params.snapshot;
-  }
-  const pluginRegistry = params.pluginRegistry ?? getActivePluginRegistry();
-  const harness = pluginRegistry?.agentHarnesses.find(
-    (entry) => entry.harness.id === runtime,
-  )?.harness;
-  if (!harness?.loadModelCatalog) {
-    return params.snapshot;
-  }
-  try {
-    const listedRows = await harness.loadModelCatalog({
-      config: params.cfg,
-      agentId: params.agentId,
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
-    });
-    if (!params.pluginRegistry && getActivePluginRegistry() !== pluginRegistry) {
-      return params.snapshot;
-    }
-    if (listedRows.length === 0) {
-      return params.snapshot;
-    }
-    const rows = enrichHarnessRows(listedRows, params.snapshot);
-    return {
-      ...params.snapshot,
-      entries: dedupeByKey([...rows, ...params.snapshot.entries], resolveModelCatalogIdentityKey),
-      routeVariants: dedupeByKey([...rows, ...params.snapshot.routeVariants], routeVariantKey),
-    };
-  } catch (error) {
-    params.onError?.(error);
-    return params.snapshot;
-  }
 }
 
-export function augmentPreparedModelCatalogWithAgentHarness(params: {
+export async function augmentModelCatalogWithAgentHarnesses(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  agentDir: string;
+  workspaceDir: string;
+  modelSelections: readonly AgentHarnessPluginSelection[];
+  snapshot: ModelCatalogSnapshot;
+  pluginRegistry?: PluginRegistry | null;
+  reuseLoadedNativeRuntimes?: boolean;
+  onError?: (error: unknown) => void;
+}): Promise<ModelCatalogSnapshot> {
+  const usesActiveRegistry = params.pluginRegistry == null;
+  const pluginRegistry = params.pluginRegistry ?? getActivePluginRegistry();
+  const loadedNativeRuntimes = params.reuseLoadedNativeRuntimes
+    ? new Set(
+        [...params.snapshot.entries, ...params.snapshot.routeVariants].map(
+          (entry) => entry.nativeRuntime,
+        ),
+      )
+    : undefined;
+  const seenRuntimes = new Set<string>();
+  const catalogLoaders: LoadHarnessModelCatalog[] = [];
+  // Every selected fallback can become the executing route. Discover each distinct runtime once
+  // so catalog capabilities never depend on which runtime happens to own the primary model.
+  for (const selection of params.modelSelections) {
+    const runtime = resolveHarnessRuntime({ ...params, selection });
+    if (
+      runtime === "auto" ||
+      runtime === "openclaw" ||
+      seenRuntimes.has(runtime) ||
+      loadedNativeRuntimes?.has(runtime)
+    ) {
+      continue;
+    }
+    seenRuntimes.add(runtime);
+    const harness = pluginRegistry?.agentHarnesses.find(
+      (entry) => entry.harness.id === runtime,
+    )?.harness;
+    if (harness?.loadModelCatalog) {
+      catalogLoaders.push(harness.loadModelCatalog.bind(harness));
+    }
+  }
+  if (catalogLoaders.length === 0) {
+    return params.snapshot;
+  }
+  const listedRows = await Promise.all(
+    catalogLoaders.map(async (loadModelCatalog) => {
+      try {
+        return await loadModelCatalog({
+          config: params.cfg,
+          agentId: params.agentId,
+          agentDir: params.agentDir,
+          workspaceDir: params.workspaceDir,
+        });
+      } catch (error) {
+        params.onError?.(error);
+        return [];
+      }
+    }),
+  );
+  if (usesActiveRegistry && getActivePluginRegistry() !== pluginRegistry) {
+    return params.snapshot;
+  }
+  const rows = listedRows.flatMap((entries) => enrichHarnessRows(entries, params.snapshot));
+  if (rows.length === 0) {
+    return params.snapshot;
+  }
+  return {
+    ...params.snapshot,
+    entries: dedupeByKey([...rows, ...params.snapshot.entries], resolveModelCatalogIdentityKey),
+    routeVariants: dedupeByKey([...rows, ...params.snapshot.routeVariants], routeVariantKey),
+  };
+}
+
+export function augmentPreparedModelCatalogWithAgentHarnesses(params: {
   input: PreparedModelRuntimeInput;
   snapshot: ModelCatalogSnapshot;
   pluginRegistry?: PluginRegistry;
 }): Promise<ModelCatalogSnapshot> {
   const agentId = params.input.agentId ?? resolveDefaultAgentId(params.input.config);
-  return augmentModelCatalogWithAgentHarness({
+  const defaultModel = resolveAgentEffectiveModelPrimary(params.input.config, agentId)?.trim();
+  const defaultRef = defaultModel
+    ? resolveModelRefFromString({
+        cfg: params.input.config,
+        raw: defaultModel,
+        defaultProvider: DEFAULT_PROVIDER,
+        allowManifestNormalization: true,
+        allowPluginNormalization: true,
+      })?.ref
+    : undefined;
+  const modelSelections =
+    params.input.runtimePluginSelections ??
+    (defaultRef ? [{ provider: defaultRef.provider, modelId: defaultRef.model, agentId }] : []);
+  return augmentModelCatalogWithAgentHarnesses({
     cfg: params.input.config,
     agentId,
     agentDir: params.input.agentDir,
@@ -190,9 +238,11 @@ export function augmentPreparedModelCatalogWithAgentHarness(params: {
       params.input.workspaceDir ??
       resolveAgentWorkspaceDir(params.input.config, agentId) ??
       resolveDefaultAgentWorkspaceDir(),
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: resolveAgentEffectiveModelPrimary(params.input.config, agentId),
+    modelSelections,
     snapshot: params.snapshot,
     pluginRegistry: params.pluginRegistry,
+    // Prepared native rows prove that this generation already captured the runtime catalog.
+    // Reopening its loader would violate the lifecycle-owned no-rediscovery boundary.
+    reuseLoadedNativeRuntimes: true,
   });
 }

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -380,8 +380,8 @@ export async function loadProviderScopedThinkingCatalog(params: {
   };
   const augmentHarnessCatalog = async (snapshot: ModelCatalogSnapshot) => {
     const agentId = params.agentId ?? resolveAmbientOwnerAgentId(params.config);
-    const { augmentModelCatalogWithAgentHarness } = await import("./harness/model-catalog.js");
-    const augmented = await augmentModelCatalogWithAgentHarness({
+    const { augmentModelCatalogWithAgentHarnesses } = await import("./harness/model-catalog.js");
+    const augmented = await augmentModelCatalogWithAgentHarnesses({
       cfg: params.config,
       agentId,
       agentDir: params.agentDir ?? resolveAgentDir(params.config, agentId),
@@ -389,8 +389,7 @@ export async function loadProviderScopedThinkingCatalog(params: {
         params.workspaceDir ??
         resolveAgentWorkspaceDir(params.config, agentId) ??
         resolveDefaultAgentWorkspaceDir(),
-      defaultProvider: params.provider,
-      defaultModel: `${params.provider}/${params.model}`,
+      modelSelections: [{ provider: params.provider, modelId: params.model, agentId }],
       snapshot,
     });
     const entries = normalizeThinkingCatalogProviders(augmented.entries);

--- a/src/agents/prepared-model-runtime.plugin-generation.ts
+++ b/src/agents/prepared-model-runtime.plugin-generation.ts
@@ -3,7 +3,7 @@ import {
   registryContainsRuntimePluginIds,
 } from "../plugins/active-runtime-registry.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
-import { augmentPreparedModelCatalogWithAgentHarness } from "./harness/model-catalog.js";
+import { augmentPreparedModelCatalogWithAgentHarnesses } from "./harness/model-catalog.js";
 import {
   resolveAgentRuntimePluginLoadPlan,
   resolveAgentRuntimePluginSelections,
@@ -136,7 +136,7 @@ export async function buildPreparedPluginModelCatalog(params: {
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     });
     return params.catalogMode === "live"
-      ? await augmentPreparedModelCatalogWithAgentHarness({
+      ? await augmentPreparedModelCatalogWithAgentHarnesses({
           input,
           snapshot,
           pluginRegistry,

--- a/src/gateway/server-methods/models-list-harness-catalog.ts
+++ b/src/gateway/server-methods/models-list-harness-catalog.ts
@@ -1,7 +1,9 @@
 import { resolveAgentDir, resolveAgentEffectiveModelPrimary } from "../../agents/agent-scope.js";
+import { resolveConfiguredModelEntries } from "../../agents/configured-model-entries.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
-import { augmentModelCatalogWithAgentHarness } from "../../agents/harness/model-catalog.js";
+import { augmentModelCatalogWithAgentHarnesses } from "../../agents/harness/model-catalog.js";
 import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import { RUNTIME_MODEL_VISIBILITY_NORMALIZATION } from "../../agents/model-visibility-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { includeConfiguredStaticCatalogEntries } from "./models-list-configured-static.js";
@@ -18,14 +20,27 @@ export async function prepareModelsListHarnessCatalog(params: {
   onError?: (error: unknown) => void;
 }) {
   const defaultModel = resolveAgentEffectiveModelPrimary(params.cfg, params.agentId);
+  const modelSelections = defaultModel
+    ? resolveConfiguredModelEntries({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel,
+        ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
+        manifestPlugins: params.metadataSnapshot,
+      }).entries.map(({ ref }) => ({
+        provider: ref.provider,
+        modelId: ref.model,
+        agentId: params.agentId,
+      }))
+    : [];
   const snapshot = params.allowHarnessDiscovery
-    ? await augmentModelCatalogWithAgentHarness({
+    ? await augmentModelCatalogWithAgentHarnesses({
         cfg: params.cfg,
         agentId: params.agentId,
         agentDir: params.agentDir ?? resolveAgentDir(params.cfg, params.agentId),
         workspaceDir: params.workspaceDir,
-        defaultProvider: DEFAULT_PROVIDER,
-        defaultModel,
+        modelSelections,
         snapshot: params.snapshot,
         onError: params.onError,
       })


### PR DESCRIPTION
> [!IMPORTANT]\n> **Withdrawn after exact-base verification (2026-09-02):** The merge base already returns Sol `off, low, medium, high, xhigh, max, ultra` after the real model-picker refresh in both tested primary/fallback directions, and the following `chat.metadata` retains that profile. This branch does not provide the claimed missing-level fix; it adds an unrelated multi-harness path (+64 net production LOC). The original root-cause and proof narrative below should not be relied on. Maintainers closed this PR unmerged as superseded by #136061.

Closes #135821

## What Problem This Solves

Fixes an issue where users opening a new Control UI session would see only the generic five-stop effort slider for a model backed by a non-primary agent harness. In the reported configuration, Claude was the primary model and GPT-5.6 Sol was a Codex fallback; selecting Sol exposed only up to `High`, hiding its advertised `xhigh`, `max`, and `ultra` levels.

The model remained runnable. The failure was silent metadata loss: `models.list` and `chat.metadata` contained the fallback model identity but not its harness-owned reasoning profile, so the Control UI correctly fell back to its generic unknown-capability slider.

## Why This Change Was Made

The catalog preparation path hydrated exactly one agent harness, chosen from the primary model. With a Claude primary, it invoked only the Claude harness catalog loader; the Codex `model/list` producer was never called, even though a Codex fallback was configured and selectable.

This change repairs the producer boundary instead of hardcoding GPT-5.6 or adding a UI exception:

- project configured primary, fallback, and selectable model refs into canonical runtime selections;
- resolve every distinct selected agent-harness runtime and load each catalog once;
- preserve deterministic configured-selection precedence when catalogs overlap;
- isolate one harness catalog failure so another configured harness can still publish metadata;
- retain the active plugin-registry generation guard so stale asynchronous results are discarded;
- reuse the same multi-harness owner from prepared catalog generation, scoped thinking hydration, and `models.list`.

No configuration, protocol, storage schema, provider manifest, or UI fallback contract changes.

**Root cause:** `src/gateway/server-methods/models-list-harness-catalog.ts` passed only `resolveAgentEffectiveModelPrimary(...)` into the singular loader in `src/agents/harness/model-catalog.ts`. Runtime policy therefore selected only the primary harness. Downstream reasoning projection intentionally treats missing catalog capability as unknown, which produced the generic slider.

**Provenance:** the primary-only catalog hydration path was added by [`34c3d15a6b0af05e554060ebf6504a9d0d3c9d75`](https://github.com/openclaw/openclaw/commit/34c3d15a6b0af05e554060ebf6504a9d0d3c9d75) in #124829 (verified against raw parent `72c227c7cc30126b0cdaafc80e564e48965f5fad`). #126182 and #126492 repaired partial Codex row merging and Max/Ultra preservation after Codex metadata exists; they do not cause the fallback Codex loader to run.

## User Impact

Control UI model selection now reflects the real account-scoped effort profile for configured fallback models, even when the primary model uses a different harness. For GPT-5.6 Sol through Codex, the new-session effort control can expose `xhigh`, `max`, and `ultra` instead of stopping at `high`.

A failed primary harness discovery also no longer suppresses usable metadata from another configured harness.

Production LOC: **+130/-66 (net +64)** | Tests: **+80/-10**. The production growth replaces a single-harness branch with the required multi-harness capability: runtime deduplication, independent loader failure handling, deterministic merge order, and lifecycle-generation safety. No parallel compatibility path remains.

## Evidence

### Before / after Control UI

Both screenshots use the exact production Control UI bundle in Chromium with a deterministic mocked Gateway response. The fixture is sanitized and models the wire-level difference caused by this bug; browser console/page errors were asserted empty.

| Before: fallback metadata missing (`High`, 5 stops) | After: Codex metadata present (`Ultra`, 8 stops) |
| --- | --- |
| ![Before: GPT-5.6 Sol effort slider stops at High](https://github.com/user-attachments/assets/a77a29ef-3eff-4b57-b1af-dce8d982902f) | ![After: GPT-5.6 Sol effort slider reaches Ultra](https://github.com/user-attachments/assets/02330646-c631-42ba-8a6d-7f993dd998e4) |

The browser proof asserted these exact DOM profiles:

```text
before: off,minimal,low,medium,high -> selected high
after:  off,minimal,low,medium,high,xhigh,max,ultra -> selected ultra
```

### Dependency contract

Personally inspected OpenAI Codex at commit [`55e5158e1841bb4b0b392a462c24b4d9fc38d597`](https://github.com/openai/codex/commit/55e5158e1841bb4b0b392a462c24b4d9fc38d597):

- [`codex-rs/models-manager/models.json:37-63`](https://github.com/openai/codex/blob/55e5158e1841bb4b0b392a462c24b4d9fc38d597/codex-rs/models-manager/models.json#L37-L63) declares Sol default `low` and supported `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.
- [`codex-rs/app-server/src/models.rs:13-50`](https://github.com/openai/codex/blob/55e5158e1841bb4b0b392a462c24b4d9fc38d597/codex-rs/app-server/src/models.rs#L13-L50) publishes those presets through model listing.
- [`codex-rs/app-server-protocol/src/protocol/v2/model.rs:92-104`](https://github.com/openai/codex/blob/55e5158e1841bb4b0b392a462c24b4d9fc38d597/codex-rs/app-server-protocol/src/protocol/v2/model.rs#L92-L104) carries `supported_reasoning_efforts` and the default in the app-server protocol.

The installed Codex app server was also queried directly and returned the full Sol effort set. In the affected live OpenClaw configuration, refreshed `models.list` omitted `reasoning`/thinking metadata for Sol while Claude was primary and Sol was fallback.

### Regression and validation

A temporary regression test applied to clean `origin/main` at `8fe71d40ff1d58779e877d7ba89c82651289606e` reproduced the defect before implementation: the primary Claude loader ran once, while the expected Codex fallback loader ran **0** times. The committed regression now verifies both loaders are attempted, the primary may fail independently, and the Sol result retains `ultra`.

Exact-head validation on `cae21f05103fd1b9f807597cec99f95977b76c97`:

```text
node scripts/run-vitest.mjs run \
  src/agents/harness/model-catalog.test.ts \
  src/gateway/server-chat-metadata-lifecycle.integration.test.ts \
  src/gateway/server-methods/models-list-result.plugin-runtime.test.ts --reporter=dot
# 22 passed across 2 projects; includes fallback loader isolation,
# prepared-owner lifecycle, and Gateway plugin-runtime projection

node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner \
  ui/src/e2e/chat-thinking-arguments.e2e.test.ts --reporter=verbose
# 5 passed; mobile/tablet/desktop include Ultra selection and sessions.patch payload

npm_config_manage_package_manager_versions=false node scripts/check-changed.mjs
# passed: format, core + test typecheck, lint, dead exports, import cycles,
# plugin boundaries, database guards, and other changed-surface checks

pnpm build
# passed: core/packages, 67 plugin distributions, SDK export graph,
# CLI bootstrap guards, and production Control UI bundle
```

Bundled adversarial autoreview on the exact committed SHA (`gpt-5.6-sol`, high reasoning, complete `origin/main...HEAD` diff): **patch is correct**, confidence **0.98**, no actionable findings and no suspected credentials.

### Real mixed-runtime Gateway proof

The exact-head source build was run through an isolated temporary Gateway, state directory, config, device identity, and loopback port. It used the normal bundled `anthropic`, `openai`, and `codex` plugins, the native Codex app-server, and the default Codex discovery timeout. It did not touch the operator's managed Gateway or config, and the trace below contains no credentials.

```text
primary:  anthropic/claude-opus-5 @ claude-cli
fallback: openai/gpt-5.6-sol @ codex

models.list { view: configured, refresh: true }  4103 ms (cold discovery)
Sol: available=true, reasoning=true, runtime=codex
thinkingLevels: off, low, medium, high, xhigh, max, ultra

chat.metadata { agentId: main }                    9 ms (prepared read)
Sol: available=true, reasoning=true, runtime=codex
thinkingLevels: off, low, medium, high, xhigh, max, ultra
```

This proves both the refresh path and the no-I/O prepared metadata path expose the native fallback profile while preserving the fast `chat.metadata` read.

### CI-discovered lifecycle regression

The first pushed revision caused five failures in the 14-test prepared chat-metadata lifecycle suite by reopening a native catalog loader after the prepared snapshot already owned that runtime. The same suite passed 14/14 on clean `origin/main`, proving the regression belonged to the patch. The final repair reuses already-loaded native runtime rows inside a prepared generation while still allowing explicit `models.list refresh:true` discovery. The final lifecycle suite passes 14/14, and exact-head GitHub `openclaw/ci-gate` is green.

AI-assisted: yes (Codex). The author inspected the affected owner/caller/callee paths, sibling catalog consumers, history, upstream Codex source, generated visual evidence, and final patch.
