### PR TITLE
test(codex): keep sandbox exec-server suites inside the isolated state home

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server-node-relay.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server-node-relay.test.ts
@@ -1,5 +1,6 @@
 import { once } from "node:events";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { useIsolatedStateGuard } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
 import {
@@ -154,6 +155,8 @@ async function expectPairedNodeHttpCredentialRejection(params: {
   expect(transport.channel.send).not.toHaveBeenCalled();
   expect(onExecutionDisconnect).not.toHaveBeenCalled();
 }
+
+useIsolatedStateGuard();
 
 afterEach(async () => {
   customLoggingPattern.value = "";

--- a/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover sandbox exec-server child and backend lease lifecycle ordering.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
@@ -99,12 +100,25 @@ afterEach(() => {
 });
 
 describe("Codex sandbox exec-server lifecycle", () => {
-  it.each(["HOME", "OPENCLAW_STATE_DIR"])(
-    "refuses host metadata discovery outside the isolated home after %s changes",
-    async (key) => {
-      const foreignRoot = path.join(process.env.OPENCLAW_TEST_HOME!, "..", "foreign-state");
+  it.each([
+    { key: "HOME", via: "path" },
+    { key: "OPENCLAW_STATE_DIR", via: "path" },
+    { key: "OPENCLAW_STATE_DIR", via: "symlink" },
+  ] as const)(
+    "refuses host metadata discovery outside the isolated home after $key changes ($via)",
+    async ({ key, via }) => {
+      const testHome = process.env.OPENCLAW_TEST_HOME!;
+      const foreignRoot = path.join(testHome, "..", `foreign-state-${via}`);
+      let target = foreignRoot;
+      if (via === "symlink") {
+        // A state root that lexically sits inside the home but physically points outside.
+        fs.mkdirSync(foreignRoot, { recursive: true });
+        target = path.join(testHome, "linked-state");
+        fs.rmSync(target, { force: true });
+        fs.symlinkSync(foreignRoot, target, "dir");
+      }
       spawnMock.mockReturnValue(createFakeChild());
-      await withEnvAsync({ [key]: foreignRoot }, async () => {
+      await withEnvAsync({ [key]: target }, async () => {
         await expect(
           startProcess(
             createExecServer(createSandboxContext({})),

--- a/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
@@ -2,6 +2,7 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
@@ -108,27 +109,35 @@ describe("Codex sandbox exec-server lifecycle", () => {
     "refuses host metadata discovery outside the isolated home after $key changes ($via)",
     async ({ key, via }) => {
       const testHome = process.env.OPENCLAW_TEST_HOME!;
-      const foreignRoot = path.join(testHome, "..", `foreign-state-${via}`);
+      // The path cases only point outside the home; nothing is created there.
+      let foreignRoot = path.join(testHome, "..", "foreign-state-path");
       let target = foreignRoot;
+      const cleanup: string[] = [];
       if (via === "symlink") {
         // A state root that lexically sits inside the home but physically points outside.
-        fs.mkdirSync(foreignRoot, { recursive: true });
+        foreignRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-foreign-state-"));
         target = path.join(testHome, "linked-state");
-        fs.rmSync(target, { force: true });
         fs.symlinkSync(foreignRoot, target, "dir");
+        cleanup.push(target, foreignRoot);
       }
       spawnMock.mockReturnValue(createFakeChild());
-      await withEnvAsync({ [key]: target }, async () => {
-        await expect(
-          startProcess(
-            createExecServer(createSandboxContext({})),
-            new Map(),
-            createFakeNotifications().send,
-            processStartParams("foreign-state"),
-          ),
-        ).rejects.toThrow("state escaped the isolated test home");
-      });
-      expect(spawnMock).not.toHaveBeenCalled();
+      try {
+        await withEnvAsync({ [key]: target }, async () => {
+          await expect(
+            startProcess(
+              createExecServer(createSandboxContext({})),
+              new Map(),
+              createFakeNotifications().send,
+              processStartParams("foreign-state"),
+            ),
+          ).rejects.toThrow("state escaped the isolated test home");
+        });
+        expect(spawnMock).not.toHaveBeenCalled();
+      } finally {
+        for (const entry of cleanup) {
+          fs.rmSync(entry, { recursive: true, force: true });
+        }
+      }
     },
   );
 

--- a/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
@@ -1,8 +1,10 @@
 // Codex tests cover sandbox exec-server child and backend lease lifecycle ordering.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
+import { useIsolatedStateGuard, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -88,6 +90,8 @@ function streamingHttpParams(requestId: string) {
   };
 }
 
+useIsolatedStateGuard();
+
 afterEach(() => {
   vi.useRealTimers();
   spawnMock.mockReset();
@@ -95,6 +99,25 @@ afterEach(() => {
 });
 
 describe("Codex sandbox exec-server lifecycle", () => {
+  it.each(["HOME", "OPENCLAW_STATE_DIR"])(
+    "refuses host metadata discovery outside the isolated home after %s changes",
+    async (key) => {
+      const foreignRoot = path.join(process.env.OPENCLAW_TEST_HOME!, "..", "foreign-state");
+      spawnMock.mockReturnValue(createFakeChild());
+      await withEnvAsync({ [key]: foreignRoot }, async () => {
+        await expect(
+          startProcess(
+            createExecServer(createSandboxContext({})),
+            new Map(),
+            createFakeNotifications().send,
+            processStartParams("foreign-state"),
+          ),
+        ).rejects.toThrow("state escaped the isolated test home");
+      });
+      expect(spawnMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("owns JSON-RPC delivery, ordered process notifications, and idempotent session cleanup", async () => {
     const child = createFakeChild();
     spawnMock.mockReturnValue(child);

--- a/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts
@@ -113,15 +113,17 @@ describe("Codex sandbox exec-server lifecycle", () => {
       let foreignRoot = path.join(testHome, "..", "foreign-state-path");
       let target = foreignRoot;
       const cleanup: string[] = [];
-      if (via === "symlink") {
-        // A state root that lexically sits inside the home but physically points outside.
-        foreignRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-foreign-state-"));
-        target = path.join(testHome, "linked-state");
-        fs.symlinkSync(foreignRoot, target, "dir");
-        cleanup.push(target, foreignRoot);
-      }
       spawnMock.mockReturnValue(createFakeChild());
       try {
+        if (via === "symlink") {
+          // A state root that lexically sits inside the home but physically points outside.
+          // Register each path before the next fallible call so a failed setup still cleans up.
+          foreignRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-foreign-state-"));
+          cleanup.push(foreignRoot);
+          target = path.join(testHome, "linked-state");
+          cleanup.push(target);
+          fs.symlinkSync(foreignRoot, target, "dir");
+        }
         await withEnvAsync({ [key]: target }, async () => {
           await expect(
             startProcess(

--- a/extensions/codex/src/app-server/sandbox-exec-server.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test.ts
@@ -1,4 +1,5 @@
 // Codex tests cover sandbox exec server plugin behavior.
+import { useIsolatedStateGuard, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
 import {
@@ -20,8 +21,9 @@ import {
   waitForSocketClose,
 } from "./sandbox-exec-server.test-helpers.js";
 
+useIsolatedStateGuard();
+
 afterEach(async () => {
-  vi.unstubAllEnvs();
   await sandboxExecServerRegistry.closeAll();
 });
 
@@ -639,49 +641,52 @@ describe("OpenClaw Codex sandbox exec-server", () => {
   });
 
   it("does not let Codex env policy inherit host secret variables", async () => {
-    vi.stubEnv("HOME", "/gateway-home");
-    vi.stubEnv("USER", "gateway-user");
-    vi.stubEnv("TMPDIR", "/gateway-tmp");
-    vi.stubEnv("OPENCLAW_TEST_SECRET_TOKEN", "host-secret");
-    vi.stubEnv("OPENCLAW_TEST_DATABASE_PASSWORD", "host-password");
-    vi.stubEnv("OPENCLAW_TEST_PRIVATE_KEY", "host-private-key");
-    const buildExecSpec = vi.fn(async () => ({
-      argv: [process.execPath, "-e", ""],
-      env: {},
-      stdinMode: "pipe-closed" as const,
-    }));
-    const sandbox = createSandboxContext({ buildExecSpec });
-    const client = createClient();
-    await ensureCodexSandboxExecServerEnvironment({
-      client: client as never,
-      sandbox,
-    });
-    const socket = await openSocket(execServerUrlFromClient(client));
-    await rpc(socket, "initialize", { clientName: "test" });
-    socket.send(JSON.stringify({ method: "initialized" }));
-
-    await rpc(socket, "process/start", {
-      processId: "proc-secret-env",
-      argv: ["/bin/sh", "-lc", "true"],
-      cwd: "file:///workspace",
-      env: {},
-      envPolicy: {
-        inherit: "all",
-        ignoreDefaultExcludes: true,
-        exclude: [],
-        set: {},
-        includeOnly: [],
+    await withEnvAsync(
+      {
+        OPENCLAW_TEST_SECRET_TOKEN: "host-secret",
+        OPENCLAW_TEST_DATABASE_PASSWORD: "host-password",
+        OPENCLAW_TEST_PRIVATE_KEY: "host-private-key",
       },
-      tty: false,
-      pipeStdin: false,
-      arg0: null,
-    });
+      async () => {
+        const buildExecSpec = vi.fn(async () => ({
+          argv: [process.execPath, "-e", ""],
+          env: {},
+          stdinMode: "pipe-closed" as const,
+        }));
+        const sandbox = createSandboxContext({ buildExecSpec });
+        const client = createClient();
+        await ensureCodexSandboxExecServerEnvironment({
+          client: client as never,
+          sandbox,
+        });
+        const socket = await openSocket(execServerUrlFromClient(client));
+        await rpc(socket, "initialize", { clientName: "test" });
+        socket.send(JSON.stringify({ method: "initialized" }));
 
-    const [{ env: execEnv }] = buildExecSpec.mock.calls[0] as unknown as [
-      { env: Record<string, string> },
-    ];
-    expect(execEnv).toEqual({ CODEX_SANDBOX_EXEC_ID: expect.any(String) });
-    socket.close();
+        await rpc(socket, "process/start", {
+          processId: "proc-secret-env",
+          argv: ["/bin/sh", "-lc", "true"],
+          cwd: "file:///workspace",
+          env: {},
+          envPolicy: {
+            inherit: "all",
+            ignoreDefaultExcludes: true,
+            exclude: [],
+            set: {},
+            includeOnly: [],
+          },
+          tty: false,
+          pipeStdin: false,
+          arg0: null,
+        });
+
+        const [{ env: execEnv }] = buildExecSpec.mock.calls[0] as unknown as [
+          { env: Record<string, string> },
+        ];
+        expect(execEnv).toEqual({ CODEX_SANDBOX_EXEC_ID: expect.any(String) });
+        socket.close();
+      },
+    );
   });
 
   it("keeps process/read cursors at the last returned byte-limited chunk", async () => {

--- a/src/plugin-sdk/test-env.ts
+++ b/src/plugin-sdk/test-env.ts
@@ -3,6 +3,7 @@ export { jsonResponse, requestBodyText, requestUrl } from "../test-helpers/http.
 export { mockPinnedHostnameResolution } from "../test-helpers/ssrf.js";
 export { createWindowsCmdShimFixture } from "../test-helpers/windows-cmd-shim.js";
 export { createProviderUsageFetch, makeResponse } from "../test-utils/provider-usage-fetch.js";
+export { useIsolatedStateGuard } from "../test-utils/state-path-guard.js";
 export { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 export { captureEnv, withEnv, withEnvAsync } from "../test-utils/env.js";
 export { withFetchPreconnect, type FetchMock } from "../test-utils/fetch-mock.js";

--- a/src/test-utils/state-path-guard.ts
+++ b/src/test-utils/state-path-guard.ts
@@ -1,6 +1,7 @@
 // Test instrumentation rejects state access outside the shared worker home without redirecting it.
 import path from "node:path";
 import { afterEach, beforeEach, vi } from "vitest";
+import { resolveIdentityPathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import * as nodeSqlite from "../infra/node-sqlite.js";
 import * as statePaths from "../state/openclaw-state-db.paths.js";
 
@@ -14,8 +15,14 @@ export function useIsolatedStateGuard(): void {
     if (!testHome) {
       throw new Error("State isolation checks require the shared isolated test home.");
     }
+    // Physical containment: a symlinked state root inside the home would pass a lexical
+    // check while SQLite follows it elsewhere; the home itself may be a tmpdir symlink.
+    const ownedRoot = resolveIdentityPathViaExistingAncestorSync(testHome);
     const assertOwnedPath = (pathname: string) => {
-      const relative = path.relative(testHome, pathname);
+      const relative = path.relative(
+        ownedRoot,
+        resolveIdentityPathViaExistingAncestorSync(pathname),
+      );
       if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
         throw new Error(`OpenClaw state escaped the isolated test home: ${pathname}`);
       }

--- a/src/test-utils/state-path-guard.ts
+++ b/src/test-utils/state-path-guard.ts
@@ -1,0 +1,45 @@
+// Test instrumentation rejects state access outside the shared worker home without redirecting it.
+import path from "node:path";
+import { afterEach, beforeEach, vi } from "vitest";
+import * as nodeSqlite from "../infra/node-sqlite.js";
+import * as statePaths from "../state/openclaw-state-db.paths.js";
+
+/** Fail before host metadata discovery can read state outside the worker's owned home. */
+export function useIsolatedStateGuard(): void {
+  const resolveStatePath = statePaths.resolveOpenClawStateSqlitePath;
+  const openDatabase = nodeSqlite.openNodeSqliteDatabase;
+  let restore = () => {};
+  beforeEach(() => {
+    const testHome = process.env.OPENCLAW_TEST_HOME;
+    if (!testHome) {
+      throw new Error("State isolation checks require the shared isolated test home.");
+    }
+    const assertOwnedPath = (pathname: string) => {
+      const relative = path.relative(testHome, pathname);
+      if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        throw new Error(`OpenClaw state escaped the isolated test home: ${pathname}`);
+      }
+    };
+    // Check resolution too: a missing foreign DB would otherwise make the leak silently pass.
+    const pathSpy = vi
+      .spyOn(statePaths, "resolveOpenClawStateSqlitePath")
+      .mockImplementation((env) => {
+        const pathname = resolveStatePath(env);
+        assertOwnedPath(pathname);
+        return pathname;
+      });
+    const openSpy = vi
+      .spyOn(nodeSqlite, "openNodeSqliteDatabase")
+      .mockImplementation((location, options) => {
+        if (location !== ":memory:") {
+          assertOwnedPath(location);
+        }
+        return openDatabase(location, options);
+      });
+    restore = () => {
+      openSpy.mockRestore();
+      pathSpy.mockRestore();
+    };
+  });
+  afterEach(() => restore());
+}


### PR DESCRIPTION
## What Problem This Solves

While triaging a stale-base CI failure on PR #135812, the Codex sandbox exec-server suites failed with `OpenClaw state database /Users/<operator>/.openclaw/state/openclaw.sqlite uses newer schema version 16; this build supports 15` — i.e. a unit test was opening the **operator's live** state database. Tests must never touch real operator state; on a schema-compatible checkout this would have been a silent read instead of a failure.

Root cause (source-traced): the exec-server's host-metadata lookup runs before spawn — `startProcess` → `sanitizeEnvVars` → provider metadata snapshot → `readConfigMachineState` → `withExistingOpenClawStateDatabaseReadOnly` — and resolves the state DB from the effective `HOME`/`OPENCLAW_STATE_DIR`. The broad `sandbox-exec-server.test.ts` suite stubbed `HOME=/gateway-home` around `process/start`, so that lookup targeted a foreign `~/.openclaw/state` path. The original 8+1 failure did not reproduce on a fresh checkout (the shared harness normally isolates `HOME`; an ambient harness flag in the original shell is the likely trigger and is still unproven), but the escape path is real and now fails loudly.

## Why This Change Was Made

- New test-only `useIsolatedStateGuard()` (`src/test-utils/state-path-guard.ts`, exported through the existing `openclaw/plugin-sdk/test-env` seam): spies on the real `resolveOpenClawStateSqlitePath` and `openNodeSqliteDatabase`, delegates to them, and throws before any access whose path is outside `OPENCLAW_TEST_HOME`. Checking resolution (not only opens) means a *missing* foreign DB cannot make the leak pass silently.
- Installed in the three state-reading sandbox suites (`sandbox-exec-server.test.ts`, `.lifecycle.test.ts`, `-node-relay.test.ts`).
- Fixed the sibling fixture: the secret-inheritance test keeps the isolated `HOME` and stubs only the synthetic secret variables via the tracked `withEnvAsync`; the broad `vi.unstubAllEnvs()` cleanup is gone.
- Containment is **physical**, not lexical: both the owned home and each candidate are canonicalized through the existing `resolveIdentityPathViaExistingAncestorSync` (deepest-existing-ancestor realpath), so a symlinked state root inside the home cannot smuggle a foreign database past the guard, and macOS `/var` → `/private/var` tmpdir homes compare correctly.
- Three lifecycle regressions redirect `HOME`, `OPENCLAW_STATE_DIR`, and a **symlinked** `OPENCLAW_STATE_DIR` (link inside the home → foreign target) outside the worker home and require rejection **before** spawn. The symlink case uses a unique `mkdtemp` target and removes link and target in `finally`; the path-only cases create nothing outside the home.

Production runtime is unchanged: no env/config surface, no schema, no resolver change. Direct upstream check (`codex-rs/exec-server/src/server/process_handler.rs:42`, `local_process.rs:697`): nothing requires host OpenClaw state to reach sandbox children.

## User Impact

None at runtime. Test hygiene: the sandbox exec-server suites can no longer read or depend on an operator's real `~/.openclaw` state, and any future escape fails with a clear message.

## Evidence

- Negative controls: original fixture + guard → 1 failed (the `/gateway-home` escape); guard removed from the final lifecycle suite → the two new regressions fail (promises resolve instead of rejecting) — proving the guard, not schema incompatibility, blocks the escape.
- Final matrix: the two originally failing files, 3× with `OPENCLAW_STATE_DIR` unset and 3× set to an isolated dir — 6/6 runs, 81 tests each. All seven `sandbox-exec-server*.test.ts` suites: 180 passed.
- Synthetic schema probe: the real sanitizer reads a schema-15 DB silently and errors on schema-16 — confirming a schema fence is not an isolation guard.
- Blacksmith Testbox (Linux) run of all seven `sandbox-exec-server*.test.ts` suites via `node scripts/crabbox-wrapper.mjs run` (provider `blacksmith-testbox`, lease `tbx_01m1g7ppfp9r85pbn3edpxfjwv`, https://github.com/openclaw/openclaw/actions/runs/33592821254): 7/7 files passed, command 1m53s. Rerun after the physical-containment fix (lease `tbx_01m1g8stwrs9hwqhdz6jf9f0j1`, https://github.com/openclaw/openclaw/actions/runs/33594090399): 7/7 files passed, command 2m31s. Rerun after the symlink-target cleanup (lease `tbx_01m1ga66j1r6p6yfxzgt7ezf0v`, https://github.com/openclaw/openclaw/actions/runs/33595705392): 7/7 files passed, command 1m57s.
- `pnpm check:changed` passed (SDK surface, typecheck lanes, lint, dead exports, import cycles = 0). Codex-backed autoreview: scoped-clean (0.99).
- LOC: production 0; tests +73/−42; test support +46.
