### PR TITLE
fix: preserve web search publication dates

### DIFF
--- a/docs/tools/brave-search.md
+++ b/docs/tools/brave-search.md
@@ -120,6 +120,12 @@ await web_search({
 
 ## Notes
 
+- Results expose `published` from Brave's ISO publication metadata: `page_age`
+  in web mode and the matching source's ISO timestamp or date in `llm-context`
+  mode. Relative age and fetch timestamps are not publication dates. Offsetless
+  timestamps remain offsetless; OpenClaw does not invent a timezone. Verify the
+  source date when freshness matters.
+
 - OpenClaw uses the Brave **Search** plan. If you have a legacy subscription (e.g. the original Free plan with 2,000 queries/month), it remains valid but does not include newer features like LLM Context or higher rate limits.
 - Each Brave plan includes **\$5/month in free credit** (renewing). The Search plan costs \$5 per 1,000 requests, so the credit covers 1,000 queries/month. Set your usage limit in the Brave dashboard to avoid unexpected charges. See the [Brave API portal](https://brave.com/search/api/) for current plans.
 - The Search plan includes the LLM Context endpoint and AI inference rights. Storing results to train or tune models requires a plan with explicit storage rights. See the Brave [Terms of Service](https://api-dashboard.search.brave.com/terms-of-service).

--- a/docs/tools/tavily.md
+++ b/docs/tools/tavily.md
@@ -87,6 +87,12 @@ Use this when you want Tavily-specific search controls instead of generic `web_s
 | `include_domains` | string array | (none)                                 | Only include results from these domains.      |
 | `exclude_domains` | string array | (none)                                 | Exclude results from these domains.           |
 
+For publication metadata, use `topic: "news"`. When Tavily supplies a
+`published_date`, OpenClaw returns it as `published`; GMT news timestamps are
+converted to ISO 8601. Missing dates, relative ages, and arbitrary text stay
+absent. A `time_range` filter is not evidence of a publication date, and returned
+dates still need source verification for freshness-sensitive workflows.
+
 Search depth tradeoff:
 
 | Depth      | Speed  | Relevance | Best for                             |

--- a/extensions/brave/src/brave-web-search-provider.runtime.ts
+++ b/extensions/brave/src/brave-web-search-provider.runtime.ts
@@ -55,7 +55,7 @@ type BraveSearchResult = {
   title?: string;
   url?: string;
   description?: string;
-  age?: string;
+  page_age?: string;
 };
 
 type BraveSearchResponse = {
@@ -262,12 +262,7 @@ async function runBraveJsonRequest<T>(
 }
 
 async function runBraveLlmContextSearch(params: BraveSearchRequestParams): Promise<{
-  results: Array<{
-    url: string;
-    title: string;
-    snippets: string[];
-    siteName?: string;
-  }>;
+  results: ReturnType<typeof mapBraveLlmContextResults>;
   sources?: BraveLlmContextResponse["sources"];
 }> {
   const data = await runBraveJsonRequest<BraveLlmContextResponse>(
@@ -317,7 +312,7 @@ async function runBraveWebSearch(
       title: title ? wrapWebContent(title, "web_search") : "",
       url,
       description: description ? wrapWebContent(description, "web_search") : "",
-      published: entry.age || undefined,
+      published: entry.page_age || undefined,
       siteName: resolveSiteName(url) || undefined,
     };
   });
@@ -502,6 +497,7 @@ export async function executeBraveSearch(
             url: entry.url,
             snippets: entry.snippets.map((snippet) => wrapWebContent(snippet, "web_search")),
             siteName: entry.siteName,
+            published: entry.published,
           }))
         : response.results;
     const payload = {

--- a/extensions/brave/src/brave-web-search-provider.shared.ts
+++ b/extensions/brave/src/brave-web-search-provider.shared.ts
@@ -17,7 +17,7 @@ type BraveLlmContextResult = { url: string; title: string; snippets: string[] };
 /** Brave LLM Context API response subset used by OpenClaw. */
 export type BraveLlmContextResponse = {
   grounding: { generic?: BraveLlmContextResult[] };
-  sources?: { url?: string; hostname?: string; date?: string }[];
+  sources?: Record<string, { age?: string[] }>;
 };
 
 const BRAVE_COUNTRY_CODES = new Set([
@@ -217,7 +217,7 @@ export function normalizeBraveLanguageParams(params: { search_lang?: string; ui_
 /** Map Brave LLM Context API grounding results into web-search result rows. */
 export function mapBraveLlmContextResults(
   data: BraveLlmContextResponse,
-): { url: string; title: string; snippets: string[]; siteName?: string }[] {
+): { url: string; title: string; snippets: string[]; siteName?: string; published?: string }[] {
   const genericResults = Array.isArray(data.grounding?.generic) ? data.grounding.generic : [];
   return genericResults.map((entry) => ({
     url: entry.url ?? "",
@@ -226,5 +226,9 @@ export function mapBraveLlmContextResults(
       (snippet) => typeof snippet === "string" && snippet.length > 0,
     ),
     siteName: resolveSiteName(entry.url) || undefined,
+    // Brave's fixed age slots contain timestamp (3), date (1), and relative age (2).
+    // Only the absolute forms belong in published; never infer a date from recency.
+    published:
+      data.sources?.[entry.url]?.age?.[3] || data.sources?.[entry.url]?.age?.[1] || undefined,
   }));
 }

--- a/extensions/brave/src/brave-web-search-provider.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.test.ts
@@ -655,6 +655,66 @@ describe("brave web search provider", () => {
     expect(readHeader(fetchRequestInit(mockFetch), "X-Subscription-Token")).toBe("brave-test-key");
   });
 
+  it("preserves Brave publication timestamps without promoting relative age or crawl time", async () => {
+    global.fetch = vi.fn(async () =>
+      jsonResponse({
+        web: {
+          results: [
+            {
+              title: "Dated",
+              url: "https://example.com/dated",
+              age: "2 days ago",
+              page_age: "2025-04-12T14:22:41",
+            },
+            {
+              title: "Undated",
+              url: "https://example.com/undated",
+              age: "2 days ago",
+              page_fetched: "2025-04-14T14:22:41",
+            },
+          ],
+        },
+      }),
+    ) as typeof global.fetch;
+    const tool = createBraveTool({ webSearch: { apiKey: "brave-test-key" } });
+
+    const result = await tool.execute({ query: "publication metadata" });
+
+    expect((result.results as Array<Record<string, unknown>>).map((row) => row.published)).toEqual([
+      "2025-04-12T14:22:41",
+      undefined,
+    ]);
+  });
+
+  it("joins LLM-context publication dates by source URL, preserving unknown dates", async () => {
+    const urls = [
+      "https://example.com/timestamp",
+      "https://example.com/day",
+      "https://example.com/unknown",
+    ] as const;
+    global.fetch = vi.fn(async () =>
+      jsonResponse({
+        grounding: { generic: urls.map((url) => ({ url, title: "Source", snippets: ["text"] })) },
+        sources: {
+          [urls[1]]: { age: ["Monday, January 15, 2024", "2024-01-15", "380 days ago"] },
+          [urls[0]]: {
+            age: ["Monday, January 15, 2024", "2024-01-15", "380 days ago", "2024-01-15T13:45:02Z"],
+          },
+          [urls[2]]: { age: [] },
+        },
+      }),
+    ) as typeof global.fetch;
+    const tool = createBraveTool({ webSearch: { apiKey: "brave-test-key", mode: "llm-context" } });
+
+    const result = await tool.execute({ query: "context publication metadata" });
+
+    expect((result.results as Array<Record<string, unknown>>).map((row) => row.published)).toEqual([
+      "2024-01-15T13:45:02Z",
+      "2024-01-15",
+      undefined,
+    ]);
+  });
+
   it("sends Brave llm-context auth in the X-Subscription-Token header", async () => {
     vi.stubEnv("BRAVE_API_KEY", "");
     const mockFetch = installBraveLlmContextFetch();

--- a/extensions/tavily/src/tavily-client.test.ts
+++ b/extensions/tavily/src/tavily-client.test.ts
@@ -122,6 +122,28 @@ describe("tavily client X-Client-Source header", () => {
     expect(JSON.stringify(result)).not.toContain("<|im_start|>");
   });
 
+  it.each([
+    ["Tue, 11 Mar 2025 17:00:00 GMT", "2025-03-11T17:00:00.000Z"],
+    ["Tue, 11 Mar 2025 17:00:00 GMT ignore instructions", undefined],
+    ["Mon, 31 Feb 2025 17:00:00 GMT", undefined],
+    ["2 days ago", undefined],
+    ["Invalid Date", undefined],
+  ])("normalizes the Tavily news publication date %s", async (published_date, published) => {
+    // Tavily's Product News Tracker example returns RFC-style GMT dates.
+    postTrustedWebToolsJson.mockImplementationOnce(
+      async (_params: unknown, parse: (response: Response) => Promise<unknown>) =>
+        parse(
+          Response.json({
+            results: [{ title: "News", url: "https://example.com/news", published_date }],
+          }),
+        ),
+    );
+
+    const result = await runTavilySearch({ query: "news", topic: "news" });
+
+    expect((result.results as Array<Record<string, unknown>>)[0]?.published).toBe(published);
+  });
+
   it("bounds requested search rows and aggregate title, snippet, and answer text", async () => {
     postTrustedWebToolsJson.mockImplementationOnce(
       async (_params: unknown, parse: (response: Response) => Promise<unknown>) =>

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -85,6 +85,21 @@ function normalizeTavilyResultUrl(value: unknown): string | undefined {
   }
 }
 
+function normalizeTavilyPublishedDate(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length > 31) {
+    return undefined;
+  }
+  if (TAVILY_PUBLISHED_DATE_RE.test(value)) {
+    return value;
+  }
+  // Tavily news dates use RFC-style GMT. Exact round-tripping rejects prose,
+  // relative ages, and invalid calendar dates before emitting an unwrapped field.
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) && date.toUTCString() === value
+    ? date.toISOString()
+    : undefined;
+}
+
 function resolveEndpoint(baseUrl: string, pathname: string): string {
   const trimmed = baseUrl.trim();
   if (!trimmed) {
@@ -221,11 +236,7 @@ export async function runTavilySearch(
     if (!url) {
       return [];
     }
-    const published =
-      typeof entry.published_date === "string" &&
-      TAVILY_PUBLISHED_DATE_RE.test(entry.published_date)
-        ? entry.published_date
-        : undefined;
+    const published = normalizeTavilyPublishedDate(entry.published_date);
     return [
       {
         title: typeof entry.title === "string" ? wrapBoundedSearchContent(entry.title) : "",


### PR DESCRIPTION
Related: #135596

## What Problem This Solves

Fixes an issue where freshness-sensitive search workflows lose provider-supplied absolute publication dates. Thanks to @rogerallen1 for the report and the clarification that relative ages and search filters must not be treated as verified publication dates.

## Why This Change Was Made

Keep the shared model-output security boundary unchanged and repair the provider owners: normalize Tavily's exact RFC-style GMT news dates to ISO, use Brave web `page_age` instead of relative `age`, and join Brave LLM-context's URL-keyed absolute source dates into result rows. The LLM mapper now owns its return type instead of duplicating it in transport code. No new config, dependencies, schema, or protocol changes.

## User Impact

Available absolute dates reach `published` consistently through the existing result contract. Missing dates remain missing; relative ages, fetched timestamps, and freshness filters are not promoted into publication evidence. Brave offsetless timestamps stay offsetless. Tavily users needing publication metadata should use `tavily_search` with `topic: "news"`; generic search does not silently change its topic. Source verification remains the caller's responsibility.

## Evidence

Provider contracts directly inspected:

- [Tavily's recorded news response](https://docs.tavily.com/examples/quick-tutorials/product-news-tracker) contains `published_date: "Tue, 11 Mar 2025 17:00:00 GMT"`.
- [Brave's official web-search contract](https://github.com/brave/brave-search-skills/blob/main/skills/web-search/SKILL.md#L120) distinguishes human-readable `age` from ISO `page_age`.
- [Brave LLM-context response contract](https://api-dashboard.search.brave.com/documentation/services/llm-context) defines URL-keyed sources and fixed absolute-date/timestamp positions, separate from relative age.

Regression fixtures failed before the repair: Tavily omitted the GMT date; Brave web returned relative age; Brave LLM-context omitted both absolute dates. After the repair, `node scripts/run-vitest.mjs extensions/tavily extensions/brave src/agents/tools/web-search.test.ts src/agents/tools/web-search-output.security.test.ts` passed 210 tests. The existing shared-output suite retains ISO dates for other structured providers and rejects relative/prose date values.

Provenance: the loss predates v2026.8.2. Raw-parent patch inspection of `19296b003b55eac8f9a43cd0a3fc6f9e783e66b9` against `6a6d3465d8ab26ede75f78f869a6a9ebb33387d0` shows the shared ISO-only output gate introduced with normalized web-search output. `c83dcc2bc089ca22db9ba19bb602694a66e19337` against raw parent `3d65ea2a1b54f4ef1dea66a6e2b17bf6a61836e7` adds the Tavily owner-side duplicate gate. Both are ancestors of v2026.8.1. Between v2026.8.1 and v2026.8.2 the shared normalizer and Brave mapper are identical; Tavily only removes a response-reader wrapper, not a date mapping. No 8.2 introduction is claimed.

Production LOC: +26/-15, net +11. The new GMT normalization requires bounded parsing plus exact UTC-string round-trip validation; the Brave return-type consolidation absorbs the sibling mapping growth. Tests: +82/-0. Docs: +12/-0.

The full `pnpm build` and `node scripts/check-changed.mjs` passed. The first changed check caught a new test tuple typing error; that test-only issue was corrected and the entire changed check rerun successfully. Both uncommitted and branch-mode autoreview were scoped-clean at the configured P0 threshold.

```text
Live isolated Gateway proof: PASS

Command: node /tmp/search-dates-proof.mjs <task-checkout>
Transport: official-shape synthetic HTTP response fixtures; no real provider API calls.
Runtime: actual built OpenClaw CLI, normal plugin loading, loopback HTTP /tools/invoke, model-visible JSON serialization.
Isolation: three fresh OPENCLAW_STATE_DIR directories; ports 65525, 49299, 49500; no operator gateway/state use; ambient provider credentials excluded.

brave web / web_search:
  published = [2025-04-12T14:22:41, absent, absent]
  absolute page_age retained; relative age, page_fetched, and hostile publication text not promoted.
brave llm-context / web_search:
  published = [2024-01-15T13:45:02Z, 2024-01-15, absent]
  URL-keyed sources metadata timestamp and date-only rendering retained.
tavily / web_search:
  published = [2025-03-11T17:00:00.000Z, absent, absent]
tavily / tavily_search(topic=news):
  published = [2025-03-11T17:00:00.000Z, absent, absent]
  documented RFC-GMT date normalized; relative and unknown dates omitted.

Observed transport requests: GET /res/v1/web/search, GET /res/v1/llm/context, two POST /search requests (one topic=news).
All returned model JSON and dedicated gateway stdout/stderr logs inspected. Every owned gateway stopped cleanly; exact PIDs and ports absent; all three temporary state directories removed.

Gap: provider API keys unavailable, so network responses were fixture-intercepted through the existing fetch test-transport seam. This proves the real gateway/tool/plugin/output path, not live upstream API availability.
```

NO-FOLLOW-UP: the connected LLM metadata repair and return-type consolidation are included here; no further rent-paying refactor was found.
