### PR TITLE
improve: avoid line arrays when stripping reasoning preambles

### DIFF
--- a/src/shared/text/formatted-reasoning-message.test.ts
+++ b/src/shared/text/formatted-reasoning-message.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { stripFormattedReasoningMessage } from "./formatted-reasoning-message.js";
+
+describe("stripFormattedReasoningMessage", () => {
+  it.each([
+    "  Ordinary😀\r\n  visible text \r\n",
+    "Thinking...\r\n  I'll check now\r\n_visible_ \r\n",
+    "Thinking\r\n \t\r\n",
+    "Thinking\n_\nVisible",
+    "Thinking....\n_summary_\nVisible",
+    "Thinking…\n_summary_\nVisible",
+    "\nThinking\n_summary_\nVisible",
+    "Thinking\r_summary_\rVisible",
+    "Thinking\u2028_summary_\nVisible",
+  ])("preserves non-preamble text byte for byte: %j", (input) => {
+    expect(stripFormattedReasoningMessage(input)).toBe(input);
+  });
+
+  it.each(["Reasoning:", "Thinking", "Thinking.", "Thinking..", "Thinking..."])(
+    "removes only the %s preamble and normalizes answer line endings",
+    (header) => {
+      const input = `\u00a0${header} \t\r\n\r\n _summary_ \r\n_more_\r\n Answer😀\r\r\n_keep this_\r\nlast \r\n`;
+      expect(stripFormattedReasoningMessage(input)).toBe("Answer😀\r\n_keep this_\nlast");
+    },
+  );
+
+  it.each([
+    ["Reasoning:\r\n \r\nVisible", "Visible"],
+    ["Reasoning:", ""],
+    ["Thinking\n__", ""],
+    ["<think>private</think>Thinking\n_summary_\nVisible", "Visible"],
+    ["Normal\n<internal>private</internal>\nanswer", "Normal\n\nanswer"],
+    ["<thinking>outer<internal>private", ""],
+    ["Use `<think>literal</think>` exactly.", "Use `<think>literal</think>` exactly."],
+  ])("keeps tag privacy and distinct header rules: %j", (input, expected) => {
+    expect(stripFormattedReasoningMessage(input)).toBe(expected);
+  });
+});

