### PR TITLE
fix: reject oversized QA uploads without crashing or stranding shutdown

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1048,7 +1048,7 @@ extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts	4
 extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts	4
 extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts	11
 extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts	2
-extensions/qa-lab/src/providers/mock-openai/server.ts	18
+extensions/qa-lab/src/providers/mock-openai/server.ts	16
 extensions/qa-lab/src/providers/shared/auth-store.ts	1
 extensions/qa-lab/src/qa-bus-protocol.ts	1
 extensions/qa-lab/src/qa-transport.ts	1

--- a/extensions/qa-lab/src/bus-server-shutdown.test-support.ts
+++ b/extensions/qa-lab/src/bus-server-shutdown.test-support.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+
+const provider = process.argv[2] === "provider";
+const server = provider
+  ? await startQaMockOpenAiServer({ host: "127.0.0.1", port: 0 })
+  : await startQaBusServer({ state: createQaBusState() });
+try {
+  const response = await fetch(
+    `${server.baseUrl}${provider ? "/v1/responses" : "/v1/inbound/message"}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: "x".repeat(16 * 1024 * 1024 + 1) }),
+    },
+  );
+  assert.equal(response.status, 413);
+  assert.deepEqual(await response.json(), { error: "Payload too large" });
+} finally {
+  await server.stop();
+}
+console.log("shutdown-complete");

--- a/extensions/qa-lab/src/bus-server.shutdown.test.ts
+++ b/extensions/qa-lab/src/bus-server.shutdown.test.ts
@@ -1,0 +1,21 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const fixturePath = fileURLToPath(
+  new URL("./bus-server-shutdown.test-support.ts", import.meta.url),
+);
+
+// Vitest's own handles would keep an unreferenced shutdown timer alive.
+it.each(["bus", "provider"])("finishes %s shutdown after rejecting an upload", async (kind) => {
+  const { stdout, stderr } = await execFileAsync(
+    process.execPath,
+    ["--import", "./scripts/tsx.mjs", fixturePath, kind],
+    { cwd: repoRoot, encoding: "utf8", timeout: 20_000 },
+  );
+  expect(stdout.trim()).toBe("shutdown-complete");
+  expect(stderr).toBe("");
+});

--- a/extensions/qa-lab/src/bus-server.shutdown.test.ts
+++ b/extensions/qa-lab/src/bus-server.shutdown.test.ts
@@ -6,7 +6,7 @@ import { expect, it } from "vitest";
 const execFileAsync = promisify(execFile);
 const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
 const fixturePath = fileURLToPath(
-  new URL("./bus-server-shutdown.test-support.ts", import.meta.url),
+  new URL("./test-support/bus-server-shutdown.ts", import.meta.url),
 );
 
 // Vitest's own handles would keep an unreferenced shutdown timer alive.

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -322,10 +322,10 @@ export async function closeQaHttpServer(server: Server, state?: QaBusState): Pro
       server.close((error) => (error ? reject(error) : resolve()));
       state?.reset(true); // Fence first so late request bodies cannot add waiter timers.
       server.closeIdleConnections?.();
+      // Awaited shutdown must keep its deadline alive even when paused sockets cannot wake Node.
       forceCloseTimer = setTimeout(() => {
         server.closeAllConnections?.();
       }, 250);
-      forceCloseTimer.unref();
     });
   } finally {
     if (forceCloseTimer) {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -4,7 +4,6 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
-import { writeJson } from "../shared/http-json.js";
 
 export type ResponsesInputItem = Record<string, unknown>;
 
@@ -410,6 +409,8 @@ export function readBody(req: IncomingMessage): Promise<string> {
   return readRequestBodyWithLimit(req, {
     maxBytes: MOCK_OPENAI_MAX_BODY_BYTES,
     timeoutMs: MOCK_OPENAI_BODY_TIMEOUT_MS,
+    // The HTTP handler must deliver the rejection before closing the request.
+    destroyOnLimit: false,
   });
 }
 
@@ -422,15 +423,6 @@ export function parseJsonObjectBody(raw: string): Record<string, unknown> | null
   }
 }
 
-export function writeOpenAiMalformedJsonError(res: ServerResponse, label: string) {
-  writeJson(res, 400, {
-    error: {
-      type: "invalid_request_error",
-      message: `Malformed JSON body for ${label} request.`,
-    },
-  });
-}
-
 export function transcriptionTextForAudioRequest(rawBody: string) {
   if (rawBody.includes(QA_MATRIX_VOICE_TRANSCRIPTION_TRIGGER)) {
     return QA_MATRIX_VOICE_TRANSCRIPTION_TEXT;
@@ -441,14 +433,34 @@ export function transcriptionTextForAudioRequest(rawBody: string) {
   return QA_AUDIO_TRANSCRIPTION_TEXT;
 }
 
-export function writeSse(res: ServerResponse, events: StreamEvent[]) {
-  const body = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+export async function writeSse(
+  res: ServerResponse,
+  events: Array<StreamEvent | AnthropicStreamEvent>,
+  protocol: "responses" | "anthropic",
+  pauseMs?: number,
+) {
+  const frames = events.map(
+    (event) =>
+      `${protocol === "anthropic" ? `event: ${event.type}\n` : ""}data: ${JSON.stringify(event)}\n\n`,
+  );
+  const completionIndex =
+    pauseMs === undefined
+      ? -1
+      : events.findIndex((event) => event.type === "response.output_text.done");
+  const body =
+    frames.slice(Math.max(0, completionIndex)).join("") +
+    (protocol === "responses" ? "data: [DONE]\n\n" : "");
   res.writeHead(200, {
     "content-type": "text/event-stream",
     "cache-control": "no-store",
     connection: "keep-alive",
-    "content-length": Buffer.byteLength(body),
+    ...(completionIndex < 0 ? { "content-length": Buffer.byteLength(body) } : {}),
   });
+  if (completionIndex >= 0) {
+    // Flush preview deltas before delaying the final text and completion frames.
+    res.write(frames.slice(0, completionIndex).join(""));
+    await sleep(pauseMs);
+  }
   res.end(body);
 }
 
@@ -480,47 +492,9 @@ export function buildRemoteCompactionV2Events(): [
   ];
 }
 
-export async function writeSseWithPreviewPause(
-  res: ServerResponse,
-  events: StreamEvent[],
-  pauseMs: number,
-) {
-  const completionIndex = events.findIndex((event) => event.type === "response.output_text.done");
-  if (completionIndex < 0) {
-    writeSse(res, events);
-    return;
-  }
-  res.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  for (const event of events.slice(0, completionIndex)) {
-    res.write(`data: ${JSON.stringify(event)}\n\n`);
-  }
-  await sleep(pauseMs);
-  for (const event of events.slice(completionIndex)) {
-    res.write(`data: ${JSON.stringify(event)}\n\n`);
-  }
-  res.end("data: [DONE]\n\n");
-}
-
 export type AnthropicStreamEvent = Record<string, unknown> & {
   type: string;
 };
-
-export function writeAnthropicSse(res: ServerResponse, events: AnthropicStreamEvent[]) {
-  const body = events
-    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
-    .join("");
-  res.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-    "content-length": Buffer.byteLength(body),
-  });
-  res.end(body);
-}
 
 export function countApproxTokens(text: string) {
   const trimmed = text.trim();

--- a/extensions/qa-lab/src/providers/mock-openai/server.http.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.http.test.ts
@@ -1,0 +1,31 @@
+import { postRawWebhook } from "openclaw/plugin-sdk/test-env";
+import { expect, it } from "vitest";
+import { startQaMockOpenAiServer } from "./server.js";
+
+it.each([
+  "/v1/responses",
+  "/v1/messages",
+  "/v1/images/generations",
+  "/v1/audio/transcriptions",
+  "/v1/embeddings",
+])("rejects an oversized %s upload without taking down the provider", async (pathname) => {
+  const server = await startQaMockOpenAiServer({ host: "127.0.0.1", port: 0 });
+  try {
+    const result = await postRawWebhook({
+      url: `${server.baseUrl}${pathname}`,
+      body: "{}",
+      contentLength: 16 * 1024 * 1024 + 1,
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(result.statusLine).toBe("HTTP/1.1 413 Payload Too Large");
+    expect(JSON.parse(result.body)).toEqual({ error: "Payload too large" });
+    expect(result.closedByServer).toBe(true);
+
+    const health = await fetch(`${server.baseUrl}/healthz`);
+    expect(health.status).toBe(200);
+    await expect(health.json()).resolves.toEqual({ ok: true, status: "live" });
+  } finally {
+    await server.stop();
+  }
+});

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1,7 +1,11 @@
 // QA Lab mock Responses dispatcher, HTTP transport, and debug endpoints.
 import { createServer } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
-import { closeQaHttpServer } from "../../bus-server.js";
+import {
+  closeQaHttpServer,
+  dispatchQaHttpRequest,
+  writeQaRequestBodyLimitError,
+} from "../../bus-server.js";
 import { parseQaDebugRequestCursor } from "../shared/debug-request-cursor.js";
 import { writeJson } from "../shared/http-json.js";
 import {
@@ -109,13 +113,10 @@ import {
   MOCK_OPENAI_DEBUG_REQUEST_LIMIT,
   readBody,
   parseJsonObjectBody,
-  writeOpenAiMalformedJsonError,
   transcriptionTextForAudioRequest,
   writeSse,
   isRemoteCompactionV2Request,
   buildRemoteCompactionV2Events,
-  writeSseWithPreviewPause,
-  writeAnthropicSse,
   countApproxTokens,
   extractEmbeddingInputTexts,
   buildDeterministicEmbedding,
@@ -198,6 +199,13 @@ import {
   extractSnackPreference,
 } from "./mock-openai-tooling.js";
 
+const MOCK_HTTP_POST_ROUTES = new Map([
+  ["/v1/images/generations", "OpenAI Images"],
+  ["/v1/audio/transcriptions", "OpenAI Audio"],
+  ["/v1/embeddings", "OpenAI Embeddings"],
+  ["/v1/responses", "OpenAI Responses"],
+  ["/v1/messages", "Anthropic Messages"],
+]);
 const QA_COMPACTION_RETRY_PROMPT_RE = /compaction retry mutating tool check/i;
 const QA_COMPACTION_SUMMARY_INSTRUCTIONS_RE =
   /context summarization assistant[\s\S]*structured summary[\s\S]*do not continue/i;
@@ -2768,7 +2776,7 @@ export async function startQaMockOpenAiServer(params?: {
   const dispatchResponses = (request: Omit<QaMockProviderDispatchRequest, "route">) =>
     dispatchProvider({ ...request, route: "responses" });
   const server = createServer((req, res) => {
-    void (async () => {
+    dispatchQaHttpRequest(res, async () => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");
       if (req.method === "GET" && (url.pathname === "/healthz" || url.pathname === "/readyz")) {
         writeJson(res, 200, { ok: true, status: "live" });
@@ -2837,13 +2845,36 @@ export async function startQaMockOpenAiServer(params?: {
         writeJson(res, 200, imageGenerationRequests);
         return;
       }
-      if (req.method === "POST" && url.pathname === "/v1/images/generations") {
-        const raw = await readBody(req);
-        const body = parseJsonObjectBody(raw);
-        if (!body) {
-          writeOpenAiMalformedJsonError(res, "OpenAI Images");
-          return;
+      const requestLabel = req.method === "POST" && MOCK_HTTP_POST_ROUTES.get(url.pathname);
+      if (!requestLabel) {
+        writeJson(res, 404, { error: "not found" });
+        return;
+      }
+      let raw: string;
+      try {
+        raw = await readBody(req);
+      } catch (error) {
+        if (!(await writeQaRequestBodyLimitError(req, res, error))) {
+          throw error;
         }
+        return;
+      }
+      if (url.pathname === "/v1/audio/transcriptions") {
+        writeJson(res, 200, { text: transcriptionTextForAudioRequest(raw) });
+        return;
+      }
+      const body = parseJsonObjectBody(raw);
+      if (!body) {
+        writeJson(res, 400, {
+          ...(url.pathname === "/v1/messages" ? { type: "error" } : {}),
+          error: {
+            type: "invalid_request_error",
+            message: `Malformed JSON body for ${requestLabel} request.`,
+          },
+        });
+        return;
+      }
+      if (url.pathname === "/v1/images/generations") {
         imageGenerationRequests.push(body);
         if (imageGenerationRequests.length > 20) {
           imageGenerationRequests.splice(0, imageGenerationRequests.length - 20);
@@ -2858,20 +2889,7 @@ export async function startQaMockOpenAiServer(params?: {
         });
         return;
       }
-      if (req.method === "POST" && url.pathname === "/v1/audio/transcriptions") {
-        const raw = await readBody(req);
-        writeJson(res, 200, {
-          text: transcriptionTextForAudioRequest(raw),
-        });
-        return;
-      }
-      if (req.method === "POST" && url.pathname === "/v1/embeddings") {
-        const raw = await readBody(req);
-        const body = parseJsonObjectBody(raw);
-        if (!body) {
-          writeOpenAiMalformedJsonError(res, "OpenAI Embeddings");
-          return;
-        }
+      if (url.pathname === "/v1/embeddings") {
         const inputs = extractEmbeddingInputTexts(body.input);
         writeJson(res, 200, {
           object: "list",
@@ -2891,13 +2909,7 @@ export async function startQaMockOpenAiServer(params?: {
         });
         return;
       }
-      if (req.method === "POST" && url.pathname === "/v1/responses") {
-        const raw = await readBody(req);
-        const body = parseJsonObjectBody(raw);
-        if (!body) {
-          writeOpenAiMalformedJsonError(res, "OpenAI Responses");
-          return;
-        }
+      if (url.pathname === "/v1/responses") {
         const dispatched = await dispatchResponses({ body, raw });
         if (dispatched.failure) {
           writeJson(res, dispatched.failure.status, {
@@ -2923,50 +2935,23 @@ export async function startQaMockOpenAiServer(params?: {
           dispatched.onResponseSent?.();
           return;
         }
-        if (dispatched.previewPauseMs !== undefined) {
-          await writeSseWithPreviewPause(res, events, dispatched.previewPauseMs);
-        } else {
-          writeSse(res, events);
-        }
+        await writeSse(res, events, "responses", dispatched.previewPauseMs);
         dispatched.onResponseSent?.();
         return;
       }
-      if (req.method === "POST" && url.pathname === "/v1/messages") {
-        const raw = await readBody(req);
-        const body = parseJsonObjectBody(raw) as AnthropicMessagesRequest | null;
-        if (!body) {
-          writeJson(res, 400, {
-            type: "error",
-            error: {
-              type: "invalid_request_error",
-              message: "Malformed JSON body for Anthropic Messages request.",
-            },
-          });
-          return;
-        }
-        const dispatched = await dispatchProvider({
-          route: "anthropic-messages",
-          body: body as Record<string, unknown>,
-          raw,
-        });
-        const { responseBody, streamEvents } = buildMessagesPayload(dispatched);
-        if (dispatched.failure?.presentation !== "anthropic-thinking") {
-          if (dispatched.failure) {
-            writeJson(res, dispatched.failure.status, responseBody);
-            return;
-          }
-        }
-        if (body.stream === true) {
-          writeAnthropicSse(res, streamEvents);
-          dispatched.onResponseSent?.();
-          return;
-        }
+      const dispatched = await dispatchProvider({ route: "anthropic-messages", body, raw });
+      const { responseBody, streamEvents } = buildMessagesPayload(dispatched);
+      if (dispatched.failure && dispatched.failure.presentation !== "anthropic-thinking") {
+        writeJson(res, dispatched.failure.status, responseBody);
+        return;
+      }
+      if (body.stream === true) {
+        await writeSse(res, streamEvents, "anthropic");
+      } else {
         writeJson(res, dispatched.failure?.status ?? 200, responseBody);
-        dispatched.onResponseSent?.();
-        return;
       }
-      writeJson(res, 404, { error: "not found" });
-    })();
+      dispatched.onResponseSent?.();
+    });
   });
   const responsesWebSocket = attachQaMockResponsesWebSocketServer({
     server,

--- a/extensions/qa-lab/src/test-support/bus-server-shutdown.ts
+++ b/extensions/qa-lab/src/test-support/bus-server-shutdown.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { startQaBusServer } from "./bus-server.js";
-import { createQaBusState } from "./bus-state.js";
-import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { startQaBusServer } from "../bus-server.js";
+import { createQaBusState } from "../bus-state.js";
+import { startQaMockOpenAiServer } from "../providers/mock-openai/server.js";
 
 const provider = process.argv[2] === "provider";
 const server = provider


### PR DESCRIPTION
Closes #135920
Closes #135930

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where QA Lab runs crash when a mock provider upload exceeds the 16 MiB request limit. The requester receives no HTTP error, and the provider process exits with an unhandled `RequestBodyLimitError`.

Also fixes incomplete shutdown after a rejected upload: the QA bus or mock provider can exit with Node code 13 while still awaiting `stop()`.

## Why This Change Was Made

The mock provider now uses the QA bus's existing request dispatcher and rejection writer. All five POST routes share one body-reading boundary, and the request stays open until its framed rejection is written. The shared shutdown owner retains its existing 250 ms cleanup deadline until paused sockets are released.

Consolidating request parsing and SSE writing removes duplicate paths, a one-use error helper, and two casts. Responses and Anthropic framing, terminal event order, and the preview pause point remain the same.

## User Impact

QA callers receive an HTTP 413 with a readable error, subsequent requests still work, and both HTTP servers finish shutdown. Failures stay within the failed request rather than ending the QA run.

## Evidence

| Failure | Before | After |
| --- | --- | --- |
| Oversized provider request | Five route regressions fail with no HTTP response and unhandled rejections | All five return 413, close the rejected connection, and answer the next health check |
| Shutdown after rejection | Fresh Node processes for both QA bus and provider exit 13 at `await stop()` | Both finish shutdown and exit 0 |

The focused six-file run passes 324 cases, including existing Responses, Anthropic, preview-pause, WebSocket, and QA bus coverage. The provider's 282-case suite passed again after the final lint cleanup. Fresh isolated Codex review is clean through P2. Full repository changed checks passed, including extension typechecks, lint, dead exports, import cycles, and five required doctor-contract cases.

Production TypeScript: **+82/-123, net -41**. Tests/support: **+76/-0**. The assertion baseline shrinks from 18 to 16 for the two removed casts.

Codex's actual consumer was inspected at `94cbbddafc1776d5e377bca1b05932c697e82238`: `codex-rs/codex-api/src/sse/responses.rs:564` parses SSE data frames, `:652` completes on `response.completed`, and `:1034` tests completion without waiting for stream EOF. The unchanged `[DONE]` suffix is not used as the completion signal.
