### PR TITLE
improve(docker): shorten release image preparation

### DIFF
--- a/.github/workflows/docker-release-prepare.yml
+++ b/.github/workflows/docker-release-prepare.yml
@@ -166,9 +166,9 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Prepare OCI output directory
         run: mkdir -p "${RUNNER_TEMP}/docker-release/oci"
-      # Keep intermediate stages in the shared builder for the browser build.
-      # Export runtime layers only; archiving build stages dominates preparation.
-      # Separate scopes avoid importing the retired full-stage cache.
+      # Both variants reuse this builder's local cache. Fresh provenance timestamps
+      # invalidate application layers across runs; remote transfers cost more than
+      # reusing the remaining runtime setup saves.
       # Fast gzip keeps new layers compatible with the Skopeo smoke transport.
       - name: Build default OCI image
         id: build
@@ -177,8 +177,6 @@ jobs:
           context: source
           platforms: linux/${{ matrix.architecture }}
           outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/default,tar=false,compression=gzip,compression-level=1
-          cache-from: type=gha,scope=docker-release-min-${{ matrix.architecture }}
-          cache-to: type=gha,mode=min,scope=docker-release-min-${{ matrix.architecture }}
           build-args: |
             GIT_COMMIT=${{ inputs.release_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve.outputs.built_at }}
@@ -199,8 +197,6 @@ jobs:
           context: source
           platforms: linux/${{ matrix.architecture }}
           outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/browser,tar=false,compression=gzip,compression-level=1
-          cache-from: type=gha,scope=docker-release-browser-min-${{ matrix.architecture }}
-          cache-to: type=gha,mode=min,scope=docker-release-browser-min-${{ matrix.architecture }}
           build-args: |
             GIT_COMMIT=${{ inputs.release_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve.outputs.built_at }}

--- a/.github/workflows/docker-release-prepare.yml
+++ b/.github/workflows/docker-release-prepare.yml
@@ -169,13 +169,14 @@ jobs:
       # Keep intermediate stages in the shared builder for the browser build.
       # Export runtime layers only; archiving build stages dominates preparation.
       # Separate scopes avoid importing the retired full-stage cache.
+      # Fast gzip keeps new layers compatible with the Skopeo smoke transport.
       - name: Build default OCI image
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: source
           platforms: linux/${{ matrix.architecture }}
-          outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/default,tar=false
+          outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/default,tar=false,compression=gzip,compression-level=1
           cache-from: type=gha,scope=docker-release-min-${{ matrix.architecture }}
           cache-to: type=gha,mode=min,scope=docker-release-min-${{ matrix.architecture }}
           build-args: |
@@ -197,7 +198,7 @@ jobs:
         with:
           context: source
           platforms: linux/${{ matrix.architecture }}
-          outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/browser,tar=false
+          outputs: type=oci,dest=${{ runner.temp }}/docker-release/oci/browser,tar=false,compression=gzip,compression-level=1
           cache-from: type=gha,scope=docker-release-browser-min-${{ matrix.architecture }}
           cache-to: type=gha,mode=min,scope=docker-release-browser-min-${{ matrix.architecture }}
           build-args: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,17 +173,18 @@ RUN if grep -qx 'qa-lab' /tmp/openclaw-selected-plugin-dirs; then \
       cp -R extensions/qa-lab/web/dist dist/extensions/qa-lab/web/dist; \
     fi
 
-# Replace build dependencies without asking pnpm to mutate inherited directories.
-# Preserve compiled workspace output; copy all production workspace installs and
-# pnpm metadata together so nested dependencies and lifecycle outputs survive.
-FROM build AS runtime-assets
+# Keep compiled workspaces and generated plugin assets, but omit development
+# dependency trees before merging the build output into the production install.
+FROM build AS runtime-build-output
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 RUN rm -rf node_modules ui/node_modules && \
     find packages "${OPENCLAW_BUNDLED_PLUGIN_DIR}" -name node_modules -prune -exec rm -rf {} +
