### PR TITLE
refactor: keep Gateway session metadata reads lightweight

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import type { Compilable, QueryResult } from "kysely";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../../infra/kysely-sync.js";
@@ -19,35 +18,13 @@ import {
   upsertSessionEntryCore,
 } from "./session-accessor.js";
 import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
+import {
+  readSessionEntryCount,
+  readSessionEntryKeys,
+} from "./session-accessor.sqlite-entry-store.js";
 import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 
 const parseSessionEntryCalls = vi.hoisted(() => vi.fn());
-const sessionNodeVersionScans = vi.hoisted(() => ({
-  onScan: undefined as ((database: DatabaseSync) => void) | undefined,
-  rowCounts: [] as number[],
-}));
-
-vi.mock("../../infra/kysely-sync.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../infra/kysely-sync.js")>();
-  return {
-    ...actual,
-    executeSqliteQuerySync<Row>(database: DatabaseSync, query: Compilable<Row>): QueryResult<Row> {
-      const compiled = query.compile();
-      const result = actual.executeSqliteQuerySync(database, query);
-      if (
-        compiled.sql.replace(/\s+/gu, " ").trim() ===
-        'select "session_key", "updated_at" from "session_nodes"'
-      ) {
-        sessionNodeVersionScans.rowCounts.push(result.rows.length);
-        const onScan = sessionNodeVersionScans.onScan;
-        sessionNodeVersionScans.onScan = undefined;
-        onScan?.(database);
-      }
-      return result;
-    },
-  };
-});
-
 vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-status.js")>();
   return {
@@ -63,8 +40,6 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 beforeEach(() => {
   parseSessionEntryCalls.mockClear();
-  sessionNodeVersionScans.onScan = undefined;
-  sessionNodeVersionScans.rowCounts.length = 0;
 });
 
 afterEach(() => {
@@ -143,6 +118,8 @@ describe("SQLite session entry cache", () => {
   it.each([
     ["malformed", "{", false],
     ["JSON5", '{sessionId:"raw",updatedAt:1}', false],
+    ["non-finite identity", '{"sessionId":"raw","updatedAt":1e999}', false],
+    ["duplicate identity", '{"sessionId":null,"sessionId":"raw","updatedAt":1}', true],
     [
       "duplicate prompts",
       '{"sessionId":"raw","updatedAt":1,"skillsSnapshot":{},"skillsSnapshot":{"prompt":"last","skills":[]}}',
@@ -164,6 +141,8 @@ describe("SQLite session entry cache", () => {
     const snapshot = readSessionEntryCache(database, { cache: false });
     expect(snapshot.keys).toEqual([scope.sessionKey]);
     expect(snapshot.entries.size).toBe(readable ? 1 : 0);
+    expect(readSessionEntryCount(database)).toBe(readable ? 1 : 0);
+    expect(readSessionEntryKeys(database)).toEqual(readable ? [scope.sessionKey] : []);
     expect(snapshot.entries.get(scope.sessionKey)?.skillsSnapshot).toBeUndefined();
   });
 
@@ -331,7 +310,6 @@ describe("SQLite session entry cache", () => {
     expect(second[0]?.entry).toBe(first[0]?.entry);
     expect(second[1]?.entry).toBe(first[1]?.entry);
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(sessionNodeVersionScans.rowCounts).toEqual([]);
   });
 
   it("fully reloads after another connection commits", async () => {
@@ -424,7 +402,7 @@ describe("SQLite session entry cache", () => {
     }
   });
 
-  it("fully reloads when an external commit races incremental row reads", async () => {
+  it("observes a commit during a listing on the next snapshot", async () => {
     const scope = createSessionScope("external-race");
     const siblingScope = { ...scope, sessionKey: "agent:main:external-race-sibling" };
     await upsertSessionEntryCore(scope, {
@@ -463,25 +441,29 @@ describe("SQLite session entry cache", () => {
         sessionId: "external-race-sibling",
         updatedAt: 2,
       };
-      sessionNodeVersionScans.onScan = () => {
+      parseSessionEntryCalls.mockImplementationOnce(() => {
         external
           .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
           .run(JSON.stringify(externalEntry), externalEntry.updatedAt, siblingScope.sessionKey);
-      };
+      });
 
       const entries = listSessionEntriesCore(scope);
       const byId = new Map(entries.map((row) => [row.entry.sessionId, row.entry]));
 
       expect(byId.get("external-race-local")?.label).toBe("local-after");
-      expect(byId.get("external-race-sibling")?.label).toBe("external-after");
-      expect(sessionNodeVersionScans.rowCounts).toEqual([2]);
+      expect(byId.get("external-race-sibling")?.label).toBe("external-before");
+      expect(
+        listSessionEntriesCore(scope).find(
+          ({ entry }) => entry.sessionId === "external-race-sibling",
+        )?.entry.label,
+      ).toBe("external-after");
     } finally {
       maintenance.close();
       external.close();
     }
   });
 
-  it("incrementally handles added and removed keys on the cached connection", async () => {
+  it("reloads added and removed keys after an untracked connection write", async () => {
     const scope = createSessionScope("same-connection-keys");
     const removedScope = { ...scope, sessionKey: "agent:main:same-connection-removed" };
     await upsertSessionEntryCore(scope, {
@@ -524,14 +506,16 @@ describe("SQLite session entry cache", () => {
     expect(entries.map((row) => row.sessionKey)).toEqual(
       [scope.sessionKey, insertedKey].toSorted(),
     );
-    expect(entries.find((row) => row.sessionKey === scope.sessionKey)?.entry).toBe(keptProjection);
+    expect(entries.find((row) => row.sessionKey === scope.sessionKey)?.entry).toEqual(
+      keptProjection,
+    );
     expect(entries.find((row) => row.sessionKey === insertedKey)?.entry).toMatchObject(
       insertedEntry,
     );
-    expect(parseSessionEntryCalls).toHaveBeenCalledOnce();
+    expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
   });
 
-  it("scales parse and projection work with changed keys instead of store size", async () => {
+  it("scales tracked projection work with changed keys without parsing saved prompts", async () => {
     const scope = createSessionScope("changed-key-scaling");
     const rowCount = 24;
     for (let index = 0; index < rowCount; index++) {
@@ -546,7 +530,7 @@ describe("SQLite session entry cache", () => {
     }
     listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
-    const database = openOpenClawAgentDatabase(scope);
+    parseSessionEntryCalls.mockClear();
     for (const index of [3, 19]) {
       const sessionKey = `agent:main:changed-key-scaling-${index}`;
       const entry = {
@@ -555,13 +539,8 @@ describe("SQLite session entry cache", () => {
         updatedAt: 1_000 + index,
         skillsSnapshot: { prompt: "large skill prompt".repeat(8192), skills: [] },
       };
-      database.db
-        .prepare(
-          "UPDATE session_nodes SET entry_json = ?, label = ?, updated_at = ? WHERE session_key = ?",
-        )
-        .run(JSON.stringify(entry), entry.label, entry.updatedAt, sessionKey);
+      await upsertSessionEntryCore({ ...scope, sessionKey }, entry);
     }
-    parseSessionEntryCalls.mockClear();
 
     const entries = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
@@ -608,7 +587,6 @@ describe("SQLite session entry cache", () => {
       siblingBefore,
     );
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(sessionNodeVersionScans.rowCounts).toEqual([]);
 
     const cachedAfter = readSessionEntryCache(database, { cache: true });
     expect(cachedAfter.entries).toBe(cachedBefore.entries);
@@ -656,36 +634,43 @@ describe("SQLite session entry cache", () => {
     expect(cachedAfter.entries.get(scope.sessionKey)).toBe(existing);
   });
 
-  it("does not let a tracked write mask an earlier raw connection write", async () => {
-    const scope = createSessionScope("raw-before-tracked");
-    const trackedScope = { ...scope, sessionKey: "agent:main:tracked-after-raw" };
-    await upsertSessionEntryCore(scope, { label: "raw-before", sessionId: "raw", updatedAt: 1 });
-    await upsertSessionEntryCore(trackedScope, {
-      label: "tracked-before",
-      sessionId: "tracked",
-      updatedAt: 1,
-    });
-    listSessionEntriesCore(scope);
+  it.each([false, true])(
+    "does not mask a raw write before a tracked write (same timestamp: %s)",
+    async (sameTimestamp) => {
+      const scope = createSessionScope("raw-before-tracked");
+      const trackedScope = { ...scope, sessionKey: "agent:main:tracked-after-raw" };
+      await upsertSessionEntryCore(scope, { label: "raw-before", sessionId: "raw", updatedAt: 1 });
+      await upsertSessionEntryCore(trackedScope, {
+        label: "tracked-before",
+        sessionId: "tracked",
+        updatedAt: 1,
+      });
+      listSessionEntriesCore(scope);
 
-    const database = openOpenClawAgentDatabase(scope);
-    const rawEntry = { label: "raw-after", sessionId: "raw", updatedAt: Date.now() };
-    database.db
-      .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
-      .run(JSON.stringify(rawEntry), rawEntry.updatedAt, scope.sessionKey);
-    await upsertSessionEntryCore(trackedScope, { label: "tracked-after", updatedAt: 2 });
+      const database = openOpenClawAgentDatabase(scope);
+      const previous = loadSessionEntry(scope)!;
+      const rawEntry = {
+        ...previous,
+        label: "raw-after",
+        updatedAt: previous.updatedAt + (sameTimestamp ? 0 : 1),
+      };
+      database.db
+        .prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?")
+        .run(JSON.stringify(rawEntry), rawEntry.updatedAt, scope.sessionKey);
+      await upsertSessionEntryCore(trackedScope, { label: "tracked-after", updatedAt: 2 });
 
-    parseSessionEntryCalls.mockClear();
-    const entries = listSessionEntriesCore(scope);
-    const entriesBySessionId = new Map(entries.map((row) => [row.entry.sessionId, row.entry]));
+      parseSessionEntryCalls.mockClear();
+      const entries = listSessionEntriesCore(scope);
+      const entriesBySessionId = new Map(entries.map((row) => [row.entry.sessionId, row.entry]));
 
-    expect(entriesBySessionId.get("raw")).toMatchObject(rawEntry);
-    expect(entriesBySessionId.get("tracked")).toMatchObject({
-      label: "tracked-after",
-      sessionId: "tracked",
-    });
-    expect(parseSessionEntryCalls).toHaveBeenCalledOnce();
-    expect(sessionNodeVersionScans.rowCounts).toEqual([2]);
-  });
+      expect(entriesBySessionId.get("raw")).toMatchObject(rawEntry);
+      expect(entriesBySessionId.get("tracked")).toMatchObject({
+        label: "tracked-after",
+        sessionId: "tracked",
+      });
+      expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("invalidates cached keys when transcript creation inserts a placeholder node", async () => {
     const scope = createSessionScope("placeholder-key");
@@ -802,7 +787,6 @@ describe("SQLite session entry cache", () => {
       .run(JSON.stringify(updated), updated.updatedAt, scope.sessionKey);
 
     expect(listSessionEntriesCore(scope)[0]?.entry.label).toBe("latest");
-    expect(sessionNodeVersionScans.rowCounts).toEqual([1]);
     expect(loadSessionEntry({ ...scope, readConsistency: "latest" })?.label).toBe("latest");
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-doctor-rewrite.ts
+++ b/src/config/sessions/session-accessor.sqlite-doctor-rewrite.ts
@@ -97,7 +97,7 @@ export function rewriteDoctorSessionEntries(params: {
           });
           publishSessionEntryCacheInvalidation(
             database,
-            { ...row, entry_json: entryJson },
+            { sessionKey, entry: nextEntry },
             writeGeneration,
           );
           batchRewritten += 1;

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -23,12 +23,8 @@ export type SessionEntryCacheSnapshot = {
   keys: string[];
 };
 
-type SqliteSessionEntryCache = LoadedSessionEntrySnapshot & {
+type SqliteSessionEntryCache = SessionEntryCacheSnapshot & {
   validityToken: SqliteSessionEntryCacheValidityToken;
-};
-
-type LoadedSessionEntrySnapshot = SessionEntryCacheSnapshot & {
-  updatedAtByKey: Map<string, number>;
 };
 
 type SqliteSessionEntryCacheValidityToken = {
@@ -40,8 +36,6 @@ type SqliteSessionEntryCacheWriteGeneration = {
   after: number;
   before: number;
 };
-
-const MAX_INCREMENTAL_ENTRY_READ_KEYS = 500;
 
 // Retain listing metadata only; complete prompt snapshots belong to the caller's full read.
 // Weak connection ownership lets closed read-only and evicted database handles release their
@@ -169,7 +163,7 @@ function selectSessionEntrySnapshotRows(
 function loadSessionEntrySnapshot(
   database: SessionEntryCacheDatabase,
   projection: "full" | "list" = "list",
-): LoadedSessionEntrySnapshot {
+): SessionEntryCacheSnapshot {
   const rows = iterateSqliteQuerySync(
     database.db,
     selectSessionEntrySnapshotRows(database, projection)
@@ -178,11 +172,9 @@ function loadSessionEntrySnapshot(
   );
   const parsedEntries = new Map<string, SessionEntry>();
   const keys: string[] = [];
-  const updatedAtByKey = new Map<string, number>();
   // Stream raw JSON so a full read never holds both serialized and parsed store-wide payloads.
   for (const row of rows) {
     keys.push(row.session_key);
-    updatedAtByKey.set(row.session_key, row.updated_at);
     const entry = parseSessionEntryProjection(row, projection);
     if (!entry) {
       continue;
@@ -193,62 +185,6 @@ function loadSessionEntrySnapshot(
   return {
     entries,
     keys,
-    updatedAtByKey,
-  };
-}
-
-function incrementallyRevalidateSessionEntrySnapshot(
-  database: SessionEntryCacheDatabase,
-  cached: SqliteSessionEntryCache,
-  validityToken: SqliteSessionEntryCacheValidityToken,
-): SqliteSessionEntryCache {
-  const db = getSessionKysely(database.db);
-  const versions = executeSqliteQuerySync(
-    database.db,
-    db.selectFrom("session_nodes").select(["session_key", "updated_at"]),
-  ).rows;
-  const updatedAtByKey = new Map(versions.map((row) => [row.session_key, row.updated_at]));
-  const changedKeys = versions
-    .filter((row) => cached.updatedAtByKey.get(row.session_key) !== row.updated_at)
-    .map((row) => row.session_key);
-  const removedKeys = cached.keys.filter((sessionKey) => !updatedAtByKey.has(sessionKey));
-
-  if (changedKeys.length === 0 && removedKeys.length === 0) {
-    cached.validityToken = validityToken;
-    return cached;
-  }
-
-  // Keep the parameterized IN probe below SQLite variable limits. A bulk change is
-  // already cheaper to reload than to preserve individual parsed identities.
-  if (changedKeys.length > MAX_INCREMENTAL_ENTRY_READ_KEYS) {
-    const loaded = loadSessionEntrySnapshot(database);
-    return { ...loaded, validityToken };
-  }
-
-  const entries = new Map(cached.entries);
-  for (const sessionKey of [...changedKeys, ...removedKeys]) {
-    entries.delete(sessionKey);
-  }
-  if (changedKeys.length > 0) {
-    const changedRows = iterateSqliteQuerySync(
-      database.db,
-      selectSessionEntrySnapshotRows(database).where("session_key", "in", changedKeys),
-    );
-    for (const row of changedRows) {
-      const entry = parseSessionEntryProjection(row);
-      if (entry) {
-        entries.set(
-          row.session_key,
-          projectSqliteSessionParticipants(database.db, row.session_key, entry),
-        );
-      }
-    }
-  }
-  return {
-    entries,
-    keys: versions.map((row) => row.session_key).toSorted(),
-    updatedAtByKey,
-    validityToken,
   };
 }
 
@@ -269,47 +205,12 @@ export function readSessionEntryCache(
   if (cached && cacheValidityTokensEqual(cached.validityToken, validityToken)) {
     return cached;
   }
-  if (cached && cached.validityToken.dataVersion === validityToken.dataVersion) {
-    // updated_at is entry-controlled, not a rowversion. Other connections can rewrite entry_json
-    // without advancing it, so data_version changes must fully reload or same-ms rewrites go stale.
-    // The TEMP generation changes only for session_nodes DML, including raw same-connection
-    // writers. Unrelated transcript-table writes therefore stay on the O(1) cache-hit path.
-    const revalidated = incrementallyRevalidateSessionEntrySnapshot(
-      database,
-      cached,
-      validityToken,
-    );
-    if (readDataVersion(database.db) !== validityToken.dataVersion) {
-      // An external commit raced the two incremental reads. Reload from one row snapshot;
-      // publishing their mixed result could temporarily omit or retain the wrong keys.
-      const reloadToken = readCacheValidityToken(database.db);
-      const loaded = loadSessionEntrySnapshot(database);
-      const next = { ...loaded, validityToken: reloadToken };
-      sessionEntryCaches.set(database.db, next);
-      return next;
-    }
-    sessionEntryCaches.set(database.db, revalidated);
-    return revalidated;
-  }
+  // Only tracked publications identify changed rows. A generation gap can contain
+  // same-timestamp or owner-only edits; updated_at cannot validate a partial reload.
   const loaded = loadSessionEntrySnapshot(database);
   const next = { ...loaded, validityToken };
   sessionEntryCaches.set(database.db, next);
   return next;
-}
-
-function invalidateTrackedCache(database: OpenClawAgentDatabase): void {
-  const invalidate = () => {
-    sessionEntryCaches.delete(database.db);
-  };
-  if (deferOpenClawAgentPostCommitPublication(database, invalidate)) {
-    return;
-  }
-  if (database.db.isTransaction) {
-    throw new Error(
-      "SQLite session entry writes must use runOpenClawAgentWriteTransaction for cache publication",
-    );
-  }
-  invalidate();
 }
 
 function publishTrackedCacheUpdate(database: OpenClawAgentDatabase, publish: () => void): void {
@@ -326,14 +227,13 @@ function publishTrackedCacheUpdate(database: OpenClawAgentDatabase, publish: () 
 
 function publishSqliteSessionEntryCacheUpsert(
   database: OpenClawAgentDatabase,
-  row: {
-    current_session_id: string;
-    entry_json: string;
-    session_key: string;
-    updated_at: number;
-  },
-  writeGeneration?: SqliteSessionEntryCacheWriteGeneration,
+  update: { sessionKey: string; entry: SessionEntry },
+  writeGeneration: SqliteSessionEntryCacheWriteGeneration,
 ): void {
+  const { sessionKey } = update;
+  // Carry the writer's canonical metadata forward, but own detached nested values.
+  // Saved prompts are caller-owned and must never be serialized into the listing cache.
+  const { skillsSnapshot: _skills, systemPromptReport: _report, ...metadata } = update.entry;
   const ownerRow = hasSqliteSessionOwnerColumns(database.db)
     ? executeSqliteQuerySync(
         database.db,
@@ -346,25 +246,19 @@ function publishSqliteSessionEntryCacheUpsert(
             "owner_assigned_by_id",
             "owner_assigned_at",
           ])
-          .where("session_key", "=", row.session_key)
+          .where("session_key", "=", sessionKey)
           .limit(1),
       ).rows[0]
     : undefined;
   const parsedEntry = parseSessionEntryProjection({
-    current_session_id: row.current_session_id,
-    entry_json: row.entry_json,
-    updated_at: row.updated_at,
+    entry_json: JSON.stringify(metadata),
     ...ownerRow,
   });
   if (!parsedEntry) {
-    invalidateTrackedCache(database);
+    publishTrackedCacheUpdate(database, () => sessionEntryCaches.delete(database.db));
     return;
   }
-  const entry = projectSqliteSessionParticipants(database.db, row.session_key, parsedEntry);
-  if (!writeGeneration) {
-    invalidateTrackedCache(database);
-    return;
-  }
+  const entry = projectSqliteSessionParticipants(database.db, sessionKey, parsedEntry);
   publishTrackedCacheUpdate(database, () => {
     const cached = sessionEntryCaches.get(database.db);
     if (!cached) {
@@ -374,12 +268,10 @@ function publishSqliteSessionEntryCacheUpsert(
       cached.validityToken.sessionNodesGeneration === writeGeneration.before;
     // Borrowed cache views are synchronous, so the commit owner can update one
     // row in place without cloning every session map on each active-run write.
-    cached.entries.set(row.session_key, entry);
-    const knownKey = cached.updatedAtByKey.has(row.session_key);
-    cached.updatedAtByKey.set(row.session_key, row.updated_at);
-    if (!knownKey) {
-      cached.keys = [...cached.keys, row.session_key].toSorted();
+    if (!cached.entries.has(sessionKey) && !cached.keys.includes(sessionKey)) {
+      cached.keys = [...cached.keys, sessionKey].toSorted();
     }
+    cached.entries.set(sessionKey, entry);
     // Advance only across the bracketed row write. A raw write before/after this bracket leaves
     // a generation gap, while the retained data_version still exposes external commits.
     if (generationIsContinuous) {
@@ -393,17 +285,13 @@ function publishSqliteSessionEntryCacheUpsert(
 
 export function publishSessionEntryCacheInvalidation(
   database: OpenClawAgentDatabase,
-  row?: {
-    current_session_id: string;
-    entry_json: string;
-    session_key: string;
-    updated_at: number;
-  },
+  update?: { sessionKey: string; entry: SessionEntry },
   writeGeneration?: SqliteSessionEntryCacheWriteGeneration,
 ): void {
-  if (row) {
-    publishSqliteSessionEntryCacheUpsert(database, row, writeGeneration);
+  if (update && writeGeneration) {
+    publishSqliteSessionEntryCacheUpsert(database, update, writeGeneration);
     return;
   }
-  invalidateTrackedCache(database);
+  // A cold write has no snapshot to patch; do not hydrate owner/participants or prompt JSON.
+  publishTrackedCacheUpdate(database, () => sessionEntryCaches.delete(database.db));
 }

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -48,6 +48,7 @@ import {
   hasValidSessionEntryIdentity,
   parseSessionEntryJson as parseSessionEntryRow,
   sessionEntryMetadataJson,
+  sessionEntryInventoryJson,
 } from "./session-accessor.sqlite-status.js";
 import { readTranscriptMutationStateInTransaction } from "./session-accessor.sqlite-transcript-state.js";
 import {
@@ -243,11 +244,12 @@ export function readSessionEntryCount(database: OpenClawAgentDatabase): number {
   const db = getSessionKysely(database.db);
   const rows = iterateSqliteQuerySync(
     database.db,
-    db.selectFrom("session_nodes").select(sessionEntryMetadataJson),
+    db.selectFrom("session_nodes").select(sessionEntryInventoryJson),
   );
   let count = 0;
   for (const row of rows) {
-    count += parseSessionEntryRow(row) ? 1 : 0;
+    count +=
+      row.entry_json === null || parseSessionEntryRow({ entry_json: row.entry_json }) ? 1 : 0;
   }
   return count;
 }
@@ -259,10 +261,10 @@ export function readSessionEntryKeys(database: OpenClawAgentDatabaseReader): str
     database.db,
     db
       .selectFrom("session_nodes")
-      .select([sessionEntryMetadataJson, "session_key"])
+      .select([sessionEntryInventoryJson, "session_key"])
       .orderBy("session_key", "asc"),
   )) {
-    if (parseSessionEntryRow(row)) {
+    if (row.entry_json === null || parseSessionEntryRow({ entry_json: row.entry_json })) {
       keys.push(row.session_key);
     }
   }
@@ -729,6 +731,10 @@ export function writeSessionEntry(
       updatedAt,
     });
   }
-  publishSessionEntryCacheInvalidation(database, sessionNode, writeGeneration);
+  publishSessionEntryCacheInvalidation(
+    database,
+    { sessionKey, entry: normalizedEntry },
+    writeGeneration,
+  );
   return normalizedEntry;
 }

--- a/src/config/sessions/session-accessor.sqlite-status.ts
+++ b/src/config/sessions/session-accessor.sqlite-status.ts
@@ -26,6 +26,15 @@ export const sessionEntryMetadataJson =
   THEN json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')
   ELSE entry_json END`.as("entry_json");
 
+// Canonical writers settle entry_valid; raw writes clear it. Inventory readers need
+// no payload for settled rows, but must retain parser semantics for pending/retained rows.
+export const sessionEntryInventoryJson =
+  /* kysely-allow-raw: reuse the writer-owned validity projection without loading saved prompts. */ sql<
+    string | null
+  >`CASE WHEN entry_valid = 1 THEN NULL ELSE ${sessionEntryMetadataJson.expression} END`.as(
+    "entry_json",
+  );
+
 export function normalizeStatus(value: unknown): SessionEntryStatus | null {
   return value === "running" ||
     value === "done" ||

--- a/test/scripts/write-plugin-sdk-entry-dts.test.ts
+++ b/test/scripts/write-plugin-sdk-entry-dts.test.ts
@@ -144,34 +144,6 @@ describe("write-plugin-sdk-entry-dts", () => {
       expect(fs.existsSync(path.join(root, `dist/${entry}.d.ts`)), entry).toBe(false);
     }
 
-    write("test/unrelated.test.ts", "export const test = 2;\n");
-    write("ui/unrelated.ts", "export const view = 2;\n");
-    write(".github/workflows/unrelated.yml", "name: unrelated after\n");
-    const unrelated = runWriter(root);
-    expect(unrelated.status, unrelated.stdout + unrelated.stderr).toBe(0);
-    expect(unrelated.stdout + unrelated.stderr).not.toContain("[tsdown-build] invocation");
-    expect(treeHashes(path.join(root, "dist"))).toEqual(before);
-    expectStagingClean(root);
-
-    // Restore into an equivalent checkout; copying the whole fixture can turn
-    // Windows junctions into source directories and correctly invalidate its cache.
-    const { root: relocated } = createFixture();
-    fs.cpSync(
-      path.join(root, ".artifacts/build-all-cache"),
-      path.join(relocated, ".artifacts/build-all-cache"),
-      { recursive: true },
-    );
-    const restored = runWriter(relocated);
-    expect(restored.status, restored.stdout + restored.stderr).toBe(0);
-    expect(restored.stdout + restored.stderr).not.toContain("[tsdown-build] invocation");
-    const restoredFiles = treeHashes(path.join(relocated, "dist"));
-    expect(restoredFiles).toEqual(
-      Object.fromEntries(
-        Object.entries(before).filter(([file]) => !Object.hasOwn(preserved, `dist/${file}`)),
-      ),
-    );
-    expectOutputs(relocated, production, Object.keys(restoredFiles));
-    expectStagingClean(relocated);
     // Identical sources with a different QA selection must emit the extra canonical entries.
     const privateQa = runWriter(root, true);
     expect(privateQa.status, privateQa.stdout + privateQa.stderr).toBe(0);
@@ -193,12 +165,6 @@ describe("write-plugin-sdk-entry-dts", () => {
     expectOutputs(root, qa, Object.keys(first));
     expectStagingClean(root);
     expect(first).not.toEqual(before);
-    const repeated = runWriter(root, true);
-    expect(repeated.status, repeated.stdout + repeated.stderr).toBe(0);
-    expect(repeated.stdout + repeated.stderr).not.toContain("[tsdown-build] invocation");
-    // Include shared root chunks, not just flat SDK entries, in filename/byte determinism.
-    expect(treeHashes(path.join(root, "dist"))).toEqual(first);
-    expectStagingClean(root);
     expect(fs.existsSync(path.join(root, "dist/plugin-sdk/obsolete.d.ts"))).toBe(false);
     for (const [relative, content] of Object.entries(preserved)) {
       expect(fs.readFileSync(path.join(root, relative), "utf8")).toBe(content);
@@ -206,6 +172,44 @@ describe("write-plugin-sdk-entry-dts", () => {
     expect(fs.readFileSync(path.join(root, "src/schema.sql"), "utf8")).toBe(
       "CREATE TABLE fixture (value TEXT NOT NULL);",
     );
+
+    // One restore proves portable, byte-stable reuse despite unrelated edits.
+    // Copy only the cache: copying Windows junctions can change the source topology.
+    const {
+      root: relocated,
+      write: writeRelocated,
+      writeDeclarations: writeRelocatedDeclarations,
+    } = createFixture();
+    writeRelocatedDeclarations("after");
+    fs.rmSync(path.join(relocated, "contracts/before.ts"));
+    writeRelocated("test/unrelated.test.ts", "export const test = 2;\n");
+    writeRelocated("ui/unrelated.ts", "export const view = 2;\n");
+    writeRelocated(".github/workflows/unrelated.yml", "name: unrelated after\n");
+    for (const [relative, content] of Object.entries(preserved)) {
+      writeRelocated(relative, content);
+    }
+    // SDK publication owns flat entries; historical shared chunks belong to other groups.
+    for (const file of Object.keys(before).filter((entry) => !entry.startsWith("plugin-sdk/"))) {
+      expect(first[file]).toBe(before[file]);
+      writeRelocated(`dist/${file}`, fs.readFileSync(path.join(root, "dist", file), "utf8"));
+    }
+    writeRelocated("dist/plugin-sdk/obsolete.d.ts", "obsolete restored declaration");
+    fs.cpSync(
+      path.join(root, ".artifacts/build-all-cache"),
+      path.join(relocated, ".artifacts/build-all-cache"),
+      { recursive: true },
+    );
+    const restored = runWriter(relocated, true);
+    expect(restored.status, restored.stdout + restored.stderr).toBe(0);
+    expect(restored.stdout + restored.stderr).not.toContain("[tsdown-build] invocation");
+    const restoredFiles = treeHashes(path.join(relocated, "dist"));
+    // Include shared root chunks, not just flat SDK entries, in filename/byte determinism.
+    expect(restoredFiles).toEqual(first);
+    expectOutputs(relocated, qa, Object.keys(restoredFiles));
+    expectStagingClean(relocated);
+    for (const [relative, content] of Object.entries(preserved)) {
+      expect(fs.readFileSync(path.join(relocated, relative), "utf8")).toBe(content);
+    }
 
     write(
       "consumer.ts",


### PR DESCRIPTION
## What Problem This Solves

Reduces synchronous session metadata work during concurrent Gateway updates. Counting sessions and enumerating their keys previously processed every complete saved-entry JSON document, and cache publication decoded complete entries even when no listing cache existed. Cached listings could also remain stale after an untracked same-timestamp row rewrite.

## Why This Change Was Made

Keep metadata preparation with the canonical session writer and doctor rewrite owner. Warm listing updates now detach only the metadata they need; cold writes skip cache materialization. Count/key readers use the existing validated-row projection and preserve the JSON parser for unsettled or retained rows. The validity triggers, schema, transaction boundaries, and persisted formats are unchanged.

Remove timestamp-based incremental reconciliation and its duplicate timestamp map. Only a tracked writer proves which row changed; unknown writes now reload the existing metadata snapshot. Ordinary tracked updates still preserve unchanged entries without reparsing siblings. This deliberately trades a full metadata reload after an unknown write for correct freshness.

## User Impact

Less prompt-sized allocation and parsing on session control paths, with current listings after equal-timestamp edits. Full session reads retain saved prompts, and owner/participant projection, rollback, and post-commit publication remain intact. This is a measured reduction in the remaining synchronous work, not a claim that all Gateway saturation is resolved.

## Evidence

- New equal-timestamp regression failed on base `2dce74a421ef580d3f84563e4e37cb5cd623980b` (`raw-before` instead of `raw-after`); 22 siblings passed. All 226 focused and sibling cases pass with the refactor, including session lifecycle/maintenance, readonly access, and doctor rewrites.
- Retained coverage includes cold/missing stores, malformed/duplicate/deep JSON, retained transcript nodes, external commits, rollback, isolated connections, metadata detachment, and tracked-write scaling without saved-prompt parsing.
- Independent Codex review completed with no accepted/actionable findings at its P0 threshold.
- Production delta: **−97 lines**; tests: **−12 lines**. No new dependencies, options, schema, protocol, or transaction changes.

Controlled four-CPU Blacksmith comparison: separate exact-source builds, ABBA at 32/64 turns and two additional profiles. All ten runs passed unchanged 2000ms budgets with zero operation failures or metadata rescans. At 512 sessions with 64KiB saved prompts, count reads improved from 13.97ms to 0.306ms (46×); key enumeration from 12.44ms to 0.427ms (29×). Live-profile session-count cost fell from 84.9ms (0.818% of samples) to 2.12ms (0.0225%).

End-to-end latency remains variable: at 64 turns, per-run list maxima were 703–1095ms before and 811–825ms after, and history p99 was 723–1091ms versus 866–925ms. Pair directions are mixed, background request counts vary, and median event-loop utilization remains 100%; these results do not establish a general latency win. This PR lands the demonstrated metadata improvement and freshness fix while retaining the residual SQLite/history performance work as a follow-up.

Reproduction uses the unchanged `scripts/bench-gateway-concurrency.ts` mixed workload (128 updates/4 clients, 3 history clients ×5, 6 subscribers, visible observer, 100ms cadence, 1000ms stream delay), isolated HOME/state/loopback ports, and synthetic provider responses through real Gateway HTTP/RPC. Both temporary worktrees and all Gateway state were cleaned up. [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/33593794105).

Required changed gate passed on [Blacksmith](https://github.com/openclaw/openclaw/actions/runs/33593713207): core/test typechecks, lint, dead-export scan, database/schema and import guards. The delegated command exited 0 and its one-shot worker was stopped.

The first exact-head CI run and its single unchanged-head retry both timed out the preexisting synthetic SDK declaration case on Windows (120s limit; 120.3s and137.9s observed). The fixture does not execute the changed session code. A focused test-only consolidation reduces six writer launches to four: independent production, QA-selection and changed-input builds remain, while one restored generation checks cache reuse, portability, ignored unrelated edits and exact output bytes together. Full public entry inventory, nominal types, stale-output cleanup, historical shared chunks and unrelated/local artifacts remain covered. No timeout, assertion, compiler or scheduling requirement was relaxed.

The complete SDK file passes11 cases locally; the consolidated case takes95.1s versus112.1s before. Temporary faults that skip cached stale-output cleanup or incorrectly include an unrelated file in the cache signature both fail the intended assertions, without timeouts; the production generator was restored exactly. [Exact-head full CI](https://github.com/openclaw/openclaw/actions/runs/33599449798) passed205 jobs, including both Windows jobs, with16 skipped. The formerly failing Windows SDK case completed in55.8s under the unchanged120s limit. The Gateway production afterimages used for the four-CPU benchmark are unchanged.

The SDK test correction also passed the full required changed gate on [Blacksmith](https://github.com/openclaw/openclaw/actions/runs/33599020791), including test-root typechecking, script lint and targeted test lint. Its one-shot worker stopped after command exit0. Fresh independent Codex review of the final test change is scoped-clean.
