### PR TITLE
refactor(gateway): streamline Control UI manifest validation

### DIFF
--- a/src/gateway/control-ui-asset-manifest-parse.ts
+++ b/src/gateway/control-ui-asset-manifest-parse.ts
@@ -13,9 +13,8 @@ const CONTROL_UI_ASSET_MANIFEST_MAX_FILE_BYTES = 64 * 1024 * 1024;
 const CONTROL_UI_ASSET_MANIFEST_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
 
 function hasExactKeys(record: Record<string, unknown>, keys: readonly string[]): boolean {
-  const actual = Object.keys(record).toSorted();
-  const expected = [...keys].toSorted();
-  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+  const actual = Object.keys(record);
+  return actual.length === keys.length && actual.every((key) => keys.includes(key));
 }
 
 function isControlUiAssetManifestPath(value: string): boolean {
@@ -23,12 +22,8 @@ function isControlUiAssetManifestPath(value: string): boolean {
     return false;
   }
   const normalized = path.posix.normalize(value);
-  return (
-    normalized === value &&
-    !path.posix.isAbsolute(normalized) &&
-    !normalized.endsWith("/") &&
-    !normalized.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
-  );
+  // The assets/ prefix is relative; equality rejects dot segments and repeated separators.
+  return normalized === value && !normalized.endsWith("/");
 }
 
 export function parseControlUiAssetManifest(value: unknown): ControlUiAssetManifest | null {
@@ -77,9 +72,10 @@ export function parseControlUiAssetManifest(value: unknown): ControlUiAssetManif
     assets.push({ path: assetPath, sha256, size });
   }
 
-  const sorted = assets.toSorted((left, right) => left.path.localeCompare(right.path));
-  if (sorted.some((entry, index) => entry.path !== assets[index]?.path)) {
-    return null;
+  for (let index = 1; index < assets.length; index += 1) {
+    if (assets[index - 1]!.path.localeCompare(assets[index]!.path) > 0) {
+      return null;
+    }
   }
   if (hashControlUiAssetManifestEntries(assets) !== value.generation) {
     return null;


### PR DESCRIPTION
## What Problem This Solves

Control UI asset inventories pay unnecessary allocation and sorting costs every time the Gateway validates them. The overhead scales with the number of assets, including inventories read during asset retention and publication.

## Why This Change Was Made

Validate the fixed three-key records directly, check adjacent asset paths instead of copying and sorting an already ordered inventory, and remove path checks already implied by the required relative prefix and normalization equality. The trailing-slash rejection remains explicit. Generation hashing, duplicate detection, size limits, accessor order, collation ties, and returned object isolation are unchanged.

Production is +8/-12 (net -4); tests are unchanged. No configuration, dependency, schema, persistence, plugin, or protocol changes.

## User Impact

The complete manifest-validation operation is faster with the same accepted inventories and rejection behavior. This does not claim faster JSON decoding, asset copying, full Gateway startup, or provider requests. There is no visual UI change.

## Evidence

Measured on `fd141ddb2777528f28abb647aa71412cf8c9d45d`, Node 26.8.1, Darwin arm64, using the exact production candidate in this PR:

| Inventory | Forward median, before → after | Reverse median, before → after |
| --- | --- | --- |
| 32 assets | 35.396 → 25.823 µs (-27.05%) | 29.000 → 18.792 µs (-35.20%) |
| Retained 1,215-asset inventory | 1.238 → 0.839 ms (-32.21%) | 1.318 → 0.935 ms (-29.04%) |

Four fresh hosts ran the fixed before/candidate/candidate/before sequence across 12 workloads: 1,920 observations and 15,024 complete public calls. Each workload retains its first call, eight warmup batches, and 31 measured batches. Each batch contains eight calls; medians are divided by eight. The clock includes the full parser and real generation hashing, plus the same result-slot assignment, and excludes fixture construction, JSON decoding, serialization, compression, and assertions.

Both ordinary workloads pass the predeclared 3% improvement threshold in both orders. Every control median also improves. Two slower individual first calls remain explicit: early root-key rejection 1.750 → 2.708 µs, and the Unicode-collation case 36.708 → 38.459 µs. No samples, slower results, or controls were discarded, and no numerical thresholds or workloads changed after timing began.

An independent reviewer streamed all complete raw returns, checked every timing vector, and froze its numerical results before opening the root aggregate. Both results agree exactly. The 1,068,108,283 decoded evidence bytes remain losslessly retained locally; no private host data is published. All task-owned processes, groups, worker generations, test HOME directories, and coordinator files were verified closed.

Native behavior proof compares 32 complete cases and 38 public calls per variant, including exact resource limits, unsafe paths, duplicates, Unicode ties, inherited/nonenumerable/symbol keys, getter order, and return mutation isolation. Five existing whole test files pass 61 tests per variant with no skips or unhandled errors: the manifest suite and retention, integrity, publication, and cancellation suites. The first canonical attempt passed all 61 baseline tests but its observer incorrectly expected repository-relative module IDs; a fresh driver corrected only the five exact project-relative mappings, preserved the original failure, and passed both variants. Production source, tests, config, and thresholds did not change.

The checked-in candidate bytes match the measured candidate. Required Codex autoreview is clean at the requested P0 threshold. `pnpm check:changed -- src/gateway/control-ui-asset-manifest-parse.ts` passes, including formatting, type checks, lint, and repository guards. The branch was rebased onto `9fbf676ef1a`; affected production/test sources and dependency manifests are unchanged from the measured base. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33594556834) passed on `d7f4484f1ad4460a995ee0b412612da1aa2f864f`. A fresh pre-land Codex autoreview is also scoped-clean at P0. The latest ClawSweeper review has no correctness/security findings; its only before-merge item was completing this CI run, now satisfied.
