### PR TITLE
feat(android): let chat composer grow to 6 visible lines

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -3144,7 +3144,7 @@ private fun ChatInputPill(
           textStyle = draftStyle.copy(color = ClawTheme.colors.text),
           cursorBrush = SolidColor(ClawTheme.colors.primary),
           minLines = 1,
-          maxLines = 8,
+          maxLines = 6,
           modifier =
             Modifier
               .fillMaxWidth()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -3144,7 +3144,7 @@ private fun ChatInputPill(
           textStyle = draftStyle.copy(color = ClawTheme.colors.text),
           cursorBrush = SolidColor(ClawTheme.colors.primary),
           minLines = 1,
-          maxLines = 4,
+          maxLines = 8,
           modifier =
             Modifier
               .fillMaxWidth()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -285,6 +285,25 @@ class ChatComposerLayoutTest {
   }
 
   @Test
+  fun multilineDraftGrowsThroughSixLinesAndStopsGrowingAtTheSeventh() {
+    showChat(viewportWidth = 360.dp, viewportHeight = 640.dp)
+    val editor = composeRule.onNode(hasSetTextAction())
+    val heights =
+      (1..7).map { lineCount ->
+        val draft = (1..lineCount).joinToString("\n") { line -> "Line $line" }
+        editor.performTextReplacement(draft)
+        editor.assertTextEquals(draft)
+        editor.getUnclippedBoundsInRoot().let { bounds -> bounds.bottom - bounds.top }
+      }
+
+    heights.take(6).zipWithNext().forEachIndexed { index, (current, next) ->
+      assertTrue("The editor must grow from ${index + 1} to ${index + 2} visible lines", next > current)
+    }
+    assertEquals("The seventh line must scroll inside the six-line editor", heights[5], heights[6])
+    assertComposerControlsVisible()
+  }
+
+  @Test
   fun compactPickersExposeFullSettingsWithoutExpandingTheComposer() {
     showChat(viewportWidth = 320.dp, fontScale = { 1.5f }, talkActive = true)
     composeRule.runOnIdle {


### PR DESCRIPTION
## What Problem This Solves

When drafting longer prompts on a phone, the Android chat composer stops growing at 4 visible lines, so users end up editing long messages through a small scrolling window that only shows a fraction of the draft.

## Why This Change Was Made

Raises the composer input cap from `maxLines = 4` to `maxLines = 6` in `ChatInputPill` (`ChatScreen.kt`). `minLines` stays 1, so short messages are unchanged and longer drafts expand before scrolling internally.

The fixed six-line cap was selected after comparing the original eight-line proposal with an adaptive 4–12-line alternative. Six lines materially improves long-draft editing while preserving more chat context on compact and large-font layouts, and it keeps the editor boundary predictable across devices.

## User Impact

Long prompts are easier to review and edit before sending. Short messages look and behave as before; drafts longer than six lines scroll inside the composer.

## Evidence

`multilineDraftGrowsThroughSixLinesAndStopsGrowingAtTheSeventh` verifies that the editor grows from one through six visible lines, stops growing at the seventh, and retains its controls. The rebased exact head is covered by the PR's Android CI.

### Maintainer visual proof

API 36 with the software keyboard open:

| 1080×1920, 1.0× font scale | 720×1600, 1.5× font scale |
| --- | --- |
| ![Six-line composer at normal font scale](https://github.com/user-attachments/assets/2cc58b3c-de61-414a-b425-d3f3e5f7b5cd) | ![Six-line composer on a compact large-font layout](https://github.com/user-attachments/assets/92b32f7e-09b7-4ea2-b0d9-ea80807430c9) |

Both captures show six complete draft lines with the keyboard and action row visible. The contributor's broader adaptive-layout matrix remains available in the [PR discussion](https://github.com/openclaw/openclaw/pull/135923#issuecomment-5512546682).

### Original contributor evidence

Benny built and daily-drove the change on a Galaxy S25. The original evidence shows a long draft with the keyboard open and the action row intact:

<img src="https://raw.githubusercontent.com/BennyAI2/openclaw/assets/evidence/composer-expanded.jpg" width="300" alt="Composer expanded with a long draft" />

| 2026.7.4 release | Current composer design with the expanded cap |
| --- | --- |
| <img src="https://raw.githubusercontent.com/BennyAI2/openclaw/assets/evidence/composer-before.jpg" width="300" alt="Release composer squeezed" /> | <img src="https://raw.githubusercontent.com/BennyAI2/openclaw/assets/evidence/composer-after.jpg" width="300" alt="Composer with the expanded cap" /> |

## Worked on by

- Benny Water ([@BennyAI2](https://github.com/BennyAI2))
