### PR TITLE
refactor(pairing): use canonical timestamp parser

### DIFF
--- a/src/pairing/pairing-store-sqlite.ts
+++ b/src/pairing/pairing-store-sqlite.ts
@@ -31,10 +31,6 @@ type ChannelPairingState = {
   allowFrom?: Record<string, string[]>;
 };
 
-function parseTimestamp(value: string | undefined): number | null {
-  return parseDateStringTimestampMs(value) ?? null;
-}
-
 function normalizePersistedPairingMeta(value: unknown): Record<string, string> | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -62,8 +58,8 @@ function normalizePersistedPairingRequest(value: unknown): PairingRequest | unde
     !code ||
     !createdAt ||
     !lastSeenAt ||
-    parseTimestamp(createdAt) === null ||
-    parseTimestamp(lastSeenAt) === null
+    parseDateStringTimestampMs(createdAt) === undefined ||
+    parseDateStringTimestampMs(lastSeenAt) === undefined
   ) {
     return undefined;
   }

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -42,13 +42,9 @@ export function resolveChannelPairingRequestId(
     .slice(0, 32);
 }
 
-function parseTimestamp(value: string | undefined): number | null {
-  return parseDateStringTimestampMs(value) ?? null;
-}
-
 function isExpired(entry: PairingRequest, nowMs: number): boolean {
-  const createdAt = parseTimestamp(entry.createdAt);
-  return createdAt === null || nowMs - createdAt > CHANNEL_PAIRING_PENDING_TTL_MS;
+  const createdAt = parseDateStringTimestampMs(entry.createdAt);
+  return createdAt === undefined || nowMs - createdAt > CHANNEL_PAIRING_PENDING_TTL_MS;
 }
 
 function pruneExpiredRequests(reqs: PairingRequest[], nowMs: number) {
@@ -65,7 +61,9 @@ function pruneExpiredRequests(reqs: PairingRequest[], nowMs: number) {
 }
 
 function resolveLastSeenAt(entry: PairingRequest): number {
-  return parseTimestamp(entry.lastSeenAt) ?? parseTimestamp(entry.createdAt) ?? 0;
+  return (
+    parseDateStringTimestampMs(entry.lastSeenAt) ?? parseDateStringTimestampMs(entry.createdAt) ?? 0
+  );
 }
 
 function normalizePairingAccountId(accountId?: string): string {


### PR DESCRIPTION
## What Problem This Solves

Channel pairing maintained two private timestamp adapters that only translated the canonical parser's `undefined` result to `null`. That duplicated sentinel policy across the runtime expiry path and SQLite normalization path, making future parser changes easier to apply inconsistently.

## Why This Change Was Made

`@openclaw/normalization-core/number-coercion` remains the parsing owner. The channel-pairing runtime and SQLite reader now call `parseDateStringTimestampMs` directly and retain their existing strict rejection, expiry, and nullish fallback policies.

The cleanup preserves `lastSeenAt ?? createdAt ?? 0` ordering and treats epoch `0` as valid. It adds no export, helper, SDK seam, schema, migration, dependency, configuration, or persistence behavior.

## User Impact

No user-visible behavior changes. Invalid or missing pending-request timestamps are still rejected or expired, valid persisted rows are unchanged, and legacy channel-pairing migration still writes through the same SQLite validator.

## Evidence

- Exact signed candidate:
  - head `97f58d51655943a12d2335634237d035803cf8a7`
  - parent `5dd3796bb12126c0bd00d6b21dd8b16a623c25cb`
  - tree `f4ed56364a7910d742605cf36066fec2288b3ff3`
  - signature verified good
- Exact scope: `src/pairing/pairing-store.ts` and `src/pairing/pairing-store-sqlite.ts`.
- Production LOC: +7/-13, net -6. Tests: +0/-0.
- Patch IDs:
  - aggregate `d146391cccdfd40042f75b3493ee523f4c4300a4`
  - `src/pairing/pairing-store.ts`: `745231cc778ee626b46c31ac4ebed7b67d27f4b9`
  - `src/pairing/pairing-store-sqlite.ts`: `5df407505451eed98d8a2a8844307b88ce1b0cea`
- 53 focused tests passed:
  - `src/pairing/pairing-store.test.ts`
  - `src/gateway/server-methods/channel-pairing.test.ts`
  - `src/infra/state-migrations.channel-pairing.test.ts`
  - `packages/normalization-core/src/number-coercion.test.ts`
- Deterministic differential proof: 313,689 comparisons across `UTC`, `America/New_York`, and `Asia/Singapore`, with zero mismatches. The harness compared expiry, fallback, persisted-row validation, return/throw behavior, and `Date.parse` call order over valid, invalid, numeric, local-time, timezone-qualified, boundary, proxy, getter, and forced-exception inputs.
- Passed:
  - targeted format check
  - `git diff --check`
  - coercion-helper declaration guard
  - pairing-store group-auth guard
  - pairing account-scope guard
  - import-cycle check: 0 runtime value cycles
  - core TypeScript check
  - core-test TypeScript shards
  - full build, including plugin SDK export and Control UI build checks
- Test audit: no new test is justified for this behavior-neutral sentinel translation removal; existing owner, caller, migration, parser, malformed-row, expiry, recency, approval, and account-isolation coverage remains intact.
- Fresh `gpt-5.6-sol` high autoreview on the exact commit: scoped clean, patch correct at 0.99 confidence, no accepted or actionable findings.

## Drift And Contract Checks

- Current `main` at verification was `7aff510afad21033fd0e7cd9bfc8197fdab1d4f3`. The two pairing files and canonical parser blob are byte-identical to the reviewed parent, so no relevant-main drift exists.
- Open overlap heads remained unchanged:
  - #132857 `0f42cad0ef42bbf68ff854153e3f81a653495fa6`
  - #132397 `37131ec80030015723ddc303fe15aaf5dc362b75`
  - #136267 `db47fa3ec7057fd1bbc77e36c3bf8784c4e77f8d`
  - #101294 `793617f96c70d299b8b0973711c8c17af7d94a16`
- None of those PRs touches either changed file or the canonical timestamp parser.
- Storage contract: no SQLite schema, migration, stored representation, transaction, or persistence semantic change.
- Security contract: invalid timestamps remain rejected, expired requests remain pruned, indexed account identity remains authoritative, and approval still requires the same account/request match and transaction.
- Codex contract: personally inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI declaration and newline-normalization paths are unrelated to this cleanup.
