### PR TITLE
fix(release): prevent FRV tooling checkout omissions

### DIFF
--- a/.github/workflows/full-release-candidate.yml
+++ b/.github/workflows/full-release-candidate.yml
@@ -74,15 +74,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
-          sparse-checkout: |
-            scripts/full-release-candidate-contract.mjs
-            scripts/full-release-candidate-reuse.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/lib/actions-artifact-archive.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/full-release-candidate-reuse.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
+          sparse-checkout: scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -161,15 +153,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
-          sparse-checkout: |
-            scripts/full-release-candidate-contract.mjs
-            scripts/full-release-candidate-reuse.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/lib/actions-artifact-archive.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/full-release-candidate-reuse.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
+          sparse-checkout: scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
 

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -202,17 +202,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           path: workflow
-          sparse-checkout: |
-            scripts/release-tooling-identity.mjs
-            scripts/github/resolve-openclaw-ref.sh
-            scripts/github/validate-release-suite-filters.sh
-            scripts/full-release-candidate-contract.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/lib/release-context.mjs
-            scripts/lib/release-version.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
+          sparse-checkout: scripts
           sparse-checkout-cone-mode: false
           fetch-depth: 1
           persist-credentials: false
@@ -599,26 +589,8 @@ jobs:
           ref: ${{ github.sha }}
           path: workflow
           sparse-checkout: |
-            scripts/github/find-reusable-release-validation.sh
-            scripts/release-ci-summary.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/full-release-candidate-contract.mjs
-            scripts/release-preflight.mjs
-            scripts/release-preflight.mts
-            scripts/windows-cmd-helpers.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
-            scripts/lib/plain-gh.mjs
-            scripts/lib/tsx-cli-shim.mjs
-            scripts/lib/local-check-runtime.mts
-            scripts/lib/failed-trailer.mts
-            scripts/lib/error-format.mts
-            scripts/lib/managed-child-process.mts
-            scripts/lib/vitest-resource-ownership.mts
-            scripts/lib/windows-taskkill.mjs
-            scripts/lib/release-version.mjs
-            .github/actions/setup-pnpm-store-cache/ensure-node.sh
+            scripts
+            .github/actions/setup-pnpm-store-cache
           sparse-checkout-cone-mode: false
           fetch-depth: 1
           persist-credentials: false
@@ -1427,15 +1399,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
-          sparse-checkout: |
-            scripts/full-release-validation-state.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/full-release-candidate-contract.mjs
-            scripts/release-ci-summary.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/plain-gh.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
+          sparse-checkout: scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -1667,15 +1631,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
-          sparse-checkout: |
-            scripts/full-release-validation-state.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/full-release-candidate-contract.mjs
-            scripts/release-ci-summary.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/plain-gh.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
+          sparse-checkout: scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -1741,15 +1697,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
-          sparse-checkout: |
-            scripts/full-release-validation-state.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/full-release-candidate-contract.mjs
-            scripts/release-ci-summary.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/plain-gh.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
+          sparse-checkout: scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -1851,18 +1799,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
-          sparse-checkout: |
-            scripts/full-release-validation-state.mjs
-            scripts/full-release-validation-policy.mjs
-            scripts/full-release-candidate-contract.mjs
-            scripts/full-release-candidate-reuse.mjs
-            scripts/release-ci-summary.mjs
-            scripts/lib/actions-artifact-archive.mjs
-            scripts/lib/canonical-json.mjs
-            scripts/lib/full-release-candidate-reuse.mjs
-            scripts/lib/plain-gh.mjs
-            scripts/lib/record-shared.mjs
-            scripts/lib/upgrade-survivor-policy.mjs
+          sparse-checkout: scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -13309,32 +13309,18 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(telegramProvenanceHelper).not.toContain(".baseRefName ==");
   });
 