-COPY --from=production-deps /app/ ./
-# Production dependencies carry the base source version. Restore the release
-# manifest so every runtime surface keeps the version used during the build.
-COPY --from=build /app/package.json ./package.json
+
+# Inherit production dependencies instead of copying their full tree again.
+# The build overlay also carries the stamped release package.json.
+FROM production-deps AS runtime-assets
+ARG OPENCLAW_BUNDLED_PLUGIN_DIR
+COPY --from=runtime-build-output /app/ ./
 
 # Prune omitted plugins and build metadata. Keep SDK-native binaries only for
 # selected plugins that explicitly require them.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -577,11 +577,13 @@ does not reveal the full token.
     keeps both dependency layers cacheable without omitting `packages/*`, selected
     `extensions/*`, or other required workspace metadata.
 
-    Runtime assembly replaces the build dependency trees with the fresh production
-    install while retaining compiled workspace packages and native addon outputs.
-    It does not run `pnpm prune` on dependencies inherited from an image layer;
-    pnpm 12 can fail that operation with `EXDEV` on OverlayFS. The `build` target
-    retains development dependencies for live-test containers.
+    The `runtime-assets` stage inherits `production-deps` and overlays `/app`
+    from `runtime-build-output`, a copy of `build` with dependency trees removed.
+    This reuses the fresh production install's layers while preserving compiled
+    workspace packages and native addon outputs. It does not run `pnpm prune`
+    on dependencies inherited from an image layer; pnpm 12 can fail that operation
+    with `EXDEV` on OverlayFS. The `build` target retains development dependencies
+    for live-test containers.
 
     The same Dockerfile preserves the production runtime contract: digest-pinned
     Node and Bun bases, non-root uid 1000, `tini`, the built-in health check, and

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -326,9 +326,11 @@ indexes and their SBOM/provenance, and runs image smoke checks before approval.
 OCI export uses gzip level 1 for new layers and reuses cached layers without
 forced recompression, preserving the image format used by smoke and promotion.
 
-Its GitHub Actions cache exports final image layers with `mode=min`; intermediate
-build stages stay in the shared local builder for the browser variant. This
-avoids compressing and uploading build-only layers on the release critical path.
+Default and browser images share the builder's local cache. Preparation does not
+transfer a remote build cache: fresh provenance timestamps invalidate application
+layers, and measured transfers cost more than reusing runtime setup saves.
+Fresh runners rebuild that setup, including mutable Debian and npm updates;
+the sealed OCI artifacts remain the reusable inputs for publication.
 The final manifest records `publicationArtifacts.docker`. Preparation has no
 publication secrets or registry-write permission. After approval, `Docker
 Release` verifies the source/tag, producer, artifact hashes, and image digests,

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -323,6 +323,9 @@ targets keep their required channel.
 
 `docker-release-prepare.yml` builds both native architectures, retains OCI
 indexes and their SBOM/provenance, and runs image smoke checks before approval.
