### PR TITLE
improve: reduce repeated Gateway method inventory allocations

### DIFF
--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -696,7 +696,7 @@ export function listCoreAdvertisedGatewayMethodNames(): string[] {
 
 /** Returns all registered core method names, including hidden/internal compatibility methods. */
 export function listCoreGatewayMethodNames(): string[] {
-  return listCoreGatewayMethodMetadata().map((spec) => spec.name);
+  return CORE_GATEWAY_METHOD_SPEC_LIST.map((spec) => spec.name);
 }
 
 /** Returns the public metadata emitted for every core gateway method. */
@@ -755,9 +755,7 @@ export function createCoreGatewayMethodDescriptors(
   handlers: Record<string, GatewayMethodHandler>,
 ): GatewayMethodDescriptorInput[] {
   const descriptors: GatewayMethodDescriptorInput[] = [];
-  const specNames = new Set<string>();
   for (const spec of CORE_GATEWAY_METHOD_SPEC_LIST) {
-    specNames.add(spec.name);
     const handler = handlers[spec.name];
     if (!handler) {
       continue;
@@ -776,7 +774,7 @@ export function createCoreGatewayMethodDescriptors(
     });
   }
   for (const name of Object.keys(handlers)) {
-    if (!specNames.has(name)) {
+    if (!CORE_GATEWAY_METHOD_SPEC_BY_NAME.has(name)) {
       // Unclassified core handlers would bypass scope/startup/write metadata, so fail before the
       // dispatcher can expose a method with missing policy.
       throw new Error(`gateway method handler is missing a descriptor: ${name}`);

--- a/src/gateway/methods/registry.test.ts
+++ b/src/gateway/methods/registry.test.ts
@@ -62,6 +62,15 @@ describe("gateway method registry", () => {
     ).toThrow("gateway method already registered: example.duplicate");
   });
 
+  it("rejects unknown core handlers while accepting hidden core methods", () => {
+    expect(() => createCoreGatewayMethodDescriptors({ "example.unknown": handler })).toThrow(
+      "gateway method handler is missing a descriptor: example.unknown",
+    );
+    expect(createCoreGatewayMethodDescriptors({ "config.openFile": handler })).toMatchObject([
+      { name: "config.openFile", advertise: false, handler },
+    ]);
+  });
+
   it("coerces reserved plugin namespaces to admin scope", () => {
     const descriptor = createPluginGatewayMethodDescriptor({
       pluginId: "demo",

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -253,7 +253,8 @@ function resolveCoreGatewayMethodNames(options: PluginLoadOptions): string[] {
   for (const name of Object.keys(options.coreGatewayHandlers ?? {})) {
     names.add(name);
   }
-  return Array.from(names).toSorted();
+  // oxlint-disable-next-line unicorn/no-array-sort -- Array.from creates a private array.
+  return Array.from(names).sort();
 }
 
 function mergePluginTrustList(runtimeList: string[], sourceList: readonly string[]): string[] {

--- a/src/plugins/registry-state.ts
+++ b/src/plugins/registry-state.ts
@@ -59,13 +59,12 @@ export function resolveTypedHookTimeoutMs(params: {
 export function createPluginRegistryState(registryParams: PluginRegistryParams) {
   const registry = createEmptyPluginRegistry();
   bindPluginRegistryRuntime(registry, registryParams.runtime);
-  const coreGatewayMethodNames = Array.from(
-    new Set([
-      ...(registryParams.coreGatewayMethodNames ?? []),
-      ...Object.keys(registryParams.coreGatewayHandlers ?? {}),
-    ]),
-  ).toSorted();
-  registry.coreGatewayMethodNames = coreGatewayMethodNames;
+  const coreGatewayMethods = new Set(registryParams.coreGatewayMethodNames);
+  for (const name of Object.keys(registryParams.coreGatewayHandlers ?? {})) {
+    coreGatewayMethods.add(name);
+  }
+  // oxlint-disable-next-line unicorn/no-array-sort -- This array is separate from the membership index.
+  registry.coreGatewayMethodNames = Array.from(coreGatewayMethods).sort();
 
   const pushDiagnostic = (diagnostic: PluginDiagnostic) => {
     registry.diagnostics.push(diagnostic);
@@ -85,7 +84,7 @@ export function createPluginRegistryState(registryParams: PluginRegistryParams) 
     registry,
     registryParams,
     allowProcessHomeSessionCatalogs: registryParams.allowProcessHomeSessionCatalogs ?? true,
-    coreGatewayMethods: new Set(coreGatewayMethodNames),
+    coreGatewayMethods,
     getHostCronService: () => registryParams.hostServices?.cron,
     pluginsWithChannelRegistrationConflict: new Set<string>(),
     pluginSideEffectGuards: new Map<string, Set<PluginSideEffectGuard>>(),

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -241,7 +241,10 @@ describe("production lint suppressions", () => {
         "src/plugins/hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/host-hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/lazy-service-module.ts|typescript/no-unnecessary-type-parameters|1",
+        // These snapshots own their arrays, so sorting in place avoids another copy.
+        "src/plugins/loader-load-context.ts|unicorn/no-array-sort|1",
         "src/plugins/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|3",
+        "src/plugins/registry-state.ts|unicorn/no-array-sort|1",
         "src/plugins/runtime/runtime-plugin-boundary.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/runtime/types-channel.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/trusted-tool-policy.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

Gateway method inventory construction rebuilt metadata and membership indexes that the descriptor module and plugin registry already owned. Plugin loading paid for additional sorted array copies while preparing the same public name inventory.

## Why This Change Was Made

Project method names directly from the private specs, validate handler names with the existing by-name Map, retain the registry’s original membership Set, and sort fresh private arrays in place. Public names/order, hidden methods, collision handling, cache keys and independent output ownership remain unchanged. The private membership index is not exposed through the public name array.

Production is +11/−13 (net −2), with twelve test/inventory lines (nine behavioral and three suppression-inventory lines). No configuration, protocol, persistence or dependency changes.

## User Impact

Each composed inventory/registry construction avoids 409 temporary metadata records, four temporary arrays and two temporary membership Sets. These are observed logical construction counts, not RSS or retained-heap measurements. A single descriptive local timing process per arm measured 0.2473→0.2320 ms per composed call; this is not a whole-Gateway startup claim.

## Evidence

- The actual-source fixture composes name production, all 409 core descriptors, cache-context construction and plugin registration. Complete semantic receipts match before and after, including all-core collision rejection after public-list mutation, hidden methods, unknown handlers, fresh output ownership and exact cache-key equivalence/partitioning.
- 38 Gateway tests passed before and after. Six selected plugin-loader cases passed; the other 177 cases were explicitly skipped. The expanded unknown/hidden-handler test also passes on baseline because the change preserves behavior.
- Focused type-aware lint and the complete changed-file gate passed. Two initial lint findings were resolved with narrowly explained exceptions for sorting newly owned arrays. Independent source review and Codex autoreview found no accepted issues.

The fixture executes the actual registration and response-adapter functions with synthetic handlers/runtime inputs; it does not start a Gateway socket or provider turn. The change only removes duplicated construction and leaves operator-visible behavior unchanged. Baseline: `173f41d682b0d4a05674820a3d390d934da8b066`.

CI follow-up: the two intentional owned-array sorting directives are now recorded in the exact lint-suppression inventory. The guard failed on the original PR head and passes after the repair; production source and its behavior/allocation evidence are unchanged. The latest exact-head CI run is green.
