### PR TITLE
improve: defer update recovery modules until an update starts

### DIFF
--- a/src/cli/update-cli/update-command-triage.ts
+++ b/src/cli/update-cli/update-command-triage.ts
@@ -7,10 +7,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { readControlPlaneUpdateSentinelMeta } from "../../infra/update-control-plane-sentinel.js";
 import { POST_CORE_UPDATE_ENV } from "../../infra/update-post-core-context.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
-import {
-  prepareUpdateFailureTriage,
-  type UpdateTriageTarget as TriageTarget,
-} from "../../infra/update-triage.js";
+import type { UpdateTriageTarget as TriageTarget } from "../../infra/update-triage.js";
 import { defaultRuntime } from "../../runtime.js";
 import { classifyUpdateOutcome } from "../../shared/update-outcome.js";
 import { exitCliAfterOutput } from "../one-shot-exit.js";
@@ -30,6 +27,7 @@ export async function withUpdateFailureTriage(
     : !opts.yes && isTerminalInteractive()
       ? "interactive"
       : "non-interactive";
+  const { prepareUpdateFailureTriage } = await import("../../infra/update-triage.js");
   const runTriage = await prepareUpdateFailureTriage({
     mode,
     runtime: {

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -19,7 +19,6 @@ import type { UpdateRecovery } from "../infra/update-recovery.js";
 import { UPDATE_RUNNER_TIMEOUT_MS } from "../infra/update-runner-command.js";
 import { runGatewayUpdate } from "../infra/update-runner.js";
 import type { UpdateRunResult } from "../infra/update-runner.js";
-import { prepareUpdateFailureTriage } from "../infra/update-triage.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { classifyUpdateOutcome } from "../shared/update-outcome.js";
@@ -85,6 +84,7 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
     const updateRoot = params.root;
     const invocationCwd = tryResolveInvocationCwd();
     const operatorEnv = resolveServiceRefreshEnv(process.env, invocationCwd);
+    const { prepareUpdateFailureTriage } = await import("../infra/update-triage.js");
     const runTriage = await prepareUpdateFailureTriage({
       runtime: params.runtime,
       mode: isTerminalInteractive() ? "interactive" : "non-interactive",

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -67,7 +67,6 @@ import {
 } from "./update-managed-service-handoff.js";
 import { buildUpdateRestartSentinelPayload } from "./update-restart-sentinel-payload.js";
 import { runGatewayUpdatePreflight, type UpdateRunResult } from "./update-runner.js";
-import { runUpdateFailureTriage } from "./update-triage.js";
 
 type UpdateCheckState = {
   lastCheckedAt?: string;
@@ -706,6 +705,8 @@ async function runCampaignUpdate(params: {
   if (!isCurrent()) {
     return "failed";
   }
+  // Capture recovery code before the updater can replace the running installation.
+  const { runUpdateFailureTriage } = await import("./update-triage.js");
   const { sentinel, revision } = await readRestartSentinelSnapshot();
   if (!isCurrent()) {
     return "failed";


### PR DESCRIPTION
## What Problem This Solves

The update scheduler loaded recovery-triage modules even while idle or only checking availability. Doctor and the CLI wrapper also imported that owner before an update was chosen.

## Why This Change Was Made

All three callers load triage when an update starts, before the updater can replace the running installation. Interactive preparation still captures the recovery command and operator environment before replacement; recovery still runs after cleanup. Gateway campaign identity is rechecked after awaited work before attempt-state writes.

Production is +5/−6 lines (net −1), with no test/config/schema/protocol/dependency changes. Existing dynamic import owns the deferred load; no second recovery implementation or cache is added.

## User Impact

An idle scheduler no longer loads ten source modules through the triage edge. Three fresh source-loader processes per revision showed median post-GC retained import heap of 115,946,752→114,817,032 bytes, about 1.1 MB lower. That includes the TypeScript loader/compiler and is not a built-Gateway heap claim.

The built Gateway reaches readiness with five recovery-related chunks absent; shared redaction helpers still load through other owners. Three alternating startup pairs showed no clear Gateway-wide memory or latency improvement: median readiness 2732.0→2723.5 ms and sampled peak RSS 474.69→476.09 MiB. Those small, noisy samples are retained as a limit on the claim.

## Evidence

- 161 existing tests pass on original and candidate source across update scheduling, triage lifecycle, Doctor and CLI update recovery. They include real synthetic installed-command children, cleanup ordering, original-error preservation, inaccessible state, removed cwd, saved operator environment and stale/cancelled campaign completion.
- The canonical sourcePerformance build and full changed-file gate passed. An independent subagent reviewed full owners/callers and cancellation/capture timing; Codex autoreview found no accepted issue.
- Actual source-load inventories have identical exports and ten removed modules with no additions. Six separate import-memory runs exclude the load hook. Real built-Gateway diagnostic runs and six uninstrumented startup runs all reached readiness through the existing benchmark harness.

The probe baseline is `173f41d682b0d4a05674820a3d390d934da8b066`. Measurements are descriptive local samples under concurrent host activity; they do not establish a general startup speedup, whole-Gateway RSS reduction or a long-session leak fix.
