### PR TITLE
test: reuse performance fixture snapshot metadata

### DIFF
--- a/test/scripts/openclaw-performance-workflow.test-support.ts
+++ b/test/scripts/openclaw-performance-workflow.test-support.ts
@@ -11,8 +11,15 @@ import path from "node:path";
 import { afterAll } from "vitest";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
+type PerformanceTemplate = {
+  root: string;
+  git: string;
+  target: string;
+  reportCommit: string;
+};
+
 const templateDirs = createTempDirTracker();
-const performanceTemplates = new Map<"base" | "publish", string>();
+const performanceTemplates = new Map<"base" | "publish", PerformanceTemplate>();
 afterAll(() => {
   templateDirs.cleanup();
   performanceTemplates.clear();
@@ -33,7 +40,10 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
   const seed = path.join(workspace, "seed");
   const reports = path.join(temp, "reports");
   const input = path.join(temp, "input");
-  const git = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+  const reuseDefault = !options.baseline && !options.duplicate;
+  const templateKind = options.mode === "publish" ? "publish" : "base";
+  const template = reuseDefault ? performanceTemplates.get(templateKind) : undefined;
+  const git = template?.git ?? execFileSync("which", ["git"], { encoding: "utf8" }).trim();
   const gitEnv = {
     PATH: process.env.PATH,
     SystemRoot: process.env.SystemRoot,
@@ -64,12 +74,9 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
     run(cwd, "add", ".");
     run(cwd, "commit", "-m", "fixture report");
   };
-  const reuseDefault = !options.baseline && !options.duplicate;
-  const templateKind = options.mode === "publish" ? "publish" : "base";
-  const template = reuseDefault ? performanceTemplates.get(templateKind) : undefined;
   const copyOptions = { recursive: true, mode: fsConstants.COPYFILE_FICLONE };
   if (template) {
-    cpSync(template, workspace, copyOptions);
+    cpSync(template.root, workspace, copyOptions);
   } else {
     mkdirSync(temp, { recursive: true });
     mkdirSync(seed);
@@ -78,9 +85,12 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
     write(path.join(seed, "README.md"), "fixture\n");
     if (options.baseline !== "absent") {
       commitReport(seed, options.duplicate ? dest : previous);
-      if (options.baseline === "invalid") write(path.join(seed, pointer), "{invalid");
-      if (options.baseline === "trailing-newline")
+      if (options.baseline === "invalid") {
+        write(path.join(seed, pointer), "{invalid");
+      }
+      if (options.baseline === "trailing-newline") {
         write(path.join(seed, pointer), JSON.stringify({ path: previous + "\n" }));
+      }
     }
     run(seed, "add", ".");
     run(seed, "commit", "--allow-empty", "-m", "fixture seed");
@@ -100,22 +110,21 @@ export function preparePerformanceFixture(root: string, options: PerformanceFixt
       commitReport(reports, dest);
       write(path.join(reports, ".git/preexisting.lock"), "not invocation-owned\n");
     }
-    if (reuseDefault) {
-      // Snapshot complete repositories before any scenario mutation. Copies own
-      // their refs, index and objects; no live process or absolute remote is shared.
-      const template = templateDirs.make(`openclaw-performance-${templateKind}-template-`);
-      cpSync(workspace, template, copyOptions);
-      performanceTemplates.set(templateKind, template);
-    }
   }
-  const target = run(workspace, "rev-parse", "HEAD");
-  let reportCommit = "a".repeat(40);
-  if (options.mode === "publish") {
-    reportCommit = run(reports, "rev-parse", "HEAD");
-    if (options.race) {
-      commitReport(seed, "openclaw-performance/main/200-1/mock-provider");
-      run(seed, "push", remote, "HEAD:main");
-    }
+  const target = template?.target ?? run(workspace, "rev-parse", "HEAD");
+  const reportCommit =
+    template?.reportCommit ??
+    (options.mode === "publish" ? run(reports, "rev-parse", "HEAD") : "a".repeat(40));
+  if (!template && reuseDefault) {
+    // Snapshot complete repositories and their identities before scenario mutation.
+    // Copies own their refs, index and objects; no live process or remote is shared.
+    const templateRoot = templateDirs.make(`openclaw-performance-${templateKind}-template-`);
+    cpSync(workspace, templateRoot, copyOptions);
+    performanceTemplates.set(templateKind, { root: templateRoot, git, target, reportCommit });
+  }
+  if (options.mode === "publish" && options.race) {
+    commitReport(seed, "openclaw-performance/main/200-1/mock-provider");
+    run(seed, "push", remote, "HEAD:main");
   }
   write(path.join(input, "kova/reports/mock-provider/report.json"), "{}\n");
   write(path.join(input, "kova/reports/mock-provider/report.md"), "report\n");


### PR DESCRIPTION
## What problem does this PR solve?

The 105-case performance workflow lifecycle suite copied its existing repository snapshots, then launched `which git` and `git rev-parse HEAD` again for every copy. Those executable and commit identities belong to the immutable snapshot.

## Why is this the best solution?

Keep the identities in the existing fixture-owned snapshot record. Each case still owns a full repository copy, and custom baseline/duplicate fixtures still read their own identities. Concurrent-publication mutations happen after snapshot capture. All workflow Git commands and final repository inspections remain real and unchanged.

## User impact

Test infrastructure only; production LOC +0/-0. Test support +32/-23. Two existing unbraced conditionals were also fixed after the changed-file lint gate identified them. No configuration, storage, timeout, or assertion changes.

## Evidence

Same Node 24.19.0 checkout toolchain, one Vitest worker and the suite's existing concurrency 2:

| Measurement | Before | After |
| --- | ---: | ---: |
| Full lifecycle cases | 105 passed | 105 passed |
| Test execution | 265.32s | 245.70s |
| Actual workflow commands | 733 | 733 |
| Process-lifetime checkpoints | 1,524 | 1,524 |

Both runs retained 672 ready attempts, identical expected exit-code counts, zero remaining owned processes, and a live sentinel at every checkpoint.

An isolated 105-fixture construction benchmark, using the same default/publish/custom mix and reversed order for the second pair, measured setup probes falling from 252 to 13 (239 subprocesses removed). Construction took 11.95s→10.74s and 10.17s→8.40s. The full-suite timing is a single observation; subprocess scheduling contributes variance.

Validation commands:

```sh
node scripts/run-vitest.mjs test/scripts/openclaw-performance-git-lifecycle.test.ts
node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts -t "advertises a clawgrit URL only after verified success|preserves both reports when concurrent writers update one latest pointer"
node scripts/check-changed.mjs -- test/scripts/openclaw-performance-workflow.test-support.ts
```

The five publication siblings cover direct publication, ambiguous remote success, exhausted retries, missing credentials, and preservation of both reports after a concurrent push. Codex review found no actionable P0 issue.
