### PR TITLE
fix(codex): hide node exec when no capable node is connected

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -67,7 +67,9 @@ starting more work. This uses Codex's terminal ownership; it does not guarantee
 cleanup of commands that deliberately detach from that ownership.
 
 With the default `tools.exec.host: "auto"` and no active OpenClaw sandbox,
-Codex also receives `node_exec` for commands on paired nodes. Native shell
+Codex also receives `node_exec` when a connected node supports `system.run`.
+Offline paired devices and devices without shell support do not expose this tool.
+When a node is configured, that binding must resolve to an eligible node. Native shell
 remains on the Codex app-server host and workspace
 (Gateway-local for the default stdio deployment); `node_exec` selects the sole
 connected node that supports `system.run`, or requires a name or id when several
@@ -78,9 +80,10 @@ an execution environment, OpenClaw keeps its policy-filtered `exec` and
 `process` tools available instead for direct, unsandboxed execution.
 
 When `tools.exec.host: "node"` or `/exec host=node` makes the node the session
-default, OpenClaw hides the Codex-native shell and exposes `node_exec` as the
-shell path. This keeps the configured execution host from silently falling
-back to the app-server or Gateway machine.
+default, OpenClaw hides the Codex-native shell and exposes `node_exec` only while
+the node target is eligible. If it is unavailable, reconnect the configured node
+or explicitly change the exec host. OpenClaw does not silently fall back to the
+app-server or Gateway machine.
 
 `gateway_exec` is not exposed when an active OpenClaw sandbox, a node-default
 execution policy, memory-flush restrictions, tool allow/deny policy, or

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -54,6 +54,7 @@ import { createCodexTestModel } from "./test-support.js";
 const hoisted = vi.hoisted(() => ({
   normalizeAgentRuntimeTools: vi.fn(),
   resolveWebSearchToolPolicy: vi.fn(),
+  listNodes: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-harness", async (importOriginal) => {
@@ -74,6 +75,7 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
   return {
     ...actual,
+    listNodes: hoisted.listNodes,
     normalizeAgentRuntimeTools: (...args: Parameters<typeof actual.normalizeAgentRuntimeTools>) => {
       hoisted.normalizeAgentRuntimeTools(...args);
       return actual.normalizeAgentRuntimeTools(...args);
@@ -527,6 +529,13 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   beforeEach(async () => {
+    hoisted.listNodes.mockResolvedValue(
+      ["mac-mini", "worker-1", "bound-mac-mini"].map((nodeId) => ({
+        nodeId,
+        connected: true,
+        commands: ["system.run"],
+      })),
+    );
     hoisted.normalizeAgentRuntimeTools.mockClear();
     hoisted.resolveWebSearchToolPolicy.mockClear();
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-tools-"));
@@ -1669,6 +1678,97 @@ describe("Codex app-server dynamic tool build", () => {
 
     expect(shellTestToolNames(tools)).toEqual(testCase.expected);
   });
+
+  it.each([
+    { label: "no nodes", nodes: [], available: false },
+    {
+      label: "offline executor",
+      nodes: [{ nodeId: "worker", connected: false, commands: ["system.run"] }],
+      available: false,
+    },
+    {
+      label: "connected approval device",
+      nodes: [{ nodeId: "phone", connected: true, commands: [] }],
+      available: false,
+    },
+    {
+      label: "unknown capabilities",
+      nodes: [{ nodeId: "phone", connected: true }],
+      available: false,
+    },
+    {
+      label: "eligible executor",
+      nodes: [{ nodeId: "worker", connected: true, commands: ["system.run"] }],
+      available: true,
+    },
+    {
+      label: "multiple executors",
+      nodes: ["one", "two"].map((nodeId) => ({
+        nodeId,
+        connected: true,
+        commands: ["system.run"],
+      })),
+      available: true,
+    },
+    {
+      label: "offline binding beside eligible executor",
+      node: "phone",
+      nodes: [
+        { nodeId: "phone", connected: false, commands: [] },
+        { nodeId: "worker", connected: true, commands: ["system.run"] },
+      ],
+      available: false,
+    },
+    {
+      label: "eligible named binding",
+      node: "Build Worker",
+      nodes: [
+        {
+          nodeId: "worker",
+          displayName: "Build Worker",
+          connected: true,
+          commands: ["system.run"],
+        },
+      ],
+      available: true,
+    },
+    {
+      label: "ambiguous binding",
+      node: "Build Worker",
+      nodes: [
+        { nodeId: "phone", displayName: "Build Worker", connected: true, commands: [] },
+        {
+          nodeId: "worker",
+          displayName: "Build Worker",
+          connected: true,
+          commands: ["system.run"],
+        },
+      ],
+      available: false,
+    },
+  ])(
+    "gates node_exec on live execution eligibility: $label",
+    async ({ nodes, node, available }) => {
+      hoisted.listNodes.mockResolvedValue(nodes);
+      setOpenClawCodingToolsFactoryForTests(() => [
+        createRuntimeDynamicTool("exec"),
+        createRuntimeDynamicTool("message"),
+      ]);
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(path.join(tempDir, "eligibility.jsonl"), workspaceDir);
+      params.disableTools = false;
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      for (const host of ["auto", "node"] as const) {
+        params.execOverrides = { host, node };
+        const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params);
+        const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+          nativeToolSurfaceEnabled,
+        });
+        expect(tools.some((tool) => tool.name === "node_exec")).toBe(available);
+        expect(nativeToolSurfaceEnabled).toBe(host === "auto");
+      }
+    },
+  );
 
   it("exposes pinned node shell tools for node-targeted Codex app-server runs", async () => {
     const execTool = {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -454,7 +454,7 @@ export async function buildDynamicTools(
     hostSystemAgentActive && isSystemAgentOnlyCodexDynamicToolAllowlist(params.toolsAllow)
       ? preserveRingZeroSystemAgentTool(readableAllTools, normallyProfiledTools)
       : normallyProfiledTools;
-  const codexFilteredTools = addNodeShellDynamicToolsIfNeeded(
+  const codexFilteredTools = await addNodeShellDynamicToolsIfNeeded(
     addGatewayShellDynamicToolsIfAvailable(
       addSandboxShellDynamicToolsIfAvailable(
         isCodexMemoryFlushRun(params)
@@ -882,12 +882,12 @@ function addSandboxShellDynamicToolsIfAvailable(
 function isSandboxShellDynamicToolExcluded(config: CodexPluginConfig): boolean {
   return isCodexDynamicToolExcluded(config, ["exec", "sandbox_exec", "process", "sandbox_process"]);
 }
-function addNodeShellDynamicToolsIfNeeded(
+async function addNodeShellDynamicToolsIfNeeded(
   filteredTools: OpenClawDynamicTool[],
   allTools: OpenClawDynamicTool[],
   input: DynamicToolBuildParams,
   nodePolicy: CodexNativeExecutionPolicy,
-): OpenClawDynamicTool[] {
+): Promise<OpenClawDynamicTool[]> {
   if (isCodexMemoryFlushRun(input.params)) {
     return filteredTools;
   }
@@ -898,18 +898,21 @@ function addNodeShellDynamicToolsIfNeeded(
     return filteredTools;
   }
   const execTool = allTools.find((tool) => normalizeCodexDynamicToolName(tool.name) === "exec");
-  if (!execTool) {
-    return filteredTools;
-  }
   if (
-    !isCodexDynamicToolExcluded(input.pluginConfig, ["exec", CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME]) &&
-    !filteredTools.some(
+    !execTool ||
+    isCodexDynamicToolExcluded(input.pluginConfig, ["exec", CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME]) ||
+    filteredTools.some(
       (tool) => normalizeCodexDynamicToolName(tool.name) === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
     )
   ) {
-    return [...filteredTools, createNodeExecAliasDynamicTool(execTool, nodePolicy.node)];
+    return filteredTools;
   }
-  return filteredTools;
+  const nodeExec = await createNodeExecAliasDynamicTool(
+    execTool,
+    nodePolicy.node,
+    input.runAbortController.signal,
+  );
+  return nodeExec ? [...filteredTools, nodeExec] : filteredTools;
 }
 function shouldKeepOpenClawShellDynamicTools(
   input: DynamicToolBuildParams,

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,3 +1,4 @@
+import { listNodes, resolveNodeIdFromList } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   pinExecToolTarget,
   type CodexScheduledToolProjectionFactory,
@@ -26,11 +27,32 @@ export function isCodexDynamicToolExcluded(
   );
 }
 
-export function createNodeExecAliasDynamicTool(
+export async function createNodeExecAliasDynamicTool(
   execTool: OpenClawDynamicTool,
   node?: string,
-): OpenClawDynamicTool {
+  discoverySignal?: AbortSignal,
+): Promise<OpenClawDynamicTool | undefined> {
   const pinnedNode = node?.trim();
+  try {
+    const nodes = await listNodes({}, discoverySignal);
+    // Resolve bindings before filtering: an unavailable or ambiguous target must
+    // never redirect execution to another device that happens to support shell.
+    const nodeId = pinnedNode ? resolveNodeIdFromList(nodes, pinnedNode) : undefined;
+    if (
+      !nodes.some(
+        (candidate) =>
+          (!nodeId || candidate.nodeId === nodeId) &&
+          candidate.connected === true &&
+          candidate.commands?.includes("system.run") === true,
+      )
+    ) {
+      return undefined;
+    }
+  } catch {
+    discoverySignal?.throwIfAborted();
+    // Discovery failure hides the optional remote shell, not the working local shell.
+    return undefined;
+  }
   const pinnedTool = pinExecToolTarget(execTool, {
     host: "node",
     ...(pinnedNode ? { node: pinnedNode } : {}),


### PR DESCRIPTION
Closes #135966.

## What Problem This Solves

Fixes an issue where Codex users with automatic exec-host selection could be offered a remote shell even though their only paired device was offline or could not execute commands. Elton Lau reported a Linux Gateway selecting an offline, approval-only iPhone through `node_exec` while the local native shell worked.

## Why This Change Was Made

The Codex node-shell projection now reads the current Gateway node inventory before exposing `node_exec`. It requires a connected node advertising `system.run`. Configured bindings resolve against the full inventory before capability filtering, so an unavailable or ambiguous binding cannot silently redirect to a different device. Several eligible unbound nodes still expose the tool with its explicit target argument.

Core automatic execution already selects sandbox or Gateway, not a paired device. The recently landed capable-node selector (#131767) remains the execution-time authority; this completes the missing advertisement gate. No configuration, schema, protocol, approval policy, or dependency changes.

## User Impact

Offline paired devices and approval-only devices no longer divert Codex into an unusable remote shell. Automatic mode retains native/local execution. Explicit node mode continues to prohibit fallback to the Gateway or app-server machine; reconnect the node or explicitly change the host when it is unavailable. The Codex harness docs describe both cases.

## Evidence

- Pre-fix: the tool-build regression reproduced unwanted `node_exec` exposure with no nodes, an offline executor, a connected capability-less device, missing capability facts, and an unavailable binding. Those five unavailable-node scenarios failed before the fix; eligible-node entries passed.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/native-execution-policy.test.ts src/agents/bash-tools.exec-host-node-phases.test.ts`: 143 tests passed. Includes ambiguous bindings, several eligible nodes, sandbox/Gateway/native policies, and the existing dispatch-selection boundary.
- Independent Codex autoreview of the complete local candidate: no accepted/actionable findings at the configured threshold.
- Direct Codex dependency inspection: `codex-rs/core/src/tools/handlers/dynamic.rs:39-79` constructs supplied dynamic-tool specs; `:120-167` forwards dynamic calls back to their owner. Checked source commit `0ae94fdd49b05ee7faa4d984d06a68492cb32b54`; Codex does not discover OpenClaw node eligibility on the plugin's behalf.

### Isolated live-proof transcript

Command: `node --import tsx /tmp/exec-node-live-proof.mts`. Rerun after the successful build on exact PR head `86df4099cb2a42ad9f54fbb3196e476cdae90fcc`; exited 0. The standalone proof used the existing QA Gateway fixture, temporary synthetic state, free port 52160, actual Gateway WebSocket pairing/inventory, mock node protocol clients, and the real source Codex tool builder. The existing coding-factory seam supplied the real exec tool. It did not invoke a live model or Codex app-server, and did not execute commands on the mock executor.

```text
no-nodes: node_exec=false; native=true
connected-capability-less-phone: connected=true; system.run=false; node_exec=false; native=true
offline-paired-phone: connected=false; node_exec=false; native=true
auto-local-shell: completed; exitCode=0; nodeRouted=false
eligible-connected-executor: system.run=true; node_exec=true; native=true
offline-phone-bound-beside-executor: node_exec=false; native=true
eligible-named-binding: node_exec=true; native=true
offline-executor-rebuild: connected=false; node_exec=false; native=true
verdict: pass; cleanup exitCode=0; temporary Gateway port no longer listening
```

Production LOC: +37/-12 (net +25). Tests: +100/-0. Docs: +7/-4. The production growth adds the previously absent live-availability boundary and async propagation; it reuses existing inventory and target resolution rather than adding another selector, cache, or fallback.

### Follow-up and remaining limits

A node can disconnect after a tool surface is built; the existing execution-time selector still rejects it. Inventory failure hides the optional node shell without changing local/native-host policy. A separate follow-up is auditing the same policy-only availability gap in CLI loopback tools and their schema cache.

All selected changed-file check steps passed. The first `node scripts/check-changed.mjs -- <four changed paths>` invocation reached typed lint and found one shadowed parameter; after renaming it, the same targeted typed-lint command passed, followed by the remaining database-first, media-download, runtime-sidecar, and import-cycle guards. Both production/test typechecks, all preceding guards, formatting, and the five doctor-contract tests passed in the initial gate. The patch rebased unchanged onto current main.

`pnpm build sourcePerformance` passed (2m25), including 67 local plugin packages, CLI bootstrap, and runtime postbuild checks. Fresh `autoreview --mode branch` passed with no accepted/actionable findings.

Exact-head [CI run 33595883111](https://github.com/openclaw/openclaw/actions/runs/33595883111) is green; the required watcher exited 0. Native review artifacts validated with no findings. ClawSweeper was rechecked before prepare: no completed review or rank-up moves available; skipping only that unavailable review. Independent branch autoreview and the manual evidence map are complete. Native prepare/merge remain before landing.
