### PR TITLE
test(gateway): drain each dispatched run's background delivery before returning

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -850,6 +850,15 @@ function lastNodeSendCall(context: ChatContext) {
     | undefined;
 }
 
+// A wait keyed only on array length can be satisfied by a foreign update left over
+// from a prior test's detached background work; correlate on this test's own
+// dispatched session instead so a foreign update can never resolve the wait.
+function hasEmittedTranscriptUpdateForSession(sessionId: string): boolean {
+  return mockState.emittedTranscriptUpdates.some(
+    (update) => update.target?.sessionId === sessionId,
+  );
+}
+
 function findAssistantTranscriptUpdates() {
   return mockState.emittedTranscriptUpdates
     .filter(
@@ -863,6 +872,15 @@ function findAssistantTranscriptUpdates() {
       const projected = projectAssistantDisplayContent(message);
       return projected === message ? update : Object.assign({}, update, { message: projected });
     });
+}
+
+// The session-only correlation above still resolves on this session's own
+// user-turn persistence, which the dispatch owner appends before the assistant
+// transcript. Reuse the file's assistant-role filter so a background-delivery
+// wait only resolves on the run's own final assistant update, not its earlier
+// same-session user-turn write.
+function hasEmittedAssistantTranscriptUpdateForSession(sessionId: string): boolean {
+  return findAssistantTranscriptUpdates().some((update) => update.target?.sessionId === sessionId);
 }
 
 function findAssistantUpdateWithBlock(predicate: (block: Record<string, any>) => boolean) {
@@ -1595,6 +1613,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       parentId: "background-compaction",
     });
     const before = loadTranscriptEventsSync(transcriptScope());
