### PR TITLE
refactor(release): share ASCII comparator

### DIFF
--- a/scripts/full-release-candidate-contract.mjs
+++ b/scripts/full-release-candidate-contract.mjs
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { canonicalAsciiJson } from "./lib/canonical-json.mjs";
+import { canonicalAsciiJson, compareAscii } from "./lib/canonical-json.mjs";
 import { isRecord } from "./lib/record-shared.mjs";
 import {
   normalizeUpgradeSurvivorBaselineSpec,
@@ -28,8 +28,6 @@ const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u;
 const WORKFLOW_PATH_PATTERN = /^\.github\/workflows\/[A-Za-z0-9_.-]+\.ya?ml$/u;
 const RELEASE_PROFILES = new Set(["minimum", "beta", "stable", "full"]);
 const SHARED_IMAGE_POLICIES = new Set(["existing-only", "no-push-artifact"]);
-const compareAscii = (left, right) => (left < right ? -1 : left > right ? 1 : 0);
-
 function fail(message) {
   throw new Error(message);
 }

--- a/scripts/lib/canonical-json.d.mts
+++ b/scripts/lib/canonical-json.d.mts
@@ -1,3 +1,4 @@
 export function sortJsonValueKeys(value: unknown): unknown;
+export function compareAscii(left: string, right: string): number;
 export function canonicalizeJsonValue(value: unknown): unknown;
 export function canonicalAsciiJson(value: unknown): string;

--- a/scripts/lib/canonical-json.mjs
+++ b/scripts/lib/canonical-json.mjs
@@ -1,5 +1,5 @@
 const ASCII_JSON_PATTERN = /^[\x20-\x7e]+\n$/u;
-const compareAscii = (left, right) => (left < right ? -1 : left > right ? 1 : 0);
+export const compareAscii = (left, right) => (left < right ? -1 : left > right ? 1 : 0);
 
 function fail(message) {
   throw new Error(message);

--- a/scripts/release-plan-contract.mjs
+++ b/scripts/release-plan-contract.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { canonicalAsciiJson, canonicalizeJsonValue } from "./lib/canonical-json.mjs";
+import { canonicalAsciiJson, canonicalizeJsonValue, compareAscii } from "./lib/canonical-json.mjs";
 import { isRecord } from "./lib/record-shared.mjs";
 import { parseReleaseVersion } from "./lib/release-version.mjs";
 import {
@@ -18,8 +18,6 @@ const ASCII_PATTERN = /^[\x20-\x7e]+$/u;
 const REPOSITORY = "openclaw/openclaw";
 const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
 const PACKAGE_TARGETS = new Set(["clawhub", "npm"]);
-const compareAscii = (left, right) => (left < right ? -1 : left > right ? 1 : 0);
-
 function fail(message) {
   throw new Error(message);
 }

--- a/scripts/release-plan-producer-core.mts
+++ b/scripts/release-plan-producer-core.mts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { compareAscii } from "./lib/canonical-json.mjs";
 import { collectExtensionPackageJsonCandidates } from "./lib/plugin-publication-candidates.ts";
 import {
   collectPublishablePluginPackagesFromCandidates,
@@ -66,7 +67,6 @@ const NPM_CORE_PACKAGE_POLICY_PATH = "scripts/lib/npm-core-release-packages.json
 const YAML_PACKAGE_VERSION = "2.9.0";
 const YAML_PACKAGE_INTEGRITY =
   "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==";
-const compareAscii = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
 function git(repoRoot: string, args: string[]): string {
   return execFileSync("git", args, {
     cwd: repoRoot,

--- a/scripts/release-plan-producer.mts
+++ b/scripts/release-plan-producer.mts
@@ -79,6 +79,8 @@ const YAML_PACKAGE_TREE_SHA256 = "610ccacfe592d226ac1eb04842d1f591c5381f2a68b9f7
 const YAML_PACKAGE_MAX_FILES = 512;
 const YAML_PACKAGE_MAX_ENTRIES = 1024;
 const YAML_PACKAGE_MAX_BYTES = 4 * 1024 * 1024;
+// Keep both comparators local: this one precedes tooling verification, and CHILD_RUNNER's precedes
+// loader-hook registration. Importing either would execute code before its integrity boundary.
 const compareAscii = (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0);
 
 type ToolingModule = { path: string; bytes: Buffer; imports: Array<[string, string]> };


### PR DESCRIPTION
## What Problem This Solves

Three release tooling contracts independently declared the same ASCII comparator even though `scripts/lib/canonical-json.mjs` already owned the identical deterministic ordering rule. Keeping those copies separate made release-plan and full-release candidate ordering easier to drift.

This is a bounded maintainer-requested refactor from the function-duplication cleanup campaign.

## Why This Change Was Made

`scripts/lib/canonical-json.mjs` now exports its private `compareAscii` helper, and the release-plan contract, release-plan producer core, and full-release candidate contract import it directly.

The two copies in `scripts/release-plan-producer.mts` intentionally remain local. The outer comparator runs before tooling bytes are verified, while the `CHILD_RUNNER` comparator runs before loader hooks are registered. A nearby comment records that importing either copy would execute code before its integrity boundary.

`sortJsonValueKeys`, workflow sparse-checkout lists, the child runner structure, tests, public SDK surfaces, configuration, and release behavior are unchanged.

## User Impact

No user-visible behavior changes. Deterministic release ordering keeps the same comparator semantics while three duplicate declarations move to their existing private owner.

## Evidence

- Refreshed signed head: `fbe028520cef7bdabc47c453ccf80403dba0bf82`, rebased onto `677b2706bf828a17ce250c5a69fcec6ddb346a4d`.
- Focused release contract suite: 123 tests passed across `canonical-json`, release-plan contract/producer, and full-release candidate contract coverage.
- Script TypeScript erasability passed across 571 implementation files.
- Changed-file guards passed through formatting, dependency/package guards, tooling boundaries, erasability, coercion declarations, scoped oxlint, Docker/tooling boundaries, both import-cycle checks, and diff checks.
- `tsgo:scripts` is not proven locally: the shared dependency tree is missing unrelated Shiki, Discord, Slack, Markdown, phone-number, and other declared workspace packages. No install or dependency reconciliation was performed in the worktree.
- Fresh autoreview passed with `gpt-5.6-sol` at high reasoning: no accepted/actionable findings, score `0.99`.
- LOC: production `0`; tests/test support `0`; tooling `+7/-8`, net `-1`.
- Exact-head CI passed on both the ready-for-review run https://github.com/openclaw/openclaw/actions/runs/33703171248 and the native dispatched run https://github.com/openclaw/openclaw/actions/runs/33703178864.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 135886` passed at `2026-09-03T01:49:52Z`. The hosted gate verifier classified `Blacksmith Testbox`, `Blacksmith ARM Testbox`, and `Blacksmith Build Artifacts Testbox` as not applicable for this scripts-only patch, so no remote lease was issued (`REMOTE_GATES_LEASE_ID=''`).
- Current overlap: #136466 changes `scripts/release-plan-producer.mts` only by adding two verified-tooling allowlist entries. At head `967b318d40f9cfdd4e6895e20498c2fe19cf36c8`, it does not change comparator semantics or either pre-trust integrity boundary.
- Codex hard gate inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI/completion paths do not constrain this scripts-only change.