-  it("checks out the complete Release Decision evidence validator closure", () => {
+  it("checks out the complete trusted Release Decision scripts tree", () => {
     const workflow = readWorkflow(".github/workflows/full-release-validation.yml");
     const checkout = workflow.jobs.release_decision.steps.find(
       (step: WorkflowStep) => step.name === "Checkout release decision tooling",
     );
-    const sparseCheckoutPaths = String(checkout?.with?.["sparse-checkout"] ?? "")
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
 
-    expect(sparseCheckoutPaths).toEqual([
-      "scripts/full-release-validation-state.mjs",
-      "scripts/full-release-validation-policy.mjs",
-      "scripts/full-release-candidate-contract.mjs",
-      "scripts/release-ci-summary.mjs",
-      "scripts/lib/canonical-json.mjs",
-      "scripts/lib/plain-gh.mjs",
-      "scripts/lib/record-shared.mjs",
-      "scripts/lib/upgrade-survivor-policy.mjs",
-    ]);
-    for (const sparsePath of sparseCheckoutPaths) {
-      expect({ sparsePath, exists: existsSync(sparsePath) }).toEqual({
-        sparsePath,
-        exists: true,
-      });
-    }
+    expect(checkout?.with).toMatchObject({
+      ref: "${{ github.sha }}",
+      "sparse-checkout": "scripts",
+      "sparse-checkout-cone-mode": false,
+      "persist-credentials": false,
+    });
   });
 
   it("keeps maturity scorecard release docs opt-in from release checks", () => {

--- a/test/scripts/full-release-validation-continuation-workflow.test.ts
+++ b/test/scripts/full-release-validation-continuation-workflow.test.ts
@@ -1,104 +1,177 @@
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { copyFileSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
 const source = readFileSync(".github/workflows/full-release-validation.yml", "utf8");
-const workflow = parse(source) as {
+type Workflow = {
   jobs: Record<
     string,
     { if?: string; steps: Array<Record<string, unknown>>; "timeout-minutes"?: number }
   >;
   on: { workflow_dispatch: { inputs: Record<string, unknown> } };
 };
+const workflow = parse(source) as Workflow;
 
-function step(job: string, name: string) {
-  const match = workflow.jobs[job]?.steps.find((entry) => entry.name === name);
+function step(job: string, name: string, owner = workflow) {
+  const match = owner.jobs[job]?.steps.find((entry) => entry.name === name);
   if (!match) {
     throw new Error(`missing workflow step: ${job}/${name}`);
   }
   return match;
 }
 
+function sparsePaths(checkout: Record<string, unknown>) {
+  const value = checkout["sparse-checkout"];
+  if (typeof value !== "string") {
+    throw new TypeError("sparse-checkout must be a string");
+  }
+  return value
+    .split("\n")
+    .map((path) => path.trim())
+    .filter(Boolean);
+}
+
+function checkoutPath(checkout: Record<string, unknown>) {
+  if (checkout.path === undefined) {
+    return "";
+  }
+  if (typeof checkout.path !== "string") {
+    throw new TypeError("checkout path must be a string");
+  }
+  return checkout.path;
+}
+
 describe("full release metadata checkouts", () => {
   it.each([
     {
       job: "resolve_target",
-      targetCheckout: "Checkout target package manifest",
-      imports: [
-        "release-tooling-identity.mjs",
-        "full-release-candidate-contract.mjs",
-        "full-release-validation-policy.mjs",
-        "lib/release-context.mjs",
-      ],
+      checkout: "Checkout trusted workflow helper",
+      entrypoint: "release-tooling-identity.mjs",
     },
     {
       job: "evidence_reuse",
-      targetCheckout: "Checkout target SHA",
-      imports: ["release-ci-summary.mjs"],
+      checkout: "Checkout trusted workflow helper",
+      entrypoint: "release-ci-summary.mjs",
+      extraPath: ".github/actions/setup-pnpm-store-cache",
     },
-  ])("runs $job tooling from only its sparse files", ({ job, targetCheckout, imports }) => {
+    {
+      job: "release_execution_plan",
+      checkout: "Checkout release execution plan tooling",
+      entrypoint: "full-release-validation-state.mjs",
+    },
+    {
+      job: "release_decision",
+      checkout: "Checkout release decision tooling",
+      entrypoint: "full-release-validation-state.mjs",
+    },
+    {
+      job: "diagnostic_drain",
+      checkout: "Checkout diagnostic drain tooling",
+      entrypoint: "full-release-validation-state.mjs",
+    },
+    {
+      job: "summary",
+      checkout: "Checkout release state verifier",
+      entrypoint: "full-release-candidate-reuse.mjs",
+    },
+  ])(
+    "runs $job tooling from the complete scripts tree",
+    ({ job, checkout, entrypoint, extraPath }) => {
+      const root = mkdtempSync(join(tmpdir(), "openclaw-release-sparse-"));
+      try {
+        const toolingCheckout = step(job, checkout).with as Record<string, unknown>;
+        expect(toolingCheckout["sparse-checkout-cone-mode"]).toBe(false);
+        const paths = sparsePaths(toolingCheckout);
+        expect(paths).toEqual(extraPath ? ["scripts", extraPath] : ["scripts"]);
+
+        const checkoutRoot = join(root, checkoutPath(toolingCheckout));
+        cpSync("scripts", join(checkoutRoot, "scripts"), { recursive: true });
+        if (extraPath) {
+          cpSync(extraPath, join(checkoutRoot, extraPath), { recursive: true });
+        }
+
+        const runNode = (args: string[], cwd = root) =>
+          execFileSync(process.execPath, args, {
+            cwd,
+            encoding: "utf8",
+            timeout: 10_000,
+            env: { ...process.env, NODE_OPTIONS: "", NODE_PATH: "" },
+          });
+        expect(
+          runNode(
+            ["--input-type=module", "-e", `await import("./scripts/${entrypoint}");`],
+            checkoutRoot,
+          ),
+        ).toBe("");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("keeps target metadata narrow and runs the macOS preflight from the tooling tree", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-release-sparse-"));
     try {
-      for (const name of ["Checkout trusted workflow helper", targetCheckout]) {
+      const targetCheckouts = [
+        ["resolve_target", "Checkout target package manifest"],
+        ["evidence_reuse", "Checkout target SHA"],
+      ] as const;
+      for (const [job, name] of targetCheckouts) {
         const checkout = step(job, name).with as Record<string, unknown>;
         expect(checkout["sparse-checkout-cone-mode"]).toBe(false);
-        const paths = String(checkout["sparse-checkout"] ?? "")
-          .split("\n")
-          .map((path) => path.trim())
-          .filter(Boolean);
-        expect(paths.length).toBeGreaterThan(0);
+        const paths = sparsePaths(checkout);
+        expect(paths).not.toContain("scripts");
         for (const path of paths) {
-          const destination = join(root, String(checkout.path), path);
+          const destination = join(root, checkoutPath(checkout), path);
           mkdirSync(dirname(destination), { recursive: true });
           copyFileSync(path, destination);
         }
       }
 
-      const runNode = (args: string[], cwd = root) =>
-        execFileSync(process.execPath, args, {
-          cwd,
-          encoding: "utf8",
-          timeout: 10_000,
-          env: { ...process.env, NODE_OPTIONS: "", NODE_PATH: "" },
-        });
+      const toolingCheckout = step("evidence_reuse", "Checkout trusted workflow helper")
+        .with as Record<string, unknown>;
+      cpSync("scripts", join(root, checkoutPath(toolingCheckout), "scripts"), { recursive: true });
+      cpSync(
+        ".github/actions/setup-pnpm-store-cache",
+        join(root, checkoutPath(toolingCheckout), ".github/actions/setup-pnpm-store-cache"),
+        { recursive: true },
+      );
+
+      const setup = step("evidence_reuse", "Setup Node.js");
+      const steps = workflow.jobs.evidence_reuse!.steps;
+      expect(steps.indexOf(setup)).toBeLessThan(
+        steps.indexOf(step("evidence_reuse", "Find reusable validation evidence")),
+      );
+      expect(setup.env).toMatchObject({ REQUESTED_NODE_VERSION: "24.x" });
+      execFileSync("bash", ["-c", String(setup.run)], {
+        cwd: root,
+        encoding: "utf8",
+        timeout: 10_000,
+        env: {
+          ...process.env,
+          ...(setup.env as Record<string, string>),
+          // Keep this sparse-checkout proof offline on every supported test runtime.
+          REQUESTED_NODE_VERSION: process.versions.node,
+          PATH: `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ""}`,
+          NODE_OPTIONS: "",
+          GITHUB_PATH: join(root, "github-path"),
+        },
+      });
       expect(
-        runNode([
-          "--input-type=module",
-          "-e",
-          imports.map((file) => `await import("./workflow/scripts/${file}");`).join("\n"),
-        ]),
-      ).toBe("");
-      if (job === "evidence_reuse") {
-        const setup = step(job, "Setup Node.js");
-        const steps = workflow.jobs[job]!.steps;
-        expect(steps.indexOf(setup)).toBeLessThan(
-          steps.indexOf(step(job, "Find reusable validation evidence")),
-        );
-        expect(setup.env).toMatchObject({ REQUESTED_NODE_VERSION: "24.x" });
-        execFileSync("bash", ["-c", String(setup.run)], {
-          cwd: root,
-          encoding: "utf8",
-          timeout: 10_000,
-          env: {
-            ...process.env,
-            ...(setup.env as Record<string, string>),
-            // Keep this sparse-file proof offline on every supported test runtime.
-            REQUESTED_NODE_VERSION: process.versions.node,
-            PATH: `${dirname(process.execPath)}${delimiter}${process.env.PATH ?? ""}`,
-            NODE_OPTIONS: "",
-            GITHUB_PATH: join(root, "github-path"),
+        execFileSync(
+          process.execPath,
+          [join(root, "workflow/scripts/release-preflight.mjs"), "--macos-versions-only"],
+          {
+            cwd: join(root, "target"),
+            encoding: "utf8",
+            timeout: 10_000,
+            env: { ...process.env, NODE_OPTIONS: "", NODE_PATH: "" },
           },
-        });
-        expect(
-          runNode(
-            [join(root, "workflow/scripts/release-preflight.mjs"), "--macos-versions-only"],
-            join(root, "target"),
-          ),
-        ).toContain("macOS app version metadata OK");
-      }
+        ),
+      ).toContain("macOS app version metadata OK");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4763,9 +4763,7 @@ describe("package artifact reuse", () => {
       workflowStep(candidateBinding, "Checkout candidate binding authority"),
       workflowStep(summary, "Checkout release state verifier"),
     ]) {
-      expect(checkout.with?.["sparse-checkout"]).toContain(
-        "scripts/lib/full-release-candidate-reuse.mjs",
-      );
+      expect(checkout.with?.["sparse-checkout"]).toBe("scripts");
     }
     expect(discovery.outputs?.state).toBe("${{ steps.discover.outputs.state }}");
     expect(workflowStep(discovery, "Discover trusted release candidate").run).toContain(


### PR DESCRIPTION
Related: #135902

## What Problem This Solves

Fixes an issue where Full Release Validation and release-candidate jobs could fail before dispatch when a trusted release script gained a new transitive import that was absent from a manually maintained sparse-checkout file list.

FRV run https://github.com/openclaw/openclaw/actions/runs/33589505469 failed this way when `scripts/lib/release-context.mjs` was not materialized. Adding that one file repaired the immediate run, but left the same omission class open.

## Why This Change Was Made

Trusted orchestration checkouts now materialize the complete `scripts/` tree. Target revision checkouts remain deliberately narrow, including package metadata and macOS plist inputs.

The workflow tests independently assert this ownership boundary and import representative release entrypoints from the copied sparse trees, so they no longer mirror a manual production inventory.

## User Impact

Release operators can add or reorganize shared release-script imports without silently breaking FRV dispatch, evidence reuse, artifact preparation, or release-candidate validation.

## Evidence

- Pre-fix regression proof: applying the new boundary test to the old workflows produced 6/6 expected failures for incomplete tooling checkouts.
- Focused tests: `node scripts/run-vitest.mjs test/scripts/full-release-validation-continuation-workflow.test.ts test/scripts/package-acceptance-workflow.test.ts` passed 313/313 tests.
- Workflow lint: `actionlint .github/workflows/full-release-validation.yml .github/workflows/full-release-candidate.yml` passed.
- CI-discovered sibling guard: `test/scripts/ci-workflow-guards.test.ts` now independently enforces the complete trusted `scripts` checkout; its exact formerly failing case passes locally.
- Real Git sparse-checkout proof: non-cone `scripts` materialized `scripts/lib/release-context.mjs`, release policy inputs, and 1,222 script files.
- Fresh autoreview: no actionable findings; correctness confidence 0.98.
- Crabbox/Testbox run https://github.com/openclaw/openclaw/actions/runs/33594878455 reached the repository checks. It stopped on a pre-existing assertion-SAFETY baseline mismatch after the remote checkout reported no common ancestor with `origin/main`; the changed workflow/test surfaces had already passed the focused gates above.
- Production/workflow delta: 9 additions, 88 deletions (net -79). Tests: 143 additions, 86 deletions (net +57). Total: net -22.

No configuration, protocol, storage, or SQLite changes.
