### PR TITLE
refactor(telegram): share edit error classifiers

### DIFF
--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -121,9 +121,6 @@ export function toAcceptedThreadScopedParams(
   return Object.keys(scoped).length > 0 ? scoped : undefined;
 }
 
-const MESSAGE_NOT_MODIFIED_RE =
-  /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
-const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
 const MESSAGE_DELETE_NOOP_RE =
   /message to delete not found|message can't be deleted|MESSAGE_ID_INVALID|MESSAGE_DELETE_FORBIDDEN/i;
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
@@ -376,14 +373,6 @@ export function normalizeMessageId(raw: string | number): number {
     }
   }
   throw new Error("Message id is required for Telegram actions");
-}
-
-export function isTelegramMessageNotModifiedError(err: unknown): boolean {
-  return MESSAGE_NOT_MODIFIED_RE.test(formatErrorMessage(err));
-}
-
-export function isTelegramMessageHasNoTextError(err: unknown): boolean {
-  return MESSAGE_HAS_NO_TEXT_RE.test(formatErrorMessage(err));
 }
 
 export function isTelegramMessageDeleteNoopError(err: unknown): boolean {

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -4,7 +4,12 @@ import { resolveTelegramMessageThreadSpec } from "./bot/helpers.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
-import { isRecoverableTelegramNetworkError, isTelegramServerError } from "./network-errors.js";
+import {
+  isRecoverableTelegramNetworkError,
+  isTelegramMessageHasNoTextError,
+  isTelegramMessageNotModifiedError,
+  isTelegramServerError,
+} from "./network-errors.js";
 import {
   recordOutboundMessageForPromptContext,
   type TelegramOutboundPromptContextMessage,
@@ -12,8 +17,6 @@ import {
 import { buildTelegramRichMarkdownPlan } from "./rich-message.js";
 import { withTelegramPlainFallback } from "./rich-plain-fallback.js";
 import {
-  isTelegramMessageHasNoTextError,
-  isTelegramMessageNotModifiedError,
   resolveTelegramApiContext,
   sendLogger,
   withTelegramApiContextLease,


### PR DESCRIPTION
## What Problem This Solves

Telegram edit error classifiers were duplicated in `send-context.ts` even though `network-errors.ts` already owns the same regexes and exported classifiers. Keeping both copies creates a drift risk for edit no-op and caption-fallback handling.

## Why This Change Was Made

- Removes the duplicate regexes and classifier exports from `extensions/telegram/src/send-context.ts`.
- Imports the existing canonical classifiers from `extensions/telegram/src/network-errors.ts` in `send-edit.ts`.
- Leaves `network-errors.ts` and callback string checks unchanged.
- Preserves the exact classifier behavior and creates no new import edge because `send-edit.ts` already imports `network-errors.ts`.

Production LOC: `+6/-14` (net `-8`).
Test LOC: `+0/-0`.

## User Impact

No user-visible behavior change. This is an import-only consolidation around the existing Telegram network-error owner.

No changelog entry is needed for this mechanical refactor.

## Evidence

- Before the mechanical refresh, `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/transport-payload.test.ts` passed 3 files and 356 tests at head `9a523e27422704684f39141fb6025a8a14a2752e`.
- Before the mechanical refresh, `pnpm test:extension telegram` passed all 222 Telegram test files at head `9a523e27422704684f39141fb6025a8a14a2752e`.
- On exact rebased head `1ee2fad8c3ff87207784c57e97fa4598c2fa4037`, the focused local suites were blocked before collection by the shared dependency tree missing `mdast-util-from-markdown`; zero tests executed.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- Changed-file dry-run selected the `extensions` and `extensionTests` lanes for the two production files.
- On exact rebased head `1ee2fad8c3ff87207784c57e97fa4598c2fa4037`, changed-file static and formatting checks passed, while the plugin test was blocked before collection by the shared dependency tree missing `@noble/hashes/sha2.js`.
- Exact-head CI and native Testbox validation remain required before landing.
- `git diff --check`: passed.
- Autoreview: patch correct `0.98`, no accepted/actionable findings.
- Test audit: no new test was added because existing send, draft-stream, and transport-payload coverage exercises both classifiers; an additional import-location test would be implementation-coupled.
- PR #131347 also touches `send-edit.ts`, but its hunk changes rich-media edit limits lower in the module. This PR changes only classifier imports, so there is no hunk overlap; merge order may require only mechanical rebase sequencing.
- Codex hard gate: personally inspected upstream `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`. Those sections cover CLI dispatch/completion setup and do not affect this Telegram import-only refactor.
- No Crabbox or live Telegram proof: the canonical regex bytes and all call sites are unchanged, with no transport, streaming, topic, callback, authentication, or reply behavior change.
