### PR TITLE
improve: avoid full plugin scans for known contribution owners

### DIFF
--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -188,6 +188,18 @@ function resolveContributionPluginIds(params: {
     .map((plugin) => plugin.pluginId);
 }
 
+function createContributionPluginFilter(
+  params: PluginRegistryContributionOptions,
+  index: PluginRegistrySnapshot,
+): (pluginId: string) => boolean {
+  if (params.includeDisabled) {
+    // Keep disabled-owner inspection within the supplied installed inventory.
+    const installedPluginIds = new Set(index.plugins.map((plugin) => plugin.pluginId));
+    return (pluginId) => installedPluginIds.has(pluginId);
+  }
+  return (pluginId) => isInstalledPluginEnabled(index, pluginId, params.config, params.env);
+}
+
 function loadContributionManifestRegistry(
   params: LoadPluginRegistryParams & {
     index: PluginRegistrySnapshot;
@@ -216,15 +228,8 @@ function listContributionManifestPlugins(
 ): readonly PluginManifestRecord[] {
   const plugins = params.lookUpTable?.plugins;
   if (plugins) {
-    const enabledPluginIds = new Set(
-      resolveContributionPluginIds({
-        index: params.index,
-        includeDisabled: params.includeDisabled,
-        config: params.config,
-        env: params.env,
-      }),
-    );
-    return plugins.filter((plugin) => enabledPluginIds.has(plugin.id));
+    const includePlugin = createContributionPluginFilter(params, params.index);
+    return plugins.filter((plugin) => includePlugin(plugin.id));
   }
   return loadContributionManifestRegistry({
     ...params,
@@ -280,16 +285,8 @@ export function resolvePluginContributionOwners(
     if (!owners) {
       return [];
     }
-    const enabledPluginIds = new Set(
-      resolveContributionPluginIds({
-        index,
-        includeDisabled: params.includeDisabled,
-        config: params.config,
-        env: params.env,
-      }),
-    );
     return normalizeSortedUniqueStringEntries(
-      owners.filter((owner) => enabledPluginIds.has(owner)),
+      owners.filter(createContributionPluginFilter(params, index)),
     );
   }
   const matcher =

--- a/src/plugins/plugin-registry.test.ts
+++ b/src/plugins/plugin-registry.test.ts
@@ -404,6 +404,16 @@ describe("plugin registry facade", () => {
         ]);
       }
     }
+
+    const withoutInstalledOwners = {
+      lookUpTable: { ...lookUpTable, index: { ...index, plugins: [] } },
+      contribution: "modelCatalogProviders" as const,
+      includeDisabled: true,
+    };
+    expect(listPluginContributionIds(withoutInstalledOwners)).toEqual([]);
+    for (const matches of ["demo-alias", (id: string) => id === "demo-alias"]) {
+      expect(resolvePluginContributionOwners({ ...withoutInstalledOwners, matches })).toEqual([]);
+    }
   });
 
   it("normalizes plugin config ids through registry contribution aliases", () => {


### PR DESCRIPTION
## Summary

Exact plugin contribution lookups already know their candidate owners, but they recomputed enablement for the entire installed inventory before filtering those candidates. Model catalog coverage repeated that work for every provider. Both lookup-backed selectors now ask the canonical enablement owner only about the selected plugins.

A query-scoped predicate preserves current config, platform defaults and caller-specific compatibility state without adding a cache. Disabled-owner inspection still uses a bulk installed-ID Set: disabling activation filtering must not admit manifests absent from the installed inventory or turn broad inspection into repeated linear membership scans. The cold full-inventory path remains canonical.

Production is +15/−18 (net −3). The existing lookup test gains ten lines covering a manifest-only owner with `includeDisabled` across exact, predicate and list queries. No configuration, storage, protocol or plugin API changes.

## Validation

The four affected/sibling test files pass all 35 tests before and after. The expanded membership assertion also passes on the original implementation. The complete changed-file gate passes, with independent owner/caller review and Codex autoreview finding no accepted issues.

An actual-source probe restores the real 151-plugin metadata fixture and calls contribution selectors plus the model catalog coverage and row loaders. Before/after outputs match exactly: 524,351 bytes, SHA-256 `ddc9ea478434cce1f0e85066427d7807fbca9f39c1f8514ae794fd5fb4a14030`. Coverage includes all eight contribution families, five activation policies, exact/predicate matching, full and one-plugin projections, all 50 catalog provider keys, duplicate owners, output independence, same-object policy changes and two independent caller compatibility roots. No manifest rereads occur.

## Resource evidence

Three actual catalog coverage calls reduce installed-record lookups from 22,896 to 396 and record comparisons from 1,738,758 to 24,990. The normal-query path removes 150 temporary full-inventory Sets. For one catalog coverage pass, it also removes 100 intermediate arrays containing 8,400 logical reference slots.

These are instrumented language-level operations, not measured retained heap or RSS. One descriptive timing process per arm measured a 32-call median of 27.300→0.437 ms, but host load differed; it is not a controlled whole-command speed claim. The probe exercises the real catalog/contribution owners and local state with synthetic policy cases, not a provider request or channel delivery. All owned probe processes and private state roots were cleaned up.
