### PR TITLE
refactor(google-meet): centralize browser route preparation

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -5553,8 +5553,8 @@ describe("google-meet plugin", () => {
         tab: { targetId: "created-meet-tab-b", openedByPlugin: false },
         browser: { inCall: true, micMuted: true },
       });
-    const leaveChromeMeetOnNode = vi
-      .spyOn(chromeTransport, "leaveChromeMeetOnNode")
+    const leaveChromeMeet = vi
+      .spyOn(chromeTransport, "leaveChromeMeet")
       .mockResolvedValue({ left: true, note: "left created tab" });
     try {
       const runtime = meetRuntime(
@@ -5586,16 +5586,18 @@ describe("google-meet plugin", () => {
       });
       await runtime.leave(joinedA.session.id);
       await runtime.leave(joinedB.session.id);
-      expect(leaveChromeMeetOnNode).toHaveBeenNthCalledWith(1, {
+      expect(leaveChromeMeet).toHaveBeenNthCalledWith(1, {
         runtime: expect.any(Object),
+        transport: "chrome-node",
         nodeId: "meet-node",
         config: expect.any(Object),
         meetingSessionId: expect.any(String),
         meetingUrl: "https://meet.google.com/drf-ihtb-pad",
         tab: { targetId: "created-meet-tab-a", openedByPlugin: true },
       });
-      expect(leaveChromeMeetOnNode).toHaveBeenNthCalledWith(2, {
+      expect(leaveChromeMeet).toHaveBeenNthCalledWith(2, {
         runtime: expect.any(Object),
+        transport: "chrome-node",
         nodeId: "meet-node",
         config: expect.any(Object),
         meetingSessionId: expect.any(String),
@@ -5603,7 +5605,7 @@ describe("google-meet plugin", () => {
         tab: { targetId: "created-meet-tab-b", openedByPlugin: true },
       });
     } finally {
-      leaveChromeMeetOnNode.mockRestore();
+      leaveChromeMeet.mockRestore();
       launchChromeMeetOnNode.mockRestore();
       createMeet.mockRestore();
     }

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -39,11 +39,8 @@ import {
   launchChromeMeet,
   launchChromeMeetOnNode,
   leaveChromeMeet,
-  leaveChromeMeetOnNode,
   readChromeMeetTranscript,
-  readChromeMeetTranscriptOnNode,
   recoverCurrentMeetTab,
-  recoverCurrentMeetTabOnNode,
 } from "./transports/chrome.js";
 import { GOOGLE_MEET_PLATFORM_ADAPTER } from "./transports/google-meet-platform-adapter.js";
 import type {
@@ -247,19 +244,13 @@ export class GoogleMeetRuntime {
     const url = request.url
       ? GOOGLE_MEET_PLATFORM_ADAPTER.urls.validateAndNormalize(request.url)
       : undefined;
-    return transport === "chrome-node"
-      ? await recoverCurrentMeetTabOnNode({
-          runtime: this.params.runtime,
-          config: this.params.config,
-          fullConfig: this.params.fullConfig,
-          url,
-        })
-      : await recoverCurrentMeetTab({
-          runtime: this.params.runtime,
-          config: this.params.config,
-          fullConfig: this.params.fullConfig,
-          url,
-        });
+    return await recoverCurrentMeetTab({
+      runtime: this.params.runtime,
+      config: this.params.config,
+      fullConfig: this.params.fullConfig,
+      transport,
+      url,
+    });
   }
 
   async join(request: GoogleMeetJoinRequest): Promise<GoogleMeetJoinResult> {
@@ -313,28 +304,18 @@ export class GoogleMeetRuntime {
   ): Promise<{ delegatedSpoken?: boolean }> {
     if (isBrowserTransport(session.transport)) {
       const chromeConfig = withSessionAgentConfig(this.params.config, session.agentId);
-      const result: ChromeLaunchResult =
-        session.transport === "chrome-node"
-          ? await launchChromeMeetOnNode({
-              runtime: this.params.runtime,
-              config: chromeConfig,
-              fullConfig: this.params.fullConfig,
-              meetingSessionId: session.id,
-              requesterSessionKey: request.requesterSessionKey,
-              mode: session.mode,
-              url: session.url,
-              logger: this.params.logger,
-            })
-          : await launchChromeMeet({
-              runtime: this.params.runtime,
-              config: chromeConfig,
-              fullConfig: this.params.fullConfig,
-              meetingSessionId: session.id,
-              requesterSessionKey: request.requesterSessionKey,
-              mode: session.mode,
-              url: session.url,
-              logger: this.params.logger,
-            });
+      const launch =
+        session.transport === "chrome-node" ? launchChromeMeetOnNode : launchChromeMeet;
+      const result: ChromeLaunchResult = await launch({
+        runtime: this.params.runtime,
+        config: chromeConfig,
+        fullConfig: this.params.fullConfig,
+        meetingSessionId: session.id,
+        requesterSessionKey: request.requesterSessionKey,
+        mode: session.mode,
+        url: session.url,
+        logger: this.params.logger,
+      });
       const nodeId = "nodeId" in result ? result.nodeId : undefined;
       let tab = result.tab;
       const createdKey =
@@ -492,26 +473,16 @@ export class GoogleMeetRuntime {
         ? { chromeNode: { ...config.chromeNode, node: session.chrome.nodeId } }
         : {}),
     };
-    const result: ChromeLaunchResult =
-      session.transport === "chrome-node"
-        ? await launchChromeMeetOnNode({
-            runtime: this.params.runtime,
-            config: recoveryConfig,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            mode: session.mode,
-            url: session.url,
-            logger: this.params.logger,
-          })
-        : await launchChromeMeet({
-            runtime: this.params.runtime,
-            config: recoveryConfig,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            mode: session.mode,
-            url: session.url,
-            logger: this.params.logger,
-          });
+    const launch = session.transport === "chrome-node" ? launchChromeMeetOnNode : launchChromeMeet;
+    const result: ChromeLaunchResult = await launch({
+      runtime: this.params.runtime,
+      config: recoveryConfig,
+      fullConfig: this.params.fullConfig,
+      meetingSessionId: session.id,
+      mode: session.mode,
+      url: session.url,
+      logger: this.params.logger,
+    });
     session.updatedAt = nowIso();
     return this.#attachChromeAudioBridge(session, result.audioBridge);
   }
@@ -521,28 +492,17 @@ export class GoogleMeetRuntime {
     options: { force?: boolean; readOnly?: boolean } = {},
   ): Promise<void> {
     try {
-      const result =
-        session.transport === "chrome-node"
-          ? await recoverCurrentMeetTabOnNode({
-              runtime: this.params.runtime,
-              config: this.params.config,
-              fullConfig: this.params.fullConfig,
-              mode: session.mode,
-              readOnly: options.readOnly,
-              trackedMeetingUrl: session.url,
-              trackedTargetId: session.chrome?.browserTab?.targetId,
-              url: session.url,
-            })
-          : await recoverCurrentMeetTab({
-              runtime: this.params.runtime,
-              config: this.params.config,
-              fullConfig: this.params.fullConfig,
-              mode: session.mode,
-              readOnly: options.readOnly,
-              trackedMeetingUrl: session.url,
-              trackedTargetId: session.chrome?.browserTab?.targetId,
-              url: session.url,
-            });
+      const result = await recoverCurrentMeetTab({
+        runtime: this.params.runtime,
+        config: this.params.config,
+        fullConfig: this.params.fullConfig,
+        transport: session.transport === "chrome-node" ? "chrome-node" : "chrome",
+        mode: session.mode,
+        readOnly: options.readOnly,
+        trackedMeetingUrl: session.url,
+        trackedTargetId: session.chrome?.browserTab?.targetId,
+        url: session.url,
+      });
       if (result.found && session.chrome) {
         if (result.targetId) {
           const currentTab = session.chrome.browserTab;
@@ -631,24 +591,17 @@ export class GoogleMeetRuntime {
     if (!tab) {
       return undefined;
     }
-    return session.transport === "chrome-node"
-      ? await readChromeMeetTranscriptOnNode({
-          runtime: this.params.runtime,
-          nodeId: session.chrome?.nodeId,
-          config: this.params.config,
-          ...(options.finalize === undefined ? {} : { finalize: options.finalize }),
-          meetingUrl: session.url,
-          meetingSessionId: session.id,
-          tab,
-        })
-      : await readChromeMeetTranscript({
-          runtime: this.params.runtime,
-          config: this.params.config,
-          ...(options.finalize === undefined ? {} : { finalize: options.finalize }),
-          meetingUrl: session.url,
-          meetingSessionId: session.id,
-          tab,
-        });
+    return await readChromeMeetTranscript({
+      runtime: this.params.runtime,
+      ...(session.transport === "chrome-node"
+        ? { transport: "chrome-node", nodeId: session.chrome?.nodeId }
+        : {}),
+      config: this.params.config,
+      ...(options.finalize === undefined ? {} : { finalize: options.finalize }),
+      meetingUrl: session.url,
+      meetingSessionId: session.id,
+      tab,
+    });
   }
 
   async #releaseBrowserTab(session: GoogleMeetSession): Promise<boolean | undefined> {
@@ -679,23 +632,16 @@ export class GoogleMeetRuntime {
     }
     let left: boolean;
     try {
-      const result =
-        session.transport === "chrome-node"
-          ? await leaveChromeMeetOnNode({
-              runtime: this.params.runtime,
-              nodeId: session.chrome?.nodeId,
-              config: this.params.config,
-              meetingSessionId: session.id,
-              meetingUrl: session.url,
-              tab,
-            })
-          : await leaveChromeMeet({
-              runtime: this.params.runtime,
-              config: this.params.config,
-              meetingSessionId: session.id,
-              meetingUrl: session.url,
-              tab,
-            });
+      const result = await leaveChromeMeet({
+        runtime: this.params.runtime,
+        ...(session.transport === "chrome-node"
+          ? { transport: "chrome-node", nodeId: session.chrome?.nodeId }
+          : {}),
+        config: this.params.config,
+        meetingSessionId: session.id,
+        meetingUrl: session.url,
+        tab,
+      });
       noteSession(session, result.note);
       left = result.left;
     } catch (error) {

--- a/extensions/google-meet/src/transports/chrome.test.ts
+++ b/extensions/google-meet/src/transports/chrome.test.ts
@@ -1,9 +1,17 @@
 // Google Meet tests cover chrome plugin behavior.
+import { runInNewContext } from "node:vm";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { resolveGoogleMeetConfig } from "../config.js";
-import { launchChromeMeet, recoverCurrentMeetTab } from "./chrome.js";
+import { GoogleMeetRuntime } from "../runtime.js";
+import { MEET_URL, MEET_URL_EN } from "../test-support/fixtures.test-helpers.js";
+import {
+  launchChromeMeet,
+  leaveChromeMeet,
+  readChromeMeetTranscript,
+  recoverCurrentMeetTab,
+} from "./chrome.js";
 
 const logger = {
   info() {},
@@ -18,7 +26,10 @@ type TestGatewayRequest = (
   options?: unknown,
 ) => Promise<unknown>;
 
-function browserRuntime(request: TestGatewayRequest): PluginRuntime {
+function browserRuntime(
+  request: TestGatewayRequest,
+  nodes?: Pick<PluginRuntime["nodes"], "list" | "invoke">,
+): PluginRuntime {
   const gateway: PluginRuntime["gateway"] = {
     isAvailable: async () => true,
     request: async <T = unknown>(
@@ -27,60 +38,68 @@ function browserRuntime(request: TestGatewayRequest): PluginRuntime {
       options?: unknown,
     ) => (await request(method, params ?? {}, options)) as T,
   };
-  return { gateway } as PluginRuntime;
+  return { gateway, ...(nodes ? { nodes } : {}) } as PluginRuntime;
 }
 
 describe("google meet chrome transport", () => {
-  it("prefers a meeting tab over a login fallback during untargeted recovery", async () => {
-    const statusScripts: string[] = [];
-    const gatewayRequest = vi.fn(async (_method, params) => {
-      if (params.path === "/tabs") {
-        return {
-          tabs: [
-            {
-              targetId: "google-login-tab",
-              title: "Sign in - Google Accounts",
-              url: "https://accounts.google.com/signin",
-            },
-            {
-              targetId: "meet-tab",
-              title: "Meet",
-              url: "https://meet.google.com/abc-defg-hij?hl=en",
-            },
-          ],
-        };
-      }
-      if (params.path === "/tabs/focus") {
-        return { ok: true };
-      }
-      if (params.path === "/act") {
-        const fn = (params.body as { fn?: unknown } | undefined)?.fn;
-        if (typeof fn === "string") {
-          statusScripts.push(fn);
+  it.each([
+    { mode: "agent" as const, fullConfig: { transcripts: { enabled: false } }, capture: false },
+    { mode: "bidi" as const, fullConfig: undefined, capture: true },
+    { mode: "transcribe" as const, fullConfig: { transcripts: { enabled: false } }, capture: true },
+  ])(
+    "prefers a meeting tab over login ($mode, captions $capture)",
+    async ({ mode, fullConfig, capture }) => {
+      const statusScripts: string[] = [];
+      const gatewayRequest = vi.fn(async (_method, params) => {
+        if (params.path === "/tabs") {
+          return {
+            tabs: [
+              {
+                targetId: "google-login-tab",
+                title: "Sign in - Google Accounts",
+                url: "https://accounts.google.com/signin",
+              },
+              {
+                targetId: "meet-tab",
+                title: "Meet",
+                url: "https://meet.google.com/abc-defg-hij?hl=en",
+              },
+            ],
+          };
         }
-        return {
-          result: JSON.stringify({
-            inCall: true,
-            micMuted: true,
-            url: "https://meet.google.com/abc-defg-hij?hl=en",
-          }),
-        };
-      }
-      throw new Error(`unexpected browser request path ${String(params.path)}`);
-    });
+        if (params.path === "/tabs/focus") {
+          return { ok: true };
+        }
+        if (params.path === "/act") {
+          const fn = (params.body as { fn?: unknown } | undefined)?.fn;
+          if (typeof fn === "string") {
+            statusScripts.push(fn);
+          }
+          return {
+            result: JSON.stringify({
+              inCall: true,
+              micMuted: true,
+              url: "https://meet.google.com/abc-defg-hij?hl=en",
+            }),
+          };
+        }
+        throw new Error(`unexpected browser request path ${String(params.path)}`);
+      });
 
-    const recovered = await recoverCurrentMeetTab({
-      runtime: browserRuntime(gatewayRequest),
-      config: resolveGoogleMeetConfig({}),
-      fullConfig: { transcripts: { enabled: false } },
-      mode: "agent",
-      readOnly: true,
-    });
+      const recovered = await recoverCurrentMeetTab({
+        runtime: browserRuntime(gatewayRequest),
+        config: resolveGoogleMeetConfig({}),
+        fullConfig,
+        mode,
+        readOnly: true,
+      });
 
-    expect(recovered).toMatchObject({ found: true, targetId: "meet-tab" });
-    expect(statusScripts).toHaveLength(1);
-    expect(statusScripts[0]).toContain("const captureCaptions = false");
-  });
+      expect(recovered).toMatchObject({ transport: "chrome", found: true, targetId: "meet-tab" });
+      expect(Object.hasOwn(recovered, "nodeId")).toBe(false);
+      expect(statusScripts).toHaveLength(1);
+      expect(statusScripts[0]).toContain(`const captureCaptions = ${capture}`);
+    },
+  );
 
   it("prefers the tracked target for an unchanged Google Meet URL", async () => {
     const gatewayRequest = vi.fn(async (_method, params) => {
@@ -286,4 +305,252 @@ describe("google meet chrome transport", () => {
       { timeoutMs: 10_000, scopes: ["operator.admin"] },
     );
   });
+  it.each(["pinned-node", ""])(
+    "leaves through a pinned node %j before yielding to inventory",
+    async (nodeId) => {
+      const requests: Parameters<PluginRuntime["nodes"]["invoke"]>[0][] = [];
+      const runtime = browserRuntime(
+        async () => {
+          throw new Error("Pinned node leave must not use the local browser");
+        },
+        {
+          list: async () => {
+            throw new Error("Pinned node leave must not resolve inventory");
+          },
+          invoke: async (request) => {
+            requests.push(request);
+            return { payload: { result: { tabs: [] } } };
+          },
+        },
+      );
+      const leaving = leaveChromeMeet({
+        transport: "chrome-node",
+        runtime,
+        config: resolveGoogleMeetConfig({ chromeNode: { node: "different-configured-node" } }),
+        nodeId,
+        meetingSessionId: "pinned-session",
+        meetingUrl: MEET_URL,
+        tab: { targetId: "pinned-tab", openedByPlugin: false },
+      });
+      const beforeYield = [...requests];
+      const result = await leaving;
+
+      expect(result).toStrictEqual({ left: true, note: "Meet tab is already closed." });
+      expect(beforeYield).toStrictEqual([
+        {
+          nodeId,
+          command: "browser.proxy",
+          params: { method: "GET", path: "/tabs", body: undefined, timeoutMs: 5_000 },
+          timeoutMs: 10_000,
+          scopes: ["operator.admin"],
+        },
+      ]);
+    },
+  );
+
+  it.each(["chrome", "chrome-node"] as const)(
+    "preserves %s route failures before launch-disabled leave",
+    async (transport) => {
+      const failure = new Error("route unavailable");
+      const events: string[] = [];
+      const runtime = browserRuntime(
+        async () => {
+          throw new Error("Disabled leave must not dispatch a local browser request");
+        },
+        {
+          list: async () => {
+            events.push("inventory");
+            throw failure;
+          },
+          invoke: async () => {
+            throw new Error("Disabled leave must not invoke a node");
+          },
+        },
+      );
+      runtime.gateway.isAvailable = async () => {
+        events.push("availability");
+        throw failure;
+      };
+      const leaving = leaveChromeMeet({
+        ...(transport === "chrome-node" ? { transport } : {}),
+        runtime,
+        config: resolveGoogleMeetConfig({ chrome: { launch: false } }),
+        meetingSessionId: "disabled-session",
+        meetingUrl: MEET_URL,
+        tab: { targetId: "disabled-tab", openedByPlugin: false },
+      });
+
+      if (transport === "chrome-node") {
+        await expect(leaving).rejects.toMatchObject({
+          message: "Google Meet node inventory unavailable",
+          cause: failure,
+        });
+        expect(events).toStrictEqual(["inventory"]);
+      } else {
+        await expect(leaving).rejects.toBe(failure);
+        expect(events).toStrictEqual(["availability"]);
+      }
+    },
+  );
+
+  it("re-resolves configured recovery nodes and preserves node response identity", async () => {
+    const invocations: Parameters<PluginRuntime["nodes"]["invoke"]>[0][] = [];
+    const config = resolveGoogleMeetConfig({ chromeNode: { node: "first-host" } });
+    const runtime = browserRuntime(
+      async () => {
+        throw new Error("Node recovery must not fall back to the local browser");
+      },
+      {
+        list: async () => ({
+          nodes: ["first", "second"].map((id) => ({
+            nodeId: `${id}-node`,
+            displayName: `${id}-host`,
+            connected: true,
+            commands: ["googlemeet.chrome", "browser.proxy"],
+          })),
+        }),
+        invoke: async (request) => {
+          invocations.push(request);
+          return { payload: { result: { tabs: [] } } };
+        },
+      },
+    );
+    const meet = new GoogleMeetRuntime({ runtime, config, fullConfig: {}, logger });
+    const first = await meet.recoverCurrentTab({ transport: "chrome-node" });
+    config.chromeNode.node = "second-host";
+    const second = await meet.recoverCurrentTab({ transport: "chrome-node" });
+
+    for (const [result, nodeId] of [
+      [first, "first-node"],
+      [second, "second-node"],
+    ] as const) {
+      expect(Object.hasOwn(result, "nodeId")).toBe(true);
+      expect(result).toStrictEqual({
+        transport: "chrome-node",
+        nodeId,
+        found: false,
+        tab: undefined,
+        message: "No existing Meet tab found on the selected Chrome node.",
+      });
+    }
+    expect(invocations).toStrictEqual(
+      ["first-node", "second-node"].map((nodeId) => ({
+        nodeId,
+        command: "browser.proxy",
+        params: { method: "GET", path: "/tabs", body: undefined, timeoutMs: 5_000 },
+        timeoutMs: 10_000,
+        scopes: ["operator.admin"],
+      })),
+    );
+  });
+
+  it.each([
+    { transport: "chrome" as const, finalize: undefined, joinTimeoutMs: 1_234, timeoutMs: 1_234 },
+    { transport: "chrome-node" as const, finalize: false, joinTimeoutMs: 1, timeoutMs: 1_000 },
+    { transport: "chrome-node" as const, finalize: true, joinTimeoutMs: 30_000, timeoutMs: 10_000 },
+  ])(
+    "reads $transport captions with finalize=$finalize and bounded envelope",
+    async ({ transport, finalize, joinTimeoutMs, timeoutMs }) => {
+      const committed = {
+        at: "2026-09-01T00:00:00.000Z",
+        speaker: "First",
+        text: "Completed caption",
+      };
+      const visible = {
+        at: "2026-09-01T00:00:01.000Z",
+        speaker: "Second",
+        text: "Progressive caption",
+      };
+      const captionState = {
+        sessionId: "transcript-session",
+        epoch: "caption-epoch",
+        droppedLines: 0,
+        lines: [committed],
+        visible: [visible],
+        settleTimer: undefined,
+      };
+      const browserCalls: Array<{
+        method: string;
+        params: Record<string, unknown>;
+        options: unknown;
+      }> = [];
+      const nodeCalls: Parameters<PluginRuntime["nodes"]["invoke"]>[0][] = [];
+      const evaluate = (params: Record<string, unknown>) => {
+        const body = params.body as { fn: string };
+        return {
+          result: runInNewContext(`(${body.fn})()`, {
+            JSON,
+            URL,
+            location: { href: MEET_URL_EN },
+            window: { __openclawMeetCaptions: captionState },
+            clearTimeout,
+          }),
+        };
+      };
+      const runtime = browserRuntime(
+        async (method, params, options) => {
+          browserCalls.push({ method, params, options });
+          return evaluate(params);
+        },
+        {
+          list: async () => {
+            throw new Error("Pinned transcript read must not resolve inventory");
+          },
+          invoke: async (request) => {
+            nodeCalls.push(request);
+            return { payload: { result: evaluate(request.params as Record<string, unknown>) } };
+          },
+        },
+      );
+      const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+      try {
+        const result = await readChromeMeetTranscript({
+          runtime,
+          config: resolveGoogleMeetConfig({ chrome: { joinTimeoutMs } }),
+          ...(transport === "chrome-node" ? { transport, nodeId: "transcript-node" } : {}),
+          ...(finalize === undefined ? {} : { finalize }),
+          meetingUrl: MEET_URL,
+          meetingSessionId: "transcript-session",
+          tab: { targetId: "transcript-tab", openedByPlugin: false },
+        });
+        const expectedLines = finalize === true ? [committed, visible] : [committed];
+        expect(result).toStrictEqual({
+          droppedLines: 0,
+          epoch: "caption-epoch",
+          lines: expectedLines,
+        });
+        expect(captionState.lines).toEqual(expectedLines);
+        expect(captionState.visible).toEqual(finalize === true ? [] : [visible]);
+        const params = {
+          method: "POST",
+          path: "/act",
+          body: { kind: "evaluate", targetId: "transcript-tab", fn: expect.any(String) },
+          timeoutMs,
+        };
+        if (transport === "chrome-node") {
+          expect(browserCalls).toStrictEqual([]);
+          expect(nodeCalls).toStrictEqual([
+            {
+              nodeId: "transcript-node",
+              command: "browser.proxy",
+              params,
+              timeoutMs: timeoutMs + 5_000,
+              scopes: ["operator.admin"],
+            },
+          ]);
+        } else {
+          expect(nodeCalls).toStrictEqual([]);
+          expect(browserCalls).toStrictEqual([
+            {
+              method: "browser.request",
+              params,
+              options: { timeoutMs: timeoutMs + 5_000, scopes: ["operator.admin"] },
+            },
+          ]);
+        }
+      } finally {
+        now.mockRestore();
+      }
+    },
+  );
 });

--- a/extensions/google-meet/src/transports/chrome.ts
+++ b/extensions/google-meet/src/transports/chrome.ts
@@ -19,16 +19,13 @@ import { addTimerTimeoutGraceMs } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveTranscriptsConfig } from "openclaw/plugin-sdk/transcripts";
 import type { GoogleMeetConfig, GoogleMeetMode } from "../config.js";
-import {
-  callBrowserProxyOnNode,
-  resolveChromeNode,
-  type BrowserTab,
-} from "./chrome-browser-proxy.js";
+import { callBrowserProxyOnNode, resolveChromeNode } from "./chrome-browser-proxy.js";
 import { GOOGLE_MEET_PLATFORM_ADAPTER } from "./google-meet-platform-adapter.js";
 import { GOOGLE_MEET_NODE_COMMAND } from "./google-meet-platform-constants.js";
 import type {
   GoogleMeetBrowserTab,
   GoogleMeetChromeHealth,
+  GoogleMeetSession,
   GoogleMeetTranscriptSnapshot,
 } from "./types.js";
 
@@ -282,16 +279,53 @@ function parseNodeStartResult(raw: unknown): {
   };
 }
 
-export async function leaveChromeMeet(params: {
+type ChromeBrowserRouteParams = {
   runtime: PluginRuntime;
   config: GoogleMeetConfig;
-  meetingSessionId: string;
-  meetingUrl: string;
-  tab: GoogleMeetBrowserTab;
-}): Promise<{ left: boolean; note: string }> {
+  transport?: "chrome" | "chrome-node";
+  nodeId?: string;
+};
+
+function chromeNodeBrowserRequest(
+  runtime: PluginRuntime,
+  nodeId: string,
+): MeetingBrowserRequestCaller {
+  return async (request) =>
+    await callBrowserProxyOnNode({
+      runtime,
+      nodeId,
+      method: request.method,
+      path: request.path,
+      body: request.body,
+      timeoutMs: request.timeoutMs,
+    });
+}
+
+export async function leaveChromeMeet(
+  params: ChromeBrowserRouteParams & {
+    meetingSessionId: string;
+    meetingUrl: string;
+    tab: GoogleMeetBrowserTab;
+  },
+): Promise<{ left: boolean; note: string }> {
+  // A pinned session node bypasses inventory, including the empty-string value.
+  // Keep this await conditional; launch:false leave still resolves the route.
+  const node =
+    params.transport === "chrome-node"
+      ? {
+          nodeId:
+            params.nodeId ??
+            (await resolveChromeNode({
+              runtime: params.runtime,
+              requestedNode: params.config.chromeNode.node,
+            })),
+        }
+      : undefined;
   return await leaveMeetingWithBrowser({
     adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-    callBrowser: await resolveLocalMeetingBrowserRequest(params.runtime),
+    callBrowser: node
+      ? chromeNodeBrowserRequest(params.runtime, node.nodeId)
+      : await resolveLocalMeetingBrowserRequest(params.runtime),
     launch: params.config.chrome.launch,
     meetingSessionId: params.meetingSessionId,
     meetingUrl: params.meetingUrl,
@@ -300,90 +334,35 @@ export async function leaveChromeMeet(params: {
   });
 }
 
-export async function readChromeMeetTranscript(params: {
-  runtime: PluginRuntime;
-  config: GoogleMeetConfig;
-  finalize?: boolean;
-  meetingUrl: string;
-  meetingSessionId: string;
-  tab: GoogleMeetBrowserTab;
-}): Promise<GoogleMeetTranscriptSnapshot> {
+export async function readChromeMeetTranscript(
+  params: ChromeBrowserRouteParams & {
+    finalize?: boolean;
+    meetingUrl: string;
+    meetingSessionId: string;
+    tab: GoogleMeetBrowserTab;
+  },
+): Promise<GoogleMeetTranscriptSnapshot> {
+  const node =
+    params.transport === "chrome-node"
+      ? {
+          nodeId:
+            params.nodeId ??
+            (await resolveChromeNode({
+              runtime: params.runtime,
+              requestedNode: params.config.chromeNode.node,
+            })),
+        }
+      : undefined;
   return await readMeetingTranscriptWithBrowser({
     adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-    callBrowser: await resolveLocalMeetingBrowserRequest(params.runtime),
+    callBrowser: node
+      ? chromeNodeBrowserRequest(params.runtime, node.nodeId)
+      : await resolveLocalMeetingBrowserRequest(params.runtime),
     finalize: params.finalize === true,
     meetingUrl: params.meetingUrl,
     meetingSessionId: params.meetingSessionId,
     tab: params.tab,
     timeoutMs: Math.min(Math.max(1_000, params.config.chrome.joinTimeoutMs), 10_000),
-  });
-}
-
-export async function readChromeMeetTranscriptOnNode(params: {
-  runtime: PluginRuntime;
-  nodeId?: string;
-  config: GoogleMeetConfig;
-  finalize?: boolean;
-  meetingUrl: string;
-  meetingSessionId: string;
-  tab: GoogleMeetBrowserTab;
-}): Promise<GoogleMeetTranscriptSnapshot> {
-  const nodeId =
-    params.nodeId ??
-    (await resolveChromeNode({
-      runtime: params.runtime,
-      requestedNode: params.config.chromeNode.node,
-    }));
-  const timeoutMs = Math.min(Math.max(1_000, params.config.chrome.joinTimeoutMs), 10_000);
-  return await readMeetingTranscriptWithBrowser({
-    adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-    callBrowser: async (request) =>
-      await callBrowserProxyOnNode({
-        runtime: params.runtime,
-        nodeId,
-        method: request.method,
-        path: request.path,
-        body: request.body,
-        timeoutMs: request.timeoutMs,
-      }),
-    finalize: params.finalize === true,
-    meetingUrl: params.meetingUrl,
-    meetingSessionId: params.meetingSessionId,
-    tab: params.tab,
-    timeoutMs,
-  });
-}
-
-export async function leaveChromeMeetOnNode(params: {
-  runtime: PluginRuntime;
-  nodeId?: string;
-  config: GoogleMeetConfig;
-  meetingSessionId: string;
-  meetingUrl: string;
-  tab: GoogleMeetBrowserTab;
-}): Promise<{ left: boolean; note: string }> {
-  const nodeId =
-    params.nodeId ??
-    (await resolveChromeNode({
-      runtime: params.runtime,
-      requestedNode: params.config.chromeNode.node,
-    }));
-  return await leaveMeetingWithBrowser({
-    adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-    callBrowser: async (request) =>
-      await callBrowserProxyOnNode({
-        runtime: params.runtime,
-        nodeId,
-        method: request.method,
-        path: request.path,
-        body: request.body,
-        timeoutMs: request.timeoutMs,
-      }),
-    launch: params.config.chrome.launch,
-    meetingSessionId: params.meetingSessionId,
-    meetingUrl: params.meetingUrl,
-    tab: params.tab,
-    timeoutMs: params.config.chrome.joinTimeoutMs,
   });
 }
 
@@ -439,80 +418,50 @@ async function openMeetWithBrowserProxy(params: {
   });
 }
 
-export async function recoverCurrentMeetTab(params: {
-  runtime: PluginRuntime;
-  config: GoogleMeetConfig;
-  fullConfig?: OpenClawConfig;
-  mode?: GoogleMeetMode;
-  readOnly?: boolean;
-  trackedMeetingUrl?: string;
-  trackedTargetId?: string;
-  url?: string;
-}): Promise<{
-  transport: "chrome";
-  nodeId?: undefined;
-  found: boolean;
-  targetId?: string;
-  tab?: BrowserTab;
-  browser?: GoogleMeetChromeHealth;
-  message: string;
-}> {
+export async function recoverCurrentMeetTab(
+  params: Omit<ChromeBrowserRouteParams, "nodeId"> & {
+    fullConfig?: OpenClawConfig;
+    mode?: GoogleMeetMode;
+    readOnly?: boolean;
+    trackedMeetingUrl?: string;
+    trackedTargetId?: string;
+    url?: string;
+  },
+): Promise<
+  Awaited<
+    ReturnType<
+      typeof recoverMeetingBrowserTab<
+        GoogleMeetSession,
+        GoogleMeetMode,
+        GoogleMeetChromeHealth,
+        GoogleMeetTranscriptSnapshot
+      >
+    >
+  > &
+    ({ transport: "chrome"; nodeId?: undefined } | { transport: "chrome-node"; nodeId: string })
+> {
+  // Recovery deliberately re-resolves the configured node, not the session pin.
+  const node =
+    params.transport === "chrome-node"
+      ? {
+          nodeId: await resolveChromeNode({
+            runtime: params.runtime,
+            requestedNode: params.config.chromeNode.node,
+          }),
+        }
+      : undefined;
   return {
-    transport: "chrome",
+    ...(node
+      ? { transport: "chrome-node" as const, nodeId: node.nodeId }
+      : { transport: "chrome" as const }),
     ...(await recoverMeetingBrowserTab({
       adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-      callBrowser: await resolveLocalMeetingBrowserRequest(params.runtime),
+      callBrowser: node
+        ? chromeNodeBrowserRequest(params.runtime, node.nodeId)
+        : await resolveLocalMeetingBrowserRequest(params.runtime),
       captureCaptions: shouldCaptureCaptions(params.mode ?? "bidi", params.fullConfig),
       config: params.config.chrome,
-      locationLabel: "in local Chrome",
-      mode: params.mode ?? "bidi",
-      readOnly: params.readOnly,
-      requestedMeetingUrl: params.url,
-      trackedMeetingUrl: params.trackedMeetingUrl,
-      trackedTargetId: params.trackedTargetId,
-    })),
-  };
-}
-
-export async function recoverCurrentMeetTabOnNode(params: {
-  runtime: PluginRuntime;
-  config: GoogleMeetConfig;
-  fullConfig?: OpenClawConfig;
-  mode?: GoogleMeetMode;
-  readOnly?: boolean;
-  trackedMeetingUrl?: string;
-  trackedTargetId?: string;
-  url?: string;
-}): Promise<{
-  transport: "chrome-node";
-  nodeId: string;
-  found: boolean;
-  targetId?: string;
-  tab?: BrowserTab;
-  browser?: GoogleMeetChromeHealth;
-  message: string;
-}> {
-  const nodeId = await resolveChromeNode({
-    runtime: params.runtime,
-    requestedNode: params.config.chromeNode.node,
-  });
-  return {
-    transport: "chrome-node",
-    nodeId,
-    ...(await recoverMeetingBrowserTab({
-      adapter: GOOGLE_MEET_PLATFORM_ADAPTER,
-      callBrowser: async (request) =>
-        await callBrowserProxyOnNode({
-          runtime: params.runtime,
-          nodeId,
-          method: request.method,
-          path: request.path,
-          body: request.body,
-          timeoutMs: request.timeoutMs,
-        }),
-      captureCaptions: shouldCaptureCaptions(params.mode ?? "bidi", params.fullConfig),
-      config: params.config.chrome,
-      locationLabel: "on the selected Chrome node",
+      locationLabel: node ? "on the selected Chrome node" : "in local Chrome",
       mode: params.mode ?? "bidi",
       readOnly: params.readOnly,
       requestedMeetingUrl: params.url,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Please keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Google Meet's local and node-browser workflows repeated route preparation across meeting actions. Keeping those copies aligned made recovery, leaving, and browser-session handling harder to maintain consistently.

## Why This Change Was Made

Consolidate private route preparation while keeping the existing browser controller and session-control owners. Remove the duplicate wrappers without adding a plugin SDK, configuration, dependency, authentication, or persistence surface.

Preserve conditional awaits, nullish node selection (including an explicitly pinned empty ID), fresh configured-node recovery, local/node result shapes, launch-disabled errors, and finalize/caption behavior. The recovery result type derives its payload from the existing owner and preserves the local optional node ID type without adding an own runtime property.

## User Impact

No intended operator-visible behavior change. Existing Google Meet local and node-browser actions keep their routing, errors, and result envelopes.

Production: **+167/−272 (net −105)**. Tests: **+324/−55 (net +269)**. The extra cases protect observable ordering, route failure, property-presence, and session-finalization contracts.

## Evidence

- Original 196-case baseline and characterized 206-case candidate passed. Five deliberately broken route variants produced their expected assertion failures; each mutation was restored and checked. The integrated current-base six-suite run passed all 206 cases.
- The configured 25-check gate and normal 16-step build passed. The final recovery annotation produced identical JavaScript before and after the type-only correction.
- A real built CLI and isolated Gateway used a real managed Chrome browser with a reachable `about:blank` tab. CLI JSON and direct Gateway JSON returned the same `found: false` local no-Meet-tab result; CLI text reported the same outcome. The tab inventory stayed unchanged, and normal browser stop plus Gateway SIGINT completed.
- Final managed source review completed with no accepted, filtered, or rejected findings at its P0 threshold. This is not an all-priority correctness certificate.

The operator run did **not** exercise a live Google Meet call, found-tab adoption, captions/audio, or a remote-node browser. Those are not claimed as live proof. Deterministic owner-boundary tests cover the refactor's route and session contracts.

Retained failures were resolved through their owning causes: formatting, a stale source/dependency-generation prerequisite, and a recovery return-type error. No failed run was counted as a pass and no validation gate was bypassed.

Exact-commit managed review of `d644b2e02e486c6b17c4325744d6d30af24d33d0` completed with no accepted, filtered, or rejected findings at P0. Pull-request exact-head CI is still pending; the completed local checks above are not a substitute for that hosted CI.
