### PR TITLE
refactor(claws): speed up lifecycle E2E checks

### DIFF
--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -28,11 +28,11 @@ async function runOpenClaw(
     VITEST: "",
   };
   try {
-    const result = await execFileAsync(
-      process.execPath,
-      ["--import", "tsx", "src/entry.ts", ...args],
-      { cwd: process.cwd(), env, maxBuffer: 1024 * 1024 },
-    );
+    const result = await execFileAsync(process.execPath, ["openclaw.mjs", ...args], {
+      cwd: process.cwd(),
+      env,
+      maxBuffer: 1024 * 1024,
+    });
     if (options?.expectFailure) {
       throw new Error(`expected command to fail: ${args.join(" ")}`);
     }


### PR DESCRIPTION
## What Problem This Solves

Claws lifecycle E2E checks spend most of their time repeatedly starting the TypeScript CLI. The eight cases took 134.2 seconds of test execution in the measured baseline.

## Why This Change Was Made

Run each command through `openclaw.mjs`, using the runtime that the existing E2E setup already builds. This retains all 20 fresh CLI processes, isolated state directories, consent checks, and assertions without adding a build, cache, or mock to the fixture.

## User Impact

Developers get faster lifecycle coverage. There is no production behavior change.

## Evidence

| Same Linux Testbox, Node 24.19.0, one worker | Before | After |
| --- | ---: | ---: |
| Test execution | 134.21 s | 33.29 s |
| Cases passing | 8/8 | 8/8 |

This paired run reduced test execution by 100.92 seconds (75.2%). Build setup is excluded: the initial invocation prepared the runtime, while the second reused the same prepared source generation.

Both runs used `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/claws/lifecycle.e2e.test.ts --reporter=verbose --reporter=json`. The remote tracked source tree matched `bebbfa51e47d00cbfe340695823ab79ccebd9d24` before the baseline; the measured change only replaced the CLI entry arguments. Test names, ordering, assertions, and outcomes matched. The existing export-and-reimport case and plan-first add/remove cases passed.

The E2E prerequisite owner is `scripts/lib/vitest-build-prerequisites.mts`; `src/entry.ts` explicitly recognizes the launcher, and the same E2E project already uses it in plugin-install and Gateway skill-refresh tests. Source-only process tests retain their existing entrypoint.

`node scripts/check-changed.mjs -- src/claws/lifecycle.e2e.test.ts` passed, including core-test typechecking, lint, formatting, and repository guards. The subsequent rebase onto current main was clean and did not change the measured Claws launch or E2E prerequisite paths.

Production LOC: +0/-0. Test LOC: +5/-5 (including formatting). Diff cleanup and Codex P0 review completed without accepted findings. No additional test was added because the existing eight real CLI cases exercise the changed launch path.
