### PR TITLE
refactor(infra): reuse macOS version probes across startup consumers

### DIFF
--- a/src/infra/os-summary.test.ts
+++ b/src/infra/os-summary.test.ts
@@ -11,7 +11,11 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-import { resolveOsSummary, resolveRuntimeOsLabel } from "./os-summary.js";
+import {
+  resolveDarwinProductVersion,
+  resolveOsSummary,
+  resolveRuntimeOsLabel,
+} from "./os-summary.js";
 
 type OsSummaryCase = {
   name: string;
@@ -149,6 +153,8 @@ describe("resolveRuntimeOsLabel", () => {
     vi.spyOn(os, "arch").mockReturnValue("x64");
 
     expect(resolveRuntimeOsLabel()).toBe("Windows_NT 10.0.26100");
+    expect(resolveOsSummary().label).toBe("windows 10.0.26100 (x64)");
+    expect(spawnSyncMock).not.toHaveBeenCalled();
   });
 
   it("preserves the old Linux os.type/os.release shape", () => {
@@ -177,5 +183,121 @@ describe("resolveRuntimeOsLabel", () => {
     expect(resolveRuntimeOsLabel()).toBe("macOS 26.8.0");
     expect(resolveRuntimeOsLabel()).toBe("macOS 26.8.0");
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("shared OS source facts and independent label outcomes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    spawnSyncMock.mockReset();
+  });
+
+  function darwin(release: string) {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    vi.spyOn(os, "type").mockReturnValue("Darwin");
+    vi.spyOn(os, "release").mockReturnValue(release);
+    vi.spyOn(os, "arch").mockReturnValue("arm64");
+  }
+
+  it("keeps an early direct probe failure retryable by later label consumers", () => {
+    darwin("90.1.0");
+    spawnSyncMock.mockReturnValueOnce({ stdout: " " }).mockReturnValue({ stdout: "26.1\n" });
+    expect(resolveDarwinProductVersion()).toBe("90.1.0");
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.1");
+    expect(resolveOsSummary()).toEqual({
+      platform: "darwin",
+      arch: "arm64",
+      release: "90.1.0",
+      label: "macos 26.1 (arm64)",
+    });
+  });
+
+  it("retains a runtime fallback after a later diagnostic probe succeeds", () => {
+    darwin("90.2.0");
+    spawnSyncMock
+      .mockReturnValueOnce({ stdout: null, error: new Error("probe unavailable") })
+      .mockReturnValue({ stdout: "26.2" });
+    expect(resolveRuntimeOsLabel()).toBe("macOS 90.2.0");
+    expect(resolveOsSummary().label).toBe("macos 26.2 (arm64)");
+    expect(resolveRuntimeOsLabel()).toBe("macOS 90.2.0");
+    expect(resolveDarwinProductVersion()).toBe("26.2");
+  });
+
+  it("retains a diagnostic fallback after a later runtime probe succeeds", () => {
+    darwin("90.3.0");
+    spawnSyncMock.mockReturnValueOnce({ stdout: "" }).mockReturnValue({ stdout: "26.3" });
+    const summary = resolveOsSummary();
+    expect(summary.label).toBe("macos 90.3.0 (arm64)");
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.3");
+    expect(resolveOsSummary()).toBe(summary);
+    expect(summary.label).toBe("macos 90.3.0 (arm64)");
+  });
+
+  it("does not publish a thrown probe as either label outcome", () => {
+    darwin("90.4.0");
+    const error = new Error("native probe threw");
+    spawnSyncMock
+      .mockImplementationOnce(() => {
+        throw error;
+      })
+      .mockReturnValue({ stdout: "26.4" });
+    expect(() => resolveRuntimeOsLabel()).toThrow(error);
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.4");
+    expect(resolveOsSummary().label).toBe("macos 26.4 (arm64)");
+  });
+
+  it("retains the existing nonblank stdout acceptance independently of exit status", () => {
+    darwin("90.5.0");
+    spawnSyncMock.mockReturnValue({
+      stdout: " 26.5\n",
+      status: 1,
+      signal: null,
+      error: new Error("reported error"),
+    });
+    expect(resolveDarwinProductVersion()).toBe("26.5");
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.5");
+    expect(resolveOsSummary().label).toBe("macos 26.5 (arm64)");
+  });
+
+  it("keeps the mutable summary separate from runtime and source facts", () => {
+    darwin("90.6.0");
+    spawnSyncMock.mockReturnValue({ stdout: "26.6" });
+    const summary = resolveOsSummary();
+    expect(Object.keys(summary)).toEqual(["platform", "arch", "release", "label"]);
+    summary.label = "caller label";
+    summary.release = "caller release";
+    summary.arch = "caller arch";
+    expect(resolveOsSummary()).toBe(summary);
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.6");
+    expect(resolveDarwinProductVersion()).toBe("26.6");
+    expect(summary.label).toBe("caller label");
+  });
+
+  it("keeps raw platform release and architecture tuple boundaries", () => {
+    darwin("90.7.0");
+    spawnSyncMock.mockImplementation(() => ({ stdout: os.arch() === "arm64" ? "26.7" : "26.8" }));
+    const arm = resolveOsSummary();
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.7");
+    vi.mocked(os.arch).mockReturnValue("x64");
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.8");
+    expect(resolveOsSummary().label).toBe("macos 26.8 (x64)");
+    vi.mocked(os.arch).mockReturnValue("arm64");
+    expect(resolveOsSummary()).toBe(arm);
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.7");
+  });
+
+  it("shares the first successful product version across later consumers", () => {
+    darwin("90.8.0");
+    spawnSyncMock.mockReturnValue({ stdout: "26.8" });
+    expect(resolveDarwinProductVersion()).toBe("26.8");
+    spawnSyncMock.mockReturnValue({ stdout: "27.0" });
+    expect(resolveRuntimeOsLabel()).toBe("macOS 26.8");
+    expect(resolveOsSummary()).toEqual({
+      platform: "darwin",
+      arch: "arm64",
+      release: "90.8.0",
+      label: "macos 26.8 (arm64)",
+    });
+    expect(resolveDarwinProductVersion()).toBe("26.8");
   });
 });

--- a/src/infra/os-summary.ts
+++ b/src/infra/os-summary.ts
@@ -10,29 +10,56 @@ type OsSummary = {
   label: string;
 };
 
-const cachedOsSummaryByKey = new Map<string, OsSummary>();
-const cachedRuntimeOsLabelByKey = new Map<string, string>();
+type OsFacts = Omit<OsSummary, "label"> & {
+  productVersion?: string;
+  runtimeLabel?: string;
+  summary?: OsSummary;
+};
+const cachedOsFactsByKey = new Map<string, OsFacts>();
 
-// These synchronous probes run during both gateway startup and first-turn prompt
-// preparation, so keep one hard bound for every macOS system metadata lookup.
+function resolveOsFacts(): OsFacts {
+  const platform = os.platform();
+  const release = os.release();
+  const arch = os.arch();
+  // Preserve the raw OS tuple identity: a product-version update alone does not
+  // invalidate metadata already observed during this process.
+  const cacheKey = `${platform}\0${release}\0${arch}`;
+  let facts = cachedOsFactsByKey.get(cacheKey);
+  if (!facts) {
+    facts = { platform, arch, release };
+    cachedOsFactsByKey.set(cacheKey, facts);
+  }
+  return facts;
+}
+
+// Startup and first-turn probes share one timeout and kill policy. spawnSync
+// still waits for the child to exit after sending the kill signal.
 export const DARWIN_SYSTEM_PROBE_TIMEOUT_MS = 5_000;
 
-/**
- * Resolve Darwin product version via sw_vers.
- *
- * Darwin kernel version and macOS product version are no longer in sync starting
- * with macOS 26 (Tahoe), where Darwin 25.x maps to macOS 26.x instead of the
- * historical Darwin N → macOS N+9 formula. Prefer sw_vers over os.release() on
- * macOS to avoid stale mappings.
- */
-export function resolveDarwinProductVersion(): string {
+function readDarwinProductVersion(facts: OsFacts): string {
+  if (facts.productVersion !== undefined) {
+    return facts.productVersion;
+  }
   const res = spawnSync("sw_vers", ["-productVersion"], {
     encoding: "utf-8",
     timeout: DARWIN_SYSTEM_PROBE_TIMEOUT_MS,
     killSignal: "SIGKILL",
   });
   const out = normalizeOptionalString(res.stdout) ?? "";
+  // Share only observed product versions; an early failed probe must not prevent
+  // a later consumer from succeeding. Each label keeps its own first fallback.
+  if (out) {
+    facts.productVersion = out;
+  }
   return out || os.release();
+}
+
+/**
+ * Resolve Darwin product version via sw_vers. Kernel and product versions diverge
+ * starting with macOS 26, so keep the product fact separate from the raw release.
+ */
+export function resolveDarwinProductVersion(): string {
+  return readDarwinProductVersion(resolveOsFacts());
 }
 
 /**
@@ -41,44 +68,23 @@ export function resolveDarwinProductVersion(): string {
  * Darwin this preserves the historical `${os.type()} ${os.release()}` shape.
  */
 export function resolveRuntimeOsLabel(): string {
-  const platform = os.platform();
-  const release = os.release();
-  const arch = os.arch();
-  const cacheKey = `${platform}\0${release}\0${arch}`;
-  const cached = cachedRuntimeOsLabelByKey.get(cacheKey);
-  if (cached !== undefined) {
-    return cached;
-  }
-  const label =
-    platform === "darwin" ? `macOS ${resolveDarwinProductVersion()}` : `${os.type()} ${release}`;
-  cachedRuntimeOsLabelByKey.set(cacheKey, label);
-  return label;
+  const facts = resolveOsFacts();
+  return (facts.runtimeLabel ??=
+    facts.platform === "darwin"
+      ? `macOS ${readDarwinProductVersion(facts)}`
+      : `${os.type()} ${facts.release}`);
 }
 
 /** Resolves a compact OS label for diagnostics, logs, and environment summaries. */
 export function resolveOsSummary(): OsSummary {
-  const platform = os.platform();
-  const rawRelease = os.release();
-  const arch = os.arch();
-  // Cache key uses raw os.release() (stable per kernel) so sw_vers drift across
-  // minor macOS updates does not invalidate the cache.
-  const cacheKey = `${platform}\0${rawRelease}\0${arch}`;
-  const cached = cachedOsSummaryByKey.get(cacheKey);
-  if (cached) {
-    return cached;
+  const facts = resolveOsFacts();
+  if (!facts.summary) {
+    const { platform, arch, release } = facts;
+    const label =
+      platform === "darwin"
+        ? `macos ${readDarwinProductVersion(facts)}`
+        : `${platform === "win32" ? "windows" : platform} ${release}`;
+    facts.summary = { platform, arch, release, label: `${label} (${arch})` };
   }
-  const release = rawRelease;
-  const label = (() => {
-    if (platform === "darwin") {
-      const productVersion = resolveDarwinProductVersion();
-      return `macos ${productVersion} (${arch})`;
-    }
-    if (platform === "win32") {
-      return `windows ${release} (${arch})`;
-    }
-    return `${platform} ${release} (${arch})`;
-  })();
-  const summary = { platform, arch, release, label };
-  cachedOsSummaryByKey.set(cacheKey, summary);
-  return summary;
+  return facts.summary;
 }


### PR DESCRIPTION
## What Problem This Solves

On macOS, startup presence, runtime prompt preparation, and trajectory metadata independently repeat the same synchronous product-version command. The first prompt/trajectory preparation therefore pays for two extra native processes even when presence already obtained the version.

## Why This Change Was Made

One private cache now owns the successful product-version fact for the raw platform/release/architecture tuple. Runtime and diagnostic labels retain separate publication state: an early failure remains retryable by a later consumer, each published fallback stays sticky, and a caller's mutable summary cannot modify the private source facts. The two duplicate cache/lookup flows are removed. Native arguments, timeout/kill policy, nonblank-stdout acceptance, Linux/Windows labels, and summary identity remain unchanged.

Production is +54/-48 (net +6); the small increase separates shared successful facts from the two existing independent fallback contracts. Tests are +123/-1 (net +122), including a regression that fails before the change. No configuration, schema, dependency, or protocol changes.

## User Impact

The first macOS prompt/trajectory preparation reuses the version already collected during presence initialization. This PR does not claim faster provider requests or whole-Gateway startup.

## Evidence

- Native comparative measurements on `76285a99ecc8c29b2b40909a8d75585cdd20dc60`, Node 26.8.1, Darwin arm64: 44 fresh hosts in fixed before/candidate/candidate/before blocks, 11 cold observations per block; all firsts, warmups, measured calls, and outliers retained. Presence followed by the complete runtime-prompt/trajectory pair performs three `sw_vers` calls before, one after.
- Cold pair medians: 67.173459 → 54.733542 ms (-18.52%) forward; 68.034667 → 51.164333 ms (-24.80%) reverse. The frozen >=3% improvement gate passes both orders. Warm medians: -0.22%/-4.55%; native RSS: +0.31%/-0.32%.
- Adverse evidence remains explicit: reverse first-warm median +1.78%, candidate warm outliers, and whole-host medians about +0.55% in both orders. No samples or controls were discarded. The probe observer adds some work to native calls, so these are instrumented complete-operation measurements, not exact uninstrumented savings.
- An independent reviewer compared every retained raw value, measurement vector, and resource-closure record and reproduced all fixed gates. Full private evidence is retained locally; no sensitive host data is published.
- At that measured revision, four complete existing caller test files pass 23 tests per variant. The expanded owner suite has 16 passes plus the expected sharing regression before, and 17 passes after, with no skips or unhandled errors. Overlapping tests are not counted twice as distinct cases.
- Integrated on `bebbfa51e47d00cbfe340695823ab79ccebd9d24`; executable candidate source is identical to the measured version. The only production text difference clarifies that Node waits for child exit after its timeout signal. Current `pnpm check:changed` passes formatting, lint, core/test type checks, and repository guards; required Codex autoreview reports no P0 findings.
- Current-main canonical validation now passes on `bebb`: the same four whole files pass 23 tests per variant, and the expanded regression suite gives 16 passes plus the one expected baseline failure versus 17 candidate passes. No skipped tests or native unhandled errors; all owned processes, worker generations, and temporary state are closed. The initial baseline attempt failed before collection on a missing Vitest filesystem-cache directory; its original failure remains retained as a separate runner follow-up. The fresh ordinary run used unchanged source, dependencies, tests, and cache settings, with no manual cache creation or cache disabling.
- Full `pnpm build` passes at candidate `2ec54e9fb852ee2c43f90e23bc163b72d7c10907`; 12,326 distribution files are inventoried. A freshly built isolated Gateway then completed four real OpenAI turns (`READY`, full synthetic skill read → `42`, recall → `42`, and the correct Node documentation title/URL), two sequential uncached HTTP-200 web fetches, and four health/status RPCs. No degraded plugins/secrets or errors were reported. Complete private transcript, web spills and CPU profiles are retained; Gateway/process groups, port, coordinator files, stdin FIFO and task credential window were independently checked closed.
- Live observations, not a paired performance comparison: readiness 7.532 s; turns 1.427/2.964/1.620/7.666 s with CPU profiling enabled. The four WARN records are existing normal-continuation diagnostics, not retries or failed turns.
- Exact-head CI [33590982893](https://github.com/openclaw/openclaw/actions/runs/33590982893) completed successfully at `2ec54e9fb852ee2c43f90e23bc163b72d7c10907`, satisfying the current ClawSweeper rank-up request. Its generated persistent-cache classification does not apply: this owner uses only a process-local JavaScript `Map`; no stored representation, database table, file cache or migration changes. Normal maintainer review is being completed through the native workflow.