--- a/src/shared/text/formatted-reasoning-message.ts
+++ b/src/shared/text/formatted-reasoning-message.ts
@@ -4,36 +4,27 @@ import { stripReasoningTagsFromText } from "./reasoning-tags.js";
 /** Strip provider-formatted Reasoning/Thinking preambles from visible text. */
 export function stripFormattedReasoningMessage(text: string): string {
   const stripped = stripReasoningTagsFromText(text);
-  const lines = stripped.split(/\r?\n/u);
-  const prefix = lines[0]?.trim();
-  if (prefix !== "Reasoning:" && !/^Thinking\.{0,3}$/u.test(prefix ?? "")) {
+  const firstNewline = stripped.indexOf("\n");
+  const prefix = (firstNewline === -1 ? stripped : stripped.slice(0, firstNewline)).trim();
+  const thinking = /^Thinking\.{0,3}$/u.test(prefix);
+  if (prefix !== "Reasoning:" && !thinking) {
     return stripped;
   }
-  if (/^Thinking\.{0,3}$/u.test(prefix ?? "")) {
-    const firstBodyLine = lines.slice(1).find((line) => line.trim());
-    const trimmedBodyLine = firstBodyLine?.trim() ?? "";
-    if (
-      !trimmedBodyLine ||
-      !(
-        trimmedBodyLine.startsWith("_") &&
-        trimmedBodyLine.endsWith("_") &&
-        trimmedBodyLine.length >= 2
-      )
-    ) {
-      return stripped;
-    }
-  }
 
-  // Remove blank/italic summary preamble lines but preserve the substantive
-  // answer body exactly after the first non-preamble line.
-  let index = 1;
-  while (index < lines.length) {
-    const trimmed = lines[index]?.trim() ?? "";
-    if (!trimmed || (trimmed.startsWith("_") && trimmed.endsWith("_") && trimmed.length >= 2)) {
-      index += 1;
-      continue;
+  let offset = firstNewline === -1 ? stripped.length : firstNewline + 1;
+  let hasSummary = false;
+  while (offset < stripped.length) {
+    const newline = stripped.indexOf("\n", offset);
+    const end = newline === -1 ? stripped.length : newline;
+    const line = stripped.slice(offset, end).trim();
+    const isSummary = line.length >= 2 && line.startsWith("_") && line.endsWith("_");
+    if (line && !isSummary) {
+      break;
     }
-    break;
+    hasSummary ||= isSummary;
+    offset = end + 1;
   }
-  return lines.slice(index).join("\n").trim();
+  // Thinking needs an italic summary. Normalize CRLF only when removing a preamble;
+  // ordinary messages retain their original bytes, including bare carriage returns.
+  return thinking && !hasSummary ? stripped : stripped.slice(offset).replace(/\r\n/g, "\n").trim();
 }


### PR DESCRIPTION
## What Problem This Solves

Visible-message cleanup splits every message into all its lines before deciding whether it has a Reasoning or Thinking preamble. Ordinary long messages therefore allocate a line array that the sanitizer immediately discards.

## Why This Change Was Made

Check the first line and advance one offset through a recognized preamble. Keep the existing reasoning-tag parser, Thinking's italic-summary requirement, and line-ending rules in the shared sanitizer used by outbound and inter-session callers.

Production **−9 lines**; 21 additional behavior cases add **38 test lines**. No channel-specific branch, configuration option, dependency, or persistence change.

## User Impact

Visible output and attachment handling are preserved. Ordinary 512-line messages avoid their 512-slot line array. Three-process descriptive medians for 512 calls fell from **12.558 ms to 4.488 ms** in the actual helper probe; this is an owner measurement, not a Gateway memory or latency claim.

## Evidence

The focused suite passed **383 baseline / 404 candidate tests**, along with the full changed-file gate and managed Codex review. Six actual-source probe processes agree on 212 parser cases, four visible-payload sanitizer cases, and seven outbound-builder cases, including intentional rejection of empty or private-only sends. Exact-head CI passed: [run 33597810498](https://github.com/openclaw/openclaw/actions/runs/33597810498).

The previously pending canonical Gateway-send check is **complete** on `ed3160c0fc6d6292c56aa5361b9bf83277682fdf`. An ephemeral real Gateway and the actual Signal plugin used local mock OpenAI and Signal APIs with synthetic input. The documented `messages.visibleReplies: message_tool` mode exposed the ordinary message tool; production tool policy, source authority, attachment access, and publication guards were unchanged.

| Provider argument | Accepted native Signal output | Attachment |
| --- | --- | --- |
| `message`: Thinking preamble, CRLF, italic private summary, visible Unicode lines | Only the two expected visible lines; private summary absent | Exact 66 bytes |
| `content` alias: Thinking preamble, two italic private summary lines, visible CJK lines | Only the two expected visible lines; private summaries absent | Exact 66 bytes |
| Ordinary Thinking text without an italic summary | All original ordinary prose survives | Exact 66 bytes |

Each case records one provider HTTP 200, the exact tool arguments, a matching persisted `call_id|item_id`, a successful same-run tool result, `deliveryStatus: sent`, the current-source route, and an accepted native Signal RPC with matching quote/recipient and attachment bytes. Final source delivery terminates the turn normally. Main-process V8 coverage records four calls to the changed helper; the retained compiled source and function ranges match. The parent independently replayed all 20 retained data-file hashes and output assertions.

The physical proof copy matches all 36,570 tracked blobs after accounting for its sole declared task-only mock-provider overlay. Dependency roots, links, and the publication guard were also verified. All four attempted CLI runs joined; their 37 recorded child identities were gone and task runtime state was removed. Earlier attempts failed on fixture tool exposure and then on a verifier assumption about the combined call ID; neither changed production guards or contributes to the successful result.

Frozen proof identities: compiled helper SHA-256 `8fd4b6353e70db09b26ee11d714f2ff31afe720fc4393864f30148d64bee118c`; successful receipt `b8abf8de9937f08c06586d2bc939b03bbb7cdad895af9e3e3f7dbee078131c9e`; attachment in every case `1c3eaedd50133b82010a56527d09c066acc1dc07da1f95378b9de4e4732980a3`.

This proves Gateway/plugin delivery through local service fixtures, not public Signal encryption/upload or remote receipt. No live provider credential or external recipient was used for this focused proof. The broader performance campaign separately measures real OpenAI Gateway/web turns. ClawSweeper's pending-proof item and Rank-up request are addressed by the completed result above; ordinary parent maintainer review is complete.
