### PR TITLE
test(ui): fix chat pane metadata listener fixtures

### DIFF
--- a/ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts
@@ -1,10 +1,17 @@
 /* @vitest-environment jsdom */
 /* @vitest-environment-options {"url":"http://chat-pane-companion-lifecycle.test/"} */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ModelCatalogEntry } from "../../api/types.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
-import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
+import { createGatewayRequestMock } from "../../test-helpers/gateway-client.ts";
+import { getChatHistoryLoadState } from "./chat-history-state.ts";
+import {
+  createGatewayBrowserClientFixture,
+  createTestChatPane,
+  type TestChatPane,
+} from "./chat-pane.test-support.ts";
 import type { ChatSessionCompanionThreads } from "./chat-session-companion.ts";
 
 const companionThreads = (pane: TestChatPane) =>
@@ -13,8 +20,31 @@ const companionThreads = (pane: TestChatPane) =>
 
 describe("chat pane companion connection lifecycle", () => {
   it("preserves threads while a same-client reconnect settles a pending answer", async () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
-    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const consoleError = vi.spyOn(console, "error");
+    onTestFinished(() => consoleError.mockRestore());
+    const models: ModelCatalogEntry[] = [
+      { id: "fixture-model", name: "Fixture model", provider: "test", available: true },
+    ];
+    const request = createGatewayRequestMock(async (method) => {
+      switch (method) {
+        case "chat.startup":
+          return { messages: [], sessionId: "session-current", hasMore: false, totalMessages: 0 };
+        case "chat.metadata":
+          return { commands: [], models, swarmEnabled: false };
+        default:
+          throw new Error(`Unexpected gateway request: ${method}`);
+      }
+    });
+    const client = createGatewayBrowserClientFixture({ request });
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    onTestFinished(() => {
+      pane.applyGatewaySnapshot({
+        ...pane.context.gateway.snapshot,
+        phase: "stopped",
+        hello: null,
+      });
+      pane.disconnectedCallback();
+    });
     let rejectAnswer!: (error: Error) => void;
     const threads = companionThreads(pane);
     await threads.hydrate(
@@ -57,6 +87,7 @@ describe("chat pane companion connection lifecycle", () => {
 
     pane.connectedClient = client;
     pane.applyGatewaySnapshot({ ...pane.context.gateway.snapshot, phase: "connected" });
+    expect(state.chatModelsLoading).toBe(true);
     expect(threads.view("agent:main:other", "main").draft).toBe("other draft");
     await threads.hydrate(
       "agent:main:current",
@@ -76,6 +107,12 @@ describe("chat pane companion connection lifecycle", () => {
       failedQuestion: null,
       pendingQuestion: null,
     });
+    await vi.waitFor(() => expect(state.chatModelsLoading).toBe(false));
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(state.chatModelCatalog).toEqual(models);
+    expect(state.chatModelCatalogError).toBeNull();
+    expect(getChatHistoryLoadState(state).phase).toBe("committed");
+    expect(state.chatError).toBeNull();
   });
 
   it("retires every thread and late answer when the Gateway client is replaced", async () => {

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -357,6 +357,7 @@ export function createTestChatPane(params: {
     connectionEpoch: 4,
     hello: sessionMutationGatewayHello(),
     lastError: null,
+    modelAuthStatusRequestVersion: 0,
     requestUpdate,
     sessionKey: "agent:main:current",
     sessions: params.sessions,

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -1,12 +1,13 @@
 /* @vitest-environment jsdom */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewaySessionRow } from "../../api/types.ts";
+import type { GatewaySessionRow, ModelCatalogEntry } from "../../api/types.ts";
 import { createChatSubmissions } from "../../app/chat-submissions.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { showToast } from "../../lib/toast.ts";
+import { createGatewayRequestMock } from "../../test-helpers/gateway-client.ts";
 import {
   installDialogPolyfill,
   submitInputDialog,
@@ -701,13 +702,30 @@ describe("chat pane initialization", () => {
     );
   });
 
-  it("keeps active turn state when re-entry canonicalizes the main route alias", () => {
+  it("keeps active turn state when re-entry canonicalizes the main route alias", async () => {
+    const consoleError = vi.spyOn(console, "error");
+    onTestFinished(() => consoleError.mockRestore());
     const canonicalSessionKey = "agent:main:main";
-    const client = createGatewayBrowserClientFixture({ request: vi.fn() });
+    const models: ModelCatalogEntry[] = [
+      { id: "fixture-model", name: "Fixture model", provider: "test", available: true },
+    ];
+    const authStatus = { ts: 1, providers: [] };
+    const request = createGatewayRequestMock(async (method) => {
+      switch (method) {
+        case "chat.metadata":
+          return { commands: [], models, swarmEnabled: false };
+        case "models.authStatus":
+          return authStatus;
+        default:
+          throw new Error(`Unexpected gateway request: ${method}`);
+      }
+    });
+    const client = createGatewayBrowserClientFixture({ request });
     const { pane, state } = createTestChatPane({
       client,
       sessions: createSessionCapabilityFixture(),
     });
+    onTestFinished(() => pane.disconnectedCallback());
     const hello = {
       snapshot: {
         sessionDefaults: {
@@ -738,6 +756,12 @@ describe("chat pane initialization", () => {
       }
     ).willUpdate(new Map([["sessionKey", "main"]]));
 
+    expect(state.chatModelsLoading).toBe(true);
+    await vi.waitFor(() => expect(state.chatModelsLoading).toBe(false));
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(state.chatModelCatalog).toEqual(models);
+    expect(state.chatModelCatalogError).toBeNull();
+    expect(state.modelAuthStatusResult).toEqual(authStatus);
     expect(state.sessionKey).toBe(canonicalSessionKey);
     expect(state.chatRunId).toBe("run-reconnected");
     expect(state.chatStream).toBe("The response survived navigation.");


### PR DESCRIPTION
Related: #133799 (personal GitHub account connections; this is a separate test-only follow-up).

## What Problem This Solves

Resolves a problem where passing chat-pane tests emit swallowed metadata-listener exceptions, making successful CI output noisy and leaving an asynchronous fixture failure unasserted. The warnings were observed in [the checks-ui job](https://github.com/openclaw/openclaw/actions/runs/33422228657/job/99587998605) while working on the personal GitHub account feature. They were separate from that job's actual Gateway-lineage test failures.

## Why This Change Was Made

The two tests used unconfigured `request: vi.fn()` stubs. These return `undefined`; the real metadata store publishes that value, and its listener reads `result.models`. The store intentionally catches and logs listener exceptions, so the original tests still passed. This is an incomplete RPC fixture, not a missing application context or a demonstrated production defect: the inspected Gateway metadata owner returns an object or rejects.

Provide explicit method-specific startup, metadata, and model-auth responses in the existing tests; await metadata completion and assert the catalog plus zero console errors without suppressing logging. Preserve the original companion reconnect ordering and active-response assertions. Initialize the model-auth request counter in the shared pane fixture, matching production state initialization, and retire test-owned subscriptions through the existing lifecycle.

## User Impact

No runtime or UI behavior changes. Developers get meaningful coverage of asynchronous metadata hydration instead of green tests with caught listener failures. No production optional chaining, blanket context mocks, or weaker assertions were added.

Production LOC: +0/-0. Tests and test support: +70/-8 (net +62).

## Evidence

- Before repair, the repository test wrapper ran both original files successfully: 43 passing tests, two `[chat-metadata] listener error` TypeErrors. After adding the console-error assertions but before fixing the request fixtures, both affected tests failed on those exact errors. The repaired focused run passed all 43 tests with zero metadata-listener errors.
- The original CI UI configuration passed 94 tests across six relevant suites, including metadata publication/invalidation, companion replacement/reconnect, history issuance, and identity rebinding:
  ```bash
  node scripts/run-vitest.mjs run --config ui/vitest.config.ts src/pages/chat/chat-pane-companion-lifecycle.test.ts src/pages/chat/chat-pane.test.ts src/pages/chat/chat-pane-lifecycle.test.ts src/pages/chat/chat-pane-history-issuance.test.ts src/pages/chat/chat-pane-identity.test.ts src/lib/chat/chat-metadata-store.test.ts
  ```
- Independent Codex review completed with no accepted/actionable findings. The commit rebased cleanly onto current `main`, and `git range-diff` confirmed the reviewed patch is unchanged.
- UI test types passed: `node scripts/run-tsgo-core-test-shards.mjs ui`.
- Touched-file formatting and type-aware lint passed using the installed formatter and `scripts/run-oxlint.mjs`; `git diff --check` passed.
- The pre-existing `wa-dialog` Lit development warning remains and is not suppressed by this change.
- After rebasing onto current `main` and refreshing dependencies, the same six-suite UI command again passed all 94 tests. The complete changed-check plan also passed: `node scripts/check-changed.mjs -- ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts ui/src/pages/chat/chat-pane.test.ts ui/src/pages/chat/chat-pane.test-support.ts` (including core test types, i18n, ratchets, dead-export scans, formatting, and lint).
- This test-only change does not require visual proof or a live Gateway.
