### PR TITLE
feat(worktrees): raise managed checkout limit to 100

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -46,7 +46,7 @@ Each `git worktree add` checkout during creation or snapshot restore has a five-
 
 ## Capacity and disk space
 
-OpenClaw allows up to 30 live managed worktrees per state directory. Manual and protected worktrees count toward this limit. Creating or restoring a checkout at the limit reports how to free a slot; it never evicts another session as part of creation. Reusing an existing valid checkout does not require a new slot.
+OpenClaw allows up to 100 live managed worktrees per state directory. Manual and protected worktrees count toward this limit. Creating or restoring a checkout at the limit reports how to free a slot; it never evicts another session as part of creation. Reusing an existing valid checkout does not require a new slot.
 
 Before allocating a checkout, OpenClaw checks its destination, Git metadata, source checkout, and state volumes. It keeps 10% of each volume free, with a minimum reserve of 4 GiB and a maximum of 16 GiB, plus twice the estimated Git checkout and provisioned-file size. An executable setup script requires additional room equal to the larger of 4 GiB or the current source checkout footprint excluding Git metadata. Space is checked again before provisioning/setup and after setup. An unavailable capacity reading stops allocation with an actionable error.
 
@@ -124,7 +124,7 @@ OpenClaw applies these cleanup rules:
 
 - At run end, it removes a worktree only when `git status --porcelain` is empty and `git log HEAD --not --remotes --oneline` finds no unpushed commits. Otherwise it only releases the activity lock.
 - Startup and hourly cleanup snapshot and remove unlocked Workboard- and session-owned worktrees idle for more than 7 days, even when dirty. Session worktrees whose owner is archived or absent are eligible immediately. Failed owner lookups preserve the checkout.
-- Cleanup also removes the least recently active eligible run-owned worktrees above the default limit of 30. Manual worktrees are never automatically removed, and protected worktrees can keep the total above the limit until they are released or explicitly cleaned up.
+- Cleanup also removes the least recently active eligible run-owned worktrees above the default limit of 100. Manual worktrees are never automatically removed, and protected worktrees can keep the total above the limit until they are released or explicitly cleaned up.
 - Snapshot records remain restorable for 30 days. Cleanup then deletes the snapshot ref and registry row.
 - A live OpenClaw process lock and any foreign or unrecognized git worktree lock protect a worktree from garbage collection.
 

--- a/src/agents/worktrees/service.capacity.test.ts
+++ b/src/agents/worktrees/service.capacity.test.ts
@@ -126,8 +126,24 @@ describe("ManagedWorktreeService capacity", () => {
     expect(await git(repo, "branch", "--list", "openclaw/unknown-space")).toBe("");
   });
 
