### PR TITLE
fix(discord): bound voice capture under one lifecycle owner

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1360,6 +1360,7 @@ STT plus TTS pipeline:
 
 - Discord PCM capture is converted to a WAV temp file.
 - `tools.media.audio` handles STT, for example `openai/gpt-4o-mini-transcribe`.
+- Batch capture respects the largest applicable [audio input limit](/nodes/audio), including configured model and CLI fallbacks. Oversized captures stop with a warning to speak a shorter segment; partial audio is not transcribed. This limit does not buffer or truncate direct realtime streams.
 - The transcript is sent through Discord ingress and routing while the response LLM runs with a voice-output policy that hides the agent `tts` tool and asks for returned text, because Discord voice owns final TTS playback.
 - `voice.model`, when set, overrides only the response LLM for this voice-channel turn.
 - `voice.tts` is merged over `tts`; streaming-capable providers feed the player directly, otherwise the resulting audio file is played in the joined channel.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -790,6 +790,13 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
       agentDir: "/tmp/agent",
     });
 
+    // Prepare a capture limit before installing audio receive listeners.
+    const budget = await api.runtime.mediaUnderstanding.resolveAudioInputBudget({
+      cfg: api.config,
+    });
+    // budget.enabled is false when audio understanding is disabled. Otherwise,
+    // budget.maxBytes includes the container header and covers the largest fallback.
+
     // Transcribe audio
     const { text } = await api.runtime.mediaUnderstanding.transcribeAudioFile({
       filePath: "/tmp/inbound-audio.ogg",

--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -107,7 +107,11 @@ describe("discord voice opus codec", () => {
 
       const onVerbose = vi.fn();
       const onWarn = vi.fn();
-      const decoded = await decode(Readable.from(packets), { onVerbose, onWarn });
+      const decoded = await decode(Readable.from(packets), {
+        maxBytes: 20 * 1024 * 1024,
+        onVerbose,
+        onWarn,
+      });
       expect(decoded.length).toBe(960 * 2 * 2);
       expect(onVerbose).toHaveBeenCalledWith("opus decoder: libopus-wasm");
       expect(onWarn).not.toHaveBeenCalled();
@@ -123,6 +127,7 @@ describe("discord voice opus codec", () => {
 
     expect(packets).toHaveLength(1);
     const decoded = await decodeOpusStream(Readable.from(packets), {
+      maxBytes: 20 * 1024 * 1024,
       onVerbose: vi.fn(),
       onWarn: vi.fn(),
     });
@@ -142,6 +147,7 @@ describe("discord voice opus codec", () => {
       );
 
       const decoded = await decode(stream, {
+        maxBytes: 20 * 1024 * 1024,
         onError,
         onVerbose: vi.fn(),
         onWarn: vi.fn(),
@@ -151,6 +157,35 @@ describe("discord voice opus codec", () => {
       expect(decoded).toHaveLength(960 * 2 * 2);
     },
   );
+  it("rejects oversized decoded input without returning a truncated successful capture", async () => {
+    const stream = Readable.from([
+      Buffer.from([0xf8, 0xff, 0xfe]),
+      Buffer.from([0xf8, 0xff, 0xfe]),
+    ]);
+    await expect(
+      decodeOpusStream(stream, {
+        maxBytes: 3840,
+        onVerbose: vi.fn(),
+        onWarn: vi.fn(),
+      }),
+    ).rejects.toThrow("speak a shorter segment");
+    expect(stream.destroyed).toBe(true);
+  });
+
+  it("streams audio beyond a batch-sized budget without accumulating or truncating it", async () => {
+    let bytes = 0;
+    await decodeOpusStreamChunks(
+      Readable.from(Array.from({ length: 3 }, () => Buffer.from([0xf8, 0xff, 0xfe]))),
+      {
+        onChunk: (pcm) => {
+          bytes += pcm.length;
+        },
+        onVerbose: vi.fn(),
+        onWarn: vi.fn(),
+      },
+    );
+    expect(bytes).toBe(3 * 3840);
+  });
 });
 
 describe("createDiscordOpusPlaybackStream child stream errors", () => {

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -12,6 +12,7 @@ import {
 } from "libopus-wasm";
 import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 import { resamplePcm } from "openclaw/plugin-sdk/realtime-voice";
+import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
@@ -19,6 +20,7 @@ import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-s
 const SAMPLE_RATE = 48_000;
 const CHANNELS = 2;
 const BIT_DEPTH = 16;
+export const VOICE_WAV_HEADER_BYTES = 44;
 const FFMPEG_ERROR_OUTPUT_BYTES = 8_192;
 const DISCORD_OPUS_FRAME_SIZE = 960;
 const DISCORD_OPUS_FRAME_BYTES = DISCORD_OPUS_FRAME_SIZE * CHANNELS * (BIT_DEPTH / 8);
@@ -49,7 +51,7 @@ let warnedOpusMissing = false;
 function buildWavBuffer(pcm: Buffer): Buffer {
   const blockAlign = (CHANNELS * BIT_DEPTH) / 8;
   const byteRate = SAMPLE_RATE * blockAlign;
-  const header = Buffer.alloc(44);
+  const header = Buffer.alloc(VOICE_WAV_HEADER_BYTES);
   header.write("RIFF", 0);
   header.writeUInt32LE(36 + pcm.length, 4);
   header.write("WAVE", 8);
@@ -211,11 +213,15 @@ function pcmInt16ToBuffer(pcm: Int16Array): Buffer {
 
 export async function decodeOpusStream(
   stream: Readable,
-  params: OpusDecodeCallbacks,
+  params: OpusDecodeCallbacks & { maxBytes: number },
 ): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  await decodeOpusStreamChunks(stream, { ...params, onChunk: (chunk) => chunks.push(chunk) });
-  return Buffer.concat(chunks);
+  return await readByteStreamWithLimit(decodeOpusFrames(stream, params), {
+    maxBytes: params.maxBytes,
+    onOverflow: () =>
+      new Error(
+        `Discord voice capture exceeds the transcription PCM limit (${params.maxBytes} bytes); speak a shorter segment.`,
+      ),
+  });
 }
 
 export async function decodeOpusStreamChunks(
@@ -224,6 +230,19 @@ export async function decodeOpusStreamChunks(
     onChunk: (pcm48kStereo: Buffer) => void;
   },
 ): Promise<void> {
+  try {
+    for await (const pcm of decodeOpusFrames(stream, params)) {
+      params.onChunk(pcm);
+    }
+  } catch (err) {
+    params.onError?.(err);
+  }
+}
+
+async function* decodeOpusFrames(
+  stream: Readable,
+  params: OpusDecodeCallbacks,
+): AsyncGenerator<Buffer> {
   let decoder: LibopusDecoder;
   try {
     decoder = await createLibopusDecoder({ channels: CHANNELS, sampleRate: SAMPLE_RATE });
@@ -244,7 +263,7 @@ export async function decodeOpusStreamChunks(
       }
       const decoded = decoder.decode(chunk, { maxFrameSize: DISCORD_OPUS_FRAME_SIZE });
       if (decoded.length > 0) {
-        params.onChunk(pcmInt16ToBuffer(decoded));
+        yield pcmInt16ToBuffer(decoded);
       }
     }
   } catch (err) {

--- a/extensions/discord/src/voice/capture-state.test.ts
+++ b/extensions/discord/src/voice/capture-state.test.ts
@@ -6,17 +6,27 @@ import {
   createVoiceCaptureState,
   finishVoiceCapture,
   scheduleVoiceCaptureFinalize,
+  stopVoiceCaptureState,
 } from "./capture-state.js";
 
 describe("voice capture state", () => {
-  it("increments generations per speaker", () => {
-    const state = createVoiceCaptureState();
-    const first = beginVoiceCapture(state, "u1", { destroy: vi.fn() } as never);
-    finishVoiceCapture(state, "u1", first);
-    const second = beginVoiceCapture(state, "u1", { destroy: vi.fn() } as never);
+  it("keeps a replacement's finalize timer when an old decode finishes", async () => {
+    vi.useFakeTimers();
+    try {
+      const state = createVoiceCaptureState();
+      const first = beginVoiceCapture(state, "u1", { destroy: vi.fn() } as never);
+      finishVoiceCapture(state, "u1", first);
+      const destroy = vi.fn();
+      beginVoiceCapture(state, "u1", { destroy } as never);
+      scheduleVoiceCaptureFinalize({ state, userId: "u1", delayMs: 1_200 });
 
-    expect(first).toBe(1);
-    expect(second).toBe(2);
+      expect(finishVoiceCapture(state, "u1", first)).toBe(false);
+      await vi.advanceTimersByTimeAsync(1_200);
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(state.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("clears active speaker state before destroying a finalized capture", async () => {
@@ -24,8 +34,7 @@ describe("voice capture state", () => {
     try {
       const state = createVoiceCaptureState();
       const destroy = vi.fn(() => {
-        expect(state.activeSpeakers.has("u1")).toBe(false);
-        expect(state.activeCaptureStreams.has("u1")).toBe(false);
+        expect(state.has("u1")).toBe(false);
       });
       beginVoiceCapture(state, "u1", { destroy } as never);
 
@@ -38,12 +47,32 @@ describe("voice capture state", () => {
     }
   });
 
-  it("lets a pending finalize be canceled for the same generation", () => {
+  it("lets a pending finalize be canceled for the same capture", () => {
     const state = createVoiceCaptureState();
-    const generation = beginVoiceCapture(state, "u1", { destroy: vi.fn() } as never);
+    const capture = beginVoiceCapture(state, "u1", { destroy: vi.fn() } as never);
 
     expect(scheduleVoiceCaptureFinalize({ state, userId: "u1", delayMs: 1_200 })).toBe(true);
-    expect(clearVoiceCaptureFinalizeTimer(state, "u1", generation)).toBe(true);
-    expect(state.captureFinalizeTimers.has("u1")).toBe(false);
+    expect(clearVoiceCaptureFinalizeTimer(capture)).toBe(true);
+    expect(clearVoiceCaptureFinalizeTimer(capture)).toBe(false);
+  });
+
+  it("retires every capture and cancels timers before terminal stream teardown", async () => {
+    vi.useFakeTimers();
+    try {
+      const state = createVoiceCaptureState();
+      const destroy = vi.fn(() => expect(state.size).toBe(0));
+      const onFinalize = vi.fn();
+      for (const userId of ["u1", "u2"]) {
+        beginVoiceCapture(state, userId, { destroy } as never);
+        scheduleVoiceCaptureFinalize({ state, userId, delayMs: 1_200, onFinalize });
+      }
+
+      stopVoiceCaptureState(state);
+      await vi.advanceTimersByTimeAsync(1_200);
+      expect(destroy).toHaveBeenCalledTimes(2);
+      expect(onFinalize).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/discord/src/voice/capture-state.ts
+++ b/extensions/discord/src/voice/capture-state.ts
@@ -2,94 +2,56 @@
 import type { Readable } from "node:stream";
 
 type VoiceCaptureEntry = {
-  generation: number;
-  stream: Readable;
+  stream?: Readable;
+  finalizeTimer?: ReturnType<typeof setTimeout>;
 };
 
-type VoiceCaptureFinalizeTimer = {
-  generation: number;
-  timer: ReturnType<typeof setTimeout>;
-};
-
-export type VoiceCaptureState = {
-  activeSpeakers: Set<string>;
-  activeCaptureStreams: Map<string, VoiceCaptureEntry>;
-  captureFinalizeTimers: Map<string, VoiceCaptureFinalizeTimer>;
-  captureGenerations: Map<string, number>;
-};
+export type VoiceCaptureState = Map<string, VoiceCaptureEntry>;
 
 export function createVoiceCaptureState(): VoiceCaptureState {
-  return {
-    activeSpeakers: new Set(),
-    activeCaptureStreams: new Map(),
-    captureFinalizeTimers: new Map(),
-    captureGenerations: new Map(),
-  };
+  return new Map();
 }
 
 export function stopVoiceCaptureState(state: VoiceCaptureState): void {
-  for (const { timer } of state.captureFinalizeTimers.values()) {
-    clearTimeout(timer);
+  const captures = [...state.values()];
+  // Retire every capture before stream teardown can invoke retained callbacks.
+  state.clear();
+  for (const capture of captures) {
+    clearVoiceCaptureFinalizeTimer(capture);
+    capture.stream?.destroy();
   }
-  state.captureFinalizeTimers.clear();
-  for (const { stream } of state.activeCaptureStreams.values()) {
-    stream.destroy();
-  }
-  state.activeCaptureStreams.clear();
-  state.captureGenerations.clear();
-  state.activeSpeakers.clear();
 }
 
-export function getActiveVoiceCapture(
-  state: VoiceCaptureState,
-  userId: string,
-): VoiceCaptureEntry | undefined {
-  return state.activeCaptureStreams.get(userId);
-}
-
-export function isVoiceCaptureActive(state: VoiceCaptureState, userId: string): boolean {
-  return state.activeSpeakers.has(userId);
-}
-
-export function clearVoiceCaptureFinalizeTimer(
-  state: VoiceCaptureState,
-  userId: string,
-  generation?: number,
-): boolean {
-  const scheduled = state.captureFinalizeTimers.get(userId);
-  if (!scheduled || (generation !== undefined && scheduled.generation !== generation)) {
+export function clearVoiceCaptureFinalizeTimer(capture: VoiceCaptureEntry): boolean {
+  if (!capture.finalizeTimer) {
     return false;
   }
-  clearTimeout(scheduled.timer);
-  state.captureFinalizeTimers.delete(userId);
+  clearTimeout(capture.finalizeTimer);
+  delete capture.finalizeTimer;
   return true;
 }
 
 export function beginVoiceCapture(
   state: VoiceCaptureState,
   userId: string,
-  stream: Readable,
-): number {
-  const generation = (state.captureGenerations.get(userId) ?? 0) + 1;
-  state.captureGenerations.set(userId, generation);
-  state.activeSpeakers.add(userId);
-  state.activeCaptureStreams.set(userId, { generation, stream });
-  clearVoiceCaptureFinalizeTimer(state, userId, generation);
-  return generation;
+  stream?: Readable,
+): VoiceCaptureEntry {
+  const capture = { stream };
+  state.set(userId, capture);
+  return capture;
 }
 
 export function finishVoiceCapture(
   state: VoiceCaptureState,
   userId: string,
-  generation: number,
+  capture: VoiceCaptureEntry,
 ): boolean {
-  clearVoiceCaptureFinalizeTimer(state, userId, generation);
-  const activeCapture = state.activeCaptureStreams.get(userId);
-  if (activeCapture?.generation !== generation) {
+  clearVoiceCaptureFinalizeTimer(capture);
+  // An old decode can finish after silence finalized it and a new capture started.
+  if (state.get(userId) !== capture) {
     return false;
   }
-  state.activeCaptureStreams.delete(userId);
-  state.activeSpeakers.delete(userId);
+  state.delete(userId);
   return true;
 }
 
@@ -100,22 +62,17 @@ export function scheduleVoiceCaptureFinalize(params: {
   onFinalize?: (capture: VoiceCaptureEntry) => void;
 }): boolean {
   const { state, userId, delayMs, onFinalize } = params;
-  const capture = state.activeCaptureStreams.get(userId);
+  const capture = state.get(userId);
   if (!capture) {
     return false;
   }
-  clearVoiceCaptureFinalizeTimer(state, userId, capture.generation);
-  const timer = setTimeout(() => {
-    const activeCapture = state.activeCaptureStreams.get(userId);
-    if (!activeCapture || activeCapture.generation !== capture.generation) {
+  clearVoiceCaptureFinalizeTimer(capture);
+  capture.finalizeTimer = setTimeout(() => {
+    if (!finishVoiceCapture(state, userId, capture)) {
       return;
     }
-    state.captureFinalizeTimers.delete(userId);
-    state.activeCaptureStreams.delete(userId);
-    state.activeSpeakers.delete(userId);
-    onFinalize?.(activeCapture);
-    activeCapture.stream.destroy();
+    onFinalize?.(capture);
+    capture.stream?.destroy();
   }, delayMs);
-  state.captureFinalizeTimers.set(userId, { generation: capture.generation, timer });
   return true;
 }

--- a/extensions/discord/src/voice/realtime-playback.integration.test.ts
+++ b/extensions/discord/src/voice/realtime-playback.integration.test.ts
@@ -44,6 +44,7 @@ it("plays every frame of a burst through the real Opus encoder before releasing 
     player,
     playbackQueue: Promise.resolve(),
     processingQueue: Promise.resolve(),
+    audioInputBudget: { enabled: false },
     ttsStreamFallbackWarned: false,
     capture: createVoiceCaptureState(),
     realtimeLifecycle: { status: "inactive", generation: 0 },

--- a/extensions/discord/src/voice/session.ts
+++ b/extensions/discord/src/voice/session.ts
@@ -1,3 +1,4 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 // Discord plugin module implements session behavior.
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -104,6 +105,9 @@ export type VoiceSessionEntry = {
   player: import("@discordjs/voice").AudioPlayer;
   playbackQueue: Promise<void>;
   processingQueue: Promise<void>;
+  audioInputBudget: Awaited<
+    ReturnType<PluginRuntime["mediaUnderstanding"]["resolveAudioInputBudget"]>
+  >;
   ttsStreamFallbackWarned: boolean;
   capture: VoiceCaptureState;
   realtimeLifecycle: VoiceRealtimeLifecycle;

--- a/extensions/discord/src/voice/voice-receive.test.ts
+++ b/extensions/discord/src/voice/voice-receive.test.ts
@@ -1,4 +1,6 @@
 import type { Readable } from "node:stream";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { DiscordVoiceIngressContext } from "./ingress.js";
 import type { MockCallSource } from "./manager.e2e.test-support.js";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
@@ -17,6 +19,8 @@ defineDiscordVoiceTests(
     createConnectionMock,
     joinVoiceChannelMock,
     transcribeAudioFileMock,
+    resolveVoiceIngressWithParticipantsMock,
+    loggerWarnMock,
     realtimeSessionMock,
     decodeOpusStreamMock,
     decodeOpusStreamChunksMock,
@@ -89,6 +93,81 @@ defineDiscordVoiceTests(
       expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();
       expect(client.fetchMember).toHaveBeenCalledWith("g1", "u-denied");
     });
+
+    it("owns start/end/start during realtime admission without subscribing before authorization", async () => {
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const manager = createAgentProxyManager();
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+      const admission = createDeferred<DiscordVoiceIngressContext | null>();
+      resolveVoiceIngressWithParticipantsMock.mockReturnValue(admission.promise);
+      vi.useFakeTimers();
+      try {
+        const first = handleSpeakingStart(manager, entry, "u-speaker");
+        getVoiceReceive(manager).scheduleCaptureFinalize(entry, "u-speaker", "speaker end");
+        const resumed = handleSpeakingStart(manager, entry, "u-speaker");
+        expect(resolveVoiceIngressWithParticipantsMock).toHaveBeenCalledOnce();
+        expect(connection.receiver.subscribe).not.toHaveBeenCalled();
+        expect(decodeOpusStreamChunksMock).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(2_500);
+        expect(entry.capture.size).toBe(1);
+
+        admission.resolve({ speakerLabel: "Speaker", senderIsOwner: false });
+        await Promise.all([first, resumed]);
+        expect(connection.receiver.subscribe).toHaveBeenCalledOnce();
+        expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce();
+        expect(entry.capture.size).toBe(0);
+      } finally {
+        admission.resolve(null);
+        await manager.destroy();
+        vi.useRealTimers();
+      }
+    });
+
+    it.each(["denied", "failed", "stopped", "silence expired"] as const)(
+      "retires %s realtime admission without a late subscription",
+      async (reason) => {
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const manager = createAgentProxyManager();
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const entry = getSessionEntry(manager);
+        const admission = createDeferred<DiscordVoiceIngressContext | null>();
+        resolveVoiceIngressWithParticipantsMock.mockReturnValue(admission.promise);
+        vi.useFakeTimers();
+        try {
+          const completion = handleSpeakingStart(manager, entry, "u-speaker");
+          const outcome =
+            reason === "failed"
+              ? expect(completion).rejects.toThrow("admission failed")
+              : expect(completion).resolves.toBeUndefined();
+          getVoiceReceive(manager).scheduleCaptureFinalize(entry, "u-speaker", "speaker end");
+          expect(connection.receiver.subscribe).not.toHaveBeenCalled();
+          if (reason === "stopped") {
+            await manager.destroy();
+          } else if (reason === "silence expired") {
+            await vi.advanceTimersByTimeAsync(2_500);
+          }
+          if (reason === "failed") {
+            admission.reject(new Error("admission failed"));
+          } else {
+            admission.resolve(
+              reason === "denied" ? null : { speakerLabel: "Speaker", senderIsOwner: false },
+            );
+          }
+          await outcome;
+          await vi.advanceTimersByTimeAsync(2_500);
+          expect(connection.receiver.subscribe).not.toHaveBeenCalled();
+          expect(decodeOpusStreamChunksMock).not.toHaveBeenCalled();
+          expect(entry.capture.size).toBe(0);
+        } finally {
+          admission.resolve(null);
+          await manager.destroy();
+          vi.useRealTimers();
+        }
+      },
+    );
 
     it("stores guild metadata on joined voice sessions", async () => {
       const manager = createManager();
@@ -664,7 +743,7 @@ defineDiscordVoiceTests(
       expect(manager.status()).toEqual([]);
     });
 
-    it("resets DAVE receive recovery after realtime audio decodes", async () => {
+    it("streams realtime with batch transcription disabled and resets receive recovery", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
       decodeOpusStreamChunksMock.mockImplementationOnce(
@@ -677,9 +756,11 @@ defineDiscordVoiceTests(
           params.onChunk(Buffer.alloc(8));
         },
       );
-      const manager = createAgentProxyManager(undefined, {
-        allowFrom: ["discord:u-speaker"],
-      });
+      const manager = createAgentProxyManager(
+        undefined,
+        { allowFrom: ["discord:u-speaker"] },
+        { tools: { media: { audio: { enabled: false } } } },
+      );
 
       await manager.join({ guildId: "g1", channelId: "1001" });
       emitDecryptFailure(manager);
@@ -698,6 +779,10 @@ defineDiscordVoiceTests(
       await handleSpeakingStart(manager, entry, "u-speaker");
 
       expect(decodeOpusStreamChunksMock).toHaveBeenCalledTimes(1);
+      expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+      expect(loggerWarnMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("audio understanding is disabled"),
+      );
       expect(entry.receiveRecovery.decryptFailureCount).toBe(0);
       expect(entry.receiveRecovery.lastDecryptFailureAt).toBe(0);
       expect(attempts.has("g1")).toBe(false);
@@ -747,8 +832,7 @@ defineDiscordVoiceTests(
       expect(errorListener).toBeTypeOf("function");
       expect(stream.off).toHaveBeenCalledWith("error", errorListener);
       expect(stream.destroy).toHaveBeenCalledTimes(1);
-      expect(entry.capture.activeSpeakers.has("u-speaker")).toBe(false);
-      expect(entry.capture.activeCaptureStreams.has("u-speaker")).toBe(false);
+      expect(entry.capture.has("u-speaker")).toBe(false);
       expect(entry.receiveRecovery.decryptFailureCount).toBe(1);
     });
 
@@ -787,6 +871,95 @@ defineDiscordVoiceTests(
       expect(entry.receiveRecovery.decryptFailureCount).toBe(1);
       expect(entry.receiveRecovery.lastDecryptFailureAt).toBeGreaterThan(0);
       expect(stream.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([0, -1])(
+      "accounts for the WAV header at the transcription limit (offset %i)",
+      async (offset) => {
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const manager = createManager(
+          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+          undefined,
+          { tools: { media: { audio: { maxBytes: 20 * 3840 + 44 + offset } } } },
+        );
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const entry = getSessionEntry(manager);
+        const stream = new PassThrough({ objectMode: true });
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+        const completion = handleSpeakingStart(manager, entry, "u-speaker");
+        const outcome =
+          offset === 0
+            ? expect(completion).resolves.toBeUndefined()
+            : expect(completion).rejects.toThrow("speak a shorter segment");
+        for (let frame = 0; frame < 20; frame += 1) {
+          stream.write(Buffer.from([0xf8, 0xff, 0xfe]));
+        }
+        stream.end();
+        await outcome;
+        await entry.processingQueue;
+        expect(transcribeAudioFileMock).toHaveBeenCalledTimes(offset === 0 ? 1 : 0);
+        expect(stream.destroyed).toBe(true);
+        expect(entry.capture.size).toBe(0);
+        if (offset < 0) {
+          expect(loggerWarnMock).toHaveBeenCalledWith(
+            expect.stringContaining("speak a shorter segment"),
+          );
+        }
+        await manager.destroy();
+      },
+    );
+
+    it("allows the same speaker to restart after an oversized capture without transcribing a prefix", async () => {
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+        undefined,
+        { tools: { media: { audio: { maxBytes: 20 * 3840 + 44 } } } },
+      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+      for (const frames of [21, 20]) {
+        const stream = new PassThrough({ objectMode: true });
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+        const completion = handleSpeakingStart(manager, entry, "u-speaker");
+        const outcome =
+          frames === 21
+            ? expect(completion).rejects.toThrow("speak a shorter segment")
+            : expect(completion).resolves.toBeUndefined();
+        for (let frame = 0; frame < frames; frame += 1) {
+          stream.write(Buffer.from([0xf8, 0xff, 0xfe]));
+        }
+        stream.end();
+        await outcome;
+        await entry.processingQueue;
+        expect(transcribeAudioFileMock).toHaveBeenCalledTimes(frames === 21 ? 0 : 1);
+        expect(stream.destroyed).toBe(true);
+        expect(entry.capture.size).toBe(0);
+      }
+      await manager.destroy();
+    });
+
+    it("records disabled batch transcription without decoding or retaining a capture", async () => {
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const manager = createManager(undefined, undefined, {
+        tools: { media: { audio: { enabled: false } } },
+      });
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+      const stream = new PassThrough({ objectMode: true });
+      connection.receiver.subscribe.mockReturnValueOnce(stream);
+      await handleSpeakingStart(manager, entry, "u-speaker");
+      expect(decodeOpusStreamMock).not.toHaveBeenCalled();
+      expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining("audio understanding is disabled"),
+      );
+      expect(stream.destroyed).toBe(true);
+      expect(entry.capture.size).toBe(0);
+      await manager.destroy();
     });
 
     it("processes partial non-realtime audio after abort-like stream endings", async () => {
@@ -841,16 +1014,14 @@ defineDiscordVoiceTests(
 
         const firstStream = new PassThrough();
         const destroyFirstStream = vi.spyOn(firstStream, "destroy");
-        entry.capture.activeSpeakers.add("u1");
-        entry.capture.captureGenerations.set("u1", 1);
-        entry.capture.activeCaptureStreams.set("u1", { generation: 1, stream: firstStream });
+        entry.capture.set("u1", { stream: firstStream });
 
         getVoiceReceive(manager).scheduleCaptureFinalize(entry, "u1", "test");
 
         await vi.advanceTimersByTimeAsync(2_500);
 
         expect(destroyFirstStream).toHaveBeenCalledTimes(1);
-        expect(entry?.capture.activeSpeakers.has("u1")).toBe(false);
+        expect(entry.capture.has("u1")).toBe(false);
 
         const secondStream = {
           on: vi.fn(),
@@ -889,10 +1060,7 @@ defineDiscordVoiceTests(
           channelId: "1001",
           capture: createVoiceCaptureState(),
         };
-        entry.capture.activeSpeakers.add("u1");
-        entry.capture.captureGenerations.set("u1", 1);
-        entry.capture.activeCaptureStreams.set("u1", {
-          generation: 1,
+        entry.capture.set("u1", {
           stream: stream as unknown as Readable,
         });
 

--- a/extensions/discord/src/voice/voice-receive.ts
+++ b/extensions/discord/src/voice/voice-receive.ts
@@ -3,13 +3,16 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { Client } from "../internal/discord.js";
-import { decodeOpusStream, decodeOpusStreamChunks, writeVoiceWavFile } from "./audio.js";
+import {
+  decodeOpusStream,
+  decodeOpusStreamChunks,
+  VOICE_WAV_HEADER_BYTES,
+  writeVoiceWavFile,
+} from "./audio.js";
 import {
   beginVoiceCapture,
   clearVoiceCaptureFinalizeTimer,
   finishVoiceCapture,
-  getActiveVoiceCapture,
-  isVoiceCaptureActive,
   scheduleVoiceCaptureFinalize,
 } from "./capture-state.js";
 import { type DiscordVoiceIngressContext, runDiscordVoiceAgentTurn } from "./ingress.js";
@@ -109,11 +112,9 @@ export class DiscordVoiceReceive {
       return;
     }
     this.params.membership.notePresent(entry, userId);
-    if (isVoiceCaptureActive(entry.capture, userId)) {
-      const activeCapture = getActiveVoiceCapture(entry.capture, userId);
-      const extended = activeCapture
-        ? clearVoiceCaptureFinalizeTimer(entry.capture, userId, activeCapture.generation)
-        : false;
+    const activeCapture = entry.capture.get(userId);
+    if (activeCapture) {
+      const extended = clearVoiceCaptureFinalizeTimer(activeCapture);
       logVoiceVerbose(
         `capture start ignored (already active): guild ${entry.guildId} channel ${entry.channelId} user ${userId}${extended ? " (finalize canceled)" : ""}`,
       );
@@ -137,44 +138,8 @@ export class DiscordVoiceReceive {
       );
       return;
     }
-    const realtimeIngress = realtime
-      ? await this.resolveDiscordVoiceIngressContext(entry, userId)
-      : undefined;
-    if (realtime && !realtimeIngress) {
-      logVoiceVerbose(
-        `realtime capture unauthorized: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-      );
-      return;
-    }
-    if (!this.params.isEntryCurrent(entry)) {
-      return;
-    }
-    if (entry.player.state.status === voiceSdk.AudioPlayerStatus.Playing && realtime) {
-      if (!realtime.isBargeInEnabled()) {
-        logger.info(
-          `discord voice: realtime capture ignored during playback (barge-in disabled): guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-        );
-        return;
-      }
-      logVoiceVerbose(
-        `realtime barge-in: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-      );
-      logger.info(
-        `discord voice: realtime barge-in detected source=speaker-start guild=${entry.guildId} channel=${entry.channelId} user=${userId} playerStatus=${entry.player.state.status}`,
-      );
-      realtime.handleBargeIn("speaker-start");
-    }
-    this.enableDaveReceivePassthrough(
-      entry,
-      `speaker ${userId} start`,
-      DAVE_RECEIVE_PASSTHROUGH_REARM_EXPIRY_SECONDS,
-    );
-    const stream = entry.connection.receiver.subscribe(userId, {
-      end: {
-        behavior: voiceSdk.EndBehaviorType.Manual,
-      },
-    });
-    const generation = beginVoiceCapture(entry.capture, userId, stream);
+    // Own start/end events while admission awaits; subscribing still requires authorization.
+    const capture = beginVoiceCapture(entry.capture, userId);
     let streamAborted = false;
     let receiveFailureHandled = false;
     let receiveStreamEndHandled = false;
@@ -195,9 +160,45 @@ export class DiscordVoiceReceive {
       receiveFailureHandled = true;
       this.handleReceiveError(entry, err);
     };
-    stream.on("error", handleStreamError);
-
     try {
+      const realtimeIngress = realtime
+        ? await this.resolveDiscordVoiceIngressContext(entry, userId)
+        : undefined;
+      if (realtime && !realtimeIngress) {
+        logVoiceVerbose(
+          `realtime capture unauthorized: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
+        );
+        return;
+      }
+      if (!this.params.isEntryCurrent(entry) || entry.capture.get(userId) !== capture) {
+        return;
+      }
+      if (entry.player.state.status === voiceSdk.AudioPlayerStatus.Playing && realtime) {
+        if (!realtime.isBargeInEnabled()) {
+          logger.info(
+            `discord voice: realtime capture ignored during playback (barge-in disabled): guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
+          );
+          return;
+        }
+        logVoiceVerbose(
+          `realtime barge-in: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
+        );
+        logger.info(
+          `discord voice: realtime barge-in detected source=speaker-start guild=${entry.guildId} channel=${entry.channelId} user=${userId} playerStatus=${entry.player.state.status}`,
+        );
+        realtime.handleBargeIn("speaker-start");
+      }
+      this.enableDaveReceivePassthrough(
+        entry,
+        `speaker ${userId} start`,
+        DAVE_RECEIVE_PASSTHROUGH_REARM_EXPIRY_SECONDS,
+      );
+      const stream = (capture.stream = entry.connection.receiver.subscribe(userId, {
+        end: {
+          behavior: voiceSdk.EndBehaviorType.Manual,
+        },
+      }));
+      stream.on("error", handleStreamError);
       if (realtime && realtimeIngress) {
         const turn = realtime.beginSpeakerTurn(realtimeIngress, userId);
         try {
@@ -212,7 +213,14 @@ export class DiscordVoiceReceive {
         }
         return;
       }
+      if (!entry.audioInputBudget.enabled) {
+        logger.warn(
+          "discord voice: capture skipped: audio understanding is disabled; enable tools.media.audio.enabled to transcribe voice.",
+        );
+        return;
+      }
       const pcm = await decodeOpusStream(stream, {
+        maxBytes: Math.max(0, entry.audioInputBudget.maxBytes - VOICE_WAV_HEADER_BYTES),
         onError: handleStreamError,
         onVerbose: logVoiceVerbose,
         onWarn: (message) => logger.warn(message),
@@ -263,9 +271,10 @@ export class DiscordVoiceReceive {
       }
       throw err;
     } finally {
-      stream.off?.("error", handleStreamError);
-      const finishedActiveCapture = finishVoiceCapture(entry.capture, userId, generation);
-      if (finishedActiveCapture && !stream.destroyed) {
+      const stream = capture.stream;
+      stream?.off?.("error", handleStreamError);
+      const finishedActiveCapture = finishVoiceCapture(entry.capture, userId, capture);
+      if (finishedActiveCapture && stream && !stream.destroyed) {
         stream.destroy();
       }
     }

--- a/extensions/discord/src/voice/voice-session.terminal.test.ts
+++ b/extensions/discord/src/voice/voice-session.terminal.test.ts
@@ -62,7 +62,7 @@ defineDiscordVoiceTests(
             "voice capture stream",
           );
           getVoiceReceive(manager).scheduleCaptureFinalize(entry, "u-owner", "speaker end");
-          expect(entry.capture.captureFinalizeTimers.size).toBe(1);
+          expect(entry.capture.get("u-owner")?.finalizeTimer).toBeDefined();
           const turn = beginSpeakerTurn(entry);
           const provider = lastRealtimeBridgeParams();
           const player = getLastAudioPlayer();
@@ -76,8 +76,7 @@ defineDiscordVoiceTests(
           expect(entry.transcripts).toBeUndefined();
           expect(onStop).toHaveBeenCalledExactlyOnceWith(undefined);
           expect(captureStream.destroy).toHaveBeenCalledOnce();
-          expect(entry.capture.activeCaptureStreams.size).toBe(0);
-          expect(entry.capture.captureFinalizeTimers.size).toBe(0);
+          expect(entry.capture.size).toBe(0);
           expect(oldConnection.destroy).toHaveBeenCalledOnce();
           expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
           expect(loggerErrorMock).toHaveBeenCalledExactlyOnceWith(

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -5,6 +5,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { Client } from "../internal/discord.js";
 import type { VoicePlugin } from "../internal/voice.js";
 import { formatMention } from "../mentions.js";
+import { getDiscordRuntime } from "../runtime.js";
 import { parseDiscordTarget } from "../target-parsing.js";
 import { createVoiceCaptureState, stopVoiceCaptureState } from "./capture-state.js";
 import { resolveDiscordVoiceRealtimeBootstrapContext } from "./ingress.js";
@@ -254,6 +255,12 @@ export class DiscordVoiceSessions {
       return { ok: false, message: "Discord voice plugin is not available." };
     }
 
+    const audioInputBudget = await getDiscordRuntime().mediaUnderstanding.resolveAudioInputBudget({
+      cfg: this.params.cfg,
+    });
+    if (authority && !authority.isCurrent()) {
+      return cancelledJoinResult();
+    }
     const adapterCreator = voicePlugin.getGatewayAdapterCreator(guildId);
     const daveEncryption = voiceConfig?.daveEncryption;
     const decryptionFailureTolerance = voiceConfig?.decryptionFailureTolerance;
@@ -460,6 +467,7 @@ export class DiscordVoiceSessions {
       player,
       playbackQueue: Promise.resolve(),
       processingQueue: Promise.resolve(),
+      audioInputBudget,
       ttsStreamFallbackWarned: false,
       capture: createVoiceCaptureState(),
       transcripts: options?.transcripts,

--- a/extensions/discord/src/voice/voice-test-harness.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-harness.test-support.ts
@@ -559,6 +559,7 @@ function buildVoiceTestHarness() {
         sessionLifecycle: { status: "active" },
         playbackQueue: Promise.resolve(),
         processingQueue: Promise.resolve(),
+        audioInputBudget: { enabled: true, maxBytes: 20 * 1024 * 1024 },
         ttsStreamFallbackWarned: false,
         capture: createVoiceCaptureState(),
         receiveRecovery: createVoiceReceiveRecoveryState(),

--- a/extensions/discord/src/voice/voice-test-mocks.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-mocks.test-support.ts
@@ -437,6 +437,14 @@ vi.mock("../runtime.js", () => ({
   getDiscordRuntime: () => ({
     agent: { runCommandFromIngress: agentCommandMock },
     mediaUnderstanding: {
+      resolveAudioInputBudget: async ({
+        cfg,
+      }: {
+        cfg: import("openclaw/plugin-sdk/config-contracts").OpenClawConfig;
+      }) =>
+        cfg.tools?.media?.audio?.enabled === false
+          ? { enabled: false }
+          : { enabled: true, maxBytes: cfg.tools?.media?.audio?.maxBytes ?? 20 * 1024 * 1024 },
       transcribeAudioFile: transcribeAudioFileMock,
     },
     tts: {

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -132,6 +132,9 @@ export type TranscribeAudioFileParams = {
 };
 
 export type MediaUnderstandingRuntime = {
+  resolveAudioInputBudget: (params: {
+    cfg: OpenClawConfig;
+  }) => Promise<{ enabled: false } | { enabled: true; maxBytes: number }>;
   runMediaUnderstandingFile: (
     params: RunMediaUnderstandingFileParams,
   ) => Promise<RunMediaUnderstandingFileResult>;

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -12,6 +12,7 @@ import {
   describeImageFileWithModel,
   extractStructuredWithModel,
   runMediaUnderstandingFile,
+  resolveAudioInputBudget,
   transcribeAudioFile,
 } from "./runtime.js";
 
@@ -75,6 +76,84 @@ function requireRunCapabilityRequest(): unknown {
 }
 
 describe("media-understanding runtime", () => {
+  it.each([
+    { name: "automatic selection", cfg: {}, maxBytes: 20 * 1024 * 1024 },
+    {
+      name: "automatic input override",
+      cfg: { tools: { media: { audio: { maxBytes: 4096 } } } },
+      maxBytes: 4096,
+    },
+    {
+      name: "larger audio fallback but not an image entry",
+      cfg: {
+        tools: {
+          media: {
+            audio: { maxBytes: 256 },
+            models: [
+              { provider: "first", capabilities: ["audio"], maxBytes: 1024 },
+              { provider: "second", capabilities: ["audio"], maxBytes: 4096 },
+              { provider: "image", capabilities: ["image"], maxBytes: 8192 },
+            ],
+          },
+        },
+      },
+      maxBytes: 4096,
+    },
+    {
+      name: "explicit local CLI override",
+      cfg: {
+        tools: {
+          media: {
+            audio: { maxBytes: 4096 },
+            models: [
+              { type: "cli", command: "fixture-asr", capabilities: ["audio"], maxBytes: 1024 },
+            ],
+          },
+        },
+      },
+      maxBytes: 1024,
+    },
+    {
+      name: "local CLI inheriting audio input limit",
+      cfg: {
+        tools: {
+          media: {
+            audio: { maxBytes: 4096 },
+            models: [{ type: "cli", command: "fixture-asr", capabilities: ["audio"] }],
+          },
+        },
+      },
+      maxBytes: 4096,
+    },
+    {
+      name: "inferred provider capability",
+      cfg: {
+        tools: {
+          media: {
+            models: [{ provider: "registered-audio", maxBytes: 8192 }],
+          },
+        },
+      },
+      maxBytes: 8192,
+    },
+  ] satisfies Array<{ name: string; cfg: OpenClawConfig; maxBytes: number }>)(
+    "prepares the existing transcription input budget for $name",
+    async ({ cfg, maxBytes }) => {
+      mocks.buildProviderRegistry.mockReturnValue(
+        new Map([["registered-audio", { capabilities: ["audio"] }]]),
+      );
+      await expect(resolveAudioInputBudget({ cfg })).resolves.toEqual({ enabled: true, maxBytes });
+      expect(mocks.runCapability).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not load providers to prepare disabled audio input", async () => {
+    await expect(
+      resolveAudioInputBudget({ cfg: { tools: { media: { audio: { enabled: false } } } } }),
+    ).resolves.toEqual({ enabled: false });
+    expect(mocks.buildProviderRegistry).not.toHaveBeenCalled();
+  });
+
   afterEach(() => {
     mocks.buildProviderRegistry.mockReset();
     mocks.createMediaAttachmentCache.mockReset();

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -13,7 +13,7 @@ import {
   getMediaUnderstandingProvider,
   normalizeMediaProviderId,
 } from "./provider-registry.js";
-import { resolveMediaRuntimeTimeoutMs } from "./resolve.js";
+import { resolveMaxBytes, resolveMediaRuntimeTimeoutMs, resolveModelEntries } from "./resolve.js";
 import { findDecisionReason, normalizeDecisionReason } from "./runner.entries.js";
 import {
   buildProviderRegistry,
@@ -390,6 +390,32 @@ export async function describeVideoFile(
   params: DescribeVideoFileParams,
 ): Promise<RunMediaUnderstandingFileResult> {
   return await runMediaUnderstandingFile({ ...params, capability: "video" });
+}
+
+/** Prepares the largest input that any configured transcription fallback can accept. */
+export async function resolveAudioInputBudget(params: {
+  cfg: OpenClawConfig;
+}): Promise<{ enabled: false } | { enabled: true; maxBytes: number }> {
+  const { cfg } = params;
+  const config = cfg.tools?.media?.audio;
+  if (config?.enabled === false) {
+    return { enabled: false };
+  }
+  const capability = "audio";
+  const entries = resolveModelEntries({
+    cfg,
+    capability,
+    config,
+    providerRegistry: buildProviderRegistry(undefined, cfg),
+  }).map(({ entry }) => entry);
+  // Auto-detected provider and CLI entries inherit the capability limit.
+  const candidates = entries.length > 0 ? entries : [{}];
+  return {
+    enabled: true,
+    maxBytes: Math.max(
+      ...candidates.map((entry) => resolveMaxBytes({ cfg, capability, config, entry })),
+    ),
+  };
 }
 
 /** Transcribes one audio file or URL through the configured audio-understanding pipeline. */

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -687,6 +687,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       listVoices: vi.fn<PluginRuntime["tts"]["listVoices"]>(),
     },
     mediaUnderstanding: {
+      resolveAudioInputBudget: vi
+        .fn<PluginRuntime["mediaUnderstanding"]["resolveAudioInputBudget"]>()
+        .mockResolvedValue({ enabled: true, maxBytes: 20 * 1024 * 1024 }),
       runFile: vi.fn<PluginRuntime["mediaUnderstanding"]["runFile"]>(),
       describeImageFile: vi.fn<PluginRuntime["mediaUnderstanding"]["describeImageFile"]>(),
       describeImageFileWithModel:

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -331,6 +331,7 @@ describe("plugin runtime command execution", () => {
       name: "exposes runtime.mediaUnderstanding helpers",
       assert: (runtime: ReturnType<typeof createPluginRuntime>) => {
         expectFunctionKeys(runtime.mediaUnderstanding as Record<string, unknown>, [
+          "resolveAudioInputBudget",
           "runFile",
           "describeImageFile",
           "describeImageFileWithModel",

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -75,6 +75,9 @@ function createRuntimeMediaUnderstandingFacade(): PluginRuntime["mediaUnderstand
     loadMediaUnderstandingRuntime,
   );
   return {
+    resolveAudioInputBudget: bindMediaUnderstandingRuntime(
+      (runtime) => runtime.resolveAudioInputBudget,
+    ),
     runFile: bindMediaUnderstandingRuntime((runtime) => runtime.runMediaUnderstandingFile),
     describeImageFile: bindMediaUnderstandingRuntime((runtime) => runtime.describeImageFile),
     describeImageFileWithModel: bindMediaUnderstandingRuntime(

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -443,6 +443,7 @@ export type PluginRuntimeCore = {
     listVoices: ListSpeechVoices;
   };
   mediaUnderstanding: {
+    resolveAudioInputBudget: MediaUnderstandingRuntime["resolveAudioInputBudget"];
     runFile: MediaUnderstandingRuntime["runMediaUnderstandingFile"];
     describeImageFile: MediaUnderstandingRuntime["describeImageFile"];
     describeImageFileWithModel: MediaUnderstandingRuntime["describeImageFileWithModel"];


### PR DESCRIPTION
Related: #130860. Reworks the capture-limit contribution in #110004 by @LZY3538.

<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** remains enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Fixes an issue where Discord voice users could grow the bot's memory without bound when a batch utterance did not reach its silence boundary. It also fixes competing or stranded realtime captures when speaking-start/end events overlap delayed speaker authorization.

## Why This Change Was Made

One per-speaker capture entry now owns pending authorization, its silence timer, and its eventual receiver stream. For realtime input, the entry is reserved before awaiting speaker authorization; only that authorized, still-current entry can subscribe afterward. Denial, failure, silence expiry, and shutdown retire the same owner. This replaces the parallel capture registries without changing when a completed batch utterance is processed.

Batch PCM uses the existing transcription input-size contract, prepared once before capture listeners start. The ceiling is the maximum effective limit across applicable audio model/CLI fallbacks, with 44 bytes reserved for the WAV header. Automatic selection inherits the existing audio limit, including its 20 MiB default. The shared bounded-stream collector rejects overflow instead of returning a successful truncated transcript. No configuration key, duration policy, rolling segmentation, dependency, or persistence change is added.

## User Impact

Normal batch utterances and configured transcription fallbacks retain their existing behavior. Oversized utterances stop with an actionable warning asking for a shorter segment; disabled batch transcription records an explicit warning. Cleanup permits the same speaker to start again. Direct realtime audio remains streaming and works when batch transcription is disabled. Realtime speaker authorization still completes before its receiver subscription is created.

## Evidence

- Focused Discord voice validation passed **68 tests across five files**, covering the decoder, capture owner, receive path, terminal cleanup, and realtime playback. Shared media/runtime and model-auth checks passed, as did production TypeScript checking. Fresh whole-candidate Codex review found no remaining actionable P0–P2 findings. [CI run 33588419063](https://github.com/openclaw/openclaw/actions/runs/33588419063) passed on head `da9ef5223036be5275a3127213ca6f586b5bd1b0`; the committed patch and all 21 source files match the reviewed candidate.
- A real `libopus-wasm@0.2.0` reproduction decoded 6,000 valid Opus packets. Before the fix it accepted **23,040,000 PCM bytes** despite a **20,971,476-byte** allowance (20 MiB minus the WAV header). After the fix the same input rejects with the actionable size error and destroys its source.
- A synthetic flow through the actual `@discordjs/voice@0.19.2` Manual receiver, decoder, receive owner, and WAV writer verified exact-header-limit acceptance, overflow rejection without a partial transcript, two successful same-speaker captures, terminal cancellation, and zero retained capture entries or SDK subscriptions.
- A real SDK SpeakingMap start/end/start sequence with deliberately deferred authorization failed before the fix with **two admissions and two consumers sharing one subscription**. It passes afterward with **one admission and one consumer**, and no subscription before authorization. Regression cases also cover denial, authorization failure, shutdown, and silence expiring before authorization completes.

- A Gateway-backed synthetic run also passed through the actual Manual receiver, candidate receive owner, configured STT HTTP client, agent ingress/dispatch, and normal TTS/playback pipeline. Two accepted captures each uploaded a **76,844-byte WAV** (76,800 PCM bytes plus its header); the smaller first model limit skipped the file and the larger fallback accepted it. Both agent requests contained the synthetic transcript. Overflow recorded its actionable warning without another STT upload or agent turn; same-speaker restart and delayed realtime admission passed with no retained capture/subscription. The first capture used no decoder warm-up. Verdict: `{"result":"PASS","acceptedWavBytes":[76844,76844],"agentTurns":2,"oversizeDispatched":false,"realtimeTurns":1,"pregrantSubscriptions":0}`.

The Gateway proof used the controlled built CLI plus canonical source-checkout QA auth/plugin staging. Candidate Discord sources were based on `d650e7a2a7b0234a65dd1853998c79d88e2dcfea`; all 420 staged sources were checked against that base (415 identical, five intentional production overlays). Core candidate runtime inputs matched the completed shared-root build, whose base was `213975df7583433c088dc18e755d5c870156fa9f`; this is not an isolated clean-candidate or installed-package build claim. Launch and completion hashes verified the tested inputs stayed unchanged.

Discord identity/packets, local STT/model responses, and speech output were synthetic. No live Discord transport, microphone/recognition quality, actual provider inference, audible end-user talkback, real-channel message, credential, or private audio is claimed. Earlier fixture composition failures were corrected before the successful run. An immediate synthetic EOF injected before cold decoder construction returned no STT dispatch; the actual Manual receive/silence-finalizer path passes without warm-up. That non-Manual EOF edge remains an unclassified follow-up, not a claimed repair. The successful run logged host SQLite latency warnings but exited 0.

The previous review's outbound-quota and retired-test-owner findings are addressed by the existing inbound transcription budget and the current receive/capture tests. The latest ClawSweeper review reports no code findings and requests confirmation of the public runtime boundary and dependency contracts. The additive `mediaUnderstanding.resolveAudioInputBudget` method is intentional: core owns the transcription fallback policy, while a Discord-private calculation would duplicate it or cross the private core boundary. The generic method is documented and covered through the runtime facade.

Installed dependency source was inspected directly: `@discordjs/voice@0.19.2` uses Manual receive streams, reuses the per-user subscription until close, and emits SpeakingMap start/end independently of awaited admission. `libopus-wasm@0.2.0` returns an owned `HEAP16.slice` for each decoded frame. The real-library and Gateway proofs above exercise those contracts; they were not inferred from wrapper mocks.

**Overlap follow-up:** #130860 also rewrites Discord receive/audio ownership. At its reviewed head `c3421dfcb6b37a8c5a3f14848623d0cb51f3fb58`, ordinary non-recording batch capture remains unbounded, while recording uses minimum/outbound limits. Its post-authorization duplicate check does not retain speaking-end ownership during admission. When rebasing that work, preserve this prepared maximum transcription budget, WAV-header accounting, and pending-capture ownership, and rerun the shared receive/lifecycle cases. This is a concrete integration follow-up, not a verdict on that broader PR.

Production: **+161/-131 (net +30)**. Tests/support: **+355/-31 (net +324)**. Documentation: **+8**. The remaining production growth supplies the generic prepared input-budget contract, shared bounded collector/error outcome, and pending-admission ownership; it follows removal of the redundant capture registries.

Credit: @LZY3538 supplied the original capture-limit patch. Commit attribution is preserved as `Co-authored-by: LZY3538 <liu.zhenye@xydigit.com>`.
