### PR TITLE
improve: avoid a redundant copy when building the base config schema

### DIFF
--- a/src/config/schema-base.ts
+++ b/src/config/schema-base.ts
@@ -104,10 +104,10 @@ type BaseConfigSchemaResponse = {
 type BaseConfigSchemaStablePayload = Omit<BaseConfigSchemaResponse, "generatedAt">;
 
 function preparePublicSchema(schema: ConfigSchema): ConfigSchema {
-  const next = cloneSchema(schema);
-  const root = asSchemaObject(next);
+  // Zod returns an independent JSON tree; prepare it before publishing the cache.
+  const root = asSchemaObject(schema);
   if (!root || !root.properties) {
-    return next;
+    return schema;
   }
   // Allow `$schema` in config files for editor tooling, but hide it from the
   // Control UI form schema so it does not show up as a configurable section.
@@ -120,18 +120,14 @@ function preparePublicSchema(schema: ConfigSchema): ConfigSchema {
     // Keep plugin config permissive without advertising an untyped lookup wildcard.
     channelsNode.additionalProperties = true;
   }
-  return next;
+  return schema;
 }
 
 let baseConfigSchemaStablePayload: BaseConfigSchemaStablePayload | null = null;
 
 function computeBaseConfigSchemaStablePayload(): BaseConfigSchemaStablePayload {
   if (baseConfigSchemaStablePayload) {
-    return {
-      schema: cloneSchema(baseConfigSchemaStablePayload.schema),
-      uiHints: cloneSchema(baseConfigSchemaStablePayload.uiHints),
-      version: baseConfigSchemaStablePayload.version,
-    };
+    return baseConfigSchemaStablePayload;
   }
   const schema = OpenClawSchema.toJSONSchema({
     io: "input",
@@ -161,11 +157,7 @@ function computeBaseConfigSchemaStablePayload(): BaseConfigSchemaStablePayload {
     version: VERSION,
   } satisfies BaseConfigSchemaStablePayload;
   baseConfigSchemaStablePayload = stablePayload;
-  return {
-    schema: cloneSchema(stablePayload.schema),
-    uiHints: cloneSchema(stablePayload.uiHints),
-    version: stablePayload.version,
-  };
+  return stablePayload;
 }
 
 export function computeBaseConfigSchemaResponse(params?: {
@@ -173,8 +165,8 @@ export function computeBaseConfigSchemaResponse(params?: {
 }): BaseConfigSchemaResponse {
   const stablePayload = computeBaseConfigSchemaStablePayload();
   return {
-    schema: stablePayload.schema,
-    uiHints: stablePayload.uiHints,
+    schema: cloneSchema(stablePayload.schema),
+    uiHints: cloneSchema(stablePayload.uiHints),
     version: stablePayload.version,
     generatedAt: params?.generatedAt ?? new Date().toISOString(),
   };

--- a/src/config/schema.base.generated.test.ts
+++ b/src/config/schema.base.generated.test.ts
@@ -1,5 +1,6 @@
 // Verifies generated base config schema snapshots and sensitive redaction.
 import { SENSITIVE_URL_HINT_TAG } from "@openclaw/net-policy/redact-sensitive-url";
+import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { computeBaseConfigSchemaResponse } from "./schema-base.js";
 
@@ -111,11 +112,17 @@ function collectSchemaConsts(
 }
 
 describe("base config schema", () => {
-  it("is deterministic for a fixed generatedAt timestamp", () => {
+  it("returns independent schema and hint trees for a fixed generatedAt timestamp", () => {
+    const response = computeBaseConfigSchemaResponse({
+      generatedAt: BASE_CONFIG_SCHEMA.generatedAt,
+    });
+    expect(response).toEqual(BASE_CONFIG_SCHEMA);
+    delete (response.schema.properties as Record<string, unknown>).logging;
+    const hint = expectDefined(response.uiHints["mcp.servers.*.url"], "URL hint");
+    hint.help = "Changed by caller";
+    hint.tags?.push("caller-tag");
     expect(
-      computeBaseConfigSchemaResponse({
-        generatedAt: BASE_CONFIG_SCHEMA.generatedAt,
-      }),
+      computeBaseConfigSchemaResponse({ generatedAt: BASE_CONFIG_SCHEMA.generatedAt }),
     ).toEqual(BASE_CONFIG_SCHEMA);
   });
 


### PR DESCRIPTION
## Summary

Base configuration schema generation cloned Zod's newly created JSON tree before preparing it, then cloned it again for callers. Prepare the already-owned tree directly and keep deep copying at the public response boundary. This also removes duplicate return construction in the private cache owner. Production is net −8 lines; the expanded existing ownership test adds seven, for total net −1.

Zod4.4.3 [finalizes each tree through a JSON round trip](https://github.com/colinhacks/zod/blob/1fb56a5c18c27102dbc92260a4007c7732a0ccca/packages/zod/src/v4/core/to-json-schema.ts#L507). Public responses still independently own their schema and hint trees. No configuration, validation, default, storage or RPC shape changes.

## Validation

- 87 canonical tests across schema generation, composition/lookup and the Control UI contract pass before and after. The expanded nested-mutation test also passes against original production code. Full changed-file gate, independent source/dependency review and Codex autoreview pass.
- Eight actual-source observations agree on a 2,478,633-byte semantic digest, including nested mutation isolation, independent raw Zod conversions, plugin schema composition and lookups.
- A fresh built Gateway handled two real CLI `config.schema` calls and `config.schema.lookup`. Replies remained stable after local decoded-tree mutation. Its own V8 coverage records both changed schema functions; the process group, port and private state were cleaned up after successful shutdown.

## Resource evidence and limits

Cold construction performs two structured clones instead of three, removing one copy of 6,632 objects/arrays whose JSON representation is 437,831 bytes. Subsequent public requests keep their required two clones. Three fresh source processes per arm had first-call medians of 60.162→55.144 ms, with imports outside timing; separate batches and concurrent host work limit that timing result.

The private cache now retains Zod's small nonenumerable Standard Schema descriptor; public clones still omit it. Instantaneous heap observations were affected by different GC timing. This PR claims less temporary copying, not lower retained-cache memory, Gateway RSS or overall startup latency.
