### PR TITLE
test: avoid waiting for delegated approval expiry

### DIFF
--- a/src/gateway/server-methods/system-agent-chat-turn.test.ts
+++ b/src/gateway/server-methods/system-agent-chat-turn.test.ts
@@ -159,10 +159,13 @@ describe("system-agent chat input", () => {
       60_000,
       "system-agent:disabled-ui",
     );
-    await manager.register(record, 60_000);
+    const decisionPromise = manager.register(record, 60_000);
+    try {
+      const snapshot = manager.getSnapshot(record.id);
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.resolvedAtMs).toBeUndefined();
 
-    expect(
-      buildDelegatedApprovalPendingReply({
+      const replyParams = {
         cfg: {
           gateway: {
             publicOrigin: "https://control.example.com",
@@ -171,7 +174,21 @@ describe("system-agent chat input", () => {
         },
         manager,
         approvalId: record.id,
-      }),
-    ).not.toContain("Review:");
+        nowMs: record.createdAtMs,
+      };
+      const reply = buildDelegatedApprovalPendingReply(replyParams);
+      expect(reply).toContain("OpenClaw change pending approval: restart the Gateway.");
+      expect(reply).toContain("No change has been made.");
+      expect(reply).toContain("Expires in 1m.");
+      expect(reply).not.toContain("Review:");
+
+      replyParams.cfg.gateway.controlUi.enabled = true;
+      expect(buildDelegatedApprovalPendingReply(replyParams)).toContain(
+        "Review: https://control.example.com/approve/system-agent%3Adisabled-ui.",
+      );
+    } finally {
+      manager.expire(record.id);
+      await decisionPromise;
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The disabled-Control-UI approval test waits for `ExecApprovalManager.register()` before formatting a pending approval reply. Registration inserts the record synchronously, but its returned promise waits for a decision or expiry. With no decision, this fixture spends 60 seconds waiting and then checks an expired record retained by the manager's cleanup grace period. CI measured 60.014s in this case.

## Why This Change Was Made

Keep the decision promise, inspect the pending reply immediately, and settle and join the owned approval in `finally`. The fixture now proves that the record is unresolved, preserves its disabled-link assertion, and also checks the enabled-link control. The real 60,000ms lifetime and production manager behavior are unchanged.

## User Impact

This removes an accidental wait from CI and strengthens the existing fixture. Production delta is zero; the existing test changes by +22/-5 lines.

## Evidence

The regression assertion fails on the original await after 60,040ms because the record is already resolved. The fixed focused case passes in 9ms. Both complete formatter and approval-manager suites pass all 73 tests; the scoped changed-file gates and formatting pass. Independent source review found no actionable issues, and Codex P0 autoreview is scoped-clean.

Whole-command timings include different cache warmth, so these measurements establish removal of the 60-second fixture wait rather than a full-workflow speedup. Exact-head CI will verify the PR before landing.
