### PR TITLE
feat(reef): control inbound friend messaging

### DIFF
--- a/docs/channels/reef.md
+++ b/docs/channels/reef.md
@@ -45,6 +45,7 @@ openclaw reef friend code
 openclaw reef friend request @friend --code CODE
 openclaw reef friend list --json
 openclaw reef friend autonomy @friend extended
+openclaw reef friend inbound @friend block
 openclaw reef friend remove @friend
 ```
 
@@ -110,7 +111,7 @@ openclaw pairing list reef
 openclaw pairing approve reef <CODE>
 ```
 
-`/reef friend list` shows friendships with status, key epoch, fingerprint, and autonomy tier.
+`/reef friend list` shows friendships with status, key epoch, fingerprint, autonomy tier, and the current inbound and outbound permissions.
 
 Change the local autonomy tier without editing config:
 
@@ -119,6 +120,14 @@ Change the local autonomy tier without editing config:
 ```
 
 The headless equivalent is `openclaw reef friend autonomy @friend notify-only`. If an active relay friendship has no matching local pin (for example, after restoring keys without the shared state database), Reef surfaces a new pairing request and stays fail-closed until you compare the fingerprint and approve it.
+
+Block new inbound messages from one friend without removing the friendship or preventing your claw from sending to them:
+
+```text
+/reef friend inbound @friend block
+```
+
+Use `allow` to restore that direction. The headless equivalent is `openclaw reef friend inbound @friend block`. The receiving owner controls this permission; `outbound=block` in your friend list means the peer has blocked new messages from your claw. Messages whose relay authorization check began before a block may still be delivered, and delivery receipts remain enabled in both directions.
 
 ## Sending and receiving
 

--- a/extensions/reef/src/cli.ts
+++ b/extensions/reef/src/cli.ts
@@ -441,6 +441,8 @@ export function registerReefCli({ program }: { program: Command }): void {
               peer: friend.peer,
               status: friend.status,
               autonomy: friend.autonomy ?? null,
+              inboundAllowed: friend.inbound_allowed,
+              outboundAllowed: friend.outbound_allowed,
               fingerprint: friend.fingerprint,
             })),
           },
@@ -450,7 +452,7 @@ export function registerReefCli({ program }: { program: Command }): void {
             `Fingerprint: ${printed}`,
             ...friends.map(
               (friend) =>
-                `- @${friend.peer}: ${friend.status}${friend.autonomy ? ` (${friend.autonomy})` : ""}`,
+                `- @${friend.peer}: ${friend.status}${friend.autonomy ? ` (${friend.autonomy})` : ""} inbound=${friend.inbound_allowed ? "allow" : "block"} outbound=${friend.outbound_allowed ? "allow" : "block"}`,
             ),
             ...(friends.length === 0 ? ["No friendships yet."] : []),
           ],
@@ -490,6 +492,27 @@ export function registerReefCli({ program }: { program: Command }): void {
     );
 
   friend
+    .command("inbound <handle> <access>")
+    .description("Allow or block new inbound messages from a friend")
+    .option("--json", "Emit JSON", false)
+    .action(
+      reefCliAction<{ json: boolean }, [string, string]>(
+        async (output, _options, handle, access) => {
+          if (access !== "allow" && access !== "block") {
+            throw new Error("Reef inbound access must be allow or block");
+          }
+          const { manager } = await loadConfiguredManager(output);
+          const peer = handle.replace(/^@/, "").toLowerCase();
+          const inboundAllowed = access === "allow";
+          await manager.setInboundAllowed(peer, inboundAllowed);
+          emit(output, { peer, inboundAllowed }, [
+            `${inboundAllowed ? "Allowed" : "Blocked"} new inbound messages from @${peer}.`,
+          ]);
+        },
+      ),
+    );
+
+  friend
     .command("request <handle>")
     .description("Request a friendship (adopted automatically once accepted)")
     .option("--code <code>", "Friend code minted by the recipient")
@@ -520,6 +543,8 @@ export function registerReefCli({ program }: { program: Command }): void {
               peer: entry.peer,
               status: entry.status,
               autonomy: entry.autonomy ?? null,
+              inboundAllowed: entry.inbound_allowed,
+              outboundAllowed: entry.outbound_allowed,
               keyEpoch: entry.key_epoch,
               fingerprint: entry.fingerprint,
             })),
@@ -527,7 +552,7 @@ export function registerReefCli({ program }: { program: Command }): void {
           friends.length
             ? friends.map(
                 (entry) =>
-                  `@${entry.peer} ${entry.status} epoch=${entry.key_epoch} fingerprint=${entry.fingerprint}${entry.autonomy ? ` autonomy=${entry.autonomy}` : ""}`,
+                  `@${entry.peer} ${entry.status} epoch=${entry.key_epoch} fingerprint=${entry.fingerprint}${entry.autonomy ? ` autonomy=${entry.autonomy}` : ""} inbound=${entry.inbound_allowed ? "allow" : "block"} outbound=${entry.outbound_allowed ? "allow" : "block"}`,
               )
             : ["No friendships yet."],
         );

--- a/extensions/reef/src/commands.ts
+++ b/extensions/reef/src/commands.ts
@@ -10,7 +10,7 @@ export async function handleReefCommand({
 }): Promise<{ text: string }> {
   const words = (args ?? "").trim().split(/\s+/).filter(Boolean);
   const changesFriendship =
-    words[0] === "friend" && /^(code|request|remove|block|autonomy)$/.test(words[1] ?? "");
+    words[0] === "friend" && /^(code|request|remove|block|autonomy|inbound)$/.test(words[1] ?? "");
   const decidesReview = words[0] === "review" && /^(approve|deny)$/.test(words[1] ?? "");
   if ((changesFriendship || decidesReview) && senderIsOwner !== true) {
     return {
@@ -35,7 +35,7 @@ export async function handleReefCommand({
         ? friends
             .map(
               (friend) =>
-                `@${friend.peer} ${friend.status} epoch=${friend.key_epoch} fingerprint=${friend.fingerprint} autonomy=${friend.autonomy ?? "unapproved"}`,
+                `@${friend.peer} ${friend.status} epoch=${friend.key_epoch} fingerprint=${friend.fingerprint} autonomy=${friend.autonomy ?? "unapproved"} inbound=${friend.inbound_allowed ? "allow" : "block"} outbound=${friend.outbound_allowed ? "allow" : "block"}`,
             )
             .join("\n")
         : "No Reef friends.",
@@ -51,6 +51,19 @@ export async function handleReefCommand({
     const autonomy = ReefAutonomySchema.parse(words[3]);
     await active.friends.setAutonomy(peer, autonomy);
     return { text: `Reef friend @${peer} autonomy set to ${autonomy}.` };
+  }
+  if (
+    words[0] === "friend" &&
+    words[1] === "inbound" &&
+    words[2] &&
+    /^(allow|block)$/.test(words[3] ?? "")
+  ) {
+    const peer = words[2].replace(/^@/, "").toLowerCase();
+    const inboundAllowed = words[3] === "allow";
+    await active.friends.setInboundAllowed(peer, inboundAllowed);
+    return {
+      text: `Reef friend @${peer} inbound messages ${inboundAllowed ? "allowed" : "blocked"}.`,
+    };
   }
   if (words[0] === "review" && words[1] === "list") {
     const reviews = await active.reviews.list();
@@ -78,6 +91,6 @@ export async function handleReefCommand({
     };
   }
   return {
-    text: "Usage: /reef friend code|request <handle> [code]|list|remove <handle>|autonomy <handle> <notify-only|bounded|extended>; /reef review list|approve <digest>|deny <digest>",
+    text: "Usage: /reef friend code|request <handle> [code]|list|remove <handle>|autonomy <handle> <notify-only|bounded|extended>|inbound <handle> <allow|block>; /reef review list|approve <digest>|deny <digest>",
   };
 }

--- a/extensions/reef/src/config-schema.test.ts
+++ b/extensions/reef/src/config-schema.test.ts
@@ -107,6 +107,7 @@ describe("Reef configuration boundary", () => {
     const requestFriend = vi.fn();
     const removeFriend = vi.fn();
     const setAutonomy = vi.fn();
+    const setInboundAllowed = vi.fn();
     const decide = vi.fn().mockResolvedValue(true);
     const listFriends = vi.fn().mockResolvedValue([]);
     createReefRuntimeAuthority().activate({
@@ -117,6 +118,7 @@ describe("Reef configuration boundary", () => {
         list: listFriends,
         remove: removeFriend,
         setAutonomy,
+        setInboundAllowed,
       },
       reviews: { list: vi.fn(), decide },
     } as never);
@@ -125,6 +127,9 @@ describe("Reef configuration boundary", () => {
     };
     await expect(
       command.handler({ args: "friend autonomy peer extended", senderIsOwner: false }),
+    ).resolves.toEqual(ownerRequired);
+    await expect(
+      command.handler({ args: "friend inbound peer block", senderIsOwner: false }),
     ).resolves.toEqual(ownerRequired);
     await expect(
       command.handler({ args: `review approve ${"a".repeat(64)}`, senderIsOwner: false }),
@@ -136,6 +141,7 @@ describe("Reef configuration boundary", () => {
     expect(requestFriend).not.toHaveBeenCalled();
     expect(removeFriend).not.toHaveBeenCalled();
     expect(setAutonomy).not.toHaveBeenCalled();
+    expect(setInboundAllowed).not.toHaveBeenCalled();
     expect(decide).not.toHaveBeenCalled();
 
     await expect(command.handler({ args: "friend list", senderIsOwner: false })).resolves.toEqual({
@@ -147,11 +153,15 @@ describe("Reef configuration boundary", () => {
       command.handler({ args: "friend autonomy peer extended", senderIsOwner: true }),
     ).resolves.toEqual({ text: "Reef friend @peer autonomy set to extended." });
     await expect(
+      command.handler({ args: "friend inbound peer block", senderIsOwner: true }),
+    ).resolves.toEqual({ text: "Reef friend @peer inbound messages blocked." });
+    await expect(
       command.handler({ args: `review approve ${"a".repeat(64)}`, senderIsOwner: true }),
     ).resolves.toEqual({
       text: "Reef review approved. Retry the identical message to re-run the guard.",
     });
     expect(setAutonomy).toHaveBeenCalledWith("peer", "extended");
+    expect(setInboundAllowed).toHaveBeenCalledWith("peer", false);
     expect(decide).toHaveBeenCalledWith("a".repeat(64), true);
 
     await expect(

--- a/extensions/reef/src/flow-send.test.ts
+++ b/extensions/reef/src/flow-send.test.ts
@@ -19,12 +19,76 @@ import {
 } from "./flow.test-helpers.js";
 import { reefPeerIdentity } from "./friend-types.js";
 import { reefMessageTextHash } from "./rejection-resend.js";
-import type { ReefTransportClient } from "./transport.js";
+import { ReefRelayError, type ReefTransportClient } from "./transport.js";
 
 beforeEach(resetFlowStoresForTests);
 afterEach(resetFlowStoresForTests);
 
 describe("ReefMessageFlow send recovery", () => {
+  it("discards a delivery binding after the recipient disables its direction", async () => {
+    const alice = reefKeys();
+    const bob = generateIdentity();
+    const cfg = config();
+    cfg.handle = "alice";
+    const trusted = trust({ bob: peerTrust(bob) });
+    const relay = transport();
+    relay.sendEnvelope.mockRejectedValueOnce(
+      new ReefRelayError(
+        403,
+        "Reef peer @bob has disabled inbound messages from this friendship.",
+        "friendship_direction_disabled",
+      ),
+    );
+    const flow = new ReefMessageFlow({
+      config: cfg,
+      trust: trusted.store,
+      keys: alice,
+      transport: relay as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(7)),
+      replay: new MemoryReplayStore(),
+      ...flowStores(),
+      onIngress: async () => {},
+      onOwnerNotice: async () => {},
+    });
+    const id = "01JZ0000000000000000000202";
+
+    await expect(flow.send("bob", "blocked", { messageId: id })).rejects.toMatchObject({
+      status: 403,
+      code: "friendship_direction_disabled",
+    });
+
+    expect(trusted.deliveries.has(`bob:${id}`)).toBe(false);
+  });
+
+  it("retains a delivery binding when the relay outcome is ambiguous", async () => {
+    const alice = reefKeys();
+    const bob = generateIdentity();
+    const cfg = config();
+    cfg.handle = "alice";
+    const trusted = trust({ bob: peerTrust(bob) });
+    const relay = transport();
+    const cause = new Error("relay outcome unknown");
+    relay.sendEnvelope.mockRejectedValueOnce(cause);
+    const flow = new ReefMessageFlow({
+      config: cfg,
+      trust: trusted.store,
+      keys: alice,
+      transport: relay as unknown as ReefTransportClient,
+      guard: guard(allow),
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(7)),
+      replay: new MemoryReplayStore(),
+      ...flowStores(),
+      onIngress: async () => {},
+      onOwnerNotice: async () => {},
+    });
+    const id = "01JZ0000000000000000000203";
+
+    await expect(flow.send("bob", "uncertain", { messageId: id })).rejects.toBe(cause);
+
+    expect(trusted.deliveries.has(`bob:${id}`)).toBe(true);
+  });
+
   it("persists automatic resends as non-resendable deliveries", async () => {
     const alice = reefKeys();
     const bob = generateIdentity();

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -33,7 +33,7 @@ import {
 } from "./friend-types.js";
 import { reefMessageTextHash } from "./rejection-resend.js";
 import { ReefDeliveredStore, ReviewApprovalStore } from "./state.js";
-import { ReefInboxEntryParkedError, ReefTransportClient } from "./transport.js";
+import { ReefInboxEntryParkedError, ReefRelayError, ReefTransportClient } from "./transport.js";
 import {
   REEF_OUTBOUND_DELIVERY_MAX_ENTRIES,
   REEF_OUTBOUND_DELIVERY_TTL_MS,
@@ -110,6 +110,9 @@ class ReefOutboundRejectedError extends Error {
 }
 
 export function isPermanentReefOutboundRejection(error: unknown): boolean {
+  if (isReefFriendshipDirectionDisabled(error)) {
+    return true;
+  }
   if (error instanceof ReefOutboundRejectedError) {
     return true;
   }
@@ -125,6 +128,14 @@ export function isPermanentReefOutboundRejection(error: unknown): boolean {
     error.stage === "guard" &&
     error.verdict?.decision === "deny" &&
     error.verdict.category !== "guard_failure"
+  );
+}
+
+function isReefFriendshipDirectionDisabled(error: unknown): error is ReefRelayError {
+  return (
+    error instanceof ReefRelayError &&
+    error.status === 403 &&
+    error.code === "friendship_direction_disabled"
   );
 }
 
@@ -201,21 +212,29 @@ export class ReefMessageFlow {
         `Reef peer @${peer} changed keys while composing the message`,
       );
     }
+    const delivery = {
+      bodyHash: hashMessageBody(body),
+      textHash: reefMessageTextHash(text),
+      recipient,
+    };
     this.options.trust.recordOutboundDelivery(
       peer,
       id,
-      {
-        bodyHash: hashMessageBody(body),
-        textHash: reefMessageTextHash(text),
-        recipient,
-      },
+      delivery,
       context.resendDisabled ? { resendDisabled: true } : {},
     );
     // Guard/review/encryption are local and may reject safely. Mark ambiguity
     // only at the relay boundary so recovery never treats those failures as sent.
     await context.onPlatformSendDispatch?.();
     signal?.throwIfAborted();
-    await this.options.transport.sendEnvelope(peer, result.envelope, signal);
+    try {
+      await this.options.transport.sendEnvelope(peer, result.envelope, signal);
+    } catch (error) {
+      if (isReefFriendshipDirectionDisabled(error)) {
+        this.options.trust.discardOutboundDelivery(peer, id, delivery);
+      }
+      throw error;
+    }
     signal?.throwIfAborted();
     return id;
   }

--- a/extensions/reef/src/friends.test.ts
+++ b/extensions/reef/src/friends.test.ts
@@ -90,6 +90,10 @@ function transport(friend: RelayFriend) {
   return {
     handle: "me",
     listFriends: vi.fn(async () => ({ friendships: [friend] })),
+    setInboundAllowed: vi.fn(async (_peer: string, inboundAllowed: boolean) => ({
+      peer: friend.peer,
+      inbound_allowed: inboundAllowed,
+    })),
     requestFriend: vi.fn(async () => ({ status: "pending" })),
     respondFriend: vi.fn(async (candidate: RelayFriend, accept: boolean) => {
       candidate.status = accept ? "active" : "blocked";
@@ -191,6 +195,42 @@ describe("ReefFriendManager pairing", () => {
     const reopened = trust();
     expect(reopened.get("alice")).toMatchObject({ autonomy: "bounded" });
     expect(fs.existsSync(path.join(stateDir, "requested.json"))).toBe(false);
+  });
+
+  it("updates only the caller-owned inbound direction and lists both relay directions", async () => {
+    const active = relayFriend("alice", "active");
+    active.inbound_allowed = false;
+    active.outbound_allowed = true;
+    const relay = transport(active);
+    const manager = new ReefFriendManager(
+      relay as unknown as ReefTransportClient,
+      trust(),
+      approvals(),
+    );
+
+    await manager.setInboundAllowed("@ALICE", true);
+    await expect(manager.list()).resolves.toEqual([
+      expect.objectContaining({
+        peer: "alice",
+        inbound_allowed: false,
+        outbound_allowed: true,
+      }),
+    ]);
+
+    expect(relay.setInboundAllowed).toHaveBeenCalledWith("alice", true, undefined);
+  });
+
+  it("treats permissions omitted by an older relay as the legacy bidirectional allow", async () => {
+    const active = relayFriend("alice", "active");
+    const manager = new ReefFriendManager(
+      transport(active) as unknown as ReefTransportClient,
+      trust(),
+      approvals(),
+    );
+
+    await expect(manager.list()).resolves.toEqual([
+      expect.objectContaining({ inbound_allowed: true, outbound_allowed: true }),
+    ]);
   });
 
   it("preserves ambiguous outbound intent when account authority closes during a relay request", async () => {

--- a/extensions/reef/src/friends.ts
+++ b/extensions/reef/src/friends.ts
@@ -21,6 +21,8 @@ type ReefPairingApprovals = {
 type ListedReefFriend = RelayFriend & {
   fingerprint: string;
   autonomy?: ReefAutonomy;
+  inbound_allowed: boolean;
+  outbound_allowed: boolean;
 };
 
 type ReefPairingApproval = {
@@ -128,6 +130,16 @@ export class ReefFriendManager {
     });
   }
 
+  setInboundAllowed(peer: string, inboundAllowed: boolean): Promise<void> {
+    return this.#serialize(async (signal) => {
+      const normalized = normalizeReefTarget(peer);
+      if (!normalized) {
+        throw new Error(`Invalid Reef peer handle: ${peer}`);
+      }
+      await this.transport.setInboundAllowed(normalized, inboundAllowed, signal);
+    });
+  }
+
   async list(): Promise<ListedReefFriend[]> {
     const signal = this.authoritySignal;
     signal?.throwIfAborted();
@@ -139,6 +151,9 @@ export class ReefFriendManager {
       const autonomy = local.get(friend.peer)?.autonomy;
       listed.push({
         ...friend,
+        // Older relays predate directional permissions and allow both ways.
+        inbound_allowed: friend.inbound_allowed ?? true,
+        outbound_allowed: friend.outbound_allowed ?? true,
         fingerprint: fingerprint(friend.ed25519_pub, friend.x25519_pub),
         ...(autonomy ? { autonomy } : {}),
       });

--- a/extensions/reef/src/outbound.test.ts
+++ b/extensions/reef/src/outbound.test.ts
@@ -21,7 +21,7 @@ import {
 } from "./flow.test-helpers.js";
 import { reefMessageAdapter, reefOutboundAdapter } from "./outbound.js";
 import { createReefRuntimeAuthority, getActiveReef } from "./runtime.js";
-import type { ReefTransportClient } from "./transport.js";
+import { ReefRelayError, type ReefTransportClient } from "./transport.js";
 
 describe("reefOutboundAdapter", () => {
   it("delegates delivery to the Gateway that owns the active encrypted flow", () => {
@@ -230,6 +230,39 @@ describe("reefOutboundAdapter", () => {
       },
       retryable: false,
     });
+  });
+
+  it("terminally rejects a recipient-disabled friendship direction after dispatch", async () => {
+    const cause = new ReefRelayError(
+      403,
+      "friendship_direction_disabled",
+      "friendship_direction_disabled",
+    );
+    const send = vi.fn(
+      async (
+        _peer: string,
+        _text: string,
+        context: { onPlatformSendDispatch?: () => Promise<void> },
+      ) => {
+        await context.onPlatformSendDispatch?.();
+        throw cause;
+      },
+    );
+    const onPlatformSendDispatch = vi.fn(async () => {});
+    createReefRuntimeAuthority().activate({ flow: { send }, friends: {}, reviews: {} } as never);
+
+    const error = await reefMessageAdapter.send
+      .text({
+        cfg: {},
+        to: "reef:Alice",
+        text: "hello",
+        onPlatformSendDispatch,
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
+    expect(error).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expect(error).toMatchObject({ cause, retryable: false });
   });
 
   it("keeps guard availability failures retryable before dispatch", async () => {

--- a/extensions/reef/src/transport-errors.ts
+++ b/extensions/reef/src/transport-errors.ts
@@ -1,0 +1,29 @@
+export class ReefRelayError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+    readonly code?: string,
+  ) {
+    super(message);
+    this.name = "ReefRelayError";
+  }
+}
+
+export class ReefRelayUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = "ReefRelayUnavailableError";
+  }
+}
+
+export class ReefProtocolCompatibilityError extends ReefRelayError {
+  constructor(
+    status: 400 | 404 | 409,
+    code: "invalid_request" | "not_found" | "client_upgrade_required",
+    readonly upgradeRequired: "reef-relay" | "openclaw-client",
+    message: string,
+  ) {
+    super(status, message, code);
+    this.name = "ReefProtocolCompatibilityError";
+  }
+}

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -178,6 +178,72 @@ describe("ReefTransportClient device authentication", () => {
     });
   });
 
+  it("signs and validates an inbound-permission update for the exact peer", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetcher: typeof fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push({ url, init: init ?? {} });
+      return Response.json({ peer: "bob", inbound_allowed: false });
+    };
+    const client = createClient(fetcher);
+
+    await expect(client.setInboundAllowed("bob", false)).resolves.toEqual({
+      peer: "bob",
+      inbound_allowed: false,
+    });
+
+    expect(calls[0]?.url).toBe("https://relay.example/v1/friends/bob");
+    expect(calls[0]?.init.method).toBe("PATCH");
+    expect(JSON.parse(new TextDecoder().decode(calls[0]?.init.body as Uint8Array))).toEqual({
+      inbound_allowed: false,
+    });
+    expect(new Headers(calls[0]?.init.headers).get("x-reef-sig")).toBeTruthy();
+  });
+
+  it.each([
+    Response.json({ peer: "mallory", inbound_allowed: false }),
+    Response.json({ peer: "bob", inbound_allowed: true }),
+    Response.json({ peer: "bob" }),
+  ])("rejects a mismatched inbound-permission response", async (response) => {
+    const client = createClient(async () => response.clone());
+
+    await expect(client.setInboundAllowed("bob", false)).rejects.toThrow(
+      "invalid Reef relay inbound-permission response",
+    );
+  });
+
+  it("diagnoses a relay that predates directional friendship permissions", async () => {
+    const client = createClient(async () => Response.json({ error: "not_found" }, { status: 404 }));
+
+    const error = await client.setInboundAllowed("bob", false).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ReefProtocolCompatibilityError);
+    expect(error).toMatchObject({
+      status: 404,
+      code: "not_found",
+      upgradeRequired: "reef-relay",
+      message:
+        "The Reef relay does not support directional friendship permissions. Update OpenClaw and the Reef relay together.",
+    });
+  });
+
+  it("explains a recipient-disabled friendship direction", async () => {
+    const client = createClient(async () =>
+      Response.json({ error: "friendship_direction_disabled" }, { status: 403 }),
+    );
+
+    const error = await client
+      .sendEnvelope("bob", { id: "01JZ0000000000000000000204" } as never)
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ReefRelayError);
+    expect(error).toMatchObject({
+      status: 403,
+      code: "friendship_direction_disabled",
+      message: "Reef peer @bob has disabled inbound messages from this friendship.",
+    });
+  });
+
   it("diagnoses an outdated relay without retrying or downgrading the signed request", async () => {
     const calls: RequestInit[] = [];
     const fetcher: typeof fetch = async (_input, init) => {

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -6,7 +6,14 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import WebSocket from "ws";
 import { sha256Hex, signDeviceRequest, utf8 } from "../protocol/index.js";
 import type { Envelope, SignedReceipt } from "../protocol/index.js";
+import {
+  ReefProtocolCompatibilityError,
+  ReefRelayError,
+  ReefRelayUnavailableError,
+} from "./transport-errors.js";
 import type { InboxEntry, ReefKeys, RelayFriend } from "./types.js";
+
+export { ReefProtocolCompatibilityError, ReefRelayError } from "./transport-errors.js";
 
 type FetchLike = typeof fetch;
 
@@ -43,36 +50,6 @@ function redactReefRelayErrorMessage(message: string, secrets: readonly string[]
     }
   }
   return redactSensitiveText(redacted, { mode: "tools" });
-}
-
-export class ReefRelayError extends Error {
-  constructor(
-    readonly status: number,
-    message: string,
-    readonly code?: string,
-  ) {
-    super(message);
-    this.name = "ReefRelayError";
-  }
-}
-
-export class ReefProtocolCompatibilityError extends ReefRelayError {
-  constructor(
-    status: 400 | 409,
-    code: "invalid_request" | "client_upgrade_required",
-    readonly upgradeRequired: "reef-relay" | "openclaw-client",
-    message: string,
-  ) {
-    super(status, message, code);
-    this.name = "ReefProtocolCompatibilityError";
-  }
-}
-
-class ReefRelayUnavailableError extends Error {
-  constructor(cause: unknown) {
-    super(cause instanceof Error ? cause.message : String(cause), { cause });
-    this.name = "ReefRelayUnavailableError";
-  }
 }
 
 export function isDefinitiveReefRegistrationFailure(error: unknown): boolean {
@@ -229,15 +206,59 @@ export class ReefTransportClient {
   listFriends(signal?: AbortSignal): Promise<{ friendships: RelayFriend[] }> {
     return this.signed("GET", "/v1/friends", undefined, signal);
   }
+  async setInboundAllowed(
+    peer: string,
+    inboundAllowed: boolean,
+    signal?: AbortSignal,
+  ): Promise<{ peer: string; inbound_allowed: boolean }> {
+    let result: unknown;
+    try {
+      result = await this.signed(
+        "PATCH",
+        `/v1/friends/${encodeURIComponent(peer)}`,
+        { inbound_allowed: inboundAllowed },
+        signal,
+      );
+    } catch (error) {
+      if (error instanceof ReefRelayError && error.status === 404 && error.code === "not_found") {
+        throw new ReefProtocolCompatibilityError(
+          404,
+          error.code,
+          "reef-relay",
+          "The Reef relay does not support directional friendship permissions. Update OpenClaw and the Reef relay together.",
+        );
+      }
+      throw error;
+    }
+    if (!isRecord(result) || result.peer !== peer || result.inbound_allowed !== inboundAllowed) {
+      throw new Error("invalid Reef relay inbound-permission response");
+    }
+    return { peer, inbound_allowed: inboundAllowed };
+  }
   removeFriend(peer: string, signal?: AbortSignal): Promise<void> {
     return this.signed("DELETE", `/v1/friends/${encodeURIComponent(peer)}`, undefined, signal);
   }
-  sendEnvelope(
+  async sendEnvelope(
     peer: string,
     envelope: Envelope,
     signal?: AbortSignal,
   ): Promise<{ id: string; status: string }> {
-    return this.signed("POST", `/v1/mail/${encodeURIComponent(peer)}`, envelope, signal);
+    try {
+      return await this.signed("POST", `/v1/mail/${encodeURIComponent(peer)}`, envelope, signal);
+    } catch (error) {
+      if (
+        error instanceof ReefRelayError &&
+        error.status === 403 &&
+        error.code === "friendship_direction_disabled"
+      ) {
+        throw new ReefRelayError(
+          error.status,
+          `Reef peer @${peer} has disabled inbound messages from this friendship.`,
+          error.code,
+        );
+      }
+      throw error;
+    }
   }
   acknowledge(peer: string, id: string, receipt: SignedReceipt): Promise<{ result: string }> {
     return this.signed("POST", `/v1/mail/${encodeURIComponent(peer)}/ack`, { id, receipt });

--- a/extensions/reef/src/types.ts
+++ b/extensions/reef/src/types.ts
@@ -22,6 +22,10 @@ export interface RelayFriend {
   status: "pending" | "active" | "blocked" | "reapprove_required";
   initiated_by: string;
   vouching_mutual: string | null;
+  /** Whether this claw currently accepts new messages from the peer. */
+  inbound_allowed?: boolean;
+  /** Whether the peer currently accepts new messages from this claw. */
+  outbound_allowed?: boolean;
   ed25519_pub: string;
   x25519_pub: string;
   key_epoch: number;


### PR DESCRIPTION
Closes #135906
Companion relay: openclaw/reef#12

## What Problem This Solves

Reef friendships are currently bidirectional, so owners cannot stop one friend from initiating new messages without deleting the relationship and losing the useful reverse direction.

## Why This Change Was Made

Adds owner-only CLI and `/reef` controls for the receiver-owned inbound direction, displays both directions in friend listings, and preserves legacy allow/allow behavior when an older relay omits the new fields. Receiver-side relay denials are terminal, operator-readable, and remove the exact pre-dispatch delivery binding so they cannot create false overdue notices.

The companion relay migration and Worker deployment must precede use of the new command. A new client diagnoses the previous relay PATCH 404 as an upgrade requirement.

## User Impact

Owners can run `openclaw reef friend inbound <handle> allow|block` or `/reef friend inbound <handle> allow|block` to create notification-only relationships without deleting friendship state. Reverse-direction messaging and delivery receipts remain available.

A message whose relay authorization check began before a block may still arrive. Concurrent distinct permission changes use arrival-order semantics.

## Evidence

- Exact client head `f116c2ce2abc679b53b74a9b24ed23220d4ba8fe`; five focused Reef files passed 88/88 tests on 2026-09-04 and `git diff --check` is clean.
- Published companion Relay head [`1eb08d09d95f`](https://github.com/openclaw/reef/commit/1eb08d09d95f48eed071cebffe12d19cd4b11415) is rebased onto Reef main `495e7d3b2a8951ba0ea391cf933c01e70081381e`; both deployment steps use Wrangler 4.129.0 and migration precedes deployment.
- Companion Relay: 18/18 tests; protocol: 86 passed, 2 skipped; documentation renderer: 3/3; recursive test and build passed.
- The client validates the exact returned peer and boolean, maps only `friendship_direction_disabled` to the terminal permission result, and removes only the exact matching pre-dispatch binding.
- Independent security/QA cross-review; accepted state-leak finding fixed and regression-tested.
- Repository autoreview found no actionable client findings (0.98 confidence).

<!-- pr-behavior-proof:start -->
## Real behavior proof

- **Claim:** The real signed client can change the receiver-owned permission against the companion Relay. The production outbound flow treats the Relay's final direction denial as terminal, removes its exact pre-dispatch binding, and leaves the reverse direction and receipts usable.
- **Exercised surface:** Exact OpenClaw head `f116c2ce2abc679b53b74a9b24ed23220d4ba8fe`, including production `ReefMessageFlow.send`, `ReefTransportClient.setInboundAllowed`, and `ReefTransportClient.sendEnvelope`; exact Relay head `1eb08d09d95f48eed071cebffe12d19cd4b11415`, including device-signature/replay authentication, D1 friendship persistence, authorization before Durable Object enqueue, mailbox pull, and receipt forwarding.
- **Scenario / fixture:** Two fresh DEV_MODE identities paired over public HTTPS. A sender queued one message. The receiver signed an inbound-block update. The run verified that the old queued message and its receipt survived, sent a new message through `ReefMessageFlow`, checked the final typed denial and binding cleanup, compared the receiver mailbox cursor before and after, then delivered and acknowledged a reverse-direction message.
- **Command / environment:** On 2026-09-05 at 02:11 UTC, Wrangler 4.129.0 applied Relay migrations `0001` and `0002` to a fresh isolated local D1 database and served the exact Worker with isolated local D1 and Durable Objects in `DEV_MODE=1`. A Cloudflare Quick Tunnel exposed it at `https://<redacted>.trycloudflare.com`. The exact OpenClaw checkout ran `pnpm exec tsx /tmp/pr135908-live-relay-proof.ts` against that endpoint.
- **Observable result:** The owner PATCH returned 200 and persisted receiver inbound `0`, peer inbound `1`. The pre-update message remained readable and its acknowledgement routed a receipt. The post-update `ReefMessageFlow` call recorded its exact binding, marked platform dispatch, received 403 `friendship_direction_disabled` from the real transport, and left the binding absent; the denied ID never appeared and the recipient cursor remained `1 -> 1`. Reverse mail returned 202, was observed by the peer, and routed its receipt back.
- **Artifact / trace:** Sanitized copied terminal output follows. Handles, endpoint, auth material, keys, signatures, and envelopes are redacted.

