### PR TITLE
fix(qa): preserve failed Anthropic completions and partial output

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-messages.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-messages.ts
@@ -6,7 +6,7 @@ import {
   buildAnthropicThinkingErrorResponse,
   buildAnthropicThinkingErrorStreamEvents,
   convertAnthropicMessagesToResponsesInput,
-  extractFinalAssistantOutputFromEvents,
+  extractAssistantOutputFromEvents,
   normalizeAnthropicSystemToString,
 } from "./mock-anthropic-wire.js";
 import type {
@@ -41,30 +41,40 @@ export function normalizeAnthropicMessagesRequest(body: AnthropicMessagesRequest
 }
 
 export function buildMessagesPayload(dispatched: QaMockProviderDispatchResult): {
+  status: number;
   responseBody: Record<string, unknown>;
-  streamEvents: AnthropicStreamEvent[];
+  // HTTP failures stay JSON errors even when streaming was requested.
+  streamEvents?: AnthropicStreamEvent[];
 } {
   if (dispatched.failure?.presentation === "anthropic-thinking") {
     return {
+      status: dispatched.failure.status,
       responseBody: buildAnthropicThinkingErrorResponse({ model: dispatched.model }),
       streamEvents: buildAnthropicThinkingErrorStreamEvents({ model: dispatched.model }),
     };
   }
   if (dispatched.failure) {
     return {
+      status: dispatched.failure.status,
       responseBody: buildAnthropicFailureResponse(dispatched.failure),
-      streamEvents: [],
     };
   }
-  const extracted = extractFinalAssistantOutputFromEvents(dispatched.events);
+  const failed = dispatched.events.find((event) => event.type === "response.failed");
+  const failure = failed
+    ? {
+        status: 500,
+        type: "api_error",
+        code: failed.response.error?.code,
+        message: failed.response.error?.message ?? "mock completion failed",
+      }
+    : undefined;
+  const message = buildAnthropicMessageResponse({
+    model: dispatched.model,
+    extracted: extractAssistantOutputFromEvents(dispatched.events),
+  });
   return {
-    responseBody: buildAnthropicMessageResponse({
-      model: dispatched.model,
-      extracted,
-    }),
-    streamEvents: buildAnthropicMessageStreamEvents({
-      model: dispatched.model,
-      extracted,
-    }),
+    status: failure?.status ?? 200,
+    responseBody: failure ? buildAnthropicFailureResponse(failure) : message,
+    streamEvents: buildAnthropicMessageStreamEvents(message, failure),
   };
 }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-anthropic-wire.ts
@@ -203,12 +203,15 @@ export function adaptAnthropicToolCallIds(events: StreamEvent[]): StreamEvent[] 
   });
 }
 
