### PR TITLE
fix(discord): preserve webhook reply limits and delivery outcomes

### DIFF
--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -1,11 +1,12 @@
 // Discord API module exposes the plugin public contract.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isDiscordThreadChannelType } from "../channel-type.js";
 import { createDiscordRestClient } from "../client.js";
 import { createChannelWebhook, getChannel } from "../internal/discord.js";
+import { canFallbackDiscordWebhookSend } from "../retry.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
 import { createThreadDiscord } from "../send.messages.js";
 import { resolveDiscordChannelId } from "../target-parsing.js";
@@ -21,6 +22,8 @@ import {
   DISCORD_UNKNOWN_CHANNEL_ERROR_CODE,
   type ThreadBindingRecord,
 } from "./thread-bindings.types.js";
+
+const log = createSubsystemLogger("discord/thread-bindings");
 
 function buildThreadTarget(threadId: string): string {
   return /^(channel:|user:)/i.test(threadId) ? threadId : `channel:${threadId}`;
@@ -149,7 +152,14 @@ export async function maybeSendBindingMessage(params: {
       });
       return;
     } catch (err) {
-      logVerbose(`discord thread binding webhook send failed: ${summarizeDiscordError(err)}`);
+      const fallbackToBot = canFallbackDiscordWebhookSend(err);
+      log.warn("discord thread binding webhook send failed", {
+        error: summarizeDiscordError(err),
+        fallbackToBot,
+      });
+      if (!fallbackToBot) {
+        return;
+      }
     }
   }
   try {

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -281,9 +281,11 @@ describe("discordOutbound", () => {
     });
   });
 
