### PR TITLE
fix(ui): open automation links beyond the loaded list page

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3942,7 +3942,7 @@ ui/src/lib/chat/tool-display.ts	1
 ui/src/lib/config-form-utils.ts	7
 ui/src/lib/config/config-draft-model.ts	5
 ui/src/lib/config/config-gateway-operations.ts	1
-ui/src/lib/cron/index.ts	14
+ui/src/lib/cron/index.ts	13
 ui/src/lib/gateway-diagnostics.ts	3
 ui/src/lib/gateway-errors.ts	1
 ui/src/lib/keyboard-shortcuts.ts	1

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -279,10 +279,14 @@ no route-specific URL parameters.
 | Skill Workshop      | `/skills/workshop`          | -                         | -                                                                 |
 | Skills              | `/skills`                   | -                         | -                                                                 |
 | Plugins             | `/settings/plugins`         | -                         | `/settings/plugins/discover`                                      |
-| Automations         | `/cron`                     | -                         | -                                                                 |
+| Automations         | `/cron`                     | -                         | `?job=<jobId>`, `?job=<jobId>&run=<runId>`                        |
 | Tasks               | `/tasks`                    | -                         | -                                                                 |
 | Devices             | `/settings/devices`         | `/nodes`                  | Shared settings parameters below                                  |
 | Plugin tab host     | `/plugin`                   | -                         | `?plugin=<pluginId>&id=<tabId>`                                   |
+
+Automation links open the exact job independently of the current list filters or
+loaded page. Adding `run` opens its run history and highlights the matching loaded
+run. A missing job shows the Gateway's lookup error.
 
 Settings routes that use schema-backed deep links accept `?section=<section>`,
 `?advanced=1`, and `#<setting-id>`. These values select content within the page;

