### PR TITLE
fix(worktrees): stop rejecting sessions at the checkout count limit

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -46,11 +46,11 @@ Each `git worktree add` checkout during creation or snapshot restore has a five-
 
 ## Capacity and disk space
 
-OpenClaw allows up to 100 live managed worktrees per state directory. Manual and protected worktrees count toward this limit. Creating or restoring a checkout at the limit reports how to free a slot; it never evicts another session as part of creation. Reusing an existing valid checkout does not require a new slot.
+OpenClaw uses 100 live managed worktrees per state directory as a cleanup target, not an admission cap. Count alone never blocks creation or snapshot restore; available disk space still bounds new allocations. Creation never evicts another session to make room. Manual and protected worktrees can keep the total above the cleanup target.
 
 Before allocating a checkout, OpenClaw checks its destination, Git metadata, source checkout, and state volumes. It keeps 10% of each volume free, with a minimum reserve of 4 GiB and a maximum of 16 GiB, plus twice the estimated Git checkout and provisioned-file size. An executable setup script requires additional room equal to the larger of 4 GiB or the current source checkout footprint excluding Git metadata. Space is checked again before provisioning/setup and after setup. An unavailable capacity reading stops allocation with an actionable error.
 
-Creation, restore, and snapshot removal share one allocation lease across repositories and processes using the same state directory. Costs on the same volume are added together. These checks are conservative estimates, not a disk quota: other OpenClaw state directories, shell commands, deployment tools, and arbitrary setup/build output can still consume space. Worktrees created directly through Git are outside the managed count and cleanup lifecycle.
+Creation, restore, and snapshot removal share one allocation lease across repositories and processes using the same state directory. Costs on the same volume are added together. These checks are conservative estimates, not a disk quota: other OpenClaw state directories, shell commands, deployment tools, and arbitrary setup/build output can still consume space. Reusing an existing valid checkout does not allocate another checkout. Worktrees created directly through Git are outside the managed cleanup lifecycle.
 
 Snapshot removal uses a smaller reserve of 128 MiB plus estimated snapshot writes, so safe cleanup remains possible below the operational reserve. If a snapshot cannot fit, removal preserves the checkout and asks you to free space first.
 
@@ -81,6 +81,8 @@ Setup failures report the exit code or termination signal, or an actual timeout 
 ## Session worktrees
 
 Start an isolated chat from a Git-backed folder with a worktree session: on the Control UI's New session page, use the **Place** picker to choose a Gateway source folder, then select **Worktree** (with an optional base branch and worktree name). Choosing a paired device or cloud profile forces this managed-worktree path from the selected Gateway source; remote placement never browses or binds a node working directory. When the name is omitted, OpenClaw derives it from the explicit session label or the concise title generated from the first message, then falls back to a crustacean-themed name. iOS exposes the same choice from Chat actions, and Android exposes it beside New Chat, when the active agent workspace is Git-backed.
+
+Remote sessions retain a durable managed-worktree mirror on the Gateway for workspace reconciliation, recovery, and publication. The same disk-space checks apply to this mirror; selecting a remote destination does not eliminate Gateway disk requirements.
 
 The Control UI offers **Worktree** only after confirming a usable Git checkout with at least one commit, or when a selected remote Git repository is awaiting cloning. Plain folders and newly initialized repositories without commits can run directly on the Gateway. A failed Git check also leaves direct execution available if the folder is accessible; a `.git` entry or saved project alone does not enable isolation. If you already selected **Worktree** and a later check fails, that selection stays visible and starting is blocked. Clear **Worktree** to run directly, or reselect the folder to check it again.
 
@@ -124,7 +126,7 @@ OpenClaw applies these cleanup rules:
 
 - At run end, it removes a worktree only when `git status --porcelain` is empty and `git log HEAD --not --remotes --oneline` finds no unpushed commits. Otherwise it only releases the activity lock.
 - Startup and hourly cleanup snapshot and remove unlocked Workboard- and session-owned worktrees idle for more than 7 days, even when dirty. Session worktrees whose owner is archived or absent are eligible immediately. Failed owner lookups preserve the checkout.
