### PR TITLE
fix(plugins): stop interrupted service startup only once

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -1166,6 +1166,10 @@ returned unsubscribe function and call it during service cleanup. The payload is
 change notice; use `api.runtime.agent.session.getSessionEntry(...)` when the plugin needs the full
 current session entry.
 
+OpenClaw calls a service's `stop()` at most once per startup attempt, including when a replacement
+times out before startup fails. Failed-start rollback and shutdown share the same cleanup result;
+a cleanup failure is recorded rather than retried within that attempt.
+
 Service startup failures from a returned or awaited promise are recorded automatically. A service
 that intentionally starts required work in the background must report later failure and recovery
 through its generation-bound health reporter:

--- a/src/plugins/services.replacement.test.ts
+++ b/src/plugins/services.replacement.test.ts
@@ -12,6 +12,7 @@ import {
   resetDiagnosticStabilityRecorderForTest,
   type DiagnosticExporterHealthUpdate,
 } from "../logging/diagnostic-stability.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { queuePluginSessionsChanged } from "./gateway-events.js";
 import { registerPluginHttpRoute, withPluginHttpRouteRegistry } from "./http-registry.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -430,6 +431,69 @@ describe("plugin service replacement", () => {
       vi.useRealTimers();
     }
   });
+
+  it.each(["fulfilled", "rejected", "pending"] as const)(
+    "does not repeat %s cleanup when startup fails after replacement settles",
+    async (cleanupState) => {
+      vi.useFakeTimers();
+      const startup = createDeferredCore();
+      const cleanup = createDeferredCore();
+      const order: string[] = [];
+      const stop = vi.fn(() => {
+        order.push("stop");
+        if (cleanupState === "rejected") {
+          throw new Error("cleanup rejected");
+        }
+        return cleanupState === "pending" ? cleanup.promise : undefined;
+      });
+      let lifecycleHandle!: PluginServicesHandle;
+      const starting = startPluginServices({
+        registry: createRegistry([
+          {
+            id: "interrupted-startup",
+            start: () => {
+              order.push("start");
+              return startup.promise;
+            },
+            stop,
+          },
+        ]),
+        config: createServiceConfig(),
+        onHandle: (handle) => {
+          lifecycleHandle = handle;
+        },
+      });
+      const stopping = lifecycleHandle.stop({
+        strict: true,
+        deadlineAtMs: Date.now() + PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS,
+      });
+      const stopped = stopping.catch((error: unknown) => error);
+
+      try {
+        await vi.advanceTimersByTimeAsync(PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS);
+        const failure = await stopped;
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect((failure as AggregateError).errors[0]).toMatchObject({
+          message: expect.stringContaining("plugin service startup settlement timed out"),
+        });
+        order.push("replacement-settled");
+        startup.reject(new Error("startup failed after replacement"));
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(stop).toHaveBeenCalledOnce();
+        expect(order).toEqual(["start", "stop", "replacement-settled"]);
+        cleanup.resolve();
+        await starting;
+        expect(lifecycleHandle.stop()).toBe(stopping);
+      } finally {
+        startup.reject(new Error("startup test cleanup"));
+        cleanup.resolve();
+        await starting;
+        await stopped;
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("revokes trusted diagnostics listeners, emitters, bridges, and exporter health with their service", async () => {
     const listener = vi.fn();

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -14,7 +14,6 @@ import {
   type DiagnosticExporterHealthUpdate,
 } from "../logging/diagnostic-stability.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { createDeferredCore } from "../shared/deferred.js";
 import {
   createPluginRuntimeCapabilityLease,
   type PluginRuntimeCapabilityLease,
@@ -198,32 +197,34 @@ export async function startPluginServices(params: {
     pluginId: string;
     diagnosticsExporter: boolean;
     stop?: () => void | Promise<void>;
+    cleanup?: Promise<void>;
     lease: PluginRuntimeCapabilityLease;
   }> = [];
   const runBeforeDeadline = async (
     run: () => void | Promise<void>,
-    deadline: number,
+    deadline: number | undefined,
     label: string,
     owner?: string,
   ): Promise<void> => {
     const operation = Promise.resolve(run());
+    if (deadline === undefined) {
+      return operation;
+    }
     const remaining = deadline - Date.now();
     const timeoutError = () =>
       new PluginServiceReplacementTimeoutError(
         `${label} timed out after ${PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS}ms${owner ? ` (${owner})` : ""}`,
       );
-    if (remaining <= 0) {
-      await Promise.race([operation, Promise.reject(timeoutError())]);
-      return;
-    }
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       await Promise.race([
         operation,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(() => reject(timeoutError()), remaining);
-          timer.unref?.();
-        }),
+        remaining <= 0
+          ? Promise.reject(timeoutError())
+          : new Promise<never>((_, reject) => {
+              timer = setTimeout(() => reject(timeoutError()), remaining);
+              timer.unref?.();
+            }),
       ]);
     } finally {
       clearTimeout(timer);
@@ -236,13 +237,20 @@ export async function startPluginServices(params: {
   ) => {
     try {
       if (entry.stop) {
-        const cleanup = () =>
-          withPluginHttpRouteRegistry(params.registry, () => entry.stop?.(), entry.lease);
-        if (deadline === undefined) {
-          await cleanup();
-        } else {
-          await runBeforeDeadline(cleanup, deadline, "plugin service stop");
-        }
+        // Replacement and failed-start rollback share even a rejected cleanup. Invoke it
+        // synchronously so an expired deadline still accepts already-settled cleanup.
+        const cleanup = () => {
+          try {
+            return (entry.cleanup ??= Promise.resolve(
+              withPluginHttpRouteRegistry(params.registry, () => entry.stop?.(), entry.lease),
+            ));
+          } catch (error) {
+            return (entry.cleanup = (async () => {
+              throw error;
+            })());
+          }
+        };
+        await runBeforeDeadline(cleanup, deadline, "plugin service stop");
       }
     } catch (err) {
       log.warn(`plugin service stop failed (${entry.id}): ${String(err)}`);
@@ -262,8 +270,6 @@ export async function startPluginServices(params: {
       entry.lease.revoke();
     }
   };
-  const startupSettled = createDeferredCore();
-  void startupSettled.promise.catch(() => {});
   let stopRequested = false;
   let stopPromise: Promise<void> | undefined;
   const handle: PluginServicesHandle = {
@@ -275,69 +281,58 @@ export async function startPluginServices(params: {
         const deadline = strict ? options.deadlineAtMs : undefined;
         stopPromise = Promise.resolve().then(async () => {
           const failures: unknown[] = [];
-          if (deadline === undefined) {
-            await startupSettled.promise.catch(() => {});
-          } else {
-            try {
-              const starting = running.at(-1);
-              await runBeforeDeadline(
-                () => startupSettled.promise.catch(() => {}),
-                deadline,
-                "plugin service startup settlement",
-                starting ? `plugin=${starting.pluginId}, service=${starting.id}` : undefined,
-              );
-            } catch (error) {
-              failures.push(error);
-              // Startup may resume after replacement timed out; its issued capabilities die now.
-              for (const entry of running) {
-                entry.lease.revoke();
-              }
+          try {
+            const starting = running.at(-1);
+            await runBeforeDeadline(
+              () => startupSettled.catch(() => {}),
+              deadline,
+              "plugin service startup settlement",
+              starting ? `plugin=${starting.pluginId}, service=${starting.id}` : undefined,
+            );
+          } catch (error) {
+            failures.push(error);
+            // Startup may resume after replacement timed out; its issued capabilities die now.
+            for (const entry of running) {
+              entry.lease.revoke();
             }
           }
           const reversed = running.toReversed();
           const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
-          const exporterFailures = strict ? failures : [];
-          const stopServices = async (services: typeof reversed, collected?: unknown[]) => {
-            for (const entry of services) {
-              await stopService(entry, collected, deadline);
-            }
-          };
-          await stopServices(
-            reversed.filter((entry) => !entry.diagnosticsExporter),
-            strict ? failures : undefined,
-          );
+          for (const entry of reversed.filter((candidate) => !candidate.diagnosticsExporter)) {
+            await stopService(entry, strict ? failures : undefined, deadline);
+          }
           if (diagnosticsExporters.length > 0) {
             // Producers stop first; this barrier preserves their queued tail before exporters detach.
-            if (deadline === undefined) {
-              await waitForDiagnosticEventsDrained();
-            } else {
-              try {
-                await runBeforeDeadline(
-                  waitForDiagnosticEventsDrained,
-                  deadline,
-                  "plugin diagnostic event drain",
-                  diagnosticsExporters
-                    .map((entry) => `plugin=${entry.pluginId}, service=${entry.id}`)
-                    .join("; "),
-                );
-              } catch (error) {
-                failures.push(error);
+            try {
+              await runBeforeDeadline(
+                waitForDiagnosticEventsDrained,
+                deadline,
+                "plugin diagnostic event drain",
+                diagnosticsExporters
+                  .map((entry) => `plugin=${entry.pluginId}, service=${entry.id}`)
+                  .join("; "),
+              );
+            } catch (error) {
+              if (!strict) {
+                throw error;
               }
+              failures.push(error);
             }
           }
           // Ordinary plugin cleanup stays warn-and-continue. Trusted diagnostics
           // exporter failures propagate because they can mean telemetry was lost.
-          await stopServices(diagnosticsExporters, exporterFailures);
-          if (strict && failures.length > 0) {
-            throw new AggregateError(failures, "plugin service replacement cleanup failed");
+          for (const entry of diagnosticsExporters) {
+            await stopService(entry, failures, deadline);
           }
-          if (exporterFailures.length === 1) {
-            throw exporterFailures[0];
+          if (!strict && failures.length === 1) {
+            throw failures[0];
           }
-          if (exporterFailures.length > 1) {
+          if (failures.length > 0) {
             throw new AggregateError(
-              exporterFailures,
-              "multiple diagnostics exporters failed to stop",
+              failures,
+              strict
+                ? "plugin service replacement cleanup failed"
+                : "multiple diagnostics exporters failed to stop",
             );
           }
         });
@@ -348,7 +343,7 @@ export async function startPluginServices(params: {
   };
   params.onHandle?.(handle);
 
-  try {
+  const startupSettled = (async () => {
     let failedCount = 0;
     for (const entry of params.registry.services) {
       if (stopRequested) {
@@ -413,10 +408,7 @@ export async function startPluginServices(params: {
       ["startedCount", running.length],
       ["failedCount", failedCount],
     ]);
-    startupSettled.resolve();
-    return handle;
-  } catch (error) {
-    startupSettled.reject(error);
-    throw error;
-  }
+  })();
+  await startupSettled;
+  return handle;
 }


### PR DESCRIPTION
Closes #135990

## What Problem This Solves

Fixes an issue where plugin replacement could stop the same service twice when its pending startup failed after the replacement deadline. A service that had already closed its resources could be asked to close them again.

## Why This Change Was Made

The service owner now retains one cleanup result per startup attempt. Shutdown and failed-start rollback share that result, including failure. The actual startup promise replaces a separate completion signal, and one failure collection replaces duplicate aggregation wrappers.

Cleanup still starts synchronously, inside the existing HTTP registry scope, before the deadline check. Retaining the raw returned promise preserves already-settled cleanup after an earlier service has consumed the deadline. An experimentally shorter async wrapper changed that behavior and was rejected.

Production: **+67/−75, net −8 lines**. Tests: +64. Docs: +4. No configuration, protocol, schema, persistence or dependency change.

## User Impact

Plugins receive at most one stop callback per startup attempt. Normal shutdown, exporter drain ordering, timeout reporting and capability retirement retain their existing behavior.

## Evidence

- Three new original-order cases fail before the fix: fulfilled, rejected and pending cleanup each receive two callbacks.
- The actual-source probe reproduces the double cleanup on the starting main and stable v2026.8.2. The candidate runs cleanup once and retains the expected strict startup timeout.
- 46 owner/sibling tests and five Gateway startup caller tests pass. The root reviewer independently ran the 33 service and replacement tests.
- Full changed checks pass, including core/core-test typechecks, lint, boundaries and unused exports. Independent Codex P2 review is clean; two subsequent lint-only corrections preserve the tested outcome and error identity.

These are actual service-owner and caller tests with synthetic registries, plus a standalone source-bound lifecycle probe. No live operator Gateway or third-party plugin was restarted.
