### PR TITLE
fix: remove redundant waiting receipt from accepted chat messages

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -127,8 +127,8 @@ On the first identified connection, the Control UI uploads existing browser-loca
 When a remote project session starts before its repository finishes cloning, chat shows workspace preparation progress. If preparation fails, opening or reloading chat restores the session's failure summary. Correct the reported problem, then send a new message in the same session to retry preparation.
 
 Accepted browser messages, including initial prompts waiting for workspace
-preparation and follow-ups during a run, remain visible with a waiting notice
-until their own turn starts. Inputs accepted through `sessions_send` or the
+preparation and follow-ups during a run, remain visible as normal message bubbles
+until their own turn starts, without an additional receipt notice. Inputs accepted through `sessions_send` or the
 Gateway `agent` method use the same display. They are stored separately from the active model transcript. If
 cancellation or a Gateway restart interrupts that wait,
 the message stays readable with its recorded disposition and is never resent

--- a/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
@@ -368,8 +368,9 @@ suite.define(() => {
       });
       await gateway.resolveDeferred("chat.startup");
       await page
-        .getByText("Message received. Waiting for the agent to start it.", { exact: true })
+        .locator('[data-chat-row-key="group:user:pending-input:accepted-project-input"]')
         .waitFor();
+      expect(await page.locator(".chat-notice").count()).toBe(0);
       const working = page.locator('.chat-working-indicator[role="status"]');
       await pollLocatorText(working).toContain("Preparing workspace…");
       if (artifactDir) {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5976,7 +5976,6 @@ export const en: TranslationMap & {
       noMatches: "No matching messages",
     },
     pendingInputs: {
-      queued: "Message received. Waiting for the agent to start it.",
       cancelled:
         "Cancelled before the agent started it. It will not run automatically; copy it and send again.",
       interrupted:

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -44,16 +44,17 @@ export function buildPendingInputItems(
       continue;
     }
     items.push({ kind: "message", key: `pending-input:${input.id}`, message: input.message });
+    if (input.state === "queued") {
+      continue;
+    }
     items.push({
       kind: "notice",
       key: `pending-input:${input.id}:state`,
       timestamp: input.acceptedAt,
       text: t(
-        input.state === "queued"
-          ? "chat.pendingInputs.queued"
-          : input.state === "cancelled"
-            ? "chat.pendingInputs.cancelled"
-            : "chat.pendingInputs.interrupted",
+        input.state === "cancelled"
+          ? "chat.pendingInputs.cancelled"
+          : "chat.pendingInputs.interrupted",
       ),
     });
   }


### PR DESCRIPTION
Closes #135899 (redundant Control UI waiting receipt beside startup progress).

<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers**: this branch is in the upstream repository.

</details>

## What Problem This Solves

Fixes an issue where users starting a project or worktree session see a generic "Message received. Waiting for the agent to start it." sentence alongside the actual workspace preparation progress.

## Why This Change Was Made

Remove the queued-disposition notice at the shared pending-input presentation owner, rather than hiding it with CSS or changing durable input custody. Accepted prompts remain ordinary message bubbles; cancelled and interrupted inputs keep their actionable warnings. Remove the now-unused English key and align the Control UI documentation.

No configuration, protocol, SQLite schema, delivery, or Codex runtime behavior changes. Production LOC: **+6/-6 (net 0)**; tests **+2/-1**; docs **+2/-2**.

## User Impact

Less redundant status text while waiting for startup. Message bubbles, image attachments, workspace/worktree progress, and cancellation/interruption warnings remain intact.

## Evidence

- Regression red: the browser assertion expecting zero `.chat-notice` rows fails on the pre-fix owner with **received 1**.
- Regression green: **5 browser E2E tests passed**, including project/worktree preparation, prompt promotion without duplicate bubbles, retained image attachments, and actionable preparation/setup failures.
- **47 unit tests passed** across pending-input custody/rendering, startup-history restoration, and working indicators.
- Fresh independent autoreview: no accepted/actionable findings at the selected P0 scope.
- Before/after captures below were inspected. These are real Chromium screenshots from the deterministic mocked-Gateway flow, not live-provider proof; the change is entirely in the client presentation owner.

Commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/chat-pending-inputs.test.ts ui/src/pages/chat/chat-history.startup.test.ts ui/src/pages/chat/components/chat-working-indicator.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.github-projects.e2e.test.ts
node scripts/check-changed.mjs -- docs/web/control-ui.md ui/src/e2e/new-session-page.github-projects.e2e.test.ts ui/src/i18n/locales/en.ts ui/src/pages/chat/chat-pending-inputs.ts
git diff --check
```

### Before

![Before: redundant receipt under the accepted prompt](https://github.com/user-attachments/assets/eb79ab26-147b-4867-9aec-f220b024c8bb)

### After

![After: accepted prompt and useful workspace progress only](https://github.com/user-attachments/assets/6b77a356-08b7-481e-ba99-c60511c822aa)

### Boundary review

`chat.history` pending-input custody → `applyChatPendingInputs` → `selectChatInputDisplay` / `buildChatItems` → `buildPendingInputItems` → normal message/notice rows. All queued inputs use this owner, not just project startup. Alternative CSS hiding would retain redundant data and copy; changing Gateway custody would violate the owner boundary.

Direct native contract inspection: `openai/codex` at `5f49aba876922d6f2f55caa153bbb0ed1b46feba`, `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:264,488` and `codex-rs/app-server/src/bespoke_event_handling.rs:160-189`. The native turn-start response/notification carries turn state, not this OpenClaw-authored receipt sentence. The native runtime is unchanged.

Introduction provenance remains unknown; this is not a claim of a first-bad stable release. Current main still contains the redundant rendering branch.
