### PR TITLE
refactor(auto-reply): simplify route runtime loaders

### DIFF
--- a/src/auto-reply/reply/commands-reset-hooks.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.ts
@@ -8,14 +8,10 @@ import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyPromise } from "../../shared/lazy-promise.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
-const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
-
-function loadRouteReplyRuntime() {
-  return routeReplyRuntimeLoader.load();
-}
+const loadRouteReplyRuntime = createLazyPromise(() => import("./route-reply.runtime.js"));
 
 export type ResetCommandAction = "new" | "reset";
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -12,7 +12,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyImportLoader, createLazyPromise } from "../../shared/lazy-promise.js";
 import {
   buildCaptionedFinalTextFallback,
   cleanDeferredFinalText,
@@ -44,7 +44,7 @@ import {
 } from "./reply-threading.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 
-const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
+const loadRouteReplyRuntime = createLazyPromise(() => import("./route-reply.runtime.js"));
 const dispatchAcpTtsRuntimeLoader = createLazyImportLoader(
   () => import("../../tts/tts.runtime.js"),
 );
@@ -54,10 +54,6 @@ const channelPluginRuntimeLoader = createLazyImportLoader(
 const messageActionRuntimeLoader = createLazyImportLoader(
   () => import("../../infra/outbound/message-action-runner.js"),
 );
-
-function loadRouteReplyRuntime() {
-  return routeReplyRuntimeLoader.load();
-}
 
 function loadDispatchAcpTtsRuntime() {
   return dispatchAcpTtsRuntimeLoader.load();

--- a/src/auto-reply/reply/dispatch-from-config.runtime-loaders.ts
+++ b/src/auto-reply/reply/dispatch-from-config.runtime-loaders.ts
@@ -1,6 +1,6 @@
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyImportLoader, createLazyPromise } from "../../shared/lazy-promise.js";
 
-const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
+export const loadRouteReplyRuntime = createLazyPromise(() => import("./route-reply.runtime.js"));
 const getReplyFromConfigRuntimeLoader = createLazyImportLoader(
   () => import("./get-reply-from-config.runtime.js"),
 );
@@ -15,10 +15,6 @@ const runtimePluginsLoader = createLazyImportLoader(
 const preparedModelRuntimeLoader = createLazyImportLoader(
   () => import("../../agents/prepared-model-runtime.js"),
 );
-
-export function loadRouteReplyRuntime() {
-  return routeReplyRuntimeLoader.load();
-}
 
 export function loadGetReplyFromConfigRuntime() {
   return getReplyFromConfigRuntimeLoader.load();


### PR DESCRIPTION
## What Problem This Solves

Three auto-reply paths wrapped the same function-shaped lazy runtime load with a `createLazyImportLoader(...)` object plus a trivial `.load()` forwarding function. That duplicated plumbing obscured that each caller owns an independent single-flight cache.

## Why This Change Was Made

Each module now uses the existing `createLazyPromise(...)` helper directly for `route-reply.runtime.js`. The caches remain owner-local and independent, preserving lazy startup timing, concurrent-load deduplication, rejection eviction and retry, and the existing dynamic import boundaries.

Other runtime loaders are unrelated to the route-reply wrapper duplication addressed here and remain unchanged. No shared loader module, SDK surface, configuration, persistence, fallback, or changelog entry was added.

## User Impact

No user-visible behavior changes. This removes duplicated private loader plumbing while preserving route-reply loading and delivery behavior.

Production LOC: `+6/-18`, net `-12`. Tests: `0`.

## Evidence

- `node scripts/run-vitest.mjs src/shared/lazy-promise.test.ts src/auto-reply/reply/commands-reset-hooks.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`
  - Passed at refreshed head `9c7fd3d09724ebad97fddf0f01f6cbbb382f943e` on parent `41419be40bbb17e5eed318992c8e3bf1aee6199b`: 4 files, 213 tests (11 shared-core + 202 auto-reply).
- `pnpm check:import-cycles`
  - Passed: 0 runtime value cycles.
- `node --import ./scripts/tsx.mjs scripts/check-madge-import-cycles.ts`
  - Passed: 0 cycles.
- `git diff --check`
  - Passed.
- Exact autoreview against `origin/main`
  - Passed with no accepted/actionable findings; overall `0.98`.
The external Testbox wrapper `tbx_01m1g1wb7gtrcd95qwaq2z9txg` recorded exit `0` after completing the changed gate and `pnpm build`. The linked GitHub Actions carrier run `33586410721` is publicly `cancelled`; it is not a passing Actions run.
  - Local `check:changed` reached core-test typechecking but the shared worktree install could not resolve `mermaid`; no install or reconciliation was performed in the worktree.
  - The current-main refresh rebuilt the exact three-file patch on `41419be40bbb17e5eed318992c8e3bf1aee6199b`; the touched files and `src/shared/lazy-promise.ts` were unchanged across the drift. Aggregate patch ID `fc5bf42238476e893541d03ef7e0110f4830daa4` and all per-file patch IDs were preserved.

No exact-symbol open PR overlap was found. PR #126605 was rechecked and has no current file overlap.

The required Codex source ranges were inspected at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; those CLI dispatch and completion boundaries are unrelated.

No live behavior Crabbox lane was run because this is behavior-preserving private loader plumbing with no user-visible, protocol, SDK, configuration, or platform behavior change. Testbox was used only to obtain dependency-matched changed-gate and build proof.
