### PR TITLE
fix: reuse console styles and handle inherited subsystem names

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -130,15 +130,18 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(log.isEnabled("info", "console")).toBe(false);
   });
 
-  it("falls back to an unknown subsystem label when a malformed logger emits", () => {
-    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
-    const warn = installConsoleMethodSpy("warn");
-    const log = createSubsystemLogger(undefined as unknown as string);
+  it.each([undefined, "constructor", "toString", "__proto__"])(
+    "emits console output for subsystem label %s",
+    (subsystem) => {
+      setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+      const warn = installConsoleMethodSpy("warn");
+      const log = createSubsystemLogger(subsystem as unknown as string);
 
-    log.warn("missing subsystem label");
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(firstMockArgAsString(warn)).toContain("[unknown]");
-  });
+      log.warn("subsystem diagnostic");
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(firstMockArgAsString(warn)).toContain(`[${subsystem ?? "unknown"}]`);
+    },
+  );
 
   it("suppresses probe warnings for embedded subsystems based on structured run metadata", () => {
     setLoggerOverride({ level: "silent", consoleLevel: "warn" });
@@ -271,21 +274,29 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(written).toContain("Bearer ");
   });
 
-  it("redacts before colorizing subsystem console messages so ANSI reset codes survive", () => {
-    vi.stubEnv("FORCE_COLOR", "1");
-    setLoggerOverride({ level: "silent", consoleLevel: "info" });
-    const logSpy = installConsoleMethodSpy("log");
-    const log = createSubsystemLogger("gateway/auth");
-    const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
+  it.each(["pretty", "compact"] as const)(
+    "preserves redaction and ANSI resets as color settings change in %s style",
+    (consoleStyle) => {
+      vi.stubEnv("NO_COLOR", "1");
+      setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle });
+      const logSpy = installConsoleMethodSpy("log");
+      const log = createSubsystemLogger("gateway/auth");
+      const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
 
-    log.info(`provider API_KEY=${secret}`);
+      for (const forceColor of ["1", "0", "1"]) {
+        vi.stubEnv("FORCE_COLOR", forceColor);
+        logSpy.mockClear();
+        log.info(`provider API_KEY=${secret}`);
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    const written = firstMockArgAsString(logSpy);
-    expect(written).not.toContain(secret);
-    expect(written).toContain("API_KEY=***");
-    expect(written.endsWith("\u001B[39m")).toBe(true);
-  });
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const written = firstMockArgAsString(logSpy);
+        expect(written).not.toContain(secret);
+        expect(written).toContain("API_KEY=***");
+        expect(written).toContain("[auth]");
+        expect(written.endsWith("\u001B[39m")).toBe(forceColor === "1");
+      }
+    },
+  );
 
   it("redacts sensitive tokens from raw subsystem console output", () => {
     setLoggerOverride({ level: "silent", consoleLevel: "info" });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -95,25 +95,26 @@ function isRichConsoleEnv(): boolean {
   return term.length > 0 && term !== "dumb";
 }
 
+// Chalk caches style builders per instance; select between fixed levels on each message.
+const consoleColors: [ChalkInstance?, ChalkInstance?] = [];
+
 function getColorForConsole(): ChalkInstance {
   const hasForceColor =
     typeof process.env.FORCE_COLOR === "string" &&
     process.env.FORCE_COLOR.trim().length > 0 &&
     process.env.FORCE_COLOR.trim() !== "0";
-  if (hasForceColor) {
-    return new Chalk({ level: 1 });
-  }
-  if (process.env.NO_COLOR && !hasForceColor) {
-    return new Chalk({ level: 0 });
-  }
-  const hasTty = process.stdout.isTTY || process.stderr.isTTY;
-  return hasTty || isRichConsoleEnv() ? new Chalk({ level: 1 }) : new Chalk({ level: 0 });
+  const level =
+    hasForceColor ||
+    (!process.env.NO_COLOR && (process.stdout.isTTY || process.stderr.isTTY || isRichConsoleEnv()))
+      ? 1
+      : 0;
+  return (consoleColors[level] ??= new Chalk({ level }));
 }
 
 const SUBSYSTEM_COLORS = ["cyan", "green", "yellow", "blue", "magenta", "red"] as const;
-const SUBSYSTEM_COLOR_OVERRIDES: Record<string, (typeof SUBSYSTEM_COLORS)[number]> = {
-  "gmail-watcher": "blue",
-};
+const SUBSYSTEM_COLOR_OVERRIDES = new Map<string, (typeof SUBSYSTEM_COLORS)[number]>([
+  ["gmail-watcher", "blue"],
+]);
 const SUBSYSTEM_PREFIXES_TO_DROP = ["gateway", "channels", "providers"] as const;
 const SUBSYSTEM_MAX_SEGMENTS = 2;
 const CHANNEL_SUBSYSTEM_PREFIXES = new Set([
@@ -153,18 +154,17 @@ function isChannelSubsystemPrefix(value: string): boolean {
   return CHANNEL_SUBSYSTEM_PREFIXES.has(normalized);
 }
 
-function pickSubsystemColor(color: ChalkInstance, subsystem: string): ChalkInstance {
-  const override = SUBSYSTEM_COLOR_OVERRIDES[subsystem];
+function pickSubsystemColor(subsystem: string): (typeof SUBSYSTEM_COLORS)[number] {
+  const override = SUBSYSTEM_COLOR_OVERRIDES.get(subsystem);
   if (override) {
-    return color[override];
+    return override;
   }
   let hash = 0;
   for (let i = 0; i < subsystem.length; i += 1) {
     hash = (hash * 31 + subsystem.charCodeAt(i)) | 0;
   }
   const idx = Math.abs(hash) % SUBSYSTEM_COLORS.length;
-  const name = expectDefined(SUBSYSTEM_COLORS[idx], "subsystem colors entry at idx");
-  return color[name];
+  return expectDefined(SUBSYSTEM_COLORS[idx], "subsystem colors entry at idx");
 }
 
 function formatSubsystemForConsole(subsystem: string): string {
@@ -244,48 +244,33 @@ export function stripRedundantSubsystemPrefixForConsole(
   return message.slice(i);
 }
 
-function formatConsoleLine(opts: {
-  level: LogLevel;
-  subsystem: string;
-  message: string;
-  style: "pretty" | "compact" | "json";
-  meta?: Record<string, unknown>;
-}): string {
-  const displaySubsystem =
-    opts.style === "json" ? opts.subsystem : formatSubsystemForConsole(opts.subsystem);
-  if (opts.style === "json") {
-    return formatJsonConsoleLine({
-      level: opts.level,
-      subsystem: displaySubsystem,
-      message: opts.message,
-      meta: opts.meta,
-    });
-  }
-  const color = getColorForConsole();
+function createConsoleLineFormatter(subsystem: string) {
+  const displaySubsystem = formatSubsystemForConsole(subsystem);
   const prefix = `[${displaySubsystem}]`;
-  const prefixColor = pickSubsystemColor(color, displaySubsystem);
-  const levelColor =
-    opts.level === "error" || opts.level === "fatal"
-      ? color.red
-      : opts.level === "warn"
-        ? color.yellow
-        : opts.level === "debug" || opts.level === "trace"
-          ? color.gray
-          : color.cyan;
-  const redactedMessage = redactSensitiveText(opts.message);
-  const displayMessage = stripRedundantSubsystemPrefixForConsole(redactedMessage, displaySubsystem);
-  const time = (() => {
-    if (opts.style === "pretty") {
-      return color.gray(formatConsoleTimestamp("pretty"));
-    }
-    if (loggingState.consoleTimestampPrefix) {
-      return color.gray(formatConsoleTimestamp(opts.style));
-    }
-    return "";
-  })();
-  const prefixToken = prefixColor(prefix);
-  const head = [time, prefixToken].filter(Boolean).join(" ");
-  return `${head} ${levelColor(displayMessage)}`;
+  const prefixColor = pickSubsystemColor(displaySubsystem);
+  return (level: LogLevel, message: string, style: "pretty" | "compact"): string => {
+    const color = getColorForConsole();
+    const levelColor =
+      level === "error" || level === "fatal"
+        ? color.red
+        : level === "warn"
+          ? color.yellow
+          : level === "debug" || level === "trace"
+            ? color.gray
+            : color.cyan;
+    const redactedMessage = redactSensitiveText(message);
+    const displayMessage = stripRedundantSubsystemPrefixForConsole(
+      redactedMessage,
+      displaySubsystem,
+    );
+    const time =
+      style === "pretty" || loggingState.consoleTimestampPrefix
+        ? color.gray(formatConsoleTimestamp(style))
+        : "";
+    const prefixToken = color[prefixColor](prefix);
+    const head = time ? `${time} ${prefixToken}` : prefixToken;
+    return `${head} ${levelColor(displayMessage)}`;
+  };
 }
 
 function writeConsoleLine(level: LogLevel, line: string, opts: { redacted?: boolean } = {}) {
@@ -366,6 +351,7 @@ function logToFile(
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   const resolvedSubsystem = normalizeSubsystemLabel(subsystem);
   let fileChild: { generation: number; logger: TsLogger<LogObj> } | undefined;
+  let formatConsoleLine: ReturnType<typeof createConsoleLineFormatter> | undefined;
 
   const getFileLogger = () => {
     if (fileChild?.generation !== loggingState.generation) {
@@ -416,13 +402,13 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     }
     writeConsoleLine(
       level,
-      formatConsoleLine({
-        level,
-        subsystem: resolvedSubsystem,
-        message: consoleSettings.style === "json" ? message : consoleMessage,
-        style: consoleSettings.style,
-        meta: fileMeta,
-      }),
+      consoleSettings.style === "json"
+        ? formatJsonConsoleLine({ level, subsystem: resolvedSubsystem, message, meta: fileMeta })
+        : (formatConsoleLine ??= createConsoleLineFormatter(resolvedSubsystem))(
+            level,
+            consoleMessage,
+            consoleSettings.style,
+          ),
       { redacted: true },
     );
   };


### PR DESCRIPTION
Text-mode subsystem logging rebuilt Chalk, its style builders, and the same subsystem label and color hash for every message. Prepare the immutable display facts lazily on each logger and reuse two private Chalk instances with fixed levels, while still evaluating `FORCE_COLOR`, `NO_COLOR`, and terminal state on every message. JSON keeps the shared envelope formatter; file-log ordering, redaction before coloring, console capture, and stderr routing are preserved.

This improves recurring allocation and CPU work, with a measured retention tradeoff of **about +182 bytes per logger after its first text emission**. It is not a retained-heap or Gateway RSS reduction. In 20,000 text messages, Chalk roots fall from 20,000 to 2, style builders from 50,000 to 6, and subsystem splits from 20,000 to 4. Three alternating owner timing pairs improve compact output by 34–49% and pretty by 23–35%. The JSON control ranges from -0.9% to +3.9%; the speed claim is limited to text formatting.

The own-entry color override lookup also fixes text logging crashes for subsystem names such as `constructor`, `toString`, and `__proto__`. Production is net **-14 lines** (+50/-64), and existing tests grow by **11 lines** (+35/-24).

Validation: 66 focused tests pass across the subsystem, console-capture, and timestamp suites; the inherited-label regression cases fail on the baseline. A 3,270-observation output matrix is byte-identical before/after, including dynamic color/style changes, timestamps, metadata, redaction, and ANSI resets. Real Node console capture produces identical stdout/stderr and nine equivalent file records, with queues flushed and children joined. The full changed-file gate passes, including core/test types, formatting, lint, dead exports, and all selected guards. Independent review is recorded separately before landing.
