### PR TITLE
fix(agents): show commentary progress before final reply validation

### DIFF
--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -2,6 +2,7 @@
 // release deferred assistant events and block replies at run completion.
 import { describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
+import type { AssistantMessage } from "../llm/types.js";
 import {
   emitAssistantTextDeltaAndEnd,
   createSubscribedSessionHarness,
@@ -25,6 +26,73 @@ function hasLifecycleEndEvent(calls: Array<unknown[]>): boolean {
 }
 
 describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
+  it("streams commentary before tools while retaining the revisable final reply gate", async () => {
+    const onAgentEvent = vi.fn();
+    const onBeforeTerminalDelivery = vi.fn(async () => ({
+      suppressTerminalDelivery: true as const,
+    }));
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run-before-terminal-commentary",
+      onAgentEvent,
+      onBeforeTerminalDelivery,
+      blockReplyBreak: "message_end",
+    });
+    const commentaryMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Checking current state.",
+          textSignature: JSON.stringify({ v: 1, id: "progress", phase: "commentary" }),
+        },
+      ],
+      stopReason: "toolUse",
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: commentaryMessage });
+    emit({ type: "message_end", message: commentaryMessage });
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "item",
+      data: expect.objectContaining({
+        kind: "preamble",
+        progressText: "Checking current state.",
+      }),
+    });
+    emit({
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-after-commentary",
+      args: {},
+    });
+    const preambleCallIndex = onAgentEvent.mock.calls.findIndex(
+      ([event]) => event.stream === "item" && event.data?.kind === "preamble",
+    );
+    const toolCallIndex = onAgentEvent.mock.calls.findIndex(
+      ([event]) => event.stream === "item" && event.data?.kind === "tool",
+    );
+    expect(preambleCallIndex).toBeGreaterThanOrEqual(0);
+    expect(toolCallIndex).toBeGreaterThan(preambleCallIndex);
+
+    emitAssistantTextDeltaAndEnd({ emit, text: "Visible final answer." });
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+
+    emit({
+      type: "agent_end",
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Visible final answer." }],
+          stopReason: "stop",
+        },
+      ],
+      willRetry: false,
+    });
+
+    await subscription.waitForPendingEvents();
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+  });
+
   it("suppresses deferred block replies when the terminal gate requests a revision", async () => {
     const onBlockReply = vi.fn();
     const onAgentEvent = vi.fn();

--- a/src/agents/embedded-agent-subscribe.reply-delivery.ts
+++ b/src/agents/embedded-agent-subscribe.reply-delivery.ts
@@ -155,7 +155,7 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
     if (!eventData && !delivery.emitPartialReply) {
       return;
     }
-    if (state.deferBlockReplyDelivery) {
+    if (state.deferBlockReplyDelivery && data.phase !== "commentary") {
       state.deferredAssistantEvents.push(delivery);
       return;
     }


### PR DESCRIPTION
Closes #135949

## What Problem This Solves

Fixes an issue where users would see a tool start without its commentary status, then receive that progress text only after the whole turn completed, whenever a plugin registered `before_agent_finalize`.

This was especially confusing for long-running tools: the Control UI showed that work was happening but withheld the model's explicit progress narration until it was no longer useful.

## Why This Change Was Made

`before_agent_finalize` validates or revises the natural final assistant answer. Explicit `commentary` is durable progress that belongs before the following tool, so it now bypasses terminal deferral. Final answers, unphased assistant output, partial replies, and block replies remain behind the existing gate.

The change is intentionally narrower than provisional final-answer streaming discussed in #102182. It does not alter Canvas projection or attempt to stream revisable final drafts.

## User Impact

Users can see phase-classified progress narration while tools are still running, even when a plugin uses `before_agent_finalize`. The plugin retains the same ability to suppress or revise the final answer before delivery.

Original report, repair and interactive capture by @JosephNatsu.

## Evidence

- An independent isolated-HOME run on trusted main drove the real subscriber, phase classifier, reply delivery and terminal lifecycle. Commentary was absent before tools when the finalizer was pending, delayed until acceptance, and lost on suppression. The no-hook control emitted it immediately; final, partial and block output stayed gated.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33593791155/job/100133196319) passes the new preamble-before-tool regression and all seven terminal-gate controls. Both tested changed-file blobs exactly match `c52ca04a58effd29d406d2c53fc6c0eca530a891`. The subscriber group passed 787 tests in 30 files; the preceding reply-dispatch group passed 1,110 in 45. All current-head hosted gates are green.
- Independent Codex review found no blocking issue. Production is **+1/-1 (net 0)**; tests **+68/-0**. No further production path or configuration is added.
- The [Codex phase contract](https://github.com/openai/codex/blob/0b509e930e191a463746799f4b2a05c0e1bbd15f/codex-rs/protocol/src/models.rs#L907) was inspected directly: commentary is mid-turn progress; absent phase remains unknown. This condition leaves unknown/final output deferred.

Earlier interactive captures supplied by the contributor illustrate the visible difference:

| Before: tool active, commentary absent | After: commentary visible during the tool |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/JosephNatsu/openclaw/14feb73c5df90c88b4c5380c398a3d984ebf7499/.github/evidence/commentary-terminal-gate/before-commentary-missing.png) | ![After](https://raw.githubusercontent.com/JosephNatsu/openclaw/14feb73c5df90c88b4c5380c398a3d984ebf7499/.github/evidence/commentary-terminal-gate/after-commentary-visible.png) |

The images are stored at [capture commit14feb](https://github.com/JosephNatsu/openclaw/tree/14feb73c5df90c88b4c5380c398a3d984ebf7499/.github/evidence/commentary-terminal-gate). That commit diverges from this PR and contains the unfixed owner; its notes describe applying the one-line change locally for the after capture. These are historical illustrations, not proof of an exact-current-head UI run. Current-head proof is the source-bound subscriber regression and hosted CI above. Both images were visually inspected and contain only the synthetic test session.

The previous review's CI and capture-provenance questions are addressed above. Final-answer validation remains unchanged.