-  it("falls back to bot send when webhook send fails", async () => {
+  it("falls back to bot send when Discord rejects the webhook send", async () => {
     mockDiscordBoundThreadManager(hoisted);
-    hoisted.sendWebhookMessageDiscordMock.mockRejectedValueOnce(new Error("rate limited"));
+    hoisted.sendWebhookMessageDiscordMock.mockRejectedValueOnce(
+      Object.assign(new Error("rate limited"), { status: 429 }),
+    );
 
     const result = await discordOutbound.sendText?.({
       cfg: {},

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,14 +1,10 @@
 // Discord plugin module implements outbound adapter behavior.
-import {
-  type OutboundIdentity,
-  resolveOutboundSendDep,
-} from "openclaw/plugin-sdk/channel-outbound";
+import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
 import {
   attachChannelToResult,
   type ChannelOutboundAdapter,
   createAttachedChannelResultAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -25,7 +21,6 @@ import {
   notifyDiscordInboundEventOutboundPayloadSuccess,
 } from "./inbound-event-delivery.js";
 import { isLikelyDiscordVideoMedia } from "./media-detection.js";
-import type { ThreadBindingRecord } from "./monitor/thread-bindings.js";
 import { normalizeDiscordOutboundTarget } from "./normalize.js";
 import { normalizeDiscordApprovalPayload } from "./outbound-approval.js";
 import {
@@ -42,10 +37,12 @@ import {
   type DiscordVoiceSendFn,
 } from "./outbound-send-context.js";
 import { resolveDiscordReplyReference } from "./reply-reference.js";
+import { canFallbackDiscordWebhookSend } from "./retry.js";
 import {
   createDiscordSendReceiptFromResults,
   toDiscordOutboundDeliveryResult,
 } from "./send.receipt.js";
+import type { DiscordSendResult } from "./send.types.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 const log = createSubsystemLogger("discord/outbound");
@@ -56,64 +53,49 @@ const loadDiscordComponentSendRuntime = createLazyRuntimeModule(
   () => import("./send.components.js"),
 );
 
-function resolveDiscordWebhookIdentity(params: {
-  identity?: OutboundIdentity;
-  binding: ThreadBindingRecord;
-}): { username?: string; avatarUrl?: string } {
-  const usernameRaw = normalizeOptionalString(params.identity?.name);
-  const fallbackUsername = normalizeOptionalString(params.binding.label) ?? params.binding.agentId;
-  const username = truncateUtf16Safe(usernameRaw || fallbackUsername || "", 80) || undefined;
-  const avatarUrl = normalizeOptionalString(params.identity?.avatarUrl);
-  return { username, avatarUrl };
+type DiscordOutboundMessageContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
+
+function resolveDiscordDeliveryOptions(params: DiscordOutboundMessageContext) {
+  return {
+    onPlatformSendDispatch: params.onPlatformSendDispatch,
+    assertPlatformSendAuthorized: params.assertDirectAdapterHandoff,
+    onDeliveryResult: params.onDeliveryResult
+      ? async (result: DiscordSendResult) =>
+          params.onDeliveryResult?.(
+            attachChannelToResult("discord", toDiscordOutboundDeliveryResult(result)),
+          )
+      : undefined,
+  };
 }
 
-async function maybeSendDiscordWebhookText(params: {
-  cfg: OpenClawConfig;
-  text: string;
-  threadId?: string | number | null;
-  accountId?: string | null;
-  identity?: OutboundIdentity;
-  replyToId?: string | null;
-  onPlatformSendDispatch?: () => Promise<void>;
-  assertPlatformSendAuthorized?: () => void;
-}): Promise<{ messageId: string; channelId: string } | null> {
-  if (params.threadId == null) {
-    return null;
-  }
+async function maybeSendDiscordWebhookText(params: DiscordOutboundMessageContext) {
   const threadId = normalizeOptionalStringifiedId(params.threadId) ?? "";
   if (!threadId) {
     return null;
   }
   const { getThreadBindingManager } = await loadDiscordThreadBindings();
-  const manager = getThreadBindingManager(params.accountId ?? undefined);
-  if (!manager) {
-    return null;
-  }
-  const binding = manager.getByThreadId(threadId);
+  const binding = getThreadBindingManager(params.accountId ?? undefined)?.getByThreadId(threadId);
   if (!binding?.webhookId || !binding?.webhookToken) {
     return null;
   }
-  const persona = resolveDiscordWebhookIdentity({
-    identity: params.identity,
-    binding,
-  });
+  const username =
+    normalizeOptionalString(params.identity?.name) ||
+    normalizeOptionalString(binding.label) ||
+    binding.agentId ||
+    "";
   const { sendWebhookMessageDiscord } = await loadDiscordSendRuntime();
-  const result = await sendWebhookMessageDiscord(params.text, {
+  return await sendWebhookMessageDiscord(params.text, {
     webhookId: binding.webhookId,
     webhookToken: binding.webhookToken,
     accountId: binding.accountId,
     threadId: binding.threadId,
     cfg: params.cfg,
     replyTo: params.replyToId ?? undefined,
-    username: persona.username,
-    avatarUrl: persona.avatarUrl,
-    onPlatformSendDispatch: params.onPlatformSendDispatch,
-    assertPlatformSendAuthorized: params.assertPlatformSendAuthorized,
+    username: truncateUtf16Safe(username, 80) || undefined,
+    avatarUrl: normalizeOptionalString(params.identity?.avatarUrl),
+    ...resolveDiscordDeliveryOptions(params),
   });
-  return result;
 }
-
-type DiscordOutboundMessageContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
 
 async function resolveDiscordOutboundMessageSend(params: DiscordOutboundMessageContext) {
   const send =
@@ -134,19 +116,7 @@ async function resolveDiscordOutboundMessageSend(params: DiscordOutboundMessageC
       silent: params.silent ?? undefined,
       cfg: params.cfg,
       ...resolveDiscordFormattingOptions({ formatting: params.formatting }),
-      onDeliveryResult: params.onDeliveryResult
-        ? async (
-            result: Parameters<
-              NonNullable<NonNullable<Parameters<DiscordSendFn>[2]>["onDeliveryResult"]>
-            >[0],
-          ) => {
-            await params.onDeliveryResult?.(
-              attachChannelToResult("discord", toDiscordOutboundDeliveryResult(result)),
-            );
-          }
-        : undefined,
-      onPlatformSendDispatch: params.onPlatformSendDispatch,
-      assertPlatformSendAuthorized: params.assertDirectAdapterHandoff,
+      ...resolveDiscordDeliveryOptions(params),
     },
   };
 }
@@ -190,28 +160,13 @@ export const discordOutbound: ChannelOutboundAdapter = {
     channel: "discord",
     sendText: async (ctx) => {
       if (!ctx.silent) {
-        let webhookSelected = false;
         try {
-          const webhookResult = await maybeSendDiscordWebhookText({
-            cfg: ctx.cfg,
-            text: ctx.text,
-            threadId: ctx.threadId,
-            accountId: ctx.accountId,
-            identity: ctx.identity,
-            replyToId: ctx.replyToId,
-            onPlatformSendDispatch: ctx.onPlatformSendDispatch
-              ? async () => {
-                  webhookSelected = true;
-                  await ctx.onPlatformSendDispatch?.();
-                }
-              : undefined,
-            assertPlatformSendAuthorized: ctx.assertDirectAdapterHandoff,
-          });
+          const webhookResult = await maybeSendDiscordWebhookText(ctx);
           if (webhookResult) {
             return toDiscordOutboundDeliveryResult(webhookResult);
           }
         } catch (error) {
-          if (webhookSelected) {
+          if (!canFallbackDiscordWebhookSend(error)) {
             throw error;
           }
           // Falling back to the plain bot send is intended (persona delivery is

--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -110,6 +110,14 @@ export function hasDiscordMessageCreateAmbiguity(error: unknown): boolean {
   );
 }
 
+export function canFallbackDiscordWebhookSend(error: unknown): boolean {
+  if (hasDiscordMessageCreateAmbiguity(error)) {
+    return false;
+  }
+  const failure = classifyDiscordDeliveryFailure(error);
+  return failure === "rejected" || failure === "pre-connect";
+}
+
 function hasDiscordRateLimitRejection(error: unknown): boolean {
   return (
     error instanceof RateLimitError ||

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -1,84 +1,195 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { chunkDiscordTextWithMode } from "./chunk.js";
+import { maybeSendBindingMessage } from "./monitor/thread-bindings.discord-api.js";
+import type { ThreadBindingRecord } from "./monitor/thread-bindings.types.js";
+import { discordOutbound } from "./outbound-adapter.js";
+import {
+  createDiscordOutboundHoisted,
+  installDiscordOutboundModuleSpies,
+  mockDiscordBoundThreadManager,
+  resetDiscordOutboundMocks,
+} from "./outbound-adapter.test-harness.js";
 import { sendWebhookMessageDiscord } from "./send.webhook.js";
 
-describe("Discord reasoning chunk delivery", () => {
-  it("sends only transport-sized reasoning chunks to the real HTTP adapter", async () => {
-    const maxChars = 2000;
-    const receivedContents: string[] = [];
-    const server = createServer((request, response) => {
-      let body = "";
-      request.setEncoding("utf8");
-      request.on("data", (part: string) => {
-        body += part;
-      });
-      request.on("end", () => {
-        const payload = JSON.parse(body) as { content: string };
-        receivedContents.push(payload.content);
-        response.setHeader("content-type", "application/json");
-        if (payload.content.length > maxChars) {
-          response.writeHead(400);
-          response.end(JSON.stringify({ code: 50035, message: "Invalid Form Body" }));
-          return;
-        }
-        response.end(
-          JSON.stringify({
-            id: String(receivedContents.length),
-            channel_id: "123",
+const realWebhookSend = sendWebhookMessageDiscord;
+const hoisted = createDiscordOutboundHoisted();
+await installDiscordOutboundModuleSpies(hoisted);
+
+async function withWebhookServer(
+  reply: (content: string, index: number) => { status?: number; body: unknown },
+  run: (contents: string[]) => Promise<void>,
+) {
+  const contents: string[] = [];
+  const server = createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (part: string) => {
+      body += part;
+    });
+    request.on("end", () => {
+      const { content } = JSON.parse(body) as { content: string };
+      contents.push(content);
+      const next = reply(content, contents.length);
+      response.writeHead(next.status ?? 200, { "content-type": "application/json" });
+      response.end(JSON.stringify(next.body));
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  const realFetch = globalThis.fetch.bind(globalThis);
+  const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const original =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const target = new URL(original);
+    target.protocol = "http:";
+    target.host = `127.0.0.1:${address.port}`;
+    return realFetch(target, init);
+  });
+  try {
+    await run(contents);
+  } finally {
+    fetchSpy.mockRestore();
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+const cfg: OpenClawConfig = { channels: { discord: { token: "Bot test-token" } } };
+
+describe("Discord webhook delivery", () => {
+  beforeEach(() => {
+    resetDiscordOutboundMocks(hoisted);
+    hoisted.sendWebhookMessageDiscordMock.mockImplementation((...args) =>
+      realWebhookSend(...(args as Parameters<typeof realWebhookSend>)),
+    );
+  });
+
+  it.each([
+    { label: "reasoning", text: `Reasoning:\n_${"a".repeat(4000)}_`, aliases: undefined },
+    {
+      label: "expanded mention",
+      text: `${"a".repeat(1995)} @ops`,
+      aliases: { ops: "123456789012345678" },
+    },
+  ])(
+    "sends only transport-sized $label chunks to the real HTTP adapter",
+    async ({ text, aliases }) => {
+      await withWebhookServer(
+        (content, index) =>
+          content.length > 2000
+            ? { status: 400, body: { code: 50035, message: "Invalid Form Body" } }
+            : { body: { id: String(index), channel_id: "thread-1" } },
+        async (contents) => {
+          const chunks = chunkDiscordTextWithMode(text, {
+            chunkMode: "length",
+            maxChars: 2000,
+            maxLines: 50,
+          });
+          const receipts: string[] = [];
+          const progress: string[] = [];
+          for (const chunk of chunks) {
+            const result = await realWebhookSend(chunk, {
+              cfg: { channels: { discord: { token: "Bot test-token", mentionAliases: aliases } } },
+              webhookId: "123",
+              webhookToken: "test-token",
+              threadId: "thread-1",
+              wait: true,
+              onDeliveryResult: (part) => {
+                progress.push(part.messageId);
+              },
+            });
+            receipts.push(...(result.receipt?.platformMessageIds ?? []));
+          }
+          expect(contents.join("")).toBe(
+            aliases ? `${"a".repeat(1995)} <@123456789012345678>` : chunks.join(""),
+          );
+          expect(contents.length).toBeGreaterThan(1);
+          expect(contents.every((content) => content.length <= 2000)).toBe(true);
+          expect(receipts).toEqual(contents.map((_, index) => String(index + 1)));
+          expect(progress).toEqual(receipts);
+        },
+      );
+    },
+  );
+
+  it.each(["adapter", "adapter with dispatch hook", "binding notification"] as const)(
+    "does not send a second message after an ambiguous webhook result through %s",
+    async (caller) => {
+      await withWebhookServer(
+        () => ({ status: 503, body: { message: "response lost after commit" } }),
+        async (contents) => {
+          if (caller === "binding notification") {
+            const record = {
+              accountId: "default",
+              channelId: "parent-1",
+              threadId: "thread-1",
+              targetKind: "subagent",
+              targetSessionKey: "agent:main:subagent:fixture",
+              agentId: "main",
+              boundBy: "fixture",
+              boundAt: 1,
+              lastActivityAt: 1,
+              webhookId: "wh-1",
+              webhookToken: "synthetic-token",
+            } satisfies ThreadBindingRecord;
+            await maybeSendBindingMessage({ cfg, record, text: "send once" });
+          } else {
+            mockDiscordBoundThreadManager(hoisted);
+            await expect(
+              discordOutbound.sendText?.({
+                cfg,
+                to: "channel:parent-1",
+                threadId: "thread-1",
+                text: "send once",
+                ...(caller === "adapter with dispatch hook"
+                  ? { onPlatformSendDispatch: async () => {} }
+                  : {}),
+              }),
+            ).rejects.toThrow("response lost after commit");
+          }
+          expect(contents).toEqual(["send once"]);
+          expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+        },
+      );
+    },
+  );
+
+  it("retains an accepted chunk without replaying it when a later webhook chunk is rejected", async () => {
+    mockDiscordBoundThreadManager(hoisted);
+    const onDeliveryResult = vi.fn();
+    await withWebhookServer(
+      (_content, index) =>
+        index === 1
+          ? { body: { id: "accepted-1", channel_id: "thread-1" } }
+          : { status: 404, body: { code: 10015, message: "Unknown Webhook" } },
+      async (contents) => {
+        await expect(
+          discordOutbound.sendText?.({
+            cfg,
+            to: "channel:parent-1",
+            threadId: "thread-1",
+            text: "x".repeat(2001),
+            onDeliveryResult,
+          }),
+        ).rejects.toThrow("Unknown Webhook");
+        expect(contents.map((content) => content.length)).toEqual([2000, 1]);
+        expect(onDeliveryResult).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            channel: "discord",
+            messageId: "accepted-1",
+            target: { kind: "channel", id: "thread-1" },
+            receipt: expect.objectContaining({ platformMessageIds: ["accepted-1"] }),
           }),
         );
-      });
-    });
-
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const address = server.address() as AddressInfo;
-    const realFetch = globalThis.fetch.bind(globalThis);
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
-      const original =
-        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      const target = new URL(original);
-      target.protocol = "http:";
-      target.host = `127.0.0.1:${address.port}`;
-      return realFetch(target, init);
-    });
-
-    try {
-      const chunks = chunkDiscordTextWithMode(`Reasoning:\n_${"a".repeat(maxChars * 2)}_`, {
-        chunkMode: "length",
-        maxChars,
-        maxLines: 50,
-      });
-      const cfg = { channels: { discord: { token: "Bot test-token" } } } as OpenClawConfig;
-
-      for (const chunk of chunks) {
-        await sendWebhookMessageDiscord(chunk, {
-          cfg,
-          webhookId: "123",
-          webhookToken: "test-token",
-          wait: true,
-        });
-      }
-
-      expect(receivedContents).toEqual(chunks);
-      expect(receivedContents.length).toBeGreaterThan(1);
-      expect(receivedContents.every((content) => content.length <= maxChars)).toBe(true);
-    } finally {
-      fetchSpy.mockRestore();
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-    }
+        expect(hoisted.sendMessageDiscordMock).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -2,6 +2,7 @@
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import { recordOutboundMessageIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import {
   readProviderJsonResponse,
@@ -9,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { chunkDiscordTextWithMode } from "./chunk.js";
 import { resolveDiscordClientAccountContext } from "./client.js";
 import {
   DiscordError,
@@ -19,12 +21,12 @@ import {
 } from "./internal/rest-errors.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
 import { DISCORD_REST_TIMEOUT_MS } from "./proxy-request-client.js";
-import { createDiscordRetryRunner } from "./retry.js";
+import { createDiscordRetryRunner, recordDiscordMessageCreateAmbiguity } from "./retry.js";
 import {
   resolveDiscordMessageFlags,
   resolveDiscordSuppressEmbeds,
 } from "./send.message-request.js";
-import { createDiscordSendResult } from "./send.receipt.js";
+import { createDiscordSendReceiptFromResults, createDiscordSendResult } from "./send.receipt.js";
 import type { DiscordSendResult } from "./send.types.js";
 
 const DISCORD_WEBHOOK_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
@@ -42,23 +44,8 @@ type DiscordWebhookSendOpts = {
   wait?: boolean;
   onPlatformSendDispatch?: () => Promise<void>;
   assertPlatformSendAuthorized?: () => void;
+  onDeliveryResult?: (result: DiscordSendResult) => Promise<void> | void;
 };
-
-function resolveWebhookExecutionUrl(params: {
-  webhookId: string;
-  webhookToken: string;
-  threadId?: string | number;
-  wait?: boolean;
-}) {
-  const baseUrl = new URL(
-    `https://discord.com/api/v10/webhooks/${encodeURIComponent(params.webhookId)}/${encodeURIComponent(params.webhookToken)}`,
-  );
-  baseUrl.searchParams.set("wait", params.wait === false ? "false" : "true");
-  if (params.threadId !== undefined && params.threadId !== null && params.threadId !== "") {
-    baseUrl.searchParams.set("thread_id", String(params.threadId));
-  }
-  return baseUrl.toString();
-}
 
 function coerceWebhookErrorBody(raw: string): unknown {
   if (!raw) {
@@ -142,87 +129,105 @@ export async function sendWebhookMessageDiscord(
     });
   }
 
-  const url = resolveWebhookExecutionUrl({
-    webhookId,
-    webhookToken,
-    threadId: opts.threadId,
-    wait: opts.wait,
-  });
+  const url = new URL(
+    `https://discord.com/api/v10/webhooks/${encodeURIComponent(webhookId)}/${encodeURIComponent(webhookToken)}`,
+  );
+  url.searchParams.set("wait", opts.wait === false ? "false" : "true");
+  if (opts.threadId != null && opts.threadId !== "") {
+    url.searchParams.set("thread_id", String(opts.threadId));
+  }
   const deadline = buildTimeoutAbortSignal({
     timeoutMs: DISCORD_WEBHOOK_TIMEOUT_MS,
     operation: "discord.webhook.send",
   });
   const request = createDiscordRetryRunner({ signal: deadline.signal });
+  // Alias expansion happens after the outer delivery planner. Bound the actual
+  // wire text here, retaining each accepted part before another can fail.
+  const chunks = chunkDiscordTextWithMode(rewrittenText, { maxLines: Number.MAX_SAFE_INTEGER });
+  const results: DiscordSendResult[] = [];
   try {
-    const response = await request(
-      async () => {
-        await opts.onPlatformSendDispatch?.();
-        opts.assertPlatformSendAuthorized?.();
-        const attemptResponse = await (proxyFetch ?? fetch)(url, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-          },
-          body: JSON.stringify({
-            content: rewrittenText,
-            username: normalizeOptionalString(opts.username),
-            avatar_url: normalizeOptionalString(opts.avatarUrl),
-            ...(flags ? { flags } : {}),
-            ...(messageReference ? { message_reference: messageReference } : {}),
-          }),
-          signal: deadline.signal,
-        });
-        if (!attemptResponse.ok) {
-          await throwWebhookResponseError(attemptResponse, deadline.signal);
-        }
-        return attemptResponse;
-      },
-      "webhook",
-      // Webhooks cannot enforce a Discord nonce, so replay only explicit 429s
-      // and proven pre-connect failures; an ambiguous 5xx could duplicate delivery.
-      { safety: "non-idempotent-create" },
-    );
-
-    const payload: {
-      id?: string;
-      channel_id?: string;
-    } =
-      response.status === 204
-        ? {}
-        : await readProviderJsonResponse<{ id?: string; channel_id?: string }>(
-            response,
-            "Discord webhook send",
-          ).catch(() => {
-            throwIfWebhookDeadlineExpired(deadline.signal);
-            return {};
+    for (const content of chunks.length ? chunks : [""]) {
+      const response = await request(
+        async () => {
+          await opts.onPlatformSendDispatch?.();
+          opts.assertPlatformSendAuthorized?.();
+          const attemptResponse = await (proxyFetch ?? fetch)(url.toString(), {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              content,
+              username: normalizeOptionalString(opts.username),
+              avatar_url: normalizeOptionalString(opts.avatarUrl),
+              ...(flags ? { flags } : {}),
+              ...(messageReference ? { message_reference: messageReference } : {}),
+            }),
+            signal: deadline.signal,
           });
-    try {
-      recordChannelActivity({
-        channel: "discord",
-        accountId: account.accountId,
-        direction: "outbound",
+          if (!attemptResponse.ok) {
+            await throwWebhookResponseError(attemptResponse, deadline.signal);
+          }
+          return attemptResponse;
+        },
+        "webhook",
+        // Webhooks cannot enforce a Discord nonce, so replay only explicit 429s
+        // and proven pre-connect failures; an ambiguous 5xx could duplicate delivery.
+        { safety: "non-idempotent-create" },
+      );
+
+      const payload: {
+        id?: string;
+        channel_id?: string;
+      } =
+        response.status === 204
+          ? {}
+          : await readProviderJsonResponse<{ id?: string; channel_id?: string }>(
+              response,
+              "Discord webhook send",
+            ).catch(() => {
+              throwIfWebhookDeadlineExpired(deadline.signal);
+              return {};
+            });
+      try {
+        recordChannelActivity({
+          channel: "discord",
+          accountId: account.accountId,
+          direction: "outbound",
+        });
+      } catch {
+        // Best-effort telemetry only.
+      }
+      const result = createDiscordSendResult({
+        result: payload,
+        fallbackChannelId: opts.threadId ? String(opts.threadId) : "",
+        kind: "text",
+        ...(opts.threadId != null ? { threadId: opts.threadId } : {}),
+        ...(replyTo ? { replyToId: replyTo } : {}),
       });
-    } catch {
-      // Best-effort telemetry only.
+      const resultConversationId = result.channelId.trim();
+      if (result.messageId !== "unknown" && resultConversationId) {
+        recordOutboundMessageIdentity({
+          channel: "discord",
+          accountId: account.accountId,
+          conversationId: resultConversationId,
+          messageId: result.messageId,
+          sourceId: webhookId,
+        });
+      }
+      results.push(result);
+      await opts.onDeliveryResult?.(result);
     }
-    const result = createDiscordSendResult({
-      result: payload,
-      fallbackChannelId: opts.threadId ? String(opts.threadId) : "",
-      kind: "text",
-      ...(opts.threadId != null ? { threadId: opts.threadId } : {}),
-      ...(replyTo ? { replyToId: replyTo } : {}),
-    });
-    const resultConversationId = result.channelId.trim();
-    if (result.messageId !== "unknown" && resultConversationId) {
-      recordOutboundMessageIdentity({
-        channel: "discord",
-        accountId: account.accountId,
-        conversationId: resultConversationId,
-        messageId: result.messageId,
-        sourceId: webhookId,
-      });
+    const last = expectDefined(results.at(-1), "Discord webhook delivery result");
+    return results.length === 1
+      ? last
+      : { ...last, receipt: createDiscordSendReceiptFromResults({ results }) };
+  } catch (error) {
+    // A later rejection cannot authorize replay of earlier accepted chunks.
+    if (results.length) {
+      recordDiscordMessageCreateAmbiguity(error);
     }
-    return result;
+    throw error;
   } finally {
     // The same deadline owns the request and every response-body read.
     deadline.cleanup();


### PR DESCRIPTION
Closes #135946
Closes #135947

## What Problem This Solves

Fixes an issue where Discord thread-bound replies could be rejected after a configured mention alias expanded an otherwise valid message beyond the webhook limit. It also prevents a webhook message from being replayed through the bot when the webhook may already have accepted it, including thread-binding notifications.

## Why This Change Was Made

The webhook owner now applies the existing character chunker after mention expansion, records each accepted part, and preserves one overall deadline. Both fallback callers use the existing transport outcome classification: only explicit rejection or a proven failure before connection permits bot fallback, and an earlier accepted chunk rules it out.

This removes the optional observer's control over delivery safety, a copied parameter shape, single-use wrappers, and duplicate receipt adaptation. Production changes are **+144/−166, net −22 lines**; tests are +184/−71. No configuration, schema, protocol or dependency changes.

## User Impact

Long replies with configured mentions retain all their text within Discord's [Execute Webhook limit](https://docs.discord.com/developers/resources/webhook#execute-webhook). An uncertain send produces the existing delivery failure instead of a second bot message; binding notifications record a warning with the fallback decision.

## Evidence

- Before the fix, real HTTP regressions reproduced the oversized expanded alias and both unsafe fallback callers; controls passed.
- After the fix, 154 tests in seven files pass, covering chunking, per-part receipts, bot siblings, proxy handling, deadlines, response cleanup and retries. The root reviewer separately reran 62 HTTP/binding/retry tests.
- A built, ephemeral Gateway with the actual Discord plugin and synthetic local Discord REST/WebSocket endpoints passes three scenarios: a 2,000-character input expands to 2,017 and is sent as 1,995 + 22 characters; an accepted webhook followed by HTTP503 causes zero bot sends; an accepted first part followed by HTTP404 on the second causes zero bot sends.

```json
{"gateway":"connected/running/ready","scenarios":3,"passed":3,"failed":0,"expandedContentLengths":[1995,22],"ambiguousWebhookBotSends":0,"partialWebhookBotSends":0,"externalDiscordMessagesSent":0}
```

The canonical QA runtime build, changed-source type/unused-export/lint/boundary checks, diff check and independent Codex P2 review pass. Synthetic Gateway and server processes were cleaned up. The external service boundary is simulated; no live Discord message was sent.

Existing native webhook reply work in #129801 and generic core delivery uncertainty in #131609 concern separate paths. The local Discord simulator lacks webhook routes and TLS, so the proof supplies those endpoints; this limitation is not counted as another product bug.
