### PR TITLE
fix(infra): stop SSH readiness probes after startup failure

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -513,6 +513,9 @@ OpenClaw launches only an SSH client found in OS-managed system directories. On 
 install the **OpenSSH Client** optional feature; Windows places it under
 `%SystemRoot%\System32\OpenSSH`.
 
+If SSH startup fails or you cancel the probe, OpenClaw stops its local connection
+checks and waits for the SSH process to exit before completing cleanup.
+
 <ParamField path="--ssh-identity <path>" type="string">
   Identity file.
 </ParamField>

--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -1,7 +1,7 @@
 // Covers SSH target parsing and tunnel startup preflight behavior.
 import { EventEmitter } from "node:events";
 import net from "node:net";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   ensurePortAvailable: vi.fn<(port: number, host?: string) => Promise<void>>(),
@@ -106,6 +106,18 @@ describe("startSshPortForward", () => {
     mocks.resolveSshClient.mockReturnValue("/usr/bin/ssh");
     mocks.spawn.mockReset();
   });
+
+  function mockPendingProbe() {
+    const socket = new net.Socket();
+    // Only the test drives probe completion; no native socket timeout races the fake clock.
+    socket.setTimeout = () => socket;
+    const connect = vi.spyOn(net, "connect").mockReturnValue(socket);
+    onTestFinished(() => {
+      socket.destroy();
+      connect.mockRestore();
+    });
+    return { socket, connect };
+  }
 
   // Fake ssh child that, when spawned, parses the -L forward spec and starts a
   // real IPv4-loopback listener on the chosen local port so waitForLocalListener
