### PR TITLE
test(google-meet): complete finite fake process streams

### DIFF
--- a/extensions/google-meet/node-host.test.ts
+++ b/extensions/google-meet/node-host.test.ts
@@ -13,6 +13,16 @@ type MockChild = EventEmitter & {
   stdin?: EventEmitter & { write: ReturnType<typeof vi.fn> };
 };
 
+function finishMockChild(child: MockChild, code: number | null, signal: NodeJS.Signals | null) {
+  child.exitCode = code;
+  child.signalCode = signal;
+  child.emit("exit", code, signal);
+  // Capture EOF follows exit; otherwise a finite fake waits for the real drain deadline.
+  child.stdout?.emit("end");
+  child.stdout?.emit("close");
+  child.emit("close", code, signal);
+}
+
 const children: MockChild[] = [];
 let handleGoogleMeetNodeHostCommand: typeof import("./src/node-host.js").handleGoogleMeetNodeHostCommand;
 let originalPlatform: NodeJS.Platform;
@@ -65,8 +75,7 @@ vi.mock("node:child_process", async (importOriginal) => {
           return true;
         }
         queueMicrotask(() => {
-          child.signalCode = resolvedSignal;
-          child.emit("exit", null, resolvedSignal);
+          finishMockChild(child, null, resolvedSignal);
         });
         return true;
       });
@@ -366,8 +375,7 @@ describe("google-meet node host bridge sessions", () => {
     expect(typeof activeList.bridges[0]?.createdAt).toBe("string");
 
     if (children[1]) {
-      children[1].exitCode = 0;
-      children[1].emit("exit", 0, null);
+      finishMockChild(children[1], 0, null);
     }
 
     const afterExitList = await invokeNodeHostJson(listParams);


### PR DESCRIPTION
## Summary
The Google Meet node-host fixture emitted process exit without capture EOF. The real shared host consequently exhausted its three-second input-drain deadline during ordinary finite-child cleanup. Complete the fake child with the same exit → stdout end/close → child close sequence already used by the shared audio fixture.

Keep all 13 cases and 57 assertion sites, including the 1,999 + 1 ms SIGTERM escalation, stale-output, concurrent stop, and active-session checks. Production code and all drain/retention deadlines are unchanged. Production LOC +0/-0; test LOC +12/-4.

## Validation
- Measured original and candidate: 13/13 passed with identical expanded test names. Case execution fell from 6,056.18 ms to 47.59 ms. The two awaited cleanup cases fell from 3,001.14/3,004.82 ms to 1.36/1.09 ms. File duration was 17.17 → 10.47 seconds; import/setup is excluded from the case-time saving.
- Shared host siblings: 28/28 passed, including delayed capture, bounded drain, terminal retention, backpressure, and process escalation behavior.
- Directly inspected the installed Node 24.19 child-process implementation: process exit is followed by flushing readable stdio to EOF. The real owner and plugin wrapper were inspected, along with the historical introduction of capture drain.
- Local changed-file gate passed, including plugin test typing, lint, structural guards, and dead-export scans.
- Codex P0 autoreview: no accepted/actionable findings (0.99).

This is a test-fixture correction; no product behavior or live-channel change is claimed.

Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33596188609 (09874be42256c82dff1e2cc73fd29db293b257e2).
