### PR TITLE
fix(pr): restore retry guidance for GraphQL quota error variants

### DIFF
--- a/scripts/pr-lib/gh-api-preflight.mjs
+++ b/scripts/pr-lib/gh-api-preflight.mjs
@@ -44,7 +44,8 @@ const reset = numericHeader("x-ratelimit-reset");
 const retryAfter = numericHeader("retry-after");
 const resource = headers.get("x-ratelimit-resource") === "graphql" ? "graphql" : "unknown";
 const rateLimited =
-  Array.isArray(body?.errors) && body.errors.some((error) => error?.type === "RATE_LIMITED");
+  Array.isArray(body?.errors) &&
+  body.errors.some((error) => ["RATE_LIMIT", "RATE_LIMITED"].includes(error?.type));
 const throttleMessage =
   typeof body?.message === "string" &&
   /\b(?:secondary rate limit|abuse detection|API rate limit exceeded)\b/i.test(body.message);

--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -2,6 +2,7 @@
 import { EventEmitter } from "node:events";
 import net from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 
 const mocks = vi.hoisted(() => ({
   ensurePortAvailable: vi.fn<(port: number, host?: string) => Promise<void>>(),
@@ -309,46 +310,85 @@ describe("startSshPortForward", () => {
     await expect(forwarding).rejects.toMatchObject({ name: "AbortError" });
   });
 
-  it("rejects with the spawn error when ssh binary is missing", async () => {
-    vi.useFakeTimers();
-    const spawnError = new Error("ENOENT: no such file or directory, spawn /usr/bin/ssh");
-    (spawnError as NodeJS.ErrnoException).code = "ENOENT";
-    const kill = vi.fn(() => false);
-    mocks.spawn.mockImplementation(() => {
-      const child = new EventEmitter() as EventEmitter & {
-        killed: boolean;
-        pid?: number;
-        stderr: EventEmitter & { setEncoding: (enc: string) => void };
-        kill: (signal?: string) => boolean;
-      };
-      child.killed = false;
-      const stderr = new EventEmitter() as EventEmitter & { setEncoding: (enc: string) => void };
-      stderr.setEncoding = () => {};
-      child.stderr = stderr;
-      child.kill = kill;
-      queueMicrotask(() => {
-        child.emit("error", spawnError);
-        child.emit("close", -2, null);
+  it.each(
+    ["error", "exit", "abort"].flatMap((terminal) =>
+      ["socket", "retry"].map((pending) => ({ terminal, pending })),
+    ),
+  )(
+    "joins pending readiness $pending before startup rejects on $terminal",
+    async ({ terminal, pending }) => {
+      const localPort = await getFreePort();
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+      const spawnError = new Error("ENOENT: no such file or directory, spawn /usr/bin/ssh");
+      (spawnError as NodeJS.ErrnoException).code = "ENOENT";
+      const child = Object.assign(new EventEmitter(), {
+        stderr: Object.assign(new EventEmitter(), { setEncoding: () => {} }),
+        kill: vi.fn(() => {
+          queueMicrotask(() => child.emit("close", -2, null));
+          return false;
+        }),
       });
-      return child;
-    });
-
-    const forwarding = startSshPortForward({
-      target: "me@example.com:2222",
-      localPortPreferred: 43210,
-      remotePort: 18789,
-      timeoutMs: 500,
-    });
-    const rejection = expect(forwarding).rejects.toMatchObject({
-      message: expect.stringContaining("ENOENT"),
-      cause: spawnError,
-    });
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(vi.getTimerCount()).toBe(0);
-    await rejection;
-    expect(kill).toHaveBeenCalledWith("SIGTERM");
-  });
+      mocks.spawn.mockReturnValue(child);
+      const controller = new AbortController();
+      const abortReason = new Error("startup owner stopped");
+      const socketCreated = createDeferred<net.Socket>();
+      const retryScheduled = createDeferred();
+      const connect = net.connect;
+      const connectSpy = vi.spyOn(net, "connect").mockImplementation((...args) => {
+        // Real refusal exercises the retry; an unconnected Socket holds the other
+        // case at pending I/O without depending on network timing or a remote host.
+        const socket = pending === "retry" ? connect(...args) : new net.Socket();
+        socketCreated.resolve(socket);
+        return socket;
+      });
+      const schedule = globalThis.setTimeout;
+      const timerSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((...args) => {
+        const timer = schedule(...args);
+        retryScheduled.resolve();
+        return timer;
+      });
+      const forwarding = startSshPortForward({
+        target: "me@example.com:2222",
+        localPortPreferred: localPort,
+        remotePort: 18789,
+        timeoutMs: 500,
+        signal: controller.signal,
+      });
+      const rejection = expect(forwarding).rejects.toMatchObject(
+        terminal === "error"
+          ? { message: expect.stringContaining("ENOENT"), cause: spawnError }
+          : terminal === "exit"
+            ? { message: "ssh exited (1)", cause: expect.any(Error) }
+            : { name: "AbortError", cause: abortReason },
+      );
+      const socket = await socketCreated.promise;
+      try {
+        if (pending === "retry") {
+          await retryScheduled.promise;
+          expect(socket.destroyed).toBe(true);
+          expect(vi.getTimerCount()).toBe(1);
+        }
+        if (terminal === "abort") {
+          controller.abort(abortReason);
+        } else if (terminal === "error") {
+          child.emit("error", spawnError);
+        } else {
+          child.emit("exit", 1, null);
+        }
+        await rejection;
+        expect(socket.closed).toBe(true);
+        expect(vi.getTimerCount()).toBe(0);
+        expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+        await vi.advanceTimersByTimeAsync(500);
+        expect(connectSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        socket.destroy();
+        timerSpy.mockRestore();
+        connectSpy.mockRestore();
+        vi.clearAllTimers();
+      }
+    },
+  );
 
   it.each(["active", "teardown"] as const)(
     "does not crash when stderr errors while the tunnel is %s",

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { createAbortError, isAbortError, racePromiseWithAbortSignal } from "./abort-signal.js";
+import { sleepWithAbort } from "./backoff.js";
 import { formatErrorMessage, isErrno } from "./errors.js";
 import { ensurePortAvailable, PortInUseError } from "./ports.js";
 import { resolveSshClient } from "./ssh-client.js";
@@ -111,29 +112,38 @@ async function pickEphemeralPort(): Promise<number> {
   });
 }
 
-async function canConnectLocal(port: number): Promise<boolean> {
+async function canConnectLocal(port: number, signal: AbortSignal): Promise<boolean> {
+  signal.throwIfAborted();
   return await new Promise<boolean>((resolve) => {
     const socket = net.connect({ host: "127.0.0.1", port });
-    const done = (ok: boolean) => {
-      socket.removeAllListeners();
-      socket.destroy();
-      resolve(ok);
-    };
-    socket.once("connect", () => done(true));
-    socket.once("error", () => done(false));
-    socket.setTimeout(250, () => done(false));
+    let connected = false;
+    const destroy = () => socket.destroy();
+    signal.addEventListener("abort", destroy, { once: true });
+    socket.once("connect", () => {
+      connected = true;
+      destroy();
+    });
+    socket.once("error", destroy);
+    socket.setTimeout(250, destroy);
+    // Closing, not just requesting destruction, releases the probe's I/O and timer.
+    socket.once("close", () => {
+      signal.removeEventListener("abort", destroy);
+      resolve(connected);
+    });
   });
 }
 
-async function waitForLocalListener(port: number, timeoutMs: number): Promise<void> {
+async function waitForLocalListener(
+  port: number,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<void> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    if (await canConnectLocal(port)) {
+    if (await canConnectLocal(port, signal)) {
       return;
     }
-    await new Promise((r) => {
-      setTimeout(r, 50);
-    });
+    await sleepWithAbort(50, signal);
   }
   throw new Error(`ssh tunnel did not start listening on localhost:${port}`);
 }
@@ -238,19 +248,32 @@ export async function startSshPortForward(opts: {
       }
     })());
 
+  const readinessController = new AbortController();
+  const readiness = waitForLocalListener(
+    localPort,
+    Math.max(250, opts.timeoutMs),
+    readinessController.signal,
+  );
   try {
-    await racePromiseWithAbortSignal(
-      Promise.race([
-        waitForLocalListener(localPort, Math.max(250, opts.timeoutMs)),
-        new Promise<void>((_, reject) => {
-          child.once("error", (err) => reject(err));
-          child.once("exit", (code, signal) => {
-            reject(new Error(`ssh exited (${code ?? "null"}${signal ? `/${signal}` : ""})`));
-          });
-        }),
-      ]),
-      opts.signal,
-    );
+    try {
+      await racePromiseWithAbortSignal(
+        Promise.race([
+          readiness,
+          new Promise<void>((_, reject) => {
+            child.once("error", (err) => reject(err));
+            child.once("exit", (code, signal) => {
+              reject(new Error(`ssh exited (${code ?? "null"}${signal ? `/${signal}` : ""})`));
+            });
+          }),
+        ]),
+        opts.signal,
+      );
+    } finally {
+      // The race owns its losing readiness work; preserve the winner's error
+      // only after its socket or retry delay has stopped and joined.
+      readinessController.abort();
+      await readiness.catch(() => {});
+    }
   } catch (err) {
     await stop();
     if (isAbortError(err)) {

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -1142,15 +1142,21 @@ exit 99
     details?: string[];
     absent?: string[];
   }[] = [
-    {
-      name: "primary GraphQL quota exhaustion",
-      status: 200,
-      code: 1,
-      body: rateError,
-      headers: quota,
-      diagnostic: "rate limited",
-      details: ["resource=graphql; remaining=0; limit=5000", "reset=2030-01-01T00:00:00Z", "Wait"],
-    },
+    ...[{ type: "RATE_LIMITED" }, { type: "RATE_LIMIT", code: "graphql_rate_limit" }].map(
+      (error) => ({
+        name: `primary GraphQL quota exhaustion (${error.type})`,
+        status: 200,
+        code: 1,
+        body: { errors: [{ ...error, message: "synthetic-private-detail" }] },
+        headers: quota,
+        diagnostic: "rate limited",
+        details: [
+          "resource=graphql; remaining=0; limit=5000",
+          "reset=2030-01-01T00:00:00Z",
+          "Wait until 2030-01-01T00:00:00Z (UTC), then retry manually.",
+        ],
+      }),
+    ),
     {
       name: "primary HTTP 403 exhaustion",
       status: 403,


### PR DESCRIPTION
Closes #135872 (missing GraphQL quota retry guidance).
Related: #135657 (separate auth/quota/network diagnostics).

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch and remains takeover-ready.

</details>

## What Problem This Solves

Fixes an issue where maintainers using the native PR workflow receive a generic failure without quota retry guidance when GitHub returns `RATE_LIMIT` with `code: graphql_rate_limit`. The operation correctly stops, but does not tell the maintainer when to retry.

The old preflight discarded failure evidence and printed login advice. #135657 repaired that auth/quota/network separation; this follow-up addresses only the missing native error variant, not the original architecture again.

## Why This Change Was Made

Recognize both `RATE_LIMIT` and `RATE_LIMITED` at the existing same-response classifier. Extend the existing shell-boundary table with the observed variant and assert the exact UTC wait guidance for both variants.

The diagnostic change adds no retry, auth path, fallback, lock change, configuration, dependency, or helper. PATH routing, single-request evidence, redaction, and the fail-closed boundary before fetch/merge side effects are preserved. A separate REST quota lookup would describe a potentially different budget and is not a substitute.

## User Impact

Maintainers get the existing safe rate-limit diagnostic and manual retry guidance for either GraphQL error variant. Credential advice remains limited to missing or rejected authentication. This aligns the missing case with the already-published [CI/preflight guidance](https://docs.openclaw.ai/ci#watching-pull-request-ci); no documentation contract changes.

## Evidence

The new `RATE_LIMIT` regression failed before the production edit at the actual `enter_worktree` → `ensure_gh_api_auth` boundary. Synthetic before:

```text
GitHub API preflight failed (HTTP 200; exit=1); authentication was not verified.
Observed exhausted primary quota (resource=graphql; remaining=0; limit=5000; reset=2030-01-01T00:00:00Z); failure cause remains unverified.
Check connectivity, GitHub service status, and access policy before retrying.
```

Synthetic after:

```text
GitHub API preflight rate limited (HTTP 200; exit=1; resource=graphql; remaining=0; limit=5000; reset=2030-01-01T00:00:00Z).
Wait until 2030-01-01T00:00:00Z (UTC), then retry manually.
```

51 focused tests passed after the patch, covering both variants, unknown/malformed errors, auth/network failures, last-quota success, redaction, selected-route behavior, native refusal before fetch/dispatch, phase ownership, writer identity, and reviewed-head preparation:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.cache/vitest/gh-auth-diagnostics-verify node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts test/scripts/pr-main-refresh.test.ts test/scripts/pr-operation-lock.test.ts -t 'GitHub API preflight|stops native merge on viewer quota|preserves native entry phase ownership|resolves review writer identity|prepares directly from the reviewed head' --reporter=dot
node scripts/check-changed.mjs -- scripts/pr-lib/gh-api-preflight.mjs test/scripts/pr-wrappers.test.ts
bash -n scripts/pr scripts/pr-lib/worktree.sh scripts/lib/plain-gh.sh
node --check scripts/pr-lib/gh-api-preflight.mjs
git diff --check
```

Changed checks passed (root test types, targeted lint, guards, and formatting). Exact-diff protected Codex autoreview was scoped-clean at the P0 threshold. No full-suite result is claimed.

Live patched `ensure_gh_api_auth` succeeded through unchanged PATH `gh` without printing the response or identity. **Live exhaustion was not induced**: intentionally exhausting shared quota or changing credentials is not appropriate proof. Failure behavior is synthetic at the real shell/preflight boundary, not a claim of live exhaustion.

Direct dependency inspection: [Microsoft's client](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/platform/github/common/githubAPI.ts#L300) records the exact `RATE_LIMIT` / `graphql_rate_limit` pair and returns the parsed response unchanged. This corroborates the operator observation, not a formal schema. [Pinned GitHub CLI response handling](https://github.com/cli/cli/blob/a255baf71d13fe5947a4eb7ad521ffd412d64cee/pkg/cmd/api/api.go#L473) and its tests preserve error JSON with `--include`; they do not rename the error type.

Production: **+2/-1 (net +1)**, solely the formatter wrap around the second observed error code in the existing predicate. Tests: **+15/-9 (net +6)**. No path is added or removed; extending the existing predicate is simpler than adding a new abstraction.

### Bounded CI repair: join SSH startup readiness

The first published head `f5d373b1d3ec930201c72405e6a22084bd716af8` remains a separate diagnostic commit. Its [CI run 33588752065](https://github.com/openclaw/openclaw/actions/runs/33588752065) exposed a pre-existing SSH startup cleanup failure in [checks-node-compact-small-30](https://github.com/openclaw/openclaw/actions/runs/33588752065/job/100118367517): the missing-binary test observed one pending timer instead of zero. A subsequent local run of the old test passed; it did not reproduce the failure and demonstrated why deterministic synchronization was needed.

The authorized CI repair is bounded to the existing SSH readiness owner and test. When a child error, early exit, or owner abort won startup's race, its losing TCP readiness probe kept a socket or 50 ms retry alive. Startup joined child teardown but never canceled/joined readiness. The fix gives that readiness task a private abort controller, destroys its current socket and waits for close, uses the existing abortable sleep for the retry, and joins readiness before propagating the original winning error. Child reaping and established-tunnel owner cancellation are unchanged. No operator options, dependencies, or generic helper are added.

Before the production edit, all **six deterministic regressions failed** for the intended leak: pending socket cases remained open and pending retry cases retained one timer after startup rejected, each covering child error, exit, and owner abort. After the repair all six pass; the table also advances the full startup budget after rejection and verifies that no new probe occurs. The prior timing-dependent missing-binary test becomes these synchronized terminal cases, preserving the ENOENT error/cause and strengthening resource assertions.

**Local proof: 98 SSH/caller/helper tests plus 51 diagnostic/wrapper tests passed.** The SSH suite uses actual isolated IPv4 loopback refusal and successful listener probes, plus a controlled pending Socket for deterministic in-flight I/O cancellation. No remote SSH host, credential, live Gateway, or operator service is involved. Node's [socket destruction](https://github.com/nodejs/node/blob/v24.15.0/lib/net.js#L867) and [handle-close event](https://github.com/nodejs/node/blob/v24.15.0/lib/net.js#L346) contracts were directly inspected; this implementation explicitly owns cancellation instead of relying on the socket's optional AbortSignal behavior.

```bash
# Before production edit: 6 failures at residual socket/timer assertions.
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.cache/vitest/ssh-startup-readiness node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts -t 'joins pending readiness' --reporter=dot
# After production edit: full SSH suite, 21 passed.
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.cache/vitest/ssh-startup-readiness node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts --reporter=dot
# SSH, abort/backoff/retry and gateway-status caller coverage: 98 passed.
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.cache/vitest/ssh-startup-joined-proof node scripts/run-vitest.mjs src/infra/ssh-tunnel.test.ts src/infra/abort-signal.test.ts src/infra/backoff.test.ts packages/retry/src/index.test.ts src/commands/gateway-status.test.ts --reporter=dot
# Original diagnostic and native-boundary regression coverage: 51 passed.
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.cache/vitest/gh-auth-ssh-diagnostic-proof node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts test/scripts/pr-main-refresh.test.ts test/scripts/pr-operation-lock.test.ts -t 'GitHub API preflight|stops native merge on viewer quota|preserves native entry phase ownership|resolves review writer identity|prepares directly from the reviewed head' --reporter=dot
node scripts/check-changed.mjs -- scripts/pr-lib/gh-api-preflight.mjs test/scripts/pr-wrappers.test.ts src/infra/ssh-tunnel.ts src/infra/ssh-tunnel.test.ts
git diff --check
```

Fresh protected Codex autoreview of the complete four-file candidate was scoped-clean at the P0 threshold. The additional source change is internal resource ownership using an existing static import, not a packaging or module-boundary change; no broad build/full-suite result is claimed. Remote-access and CI docs retain their existing contracts. Live quota exhaustion remains uninduced as described above.

SSH delta: production **+49/-26 (net +23)**; tests **+79/-39 (net +40)**. Full PR: production **+51/-27 (net +24)**; tests **+94/-48 (net +46)**. The growth buys explicit socket/delay cancellation and joining at the existing startup owner, not a parallel implementation. The original diagnostic commit remains separately attributable.

A first changed-check pass caught direct `Promise.withResolvers` usage outside this test TypeScript lane's library types. The final test uses the existing `createDeferred` helper; no compiler configuration or baseline was changed. The full 98-test proof was rerun on that final test source.

ClawSweeper's [review of the diagnostic head](https://github.com/openclaw/openclaw/pull/135873#issuecomment-5504228387) found no introduced defect. Its upstream-retrieval gap is addressed by the direct Microsoft/GitHub CLI source inspection above (not by treating the fixture as an upstream schema). Its Rank-up move to repair the SSH shard is addressed in the SSH owner and deterministic tests above; green required CI on the new exact head remains mandatory before merge.

The typed lint lane rejected an async Promise.finally callback; readiness cleanup now uses an awaited try/finally with identical error and teardown semantics. Final proof and protected review were rerun after this correction.

The complete four-file changed-check command passed on final sources (types, lint, formatting, dead exports and repository guards, including zero runtime import cycles).

Published SSH repair: `83cad58076dc54501a10d2798f0050f4082d43be`. [Exact-head CI run 33590793855](https://github.com/openclaw/openclaw/actions/runs/33590793855) completed successfully, including the formerly failing [SSH shard](https://github.com/openclaw/openclaw/actions/runs/33590793855/job/100124359270) and the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33590793855/job/100125683533). The exact-head watcher exited 0 with GREEN. No prepare or merge has run.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/135873#issuecomment-5504228387), reviewed at 04:32 UTC on this exact head, found no actionable correctness or security finding. Its Rank-up move to wait for required hosted CI is satisfied by the green run above. Its independent DNS/retrieval limitation is covered by the direct upstream GitHub CLI and Node contract inspection already documented; no gate was bypassed. The PR is ready for the maintainer merge decision.
