### PR TITLE
fix(ui): restore compact output token counts

### DIFF
--- a/ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
@@ -321,7 +321,7 @@ suite.define(() => {
             .poll(async () =>
               (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
             )
-            .toBe("2,400 output tokens");
+            .toBe("2.4k output tokens");
           await expect.poll(() => page.locator(".chat-bubble.streaming").count()).toBe(0);
           expect(
             (await page.locator(".chat-group.assistant .chat-text").allTextContents()).map(

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -635,7 +635,7 @@ suite.define(() => {
         .poll(async () =>
           (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
         )
-        .toBe("2,400 output tokens");
+        .toBe("2.4k output tokens");
 
       const response = "The streamed response is now visible.";
       await gateway.emitGatewayEvent("chat", {
@@ -656,7 +656,7 @@ suite.define(() => {
         (row, visibleResponse) => ({
           connected: row.isConnected,
           hasResponse: row.textContent?.includes(visibleResponse) ?? false,
-          hasTokens: row.textContent?.includes("2,400 output tokens") ?? false,
+          hasTokens: row.textContent?.includes("2.4k output tokens") ?? false,
           key: row.getAttribute("data-virtual-row-key"),
         }),
         response,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1819,19 +1819,19 @@ describe("grouped chat rendering", () => {
       render(renderTurnRecapRow({ runtimeMs, outputTokens: null }), container);
       expect(container.querySelector(".chat-turn-recap")?.textContent?.trim()).toBe(expected);
     }
-
-    const withTokens = document.createElement("div");
-    render(renderTurnRecapRow({ runtimeMs: 30_000, outputTokens: 2_400 }), withTokens);
-    expect(
-      withTokens.querySelector(".chat-turn-recap")?.textContent?.replace(/\s+/g, " ").trim(),
-    ).toBe("Done in 30 seconds · 2,400 output tokens");
   });
 
   it.each([
     [0, "0 output tokens"],
     [1, "1 output token"],
-    [5_500, "5,500 output tokens"],
-  ])("shows %i output tokens beside elapsed time", (outputTokens, label) => {
+    [999, "999 output tokens"],
+    [1_000, "1k output tokens"],
+    [5_500, "5.5k output tokens"],
+    [7_094, "7.1k output tokens"],
+    [999_950, "1M output tokens"],
+    [1_500_000, "1.5M output tokens"],
+    [4_132_000_000, "4.1B output tokens"],
+  ])("shows compact %i output tokens during and after a run", (outputTokens, label) => {
     const container = document.createElement("div");
 
     render(
@@ -1847,6 +1847,11 @@ describe("grouped chat rendering", () => {
     );
     // Known usage replaces the pre-usage working phrase.
     expect(container.querySelector("openclaw-working-phrase")).toBeNull();
+
+    render(renderTurnRecapRow({ runtimeMs: 30_000, outputTokens }), container);
+    expect(
+      container.querySelector(".chat-turn-recap")?.textContent?.replace(/\s+/g, " ").trim(),
+    ).toBe(`Done in 30 seconds · ${label}`);
   });
 
   it("relabels the working indicator while the run waits for approval", () => {
@@ -1866,7 +1871,7 @@ describe("grouped chat rendering", () => {
     );
     expect(container.querySelector(".chat-working-indicator__elapsed")).toBeNull();
     expect(container.querySelector(".chat-working-indicator__tokens")?.textContent).toBe(
-      "5,500 output tokens",
+      "5.5k output tokens",
     );
   });
 

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -88,7 +88,7 @@ describe("chat transcript rendering", () => {
     handleAgentEvent(host, agentEvent(runId, 1, "usage", { outputTokens: 6_900 }, sessionKey));
     rerender();
     expect(requireElement(container, ".chat-working-indicator__tokens").textContent).toBe(
-      "6,900 output tokens",
+      "6.9k output tokens",
     );
     // Final usage and lifecycle can share one browser render; neither may discard the count.
     handleAgentEvent(host, agentEvent(runId, 2, "usage", { outputTokens: 6_950 }, sessionKey));
@@ -102,13 +102,11 @@ describe("chat transcript rendering", () => {
       runtimeMs: 14_000,
     };
     rerender();
-    expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
-      "6,950 output tokens",
-    );
-    handleAgentEvent(host, agentEvent(runId, 4, "usage", { outputTokens: 6_951 }, sessionKey));
+    expect(requireElement(container, ".chat-turn-recap").textContent).toContain("7k output tokens");
+    handleAgentEvent(host, agentEvent(runId, 4, "usage", { outputTokens: 7_094 }, sessionKey));
     rerender();
     expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
-      "6,951 output tokens",
+      "7.1k output tokens",
     );
     handleAgentEvent(
       host,
@@ -116,7 +114,7 @@ describe("chat transcript rendering", () => {
     );
     rerender();
     expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
-      "6,951 output tokens",
+      "7.1k output tokens",
     );
     for (const replaceOwner of [
       () => {
@@ -137,7 +135,7 @@ describe("chat transcript rendering", () => {
       props.runWorking = false;
       rerender();
       expect(requireElement(container, ".chat-turn-recap").textContent).toContain(
-        "6,951 output tokens",
+        "7.1k output tokens",
       );
     }
     props.messages = [

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -4,6 +4,7 @@ import "../../../components/working-phrase.ts";
 import { icons } from "../../../components/icons.ts";
 import { i18n, t } from "../../../i18n/index.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
+import { formatCompactTokenCount } from "../../../lib/format.ts";
 import type { TurnRecap } from "../chat-progress.ts";
 import { selectWorkingClawSurprise } from "./chat-working-indicator-surprise.ts";
 
@@ -38,12 +39,11 @@ function formatTurnRecapDuration(ms: number): string {
   return new Intl.ListFormat(locale, { style: "long", type: "unit" }).format(parts);
 }
 
-// Keep counts exact so small response updates remain visible above 1,000 tokens.
 // 0 is valid; only null/undefined means "unknown".
 function outputTokensLabel(outputTokens: number): string {
   return outputTokens === 1
     ? t("chat.turnRecap.tokensOne")
-    : t("chat.turnRecap.tokens", { count: outputTokens.toLocaleString(i18n.getLocale()) });
+    : t("chat.turnRecap.tokens", { count: formatCompactTokenCount(outputTokens) });
 }
 
 export function renderChatWorkingIndicator(


### PR DESCRIPTION
Related: #133605 — cumulative and recoverable run output token counts.

## What Problem This Solves

Resolves a problem where the Control UI's live output-token indicator and completed-turn recap expand large totals into long exact counts instead of the compact notation used elsewhere. This is the maintainer-requested reversal of the display-only portion of #133605, not a rollback of its accounting fixes.

## Why This Change Was Made

The shared `outputTokensLabel` now reuses `formatCompactTokenCount` for both live indicators and completed recaps. This removes the exact-count display policy without touching cumulative totals, persisted usage, recovery, lifecycle handling, duration formatting, or translations. A full commit revert would undo unrelated correctness fixes; a new formatter would duplicate existing policy.

## User Impact

Counts display as `7.1k`, `1.5M`, and `4.1B`; zero, singular one-token wording, and smaller totals remain readable. Rounding occurs only at display time. Small increases inside one rounding bucket intentionally retain the same label.

## Evidence

- Before the production change, the compact-label regression failed in six large-count cases; zero, one, and 999 passed. After the change, all nine cases pass for live indicators and completed recaps.
- Focused unit/boundary proof: **336 tests across five files passed**, including shared formatter boundaries, live/approval labels, recap persistence, exact-run isolation, late usage correction, and chat progress.
- Bundled browser E2E: **20 tests across two files passed**, with a successful production UI build. Covers streaming and reconciliation, including cumulative usage across tool calls.
- Real Chromium before/after screenshots: isolated loopback Control UI with the repository's mocked Gateway. Submitted through the composer and emitted raw usage at 7,094, 1,500,000, and 4,132,000,000; verified live labels and the completed recap, then inspected every capture. This is browser rendering proof, not an authenticated model-provider run. No operator Gateway was restarted.
- Fresh Codex autoreview: scoped-clean, no accepted/actionable findings.
- Changed checks passed: formatting, guards, UI i18n, core-test and UI typechecks, unused-export scans, and lint.
- Production LOC: **+2/-2, net 0**. Tests: **+23/-20, net +3**.

Commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts -t 'shows compact'
node scripts/run-vitest.mjs ui/src/lib/format.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-working-indicator.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/pages/chat/chat-progress.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.streaming.e2e.test.ts ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
.agents/skills/autoreview/scripts/autoreview --mode uncommitted
node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-working-indicator.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/e2e/chat-flow.streaming.e2e.test.ts ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
```

### Before: exact count

![Before: 7,094 output tokens](https://github.com/user-attachments/assets/98b08acc-8087-49b0-8bac-3a33b5437a7a)

### After: compact count

![After: 7.1k output tokens](https://github.com/user-attachments/assets/42f00904-e57f-44c5-9d7b-bc8ad28d668c)

### Completed recap

![Completed recap: 4.1B output tokens](https://github.com/user-attachments/assets/2d27eb62-1d94-482e-919f-cec80067e2f9)
