### PR TITLE
improve: avoid redundant provider catalog model copies

### DIFF
--- a/src/plugin-sdk/provider-entry.test.ts
+++ b/src/plugin-sdk/provider-entry.test.ts
@@ -658,12 +658,29 @@ describe("defineSingleProviderPluginEntry", () => {
   });
 
   it("skips unreadable provider catalog model rows while preserving healthy siblings", async () => {
-    const models = Object.defineProperty([createModel("mock-model", "Mock Model")], "1", {
-      enumerable: true,
-      get() {
-        throw new Error("fuzzplugin provider model row read failed");
+    const unreadableModel = Object.defineProperty(
+      createModel("broken-model", "Broken Model"),
+      "id",
+      {
+        get() {
+          throw new Error("fuzzplugin model id read failed");
+        },
       },
-    });
+    );
+    const models = Object.defineProperty(
+      [
+        createModel("mock-model", "Mock Model"),
+        { id: "id-only" } as ModelDefinitionConfig,
+        unreadableModel,
+      ],
+      "3",
+      {
+        enumerable: true,
+        get() {
+          throw new Error("fuzzplugin provider model row read failed");
+        },
+      },
+    );
     const entry = defineSingleProviderPluginEntry({
       id: "mockplugin",
       name: "Mock Provider",
@@ -692,6 +709,13 @@ describe("defineSingleProviderPluginEntry", () => {
         provider: "mockplugin",
         model: "mock-model",
         label: "Mock Model",
+        source: "live",
+      },
+      {
+        kind: "text",
+        provider: "mockplugin",
+        model: "id-only",
+        label: "id-only",
         source: "live",
       },
     ]);

--- a/src/plugins/provider-catalog-result.ts
+++ b/src/plugins/provider-catalog-result.ts
@@ -120,13 +120,17 @@ export function copyProviderCatalogResultEntries(params: {
 }
 
 /** Copies model definitions from provider catalog provider config. */
-export function copyProviderCatalogModels(
+function copyProviderCatalogModels(
   providerConfig: ModelProviderConfig,
 ): ModelProviderConfig["models"] {
-  return copyArrayEntries(readRecordValue(providerConfig, "models")).flatMap((entry) => {
+  const models: ModelDefinitionConfig[] = [];
+  for (const entry of copyArrayEntries(readRecordValue(providerConfig, "models"))) {
     const copied = copyProviderCatalogModel(entry);
-    return copied ? [copied] : [];
-  });
+    if (copied) {
+      models.push(copied);
+    }
+  }
+  return models;
 }
 
 function copyProviderCatalogModel(model: unknown): ModelDefinitionConfig | undefined {

--- a/src/plugins/provider-catalog-unified-text.ts
+++ b/src/plugins/provider-catalog-unified-text.ts
@@ -1,10 +1,6 @@
 /** Builds unified text-inference provider catalog metadata from plugin providers. */
 import type { UnifiedModelCatalogEntry } from "@openclaw/model-catalog-core/model-catalog-types";
-import { readRecordValue } from "../shared/safe-record.js";
-import {
-  copyProviderCatalogModels,
-  copyProviderCatalogResultEntries,
-} from "./provider-catalog-result.js";
+import { copyProviderCatalogResultEntries } from "./provider-catalog-result.js";
 import type { ProviderCatalogResult } from "./types.js";
 
 /** Projects plugin provider catalog results into unified text-model catalog rows. */
@@ -14,20 +10,15 @@ export function projectProviderCatalogResultToUnifiedTextRows(params: {
   source: UnifiedModelCatalogEntry["source"];
 }): UnifiedModelCatalogEntry[] {
   const rows: UnifiedModelCatalogEntry[] = [];
-  // Runtime projection isolates unreadable catalog rows so one bad plugin-owned
-  // provider/model entry cannot hide every healthy sibling from model selection.
+  // The result copier isolates unreadable plugin rows and owns these model records;
+  // consume their validated ids and names without copying the catalog again.
   for (const [providerId, providerConfig] of copyProviderCatalogResultEntries(params)) {
-    for (const model of copyProviderCatalogModels(providerConfig)) {
-      const modelId = readRecordValue(model, "id");
-      if (typeof modelId !== "string") {
-        continue;
-      }
-      const modelName = readRecordValue(model, "name");
+    for (const model of providerConfig.models) {
       rows.push({
         kind: "text",
         provider: providerId,
-        model: modelId,
-        ...(typeof modelName === "string" && modelName ? { label: modelName } : {}),
+        model: model.id,
+        ...(model.name ? { label: model.name } : {}),
         source: params.source,
       });
     }


### PR DESCRIPTION
Provider catalog normalization created a temporary array for every model, and the SDK unified text projector copied the normalized models again. Append validated model copies directly to one output array, then let the SDK consumer use those owned records. The input snapshot, getter-read order and defensive checks stay at the plugin boundary. Production code shrinks by 5 lines; contract coverage adds 24 test lines.

Actual core prepared-catalog discovery and registered SDK callback probes preserve all 221,970 output and read-trace bytes for 246 models across 39 manifest catalogs. Per-model wrapper arrays fall from 246 to zero in core; each SDK callback also avoids 246 duplicate model records. Both owner suites pass before and after (34 tests), and the expanded malformed-row parity case passes against the original code. Canonical changed-file checks, independent review and isolated Codex autoreview pass. The small timing sample shows no speedup; this change reduces measured allocation work, with no RSS or Gateway startup claim.