@@ -274,19 +286,18 @@ describe("startSshPortForward", () => {
   });
 
   it("keeps startup abort pending until the SSH child exits", async () => {
-    const child = new EventEmitter() as EventEmitter & {
-      pid: number;
-      stderr: EventEmitter & { setEncoding: (enc: string) => void };
-      kill: (signal?: string) => boolean;
-    };
-    child.pid = 4242;
-    child.stderr = Object.assign(new EventEmitter(), { setEncoding: () => {} });
-    child.kill = vi.fn(() => true);
+    vi.useFakeTimers();
+    const { socket, connect } = mockPendingProbe();
+    const child = Object.assign(new EventEmitter(), {
+      pid: 4242,
+      stderr: Object.assign(new EventEmitter(), { setEncoding: () => {} }),
+      kill: vi.fn(() => true),
+    });
     mocks.spawn.mockReturnValue(child);
     const controller = new AbortController();
     const forwarding = startSshPortForward({
       target: "me@example.com:2222",
-      localPortPreferred: await getFreePort(),
+      localPortPreferred: 43210,
       remotePort: 18789,
       timeoutMs: 1000,
       signal: controller.signal,
@@ -298,57 +309,66 @@ describe("startSshPortForward", () => {
       })
       .catch(() => {});
 
-    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(0);
     controller.abort();
-    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith("SIGTERM"));
-    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
     expect(settled).toBe(false);
-    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
 
     child.emit("exit", null, "SIGTERM");
     await expect(forwarding).rejects.toMatchObject({ name: "AbortError" });
+    expect(socket.destroyed).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.runAllTimersAsync();
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(child.kill).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects with the spawn error when ssh binary is missing", async () => {
-    vi.useFakeTimers();
-    const spawnError = new Error("ENOENT: no such file or directory, spawn /usr/bin/ssh");
-    (spawnError as NodeJS.ErrnoException).code = "ENOENT";
-    const kill = vi.fn(() => false);
-    mocks.spawn.mockImplementation(() => {
-      const child = new EventEmitter() as EventEmitter & {
-        killed: boolean;
-        pid?: number;
-        stderr: EventEmitter & { setEncoding: (enc: string) => void };
-        kill: (signal?: string) => boolean;
-      };
-      child.killed = false;
-      const stderr = new EventEmitter() as EventEmitter & { setEncoding: (enc: string) => void };
-      stderr.setEncoding = () => {};
-      child.stderr = stderr;
-      child.kill = kill;
+  it.each(["connecting", "retrying"] as const)(
+    "rejects with the spawn error when ssh binary is missing while the probe is %s",
+    async (phase) => {
+      vi.useFakeTimers();
+      const { socket, connect } = mockPendingProbe();
+      const spawnError = new Error("ENOENT: no such file or directory, spawn /usr/bin/ssh");
+      (spawnError as NodeJS.ErrnoException).code = "ENOENT";
+      const kill = vi.fn(() => false);
+      const child = Object.assign(new EventEmitter(), {
+        stderr: Object.assign(new EventEmitter(), { setEncoding: () => {} }),
+        kill,
+      });
+      mocks.spawn.mockReturnValue(child);
+
+      const forwarding = startSshPortForward({
+        target: "me@example.com:2222",
+        localPortPreferred: 43210,
+        remotePort: 18789,
+        timeoutMs: 500,
+      });
+      const rejection = expect(forwarding).rejects.toMatchObject({
+        message: expect.stringContaining("ENOENT"),
+        cause: spawnError,
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      if (phase === "retrying") {
+        // Refuse the probe before SSH fails so its retry is already scheduled.
+        socket.emit("error", new Error("ECONNREFUSED"));
+        await vi.advanceTimersByTimeAsync(0);
+      }
       queueMicrotask(() => {
         child.emit("error", spawnError);
         child.emit("close", -2, null);
       });
-      return child;
-    });
 
-    const forwarding = startSshPortForward({
-      target: "me@example.com:2222",
-      localPortPreferred: 43210,
-      remotePort: 18789,
-      timeoutMs: 500,
-    });
-    const rejection = expect(forwarding).rejects.toMatchObject({
-      message: expect.stringContaining("ENOENT"),
-      cause: spawnError,
-    });
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(vi.getTimerCount()).toBe(0);
-    await rejection;
-    expect(kill).toHaveBeenCalledWith("SIGTERM");
-  });
+      await vi.advanceTimersByTimeAsync(0);
+      await rejection;
+      expect(socket.destroyed).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.runAllTimersAsync();
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(kill).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+    },
+  );
 
   it.each(["active", "teardown"] as const)(
     "does not crash when stderr errors while the tunnel is %s",

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { createAbortError, isAbortError, racePromiseWithAbortSignal } from "./abort-signal.js";
+import { sleepWithAbort } from "./backoff.js";
 import { formatErrorMessage, isErrno } from "./errors.js";
 import { ensurePortAvailable, PortInUseError } from "./ports.js";
 import { resolveSshClient } from "./ssh-client.js";
@@ -111,29 +112,35 @@ async function pickEphemeralPort(): Promise<number> {
   });
 }
 
-async function canConnectLocal(port: number): Promise<boolean> {
+async function canConnectLocal(port: number, signal: AbortSignal): Promise<boolean> {
+  signal.throwIfAborted();
   return await new Promise<boolean>((resolve) => {
     const socket = net.connect({ host: "127.0.0.1", port });
     const done = (ok: boolean) => {
+      signal.removeEventListener("abort", onAbort);
       socket.removeAllListeners();
       socket.destroy();
       resolve(ok);
     };
+    const onAbort = () => done(false);
+    signal.addEventListener("abort", onAbort, { once: true });
     socket.once("connect", () => done(true));
     socket.once("error", () => done(false));
     socket.setTimeout(250, () => done(false));
   });
 }
 
-async function waitForLocalListener(port: number, timeoutMs: number): Promise<void> {
+async function waitForLocalListener(
+  port: number,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<void> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    if (await canConnectLocal(port)) {
+    if (await canConnectLocal(port, signal)) {
       return;
     }
-    await new Promise((r) => {
-      setTimeout(r, 50);
-    });
+    await sleepWithAbort(50, signal);
   }
   throw new Error(`ssh tunnel did not start listening on localhost:${port}`);
 }
@@ -217,6 +224,7 @@ export async function startSshPortForward(opts: {
     child.once("exit", () => resolve());
     child.once("close", () => resolve());
   });
+  const listenerController = new AbortController();
   let onAbort: (() => void) | undefined;
   const detachAbort = () => {
     if (onAbort) {
@@ -227,6 +235,8 @@ export async function startSshPortForward(opts: {
   let stopping: Promise<void> | undefined;
   const stop = () =>
     (stopping ??= (async () => {
+      // The losing readiness probe must not leave a socket or retry timer behind.
+      listenerController.abort();
       detachAbort();
       // Sending a signal is not exit; every caller must await the same child lifetime.
       const timer = setTimeout(() => child.kill("SIGKILL"), 1500);
@@ -241,7 +251,7 @@ export async function startSshPortForward(opts: {
   try {
     await racePromiseWithAbortSignal(
       Promise.race([
-        waitForLocalListener(localPort, Math.max(250, opts.timeoutMs)),
+        waitForLocalListener(localPort, Math.max(250, opts.timeoutMs), listenerController.signal),
         new Promise<void>((_, reject) => {
           child.once("error", (err) => reject(err));
           child.once("exit", (code, signal) => {


### PR DESCRIPTION
> **Superseded by #135873**, merged as 8cfd23c94c1d2556eb7009b7ca4795478d5867e6 while this PR was in CI. Main contains the stronger cancel-and-join readiness repair and a six-case terminal-state regression matrix. This PR will not be merged over it; the proposal below is retained as historical reproduction/proof context. The [ClawSweeper cleanup finding and Rank-up move](https://github.com/openclaw/openclaw/pull/135927#issuecomment-5504544620) are accepted by retaining the canonical main implementation and closing this duplicate.

Independent main verification at 7bca0b47f72d83713f1e0068454fb899b7a0d0ba: **21 tests passed in each of five runs**; real system SSH refusal/cancellation left zero owned timers or probe sockets at rejection and no late activity. `pnpm check:changed --timed -- src/infra/ssh-tunnel.ts src/infra/ssh-tunnel.test.ts`: **passed all 29 checks** in a clean isolated checkout with frozen dependencies. The canonical repair's [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33590793855) passed. No authenticated success roundtrip or full Gateway CLI run is claimed.

---

Related: #135812 (the MCP-approval PR whose merge-commit CI exposed this unrelated SSH flake) and 0ac750ff76a (SSH probe signal cleanup).

## What Problem This Solves

Fixes readiness polling that can continue after SSH tunnel startup fails or is cancelled. The missing-SSH test intermittently reports one pending timer, including [checks-node-compact-small-30, run 33588335876, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33588335876/job/100117166164). That run passed on retry.

The timer is a real 50 ms readiness retry, not an uncleared SIGKILL timer. The losing `waitForLocalListener` branch keeps running after `Promise.race` rejects, and the preceding startup-abort test can leak the same work into the next test's fake clock. Awaiting rejection alone still reproduces the leak. The assertion predates 0ac750ff76a; that commit added the adjacent startup-abort case and carried the uncancelled polling path forward.

## Why This Change Was Made

The existing memoized `stop()` owns cancellation of the readiness socket and retry delay as well as child reaping. It reuses `sleepWithAbort`, removes the uncancellable delay, and preserves the original startup error and shared TERM/KILL exit fence.

The existing tests now control refusal/abort ordering, await rejection before asserting zero timers, and drain all timers to verify no later probe or SIGKILL. The pending socket fixture has no native idle timeout racing the fake clock. No tolerance, extra retry, or test-only production seam is added.

## User Impact

Failed or cancelled SSH startup stops local connection checks immediately while still waiting for the SSH child to exit. The flaky test becomes deterministic. No config, protocol, dependency, or public API changes; the SSH probe documentation describes the cleanup behavior.

## Evidence

- Final regression tests against unchanged production: **3 fail / 14 pass**, specifically the open socket after startup abort, open socket after spawn failure, and retry timer remaining after rejection.
- `pnpm test src/infra/ssh-tunnel.test.ts` in a bounded five-run loop: **5/5 passes**, 17 tests per run.
- `pnpm test src/infra/backoff.test.ts src/infra/abort-signal.test.ts src/commands/gateway-status.test.ts`: **64 tests pass** across all three owners/callers.
- `pnpm check:changed`: **passed** in an isolated fresh dependency install; the initial shared install was missing the existing `mermaid` dependency.
- Fresh Codex autoreview of the final uncommitted patch: scoped clean, no findings.
- Real system SSH and loopback TCP, Node 26.8.1 / OpenSSH 10.3p1: connection refusal preserves exit 255, stderr, and cause; banner-stall cancellation preserves `AbortError` and waits for SIGTERM exit. Both have **zero owned timers and probe sockets at rejection**, no new probes or late SIGKILL during another 1700 ms, and no remaining child. Exact-argument SSH config checks ruled out proxy/config redirection. Replayed independently by the lead with the same source hash.
- Live proof scope: real negative startup paths, not an authenticated forwarding roundtrip or full Gateway CLI invocation. Existing real-listener and stop/join tests remain covered by the full file.

Production LOC: **+17/-7 (net +10)**. Tests: **+69/-49 (net +20)**. Docs: **+3**. The production growth supplies missing cancellation ownership for the socket and retry timer within the existing stop path; it adds no alternate cleanup flow.
