### PR TITLE
fix(android): keep reconnect cleanup scoped to its connection

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -244,11 +244,11 @@ Terminal B (USB tunnel):
 adb reverse tcp:18789 tcp:18789
 ```
 
-Then in app **Settings → Gateway → Manual Gateway**:
+Then open **Settings → Gateway → Manual Gateway** (or **Set up manually** during first-run setup):
 
 - Host: `127.0.0.1`
 - Port: `18789`
-- TLS: off
+- Connection security: **Unencrypted**
 
 ## Hot Reload / Fast Iteration
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -385,16 +385,30 @@ class GatewaySession(
 
   @Volatile private var mainSessionKey: String? = null
 
-  private data class DesiredConnection(
+  private class DesiredConnection(
     val endpoint: GatewayEndpoint,
     val token: String?,
     val bootstrapToken: String?,
     val password: String?,
     val options: GatewayConnectOptions,
     val tls: GatewayTlsParams?,
-  )
+  ) {
+    // Retry state belongs to this connect intent, not a later target whose socket may already be ready.
+    @Volatile var pendingDeviceTokenRetry = false
+
+    // A shared-token mismatch gets only one retry with the stored device token.
+    @Volatile var deviceTokenRetryBudgetUsed = false
+
+    @Volatile var reconnectPausedForAuthFailure = false
+
+    var attempt = 0
+  }
 
   private val lifecycleLock = Any()
+
+  // Acquire notificationLock before lifecycleLock. Disconnect can retire an owner while its
+  // callback drains, but a replacement cannot publish until that notification has finished.
+  private val notificationLock = Any()
 
   @Volatile private var desired: DesiredConnection? = null
 
@@ -405,14 +419,6 @@ class GatewaySession(
   private var disconnectTail: Job? = null
 
   @Volatile private var currentConnection: Connection? = null
-
-  // One reconnect can retry a shared-token mismatch by pairing the shared token with the stored device token.
-  @Volatile private var pendingDeviceTokenRetry = false
-
-  // Keep the mismatch retry single-shot so an invalid stored token cannot create an auth loop.
-  @Volatile private var deviceTokenRetryBudgetUsed = false
-
-  @Volatile private var reconnectPausedForAuthFailure = false
 
   // Network recovery must interrupt the current backoff without creating a parallel loop.
   private val reconnectSignal = Channel<Unit>(Channel.CONFLATED)
@@ -426,20 +432,19 @@ class GatewaySession(
     options: GatewayConnectOptions,
     tls: GatewayTlsParams? = null,
   ) {
-    val connectionToClose: Connection?
-    synchronized(lifecycleLock) {
-      desired = DesiredConnection(endpoint, token, bootstrapToken, password, options, tls)
-      pendingDeviceTokenRetry = false
-      deviceTokenRetryBudgetUsed = false
-      reconnectPausedForAuthFailure = false
-      connectionToClose = currentConnection
-      if (job?.isActive != true) {
-        job = scope.launch(Dispatchers.IO) { runLoop() }
-      } else {
-        reconnectSignal.trySend(Unit)
+    synchronized(notificationLock) {
+      val connectionToClose: Connection?
+      synchronized(lifecycleLock) {
+        desired = DesiredConnection(endpoint, token, bootstrapToken, password, options, tls)
+        connectionToClose = currentConnection
+        if (job?.isActive != true) {
+          job = scope.launch(Dispatchers.IO) { runLoop() }
+        } else {
+          reconnectSignal.trySend(Unit)
+        }
       }
+      connectionToClose?.closeQuietly()
     }
-    connectionToClose?.closeQuietly()
   }
 
   /** Clears desired connection state, closes the socket, and stops reconnect attempts. */
@@ -458,23 +463,24 @@ class GatewaySession(
     val cleanup: Job
     synchronized(lifecycleLock) {
       desired = null
-      pendingDeviceTokenRetry = false
-      deviceTokenRetryBudgetUsed = false
-      reconnectPausedForAuthFailure = false
       drainReconnectSignals()
       connectionToClose = currentConnection
       jobToCancel = job
       job = null
+      // Stop retry work now; the ordered tail still drains accepted tokens and callbacks.
+      jobToCancel?.cancel()
       val previousCleanup = disconnectTail
       cleanup =
         scope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
           previousCleanup?.join()
-          jobToCancel?.cancelAndJoin()
+          jobToCancel?.join()
           connectionToClose?.joinOwnedWork()
-          if (desired == null) {
-            pluginSurfaceUrls = emptyMap()
-            mainSessionKey = null
-            onDisconnected("Offline")
+          synchronized(notificationLock) {
+            if (desired == null) {
+              pluginSurfaceUrls = emptyMap()
+              mainSessionKey = null
+              onDisconnected("Offline")
+            }
           }
         }
       disconnectTail = cleanup
@@ -496,12 +502,12 @@ class GatewaySession(
 
   private fun signalReconnect(resumeAuthPaused: Boolean) {
     synchronized(lifecycleLock) {
+      val target = desired ?: return
       if (resumeAuthPaused) {
-        reconnectPausedForAuthFailure = false
-      } else if (reconnectPausedForAuthFailure) {
+        target.reconnectPausedForAuthFailure = false
+      } else if (target.reconnectPausedForAuthFailure) {
         return
       }
-      if (desired == null) return
       currentConnection?.closeQuietly()
       reconnectSignal.trySend(Unit)
     }
@@ -536,7 +542,7 @@ class GatewaySession(
           gatewayTlsFingerprintForCanvasSurface(
             fingerprint = fingerprint,
             surfaceUrl = url,
-            endpoint = connection.endpoint,
+            endpoint = connection.target.endpoint,
             isTlsConnection = connection.tlsConfig != null,
           ),
       )
@@ -613,7 +619,7 @@ class GatewaySession(
   }
 
   /** Current physical connection identity, including events sent during connect publication. */
-  internal fun currentEndpointStableId(): String? = currentConnection?.endpoint?.stableId
+  internal fun currentEndpointStableId(): String? = currentConnection?.target?.endpoint?.stableId
 
   /** Sends a best-effort node.event and returns false instead of throwing on failure. */
   suspend fun sendNodeEvent(
@@ -799,7 +805,7 @@ class GatewaySession(
     synchronized(lifecycleLock) {
       val conn = readyConnection(expectedEndpointStableId) ?: return@synchronized null
       RequestLease(
-        endpointStableId = conn.endpoint.stableId,
+        endpointStableId = conn.target.endpoint.stableId,
         isCurrentImpl = { currentConnection === conn && conn.isReady() },
         commitIfCurrentImpl = { block ->
           synchronized(lifecycleLock) {
@@ -872,7 +878,7 @@ class GatewaySession(
 
   private fun readyConnection(expectedEndpointStableId: String?): Connection? =
     readyConnection()?.takeIf { connection ->
-      expectedEndpointStableId == null || connection.endpoint.stableId == expectedEndpointStableId
+      expectedEndpointStableId == null || connection.target.endpoint.stableId == expectedEndpointStableId
     }
 
   /** Sends an RPC request frame and reports errors asynchronously through [onError]. */
@@ -930,12 +936,7 @@ class GatewaySession(
   }
 
   private inner class Connection(
-    val endpoint: GatewayEndpoint,
-    private val token: String?,
-    private val bootstrapToken: String?,
-    private val password: String?,
-    private val options: GatewayConnectOptions,
-    val tls: GatewayTlsParams?,
+    val target: DesiredConnection,
   ) {
     private val connectionJob = SupervisorJob(scope.coroutineContext[Job])
     private val connectionScope = CoroutineScope(scope.coroutineContext + connectionJob)
@@ -952,8 +953,8 @@ class GatewaySession(
     @Volatile
     private var connectRequestId: String? = null
     val tlsConfig: GatewayTlsConfig? =
-      buildGatewayTlsConfig(tls) { fingerprint ->
-        onTlsFingerprint?.invoke(tls?.stableId ?: endpoint.stableId, fingerprint)
+      buildGatewayTlsConfig(target.tls) { fingerprint ->
+        onTlsFingerprint?.invoke(target.tls?.stableId ?: target.endpoint.stableId, fingerprint)
       }
     private val client: OkHttpClient = buildClient()
     private val listener = Listener()
@@ -982,13 +983,13 @@ class GatewaySession(
         }
       }
 
-    val remoteAddress: String = formatGatewayAuthority(endpoint.host, endpoint.port)
+    val remoteAddress: String = formatGatewayAuthority(target.endpoint.host, target.endpoint.port)
 
     suspend fun connect(): ConnectedGateway {
       val request =
         buildGatewayWebSocketUpgradeRequest(
-          endpoint = endpoint,
-          tls = tls,
+          endpoint = target.endpoint,
+          tls = target.tls,
           customHeadersProvider = customHeadersProvider,
         )
       socket = client.newWebSocket(request, listener)
@@ -1107,7 +1108,7 @@ class GatewaySession(
         } else {
           ticketedPath
         }
-      val url = "$scheme://${formatGatewayAuthority(endpoint.host, endpoint.port)}${endpoint.contextPath}$playbackPath"
+      val url = "$scheme://${formatGatewayAuthority(target.endpoint.host, target.endpoint.port)}${target.endpoint.contextPath}$playbackPath"
       val headers = mediaTransportHeaders()
       return TicketedMediaRequest(url = url, headers = headers)
     }
@@ -1116,7 +1117,7 @@ class GatewaySession(
       if (tlsConfig == null) {
         emptyMap()
       } else {
-        GatewayCustomHeaders.sanitized(customHeadersProvider?.invoke(endpoint.stableId).orEmpty())
+        GatewayCustomHeaders.sanitized(customHeadersProvider?.invoke(target.endpoint.stableId).orEmpty())
       }
 
     @OptIn(DelicateCoroutinesApi::class)
@@ -1134,30 +1135,27 @@ class GatewaySession(
         pending.remove(id)
         throw err
       }
-      // ATOMIC start: joinOwnedWork() cancels connectionJob right after failPending(); a
-      // DEFAULT-start watcher still queued for dispatch would be cancelled without ever running
-      // and silently drop the terminal onError owed to fire-and-forget callers. ATOMIC
-      // guarantees this block runs; await() on the already-failed deferred then surfaces the
-      // disconnect outcome without suspending.
+      // Queued callbacks still owe a terminal result when teardown cancels their owner.
+      // ATOMIC starts the waiter; NonCancellable preserves accepted replies and failPending().
       connectionScope.launch(Dispatchers.IO, start = CoroutineStart.ATOMIC) {
-        try {
-          val response =
-            try {
-              withTimeout(timeoutMs) { deferred.await() }
-            } catch (_: TimeoutCancellationException) {
-              onError(ErrorShape("UNAVAILABLE", "request timeout"))
-              return@launch
-            } catch (_: CancellationException) {
-              return@launch
-            } catch (err: GatewayRequestOutcomeUnknown) {
-              onError(ErrorShape("UNAVAILABLE", err.message ?: "request outcome unknown"))
-              return@launch
+        withContext(NonCancellable) {
+          try {
+            val response =
+              try {
+                withTimeout(timeoutMs) { deferred.await() }
+              } catch (_: TimeoutCancellationException) {
+                onError(ErrorShape("UNAVAILABLE", "request timeout"))
+                return@withContext
+              } catch (err: GatewayRequestOutcomeUnknown) {
+                onError(ErrorShape("UNAVAILABLE", err.message ?: "request outcome unknown"))
+                return@withContext
+              }
+            if (!response.ok) {
+              onError(response.error ?: ErrorShape("UNAVAILABLE", "request failed"))
             }
-          if (!response.ok) {
-            onError(response.error ?: ErrorShape("UNAVAILABLE", "request failed"))
+          } finally {
+            pending.remove(id)
           }
-        } finally {
-          pending.remove(id)
         }
       }
     }
@@ -1250,7 +1248,9 @@ class GatewaySession(
             } else {
               connectChallengeDeferred.completeExceptionally(connectError)
             }
-            if (shouldNotify) onDisconnected(message)
+            synchronized(notificationLock) {
+              if (shouldNotify && currentConnection === this@Connection && desired === target) onDisconnected(message)
+            }
           } finally {
             finalizeTransport(connectError)
           }
@@ -1336,21 +1336,19 @@ class GatewaySession(
 
     private suspend fun sendConnect(connectChallenge: ConnectChallenge) {
       val identity = identityStore.loadOrCreate()
-      val storedEntry = deviceAuthStore.loadEntry(endpoint.stableId, identity.deviceId, options.role)
+      val storedEntry = deviceAuthStore.loadEntry(target.endpoint.stableId, identity.deviceId, target.options.role)
       val storedToken = storedEntry?.token?.trim()
       val selectedAuth =
         selectConnectAuth(
-          endpoint = endpoint,
-          tls = tls,
-          role = options.role,
-          explicitGatewayToken = token?.trim()?.takeIf { it.isNotEmpty() },
-          explicitBootstrapToken = bootstrapToken?.trim()?.takeIf { it.isNotEmpty() },
-          explicitPassword = password?.trim()?.takeIf { it.isNotEmpty() },
+          target = target,
+          explicitGatewayToken = target.token?.trim()?.takeIf { it.isNotEmpty() },
+          explicitBootstrapToken = target.bootstrapToken?.trim()?.takeIf { it.isNotEmpty() },
+          explicitPassword = target.password?.trim()?.takeIf { it.isNotEmpty() },
           storedToken = storedToken?.takeIf { it.isNotEmpty() },
           storedScopes = storedEntry?.scopes.orEmpty(),
         )
       if (selectedAuth.attemptedDeviceTokenRetry) {
-        pendingDeviceTokenRetry = false
+        target.pendingDeviceTokenRetry = false
       }
       val payload =
         buildConnectParams(
@@ -1363,21 +1361,20 @@ class GatewaySession(
         val error = res.error ?: ErrorShape("UNAVAILABLE", "connect failed")
         val shouldRetryWithDeviceToken =
           shouldRetryWithStoredDeviceToken(
+            target = target,
             error = error,
-            explicitGatewayToken = token?.trim()?.takeIf { it.isNotEmpty() },
+            explicitGatewayToken = target.token?.trim()?.takeIf { it.isNotEmpty() },
             storedToken = storedToken?.takeIf { it.isNotEmpty() },
             attemptedDeviceTokenRetry = selectedAuth.attemptedDeviceTokenRetry,
-            endpoint = endpoint,
-            tls = tls,
           )
         if (shouldRetryWithDeviceToken) {
-          pendingDeviceTokenRetry = true
-          deviceTokenRetryBudgetUsed = true
+          target.pendingDeviceTokenRetry = true
+          target.deviceTokenRetryBudgetUsed = true
         } else if (
           selectedAuth.attemptedDeviceTokenRetry &&
           shouldClearStoredDeviceTokenAfterRetry(error)
         ) {
-          deviceAuthStore.clearToken(endpoint.stableId, identity.deviceId, options.role)
+          deviceAuthStore.clearToken(target.endpoint.stableId, identity.deviceId, target.options.role)
         }
         throw GatewayConnectFailure(error)
       }
@@ -1387,8 +1384,8 @@ class GatewaySession(
 
     private fun shouldPersistBootstrapHandoffTokens(authSource: GatewayConnectAuthSource): Boolean {
       if (authSource != GatewayConnectAuthSource.BOOTSTRAP_TOKEN) return false
-      if (isLocalCleartextGatewayHost(endpoint.host)) return true
-      return tls != null
+      if (isLocalCleartextGatewayHost(target.endpoint.host)) return true
+      return target.tls != null
     }
 
     private fun filteredBootstrapHandoffScopes(
@@ -1427,7 +1424,7 @@ class GatewaySession(
       scopes: List<String>,
     ) {
       val filteredScopes = filteredBootstrapHandoffScopes(role, scopes) ?: return
-      deviceAuthStore.saveToken(endpoint.stableId, deviceId, role, token, filteredScopes)
+      deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, token, filteredScopes)
     }
 
     private fun persistIssuedDeviceToken(
@@ -1442,7 +1439,7 @@ class GatewaySession(
         persistBootstrapHandoffToken(deviceId, role, token, scopes)
         return
       }
-      deviceAuthStore.saveToken(endpoint.stableId, deviceId, role, token, scopes)
+      deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, token, scopes)
     }
 
     private fun parseConnectSuccess(
@@ -1452,9 +1449,9 @@ class GatewaySession(
     ): ConnectedGateway {
       val payloadJson = res.payloadJson ?: throw IllegalStateException("connect failed: missing payload")
       val obj = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: throw IllegalStateException("connect failed")
-      pendingDeviceTokenRetry = false
-      deviceTokenRetryBudgetUsed = false
-      reconnectPausedForAuthFailure = false
+      target.pendingDeviceTokenRetry = false
+      target.deviceTokenRetryBudgetUsed = false
+      target.reconnectPausedForAuthFailure = false
       val server = obj["server"].asObjectOrNull()
       val serverName = server?.get("host").asStringOrNull()
       val serverVersion = server?.get("version").asStringOrNull()
@@ -1474,7 +1471,7 @@ class GatewaySession(
           ?.toSet()
       val authObj = obj["auth"].asObjectOrNull()
       val deviceToken = authObj?.get("deviceToken").asStringOrNull()
-      val authRole = authObj?.get("role").asStringOrNull() ?: options.role
+      val authRole = authObj?.get("role").asStringOrNull() ?: target.options.role
       val authScopes =
         authObj
           ?.get("scopes")
@@ -1486,7 +1483,7 @@ class GatewaySession(
         // reusable grant metadata, while a rotated token starts with the live approved scopes.
         val sameStoredTokenRecord =
           deviceToken.trim() == selectedAuth.storedToken &&
-            authRole.trim().equals(options.role.trim(), ignoreCase = true)
+            authRole.trim().equals(target.options.role.trim(), ignoreCase = true)
         val persistedScopes = if (sameStoredTokenRecord) selectedAuth.storedScopes else authScopes
         persistIssuedDeviceToken(selectedAuth.authSource, deviceId, authRole, deviceToken, persistedScopes)
       }
@@ -1513,7 +1510,7 @@ class GatewaySession(
       val normalizedPluginSurfaceUrls =
         rawPluginSurfaceUrls?.mapNotNull { (surface, value) ->
           // Canvas URLs may be loopback gateway metadata; normalize them to the reachable Android endpoint.
-          normalizeCanvasHostUrl(value.asStringOrNull(), endpoint, isTlsConnection = tls != null)
+          normalizeCanvasHostUrl(value.asStringOrNull(), target.endpoint, isTlsConnection = target.tls != null)
             ?.let { normalized -> surface to normalized }
         } ?: emptyList()
       val nextPluginSurfaceUrls = normalizedPluginSurfaceUrls.toMap()
@@ -1558,7 +1555,7 @@ class GatewaySession(
       connectChallenge: ConnectChallenge,
       selectedAuth: SelectedConnectAuth,
     ): JsonObject {
-      val client = options.client
+      val client = target.options.client
       val locale = Locale.getDefault().toLanguageTag()
       val clientObj =
         buildJsonObject {
@@ -1607,7 +1604,7 @@ class GatewaySession(
           deviceId = identity.deviceId,
           clientId = client.id,
           clientMode = client.mode,
-          role = options.role,
+          role = target.options.role,
           scopes = connectScopes,
           signedAtMs = signedAtMs,
           token = selectedAuth.signatureToken,
@@ -1634,24 +1631,24 @@ class GatewaySession(
         put("minProtocol", JsonPrimitive(GATEWAY_MIN_PROTOCOL_VERSION))
         put("maxProtocol", JsonPrimitive(GATEWAY_PROTOCOL_VERSION))
         put("client", clientObj)
-        if (options.caps.isNotEmpty()) put("caps", JsonArray(options.caps.map(::JsonPrimitive)))
-        if (options.commands.isNotEmpty()) put("commands", JsonArray(options.commands.map(::JsonPrimitive)))
-        if (options.permissions.isNotEmpty()) {
+        if (target.options.caps.isNotEmpty()) put("caps", JsonArray(target.options.caps.map(::JsonPrimitive)))
+        if (target.options.commands.isNotEmpty()) put("commands", JsonArray(target.options.commands.map(::JsonPrimitive)))
+        if (target.options.permissions.isNotEmpty()) {
           put(
             "permissions",
             buildJsonObject {
-              options.permissions.forEach { (key, value) ->
+              target.options.permissions.forEach { (key, value) ->
                 put(key, JsonPrimitive(value))
               }
             },
           )
         }
-        put("role", JsonPrimitive(options.role))
+        put("role", JsonPrimitive(target.options.role))
         if (connectScopes.isNotEmpty()) put("scopes", JsonArray(connectScopes.map(::JsonPrimitive)))
         authJson?.let { put("auth", it) }
         deviceJson?.let { put("device", it) }
         put("locale", JsonPrimitive(locale))
-        options.userAgent?.trim()?.takeIf { it.isNotEmpty() }?.let {
+        target.options.userAgent?.trim()?.takeIf { it.isNotEmpty() }?.let {
           put("userAgent", JsonPrimitive(it))
         }
       }
@@ -1659,26 +1656,20 @@ class GatewaySession(
 
     private fun resolveConnectScopes(selectedAuth: SelectedConnectAuth): List<String> {
       if (selectedAuth.authSource == GatewayConnectAuthSource.BOOTSTRAP_TOKEN) {
-        return filteredBootstrapHandoffScopes(options.role, options.scopes).orEmpty()
+        return filteredBootstrapHandoffScopes(target.options.role, target.options.scopes).orEmpty()
       }
       if (selectedAuth.authSource == GatewayConnectAuthSource.DEVICE_TOKEN && selectedAuth.storedScopes.isNotEmpty()) {
         return selectedAuth.storedScopes
       }
-      return options.scopes
+      return target.options.scopes
     }
 
     private suspend fun handleMessage(text: String) {
       val frame = json.parseToJsonElement(text).asObjectOrNull() ?: return
-      val frameType = frame["type"].asStringOrNull()
-      if (
-        state.get() == ConnectionState.CLOSED &&
-        (frameType != "res" || frame["id"].asStringOrNull() != connectRequestId)
-      ) {
-        return
-      }
-      when (frameType) {
+      // Accepted responses settle this socket's pending requests even after close.
+      when (frame["type"].asStringOrNull()) {
         "res" -> handleResponse(frame)
-        "event" -> handleEvent(frame)
+        "event" -> if (state.get() != ConnectionState.CLOSED) handleEvent(frame)
       }
     }
 
@@ -1884,42 +1875,53 @@ class GatewaySession(
   }
 
   private suspend fun runLoop() {
-    var attempt = 0
-    while (scope.isActive) {
-      val target = desired
-      if (target == null) {
-        currentConnection?.closeQuietly()
-        currentConnection = null
-        withTimeoutOrNull(250) { reconnectSignal.receive() }
-        continue
-      }
-      if (reconnectPausedForAuthFailure) {
+    val loopJob = currentCoroutineContext().job
+    while (loopJob.isActive) {
+      val target =
+        synchronized(lifecycleLock) {
+          if (job !== loopJob) return
+          desired ?: return
+        }
+      if (target.reconnectPausedForAuthFailure) {
         withTimeoutOrNull(250) { reconnectSignal.receive() }
         continue
       }
 
       try {
-        onDisconnected(if (attempt == 0) "Connecting…" else "Reconnecting…")
-        drainReconnectSignals()
-        connectOnce(target)
-        attempt = 0
-      } catch (err: Throwable) {
-        attempt += 1
-        onDisconnected("Gateway error: ${err.message ?: err::class.java.simpleName}")
-        val gatewayConnectFailure = err as? GatewayConnectFailure
-        val pauseForAuthFailure =
-          gatewayConnectFailure
-            ?.let { shouldPauseReconnectAfterAuthFailure(it.gatewayError) } == true
-        if (gatewayConnectFailure != null) {
-          onConnectFailure(gatewayConnectFailure.gatewayError, pauseForAuthFailure)
-        }
-        if (pauseForAuthFailure) {
-          synchronized(lifecycleLock) {
-            reconnectPausedForAuthFailure = true
+        synchronized(notificationLock) {
+          if (synchronized(lifecycleLock) { job === loopJob && loopJob.isActive && desired === target }) {
+            drainReconnectSignals()
+            onDisconnected(if (target.attempt == 0) "Connecting…" else "Reconnecting…")
           }
-          continue
         }
-        val sleepMs = minOf(8_000L, (350.0 * Math.pow(1.7, attempt.toDouble())).toLong())
+        connectOnce(target)
+        target.attempt = 0
+      } catch (err: Throwable) {
+        loopJob.ensureActive()
+        if (err is CancellationException) throw err
+        target.attempt += 1
+        synchronized(notificationLock) {
+          val failure = err as? GatewayConnectFailure
+          val current =
+            synchronized(lifecycleLock) {
+              if (job !== loopJob || !loopJob.isActive || desired !== target) {
+                false
+              } else {
+                // Commit before callbacks so a reentrant connect/reconnect owns the next state.
+                target.reconnectPausedForAuthFailure =
+                  failure?.let { shouldPauseReconnectAfterAuthFailure(target, it.gatewayError) } == true
+                true
+              }
+            }
+          if (current) {
+            onDisconnected("Gateway error: ${err.message ?: err::class.java.simpleName}")
+            if (failure != null && synchronized(lifecycleLock) { job === loopJob && loopJob.isActive && desired === target }) {
+              onConnectFailure(failure.gatewayError, target.reconnectPausedForAuthFailure)
+            }
+          }
+        }
+        if (desired !== target || target.reconnectPausedForAuthFailure) continue
+        val sleepMs = minOf(8_000L, (350.0 * Math.pow(1.7, target.attempt.toDouble())).toLong())
         withTimeoutOrNull(sleepMs) { reconnectSignal.receive() }
       }
     }
@@ -1927,48 +1929,23 @@ class GatewaySession(
 
   private suspend fun connectOnce(target: DesiredConnection) =
     withContext(Dispatchers.IO) {
-      val conn =
-        Connection(
-          target.endpoint,
-          target.token,
-          target.bootstrapToken,
-          target.password,
-          target.options,
-          target.tls,
-        )
-      val shouldConnect =
-        synchronized(lifecycleLock) {
-          if (desired === target) {
-            currentConnection = conn
-            true
-          } else {
-            false
-          }
-        }
-      if (!shouldConnect) {
-        conn.closeQuietly()
-        conn.joinOwnedWork()
-        return@withContext
-      }
+      val conn = Connection(target)
       try {
-        val connected = conn.connect()
-        val published =
-          synchronized(lifecycleLock) {
-            if (currentConnection !== conn || desired !== target || !conn.markReady()) {
-              false
-            } else {
-              // Readiness and its metadata must become visible before callbacks flush queued events.
-              pluginSurfaceUrls = connected.pluginSurfaceUrls
-              mainSessionKey = connected.mainSessionKey
-              onConnected(connected.hello)
-              true
-            }
-          }
-        if (!published) {
-          conn.closeQuietly()
-          return@withContext
+        synchronized(lifecycleLock) {
+          if (desired !== target) return@withContext
+          currentConnection = conn
         }
-        drainReconnectSignals()
+        val connected = conn.connect()
+        synchronized(notificationLock) {
+          synchronized(lifecycleLock) {
+            if (currentConnection !== conn || desired !== target || job?.isActive != true || !conn.markReady()) return@withContext
+            // Ready metadata precedes callbacks; retries requested by a callback remain queued.
+            pluginSurfaceUrls = connected.pluginSurfaceUrls
+            mainSessionKey = connected.mainSessionKey
+            drainReconnectSignals()
+            onConnected(connected.hello)
+          }
+        }
         conn.awaitClose()
       } finally {
         // Callback failures and cancellation must drain this socket's owned work before the loop
@@ -2054,9 +2031,7 @@ class GatewaySession(
   }
 
   private fun selectConnectAuth(
-    endpoint: GatewayEndpoint,
-    tls: GatewayTlsParams?,
-    role: String,
+    target: DesiredConnection,
     explicitGatewayToken: String?,
     explicitBootstrapToken: String?,
     explicitPassword: String?,
@@ -2064,10 +2039,10 @@ class GatewaySession(
     storedScopes: List<String>,
   ): SelectedConnectAuth {
     val shouldUseDeviceRetryToken =
-      pendingDeviceTokenRetry &&
+      target.pendingDeviceTokenRetry &&
         explicitGatewayToken != null &&
         storedToken != null &&
-        isTrustedDeviceRetryEndpoint(endpoint, tls)
+        isTrustedDeviceRetryEndpoint(target.endpoint, target.tls)
     val authToken =
       explicitGatewayToken
         ?: if (
@@ -2116,17 +2091,16 @@ class GatewaySession(
   }
 
   private fun shouldRetryWithStoredDeviceToken(
+    target: DesiredConnection,
     error: ErrorShape,
     explicitGatewayToken: String?,
     storedToken: String?,
     attemptedDeviceTokenRetry: Boolean,
-    endpoint: GatewayEndpoint,
-    tls: GatewayTlsParams?,
   ): Boolean {
-    if (deviceTokenRetryBudgetUsed) return false
+    if (target.deviceTokenRetryBudgetUsed) return false
     if (attemptedDeviceTokenRetry) return false
     if (explicitGatewayToken == null || storedToken == null) return false
-    if (!isTrustedDeviceRetryEndpoint(endpoint, tls)) return false
+    if (!isTrustedDeviceRetryEndpoint(target.endpoint, target.tls)) return false
     val detailCode = error.details?.code
     val recommendedNextStep = error.details?.recommendedNextStep
     // New gateways set canRetryWithDeviceToken; older builds expose equivalent string codes.
@@ -2135,16 +2109,17 @@ class GatewaySession(
       detailCode == "AUTH_TOKEN_MISMATCH"
   }
 
-  private fun shouldPauseReconnectAfterAuthFailure(error: ErrorShape): Boolean {
-    val target = desired
-    return shouldPauseGatewayReconnectAfterAuthFailure(
+  private fun shouldPauseReconnectAfterAuthFailure(
+    target: DesiredConnection,
+    error: ErrorShape,
+  ): Boolean =
+    shouldPauseGatewayReconnectAfterAuthFailure(
       error = error,
-      hasBootstrapToken = target?.bootstrapToken?.trim()?.isNotEmpty() == true,
-      role = target?.options?.role,
-      scopes = target?.options?.scopes ?: emptyList(),
-      pendingDeviceTokenRetry = pendingDeviceTokenRetry,
+      hasBootstrapToken = target.bootstrapToken?.trim()?.isNotEmpty() == true,
+      role = target.options.role,
+      scopes = target.options.scopes,
+      pendingDeviceTokenRetry = target.pendingDeviceTokenRetry,
     )
-  }
 
   private fun shouldClearStoredDeviceTokenAfterRetry(error: ErrorShape): Boolean = error.details?.code == "AUTH_DEVICE_TOKEN_MISMATCH"
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -14,6 +16,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.yield
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -40,8 +43,12 @@ import org.robolectric.annotation.Config
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 private const val TEST_TIMEOUT_MS = 8_000L
 private const val CONNECT_CHALLENGE_TS = 1_700_000_000_123L
@@ -79,6 +86,44 @@ private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
   ) {
     tokens.remove("${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}")
+  }
+}
+
+private class RpcCallbackEntryGate :
+  AbstractCoroutineContextElement(Key),
+  ThreadContextElement<Job?> {
+  companion object Key : CoroutineContext.Key<RpcCallbackEntryGate>
+
+  val currentJob = ThreadLocal<Job?>()
+  val select = AtomicReference<(Job) -> Boolean> { false }
+  val paused = CompletableDeferred<Job>()
+  val release = CountDownLatch(1)
+  val released = CompletableDeferred<Boolean>()
+  private val claimed = AtomicBoolean(false)
+
+  override fun updateThreadContext(context: CoroutineContext): Job? {
+    val previous = currentJob.get()
+    val job = context[Job]
+    currentJob.set(job)
+    if (job != null && select.get()(job) && claimed.compareAndSet(false, true)) {
+      paused.complete(job)
+      val opened =
+        try {
+          release.await(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        } catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          false
+        }
+      released.complete(opened)
+    }
+    return previous
+  }
+
+  override fun restoreThreadContext(
+    context: CoroutineContext,
+    oldState: Job?,
+  ) {
+    currentJob.set(oldState)
   }
 }
 
@@ -494,54 +539,95 @@ class GatewaySessionInvokeTest {
   }
 
   @Test
-  fun disconnectReportsUnknownOutcomeForFireAndForgetRpc() {
+  fun disconnectReportsFireAndForgetErrorsAfterAcceptedFramesDrain() =
     runBlocking {
-      val json = testJson()
-      val connected = CompletableDeferred<Unit>()
-      val requestSeen = CompletableDeferred<Unit>()
-      val requestError = CompletableDeferred<GatewaySession.ErrorShape>()
-      val lastDisconnect = AtomicReference("")
-      val serverWebSocket = AtomicReference<WebSocket?>(null)
-      val server =
-        startGatewayServer(json) { webSocket, id, method, _ ->
-          serverWebSocket.set(webSocket)
-          when (method) {
-            "connect" -> webSocket.send(connectResponseFrame(id))
-            "fire.and.forget" -> requestSeen.complete(Unit)
+      for (peerRejects in listOf(false, true)) {
+        val json = testJson()
+        val connected = CompletableDeferred<Unit>()
+        val requestSeen = CompletableDeferred<Pair<WebSocket, String>>()
+        val errors = CopyOnWriteArrayList<GatewaySession.ErrorShape>()
+        val entryGate = RpcCallbackEntryGate()
+        val responsePumpHeld = CompletableDeferred<Job?>()
+        val releaseResponsePump = CountDownLatch(1)
+        val responsePumpReleased = CompletableDeferred<Boolean>()
+        val lastDisconnect = AtomicReference("")
+        val serverWebSocket = AtomicReference<WebSocket?>(null)
+        val server =
+          startGatewayServer(json) { webSocket, id, method, _ ->
+            serverWebSocket.set(webSocket)
+            when (method) {
+              "connect" -> webSocket.send(connectResponseFrame(id))
+              "fire.and.forget" -> requestSeen.complete(webSocket to id)
+            }
           }
+        val harness =
+          createNodeHarness(
+            connected = connected,
+            lastDisconnect = lastDisconnect,
+            extraContext = entryGate,
+            onEvent = { event, _ ->
+              if (event == "test.block.responses") {
+                responsePumpHeld.complete(entryGate.currentJob.get())
+                responsePumpReleased.complete(releaseResponsePump.await(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+              }
+            },
+          ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
+        try {
+          connectNodeSession(harness.session, server.port)
+          awaitConnectedOrThrow(connected, lastDisconnect, server)
+          val lease = requireNotNull(harness.session.captureRequestLease())
+          assertTrue(
+            requireNotNull(serverWebSocket.get()).send("""{"type":"event","event":"test.block.responses","payload":{}}"""),
+          )
+          val pump = requireNotNull(withTimeout(TEST_TIMEOUT_MS) { responsePumpHeld.await() })
+          // Locate the waiter only to schedule this race; the assertions below use the public result and join.
+          val connectionOwner = harness.sessionJob.children.single { owner -> owner.children.any { it === pump } }
+          val previousChildren = connectionOwner.children.toSet()
+          entryGate.select.set { candidate ->
+            candidate !in previousChildren && connectionOwner.children.any { it === candidate }
+          }
+          harness.session.sendRequestFrame(
+            method = "fire.and.forget",
+            paramsJson = null,
+            timeoutMs = 30_000,
+            onError = { errors.add(it) },
+          )
+          val (peer, id) = withTimeout(TEST_TIMEOUT_MS) { requestSeen.await() }
+          val callbackWatcher = withTimeout(TEST_TIMEOUT_MS) { entryGate.paused.await() }
+
+          if (peerRejects) {
+            assertTrue(
+              peer.send("""{"type":"res","id":"$id","ok":false,"error":{"code":"RATE_LIMITED","message":"slow down"}}"""),
+            )
+          }
+          assertTrue(peer.close(1000, "done"))
+          // Peer frame order plus this close checkpoint puts the accepted reply behind the held pump.
+          withTimeout(TEST_TIMEOUT_MS) {
+            while (lease.isCurrent()) yield()
+          }
+          harness.session.disconnect()
+          releaseResponsePump.countDown()
+          // Wait for cancellation to reach this waiter, not just for its owner to start cancelling.
+          withTimeout(TEST_TIMEOUT_MS) {
+            while (!callbackWatcher.isCancelled) yield()
+          }
+          entryGate.release.countDown()
+          withTimeout(TEST_TIMEOUT_MS) { harness.session.disconnectAndJoin() }
+
+          assertTrue("response pump timed out", withTimeout(TEST_TIMEOUT_MS) { responsePumpReleased.await() })
+          assertTrue("callback entry gate timed out", withTimeout(TEST_TIMEOUT_MS) { entryGate.released.await() })
+          assertTrue("app scope must remain alive until after callback verification", harness.sessionJob.isActive)
+          assertEquals("onError must be delivered exactly once; peerRejects=$peerRejects", 1, errors.size)
+          val error = errors.single()
+          assertEquals(if (peerRejects) "RATE_LIMITED" else "UNAVAILABLE", error.code)
+          assertEquals(if (peerRejects) "slow down" else "Gateway disconnected before response", error.message)
+        } finally {
+          releaseResponsePump.countDown()
+          entryGate.release.countDown()
+          shutdownHarness(harness, server)
         }
-      val harness =
-        createNodeHarness(
-          connected = connected,
-          lastDisconnect = lastDisconnect,
-        ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
-
-      try {
-        connectNodeSession(harness.session, server.port)
-        awaitConnectedOrThrow(connected, lastDisconnect, server)
-        harness.session.sendRequestFrame(
-          method = "fire.and.forget",
-          paramsJson = null,
-          timeoutMs = 30_000,
-          onError = { requestError.complete(it) },
-        )
-        withTimeout(TEST_TIMEOUT_MS) { requestSeen.await() }
-
-        harness.session.disconnect()
-
-        val error = withTimeout(2_000) { requestError.await() }
-        assertEquals("UNAVAILABLE", error.code)
-        assertEquals("Gateway disconnected before response", error.message)
-        serverWebSocket.get()?.close(1000, "done")
-      } finally {
-        runCatching { serverWebSocket.get()?.close(1000, "done") }
-        delay(100)
-        harness.session.disconnect()
-        harness.sessionJob.cancelAndJoin()
-        server.shutdown()
       }
     }
-  }
 
   @Test
   fun eventsAreDispatchedInWebSocketFrameOrder() =
@@ -1407,9 +1493,15 @@ class GatewaySessionInvokeTest {
       val json = testJson()
       val connected = CompletableDeferred<Unit>()
       val nodeEventParams = CompletableDeferred<JsonObject>()
+      val responseQueued = CompletableDeferred<Boolean>()
+      val responsePumpHeld = CompletableDeferred<Unit>()
+      val releaseResponsePump = CountDownLatch(1)
+      val responsePumpReleased = CompletableDeferred<Boolean>()
       val lastDisconnect = AtomicReference("")
+      val serverWebSocket = AtomicReference<WebSocket?>(null)
       val server =
         startGatewayServer(json) { webSocket, id, method, frame ->
+          serverWebSocket.set(webSocket)
           when (method) {
             "connect" -> {
               webSocket.send(connectResponseFrame(id))
@@ -1419,8 +1511,10 @@ class GatewaySessionInvokeTest {
               if (!nodeEventParams.isCompleted) {
                 nodeEventParams.complete(frame["params"]?.jsonObject ?: JsonObject(emptyMap()))
               }
-              webSocket.send(
-                """{"type":"res","id":"$id","ok":false,"error":{"code":"RATE_LIMITED","message":"slow down"}}""",
+              responseQueued.complete(
+                webSocket.send(
+                  """{"type":"res","id":"$id","ok":false,"error":{"code":"RATE_LIMITED","message":"slow down"}}""",
+                ),
               )
               webSocket.close(1000, "done")
             }
@@ -1431,22 +1525,44 @@ class GatewaySessionInvokeTest {
         createNodeHarness(
           connected = connected,
           lastDisconnect = lastDisconnect,
+          onEvent = { event, _ ->
+            if (event == "test.block.responses") {
+              responsePumpHeld.complete(Unit)
+              responsePumpReleased.complete(releaseResponsePump.await(TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+            }
+          },
         ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
 
       try {
         connectNodeSession(harness.session, server.port)
         awaitConnectedOrThrow(connected, lastDisconnect, server)
+        val lease = requireNotNull(harness.session.captureRequestLease())
+        assertTrue(
+          requireNotNull(serverWebSocket.get()).send("""{"type":"event","event":"test.block.responses","payload":{}}"""),
+        )
+        withTimeout(TEST_TIMEOUT_MS) { responsePumpHeld.await() }
 
         val sent =
-          harness.session.sendNodeEvent(
-            event = "agent.request",
-            payloadJson = """{"message":"restore"}""",
-          )
+          async {
+            harness.session.sendNodeEvent(
+              event = "agent.request",
+              payloadJson = """{"message":"restore"}""",
+            )
+          }
         val params = withTimeout(TEST_TIMEOUT_MS) { nodeEventParams.await() }
+        assertTrue("The response must enter the peer's outgoing queue", withTimeout(TEST_TIMEOUT_MS) { responseQueued.await() })
+        // The held callback prevents loop retirement, so this observes physical close
+        // before the already-received response can leave the message queue.
+        withTimeout(TEST_TIMEOUT_MS) {
+          while (lease.isCurrent()) yield()
+        }
+        releaseResponsePump.countDown()
+        assertTrue("The message-pump gate must be released", withTimeout(TEST_TIMEOUT_MS) { responsePumpReleased.await() })
 
-        assertEquals(true, sent)
+        assertEquals(true, withTimeout(TEST_TIMEOUT_MS) { sent.await() })
         assertEquals("agent.request", params["event"]?.jsonPrimitive?.content)
       } finally {
+        releaseResponsePump.countDown()
         shutdownHarness(harness, server)
       }
     }
@@ -1534,6 +1650,7 @@ class GatewaySessionInvokeTest {
     connected: CompletableDeferred<Unit>,
     lastDisconnect: AtomicReference<String>,
     onEvent: (event: String, payloadJson: String?) -> Unit = { _, _ -> },
+    extraContext: CoroutineContext = EmptyCoroutineContext,
     onInvoke: suspend (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult,
   ): NodeHarness {
     val app = RuntimeEnvironment.getApplication()
@@ -1541,7 +1658,7 @@ class GatewaySessionInvokeTest {
     val deviceAuthStore = InMemoryDeviceAuthStore()
     val session =
       GatewaySession(
-        scope = CoroutineScope(sessionJob + Dispatchers.Default),
+        scope = CoroutineScope(sessionJob + Dispatchers.Default + extraContext),
         identityStore = testDeviceIdentityStore(app),
         deviceAuthStore = deviceAuthStore,
         onConnected = {

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -484,7 +484,10 @@ class GatewaySessionReconnectTest {
               val methods = if (connectRequests.incrementAndGet() == 1) initialMethods else replacementMethods
               webSocket.send(connectResponseFrame(id, methods))
             }
-            "health" -> webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+
+            "health" -> {
+              webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+            }
           }
         }
       val harness =

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -38,11 +38,13 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.io.IOException
+import java.lang.management.ManagementFactory
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 private const val LIFECYCLE_TEST_TIMEOUT_MS = 8_000L
 private const val LIFECYCLE_CONNECT_CHALLENGE_FRAME =
@@ -73,6 +75,7 @@ private class ReconnectDeviceAuthStore : DeviceAuthTokenStore {
 private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
   val saveStarted = CountDownLatch(1)
   val allowSave = CountDownLatch(1)
+  val savedToken = CompletableDeferred<String>()
 
   override fun loadEntry(
     gatewayId: String,
@@ -89,6 +92,7 @@ private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
   ) {
     saveStarted.countDown()
     allowSave.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    savedToken.complete(token)
   }
 
   override fun clearToken(
@@ -458,6 +462,118 @@ class GatewaySessionReconnectTest {
     }
 
   @Test
+  fun replacementLeaseCannotObserveUnpublishedHelloMetadata() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val threads = ManagementFactory.getThreadMXBean()
+      val initialMethods = setOf("health", "users.prefs.get", "users.prefs.set")
+      val replacementMethods = setOf("health", "users.prefs.get")
+      val connectRequests = AtomicInteger()
+      val publishedMethods = AtomicReference<Set<String>?>(null)
+      val connected = CompletableDeferred<Unit>()
+      val replacementPublished = CompletableDeferred<Unit>()
+      val replacementHelloStarted = CountDownLatch(1)
+      val publicationThread = AtomicReference<Thread?>(null)
+      val allowReplacementHello = CountDownLatch(1)
+      val observerStarted = CountDownLatch(1)
+      val observation = CompletableDeferred<Pair<GatewaySession.RequestLease?, Set<String>?>>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          when (method) {
+            "connect" -> {
+              val methods = if (connectRequests.incrementAndGet() == 1) initialMethods else replacementMethods
+              webSocket.send(connectResponseFrame(id, methods))
+            }
+            "health" -> webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{}}""")
+          }
+        }
+      val harness =
+        createReconnectHarness(
+          onHello = { hello ->
+            if (hello.methods == replacementMethods) {
+              publicationThread.set(Thread.currentThread())
+              replacementHelloStarted.countDown()
+              try {
+                check(allowReplacementHello.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                  "Replacement hello publication was not released"
+                }
+              } catch (err: Throwable) {
+                replacementPublished.completeExceptionally(err)
+                throw err
+              }
+            }
+            publishedMethods.set(hello.methods)
+            if (hello.methods == initialMethods) connected.complete(Unit) else replacementPublished.complete(Unit)
+          },
+        )
+      val gatewayId = "manual|127.0.0.1|${server.port}"
+      val captureLease = harness.session::captureRequestLease
+      val captureMethodName = captureLease.name.substringBefore('$')
+      val observer =
+        Thread {
+          try {
+            observerStarted.countDown()
+            val lease = captureLease(gatewayId)
+            observation.complete(lease to publishedMethods.get())
+          } catch (err: Throwable) {
+            observation.completeExceptionally(err)
+          }
+        }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        val initialLease = requireNotNull(captureLease(gatewayId))
+        assertEquals(initialMethods, publishedMethods.get())
+
+        harness.session.reconnect()
+        assertTrue(replacementHelloStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        assertFalse(initialLease.isCurrent())
+        observer.start()
+        assertTrue(observerStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        val observerThreadId = observer.threadId()
+        val publicationThreadId = requireNotNull(publicationThread.get()).threadId()
+        // Unrelated parking or class loading must not release hello early. Require
+        // the capture call to be waiting on a lock owned by the paused publisher.
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) {
+          while (!observation.isCompleted) {
+            val read = threads.getThreadInfo(observerThreadId, Int.MAX_VALUE)
+            if (
+              read != null &&
+              read.lockOwnerId == publicationThreadId &&
+              read.stackTrace.any {
+                it.className == GatewaySession::class.java.name &&
+                  it.methodName.substringBefore('$') == captureMethodName
+              }
+            ) {
+              break
+            }
+            delay(10)
+          }
+        }
+
+        allowReplacementHello.countDown()
+        val (observedLease, observedMethods) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { observation.await() }
+        if (observedLease != null) {
+          assertEquals("A ready replacement must expose its own hello metadata", replacementMethods, observedMethods)
+          assertTrue(observedLease.isCurrent())
+        }
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { replacementPublished.await() }
+        val currentLease = requireNotNull(captureLease(gatewayId))
+        assertEquals(replacementMethods, publishedMethods.get())
+        assertEquals("{}", currentLease.request("health", null))
+      } finally {
+        allowReplacementHello.countDown()
+        try {
+          observer.join(LIFECYCLE_TEST_TIMEOUT_MS)
+          assertFalse("The hello observer must finish before teardown", observer.isAlive)
+        } finally {
+          shutdownReconnectHarness(harness, server)
+        }
+      }
+    }
+
+  @Test
   fun connectedHelloPublishesCanonicalAndLegacyApprovalMethods() =
     runBlocking {
       val catalogs =
@@ -648,6 +764,195 @@ class GatewaySessionReconnectTest {
       } finally {
         authStore.allowSave.countDown()
         shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun disconnectDrainsConnectionCancelledBeforeInstallation() =
+    runBlocking {
+      val threads = ManagementFactory.getThreadMXBean()
+      val connectingStarted = CountDownLatch(1)
+      val allowConstruction = CountDownLatch(1)
+      val connectionThread = AtomicReference<Thread?>(null)
+      val server =
+        startGatewayServer(json = Json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onDisconnected = { message ->
+            if (message == "Connecting…") {
+              connectionThread.set(Thread.currentThread())
+              connectingStarted.countDown()
+              check(allowConstruction.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                "Connection construction was not released"
+              }
+            }
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        assertTrue(connectingStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        val lifecycleLock = readField<Any>(harness.session, "lifecycleLock")
+        val previousChildren = harness.sessionJob.children.toSet()
+        lateinit var constructedOwner: Job
+        lateinit var disconnect: Job
+        synchronized(lifecycleLock) {
+          val observerThreadId = Thread.currentThread().threadId()
+          val connectionThreadId = requireNotNull(connectionThread.get()).threadId()
+          val lockIdentity = System.identityHashCode(lifecycleLock)
+          val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(LIFECYCLE_TEST_TIMEOUT_MS)
+          allowConstruction.countDown()
+          var waitingToInstall = false
+          // The callback already passed the loop's first lifecycle read. Blocking on this
+          // exact monitor now proves construction finished before cancellation retires it.
+          while (System.nanoTime() < deadline) {
+            val observed = threads.getThreadInfo(connectionThreadId)
+            if (
+              observed != null &&
+              observed.lockOwnerId == observerThreadId &&
+              observed.lockInfo?.identityHashCode == lockIdentity
+            ) {
+              waitingToInstall = true
+              break
+            }
+            Thread.sleep(1)
+          }
+          assertTrue("The constructed connection must be waiting to install", waitingToInstall)
+          constructedOwner = harness.sessionJob.children.single { it !in previousChildren }
+          assertTrue(constructedOwner.isActive)
+          assertNull(readField<Any?>(harness.session, "currentConnection"))
+          harness.session.disconnect()
+          disconnect = readField(harness.session, "disconnectTail")
+        }
+
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { disconnect.join() }
+        assertTrue("Disconnect must retire even a connection that never installed", constructedOwner.isCompleted)
+        assertEquals(0, server.requestCount)
+      } finally {
+        allowConstruction.countDown()
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun retiredDisconnectCleanupCannotOverwriteReplacementConnectionState() =
+    runBlocking {
+      assertRetiredConnectionCannotOverwriteReplacementState(failTransportBeforeDisconnect = false)
+    }
+
+  @Test
+  fun retiredTransportFailureCannotOverwriteReplacementConnectionState() =
+    runBlocking {
+      assertRetiredConnectionCannotOverwriteReplacementState(failTransportBeforeDisconnect = true)
+    }
+
+  private suspend fun assertRetiredConnectionCannotOverwriteReplacementState(failTransportBeforeDisconnect: Boolean) {
+    val json = Json { ignoreUnknownKeys = true }
+    val authStore = BlockingSaveDeviceAuthStore()
+    val replacementConnected = CompletableDeferred<Unit>()
+    val observedState = AtomicReference("Offline")
+    val firstServer =
+      startGatewayServer(json = json) { webSocket, id, method ->
+        if (method == "connect") {
+          webSocket.send(
+            """{"type":"res","id":"$id","ok":true,"payload":{"auth":{"deviceToken":"issued-token","role":"node","scopes":[]},"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+          )
+        }
+      }
+    val secondServer =
+      startGatewayServer(json = json) { webSocket, id, method ->
+        when (method) {
+          "connect" -> webSocket.send(connectResponseFrame(id))
+          "health" -> webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{"connection":2}}""")
+        }
+      }
+    val harness =
+      createReconnectHarness(
+        onConnected = {
+          observedState.set("Connected")
+          replacementConnected.complete(Unit)
+        },
+        onDisconnected = observedState::set,
+        deviceAuthStore = authStore,
+      )
+
+    try {
+      connectNodeSession(harness.session, firstServer.port)
+      assertTrue(authStore.saveStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+      if (failTransportBeforeDisconnect) {
+        val retiredConnection = readField<Any>(harness.session, "currentConnection")
+        val terminalClaimed = readField<AtomicBoolean>(retiredConnection, "terminalCallbackClaimed")
+        val transportState = readField<AtomicReference<*>>(retiredConnection, "state")
+        // Server WebSockets have no client Call for cancel(); shutdown closes the actual peer socket.
+        firstServer.shutdown()
+        // Observe the real peer failure before disconnect; its callback is still held by token persistence.
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) {
+          while (!terminalClaimed.get() || transportState.get().toString() != "CLOSED") {
+            delay(10)
+          }
+        }
+      }
+
+      harness.session.disconnect()
+      val retiredCleanup = readField<Job>(harness.session, "disconnectTail")
+      connectNodeSession(harness.session, secondServer.port)
+      withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { replacementConnected.await() }
+      assertFalse(retiredCleanup.isCompleted)
+
+      authStore.allowSave.countDown()
+      withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { retiredCleanup.join() }
+      assertEquals("issued-token", withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { authStore.savedToken.await() })
+      assertEquals("""{"connection":2}""", harness.session.request("health", null))
+      assertEquals("Connected", observedState.get())
+    } finally {
+      authStore.allowSave.countDown()
+      shutdownReconnectHarness(harness, firstServer, secondServer)
+    }
+  }
+
+  @Test
+  fun retiredAuthenticationFailureCannotPauseReplacementConnection() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val originalFailure = CompletableDeferred<Pair<GatewaySession.ErrorShape, Boolean>>()
+      val replacementConnected = CompletableDeferred<Unit>()
+      var currentSession: GatewaySession? = null
+      val firstServer =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") {
+            webSocket.send(
+              """{"type":"res","id":"$id","ok":false,"error":{"code":"INVALID_REQUEST","message":"authentication failed","details":{"code":"AUTH_TOKEN_MISMATCH"}}}""",
+            )
+          }
+        }
+      val secondServer =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = { replacementConnected.complete(Unit) },
+          onConnectFailure = { error, pauseReconnect ->
+            if (originalFailure.complete(error to pauseReconnect)) {
+              connectNodeSession(checkNotNull(currentSession), secondServer.port)
+            }
+          },
+        )
+      currentSession = harness.session
+
+      try {
+        connectNodeSession(harness.session, firstServer.port)
+        val (error, pauseReconnect) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { originalFailure.await() }
+        assertEquals("AUTH_TOKEN_MISMATCH", error.details?.code)
+        assertTrue(pauseReconnect)
+        assertTrue(
+          "The retired authentication failure must not pause the replacement requested by its callback",
+          withTimeoutOrNull(LIFECYCLE_TEST_TIMEOUT_MS) { replacementConnected.await() } != null,
+        )
+      } finally {
+        shutdownReconnectHarness(harness, firstServer, secondServer)
       }
     }
 
@@ -1342,7 +1647,7 @@ class GatewaySessionReconnectTest {
     return ReconnectHarness(session = session, sessionJob = sessionJob)
   }
 
-  private suspend fun connectNodeSession(
+  private fun connectNodeSession(
     session: GatewaySession,
     port: Int,
   ) {

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -1,5 +1,5 @@
 ---
-summary: "Android app (node): connection runbook + Connect/Chat/OpenClaw/Voice command surface"
+summary: "Android app (node): pairing, connection recovery, and Home/Chat/Settings navigation"
 read_when:
   - Pairing or reconnecting the Android node
   - Debugging Android gateway discovery or auth
@@ -232,11 +232,13 @@ Details and example CoreDNS config: [Bonjour](/gateway/bonjour).
 In the Android app:
 
 - The app keeps its gateway connection alive via a **foreground service** (persistent notification).
-- Open the **Connect** tab.
-- Use **Setup Code** or **Manual** mode.
-- If discovery is blocked, use manual host/port in **Advanced controls**. For private LAN hosts, `ws://` still works. For Tailscale/public hosts, turn on TLS and use a `wss://` / Tailscale Serve endpoint.
+- During first-run setup, choose **Scan QR or setup code** or **Set up manually**.
+- After setup, open **Settings → Gateway**. **Add Gateway** lets you scan or paste a setup code, or connect to a discovered Gateway.
+- If discovery is blocked, use **Manual Gateway** on that page: enter the host and port, select **Connection security**, and tap **Save & Connect**. Private LAN hosts support `ws://`; for Tailscale/public hosts, use **Secure (TLS)** with a `wss://` / Tailscale Serve endpoint.
 
 After the first successful pairing, Android auto-reconnects on launch to the active paired gateway (best-effort for discovered gateways, which must be visible on the network).
