### PR TITLE
fix(build): keep plugin dependencies after checkout relocation

### DIFF
--- a/scripts/copy-bundled-plugin-metadata.mts
+++ b/scripts/copy-bundled-plugin-metadata.mts
@@ -6,7 +6,6 @@ import {
   collectBundledPluginBuildEntries,
   NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
 } from "./lib/bundled-plugin-build-entries.mjs";
-import { ensureRepoNodeModulesLink } from "./lib/local-check-runtime.mts";
 import { shouldBuildBundledCluster } from "./lib/optional-bundled-clusters.mjs";
 import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
 import {
@@ -375,8 +374,19 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
     }
 
     writeTextFileIfChanged(distPackageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
-    if (hasExternalLocalDist) {
-      ensureRepoNodeModulesLink(path.join(pluginDir, "node_modules"), { cwd: distPluginDir });
+    const sourceNodeModules = path.resolve(pluginDir, "node_modules");
+    if (
+      hasExternalLocalDist &&
+      fs.existsSync(sourceNodeModules) &&
+      !fs.existsSync(distNodeModules)
+    ) {
+      // Published source builds move as a complete checkout; POSIX links must
+      // keep each plugin's dependency owner without retaining the build path.
+      const target =
+        process.platform === "win32"
+          ? sourceNodeModules
+          : path.relative(distPluginDir, sourceNodeModules);
+      fs.symlinkSync(target, distNodeModules, process.platform === "win32" ? "junction" : "dir");
     }
   }
 

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -17,86 +17,116 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("external plugin local dist build", () => {
-  it("retains each plugin's dependency owner and the shared host SDK", async () => {
-    const repoRoot = tempDirs.make("openclaw-external-plugin-owners-");
-    fs.writeFileSync(
-      path.join(repoRoot, "package.json"),
-      JSON.stringify({
-        name: "openclaw",
-        version: "1.0.0",
-        type: "module",
-        exports: { "./plugin-sdk/probe": "./probe.js" },
-      }),
-    );
-    fs.writeFileSync(path.join(repoRoot, "probe.js"), "export const shared = {};\n");
-    for (const [pluginId, version] of [
-      ["first", "1.0.0"],
-      ["second", "2.0.0"],
-    ] as const) {
-      const packageDir = path.join(repoRoot, "extensions", pluginId);
-      const dependencyDir = path.join(packageDir, "node_modules", "private-dep");
-      fs.mkdirSync(dependencyDir, { recursive: true });
+  it.for([false, true])(
+    "retains each plugin's dependency owner and the shared host SDK (relocate=%s)",
+    async (relocate, context) => {
+      // Windows junctions remain absolute; release relocation uses POSIX symlinks.
+      if (relocate && process.platform === "win32") {
+        context.skip();
+      }
+      const repoRoot = fs.realpathSync(tempDirs.make("openclaw-external-plugin-owners-"));
       fs.writeFileSync(
-        path.join(packageDir, "package.json"),
+        path.join(repoRoot, "package.json"),
         JSON.stringify({
-          name: `@openclaw/${pluginId}`,
+          name: "openclaw",
           version: "1.0.0",
           type: "module",
-          dependencies: { "private-dep": version },
-          peerDependencies: { openclaw: "1.0.0" },
-          openclaw: {
-            extensions: ["./index.ts"],
-            build: { bundledDist: false },
-            release: { publishToNpm: true },
-          },
+          exports: { "./plugin-sdk/probe": "./probe.js" },
         }),
       );
-      fs.writeFileSync(
-        path.join(dependencyDir, "package.json"),
-        JSON.stringify({ name: "private-dep", version, type: "module", main: "index.js" }),
-      );
-      fs.writeFileSync(
-        path.join(dependencyDir, "index.js"),
-        `export default ${JSON.stringify(version)};\n`,
-      );
-      fs.symlinkSync(
-        repoRoot,
-        path.join(packageDir, "node_modules", "openclaw"),
-        process.platform === "win32" ? "junction" : "dir",
-      );
-      fs.writeFileSync(
-        path.join(packageDir, "index.ts"),
-        'export { default as version } from "private-dep";\nexport { shared } from "openclaw/plugin-sdk/probe";\n',
-      );
-      fs.writeFileSync(
-        path.join(packageDir, "openclaw.plugin.json"),
-        JSON.stringify({ id: pluginId, skills: ["./node_modules/private-dep"] }),
-      );
-    }
-    await buildExternalPluginLocalDist({ repoRoot, env: {}, logLevel: "silent" });
-    copyBundledPluginMetadata({ repoRoot, env: {} });
-    // Repeating postbuild must not remove source packages through the output link.
-    copyBundledPluginMetadata({ repoRoot, env: {} });
-    const entryUrl = (pluginId: string) =>
-      pathToFileURL(path.join(repoRoot, "dist", "extensions", pluginId, "index.js")).href;
-    const stagedDir = path.join(repoRoot, "staged", "first");
-    fs.cpSync(path.join(repoRoot, "dist", "extensions", "first"), stagedDir, { recursive: true });
-    const output = execFileSync(
-      process.execPath,
-      [
-        "--input-type=module",
-        "-e",
-        `
+      fs.writeFileSync(path.join(repoRoot, "probe.js"), "export const shared = {};\n");
+      for (const [pluginId, version] of [
+        ["first", "1.0.0"],
+        ["second", "2.0.0"],
+      ] as const) {
+        const packageDir = path.join(repoRoot, "extensions", pluginId);
+        const dependencyDir = path.join(packageDir, "node_modules", "private-dep");
+        fs.mkdirSync(dependencyDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(packageDir, "package.json"),
+          JSON.stringify({
+            name: `@openclaw/${pluginId}`,
+            version: "1.0.0",
+            type: "module",
+            dependencies: { "private-dep": version },
+            peerDependencies: { openclaw: "1.0.0" },
+            openclaw: {
+              extensions: ["./index.ts"],
+              build: { bundledDist: false },
+              release: { publishToNpm: true },
+            },
+          }),
+        );
+        fs.writeFileSync(
+          path.join(dependencyDir, "package.json"),
+          JSON.stringify({ name: "private-dep", version, type: "module", main: "index.js" }),
+        );
+        fs.writeFileSync(
+          path.join(dependencyDir, "index.js"),
+          `export default ${JSON.stringify(version)};\n`,
+        );
+        fs.symlinkSync(
+          process.platform === "win32" ? repoRoot : "../../..",
+          path.join(packageDir, "node_modules", "openclaw"),
+          process.platform === "win32" ? "junction" : "dir",
+        );
+        fs.writeFileSync(
+          path.join(packageDir, "index.ts"),
+          'export { default as version } from "private-dep";\nexport { shared } from "openclaw/plugin-sdk/probe";\n',
+        );
+        fs.writeFileSync(
+          path.join(packageDir, "openclaw.plugin.json"),
+          JSON.stringify({ id: pluginId, skills: ["./node_modules/private-dep"] }),
+        );
+      }
+      await buildExternalPluginLocalDist({ repoRoot, env: {}, logLevel: "silent" });
+      copyBundledPluginMetadata({ repoRoot, env: {} });
+      // Repeating postbuild must not remove source packages through the output link.
+      copyBundledPluginMetadata({ repoRoot, env: {} });
+      let runtimeRoot = repoRoot;
+      if (relocate) {
+        runtimeRoot = fs.realpathSync(tempDirs.make("openclaw-external-plugin-relocated-"));
+        fs.cpSync(repoRoot, runtimeRoot, { recursive: true, verbatimSymlinks: true });
+        fs.rmSync(repoRoot, { recursive: true });
+      }
+      const entryUrl = (pluginId: string) =>
+        pathToFileURL(path.join(runtimeRoot, "dist", "extensions", pluginId, "index.js")).href;
+      const stagedDir = path.join(runtimeRoot, "staged", "first");
+      fs.cpSync(path.join(runtimeRoot, "dist", "extensions", "first"), stagedDir, {
+        recursive: true,
+      });
+      const output = execFileSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          `
       const first = await import(${JSON.stringify(entryUrl("first"))});
       const second = await import(${JSON.stringify(entryUrl("second"))});
       const staged = await import(${JSON.stringify(pathToFileURL(path.join(stagedDir, "index.js")).href)});
       console.log(JSON.stringify({ versions: [first.version, second.version, staged.version], shared: first.shared === second.shared && first.shared === staged.shared }));
     `,
-      ],
-      { encoding: "utf8" },
-    );
-    expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
-  });
+        ],
+        { encoding: "utf8" },
+      );
+      expect(JSON.parse(output)).toEqual({ versions: ["1.0.0", "2.0.0", "1.0.0"], shared: true });
+      for (const pluginId of ["first", "second"]) {
+        const runtimeModules = path.join(
+          runtimeRoot,
+          "dist",
+          "extensions",
+          pluginId,
+          "node_modules",
+        );
+        if (process.platform !== "win32") {
+          expect(path.isAbsolute(fs.readlinkSync(runtimeModules))).toBe(false);
+        }
+        expect(fs.realpathSync(runtimeModules)).toBe(
+          path.join(runtimeRoot, "extensions", pluginId, "node_modules"),
+        );
+      }
+    },
+  );
 
   it("selects every externalized first-party plugin behind a package exclusion", () => {
     const packageDirs = listExternalPluginLocalDistPackageDirs();


### PR DESCRIPTION
Closes #135896 — source-built plugin dependencies break after checkout relocation.

## What Problem This Solves

Fixes an issue where operators moving a complete POSIX source build would lose external-plugin dependency resolution once the original build directory was removed. Release validation correctly rejected the generated absolute dependency links before publication; weakening that check would have produced broken runtimes.

## Why This Change Was Made

The metadata producer was borrowing a local-toolchain linker that writes absolute paths. Emit relative POSIX links at the artifact owner instead, so each generated plugin runtime continues to resolve its own source-owned dependencies after the whole checkout moves. Preserve Windows junction behavior, missing-dependency behavior, existing dependency directories, and the unlink-before-metadata-copy protection.

This follows [#135728 — isolated source installs](https://github.com/openclaw/openclaw/pull/135728), which introduced the backlink. Its raw commit/parent patch was verified: `4675e3d6dcab5899fcac113582105c295189d7f5` against `ef3b44744446c9f7df0d93b842722c451f8709cc`; author and merger were @steipete. This repair keeps the isolated linker and per-plugin dependency ownership rather than reverting them or relaxing release validation.

## User Impact

Complete POSIX source builds can move without leaving external plugins dependent on a deleted build directory. Plugins retain their distinct dependency versions and the shared host SDK. No configuration, schema, protocol, dependency version, or deployment-controller change is introduced. Windows junctions retain their previous absolute-path behavior; this PR does not claim Windows relocation support.

## Evidence

The new whole-checkout relocation case failed before the production edit with `ERR_MODULE_NOT_FOUND` for a synthetic plugin dependency after the original fixture was removed. The test now covers both ordinary and relocated loading, distinct dependency versions, shared SDK identity, repeated postbuild safety, and release-local link resolution.

- `pnpm test test/scripts/build-external-plugin-local-dist.test.ts src/plugins/copy-bundled-plugin-metadata.test.ts test/scripts/runtime-postbuild.test.ts test/scripts/build-all.test.ts` — 142 tests passed in the final run.
- `node scripts/check-changed.mjs` — final scripts/root-test typechecks, formatting, lint, and guards passed. An earlier run caught a test callback typing error; using the supported `it.for` API resolved it and both tests and checks were rerun.
- `pnpm build` — full build passed.
- Whole-checkout relocation audit — 5,516 symlinks, zero absolute/escaping/dangling links, and all 67 external-plugin dependency links resolved within the relocated checkout. Native Zoom and Teams runtime imports verified plugin-local dependency resolution and shared SDK identity while the original runtime/dependency directories were unavailable. Those original directories were restored afterward. This is filesystem/native-module proof, not a live provider call.
- Fresh Codex autoreview — no accepted findings, P0 scope; the reviewer did not run tests.

Production/tooling LOC: +13/-3 (net +10). Tests: +99/-69 (net +30; most raw churn is parameterization indentation). The small production growth moves generated-artifact link responsibility out of the unrelated local-check toolchain helper while preserving its platform and existence guards. No new helper or public API was added; the existing build-local link helper carries overlay replacement/copy policy and is not a suitable reusable owner.
