### PR TITLE
fix(ui): hide saved Codex reasoning unless enabled

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -521,8 +521,10 @@ content into the fresh Codex thread. It does not copy raw tool-call argument
 values into that projection.
 
 The mirror includes the user prompt, final assistant text, and lightweight
-Codex reasoning or plan records when the app-server emits them. OpenClaw
-records the native compaction start and terminal status, but it does not
+Codex reasoning records when the app-server emits them. Reasoning retains
+typed `thinking` content rather than ordinary final-answer text, so OpenClaw's
+existing reasoning visibility and history controls apply. OpenClaw records
+the native compaction start and terminal status, but it does not
 expose a human-readable compaction summary or an auditable list of which
 entries Codex kept after compaction.
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -113,6 +113,7 @@ title: "Thinking levels"
 - Directive-only message toggles whether thinking blocks are shown in replies.
 - When enabled, reasoning is sent as a **separate message** prefixed with `Thinking`.
 - `stream`: streams reasoning while the reply is generating when the active channel supports reasoning previews, then sends the final answer without reasoning.
+- Control UI history shows saved reasoning only for `on`, with **View → Reasoning** enabled. `off` and `stream` keep it hidden, including after reload.
 - Alias: `/reason`.
 - Send `/reasoning` (or `/reasoning:`) with no argument to see the current reasoning level.
 - Resolution order: inline directive, then session override, then per-agent default (`agents.entries.*.reasoningDefault`), then global default (`agents.defaults.reasoningDefault`), then fallback (`off`).

--- a/extensions/codex/src/app-server/event-projector-assistant-message.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant-message.ts
@@ -149,15 +149,15 @@ export function createAssistantAsyncMessage(
   };
 }
 
