### PR TITLE
fix(infra): cancel the SSH tunnel listener poll when startup fails

### DIFF
--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -310,44 +310,51 @@ describe("startSshPortForward", () => {
   });
 
   it("rejects with the spawn error when ssh binary is missing", async () => {
-    vi.useFakeTimers();
-    const spawnError = new Error("ENOENT: no such file or directory, spawn /usr/bin/ssh");
-    (spawnError as NodeJS.ErrnoException).code = "ENOENT";
-    const kill = vi.fn(() => false);
-    mocks.spawn.mockImplementation(() => {
-      const child = new EventEmitter() as EventEmitter & {
-        killed: boolean;
-        pid?: number;
-        stderr: EventEmitter & { setEncoding: (enc: string) => void };
-        kill: (signal?: string) => boolean;
-      };
-      child.killed = false;
-      const stderr = new EventEmitter() as EventEmitter & { setEncoding: (enc: string) => void };
-      stderr.setEncoding = () => {};
-      child.stderr = stderr;
-      child.kill = kill;
-      queueMicrotask(() => {
-        child.emit("error", spawnError);
-        child.emit("close", -2, null);
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    for (const probeFailed of [false, true]) {
+      const socket = new net.Socket();
+      const connect = vi.spyOn(net, "connect").mockReturnValue(socket);
+      const spawnError = Object.assign(new Error("ENOENT: spawn /usr/bin/ssh"), { code: "ENOENT" });
+      const kill = vi.fn(() => false);
+      const child = Object.assign(new EventEmitter(), {
+        stderr: Object.assign(new EventEmitter(), { setEncoding: () => {} }),
+        kill,
       });
-      return child;
-    });
+      mocks.spawn.mockReturnValue(child);
+      const forwarding = startSshPortForward({
+        target: "me@example.com:2222",
+        localPortPreferred: 43210,
+        remotePort: 18789,
+        timeoutMs: 500,
+      });
+      const rejection = expect(forwarding).rejects.toMatchObject({
+        message: expect.stringContaining("ENOENT"),
+        cause: spawnError,
+      });
 
-    const forwarding = startSshPortForward({
-      target: "me@example.com:2222",
-      localPortPreferred: 43210,
-      remotePort: 18789,
-      timeoutMs: 500,
-    });
-    const rejection = expect(forwarding).rejects.toMatchObject({
-      message: expect.stringContaining("ENOENT"),
-      cause: spawnError,
-    });
+      try {
+        await vi.advanceTimersByTimeAsync(0);
+        if (probeFailed) {
+          // Exercise cancellation during the retry delay as well as an in-flight socket.
+          socket.emit("error", new Error("ECONNREFUSED"));
+          await vi.advanceTimersByTimeAsync(0);
+        }
+        child.emit("error", spawnError);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(kill).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+        child.emit("close", -2, null);
+        await rejection;
 
-    await vi.advanceTimersByTimeAsync(0);
-    expect(vi.getTimerCount()).toBe(0);
-    await rejection;
-    expect(kill).toHaveBeenCalledWith("SIGTERM");
+        expect(socket.destroyed).toBe(true);
+        expect(vi.getTimerCount()).toBe(0);
+        await vi.runAllTimersAsync();
+        expect(kill).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        socket.destroy();
+        connect.mockRestore();
+      }
+    }
   });
 
   it.each(["active", "teardown"] as const)(

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { createAbortError, isAbortError, racePromiseWithAbortSignal } from "./abort-signal.js";
+import { sleepWithAbort } from "./backoff.js";
 import { formatErrorMessage, isErrno } from "./errors.js";
 import { ensurePortAvailable, PortInUseError } from "./ports.js";
 import { resolveSshClient } from "./ssh-client.js";
@@ -111,29 +112,37 @@ async function pickEphemeralPort(): Promise<number> {
   });
 }
 
-async function canConnectLocal(port: number): Promise<boolean> {
+async function canConnectLocal(port: number, signal: AbortSignal): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     const socket = net.connect({ host: "127.0.0.1", port });
     const done = (ok: boolean) => {
+      signal.removeEventListener("abort", onAbort);
       socket.removeAllListeners();
       socket.destroy();
       resolve(ok);
     };
+    const onAbort = () => done(false);
     socket.once("connect", () => done(true));
     socket.once("error", () => done(false));
     socket.setTimeout(250, () => done(false));
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
   });
 }
 
