### PR TITLE
fix(release): include sparse release context helper

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -208,6 +208,7 @@ jobs:
             scripts/github/validate-release-suite-filters.sh
             scripts/full-release-candidate-contract.mjs
             scripts/full-release-validation-policy.mjs
+            scripts/lib/release-context.mjs
             scripts/lib/release-version.mjs
             scripts/lib/record-shared.mjs
             scripts/lib/canonical-json.mjs

--- a/test/scripts/full-release-validation-continuation-workflow.test.ts
+++ b/test/scripts/full-release-validation-continuation-workflow.test.ts
@@ -31,6 +31,7 @@ describe("full release metadata checkouts", () => {
         "release-tooling-identity.mjs",
         "full-release-candidate-contract.mjs",
         "full-release-validation-policy.mjs",
+        "lib/release-context.mjs",
       ],
     },
     {


### PR DESCRIPTION
## Root cause

Full Release Validation run 33589505469 failed before candidate acquisition because `resolve_target` imports `scripts/lib/release-context.mjs`, but its trusted-workflow sparse checkout did not materialize that module.

## Fix

Include the existing helper in the same sparse checkout and extend the sparse-import closure test.

## Proof

- `node scripts/run-vitest.mjs test/scripts/full-release-validation-continuation-workflow.test.ts` (7 passed)
- `actionlint .github/workflows/full-release-validation.yml`
- `git diff --check`

Production/workflow: +1/-0. Tests: +1/-0. No candidate branch, tag, registry, or publication change.