### PR TITLE
fix(release): report missing FRV child dispatches

### DIFF
--- a/scripts/frv.d.mts
+++ b/scripts/frv.d.mts
@@ -1,15 +1,16 @@
 export interface FrvChildStatus extends Record<string, unknown> {
-  effectiveRunAttempt: number;
+  effectiveRunAttempt: number | null;
   key: string;
-  plannedRunAttempt: number;
+  plannedRunAttempt: number | null;
   runId: string;
-  status: string;
+  status: "active" | "failed" | "missing" | "passed";
 }
 
 export interface FrvContinuationStatus {
   active: FrvChildStatus[];
   children: FrvChildStatus[];
   failed: FrvChildStatus[];
+  missing: FrvChildStatus[];
   passed: FrvChildStatus[];
 }
 

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -228,6 +228,15 @@ function selectedChildren(plan) {
   return plan.children.filter((child) => child.selected);
 }
 
+function hasExactChildRunIdentity(child) {
+  return (
+    typeof child.runId === "string" &&
+    /^[1-9][0-9]*$/u.test(child.runId) &&
+    Number.isSafeInteger(child.runAttempt) &&
+    child.runAttempt > 0
+  );
+}
+
 function assertChildRunIdentity(child, run, repository = DEFAULT_REPOSITORY) {
   return validateReleaseChildRunProvenance(run, {
     ...child,
@@ -304,6 +313,15 @@ export async function preflightContinuation(
       "parent-owned publication artifacts do not survive parent reruns; start a fresh all-group FRV",
     );
   }
+  const missingChildren = selectedChildren(plan)
+    .filter((child) => !hasExactChildRunIdentity(child))
+    .map((child) => child.key)
+    .toSorted();
+  if (missingChildren.length > 0) {
+    throw new Error(
+      `selected FRV children did not record exact run IDs and attempts: ${missingChildren.join(", ")}; start a fresh all-group FRV`,
+    );
+  }
   const resolveJobs = parentJobs.filter(
     (job) =>
       job.name === "Resolve target ref" &&
@@ -349,6 +367,19 @@ export async function preflightContinuation(
 export async function inspectContinuation(plan, client) {
   const children = await Promise.all(
     selectedChildren(plan).map(async (child) => {
+      if (!hasExactChildRunIdentity(child)) {
+        return {
+          compositeJobsSha256: "",
+          conclusion: "",
+          effectiveRunAttempt: null,
+          key: child.key,
+          passed: false,
+          plannedRunAttempt: child.runAttempt ?? null,
+          runId: String(child.runId ?? ""),
+          status: "missing",
+          url: String(child.url ?? ""),
+        };
+      }
       const run = await client.getRun(child.runId);
       assertChildRunIdentity(child, run, client.repository ?? DEFAULT_REPOSITORY);
       const effectiveRunAttempt = positiveInteger(run.run_attempt, `${child.key} run attempt`);
@@ -419,6 +450,7 @@ export async function inspectContinuation(plan, client) {
     children,
     failed: children.filter((child) => child.status === "failed"),
     active: children.filter((child) => child.status === "active"),
+    missing: children.filter((child) => child.status === "missing"),
     passed: children.filter((child) => child.status === "passed"),
   };
 }

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -54,6 +54,14 @@ function child(key: string, runId: string) {
   };
 }
 
+function withoutChildRunIdentity(entry: ReturnType<typeof child>) {
+  const missing = structuredClone(entry);
+  Reflect.set(missing, "runAttempt", null);
+  Reflect.set(missing, "runId", "");
+  Reflect.set(missing, "url", "");
+  return missing;
+}
+
 function requiredChildren() {
   return [
     child("normalCi", "101"),
@@ -427,7 +435,7 @@ describe("FRV continuation preflight", () => {
     "Prepare release npm artifacts / Prepare publishable npm package",
     "Prepare release Docker artifacts / Seal prepared Docker images",
   ])("rejects rerunning a parent that owns publication artifacts from %s", async (name) => {
-    const selected = child("normalCi", "101");
+    const selected = withoutChildRunIdentity(child("normalCi", "101"));
     const client = preflightMethods([selected], (entry) => runFor(entry, 1, "failure"));
     await expect(
       preflightContinuation(plan([selected]), "77", {
@@ -439,7 +447,7 @@ describe("FRV continuation preflight", () => {
     ).rejects.toThrow("parent-owned publication artifacts");
   });
   it("rejects parent-owned candidate artifacts before any GitHub access", async () => {
-    const selected = child("normalCi", "101");
+    const selected = withoutChildRunIdentity(child("normalCi", "101"));
     const parentOwnedPlan = {
       ...plan([selected]),
       candidate: { producer: { runId: "77" } },
@@ -533,6 +541,46 @@ describe("FRV continuation preflight", () => {
     expect(mutations).toBe(0);
   });
 
+  it("rejects missing selected child identities before child reads or mutations", async () => {
+    const first = withoutChildRunIdentity(child("pluginPrerelease", "202"));
+    const second = withoutChildRunIdentity(child("normalCi", "101"));
+    let downstreamReads = 0;
+    let mutations = 0;
+    const downstreamRead = async () => {
+      downstreamReads += 1;
+      throw new Error("unexpected downstream read");
+    };
+    const mutate = async () => {
+      mutations += 1;
+    };
+
+    await expect(
+      continueFailed(plan([first, second]), "77", {
+        getAttemptJobs: downstreamRead,
+        getJobLog: downstreamRead,
+        getParentJobs: async () => [
+          {
+            conclusion: "success",
+            id: 1,
+            name: "Resolve target ref",
+            run_attempt: 1,
+            status: "completed",
+          },
+        ],
+        getRun: downstreamRead,
+        getRunAttempt: async () => rootRun(),
+        repository: REPOSITORY,
+        rerunFailed: mutate,
+        rerunParent: mutate,
+        verify: mutate,
+      }),
+    ).rejects.toThrow(
+      "selected FRV children did not record exact run IDs and attempts: normalCi, pluginPrerelease; start a fresh all-group FRV",
+    );
+    expect(downstreamReads).toBe(0);
+    expect(mutations).toBe(0);
+  });
+
   it("requires every selected child to be emitted by its exact parent job", async () => {
     const selected = child("normalCi", "101");
     await expect(
@@ -546,6 +594,45 @@ describe("FRV continuation preflight", () => {
 });
 
 describe("FRV same-parent recovery", () => {
+  it("reports missing selected children without reading nonexistent runs", async () => {
+    const selected = child("normalCi", "101");
+    const missing = withoutChildRunIdentity(child("pluginPrerelease", "202"));
+    const runReads: string[] = [];
+    const attemptReads: Array<[string, number]> = [];
+    const result = await inspectContinuation(plan([selected, missing]), {
+      getAttemptJobs: async (runId: string, attempt: number) => {
+        attemptReads.push([runId, attempt]);
+        return [job("test")];
+      },
+      getRun: async (runId: string) => {
+        runReads.push(runId);
+        return runFor(selected, 1, "success");
+      },
+      repository: REPOSITORY,
+    });
+
+    expect(runReads).toEqual(["101"]);
+    expect(attemptReads).toEqual([["101", 1]]);
+    expect(result.children).toEqual([
+      expect.objectContaining({ key: "normalCi", status: "passed" }),
+      {
+        compositeJobsSha256: "",
+        conclusion: "",
+        effectiveRunAttempt: null,
+        key: "pluginPrerelease",
+        passed: false,
+        plannedRunAttempt: null,
+        runId: "",
+        status: "missing",
+        url: "",
+      },
+    ]);
+    expect(result.active).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(result.missing).toEqual([result.children[1]]);
+    expect(result.passed).toEqual([result.children[0]]);
+  });
+
   it("reports the effective attempt and composite job evidence", async () => {
     const selected = child("normalCi", "101");
     const result = await inspectContinuation(plan([selected]), {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `pnpm frv status` returned a GitHub 404 when an FRV plan required a child workflow but its parent dispatch was skipped or failed before recording a run ID and attempt.

Run https://github.com/openclaw/openclaw/actions/runs/33592689200 contains this valid fail-closed plan state for `pluginPrereleaseCandidate` and `releaseChecksCandidate`.

## Why This Change Was Made

The continuation controller now follows the existing release-state contract: required children without exact dispatch identities remain selected and are reported as `missing`, but are never queried, classified as failed, or submitted for rerun.

Continuation preserves the stronger candidate/publication-artifact recovery refusals, then rejects any other missing child identities before child provenance reads or mutations with fresh all-group FRV guidance.

## User Impact

Release operators get the actual missing-dispatch diagnosis and can still inspect valid sibling children. Recovery refuses safely and explains the required next action instead of leaking an empty Actions API path.

## Evidence

- Live pre-fix reproduction on September 2, 2026: `pnpm frv status --run 33592689200 --json` called `actions/runs/` and failed with HTTP 404.
- Live post-fix proof: the same command inspected four bound children and returned deterministic `missing` rows for the two undispatched candidate children.
- Guard precedence: `pnpm frv continue --run 33592689200 --failed --dry-run` retained the stronger parent-owned publication-artifact refusal and performed no mutation.
- Focused local proof: `test/scripts/frv.test.ts` plus `test/scripts/full-release-validation-state.test.ts`, 277/277 passed.
- Crabbox/Testbox proof: 277/277 passed on lease `tbx_01m1gafn2g9dg2fhkvc88wv5jk`, https://github.com/openclaw/openclaw/actions/runs/33596060821.
- Fresh autoreview: no actionable findings; correctness confidence 0.93.
- Tooling/type delta: 36 additions, 3 deletions. This adds the explicit missing-state projection and fail-closed continuation boundary. Tests: 89 additions, 2 deletions.

No configuration, protocol, storage, or SQLite changes.
