### PR TITLE
refactor(msteams): use canonical timestamp parser

### DIFF
--- a/extensions/msteams/src/conversation-store-helpers.ts
+++ b/extensions/msteams/src/conversation-store-helpers.ts
@@ -10,10 +10,6 @@ export function normalizeStoredConversationId(raw: string): string {
   return raw.split(";")[0] ?? raw;
 }
 
-export function parseStoredConversationTimestamp(value: string | undefined): number | null {
-  return parseDateStringTimestampMs(value) ?? null;
-}
-
 export function toConversationStoreEntries(
   entries: Iterable<[string, StoredConversationReference]>,
 ): MSTeamsConversationStoreEntry[] {
@@ -87,8 +83,8 @@ export function findPreferredDmConversationByUserId(
   if (candidates.length > 1) {
     candidates.sort(
       (a, b) =>
-        (parseStoredConversationTimestamp(b.reference.lastSeenAt) ?? 0) -
-        (parseStoredConversationTimestamp(a.reference.lastSeenAt) ?? 0),
+        (parseDateStringTimestampMs(b.reference.lastSeenAt) ?? 0) -
+        (parseDateStringTimestampMs(a.reference.lastSeenAt) ?? 0),
     );
   }
 

--- a/extensions/msteams/src/conversation-store-state.ts
+++ b/extensions/msteams/src/conversation-store-state.ts
@@ -1,10 +1,10 @@
 // Msteams plugin module implements conversation store state behavior.
 import crypto from "node:crypto";
+import { parseDateStringTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   findPreferredDmConversationByUserId,
   mergeStoredConversationReference,
   normalizeStoredConversationId,
-  parseStoredConversationTimestamp,
   toConversationStoreEntries,
 } from "./conversation-store-helpers.js";
 import type {
@@ -88,15 +88,15 @@ export function selectRetainedMSTeamsConversations(
   ttlMs = MSTEAMS_CONVERSATION_TTL_MS,
 ): Array<[string, StoredConversationReference]> {
   const retained = Object.entries(conversations).filter(([, reference]) => {
-    const lastSeenAt = parseStoredConversationTimestamp(reference.lastSeenAt);
+    const lastSeenAt = parseDateStringTimestampMs(reference.lastSeenAt);
     return lastSeenAt == null || Date.now() - lastSeenAt <= ttlMs;
   });
   if (retained.length <= MSTEAMS_MAX_CONVERSATIONS) {
     return retained;
   }
   retained.sort((a, b) => {
-    const aTs = parseStoredConversationTimestamp(a[1].lastSeenAt) ?? 0;
-    const bTs = parseStoredConversationTimestamp(b[1].lastSeenAt) ?? 0;
+    const aTs = parseDateStringTimestampMs(a[1].lastSeenAt) ?? 0;
+    const bTs = parseDateStringTimestampMs(b[1].lastSeenAt) ?? 0;
     return aTs - bTs || a[0].localeCompare(b[0]);
   });
   return retained.slice(retained.length - MSTEAMS_MAX_CONVERSATIONS);
@@ -109,7 +109,7 @@ export function createMSTeamsConversationStoreState(
   const conversationStore = createConversationStateStore(params);
 
   const isExpired = (reference: StoredConversationReference): boolean => {
-    const lastSeenAt = parseStoredConversationTimestamp(reference.lastSeenAt);
+    const lastSeenAt = parseDateStringTimestampMs(reference.lastSeenAt);
     // Preserve migrated legacy entries that have no lastSeenAt until they're seen again.
     return lastSeenAt != null && Date.now() - lastSeenAt > ttlMs;
   };
@@ -168,8 +168,8 @@ export function createMSTeamsConversationStoreState(
       return;
     }
     const sorted = rows.toSorted((a, b) => {
-      const aTs = parseStoredConversationTimestamp(a.value.lastSeenAt) ?? 0;
-      const bTs = parseStoredConversationTimestamp(b.value.lastSeenAt) ?? 0;
+      const aTs = parseDateStringTimestampMs(a.value.lastSeenAt) ?? 0;
+      const bTs = parseDateStringTimestampMs(b.value.lastSeenAt) ?? 0;
       const aId = getStoredConversationId(a.value) ?? a.key;
       const bId = getStoredConversationId(b.value) ?? b.key;
       return aTs - bTs || aId.localeCompare(bId);

--- a/extensions/msteams/src/polls.ts
+++ b/extensions/msteams/src/polls.ts
@@ -264,16 +264,12 @@ function createPollVoteBucketStateStore(params?: MSTeamsPollStoreStateOptions) {
   });
 }
 
-function parseTimestamp(value?: string): number | null {
-  return parseDateStringTimestampMs(value) ?? null;
-}
-
 function pruneExpired<T extends { createdAt: string; updatedAt?: string }>(
   polls: Record<string, T>,
 ) {
   const cutoff = Date.now() - MSTEAMS_POLL_TTL_MS;
   const entries = Object.entries(polls).filter(([, poll]) => {
-    const ts = parseTimestamp(poll.updatedAt ?? poll.createdAt) ?? 0;
+    const ts = parseDateStringTimestampMs(poll.updatedAt ?? poll.createdAt) ?? 0;
     return ts >= cutoff;
   });
   return Object.fromEntries(entries);
@@ -287,8 +283,8 @@ export function selectRetainedMSTeamsPolls(
     return retained;
   }
   retained.sort((a, b) => {
-    const aTs = parseTimestamp(a[1].updatedAt ?? a[1].createdAt) ?? 0;
-    const bTs = parseTimestamp(b[1].updatedAt ?? b[1].createdAt) ?? 0;
+    const aTs = parseDateStringTimestampMs(a[1].updatedAt ?? a[1].createdAt) ?? 0;
+    const bTs = parseDateStringTimestampMs(b[1].updatedAt ?? b[1].createdAt) ?? 0;
     return aTs - bTs || a[0].localeCompare(b[0]);
   });
   return retained.slice(retained.length - MSTEAMS_MAX_POLLS);
@@ -420,8 +416,8 @@ export function createMSTeamsPollStoreState(
       return;
     }
     const sorted = rows.toSorted((a, b) => {
-      const aTs = parseTimestamp(a.value.updatedAt ?? a.value.createdAt) ?? 0;
-      const bTs = parseTimestamp(b.value.updatedAt ?? b.value.createdAt) ?? 0;
+      const aTs = parseDateStringTimestampMs(a.value.updatedAt ?? a.value.createdAt) ?? 0;
+      const bTs = parseDateStringTimestampMs(b.value.updatedAt ?? b.value.createdAt) ?? 0;
       return aTs - bTs || a.key.localeCompare(b.key);
     });
     for (const row of sorted.slice(0, rows.length - MSTEAMS_MAX_POLLS)) {


### PR DESCRIPTION
## What Problem This Solves

Removes duplicate Microsoft Teams timestamp wrapper functions that only forwarded to the canonical plugin SDK parser.

## Why This Change Was Made

Microsoft Teams conversation and poll retention now call `parseDateStringTimestampMs` directly from `openclaw/plugin-sdk/number-runtime`. The existing `?? 0`, `== null`, survival, ranking, TTL, and expiry policies are unchanged.

This intentionally overlaps files, but not hunks or semantics, with https://github.com/openclaw/openclaw/pull/112811. A live recheck confirmed that PR remains open at head `14f1771a14a5f9bba94bbda6eb10d4f674afb4c5` and only adds account-scoped state namespaces, options, and mutation lock keys in these files; it does not modify timestamp parsing or retention behavior.

## User Impact

No user-visible behavior changes. Missing and invalid timestamps continue through
the existing `== null` and `?? 0` retention, expiry, ranking, and pruning
policies.

SQLite schemas, namespaces, stored JSON, reads, writes, migrations, and legacy
row handling are unchanged.

## Evidence

- Exact refreshed head: `4ce1b389df6362ff8b6acfe6a5def7433ca786b1`.
- Refresh parent: `3100ba535f1d003d67a6a7536deacf8666367b38`.
- Source head/parent: `e24dbbff48009ce2d99d74d9df9d6b8bb61985bb` / `c6e445d2fba4f28ae1cbe67fc23cf4c868facd31`.
- The refreshed commit has a valid ED25519 signature and preserves the source author and message.
- Production diff: 3 files, `+14/-22` (net `-8`); tests: `0`.
- Aggregate patch ID: `8c200721945de72424fb8c3478b6829a2a9f0d15`.
- Per-file patch IDs: `conversation-store-helpers.ts` `ca56f609b9ee9e56352e04535a51bbe91dc4a26a`; `conversation-store-state.ts` `63916c989bbac0fe870a06f22a278b6cc357e7bb`; `polls.ts` `5f38a47e3fb487cf66c282eff23d3c44498383ee`.
- The refreshed blobs are byte-identical to the source head for all three files.
- Focused verification passed 70 tests: 30 normalization-core parser tests, 30 Microsoft Teams owner tests, and 10 Teams migration-retention tests.
- The 50,025-input differential across the affected caller contexts found zero mismatches.
- `git diff --check` passed.
- Actions runs `33595522849` and `33596233130` are cancelled. The first checked out `5170c246b98f3bddea7b8b2f36d9c2d88a0d0b63`; the second used the former PR head. Their public logs contain no claimed test or gate results.
- Native prepare passed at `2026-09-03T04:01:36Z` in `hosted_exact_or_recent_parent` mode using exact-head CI run https://github.com/openclaw/openclaw/actions/runs/33711421404 and Workflow Sanity run https://github.com/openclaw/openclaw/actions/runs/33711421458; Blacksmith Testbox lanes were reported not applicable for this changed-file set.
- Fresh exact-head autoreview completed scoped-clean with 0.99 confidence.
- Live Microsoft Teams tenant proof is not required for this behavior-preserving internal refactor.
- Codex gate: inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI and completion paths are unrelated.