-- Cleanup also removes the least recently active eligible run-owned worktrees above the default limit of 100. Manual worktrees are never automatically removed, and protected worktrees can keep the total above the limit until they are released or explicitly cleaned up.
+- Cleanup also removes the least recently active eligible run-owned worktrees above the default target of 100. Manual worktrees are never automatically removed, and protected worktrees can keep the total above the target until they are released or explicitly cleaned up.
 - Snapshot records remain restorable for 30 days. Cleanup then deletes the snapshot ref and registry row.
 - A live OpenClaw process lock and any foreign or unrecognized git worktree lock protect a worktree from garbage collection.
 

--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -13,6 +13,8 @@ Enrollment is environment-owned and replay-safe. The Gateway persists one setup 
 
 When the work is done (or the box dies), the machine is discarded. The durable state — transcript, last-reconciled workspace files, and placement records — lives with the Gateway.
 
+Each cloud session retains a session-owned [managed-worktree mirror](/concepts/managed-worktrees) on the Gateway for reconciliation, recovery, and publication. The Gateway creates this checkout before cloud dispatch. The default count of 100 is a cleanup target, not an admission cap: count alone does not block creating or restoring the mirror, but the Gateway's disk-space checks still apply.
+
 A missing setup environment value, a current Crabbox CLI/backend refusal, or changed provider metadata does not prove that an earlier attempt allocated nothing. These failures remain retryable with the original operation identity. Cleanup resolves that operation's handle and retries teardown until the provider confirms release or absence; it never reruns provisioning, setup, or enrollment to discover the lease. Malformed immutable profiles still fail permanently; policy and setup rejections become permanent only after confirmed cleanup.
 
 <Note>

--- a/src/agents/worktrees/service.capacity.test.ts
+++ b/src/agents/worktrees/service.capacity.test.ts
@@ -126,26 +126,35 @@ describe("ManagedWorktreeService capacity", () => {
     expect(await git(repo, "branch", "--list", "openclaw/unknown-space")).toBe("");
   });
 
