### PR TITLE
fix(ui): sidebar counts and new-session controls do not align across catalogs

### DIFF
--- a/test/scripts/repo-e2e-artifacts.test.ts
+++ b/test/scripts/repo-e2e-artifacts.test.ts
@@ -104,7 +104,8 @@ describe("repo E2E artifact transfer", () => {
         fs.statSync(path.join(root, "package.json")).mtimeMs,
       );
       expect(fs.readlinkSync(path.join(root, "dist-runtime/index.js"))).toBe("../dist/index.js");
-      expect(fs.statSync(path.join(root, "dist/index.js")).mode & 0o777).toBe(0o755);
+      // Tar honors the operator's umask; only owner execution is required here.
+      expect(fs.statSync(path.join(root, "dist/index.js")).mode & 0o100).toBe(0o100);
       expect(fs.readFileSync(path.join(root, "dist/private-qa.js"), "utf8")).toBe("private QA\n");
       expect(fs.readFileSync(path.join(root, "packages/demo/dist/index.d.ts"), "utf8")).toContain(
         "ready",

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -210,6 +210,11 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const loadingMore = params.loadingMoreCatalogIds.has(catalog.id);
     const hasMore = hosts.some((host) => Boolean(host.nextCursor));
     const canCreateSession = catalog.capabilities.startTerminal === true;
+    const newSessionDisabledReason =
+      params.newSessionDisabledReason ??
+      (canCreateSession
+        ? undefined
+        : t("chat.sidebar.catalogCreateUnavailable", { catalog: catalog.label }));
     const errorMessages = catalogErrorMessages(catalog);
     const hasError = errorMessages.length > 0;
     // Keep provider failures distinguishable from successful empty results.
@@ -315,18 +320,16 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
             >
               ${icons.listFilter}
             </button>
-            ${canCreateSession
-              ? renderNewSessionLink({
-                  basePath: params.basePath,
-                  agentId: params.newSessionAgentId,
-                  target: { catalogId: catalog.id },
-                  className:
-                    "sidebar-session-group-actions sidebar-session-new sidebar-session-catalog-new",
-                  label: `${t("chat.runControls.newSession")} — ${catalog.label}`,
-                  disabledReason: params.newSessionDisabledReason,
-                  onOpen: params.onOpenNewSession,
-                })
-              : nothing}
+            ${renderNewSessionLink({
+              basePath: params.basePath,
+              agentId: params.newSessionAgentId,
+              target: { catalogId: catalog.id },
+              className:
+                "sidebar-session-group-actions sidebar-session-new sidebar-session-catalog-new",
+              label: `${t("chat.runControls.newSession")} — ${catalog.label}`,
+              disabledReason: newSessionDisabledReason,
+              onOpen: params.onOpenNewSession,
+            })}
           `,
         })}
         ${collapsed

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -291,7 +291,6 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
               <span class="sidebar-recent-sessions__label-text hover-marquee"
                 >${catalog.label}</span
               >
-              ${renderCatalogHeaderStatus(hasActiveRun, hasUnread)}
               ${hasError || (collapsed && rows.length > 0)
                 ? html`<span
                     class="sidebar-session-group-count ${hasError
@@ -302,6 +301,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
                     >${hasError ? icons.alertTriangle : rows.length}</span
                   >`
                 : nothing}
+              ${renderCatalogHeaderStatus(hasActiveRun, hasUnread)}
             </button>
             <button
               type="button"

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -197,17 +197,6 @@ function renderSessionSection(params: {
               </button>
               ${group
                 ? html`
-                    ${renderNewSessionLink({
-                      basePath: host.basePath,
-                      agentId: host.expandedAgentId(),
-                      target: { group },
-                      className: "sidebar-session-group-actions sidebar-new-session",
-                      label: t("sessionsView.newSessionInGroup", { group }),
-                      disabledReason: newSessionAccess.allowed
-                        ? undefined
-                        : newSessionAccess.reason,
-                      onOpen: (agentId, target) => host.requestOpenNewSession(agentId, target),
-                    })}
                     <button
                       type="button"
                       class="sidebar-session-group-actions"
@@ -229,6 +218,17 @@ function renderSessionSection(params: {
                     >
                       ${icons.moreHorizontal}
                     </button>
+                    ${renderNewSessionLink({
+                      basePath: host.basePath,
+                      agentId: host.expandedAgentId(),
+                      target: { group },
+                      className: "sidebar-session-group-actions sidebar-new-session",
+                      label: t("sessionsView.newSessionInGroup", { group }),
+                      disabledReason: newSessionAccess.allowed
+                        ? undefined
+                        : newSessionAccess.reason,
+                      onOpen: (agentId, target) => host.requestOpenNewSession(agentId, target),
+                    })}
                   `
                 : nothing}
             `,

--- a/ui/src/components/new-session-link.ts
+++ b/ui/src/components/new-session-link.ts
@@ -16,7 +16,10 @@ export function renderNewSessionLink(params: {
 }) {
   const disabled = Boolean(params.disabledReason);
   const href = `${pathForRoute("new-session", params.basePath)}${newSessionSearch(params.agentId, params.target)}`;
-  return html`<openclaw-tooltip .content=${params.disabledReason ?? params.label}>
+  return html`<openclaw-tooltip
+    .content=${params.disabledReason ?? params.label}
+    .openOnClick=${disabled}
+  >
     <a
       class=${params.className}
       role="link"

--- a/ui/src/components/new-session-link.ts
+++ b/ui/src/components/new-session-link.ts
@@ -26,7 +26,7 @@ export function renderNewSessionLink(params: {
       href=${disabled ? nothing : href}
       aria-label=${params.label}
       aria-disabled=${disabled ? "true" : nothing}
-      tabindex=${disabled ? "-1" : nothing}
+      tabindex=${disabled ? "0" : nothing}
       @contextmenu=${(event: MouseEvent) => {
         // Section menus must not replace the browser's Open Link in New Tab actions.
         event.stopPropagation();

--- a/ui/src/e2e/sidebar-section-alignment.e2e.test.ts
+++ b/ui/src/e2e/sidebar-section-alignment.e2e.test.ts
@@ -1,0 +1,196 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  defaultControlUiFeatureMethods,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
+import { sessionRow, sessionsListResponse } from "./session-management.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Sidebar section column alignment" });
+
+suite.define(() => {
+  it.each([false, true])(
+    "aligns counts and explains unavailable creation (touch: %s)",
+    async (hasTouch) => {
+      await suite.withPage(
+        {
+          hasTouch,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { width: 1440, height: 1000 },
+        },
+        async ({ page }) => {
+          const timestamp = Date.parse("2026-08-27T12:00:00.000Z");
+          const sections = [
+            { id: "category:Personal", count: 1 },
+            { id: "category:Automations", count: 1 },
+            { id: "ungrouped", count: 1 },
+            { id: "work", count: 1 },
+            { id: "catalog:claude", count: 51 },
+            { id: "catalog:codex", count: 12 },
+          ];
+          const gateway = await installMockGateway(page, {
+            sessionKey: "agent:main:main",
+            sessionGroups: ["Personal", "Automations"],
+            featureMethods: [...defaultControlUiFeatureMethods, "sessions.catalog.list"],
+            methodResponses: {
+              "sessions.list": sessionsListResponse([
+                sessionRow("agent:main:main", "Home", timestamp),
+                sessionRow("agent:main:personal", "Personal thread", timestamp, {
+                  category: "Personal",
+                }),
+                sessionRow("agent:main:automation", "Scheduled review", timestamp, {
+                  category: "Automations",
+                }),
+                sessionRow("agent:main:other", "Ungrouped thread", timestamp),
+                sessionRow("agent:main:work", "Coding thread", timestamp, {
+                  worktree: { branch: "feature/sidebar", repoRoot: "/workspace/project" },
+                }),
+              ]),
+              "sessions.catalog.list": {
+                catalogs: [
+                  { id: "claude", label: "Claude Code", count: 51, creatable: false },
+                  { id: "codex", label: "Codex", count: 12, creatable: true },
+                ].map(({ id, label, count, creatable }) => ({
+                  id,
+                  label,
+                  capabilities: {
+                    continueSession: false,
+                    archive: false,
+                    ...(creatable ? { createSession: { model: "openai/gpt-5.6-luna" } } : {}),
+                  },
+                  hosts: [
+                    {
+                      hostId: "gateway:local",
+                      label: `Local ${label}`,
+                      kind: "gateway",
+                      connected: true,
+                      sessions: Array.from({ length: count }, (_, index) => ({
+                        threadId: `${id}-${index}`,
+                        name: `${label} thread ${index}`,
+                        status: "stored",
+                        canContinue: false,
+                        canArchive: false,
+                      })),
+                    },
+                  ],
+                })),
+              },
+            },
+          });
+          await page.goto(`${suite.server.baseUrl}chat`);
+          for (const { id } of sections) {
+            const toggle = page.locator(
+              `[data-session-section="${id}"] .sidebar-session-group-toggle`,
+            );
+            await toggle.waitFor({ state: "visible" });
+            if ((await toggle.getAttribute("aria-expanded")) === "true") {
+              await toggle.click();
+            }
+            await page
+              .locator(
+                `[data-session-section="${id}"] .sidebar-session-group-toggle[aria-expanded="false"]`,
+              )
+              .waitFor({ state: "visible" });
+          }
+          const codex = page.locator('[data-session-section="catalog:codex"]');
+          await codex.locator(".sidebar-recent-sessions__head").hover();
+          const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          if (artifactDir) {
+            await mkdir(artifactDir, { recursive: true });
+            await page.screenshot({
+              path: path.join(
+                artifactDir,
+                `sidebar-section-alignment-${hasTouch ? "touch" : "mouse"}.png`,
+              ),
+              animations: "disabled",
+              fullPage: true,
+            });
+          }
+          const geometry = await page.evaluate(
+            (expectedSections) =>
+              expectedSections.map(({ id }) => {
+                const header = document.querySelector(
+                  `[data-session-section="${id}"] .sidebar-recent-sessions__head`,
+                );
+                const measure = (selector: string) => {
+                  const element = header?.querySelector(selector);
+                  if (!element) {
+                    return null;
+                  }
+                  const rect = element.getBoundingClientRect();
+                  return { right: rect.right, center: rect.left + rect.width / 2 };
+                };
+                return {
+                  id,
+                  countText: header
+                    ?.querySelector(".sidebar-session-group-count")
+                    ?.textContent?.trim(),
+                  count: measure(".sidebar-session-group-count"),
+                  menu: measure('.sidebar-session-group-actions[aria-haspopup="menu"]'),
+                  add: measure(".sidebar-new-session, .sidebar-session-catalog-new"),
+                };
+              }),
+            sections,
+          );
+          expect(geometry.map((header) => header.countText)).toEqual(
+            sections.map(({ count }) => String(count)),
+          );
+          const countEdges = geometry.map((header) => header.count?.right ?? Number.NaN);
+          expect(Math.max(...countEdges) - Math.min(...countEdges)).toBeLessThanOrEqual(1);
+          for (const control of ["menu", "add"] as const) {
+            const centers = geometry.flatMap((header) => {
+              const position = header[control];
+              return position ? [position.center] : [];
+            });
+            expect(centers).toHaveLength(4);
+            expect(Math.max(...centers) - Math.min(...centers)).toBeLessThanOrEqual(1);
+          }
+          const codexAdd = codex.locator(".sidebar-session-catalog-new");
+          expect(await codexAdd.getAttribute("href")).toBe("/new?agent=main&catalog=codex");
+          expect(await codexAdd.getAttribute("aria-disabled")).toBeNull();
+          const claude = page.locator('[data-session-section="catalog:claude"]');
+          const claudeAdd = claude.locator(".sidebar-session-catalog-new");
+          expect(await claudeAdd.getAttribute("aria-disabled")).toBe("true");
+          expect(await claudeAdd.getAttribute("href")).toBeNull();
+          expect(await claudeAdd.getAttribute("tabindex")).toBe("-1");
+          if (hasTouch) {
+            const bounds = await claudeAdd.boundingBox();
+            if (!bounds) {
+              throw new Error("The unavailable add control must remain visible on touch");
+            }
+            await page.touchscreen.tap(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+          } else {
+            await claude.locator(".sidebar-recent-sessions__head").hover();
+            await claudeAdd.hover();
+          }
+          await claude
+            .locator("openclaw-tooltip[open] .tooltip-content")
+            .waitFor({ state: "visible" });
+          await expect
+            .poll(() => tooltipTitleText(claudeAdd))
+            .toBe(
+              "New sessions are unavailable for Claude Code with this agent. Check its model and runtime settings.",
+            );
+          if (artifactDir) {
+            await page.emulateMedia({ colorScheme: "dark" });
+            await page.screenshot({
+              path: path.join(
+                artifactDir,
+                `sidebar-disabled-add-${hasTouch ? "touch" : "mouse"}.png`,
+              ),
+              animations: "disabled",
+              fullPage: true,
+            });
+          }
+          const originalUrl = page.url();
+          await claudeAdd.dispatchEvent("click");
+          expect(page.url()).toBe(originalUrl);
+          expect(await gateway.getRequests("sessions.create")).toEqual([]);
+        },
+      );
+    },
+  );
+});

--- a/ui/src/e2e/sidebar-section-alignment.e2e.test.ts
+++ b/ui/src/e2e/sidebar-section-alignment.e2e.test.ts
@@ -12,11 +12,12 @@ const suite = createControlUiE2eSuite({ name: "Sidebar section column alignment"
 
 suite.define(() => {
   it.each([false, true])(
-    "aligns counts and explains unavailable creation (touch: %s)",
+    "keeps counts beside labels and aligns actions (touch: %s)",
     async (hasTouch) => {
       await suite.withPage(
         {
           hasTouch,
+          colorScheme: "dark",
           locale: "en-US",
           serviceWorkers: "block",
           viewport: { width: 1440, height: 1000 },
@@ -29,7 +30,7 @@ suite.define(() => {
             { id: "ungrouped", count: 1 },
             { id: "work", count: 1 },
             { id: "catalog:claude", count: 51 },
-            { id: "catalog:codex", count: 12 },
+            { id: "catalog:codex", count: 11 },
           ];
           const gateway = await installMockGateway(page, {
             sessionKey: "agent:main:main",
@@ -52,7 +53,7 @@ suite.define(() => {
               "sessions.catalog.list": {
                 catalogs: [
                   { id: "claude", label: "Claude Code", count: 51, creatable: false },
-                  { id: "codex", label: "Codex", count: 12, creatable: true },
+                  { id: "codex", label: "Codex", count: 11, creatable: true },
                 ].map(({ id, label, count, creatable }) => ({
                   id,
                   label,
@@ -108,6 +109,13 @@ suite.define(() => {
               animations: "disabled",
               fullPage: true,
             });
+            await page.locator(".sidebar-sessions").screenshot({
+              path: path.join(
+                artifactDir,
+                `sidebar-label-count-${hasTouch ? "touch" : "mouse"}.png`,
+              ),
+              animations: "disabled",
+            });
           }
           const geometry = await page.evaluate(
             (expectedSections) =>
@@ -121,13 +129,14 @@ suite.define(() => {
                     return null;
                   }
                   const rect = element.getBoundingClientRect();
-                  return { right: rect.right, center: rect.left + rect.width / 2 };
+                  return { left: rect.left, right: rect.right, center: rect.left + rect.width / 2 };
                 };
                 return {
                   id,
                   countText: header
                     ?.querySelector(".sidebar-session-group-count")
                     ?.textContent?.trim(),
+                  label: measure(".sidebar-recent-sessions__label-text"),
                   count: measure(".sidebar-session-group-count"),
                   menu: measure('.sidebar-session-group-actions[aria-haspopup="menu"]'),
                   add: measure(".sidebar-new-session, .sidebar-session-catalog-new"),
@@ -138,8 +147,12 @@ suite.define(() => {
           expect(geometry.map((header) => header.countText)).toEqual(
             sections.map(({ count }) => String(count)),
           );
-          const countEdges = geometry.map((header) => header.count?.right ?? Number.NaN);
-          expect(Math.max(...countEdges) - Math.min(...countEdges)).toBeLessThanOrEqual(1);
+          for (const header of geometry) {
+            const countGap =
+              (header.count?.left ?? Number.NaN) - (header.label?.right ?? Number.NaN);
+            expect(countGap, header.id).toBeGreaterThanOrEqual(4);
+            expect(countGap, header.id).toBeLessThanOrEqual(12);
+          }
           for (const control of ["menu", "add"] as const) {
             const centers = geometry.flatMap((header) => {
               const position = header[control];

--- a/ui/src/e2e/sidebar-section-alignment.e2e.test.ts
+++ b/ui/src/e2e/sidebar-section-alignment.e2e.test.ts
@@ -1,12 +1,12 @@
-import { mkdir } from "node:fs/promises";
-import path from "node:path";
 import { expect, it } from "vitest";
 import {
   defaultControlUiFeatureMethods,
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { createControlUiE2eSuite, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
-import { sessionRow, sessionsListResponse } from "./session-management.test-support.ts";
+import { sessionsListResponse } from "./session-management.test-support.ts";
+import { captureSidebarUiProof } from "./sidebar-customization.test-support.ts";
 
 const suite = createControlUiE2eSuite({ name: "Sidebar section column alignment" });
 
@@ -60,7 +60,10 @@ suite.define(() => {
                   capabilities: {
                     continueSession: false,
                     archive: false,
-                    ...(creatable ? { createSession: { model: "openai/gpt-5.6-luna" } } : {}),
+                    // Model-chat creation does not enable the native-terminal action.
+                    ...(creatable
+                      ? { startTerminal: true }
+                      : { createSession: { model: "openai/gpt-5.6-luna" } }),
                   },
                   hosts: [
                     {
@@ -68,6 +71,7 @@ suite.define(() => {
                       label: `Local ${label}`,
                       kind: "gateway",
                       connected: true,
+                      canStartTerminal: creatable,
                       sessions: Array.from({ length: count }, (_, index) => ({
                         threadId: `${id}-${index}`,
                         name: `${label} thread ${index}`,
@@ -98,37 +102,28 @@ suite.define(() => {
           }
           const codex = page.locator('[data-session-section="catalog:codex"]');
           await codex.locator(".sidebar-recent-sessions__head").hover();
-          const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-          if (artifactDir) {
-            await mkdir(artifactDir, { recursive: true });
-            await page.screenshot({
-              path: path.join(
-                artifactDir,
-                `sidebar-section-alignment-${hasTouch ? "touch" : "mouse"}.png`,
-              ),
-              animations: "disabled",
-              fullPage: true,
-            });
-            await page.locator(".sidebar-sessions").screenshot({
-              path: path.join(
-                artifactDir,
-                `sidebar-label-count-${hasTouch ? "touch" : "mouse"}.png`,
-              ),
-              animations: "disabled",
-            });
-          }
+          await captureSidebarUiProof(
+            suite,
+            page,
+            `sidebar-alignment-${hasTouch ? "touch" : "mouse"}.png`,
+          );
           const geometry = await page.evaluate(
             (expectedSections) =>
               expectedSections.map(({ id }) => {
                 const header = document.querySelector(
                   `[data-session-section="${id}"] .sidebar-recent-sessions__head`,
                 );
-                const measure = (selector: string) => {
+                const measure = (selector: string, textOnly = false) => {
                   const element = header?.querySelector(selector);
                   if (!element) {
                     return null;
                   }
-                  const rect = element.getBoundingClientRect();
+                  const range = document.createRange();
+                  range.selectNodeContents(element);
+                  // The label box can flex wider than its text and hide the actual gap.
+                  const rect = textOnly
+                    ? range.getBoundingClientRect()
+                    : element.getBoundingClientRect();
                   return { left: rect.left, right: rect.right, center: rect.left + rect.width / 2 };
                 };
                 return {
@@ -136,7 +131,7 @@ suite.define(() => {
                   countText: header
                     ?.querySelector(".sidebar-session-group-count")
                     ?.textContent?.trim(),
-                  label: measure(".sidebar-recent-sessions__label-text"),
+                  label: measure(".sidebar-recent-sessions__label-text", true),
                   count: measure(".sidebar-session-group-count"),
                   menu: measure('.sidebar-session-group-actions[aria-haspopup="menu"]'),
                   add: measure(".sidebar-new-session, .sidebar-session-catalog-new"),
@@ -168,7 +163,6 @@ suite.define(() => {
           const claudeAdd = claude.locator(".sidebar-session-catalog-new");
           expect(await claudeAdd.getAttribute("aria-disabled")).toBe("true");
           expect(await claudeAdd.getAttribute("href")).toBeNull();
-          expect(await claudeAdd.getAttribute("tabindex")).toBe("-1");
           if (hasTouch) {
             const bounds = await claudeAdd.boundingBox();
             if (!bounds) {
@@ -185,23 +179,30 @@ suite.define(() => {
           await expect
             .poll(() => tooltipTitleText(claudeAdd))
             .toBe(
-              "New sessions are unavailable for Claude Code with this agent. Check its model and runtime settings.",
+              "Starting new sessions is not supported by Claude Code. Choose another session source.",
             );
-          if (artifactDir) {
-            await page.emulateMedia({ colorScheme: "dark" });
-            await page.screenshot({
-              path: path.join(
-                artifactDir,
-                `sidebar-disabled-add-${hasTouch ? "touch" : "mouse"}.png`,
-              ),
-              animations: "disabled",
-              fullPage: true,
-            });
+          await captureSidebarUiProof(
+            suite,
+            page,
+            `sidebar-disabled-${hasTouch ? "touch" : "mouse"}.png`,
+          );
+          if (!hasTouch) {
+            await page.mouse.move(800, 700);
+            await claude.locator("[data-session-catalog-view-menu]").focus();
+            await page.keyboard.press("Tab");
+            expect(await claudeAdd.evaluate((element) => element === document.activeElement)).toBe(
+              true,
+            );
+            await claude
+              .locator("openclaw-tooltip[open] .tooltip-content")
+              .waitFor({ state: "visible" });
+            await page.keyboard.press("Enter");
           }
           const originalUrl = page.url();
           await claudeAdd.dispatchEvent("click");
           expect(page.url()).toBe(originalUrl);
           expect(await gateway.getRequests("sessions.create")).toEqual([]);
+          expect(await gateway.getRequests("sessions.catalog.startTerminal")).toEqual([]);
         },
       );
     },

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5663,6 +5663,8 @@ export const en: TranslationMap & {
       groups: "Groups",
       coding: "Coding",
       catalogViewOptions: "View options",
+      catalogCreateUnavailable:
+        "New sessions are unavailable for {catalog} with this agent. Check its model and runtime settings.",
       hideFromSidebar: "Hide from sidebar",
       sectionHidden: "{section} hidden.",
       sectionHiddenRecovery: "Show it again in Settings > Appearance > Sidebar.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5664,7 +5664,7 @@ export const en: TranslationMap & {
       coding: "Coding",
       catalogViewOptions: "View options",
       catalogCreateUnavailable:
-        "New sessions are unavailable for {catalog} with this agent. Check its model and runtime settings.",
+        "Starting new sessions is not supported by {catalog}. Choose another session source.",
       hideFromSidebar: "Hide from sidebar",
       sectionHidden: "{section} hidden.",
       sectionHiddenRecovery: "Show it again in Settings > Appearance > Sidebar.",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1462,8 +1462,6 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-session-group-count {
   flex: 0 0 auto;
-  order: 1;
-  margin-left: auto;
   color: var(--muted);
   font-size: calc(10px * var(--control-ui-text-scale));
   font-variant-numeric: tabular-nums;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1398,12 +1398,6 @@ openclaw-settings-save-indicator:empty {
   text-align: left;
 }
 
-.sidebar-session-group-toggle .sidebar-recent-sessions__label-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .sidebar-session-group-toggle__lead {
   position: relative;
   display: inline-grid;
@@ -1643,9 +1637,10 @@ a.sidebar-session-group-actions {
   color: var(--muted);
 }
 
+/* Shrink long marquee labels, but keep counts beside the text on short labels. */
 .sidebar-session-group-toggle > .sidebar-recent-sessions__label-text {
   min-width: 0;
-  flex: 1 1 0;
+  flex: 0 1 auto;
 }
 
 /* Flex, not grid: WebKit does not re-run a grid flex-item's intrinsic sizing

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1390,7 +1390,6 @@ openclaw-settings-save-indicator:empty {
   align-items: center;
   gap: var(--sidebar-row-gap);
   min-width: 0;
-  grid-area: 1 / 1;
   padding: 2px 0;
   border: none;
   background: transparent;
@@ -1422,19 +1421,13 @@ openclaw-settings-save-indicator:empty {
   opacity: 0;
 }
 
-.sidebar-recent-sessions__head:hover
-  .sidebar-session-group-toggle__lead--branded
-  .sidebar-session-catalog-provider-icon,
-.sidebar-recent-sessions__head:has(:focus-visible)
+.sidebar-recent-sessions__head:where(:hover, :has(:focus-visible))
   .sidebar-session-group-toggle__lead--branded
   .sidebar-session-catalog-provider-icon {
   opacity: 0;
 }
 
-.sidebar-recent-sessions__head:hover
-  .sidebar-session-group-toggle__lead--branded
-  .sidebar-session-group-toggle__icon,
-.sidebar-recent-sessions__head:has(:focus-visible)
+.sidebar-recent-sessions__head:where(:hover, :has(:focus-visible))
   .sidebar-session-group-toggle__lead--branded
   .sidebar-session-group-toggle__icon {
   opacity: 0.75;
@@ -1451,7 +1444,6 @@ openclaw-settings-save-indicator:empty {
 .sidebar-session-catalog-provider-icon {
   width: 12px;
   height: 12px;
-  flex: 0 0 12px;
 }
 
 .sidebar-session-group-count {
@@ -1558,12 +1550,10 @@ openclaw-settings-save-indicator:empty {
    reachable on touch pointers where hover does not exist. */
 .sidebar-session-group-actions {
   display: inline-flex;
-  grid-area: 1 / 2;
   align-items: center;
   justify-content: center;
   width: 22px;
   height: 22px;
-  flex: 0 0 auto;
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -1574,10 +1564,6 @@ openclaw-settings-save-indicator:empty {
     opacity var(--duration-fast) ease,
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
-}
-
-a.sidebar-session-group-actions {
-  grid-column: 3;
 }
 
 .sidebar-session-group-actions[aria-disabled="true"] {
@@ -1640,7 +1626,6 @@ a.sidebar-session-group-actions {
 /* Shrink long marquee labels, but keep counts beside the text on short labels. */
 .sidebar-session-group-toggle > .sidebar-recent-sessions__label-text {
   min-width: 0;
-  flex: 0 1 auto;
 }
 
 /* Flex, not grid: WebKit does not re-run a grid flex-item's intrinsic sizing

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1368,7 +1368,8 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-recent-sessions__head {
   position: relative;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 22px 22px;
   align-items: center;
   gap: 8px;
   min-height: 24px;
@@ -1389,12 +1390,18 @@ openclaw-settings-save-indicator:empty {
   align-items: center;
   gap: var(--sidebar-row-gap);
   min-width: 0;
-  flex: 1 1 auto;
+  grid-area: 1 / 1;
   padding: 2px 0;
   border: none;
   background: transparent;
   color: inherit;
   text-align: left;
+}
+
+.sidebar-session-group-toggle .sidebar-recent-sessions__label-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar-session-group-toggle__lead {
@@ -1455,6 +1462,8 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-session-group-count {
   flex: 0 0 auto;
+  order: 1;
+  margin-left: auto;
   color: var(--muted);
   font-size: calc(10px * var(--control-ui-text-scale));
   font-variant-numeric: tabular-nums;
@@ -1557,6 +1566,7 @@ openclaw-settings-save-indicator:empty {
    reachable on touch pointers where hover does not exist. */
 .sidebar-session-group-actions {
   display: inline-flex;
+  grid-area: 1 / 2;
   align-items: center;
   justify-content: center;
   width: 22px;
@@ -1574,6 +1584,14 @@ openclaw-settings-save-indicator:empty {
     color var(--duration-fast) ease;
 }
 
+a.sidebar-session-group-actions {
+  grid-column: 3;
+}
+
+.sidebar-session-group-actions[aria-disabled="true"] {
+  color: color-mix(in srgb, var(--muted) 45%, transparent);
+}
+
 .sidebar-recent-sessions__head:where(:hover, :has(:focus-visible)) .sidebar-session-group-actions,
 .sidebar-session-group-actions[aria-expanded="true"],
 .sidebar-session-group-actions.sidebar-session-sort--filtered {
@@ -1581,7 +1599,7 @@ openclaw-settings-save-indicator:empty {
   pointer-events: auto;
 }
 
-.sidebar-session-group-actions:is(:hover, :focus-visible),
+.sidebar-session-group-actions:not([aria-disabled="true"]):is(:hover, :focus-visible),
 .sidebar-session-group-actions[aria-expanded="true"] {
   background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
   color: var(--text);

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -71,7 +71,7 @@ describe("AppSidebar new session navigation", () => {
     expect(brandLink).toBeInstanceOf(HTMLAnchorElement);
     expect(brandLink?.getAttribute("aria-disabled")).toBe("true");
     expect(brandLink?.hasAttribute("href")).toBe(false);
-    expect(brandLink?.tabIndex).toBe(-1);
+    expect(brandLink?.tabIndex).toBe(0);
     brandLink?.click();
     expect(onOpenNewSession).not.toHaveBeenCalled();
 


### PR DESCRIPTION
Closes #135992 — sidebar counts and new-session controls do not align across catalogs.

**Landing blocked:** hosted CI exposed a real Web Awesome tooltip hide/reopen race in the new keyboard scenario. The focused local runs passed, but the hosted failure below is authoritative counterevidence. The dependency lifecycle repair and regression coverage must be completed before landing; no merge has been attempted.

## What Problem This Solves

Collapsed sidebar counts drift away from their labels, trailing actions shift between section types, and an unavailable catalog action disappears without explanation. The reporter's [original screenshot](https://github.com/user-attachments/assets/7d3c49b9-a0f2-4540-9b33-8602df0ccf8b) established the intended presentation: counts directly beside text, with only trailing actions aligned independently.

## Why This Change Was Made

The sidebar header owns one flexible label/count area followed by fixed menu and new-session columns. Labels shrink for long-title marquee behavior but no longer grow into the space between text and count. Catalog status badges follow the count, and custom groups use the same menu-then-plus order.

Catalogs reuse the canonical new-session link, including a dimmed, explained unavailable state. The refreshed patch preserves current `main`'s `startTerminal` capability and native CLI launch flow from #136230; model-chat `createSession` is a distinct capability and does not enable this action. The explanation no longer incorrectly directs users to model/runtime settings. Disabled links have no destination or action, but remain keyboard-focusable and reveal their explanation on focus, hover, or tap.

Review improvements:

- Resolved current-main renderer/CSS conflicts without losing marquee, dimmed actions, or keyboard-visible styling.
- Replaced label-box geometry with actual text-range geometry. The old assertion could pass while the count remained far from the visible text.
- Added genuine Tab-navigation proof for the disabled explanation; retained native modified-click behavior.
- Reused existing screenshot and session-fixture helpers instead of maintaining a separate capture path.

## User Impact

Counts stay beside Personal, Automations, custom-group, Other, Coding, and catalog labels. Menus and `+` controls align independently. Unsupported catalog creation is explained instead of silently omitted. Long labels still reveal their full text on hover. Catalog capability policy, provider/runtime selection, native terminal launch, storage, configuration, and protocol are unchanged.

## Evidence

Reviewed source head: `0247a1fdab15de20bf7fd53d82896f672fc2f95a`, refreshed onto `507e5faf28500d12b8b43c8d0ad7996190e27d5d` after #136878 repaired the stale artifact-freshness assertions.

### Before and after — same browser fixture

These captures use the same sanitized data, dark theme, 1440×1000 viewport, and touch-visible controls in a real Chromium Control UI. The before image is the conflicted PR after mechanical integration but before repairing main's growing-label rule; it is not a released build or the reporter's original screenshot. Both were visually inspected.

| Before: count separated from text | After: count beside text, actions aligned |
| --- | --- |
| ![Before spacing correction](https://github.com/user-attachments/assets/fcb63218-267f-4a56-8c7b-fe7d2700af17) | ![After spacing correction](https://github.com/user-attachments/assets/211b7162-5b21-4831-90bc-dda3cb75d0af) |

![Unavailable action explains the missing capability on tap](https://github.com/user-attachments/assets/d0cc2b05-e725-4081-8356-e7c9a5fcabbe)

The screenshots precede the final mechanical rebase; the sidebar production delta is patch-identical, and both mouse/touch scenarios were rerun successfully on the integrated head.

The fixture deliberately supplies a catalog without terminal-start capability. It does not assert that the installed Claude Code plugin lacks that capability.

### Validation

- **Red/green geometry:** mouse and touch both failed with Personal's actual text-to-count gap at **50.328125px** (required 4–12px); both pass after the label-owner repair. Trailing action centers align within 1px.
- **Red/green keyboard:** after the spacing repair, Tab still skipped the disabled control; changing its tabindex to 0 makes focus and visible-tooltip proof pass. Click/Enter/tap do not navigate or request session/terminal creation.
- **6 browser scenarios passed**, covering geometry, mouse/touch/keyboard affordances, native links and modified clicks, catalog grouping, and long-title marquee. The lane builds and runs the production UI bundle.
- **335 unit tests passed**, including sidebar siblings and new-session catalog targeting. One old unit assertion was updated to the deliberately focusable disabled-link contract.
- Main-CI investigation: the matching **268-file / 4,364-test** UI selection passed locally with the same config and two workers; a bounded ordered predecessor run passed **3 files / 59 tests**. Exact CI worker assignment was not reproduced, and the origin of its extra timer remains unknown. No speculative timer code or assertion weakening was included; #136845 tracks the related ongoing investigation.
- Fresh structured Codex autoreview of the full staged delta against `origin/main`: no actionable P0 findings. Independent read-only owner/capability review informed the integration fixes.
- `git diff --check` and the full changed-file type/lint/guard plan passed. The final CSS/test-assertion follow-up check also passed; exact-head CI is recorded in the landing comment.
- `pnpm ui:build` passes the unchanged startup CSS budget at **46,061 / 46,080 bytes**. Current main failed at 46,097 bytes. Canonical DOM ordering makes explicit per-child grid placement unnecessary; duplicate hover/focus selectors and obsolete flex rules were removed. This keeps the bug fix lean without raising the budget.

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/sidebar-section-alignment.e2e.test.ts \
  ui/src/e2e/claude-sessions.e2e.test.ts ui/src/e2e/sidebar-interactions.e2e.test.ts \
  ui/src/e2e/session-management.groups.e2e.test.ts \
  -t 'keeps counts beside labels|shows catalog header affordances|groups Claude and Codex sessions|opens every new-session plus|keeps long group titles'
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner \
  ui/src/components/app-sidebar.test.ts ui/src/pages/new-session/catalog-target.test.ts
```

### Integration repair

The prior head hit the same stale artifact-freshness assertions already fixed by merged #136878. The PR was rebased onto that repair without changing its sidebar production delta; build and both sidebar browser cases pass again. The artifact-transfer suite exposed a separate local assertion issue under `umask 077`: tar correctly restores the executable file as `0700` rather than `0755`. The test now asserts the required owner-executable bit instead of requiring group/world access. Production extraction and the operator's umask are unchanged; all 9 artifact-transfer cases pass. This bounded test-only portability correction is included explicitly, not an environment override or a relaxed runtime guarantee.

### Review judgment and limits

**Best-fix verdict: best.** The presentation owner and existing link/tooltip are the canonical repair; provider changes or another launch path would be the wrong layer. Both ClawSweeper rank-up moves are addressed: current-main conflict resolution preserves newer styling, and the resolved browser scenario has fresh attached proof.

Code read: sidebar catalog/list/header renderers, shared new-session link and tooltip, hover-marquee owner, new-session catalog target, catalog capability producer/schema, sibling shell callers, existing browser/unit coverage. Personally inspected sibling Codex `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:62`, `codex-rs/app-server/src/request_processors/thread_processor.rs:505`, `codex-rs/tui/src/cli.rs:10`, and `codex-rs/cli/src/main.rs:1091`; this patch changes none of those contracts.

Provenance: current-main short-label growth is from #135523 (`8a7ac3cd21fe09c93ad547a65335435cd0e65422`, September 1, 2026), authored and merged by @Patrick-Erichsen to support long-title marquees. This patch preserves that behavior while removing short-label growth. No stable-release regression range is claimed.

**Production LOC: +44/-40 (net +4); tests/test support: +213/-2 (net +211).** Growth provides fixed action columns and an explained unavailable capability; duplicate truncation CSS and bespoke capture code were removed. No new dependency, option, protocol, or persistence surface.

Proof uses a real browser with mocked Gateway/catalog responses, not live-provider or live-Gateway execution. This is a presentation-only change; backend launch contracts are unchanged. The operator's Gateway was neither modified nor restarted. Related #132794 concerns row/scroller alignment rather than this label/count/action invariant and remains separate.

### Latest ClawSweeper review dispositions

The completed review at 03:13 UTC found no correctness/security defect and raised two merge-risk items. Both have an explicit maintainer disposition:

- **Current-main stylesheet proof: resolved.** The full 507e5faf285 stylesheet blob is available locally (114,145 bytes), was directly inspected/diffed, and the branch rebased cleanly onto it. The subsequent 3100ba535f1 main commit does not change that stylesheet. Fresh integrated browser/build proof passes; the reviewer's missing promisor blob is an environment limitation, not an unexamined merge conflict.
- **Net +4 production lines: accepted with contract justification.** The requested discoverable disabled-action explanation needs a catalog-capability reason and canonical localized copy. Removing that behavior would restore the reported silent omission. The existing tooltip/link is reused; header CSS is net-negative after deleting redundant grid/flex/hover rules. A new wrapper or per-catalog workaround would be larger. No option, dependency, or alternate launch path was added.

AI-assisted implementation and verification.

## Blocking hosted-CI finding

[Hosted UI E2E shard 8/13](https://github.com/openclaw/openclaw/actions/runs/33711707519/job/100512554913) failed `sidebar-section-alignment.e2e.test.ts:198`: after hover→leave→keyboard Tab, the disabled plus is focused and the wrapper is marked open, but the tooltip content remains hidden for 30 seconds. The downloaded failure screenshot was inspected and confirms focused control/no explanation.

Installed Web Awesome 3.12.0 tooltip `dist/chunks/chunk.BCXHEFKE.js:234` makes the popup visible on show; its hide path awaits animation at 249 then unconditionally hides/deactivates the popup at 250–251. Its async property watcher permits overlapping transitions. A stale hide completion can therefore hide a newly reopened tooltip. This is a real user transition, not a reason to increase timeouts or insert an interaction delay.

Required repair: extend the existing Web Awesome dependency patch's generation/current-state lifecycle approach (already used for dropdowns/submenus) to tooltip transitions, with real-animation regression coverage for reopen, close, and disconnect. Dependency patch approval is required before implementation. No dependency files have been modified, and no assertion has been weakened to pass this failure.
