### PR TITLE
improve: give chat compaction a folding shimmer animation

### DIFF
--- a/ui/src/components/assistant-panel.ts
+++ b/ui/src/components/assistant-panel.ts
@@ -41,7 +41,11 @@ const HOME_SESSION_ELEMENT = {
   get label() {
     return t("assistantPanel.home");
   },
-  loadModule: () => import("./home-session.runtime.ts"),
+  loadModule: () =>
+    Promise.all([
+      import("./home-session.runtime.ts"),
+      import("../styles/chat/composer-status.css"),
+    ]),
 };
 
 type AssistantDestination = "home" | "custodian";

--- a/ui/src/components/assistant-panel.ts
+++ b/ui/src/components/assistant-panel.ts
@@ -41,11 +41,7 @@ const HOME_SESSION_ELEMENT = {
   get label() {
     return t("assistantPanel.home");
   },
-  loadModule: () =>
-    Promise.all([
-      import("./home-session.runtime.ts"),
-      import("../styles/chat/composer-status.css"),
-    ]),
+  loadModule: () => import("./home-session.runtime.ts"),
 };
 
 type AssistantDestination = "home" | "custodian";

--- a/ui/src/components/home-session.runtime.ts
+++ b/ui/src/components/home-session.runtime.ts
@@ -9,6 +9,7 @@ import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { formatChatWorkContext, type ChatWorkContext } from "../pages/chat/chat-work-context.ts";
 import "../pages/chat/chat-pane.ts";
 import "../styles/chat.css";
+import "../styles/chat/composer-status.css";
 import { icons } from "./icons.ts";
 
 /** The real Home conversation; its surrounding dock owns placement and focus. */

--- a/ui/src/css.d.ts
+++ b/ui/src/css.d.ts
@@ -1,6 +1,11 @@
 // Control UI type declarations define css contracts.
 declare module "*.css";
 
