### PR TITLE
fix(cron): preserve NO_REPLY after completed tool calls

### DIFF
--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -115,26 +115,25 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): boolean {
-  // "optional" is the run consumer's declaration that no user-facing reply is
-  // owed (e.g. cron without a delivery route). Silence after side-effecting
-  // tools is intentional there; retry is replay-unsafe, so erroring would mark
-  // successful tool-only runs as failures.
+  // Optional runs owe no reply. An explicit silent reply also closes a
+  // successful side-effecting tool turn; replaying it could repeat the effect.
   const terminalReplyOptional = params.terminalReplyExpectation === "optional";
+  const assistant = resolveCurrentAttemptAssistant(params.attempt);
+  const explicitSilentReply =
+    params.payloadCount === 0 &&
+    assistant?.stopReason !== "error" &&
+    hasOnlySilentAssistantReply(params.attempt.assistantTexts);
+  const tolerateSideEffects = terminalReplyOptional || explicitSilentReply;
   if (
     !params.allowEmptyAssistantReplyAsSilent ||
-    shouldSkipNonVisibleTurnRetry({ ...params, tolerateSideEffects: terminalReplyOptional })
+    shouldSkipNonVisibleTurnRetry({ ...params, tolerateSideEffects })
   ) {
     return false;
   }
   if (hasCommittedMessagingToolDeliveryEvidence(params.attempt)) {
     return false;
   }
-  const assistant = resolveCurrentAttemptAssistant(params.attempt);
-  if (
-    params.payloadCount === 0 &&
-    assistant?.stopReason !== "error" &&
-    hasOnlySilentAssistantReply(params.attempt.assistantTexts)
-  ) {
+  if (explicitSilentReply) {
     return true;
   }
   // A visible turn owes a reply unless the model explicitly chose NO_REPLY.

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -241,7 +241,7 @@ describe("resolveSettledTurnFinalizationRequest", () => {
     ).toBeNull();
   });
 
-  it("keeps explicit silence terminal only for reply-optional settled turns", () => {
+  it("keeps explicit silence terminal across required and optional settled turns", () => {
     const toolUseAssistant = buildEmbeddedRunnerAssistant({
       stopReason: "toolUse",
       content: [{ type: "toolCall", id: "tool-1", name: "write", arguments: {} }],
@@ -274,6 +274,7 @@ describe("resolveSettledTurnFinalizationRequest", () => {
         runParams: {
           sessionId: "session:settled-silent",
           runId: "run:settled-silent",
+          allowEmptyAssistantReplyAsSilent: true,
           ...runParams,
         } as never,
         attempt,
@@ -290,9 +291,7 @@ describe("resolveSettledTurnFinalizationRequest", () => {
       });
 
     expect(request({ trigger: "heartbeat" })).toBeNull();
-    expect(request({ trigger: "user", terminalReplyExpectation: "required" })).toBe(
-      SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION,
-    );
+    expect(request({ trigger: "user", terminalReplyExpectation: "required" })).toBeNull();
   });
 
   it("requires an available finalizer and no visible structured error", () => {


### PR DESCRIPTION
Fixes #135658

Thanks @Frank683456 for the exact released regression report and @leilei3167 for the initial repair.

## What Problem This Solves

Fixes an issue where isolated cron announce jobs ran tools, ended with the documented `NO_REPLY` token, and then sent a synthesized “no final summary was produced” message instead of staying silent.

## Why This Change Was Made

The shared terminal classifier now records an explicit silent reply before applying the replay-safety block for completed side effects. It still applies every error, abort, pending-work, and prior-delivery guard, so a failed tool or genuinely empty final answer cannot hide behind silence.

This keeps one terminal outcome owner for cron, heartbeat, and other callers that explicitly allow silent replies. It does not add a cron-specific branch or a second delivery path.

## User Impact

Quiet scheduled jobs no longer post a fallback message or make two extra finalization model calls after a successful tool run ends with `NO_REPLY`.

Runs still record `status: ok`, `deliveryStatus: not-delivered`, and `deliverySuppressionReason: silent`. Truly missing summaries still use the existing finalization and fallback path.

## Evidence

Exact-main product proof at `54a9f3481d87916617414315cdde3e1cc42330e3` used a real Gateway child, `cron.add`, `cron.run`, the QA mock provider, one real `exec` tool call, embedded turn-terminal resolution, cron announce delivery, and a task-local capture channel.

| Case | Provider calls | Delivery |
| --- | ---: | --- |
| Main: tool then `NO_REPLY` | 4: tool plan, `NO_REPLY`, two finalizers | Delivered the synthesized fallback |
| Head: tool then `NO_REPLY` | 2: tool plan, `NO_REPLY` | Silent; no outbound message |
| Head control: tool then visible reply | 2 | Delivered `ISSUE-135658-VISIBLE-OK` |

The head proof at `10ac117aa29a570dbc58a53157e9a68dcbf7107c` recorded the silent run as `ok`, `not-delivered`, suppression `silent`, zero outbound messages, and zero finalization requests.

The corrected regression failed on pre-fix code because required delivery returned the settled-turn continuation prompt. It passes on this head.

Focused validation:

- 50 tests passed across settled-turn finalization, incomplete-turn recovery, error recovery, and cron suppression readback.
- Focused Oxlint passed.
- Conflict-marker, max-lines, assertion-safety, formatting, and diff checks passed.

Production code is net `-1` line. Tests are net `-1` line.
