### PR TITLE
fix(watch): stop command delivery after device revocation

### DIFF
--- a/src/gateway/watch-node-http.test-helpers.ts
+++ b/src/gateway/watch-node-http.test-helpers.ts
@@ -1,0 +1,97 @@
+import { createServer, type Server, type ServerResponse } from "node:http";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getPairedDevice, resolveNodePairingState } from "../infra/device-pairing.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import { NodeRegistry } from "./node-registry.js";
+import { createWatchNodeHttpRuntime } from "./watch-node-http.js";
+
+export async function startWatchNodeHttpRuntime(
+  baseDir: string,
+  servers: Server[],
+  options?: {
+    rateLimiter?: AuthRateLimiter;
+    abortConnectResponse?: boolean;
+    config?: OpenClawConfig;
+    now?: () => number;
+    onConnectResponseStart?: () => void;
+    onPollReady?: (response: ServerResponse) => void;
+  },
+) {
+  const nodeRegistry = new NodeRegistry({
+    resolveCurrentPairingState: async (nodeId) => {
+      const state = resolveNodePairingState(await getPairedDevice(nodeId, baseDir));
+      return state
+        ? {
+            identity: state.identity.key,
+            ...(state.generation ? { generation: state.generation.key } : {}),
+          }
+        : undefined;
+    },
+  });
+  const broadcasts: Array<{ event: string; payload: unknown }> = [];
+  const connectedNodes: string[] = [];
+  const disconnectedNodes: Array<{ nodeId: string; reason: string }> = [];
+  const runtime = createWatchNodeHttpRuntime({
+    nodeRegistry,
+    getConfig: () => options?.config ?? {},
+    pairingBaseDir: baseDir,
+    broadcast: (event, payload) => broadcasts.push({ event, payload }),
+    onNodeConnected: (session) => connectedNodes.push(session.nodeId),
+    onNodeDisconnected: (nodeId, reason) => disconnectedNodes.push({ nodeId, reason }),
+    ...(options?.rateLimiter ? { rateLimiter: options.rateLimiter } : {}),
+    ...(options?.now ? { now: options.now } : {}),
+  });
+  let resolveConnectHandled: () => void = () => undefined;
+  const connectHandled = new Promise<void>((resolve) => {
+    resolveConnectHandled = resolve;
+  });
+  const server = createServer((req, res) => {
+    const isConnect = req.url === "/api/nodes/watch/connect";
+    if (isConnect && options?.onConnectResponseStart) {
+      const end = res.end.bind(res);
+      res.end = ((...args: Parameters<typeof res.end>) => {
+        options.onConnectResponseStart?.();
+        return end(...args);
+      }) as typeof res.end;
+    }
+    if (isConnect && options?.abortConnectResponse) {
+      res.end = (() => {
+        res.destroy();
+        return res;
+      }) as typeof res.end;
+    }
+    void runtime
+      .handleRequest(req, res)
+      .then((handled) => {
+        if (!handled && !res.writableEnded) {
+          res.statusCode = 404;
+          res.end();
+        }
+        if (req.url === "/api/nodes/watch/poll" && !res.writableEnded) {
+          options?.onPollReady?.(res);
+        }
+      })
+      .finally(() => {
+        if (isConnect) {
+          resolveConnectHandled();
+        }
+      });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  return {
+    nodeRegistry,
+    broadcasts,
+    connectedNodes,
+    disconnectedNodes,
+    runtime,
+    connectHandled,
+    baseUrl: `http://127.0.0.1:${address.port}/api/nodes/watch`,
+  };
+}

--- a/src/gateway/watch-node-http.test.ts
+++ b/src/gateway/watch-node-http.test.ts
@@ -1,5 +1,4 @@
 import {
-  createServer,
   request as httpRequest,
   type ClientRequest,
   type Server,
@@ -13,7 +12,6 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { PROTOCOL_VERSION, type ConnectParams } from "../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../test/helpers/promise.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   issueDeviceBootstrapToken,
   issueDevicePairSetupBootstrapToken,
@@ -29,17 +27,13 @@ import { listNodePairing } from "../infra/device-pairing-node.js";
 import { withDevicePairingLock } from "../infra/device-pairing-state.js";
 import { loadDevicePairSetupCompletionRecord } from "../infra/device-pairing-store.js";
 import { revokeDeviceToken } from "../infra/device-pairing-tokens.js";
-import {
-  getPairedDevice,
-  requestDevicePairing,
-  resolveNodePairingState,
-} from "../infra/device-pairing.js";
+import { getPairedDevice, requestDevicePairing } from "../infra/device-pairing.js";
 import { NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE } from "../shared/device-bootstrap-profile.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
-import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
+import { createAuthRateLimiter } from "./auth-rate-limit.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
-import { NodeRegistry, serializeEventPayload } from "./node-registry.js";
-import { createWatchNodeHttpRuntime } from "./watch-node-http.js";
+import { serializeEventPayload } from "./node-registry.js";
+import { startWatchNodeHttpRuntime } from "./watch-node-http.test-helpers.js";
 
 const tempDirs = createTrackedTempDirs();
 const servers: Server[] = [];
@@ -114,99 +108,9 @@ function makeConnectParams(params: {
   } as ConnectParams;
 }
 
-async function startRuntime(
-  baseDir: string,
-  options?: {
-    rateLimiter?: AuthRateLimiter;
-    abortConnectResponse?: boolean;
-    config?: OpenClawConfig;
-    now?: () => number;
-    onConnectResponseStart?: () => void;
-    onPollReady?: (response: ServerResponse) => void;
-  },
-) {
-  const nodeRegistry = new NodeRegistry({
-    resolveCurrentPairingState: async (nodeId) => {
-      const state = resolveNodePairingState(await getPairedDevice(nodeId, baseDir));
-      return state
-        ? {
-            identity: state.identity.key,
-            ...(state.generation ? { generation: state.generation.key } : {}),
-          }
-        : undefined;
-    },
-  });
-  const broadcasts: Array<{ event: string; payload: unknown }> = [];
-  const connectedNodes: string[] = [];
-  const disconnectedNodes: Array<{ nodeId: string; reason: string }> = [];
-  const runtime = createWatchNodeHttpRuntime({
-    nodeRegistry,
-    getConfig: () => options?.config ?? {},
-    pairingBaseDir: baseDir,
-    broadcast: (event, payload) => broadcasts.push({ event, payload }),
-    onNodeConnected: (session) => connectedNodes.push(session.nodeId),
-    onNodeDisconnected: (nodeId, reason) => disconnectedNodes.push({ nodeId, reason }),
-    ...(options?.rateLimiter ? { rateLimiter: options.rateLimiter } : {}),
-    ...(options?.now ? { now: options.now } : {}),
-  });
-  let resolveConnectHandled: () => void = () => undefined;
-  const connectHandled = new Promise<void>((resolve) => {
-    resolveConnectHandled = resolve;
-  });
-  const server = createServer((req, res) => {
-    const isConnect = req.url === "/api/nodes/watch/connect";
-    if (isConnect && options?.onConnectResponseStart) {
-      const end = res.end.bind(res);
-      res.end = ((...args: Parameters<typeof res.end>) => {
-        options.onConnectResponseStart?.();
-        return end(...args);
-      }) as typeof res.end;
-    }
-    if (isConnect && options?.abortConnectResponse) {
-      res.end = (() => {
-        res.destroy();
-        return res;
-      }) as typeof res.end;
-    }
-    void runtime
-      .handleRequest(req, res)
-      .then((handled) => {
-        if (!handled && !res.writableEnded) {
-          res.statusCode = 404;
-          res.end();
-        }
-        if (req.url === "/api/nodes/watch/poll" && !res.writableEnded) {
-          options?.onPollReady?.(res);
-        }
-      })
-      .finally(() => {
-        if (isConnect) {
-          resolveConnectHandled();
-        }
-      });
-  });
-  servers.push(server);
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("expected TCP server address");
-  }
-  return {
-    nodeRegistry,
-    broadcasts,
-    connectedNodes,
-    disconnectedNodes,
-    runtime,
-    connectHandled,
-    baseUrl: `http://127.0.0.1:${address.port}/api/nodes/watch`,
-  };
-}
-
 async function createWatchNodeFixture(
   prefix: string,
-  options?: Parameters<typeof startRuntime>[1],
+  options?: Parameters<typeof startWatchNodeHttpRuntime>[2],
 ) {
   const baseDir = await tempDirs.make(prefix);
   const identity = loadOrCreateDeviceIdentity({
@@ -216,7 +120,12 @@ async function createWatchNodeFixture(
     baseDir,
     profile: NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   });
-  return { baseDir, identity, issued, ...(await startRuntime(baseDir, options)) };
+  return {
+    baseDir,
+    identity,
+    issued,
+    ...(await startWatchNodeHttpRuntime(baseDir, servers, options)),
+  };
 }
 
 async function readJson(response: Response): Promise<Record<string, unknown>> {
@@ -593,6 +502,56 @@ describe("watch node HTTP transport", () => {
     runtime.close();
   });
 
+  it("does not deliver queued work after a verified HTTP session is retired", async () => {
+    const { baseDir, identity, issued, nodeRegistry, runtime, baseUrl } =
+      await createWatchNodeFixture("openclaw-watch-node-poll-retirement-");
+    try {
+      const connected = await readJson(
+        await connectWatchNode({ baseUrl, identity, bootstrapToken: issued.token }),
+      );
+      expect(
+        nodeRegistry.sendEvent(identity.deviceId, "node.invoke.request", {
+          id: "retired-invoke",
+          command: "device.info",
+        }),
+      ).toBe(true);
+
+      const checkCurrentPairing = nodeRegistry.isConnectionCurrentPairingState.bind(nodeRegistry);
+      // A concurrent revoke can retire the connection after a real pairing
+      // verdict resolves but before the awaiting HTTP handler uses it.
+      vi.spyOn(nodeRegistry, "isConnectionCurrentPairingState").mockImplementationOnce(
+        async (connId) => {
+          const wasCurrent = await checkCurrentPairing(connId);
+          expect(wasCurrent).toBe(true);
+          const revoked = await revokeDeviceToken({
+            deviceId: identity.deviceId,
+            role: "node",
+            baseDir,
+          });
+          expect(revoked.ok).toBe(true);
+          runtime.invalidateSessionsForDevice(identity.deviceId, {
+            role: "node",
+            reason: "device-token-revoked",
+          });
+          queueMicrotask(() =>
+            runtime.disconnectSessionsForDevice(identity.deviceId, { role: "node" }),
+          );
+          return wasCurrent;
+        },
+      );
+
+      const response = await fetch(`${baseUrl}/poll`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${String(connected.sessionToken)}` },
+      });
+      const body = await readJson(response);
+      expect(response.status, JSON.stringify(body)).toBe(401);
+      expect(nodeRegistry.get(identity.deviceId)).toBeUndefined();
+    } finally {
+      runtime.close();
+    }
+  });
+
   it("rejects an invoke result when pairing changes during body upload", async () => {
     const { baseDir, identity, issued, nodeRegistry, disconnectedNodes, runtime, baseUrl } =
       await createWatchNodeFixture("openclaw-watch-node-result-generation-");
@@ -708,7 +667,7 @@ describe("watch node HTTP transport", () => {
     });
     const abortedLimiter = createAuthRateLimiter(limiterConfig);
     try {
-      const abortedRuntime = await startRuntime(abortedBaseDir, {
+      const abortedRuntime = await startWatchNodeHttpRuntime(abortedBaseDir, servers, {
         rateLimiter: abortedLimiter,
         abortConnectResponse: true,
       });
@@ -770,7 +729,7 @@ describe("watch node HTTP transport", () => {
     });
     const completedLimiter = createAuthRateLimiter(limiterConfig);
     try {
-      const completedRuntime = await startRuntime(completedBaseDir, {
+      const completedRuntime = await startWatchNodeHttpRuntime(completedBaseDir, servers, {
         rateLimiter: completedLimiter,
       });
       const connectResponse = await connectWatchNode({
@@ -799,7 +758,9 @@ describe("watch node HTTP transport", () => {
       baseDir,
       profile: NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
     });
-    const runtime = await startRuntime(baseDir, { abortConnectResponse: true });
+    const runtime = await startWatchNodeHttpRuntime(baseDir, servers, {
+      abortConnectResponse: true,
+    });
 
     await expect(
       connectWatchNode({

--- a/src/gateway/watch-node-http.ts
+++ b/src/gateway/watch-node-http.ts
@@ -493,8 +493,31 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
       sendUnauthorized(res);
       return null;
     }
-    touchSession(session);
     return session;
+  };
+
+  const withCurrentSession = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    operation: (session: WatchNodeSession) => undefined,
+  ): Promise<void> => {
+    const session = await getSession(req, res);
+    if (!session) {
+      return;
+    }
+    // Pairing verification yields. Commit only while both transport owners
+    // still hold this exact connection, without another await before the effect.
+    if (
+      session.invalidatedReason ||
+      sessionsByToken.get(session.token) !== session ||
+      options.nodeRegistry.get(session.nodeId)?.connId !== session.connId
+    ) {
+      closeSession(session, session.invalidatedReason ?? "node connection changed");
+      sendUnauthorized(res);
+      return;
+    }
+    touchSession(session);
+    operation(session);
   };
 
   const handleChallenge = (req: IncomingMessage, res: ServerResponse) => {
@@ -1036,39 +1059,37 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
       sendMethodNotAllowed(res);
       return;
     }
-    const session = await getSession(req, res);
-    if (!session) {
-      return;
-    }
-    const queued = session.queue.shift();
-    if (queued) {
-      session.queuedBytes -= queued.byteLength;
-      if (!sendQueuedEvent(res, queued)) {
-        closeSession(session, "event delivery failed");
-      }
-      return;
-    }
-    if (session.waiter) {
-      clearTimeout(session.waiter.timer);
-      sendJson(session.waiter.res, 409, { ok: false, reason: "superseded poll" });
-    }
-    const timer = setTimeout(() => {
-      if (session.waiter?.res !== res) {
+    await withCurrentSession(req, res, (session) => {
+      const queued = session.queue.shift();
+      if (queued) {
+        session.queuedBytes -= queued.byteLength;
+        if (!sendQueuedEvent(res, queued)) {
+          closeSession(session, "event delivery failed");
+        }
         return;
       }
-      session.waiter = undefined;
-      if (!res.writableEnded) {
-        sendJson(res, 200, { ok: true, event: null });
-      }
-    }, POLL_TIMEOUT_MS);
-    timer.unref?.();
-    session.waiter = { res, timer };
-    res.once("close", () => {
-      if (!res.writableEnded && session.waiter?.res === res) {
+      if (session.waiter) {
         clearTimeout(session.waiter.timer);
-        session.waiter = undefined;
-        closeSession(session, "poll connection closed");
+        sendJson(session.waiter.res, 409, { ok: false, reason: "superseded poll" });
       }
+      const timer = setTimeout(() => {
+        if (session.waiter?.res !== res) {
+          return;
+        }
+        session.waiter = undefined;
+        if (!res.writableEnded) {
+          sendJson(res, 200, { ok: true, event: null });
+        }
+      }, POLL_TIMEOUT_MS);
+      timer.unref?.();
+      session.waiter = { res, timer };
+      res.once("close", () => {
+        if (!res.writableEnded && session.waiter?.res === res) {
+          clearTimeout(session.waiter.timer);
+          session.waiter = undefined;
+          closeSession(session, "poll connection closed");
+        }
+      });
     });
   };
 
@@ -1077,12 +1098,10 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
       sendMethodNotAllowed(res);
       return;
     }
-    const session = await getSession(req, res);
-    if (!session) {
-      return;
-    }
-    closeSession(session, "watch disconnected");
-    sendJson(res, 200, { ok: true });
+    await withCurrentSession(req, res, (session) => {
+      closeSession(session, "watch disconnected");
+      sendJson(res, 200, { ok: true });
+    });
   };
 
   const handleResult = async (req: IncomingMessage, res: ServerResponse) => {
@@ -1090,8 +1109,7 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
       sendMethodNotAllowed(res);
       return;
     }
-    const session = await getSession(req, res);
-    if (!session) {
+    if (!(await getSession(req, res))) {
       return;
     }
     const body = await readJsonBodyOrError(req, res, MAX_BODY_BYTES);
@@ -1102,29 +1120,26 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
       sendInvalidRequest(res, "invalid node invoke result");
       return;
     }
-    const error = isRecord(body.error)
-      ? {
-          ...(typeof body.error.code === "string" ? { code: body.error.code } : {}),
-          ...(typeof body.error.message === "string" ? { message: body.error.message } : {}),
-        }
-      : null;
-    // Body upload can yield long enough for an external pairing mutation.
-    // Recheck the exact HTTP transport before committing its invoke result.
-    if (!(await options.nodeRegistry.isConnectionCurrentPairingState(session.connId))) {
-      closeSession(session, "node pairing changed");
-      sendUnauthorized(res);
-      return;
-    }
-    const accepted = options.nodeRegistry.handleInvokeResult({
+    const result = {
       id: body.id,
-      nodeId: session.nodeId,
-      connId: session.connId,
       ok: body.ok,
       payload: body.payload,
       payloadJSON: typeof body.payloadJSON === "string" ? body.payloadJSON : null,
-      error,
+      error: isRecord(body.error)
+        ? {
+            ...(typeof body.error.code === "string" ? { code: body.error.code } : {}),
+            ...(typeof body.error.message === "string" ? { message: body.error.message } : {}),
+          }
+        : null,
+    };
+    await withCurrentSession(req, res, (session) => {
+      const accepted = options.nodeRegistry.handleInvokeResult({
+        ...result,
+        nodeId: session.nodeId,
+        connId: session.connId,
+      });
+      sendJson(res, 200, accepted ? { ok: true } : { ok: true, ignored: true });
     });
-    sendJson(res, 200, accepted ? { ok: true } : { ok: true, ignored: true });
   };
 
   const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Watch could receive queued commands after its device pairing was revoked or its HTTP connection was retired while a poll was being authenticated. This affects the existing Watch HTTP transport; it does not depend on the standalone voice feature in #135808.

## Why This Change Was Made

Pairing verification suspends, so its successful result is only a snapshot. Poll, disconnect, and uploaded invoke-result handlers now commit through one synchronous owner check immediately after that await: the session must still be valid, the token map must hold that exact session, and the node registry must still hold its exact connection. Session renewal and the effect happen without another suspension. A check only inside the asynchronous getter leaves the same gap for its callers; clearing one queue would not protect waiter installation or invoke results.

The result-upload path retains authentication before reading the body and revalidates after it. No pairing schema, token format, protocol version, configuration option, or timeout is changed. The existing server test factory moves to a test-support module, unchanged, to keep the regression within the repository's file-length limit.

## User Impact

A revoked or replaced Watch connection cannot deliver queued work, install a new poll waiter, refresh its idle lifetime, or submit a result using an earlier successful pairing check. Normal authenticated polling and result delivery remain supported.

## Evidence

The regression uses real loopback HTTP, signed Watch bootstrap, the actual node registry, and the real temporary SQLite pairing store. A call-through test seam holds a genuine successful pairing verdict across a concurrent token revocation and transport retirement. Before the fix the poll returned HTTP 200 with the queued synthetic command; after the fix it returns HTTP 401 and the retired node is absent. The seam deterministically exposes the await boundary; this is not a claim to reproduce an uncontrolled network race on Watch hardware.

All 16 current-main Watch HTTP tests pass, including ordinary bootstrap/poll/result, external pairing generation change, mutation during result upload, authenticated disconnect, connection abort, and bootstrap response rollback. The feature branch's 21 related tests also pass. Both checkouts pass scoped type-aware lint, Gateway test typecheck and formatting. The main full changed-file run passed core and core-test typechecks, dependency/boundary guards and all three Knip scans before failing the test-length gate; the subsequent factory extraction passed that exact lint gate without suppressions. Fresh P0-scoped autoreview found no accepted findings; the lead and an independent reviewer also checked the real owner/caller/sibling lifecycle paths.

The full isolated production Gateway passed 19 live stages on exact head `4a537fc608176f6e831a117f2b4023dba6f3192a`. A real signed operator requested node-only setup, and a signed Watch-protocol client completed three actual `node.invoke` → HTTP poll → result marker round trips across initial connection, replacement, and fresh reauthorization. A real `device.token.revoke` RPC ended an outstanding poll with HTTP 401 and appeared in the canonical paired-device projection. Superseded poll/result/disconnect, consumed setup, revoked credentials, and six old-session polls after renewal all returned 401. The current authorized connection still completed its round trip and disconnected normally. The client and Gateway exited zero; the owned port closed and source hashes stayed unchanged.

This uses the real Gateway, SQLite/auth, HTTP and WebSocket paths with a diagnostic client, not Watch hardware, audio, a provider, or an artificially injected server callback. The live pending-poll revocation does not claim to reproduce the microscopic post-verification race naturally; the deterministic regression proves that window separately. Initial local-launch failures for an obsolete harness config key and a source-loader prerequisite were fixed only in the task harness, without changing production or relaxing checks.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33590398438) completed successfully, including the [required ci-gate](https://github.com/openclaw/openclaw/actions/runs/33590398438/job/100124409869). Fresh main `61e579ee611c3fee3607b346787723bfc334ac02` was inspected from available local blobs: Watch HTTP, node registry, request-context retirement and device-method owners are unchanged from this PR's base. Both latest ClawSweeper rank-up requests—live revocation verification and a current-main comparison—are complete. No physical Watch, microphone, provider audio, or endurance proof is claimed for this repair.

Production +71/-56 (net +15); tests and test support +163/-105 (net +58), including a pure factory move. The production growth is the shared synchronous authorization/transport ownership boundary used by all three effects, not a retry or fallback. Introducing provenance is not established; no attribution is inferred from blame.

Release note: Watch HTTP commands and results respect pairing revocation and connection retirement even when those occur during authentication.