+
+Android retries temporary connection losses automatically. For a fresh attempt with the saved endpoint, open **Settings → Gateway** and tap **Reconnect**. **Disconnect** stops the connections and suppresses automatic reconnect for the current app session; it does not forget the pairing. Authentication or pairing errors can pause retries until you address the reported problem.
 
 Official setup codes connect Android as a node and grant full Gateway operator
 access by default over `wss://`. Plaintext non-loopback `ws://` setup
@@ -251,9 +253,8 @@ who want the reduced profile can select **Limited access** in Control UI or run
 
 The app keeps a registry of every gateway it has paired with, so you can keep operator sessions connected and change focus without pairing again:
 
-- **Settings → Gateway** lists paired gateways with the focused one marked. Tap an entry to focus it; the other enabled operator sessions remain connected.
+- **Settings → Gateway** lists paired gateways in the **Gateways** section, with a checkmark beside the focused one. Tap another entry to focus it; the other enabled operator sessions remain connected.
 - Each switch controls whether that non-focused Gateway stays connected while the app is in the foreground. The focused Gateway remains enabled and owns the phone's node connection and device capabilities.
-- The **Connect** tab shows a quick switcher when more than one gateway is paired.
 - Credentials, device tokens, TLS trust, chat history, and queued offline messages are stored per Gateway. Changing focus never mixes state between Gateways, and messages queued while offline are delivered only to the Gateway they were written for.
 - **Forget** removes a gateway's registry entry together with its credentials, device tokens, TLS pin, and cached chats.
 