-export function extractFinalAssistantOutputFromEvents(
-  events: StreamEvent[],
-): ExtractedAssistantOutput {
+export function extractAssistantOutputFromEvents(events: StreamEvent[]): ExtractedAssistantOutput {
   const toolCalls: ExtractedAssistantOutput["toolCalls"] = [];
   let text = "";
   for (const event of events) {
+    // Failed streams may never finish an output item; retain text emitted before failure.
+    if (event.type === "response.output_text.delta") {
+      text += event.delta;
+      continue;
+    }
     if (event.type !== "response.output_item.done") {
       continue;
     }
@@ -253,8 +256,8 @@ export function extractFinalAssistantOutputFromEvents(
 export function buildAnthropicMessageResponse(params: {
   model: string;
   extracted: ExtractedAssistantOutput;
-}): Record<string, unknown> {
-  const content: Array<Record<string, unknown>> = [];
+}) {
+  const content: Array<Extract<AnthropicMessageContentBlock, { type: "text" | "tool_use" }>> = [];
   if (params.extracted.text) {
     content.push({ type: "text", text: params.extracted.text });
   }
@@ -290,9 +293,7 @@ export function buildAnthropicMessageResponse(params: {
   };
 }
 
-export function buildAnthropicFailureResponse(
-  failure: QaMockProviderFailure,
-): Record<string, unknown> {
+export function buildAnthropicFailureResponse(failure: QaMockProviderFailure) {
   return {
     type: "error",
     error: {
@@ -389,94 +390,59 @@ export function buildAnthropicThinkingErrorStreamEvents(params: {
   ];
 }
 
-export function buildAnthropicMessageStreamEvents(params: {
-  model: string;
-  extracted: ExtractedAssistantOutput;
-}): AnthropicStreamEvent[] {
-  const approxInputTokens = 64;
-  const approxOutputTokens = Math.max(
-    16,
-    countApproxTokens(params.extracted.text) + params.extracted.toolCalls.length * 16,
-  );
-  const messageId = `msg_mock_${Math.floor(Math.random() * 1_000_000).toString(16)}`;
+export function buildAnthropicMessageStreamEvents(
+  message: ReturnType<typeof buildAnthropicMessageResponse>,
+  failure?: QaMockProviderFailure,
+): AnthropicStreamEvent[] {
   const events: AnthropicStreamEvent[] = [
     {
       type: "message_start",
       message: {
-        id: messageId,
-        type: "message",
-        role: "assistant",
-        model: params.model || "claude-opus-4-8",
+        ...message,
         content: [],
         stop_reason: null,
-        stop_sequence: null,
         usage: {
-          input_tokens: approxInputTokens,
+          input_tokens: message.usage.input_tokens,
           output_tokens: 0,
         },
       },
     },
   ];
-  let index = 0;
-  if (params.extracted.text || params.extracted.toolCalls.length === 0) {
+  for (const [index, block] of message.content.entries()) {
     events.push({
       type: "content_block_start",
       index,
       content_block: {
-        type: "text",
-        text: "",
+        ...block,
+        ...(block.type === "text" ? { text: "" } : { input: {} }),
       },
     });
-    if (params.extracted.text) {
+    const delta = block.type === "text" ? block.text : JSON.stringify(block.input);
+    if (delta) {
       events.push({
         type: "content_block_delta",
         index,
-        delta: {
-          type: "text_delta",
-          text: params.extracted.text,
-        },
+        delta:
+          block.type === "text"
+            ? { type: "text_delta", text: delta }
+            : { type: "input_json_delta", partial_json: delta },
       });
     }
     events.push({
       type: "content_block_stop",
       index,
     });
-    index += 1;
   }
-  for (const call of params.extracted.toolCalls) {
-    events.push({
-      type: "content_block_start",
-      index,
-      content_block: {
-        type: "tool_use",
-        id: call.id,
-        name: call.name,
-        input: {},
-      },
-    });
-    events.push({
-      type: "content_block_delta",
-      index,
-      delta: {
-        type: "input_json_delta",
-        partial_json: JSON.stringify(call.input ?? {}),
-      },
-    });
-    events.push({
-      type: "content_block_stop",
-      index,
-    });
-    index += 1;
+  if (failure) {
+    events.push(buildAnthropicFailureResponse(failure));
+    return events;
   }
   events.push({
     type: "message_delta",
     delta: {
-      stop_reason: params.extracted.toolCalls.length > 0 ? "tool_use" : "end_turn",
+      stop_reason: message.stop_reason,
     },
-    usage: {
-      input_tokens: approxInputTokens,
-      output_tokens: approxOutputTokens,
-    },
+    usage: message.usage,
   });
   events.push({
     type: "message_stop",

--- a/extensions/qa-lab/src/providers/mock-openai/server.anthropic-failure.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.anthropic-failure.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { startQaMockOpenAiServer } from "./server.js";
+
+describe.each([
+  { name: "before output", prompt: "Telegram unsent failure QA check.", partialText: "" },
+  {
+    name: "after partial output",
+    prompt: "Telegram visible partial failure QA check.",
+    partialText: "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE",
+  },
+])("Anthropic failure $name", ({ prompt, partialText }) => {
+  it.each([false, true])("preserves failure when stream=%s", async (stream) => {
+    const server = await startQaMockOpenAiServer({ host: "127.0.0.1", port: 0 });
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "qa-model",
+          max_tokens: 256,
+          stream,
+          messages: [{ role: "user", content: prompt }],
+        }),
+      });
+      const body = await response.text();
+      const expectedError = { type: "api_error", message: expect.any(String) };
+      if (stream) {
+        expect(response.status).toBe(200);
+        const events = body
+          .split("\n")
+          .filter((line) => line.startsWith("data: "))
+          .map((line) => JSON.parse(line.slice(6)));
+        expect(events.at(-1)).toMatchObject({ type: "error", error: expectedError });
+        expect(body).not.toContain("event: message_stop");
+        expect(body).not.toContain('"stop_reason":"end_turn"');
+        expect(
+          events
+            .filter((event) => event.type === "content_block_delta")
+            .map((event) => event.delta.text)
+            .join(""),
+        ).toBe(partialText);
+      } else {
+        expect(response.status).toBe(500);
+        expect(JSON.parse(body)).toEqual({ type: "error", error: expectedError });
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -2940,15 +2940,15 @@ export async function startQaMockOpenAiServer(params?: {
         return;
       }
       const dispatched = await dispatchProvider({ route: "anthropic-messages", body, raw });
-      const { responseBody, streamEvents } = buildMessagesPayload(dispatched);
-      if (dispatched.failure && dispatched.failure.presentation !== "anthropic-thinking") {
-        writeJson(res, dispatched.failure.status, responseBody);
+      const { status, responseBody, streamEvents } = buildMessagesPayload(dispatched);
+      if (!streamEvents) {
+        writeJson(res, status, responseBody);
         return;
       }
       if (body.stream === true) {
         await writeSse(res, streamEvents, "anthropic");
       } else {
-        writeJson(res, dispatched.failure?.status ?? 200, responseBody);
+        writeJson(res, status, responseBody);
       }
       dispatched.onResponseSent?.();
     });


### PR DESCRIPTION
Closes #135999

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

QA Lab's mock Anthropic adapter turns shared `response.failed` events into successful empty completions. The provider records an error, but the Anthropic SDK sees `end_turn` or `message_stop` and resolves normally. This also drops text emitted before a stream fails.

## Why This Change Was Made

The adapter now owns the terminal outcome and its HTTP/SSE presentation. A failed event produces a JSON `api_error` with HTTP 500 for nonstreaming callers, or a terminal SSE `error` after any partial text. Existing injected HTTP failures and the signed-thinking error fixture keep their existing behavior.

Successful streams now derive content, model, ID, usage, and stop reason from the same Anthropic message used for JSON responses. This deletes the separate content loops and repeated message construction.

## User Impact

QA callers observe the intended failure in both Anthropic response modes. Partial text remains visible before a streaming failure, and failed runs cannot end with a successful stop marker.

## Evidence

Four maintained HTTP regressions fail on the starting source: failure before output and after partial output, each with streaming enabled and disabled. All four pass after the fix. The selected provider, event, WebSocket, and regression suites pass **305 tests**; the four regressions pass again after the final naming/comment cleanup.

The real Anthropic SDK previously accepted both failed responses. It now throws the expected API error in both modes, while the Responses control still emits `response.failed`. Four additional success fixtures compare the actual old Git-object module with the candidate: empty, text-only, tool-only, and text-plus-multiple-tool replies. JSON and SSE match with only random message IDs normalized.

Production TypeScript: **+55/-79, net -24**. Tests: **+50/-0**.

The acting agent inspected Codex at `94cbbddafc1776d5e377bca1b05932c697e82238`, `codex-rs/codex-api/src/sse/responses.rs:413-467`: `response.failed` is an error even without details. Anthropic SDK 0.120.0 `src/core/streaming.ts:139-143` throws on the named SSE `error` event. The actual loopback SDK proof exercises these protocol outcomes without external provider credentials.

Full changed-file checks pass. Fresh independent Codex review through P2 is scoped-clean with no findings (confidence 0.96).

Root follow-through: all four new actual HTTP regressions pass independently. This branch was rebased onto current main after the HTTP lifecycle PR landed; its four reviewed source/test hashes are unchanged.