-async function waitForLocalListener(port: number, timeoutMs: number): Promise<void> {
+async function waitForLocalListener(
+  port: number,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<void> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    if (await canConnectLocal(port)) {
+    if (await canConnectLocal(port, signal)) {
       return;
     }
-    await new Promise((r) => {
-      setTimeout(r, 50);
-    });
+    await sleepWithAbort(50, signal);
   }
   throw new Error(`ssh tunnel did not start listening on localhost:${port}`);
 }
@@ -224,10 +233,13 @@ export async function startSshPortForward(opts: {
       onAbort = undefined;
     }
   };
+  const listenerAbort = new AbortController();
   let stopping: Promise<void> | undefined;
   const stop = () =>
     (stopping ??= (async () => {
       detachAbort();
+      // A rejected startup race does not cancel its losing socket/poll operation.
+      listenerAbort.abort();
       // Sending a signal is not exit; every caller must await the same child lifetime.
       const timer = setTimeout(() => child.kill("SIGKILL"), 1500);
       try {
@@ -241,7 +253,7 @@ export async function startSshPortForward(opts: {
   try {
     await racePromiseWithAbortSignal(
       Promise.race([
-        waitForLocalListener(localPort, Math.max(250, opts.timeoutMs)),
+        waitForLocalListener(localPort, Math.max(250, opts.timeoutMs), listenerAbort.signal),
         new Promise<void>((_, reject) => {
           child.once("error", (err) => reject(err));
           child.once("exit", (code, signal) => {


### PR DESCRIPTION
## What Problem This Solves

`startSshPortForward` (`src/infra/ssh-tunnel.ts`) races the local-listener poll against the ssh child's error/exit. When the child fails — e.g. the ssh binary is missing — the race rejects, but the losing poll keeps running: its 50 ms retry timer and the in-flight probe socket survive the rejection and keep the event loop alive until the timeout budget drains. The spawn-error test added on `main` in `0ac750ff76a` caught this as a flaky `expect(vi.getTimerCount()).toBe(0)` (received 1) on PR #135812's merge-commit CI run (`checks-node-compact-small-30`, run 33588335876 attempt 1); it passed on rerun and locally because the assertion raced the poll's timer.

## Why This Change Was Made

This is a production leak, not just a flaky assertion, so the fix is at the owner: an `AbortController` is threaded through `waitForLocalListener` / `canConnectLocal` and aborted in `stop()`, which the rejection path already calls. Teardown now cancels the probe socket and the retry sleep (`sleepWithAbort`) together with the child; the SIGKILL fallback timer was already cleared correctly. The test keeps its name and intent and now exercises both cancellation phases (in-flight probe socket and retry delay), awaits the rejection, then asserts zero timers and exactly one `SIGTERM` after draining — deterministic instead of timing-dependent.

## User Impact

No user-visible behavior change; a failed tunnel startup (gateway probe/status over SSH) no longer leaves a lingering poll running until the timeout budget expires. Removes a flaky CI assertion that could red-flag unrelated PRs.

## Evidence

- Root cause reproduced natively and under fake timers: pending timers after rejection went from `[50]` (the listener poll) to `[]`.
- `pnpm test src/infra/ssh-tunnel.test.ts` — 5/5 runs green locally (16 tests each).
- Blacksmith Testbox (Linux) run of the same test via `scripts/crabbox-wrapper.mjs` — see comment/evidence below.
- `pnpm check:changed` — passed.
- Codex-backed autoreview — see below.
- Production LOC +19/−7 (net +12): the abort plumbing through two helpers plus the `stop()` hook; tests +42/−35.
