### PR TITLE
refactor(scripts): share timeout error factory

### DIFF
--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -6,6 +6,7 @@ import {
   createBoundedResponseTooLargeError,
   readBoundedResponseText,
 } from "../../../lib/bounded-response.mjs";
+import { createTimeoutError } from "../../../lib/timeout-error.mjs";
 import { readPositiveIntEnv } from "../env-limits.mjs";
 import {
   readPluginInstallIndex,
@@ -30,12 +31,6 @@ function readClawHubPreflightLimits() {
     ),
     timeoutMs: readPositiveIntEnv("OPENCLAW_PLUGINS_E2E_CLAWHUB_PREFLIGHT_TIMEOUT_MS", 30_000),
   };
-}
-
-function createTimeoutError(label, timeoutMs) {
-  const error = new Error(`${label} timed out after ${timeoutMs}ms`);
-  error.code = "ETIMEDOUT";
-  return error;
 }
 
 async function withTimeout(label, timeoutMs, run) {

--- a/scripts/e2e/openwebui-probe.mjs
+++ b/scripts/e2e/openwebui-probe.mjs
@@ -5,6 +5,7 @@ import {
   readBoundedResponseText as readBoundedResponseTextWithLimit,
 } from "../lib/bounded-response.mjs";
 import { escapeRegExp } from "../lib/regexp.mjs";
+import { createTimeoutError } from "../lib/timeout-error.mjs";
 
 const baseUrl = process.env.OPENWEBUI_BASE_URL ?? "";
 const email = process.env.OPENWEBUI_ADMIN_EMAIL ?? "";
@@ -82,12 +83,6 @@ function readPositiveTimerMs(name, fallback) {
 
 function readNonNegativeTimerMs(name, fallback) {
   return clampOpenWebUiTimerTimeoutMs(readNonNegativeInt(name, fallback), 0);
-}
-
-function createTimeoutError(label, timeoutMs) {
-  const error = new Error(`${label} timed out after ${timeoutMs}ms`);
-  error.code = "ETIMEDOUT";
-  return error;
 }
 
 async function withRequestTimeout(label, timeoutMs, run) {

--- a/scripts/github/real-behavior-proof-policy.mjs
+++ b/scripts/github/real-behavior-proof-policy.mjs
@@ -1,6 +1,7 @@
 // Shared PR context and evidence policy for GitHub checks and label decisions.
 import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 import { escapeRegExp } from "../lib/regexp.mjs";
+import { createTimeoutError } from "../lib/timeout-error.mjs";
 
 /** @typedef {Record<string, unknown>} PullRequest */
 /** @typedef {Record<string, unknown>} Comment */
@@ -64,12 +65,6 @@ const legacyProofFieldNames = [
 
 const missingValueRegex =
   /^(?:n\/?a|none|not applicable|tbd|todo|unknown|unsure|none provided|no evidence|not tested|untested|did not test|didn't test|could not test|couldn't test|-|(?:-{3,}|\*{3,}|_{3,})|\[[^\]]*\])\.?$/i;
-
-function createTimeoutError(label, timeoutMs) {
-  const error = new Error(`${label} timed out after ${timeoutMs}ms`);
-  error.code = "ETIMEDOUT";
-  return error;
-}
 
 function createTooLargeGitHubApiBodyError(label, maxBytes) {
   const error = new Error(`${label} response body exceeded ${maxBytes} bytes`);

--- a/scripts/lib/timeout-error.mjs
+++ b/scripts/lib/timeout-error.mjs
@@ -1,0 +1,5 @@
+export function createTimeoutError(label, timeoutMs) {
+  const error = new Error(`${label} timed out after ${timeoutMs}ms`);
+  error.code = "ETIMEDOUT";
+  return error;
+}

--- a/test/scripts/real-behavior-proof-policy.test.ts
+++ b/test/scripts/real-behavior-proof-policy.test.ts
@@ -637,7 +637,10 @@ describe("isMaintainerTeamMember", () => {
         timeoutMs: 5,
         token: "t",
       }),
-    ).rejects.toThrow(/maintainer membership lookup for u timed out after 5ms/);
+    ).rejects.toMatchObject({
+      code: "ETIMEDOUT",
+      message: "maintainer membership lookup for u timed out after 5ms",
+    });
   });
 
   it("times out stalled membership response bodies", async () => {


### PR DESCRIPTION
Related follow-up: #135887

## What Problem This Solves

Three test and proof entrypoints independently created the same timeout error, including the same message and `ETIMEDOUT` code. Keeping those copies aligned made a small observable error contract unnecessarily easy to drift.

## Why This Change Was Made

`scripts/lib/timeout-error.mjs` now owns the private assignment-based factory. The OpenWebUI probe, plugin E2E assertions, and GitHub proof policy import it while retaining their distinct timer wrappers, clamping, abort behavior, and response handling.

The existing GitHub policy test now asserts the observable timeout `code` and `message`. No helper-specific or descriptor test was added because that would couple coverage to the extraction rather than the caller contract.

## User Impact

No functional user-visible behavior changes. Error name, message, `ETIMEDOUT`
code, absent `cause`, and property descriptors are preserved. Timer, abort,
race, cleanup, clamping, and response handling remain caller-local.

Stack traces now originate from `scripts/lib/timeout-error.mjs`; this is the
only intentional diagnostic difference.

## Evidence

- Exact refreshed and locally tested head: `c245b4c17902ffe91defb0980c649c13f468e52a`
- Refresh parent: `c5bde6ac9349d45b71bcd1d60f0048d686ac5964`
- The refreshed commit has a valid ED25519 signature and preserves the original author and commit message.
- Aggregate patch ID remained `4ae532ef1d6065dd2c64553f3bc2ab32a9d466b2`; all five per-file patch IDs were also preserved.
- `node scripts/run-vitest.mjs test/scripts/real-behavior-proof-policy.test.ts test/scripts/plugins-assertions.test.ts`: 2 files, 83 tests passed. The current-main suites contain two more tests than the 81-test source-head run.
- `node --check` passed for all four changed JavaScript modules.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- Focused `oxfmt --check` and `git diff --check` passed.
- Exact-head hosted CI passed in run `33712072147`.
- Fresh isolated Codex autoreview at `gpt-5.6-sol` / high returned scoped-clean with 0.99 confidence.
- Real OpenWebUI Docker E2E passed on Blacksmith Testbox lease `tbx_01m1jqw1ty4d4fyt0kpsxfqa1g`, carrier run `33714607323`, with exit 0. Command: `CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=install OPENCLAW_OPENWEBUI_MODEL=openai/gpt-5.4-mini OPENCLAW_OPENWEBUI_PROVIDER_TIMEOUT_SECONDS=300 corepack pnpm test:docker:openwebui`.
- Testbox observed the gateway model endpoint, started Open WebUI, completed the Open WebUI -> OpenClaw smoke, reported `OK`, and stopped the one-shot lease.
- ClawSweeper rank-up moves resolved: current-main comparison through `4e106e66581fd7f18d28f0b0411ee0e356e04688` found only a distant plugin-reinstall assertion in `scripts/e2e/lib/plugins/assertions.mjs`; the timeout hunks and semantics are unaffected. The maintainer decision is explicit: land this reviewed exact head after required checks and proof.

## Scope

- Production runtime: `+0/-0`
- Tooling: `+8/-18` (net `-10`)
- Tests: `+4/-1` (net `+3`)
- Total: `+12/-19` (net `-7`)

The oversized ClawHub preflight timer limit discovered during review is intentionally out of scope and tracked in #135887.