--- a/ui/src/e2e/cron-job-link.e2e.test.ts
+++ b/ui/src/e2e/cron-job-link.e2e.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI automation job links" });
+
+suite.define(() => {
+  it("opens a linked automation outside the first inventory page", async () => {
+    const job = {
+      id: "linked-automation",
+      agentId: "writer",
+      configRevision: "linked-definition",
+      name: "Linked automation",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Produce the scheduled report." },
+      state: {},
+    };
+    const jobs = Array.from({ length: 50 }, (_, index) => ({
+      ...job,
+      id: `other-${index}`,
+      agentId: "main",
+      name: `Other automation ${index}`,
+    }));
+    const run = {
+      ts: 2,
+      jobId: job.id,
+      action: "finished",
+      runId: "linked-run",
+      status: "ok",
+      summary: "Linked report completed.",
+    };
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { width: 1280, height: 900 },
+        recordVideo: { dir: suite.artifactDir, size: { width: 1280, height: 900 } },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "cron.status": { enabled: true, jobs: 51, nextWakeAtMs: null },
+            "cron.list": {
+              jobs,
+              total: 51,
+              offset: 0,
+              limit: 50,
+              hasMore: true,
+              nextOffset: 50,
+              snapshotRevision: "linked-inventory",
+            },
+            "cron.get": job,
+            "cron.runs": {
+              cases: [
+                {
+                  match: { id: job.id },
+                  response: {
+                    entries: [run],
+                    total: 1,
+                    offset: 0,
+                    limit: 50,
+                    hasMore: false,
+                    nextOffset: null,
+                  },
+                },
+                {
+                  response: {
+                    entries: [],
+                    total: 0,
+                    offset: 0,
+                    limit: 50,
+                    hasMore: false,
+                    nextOffset: null,
+                  },
+                },
+              ],
+            },
+          },
+        });
+        try {
+          await page.goto(`${suite.server.baseUrl}cron?job=${job.id}&run=${run.runId}`);
+          await gateway.waitForRequest("cron.list");
+          await expect.poll(() => page.locator(".cron-detail-title").textContent()).toBe(job.name);
+          expect((await gateway.getRequests("cron.get")).map(({ params }) => params)).toEqual([
+            { id: job.id },
+          ]);
+          await expect
+            .poll(() => page.locator(".cron-run-entry--highlighted").textContent())
+            .toContain(run.summary);
+          const history = await gateway.getRequests("cron.runs");
+          expect(history).toContainEqual(
+            expect.objectContaining({
+              params: expect.objectContaining({ id: job.id, scope: "job" }),
+            }),
+          );
+          expect(history).not.toContainEqual(
+            expect.objectContaining({
+              params: expect.objectContaining({ id: job.id, agentId: expect.anything() }),
+            }),
+          );
+        } finally {
+          await page.screenshot({
+            path: path.join(suite.artifactDir, "linked-automation.png"),
+            fullPage: true,
+          });
+          await fs.writeFile(
+            path.join(suite.artifactDir, "gateway-requests.json"),
+            JSON.stringify(await gateway.getRequests(), null, 2),
+          );
+        }
+      },
+    );
+  });
+});

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -13,7 +13,6 @@ import {
   addCronJob,
   cancelCronEdit,
   createInitialCronState,
-  getVisibleCronJobs,
   loadCronModelSuggestions,
   toggleCronJob,
   loadCronJobsPage,
@@ -878,7 +877,6 @@ describe("cron controller", () => {
     );
     expect(request).toHaveBeenCalledWith("cron.get", { id: staleJob.id });
     expect(state.cronJobs).toEqual([]);
-    expect(getVisibleCronJobs(state)).toEqual([]);
     expect(state.cronJobsTotal).toBe(0);
     expect(state.cronEditingJobId).toBe(authoritativeJob.id);
     expect(state.cronEditingJob).toEqual(authoritativeJob);

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -24,7 +24,6 @@ import type {
   CronPayload,
 } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
-import { resolveCronJobLastRunStatus } from "../cron-status.ts";
 import { formatUiError } from "../format-error.ts";
 import { toNumber } from "../format.ts";
 import {
@@ -791,54 +790,8 @@ export function updateCronJobsFilter(
   state.cronJobsSortDir = patch.cronJobsSortDir ?? state.cronJobsSortDir;
 }
 
-export function getVisibleCronJobs(
-  state: Pick<
-    CronState,
-    "cronJobs" | "cronJobsScheduleKindFilter" | "cronJobsLastStatusFilter" | "cronJobsTriggerFilter"
-  >,
-): CronJob[] {
-  return state.cronJobs.filter((job) => {
-    const scheduleKind = resolveCronJobScheduleKind(job);
-    if (!scheduleKind) {
-      return false;
-    }
-    if (
-      state.cronJobsScheduleKindFilter !== "all" &&
-      scheduleKind !== state.cronJobsScheduleKindFilter
-    ) {
-      return false;
-    }
-    if (
-      state.cronJobsLastStatusFilter !== "all" &&
-      resolveCronJobLastRunStatus(job) !== state.cronJobsLastStatusFilter
-    ) {
-      return false;
-    }
-    if (state.cronJobsTriggerFilter === "conditional" && !job.trigger) {
-      return false;
-    }
-    if (state.cronJobsTriggerFilter === "unconditional" && job.trigger) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function resolveCronJobScheduleKind(job: CronJob): string | null {
-  const scheduleKind = (job.schedule as { kind?: unknown } | null | undefined)?.kind;
-  if (
-    scheduleKind === "at" ||
-    scheduleKind === "every" ||
-    scheduleKind === "cron" ||
-    scheduleKind === "on-exit" ||
-    scheduleKind === "stream"
-  ) {
-    return scheduleKind;
-  }
-  return null;
-}
-
 function clearCronEditState(state: CronState) {
+  state.cronError = null;
   state.cronEditingJob = null;
   state.cronCloningJob = null;
   state.cronEditingJobId = null;
@@ -1537,7 +1490,8 @@ export async function loadCronRuns(
   state.cronRunsLoadingMore = append;
   try {
     const res = await client.request<CronRunsResult>("cron.runs", {
-      ...(request.agentId ? { agentId: request.agentId } : {}),
+      // An exact job owns its history; the overview's agent filter may select another owner.
+      ...(request.scope === "all" && request.agentId ? { agentId: request.agentId } : {}),
       scope: request.scope,
       id: request.jobId ?? undefined,
       limit: request.limit,
@@ -1618,6 +1572,7 @@ export function updateCronRunsFilter(
 }
 
 function setCronEditState(state: CronState, job: CronJob, form: CronFormState) {
+  state.cronError = null;
   state.cronEditingJob = job;
   state.cronCloningJob = null;
   state.cronEditingJobId = job.id;

--- a/ui/src/pages/cron/cron-page.test.ts
+++ b/ui/src/pages/cron/cron-page.test.ts
@@ -5,6 +5,7 @@ import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gatew
 import type { CronJob, CronJobsListResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { CronState } from "../../lib/cron/index.ts";
+import { createCronViewJob } from "./view.test-support.ts";
 import "./cron-page.ts";
 
 type CronTestPage = HTMLElement & {
@@ -205,75 +206,212 @@ describe("CronPage header", () => {
 });
 
 describe("CronPage editor state sync", () => {
-  it("opens a linked job's history after its jobs load and highlights the linked run", async () => {
-    const job: CronJob = {
-      id: "linked-job",
-      name: "Linked automation",
-      enabled: true,
-      createdAtMs: 0,
-      updatedAtMs: 0,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "now",
-      payload: { kind: "agentTurn", message: "digest" },
-      state: {},
-    };
-    const jobs = createDeferred<CronJobsListResult>();
+  it.each(["visible", "later page", "another agent"])(
+    "opens a linked job's history when the job is on %s",
+    async (placement) => {
+      const job: CronJob = {
+        id: "linked-job",
+        agentId: placement === "another agent" ? "writer" : "main",
+        name: "Linked automation",
+        enabled: true,
+        createdAtMs: 0,
+        updatedAtMs: 0,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentTurn", message: "digest" },
+        state: {},
+      };
+      const jobs = createDeferred<CronJobsListResult>();
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "cron.list") {
+          return jobs.promise;
+        }
+        if (method === "cron.get") {
+          return job;
+        }
+        if (method === "cron.status") {
+          return { enabled: true, jobs: 1, triggersEnabled: true };
+        }
+        if (method === "cron.runs") {
+          const filter = params as { id?: string; agentId?: string };
+          if (filter.id === job.id && filter.agentId && filter.agentId !== job.agentId) {
+            throw new Error("Automation not found");
+          }
+          const entries =
+            (params as { id?: string }).id === job.id
+              ? [
+                  {
+                    ts: 2,
+                    jobId: job.id,
+                    action: "finished",
+                    runId: "cron:linked-job:2",
+                    summary: "Another run",
+                  },
+                  {
+                    ts: 1,
+                    jobId: job.id,
+                    action: "finished",
+                    runId: "cron:linked-job:1",
+                    summary: "Linked run",
+                  },
+                ]
+              : [];
+          return { entries, total: entries.length, offset: 0, hasMore: false };
+        }
+        if (method === "models.list") {
+          return { models: [] };
+        }
+        return {};
+      });
+      const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+      const page = createPage(createContext(gateway), { render: true });
+      page.routeSearch = "?job=linked-job&run=cron%3Alinked-job%3A1";
+
+      await waitForCronPage(() => expect(page.cron.cronLoading).toBe(true));
+      const inventory = cronListResponse(
+        placement === "visible"
+          ? [job]
+          : Array.from({ length: 50 }, (_, index) => ({
+              ...job,
+              id: `other-${index}`,
+              name: `Other automation ${index}`,
+            })),
+      );
+      if (placement === "later page") {
+        inventory.total = 51;
+        inventory.hasMore = true;
+        inventory.nextOffset = 50;
+      }
+      jobs.resolve(inventory);
+
+      await waitForCronPage(() => {
+        expect(page.cron.cronEditingJobId).toBe(job.id);
+        expect(
+          page
+            .querySelector('[data-test-id="cron-detail-tab-history"]')
+            ?.getAttribute("aria-selected"),
+        ).toBe("true");
+        expect(page.querySelector(".cron-run-entry--highlighted")?.textContent).toContain(
+          "Linked run",
+        );
+      });
+      expect(page.querySelectorAll(".cron-run-entry--highlighted")).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    "selecting another job",
+    "changing agent scope",
+    "opening another link",
+    "disconnecting",
+  ])("ignores a pending job link after %s", async (action) => {
+    const linked = createCronViewJob("linked-job", { state: {} });
+    const selected = createCronViewJob("selected-job", { state: {} });
+    const pending = createDeferred<CronJob>();
+    const fallbackRequest = createRequest();
     const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "cron.get") {
+        return (params as { id: string }).id === linked.id ? pending.promise : selected;
+      }
       if (method === "cron.list") {
-        return jobs.promise;
+        return cronListResponse([selected]);
       }
-      if (method === "cron.status") {
-        return { enabled: true, jobs: 1, triggersEnabled: true };
+      return fallbackRequest(method);
+    });
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const context = createContext(gateway);
+    const page = createPage(context, { render: true });
+    page.routeSearch = "?job=linked-job";
+    await waitForCronPage(() =>
+      expect(request).toHaveBeenCalledWith("cron.get", { id: linked.id }),
+    );
+    await waitForCronPage(() =>
+      expect(page.querySelector('[data-test-id="cron-row-selected-job"]')).not.toBeNull(),
+    );
+
+    if (action === "selecting another job") {
+      (page.querySelector('[data-test-id="cron-row-selected-job"]') as HTMLElement).click();
+    } else if (action === "changing agent scope") {
+      context.agentSelection.setScope("writer");
+    } else if (action === "opening another link") {
+      page.routeSearch = "?job=selected-job";
+    } else {
+      gateway.emitSnapshot({ phase: "stopped" });
+    }
+    const expectedJobId =
+      action === "selecting another job" || action === "opening another link" ? selected.id : null;
+    await waitForCronPage(() => expect(page.cron.cronEditingJobId).toBe(expectedJobId));
+    pending.resolve(linked);
+    // Drain the held response and its page update before checking the user's selection.
+    await pending.promise;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    await page.updateComplete;
+    expect(page.cron.cronEditingJobId).toBe(expectedJobId);
+    expect(page.cron.cronError).toBeNull();
+  });
+
+  it("shows an exact job lookup failure instead of silently discarding the link", async () => {
+    const fallbackRequest = createRequest();
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.get") {
+        throw new Error("Automation no longer exists");
       }
-      if (method === "cron.runs") {
-        const entries =
-          (params as { id?: string }).id === job.id
-            ? [
-                {
-                  ts: 2,
-                  jobId: job.id,
-                  action: "finished",
-                  runId: "cron:linked-job:2",
-                  summary: "Another run",
-                },
-                {
-                  ts: 1,
-                  jobId: job.id,
-                  action: "finished",
-                  runId: "cron:linked-job:1",
-                  summary: "Linked run",
-                },
-              ]
-            : [];
-        return { entries, total: entries.length, offset: 0, hasMore: false };
-      }
-      if (method === "models.list") {
-        return { models: [] };
-      }
-      return {};
+      return fallbackRequest(method);
     });
     const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
     const page = createPage(createContext(gateway), { render: true });
-    page.routeSearch = "?job=linked-job&run=cron%3Alinked-job%3A1";
+    page.routeSearch = "?job=removed-job";
 
-    await waitForCronPage(() => expect(page.cron.cronLoading).toBe(true));
+    await waitForCronPage(() => expect(page.textContent).toContain("Automation no longer exists"));
     expect(page.cron.cronEditingJobId).toBeNull();
-    jobs.resolve(cronListResponse([job]));
-
-    await waitForCronPage(() => {
-      expect(page.cron.cronEditingJobId).toBe(job.id);
-      expect(
-        page
-          .querySelector('[data-test-id="cron-detail-tab-history"]')
-          ?.getAttribute("aria-selected"),
-      ).toBe("true");
-      expect(page.querySelector(".cron-run-entry--highlighted")?.textContent).toContain(
-        "Linked run",
-      );
-    });
-    expect(page.querySelectorAll(".cron-run-entry--highlighted")).toHaveLength(1);
+    expect(request.mock.calls.filter(([method]) => method === "cron.get")).toHaveLength(1);
   });
+
+  it.each(["another link", "another row", "a new task"])(
+    "clears a failed job link when opening %s",
+    async (destination) => {
+      const job = createCronViewJob("current-job", { state: {} });
+      const fallbackRequest = createRequest();
+      const request = vi.fn(async (method: string, params?: unknown) => {
+        if (method === "cron.get") {
+          if ((params as { id: string }).id === "removed-job") {
+            throw new Error("Automation no longer exists");
+          }
+          return job;
+        }
+        if (method === "cron.list") {
+          return cronListResponse([job]);
+        }
+        return fallbackRequest(method);
+      });
+      const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+      const page = createPage(createContext(gateway), { render: true });
+      page.routeSearch = "?job=removed-job";
+      await waitForCronPage(() =>
+        expect(page.textContent).toContain("Automation no longer exists"),
+      );
+
+      if (destination === "another link") {
+        page.routeSearch = "?job=current-job";
+      } else {
+        const selector =
+          destination === "another row"
+            ? '[data-test-id="cron-row-current-job"]'
+            : '[data-test-id="cron-new-task"]';
+        (page.querySelector(selector) as HTMLElement).click();
+      }
+      await waitForCronPage(() =>
+        expect(
+          destination === "a new task" ? page.cron.cronCreateOpen : page.cron.cronEditingJobId,
+        ).toBe(destination === "a new task" ? true : job.id),
+      );
+      expect(page.cron.cronError).toBeNull();
+      expect(page.textContent).not.toContain("Automation no longer exists");
+    },
+  );
 
   it.each([
     { scenario: "an unsaved enable edit", active: false, edited: true, saved: false },

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -15,7 +15,6 @@ import {
   addCronJob,
   cancelCronEdit,
   createInitialCronState,
-  getVisibleCronJobs,
   hasCronFormErrors,
   loadCronJobsPage,
   loadCronModelSuggestions,
@@ -35,6 +34,7 @@ import {
   type CronModelSuggestionsState,
   type CronState,
 } from "../../lib/cron/index.ts";
+import { formatUiError } from "../../lib/format-error.ts";
 import {
   resolveSessionNavigationAgentId,
   sessionNavigationTarget,
@@ -58,6 +58,7 @@ class CronPage extends OpenClawLightDomElement {
   @state() private detailTab: CronDetailTab = "settings";
 
   private pendingRouteData: ReturnType<typeof resolveCronRouteData> | null = null;
+  private routeJobState: CronState | null = null;
   private highlightedRunId: string | null = null;
   private pendingRunScroll = false;
   private modelSuggestionsState: CronState | null = null;
@@ -72,6 +73,7 @@ class CronPage extends OpenClawLightDomElement {
     ensureInitialData: () => this.ensureInitialData(),
   });
   private readonly observeAgentScope = watchAgentScope((scopeId) => {
+    this.pendingRouteData = null;
     // Replace the mutable request state so responses started for the old
     // scope cannot populate the newly selected agent's page.
     this.resetGatewayState(this.context.gateway.snapshot);
@@ -169,8 +171,10 @@ class CronPage extends OpenClawLightDomElement {
 
   override willUpdate(changed: PropertyValues) {
     if (changed.has("routeSearch")) {
+      this.cron.cronError = null;
       const routeData = resolveCronRouteData(this.routeSearch);
       this.pendingRouteData = routeData.jobId ? routeData : null;
+      this.routeJobState = null;
       this.highlightedRunId = null;
       this.pendingRunScroll = false;
     }
@@ -190,14 +194,26 @@ class CronPage extends OpenClawLightDomElement {
         scroller.scrollTo({ top: 0 });
       }
     }
-    if (this.pendingRouteData && !this.cron.cronLoading && this.cron.cronJobsSnapshotRevision) {
-      // Consume the link only after its inventory arrives so later clicks cannot re-adopt it.
-      const routeData = this.pendingRouteData;
-      this.pendingRouteData = null;
-      const job = this.cron.cronJobs.find((entry) => entry.id === routeData.jobId);
-      if (job) {
-        this.selectJob(job, routeData.runId);
-      }
+    const routeData = this.pendingRouteData;
+    const client = this.cron.client;
+    if (routeData && client && this.cron.connected && this.routeJobState !== this.cron) {
+      this.routeJobState = this.cron;
+      void this.runCronTask(async (current) => {
+        const isCurrent = () =>
+          this.isConnected && this.cron === current && this.pendingRouteData === routeData;
+        try {
+          // Links identify an exact job; a filtered inventory page cannot resolve them.
+          const job = await client.request<CronJob>("cron.get", { id: routeData.jobId });
+          if (isCurrent()) {
+            this.selectJob(job, routeData.runId);
+          }
+        } catch (error) {
+          if (isCurrent()) {
+            this.pendingRouteData = null;
+            current.cronError = formatUiError(error);
+          }
+        }
+      });
     }
     if (this.pendingRunScroll) {
       const run = this.querySelector<HTMLElement>(".cron-run-entry--highlighted");
@@ -276,6 +292,7 @@ class CronPage extends OpenClawLightDomElement {
   }
 
   private selectJob(job: CronJob, runId: string | null = null) {
+    this.pendingRouteData = null;
     this.highlightedRunId = runId;
     this.pendingRunScroll = Boolean(runId);
     if (runId) {
@@ -298,6 +315,7 @@ class CronPage extends OpenClawLightDomElement {
     if (!this.canManageCron) {
       return;
     }
+    this.pendingRouteData = null;
     cancelCronEdit(this.cron, this.context.agentSelection.state.selectedId);
     this.cron.cronCreateOpen = true;
     if (patch) {
@@ -311,6 +329,7 @@ class CronPage extends OpenClawLightDomElement {
     if (!this.canManageCron) {
       return;
     }
+    this.pendingRouteData = null;
     // A clone is a prefilled create: the editor submits cron.add, not update.
     startCronClone(this.cron, job);
     this.cron.cronCreateOpen = true;
@@ -369,6 +388,7 @@ class CronPage extends OpenClawLightDomElement {
   }
 
   private closePanel() {
+    this.pendingRouteData = null;
     cancelCronEdit(this.cron, this.context.agentSelection.state.selectedId);
     this.cron.cronCreateOpen = false;
     this.requestCronUpdate();
@@ -433,7 +453,7 @@ class CronPage extends OpenClawLightDomElement {
           listError: this.cron.cronJobsError,
           canManage,
           status: this.cron.cronStatus,
-          jobs: getVisibleCronJobs(this.cron),
+          jobs: this.cron.cronJobs,
           jobsLoadingMore: this.cron.cronJobsLoadingMore,
           jobsTotal: this.cron.cronJobsTotal,
           jobsHasMore: this.cron.cronJobsHasMore,


### PR DESCRIPTION
Closes #135948

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Opening an automation link silently returns to the list when the job is outside the first loaded inventory page or excluded by its filters. A link to another agent's job can also send the overview's agent filter with the history request, hiding that job's runs.

## Why This Change Was Made

The page resolves links through the existing authorized `cron.get` method. Route, connection, agent-scope, and user-navigation changes fence late responses. Lookup errors are visible and clear when another job or editor is opened. Exact-job history follows the job's owner; overview history retains its agent filter.

The Gateway already owns inventory filtering. Removing the duplicate client filter and schedule-shape helper leaves one list policy and absorbs the lookup repair with **25 fewer production lines**. No Gateway authorization, configuration, protocol, or storage contract changes.

## User Impact

Automation links open the requested job and run-history tab regardless of the currently loaded list page. Missing jobs show the lookup error. The existing URL reference now documents job and run links.

## Evidence

The original page-state regression and bundled Chromium test fail on the starting source: the list loads 50 other jobs, makes no exact lookup, and leaves the linked job closed. Both pass after the repair. The final browser scenario additionally links a writer-owned job while the overview selects the main agent, verifies the exact lookup and job-scoped history request, and displays the matching run.

**Before:** the link stops at the unrelated inventory page.

![Before: automation link remains on the inventory page](https://github.com/user-attachments/assets/9a6acf0a-9ae3-434e-9a08-0b2cf33f5374)

**After:** the same link opens the requested automation and run history.

![After: linked automation run is displayed](https://github.com/user-attachments/assets/cc6658f7-607a-4dbb-a464-c15478e68df0)

Both captures contain only synthetic fixtures. They come from the bundled Control UI with Playwright and the mock Gateway; no operator Gateway or real user state was involved.

Validation: **178 unit tests** across the page and cron client; **15 bundled browser tests** across link navigation, filtering, and loading; the final cross-agent browser scenario rerun after review. Coverage includes missing jobs, stale responses, connection and scope changes, navigation cancellation, error recovery, and server-owned filtering. Four additional assertions failed before the cross-agent/error-reset review corrections and pass afterward.

All underlying changed-file gates passed: repository guards, core/test/UI types, the three dead-export scans, core/UI/style/scripts lint, formatting, and diff checks. The gate run exposed one test-only Promise-executor lint issue; after correcting it, the owning lint check and remaining planned gates passed. Fresh isolated Codex review is clean through P2. The assertion-safety baseline decreases with the removed cast.
