### PR TITLE
fix: keep recently connected nodes in list age filters

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -24,7 +24,7 @@ openclaw nodes list
 openclaw nodes describe --node <idOrNameOrIp>
 ```
 
-`status` and `list` both accept `--connected` (only connected nodes) and `--last-connected <duration>` (e.g. `24h`, `7d`; only nodes that connected within the duration). `list` shows pending and paired nodes in separate tables, with paired rows including the most recent connect age (Last Connect); `status` shows one merged table with per-node capability, version, and last-input detail. A connected macOS node reports last input only after the user enables **Active computer detection** and grants Accessibility; the freshest row is marked `active`. See [Active computer presence](/nodes/presence). `describe` prints one node's capabilities, permissions, activity, and effective/pending invoke commands.
+`status` and `list` both accept `--connected` (only connected nodes) and `--last-connected <duration>` (e.g. `24h`, `7d`; only nodes that connected within the duration). Both use the Gateway's recorded last connection time, including recent reconnects and disconnected nodes with known connection history. `list` shows pending and paired nodes in separate tables, with paired rows including the most recent connect age (Last Connect); `status` shows one merged table with per-node capability, version, and last-input detail. A connected macOS node reports last input only after the user enables **Active computer detection** and grants Accessibility; the freshest row is marked `active`. See [Active computer presence](/nodes/presence). `describe` prints one node's capabilities, permissions, activity, and effective/pending invoke commands.
 
 ## Pairing
 

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -116,9 +116,9 @@ function formatNodeTerminalLabel(node: { nodeId: string; displayName?: string })
   return sanitizeTerminalText(label);
 }
 
-function formatLastActive(now: number, lastActiveAtMs: unknown): string | null {
-  return typeof lastActiveAtMs === "number" && Number.isFinite(lastActiveAtMs)
-    ? formatTimeAgo(Math.max(0, now - lastActiveAtMs))
+function formatNodeTimeAgo(now: number, timestamp: unknown): string | null {
+  return typeof timestamp === "number" && Number.isFinite(timestamp)
+    ? formatTimeAgo(Math.max(0, now - timestamp))
     : null;
 }
 
@@ -171,6 +171,23 @@ function parseSinceMs(raw: string | undefined, label: string): number | undefine
   }
 }
 
+function matchesNodeConnectionFilter(
+  node: NodeListNode,
+  connectedOnly: boolean,
+  sinceMs: number | undefined,
+  now: number,
+): boolean {
+  if (connectedOnly && !node.connected) {
+    return false;
+  }
+  // Older gateways lack the recorded lastConnectedAtMs field.
+  const lastConnectedAtMs = node.lastConnectedAtMs ?? node.connectedAtMs;
+  return (
+    sinceMs === undefined ||
+    (typeof lastConnectedAtMs === "number" && now - lastConnectedAtMs <= sinceMs)
+  );
+}
+
 function mergePairedNodeWithEffectiveNode(
   paired: PairedNode | undefined,
   effective: NodeListNode,
@@ -179,7 +196,9 @@ function mergePairedNodeWithEffectiveNode(
     ...paired,
     ...effective,
     createdAtMs: paired?.createdAtMs,
-    lastConnectedAtMs: paired?.lastConnectedAtMs ?? effective.connectedAtMs,
+    // node.list can record a connection newer than the separate pairing snapshot.
+    lastConnectedAtMs:
+      effective.lastConnectedAtMs ?? paired?.lastConnectedAtMs ?? effective.connectedAtMs,
     displayName: effective.displayName ?? paired?.displayName,
     platform: effective.platform ?? paired?.platform,
     version: effective.version ?? paired?.version,
@@ -252,26 +271,9 @@ export function registerNodesStatusCommands(nodes: Command) {
           const tableWidth = getTerminalTableWidth();
           const now = Date.now();
           const nodesLocal = parseNodeList(result);
-          const filtered = nodesLocal.filter((n) => {
-            if (connectedOnly && !n.connected) {
-              return false;
-            }
-            if (sinceMs !== undefined) {
-              // The gateway records lastConnectedAtMs on every node.list row
-              // (max of stored pairing history and live connection); joining a
-              // second pairing-scoped RPC re-derived that fact and made
-              // --last-connected fail for read-scoped callers. connectedAtMs
-              // covers gateways predating the recorded field.
-              const lastConnectedAtMs = n.lastConnectedAtMs ?? n.connectedAtMs;
-              if (typeof lastConnectedAtMs !== "number") {
-                return false;
-              }
-              if (now - lastConnectedAtMs > sinceMs) {
-                return false;
-              }
-            }
-            return true;
-          });
+          const filtered = nodesLocal.filter((node) =>
+            matchesNodeConnectionFilter(node, connectedOnly, sinceMs, now),
+          );
 
           if (opts.json) {
             const ts = typeof obj.ts === "number" ? obj.ts : Date.now();
@@ -295,7 +297,7 @@ export function registerNodesStatusCommands(nodes: Command) {
             const versions = formatNodeVersions(n);
             const pathEnv = formatPathEnv(n.pathEnv, n.platform);
             const client = formatClientLabel(n);
-            const lastActive = formatLastActive(now, n.lastActiveAtMs);
+            const lastActive = formatNodeTimeAgo(now, n.lastActiveAtMs);
             const detailParts = [
               client ? `client: ${client}` : null,
               n.deviceFamily ? `device: ${n.deviceFamily}` : null,
@@ -424,7 +426,7 @@ export function registerNodesStatusCommands(nodes: Command) {
               uiVersion?: string;
             },
           );
-          const lastActive = formatLastActive(Date.now(), obj.lastActiveAtMs);
+          const lastActive = formatNodeTimeAgo(Date.now(), obj.lastActiveAtMs);
 
           const { heading, ok, warn, muted } = getNodesTheme();
           const status = `${paired ? ok("paired") : warn("unpaired")} · ${
@@ -526,28 +528,9 @@ export function registerNodesStatusCommands(nodes: Command) {
             ? parseNodeList(await callNodeDiagnosticsGatewayCli("node.list", opts, {}))
             : await tryReadNodeList(opts);
           const effectivePairedRows = mergePairedNodesWithEffectiveNodes(paired, effectiveNodes);
-          const filteredPaired = effectivePairedRows.filter((node) => {
-            if (connectedOnly) {
-              if (!node.connected) {
-                return false;
-              }
-            }
-            if (sinceMs !== undefined) {
-              const lastConnectedAtMs =
-                typeof node.lastConnectedAtMs === "number"
-                  ? node.lastConnectedAtMs
-                  : typeof node.connectedAtMs === "number"
-                    ? node.connectedAtMs
-                    : undefined;
-              if (typeof lastConnectedAtMs !== "number") {
-                return false;
-              }
-              if (now - lastConnectedAtMs > sinceMs) {
-                return false;
-              }
-            }
-            return true;
-          });
+          const filteredPaired = effectivePairedRows.filter((node) =>
+            matchesNodeConnectionFilter(node, connectedOnly, sinceMs, now),
+          );
           const filteredLabel =
             hasFilters && filteredPaired.length !== effectivePairedRows.length
               ? ` (of ${effectivePairedRows.length})`
@@ -583,23 +566,13 @@ export function registerNodesStatusCommands(nodes: Command) {
           }
 
           if (filteredPaired.length > 0) {
-            const pairedTableRows = filteredPaired.map((n) => {
-              const lastConnectedAtMs =
-                typeof n.lastConnectedAtMs === "number"
-                  ? n.lastConnectedAtMs
-                  : typeof n.connectedAtMs === "number"
-                    ? n.connectedAtMs
-                    : undefined;
-              return {
-                Node: formatNodeTerminalLabel(n),
-                Id: sanitizeTerminalText(n.nodeId),
-                IP: sanitizeTerminalText(n.remoteIp ?? ""),
-                LastConnect:
-                  typeof lastConnectedAtMs === "number"
-                    ? formatTimeAgo(Math.max(0, now - lastConnectedAtMs))
-                    : muted("unknown"),
-              };
-            });
+            const pairedTableRows = filteredPaired.map((n) => ({
+              Node: formatNodeTerminalLabel(n),
+              Id: sanitizeTerminalText(n.nodeId),
+              IP: sanitizeTerminalText(n.remoteIp ?? ""),
+              LastConnect:
+                formatNodeTimeAgo(now, n.lastConnectedAtMs ?? n.connectedAtMs) ?? muted("unknown"),
+            }));
             defaultRuntime.log("");
             defaultRuntime.log(heading("Paired"));
             defaultRuntime.log(

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -384,6 +384,54 @@ describe("cli program (nodes basics)", () => {
     expect(output).not.toContain("Two");
   });
 
+  it.each(["status", "list"])(
+    "preserves recorded connection ages in nodes %s after a stale pairing snapshot",
+    async (command) => {
+      const now = Date.now();
+      const recent = now - 1_000;
+      const old = now - 2 * 24 * 60 * 60 * 1_000;
+      const nodes = [
+        {
+          nodeId: "reconnected",
+          paired: true,
+          connected: true,
+          connectedAtMs: recent,
+          lastConnectedAtMs: recent,
+        },
+        {
+          nodeId: "catalog-only",
+          paired: true,
+          connected: false,
+          lastConnectedAtMs: recent,
+        },
+        { nodeId: "old", paired: true, connected: false, lastConnectedAtMs: old },
+        { nodeId: "unknown", paired: true, connected: false },
+      ];
+      programGatewayCallMock.mockImplementation(async (...args: unknown[]) => {
+        const { method } = (args[0] ?? {}) as { method?: string };
+        return method === "node.pair.list"
+          ? { pending: [], paired: [{ nodeId: "reconnected", lastConnectedAtMs: old }] }
+          : { ts: now, nodes };
+      });
+
+      await runProgram(["nodes", command, "--last-connected", "24h", "--json"]);
+
+      const result = writeJsonArgAt(0) as {
+        nodes?: Array<{ nodeId: string; lastConnectedAtMs?: number }>;
+        paired?: Array<{ nodeId: string; lastConnectedAtMs?: number }>;
+      };
+      expect(
+        (result.nodes ?? result.paired)?.map(({ nodeId, lastConnectedAtMs }) => ({
+          nodeId,
+          lastConnectedAtMs,
+        })),
+      ).toEqual([
+        { nodeId: "reconnected", lastConnectedAtMs: recent },
+        { nodeId: "catalog-only", lastConnectedAtMs: recent },
+      ]);
+    },
+  );
+
   it.each([
     { command: "status", duration: "24h" },
     { command: "status", duration: "1h30m" },


### PR DESCRIPTION
Closes #135914

## What Problem This Solves

Fixes an issue where operators running `nodes list --last-connected 24h` would lose recently connected nodes when the separate pairing snapshot contained an older timestamp or no row. The same nodes already appeared correctly in `nodes status`.

## Why This Change Was Made

The Gateway catalog records the latest connection time, but the list command overwrote it while merging pairing history. The merger now retains that authoritative timestamp. Both commands share the connection filter, and connection ages reuse the existing time formatter. The existing fallback for older Gateways that omit the recorded field remains intact.

Production code is **27 lines smaller** (+38/-65); tests add 48 lines and docs change one line. Two duplicated filters and the separate paired-row age formatting are removed. No Gateway protocol, configuration, authorization or persistence behavior changes.

## User Impact

Recently reconnected and recently disconnected paired nodes remain visible in the requested age window. Old nodes and nodes with unknown connection history remain excluded. The CLI documentation now explains that both views use the Gateway's recorded connection time.

## Evidence

The new regression runs real Commander registration through the normal full-program E2E harness with synthetic Gateway snapshots. On unchanged production source at `a8fdaeaa455178bb99a3a8afa9e113c5cc241200`, the status case passes while the list case fails with an empty result instead of two recent nodes. On the candidate, all **100 tests in three files pass**, including older-Gateway timestamp coverage:

```text
node scripts/run-vitest.mjs src/cli/program.nodes-basic.e2e.test.ts src/cli/program.nodes-diagnostics-auth.e2e.test.ts src/cli/nodes-cli.coverage.test.ts
```

Scoped `check-changed` passes, including production/test typechecks, three dead-export scans, lint and selected guards. Diff-scoped cleanup and fresh independent Codex autoreview are complete with no actionable finding. The parent agent also reproduced the bug independently using actual command registration and parser.

The affected catalog fact and faulty merge are present in stable `v2026.8.2`. This proof uses synthetic RPC responses to reproduce the ordering deterministically; no production Gateway or user devices were changed, and no live-device claim is made.
