### PR TITLE
test: reuse prepared CLI in lifecycle E2E suites

### DIFF
--- a/src/cli/skills-cli.clawhub-install.e2e.test.ts
+++ b/src/cli/skills-cli.clawhub-install.e2e.test.ts
@@ -20,7 +20,7 @@ async function spawnOpenClaw(
   options: { cwd: string; env: NodeJS.ProcessEnv },
 ): Promise<{ status: number | null; stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, ["--import", "tsx", "src/entry.ts", ...args], {
+    const child = spawn(process.execPath, ["openclaw.mjs", ...args], {
       cwd: options.cwd,
       env: options.env,
       stdio: ["ignore", "pipe", "pipe"],

--- a/src/hooks/hooks-lifecycle.e2e.test.ts
+++ b/src/hooks/hooks-lifecycle.e2e.test.ts
@@ -27,17 +27,13 @@ afterEach(() => {
 
 async function runHooksCli(args: string[], env: NodeJS.ProcessEnv) {
   try {
-    const result = await execFileAsync(
-      process.execPath,
-      ["--import", "tsx", "src/entry.ts", "hooks", ...args],
-      {
-        cwd: process.cwd(),
-        env,
-        encoding: "utf8",
-        maxBuffer: 1024 * 1024,
-        timeout: 90_000,
-      },
-    );
+    const result = await execFileAsync(process.execPath, ["openclaw.mjs", "hooks", ...args], {
+      cwd: process.cwd(),
+      env,
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      timeout: 90_000,
+    });
     return { stdout: result.stdout, stderr: result.stderr };
   } catch (error) {
     const failed = error as Error & { stdout?: string; stderr?: string };

--- a/test/cli-state-sqlite.e2e.test.ts
+++ b/test/cli-state-sqlite.e2e.test.ts
@@ -13,6 +13,15 @@ import {
   openOpenClawStateDatabase,
 } from "../src/state/openclaw-state-db.js";
 
+function runDoctorCli(args: string[], env: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, ["openclaw.mjs", "doctor", ...args], {
+    cwd: process.cwd(),
+    env,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+}
+
 describe("SQLite CLI maintenance ownership", () => {
   it("compacts after full CLI startup without retaining a config-health database handle", async () => {
     await withTempHome(
@@ -54,17 +63,7 @@ describe("SQLite CLI maintenance ownership", () => {
           closeOpenClawStateDatabase();
         }
 
-        const entry = path.resolve(process.cwd(), "src/entry.ts");
-        const result = spawnSync(
-          process.execPath,
-          ["--import", "tsx", entry, "doctor", "--state-sqlite", "compact", "--json"],
-          {
-            cwd: process.cwd(),
-            env,
-            encoding: "utf8",
-            timeout: 60_000,
-          },
-        );
+        const result = runDoctorCli(["--state-sqlite", "compact", "--json"], env);
 
         expect(result.status, result.stderr || result.stdout).toBe(0);
         const report = JSON.parse(result.stdout.trim()) as {
@@ -124,17 +123,7 @@ describe("SQLite CLI maintenance ownership", () => {
             const externalWalBefore = fs.readFileSync(externalWalPath);
             expect(externalWalBefore.byteLength).toBeGreaterThan(0);
 
-            const entry = path.resolve(process.cwd(), "src/entry.ts");
-            const result = spawnSync(
-              process.execPath,
-              ["--import", "tsx", entry, "doctor", "--state-sqlite", "compact", "--json"],
-              {
-                cwd: process.cwd(),
-                env,
-                encoding: "utf8",
-                timeout: 60_000,
-              },
-            );
+            const result = runDoctorCli(["--state-sqlite", "compact", "--json"], env);
 
             expect(result.status).not.toBe(0);
             expect(`${result.stderr}\n${result.stdout}`).toContain("hard-linked path");
@@ -173,26 +162,9 @@ describe("SQLite CLI maintenance ownership", () => {
         delete env.OPENCLAW_HOME;
         delete env.VITEST;
 
-        const entry = path.resolve(process.cwd(), "src/entry.ts");
-        const result = spawnSync(
-          process.execPath,
-          [
-            "--import",
-            "tsx",
-            entry,
-            "doctor",
-            "--session-sqlite",
-            "compact",
-            "--session-sqlite-store",
-            externalStorePath,
-            "--json",
-          ],
-          {
-            cwd: process.cwd(),
-            env,
-            encoding: "utf8",
-            timeout: 60_000,
-          },
+        const result = runDoctorCli(
+          ["--session-sqlite", "compact", "--session-sqlite-store", externalStorePath, "--json"],
+          env,
         );
 
         expect(result.status).not.toBe(0);
@@ -230,26 +202,9 @@ describe("SQLite CLI maintenance ownership", () => {
         delete env.OPENCLAW_HOME;
         delete env.VITEST;
 
-        const entry = path.resolve(process.cwd(), "src/entry.ts");
-        const result = spawnSync(
-          process.execPath,
-          [
-            "--import",
-            "tsx",
-            entry,
-            "doctor",
-            "--session-sqlite",
-            "compact",
-            "--session-sqlite-store",
-            storePath,
-            "--json",
-          ],
-          {
-            cwd: process.cwd(),
-            env,
-            encoding: "utf8",
-            timeout: 60_000,
-          },
+        const result = runDoctorCli(
+          ["--session-sqlite", "compact", "--session-sqlite-store", storePath, "--json"],
+          env,
         );
 
         expect(result.status).not.toBe(0);
@@ -292,26 +247,9 @@ describe("SQLite CLI maintenance ownership", () => {
           delete env.OPENCLAW_HOME;
           delete env.VITEST;
 
-          const entry = path.resolve(process.cwd(), "src/entry.ts");
-          const result = spawnSync(
-            process.execPath,
-            [
-              "--import",
-              "tsx",
-              entry,
-              "doctor",
-              "--session-sqlite",
-              "compact",
-              "--session-sqlite-store",
-              storePath,
-              "--json",
-            ],
-            {
-              cwd: process.cwd(),
-              env,
-              encoding: "utf8",
-              timeout: 60_000,
-            },
+          const result = runDoctorCli(
+            ["--session-sqlite", "compact", "--session-sqlite-store", storePath, "--json"],
+            env,
           );
 
           expect(result.status).not.toBe(0);
@@ -369,17 +307,7 @@ describe("SQLite CLI maintenance ownership", () => {
           const externalWalBefore = fs.readFileSync(externalWalPath);
           expect(externalWalBefore.byteLength).toBeGreaterThan(0);
 
-          const entry = path.resolve(process.cwd(), "src/entry.ts");
-          const result = spawnSync(
-            process.execPath,
-            ["--import", "tsx", entry, "doctor", "--session-sqlite", "compact", "--json"],
-            {
-              cwd: process.cwd(),
-              env,
-              encoding: "utf8",
-              timeout: 60_000,
-            },
-          );
+          const result = runDoctorCli(["--session-sqlite", "compact", "--json"], env);
 
           expect(result.status).not.toBe(0);
           expect(`${result.stderr}\n${result.stdout}`).toContain("hard-linked path");


### PR DESCRIPTION
## What Problem This Solves

Three CLI E2E suites repeatedly start the TypeScript loader even though their global setup already prepares the CLI build. Nine command invocations spent most of their time loading source.

## Why This Change Was Made

Run the existing public `openclaw.mjs` entrypoint, which enters the same full CLI through the prepared build. Consolidate the six identical SQLite doctor launch blocks into one local helper. The suites keep their respective subprocess APIs, arguments, environments, output capture and deadlines.

All eight cases and 37 assertion sites remain. Hooks still install a real archive, toggle persisted config and dispatch a real handler. Skill installation still uses the local resolver/archive server and checks installed files and telemetry. SQLite still runs full CLI startup and checks real compaction, hardlink/symlink rejection, external ownership and unchanged sentinel bytes. Each case retains its independent state; no production, schema or source-entry/PID test changes.

## User Impact

Test-only performance and cleanup; no production behavior change.

## Evidence

Same Linux Blacksmith Testbox, Node 24.19.0, one Vitest worker, original then revised test files:

| Test execution | Before | After |
| --- | ---: | ---: |
| SQLite maintenance, 6 cases | 35.50s | 5.46s |
| Hook lifecycle | 23.85s | 2.80s |
| ClawHub skill installation | 5.84s | 1.08s |
| Total, 8/8 passed | 65.20s | 9.34s |

The original run included the cold canonical build, while the revised run reused it. The table compares case execution only and does not claim the build-time difference as savings. Both runs retained the same eight expanded case names and passed all assertions. The owned Testbox was stopped after proof.

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/hooks/hooks-lifecycle.e2e.test.ts src/cli/skills-cli.clawhub-install.e2e.test.ts test/cli-state-sqlite.e2e.test.ts
node scripts/check-changed.mjs --base c4f291ccaa317e3a73c71595cf5700d8dde31155 -- src/hooks/hooks-lifecycle.e2e.test.ts src/cli/skills-cli.clawhub-install.e2e.test.ts test/cli-state-sqlite.e2e.test.ts
```

Production LOC: +0/-0. Tests: +29/-105, including the consolidated SQLite launcher.


Codex autoreview is scoped-clean at P0 (correctness confidence0.99). The local changed-file gate passed formatting and structural guards, then stopped because the shared local install lacks the package-local Mermaid dependency during the broad core-test typecheck. Dependency files were not changed. Exact-head hosted CI must pass before landing.

Final gate: exact-head [CI33594543750](https://github.com/openclaw/openclaw/actions/runs/33594543750) passed at ab61f35b11975558c5b5321600fc5290e611a1a6. Native prepare passed. The completed ClawSweeper review has no repair findings; its remaining normal CI/merge step is satisfied by this verified native landing.
