### PR TITLE
fix(agents): keep fenced code intact when collapsing duplicate reply blocks

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.code-blocks.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.code-blocks.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-facing-text.js";
+
+describe("sanitizeUserFacingText duplicate block collapsing", () => {
+  it("collapses consecutive duplicate prose blocks", () => {
+    expect(sanitizeUserFacingText("Done.\n\nDone.\n\nNext step.")).toBe("Done.\n\nNext step.");
+  });
+
+  it("keeps repeated blank-separated lines inside a fenced block", () => {
+    const text = [
+      "Log excerpt:",
+      "",
+      "```text",
+      "[worker] retrying",
+      "",
+      "[worker] retrying",
+      "",
+      "[worker] retrying",
+      "",
+      "[worker] done",
+      "```",
+    ].join("\n");
+    expect(sanitizeUserFacingText(text)).toBe(text);
+  });
+
+  it("keeps indentation inside fenced code when a prose duplicate is collapsed", () => {
+    const code = [
+      "```python",
+      "class Worker:",
+      "    def run(self):",
+      "        self.log()",
+      "",
+      "    def log(self):",
+      "        print(1)",
+      "```",
+    ].join("\n");
+    const text = `Here it is.\n\nHere it is.\n\n${code}`;
+    expect(sanitizeUserFacingText(text)).toBe(`Here it is.\n\n${code}`);
+  });
+
+  it("keeps a message that opens with indented code intact", () => {
+    const text = "    one\n\n    one\n\nDone.\n\nDone.";
+    expect(sanitizeUserFacingText(text)).toBe("    one\n\n    one\n\nDone.");
+  });
+
+  it("keeps indented code blocks intact when a duplicate is collapsed", () => {
+    const text = "Same.\n\nSame.\n\n    indented one\n\n    indented one";
+    expect(sanitizeUserFacingText(text)).toBe("Same.\n\n    indented one\n\n    indented one");
+  });
+});

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -223,23 +223,51 @@ export function createVerifiedConversationContextStreamFilter(
   };
 }
 