-  it("serializes distinct repositories competing for the thirtieth checkout", async () => {
-    await fill(29);
+  it.each(["create", "restore"])("allows %s above thirty live worktrees", async (operation) => {
+    const snapshot = await service.create({ repoRoot: repo, name: "archived", baseRef: "HEAD" });
+    await service.remove({ id: snapshot.id, reason: "archive" });
+    await fill(30);
+
+    const created =
+      operation === "restore"
+        ? await service.restore({ id: snapshot.id })
+        : await service.create({ repoRoot: repo, name: "next", baseRef: "HEAD" });
+
+    expect(
+      service.listRegistryRecords().filter((record) => record.removedAt === undefined),
+    ).toHaveLength(31);
+    expect(await fs.readFile(path.join(created.path, "README.md"), "utf8")).toBe("base\n");
+  });
+
+  it("serializes distinct repositories competing for the hundredth checkout", async () => {
+    await fill(99);
     const otherRepo = await initializeRepository(path.join(root, "other"));
     const otherService = new ManagedWorktreeService({ env });
     const outcomes = await Promise.allSettled([
@@ -138,13 +154,13 @@ describe("ManagedWorktreeService capacity", () => {
     expect(outcomes.filter((result) => result.status === "rejected")).toEqual([
       expect.objectContaining({
         reason: expect.objectContaining({
-          message: expect.stringMatching(/30.*archive|30.*remove/i),
+          message: expect.stringMatching(/100.*archive|100.*remove/i),
         }),
       }),
     ]);
     expect(
       service.listRegistryRecords().filter((record) => record.removedAt === undefined),
-    ).toHaveLength(30);
+    ).toHaveLength(100);
     expect(
       await fs.readFile(
         path.join(stateDir, "worktrees", "downstream-fixture", "kept-0", "README.md"),
@@ -162,10 +178,10 @@ describe("ManagedWorktreeService capacity", () => {
       ownerId: "agent:main:owned",
     };
     const created = await service.create(params);
-    await fill(29);
+    await fill(99);
     availableBytes = GiB;
     expect(await service.create(params)).toEqual(created);
-    expect(service.listRegistryRecords()).toHaveLength(30);
+    expect(service.listRegistryRecords()).toHaveLength(100);
   });
 
   it.each(["space", "count"])(
@@ -176,12 +192,12 @@ describe("ManagedWorktreeService capacity", () => {
       await service.remove({ id: created.id, reason: "archive" });
       const before = getRegistryWorktree(env, created.id);
       if (reason === "count") {
-        await fill(30);
+        await fill(100);
       } else {
         availableBytes = GiB;
       }
       await expect(service.restore({ id: created.id })).rejects.toThrow(
-        reason === "count" ? /30/ : /disk space/i,
+        reason === "count" ? /100/ : /disk space/i,
       );
       expect(getRegistryWorktree(env, created.id)).toEqual(before);
       await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });

--- a/src/agents/worktrees/service.gc.test.ts
+++ b/src/agents/worktrees/service.gc.test.ts
@@ -409,8 +409,8 @@ describe("ManagedWorktreeService garbage collection", () => {
     expect(getRegistryWorktree(env, created.id)?.removedAt).toBeUndefined();
   });
 
-  it("enforces thirty live checkouts by default without evicting manual work", async () => {
-    for (let index = 0; index < 29; index += 1) {
+  it("enforces one hundred live checkouts by default without evicting manual work", async () => {
+    for (let index = 0; index < 99; index += 1) {
       await materializeDownstreamFixture(`manual-${index}`);
     }
     const oldest = await materializeRunOwnedFixture("default-oldest", "session");
@@ -419,7 +419,7 @@ describe("ManagedWorktreeService garbage collection", () => {
     expect((await service.gc()).removed).toEqual([oldest.id]);
     expect(
       service.listRegistryRecords().filter((record) => record.removedAt === undefined),
-    ).toHaveLength(30);
+    ).toHaveLength(100);
     expect(getRegistryWorktree(env, newest.id)?.removedAt).toBeUndefined();
   });
 

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -154,7 +154,7 @@ type RemoveWorktreeParams = WorktreeMutationGuard & {
   claimToken?: string;
   runEndCleanup?: ManagedWorktreeRunEndCleanup;
 };
-const MAX_WORKTREES = 30;
+const MAX_WORKTREES = 100;
 
 /** A bounded default; manual and actively used worktrees remain protected. */
 export function resolveWorktreeCleanupLimits(): WorktreeCleanupLimits {

--- a/src/cli/worktrees-cli.test.ts
+++ b/src/cli/worktrees-cli.test.ts
@@ -42,7 +42,7 @@ describe("worktrees cli", () => {
     await program.parseAsync(["worktrees", "gc"], { from: "user" });
 
     expect(gc).toHaveBeenCalledWith({
-      limits: { maxCount: 30 },
+      limits: { maxCount: 100 },
       shouldProtectOwner: expect.any(Function),
       shouldRemoveOwner: expect.any(Function),
     });

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -420,7 +420,7 @@ describe("startGatewayMaintenanceTimers", () => {
     await Promise.resolve();
 
     expect(gc).toHaveBeenCalledWith({
-      limits: { maxCount: 30 },
+      limits: { maxCount: 100 },
       shouldProtectOwner: expect.any(Function),
       shouldRemoveOwner: expect.any(Function),
     });

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -216,7 +216,6 @@ export function startGatewayMaintenanceTimers(params: {
         // Chat runs avoid registry acquire/bump writes; recent session metadata substitutes for
         // worktree activity so idle GC cannot remove a checkout still used by the session.
         ...createManagedWorktreeOwnerPolicy(cfg),
-        // Read limits per run so a config edit applies at the next hourly sweep.
         limits: resolveWorktreeCleanupLimits(),
       });
     });

--- a/src/gateway/server-methods/worktrees.test.ts
+++ b/src/gateway/server-methods/worktrees.test.ts
@@ -102,7 +102,7 @@ describe("worktrees gateway methods", () => {
       undefined,
     ]);
     expect(service.gc).toHaveBeenCalledWith({
-      limits: { maxCount: 30 },
+      limits: { maxCount: 100 },
       shouldProtectOwner: expect.any(Function),
       shouldRemoveOwner: expect.any(Function),
     });
@@ -253,7 +253,7 @@ describe("worktrees gateway methods", () => {
     const response = await call(handlers, "worktrees.gc", {}, { context });
     expect(response?.[0]).toBe(true);
     expect(service.gc).toHaveBeenCalledWith({
-      limits: { maxCount: 30 },
+      limits: { maxCount: 100 },
       shouldProtectOwner: expect.any(Function),
       shouldRemoveOwner: expect.any(Function),
     });


### PR DESCRIPTION
Closes #135852 — raise the default managed-worktree limit to 100.

## What Problem This Solves

Busy installations run out of managed-worktree slots at 30 even when the existing checkouts are still needed and there is enough disk space. New worktree sessions and snapshot restores then require operators to archive work just to make room.

## Why This Change Was Made

Raise the existing shared default to 100 at the managed-worktree service, which owns creation, restoration, and default count-based cleanup. Keep one canonical limit rather than adding a configuration option or changing only the UI. Remove a stale maintenance comment that implied the count was configurable.

Allocation serialization, disk-space reserves, snapshot safety, and active/manual-worktree protection are unchanged. This does not raise filesystem or user disk quotas, move existing worktrees, or change the seven-day idle and 30-day snapshot-retention policies.

## User Impact

Operators can create or restore up to 100 live managed worktrees per state directory. The same default applies to session creation, manual worktrees, CLI cleanup, Gateway cleanup, and scheduled maintenance. At capacity, new allocations still provide actionable cleanup guidance; an existing valid owned checkout remains reusable.

## Evidence

The new creation and restoration regression cases both failed on the 30-limit implementation with `Managed worktree limit of 30 reached`, then passed with the new default. Focused capacity/GC coverage also checks contention for the 100th slot, refusal beyond capacity, owned-checkout reuse, snapshot preservation, and protection of manual/active work.

- `node scripts/run-vitest.mjs src/agents/worktrees/service.capacity.test.ts src/agents/worktrees/service.gc.test.ts` — 38 passed.
- `node scripts/run-vitest.mjs src/cli/worktrees-cli.test.ts src/gateway/server-methods/worktrees.test.ts src/gateway/server-maintenance.test.ts` — 46 passed.
- `pnpm build` — passed for both the unchanged 30-limit baseline and the updated 100-limit build.
- Fresh Codex autoreview of the complete eight-file change — no accepted findings, P0 scope. The reviewer did not run tests.

Live Control UI proof used an isolated Gateway, a synthetic Git repository, and normal signed browser authentication. With the same 30 real checkouts, the baseline refused `cap-31`; after rebuilding with this patch, the UI created it successfully. The API and Git checkout verification confirmed 31 live records, all 30 original IDs/paths/branches preserved, and correct new branch contents. No model turn was submitted. Attached videos show the before and after flows; all captures were inspected and contain synthetic data only.

Production LOC: +1/-2 (net -1). Tests: +31/-15. Documentation: +2/-2.

Documentation: https://docs.openclaw.ai/concepts/managed-worktrees

https://github.com/user-attachments/assets/0291c668-528b-4437-8313-c1a41b3e42d3

https://github.com/user-attachments/assets/a8b7e116-393e-4c0f-9403-47eb2ebb8f32