+OCI export uses gzip level 1 for new layers and reuses cached layers without
+forced recompression, preserving the image format used by smoke and promotion.
+
 Its GitHub Actions cache exports final image layers with `mode=min`; intermediate
 build stages stay in the shared local builder for the browser variant. This
 avoids compressing and uploading build-only layers on the release critical path.

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -469,7 +469,7 @@ describe("Dockerfile", () => {
       const buildCopy = runtime.match(/^COPY --from=(\S+) \/app\/ \.\/$/m);
       const buildOutput = stages.get(buildCopy?.[1]);
       expect(buildOutput?.parent).toBe("build");
-      const cleanCommand = buildOutput?.body.match(/^RUN (rm -rf node_modules[^\n]+)/m)?.[1];
+      const cleanCommand = buildOutput?.body?.match(/^RUN (rm -rf node_modules[^\n]+)/m)?.[1];
       if (!cleanCommand) {
         throw new Error(
           "Runtime assembly must remove development dependencies before copying build output",

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -383,7 +383,7 @@ describe("Dockerfile", () => {
     const qaLabDistCopyIndex = collapsed.indexOf(
       "cp -R extensions/qa-lab/web/dist dist/extensions/qa-lab/web/dist",
     );
-    const runtimeAssetsIndex = collapsed.indexOf("FROM build AS runtime-assets");
+    const runtimeAssetsIndex = collapsed.indexOf("FROM production-deps AS runtime-assets");
 
     expect(qaLabExtensionCheckIndex).toBeGreaterThan(-1);
     expect(buildDockerIndex).toBeGreaterThan(-1);
@@ -444,9 +444,9 @@ describe("Dockerfile", () => {
     );
   });
 
-  it.runIf(process.platform !== "win32")(
-    "replaces build dependencies with a fresh production tree without losing built assets",
-    async () => {
+  it.runIf(process.platform !== "win32").each(["extensions", "bundled-plugins"])(
+    "assembles built assets onto production dependencies with %s",
+    async (bundledPluginDir) => {
       const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
       const stages = new Map(
         [...dockerfile.matchAll(/^FROM (\S+) AS (\S+)\n([\s\S]*?)(?=^FROM |(?![\s\S]))/gm)].map(
@@ -463,58 +463,63 @@ describe("Dockerfile", () => {
       expect(production?.body).not.toMatch(/--ignore-scripts|COPY .*node_modules/);
       expect(dockerfile).not.toContain("pnpm prune");
 
-      const runtime = stages.get("runtime-assets")?.body ?? "";
-      const cleanCommand = runtime.match(/^RUN (rm -rf node_modules[^\n]+)/m)?.[1];
+      const runtimeStage = stages.get("runtime-assets");
+      expect(runtimeStage?.parent).toBe("production-deps");
+      const runtime = runtimeStage?.body ?? "";
+      const buildCopy = runtime.match(/^COPY --from=(\S+) \/app\/ \.\/$/m);
+      const buildOutput = stages.get(buildCopy?.[1]);
+      expect(buildOutput?.parent).toBe("build");
+      const cleanCommand = buildOutput?.body.match(/^RUN (rm -rf node_modules[^\n]+)/m)?.[1];
       if (!cleanCommand) {
         throw new Error(
-          "Runtime assembly must remove build dependency trees before copying production dependencies",
+          "Runtime assembly must remove development dependencies before copying build output",
         );
       }
-      const productionCopy = "COPY --from=production-deps /app/ ./";
-      expect(runtime.indexOf(productionCopy)).toBeGreaterThan(runtime.indexOf(cleanCommand));
       expect(runtime.indexOf("node scripts/prune-docker-plugin-dist.mjs")).toBeGreaterThan(
-        runtime.indexOf(productionCopy),
+        runtime.indexOf(buildCopy?.[0] ?? ""),
       );
 
       const fixture = await mkdtemp(join(tmpdir(), "openclaw-docker-deps-"));
       try {
         const app = join(fixture, "app");
-        const prod = join(fixture, "production");
+        const build = join(fixture, "build");
         const oldFiles = [
           "node_modules/dev-only/index.js",
           "ui/node_modules/dev-only/index.js",
           "packages/ai/node_modules/dev-only/index.js",
-          "extensions/selected/node_modules/dev-only/index.js",
+          `${bundledPluginDir}/selected/node_modules/dev-only/index.js`,
         ];
         const builtFiles = [
           "packages/ai/dist/index.mjs",
           "dist/index.js",
           "dist/extensions/node_modules/openclaw/package.json",
-          "extensions/selected/index.js",
+          `${bundledPluginDir}/selected/index.js`,
         ];
         const prodFiles = [
           "node_modules/native-addon/addon.node",
           "node_modules/.modules.yaml",
           "packages/ai/node_modules/runtime-dep/index.js",
-          "extensions/selected/node_modules/runtime-dep/index.js",
+          `${bundledPluginDir}/selected/node_modules/runtime-dep/index.js`,
           "pnpm-lock.yaml",
         ];
         for (const [root, files] of [
-          [app, [...oldFiles, ...builtFiles]],
-          [prod, prodFiles],
+          [build, [...oldFiles, ...builtFiles]],
+          [app, prodFiles],
         ] as const) {
           for (const file of files) {
             await mkdir(dirname(join(root, file)), { recursive: true });
             await writeFile(join(root, file), file);
           }
         }
+        await writeFile(join(app, "package.json"), JSON.stringify({ version: "2026.8.1" }));
+        await writeFile(join(build, "package.json"), JSON.stringify({ version: "2026.8.1-1" }));
         execFileSync("/bin/sh", ["-eu", "-c", cleanCommand], {
-          cwd: app,
-          env: { ...process.env, OPENCLAW_BUNDLED_PLUGIN_DIR: "extensions" },
+          cwd: build,
+          env: { ...process.env, OPENCLAW_BUNDLED_PLUGIN_DIR: bundledPluginDir },
         });
-        await mkdir(join(prod, "node_modules/@openclaw"), { recursive: true });
-        await symlink("../../packages/ai", join(prod, "node_modules/@openclaw/ai"));
-        await cp(prod, app, { recursive: true, verbatimSymlinks: true });
+        await mkdir(join(app, "node_modules/@openclaw"), { recursive: true });
+        await symlink("../../packages/ai", join(app, "node_modules/@openclaw/ai"));
+        await cp(build, app, { recursive: true, verbatimSymlinks: true });
         for (const file of oldFiles) {
           await expect(access(join(app, file))).rejects.toThrow();
         }
@@ -524,6 +529,9 @@ describe("Dockerfile", () => {
         expect(await readFile(join(app, "node_modules/@openclaw/ai/dist/index.mjs"), "utf8")).toBe(
           "packages/ai/dist/index.mjs",
         );
+        expect(JSON.parse(await readFile(join(app, "package.json"), "utf8"))).toEqual({
+          version: "2026.8.1-1",
+        });
       } finally {
         await rm(fixture, { recursive: true, force: true });
       }
@@ -582,13 +590,8 @@ describe("Dockerfile", () => {
 
     const stampIndex = dockerfile.indexOf('pnpm pkg set "version=$OPENCLAW_DOCKER_BUILD_VERSION"');
     const buildIndex = dockerfile.indexOf("pnpm build:docker");
-    const productionDepsIndex = dockerfile.indexOf("COPY --from=production-deps /app/ ./");
-    const restoreVersionIndex = dockerfile.indexOf(
-      "COPY --from=build /app/package.json ./package.json",
-    );
     expect(stampIndex).toBeGreaterThan(dockerfile.indexOf("COPY . ."));
     expect(stampIndex).toBeLessThan(buildIndex);
-    expect(restoreVersionIndex).toBeGreaterThan(productionDepsIndex);
     expect(dockerfile).toContain(
       'test "$(node -p "require(\\"/app/package.json\\").version")" = "$OPENCLAW_DOCKER_BUILD_VERSION"',
     );


### PR DESCRIPTION
## What Problem This Solves

Docker release preparation spends time copying an already-installed production dependency tree, compressing image layers, and transferring a remote build cache with little useful reuse. The fresh baseline took 14m13s. This follows #135832, which reduced the previously much larger full-stage cache export.

## Why This Change Was Made

Runtime assembly now inherits production dependencies and overlays build output after removing development dependencies. The stamped release manifest arrives with the output, eliminating the separate version-restoration copy. Both fresh frozen installs remain; compiled workspaces, generated plugin assets, nested runtime dependencies, native lifecycle output and the SDK bridge remain covered.

Both OCI exporters use gzip level 1 for newly compressed layers. This retains the existing Skopeo transport and digest-preserving promotion. Existing compressed blobs are reusable without forced recompression. The measured tradeoff is 12–14% larger combined default/browser artifacts.

The workflow removes both remote GHA cache imports/exports and retains the shared builder's internal cache. In the [source-matched warm run](https://github.com/openclaw/openclaw/actions/runs/33586281812), only four default-image setup vertices were cached; both dependency installs and compilation reran. Those setup steps had finished well before runtime assembly in the cold run. All 57 browser cache hits matched work already handled by the preceding default build. Remote exports added serial tail work without demonstrated elapsed-time savings. [Docker documents internal caching separately from remote export/import.](https://docs.docker.com/build/cache/backends/)

## User Impact

Source-built images avoid recopying production dependencies. Release preparation also reduces compression work and removes remote cache transfers. Fresh runners rebuild runtime setup, including mutable Debian and npm updates, as existing cold builds already do. The workflow still uses one builder for both variants and retains all OCI, version, dependency, non-root, browser, attestation, sealing and publication checks.

## Evidence

| Preparation run | Source | Tooling | Elapsed | Image checks and seal |
| --- | --- | --- | --- | --- |
| [Fresh baseline](https://github.com/openclaw/openclaw/actions/runs/33588239540) | `d157f910a295` | `d157f910a295` | 14m13s | Passed |
| [Assembly change](https://github.com/openclaw/openclaw/actions/runs/33589282862) | `3b60e6bff745` | `3b60e6bff745` | 14m51s | Passed |
| [+ gzip level 1](https://github.com/openclaw/openclaw/actions/runs/33590350957) | `3b60e6bff745` | `389196db509f` | 12m48s | Passed |
| [Without remote cache](https://github.com/openclaw/openclaw/actions/runs/33591209033) | `3b60e6bff745` | `aa861f0c0248` | **10m29s** | Passed |

The final preparation saved **3m44s (26.3%)** against the 14m13s baseline, and **2m19s (18.1%)** against the gzip run with remote caching. All four exports have no remote cache arguments or cache-export phase; both browser solves retained 56 local cache hits. These are observed runs, not a guaranteed duration.

The replacement copy fell from 32.9s to 6.9s on amd64 and 30.4s to 5.3s on arm64. Assembly alone did not improve whole-run time: longer cache uploads outweighed that saving. Gzip reduced default layer export from 85.1s to 33.1s on amd64 and 57.6s to 26.0s on arm64. Combined default/browser OCI artifacts grew from 2.62 to 2.98 GB on amd64 (+13.5%) and 2.64 to 2.96 GB on arm64 (+12.5%); these include duplicated shared blobs and are not individual image sizes.

The assembly/gzip/cache comparisons freeze application source at `3b60e6bf` and change workflow tooling. The first comparison changes the Dockerfile on the baseline source. All use version `v2026.8.1`, `diagnostics-otel,codex`, native 4-CPU GitHub runners, and the same Buildx/BuildKit versions; normal build timestamps vary. Completed default solves had zero cached vertices, and the browser variants reused the same-job builder. The final run imports no remote cache. Full workflow time includes setup, uploads and cleanup; component timings are not sums of overlapping BuildKit work. No package, registry image or release is published by these runs.

45 focused Docker/plugin tests and 139 release artifact/workflow tests passed. The executable assembly fixture covers both plugin-directory names, production native files and metadata, nested dependencies, the workspace link, generated SDK assets, and a correction version differing from the production manifest. CI caught `TS18048` in its optional regex capture; the guard is fixed, all 34 Dockerfile tests pass again, and the exact failed core-test stripe passes.

Workflow validators, formatting and diff checks pass, and Codex autoreview is scoped-clean at the default P0 threshold. [CI on the gzip head](https://github.com/openclaw/openclaw/actions/runs/33589786765) passed 204 jobs; [final-head CI](https://github.com/openclaw/openclaw/actions/runs/33591119016) also passed all 204 selected jobs. The final native preparation passed both architectures, both variants, OCI checks and sealing. This completes the latest ClawSweeper timing/image evidence request; a refresh for the remote-cache change was requested before landing.

The successful gzip run recorded recovered BuildKit cache-write messages. Both it and the final run recorded a non-fatal amd64 builder-volume cleanup timeout after image validation/upload; those 20 seconds remain included in the timings, and both architecture jobs plus sealing passed. Default smoke exercises workspace bootstrap without provider credentials; it does not prove an authenticated provider turn. The Matrix native-addon check is outside this selected-plugin matrix.

Production build/workflow delta: +15/-17 lines; tests: +29/-26; docs: +15/-8. No new runtime/configuration surface.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/135877#issuecomment-5504212822) has no code findings. Its timing and sealing requests are satisfied by the completed run above. The application source stayed frozen for comparison: it contains the byte-identical changed Dockerfile, while tooling is the final PR head. An additional native run for the intervening docs/test changes is unnecessary; final-head CI passed. The reviewer environment's upstream/main access gap was covered by direct Docker/BuildKit contract inspection and a current-main comparison of all five changed paths. The documented artifact-size tradeoff is accepted for the requested preparation speedup.

## Follow-up

Standalone partial Docker reruns need separate recovery proof: `resolve` records an artifact name for its attempt, while sealing validates current-attempt metadata. This pre-existing source-identified coupling is unchanged here; all measurements use fresh workflow dispatches.

The repeated amd64 Buildx volume-cleanup timeout is a separate upstream cleanup follow-up; the measured preparation result includes it.
