### PR TITLE
fix(scripts): repair Control UI proof selectors

### DIFF
--- a/scripts/capture-session-toolbar-proof.mts
+++ b/scripts/capture-session-toolbar-proof.mts
@@ -206,7 +206,7 @@ try {
       const toolbar = grouped.page.locator(".sidebar-session-toolbar");
       await toolbar.getByText("Sessions", { exact: true }).waitFor();
       const filter = toolbar.getByRole("button", { name: "Filter & sort" });
-      const add = toolbar.getByRole("button", { name: "New session" });
+      const add = toolbar.getByRole("link", { name: "New session" });
       await grouped.page.mouse.move(1_000, 850);
       const toolbarOpacity = await Promise.all([
         filter.evaluate((element) => Number.parseFloat(getComputedStyle(element).opacity)),

--- a/scripts/capture-workboard-ui-proof.mts
+++ b/scripts/capture-workboard-ui-proof.mts
@@ -72,8 +72,8 @@ try {
   await page.goto(new URL("/dashboard", baseUrl).toString());
   const widget = page.locator('[data-test-id="workboard-board-widget"]');
   await widget.waitFor();
-  await page.getByText("Validate onboarding flow", { exact: true }).waitFor();
-  await page.getByText("Review accessibility audit", { exact: true }).waitFor();
+  await widget.getByRole("heading", { name: "Validate onboarding flow", exact: true }).waitFor();
+  await widget.getByRole("heading", { name: "Review accessibility audit", exact: true }).waitFor();
   await page.locator(".board-session-surface--dock-hidden").waitFor();
   const columnCount = await widget.locator(".workboard-column").count();
   if (columnCount !== 6) {


### PR DESCRIPTION
## What Problem This Solves

Two Control UI proof scripts had stale or ambiguous Playwright locators:

- `scripts/capture-session-toolbar-proof.mts` treated the current "New session" control as a button even though the UI renders an accessible link.
- `scripts/capture-workboard-ui-proof.mts` searched the whole page for card titles, so "Validate onboarding flow" matched both the dashboard progress step and the Workboard card heading.

Both proof flows failed before they could produce the intended maintainer evidence.

## Why This Change Was Made

The toolbar proof now selects the exact "New session" link. The Workboard proof selects exact card headings inside the Workboard widget. This repairs the executable proof boundary without changing the UI, fixtures, runtime, SDK, configuration, or adding another helper or test.

The signed source head is intentionally preserved. A live merge-tree check against current `main` retained `readControlUiProofOption` and every other upstream script change while applying only these selector replacements.

## User Impact

No product behavior changes. Maintainers can run both proof scripts and receive the expected screenshots instead of a timeout or Playwright strict-mode failure.

## Evidence

Frozen identity:

- Head: `df05634a4b81f5319c2cedad00934e41889a8d17`
- Parent: `bebbfa51e47d00cbfe340695823ab79ccebd9d24`
- Tree: `fab815a28a7b8fba24b1384de06d0e40e99998e6`
- Stable patch ID: `9973ff6b35f5b8a99a7f95042eb29e3509737ad5`
- Valid ED25519 signature
- Tooling: `+3/-3`; production/tests: `+0/-0`

Parent reproductions:

- Session toolbar proof timed out waiting for `.sidebar-session-toolbar` to contain `getByRole("button", { name: "New session" })`.
- Workboard proof failed strict mode because page-wide `getByText("Validate onboarding flow", { exact: true })` resolved to the progress-step `<span>` and card `<h3>`.

Frozen-head proof:

- Session toolbar proof produced `after-grouped.png`, `after-toolbar-menu.png`, `after-filter-active.png`, and `after-ungrouped-only.png`.
- Workboard proof produced `workboard-chip.png` and `workboard-widget.png`.
- All six PNGs were inspected at their intended 560x900 or 1440x900 dimensions. They are nonblank, correctly targeted and framed, with no incoherent overlap.
- The dashboard still contains two exact "Validate onboarding flow" matches: one widget heading and one progress-step text outside the widget. The scoped selector resolves exactly one heading inside the widget.

Toolbar menu:

![Control UI session toolbar proof](https://github.com/user-attachments/assets/1a085cf7-b766-4d36-9c2c-1bba56d8963a)

Workboard dashboard widget:

![Control UI Workboard proof](https://github.com/user-attachments/assets/de16c366-be55-4856-8bfc-2ae1d4baec8e)

Validation:

- `node scripts/run-vitest.mjs ui/src/e2e/session-ownership.e2e.test.ts ui/src/e2e/workboard-board-widget-layout.e2e.test.ts` - 14/14 passed
- Both proof scripts passed on the frozen head
- `node scripts/check-changed.mjs -- scripts/capture-session-toolbar-proof.mts scripts/capture-workboard-ui-proof.mts`
- Targeted Oxfmt and Oxlint
- Script erasability and script TypeScript checks
- Full `pnpm build`
- Test audit: no new test justified; the proof scripts own the executable boundary and existing E2E owns the DOM contracts
- `gpt-5.6-sol` high autoreview: scoped clean, confidence `0.99`

Codex hard gate inspected:

- `../codex/codex-rs/cli/src/main.rs:220-245`
- `../codex/codex-rs/cli/src/main.rs:2840-2870`

Those CLI/completion paths do not interact with this scripts-only proof repair.
