### PR TITLE
fix(android): keep reconnected messages from getting stuck sending

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -5770,7 +5770,7 @@ class ChatController internal constructor(
     return key.removeSuffix(":user").takeIf { it.isNotEmpty() }
   }
 
-  // Sent: acked and removed. Continue: row vanished or failed after a gateway response.
+  // Sent: acknowledged. Continue: row vanished or failed after a gateway response.
   // Stop: transport or persistence state cannot safely advance to younger work.
   private enum class OutboxSendOutcome { Sent, Continue, Stop }
 
@@ -5830,14 +5830,14 @@ class ChatController internal constructor(
 
   private suspend fun sendOutboxItem(
     outbox: ChatCommandOutbox,
-    item: ChatOutboxItem,
+    queuedItem: ChatOutboxItem,
     flushScope: ChatCacheScope,
   ): OutboxSendOutcome {
-    val ownerAgentId = item.ownerAgentId ?: resolveAgentIdFromMainSessionKey(item.sessionKey)
+    val ownerAgentId = queuedItem.ownerAgentId ?: resolveAgentIdFromMainSessionKey(queuedItem.sessionKey)
     if (ownerAgentId == null) {
       // Pre-v5 unscoped rows have no durable owner. They must stay visible for manual resend;
       // dispatching now would bind them to whichever default agent happens to be current.
-      val parked = updateOutboxStatusOrNull(outbox, item, ChatOutboxStatus.Failed, OUTBOX_OWNER_CHANGED_ERROR)
+      val parked = updateOutboxStatusOrNull(outbox, queuedItem, ChatOutboxStatus.Failed, OUTBOX_OWNER_CHANGED_ERROR)
       if (parked == null) {
         rearmOutboxRecovery()
         _healthOk.value = false
@@ -5851,16 +5851,16 @@ class ChatController internal constructor(
     // the row's owner because the visible chat may switch while this queued turn is waiting.
     val settingsKey =
       sessionSettingsKey(
-        sessionKey = normalizeRequestedSessionKey(item.sessionKey),
+        sessionKey = normalizeRequestedSessionKey(queuedItem.sessionKey),
         gatewayScope = flushScope,
         ownerAgentId = ownerAgentId,
       )
     if (!waitForPendingSessionSettings(settingsKey)) {
       return OutboxSendOutcome.Stop
     }
-    // Atomically claim the row before sending: null means the claim could not be made durable,
-    // and 0 means the row vanished or a direct dispatch claimed it first; neither may dispatch.
-    val claimed = claimOutboxRowOrNull(outbox, item)
+    // Claiming changes Queued to Sending without changing the attempt. Carry both forward so
+    // completion's attempt/status check still rejects a later delete, retry, or branch change.
+    val claimed = claimOutboxRowOrNull(outbox, queuedItem)
     publishOutbox()
     if (claimed == null) {
       // Never bypass an older row when its claim could not be made durable.
@@ -5868,6 +5868,7 @@ class ChatController internal constructor(
       return OutboxSendOutcome.Stop
     }
     if (claimed == 0) return OutboxSendOutcome.Continue
+    val item = queuedItem.copy(status = ChatOutboxStatus.Sending)
     // Bytes are loaded once per item; a storage failure here parks the row instead of sending
     // a message without the attachments the user staged with it.
     val attachments =

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.chat
 import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
 import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.ui.chat.outboxItemsForSession
 import androidx.room3.Room
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -216,14 +217,7 @@ class ChatControllerBranchCoordinationTest {
       assertTrue(controller.messages.value.isEmpty())
 
       releaseRetryHistory.complete(Unit)
-      withContext(Dispatchers.Default.limitedParallelism(1)) {
-        withTimeout(5_000) {
-          while (gateway.callCount("chat.send") == 0) {
-            runCurrent()
-            kotlinx.coroutines.delay(10)
-          }
-        }
-      }
+      awaitBranchProgress { gateway.callCount("chat.send") > 0 }
 
       assertFalse(outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation == true)
       assertEquals(1, gateway.callCount("chat.send"))
@@ -312,13 +306,8 @@ class ChatControllerBranchCoordinationTest {
       assertTrue(controller.healthOk.value)
 
       assertTrue(controller.sendMessageAwaitAcceptance("dispatch without branches", "off", emptyList()))
-      withContext(Dispatchers.Default.limitedParallelism(1)) {
-        withTimeout(5_000) {
-          while (gateway.callCount("chat.send") == 0 && gateway.callCount("sessions.branches.list") == 0) {
-            runCurrent()
-            kotlinx.coroutines.delay(10)
-          }
-        }
+      awaitBranchProgress {
+        gateway.callCount("chat.send") > 0 || gateway.callCount("sessions.branches.list") > 0
       }
 
       assertEquals(0, gateway.callCount("sessions.branches.list"))
@@ -882,11 +871,11 @@ class ChatControllerBranchCoordinationTest {
 
   private enum class ReplacementGate { None, History, Branches, StaleBranches, ReconnectHealth }
 
-  private suspend fun TestScope.awaitBranchProgress(condition: suspend () -> Boolean) {
+  private suspend fun awaitBranchProgress(condition: suspend () -> Boolean) {
+    // runTest drives the scheduler; pumping it here would run controller callbacks concurrently.
     withContext(Dispatchers.Default.limitedParallelism(1)) {
       withTimeout(5_000) {
         while (true) {
-          runCurrent()
           if (condition()) return@withTimeout
           kotlinx.coroutines.delay(10)
         }
@@ -1062,14 +1051,22 @@ class ChatControllerBranchCoordinationTest {
     controller.onDisconnected("Reconnecting")
     healthy.set(true)
     controller.onGatewayConnected()
+    // Matching history can retire a hidden intermediate row; wait for visible failure or completed retirement.
     awaitBranchProgress {
+      val published = controller.outboxItems.value
+      val visible =
+        outboxItemsForSession(
+          items = published,
+          sessionKey = key,
+          mainSessionKey = "main",
+          ownerAgentId = branchScope.ownerAgentId,
+          messages = controller.messages.value,
+        )
       controller.healthOk.value &&
         !controller.historyLoading.value &&
         (
-          controller.outboxItems.value.isEmpty() ||
-            controller.outboxItems.value
-              .singleOrNull()
-              ?.status == ChatOutboxStatus.Failed
+          (published.isEmpty() && outbox.load("gateway-a").isEmpty()) ||
+            visible.singleOrNull()?.status == ChatOutboxStatus.Failed
         )
     }
     val retained = controller.outboxItems.value.singleOrNull()
@@ -1117,6 +1114,72 @@ class ChatControllerBranchCoordinationTest {
     awaitBranchProgress { controller.healthOk.value && !controller.historyLoading.value && !controller.sessionBranchesLoading.value }
     assertEquals("A second reconnect must not redispatch the confirmed input", 1, gateway.callCount("chat.send"))
   }
+
+  @Test
+  fun reconnectAckPublishesAcceptedUntilHistoryConfirmsDelivery() =
+    runTest {
+      val key = "agent:main:ack-proof"
+      val gateway = ScriptedGateway(json)
+      val initialLoadFinished = CompletableDeferred<Unit>()
+      val sendId = AtomicReference<String?>(null)
+      val confirmationRequested = CompletableDeferred<Unit>()
+      val releaseConfirmation = CompletableDeferred<Unit>()
+      gateway.respond("sessions.list") {
+        initialLoadFinished.complete(Unit)
+        """{"sessions":[]}"""
+      }
+      gateway.respond("chat.history") {
+        val id = sendId.get()
+        if (id != null) {
+          confirmationRequested.complete(Unit)
+          releaseConfirmation.await()
+        }
+        historyResponse(
+          sessionId = "ack-proof",
+          messages =
+            listOf(ReplayHistoryMessage("assistant", "before", 1, entryId = "entry-before")) +
+              if (id == null) {
+                emptyList()
+              } else {
+                listOf(ReplayHistoryMessage("user", "queued", 2, idempotencyKey = "$id:user", entryId = "entry-input"))
+              },
+        )
+      }
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"entry-before","headline":"Current","messageCount":1,"active":true}]}""",
+      )
+      gateway.respond("chat.send") { paramsJson ->
+        val id =
+          json
+            .parseToJsonElement(requireNotNull(paramsJson))
+            .jsonObject
+            .getValue("idempotencyKey")
+            .jsonPrimitive
+            .content
+        sendId.set(id)
+        """{"runId":"$id","status":"started"}"""
+      }
+      val controller = controller(gateway, StandardTestDispatcher(testScheduler))
+      controller.awaitOutboxRestore()
+      controller.load(key)
+      initialLoadFinished.await()
+      controller.onDisconnected("Queue offline")
+      assertTrue(controller.sendMessageAwaitAcceptance("queued", "off", emptyList()))
+      val admitted = outbox.load("gateway-a").single()
+      assertEquals(ChatOutboxStatus.Queued, admitted.status)
+      controller.onGatewayConnected()
+      try {
+        confirmationRequested.await()
+        val acknowledged = outbox.load("gateway-a").single()
+        assertEquals(admitted.id, acknowledged.id)
+        assertEquals(ChatOutboxStatus.Accepted, acknowledged.status)
+        assertEquals(1, gateway.callCount("chat.send"))
+      } finally {
+        releaseConfirmation.complete(Unit)
+      }
+      awaitBranchProgress { outbox.load("gateway-a").isEmpty() }
+    }
 
   @Test
   fun staleBranchSwitchCompletionCannotOverrideNewerNavigation() =

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
@@ -161,10 +161,25 @@ class ChatControllerOutboxTest {
       id: String,
       retryCount: Int,
       lastError: String?,
+    ): Int = claimForSending(id, retryCount, lastError, expectedAttemptVersion = null)
+
+    override suspend fun claimForSendingIfAttempt(
+      id: String,
+      expectedAttemptVersion: Int,
+      retryCount: Int,
+      lastError: String?,
+    ): Int = claimForSending(id, retryCount, lastError, expectedAttemptVersion)
+
+    private suspend fun claimForSending(
+      id: String,
+      retryCount: Int,
+      lastError: String?,
+      expectedAttemptVersion: Int?,
     ): Int {
       claimGate?.await()
       sendingStatusUpdateFailure?.let { throw it }
       val current = rows[id] ?: return 0
+      if (expectedAttemptVersion != null && current.attemptVersion != expectedAttemptVersion) return 0
       if (current.status != ChatOutboxStatus.Queued) return 0
       rows[id] = current.copy(status = ChatOutboxStatus.Sending, retryCount = retryCount, lastError = lastError)
       onStatusUpdated?.invoke(ChatOutboxStatus.Sending)
@@ -192,11 +207,38 @@ class ChatControllerOutboxTest {
       return removed
     }
 
+    override suspend fun confirmDeliveredAttempts(ids: Map<String, Int>): Int =
+      confirmDelivered(
+        ids.filter { (id, attemptVersion) -> rows[id]?.attemptVersion == attemptVersion }.keys,
+      )
+
     override suspend fun updateStatus(
       id: String,
       status: ChatOutboxStatus,
       retryCount: Int,
       lastError: String?,
+    ): Int = writeStatus(id, status, retryCount, lastError, deliveryAttemptVersion = null)
+
+    // Room rejects stale attempts and status snapshots; the interface default ignores both.
+    override suspend fun updateStatusIfAttempt(
+      id: String,
+      expectedAttemptVersion: Int,
+      status: ChatOutboxStatus,
+      retryCount: Int,
+      lastError: String?,
+      expectedStatus: ChatOutboxStatus?,
+    ): Int {
+      val current = rows[id] ?: return 0
+      if (current.attemptVersion != expectedAttemptVersion || (expectedStatus != null && current.status != expectedStatus)) return 0
+      return writeStatus(id, status, retryCount, lastError, deliveryAttemptVersion = expectedAttemptVersion)
+    }
+
+    private fun writeStatus(
+      id: String,
+      status: ChatOutboxStatus,
+      retryCount: Int,
+      lastError: String?,
+      deliveryAttemptVersion: Int?,
     ): Int {
       if (status == ChatOutboxStatus.Failed && deleteOnFailedStatus) {
         rows.remove(id)
@@ -208,9 +250,38 @@ class ChatControllerOutboxTest {
       if (status == ChatOutboxStatus.Queued) queuedStatusUpdateFailure?.let { throw it }
       if (status == ChatOutboxStatus.Sending) sendingStatusUpdateFailure?.let { throw it }
       val current = rows[id] ?: return 0
-      rows[id] = current.copy(status = status, retryCount = retryCount, lastError = lastError)
+      rows[id] =
+        current.copy(
+          status = status,
+          retryCount = retryCount,
+          lastError = lastError,
+          attemptVersion = deliveryAttemptVersion?.let { it + if (status == ChatOutboxStatus.Queued) 1 else 0 } ?: current.attemptVersion,
+          hadUnacknowledgedSend = deliveryAttemptVersion != null || current.hadUnacknowledgedSend,
+        )
       onStatusUpdated?.invoke(status)
       return 1
+    }
+
+    override suspend fun requeueForRetryIfCurrent(
+      gatewayId: String,
+      id: String,
+      expectedAttemptVersion: Int,
+      expectedRetryCount: Int,
+      expectedLastError: String?,
+      nowMs: Long,
+      gatedEpoch: Long?,
+      ownerAgentId: String?,
+      replacementId: String?,
+    ): Int {
+      val current = rows[id] ?: return 0
+      if (
+        current.attemptVersion != expectedAttemptVersion ||
+        current.retryCount != expectedRetryCount ||
+        current.lastError != expectedLastError
+      ) {
+        return 0
+      }
+      return requeueForRetry(gatewayId, id, nowMs, gatedEpoch, ownerAgentId)
     }
 
     override suspend fun requeueForRetry(
@@ -231,6 +302,9 @@ class ChatControllerOutboxTest {
           createdAtMs = createdAt,
           gatedEpoch = gatedEpoch,
           ownerAgentId = current.ownerAgentId ?: ownerAgentId,
+          attemptVersion = current.attemptVersion + 1,
+          parkedWasAccepted = false,
+          hadUnacknowledgedSend = false,
         )
       // Mirror the Room store: queued same-session successors follow the retried row.
       val successors =


### PR DESCRIPTION
## Summary

Fix Android messages getting stuck in Sending after they were queued offline and acknowledged by the Gateway on reconnect. The sender now carries the successfully claimed Sending snapshot into every completion transition, preserving the exact attempt version and stale-attempt protections.

## Root cause and repair

`flushOutboxPass` supplies an immutable Queued row. Room changes the durable row to Sending during `claimForSendingIfAttempt`, without changing its attempt version. `sendOutboxItem` previously retained the old snapshot, so completion expected Queued and updated zero rows. The acknowledgement path interpreted that result as concurrent deletion and skipped adopting the accepted run. Independent canonical-history cleanup could conceal the defect.

After a successful durable claim, use a Sending copy of that same row. Accepted, rejected, uncertain-send and attachment-failure outcomes then share the correct expectation. There is no new database read, retry, fallback, timeout, schema, configuration or protocol surface. Direct sends already expect Sending; the iOS claim path already returns its updated snapshot. Weakening the conditional write or rereading a potentially newer attempt would lose the existing lifecycle fence.

The existing fake outbox now honors conditional status/attempt writes. One real-Room regression holds history confirmation after a controller acknowledgement and proves the acknowledgement itself records Accepted. The branch fixture lets `runTest` own its scheduler and waits for visible failure or completed retirement instead of a hidden intermediate row; its exact-one-send, transcript, attachment and reconnect assertions remain intact.

Provenance: the implicated queued-snapshot/completion mismatch is present in the raw parent-to-commit change [b36342ee6fae](https://github.com/openclaw/openclaw/commit/b36342ee6fae06bd43197ced62231e74e3fd2048), from #112284, authored by @steipete and merged July 21, 2026. No first affected stable release is claimed. This was found while investigating #135796, but is not a claimed explanation for its original Android CI timeout: the unchanged-production Play selection passed all 2,583 tests locally, and that timeout remains unattributed.

## Verification

All candidate proof used the unchanged head `ac0cc2a8d9e69a81b12384d984a026bea7ccb063`.

- **Regression:** the new real-Room case failed before the production repair, expected Accepted / observed Sending, and passed afterward.
- **Native checks:** 185 Play + 185 ThirdParty tests passed, zero failures/errors/skips. Each flavor covers 44 branch-coordination, 76 controller-outbox, 47 Room-outbox and 18 timeline cases. Main/test ktlint passed; checked source hashes stayed unchanged.
- **Real owner round trip:** an external Robolectric live fixture exercised production ChatController, GatewaySession/OkHttp, file-backed Room, and a real authenticated Gateway/provider for two synthetic turns. Both durable claims and Sending-to-Accepted conditional writes affected one row; owned streaming, exactly one canonical user/assistant pair per turn, retirement and reopen-empty passed. Only the first turn held a disclosed local history-observation barrier; the second was ungated. The actual JUnit test passed in 39.508 seconds. Gradle exited 0; an outer collector looked in the wrong report directory and exited 1. The original failure and actual native XML were preserved separately; no provider rerun was used to repair collection.
- **Installed Android app:** the unchanged debug-signed APK on an isolated API 36 ARM64 emulator used normal onboarding and persisted pairing. UIAutomator then observed Ready, disabled real emulator Wi-Fi/mobile data, entered one synthetic prompt, verified the visible offline Queued row, restored connectivity, and verified its unique real assistant reply, no queued row or active turn, and Ready. AndroidJUnitRunner reported one passing test in 24.13 seconds. Network settings were restored and temporary input removed. The test APK matched the existing app signature; the app was not replaced or reset for the passing continuation.
- **Independent backend readback:** read-only inspection bound the UI test's unique marker to exactly one canonical user message and one assistant reply on the current, clean two-message branch. The logical session and physical window both recorded done; the assistant's persisted run matched the existing normal-completion record. The observer sent no new turn or provider request and made no database writes.
- **Reviews and CI:** fresh managed P0-only review had no findings; an independent owner-boundary review covered controller/store/fake/direct-send/iOS siblings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33594230242) passed, including Play/ThirdParty/Wear tests, Android builds/ktlint, native i18n and the required `openclaw/ci-gate`.

Earlier GUI attempts are retained as harness failures, not hidden product passes: a host exit-status monitor failed before a test body; a selector incorrectly required Send before entering any text and failed before offline/send; a rebuilt test APK with a mismatched debug certificate was stopped before installation. Correcting those external harness/environment errors did not change production source or relax the queue/reply assertions.

The latest ClawSweeper review's live-proof and exact-head CI requests are satisfied by these complementary owner and installed-app observations. Local screenshots show the candidate's connected, offline-queued and completed states; they are not pre-fix screenshots. They remain local because external image-upload approval is pending. This is real Gateway/provider and Android-emulator proof, not physical Android/Watch radio, audio or endurance proof.

## Landing verification

Landed as [fd141d8f6d95](https://github.com/openclaw/openclaw/commit/fd141d8f6d95a070e0461b47f8053f77bdd68679). All three changed files are byte-identical to reviewed/live-tested `ac0cc2a8d9e6` and present on main. The native workflow reported advisory mainline drift and completed without a rebase or bypass. Intervening Android GatewaySession lifecycle/accepted-response fixes were inspected independently: the outbox/Room owner and public send contract remain unchanged. The live evidence above is for the PR head, not a fresh live execution of the entire later merged tree.

## Scope and release note

Production: +9 / -8 lines (net +1), the claimed-state snapshot at the existing owner boundary. Tests: +159 / -22 lines (net +137). No generated, dependency, storage-schema or documentation-contract changes.

Release note: Android queued messages now correctly move out of Sending when the Gateway acknowledges them after reconnect, without weakening protection against stale retries or branch changes.
