### PR TITLE
fix(test): prevent canceled fixtures from outliving test cleanup

### DIFF
--- a/test/helpers/vitest-shutdown-command.ts
+++ b/test/helpers/vitest-shutdown-command.ts
@@ -2,13 +2,14 @@ import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
 import { createBoundedChildOutput } from "./bounded-child-output.ts";
 
 /** Capture fixture diagnostics without losing the managed cancellation outcome. */
-export async function runVitestShutdownCommand(
-  options: Pick<
-    Parameters<typeof runManagedCommand>[0],
-    "args" | "cwd" | "env" | "timeoutMs" | "onReady"
-  >,
-) {
-  const maxBytes = 2 * 1024 * 1024;
+export async function runVitestShutdownCommand({
+  maxBytes = 2 * 1024 * 1024,
+  signal,
+  ...options
+}: Pick<
+  Parameters<typeof runManagedCommand>[0],
+  "args" | "cwd" | "env" | "timeoutMs" | "onReady" | "signal"
+> & { maxBytes?: number }) {
   const stdout = createBoundedChildOutput(maxBytes);
   const stderr = createBoundedChildOutput(maxBytes);
   const controller = new AbortController();
@@ -20,7 +21,7 @@ export async function runVitestShutdownCommand(
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
       requireProcessTreeExit: process.platform !== "win32",
-      signal: controller.signal,
+      signal: signal ? AbortSignal.any([signal, controller.signal]) : controller.signal,
       onReady(child) {
         for (const [pipe, output] of [
           [child.stdout, stdout],
@@ -31,9 +32,10 @@ export async function runVitestShutdownCommand(
             output.append(chunk);
             bytes += chunk.byteLength;
             if (bytes > maxBytes && !overflow) {
-              overflow = Object.assign(new Error("Shutdown fixture output exceeded 2 MiB"), {
-                code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
-              });
+              overflow = Object.assign(
+                new Error(`Shutdown fixture output exceeded ${maxBytes} bytes`),
+                { code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" },
+              );
               controller.abort();
             }
           });

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -1,18 +1,16 @@
 // Regression coverage for the non-isolated runner's cross-file cleanup. Keep
 // every producer/observer pair in one child run: the contract is file-to-file
 // cleanup, not five independent Vitest process boots.
-import { execFile, type ChildProcess, type ExecFileException } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
-import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
 import { expect, it } from "vitest";
 import type { JsonTestResults } from "vitest/node";
 import type { VitestReportCapture } from "../scripts/lib/vitest-report-capture.mts";
+import { runVitestShutdownCommand } from "./helpers/vitest-shutdown-command.ts";
 import { testApiLifecycleFixtureFiles } from "./non-isolated-runner.test-api-fixtures.ts";
 
-const execFileAsync = promisify(execFile);
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const require = createRequire(import.meta.url);
 
@@ -392,7 +390,7 @@ it("reloads the redirected mock after a real import", () => {
 }
 
 type ChildCompletion = Pick<ChildProcess, "exitCode" | "signalCode" | "killed"> & {
-  rejection: unknown;
+  code: number;
   output: string;
 };
 
@@ -400,11 +398,10 @@ async function assertCompletion(
   child: ChildCompletion,
   expected: { root: string; pid: number | undefined; files: string[]; reportPath: string },
 ) {
+  expect(child.code).toBe(1);
   expect(child.exitCode).toBe(1);
   expect(child.signalCode).toBeNull();
   expect(child.killed).toBe(false);
-  expect(child.rejection).toBeInstanceOf(Error);
-  expect(child.rejection).toMatchObject({ code: 1, signal: null, killed: false });
 
   // JSON success/suite totals are not completion evidence: skips look like passed
   // files, and unhandled errors or process teardown timeouts need native hooks.
@@ -466,8 +463,11 @@ async function assertCompletion(
   expect(child.output).not.toContain("first-file");
 }
 
-it("cleans every shared runner surface between files", async () => {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-non-isolated-runner-"));
+async function verifyRunnerCleanup(signal: AbortSignal) {
+  // Outside the enclosing Vitest TMPDIR: outer cleanup must not erase unjoined writers.
+  const fixtureRoots = path.join(repoRoot, ".artifacts", "non-isolated-runner");
+  await fs.mkdir(fixtureRoots, { recursive: true });
+  const root = await fs.mkdtemp(path.join(fixtureRoots, "run-"));
   try {
     const vitestPackageDir = path.dirname(require.resolve("vitest/package.json"));
     await fs.symlink(path.dirname(vitestPackageDir), path.join(root, "node_modules"), "junction");
@@ -510,9 +510,9 @@ export default defineConfig({
     );
 
     const reportPath = path.join(root, "report.json");
-    const run = execFileAsync(
-      process.execPath,
-      [
+    let child!: ChildProcess;
+    const result = await runVitestShutdownCommand({
+      args: [
         path.join(vitestPackageDir, "vitest.mjs"),
         "run",
         "--root",
@@ -526,26 +526,25 @@ export default defineConfig({
         `--reporter=${path.join(repoRoot, "scripts/lib/vitest-report-capture.mts")}`,
         `--outputFile.json=${reportPath}`,
       ],
-      { cwd: repoRoot, env: childEnv(), maxBuffer: 16 * 1024 * 1024 },
-    );
-    let rejection: unknown;
-    const result = await run.catch(
-      (error: ExecFileException & { stdout?: string; stderr?: string }) => {
-        rejection = error;
-        return error;
+      cwd: repoRoot,
+      env: childEnv(),
+      maxBytes: 16 * 1024 * 1024,
+      signal,
+      onReady(owned) {
+        child = owned;
       },
-    );
+    });
     const completion: ChildCompletion = {
-      exitCode: run.child.exitCode,
-      signalCode: run.child.signalCode,
-      killed: run.child.killed,
-      rejection,
-      output: `${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+      exitCode: child.exitCode,
+      signalCode: child.signalCode,
+      killed: child.killed,
+      code: result.code,
+      output: `${result.stdout}\n${result.stderr}`,
     };
     const canonicalRoot = (await fs.realpath(root)).replaceAll(path.sep, "/");
     const expected = {
       root: canonicalRoot,
-      pid: run.child.pid,
+      pid: child.pid,
       files: Object.keys(files)
         .filter((name) => name.endsWith(".test.ts"))
         .map((name) => `${canonicalRoot}/${name}`)
@@ -602,7 +601,7 @@ export default defineConfig({
     for (const patch of [
       { ended: undefined },
       { processTimedOut: true },
-      { pid: run.child.pid! + 1 },
+      { pid: child.pid! + 1 },
       { root: "other" },
     ]) {
       faults.push([
@@ -625,34 +624,18 @@ export default defineConfig({
       ]);
     }
     for (const patch of [
+      { code: 0 },
+      { code: 2 },
+      { code: 143 },
       { exitCode: 0 },
       { exitCode: 2 },
       { exitCode: null },
       { signalCode: "SIGTERM" },
       { killed: true },
-      { rejection: undefined },
     ] satisfies Partial<ChildCompletion>[]) {
       faults.push([
         `abnormal child completion: ${JSON.stringify(patch)}`,
         ({ child }) => Object.assign(child, patch),
-      ]);
-    }
-    for (const patch of [
-      { code: "ENOENT" },
-      { code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" },
-      { code: 2 },
-      { signal: "SIGTERM" },
-      { killed: true },
-    ]) {
-      faults.push([
-        `abnormal exec rejection: ${JSON.stringify(patch)}`,
-        ({ child }) => {
-          child.rejection = Object.assign(
-            new Error("synthetic exec rejection"),
-            { code: 1, signal: null, killed: false },
-            patch,
-          );
-        },
       ]);
     }
     const nativeReport: JsonTestResults = JSON.parse(originals[0]!);
@@ -720,7 +703,20 @@ export default defineConfig({
       await fs.writeFile(capturePath, JSON.stringify(replay.capture));
       await expect(assertCompletion(replay.child, expected), label).rejects.toThrow();
     }
-  } finally {
+    // Release only after the managed child/group/output join and native proof.
     await fs.rm(root, { recursive: true, force: true });
+  } catch (error) {
+    if (error instanceof Error) {
+      error.message += `; retained fixture ${root}`;
+    }
+    throw error;
   }
+}
+
+it("cleans every shared runner surface between files", (context) => {
+  const run = verifyRunnerCleanup(context.signal);
+  // Timeout rejects Vitest's wrapper before this promise settles. Join it again
+  // at completion so cancellation and fixture writes cannot cross file cleanup.
+  context.onTestFinished(() => run);
+  return run;
 });

--- a/test/scripts/vitest-fork-shutdown.test.ts
+++ b/test/scripts/vitest-fork-shutdown.test.ts
@@ -2,7 +2,8 @@ import { execFileSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { expect, it } from "vitest";
+import { expect, it, type TestContext } from "vitest";
+import { inspectManagedProcessGroup } from "../../scripts/lib/managed-child-process.mts";
 import { isProcessAlive, waitForDead, waitForFile } from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 import { runVitestShutdownCommand } from "../helpers/vitest-shutdown-command.js";
@@ -13,6 +14,16 @@ const fixtureRoots = fileURLToPath(
   new URL("../../.artifacts/vitest-fork-shutdown/", import.meta.url),
 );
 fs.mkdirSync(fixtureRoots, { recursive: true });
+
+function runJoinedShutdownTest(context: TestContext, body: () => Promise<void>) {
+  // Register before the body starts: outer cancellation must join every continuation and finally.
+  const run = Promise.resolve().then(() => {
+    context.signal.throwIfAborted();
+    return body();
+  });
+  context.onTestFinished(() => run);
+  return run;
+}
 
 function expectReleasedNamespace(root: string) {
   if (process.platform !== "win32") {
@@ -27,13 +38,13 @@ async function runFixture(
   root: string,
   options: { scenario: string; setup: string; fail: boolean },
   nodeArgs: string[] = [],
-  onReady?: (child: ChildProcess) => void,
+  commandOptions: Pick<Parameters<typeof runVitestShutdownCommand>[0], "onReady" | "signal"> = {},
 ) {
   try {
     const result = await runVitestShutdownCommand({
       args: [...nodeArgs, fixture, root, JSON.stringify(options)],
       timeoutMs: 20_000,
-      onReady,
+      ...commandOptions,
     });
     if (result.code !== 0) {
       throw Object.assign(new Error(`Shutdown fixture exited with code ${result.code}`), result);
@@ -49,7 +60,7 @@ async function runFixture(
   }
 }
 
-it.each([
+it.for([
   { scenario: "slow-exit", setup: "shared", fail: false },
   { scenario: "slow-exit", setup: "env", fail: true },
   { scenario: "natural-exit", setup: "raw", fail: false },
@@ -62,184 +73,375 @@ it.each([
   { scenario: "hung-exit", setup: "shared", fail: false },
   { scenario: "bad-exit", setup: "shared", fail: false },
   { scenario: "forced", setup: "raw", fail: false },
-])("joins $scenario shutdown with $setup setup (test failure: $fail)", async (options) => {
-  const tempDirs = createTempDirTracker();
-  const root = tempDirs.make("vitest-fork-shutdown-", fixtureRoots);
-  const { stdout } = await runFixture(root, options);
-  const result = JSON.parse(stdout);
-  console.log(JSON.stringify({ root, options, ...result, output: undefined }));
-  const { scenario, setup, fail } = options;
-  if (scenario === "forced") {
-    // Node uses TerminateProcess for TERM on Windows; POSIX exercises escalation.
-    expect(result.signal).toBe(process.platform === "win32" ? "SIGTERM" : "SIGKILL");
-    expect(result.stopped).toBe(true);
-    expect(isProcessAlive(result.workerPid)).toBe(false);
+])("joins $scenario shutdown with $setup setup (test failure: $fail)", (options, context) =>
+  runJoinedShutdownTest(context, async () => {
+    const tempDirs = createTempDirTracker();
+    const root = tempDirs.make("vitest-fork-shutdown-", fixtureRoots);
+    const { stdout } = await runFixture(root, options, [], { signal: context.signal });
+    const result = JSON.parse(stdout);
+    console.log(JSON.stringify({ root, options, ...result, output: undefined }));
+    const { scenario, setup, fail } = options;
+    if (scenario === "forced") {
+      // Node uses TerminateProcess for TERM on Windows; POSIX exercises escalation.
+      expect(result.signal).toBe(process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+      expect(result.stopped).toBe(true);
+      expect(isProcessAlive(result.workerPid)).toBe(false);
+      expectReleasedNamespace(root);
+      tempDirs.cleanup();
+      return;
+    }
+    const brokenShutdown = scenario.startsWith("hung-") || scenario === "bad-exit";
+    expect(result.code, result.output).toBe(fail || brokenShutdown ? 1 : 0);
+    if (fail) {
+      expect(result.output).toContain("intentional fixture failure");
+    }
+    expect(result.workerStopped).toBe(true);
+    if (scenario === "threads") {
+      expect(result.worker.threadId).toBeGreaterThan(0);
+    } else {
+      expect(result.worker.threadId).toBe(0);
+    }
+    if (setup !== "raw") {
+      // Windows has no wrapper-owned group cleanup after a forced termination.
+      // Its unfinished home is released after this test verifies the worker stopped.
+      expect(result.homeRemoved).toBe(
+        !(process.platform === "win32" && scenario === "hung-cleanup"),
+      );
+    }
+    expect(result.callerPreserved).toBe(true);
+    if (scenario.startsWith("hung-")) {
+      // Advance the real stop deadline only after the worker reaches the hung boundary.
+      expect(result.events).toContainEqual({ event: "deadline", delay: 60_000 });
+      expect(result.output).toContain("Timeout waiting for worker to respond");
+      expect(result.events.some((event: { event: string }) => event.event === "terminate")).toBe(
+        true,
+      );
+    } else if (scenario === "bad-exit") {
+      expect(result.output).toContain("Worker exited during graceful shutdown");
+    } else if (scenario === "custom") {
+      expect(result.output).toContain("1 passed");
+      expect(result.events).toContainEqual({ event: "stopped-consumed" });
+      expect(result.events).toContainEqual({ event: "parent-stop" });
+      expect(result.events.some((event: { event: string }) => event.event === "deadline")).toBe(
+        false,
+      );
+      expect(result.events).toContainEqual({ event: "terminate", signal: "SIGTERM" });
+    } else if (scenario !== "plain") {
+      expect(result.profiles.cpu, result.output).toBeGreaterThan(0);
+      expect(result.profiles.heap, result.output).toBeGreaterThan(0);
+      expect(result.events.some((event: { event: string }) => event.event === "terminate")).toBe(
+        false,
+      );
+      if (scenario === "slow-exit") {
+        expect(result.events).toContainEqual({ event: "home-removed" });
+      }
+    }
+    // Only release after execution and shutdown assertions certify completion.
     expectReleasedNamespace(root);
     tempDirs.cleanup();
-    return;
-  }
-  const brokenShutdown = scenario.startsWith("hung-") || scenario === "bad-exit";
-  expect(result.code, result.output).toBe(fail || brokenShutdown ? 1 : 0);
-  if (fail) {
-    expect(result.output).toContain("intentional fixture failure");
-  }
-  expect(result.workerStopped).toBe(true);
-  if (scenario === "threads") {
-    expect(result.worker.threadId).toBeGreaterThan(0);
-  } else {
-    expect(result.worker.threadId).toBe(0);
-  }
-  if (setup !== "raw") {
-    // Windows has no wrapper-owned group cleanup after a forced termination.
-    // Its unfinished home is released after this test verifies the worker stopped.
-    expect(result.homeRemoved).toBe(!(process.platform === "win32" && scenario === "hung-cleanup"));
-  }
-  expect(result.callerPreserved).toBe(true);
-  if (scenario.startsWith("hung-")) {
-    // Advance the real stop deadline only after the worker reaches the hung boundary.
-    expect(result.events).toContainEqual({ event: "deadline", delay: 60_000 });
-    expect(result.output).toContain("Timeout waiting for worker to respond");
-    expect(result.events.some((event: { event: string }) => event.event === "terminate")).toBe(
-      true,
-    );
-  } else if (scenario === "bad-exit") {
-    expect(result.output).toContain("Worker exited during graceful shutdown");
-  } else if (scenario === "custom") {
-    expect(result.output).toContain("1 passed");
-    expect(result.events).toContainEqual({ event: "stopped-consumed" });
-    expect(result.events).toContainEqual({ event: "parent-stop" });
-    expect(result.events.some((event: { event: string }) => event.event === "deadline")).toBe(
-      false,
-    );
-    expect(result.events).toContainEqual({ event: "terminate", signal: "SIGTERM" });
-  } else if (scenario !== "plain") {
-    expect(result.profiles.cpu, result.output).toBeGreaterThan(0);
-    expect(result.profiles.heap, result.output).toBeGreaterThan(0);
-    expect(result.events.some((event: { event: string }) => event.event === "terminate")).toBe(
-      false,
-    );
-    if (scenario === "slow-exit") {
-      expect(result.events).toContainEqual({ event: "home-removed" });
-    }
-  }
-  // Only release after execution and shutdown assertions certify completion.
-  expectReleasedNamespace(root);
-  tempDirs.cleanup();
-});
+  }),
+);
 
-it.runIf(process.platform !== "win32").each(["signal", "timeout"])(
+it.for([
+  { maxBytes: undefined, limit: 2 * 1024 * 1024 },
+  { maxBytes: 16 * 1024 * 1024, limit: 16 * 1024 * 1024 },
+])("enforces the $limit byte output limit without accepting truncation", (options, context) =>
+  runJoinedShutdownTest(context, async () => {
+    for (const stream of ["stdout", "stderr"] as const) {
+      for (const excess of [0, 1]) {
+        context.signal.throwIfAborted();
+        let child!: ChildProcess;
+        // Overflow must cancel a live writer; taskkill cannot certify a vanished leader.
+        const keepAlive = excess ? "setInterval(() => {}, 1000);" : "";
+        const command = runVitestShutdownCommand({
+          args: [
+            "-e",
+            `${keepAlive}process.${stream}.write(Buffer.alloc(${options.limit + excess}, 120))`,
+          ],
+          maxBytes: options.maxBytes,
+          signal: context.signal,
+          onReady(owned) {
+            child = owned;
+          },
+        });
+        const proof = excess
+          ? expect(command).rejects.toMatchObject({ code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" })
+          : command.then((result) => {
+              expect(result.code).toBe(0);
+              expect(Buffer.byteLength(result[stream], "utf8")).toBe(options.limit);
+            });
+        await proof;
+        expect(child.stdout?.closed).toBe(true);
+        expect(child.stderr?.closed).toBe(true);
+      }
+    }
+  }),
+);
+
+it.runIf(process.platform !== "win32").for(["signal", "timeout"])(
   "rejects fixture cancellation by %s and joins descendants",
-  async (mode) => {
-    const ownedDirs = createTempDirTracker();
-    const root = ownedDirs.make("vitest-fork-cancellation-", fixtureRoots);
-    const control = new URL("../fixtures/vitest-shutdown-cancellation.mjs", import.meta.url);
-    control.searchParams.set("root", root);
-    let watcher: fs.FSWatcher;
-    const ready = new Promise<{ shim: number; worker: number }>((resolve) => {
-      watcher = fs.watch(root, () => {
-        if (!fs.existsSync(path.join(root, "worker.pid"))) {
-          return;
-        }
-        resolve({
-          shim: Number(fs.readFileSync(path.join(root, "shim.pid"), "utf8")),
-          worker: Number(fs.readFileSync(path.join(root, "worker.pid"), "utf8")),
+  (mode, context) =>
+    runJoinedShutdownTest(context, async () => {
+      const ownedDirs = createTempDirTracker();
+      const root = ownedDirs.make("vitest-fork-cancellation-", fixtureRoots);
+      const control = new URL("../fixtures/vitest-shutdown-cancellation.mjs", import.meta.url);
+      control.searchParams.set("root", root);
+      // Subscribe before launch; the producer publishes worker.pid atomically.
+      const watcher = fs.watch(root);
+      let child!: ChildProcess;
+      const invocation = runFixture(
+        root,
+        { scenario: "slow-exit", setup: "shared", fail: false },
+        ["--import", control.href],
+        {
+          onReady(owned) {
+            child = owned;
+          },
+          signal: context.signal,
+        },
+      );
+      const outcome = invocation.then(
+        (result) => ({ result, error: undefined }),
+        (error: unknown) => ({ result: undefined, error }),
+      );
+      let cancelReady!: () => void;
+      const ready = new Promise<{ shim: number; worker: number }>((resolve, reject) => {
+        const readReady = () => {
+          try {
+            if (fs.existsSync(path.join(root, "worker.pid"))) {
+              resolve({
+                shim: Number(fs.readFileSync(path.join(root, "shim.pid"), "utf8")),
+                worker: Number(fs.readFileSync(path.join(root, "worker.pid"), "utf8")),
+              });
+            }
+          } catch (error) {
+            reject(error);
+          }
+        };
+        cancelReady = () => reject(context.signal.reason);
+        watcher.on("change", readReady).once("error", reject);
+        context.signal.addEventListener("abort", cancelReady, { once: true });
+        if (context.signal.aborted) cancelReady();
+        else readReady();
+        void outcome.then((result) => {
+          reject(
+            new Error(`Fixture exited before worker receipt: ${JSON.stringify(result)}`, {
+              cause: result.error,
+            }),
+          );
         });
       });
-    });
-    let child!: ChildProcess;
-    const invocation = runFixture(
-      root,
-      { scenario: "slow-exit", setup: "shared", fail: false },
-      ["--import", control.href],
-      (owned) => {
-        child = owned;
-      },
-    );
-    const outcome = invocation.then(
-      (result) => ({ result, error: undefined }),
-      (error: unknown) => ({ result: undefined, error }),
-    );
-    const pids: number[] = [];
-    try {
-      const { worker, shim } = await Promise.race([
-        ready,
-        outcome.then((result) => {
-          throw new Error(`Fixture exited before worker receipt: ${JSON.stringify(result)}`, {
-            cause: result.error,
+      const pids: number[] = [];
+      try {
+        const { worker, shim } = await ready;
+        context.signal.throwIfAborted();
+        pids.push(shim, worker);
+        process.kill(shim, "SIGSTOP");
+        for (const pid of pids) {
+          await expect
+            .poll(() =>
+              execFileSync("ps", ["-o", "stat=", "-p", String(pid)], {
+                encoding: "utf8",
+                timeout: 1_000,
+              }).trim(),
+            )
+            .toMatch(/^T/);
+        }
+        const rows = execFileSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+          encoding: "utf8",
+          timeout: 1_000,
+        })
+          .trim()
+          .split("\n")
+          .map((row) => {
+            const [pid, ppid, pgid] = row.trim().split(/\s+/).map(Number);
+            return { pid: pid!, ppid: ppid!, pgid: pgid! };
           });
-        }),
-      ]);
-      pids.push(shim, worker);
-      process.kill(shim, "SIGSTOP");
-      for (const pid of pids) {
-        await expect
-          .poll(() =>
-            execFileSync("ps", ["-o", "stat=", "-p", String(pid)], {
-              encoding: "utf8",
-              timeout: 1_000,
-            }).trim(),
-          )
-          .toMatch(/^T/);
-      }
-      const rows = execFileSync("ps", ["-axo", "pid=,ppid=,pgid="], {
-        encoding: "utf8",
-        timeout: 1_000,
-      })
-        .trim()
-        .split("\n")
-        .map((row) => {
-          const [pid, ppid, pgid] = row.trim().split(/\s+/).map(Number);
-          return { pid: pid!, ppid: ppid!, pgid: pgid! };
-        });
-      const owned = new Set([child.pid!]);
-      for (let previous = 0; previous !== owned.size;) {
-        previous = owned.size;
-        for (const row of rows) {
-          if (owned.has(row.ppid)) {
-            owned.add(row.pid);
+        const owned = new Set([child.pid!]);
+        for (let previous = 0; previous !== owned.size;) {
+          previous = owned.size;
+          for (const row of rows) {
+            if (owned.has(row.ppid)) {
+              owned.add(row.pid);
+            }
           }
         }
-      }
-      expect(owned.has(shim) && owned.has(worker)).toBe(true);
-      pids.splice(0, pids.length, ...owned);
-      if (mode === "signal") {
-        child.kill("SIGTERM");
-      }
-      const result = await outcome;
-      await waitForFile(path.join(root, "term-received"), 1_000);
-      console.log(
-        JSON.stringify({
-          mode,
-          root,
-          fixture: child.pid,
-          pids,
-          processes: rows.filter((row) => owned.has(row.pid)),
-          exitCode: child.exitCode,
-          signalCode: child.signalCode,
-          ...result,
-        }),
-      );
-      expect(result.error).toMatchObject({ code: mode === "timeout" ? "ETIMEDOUT" : 143 });
-      expect(result.error).toMatchObject({
-        stderr: expect.stringContaining("exit code 143"),
-      });
-      expect(pids.filter(isProcessAlive)).toEqual([]);
-      expectReleasedNamespace(root);
-      ownedDirs.cleanup();
-    } finally {
-      watcher!.close();
-      for (const pid of pids) {
-        if (isProcessAlive(pid)) {
-          process.kill(pid, "SIGCONT");
+        expect(owned.has(shim) && owned.has(worker)).toBe(true);
+        pids.splice(0, pids.length, ...owned);
+        if (mode === "signal") {
+          child.kill("SIGTERM");
+        }
+        const result = await outcome;
+        await waitForFile(path.join(root, "term-received"), 1_000);
+        console.log(
+          JSON.stringify({
+            mode,
+            root,
+            fixture: child.pid,
+            pids,
+            processes: rows.filter((row) => owned.has(row.pid)),
+            exitCode: child.exitCode,
+            signalCode: child.signalCode,
+            ...result,
+          }),
+        );
+        expect(result.error).toMatchObject({
+          code: mode === "timeout" ? "ETIMEDOUT" : 143,
+        });
+        expect(result.error).toMatchObject({
+          stderr: expect.stringContaining("exit code 143"),
+        });
+        expect(pids.filter(isProcessAlive)).toEqual([]);
+        expect(child.stdout?.closed).toBe(true);
+        expect(child.stderr?.closed).toBe(true);
+        expectReleasedNamespace(root);
+        ownedDirs.cleanup();
+      } finally {
+        context.signal.removeEventListener("abort", cancelReady);
+        watcher.close();
+        watcher.removeAllListeners();
+        for (const pid of pids) {
+          if (isProcessAlive(pid)) {
+            process.kill(pid, "SIGCONT");
+          }
+        }
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill("SIGTERM");
+        }
+        await outcome;
+        for (const pid of pids) {
+          await waitForDead(pid, 5_000);
         }
       }
-      if (child.exitCode === null && child.signalCode === null) {
-        child.kill("SIGTERM");
+    }),
+);
+
+it.runIf(process.platform !== "win32")(
+  "rejects fixture cancellation by caller signal and joins descendants",
+  (context) =>
+    runJoinedShutdownTest(context, async () => {
+      const ownedDirs = createTempDirTracker();
+      const root = ownedDirs.make("managed-caller-signal-", fixtureRoots);
+      const descendantPidPath = path.join(root, "descendant.pid");
+      // Reuse the managed-owner tests' TERM-resistant tree and atomic ready PID.
+      // This proves the shared helper boundary, not cold Vitest initialization.
+      const descendantSource = `
+const fs = require("node:fs");
+process.on("SIGTERM", () => {
+  process.stdout.write("descendant-out\\n");
+  process.stderr.write("descendant-err\\n");
+});
+setInterval(() => {}, 1000);
+fs.writeFileSync(process.argv[1] + ".tmp", String(process.pid));
+fs.renameSync(process.argv[1] + ".tmp", process.argv[1]);
+`;
+      const controller = new AbortController();
+      // Watch before launch; the existing command deadline also bounds readiness.
+      const watcher = fs.watch(root);
+      let child!: ChildProcess;
+      const invocation = runVitestShutdownCommand({
+        args: [
+          "-e",
+          `
+const { spawn } = require("node:child_process");
+process.on("SIGTERM", () => {
+  process.stdout.write("leader-out\\n");
+  process.stderr.write("leader-err\\n");
+});
+setInterval(() => {}, 1000);
+spawn(process.execPath, ["-e", ${JSON.stringify(descendantSource)}, process.argv[1]], {
+  stdio: ["ignore", "inherit", "inherit"],
+});
+`,
+          descendantPidPath,
+        ],
+        timeoutMs: 20_000,
+        signal: AbortSignal.any([context.signal, controller.signal]),
+        onReady(owned) {
+          child = owned;
+        },
+      });
+      const outcome = invocation.then(
+        (result) => ({ result, error: undefined }),
+        (error: unknown) => ({ result: undefined, error }),
+      );
+      let cancelReady!: () => void;
+      const ready = new Promise<number>((resolve, reject) => {
+        const readReady = () => {
+          try {
+            if (fs.existsSync(descendantPidPath)) {
+              const pid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+              if (Number.isSafeInteger(pid) && pid > 0) resolve(pid);
+            }
+          } catch (error) {
+            reject(error);
+          }
+        };
+        cancelReady = () => reject(context.signal.reason);
+        watcher.on("change", readReady).once("error", reject);
+        context.signal.addEventListener("abort", cancelReady, { once: true });
+        if (context.signal.aborted) cancelReady();
+        else readReady();
+        void outcome.then((result) => {
+          reject(result.error ?? new Error("Fixture exited before descendant PID receipt"));
+        });
+      });
+      try {
+        const descendantPid = await ready;
+        context.signal.throwIfAborted();
+        const childPid = child.pid!;
+        const processes = execFileSync(
+          "ps",
+          ["-p", `${childPid},${descendantPid}`, "-o", "pid=,ppid=,pgid="],
+          { encoding: "utf8", timeout: 1_000 },
+        )
+          .trim()
+          .split("\n")
+          .map((row) => {
+            const [pid, ppid, pgid] = row.trim().split(/\s+/).map(Number);
+            return { pid, ppid, pgid };
+          });
+        expect(processes).toEqual(
+          expect.arrayContaining([
+            { pid: childPid, ppid: process.pid, pgid: childPid },
+            { pid: descendantPid, ppid: childPid, pgid: childPid },
+          ]),
+        );
+        expect([childPid, descendantPid].every(isProcessAlive)).toBe(true);
+        expect(inspectManagedProcessGroup(child, { errorPolicy: "indeterminate" })).toBe("live");
+
+        controller.abort();
+        const result = await outcome;
+        expect(result.error).toMatchObject({ code: "ABORT_ERR" });
+        for (const role of ["leader", "descendant"]) {
+          expect(result.error).toMatchObject({
+            stdout: expect.stringContaining(`${role}-out\n`),
+            stderr: expect.stringContaining(`${role}-err\n`),
+          });
+        }
+        expect(child.exitCode).toBeNull();
+        expect(child.signalCode).toBe("SIGKILL");
+        expect([childPid, descendantPid].filter(isProcessAlive)).toEqual([]);
+        expect(inspectManagedProcessGroup(child, { errorPolicy: "indeterminate" })).toBe("dead");
+        expect(child.stdout?.closed).toBe(true);
+        expect(child.stderr?.closed).toBe(true);
+        console.log(
+          JSON.stringify({
+            root,
+            childPid,
+            descendantPid,
+            processes,
+            signal: child.signalCode,
+            ...result,
+          }),
+        );
+      } finally {
+        context.signal.removeEventListener("abort", cancelReady);
+        watcher.close();
+        watcher.removeAllListeners();
+        controller.abort();
+        expect((await outcome).error).toMatchObject({ code: "ABORT_ERR" });
       }
-      await outcome;
-      for (const pid of pids) {
-        await waitForDead(pid, 5_000);
-      }
-    }
-  },
+      ownedDirs.cleanup();
+    }),
 );


### PR DESCRIPTION
Related: #132949 — preserve shutdown fixture cancellation outcomes; #133717 — require complete non-isolated runner evidence. Both are already merged; this addresses the remaining outer-test cancellation lifetime gap.

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch. This is a maintainer-requested test-support repair, not an application behavior change.

</details>

## What Problem This Solves

Resolves a problem where developers canceling or timing out runner regression tests could leave fixture processes, readiness polling, or callback cleanup active after Vitest considered the test finished. The non-isolated runner test could also remove its temporary evidence while a nested child was still writing.

The existing managed process owner already handles child/group/output completion. The missing boundary was the test callback's lifetime: forwarding a signal alone does not make Vitest await the suspended callback or its `finally` block.

## Why This Change Was Made

Reuse the existing managed-command and bounded-output owners rather than introduce another supervisor. The shared capture helper composes caller and overflow cancellation; the full runner test joins its entire fixture promise and retains failed fixtures outside the enclosing temporary namespace. Every shutdown subprocess callback now registers one whole-body completion join before starting, including asynchronous cleanup. Atomic-PID readiness closes on cancellation or command completion, and the output loop stops before issuing another probe after cancellation.

Exact-limit output probes still exit naturally; excess-output probes establish a keepalive before writing so cancellation owns termination. Cleanup uncertainty remains primary. The full runner keeps its existing 16 MiB cap and 120-second outer test deadline, with no new child timeout. Shutdown fixtures retain their 20-second operation limit and default 2 MiB cap. No timeout increase, dependency change, production seam, or application/runtime change is included.

## User Impact

No end-user behavior change. Maintainers get regression tests whose processes, readiness resources, and cleanup finish before file teardown, while failed fixture evidence remains available. The original twelve shutdown scenarios and the non-isolated runner's native completion and fault-replay assertions remain covered.

Production LOC: **+0/-0**. Tests and test support: **+426/-226 (net +200)**. The raw diff includes reindentation of existing callback bodies; new behavior is confined to test lifetime ownership, cancellation propagation, and its regression proof.

## Evidence

Proof used macOS, Node 24.20.0, and installed Vitest 4.1.11. The real managed owner and installed Vitest cancellation/finished-hook contracts were inspected directly. Fresh managed P0–P2 review and a separate ephemeral read-only native P0–P2 review completed with no actionable findings on the complete patch.

**Normal regression:** the full shutdown file passed **17/17, exit 0**, with zero failures or skips. All 28 recorded wrapper/worker/fixture process IDs were observed absent afterward. The normal run used no fault runner or leak detector. The reporter output-file location is omitted below:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_PARALLEL=1 \
  node scripts/run-vitest.mjs test/scripts/vitest-fork-shutdown.test.ts \
  --reporter=verbose --reporter=json --bail=1 --retry=0
```

**Matched cancellation diagnostics:** frozen before/fixed inputs differed only in the shutdown test bytes and used identical native Vitest cancellation, real child processes, and the built-in async-leak detector.

| Protected boundary | Before | Fixed |
| --- | --- | --- |
| Output loop after a witnessed 2 MiB + 1 byte overflow and actual outer cancellation | One further command attempt after cancellation | No further command attempt |
| Callback/readiness lifetime after cancellation of a witnessed stopped leader before PID publication | Seven callback/readiness resources at the native file boundary, including the referenced PID-poll timer | Zero reported callback/readiness leaks |

All four diagnostic runs intentionally canceled their selected test and therefore reported **17 skipped tests with native exit 0**. Those are not ordinary passing-test runs. The first diagnostic did **not** establish its originally predicted late-hook/unhandled-exception symptom; only the narrower post-abort advancement result is claimed. Two identical unresolved-promise observations in the unchanged managed owner appeared in both output-loop inputs and are neither new findings nor supporting proof.

**Historical unchanged-owner proof:** the exact original capture helper failed the real-tree caller-signal regression with `ETIMEDOUT` instead of `ABORT_ERR`; the current helper passed with child/group/output closure. Separately, the unchanged full non-isolated caller passed its outer test and executed assertions for 46 nested tests, 45 passed/1 skipped, the intentional child exit 1, native file/project/lifecycle completeness, and negative evidence replays. This was not a paired replay of the old caller's `execFile` path. Nested reports were replay-mutated and removed on successful cleanup; no separately retained raw 46-test report is claimed.

**Publication sanity:** targeted formatting and staged `git diff --check` passed. The supported warning-only temp-directory report ran with `--staged` and reported four migration advisories. Manual retention is intentional here: the joined lifetime owner, not unconditional `afterEach` deletion, releases successful fixtures and retains failed evidence. The report is not a cleanup data-flow verdict, and no baseline or warning suppression was added.

**Remaining validation and limits:** the canonical 15-command local changed-check plan was verified but **not executed because the host was CPU-saturated**; this is capacity-blocked, not a passing result or a waiver. The earlier committed-ref dry run did not cover unstaged additions. Required exact-head CI, final type/lint/check gates, and repository-native preparation must complete before any merge. There is no local Windows execution proof, no rerun of the original broader 39-file order, and no claim that the earlier cold-start delay or SIGTERM-before-worker-PID behavior is fixed. No package build was needed for this test-only change.
