### PR TITLE
test(ui): advance disclosure scroll reconciliation with browser clock

### DIFF
--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -146,6 +146,7 @@ suite.define(() => {
           recordVideo: { dir: artifactDir },
         },
         async ({ page }) => {
+          await page.clock.install();
           const gateway = await installMockGateway(page, {
             heldMethods: ["chat.message.get"],
             historyMessages: Array.from({ length: 60 }, (_, index) => ({
@@ -413,10 +414,8 @@ suite.define(() => {
           await waitForChatScrollIdle(page);
           // Outlast virtual-core's five-second scroll reconciliation deadline:
           // the assertion protects durable geometry, not a transient resize frame.
-          const final = await bubble.evaluate(async (element, nextId) => {
-            await new Promise<void>((resolve) => {
-              setTimeout(resolve, 5_500);
-            });
+          await page.clock.runFor(5_500);
+          const final = await bubble.evaluate((element, nextId) => {
             const row = element.closest<HTMLElement>(".chat-virtual-row")!;
             const scroller = row.closest<HTMLElement>(".chat-thread")!;
             const next = scroller


### PR DESCRIPTION
## What problem does this PR solve?

Four transcript geometry E2E cases each wait 5.5 seconds of wall time after interrupted scrolling. That delay protects against a late virtualizer reconciliation, but it accounts for about half this file's test execution.

## Why is this the best solution?

Install Playwright's clock before application scripts run, let the existing native scrolling and idle checks execute normally, then advance the same 5.5-second reconciliation window with `page.clock.runFor`. Unlike `fastForward`, `runFor` executes the scheduled timer and animation-frame callbacks throughout that interval.

The clock belongs to each of these four isolated page contexts. All eight cases, native pointer trust/hit-testing, reader anchoring, one-pixel adjacency, recovered row heights, remount checks, videos and screenshots remain in place. The other four cases are unchanged.

## User impact

Test infrastructure only. No production changes or reduced deadlines.

## Evidence

A clean Linux Blacksmith Testbox using Node 24.19.0 and the repository's Playwright version:

| Measurement | Before | After |
| --- | ---: | ---: |
| Cases | 8 passed | 8 passed |
| Test execution | 43.18s | 21.14s |
| Vitest duration | 49.19s | 27.06s |

Same test environment and tracked source, with only this test edit between runs. The full baseline was taken after installing Playwright's matching FFmpeg binary required by existing video recording.

A private production fault removed the virtualizer's instant target replacement on scroll cancellation. Both original and revised tests failed the synthetic-pointer and native-pointer scenarios, while both wheel cases passed. The fault was removed after the probe; it is not part of this PR.

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
node scripts/check-changed.mjs --base 228ccdf6fd08a1e3e5c6612bd2ff9bd22c8c4eea -- ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
```

The changed-file gate passed on a clean Testbox with the actual PR base pinned. Local validation was blocked by a missing package-local Mermaid dependency; no dependency files were changed. Codex review found no accepted actionable findings. Production LOC: +0/-0; tests: +3/-4.
