### PR TITLE
fix(media): preserve inferred text and promptly reject downloads

### DIFF
--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -124,6 +124,7 @@ Allowed MIME types (default): `text/plain`, `text/markdown`, `text/html`, `text/
 
 Current behavior:
 
+- Text inferred from otherwise untyped bytes retains its detected encoding, including UTF-16 and Windows-1252. Declared text charsets remain supported.
 - File content is decoded and added to the **system prompt**, not the user message, so it stays ephemeral (not persisted in session history).
 - Decoded file text is wrapped as **untrusted external content** before it is added, so file bytes are treated as data, not trusted instructions. The injected block uses explicit boundary markers (`<<<EXTERNAL_UNTRUSTED_CONTENT id="...">>>` / `<<<END_EXTERNAL_UNTRUSTED_CONTENT id="...">>>`) and a `Source: External` metadata line. It intentionally omits the long `SECURITY NOTICE:` banner to preserve prompt budget; the boundary markers and metadata still apply.
 - PDFs are parsed for text first. If little text is found, the first pages are rasterized into images and passed to the model, and the injected file block uses the placeholder `[PDF content rendered to images]`.

--- a/packages/media-core/src/attachment-classify.ts
+++ b/packages/media-core/src/attachment-classify.ts
@@ -8,7 +8,7 @@ export type AttachmentClass =
   | "video"
   | "archive"
   | "binary";
-type AttachmentCharset = "utf-16le" | "utf-16be";
+type AttachmentCharset = "utf-16le" | "utf-16be" | "windows-1252";
 export type AttachmentClassification = {
   mime: string | undefined;
   class: AttachmentClass;
@@ -94,7 +94,7 @@ function textRatios(text: string, includeWordish: boolean): [printable: number, 
   return total === 0 ? [0, 0] : [printable / total, wordish / total];
 }
 
-function looksLikeText(buffer: Buffer): boolean {
+function sniffTextCharset(buffer: Buffer): "utf-8" | "windows-1252" | undefined {
   const sample = buffer.subarray(0, 4096);
   // Finish the last sampled UTF-8 sequence without starting a new one outside the window.
   // Its lead is within the final four bytes; completion needs at most three more.
@@ -105,10 +105,10 @@ function looksLikeText(buffer: Buffer): boolean {
   const end = sample.length + Math.max(0, leadIndex + width - tail.length);
   try {
     const text = new TextDecoder("utf-8", { fatal: true }).decode(buffer.subarray(0, end));
-    return textRatios(text, false)[0] > 0.85;
+    return textRatios(text, false)[0] > 0.85 ? "utf-8" : undefined;
   } catch {
     const [printable, wordish] = textRatios(new TextDecoder("windows-1252").decode(sample), true);
-    return printable > 0.95 && wordish > 0.3;
+    return printable > 0.95 && wordish > 0.3 ? "windows-1252" : undefined;
   }
 }
 
@@ -143,12 +143,12 @@ export async function classifyAttachmentBytes(params: {
   if (signature === 0x504b0304 || signature === 0x504b0102 || signature === 0x504b0506) {
     return { mime, class: "archive" };
   }
-  const charset = resolveUtf16Charset(params.buffer);
-  if (!charset && !looksLikeText(params.buffer)) {
+  const charset = resolveUtf16Charset(params.buffer) ?? sniffTextCharset(params.buffer);
+  if (!charset) {
     return { mime, class: "binary" };
   }
   const extensionMime = mimeTypeFromFilePath(params.name);
-  const firstLine = new TextDecoder(charset ?? "utf-8")
+  const firstLine = new TextDecoder(charset)
     .decode(params.buffer.subarray(0, Math.min(params.buffer.length, 8192)))
     .split(/\r?\n/, 1)[0];
   const textMime =
@@ -158,5 +158,6 @@ export async function classifyAttachmentBytes(params: {
       : firstLine?.includes("\t")
         ? "text/tab-separated-values"
         : "text/plain");
-  return { mime: textMime, class: "text", ...(charset ? { charset } : {}) };
+  // Carry the decoder that recognized the bytes; default UTF-8 needs no override.
+  return { mime: textMime, class: "text", ...(charset !== "utf-8" ? { charset } : {}) };
 }

--- a/src/media/input-files.extract.test.ts
+++ b/src/media/input-files.extract.test.ts
@@ -10,6 +10,16 @@ import {
 } from "./input-files.js";
 
 describe("extractFileContentFromSource", () => {
+  it("preserves the encoding used to recognize otherwise untyped text", async () => {
+    const text = "Café notes: résumé et météo pour demain.";
+    const result = await extractFileContentFromSource({
+      source: { type: "base64", data: Buffer.from(text, "latin1").toString("base64") },
+      limits: resolveInputFileLimits(),
+    });
+
+    expect(result.text).toBe(text);
+  });
+
   const avi = Buffer.from("524946463800000041564920" + "00".repeat(52), "hex");
   const aviSource = { type: "base64", data: avi.toString("base64"), filename: "clip.avi" } as const;
 
@@ -121,7 +131,7 @@ describe("extractFileContentFromSource", () => {
   it.each([
     ['text/plain; charset="windows-1252', "café €"],
     ['text/plain; note="a; charset=windows-1252', "caf\uFFFD \uFFFD"],
-    ["plain; charset=windows-1252", "caf\uFFFD \uFFFD"],
+    ["plain; charset=windows-1252", "café €"],
   ])("uses MIME parser recovery without changing admission for %s", async (mediaType, text) => {
     const result = await extractFileContentFromSource({
       source: {

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -368,6 +368,31 @@ describe("HEIC input image normalization", () => {
 });
 
 describe("guarded input file URL fetches", () => {
+  it("releases a rejected fetch without waiting for its capture tee", async () => {
+    const response = new Response("server error", { status: 503 });
+    const capture = response.clone();
+    const release = vi.fn(async () => {
+      await capture.body?.cancel();
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
+    let failure: unknown;
+    const pending = extractFileContentFromSource({
+      source: { type: "url", url: "https://example.com/notes" },
+      limits: createFileSourceLimits(["text/plain"], true),
+    }).catch((error: unknown) => {
+      failure = error;
+    });
+
+    try {
+      await vi.waitFor(() => expect(failure).toBeInstanceOf(Error), { timeout: 500 });
+      expect(failure).toMatchObject({ message: expect.stringContaining("Failed to fetch: 503") });
+      expect(release).toHaveBeenCalledTimes(1);
+    } finally {
+      await capture.body?.cancel();
+      await pending;
+    }
+  });
+
   it.each([
     'text/plain; charset="windows-1252"',
     'text/plain; note="a;charset=utf-8;b"; charset=windows-1252',

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -11,7 +11,7 @@ import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coerc
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { readResponseWithLimit } from "../infra/http-body.js";
+import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
@@ -216,7 +216,7 @@ async function fetchWithGuard(params: {
 
   try {
     if (!response.ok) {
-      await discardIgnoredResponseBody(response);
+      await cancelUnreadResponseBody(response);
       throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
     }
 
@@ -224,11 +224,11 @@ async function fetchWithGuard(params: {
     try {
       contentLength = parseMediaContentLength(response.headers.get("content-length"));
     } catch (err) {
-      await discardIgnoredResponseBody(response);
+      await cancelUnreadResponseBody(response);
       throw err;
     }
     if (contentLength !== null && contentLength > params.maxBytes) {
-      await discardIgnoredResponseBody(response);
+      await cancelUnreadResponseBody(response);
       throw new Error(
         `Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`,
       );
@@ -243,18 +243,6 @@ async function fetchWithGuard(params: {
   }
 }
 
-async function discardIgnoredResponseBody(response: Response): Promise<void> {
-  const body = response.body;
-  if (!body) {
-    return;
-  }
-  try {
-    await body.cancel();
-  } catch {
-    // Best-effort cleanup after rejecting a response body.
-  }
-}
-
 function decodeTextContent(buffer: Buffer, charset: string | undefined): string {
   const encoding = normalizeOptionalLowercaseString(charset) || "utf-8";
   try {
@@ -262,13 +250,6 @@ function decodeTextContent(buffer: Buffer, charset: string | undefined): string 
   } catch {
     return new TextDecoder("utf-8").decode(buffer);
   }
-}
-
-function clampText(text: string, maxChars: number): string {
-  if (text.length <= maxChars) {
-    return text;
-  }
-  return truncateUtf16Safe(text, maxChars);
 }
 
 function withInputFileTimeout<T>(params: {
@@ -481,7 +462,7 @@ export async function extractFileContentFromBuffer(params: {
         },
       }),
     });
-    const text = extracted.text ? clampText(extracted.text, limits.maxChars) : "";
+    const text = extracted.text ? truncateUtf16Safe(extracted.text, limits.maxChars) : "";
     return {
       filename,
       text,
@@ -489,6 +470,6 @@ export async function extractFileContentFromBuffer(params: {
     };
   }
 
-  const text = clampText(decodeTextContent(buffer, charset), limits.maxChars);
+  const text = truncateUtf16Safe(decodeTextContent(buffer, charset), limits.maxChars);
   return { filename, text };
 }


### PR DESCRIPTION
Closes #135921. Closes #135922.

## What Problem This Solves

Untyped Windows-1252 input files are recognized as text but then decoded as UTF-8, damaging accents and currency symbols. Rejected file and image downloads can also wait for diagnostic response capture before reporting their error and releasing the request.

## Why This Change Was Made

The attachment classifier now carries the decoder that recognized the bytes through the existing classification result. Input download rejection uses the shared cancellation owner so transport release can settle a response capture; the duplicate cancellation and text-clamping helpers are removed.

## User Impact

Inferred legacy text retains its characters. Download failures report promptly even when HTTP debug capture is enabled. Explicit charsets, UTF-16 detection, MIME admission, and byte limits remain covered by existing controls.

## Evidence

Both new regressions failed against unchanged production code before the repair. The real input-file extraction path changed `Caf� notes: r�sum� et m�t�o pour demain.` back to the original text. A real `Response.clone()` regression changed from a pending rejection/release cycle to the expected HTTP failure and completed cleanup.

`node scripts/run-vitest.mjs packages/media-core/src/attachment-classify.test.ts src/media/input-files.extract.test.ts src/media/input-files.fetch-guard.test.ts`: 93 tests passed. Codex autoreview reported no accepted/actionable findings at its default P0 threshold; manual owner and sibling inspection covered charset precedence, MIME admission, response capture, and guarded request release. These are local deterministic owner-boundary checks, not authenticated provider tests.

The scoped `node scripts/check-changed.mjs -- <changed paths>` gate passed. An independent verifier reran eight actual-source charset and cancellation controls and found no actionable issue.

Production LOC: +15/-33 (net -18). Tests: +36/-1. Documentation: +1. No changelog change.
