### PR TITLE
refactor(ui): simplify startup worker presentation

### DIFF
--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -6,6 +6,7 @@ import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
 import { isNativeLocalGateway } from "../../app/native-editor-locality.runtime.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { isDesktopPanelAvailable } from "../../app/panel-availability.ts";
+import type { ApplicationPlacementStartupStatus } from "../../app/session-placement-startup.ts";
 import { COMMAND_PALETTE_OPEN_EVENT } from "../../components/command-palette-contract.ts";
 import { icons } from "../../components/icons.ts";
 import {
@@ -55,6 +56,7 @@ import {
   renderChatPaneHeader,
   resolveChatPaneParentSession,
 } from "./components/chat-pane-header.ts";
+import { renderChatPanePlacement } from "./components/chat-pane-placement.ts";
 import {
   canManageChatSessionSharing,
   renderChatSessionSharing,
@@ -115,6 +117,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
     catalog: boolean,
     agentWorkspace: string | undefined,
     workspaceGit: boolean,
+    placementStartupStatus: ApplicationPlacementStartupStatus | null | undefined,
     sidebarLayout?: SidebarLayout,
   ) {
     const board = this.resolveBoardView();
@@ -441,7 +444,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       navDrawerOpen: this.navDrawerOpen,
       title: (catalog ? this.catalogSession?.name?.trim() : undefined) || this.paneTitle,
       session: row,
-      placementStartupStatus: this.context.placementStartup.get(key),
       showOwnerChip,
       ownerViewing,
       personActivity,
@@ -513,6 +515,18 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
         sharing && (!this.narrow || !canManageChatSessionSharing(sharing.session))
           ? renderChatSessionSharing(sharing)
           : nothing,
+      placementControl: renderChatPanePlacement({
+        session: row,
+        placementStartupStatus,
+        placementMoving: placement.moving,
+        placementRestarting: placement.restarting,
+        placementMoveDisabledReason: placement.moveDisabledReason,
+        placementReclaimDisabledReason: placement.reclaimDisabledReason,
+        placementRestartDisabledReason: placement.restartDisabledReason,
+        onPlacementMove: () => row && void this.moveHeaderPlacement(row),
+        onPlacementReclaim: () => row && void this.reclaimHeaderPlacement(row),
+        onPlacementRestart: () => row && void this.restartHeaderPlacement(row),
+      }),
       sessionMenuAction:
         row && this.state
           ? html`<openclaw-chat-header-session-menu
@@ -562,11 +576,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .onAction=${(action: HeaderMenuAction) => this.handleHeaderSessionAction(action, row)}
             ></openclaw-chat-header-session-menu>`
           : nothing,
-      placementMoving: placement.moving,
-      placementRestarting: placement.restarting,
-      placementMoveDisabledReason: placement.moveDisabledReason,
-      placementReclaimDisabledReason: placement.reclaimDisabledReason,
-      placementRestartDisabledReason: placement.restartDisabledReason,
       nativeGateways: this.nativeGateways,
       gatewaysSnapshot: this.gatewaysSnapshot,
       onboarding: this.onboarding,
@@ -589,9 +598,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       onOpenParentSession: (sessionKey) => {
         this.onPaneSessionChange?.(this.paneId, sessionKey);
       },
-      onPlacementMove: () => row && void this.moveHeaderPlacement(row),
-      onPlacementReclaim: () => row && void this.reclaimHeaderPlacement(row),
-      onPlacementRestart: () => row && void this.restartHeaderPlacement(row),
       onBranchSelect: (leafEntryId) => {
         const access = readChatSessionActionAccess(
           this.context.gateway.snapshot,

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -107,6 +107,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
           catalog,
           agentWorkspace,
           workspaceGit,
+          chatProps.placementStartup,
           sidebarLayout,
         );
     const recovery = html`<openclaw-chat-outbox-recovery

--- a/ui/src/pages/chat/chat-pane-placement-stop.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement-stop.test.ts
@@ -3,18 +3,22 @@
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
-import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import {
   answerConfirmDialog,
   installDialogPolyfill,
   waitForConfirmDialogActions,
 } from "../../test-helpers/modal-dialog.ts";
-import { resolveChatPanePlacement } from "./chat-pane-placement.ts";
+import {
+  resolveChatPanePlacement,
+  resolveChatPaneWorkerPresentation,
+} from "./chat-pane-placement.ts";
 import {
   activePlacementSession,
+  createGatewayBrowserClientFixture,
+  createSessionCapabilityFixture,
   offlineDeviceSession,
   createTestChatPane,
 } from "./chat-pane.test-support.ts";
@@ -38,7 +42,7 @@ const workerPlacement = {
   environmentId: "node:device-looking-id",
 };
 
-describe.each([
+const startupPlacements = [
   { state: "requested", ...placementTiming },
   { state: "provisioning", ...workerPlacement },
   { state: "syncing", ...workerPlacement, workerBundleHash: "a".repeat(64) },
@@ -49,112 +53,133 @@ describe.each([
     workspaceBaseManifestRef: "base",
     remoteWorkspaceDir: "/workspace",
   },
-] as const satisfies readonly NonNullable<GatewaySessionRow["placement"]>[])(
-  "$state placement stop presentation",
-  (placement) => {
-    const phase = placement.state;
-    it.each([
-      {
-        startupPhase: phase,
-        targetKind: "device",
-        label: "device worker",
-        location: "Runs on device",
-      },
-      {
-        startupPhase: phase,
-        targetKind: "auto-device",
-        label: "device worker",
-        location: "Runs on device",
-      },
-      {
-        startupPhase: phase,
-        targetKind: "profile",
-        label: "cloud worker",
-        location: "device-service · device-profile",
-      },
-      { startupPhase: phase, targetKind: undefined, label: "worker", location: "Runs on worker" },
-      { startupPhase: "failed", targetKind: "device", label: "worker", location: "Runs on worker" },
-      {
-        startupPhase: "failed",
-        targetKind: "auto-device",
-        label: "worker",
-        location: "Runs on worker",
-      },
-      {
-        startupPhase: "failed",
-        targetKind: "profile",
-        label: "worker",
-        location: "Runs on worker",
-      },
-    ] as const)(
-      "projects $startupPhase $targetKind intent into menu and confirmation",
-      async ({ startupPhase, targetKind, label, location }) => {
-        const request = vi.fn(async () => ({ ok: true }));
-        const refreshReplacement = vi.fn(async () => undefined);
-        const { pane } = createTestChatPane({
-          client: { request } as unknown as GatewayBrowserClient,
-          sessions: { refreshReplacement } as unknown as SessionCapability,
-        });
-        const session: GatewaySessionRow = {
-          key: "agent:main:startup",
-          label: "Startup session",
-          kind: "direct",
-          updatedAt: 1,
-          placement,
-        };
-        vi.mocked(pane.context.placementStartup.get).mockImplementation((key) =>
-          key === session.key && targetKind
-            ? { sessionKey: key, phase: startupPhase, startedAt: 1, targetKind }
-            : null,
-        );
-        const container = document.createElement("div");
-        document.body.append(container);
-        render(
-          renderChatPanePlacement({
-            session,
-            placementStartupStatus: pane.context.placementStartup.get(session.key),
-          }),
-          container,
-        );
-        const chipText = container.querySelector(".chat-pane__placement-chip")?.textContent;
-        const menuText = container
-          .querySelector(".chat-pane__placement-reclaim")
-          ?.textContent?.trim();
+] as const satisfies readonly NonNullable<GatewaySessionRow["placement"]>[];
 
-        const reclaim = pane.reclaimHeaderPlacement(session);
-        const actions = await waitForConfirmDialogActions();
-        const confirmation = document.querySelector("openclaw-modal-dialog")?.textContent;
-        answerConfirmDialog(actions, "confirm");
-        await reclaim;
-        expect(request).toHaveBeenCalledExactlyOnceWith(
-          "sessions.reclaim",
-          { key: session.key, agentId: "main" },
-          { timeoutMs: null },
-        );
-        expect(pane.context.placementStartup.pause).toHaveBeenCalledBefore(request);
-        expect({ chipText, menuText, confirmation }).toEqual({
-          chipText:
-            targetKind === "profile" && phase === "requested" && startupPhase !== "failed"
-              ? "Runs on Cloud"
-              : location,
-          menuText: `Stop ${label}…`,
-          confirmation: expect.stringContaining(`Stop the ${label} for "Startup session"?`),
-        });
-      },
-    );
-  },
-);
+const deviceCopy = {
+  label: "Runs on device",
+  stopLabel: "Stop device worker…",
+  confirmMessage: 'Stop the device worker for "Startup session"?',
+  confirmLabel: "Stop device worker",
+};
+const cloudCopy = {
+  label: "Runs on Cloud",
+  stopLabel: "Stop cloud worker…",
+  confirmMessage: 'Stop the cloud worker for "Startup session"?',
+  confirmLabel: "Stop worker",
+};
+const unknownCopy = {
+  label: "Runs on worker",
+  stopLabel: "Stop worker…",
+  confirmMessage: 'Stop the worker for "Startup session"?',
+  confirmLabel: "Stop worker",
+};
+
+function startupSession(placement: GatewaySessionRow["placement"]): GatewaySessionRow {
+  return {
+    key: "agent:main:startup",
+    label: "Startup session",
+    kind: "direct",
+    updatedAt: 1,
+    placement,
+  };
+}
+
+describe.each([
+  { placement: startupPlacements[0], cloudLabel: "Runs on Cloud" },
+  { placement: startupPlacements[1], cloudLabel: "device-service · device-profile" },
+  { placement: startupPlacements[2], cloudLabel: "device-service · device-profile" },
+  { placement: startupPlacements[3], cloudLabel: "device-service · device-profile" },
+])("$placement.state placement stop presentation", ({ placement, cloudLabel }) => {
+  const phase = placement.state;
+  it.each([
+    { phase, targetKind: "device", copy: deviceCopy },
+    { phase, targetKind: "auto-device", copy: deviceCopy },
+    { phase, targetKind: "profile", copy: { ...cloudCopy, label: cloudLabel } },
+    { phase, targetKind: undefined, copy: unknownCopy },
+    { phase: "failed", targetKind: "device", copy: unknownCopy },
+    { phase: "failed", targetKind: "auto-device", copy: unknownCopy },
+    { phase: "failed", targetKind: "profile", copy: unknownCopy },
+  ] as const)(
+    "projects $phase $targetKind intent into operator copy",
+    ({ phase: startupPhase, targetKind, copy }) => {
+      expect(
+        resolveChatPaneWorkerPresentation(
+          startupSession(placement),
+          targetKind ? { phase: startupPhase, targetKind } : null,
+        ),
+      ).toEqual(copy);
+    },
+  );
+});
 
 describe("chat pane worker stop", () => {
+  it.each([
+    { placement: startupPlacements[0], targetKind: "device", copy: deviceCopy },
+    { placement: startupPlacements[1], targetKind: "auto-device", copy: deviceCopy },
+    {
+      placement: startupPlacements[2],
+      targetKind: "profile",
+      copy: { ...cloudCopy, label: "device-service · device-profile" },
+    },
+    { placement: startupPlacements[3], targetKind: undefined, copy: unknownCopy },
+  ] as const)(
+    "stops $placement.state $targetKind startup from the placement menu",
+    async ({ placement, targetKind, copy }) => {
+      const request = vi.fn(async () => ({ ok: true }));
+      const refreshReplacement = vi.fn(async () => undefined);
+      const { pane } = createTestChatPane({
+        client: createGatewayBrowserClientFixture({ request }),
+        sessions: createSessionCapabilityFixture({ refreshReplacement }),
+      });
+      const session = startupSession(placement);
+      const startup = targetKind
+        ? { sessionKey: session.key, phase: placement.state, startedAt: 1, targetKind }
+        : null;
+      vi.mocked(pane.context.placementStartup.get).mockReturnValue(startup);
+      const container = document.createElement("div");
+      document.body.append(container);
+      let reclaim: Promise<void> | undefined;
+      render(
+        renderChatPanePlacement({
+          session,
+          placementStartupStatus: startup,
+          onPlacementReclaim: () => {
+            reclaim = pane.reclaimHeaderPlacement(session);
+          },
+        }),
+        container,
+      );
+      expect(container.querySelector(".chat-pane__placement-chip")?.textContent?.trim()).toBe(
+        copy.label,
+      );
+      const stop = container.querySelector<HTMLElement>(".chat-pane__placement-reclaim");
+      expect(stop?.textContent?.trim()).toBe(copy.stopLabel);
+      stop?.click();
+      const actions = await waitForConfirmDialogActions();
+      expect(document.querySelector("openclaw-modal-dialog")?.textContent).toContain(
+        copy.confirmMessage,
+      );
+      expect(actions.querySelector(".btn.danger")?.textContent?.trim()).toBe(copy.confirmLabel);
+      answerConfirmDialog(actions, "confirm");
+      await reclaim;
+      expect(request).toHaveBeenCalledExactlyOnceWith(
+        "sessions.reclaim",
+        { key: session.key, agentId: "main" },
+        { timeoutMs: null },
+      );
+      expect(pane.context.placementStartup.pause).toHaveBeenCalledBefore(request);
+    },
+  );
+
   it("disables offline Stop while keeping Continue enabled, then restores ordinary actions", () => {
     const { pane } = createTestChatPane({
-      client: { request: vi.fn() } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture(),
+      sessions: createSessionCapabilityFixture(),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.move", "sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.move", "sessions.reclaim"],
+      ["operator.read", "operator.write"],
+    );
     const offline = { ...offlineDeviceSession(), hasActiveRun: false };
     const available = {
       ...offline,
@@ -198,13 +223,13 @@ describe("chat pane worker stop", () => {
   it("does not issue reclaim for an offline device placement", async () => {
     const request = vi.fn(async () => ({ ok: true }));
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.reclaim"],
+      ["operator.read", "operator.write"],
+    );
 
     await pane.reclaimHeaderPlacement({ ...offlineDeviceSession(), hasActiveRun: false });
 
@@ -212,35 +237,23 @@ describe("chat pane worker stop", () => {
     expect(document.body.querySelector("dialog[open]")).toBeNull();
   });
 
-  it("reclaims a provisioning placement through its session", async () => {
-    const request = vi.fn(async () => ({ ok: true }));
+  it("enables only Stop for provisioning with reclaim-only write access", () => {
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture(),
+      sessions: createSessionCapabilityFixture(),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.reclaim"],
+      ["operator.read", "operator.write"],
+    );
 
-    const session = {
-      key: "agent:main:provisioning",
-      kind: "direct",
-      updatedAt: 0,
-      placement: {
-        state: "provisioning",
-        environmentId: "worker:one",
-      } as GatewaySessionRow["placement"],
-    } satisfies GatewaySessionRow;
+    const session = startupSession(startupPlacements[1]);
     const placement = resolveChatPanePlacement({
       gatewaySnapshot: pane.context.gateway.snapshot,
       movingKey: null,
       reclaimingKey: null,
       row: session,
     });
-    const reclaim = pane.reclaimHeaderPlacement(session);
-    answerConfirmDialog(await waitForConfirmDialogActions(), "confirm");
-    await reclaim;
 
     expect(placement).toEqual({
       moving: false,
@@ -249,11 +262,6 @@ describe("chat pane worker stop", () => {
       reclaimDisabledReason: undefined,
       restartDisabledReason: "This Gateway does not support this session action.",
     });
-    expect(request).toHaveBeenCalledWith(
-      "sessions.reclaim",
-      { key: session.key, agentId: "main" },
-      { timeoutMs: null },
-    );
   });
 
   it.each([
@@ -273,13 +281,13 @@ describe("chat pane worker stop", () => {
       const request = vi.fn(async () => ({ ok: true }));
       const refreshReplacement = vi.fn(async () => undefined);
       const { pane } = createTestChatPane({
-        client: { request } as unknown as GatewayBrowserClient,
-        sessions: { refreshReplacement } as unknown as SessionCapability,
+        client: createGatewayBrowserClientFixture({ request }),
+        sessions: createSessionCapabilityFixture({ refreshReplacement }),
       });
-      pane.context.gateway.snapshot.hello = {
-        features: { methods: ["sessions.reclaim"] },
-        auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
-      } as never;
+      pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+        ["sessions.reclaim"],
+        ["operator.read", "operator.write"],
+      );
       const session = activePlacementSession();
       if (runner === "device") {
         session.placement.runner = { kind: "device", status: "available" };
@@ -324,13 +332,13 @@ describe("chat pane worker stop", () => {
   it("does not reclaim when the operator cancels", async () => {
     const request = vi.fn(async () => ({ ok: true }));
     const { pane } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.admin"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.reclaim"],
+      ["operator.admin"],
+    );
     const session = {
       ...activePlacementSession(),
       placement: {
@@ -360,13 +368,13 @@ describe("chat pane worker stop", () => {
   it("does not reclaim after the connection changes while confirmation is open", async () => {
     const request = vi.fn(async () => ({ ok: true }));
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.admin"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.reclaim"],
+      ["operator.admin"],
+    );
     const session = {
       ...activePlacementSession(),
       placement: {
@@ -401,13 +409,13 @@ describe("chat pane worker stop", () => {
       throw new Error("reclaim failed");
     });
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.admin"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.reclaim"],
+      ["operator.admin"],
+    );
     const session = activePlacementSession();
 
     const reclaim = pane.reclaimHeaderPlacement(session);
@@ -423,13 +431,13 @@ describe("chat pane worker stop", () => {
     const response = createDeferred<never>();
     const request = vi.fn(() => response.promise);
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: {} as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture(),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.admin"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.reclaim"],
+      ["operator.admin"],
+    );
     const session = activePlacementSession();
 
     const reclaim = pane.reclaimHeaderPlacement(session);
@@ -446,22 +454,17 @@ describe("chat pane worker stop", () => {
   });
 
   it("keeps reclaim progress with its session when the pane switches rows", async () => {
-    let resolveRequest!: (result: { ok: true }) => void;
-    const request = vi.fn(
-      () =>
-        new Promise<{ ok: true }>((resolve) => {
-          resolveRequest = resolve;
-        }),
-    );
+    const response = createDeferred<{ ok: true }>();
+    const request = vi.fn(() => response.promise);
     const refreshReplacement = vi.fn(async () => undefined);
     const { pane, state } = createTestChatPane({
-      client: { request } as unknown as GatewayBrowserClient,
-      sessions: { refreshReplacement } as unknown as SessionCapability,
+      client: createGatewayBrowserClientFixture({ request }),
+      sessions: createSessionCapabilityFixture({ refreshReplacement }),
     });
-    pane.context.gateway.snapshot.hello = {
-      features: { methods: ["sessions.reclaim"] },
-      auth: { role: "operator", scopes: ["operator.admin"] },
-    } as never;
+    pane.context.gateway.snapshot.hello = gatewayHelloForMethods(
+      ["sessions.reclaim"],
+      ["operator.admin"],
+    );
     const sessionA = activePlacementSession("agent:main:cloud-a");
     const sessionB = {
       ...sessionA,
@@ -477,10 +480,8 @@ describe("chat pane worker stop", () => {
     const actions = await waitForConfirmDialogActions();
     answerConfirmDialog(actions, "confirm");
     await vi.waitFor(() => expect(pane.headerPlacementReclaimingKey).toBe(sessionA.key));
-    expect(pane.headerPlacementReclaimingKey).toBe(sessionA.key);
 
     state.sessionKey = sessionB.key;
-    expect(state.sessionKey).toBe(sessionB.key);
     const placementA = resolveChatPanePlacement({
       gatewaySnapshot: pane.context.gateway.snapshot,
       movingKey: null,
@@ -496,7 +497,7 @@ describe("chat pane worker stop", () => {
     expect(placementA.reclaimDisabledReason).toBe(t("common.loading"));
     expect(placementB.reclaimDisabledReason).toBeUndefined();
 
-    resolveRequest({ ok: true });
+    response.resolve({ ok: true });
     await pendingReclaim;
 
     expect(pane.headerPlacementReclaimingKey).toBeNull();

--- a/ui/src/pages/chat/chat-pane-placement.runtime.ts
+++ b/ui/src/pages/chat/chat-pane-placement.runtime.ts
@@ -259,12 +259,12 @@ export async function reclaimChatPanePlacement(params: {
   }
   const { showConfirmDialog } = await import("../../components/confirm-dialog.js");
   const worker = resolveChatPaneWorkerPresentation(
-    placement,
+    params.row,
     params.placementStartup.get(params.row.key),
   );
   const confirmed = await showConfirmDialog({
-    message: t(`${worker.stopKey}Confirm`, { session: params.row.label || params.row.key }),
-    confirmLabel: t(`${worker.stopKey}ConfirmAction`),
+    message: worker.confirmMessage,
+    confirmLabel: worker.confirmLabel,
     danger: true,
   });
   if (!confirmed) {

--- a/ui/src/pages/chat/chat-pane-placement.ts
+++ b/ui/src/pages/chat/chat-pane-placement.ts
@@ -112,38 +112,41 @@ export function resolvePlacementComposer(params: {
 }
 
 export function resolveChatPaneWorkerPresentation(
-  placement: GatewaySessionRow["placement"],
+  session: GatewaySessionRow,
   startup: Pick<ApplicationPlacementStartupStatus, "phase" | "targetKind"> | null | undefined,
 ) {
+  const placement = session.placement;
   // Active ownership wins even when cloud placements omit runner. Failed startup
   // intent is retained for retry, not evidence of a later placement's target;
   // only a live initial handoff can identify a not-yet-active worker.
-  const targetKind =
-    placement?.state === "active"
-      ? placement.runner?.kind === "device"
-        ? "device"
-        : "profile"
-      : startup?.phase !== "failed"
-        ? startup?.targetKind
+  let targetKind = startup?.phase !== "failed" ? startup?.targetKind : undefined;
+  if (placement?.state === "active") {
+    targetKind = placement.runner?.kind === "device" ? "device" : "profile";
+  }
+  let label: string;
+  let stopKey: string;
+  if (targetKind === "device" || targetKind === "auto-device") {
+    label = t("sessionsView.runsOnDevice");
+    stopKey = "sessionsView.stopDeviceWorker";
+  } else if (targetKind === "profile") {
+    const worker =
+      placement && placement.state !== "local" && placement.state !== "requested"
+        ? placement
         : undefined;
-  const device = targetKind === "device" || targetKind === "auto-device";
-  const worker =
-    placement && placement.state !== "local" && placement.state !== "requested"
-      ? placement
-      : undefined;
+    label =
+      worker?.providerId && worker.profileId
+        ? `${worker.providerId} · ${worker.profileId}`
+        : t("newSession.runsOn", { place: t("newSession.cloud") });
+    stopKey = "sessionsView.stopCloudWorker";
+  } else {
+    label = t("sessionsView.runsOnWorker");
+    stopKey = "sessionsView.stopWorker";
+  }
   return {
-    label: device
-      ? t("sessionsView.runsOnDevice")
-      : targetKind === "profile"
-        ? worker?.providerId && worker.profileId
-          ? `${worker.providerId} · ${worker.profileId}`
-          : t("newSession.runsOn", { place: t("newSession.cloud") })
-        : t("sessionsView.runsOnWorker"),
-    stopKey: device
-      ? "sessionsView.stopDeviceWorker"
-      : targetKind === "profile"
-        ? "sessionsView.stopCloudWorker"
-        : "sessionsView.stopWorker",
+    label,
+    stopLabel: t(stopKey),
+    confirmMessage: t(`${stopKey}Confirm`, { session: session.label || session.key }),
+    confirmLabel: t(`${stopKey}ConfirmAction`),
   };
 }
 

--- a/ui/src/pages/chat/chat-pane-session-access.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-access.test.ts
@@ -44,6 +44,7 @@ describe("chat pane session access", () => {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );
@@ -245,6 +246,7 @@ describe("chat pane session access", () => {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );
@@ -279,6 +281,7 @@ describe("chat pane session access", () => {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );

--- a/ui/src/pages/chat/chat-pane-session-menu.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-menu.test.ts
@@ -108,6 +108,7 @@ describe("chat pane session menu boundary", () => {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -43,6 +43,7 @@ describe("chat pane terminal action", () => {
             false,
             undefined,
             false,
+            null,
           ),
           container,
         );
@@ -106,6 +107,7 @@ describe("chat pane terminal action", () => {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );
@@ -144,6 +146,7 @@ describe("chat pane terminal action", () => {
           false,
           undefined,
           false,
+          null,
         ),
         container,
       );
@@ -182,6 +185,7 @@ describe("chat pane terminal action", () => {
           false,
           undefined,
           false,
+          null,
         ),
         container,
       );
@@ -208,6 +212,7 @@ describe("chat pane terminal action", () => {
           false,
           undefined,
           false,
+          null,
         ),
         container,
       );
@@ -292,6 +297,7 @@ describe("chat pane terminal action", () => {
           false,
           undefined,
           false,
+          null,
         ),
         container,
       );
@@ -319,6 +325,7 @@ describe("chat pane terminal action", () => {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -22,6 +22,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import { createChatAttachmentHandoff } from "../../app/chat-attachment-handoff.ts";
 import { createChatSubmissions } from "../../app/chat-submissions.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import type { ApplicationPlacementStartupStatus } from "../../app/session-placement-startup.ts";
 import type { CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import type { TaskSuggestionAcceptMode } from "../../lib/task-suggestion-acceptance.ts";
@@ -167,6 +168,7 @@ export type TestChatPane = HTMLElement & {
     catalog: boolean,
     agentWorkspace: undefined,
     workspaceGit: boolean,
+    placementStartupStatus: ApplicationPlacementStartupStatus | null | undefined,
   ) => TemplateResult;
 };
 

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -212,6 +212,7 @@ describe("chat header session menu", () => {
           false,
           undefined,
           false,
+          null,
         ),
         container,
       );
@@ -290,6 +291,7 @@ describe("chat header session menu", () => {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../components/command-palette-contract.ts";
 import type { SessionCapability } from "../../../lib/sessions/index.ts";
 import { resolveSessionWorkspace } from "../../../lib/sessions/workspace.ts";
-import { createTestChatPane } from "../chat-pane.test-support.ts";
+import { activePlacementSession, createTestChatPane } from "../chat-pane.test-support.ts";
 import type { ChatPageHost } from "../chat-state-host.ts";
 import { createBackgroundTasksProps } from "./chat-background-tasks.ts";
 import {
@@ -27,6 +27,7 @@ import {
   renderChatPaneHeader,
   resolveChatPaneParentSession,
 } from "./chat-pane-header.ts";
+import { renderChatPanePlacement } from "./chat-pane-placement.ts";
 import { createSessionWorkspaceProps } from "./chat-session-workspace.ts";
 
 const containers: HTMLElement[] = [];
@@ -114,6 +115,7 @@ function mountIntegratedPresenceHeader(params: {
         false,
         undefined,
         false,
+        null,
       ),
       container,
     );
@@ -318,22 +320,11 @@ describe("chat pane header", () => {
     const onPlacementMove = vi.fn();
     const onPlacementReclaim = vi.fn();
     const { container } = mountHeader({
-      session: row({
-        placement: {
-          state: "active",
-          generation: 1,
-          createdAtMs: 100_000,
-          updatedAtMs: 300_000,
-          stateChangedAtMs: 300_000,
-          environmentId: "worker:one",
-          activeOwnerEpoch: 1,
-          workerBundleHash: "a".repeat(64),
-          workspaceBaseManifestRef: "base-manifest",
-          remoteWorkspaceDir: "/worker/repo",
-        },
+      placementControl: renderChatPanePlacement({
+        session: activePlacementSession(),
+        onPlacementMove,
+        onPlacementReclaim,
       }),
-      onPlacementMove,
-      onPlacementReclaim,
     });
 
     expect(container.querySelector(".chat-pane__placement-chip")?.textContent?.trim()).toBe(
@@ -374,7 +365,10 @@ describe("chat pane header", () => {
         updatedAtMs: 300_000,
       },
     });
-    const { container } = mountHeader({ session });
+    const { container } = mountHeader({
+      session,
+      placementControl: renderChatPanePlacement({ session }),
+    });
 
     expect(container.querySelector(".chat-pane__placement-chip")?.textContent?.trim()).toBe(
       "Moving to Gateway…",
@@ -383,27 +377,32 @@ describe("chat pane header", () => {
 
   it.each(["local", "reclaimed"] as const)("hides the placement chip for %s state", (state) => {
     const { container } = mountHeader({
-      session: row({
-        placement: {
-          state,
-          generation: 1,
-          createdAtMs: 1,
-          updatedAtMs: 1,
-          stateChangedAtMs: 1,
-        },
+      placementControl: renderChatPanePlacement({
+        session: row({
+          placement: {
+            state,
+            generation: 1,
+            createdAtMs: 1,
+            updatedAtMs: 1,
+            stateChangedAtMs: 1,
+          },
+        }),
       }),
     });
     expect(container.querySelector(".chat-pane__placement-chip")).toBeNull();
   });
 
-  it("places pane presence between the identity trail and face control", () => {
+  it("places placement and presence between the identity trail and face control", () => {
     const { container } = mountHeader({
+      placementControl: html`<span data-slot="placement"></span>`,
       presence: html`<span data-slot="presence"></span>`,
       faceControl: html`<span data-slot="face"></span>`,
     });
     const crumbs = container.querySelector(".chat-pane__crumbs");
-    expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("presence");
-    expect(crumbs?.nextElementSibling?.nextElementSibling?.getAttribute("data-slot")).toBe("face");
+    expect(
+      [...container.querySelectorAll("[data-slot]")].map((slot) => slot.getAttribute("data-slot")),
+    ).toEqual(["placement", "presence", "face"]);
+    expect(crumbs?.nextElementSibling?.getAttribute("data-slot")).toBe("placement");
   });
 
   it("leads with the project, then a separator, then the session title", () => {
@@ -716,10 +715,10 @@ describe("chat pane header", () => {
   });
 
   it("shows cloud placement and hides reveal when disabled", () => {
+    const session = row({ placement: { state: "active" } as GatewaySessionRow["placement"] });
     const { container } = mountHeader({
-      session: row({
-        placement: { state: "active" } as GatewaySessionRow["placement"],
-      }),
+      session,
+      placementControl: renderChatPanePlacement({ session }),
       canReveal: false,
     });
     expect(container.querySelector(".chat-pane__placement-chip")).not.toBeNull();

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -8,7 +8,6 @@ import type {
 } from "../../../app/native-gateways.runtime.ts";
 import { isNativeWebChromeHost } from "../../../app/native-web-chrome.ts";
 import { beginNativeWindowDrag } from "../../../app/native-window-drag.ts";
-import type { ApplicationPlacementStartupStatus } from "../../../app/session-placement-startup.ts";
 import {
   COMMAND_PALETTE_OPEN_EVENT,
   SHELL_NAV_DRAWER_TOGGLE_EVENT,
@@ -33,7 +32,6 @@ import {
   areUiSessionKeysEquivalent,
   resolveUiSessionNavigationParentKey,
 } from "../../../lib/sessions/session-key.ts";
-import { renderChatPanePlacement } from "./chat-pane-placement.ts";
 
 export type ChatPaneHeaderAction = "reveal" | "copy-path" | "copy-branch";
 
@@ -77,13 +75,8 @@ type ChatPaneHeaderProps = {
   presence?: TemplateResult | typeof nothing;
   faceControl?: TemplateResult | typeof nothing;
   sharingControl?: TemplateResult | typeof nothing;
+  placementControl?: TemplateResult | typeof nothing;
   sessionMenuAction: TemplateResult | typeof nothing;
-  placementMoving?: boolean;
-  placementRestarting?: boolean;
-  placementStartupStatus?: Pick<ApplicationPlacementStartupStatus, "phase" | "targetKind"> | null;
-  placementMoveDisabledReason?: string;
-  placementReclaimDisabledReason?: string;
-  placementRestartDisabledReason?: string;
   nativeGateways?: NativeGatewaysCapability | null;
   gatewaysSnapshot?: NativeGatewaysSnapshot | null;
   onboarding?: boolean;
@@ -94,9 +87,6 @@ type ChatPaneHeaderProps = {
   onMenuOpenChange: (open: boolean) => void;
   onMenuAction: (action: ChatPaneHeaderAction) => void;
   onOpenParentSession: (sessionKey: string) => void;
-  onPlacementMove?: () => void;
-  onPlacementReclaim?: () => void;
-  onPlacementRestart?: () => void;
   onBranchSelect: (leafEntryId: string) => void;
   onOpenSplitView?: () => void;
   onSplitDown?: (paneId: string) => void;
@@ -453,8 +443,8 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
             variant="session"
           ></openclaw-viewer-facepile>`
         : nothing}
-      ${renderChatPanePlacement(props)} ${props.presence ?? nothing} ${props.faceControl ?? nothing}
-      ${props.sharingControl ?? nothing}
+      ${props.placementControl ?? nothing} ${props.presence ?? nothing}
+      ${props.faceControl ?? nothing} ${props.sharingControl ?? nothing}
       ${!props.catalog && props.branches.length > 1
         ? html`
             <wa-dropdown

--- a/ui/src/pages/chat/components/chat-pane-placement.ts
+++ b/ui/src/pages/chat/components/chat-pane-placement.ts
@@ -20,12 +20,13 @@ export function renderChatPanePlacement(props: {
   onPlacementReclaim?: () => void;
   onPlacementRestart?: () => void;
 }): TemplateResult | typeof nothing {
-  const placement = props.session?.placement;
+  const session = props.session;
+  const placement = session?.placement;
   const placementState = placement?.state;
-  if (!isCloudWorkerPlacementState(placementState)) {
+  if (!session || !isCloudWorkerPlacementState(placementState)) {
     return nothing;
   }
-  const placementMove = props.session?.placementMove;
+  const placementMove = session.placementMove;
   const workerPlacement =
     placement && placement.state !== "local" && placement.state !== "requested"
       ? placement
@@ -37,7 +38,7 @@ export function renderChatPanePlacement(props: {
   const runner = placement?.state === "active" ? placement.runner : undefined;
   const deviceOffline = runner?.kind === "device" && runner.status === "offline";
   const restartable = placement?.state === "failed" && placement.recoveryAction === "restart";
-  const worker = resolveChatPaneWorkerPresentation(placement, props.placementStartupStatus);
+  const worker = resolveChatPaneWorkerPresentation(session, props.placementStartupStatus);
   const moveTarget =
     placementMove?.target.kind === "gateway"
       ? t("sessionsView.moveSessionGatewayTarget")
@@ -144,7 +145,7 @@ export function renderChatPanePlacement(props: {
               @click=${() => !reclaimDisabledReason && props.onPlacementReclaim?.()}
             >
               <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.stop}</span>
-              <span class="session-menu__text">${t(worker.stopKey)}</span>
+              <span class="session-menu__text">${worker.stopLabel}</span>
             </wa-dropdown-item>`}
       </wa-dropdown>
       ${deviceOffline


### PR DESCRIPTION
Related: #135681 — correct device-worker labels during startup.
Related: #135575 — device startup stop controls said cloud worker; already fixed by the preceding PR.

<details>
<summary>Additional instructions</summary>

Maintainer-requested cleanup of the preceding fix. This same-repository branch is writable by maintainers.

</details>

## What Problem This Solves

The chat placement menu and Stop confirmation must keep the same worker identity and wording as startup advances. The preceding fix established the correct behavior, but left placement-specific properties forwarded through an unrelated header view, repeated startup projection work during rendering, and many identical modal/RPC test workflows.

This is a behavior-preserving cleanup of that concrete fix, not a new feature or a change to worker teardown.

## Why This Change Was Made

Compose one placement-control slot at the chat header owner instead of forwarding nine placement-specific properties through the view, and reuse the startup status already prepared for the render. Keep the separate action-time status read for confirmation. The shared presentation owner now resolves chip, menu, confirmation and action text; consumers no longer manufacture related translation keys.

Reuse existing typed test fixtures and separate the complete 28-case copy matrix from representative menu/dialog integration. Stop-suite modal/RPC workflows fall from 38 to 13 without losing the active-owner, permission, offline, cancellation, connection/presentation, pause-before-reclaim, failure, progress or late-dispatch coverage.

Production LOC: **+56/-55 (net +1)**. Tests/support: **+228/-213 (net +15)** across 13 files total. The near-neutral production delta establishes the composition/prepared-status boundary and removes duplicate responsibilities; this is not a line-count reduction claim. No new helper layer, cache, fallback, config, protocol, persistence, dependency or translation surface.

## User Impact

No visible behavior or layout change is intended or observed. Active placement facts still win; only a live initial handoff supplies a startup hint; failed retained intent remains available for retry but cannot label a later restart. Explicit and automatic paired-device startup retains device wording, profile startup retains cloud wording, and an unknown current target stays neutral. The existing cloud confirmation button remains **Stop worker**.

The operation remains `sessions.reclaim`, with its existing permissions and lifecycle. Broader sidebar/Sessions-page wording and the separate node-completion work in #132180 remain out of scope. The existing [Control UI documentation](https://docs.openclaw.ai/web/control-ui) still describes the behavior and needs no change.

## Evidence

- **567 distinct passing tests across 18 files:** 457 focused startup/placement/chat tests, 109 header/caller tests and one synthetic Chromium startup Stop E2E.
- The same baseline was green: 453 focused tests, 109 header/caller tests and the E2E. All 28 copy permutations remain; four representative integration cases are now separate from that matrix.
- UI test types, the actual 13-path changed gate, formatting and `git diff --check` passed. A misplaced test-fixture argument and one shadowed table binding were caught during implementation, corrected, and all final proof rerun; no assertions, baselines or timeout guards were weakened.
- Fresh independent Codex P0 autoreview: scoped-clean, no actionable findings. The committed source was hash-checked against the verified files after the normal commit hook ran.
- The E2E freshly built and booted the real Control UI with a synthetic Gateway before and after cleanup: select device → hold dispatch → verify menu/confirmation → cancel with zero reclaim → confirm one session reclaim → release late dispatch with zero initial sends/destroys and a retained-message alert.

All eight before/after screenshots were inspected. These are synthetic-only UI/request-boundary captures, not physical-device teardown or live-provider proof; no operator services, state, credentials or device identities were used. The confirmation captures are byte-identical, so both columns use the same uploaded bytes. No pixel-identical claim is made for animated/timing-dependent states.

| Surface | Before cleanup | After cleanup |
| --- | --- | --- |
| Device startup menu | ![Before cleanup: device startup menu](https://github.com/user-attachments/assets/3d78d82e-19ce-40b4-8afb-e62d24245655) | ![After cleanup: unchanged device startup menu](https://github.com/user-attachments/assets/b1c385a0-3c7e-4440-b15d-a4159fa5c7fc) |
| Stop confirmation | ![Before cleanup: device-worker confirmation](https://github.com/user-attachments/assets/c424216e-c5ec-4f61-b5f3-430332ad9d65) | ![After cleanup: identical device-worker confirmation](https://github.com/user-attachments/assets/c424216e-c5ec-4f61-b5f3-430332ad9d65) |

<details>
<summary>Exact final local proof commands</summary>

```bash
node scripts/run-vitest.mjs ui/src/app/session-placement-startup.test.ts ui/src/app/session-placement-startup.stop.test.ts ui/src/app/session-placement-startup.disconnect.test.ts ui/src/pages/chat/chat-pane-placement-stop.test.ts ui/src/pages/chat/chat-pane-placement.test.ts ui/src/pages/chat/components/chat-pane-placement.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-pane-placement-composer.test.ts ui/src/pages/chat/chat-pane-placement-restart.test.ts ui/src/pages/chat/chat-pane-session-menu.test.ts ui/src/pages/chat/chat-pane-session-access.test.ts ui/src/pages/chat/chat-pane-terminal.test.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts ui/src/pages/chat/components/chat-pane-header.test.ts ui/src/pages/chat/components/chat-pane-header.workspace-icon.test.ts ui/src/pages/chat/components/chat-pane-header-identity.test.ts ui/src/pages/chat/components/chat-pane-header.browser.test.ts
```

```bash
node scripts/run-tsgo-core-test-shards.mjs ui
```

```bash
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.device-stop.e2e.test.ts
```

```bash
node scripts/check-changed.mjs -- ui/src/pages/chat/chat-pane-header.ts ui/src/pages/chat/chat-pane-layout-render.ts ui/src/pages/chat/chat-pane-placement-stop.test.ts ui/src/pages/chat/chat-pane-placement.runtime.ts ui/src/pages/chat/chat-pane-placement.ts ui/src/pages/chat/chat-pane-session-access.test.ts ui/src/pages/chat/chat-pane-session-menu.test.ts ui/src/pages/chat/chat-pane-terminal.test.ts ui/src/pages/chat/chat-pane.test-support.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts ui/src/pages/chat/components/chat-pane-header.test.ts ui/src/pages/chat/components/chat-pane-header.ts ui/src/pages/chat/components/chat-pane-placement.ts
```

</details>