### PR DESCRIPTION
Related: #134939. No closure of #127406 or #127873 is requested.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes #135874.

Fixes an issue where Android reconnects could be marked failed or paused by retired connection work. Teardown could also lose accepted RPC outcomes/error notifications or miss joined cleanup when cancellation happened before installation.

## Why This Change Was Made

`GatewaySession` gives each connection request its retry/authentication state and fences status publication against the current connection identity. Joined cleanup settles its accepted replies/error watchers and pre-installation cancellation; stale events and leases remain fenced.

Five files: production **+174/-199 (net -25)**, tests **+477/-52 (net +425)**, docs **+9/-8 (net +1)**. No dependency, schema, configuration, or public protocol/API change.

## User Impact

A replacement stays authoritative while old work settles its own outcomes. Docs name the current connection controls.

Separate observed follow-up: **Settings → Gateway shows Node “Not paired” after Disconnect despite the saved pairing being retained.** This UI wording and the broader #127406/#127873 investigations are not addressed here.

## Evidence

Candidate: [a4fdb9d9344e](https://github.com/openclaw/openclaw/commit/a4fdb9d9344e3fb4c6525971b5ef99c05544bb45).

**Current-base negative control:** exact landed production [5fa8356483a8](https://github.com/openclaw/openclaw/commit/5fa8356483a8357e7c7bd0943caa52f1982beefe), with only the final `GatewaySessionReconnectTest.kt` copied unchanged from the candidate, produced **four intended assertion failures**: two selected methods in both Play and ThirdParty, with zero errors/skips.

| Test | Observed on the landed base |
| --- | --- |
| `retiredDisconnectCleanupCannotOverwriteReplacementConnectionState` | The replacement answered a health RPC, but old cleanup changed status from `Connected` to `Gateway error: Gateway closed`. |
| `retiredAuthenticationFailureCannotPauseReplacementConnection` | After the original authentication error and pause classification were verified, the replacement requested by its callback did not connect within the existing test deadline. |

Both methods passed in both flavors in the retained 410-test candidate run, whose `GatewaySession` and reconnect-test bytes match the final candidate. That positive run preceded this negative control; it is not a new post-negative rerun.

**5,307** app tests passed at the candidate (2,588 Play / 2,719 ThirdParty; zero failures/errors/skips), including **410** Gateway/bootstrap tests. A separate 410-test run (205/flavor) and fresh managed Codex review (exit 0, no P0-P2 findings) covered the exact tree before commit. **13** changed checks and **four** framework-lint targets passed: zero lint errors/warnings, three existing UI hints per app flavor. Hosted CI [33588950135, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33588950135/attempts/2) completed **successfully on the unchanged candidate**: ThirdParty in 8m16s, Play in 9m08s, and the required `openclaw/ci-gate` passed. Only failed jobs were rerun; build, Wear and ktlint successes carried forward from attempt 1.

The first attempt reached both 20-minute phone-test deadlines after compilation. A separate Linux diagnostic of exact CI merge `b354fdb828a7721ea6e21f8ce462512d914694c2` passed all **2,719 unfiltered ThirdParty tests**, with 213 raw XML suites and zero failures/errors/skips. That merge has the same complete Android tree as the candidate; source stayed unchanged, and the runner exposed **four CPUs**. The hosted retry used GitHub-hosted Ubuntu. These passes do **not** identify the original timeout cause; no source change, timeout increase or runner-capacity comparison is claimed.

**ClawSweeper disposition:** [the latest review](https://github.com/openclaw/openclaw/pull/135878#issuecomment-5504194934) has no code/security findings. Its CI/Rank-up request is resolved by the successful exact-head run above. Its separate DNS retrieval limitation is covered by direct maintainer comparison against native main `4e36c68976a9474e6c7bf6dc55e2aedb4321d54d`, inspection of the pinned [kotlinx-coroutines 1.11.0 source archive](https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.11.0/kotlinx-coroutines-core-jvm-1.11.0-sources.jar), and HTTP-200 downloads of both fully inspected synthetic captures with byte-for-byte matching hashes. No behavior changed after that review.

Live scope: candidate Play APK, **one API 36 emulator**, real Gateway `5fa8356483a8357e7c7bd0943caa52f1982beefe`, **synthetic provider**, and **ADB loopback**—not cloud Codex or Wi-Fi data-path testing.

| Completed case | Observation |
| --- | --- |
| Transport-bridge outage/restoration | Ready within 30 seconds without app/reconnect action; one acknowledged send with a rendered synthetic reply, no retry. |
| Android network loss/restoration | Validated networks reached zero and returned; role acknowledgements and single-send chat followed. The UI remained Ready; this is not Wi-Fi data-path proof. |
| Disconnect, background/foreground, Reconnect | No automatic reconnects in the observed quiet period; saved pairing retained. Manual Reconnect restored Ready and node/operator acknowledgements. |

**Profile qualification:** B's observer exited 1 expecting Miami; read-only `users.self` / `users.prefs.get` proved stored B and app were Rose (A also Rose). Failure retained; no profile/source/deadline changes or distinct-family visual claim. An exact-two-ACK observer assumption also failed; readiness/chat were verified separately, not concurrent-socket counts.

The final post-Reconnect chat had one send/ACK and a following rendered reply. Preferences matched the pre-install baseline; the app PID stayed unchanged through the cases; radios/controls were restored; the captured crash buffer was empty. The 195-record transport log contained three `chat.send` mutations, no preference/configuration/session-management mutation RPCs. The owned proxy exited 0 and its port closed; Gateway/provider/emulator services were retained for the separate follow-up.

<details>
<summary>Other historical failing-test qualifications</summary>

The other retained negative cases remain historical, not reruns on exact landed base `5fa8356483a8`; they used paired source/test controls. Two early receipts omit HEAD; later recorded HEADs also had uncommitted controls. Paired fingerprints remain retained. The fixture NPE and preflight-only failure are excluded; teardown warnings are not primary proof. Pre-installation red stopped at owner completion before the zero-request assertion; watcher red stopped at callback count before error-code assertions. The hello-publication negative control proves guard sensitivity only. No heap, socket-leak, battery, or all-device inference is made.

</details>

## Installed-app captures

Both captures show the same candidate Play APK, before and after an owned transport-bridge outage. All conversation content is synthetic.

**During the outage**

![Android reporting the synthetic Gateway outage](https://github.com/user-attachments/assets/6a55dc72-500f-4e75-9635-7c840dd8d8d5)

**After automatic recovery and one acknowledged chat send**

![Android displaying a synthetic reply after automatic reconnect](https://github.com/user-attachments/assets/7b1fee2f-fc0f-4f00-9b2e-65fd2a6ac7aa)