+    const ownSessionId = mockState.sessionId;
 
     await send({
       idempotencyKey: `idem-active-ancestor-${sessionId}`,
@@ -1613,6 +1632,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(context.addChatRun).toHaveBeenCalledTimes(accepted ? 1 : 0);
     if (accepted) {
       expect(response[1]).toEqual(expect.objectContaining({ status: "started" }));
+      // The started run delivers and persists its reply in the background; wait for
+      // that delivery to land here, correlated to this test's own session AND
+      // assistant role, so it cannot be satisfied by a foreign update landing during
+      // a later test, or by this session's own earlier user-turn persist.
+      await waitForAssertion(() =>
+        expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(true),
+      );
     } else {
       expect(response[2]).toEqual(
         expect.objectContaining({ details: { reason: "active-leaf-changed" } }),
@@ -1790,6 +1816,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const { context, respond, send } = await createSqliteChatRequest(
       "openclaw-chat-send-stale-steer-no-owner-",
     );
+    const ownSessionId = mockState.sessionId;
     await appendTestTranscriptMessage({
       eventId: "current-leaf",
       role: "assistant",
@@ -1815,6 +1842,110 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     await waitForAssertion(() => expect(mockState.lastDispatchCtx?.BodyForAgent).toBe("hello"));
     expect(context.addChatRun).toHaveBeenCalledOnce();
+    // lastDispatchCtx is set before the run's reply is delivered and persisted in
+    // the background; wait for that delivery, correlated to this test's own session
+    // AND assistant role, so it cannot be satisfied by a foreign update from a later
+    // test or by this session's own earlier user-turn persist.
+    await waitForAssertion(() =>
+      expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
+  });
+
+  it("does not resolve a background-delivery wait on a foreign session's leftover update", async () => {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-foreign-update-order-",
+    );
+    const ownSessionId = mockState.sessionId;
+    await appendTestTranscriptMessage({
+      eventId: "current-leaf",
+      role: "assistant",
+      content: "finished",
+      now: 1,
+      parentId: null,
+    });
+    // Simulates a prior test's detached background delivery landing late into the
+    // shared array, for a different session, before this test's own send runs. A
+    // length-only wait (`emittedTranscriptUpdates.length > baseline`) would already
+    // be satisfied by this push alone.
+    mockState.emittedTranscriptUpdates.push({
+      target: { agentId: "main", sessionId: "foreign-session-id", sessionKey: "agent:main:main" },
+      message: { role: "assistant", content: [{ type: "text", text: "leaked from another test" }] },
+    });
+    expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(false);
+
+    await send({
+      idempotencyKey: "idem-foreign-update-order",
+      requestParams: {
+        expectedLeafEntryId: "current-leaf",
+        queueMode: "steer",
+      },
+      waitFor: "none",
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ status: "started" }),
+      undefined,
+      expect.any(Object),
+    );
+    expect(context.addChatRun).toHaveBeenCalledOnce();
+    // The foreign update above must never satisfy this wait; it only resolves once
+    // this test's own dispatched run emits its own correlated update.
+    await waitForAssertion(() =>
+      expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
+    expect(
+      mockState.emittedTranscriptUpdates.some(
+        (update) => update.target?.sessionId === "foreign-session-id",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not resolve a background-delivery wait on this session's own earlier user-turn update", async () => {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-own-user-turn-order-",
+    );
+    const ownSessionId = mockState.sessionId;
+    await appendTestTranscriptMessage({
+      eventId: "current-leaf",
+      role: "assistant",
+      content: "finished",
+      now: 1,
+      parentId: null,
+    });
+    // The ordinary dispatch owner persists this session's own user turn before it
+    // appends the assistant transcript (see publishTranscriptTurnUpdate). Simulate
+    // that same-session user-turn update landing first and prove it alone cannot
+    // satisfy an assistant-specific wait, even though it does satisfy the
+    // session-only correlation the prior iteration relied on.
+    mockState.emittedTranscriptUpdates.push({
+      target: { agentId: "main", sessionId: ownSessionId, sessionKey: "agent:main:main" },
+      message: { role: "user", content: "please keep working" },
+    });
+    expect(hasEmittedTranscriptUpdateForSession(ownSessionId)).toBe(true);
+    expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(false);
+
+    await send({
+      idempotencyKey: "idem-own-user-turn-order",
+      requestParams: {
+        expectedLeafEntryId: "current-leaf",
+        queueMode: "steer",
+      },
+      waitFor: "none",
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ status: "started" }),
+      undefined,
+      expect.any(Object),
+    );
+    expect(context.addChatRun).toHaveBeenCalledOnce();
+    // Only the run's own later assistant delivery may satisfy the wait; the
+    // earlier same-session user-turn update above must not.
+    await waitForAssertion(() =>
+      expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
   });
 
   it("injects targetless steer into the exact direct owner without a client run id", async () => {
@@ -1823,6 +1954,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
     const queueMessage = vi.fn(async () => {});
     const operation = beginMessageInjectionOperation({ queueMessage });
+    const ownSessionId = mockState.sessionId;
 
     try {
       await send({
@@ -1843,6 +1975,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(queueMessage).toHaveBeenCalledOnce();
     expect(context.addChatRun).toHaveBeenCalledOnce();
     expect(mockState.lastDispatchCtx).toBeUndefined();
+    // The accepted injection persists the user turn in the background; wait for
+    // that persistence, correlated to this test's own session, so it cannot be
+    // satisfied by a foreign update landing during a later test instead.
+    await waitForAssertion(() =>
+      expect(hasEmittedTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
   });
 
   it.each([
@@ -1987,6 +2125,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       queueMessage,
     });
     const toolBindings = { browser: { kind: "tab", tabId: 1, targetId: "target-1" } };
+    const ownSessionId = mockState.sessionId;
 
     try {
       await send({
@@ -2025,6 +2164,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       await waitForAssertion(() =>
         expect(mockState.lastDispatchCtx?.GatewayRunToolBindings).toEqual(toolBindings),
       );
+      // lastDispatchCtx is set before the run's reply is delivered and persisted in
+      // the background; wait for that delivery, correlated to this test's own session
+      // AND assistant role, so it cannot be satisfied by a foreign update from a later
+      // test or by this session's own earlier user-turn persist.
+      await waitForAssertion(() =>
+        expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(true),
+      );
     } finally {
       operation.complete();
     }
@@ -2045,6 +2191,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const successorQueue = vi.fn(async () => {});
     const successorCancel = vi.fn();
     const dispatchCallsBefore = dispatchInboundMessageMock.mock.calls.length;
+    const ownSessionId = mockState.sessionId;
     const original = beginMessageInjectionOperation({
       originatingLeafEntryId: "current-leaf",
       queueMessage: originalQueue,
@@ -2106,6 +2253,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(successorCancel).not.toHaveBeenCalled();
     expect(context.addChatRun).toHaveBeenCalledOnce();
     expect(mockState.lastMessageInjectionDisposition).toBe("rejected");
+    // The dispatch call above only proves the run started; its reply delivers and
+    // persists in the background, correlated to this test's own session AND
+    // assistant role, so wait for that too or a foreign update from a later test —
+    // or this session's own earlier user-turn persist — could satisfy this instead.
+    await waitForAssertion(() =>
+      expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
   });
 
   it("starts captured-operation injection before ACK and does not dispatch after owner clear", async () => {
@@ -3342,6 +3496,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       releaseDispatch = resolve;
     });
     const { context, send } = createChatRequestFixture();
+    const ownSessionId = mockState.sessionId;
 
     const pending = send({
       sessionKey: "agent:work:main",
@@ -3357,6 +3512,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
     releaseDispatch?.();
     await pending;
+    // This global-alias reply resolves to the transcript's existing current entry
+    // rather than appending a new assistant message, so no assistant-role update is
+    // ever emitted here (confirmed empirically: only this session's own admission-time
+    // user-turn write lands, even after the full delivery settles). Keep the
+    // session-only correlation; it cannot be satisfied by a foreign update from a
+    // later test either way.
+    await waitForAssertion(() =>
+      expect(hasEmittedTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
   });
 
   it("scopes chat history global aliases before loading session state", async () => {
@@ -6614,6 +6778,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await createReadyChatTranscript("openclaw-chat-send-text-only-attachments-");
     useChatTestModel("text-only");
     const { send } = createChatRequestFixture();
+    const ownSessionId = mockState.sessionId;
 
     await send({
       idempotencyKey: "idem-text-only-attachments",
@@ -6646,6 +6811,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         size: mockState.savedMediaCalls[0]?.size ?? 0,
       },
     ]);
+    // lastDispatchCtx is set before the run's reply is delivered and persisted in
+    // the background; wait for that delivery, correlated to this test's own session
+    // AND assistant role, so it cannot be satisfied by a foreign update from a later
+    // test or by this session's own earlier user-turn persist.
+    await waitForAssertion(() =>
+      expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
   });
 
   it("keeps image attachments inline for configured custom vision models", async () => {
@@ -6750,6 +6922,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     const { send } = createChatRequestFixture();
+    const ownSessionId = mockState.sessionId;
 
     await send({
       sessionKey: "agent:writer:main",
@@ -6783,6 +6956,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         size: mockState.savedMediaCalls[0]?.size ?? 0,
       },
     ]);
+    // This agent-scoped reply resolves to the transcript's existing current entry
+    // rather than appending a new assistant message, so no assistant-role update is
+    // ever emitted here (confirmed empirically: only this session's own admission-time
+    // user-turn write lands, even after the full delivery settles). Keep the
+    // session-only correlation; it cannot be satisfied by a foreign update from a
+    // later test either way.
+    await waitForAssertion(() =>
+      expect(hasEmittedTranscriptUpdateForSession(ownSessionId)).toBe(true),
+    );
   });
 
   it("routes non-image offloaded refs into media facts for chat.send", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes 8 tests in `chat.directive-tags.test.ts` that leave an agent run's background delivery un-awaited after receiving the "started" response, so the run's `emitSessionTranscriptUpdate` call can fire after the test has already returned — appending an assistant transcript entry to the file's shared `mockState.emittedTranscriptUpdates` array while a *different*, later test is running. See companion issue for the full reproduction (tagged-push instrumentation, order-independent, 100% reproducible across default-order and shuffled runs).

## Why This Change Was Made

`waitFor: "none"` on these 8 sends is correct — it matches this repo's real fire-and-forget dispatch design (`startChatDispatch` responds "started" immediately; the run's delivery/persistence continues in a detached `void` background promise). The gap is that each of these 8 tests already polls a *mid-flight* side effect of that background work (e.g. `lastDispatchCtx`, which the dispatch mock sets before it delivers/persists the reply) via `waitForAssertion`, and then returns — before the delivery/persistence tail that follows has actually settled.

Considered a single shared-owner fix first (tracking a promise per background-dispatch call and draining all of them in the shared `afterEach`, before `mockState.reset()`), per this repo's own shared-state/order-failure doctrine ("prefer the single-owner fix if it exists"). Investigated two levels — wrapping `dispatchInboundMessageMock` directly, then wrapping the broader `measureDiagnosticsTimelineSpan` every dispatch/delivery/persistence phase is wrapped in — and confirmed via stack-trace instrumentation that the leaked work spans multiple independent async subsystems below `chat.send` (reply-dispatcher delivery, a separate user-turn fallback-persistence path, and transcript finalization), none of which share one production seam that awaits all of them together. Draining reduced the leak count but did not eliminate it for all 8.

The fix instead adds one more `waitForAssertion` per test, waiting on the same final observable side effect (`emittedTranscriptUpdates.length` growing past its pre-send baseline) that each test's own dispatched work already produces — so the test does not return until its own background work has actually settled. Test-only; **0 production LOC** (`git diff --numstat`: 48 insertions, 0 deletions, all in the test file).

## User Impact

None (test-only change). No production code touched.

## Evidence

`git diff --numstat` (single squashed commit, replacing `cfb18d34329c3d01ef2ce45b7bd673f467b7697f`,
built on current `origin/main` tip `8342d351b280e18936bfaacf85ab4b78f4e2476c`):

```
182	0	src/gateway/server-methods/chat.directive-tags.test.ts
```

All 182 lines are test-only; **0 production LOC**.

### The fix

Read the emitter first, did not guess. `publishTranscriptTurnUpdate`
(`src/config/sessions/session-accessor.transcript-turn.ts`) emits every appended
transcript message — this session's own **user-turn** persistence and its later
**assistant** delivery alike — through the same sink, correlated only by
`target.sessionId`. The test file's own `findAssistantTranscriptUpdates()` already
narrows on `message.role === "assistant"`; reused that filter rather than inventing a
parallel one:

```ts
function hasEmittedAssistantTranscriptUpdateForSession(sessionId: string): boolean {
  return findAssistantTranscriptUpdates().some((update) => update.target?.sessionId === sessionId);
}
```

Converted **6 of the 8** waits iteration 2 touched to this predicate: "carries an
internal runtime tool cap into agent dispatch", "starts one normal turn when steer
admission finds no direct owner", the foreign-session regression, "dispatches
tool-bound input instead of injecting it into the active run", "falls back once
without touching a successor when the captured owner ends", and the new sibling
regression below.

**Deviation from the charter's "narrow all 8," found during verification, not
guessed away:** two of iteration 2's 8 sites — "registers selected-agent global
aliases under the canonical abort key" and "resolves attachment image support from
the session agent model" — never emit an assistant-role update at all in this
harness. Confirmed empirically: added a temporary 5-second dwell after each test's
real send and dumped the full `mockState.emittedTranscriptUpdates` array; only each
test's own admission-time `role: "user"` write was present, unchanged after the
extra wait. Both resolve their default `[[reply_to_current]]` reply against the
transcript's existing current entry rather than appending a new assistant message,
so no amount of waiting satisfies an assistant-role predicate there — forcing one
would hang these two tests forever, or (worse) leave them passing only by luck if a
later test's assistant update ever leaked in, reintroducing exactly the cross-test
leak this lane exists to close. Iteration 2's author extended the wait to these two
by pattern-matching the reused comment text, not by observing their actual emitted
updates. Left both on the session-only `hasEmittedTranscriptUpdateForSession`
(unchanged behavior; still correct — nothing else in the suite targets their
session), with corrected comments explaining why. Also left "injects targetless
steer into the exact direct owner without a client run id" untouched, per its own
existing comment: it waits on the injected user-turn persistence, never an assistant
delivery, and was never one of iteration 2's "8" waits.

Raw dwell/dump output for one of the two (the other is identical in shape):

```
DEBUG ownSessionId chat-directive-1
DEBUG updates [
  {
    "sessionKey": "global",
    "agentId": "work",
    "target": {
      "agentId": "work",
      "sessionId": "chat-directive-1",
      "sessionKey": "global",
      "storePath": "/tmp/oc-vt-c7xUWe/openclaw-chat-directive-suite-XDFSWx/openclaw-agent.sqlite"
    },
    "message": {
      "role": "user",
      "content": "hello",
      "timestamp": 1788800263969,
      "idempotencyKey": "idem-global-alias-abort-key:user"
    },
    "messageId": "fc388e74-4017-4344-8e39-6b6b4a89fbda",
    "messageSeq": 1
  }
]
```
(captured 5s after `await pending` resolved; no second, assistant-role entry ever appears)

### The new regression

Added one focused sibling, `"does not resolve a background-delivery wait on this
session's own earlier user-turn update"`, mirroring the existing foreign-session
regression's synthetic-push style: pushes a synthetic same-session `role: "user"`
update, asserts the session-only predicate is already `true` for it while the
assistant-specific predicate is `false`, then performs the real dispatched send and
asserts only the later real assistant delivery satisfies the assistant-specific
wait. Kept iteration 2's foreign-session regression unchanged.

### RED -> GREEN for the new regression, against the iteration-2 predicate

Re-captured live on 2026-09-08 after the rebase onto `8342d351b280`, not copied from
the prior (814ca08d88e-tip) capture.

Mutation: `hasEmittedAssistantTranscriptUpdateForSession` reverted to iteration 2's
session-only form (drops the assistant-role filter):

```
$ node scripts/run-vitest.mjs run src/gateway/server-methods/chat.directive-tags.test.ts -t "does not resolve a background-delivery wait on this session's own earlier user-turn update"

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  |gateway-methods| src/gateway/server-methods/chat.directive-tags.test.ts > chat directive tag stripping for non-streaming final payloads > does not resolve a background-delivery wait on this session's own earlier user-turn update
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/gateway/server-methods/chat.directive-tags.test.ts:1926:73
    1924|     });
    1925|     expect(hasEmittedTranscriptUpdateForSession(ownSessionId)).toBe(tr…
    1926|     expect(hasEmittedAssistantTranscriptUpdateForSession(ownSessionId)…
       |                                                                         ^
    1927|
    1928|     await send({

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed (1)
      Tests  1 failed | 217 skipped (218)
   Start at  06:41:29
   Duration  25.67s (transform 85%, import 12%, worker 2%, tests 1%)

[vitest-workers] verifying completed generation before cleanup
[test] failed 1 Vitest shard in 27.09s
[test] FAILED (exit 1)
```

Restored the committed file (`git status --short` empty, confirming a byte-exact
restore) and re-ran the same targeted test (assistant-specific predicate):

```
$ node scripts/run-vitest.mjs run src/gateway/server-methods/chat.directive-tags.test.ts -t "does not resolve a background-delivery wait on this session's own earlier user-turn update"

 Test Files  1 passed (1)
      Tests  1 passed | 217 skipped (218)
   Start at  06:42:02
   Duration  10.59s (transform 74%, import 21%, tests 4%, worker 2%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 1 Vitest shard in 11.92s
```

### Full-file green, default order x2 + shuffle (4004, 9081)

All four re-run live on 2026-09-08 against the rebased commit:

```
=== default run 1 ===
 Test Files  1 passed (1)
      Tests  218 passed (218)
   Duration  29.43s (tests 67%, transform 25%, import 7%, worker 1%)
[test] passed 1 Vitest shard in 30.71s

=== default run 2 ===
 Test Files  1 passed (1)
      Tests  218 passed (218)
   Duration  29.54s (tests 67%, transform 25%, import 8%, worker 1%)
[test] passed 1 Vitest shard in 30.85s

=== shuffle seed 4004 ===
 Test Files  1 passed (1)
      Tests  218 passed (218)
   Duration  30.93s (tests 69%, transform 23%, import 7%, worker 1%)
[test] passed 1 Vitest shard in 32.26s

=== shuffle seed 9081 ===
 Test Files  1 passed (1)
      Tests  218 passed (218)
   Duration  32.58s (tests 69%, transform 23%, import 7%, worker 1%)
[test] passed 1 Vitest shard in 33.92s
```

Honest note: the charter flagged a known, unrelated cron-authority flake on seed
9081 (`binds lazy configured-MCP cron authority to an admitted local
openclaw-control-ui turn`) as out of scope. It did not reproduce in this run either — flakes
by nature do not reproduce every time. Not chased either way, per charter guidance.

### `node scripts/check-changed.mjs -- <file>`

Re-run live on 2026-09-08 against the rebased commit, exit 0 (confirmed via the
command's own `$?`, not a piped `tail`'s): dependency-pin guard, `oxfmt --check`,
plugin-boundary report, wrapper-shadowing guard, package-patch guard, core tsgo
typecheck, coercion-helper guard, deprecated-API guard, dead-export/Knip scan,
`oxlint` all passed. No formatting fixes were needed.

Authored by Tommy Joseph with assistance from Claude (Sonnet 5).

Closes #135909

