### PR TITLE
refactor(i18n): share string array comparison

### DIFF
--- a/scripts/control-ui-i18n-verify.ts
+++ b/scripts/control-ui-i18n-verify.ts
@@ -12,6 +12,7 @@ import {
 } from "./lib/control-ui-i18n-catalog.ts";
 import { CONTROL_UI_LOCALE_ENTRIES } from "./lib/control-ui-i18n-config.ts";
 import { syncControlUiRawCopyBaseline } from "./lib/control-ui-i18n-raw-copy.ts";
+import { compareStringArrays } from "./lib/control-ui-i18n-sync-plan.ts";
 import { collectSourceFileContents } from "./lib/source-file-scan-cache.mts";
 
 export type CatalogFallbackBaseline = {
@@ -29,9 +30,6 @@ const AUTOMATIONS_FEATURE_KEYS =
   `sessionsView.showCronSessions sessionsView.subagentPrefix sessionsView.automationPrefix agents.cronPanel.schedulerSubtitle agents.cronPanel.agentJobsTitle configForm.sections.cron.label configView.sections.cron subtitles.tasks subtitles.automation memoryPage.dreaming.intro tasksPage.runtime.cron attention.cronFailed attention.cronOverdue palette.items.scheduled`.split(
     " ",
   );
-function compareStringArrays(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((value, index) => value === right[index]);
-}
 
 function toRepoPath(filePath: string): string {
   return path.relative(ROOT, filePath).split(path.sep).join("/");

--- a/scripts/lib/control-ui-i18n-sync-plan.ts
+++ b/scripts/lib/control-ui-i18n-sync-plan.ts
@@ -256,7 +256,7 @@ export function createControlUiLocaleSyncPlan(input: {
   };
 }
 
-export function compareStringArrays(left: string[], right: string[]): boolean {
+export function compareStringArrays(left: readonly string[], right: readonly string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Control UI i18n verification duplicated the ordered string-array comparison already owned by the locale sync planner. The copies had identical runtime behavior but different TypeScript mutability signatures, creating an unnecessary drift point in one tooling flow.

## Why This Change Was Made

- Reuses `compareStringArrays` from `scripts/lib/control-ui-i18n-sync-plan.ts`.
- Widens both helper parameters to `readonly string[]`, matching all existing callers without changing runtime semantics.
- Removes the verifier-local duplicate.
- Preserves `AUTOMATIONS_FEATURE_KEYS` added by https://github.com/openclaw/openclaw/pull/136138 while resolving that landed overlap.

The planner helper was introduced on July 12, 2026; the identical verifier copy followed on July 14, 2026.

## Scope And Identity

- Base commit: `abb565ea5f9feacd89a571247adb96a799a0e3ce`
- Base tree: `f54d2897e4a89e5c8f7c591059133c6ecb7027b4`
- Signed head: `5334c42403ad23dc74d9805b16e92cb891f54fb8`
- Candidate tree: `2ee8dc2fe418ccf9043ce1f581d897b89bfc40a0`
- Patch SHA-256: `2976fc7fb76616a45a4ebdf8bf40655aaebce4edde01aa19fb3cefeef96051ca`
- Scope SHA-256: `87ebfa072dded3391c3ffc269fc089f0e294e66da5f3f62459e427504b430351`

Exactly two tooling files:

- `scripts/control-ui-i18n-verify.ts`: `+1/-3`
- `scripts/lib/control-ui-i18n-sync-plan.ts`: `+1/-1`

Production LOC: `0`.
Tooling LOC: `+2/-4` (net `-2`).
Test LOC: `0`.

## Sequencing And Overlap

- https://github.com/openclaw/openclaw/pull/136138 landed first; this branch was rebased onto its squash commit and preserves its automations terminology guard.
- https://github.com/openclaw/openclaw/pull/135370 should land after this PR. Its overlap is limited to `scripts/control-ui-i18n-verify.ts` and adds Windows direct-entry URL handling.
- https://github.com/openclaw/openclaw/pull/62063 and https://github.com/openclaw/openclaw/pull/131067 also currently touch `scripts/control-ui-i18n-verify.ts`; neither changes this shared comparison helper.

Latest-main revalidation on September 2, 2026 confirmed both target blobs still equal the pinned base blobs before publication.

## Evidence

Isolated signed-candidate proof used a temporary standalone normal clone with its own dependency installation. The clone checked out the exact signed head, verified the fixed commit/tree/patch/scope/blob identities before and after testing, remained clean, and was deleted afterward.

- `pnpm install --frozen-lockfile --prefer-offline` passed.
- Both focused Control UI i18n suites passed: 29 tests total (`8 + 21`).
- `pnpm ui:i18n:verify` passed.
- Side-effect-free verifier import probe passed.
- `pnpm check:script-erasability` passed across 567 TypeScript implementation files.
- `pnpm tsgo:scripts` passed.
- `pnpm lint:scripts` passed.
- Changed-file dry-run and actual gates passed.
- Both import-cycle checks reported zero cycles.
- `git diff --check` passed.
- Sol-high autoreview reported no actionable findings at `0.99`.
- Independent frozen-head review reported no actionable findings and concluded `APPROVE-CORRECTED-SCOPE`.

No Testbox result is claimed as exact-head or candidate proof. Earlier Testbox attempts did not reach a valid candidate test result; the isolated standalone clone is the clean-environment proof used here.

## User Impact

No user-visible behavior change. Array length, ordering, and strict element equality semantics remain unchanged. No new test or changelog entry is needed for this private, behavior-preserving consolidation.

## Codex Contract Gate

Directly inspected:

- `../codex/codex-rs/cli/src/main.rs:220-245`
- `../codex/codex-rs/cli/src/main.rs:2840-2870`

Those CLI command and completion paths are unrelated to this scripts-only refactor.
