### PR TITLE
test(android): localize composer state expectations

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -333,7 +333,17 @@ class ChatComposerLayoutTest {
         """{"reason":"patch","session":{"key":"${AndroidScreenshotFixture.mainSessionKey}","thinkingLevel":"max","thinkingLevels":[{"id":"max","label":"max"}]}}""",
       )
     }
-    thinking.assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "${nativeString("Max")}, ${nativeString("Fast mode")}: ${nativeString("Off")}"))
+    thinking.assert(
+      SemanticsMatcher.expectValue(
+        SemanticsProperties.StateDescription,
+        nativeString(
+          "\$selectedLabel, \$fastModeLabel: \$fastModeState",
+          nativeString("Max"),
+          nativeString("Fast mode"),
+          nativeString("Off"),
+        ),
+      ),
+    )
     thinking.performClick()
     composeRule.onNode(hasText(nativeString("Max")) and hasClickAction()).assertIsDisplayed().assertIsSelected()
   }
@@ -717,7 +727,17 @@ class ChatComposerLayoutTest {
             .onNodeWithContentDescription(nativeString("Thinking"))
             .assertIsDisplayed()
             .assertHasClickAction()
-            .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, "$thinkingLabel, ${nativeString("Fast mode")}: ${nativeString("Off")}")),
+            .assert(
+              SemanticsMatcher.expectValue(
+                SemanticsProperties.StateDescription,
+                nativeString(
+                  "\$selectedLabel, \$fastModeLabel: \$fastModeState",
+                  thinkingLabel,
+                  nativeString("Fast mode"),
+                  nativeString("Off"),
+                ),
+              ),
+            ),
         )
     val controlBounds = controls.map { it.getUnclippedBoundsInRoot() }.toMutableList()
     val primary = controlBounds.first()


### PR DESCRIPTION
Related: #135941

## What Problem This Solves

Fixes an issue where the Android composer layout tests failed after a native locale refresh introduced locale-correct punctuation in the thinking state description.

The product localizes the complete state-description template. The layout test instead rebuilt that sentence from translated fragments with an English literal colon, so French expected `Mode rapide: Désactivé` while the product correctly rendered `Mode rapide : Désactivé`.

## Why This Change Was Made

This is a bad-test contract repair. Both affected expectations now localize the complete `$selectedLabel, $fastModeLabel: $fastModeState` template, matching the observable localized contract without calling the production helper under test.

Production code, generated locale resources, and the independent English helper coverage remain unchanged.

## User Impact

No runtime behavior changes. Native locale refreshes can retain language-specific punctuation without producing false Android CI failures.

## Evidence

- Red proof: PR #135941 exact head `891ecda4261246ff85245b1c245bd92104ef6f11` failed `android-test-play` and `android-test-third-party` on the same three French `ChatComposerLayoutTest` assertions:
  - https://github.com/openclaw/openclaw/actions/runs/33592892951/job/100130523698
  - https://github.com/openclaw/openclaw/actions/runs/33592892951/job/100130523576
- Repair GWT on current `main`:
  - `:app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatComposerLayoutTest` passed.
  - `:app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatComposerLayoutTest` passed.
  - Android ktlint and native state schema guard passed.
- Generated-head proof: cherry-picked this repair onto exact head `891ecda4261246ff85245b1c245bd92104ef6f11` without pushing that branch:
  - Both Android flavor test commands passed.
  - `node --import tsx scripts/native-app-i18n.ts check` passed with `changed=false`.
- Changed-path gate: all completed checks passed; the Android lint subprocess was rerun with the installed JDK and passed after the initial shell lacked `JAVA_HOME`.
- Autoreview: scoped clean, no accepted/actionable findings, correctness confidence `0.99`.
- LOC: production `+0/-0`; tests `+22/-2`; one changed path.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: local session
redaction: local paths, environment details, raw tool output, and credentials omitted

[user]
Implement the reviewed Android locale test-contract repair in a fresh GWT. Change only the two fragment-composed state-description expectations, prove both Android flavors on main and the exact generated locale head, run changed gates and autoreview, then open a draft PR.

[assistant]
Refreshed origin/main and verified both target assertions were unchanged. Created a full isolated GWT with linked dependencies and changed only ChatComposerLayoutTest.kt.

[assistant]
Replaced both expectations with nativeString over the complete localized template. Play and ThirdParty ChatComposerLayoutTest passed on the repair branch.

[assistant]
Cherry-picked the repair onto exact generated head 891ecda4261246ff85245b1c245bd92104ef6f11. Both Android flavor tests passed and the native locale check reported changed=false.

[assistant]
Android ktlint, native schema guard, diff checks, and mandatory Codex autoreview passed. Production LOC remained zero.
```

</details>
<!-- agent-transcript:end -->
