### PR TITLE
docs(automations): describe supported schedule options

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -83,7 +83,8 @@ In addition to positional schedules, `automations add|create` and
   `--stream-match <regex>`, `--stream-batch-ms <n>`, and
   `--stream-max-batch-bytes <n>` to configure the source and batching.
 
-`--tz`, `--exact`, and `--stagger` apply only to cron schedules. See
+`--tz` applies to cron schedules and offset-less `--at` timestamps, while
+`--exact` and `--stagger` apply only to cron schedules. See
 [Automations](/automation/cron-jobs#schedule-types) for stream lifecycle,
 batching limits, and trigger details.
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -64,6 +64,29 @@ that label with `automations add|edit --display-name`. Use
 the stable name in list and detail views. The set and clear options cannot be
 combined.
 
+## Schedule types
+
+In addition to positional schedules, `automations add|create` and
+`automations edit` accept these schedule options:
+
+- `--at <when>` creates a one-shot job from an ISO timestamp or a duration such
+  as `20m`. Offset-less timestamps use UTC unless `--tz <iana>` is supplied.
+- `--every <duration>` creates a recurring interval such as `10m`, `1h`, or
+  `1d`.
+- `--cron <expression>` creates a five- or six-field cron schedule. Use
+  `--tz <iana>` for the evaluation timezone, or `--exact`/`--stagger <duration>`
+  to control top-of-hour staggering.
+- `--on-exit <shell>` starts a watched command and fires the job once when it
+  exits. Use `--on-exit-cwd <path>` to select its working directory.
+- `--stream-command <json>` supervises a long-lived command and fires the job
+  from its output. Use `--stream-cwd`, `--stream-mode line|match`,
+  `--stream-match <regex>`, `--stream-batch-ms <n>`, and
+  `--stream-max-batch-bytes <n>` to configure the source and batching.
+
+`--tz`, `--exact`, and `--stagger` apply only to cron schedules. See
+[Automations](/automation/cron-jobs#schedule-types) for stream lifecycle,
+batching limits, and trigger details.
+
 ## Sessions
 
 `--session` accepts `main`, `isolated`, `current`, or `session:<id>`.


### PR DESCRIPTION
## What Problem This Solves

The Automation CLI reference omitted the supported command-exit and supervised-stream schedules and their options. Readers could not discover all five schedule kinds from the reference.

## Why This Change Was Made

Add a short overview of `--at`, `--every`, `--cron`, `--on-exit`, and `--stream-command`, with working-directory restrictions, stream selection and batching units, timezone scope, and cron-only staggering controls. Link directly to the canonical schedule guide for lifecycle and batching details.

## User Impact

Operators can find the supported flags and their constraints in one place. Existing session cleanup, completion, deletion, retry, precision, delivery, and model guidance is preserved. This changes documentation only; it does not change or claim new runtime behavior.

## Evidence

- Source and existing tests confirm all listed flags and restrictions, including `--tz` for cron and offset-less `--at`, and `--exact`/`--stagger` for cron only.
- Independent document acceptance and fresh source review passed. The complete prior reference is preserved byte for byte outside the new section.
- Documentation checks:

```text
docs:list                  PASS
format:docs:check           PASS (986 files)
lint:docs                  PASS (985 files; 0 issues)
docs:check-mdx              PASS (999 files)
docs:check-links            PASS (10195 links; 0 broken)
git diff --check            PASS
```

- The new guide anchor passes the full anchor audit. That extra audit reports the same three missing `windows-app-node` anchors in generated maturity pages on both pinned main and this candidate; those unrelated pages remain unchanged.
- The contributor's commits and corrected timezone wording are retained. Thanks @qingminglong.

No Automation job, watched command, stream source, or Gateway was started for this documentation proof.
