### PR TITLE
improve: prepare file log fields once per record

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3261,7 +3261,7 @@ src/logging/diagnostic.ts	1
 src/logging/json-console-line.ts	2
 src/logging/levels.ts	2
 src/logging/log-file-shared.ts	1
-src/logging/logger.ts	14
+src/logging/logger.ts	13
 src/logging/parse-log-line.ts	1
 src/logging/redact-internal-state.ts	1
 src/logging/redact.ts	3

--- a/src/logging/logger-redaction-behavior.test.ts
+++ b/src/logging/logger-redaction-behavior.test.ts
@@ -174,20 +174,59 @@ describe("file log redaction", () => {
     });
   });
 
-  it("writes trace context as top-level JSONL fields", async () => {
+  it.each(["bindings", "argument"])(
+    "writes %s trace context ahead of active scope",
+    async (source) => {
+      const logPath = logPathTracker.nextPath();
+      setLoggerOverride({ level: "info", file: logPath });
+      const trace = {
+        traceId: TRACE_ID,
+        spanId: SPAN_ID,
+        parentSpanId: "00f067aa0ba902b8",
+        traceFlags: "00",
+      };
+      const logger = getChildLogger({
+        subsystem: "gateway",
+        ...(source === "bindings" ? { trace } : {}),
+      });
+
+      runWithDiagnosticTraceContext(
+        createDiagnosticTraceContext({ traceId: "3bf92f3577b34da6a3ce929d0e0e4736" }),
+        () =>
+          logger.info(
+            { route: "/api/health", ...(source === "argument" ? { trace } : {}) },
+            "request completed",
+          ),
+      );
+
+      const [line] = (await readLogFile(logPath)).trim().split("\n");
+      const record = JSON.parse(line ?? "{}") as Record<string, unknown>;
+      expect(record.traceId).toBe(TRACE_ID);
+      expect(record.spanId).toBe(SPAN_ID);
+      expect(record.parentSpanId).toBe(trace.parentSpanId);
+      expect(record.traceFlags).toBe("00");
+    },
+  );
+
+  it("captures trace fields before message serialization invokes caller code", async () => {
     const logPath = logPathTracker.nextPath();
     setLoggerOverride({ level: "info", file: logPath });
-    const logger = getChildLogger({
-      subsystem: "gateway",
-      trace: { traceId: TRACE_ID, spanId: SPAN_ID },
-    });
+    const trace = { traceId: TRACE_ID, spanId: SPAN_ID };
 
-    logger.info({ route: "/api/health" }, "request completed");
+    getLogger().info(
+      { trace },
+      {
+        toJSON() {
+          trace.traceId = "3bf92f3577b34da6a3ce929d0e0e4736";
+          return "serialized";
+        },
+      },
+    );
 
-    const [line] = (await readLogFile(logPath)).trim().split("\n");
-    const record = JSON.parse(line ?? "{}") as Record<string, unknown>;
+    const record = JSON.parse((await readLogFile(logPath)).trim()) as Record<string, unknown>;
     expect(record.traceId).toBe(TRACE_ID);
     expect(record.spanId).toBe(SPAN_ID);
+    expect(record.message).toBe('"serialized"');
   });
 
   it("writes active request trace context as top-level JSONL fields", async () => {
@@ -208,17 +247,28 @@ describe("file log redaction", () => {
     expect(record.spanId).toBe(SPAN_ID);
   });
 
-  it("writes hostname and flattened message as top-level JSONL fields", async () => {
+  it.each([
+    {
+      name: "structured arguments",
+      args: [{ route: "/api/health" }, "request completed"],
+      message: "request completed",
+    },
+    {
+      name: "sparse numeric keys",
+      args: [{ "11": "eleven", "2": "two", "01": "leading", "1": "one" }],
+      message: "one leading two eleven",
+    },
+  ])("writes hostname and flattened message for $name", async ({ args, message }) => {
     const logPath = logPathTracker.nextPath();
     setLoggerOverride({ level: "info", file: logPath });
 
-    getLogger().info({ route: "/api/health" }, "request completed");
+    getLogger().info(...args);
 
     const [line] = (await readLogFile(logPath)).trim().split("\n");
     const record = JSON.parse(line ?? "{}") as Record<string, unknown>;
     expect(record.hostname).toBeTypeOf("string");
     expect(record.hostname).not.toBe("");
-    expect(record.message).toBe("request completed");
+    expect(record.message).toBe(message);
   });
 
   it("keeps bounded file-log messages UTF-16 safe", async () => {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -382,22 +382,10 @@ function resolveLogTraceContext(
     : { trustedTraceContext: false };
 }
 
-function buildTraceFileLogFields(logObj: TsLogRecord): Record<string, string> | undefined {
+function buildFileLogFields(logObj: TsLogRecord): Record<string, string> {
   const { bindings, args } = extractLogBindingPrefix(getSortedNumericLogArgs(logObj));
+  // Message serialization can invoke caller code; capture the normalized trace first.
   const { trace } = resolveLogTraceContext(bindings, args);
-  if (!trace) {
-    return undefined;
-  }
-  return {
-    traceId: trace.traceId,
-    ...(trace.spanId ? { spanId: trace.spanId } : {}),
-    ...(trace.parentSpanId ? { parentSpanId: trace.parentSpanId } : {}),
-    ...(trace.traceFlags ? { traceFlags: trace.traceFlags } : {}),
-  };
-}
-
-function buildStructuredFileLogFields(logObj: TsLogRecord): Record<string, string> {
-  const { bindings, args } = extractLogBindingPrefix(getSortedNumericLogArgs(logObj));
   const structuredArg = isPlainLogRecordObject(args[0]) ? args[0] : undefined;
   const sources = [structuredArg, bindings, logObj];
   const messageArgs =
@@ -412,6 +400,7 @@ function buildStructuredFileLogFields(logObj: TsLogRecord): Record<string, strin
     ...(agentId ? { agent_id: agentId } : {}),
     ...(sessionId ? { session_id: sessionId } : {}),
     ...(channel ? { channel } : {}),
+    ...trace,
   };
 }
 
@@ -625,22 +614,20 @@ function buildLogger(settings: ResolvedRuntimeSettings): TsLogger<LogObj> {
         }
       }
       const time = formatTimestamp(logObj.date ?? new Date(), { style: "long" });
-      const traceFields = buildTraceFileLogFields(logObj as TsLogRecord);
-      const structuredFields = buildStructuredFileLogFields(logObj as TsLogRecord);
+      const fields = buildFileLogFields(logObj as TsLogRecord);
       const record = {
         ...logObj,
         _meta: withResolvedLogMetaHostname(
           logObj["_meta"],
-          expectDefined(structuredFields.hostname, "structured log hostname"),
+          expectDefined(fields.hostname, "structured log hostname"),
         ),
         time,
-        ...structuredFields,
-        ...traceFields,
+        ...fields,
       };
       const line = redactSensitiveText(JSON.stringify(redactLogRecordForTransport(record)));
       fileLogTransport.enqueue({
         file: activeFile,
-        hostname: expectDefined(structuredFields.hostname, "structured log hostname"),
+        hostname: expectDefined(fields.hostname, "structured log hostname"),
         maxFileBytes: settings.maxFileBytes,
         payload: `${line}\n`,
       });


### PR DESCRIPTION
The file logger prepared each record's numeric arguments twice and parsed each JSON binding prefix twice, once for trace fields and again for structured fields. Build those fields together from one preparation, and carry the trace owner's normalized or frozen fields forward. Trace capture still precedes caller-controlled message serialization. Diagnostics retains its own preparation after redaction so its mutable argument list and trace trust remain independent.

Production is net -13 lines. Existing field tests now cover binding/argument precedence and sparse numeric ordering, with a serialization callback case protecting trace capture order. The assertion-safety inventory shrinks by one for the removed call-site cast; no suppression or policy exception is added.

Validation: 93 focused tests across seven files pass on both versions. Real child-process logging produces identical file records and diagnostic events for 19 direct, subsystem, console-capture and file-generation scenarios. For 500 actual file records, binding parses and numeric argument sorts each fall from 1,000 to 500 with identical output size. Three admitted owner timing pairs show ordinary bound-log CPU reductions of 1.7–4.5%; this excludes filesystem I/O and does not establish a Gateway RSS or retained-heap reduction. The full canonical changed-code gate passed, including both core type graphs and core/scripts lint.
