### PR TITLE
improve: reduce allocations when rendering attributed Markdown

### DIFF
--- a/packages/markdown-core/src/render-attributed.ts
+++ b/packages/markdown-core/src/render-attributed.ts
@@ -35,7 +35,7 @@ export function renderMarkdownWithAttributedRanges<TStyle extends string>(
   if (options.renderLink) {
     rendered = "";
     let cursor = 0;
-    for (const link of [...projected.links].toSorted((a, b) => a.start - b.start)) {
+    for (const link of projected.links.toSorted((a, b) => a.start - b.start)) {
       if (link.start < cursor) {
         continue;
       }
@@ -52,46 +52,43 @@ export function renderMarkdownWithAttributedRanges<TStyle extends string>(
   }
   rendered = options.trimEnd ? rendered.trimEnd() : rendered;
 
-  const spans = projected.styles.flatMap((span) => {
-    const style = options.styleMap[span.style];
-    return style === undefined ? [] : [{ start: span.start, end: span.end, style }];
-  });
-  for (const annotation of projected.annotations ?? []) {
-    const style = options.annotationStyleMap?.[annotation.type];
-    if (style !== undefined) {
-      spans.push({ start: annotation.start, end: annotation.end, style });
+  const ranges: AttributedRange<TStyle>[] = [];
+  const appendRange = (offset: number, end: number, style: TStyle) => {
+    const start = Math.max(0, Math.min(offset, rendered.length));
+    const length = Math.min(end, rendered.length) - start;
+    if (length > 0) {
+      ranges.push({ start, length, style });
     }
-  }
-
-  const ranges = spans
-    .flatMap((span) => {
-      const pieces: typeof spans = [];
-      let cursor = span.start;
-      let shift = 0;
-      for (const insertion of insertions) {
-        if (insertion.pos <= cursor) {
-          shift += insertion.length;
-        } else if (insertion.pos >= span.end) {
-          break;
-        } else {
-          pieces.push({ ...span, start: cursor + shift, end: insertion.pos + shift });
-          cursor = insertion.pos;
-          shift += insertion.length;
-        }
+  };
+  const appendSpan = (span: { start: number; end: number }, style: TStyle | undefined) => {
+    if (style === undefined) {
+      return;
+    }
+    let cursor = span.start;
+    let shift = 0;
+    for (const insertion of insertions) {
+      if (insertion.pos <= cursor) {
+        shift += insertion.length;
+      } else if (insertion.pos >= span.end) {
+        break;
+      } else {
+        appendRange(cursor + shift, insertion.pos + shift, style);
+        cursor = insertion.pos;
+        shift += insertion.length;
       }
-      pieces.push({ ...span, start: cursor + shift, end: span.end + shift });
-      return pieces;
-    })
-    .map((span) => {
-      const start = Math.max(0, Math.min(span.start, rendered.length));
-      return { start, length: Math.min(span.end, rendered.length) - start, style: span.style };
-    })
-    .filter((range) => range.length > 0)
-    .toSorted((a, b) => a.start - b.start || a.length - b.length || a.style.localeCompare(b.style));
+    }
+    appendRange(cursor + shift, span.end + shift, style);
+  };
+  projected.styles.forEach((span) => appendSpan(span, options.styleMap[span.style]));
+  for (const annotation of projected.annotations ?? []) {
+    appendSpan(annotation, options.annotationStyleMap?.[annotation.type]);
+  }
+  ranges.sort((a, b) => a.start - b.start || a.length - b.length || a.style.localeCompare(b.style));
 
-  const merged: AttributedRange<TStyle>[] = [];
+  // Ranges are freshly owned, so compacting adjacent matches cannot mutate the IR.
+  let retained = 0;
   for (const range of ranges) {
-    const previous = merged.at(-1);
+    const previous = ranges[retained - 1];
     if (
       previous &&
       previous.style === range.style &&
@@ -100,8 +97,10 @@ export function renderMarkdownWithAttributedRanges<TStyle extends string>(
       previous.length =
         Math.max(previous.start + previous.length, range.start + range.length) - previous.start;
     } else {
-      merged.push({ ...range });
+      ranges[retained] = range;
+      retained += 1;
     }
   }
-  return { text: rendered, ranges: merged };
+  ranges.length = retained;
+  return { text: rendered, ranges };
 }

--- a/packages/markdown-core/src/render.annotations.test.ts
+++ b/packages/markdown-core/src/render.annotations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { markdownToIR, sliceMarkdownIR } from "./ir.js";
+import { markdownToIR, sliceMarkdownIR, type MarkdownIR } from "./ir.js";
 import { renderMarkdownWithAttributedRanges } from "./render-attributed.js";
 import { renderMarkdownWithMarkers } from "./render.js";
 
@@ -94,6 +94,43 @@ describe("renderMarkdownWithMarkers semantic annotations", () => {
 });
 
 describe("renderMarkdownWithAttributedRanges", () => {
+  it("merges only adjacent mapped styles without mutating the source or sharing results", () => {
+    const ir: MarkdownIR = {
+      text: "abcdef",
+      styles: [
+        { start: 4, end: 6, style: "bold" },
+        { start: 2, end: 4, style: "code" },
+        { start: 1, end: 3, style: "italic" },
+        { start: 0, end: 2, style: "bold" },
+        { start: 0, end: 2, style: "code_block" },
+      ],
+      links: [],
+    };
+    for (const span of ir.styles) {
+      Object.freeze(span);
+    }
+    Object.freeze(ir.styles);
+    Object.freeze(ir.links);
+    const options = {
+      styleMap: { bold: "same", code: "same", code_block: "same", italic: "other" },
+    };
+    const expected = {
+      text: "abcdef",
+      ranges: [
+        { start: 0, length: 2, style: "same" },
+        { start: 1, length: 2, style: "other" },
+        { start: 2, length: 4, style: "same" },
+      ],
+    };
+
+    const result = renderMarkdownWithAttributedRanges(ir, options);
+    expect(result).toEqual(expected);
+    for (const range of result.ranges) {
+      range.length = 99;
+    }
+    expect(renderMarkdownWithAttributedRanges(ir, options)).toEqual(expected);
+  });
+
   it("projects annotations and splits styles around link suffixes", () => {
     const ir = markdownToIR("user[Thu] **[docs](https://example.com) tail**", {
       assistantTranscriptRoleHeaders: true,


### PR DESCRIPTION
## Summary

Attributed Markdown rendering built temporary mapped spans, piece arrays, flattened ranges and two more copies for sorting and merging. The renderer now appends final clamped ranges to one owned array and compacts adjacent matches in place. Link suffixes, annotation ordering, UTF-16 offsets and input ownership keep their existing behavior. The redundant copy before sorting links is also removed.

Production changes are +38/−39 (net −1); the existing annotation test gains 37 lines to protect adjacent-only merging and independent results. Signal, iMessage and Zalo share this owner. Their separate transport and marker-rendering rules stay with their existing owners.

## Validation

- Eight canonical owner/sibling files: 187 tests before, 188 after. The added contract test also passes on original production source. Full changed-file gate passes; independent source review and Codex autoreview found no accepted findings.
- Actual-source comparison: 14 explicit contracts, 128 seeded UTF-16 coverage cases, 50 messages through the Signal/iMessage/Zalo formatters and 10 Signal chunking cases agree across three fresh processes per arm. A final exact-source replay preserves every output and counter assertion after a local-variable lint correction.
- Canonical local QA suite: one scenario, two passing turns through an ephemeral Gateway, the real Signal plugin, local mock OpenAI HTTP provider and Crabline Signal server. The recorder contains exactly three accepted sends of 85, 4,000 and 1,801 UTF-16 units. Text and every style interval match independent goldens, including overlapping styles and a style split across chunks.
- Exit-flushed coverage from the actual Gateway records three executions of the changed renderer. Raw RPC events, Gateway logs, compiled module hash and cleanup were independently rechecked. The suite exited successfully, all observed ports closed and its runtime/plugin staging directories were removed.

## Resource evidence and limits

For eight calls on a parsed 256-span message, observed intermediate/returned array identities fall from 4,144 to 8 and object identities from 8,200 to 2,056. The complete Signal formatter falls from 4,352 to 216 observed arrays. Instrumentation runs separately from timing and counts language-level identities, not all V8 allocations or bytes.

The direct renderer's 128-call median was 7.088→4.485 ms in three fresh processes per arm. The full Signal formatter was essentially unchanged (28.908→28.957 ms per 32 calls), and heap observations were mixed. This PR claims reduced temporary construction, not lower Gateway RSS or a general channel-latency improvement. The QA provider and channel API were local fixtures; no external Signal delivery is claimed.

No configuration, schema, persisted format or protocol changes. Release-note context is contained here; no changelog update is needed outside a release.