+declare module "*.css?inline" {
+  const css: string;
+  export default css;
+}
+
 declare module "*?url" {
   const url: string;
   export default url;

--- a/ui/src/pages/chat/components/chat-composer-status.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.browser.test.ts
@@ -2,6 +2,7 @@ import type { CDPSession } from "@vitest/browser-playwright";
 import { nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cdp } from "vitest/browser";
+import "../../../components/tooltip.ts";
 import { renderCompactionIndicator, renderFallbackIndicator } from "./chat-composer-status.ts";
 import baseStyles from "../../../styles/base.css?inline";
 import composerStatusStyles from "../../../styles/chat/composer-status.css?inline";
@@ -34,7 +35,7 @@ describe("chat composer compaction motion", () => {
     await session.send("Emulation.setEmulatedMedia", { features: [] });
   });
 
-  it("folds lines without a spinner or pill, then reveals the completion check", async () => {
+  it("folds lines on a readable borderless scrim, then reveals the completion check", async () => {
     render(
       renderCompactionIndicator({
         phase: "active",
@@ -48,7 +49,8 @@ describe("chat composer compaction motion", () => {
     const lines = Array.from(container.querySelectorAll(".compaction-indicator__line"));
     const check = container.querySelector<SVGElement>(".compaction-indicator__glyph svg")!;
     expect(lines.length).toBeGreaterThan(0);
-    expect(getComputedStyle(indicator).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(indicator).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(indicator).boxShadow).not.toBe("none");
     expect(getComputedStyle(indicator).borderTopWidth).toBe("0px");
     expect(getComputedStyle(indicator).animationName).toBe("none");
     expect(getComputedStyle(check).opacity).toBe("0");
@@ -120,7 +122,7 @@ describe("chat composer compaction motion", () => {
     }
   });
 
-  it.each(["active", "cleared"] as const)("preserves the %s fallback pill", (phase) => {
+  it.each(["active", "cleared"] as const)("preserves the %s fallback pill", async (phase) => {
     render(
       renderFallbackIndicator({
         phase,
@@ -131,6 +133,7 @@ describe("chat composer compaction motion", () => {
       }),
       container,
     );
+    await container.querySelector("openclaw-tooltip")!.updateComplete;
     const indicator = container.querySelector<HTMLElement>(".compaction-indicator")!;
     const icon = indicator.querySelector("svg")!;
     expect(getComputedStyle(indicator).borderTopWidth).toBe("1px");

--- a/ui/src/pages/chat/components/chat-composer-status.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.browser.test.ts
@@ -1,0 +1,142 @@
+import type { CDPSession } from "@vitest/browser-playwright";
+import { nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cdp } from "vitest/browser";
+import { renderCompactionIndicator, renderFallbackIndicator } from "./chat-composer-status.ts";
+import baseStyles from "../../../styles/base.css?inline";
+import composerStatusStyles from "../../../styles/chat/composer-status.css?inline";
+import chatLayoutStyles from "../../../styles/chat/layout.css?inline";
+import componentStyles from "../../../styles/components.css?inline";
+
+describe("chat composer compaction motion", () => {
+  let container: HTMLDivElement;
+  let styles: HTMLStyleElement;
+  let session: CDPSession;
+
+  beforeEach(async () => {
+    session = cdp();
+    await session.send("Emulation.setEmulatedMedia", {
+      features: [{ name: "prefers-reduced-motion", value: "no-preference" }],
+    });
+    styles = document.createElement("style");
+    styles.textContent = [baseStyles, componentStyles, chatLayoutStyles, composerStatusStyles].join(
+      "\n",
+    );
+    document.head.append(styles);
+    container = document.createElement("div");
+    document.body.append(container);
+  });
+
+  afterEach(async () => {
+    render(nothing, container);
+    container.remove();
+    styles.remove();
+    await session.send("Emulation.setEmulatedMedia", { features: [] });
+  });
+
+  it("folds lines without a spinner or pill, then reveals the completion check", async () => {
+    render(
+      renderCompactionIndicator({
+        phase: "active",
+        runId: "run-motion",
+        startedAt: Date.now(),
+        completedAt: null,
+      }),
+      container,
+    );
+    const indicator = container.querySelector<HTMLElement>(".compaction-indicator")!;
+    const lines = Array.from(container.querySelectorAll(".compaction-indicator__line"));
+    const check = container.querySelector<SVGElement>(".compaction-indicator__glyph svg")!;
+    expect(lines.length).toBeGreaterThan(0);
+    expect(getComputedStyle(indicator).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(indicator).borderTopWidth).toBe("0px");
+    expect(getComputedStyle(indicator).animationName).toBe("none");
+    expect(getComputedStyle(check).opacity).toBe("0");
+    for (const line of lines) {
+      expect(getComputedStyle(line).animationName).not.toBe("none");
+      expect(getComputedStyle(line).animationIterationCount).toBe("infinite");
+    }
+    for (const element of container.querySelectorAll("*")) {
+      expect(getComputedStyle(element).animationName).not.toContain("spin");
+    }
+
+    render(
+      renderCompactionIndicator({
+        phase: "complete",
+        runId: "run-motion",
+        startedAt: Date.now(),
+        completedAt: Date.now(),
+      }),
+      container,
+    );
+    for (const line of lines) {
+      expect(getComputedStyle(line).visibility).toBe("hidden");
+      expect(getComputedStyle(line).animationName).toBe("none");
+    }
+    await expect.poll(() => getComputedStyle(check).opacity).toBe("1");
+    await expect
+      .poll(() =>
+        indicator
+          .getAnimations({ subtree: true })
+          .some((animation) => animation.playState === "running"),
+      )
+      .toBe(false);
+  });
+
+  it("keeps active, retrying, and complete states readable without reduced-motion animations", async () => {
+    await session.send("Emulation.setEmulatedMedia", {
+      features: [{ name: "prefers-reduced-motion", value: "reduce" }],
+    });
+    expect(matchMedia("(prefers-reduced-motion: reduce)").matches).toBe(true);
+    for (const phase of ["active", "retrying", "complete"] as const) {
+      render(
+        renderCompactionIndicator({
+          phase,
+          runId: "run-static",
+          startedAt: Date.now(),
+          completedAt: phase === "complete" ? Date.now() : null,
+        }),
+        container,
+      );
+      const indicator = container.querySelector<HTMLElement>(".compaction-indicator")!;
+      const label = container.querySelector<HTMLElement>(".compaction-indicator__label")!;
+      const check = container.querySelector<SVGElement>(".compaction-indicator__glyph svg")!;
+      expect(label.textContent?.trim()).not.toBe("");
+      expect(getComputedStyle(label).webkitTextFillColor).not.toBe("rgba(0, 0, 0, 0)");
+      expect(getComputedStyle(label).backgroundImage).toBe("none");
+      await expect
+        .poll(() => getComputedStyle(check).opacity)
+        .toBe(phase === "complete" ? "1" : "0");
+      for (const element of container.querySelectorAll("*")) {
+        expect(getComputedStyle(element).animationName).toBe("none");
+      }
+      await expect
+        .poll(() =>
+          indicator
+            .getAnimations({ subtree: true })
+            .some((animation) => animation.playState === "running"),
+        )
+        .toBe(false);
+    }
+  });
+
+  it.each(["active", "cleared"] as const)("preserves the %s fallback pill", (phase) => {
+    render(
+      renderFallbackIndicator({
+        phase,
+        selected: "provider/selected",
+        active: "provider/active",
+        attempts: [],
+        occurredAt: Date.now(),
+      }),
+      container,
+    );
+    const indicator = container.querySelector<HTMLElement>(".compaction-indicator")!;
+    const icon = indicator.querySelector("svg")!;
+    expect(getComputedStyle(indicator).borderTopWidth).toBe("1px");
+    expect(getComputedStyle(indicator).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(icon).width).toBe("16px");
+    expect(indicator.querySelector(".compaction-indicator__glyph")).toBeNull();
+    expect(indicator.getAttribute("role")).toBe("status");
+  });
+});

--- a/ui/src/pages/chat/components/chat-composer-status.test.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.test.ts
@@ -2,24 +2,108 @@ import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../../i18n/index.ts";
 import { captureI18nStateForTesting } from "../../../i18n/lib/translate.test-support.ts";
+import type { CompactionStatus } from "../tool-stream-contract.ts";
 import { renderCompactionIndicator, renderFallbackIndicator } from "./chat-composer-status.ts";
 
 describe("chat composer status localization", () => {
+  let container: HTMLDivElement;
   let restoreI18nState: () => Promise<void>;
 
   beforeEach(async () => {
     restoreI18nState = captureI18nStateForTesting();
     await i18n.setLocale("de");
     vi.spyOn(Date, "now").mockReturnValue(1_000);
+    container = document.createElement("div");
+    document.body.append(container);
   });
 
   afterEach(async () => {
     await restoreI18nState();
     vi.restoreAllMocks();
-    document.body.innerHTML = "";
+    container.remove();
   });
 
-  it("renders translated compaction and fallback status", () => {
+  it.each(["active", "retrying"] as const)(
+    "announces localized %s compaction without exposing the decorative glyph",
+    (phase) => {
+      render(
+        renderCompactionIndicator({
+          phase,
+          runId: "run-1",
+          startedAt: 1_000,
+          completedAt: null,
+        }),
+        container,
+      );
+      const status = container.querySelector(".compaction-indicator--active");
+      expect(status?.getAttribute("role")).toBe("status");
+      expect(status?.getAttribute("aria-live")).toBe("polite");
+      expect(status?.textContent?.trim()).toBe("Kontext wird komprimiert...");
+      const glyph = status?.querySelector(".compaction-indicator__glyph");
+      expect(glyph?.getAttribute("aria-hidden")).toBe("true");
+      expect(glyph?.textContent?.trim()).toBe("");
+    },
+  );
+
+  it("retains the glyph and its children through retry and completion for the transition", () => {
+    const status: CompactionStatus = {
+      phase: "active",
+      runId: "run-1",
+      startedAt: 1_000,
+      completedAt: null,
+    };
+    render(renderCompactionIndicator(status), container);
+    const indicator = container.querySelector(".compaction-indicator");
+    const glyph = container.querySelector(".compaction-indicator__glyph");
+    expect(glyph).not.toBeNull();
+    const children = Array.from(glyph!.children);
+    expect(children.length).toBeGreaterThan(0);
+
+    for (const phase of ["retrying", "complete"] as const) {
+      render(
+        renderCompactionIndicator({
+          ...status,
+          phase,
+          completedAt: phase === "complete" ? 1_000 : null,
+        }),
+        container,
+      );
+      expect(container.querySelector(".compaction-indicator")).toBe(indicator);
+      expect(container.querySelector(".compaction-indicator__glyph")).toBe(glyph);
+      expect(glyph!.children).toHaveLength(children.length);
+      children.forEach((child, index) => expect(glyph!.children[index]).toBe(child));
+    }
+    expect(indicator?.classList.contains("compaction-indicator--complete")).toBe(true);
+    expect(indicator?.getAttribute("role")).toBe("status");
+    expect(indicator?.getAttribute("aria-live")).toBe("polite");
+    expect(indicator?.textContent?.trim()).toBe("Kontext komprimiert");
+  });
+
+  it("removes completed feedback at the five-second boundary on rerender", () => {
+    const status: CompactionStatus = {
+      phase: "complete",
+      runId: "run-1",
+      startedAt: 900,
+      completedAt: 1_000,
+    };
+    vi.mocked(Date.now).mockReturnValue(5_999);
+    render(renderCompactionIndicator(status), container);
+    expect(container.querySelector("[role='status']")?.textContent?.trim()).toBe(
+      "Kontext komprimiert",
+    );
+    vi.mocked(Date.now).mockReturnValue(6_000);
+    render(renderCompactionIndicator(status), container);
+    expect(container.childElementCount).toBe(0);
+  });
+
+  it.each<{ name: string; status: CompactionStatus | null | undefined }>([
+    { name: "null status", status: null },
+    { name: "undefined status", status: undefined },
+    {
+      name: "completion without a timestamp",
+      status: { phase: "complete", runId: "run-1", startedAt: 900, completedAt: null },
+    },
+  ])("clears a rendered indicator for $name", ({ status }) => {
     render(
       renderCompactionIndicator({
         phase: "active",
@@ -27,12 +111,14 @@ describe("chat composer status localization", () => {
         startedAt: 1_000,
         completedAt: null,
       }),
-      document.body,
+      container,
     );
-    expect(document.querySelector(".compaction-indicator")?.textContent?.trim()).toBe(
-      "Kontext wird komprimiert...",
-    );
+    expect(container.querySelector("[role='status']")).not.toBeNull();
+    render(renderCompactionIndicator(status), container);
+    expect(container.childElementCount).toBe(0);
+  });
 
+  it("renders translated fallback status", () => {
     render(
       renderFallbackIndicator({
         selected: "provider/selected",
@@ -40,9 +126,9 @@ describe("chat composer status localization", () => {
         attempts: ["provider/selected: rate limit"],
         occurredAt: 900,
       }),
-      document.body,
+      container,
     );
-    const fallback = document.querySelector(".compaction-indicator--fallback");
+    const fallback = container.querySelector(".compaction-indicator--fallback");
     expect(fallback?.textContent?.trim()).toBe("Fallback aktiv: provider/active");
     expect(fallback?.getAttribute("aria-label")).toBe(
       "Ausgewählt: provider/selected • Aktiv: provider/active • Versuche: provider/selected: rate limit",

--- a/ui/src/pages/chat/components/chat-composer-status.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.ts
@@ -36,32 +36,32 @@ export function renderCompactionIndicator(status: CompactionStatus | null | unde
   if (!status) {
     return nothing;
   }
-  if (status.phase === "active" || status.phase === "retrying") {
-    return html`
-      <div
-        class="compaction-indicator compaction-indicator--active"
-        role="status"
-        aria-live="polite"
-      >
-        ${icons.loader} ${t("chat.composer.compactingContext")}
-      </div>
-    `;
+  const active = status.phase === "active" || status.phase === "retrying";
+  if (
+    !active &&
+    (!status.completedAt || Date.now() - status.completedAt >= COMPACTION_TOAST_DURATION_MS)
+  ) {
+    return nothing;
   }
-  if (status.completedAt) {
-    const elapsed = Date.now() - status.completedAt;
-    if (elapsed < COMPACTION_TOAST_DURATION_MS) {
-      return html`
-        <div
-          class="compaction-indicator compaction-indicator--complete"
-          role="status"
-          aria-live="polite"
-        >
-          ${icons.check} ${t("chat.composer.contextCompacted")}
-        </div>
-      `;
-    }
-  }
-  return nothing;
+  return html`
+    <div
+      class="compaction-indicator compaction-indicator--${active ? "active" : "complete"}"
+      role="status"
+      aria-live="polite"
+    >
+      <span class="compaction-indicator__glyph" aria-hidden="true">
+        <span class="compaction-indicator__line"></span>
+        <span class="compaction-indicator__line"></span>
+        <span class="compaction-indicator__line"></span>
+        <span class="compaction-indicator__line"></span>
+        <span class="compaction-indicator__line"></span>
+        ${icons.check}
+      </span>
+      <span class="compaction-indicator__label">
+        ${t(active ? "chat.composer.compactingContext" : "chat.composer.contextCompacted")}
+      </span>
+    </div>
+  `;
 }
 
 export function renderFallbackIndicator(status: FallbackStatus | null | undefined) {

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -40,6 +40,7 @@ function sessionPage(face: BoardFace) {
         import("./route-view.ts"),
         import("../../styles/chat/composer-progress.css"),
         import("../../styles/chat/composer-queue.css"),
+        import("../../styles/chat/composer-status.css"),
       ]).then(([, { renderChatRoute, sessionRenderOwnerKey }]) => ({
         header: true,
         // ChatPage's bounded inner cache owns per-session teardown, so session

--- a/ui/src/styles/chat/composer-status.css
+++ b/ui/src/styles/chat/composer-status.css
@@ -1,0 +1,179 @@
+/* Compaction indicator */
+.compaction-indicator {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  line-height: 1.2;
+  padding: 6px 14px;
+  margin-bottom: 8px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  background: var(--panel-strong);
+  color: var(--text);
+  white-space: nowrap;
+  user-select: none;
+  animation: fade-in 0.2s var(--ease-out);
+}
+
+.compaction-indicator svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
+}
+
+.compaction-indicator:is(.compaction-indicator--active, .compaction-indicator--complete) {
+  gap: 10px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 6px 12px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: none;
+  color: var(--muted);
+  white-space: normal;
+  animation: none;
+}
+
+.compaction-indicator__glyph {
+  position: relative;
+  flex: 0 0 28px;
+  width: 28px;
+  height: 28px;
+  color: var(--accent);
+}
+
+.compaction-indicator__line {
+  position: absolute;
+  left: 1px;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+  opacity: var(--fold-opacity);
+  transform: translate(3px, var(--fold-y)) scaleX(var(--fold-scale));
+}
+
+.compaction-indicator__line:nth-child(1) {
+  top: 3px;
+  width: 26px;
+  --fold-y: 6px;
+  --fold-scale: 0.65;
+  --fold-opacity: 0.85;
+}
+
+.compaction-indicator__line:nth-child(2) {
+  top: 8px;
+  width: 20px;
+  --fold-y: 1px;
+  --fold-scale: 0.85;
+  --fold-opacity: 0;
+}
+
+.compaction-indicator__line:nth-child(3) {
+  top: 13px;
+  width: 24px;
+  --fold-y: 0px;
+  --fold-scale: 0.7;
+  --fold-opacity: 1;
+}
+
+.compaction-indicator__line:nth-child(4) {
+  top: 18px;
+  width: 16px;
+  --fold-y: -1px;
+  --fold-scale: 1.05;
+  --fold-opacity: 0;
+}
+
+.compaction-indicator__line:nth-child(5) {
+  top: 23px;
+  width: 22px;
+  --fold-y: -6px;
+  --fold-scale: 0.76;
+  --fold-opacity: 0.85;
+}
+
+.compaction-indicator__glyph svg {
+  position: absolute;
+  inset: 4px;
+  width: 20px;
+  height: 20px;
+  color: var(--ok);
+  opacity: 0;
+  transform: scale(0.75);
+}
+
+.compaction-indicator--complete .compaction-indicator__line {
+  visibility: hidden;
+}
+
+.compaction-indicator--complete .compaction-indicator__glyph svg {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .compaction-indicator--active .compaction-indicator__line {
+    animation: compaction-fold 3.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  }
+
+  .compaction-indicator__glyph svg {
+    transition:
+      opacity 0.25s,
+      transform 0.25s;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) and (forced-colors: none) {
+  .compaction-indicator--active .compaction-indicator__label {
+    background: linear-gradient(105deg, var(--muted) 35%, var(--text) 48%, var(--muted) 61%);
+    background-size: 260% 100%;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: compaction-shimmer 3.2s ease-in-out infinite;
+  }
+}
+
+@keyframes compaction-fold {
+  0%,
+  12%,
+  86%,
+  100% {
+    opacity: 0.38;
+    transform: translate(0, 0) scaleX(1);
+  }
+
+  48%,
+  70% {
+    opacity: var(--fold-opacity);
+    transform: translate(3px, var(--fold-y)) scaleX(var(--fold-scale));
+  }
+}
+
+@keyframes compaction-shimmer {
+  0%,
+  12% {
+    background-position: 100% 0;
+  }
+
+  78%,
+  100% {
+    background-position: 0 0;
+  }
+}
+
+.compaction-indicator--fallback {
+  color: var(--warn-strong);
+  border-color: color-mix(in srgb, var(--warn-strong) 35%, transparent);
+}
+
+.compaction-indicator--fallback-cleared {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 35%, transparent);
+}

--- a/ui/src/styles/chat/composer-status.css
+++ b/ui/src/styles/chat/composer-status.css
@@ -35,7 +35,8 @@
   padding: 6px 12px;
   border: 0;
   border-radius: var(--radius-md);
-  background: none;
+  background: var(--bg);
+  box-shadow: 0 0 12px 8px var(--bg);
   color: var(--muted);
   white-space: normal;
   animation: none;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1984,60 +1984,6 @@ select.input {
   overflow-wrap: anywhere;
 }
 
-/* Compaction indicator */
-.compaction-indicator {
-  align-self: center;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  line-height: 1.2;
-  padding: 6px 14px;
-  margin-bottom: 8px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--border);
-  background: var(--panel-strong);
-  color: var(--text);
-  white-space: nowrap;
-  user-select: none;
-  animation: fade-in 0.2s var(--ease-out);
-}
-
-.compaction-indicator svg {
-  width: 16px;
-  height: 16px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  flex-shrink: 0;
-}
-
-.compaction-indicator--active {
-  color: var(--info);
-  border-color: color-mix(in srgb, var(--info) 35%, transparent);
-}
-
-.compaction-indicator--active svg {
-  animation: compaction-spin 1s linear infinite;
-}
-
-.compaction-indicator--complete {
-  color: var(--ok);
-  border-color: color-mix(in srgb, var(--ok) 35%, transparent);
-}
-
-.compaction-indicator--fallback {
-  color: var(--warn-strong);
-  border-color: color-mix(in srgb, var(--warn-strong) 35%, transparent);
-}
-
-.compaction-indicator--fallback-cleared {
-  color: var(--ok);
-  border-color: color-mix(in srgb, var(--ok) 35%, transparent);
-}
-
 @keyframes compaction-spin {
   to {
     transform: rotate(360deg);


### PR DESCRIPTION
Related: #100388 — compaction progress visibility. This is the visual treatment only; the broader diagnostics request remains open.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. This branch is in the upstream repository.

</details>

## What Problem This Solves

The chat composer's blue compaction pill looks like an interactive button and uses a generic spinner, unlike the quieter motion used while loading history.

## Why This Change Was Made

Replace the pill with five text-like lines folding into a compact stack and a soft label shimmer. Keep the same mounted status through retries and completion so the green check can transition in naturally. The existing compaction lifecycle, localized messages, five-second completion lifetime, and fallback indicators are unchanged.

Chat and Home load this stylesheet through their existing lazy boundaries. No dependency, configuration, gateway, protocol, or persistence changes; no bundle-budget increases.

## User Impact

- Quiet, noninteractive compaction feedback in Chat and Home.
- A stable completion check instead of replacing one pill with another.
- Static, readable feedback with reduced motion; no transparent shimmer text in forced-color mode.
- Existing fallback warning/success pills retain their appearance.

## Evidence

**Before: left. After: right.** Real `/compact` in the Control UI, isolated loopback Gateway, synthetic observatory transcript. Both native compactions complete; the new status folds/shimmers, changes to a check, and disappears. Every source capture and output video state was inspected. Cropped and setup-trimmed only; unchanged playback speed.

https://github.com/user-attachments/assets/057ea895-ec48-4d57-8f9a-41533153cb8c

Baseline uses the previously built old-pill UI, so surrounding chrome predates this PR; candidate uses this PR's source and matching runtime build. Exact-head [CI run 33597503831](https://github.com/openclaw/openclaw/actions/runs/33597503831), including `openclaw/ci-gate`, passes at `8f06b92f409ea4042736fdf6e69eb975a3b6b84d`.

Live-proof caveat: [#127148 — manual Codex compaction acquires a second writer](https://github.com/openclaw/openclaw/issues/127148) reproduced after a normal turn. Restarting only the isolated Gateway released the native writer and allowed both recorded compactions; the existing backend issue remains open. No operator Gateway/configuration/session database changed. Reduced-motion, forced-colors, and fallback styles have focused Chromium coverage rather than separate live-provider recordings.

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-composer-status.test.ts ui/src/pages/chat/components/chat-composer-status.browser.test.ts` — 12 passing tests, including actual Chromium computed styles, reduced motion, retry/completion node retention, localization, fallback styles, and exact five-second expiry.
- `pnpm ui:build` — passes all existing startup/asset budgets; startup CSS 44.8 KiB gzip, startup JS 337.1 KiB gzip. No baseline or threshold changes.
- `OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 pnpm build` — runtime build passes. Earlier declaration emission stopped on concurrent resolution-topology drift; declaration emission was not included in the successful runtime-only retry.
- `git diff --check` — clean.
- Changed-file checks — pass, including core-test/UI type checks, localization, lint, formatting, and dead-export guards.
- Fresh repository-mandated autoreview: scoped-clean, no accepted P0 findings; patch judged correct.

### Scope and ownership

The composer status renderer and its stylesheet own the presentation. Removed the active/complete pill styling and compaction spinner; retained the spin keyframe used by the unrelated chat queue control. Compaction events and cleanup remain in the existing lifecycle owner.

Production delta: +128 lines; declaration/test support: +5; tests: +231. Growth provides the folding/shimmer animation, accessible static state, and deferred CSS loading rather than a new state machine or dependency.

Direct Codex contract inspection: `codex-rs/app-server/README.md:871` and `codex-rs/app-server/src/request_processors/thread_processor.rs:2345` in the sibling Codex checkout. Native compaction is asynchronous and reports context-compaction item lifecycle events; this PR does not change that protocol or its mapping.