-export function createAssistantMirrorMessage(
+export function createAssistantReasoningMessage(
   params: CodexAssistantMessageParams,
-  title: string,
   text: string,
 ): AssistantMessage {
   const attribution = resolveCodexLocalRuntimeAttribution(params);
   return {
     role: "assistant",
-    content: [{ type: "text", text: `${title}:\n${text}` }],
+    // Shared history and visibility controls need reasoning, not final-answer text.
+    content: [{ type: "thinking", thinking: text }],
     api: attribution.api ?? "openai-chatgpt-responses",
     provider: attribution.provider,
     model: params.modelId,

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -6,7 +6,6 @@ import {
   createAssistantAsyncMessage as buildAssistantAsyncMessage,
   createAssistantCommentaryMessage as buildAssistantCommentaryMessage,
   createAssistantMessage as buildAssistantMessage,
-  createAssistantMirrorMessage as buildAssistantMirrorMessage,
   type AssistantMessageOptions,
 } from "./event-projector-assistant-message.js";
 import { shouldClearTerminalPresentationForNativeItem } from "./event-projector-items.js";
@@ -470,10 +469,6 @@ export class CodexAssistantProjection {
   createAssistantMessage(text: string, options: AssistantMessageOptions): AssistantMessage {
     const message = buildAssistantMessage(this.params, text, options);
     return this.responseModel ? { ...message, responseModel: this.responseModel } : message;
-  }
-
-  createAssistantMirrorMessage(title: string, text: string): AssistantMessage {
-    return buildAssistantMirrorMessage(this.params, title, text);
   }
 
   private rememberAssistantPhase(item: CodexThreadItem | undefined): void {

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -62,7 +62,6 @@ type CodexAttemptResultInput = {
     | "collectAsyncMessages"
     | "collectCommentaryMessages"
     | "createAssistantMessage"
-    | "createAssistantMirrorMessage"
     | "createCurrentAttemptAssistantMessage"
     | "hasAssistantItemTextForSynthesis"
   >;
@@ -161,8 +160,6 @@ export function buildCodexAttemptResult(
     commentaryMessages,
     toolMessages: input.toolTranscriptProjection.transcriptMessages,
     lastAssistant,
-    createAssistantMirrorMessage: (title, text) =>
-      input.assistantProjection.createAssistantMirrorMessage(title, text),
   });
   const turnFailed = input.completedTurn?.status === "failed";
   const promptError =

--- a/extensions/codex/src/app-server/event-projector-snapshot.test.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { buildCodexMessagesSnapshot } from "./event-projector-snapshot.js";
 import {
   buildEmptyToolTelemetry,
+  createCodexTestModel,
   createProjector,
   forCurrentTurn,
   registerCodexEventProjectorTestLifecycle,
@@ -17,10 +18,14 @@ import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
 registerCodexEventProjectorTestLifecycle();
 
 function buildSnapshot(trigger: EmbeddedRunAttemptParams["trigger"]): AgentMessage[] {
+  const model = createCodexTestModel();
   return buildCodexMessagesSnapshot({
     runParams: {
       prompt: "Pre-compaction memory flush",
       sessionId: "session-1",
+      provider: model.provider,
+      modelId: model.id,
+      model,
       trigger,
     } as EmbeddedRunAttemptParams,
     turnId: "turn-1",
@@ -43,12 +48,6 @@ function buildSnapshot(trigger: EmbeddedRunAttemptParams["trigger"]): AgentMessa
       content: [{ type: "text", text: "NO_REPLY" }],
       timestamp: Date.now() + 1,
     } as AssistantMessage,
-    createAssistantMirrorMessage: (title, text) =>
-      ({
-        role: "assistant",
-        content: [{ type: "text", text: `[${title}] ${text}` }],
-        timestamp: Date.now(),
-      }) as AssistantMessage,
   });
 }
 

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -5,6 +5,7 @@ import type {
 import { projectAgentHarnessTranscriptMessageForDisplay } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
+import { createAssistantReasoningMessage } from "./event-projector-assistant-message.js";
 import type { CodexAssistantProjection } from "./event-projector-assistant.js";
 import { applyCodexTranscriptTaint } from "./transcript-mirror-attestation.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
@@ -20,13 +21,12 @@ export function buildCodexMessagesSnapshot(params: {
   assistantMessages?: ReadonlyArray<{ itemId: string; message: AssistantMessage }>;
   toolMessages: readonly AgentMessage[];
   lastAssistant: AssistantMessage | undefined;
-  createAssistantMirrorMessage: (title: string, text: string) => AssistantMessage;
 }): AgentMessage[] {
   const messages = promptSnapshot(params.runParams, params.turnId, params.upstreamUserText);
   if (params.reasoningText) {
     messages.push(
       attachCodexMirrorIdentity(
-        params.createAssistantMirrorMessage("Codex reasoning", params.reasoningText),
+        createAssistantReasoningMessage(params.runParams, params.reasoningText),
         `${params.turnId}:reasoning`,
       ),
     );
@@ -92,8 +92,6 @@ export function buildCodexSteeringMessagesSnapshot(params: {
     assistantMessages,
     toolMessages: params.toolMessages,
     lastAssistant: undefined,
-    createAssistantMirrorMessage: (title, text) =>
-      params.assistantProjection.createAssistantMirrorMessage(title, text),
   }).filter((message) => message.role !== "user");
   return {
     messages,

--- a/extensions/codex/src/app-server/event-projector.reasoning.test.ts
+++ b/extensions/codex/src/app-server/event-projector.reasoning.test.ts
@@ -568,7 +568,10 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
     );
     expect(result.toolMetas).toEqual([{ toolName: "sessions_send", isError: false }]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual(["user", "assistant"]);
-    expect(JSON.stringify(result.messagesSnapshot[1])).toContain("Codex reasoning");
+    expect(result.messagesSnapshot[1]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "thinking" }],
+    });
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("Codex plan:");
     expect(result.compactionCount).toBe(1);
     expect(requireRecord(result.itemLifecycle, "item lifecycle")).not.toHaveProperty(

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -144,65 +144,68 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
     expect(readAttemptTerminal(result).promptError).toBeNull();
   });
 
-  it("preserves reasoning-only terminal turns for OpenClaw-owned fallback classification", async () => {
-    const projector = await createProjector();
-    await projector.handleNotification(
-      forCurrentTurn("item/reasoning/textDelta", {
-        itemId: "reasoning-1",
-        delta: OUTCOME_FALLBACK_RUNTIME_CONTRACT.reasoningOnlyText,
-      }),
-    );
-    await projector.handleNotification(
-      forCurrentTurn("turn/completed", {
-        turn: {
-          id: TURN_ID,
-          status: "completed",
-          items: [{ type: "reasoning", id: "reasoning-1" }],
+  it.each(["item/reasoning/summaryTextDelta", "item/reasoning/textDelta"] as const)(
+    "preserves typed reasoning-only terminal turns from %s for OpenClaw-owned fallback classification",
+    async (method) => {
+      const projector = await createProjector();
+      await projector.handleNotification(
+        forCurrentTurn(method, {
+          itemId: "reasoning-1",
+          delta: OUTCOME_FALLBACK_RUNTIME_CONTRACT.reasoningOnlyText,
+        }),
+      );
+      await projector.handleNotification(
+        forCurrentTurn("turn/completed", {
+          turn: {
+            id: TURN_ID,
+            status: "completed",
+            items: [{ type: "reasoning", id: "reasoning-1" }],
+          },
+        }),
+      );
+
+      const result = projector.buildResult(buildToolTelemetry());
+
+      expect(result.assistantTexts).toStrictEqual([]);
+      expect(result.lastAssistant).toBeUndefined();
+      expect(readAttemptTerminal(result).promptError).toBeNull();
+      expect(result.messagesSnapshot.map((message) => message.role)).toStrictEqual([
+        "user",
+        "assistant",
+      ]);
+      const reasoningMessage = result.messagesSnapshot[1];
+      if (reasoningMessage?.role !== "assistant") {
+        throw new Error("expected Codex reasoning mirror assistant message");
+      }
+      expect(readMirrorIdentity(reasoningMessage)).toBe(`${TURN_ID}:reasoning`);
+      expect(reasoningMessage.content).toStrictEqual([
+        {
+          type: "thinking",
+          thinking: OUTCOME_FALLBACK_RUNTIME_CONTRACT.reasoningOnlyText,
         },
-      }),
-    );
-
-    const result = projector.buildResult(buildToolTelemetry());
-
-    expect(result.assistantTexts).toStrictEqual([]);
-    expect(result.lastAssistant).toBeUndefined();
-    expect(readAttemptTerminal(result).promptError).toBeNull();
-    expect(result.messagesSnapshot.map((message) => message.role)).toStrictEqual([
-      "user",
-      "assistant",
-    ]);
-    const reasoningMessage = result.messagesSnapshot[1];
-    if (reasoningMessage?.role !== "assistant") {
-      throw new Error("expected Codex reasoning mirror assistant message");
-    }
-    expect(readMirrorIdentity(reasoningMessage)).toBe(`${TURN_ID}:reasoning`);
-    expect(reasoningMessage.content).toStrictEqual([
-      {
-        type: "text",
-        text: `Codex reasoning:\n${OUTCOME_FALLBACK_RUNTIME_CONTRACT.reasoningOnlyText}`,
-      },
-    ]);
-    expect(reasoningMessage.api).toBe("openai-chatgpt-responses");
-    expect(reasoningMessage.provider).toBe("codex");
-    expect(reasoningMessage.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel);
-    expect(reasoningMessage.usage).toStrictEqual({
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: {
+      ]);
+      expect(reasoningMessage.api).toBe("openai-chatgpt-responses");
+      expect(reasoningMessage.provider).toBe("codex");
+      expect(reasoningMessage.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel);
+      expect(reasoningMessage.usage).toStrictEqual({
         input: 0,
         output: 0,
         cacheRead: 0,
         cacheWrite: 0,
-        total: 0,
-      },
-    });
-    expect(reasoningMessage.stopReason).toBe("stop");
-    expect(typeof reasoningMessage.timestamp).toBe("number");
-    expect(reasoningMessage.timestamp).toBeGreaterThan(0);
-  });
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      });
+      expect(reasoningMessage.stopReason).toBe("stop");
+      expect(typeof reasoningMessage.timestamp).toBe("number");
+      expect(reasoningMessage.timestamp).toBeGreaterThan(0);
+    },
+  );
 
   it("preserves planning-only terminal turns for OpenClaw-owned fallback classification", async () => {
     const projector = await createProjector();

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -23,6 +23,14 @@ import {
   makeAgentUserMessage,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexAppServerEventProjector } from "./event-projector.js";
+import {
+  buildEmptyToolTelemetry,
+  createParams as createProjectorParams,
+  forCurrentTurn,
+  registerCodexEventProjectorTestLifecycle,
+  turnCompleted,
+} from "./event-projector.test-harness.js";
 import type { CodexThread } from "./protocol.js";
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
 import { projectBoundedCodexVisibleSessionHistory } from "./transcript-history-projection.js";
@@ -2070,6 +2078,66 @@ describe("mirrorCodexAppServerTranscript", () => {
     expect(mirrorOutcome.terminalAnchor?.entryId).toBe(terminalEvent?.id);
   });
 
+  describe("projected reasoning persistence", () => {
+    registerCodexEventProjectorTestLifecycle();
+
+    it("preserves reasoning as nonterminal thinking beside the final answer in SQLite", async () => {
+      const target = await createSqliteMirrorTarget("openclaw-codex-mirror-reasoning-");
+      const params: EmbeddedRunAttemptParams = {
+        ...(await createProjectorParams()),
+        ...target,
+        sessionTarget: target,
+        workspaceDir: path.dirname(target.storePath),
+      };
+      const projector = new CodexAppServerEventProjector(params, "thread-1", "turn-1");
+      await projector.handleNotification(
+        forCurrentTurn("item/reasoning/summaryTextDelta", {
+          itemId: "reason-1",
+          summaryIndex: 0,
+          delta: "checking the answer",
+        }),
+      );
+      await projector.handleNotification(
+        turnCompleted([
+          { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "hi there" },
+        ]),
+      );
+      const result = projector.buildResult(buildEmptyToolTelemetry());
+      expect(result.assistantTexts).toEqual(["hi there"]);
+
+      const mirrored = await mirrorTranscriptBestEffort({
+        params,
+        result,
+        agentId: target.agentId,
+        sessionKey: target.sessionKey,
+        notifyUserMessagePersisted: () => undefined,
+        cwd: params.workspaceDir,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+
+      expect(mirrored.assistantTranscriptOwned).toBe(true);
+      const messages = await readCodexMirroredSessionHistoryMessages({
+        ...params,
+        sessionFile: target.bogusSessionFile,
+      });
+      expect(messages).toMatchObject([
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "checking the answer" }],
+          __openclaw: { mirrorIdentity: "turn-1:reasoning", runId: "run-1" },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "hi there" }],
+          __openclaw: { mirrorIdentity: "turn-1:assistant", runTerminal: true },
+        },
+      ]);
+      expect(messages?.[1]).not.toHaveProperty("__openclaw.runTerminal");
+    });
+  });
+
   it("dedupes mirrored messages despite snapshot positional shifts", async () => {
     const target = await createSqliteMirrorTarget("openclaw-codex-mirror-shift-");
     const userMessage = attachCodexMirrorIdentity(
@@ -2094,7 +2162,7 @@ describe("mirrorCodexAppServerTranscript", () => {
     });
     const reasoningMessage = attachCodexMirrorIdentity(
       makeAgentAssistantMessage({
-        content: [{ type: "text", text: "[Codex reasoning] thinking" }],
+        content: [{ type: "thinking", thinking: "thinking" }],
         timestamp: Date.now() + 2,
       }),
       "turn-1:reasoning",
@@ -2108,7 +2176,7 @@ describe("mirrorCodexAppServerTranscript", () => {
     expect((await readMirrorMessages(target)).map((m) => m.text)).toEqual([
       "hello",
       "hi there",
-      "[Codex reasoning] thinking",
+      undefined,
     ]);
   });
 

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -207,7 +207,7 @@ suite.define(() => {
             sessionId: "current-session",
             kind: "direct",
             label: "Session A",
-            reasoningLevel: "high",
+            reasoningLevel: "on",
             updatedAt: 2,
           },
           {
@@ -215,7 +215,7 @@ suite.define(() => {
             sessionId: "trace-session",
             kind: "direct",
             label: "Session B",
-            reasoningLevel: "high",
+            reasoningLevel: "on",
             updatedAt: 1,
           },
         ]),

--- a/ui/src/e2e/chat-reasoning-visibility.e2e.test.ts
+++ b/ui/src/e2e/chat-reasoning-visibility.e2e.test.ts
@@ -1,0 +1,102 @@
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI reasoning visibility" });
+
+suite.define(() => {
+  it.each([
+    { reasoningLevel: "off", withTools: false },
+    { reasoningLevel: "on", withTools: false },
+    { reasoningLevel: "stream", withTools: false },
+    { reasoningLevel: "off", withTools: true },
+    { reasoningLevel: "on", withTools: true },
+    { reasoningLevel: "stream", withTools: true },
+  ])("keeps reasoning in work: %o", async ({ reasoningLevel, withTools }) => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 900 },
+    });
+    try {
+      const page = await context.newPage();
+      const sessionKey = "agent:main:dashboard:reasoning-visibility";
+      const reasoningText = "Compare the evidence before answering.";
+      const finalText = "The answer is ready.";
+      const gateway = await installMockGateway(page, {
+        sessionKey,
+        sessionInfo: { reasoningLevel },
+        sessions: [{ key: sessionKey, kind: "direct", reasoningLevel, updatedAt: 4_000 }],
+        historyMessages: [
+          { role: "user", content: "Check the evidence.", timestamp: 1_000 },
+          {
+            role: "assistant",
+            content: [{ type: "thinking", thinking: reasoningText }],
+            timestamp: 2_000,
+          },
+          ...(withTools
+            ? [
+                {
+                  role: "assistant",
+                  content: [
+                    {
+                      type: "toolCall",
+                      id: "read-evidence",
+                      name: "read",
+                      arguments: { path: "evidence.txt" },
+                    },
+                  ],
+                  timestamp: 2_500,
+                },
+                {
+                  role: "toolResult",
+                  toolCallId: "read-evidence",
+                  toolName: "read",
+                  content: "Evidence checked.",
+                  timestamp: 3_000,
+                },
+              ]
+            : []),
+          { role: "assistant", content: [{ type: "text", text: finalText }], timestamp: 4_000 },
+        ],
+      });
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+      const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+      const answer = pane.getByText(finalText, { exact: true });
+      const reasoning = pane.locator(".chat-thinking", { hasText: reasoningText });
+      const worked = pane.locator(".chat-work-group > .chat-activity-group__summary");
+
+      for (const reload of [false, true]) {
+        if (reload) {
+          await page.reload();
+        }
+        await answer.waitFor();
+        await expect.poll(() => reasoning.isVisible()).toBe(false);
+        await worked.click();
+        await expect.poll(() => worked.getAttribute("aria-expanded")).toBe("true");
+        await expect.poll(() => reasoning.isVisible()).toBe(reasoningLevel === "on");
+        expect(await answer.isVisible()).toBe(true);
+      }
+
+      const menuTrigger = pane.locator(".chat-header-session-menu__trigger");
+      const menu = pane.locator("wa-dropdown.chat-header-session-menu");
+      const localReasoning = menu.getByRole("menuitemcheckbox", { name: "Reasoning" });
+      for (const showReasoning of [false, true]) {
+        await menuTrigger.click();
+        await menu.getByRole("menuitem", { name: "View", exact: true }).hover();
+        await localReasoning.click();
+        await expect
+          .poll(() => localReasoning.getAttribute("aria-checked"))
+          .toBe(String(showReasoning));
+        await menuTrigger.click();
+        await expect
+          .poll(() => reasoning.isVisible())
+          .toBe(showReasoning && reasoningLevel === "on");
+        expect(await answer.isVisible()).toBe(true);
+      }
+      expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -257,6 +257,10 @@ export type MessageContentItem =
       args?: unknown;
     }
   | {
+      type: "thinking";
+      thinking: string;
+    }
+  | {
       type: "attachment";
       attachment: {
         url: string;

--- a/ui/src/lib/chat/heartbeat-display.test.ts
+++ b/ui/src/lib/chat/heartbeat-display.test.ts
@@ -35,6 +35,18 @@ describe("heartbeat display", () => {
     },
   );
 
+  it.each([{ textBlocks: [] }, { textBlocks: [{ type: "text", text: " " }] }])(
+    "does not mistake reasoning with $textBlocks for a heartbeat acknowledgement",
+    ({ textBlocks }) => {
+      expect(
+        isAssistantHeartbeatAckForDisplay({
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "Comparing the evidence." }, ...textBlocks],
+        }),
+      ).toBe(false);
+    },
+  );
+
   it("keeps visible media and silent-reply markers while hiding acknowledgement-only turns", () => {
     expect(
       isAssistantHeartbeatAckForDisplay({

--- a/ui/src/lib/chat/heartbeat-display.ts
+++ b/ui/src/lib/chat/heartbeat-display.ts
@@ -59,5 +59,6 @@ export function isAssistantHeartbeatAckForDisplay(message: unknown): boolean {
   if (hasVisibleNonTextContent) {
     return false;
   }
-  return stripHeartbeatTokenForDisplay(text).shouldSkip;
+  // Reasoning-only rows have no answer text, but that is not a heartbeat acknowledgement.
+  return text.trim().length > 0 && stripHeartbeatTokenForDisplay(text).shouldSkip;
 }

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -107,18 +107,19 @@ describe("message-normalizer", () => {
       expect(result.audioAsVoice).toBeUndefined();
     });
 
-    it("normalizes message with array content", () => {
+    it("normalizes mixed text, thinking, and tool content", () => {
       const result = normalizeMessage({
         role: "assistant",
         content: [
           { type: "text", text: "Here is the result" },
           { type: "tool_use", name: "bash", args: { command: "ls" } },
+          { type: "thinking", thinking: "Checking the result." },
         ],
         timestamp: 2000,
       });
 
       expect(result.role).toBe("toolResult");
-      expect(result.content).toHaveLength(2);
+      expect(result.content).toHaveLength(3);
       expect(result.content[0]).toEqual({
         type: "text",
         text: "Here is the result",
@@ -131,6 +132,7 @@ describe("message-normalizer", () => {
         name: "bash",
         args: { command: "ls" },
       });
+      expect(result.content[2]).toEqual({ type: "thinking", thinking: "Checking the result." });
     });
 
     it("normalizes persisted Responses text blocks as renderable text", () => {

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -465,6 +465,10 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       }
       const type = item.type;
       const text = readStringField(item, "text");
+      if (type === "thinking") {
+        const thinking = readStringField(item, "thinking");
+        return thinking === undefined ? [] : [{ type, thinking }];
+      }
       if (isAssistantMessage) {
         const managedMediaAttachment = coerceManagedMediaContentBlock(item);
         if (managedMediaAttachment) {

--- a/ui/src/pages/chat/chat-thread-grouping.test.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ChatItem } from "../../lib/chat/chat-types.ts";
-import { groupMessages } from "./chat-thread-grouping.ts";
+import {
+  assistantGroupCanOwnActiveRunStatus,
+  collapseCompletedTurnWork,
+  groupMessages,
+} from "./chat-thread-grouping.ts";
 import { buildCachedChatItems, resetChatThreadState } from "./chat-thread.ts";
 
 function forwardedMessage(sessionKey: string, content = "Forwarded report") {
@@ -26,6 +30,56 @@ function cachedGroups(messages: unknown[]) {
     showToolCalls: true,
   }).filter((item) => item.kind === "group");
 }
+
+describe("reasoning activity boundaries", () => {
+  it.each([
+    { type: "text", text: "Visible answer" },
+    { type: "image", source: { type: "url", url: "https://example.com/result.png" } },
+    {
+      type: "attachment",
+      attachment: { kind: "document", url: "https://example.com/result.pdf", label: "Result" },
+    },
+    {
+      type: "canvas",
+      preview: {
+        kind: "canvas",
+        surface: "assistant_message",
+        render: "url",
+        url: "https://example.com/result",
+      },
+    },
+    { type: "future-visible-block" },
+  ])("preserves mixed reasoning and $type as the visible outcome", (outcome) => {
+    const thinking = { type: "thinking", thinking: "Checking the evidence." };
+    const messages = [
+      { role: "user", content: "Check it.", timestamp: 1_000 },
+      { role: "assistant", content: [thinking], timestamp: 2_000 },
+      { role: "assistant", content: [thinking, outcome], timestamp: 3_000 },
+    ];
+    const groups = groupMessages(
+      messages.map((message, index) => ({
+        kind: "message",
+        key: `message:${index}`,
+        message,
+      })),
+    );
+    expect(
+      collapseCompletedTurnWork(groups, {
+        sessionKey: "agent:main:dashboard:reasoning",
+        runWorking: false,
+      }),
+    ).toMatchObject([
+      { kind: "group", role: "user" },
+      { kind: "work-group", groups: [{ messages: [{ message: messages[1] }] }] },
+      { kind: "group", messages: [{ message: messages[2] }] },
+    ]);
+    const reasoningGroup = groups[1];
+    expect(reasoningGroup?.kind).toBe("group");
+    if (reasoningGroup?.kind === "group") {
+      expect(assistantGroupCanOwnActiveRunStatus(reasoningGroup)).toBe(false);
+    }
+  });
+});
 
 describe("forwarded source-session grouping", () => {
   beforeEach(() => resetChatThreadState());

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -23,6 +23,16 @@ import {
 } from "./chat-turn-boundary.ts";
 import { indexTurnContinuations, persistedSteerTargetRunId } from "./stream-causal-boundary.ts";
 
+function assistantMessageKind(message: unknown) {
+  if (isContextCompactionActivity(message)) {
+    return "compaction";
+  }
+  if (isKeyedAssistantStreamFallbackMessage(message)) {
+    return "commentary";
+  }
+  return messageHasVisibleReplyContent(message) ? "reply" : "activity";
+}
+
 function stampReplyAttribution(
   items: Array<ChatItem | MessageGroup>,
 ): Array<ChatItem | MessageGroup> {
@@ -89,16 +99,11 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
     const shouldSplitBySender = role === "user" || role === "assistant";
     const startsProjectedTurn =
       asRecord(asRecord(item.message)?.["__openclaw"])?.turnBoundary === true;
-    const splitsAssistantCommentary =
+    const splitsAssistantKind =
       role === "assistant" &&
       currentGroup?.role === "assistant" &&
-      isKeyedAssistantStreamFallbackMessage(currentGroup.messages[0]?.message) !==
-        isKeyedAssistantStreamFallbackMessage(item.message);
-    const splitsRuntimeActivity =
-      role === "assistant" &&
-      currentGroup?.role === "assistant" &&
-      isContextCompactionActivity(currentGroup.messages[0]?.message) !==
-        isContextCompactionActivity(item.message);
+      assistantMessageKind(currentGroup.messages[0]?.message) !==
+        assistantMessageKind(item.message);
 
     if (
       !currentGroup ||
@@ -106,8 +111,7 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
       currentGroup.role !== role ||
       currentGroup.runId !== runId ||
       currentUserTurnIdentity !== userTurnIdentity ||
-      splitsAssistantCommentary ||
-      splitsRuntimeActivity ||
+      splitsAssistantKind ||
       (shouldSplitBySender &&
         ((!sender?.identity && currentGroup.senderLabel !== senderLabel) ||
           currentGroup.senderSession?.sessionKey !== normalized.senderSession?.sessionKey ||
@@ -187,7 +191,7 @@ export function coalesceStreamRuns(
   return result;
 }
 
-/** Collapsed rollup of a completed turn's intermediate work (tools, commentary). */
+/** Collapsed rollup of a completed turn's activity (tools, commentary, reasoning). */
 export type WorkGroupRenderItem = {
   kind: "work-group";
   key: string;
@@ -214,20 +218,26 @@ function isCollapsibleWorkGroup(item: TurnRenderItem): item is MessageGroup {
 // Attachment/canvas/media-only replies carry no text but are still the turn's
 // visible outcome; they must never fold into the work rollup. Normalized
 // content passes unknown block types through (e.g. raw image blocks), so
-// anything that is not a tool block counts as visible reply content.
-function groupHasVisibleReplyContent(group: MessageGroup, includeText = true): boolean {
-  return group.messages.some(({ message }) => {
-    if (includeText && extractTextCached(message)?.trim()) {
-      return true;
+// only tool and thinking blocks are activity rather than visible outcomes.
+function messageHasVisibleReplyContent(message: unknown, includeText = true): boolean {
+  if (includeText && extractTextCached(message)?.trim()) {
+    return true;
+  }
+  const content = safeNormalizeMessage(message)?.content ?? [];
+  return content.some((block) => {
+    if (block.type === "text") {
+      return includeText && Boolean(block.text?.trim());
     }
-    const content = safeNormalizeMessage(message)?.content ?? [];
-    return content.some((block) => {
-      if (block.type === "text") {
-        return includeText && Boolean(block.text?.trim());
-      }
-      return !isToolCallContentType(block.type) && !isToolResultContentType(block.type);
-    });
+    return (
+      block.type !== "thinking" &&
+      !isToolCallContentType(block.type) &&
+      !isToolResultContentType(block.type)
+    );
   });
+}
+
+function groupHasVisibleReplyContent(group: MessageGroup, includeText = true): boolean {
+  return group.messages.some(({ message }) => messageHasVisibleReplyContent(message, includeText));
 }
 
 export function assistantGroupCanOwnActiveRunStatus(group: MessageGroup): boolean {

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -314,6 +314,7 @@ export function renderGroupedMessage(
   // Suppress empty bubbles when tool cards are the only content and toggle is off
   if (
     !markdown &&
+    !reasoningMarkdown &&
     !hasToolCards &&
     !hasImages &&
     !hasPairingQrExpiryNotices &&

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -91,8 +91,7 @@ export function projectChatTranscript(
     (sessionHost !== null &&
       isUiGlobalScopeConfigured(sessionHost) &&
       resolveUiGlobalAliasAgentId(sessionHost, props.sessionKey) !== null);
-  const reasoningLevel = activeSession?.reasoningLevel ?? "off";
-  const showReasoning = props.showThinking && reasoningLevel !== "off";
+  const showReasoning = props.showThinking && activeSession?.reasoningLevel === "on";
   const assistantIdentity = {
     name: props.assistantName,
     avatar: resolveAssistantDisplayAvatar(props),


### PR DESCRIPTION
Closes #135978

<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users who disabled reasoning would still see a `Codex reasoning:` block as ordinary assistant-answer text in Control UI after a Codex turn completed or the transcript reloaded. The related reasoning-only display path also hid intentionally enabled reasoning or grouped it with the final answer instead of completed work.

## Why This Change Was Made

The Codex plugin now preserves standard typed `thinking` content through the existing transcript mirror, and Control UI preserves that type through normalization, distinguishes it from heartbeat acknowledgments and final replies, and renders it inside completed work. Saved reasoning is visible only when the session uses `/reasoning on` and **View → Reasoning** is enabled; `off`, `stream`, and missing values do not opt into saved reasoning display.

The old generic title-based mirror constructor and callback plumbing are removed. There are no new settings, protocol/schema changes, provider defaults, or prefix-matching compatibility paths. Existing malformed historical rows are not rewritten, and supported channel streaming previews are unchanged. The separate native external-session catalog view is not part of this repair.

## User Impact

Reasoning no longer appears as answer text in newly recorded Codex dashboard turns when it is disabled. When explicitly enabled, it is available inside **Worked** without hiding the final answer. The behavior survives reload, works with and without tool calls, and respects the local visibility toggle. Mixed text/media answers and actual heartbeat acknowledgment suppression remain intact.

## Evidence

### Reproduction and owner boundaries

- Read-only inspection of an affected session confirmed an explicit `/reasoning off` followed by another completed turn containing a plain-text reasoning row. No private session content or original screenshots are published here.
- The original producer defect is patch-verified in [9ac7a039 — harden Codex app-server harness](https://github.com/openclaw/openclaw/commit/9ac7a0398213977e0d40216c44c0ed61cbb5e785). That change added reasoning mirrors as `type: "text"`; the malformed shape remains present in the `v2026.8.1` source tag.
- Upstream Codex contract personally inspected: [`event_mapping.rs:378–395`](https://github.com/openai/codex/blob/0ae94fdd49b05ee7faa4d984d06a68492cb32b54/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L378-L395) keeps summary/raw reasoning notifications distinct from assistant text.
- Regression tests failed before the fixes: both native delta variants returned plain text instead of typed thinking; the SQLite read-back reproduced it; UI tests exposed heartbeat misclassification, dropped thinking content, empty-bubble suppression, and final/work grouping. The stream-mode cases separately failed before tightening the visibility gate to `on` only.

### Automated validation

741 focused tests passed across Codex projection/mirroring, Gateway display projection, and UI normalization/grouping/rendering. The SQLite regression was rerun after replacing its incomplete fixture with the existing lifecycle-managed projector fixture: 50/50 passed.

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector-snapshot.test.ts extensions/codex/src/app-server/event-projector.reasoning.test.ts extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts extensions/codex/src/app-server/transcript-mirror.test.ts ui/src/pages/chat/chat-thread-grouping.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-thread.nested-activity.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/lib/chat/message-normalizer.test.ts ui/src/lib/chat/message-extract.test.ts ui/src/lib/chat/heartbeat-display.test.ts src/gateway/chat-display-projection.test.ts src/gateway/session-transcript-message.test.ts
```

20 browser cases passed for the initial repair, covering reasoning, completed work, tool outcomes, and heartbeat rollups. After the explicit on-only requirement, all six reasoning cases passed: off/on/stream × with/without tools, including reload and the local **View → Reasoning** toggle.

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-reasoning-visibility.e2e.test.ts ui/src/e2e/chat-worked-for-visualization.e2e.test.ts ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts ui/src/e2e/chat-heartbeat-activity-rollup.e2e.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-reasoning-visibility.e2e.test.ts
```

```bash
node scripts/check-changed.mjs
```

The full changed gate passed after the fixture correction. UI typecheck, targeted lint, formatting, and `git diff --check` also passed after the on-only follow-up. A full local `pnpm build` passed before the initial push, including runtime bundles, public SDK declaration checks, external plugin builds, and the production Control UI. Fresh Codex autoreview at its configured P0 threshold found no blockers. This evidence uses real Chromium and temporary SQLite stores with synthetic Gateway/native-event fixtures; it is not a live provider or live channel test.

### Visual proof

The attached screenshots were captured from a running isolated Control UI and inspected in full. They use only synthetic conversation data and public model labels. The before case replays the pre-fix plain-text mirror shape; after cases use the canonical thinking shape verified by the producer-to-SQLite regression.

Attachments, in order: before with reasoning off; after with reasoning off; after with reasoning on and **Worked** expanded; after with stream mode and **Worked** expanded.

### Scope and size

Production: **+50/−41 (net +9)**. Tests: **+309/−66 (net +243)**. Docs: **+5/−2**. The remaining production growth supplies the missing normalized thinking variant and activity/display semantics after removing duplicate mirror plumbing and consolidating assistant grouping decisions.

Related work was checked: #117365 proposes a different per-block disclosure UI, and #128249 changes inherited/default reasoning projection. Neither is closed or claimed as fully superseded by this explicit-session Codex visibility repair. Provider-tag parsing reports #89473 and #91804 and non-persistence feature request #54496 are separate scopes.

![Before: reasoning appears as answer text with reasoning off](https://github.com/user-attachments/assets/214aa22f-fdf4-459a-825c-48a3b7debb6f)

![After: reasoning off leaves the final answer visible without reasoning](https://github.com/user-attachments/assets/9e91a600-5f4a-4240-b4b6-463e8bcb0f5b)

![After: reasoning on reveals typed reasoning only inside expanded Worked](https://github.com/user-attachments/assets/1efdfe7a-0e1b-4810-8490-9fd37a78c783)

![After: stream mode keeps saved reasoning hidden even in expanded Worked](https://github.com/user-attachments/assets/869590a7-a4b7-44d4-b551-5c4ba8a95262)