```text
clientHead=f116c2ce2abc679b53b74a9b24ed23220d4ba8fe
relayHead=1eb08d09d95f48eed071cebffe12d19cd4b11415
migrations=0001_initial.sql:ok,0002_directional_friend_permissions.sql:ok

receiver PATCH /v1/friends/<sender>                 -> 200
D1 friendship row                                  -> receiver_inbound=0 peer_inbound=1
sender POST /v1/mail/<receiver> (pre-update item)   -> 202 queued
receiver GET /v1/mail (after update)                -> pre-update item present
receiver POST /v1/mail/<sender>/ack                 -> 200 acked
sender GET /v1/mail                                 -> receipt present
ReefMessageFlow binding before transport            -> recorded=true, dispatch_marked=true
sender POST /v1/mail/<receiver> (new flow item)     -> 403 friendship_direction_disabled
ReefMessageFlow binding after typed denial           -> present=false
receiver GET /v1/mail?after=1                       -> cursor=1, denied_id_present=false
receiver POST /v1/mail/<sender>                     -> 202 queued
sender GET /v1/mail                                 -> reverse message present
sender POST /v1/mail/<receiver>/ack                 -> 200 acked
receiver GET /v1/mail                               -> reverse receipt present
```

- **Limits:** This used a public HTTPS tunnel to an isolated Wrangler local Worker runtime because the hosted Cloudflare credential was unavailable. It proves the exact production client/Relay code and network boundary, local D1 persistence, Durable Object mailbox effects, and final client state. It does not claim that production `reefwire.ai` or hosted Cloudflare D1 has been upgraded. The tunnel and proof state were removed after capture. The documented acceptance-point race and concurrent arrival-order semantics remain unchanged.
<!-- pr-behavior-proof:end -->

## Rollout boundary

The companion migration and production `reefwire.ai` deployment must still precede enabling this command for users. The real-behavior trace above proves the exact client and Relay heads through an isolated public HTTPS environment; it does not claim a production rollout. A Reef maintainer must still approve the persistent authorization semantics and coordinated rollout.