-  it.each(["create", "restore"])("allows %s above thirty live worktrees", async (operation) => {
-    const snapshot = await service.create({ repoRoot: repo, name: "archived", baseRef: "HEAD" });
-    await service.remove({ id: snapshot.id, reason: "archive" });
-    await fill(30);
-
-    const created =
-      operation === "restore"
-        ? await service.restore({ id: snapshot.id })
-        : await service.create({ repoRoot: repo, name: "next", baseRef: "HEAD" });
-
-    expect(
-      service.listRegistryRecords().filter((record) => record.removedAt === undefined),
-    ).toHaveLength(31);
+  it("creates beyond 100 live checkouts without removing prior worktrees", async () => {
+    await fill(100);
+    const before = service.listRegistryRecords();
+    const created = await service.create({
+      repoRoot: repo,
+      name: "beyond-target",
+      baseRef: "HEAD",
+    });
+    expect(service.listRegistryRecords()).toHaveLength(101);
     expect(await fs.readFile(path.join(created.path, "README.md"), "utf8")).toBe("base\n");
+    for (const record of before) {
+      expect(getRegistryWorktree(env, record.id)).toEqual(record);
+      expect(await fs.readFile(path.join(record.path, "README.md"), "utf8")).toBe("base\n");
+    }
   });
 
-  it("serializes distinct repositories competing for the hundredth checkout", async () => {
-    await fill(99);
+  it("serializes distinct repositories competing for disk headroom", async () => {
     const otherRepo = await initializeRepository(path.join(root, "other"));
     const otherService = new ManagedWorktreeService({ env });
+    const realRun = commandExec.runCommandWithTimeout;
+    vi.spyOn(commandExec, "runCommandWithTimeout").mockImplementation(async (argv, options) => {
+      const result = await realRun(argv, options);
+      if (argv[0] === "git" && argv[3] === "worktree" && argv[4] === "add") {
+        // The first checkout still passes its postchecks, but a second checkout
+        // cannot fit its estimate. Without the shared lease both adds can start.
+        availableBytes = 16 * GiB;
+      }
+      return result;
+    });
     const outcomes = await Promise.allSettled([
       service.create({ repoRoot: repo, name: "last-one", baseRef: "HEAD" }),
       otherService.create({ repoRoot: otherRepo, name: "last-two", baseRef: "HEAD" }),
@@ -154,22 +163,20 @@ describe("ManagedWorktreeService capacity", () => {
     expect(outcomes.filter((result) => result.status === "rejected")).toEqual([
       expect.objectContaining({
         reason: expect.objectContaining({
-          message: expect.stringMatching(/100.*archive|100.*remove/i),
+          message: expect.stringMatching(/disk space/i),
         }),
       }),
     ]);
     expect(
       service.listRegistryRecords().filter((record) => record.removedAt === undefined),
-    ).toHaveLength(100);
-    expect(
-      await fs.readFile(
-        path.join(stateDir, "worktrees", "downstream-fixture", "kept-0", "README.md"),
-        "utf8",
-      ),
-    ).toBe("base\n");
+    ).toHaveLength(1);
+    const created = service.listRegistryRecords()[0]!;
+    expect(await fs.readFile(path.join(created.path, "README.md"), "utf8")).toBe("base\n");
+    const rejectedRepo = created.repoRoot === repo ? otherRepo : repo;
+    expect(await git(rejectedRepo, "branch", "--list", "openclaw/*")).toBe("");
   });
 
-  it("reuses a valid owned checkout even at capacity and below the reserve", async () => {
+  it("reuses a valid owned checkout at the cleanup target and below the reserve", async () => {
     const params = {
       repoRoot: repo,
       name: "owned",
@@ -184,23 +191,44 @@ describe("ManagedWorktreeService capacity", () => {
     expect(service.listRegistryRecords()).toHaveLength(100);
   });
 
-  it.each(["space", "count"])(
-    "preserves a removed snapshot when restore lacks %s",
-    async (reason) => {
+  it.each(["sufficient", "insufficient"])(
+    "restores beyond 100 live checkouts only with %s disk space",
+    async (space) => {
       const created = await service.create({ repoRoot: repo, name: "restore", baseRef: "HEAD" });
+      await fs.writeFile(path.join(created.path, "README.md"), "dirty tracked file\n");
       await fs.writeFile(path.join(created.path, "uncommitted.txt"), "keep me\n");
       await service.remove({ id: created.id, reason: "archive" });
       const before = getRegistryWorktree(env, created.id);
-      if (reason === "count") {
-        await fill(100);
+      await fill(100);
+      const kept = service.listRegistryRecords().filter((record) => record.id !== created.id);
+      if (space === "sufficient") {
+        const restored = await service.restore({ id: created.id });
+        expect(restored).toMatchObject({
+          id: created.id,
+          path: created.path,
+          branch: created.branch,
+        });
+        expect(getRegistryWorktree(env, created.id)?.removedAt).toBeUndefined();
+        expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe(
+          "dirty tracked file\n",
+        );
+        expect(await fs.readFile(path.join(restored.path, "uncommitted.txt"), "utf8")).toBe(
+          "keep me\n",
+        );
+        expect(await git(restored.path, "status", "--porcelain")).toContain("M README.md");
+        expect(await git(restored.path, "rev-parse", "HEAD")).toBe(
+          await git(repo, "rev-parse", "HEAD"),
+        );
       } else {
         availableBytes = GiB;
+        await expect(service.restore({ id: created.id })).rejects.toThrow(/disk space/i);
+        expect(getRegistryWorktree(env, created.id)).toEqual(before);
+        await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
       }
-      await expect(service.restore({ id: created.id })).rejects.toThrow(
-        reason === "count" ? /100/ : /disk space/i,
-      );
-      expect(getRegistryWorktree(env, created.id)).toEqual(before);
-      await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+      for (const record of kept) {
+        expect(getRegistryWorktree(env, record.id)).toEqual(record);
+        expect(await fs.readFile(path.join(record.path, "README.md"), "utf8")).toBe("base\n");
+      }
       expect(await git(repo, "show", `${before!.snapshotRef}:uncommitted.txt`)).toBe("keep me");
     },
   );

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -154,11 +154,11 @@ type RemoveWorktreeParams = WorktreeMutationGuard & {
   claimToken?: string;
   runEndCleanup?: ManagedWorktreeRunEndCleanup;
 };
-const MAX_WORKTREES = 100;
+const WORKTREE_CLEANUP_TARGET = 100;
 
 /** A bounded default; manual and actively used worktrees remain protected. */
 export function resolveWorktreeCleanupLimits(): WorktreeCleanupLimits {
-  return { maxCount: MAX_WORKTREES };
+  return { maxCount: WORKTREE_CLEANUP_TARGET };
 }
 
 function validateName(name: string): string {
@@ -794,7 +794,7 @@ export class ManagedWorktreeService {
     params: WorktreeMutationGuard,
     run: (guard: WorktreeMutationGuard) => Promise<T>,
   ): Promise<T> {
-    // Count and disk headroom are shared across repositories. Hold one renewable lease
+    // Disk headroom is shared across repositories. Hold one renewable lease
     // through checkout, setup, snapshots, and publication, including CLI processes.
     return await withOpenClawStateLease(
       {
@@ -816,20 +816,6 @@ export class ManagedWorktreeService {
           },
         }),
     );
-  }
-
-  private async requireAllocationCapacity(
-    target: string,
-    repository: ResolvedRepository,
-    bytes = 0,
-  ) {
-    const live = listRegistryWorktrees(this.env).filter((record) => record.removedAt === undefined);
-    if (live.length >= MAX_WORKTREES) {
-      throw new Error(
-        `Managed worktree limit of ${MAX_WORKTREES} reached; archive a session or remove an unused worktree, then retry. Active and manual worktrees are preserved.`,
-      );
-    }
-    this.requireAllocationSpace(target, repository, bytes);
   }
 
   private requireAllocationSpace(target: string, repository: ResolvedRepository, bytes = 0) {
@@ -911,7 +897,7 @@ export class ManagedWorktreeService {
     // Default-base resolution fetches remote refs; it is an effect, not just discovery.
     params.signal?.throwIfAborted();
     params.commitGuard?.();
-    await this.requireAllocationCapacity(worktreePath, repository);
+    this.requireAllocationSpace(worktreePath, repository);
     params.commitGuard?.();
     const base = await resolveWorktreeBase(repository.repoRoot, params.baseRef, params.signal);
     const gitBytes = Math.max(
@@ -1305,7 +1291,7 @@ export class ManagedWorktreeService {
       throw new Error(`source repository no longer exists: ${record.repoRoot}`);
     }
     const repository = await resolveRepository(record.repoRoot);
-    await this.requireAllocationCapacity(record.path, repository);
+    this.requireAllocationSpace(record.path, repository);
     const provisionedState = getRegistryWorktreeProvisionedState(this.env, record.id);
     if (provisionedState === undefined) {
       throw new Error(`worktree ${record.id} snapshot lacks provisioned file metadata`);

--- a/src/gateway/server.sessions.create.projects.test.ts
+++ b/src/gateway/server.sessions.create.projects.test.ts
@@ -7,7 +7,10 @@ import { waitForFile } from "../../test/helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { runWithCanonicalSkillWorkspace } from "../agents/skill-workshop-workspace-context.js";
 import { createConfiguredSkillWorkshopTool } from "../agents/tools/skill-workshop-tool-factory.js";
+import { requireGit } from "../agents/worktrees/git.js";
+import { createManagedWorktreeOwnerPolicy } from "../agents/worktrees/owner-protection.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
+import { materializeManagedWorktreeFixture } from "../agents/worktrees/service.test-support.js";
 import type { dispatchInboundMessage } from "../auto-reply/dispatch.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
@@ -26,6 +29,7 @@ import { SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS } from "../sessions/session-lif
 import { createDeferredCore } from "../shared/deferred.js";
 import { inspectSkillProposal } from "../skills/workshop/service.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import { createChatRunState } from "./server-chat-state.js";
 import {
@@ -788,126 +792,177 @@ test("sessions.create starts directly in an outside registered project at write 
   ).toBe(project.id);
 });
 
-test("sessions.create provisions a managed worktree from a registered project at write scope", async () => {
-  const root = tempDirs.make("openclaw-session-registered-project-");
-  const workspace = await initializeRepository(root, "workspace");
-  const projectRoot = await initializeRepository(root, "project");
-  testState.agentConfig = { workspace };
-  const { storePath } = await createSessionStoreDir();
-  const project = await registerProjectRegistry({ path: projectRoot, name: "Project" });
-  let worktreeId: string | undefined;
-  let sessionKey: string | undefined;
-  const context = { chatAbortControllers: new Map<string, ChatAbortControllerEntry>() };
+test("sessions.create with an empty message preserves its owned checkout above the 100 cleanup target", async () => {
+  const state = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-session-worktree-target-",
+  });
   try {
-    const created = await directSessionReq<{
-      key?: string;
-      entry?: {
-        spawnedCwd?: string;
-        worktree?: {
-          id: string;
-          branch: string;
-          repoRoot: string;
-          canonicalWorkspaceDir?: string;
-        };
-      };
-      worktree?: { id: string; path: string };
-    }>(
-      "sessions.create",
-      { agentId: "main", projectId: project.id, worktree: true },
-      { client: { connect: { scopes: ["operator.write"] } } as never },
-    );
-
-    expect(created.ok).toBe(true);
-    worktreeId = created.payload?.worktree?.id;
-    expect(created.payload?.entry?.spawnedCwd).toBe(created.payload?.worktree?.path);
-    expect(created.payload?.entry?.worktree?.canonicalWorkspaceDir).toBe(projectRoot);
-    sessionKey = created.payload?.key ?? "";
-    const original = loadSessionEntry({ agentId: "main", sessionKey, storePath });
-    if (!original) {
-      throw new Error("expected created session");
+    const workspace = await initializeRepository(state.root, "workspace");
+    const projectRoot = await initializeRepository(state.root, "project");
+    await requireGit(projectRoot, ["tag", "selected-base"]);
+    const baseCommit = await requireGit(projectRoot, ["rev-parse", "selected-base"]);
+    await fs.writeFile(path.join(projectRoot, "README.md"), "newer project head\n");
+    await requireGit(projectRoot, ["commit", "-am", "advance main beyond selected base"]);
+    testState.agentConfig = { workspace };
+    const { storePath } = await createSessionStoreDir();
+    const project = await registerProjectRegistry({ path: projectRoot, name: "Project" });
+    for (let index = 0; index < 100; index += 1) {
+      await materializeManagedWorktreeFixture({
+        env: state.env,
+        stateDir: state.stateDir,
+        repoRoot: workspace,
+        name: `kept-${index}`,
+        now: Date.now(),
+      });
     }
-    await replaceSessionEntry(
-      { agentId: "main", sessionKey, storePath },
-      { ...original, displayName: "Repository review" },
-    );
-    dispatchInboundMessageMock.mockResolvedValueOnce({
-      queuedFinal: false,
-      counts: { block: 0, final: 0, tool: 0 },
-    });
-    const reused = await directSessionReq<{ worktree?: { id: string }; runStarted: boolean }>(
-      "sessions.create",
-      {
-        key: sessionKey,
-        agentId: "main",
-        projectId: project.id,
-        worktree: true,
-        message: "Continue in this checkout",
-      },
-      { ...controlUiClient, context },
-    );
-    expect(reused.ok, JSON.stringify(reused.error)).toBe(true);
-    expect(reused.payload).toMatchObject({ worktree: { id: worktreeId }, runStarted: true });
-    expect(titleMocks.generate).not.toHaveBeenCalled();
-    await settleWorkspaceRuns(context, storePath, sessionKey);
-    expect(dispatchInboundMessageMock).toHaveBeenCalledOnce();
-    const entry = loadSessionEntry({ agentId: "main", sessionKey, storePath });
-    if (!entry?.worktree) {
-      throw new Error("expected persisted project worktree session");
-    }
-    await replaceSessionEntry(
-      { agentId: "main", sessionKey, storePath },
-      {
-        ...entry,
-        worktree: {
-          id: entry.worktree.id,
-          branch: entry.worktree.branch,
-          repoRoot: entry.worktree.repoRoot,
+    const kept = managedWorktrees.listRegistryRecords();
+    const key = "agent:main:worktree-above-cleanup-target";
+    const scope = { agentId: "main", sessionKey: key, storePath };
+    const originalCreate = managedWorktrees.create.bind(managedWorktrees);
+    const createSpy = vi
+      .spyOn(managedWorktrees, "create")
+      .mockImplementationOnce(async (params) => {
+        const record = await originalCreate(params);
+        // GC can run after allocation but before the session row is published.
+        expect(loadSessionEntry(scope)).toBeUndefined();
+        expect(
+          await managedWorktrees.gc(createManagedWorktreeOwnerPolicy(getRuntimeConfig())),
+        ).toMatchObject({ removed: [] });
+        expect(managedWorktrees.findLiveByOwner("session", key)).toEqual(record);
+        expect(await fs.readFile(path.join(record.path, "README.md"), "utf8")).toBe("project\n");
+        return record;
+      });
+    const context = { chatAbortControllers: new Map<string, ChatAbortControllerEntry>() };
+    try {
+      const created = await directSessionReq<{
+        key: string;
+        runStarted: boolean;
+        worktree: { id: string; path: string; branch: string };
+      }>(
+        "sessions.create",
+        {
+          key,
+          agentId: "main",
+          message: "",
+          projectId: project.id,
+          worktree: true,
+          worktreeBaseRef: "selected-base",
         },
-      },
-    );
-    await migrateManagedWorktreeCanonicalWorkspaces({
-      agentId: "main",
-      cfg: getRuntimeConfig(),
-      storePath,
-    });
-    const migrated = loadSessionEntry({ agentId: "main", sessionKey, storePath });
-    const canonicalWorkspaceDir = migrated?.worktree?.canonicalWorkspaceDir;
-    const spawnedCwd = migrated?.spawnedCwd;
-    if (!canonicalWorkspaceDir || !spawnedCwd) {
-      throw new Error("expected migrated project worktree session");
-    }
-    expect(canonicalWorkspaceDir).toBe(projectRoot);
-    const proposal = await runWithCanonicalSkillWorkspace(canonicalWorkspaceDir, async () => {
-      const tool = createConfiguredSkillWorkshopTool({
-        workspaceDir: spawnedCwd,
-        config: getRuntimeConfig(),
+        controlUiClient,
+      );
+      expect(created.ok, JSON.stringify(created.error)).toBe(true);
+      expect(created.payload).toMatchObject({ key, runStarted: false });
+      const worktree = created.payload!.worktree;
+      const original = expectDefined(loadSessionEntry(scope), "created project session");
+      expect(original).toMatchObject({
+        projectId: project.id,
+        sessionRoot: worktree.path,
+        spawnedCwd: worktree.path,
+        worktree: { id: worktree.id, repoRoot: projectRoot, canonicalWorkspaceDir: projectRoot },
+      });
+      expect(managedWorktrees.findLiveByOwner("session", key)).toMatchObject({
+        id: worktree.id,
+        repoRoot: projectRoot,
+        baseRef: "selected-base",
+      });
+      expect(
+        await managedWorktrees.gc(createManagedWorktreeOwnerPolicy(getRuntimeConfig())),
+      ).toMatchObject({ removed: [] });
+      expect(managedWorktrees.findLiveById(worktree.id)).toBeDefined();
+      expect(await requireGit(worktree.path, ["rev-parse", "HEAD"])).toBe(baseCommit);
+      expect(await requireGit(worktree.path, ["branch", "--show-current"])).toBe(worktree.branch);
+      expect(await fs.readFile(path.join(worktree.path, "README.md"), "utf8")).toBe("project\n");
+      expect(managedWorktrees.listRegistryRecords()).toHaveLength(101);
+      for (const record of kept) {
+        expect(managedWorktrees.findLiveById(record.id)).toEqual(record);
+        expect(await fs.readFile(path.join(record.path, "README.md"), "utf8")).toBe("workspace\n");
+      }
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+      const sessionKey = key;
+      const worktreeId = worktree.id;
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        { ...original, displayName: "Repository review" },
+      );
+      dispatchInboundMessageMock.mockResolvedValueOnce({
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      });
+      const reused = await directSessionReq<{ worktree?: { id: string }; runStarted: boolean }>(
+        "sessions.create",
+        {
+          key: sessionKey,
+          agentId: "main",
+          projectId: project.id,
+          worktree: true,
+          message: "Continue in this checkout",
+        },
+        { ...controlUiClient, context },
+      );
+      expect(reused.ok, JSON.stringify(reused.error)).toBe(true);
+      expect(reused.payload).toMatchObject({ worktree: { id: worktreeId }, runStarted: true });
+      expect(titleMocks.generate).not.toHaveBeenCalled();
+      await settleWorkspaceRuns(context, storePath, sessionKey);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledOnce();
+      const entry = loadSessionEntry({ agentId: "main", sessionKey, storePath });
+      if (!entry?.worktree) {
+        throw new Error("expected persisted project worktree session");
+      }
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey, storePath },
+        {
+          ...entry,
+          worktree: {
+            id: entry.worktree.id,
+            branch: entry.worktree.branch,
+            repoRoot: entry.worktree.repoRoot,
+          },
+        },
+      );
+      await migrateManagedWorktreeCanonicalWorkspaces({
         agentId: "main",
-        sessionKey,
+        cfg: getRuntimeConfig(),
+        storePath,
       });
-      return await tool.execute("legacy-project-proposal", {
-        action: "create",
-        name: "legacy-project-learning",
-        description: "Preserve learning from a resumed project worktree.",
-        proposal_content: "# Legacy Project Learning\n\nPersist this in the project workspace.\n",
+      const migrated = loadSessionEntry({ agentId: "main", sessionKey, storePath });
+      const canonicalWorkspaceDir = migrated?.worktree?.canonicalWorkspaceDir;
+      const spawnedCwd = migrated?.spawnedCwd;
+      if (!canonicalWorkspaceDir || !spawnedCwd) {
+        throw new Error("expected migrated project worktree session");
+      }
+      expect(canonicalWorkspaceDir).toBe(projectRoot);
+      const proposal = await runWithCanonicalSkillWorkspace(canonicalWorkspaceDir, async () => {
+        const tool = createConfiguredSkillWorkshopTool({
+          workspaceDir: spawnedCwd,
+          config: getRuntimeConfig(),
+          agentId: "main",
+          sessionKey,
+        });
+        return await tool.execute("legacy-project-proposal", {
+          action: "create",
+          name: "legacy-project-learning",
+          description: "Preserve learning from a resumed project worktree.",
+          proposal_content: "# Legacy Project Learning\n\nPersist this in the project workspace.\n",
+        });
       });
-    });
-    const proposalDetails = proposal.details as { id: string };
-    const inspected = await inspectSkillProposal(proposalDetails.id, {
-      agentId: "main",
-      workspaceDir: projectRoot,
-    });
-    expect(inspected?.record.target.skillFile).toBe(
-      path.join(projectRoot, "skills", "legacy-project-learning", "SKILL.md"),
-    );
-  } finally {
-    await settleWorkspaceRuns(context, storePath, sessionKey, true);
-    if (worktreeId) {
-      await managedWorktrees.remove({
-        id: worktreeId,
-        reason: "test-cleanup",
-        allowSnapshotLoss: true,
+      const proposalDetails = proposal.details as { id: string };
+      const inspected = await inspectSkillProposal(proposalDetails.id, {
+        agentId: "main",
+        workspaceDir: projectRoot,
       });
+      expect(inspected?.record.target.skillFile).toBe(
+        path.join(projectRoot, "skills", "legacy-project-learning", "SKILL.md"),
+      );
+    } finally {
+      createSpy.mockRestore();
+      await settleWorkspaceRuns(context, storePath, key, true);
     }
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    testState.agentConfig = undefined;
+    testState.sessionConfig = undefined;
+    await state.cleanup();
   }
 });
 


### PR DESCRIPTION
Related: #135885 — raised the managed-checkout default from 30 to 100; this follow-up preserves its 100-worktree cleanup target.
Related: #135852 — completed request for the higher default; this PR does not reopen or close that completed issue.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users starting a session on AWS would receive “Managed worktree limit reached” while usable Gateway disk space remained. The Gateway creates the session-owned checkout before cloud dispatch, so the count gate stopped the session before AWS allocation was reached. The same shared gate also blocked local, paired-device, and manual checkout creation and snapshot restore.

## Why This Change Was Made

The maintainer explicitly approved removing hard count-based admission globally while retaining disk admission and cleanup. Creation and restore now call the existing disk-capacity owner directly; the count-only wrapper is deleted. The 100-worktree target from the recently merged default increase remains a cleanup policy, not an admission ceiling.

The durable Gateway mirror remains intentional: it owns workspace reconciliation, recovery, and publication for remote sessions. Shared cross-repository allocation serialization, volume reserves, size estimates, pre/post-setup rechecks, rollback, owner/placement locks, snapshot semantics, and retention are unchanged. There is no provider exception, new config/env option, database change, or protocol change.

## User Impact

Users can create or restore the 101st checkout and beyond when disk admission succeeds, without evicting another session during allocation. Automatic cleanup still targets 100 eligible live checkouts; manual and protected worktrees remain protected and may keep the total above that target. Remote execution still requires space for its durable Gateway mirror.

Documentation: [Managed worktrees](https://docs.openclaw.ai/concepts/managed-worktrees) and [Cloud workers](https://docs.openclaw.ai/gateway/cloud-workers).

## Evidence

Current-main red proof used the unchanged production allocator from `b394488146f52b5bc807855ebb64057d7d3c1d3f` with the new tests. Creation and restore at 100 existing live checkouts failed with the expected count error; low-space restore returned the count error instead of the disk diagnostic. The disk-contention test passed. Empty-message `sessions.create` likewise failed with `UNAVAILABLE` and the 100-worktree count error.

```sh
node scripts/run-vitest.mjs src/agents/worktrees/service.capacity.test.ts -t 'creates beyond 100|restores beyond 100|serializes distinct repositories'
node scripts/run-vitest.mjs src/gateway/server.sessions.create.projects.test.ts -t 'empty message preserves its owned checkout'
```

The repaired candidate passed **299 tests across 11 files** with no failures or skips. This covers allocation, snapshot restoration, disk contention, GC/owner protection, the selected project/base commit, empty-message session creation, cloud and paired-device dispatch siblings, CLI, Gateway methods, and maintenance defaults. The full changed-file gate passed with no baseline changes or suppressions. Fresh isolated Codex autoreview was scoped-clean at its P0 threshold.

```sh
node scripts/run-vitest.mjs src/agents/worktrees/service.capacity.test.ts src/agents/worktrees/service.gc.test.ts src/agents/worktrees/owner-protection.test.ts src/gateway/server.sessions.create.projects.test.ts src/gateway/server.sessions.create.test.ts src/gateway/server-methods/sessions.dispatch.test.ts src/gateway/server-methods/sessions.dispatch.device.test.ts src/gateway/server-methods/sessions.dispatch.authorization.test.ts src/cli/worktrees-cli.test.ts src/gateway/server-methods/worktrees.test.ts src/gateway/server-maintenance.test.ts
node scripts/check-changed.mjs -- docs/concepts/managed-worktrees.md docs/gateway/cloud-workers.md src/agents/worktrees/service.ts src/agents/worktrees/service.capacity.test.ts src/gateway/server.sessions.create.projects.test.ts
node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime
git diff --check
```

The isolated runtime build passed. A real isolated Gateway then created 100 manual checkouts through WebSocket RPC, created an empty-message session as checkout 101 at an explicitly selected base commit different from the source HEAD, preserved all manual and active-session work through real GC, and restored dirty untracked content with 100 other live checkouts. Final live count: 101. The Gateway and synthetic state were cleaned up.

The first live fixture attempt encountered the separate, unchanged 30-writes-per-minute RPC limiter. The successful fresh-state run honored three server-provided retry intervals; no rate-limit setting or production code was changed. Exact-head hosted [CI run 33595347287](https://github.com/openclaw/openclaw/actions/runs/33595347287) passed for `5ecf6a316c8628e7b4e2e1f5eb318230e4d30e3a`.

Production LOC: +5/-19 (net -14). Tests: +228/-145 (net +83); the session diff includes reindentation of retained registered-project, reuse, and skill-workspace assertions. Docs: +7/-3 (net +4). Existing create/restore-at-31 tests were consolidated into stronger 101-checkout regression coverage rather than retained as duplicates.

Provenance: the count admission was introduced in #132706, commit `8e4eb78fa20` (raw-parent patch checked), and is reachable in stable tag `v2026.8.2`. #135885 carried the gate forward while raising its threshold. This follow-up changes that policy intentionally.

Direct upstream Codex source checks: `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:62`, `codex-rs/app-server/src/request_processors/thread_processor.rs:1177`, and `codex-rs/exec-server/src/environment.rs:783`. Remote filesystem/process routing is downstream of this OpenClaw admission boundary and is unchanged.

Proof limits: no actual AWS allocation, live remote worker turn, or browser/video proof. The existing browser extension relay was unavailable with a network error. Handler tests and real isolated Gateway WebSocket RPC exercise the shared prerequisite, not end-to-end AWS provisioning. No operator Gateway restart, deployment, release, or real user-state change is included.
