### PR TITLE
improve: reduce memory and latency when truncating terminal text

### DIFF
--- a/packages/terminal-core/src/ansi.test.ts
+++ b/packages/terminal-core/src/ansi.test.ts
@@ -278,6 +278,7 @@ describe("terminal ansi helpers", () => {
     expect(truncateToVisibleWidth("abc", 2)).toBe("ab");
     expect(truncateToVisibleWidth("abc", 5)).toBe("abc");
     expect(truncateToVisibleWidth("anything", 0)).toBe("");
+    expect(truncateToVisibleWidth("abc", Number.NaN)).toBe("");
     // A wide grapheme that cannot fit the remaining budget is dropped whole,
     // never emitted half-width, so the result never exceeds the budget.
     expect(truncateToVisibleWidth("表文", 2)).toBe("表");
@@ -306,6 +307,19 @@ describe("terminal ansi helpers", () => {
     expect(truncateToVisibleWidth("a\u200Bb", 1)).toBe("a\u200B");
     expect(truncateToVisibleWidth("abc\u200B", 2)).toBe("ab");
     expect(truncateToVisibleWidth("\u200Babc", 2)).toBe("\u200Bab");
+  });
+
+  it.each([
+    ["表".repeat(16) + "a".repeat(16), 40, "表".repeat(16) + "a".repeat(8)],
+    ["a".repeat(16) + "表".repeat(16), 20, "a".repeat(16) + "表".repeat(2)],
+    ["a" + "\u200B".repeat(64) + "表b", 1, "a" + "\u200B".repeat(64)],
+    ["表" + "\u200B".repeat(64) + "b", 1, ""],
+    ["a" + "\u0300".repeat(64) + "表b", 1, "a" + "\u0300".repeat(64)],
+    ["🇬🇧".repeat(32) + "a", 63, "🇬🇧".repeat(31)],
+    ["a" + "\u093e".repeat(40) + "\u0300".repeat(32768), 40, ""],
+  ])("fits uneven and invisible grapheme runs (case %#)", (input, width, expected) => {
+    expect(truncateToVisibleWidth(input, width)).toBe(expected);
+    expect(visibleWidth(expected)).toBeLessThanOrEqual(width);
   });
 
   it("preserves ANSI sequences when truncating styled text", () => {

--- a/packages/terminal-core/src/ansi.ts
+++ b/packages/terminal-core/src/ansi.ts
@@ -38,10 +38,8 @@ const ANSI_COMPAT_SEQUENCE_AT_INDEX_REGEX = new RegExp(
   `${ANSI_OSC_SEQUENCE_PATTERN}|${ANSI_COMPAT_CONTROL_SEQUENCE_PATTERN}`,
   "y",
 );
-const graphemeSegmenter =
-  typeof Intl !== "undefined" && "Segmenter" in Intl
-    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
-    : null;
+// string-width already requires Intl.Segmenter at module initialization.
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 function hasAnsiIntroducer(input: string): boolean {
   return input.includes("\u001B") || input.includes("\u009B") || input.includes("\u009D");
@@ -153,14 +151,7 @@ export function splitGraphemes(input: string): string[] {
   if (!input) {
     return [];
   }
-  if (!graphemeSegmenter) {
-    return Array.from(input);
-  }
-  try {
-    return Array.from(graphemeSegmenter.segment(input), (segment) => segment.segment);
-  } catch {
-    return Array.from(input);
-  }
+  return Array.from(graphemeSegmenter.segment(input), (segment) => segment.segment);
 }
 
 // Construct once without embedding literal controls; DEL and C1 form one range.
@@ -235,73 +226,71 @@ export function truncateToVisibleWidth(input: string, maxWidth: number): string 
       return;
     }
 
-    const graphemes = splitGraphemes(segment);
-    let offset = 0;
-    const offsets = [offset];
-    for (const grapheme of graphemes) {
-      offset += grapheme.length;
-      offsets.push(offset);
-    }
-    let start = 0;
+    const segments = graphemeSegmenter.segment(segment);
+    const measurePrefix = remaining <= width / 2;
+    let current: Intl.SegmentData | undefined;
+    let candidateWidth = 0;
+    let low = 0;
+    let high = segment.length;
+    let end = 0;
     let fittedWidth = 0;
-    if (remaining <= width / 2) {
-      let end = Math.max(
-        1,
-        Math.min(graphemes.length - 1, Math.floor((remaining * graphemes.length) / width)),
-      );
-      let stride = 1;
-      // Estimate the cell boundary first; gallop handles uneven/zero-width clusters.
-      while (end < graphemes.length) {
-        const candidateWidth = textWidth(segment.slice(0, offsets[end]));
-        if (candidateWidth > remaining) {
-          break;
-        }
-        start = end;
-        fittedWidth = candidateWidth;
-        end = Math.min(graphemes.length, end + stride);
-        stride *= 2;
+    const fits = (position: number): boolean => {
+      if (position === segment.length) {
+        return false;
       }
-      while (start + 1 < end) {
-        const middle = Math.floor((start + end) / 2);
-        const candidateWidth = textWidth(segment.slice(0, offsets[middle]));
-        if (candidateWidth <= remaining) {
-          start = middle;
-          fittedWidth = candidateWidth;
-        } else {
-          end = middle;
-        }
+      // containing() keeps UTF-16 probes on whole graphemes without indexing the
+      // entire line. Reuse its result while probing one oversized cluster.
+      if (
+        !current ||
+        position < current.index ||
+        position >= current.index + current.segment.length
+      ) {
+        // SAFETY: the end sentinel returns above; other probes resolve inside this segment.
+        current = segments.containing(position) as Intl.SegmentData;
+        candidateWidth =
+          current.index === 0
+            ? 0
+            : measurePrefix
+              ? textWidth(segment.slice(0, current.index))
+              : width - textWidth(segment.slice(current.index));
       }
-    } else {
-      const overflow = width - remaining;
-      let tooShort = 0;
-      let removed = Math.min(graphemes.length, 1);
-      let removedWidth = width;
-      // Near-end cuts search short complete-grapheme suffixes, not repeated full prefixes.
-      while (removed < graphemes.length) {
-        removedWidth = textWidth(segment.slice(offsets[graphemes.length - removed]));
-        if (removedWidth >= overflow) {
-          break;
-        }
-        tooShort = removed;
-        removed = Math.min(graphemes.length, removed * 2);
+      if (candidateWidth > remaining) {
+        return false;
       }
-      if (removed === graphemes.length) {
-        removedWidth = width;
+      end = current.index;
+      fittedWidth = candidateWidth;
+      return true;
+    };
+    let probe = Math.min(segment.length - 1, Math.floor((remaining * segment.length) / width));
+    let fitting = fits(probe);
+    const initiallyFits = fitting;
+    let stride = 1;
+    // Bracket the estimate before bisecting so small cuts measure short prefixes
+    // or suffixes even when the line contains many variable-width graphemes.
+    while (low < high) {
+      if (fitting) {
+        low = probe;
+      } else {
+        high = probe;
       }
-      while (tooShort + 1 < removed) {
-        const middle = Math.floor((tooShort + removed) / 2);
-        const candidateWidth = textWidth(segment.slice(offsets[graphemes.length - middle]));
-        if (candidateWidth >= overflow) {
-          removed = middle;
-          removedWidth = candidateWidth;
-        } else {
-          tooShort = middle;
-        }
+      if (fitting !== initiallyFits || probe === 0 || probe === segment.length) {
+        break;
       }
-      start = graphemes.length - removed;
-      fittedWidth = width - removedWidth;
+      probe = initiallyFits
+        ? Math.min(segment.length, probe + stride)
+        : Math.max(0, probe - stride);
+      stride *= 2;
+      fitting = fits(probe);
     }
-    out += segment.slice(0, offsets[start]);
+    while (low + 1 < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (fits(middle)) {
+        low = middle;
+      } else {
+        high = middle;
+      }
+    }
+    out += segment.slice(0, end);
     used += fittedWidth;
     budgetSpent = true;
   };


### PR DESCRIPTION
## What Problem This Solves

Truncating a long terminal line indexed every grapheme and allocated an offset array even when only a few display columns were needed. A 1 MiB ASCII line required roughly 35 MiB of immediate heap growth just to keep 40 columns.

## Why This Change Was Made

The terminal width owner now finds complete grapheme boundaries with `Intl.Segments.containing()`, brackets the estimated cut and measures the shorter side. It reuses a cluster's measured width while searching within that cluster and keeps the search bounded. ANSI scanning, reset handling and display-width measurement retain their existing owners.

The unreachable optional-Segmenter fallback is removed: the locked `string-width` dependency already constructs `Intl.Segmenter` during module initialization. Production changes are +61/−72 lines (net −11); tests add 14 lines. No dependency or configuration changes.

## User Impact

Terminal formatting keeps identical text, styling and Unicode boundaries while using less temporary memory for long lines. Across three alternating Node 26.8.1 process pairs, 1 MiB ASCII truncation fell from a median 59.8 ms to 2.2 ms and immediate heap growth from 36,494,848 bytes to 2,256 bytes. Near-end cuts showed similar improvements; the mixed Unicode fixture fell from 23.1 ms to 14.1 ms.

The oversized single-cluster control was effectively unchanged (1.52 ms versus 1.54 ms). These are synthetic owner measurements; immediate heap/RSS observations include allocator effects and do not establish a whole-Gateway or retained-memory reduction.

## Evidence

- 55,824 Unicode/ANSI input-budget cases produced identical before/after digests and respected display-width limits. A real rendered table also matched byte for byte.
- Added contracts cover uneven-width runs, invisible characters, combining marks, flag boundaries, an oversized suffix cluster and invalid-width termination.
- Canonical ANSI, table and command text-format suites: 154 tests passed. Full changed-file gate passed on the final source.
- Independent source/dependency review checked callers and the V8 grapheme-boundary contract. Reported issues were repaired and rechecked; final Codex autoreview has no accepted findings.

Baseline: `173f41d682b0d4a05674820a3d390d934da8b066`. The boundary operation follows [ECMA-402's Segments containing contract](https://tc39.es/ecma402/#sec-%segmentsprototype%.containing).