+function splitBlocksOutsideCode(text: string): string[] {
+  const codeRegions = findCodeRegions(text);
+  const blocks: string[] = [];
+  let start = 0;
+  for (const match of text.matchAll(/\n{2,}/g)) {
+    if (isInsideCode(match.index, codeRegions)) {
+      continue;
+    }
+    blocks.push(text.slice(start, match.index));
+    start = match.index + match[0].length;
+  }
+  blocks.push(text.slice(start));
+  return blocks;
+}
+
+function normalizeBlockForComparison(block: string): string {
+  return block.trim().replace(/\s+/g, " ");
+}
+
+function hasConsecutiveDuplicateBlocks(blocks: string[]): boolean {
+  let lastNormalized: string | null = null;
+  for (const block of blocks) {
+    const normalized = normalizeBlockForComparison(block);
+    if (lastNormalized && normalized === lastNormalized) {
+      return true;
+    }
+    lastNormalized = normalized;
+  }
+  return false;
+}
+
 function collapseConsecutiveDuplicateBlocks(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
+  const trimmed = text.replace(/^(?:[ \t]*\r?\n)+/, "").trimEnd();
+  if (!trimmed || !hasConsecutiveDuplicateBlocks(trimmed.split(/\n{2,}/))) {
     return text;
   }
-  const blocks = trimmed.split(/\n{2,}/);
-  if (blocks.length < 2) {
-    return text;
-  }
+  const blocks = splitBlocksOutsideCode(trimmed);
   const result: string[] = [];
   let lastNormalized: string | null = null;
   for (const block of blocks) {
-    const normalized = block.trim().replace(/\s+/g, " ");
+    const normalized = normalizeBlockForComparison(block);
     if (lastNormalized && normalized === lastNormalized) {
       continue;
     }
-    result.push(block.trim());
+    result.push(block);
     lastNormalized = normalized;
   }
   return result.length === blocks.length ? text : result.join("\n\n");


### PR DESCRIPTION
## Summary
When an assistant reply contains two consecutive identical blank-line-separated blocks anywhere in the message, the delivered text is rewritten in two ways: the second copy is deleted even when it is a line inside a fenced code block, and every retained block in the whole message is trimmed, which strips the leading indentation of the first line after each blank line inside fenced and indented code. A Python class whose method follows a blank line is delivered with that method de-indented, and a log excerpt with a repeated line loses one occurrence.

The trigger is common in practice: a repeated log line quoted inside a fence, a repeated YAML or config stanza, or a prose sentence the model wrote twice. The collapse runs inside `sanitizeUserFacingText`, which `normalizeReplyPayload` applies to every reply payload, so every channel and the `openclaw agent` CLI are affected.

## Root cause
`src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`, `collapseConsecutiveDuplicateBlocks`, is the last stage of `sanitizeUserFacingText`. It splits the message on every blank-line run, including runs inside code, compares blocks whitespace-insensitively, and re-emits retained blocks trimmed:

```ts
// before
const blocks = trimmed.split(/\n{2,}/);
...
for (const block of blocks) {
  const normalized = block.trim().replace(/\s+/g, " ");
  if (lastNormalized && normalized === lastNormalized) {
    continue;
  }
  result.push(block.trim());
  lastNormalized = normalized;
}
```

Blank lines inside a fence become block boundaries, so a repeated code line is treated as a duplicate paragraph and dropped. `block.trim()` then removes the leading whitespace of every block start, which for code is the indentation of the first line after a blank line. Every other stage in this file already masks code with `findCodeRegions` and `isInsideCode`; this stage was the only one that did not.

## Fix
Split only on blank-line runs that fall outside code regions, and push retained blocks unchanged:

```ts
// after
const trimmed = text.replace(/^(?:[ \t]*\r?\n)+/, "").trimEnd();
if (!trimmed || !hasConsecutiveDuplicateBlocks(trimmed.split(/\n{2,}/))) {
  return text;
}
...
function splitBlocksOutsideCode(text: string): string[] {
  const codeRegions = findCodeRegions(text);
  const blocks: string[] = [];
  let start = 0;
  for (const match of text.matchAll(/\n{2,}/g)) {
    if (isInsideCode(match.index, codeRegions)) {
      continue;
    }
    blocks.push(text.slice(start, match.index));
    start = match.index + match[0].length;
  }
  blocks.push(text.slice(start));
  return blocks;
}
...
  const blocks = splitBlocksOutsideCode(trimmed);
...
    result.push(block);
```

A fenced or indented code block is now one opaque block, so nothing inside it can be matched or removed as a duplicate paragraph. The leading `text.trim()` becomes a leading blank-line strip plus `trimEnd()`, because trimming leading spaces off a message that opens with indented code hid that code from the region finder. Dropping `trim()` on the retained block is safe because the split boundaries already consume the surrounding blank lines, and leading whitespace on a retained block is CommonMark indented code that must survive. Consecutive duplicate prose paragraphs still collapse exactly as before, and a message with no duplicates is still returned untouched.

Cost: `sanitizeUserFacingText` also runs on every streamed partial snapshot, so the code-region parse is gated behind the same cheap blank-line split the function already did. Only a snapshot that main would have rewritten (one that has a consecutive duplicate under the naive split) pays for `findCodeRegions`; every other snapshot takes exactly the old path and returns unchanged.

## Why this is the right boundary
`collapseConsecutiveDuplicateBlocks` has a single caller, the tail of `sanitizeUserFacingText`, so this is the owner of the behavior. The fix reuses the code-region helper the file already imports for its other stages instead of adding a second masking mechanism. The two callers that reach delivery, `normalizeReplyPayload` (all channel replies) and `src/agents/command/attempt-execution.ts` (the `openclaw agent` CLI), both inherit the fix.

Related history: #41699 was closed as implemented citing #61909, but #61909 fixed `normalizeDirectiveWhitespace` in `src/utils/directive-tags.ts`, a different normalizer; the duplicate-block collapse was never changed. #41851 attempted the one-line trim removal in the since-removed `errors.ts` helper and was closed as superseded by #61909. #14629 asks for smarter duplicate detection and does not cover code safety. The live proof below shows current `main` still corrupts the reply.

## Verification
- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.sanitizeuserfacingtext.code-blocks.test.ts src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts src/agents/embedded-agent-helpers.sanitizeuserfacingtext.scaffolding.test.ts`: 3 files, 136 tests passed.
- The new test file on pristine `main`: 4 of 5 cases fail (fenced repeated line deleted, fenced indentation stripped, message opening with indented code trimmed and deduplicated, indented code stripped); the prose-collapse case passes on both, showing the existing behavior is preserved.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: clean. The `test/tsconfig/tsconfig.core.test.json` typecheck was started locally but had not finished at push time because of machine contention; CI covers it.
- `oxlint` on both files: clean. `oxfmt --check` on both files: correct format.
- `codex review --base origin/main` on an earlier revision flagged that the code-region parse ran on every streamed snapshot; the naive-split gate above addresses it.

## Real behavior proof
Behavior addressed: A delivered reply containing a repeated blank-separated line inside a fenced code block, or any repeated prose paragraph, had the repeated code line deleted and the indentation of every block in the message stripped.
Real environment tested: The `openclaw agent --local` CLI run from source in an isolated OPENCLAW_HOME, driving the real embedded agent run, the real reply pipeline and the real sanitizer, on pristine main ef3b4474444 and on this patch at 1cd7ac266ef with identical inputs. The only external seam replaced is the model provider: a loopback OpenAI-compatible HTTP server on 127.0.0.1:18931 that returns one fixed assistant reply as a streaming chat completion, configured as provider `loop` with model `mock` in openclaw.json.
Exact steps or command run after this patch: Start the loopback provider, write `~/.openclaw/openclaw.json` with `agents.defaults.model.primary: "loop/mock"` and `models.providers.loop` pointing at `http://127.0.0.1:18931/v1` (`api: "openai-completions"`), then run `node --import tsx src/entry.ts agent --local --agent main --message "show me the retry loop and its log" --json` and print `payloads[0].text`. The provider reply is a Python class whose `log` method follows a blank line, then a text fence with `[worker] retrying` three times separated by blank lines and `[worker] done`.
Evidence after fix:
````
# BEFORE (pristine main ef3b4474444)
"Here is the retry loop and the log it produced:\n\n```python\nclass Worker:\n    def run(self):\n        for attempt in range(3):\n            self.log(\"retrying\")\n\ndef log(self, msg):\n        print(msg)\n```\n\n```text\n[worker] retrying\n\n[worker] retrying\n\n[worker] done\n```"

Here is the retry loop and the log it produced:

```python
class Worker:
    def run(self):
        for attempt in range(3):
            self.log("retrying")

def log(self, msg):
        print(msg)
```

```text
[worker] retrying

[worker] retrying

[worker] done
```

# AFTER (this patch 1cd7ac266ef, identical inputs)
"Here is the retry loop and the log it produced:\n\n```python\nclass Worker:\n    def run(self):\n        for attempt in range(3):\n            self.log(\"retrying\")\n\n    def log(self, msg):\n        print(msg)\n```\n\n```text\n[worker] retrying\n\n[worker] retrying\n\n[worker] retrying\n\n[worker] done\n```"

Here is the retry loop and the log it produced:

```python
class Worker:
    def run(self):
        for attempt in range(3):
            self.log("retrying")

    def log(self, msg):
        print(msg)
```

```text
[worker] retrying

[worker] retrying

[worker] retrying

[worker] done
```
````
Observed result after fix: Before the patch the delivered reply de-indented `def log` (a Python syntax error) and dropped one of the three `[worker] retrying` lines; after the patch the delivered reply is byte-identical to the provider output, with the indentation and all three repeated log lines intact.
What was not tested: No real model provider and no real channel transport were driven; the gateway and channel delivery paths share `normalizeReplyPayload` but only the `openclaw agent --local` entry point was executed live. Full `pnpm build` was not run.

### Streamed snapshot cost
`sanitizeUserFacingText` runs on every streamed partial reply, so the added code-region lookup was timed on a 13,209 character reply made of 60 prose paragraphs and 60 fenced Python blocks, fed as 207 cumulative prefixes, on pristine main and on this head with the same runtime:

```
# main (pristine ef3b4474444)
no duplicate blocks (typical): 207 cumulative snapshots, total 10.0 ms, 0.048 ms per snapshot
with a duplicate prose block:  207 cumulative snapshots, total 10.5 ms, 0.051 ms per snapshot
# this head (1cd7ac266ef)
no duplicate blocks (typical): 207 cumulative snapshots, total 12.6 ms, 0.061 ms per snapshot
with a duplicate prose block:  207 cumulative snapshots, total 22.1 ms, 0.107 ms per snapshot
```

The typical path stays within 0.02 ms per snapshot of main because the code-region lookup only runs once the naive split has already found a consecutive duplicate.
