### PR TITLE
fix(cua): restore Mac Command shortcuts and native worker packaging

### DIFF
--- a/extensions/cua-computer/src/actions.test.ts
+++ b/extensions/cua-computer/src/actions.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it } from "vitest";
 import { normalizeModifiers, parseKeyChord, scalePoint } from "./actions.js";
 
 // normalizeKey is internal; exercise it through parseKeyChord's final segment.
-const normalizeKey = (input: string) => parseKeyChord(input).key;
+const normalizeKey = (input: string) => parseKeyChord(input, "linux").key;
 
 describe("cua-computer key normalization", () => {
   it.each([
-    ["cmd+shift", ["meta", "shift"]],
-    ["Super+Control+Option", ["meta", "ctrl", "alt"]],
-    ["win+mod1", ["meta", "alt"]],
-  ])("normalizes modifier aliases in %s", (input, expected) => {
-    expect(normalizeModifiers(input)).toEqual(expected);
+    ["cmd+shift", "linux", ["meta", "shift"]],
+    ["Super+Control+Option", "linux", ["meta", "ctrl", "alt"]],
+    ["win+mod1", "linux", ["meta", "alt"]],
+    ["cmd+shift", "darwin", ["cmd", "shift"]],
+    ["Super+Control+Option", "darwin", ["cmd", "ctrl", "alt"]],
+    ["win+mod1", "darwin", ["cmd", "alt"]],
+  ] as const)("normalizes modifier aliases in %s on %s", (input, platform, expected) => {
+    expect(normalizeModifiers(input, platform)).toEqual(expected);
   });
 
   it.each([
@@ -34,7 +37,7 @@ describe("cua-computer key normalization", () => {
   );
 
   it("keeps letter keys usable in shortcut chords", () => {
-    expect(parseKeyChord("cmd+c")).toEqual({ key: "c", modifiers: ["meta"] });
+    expect(parseKeyChord("cmd+c", "linux")).toEqual({ key: "c", modifiers: ["meta"] });
   });
 
   // Digits and punctuation are shifted on some keyboard layouts, and cua-driver
@@ -48,7 +51,7 @@ describe("cua-computer key normalization", () => {
   );
 
   it("splits the last chord segment into the key", () => {
-    expect(parseKeyChord("cmd+ctrl+Return")).toEqual({
+    expect(parseKeyChord("cmd+ctrl+Return", "linux")).toEqual({
       key: "enter",
       modifiers: ["meta", "ctrl"],
     });
@@ -56,8 +59,8 @@ describe("cua-computer key normalization", () => {
 
   it.each(["hyper", "ctrl+hyper"])("rejects unknown vocabulary in %s", (input) => {
     const operation = input.includes("+")
-      ? () => parseKeyChord(input)
-      : () => normalizeModifiers(input);
+      ? () => parseKeyChord(input, "linux")
+      : () => normalizeModifiers(input, "linux");
     expect(operation).toThrow("COMPUTER_UNSUPPORTED_KEY");
   });
 

--- a/extensions/cua-computer/src/actions.ts
+++ b/extensions/cua-computer/src/actions.ts
@@ -55,13 +55,17 @@ function unsupportedKey(message: string): Error {
   return new Error(`COMPUTER_UNSUPPORTED_KEY: ${message}`);
 }
 
-export function normalizeModifiers(value: string | undefined): string[] {
-  if (!value?.trim()) {
-    return [];
-  }
-  return value.split("+").map((entry) => {
+function modifierAlias(value: string, platform: NodeJS.Platform): string | undefined {
+  const normalized = MODIFIER_ALIASES.get(value.toLowerCase());
+  // CUA's macOS backend silently ignores meta; Linux requires that spelling.
+  // Resolve against the provider's platform for both chords and pointer input.
+  return platform === "darwin" && normalized === "meta" ? "cmd" : normalized;
+}
+
+function normalizeModifierList(entries: string[], platform: NodeJS.Platform): string[] {
+  return entries.map((entry) => {
     const raw = entry.trim();
-    const normalized = MODIFIER_ALIASES.get(raw.toLowerCase());
+    const normalized = modifierAlias(raw, platform);
     if (!normalized) {
       throw unsupportedKey(`unknown modifier ${JSON.stringify(raw)}`);
     }
@@ -69,17 +73,17 @@ export function normalizeModifiers(value: string | undefined): string[] {
   });
 }
 
-function normalizeKey(value: string): string {
+export function normalizeModifiers(value: string | undefined, platform: NodeJS.Platform): string[] {
+  return value?.trim() ? normalizeModifierList(value.split("+"), platform) : [];
+}
+
+function normalizeKey(value: string, platform: NodeJS.Platform): string {
   const raw = value.trim();
   if (!raw) {
     throw unsupportedKey("key chord contains an empty key");
   }
   const lowered = raw.toLowerCase();
-  const modifier = MODIFIER_ALIASES.get(lowered);
-  if (modifier) {
-    return modifier;
-  }
-  const named = KEY_ALIASES.get(lowered);
+  const named = modifierAlias(lowered, platform) ?? KEY_ALIASES.get(lowered);
   if (named) {
     return named;
   }
@@ -98,20 +102,14 @@ function normalizeKey(value: string): string {
   throw unsupportedKey(`unknown key ${JSON.stringify(raw)}`);
 }
 
-export function parseKeyChord(value: string | undefined): { key: string; modifiers: string[] } {
+export function parseKeyChord(value: string | undefined, platform: NodeJS.Platform) {
   const segments = value?.split("+").map((entry) => entry.trim()) ?? [];
   const rawKey = segments.pop();
   if (!rawKey) {
     throw unsupportedKey("key chord is empty");
   }
-  const modifiers = segments.map((entry) => {
-    const normalized = MODIFIER_ALIASES.get(entry.toLowerCase());
-    if (!normalized) {
-      throw unsupportedKey(`unknown modifier ${JSON.stringify(entry)}`);
-    }
-    return normalized;
-  });
-  return { key: normalizeKey(rawKey), modifiers };
+  const modifiers = normalizeModifierList(segments, platform);
+  return { key: normalizeKey(rawKey, platform), modifiers };
 }
 
 export function scalePoint(

--- a/extensions/cua-computer/src/commands.modifiers.test.ts
+++ b/extensions/cua-computer/src/commands.modifiers.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import { driver, execution } from "./commands.test-helpers.js";
+import {
+  CUA_DRIVER_CONTRACT_FIXTURES,
+  cuaToolResult,
+} from "./cua-driver-contract.test-fixtures.js";
+
+const platforms = [
+  { platform: "darwin", command: "cmd" },
+  { platform: "linux", command: "meta" },
+  { platform: "win32", command: "meta" },
+] as const;
+
+function windowDriver() {
+  const native = driver();
+  native.callTool.mockImplementation(async (name) => {
+    if (name === "list_windows") {
+      return cuaToolResult(CUA_DRIVER_CONTRACT_FIXTURES.listWindows);
+    }
+    if (name === "get_window_state") {
+      return cuaToolResult(CUA_DRIVER_CONTRACT_FIXTURES.windowState, { image: true });
+    }
+    return cuaToolResult({});
+  });
+  return native;
+}
+
+async function observeWindow(computer: Awaited<ReturnType<typeof execution>>) {
+  const listed = JSON.parse(await computer.act('{"action":"list_windows"}')) as {
+    details: { windows: Array<{ windowRef: string }> };
+  };
+  const windowRef = listed.details.windows[0]!.windowRef;
+  const observed = JSON.parse(
+    await computer.act(JSON.stringify({ action: "get_window_state", windowRef })),
+  ) as { observation: { observationId: string } };
+  return { windowRef, observationId: observed.observation.observationId };
+}
+
+describe("cua-computer platform modifiers", () => {
+  it.each(
+    platforms.flatMap(({ platform, command }) =>
+      (["desktop", "window"] as const).flatMap((scope) => [
+        {
+          platform,
+          scope,
+          keys: "Command+Shift+Left",
+          expected: { key: "left", modifiers: [command, "shift"] },
+        },
+        { platform, scope, keys: "Cmd", expected: { key: command, modifiers: [] } },
+        { platform, scope, keys: "Ctrl+Return", expected: { key: "enter", modifiers: ["ctrl"] } },
+      ]),
+    ),
+  )("preserves $keys on $platform $scope input", async ({ platform, scope, keys, expected }) => {
+    const native = windowDriver();
+    const computer = await execution(native.session, platform);
+    try {
+      const target = scope === "window" ? await observeWindow(computer) : {};
+      await computer.act(JSON.stringify({ action: "key", keys, ...target }));
+
+      if (scope === "desktop") {
+        expect(native.pressKey).toHaveBeenCalledExactlyOnceWith(expected, undefined);
+      } else {
+        expect(native.callTool).toHaveBeenLastCalledWith(
+          "press_key",
+          { pid: 4242, window_id: 99, ...expected },
+          undefined,
+        );
+        expect(native.pressKey).not.toHaveBeenCalled();
+      }
+    } finally {
+      await computer.close("completion");
+    }
+  });
+
+  it.each(
+    (["desktop", "window"] as const).flatMap((scope) =>
+      ["+a", "Hyper+a"].map((keys) => ({ scope, keys })),
+    ),
+  )("rejects malformed $keys on $scope input before dispatch", async ({ scope, keys }) => {
+    const native = windowDriver();
+    const computer = await execution(native.session, "darwin");
+    try {
+      const target = scope === "window" ? await observeWindow(computer) : {};
+      await expect(
+        computer.act(JSON.stringify({ action: "key", keys, ...target })),
+      ).rejects.toThrow("COMPUTER_UNSUPPORTED_KEY");
+      expect(native.pressKey).not.toHaveBeenCalled();
+      expect(native.callTool).toHaveBeenCalledTimes(scope === "window" ? 2 : 0);
+    } finally {
+      await computer.close("completion");
+    }
+  });
+
+  it.each(platforms)(
+    "preserves Command+Shift on $platform window click",
+    async ({ platform, command }) => {
+      const native = windowDriver();
+      const computer = await execution(native.session, platform);
+      try {
+        const target = await observeWindow(computer);
+        await computer.act(
+          JSON.stringify({
+            action: "left_click",
+            ...target,
+            x: 20,
+            y: 30,
+            modifiers: "Command+Shift",
+            deliveryMode: "foreground",
+          }),
+        );
+
+        expect(native.callTool).toHaveBeenLastCalledWith(
+          "click",
+          {
+            pid: 4242,
+            window_id: 99,
+            modifier: [command, "shift"],
+            delivery_mode: "foreground",
+            x: 20,
+            y: 30,
+            button: "left",
+            count: 1,
+          },
+          undefined,
+        );
+      } finally {
+        await computer.close("completion");
+      }
+    },
+  );
+
+  it.each(
+    platforms.flatMap(({ platform }) =>
+      [
+        { action: "left_click", scope: "desktop" },
+        { action: "scroll", scope: "desktop" },
+        { action: "scroll", scope: "window" },
+      ].map((input) => Object.assign({ platform }, input)),
+    ),
+  )(
+    "keeps modified $scope $action unavailable on $platform",
+    async ({ platform, action, scope }) => {
+      const native = windowDriver();
+      const computer = await execution(native.session, platform);
+      try {
+        const frame = JSON.parse(await computer.snapshot('{"format":"png","maxWidth":100}')) as {
+          displayFrameId: string;
+          width: number;
+        };
+        const target =
+          scope === "window"
+            ? await observeWindow(computer)
+            : { displayFrameId: frame.displayFrameId, refWidth: frame.width };
+        await expect(
+          computer.act(
+            JSON.stringify({
+              action,
+              ...target,
+              x: 20,
+              y: 30,
+              ...(action === "scroll" ? { scrollDirection: "down" } : {}),
+              modifiers: "cmd",
+            }),
+          ),
+        ).rejects.toThrow("COMPUTER_UNSUPPORTED_ACTION");
+        expect(native.click).not.toHaveBeenCalled();
+        expect(native.drag).not.toHaveBeenCalled();
+        expect(native.scroll).not.toHaveBeenCalled();
+        expect(native.callTool).toHaveBeenCalledTimes(scope === "window" ? 2 : 0);
+      } finally {
+        await computer.close("completion");
+      }
+    },
+  );
+
+  it("rejects unknown window click modifiers before dispatch", async () => {
+    const native = windowDriver();
+    const computer = await execution(native.session, "darwin");
+    try {
+      const target = await observeWindow(computer);
+      await expect(
+        computer.act(
+          JSON.stringify({
+            action: "left_click",
+            ...target,
+            x: 20,
+            y: 30,
+            modifiers: "Hyper",
+            deliveryMode: "foreground",
+          }),
+        ),
+      ).rejects.toThrow("COMPUTER_UNSUPPORTED_KEY");
+      expect(native.callTool).toHaveBeenCalledTimes(2);
+    } finally {
+      await computer.close("completion");
+    }
+  });
+
+  it("rejects unsupported drag modifiers at the public request boundary", async () => {
+    const native = windowDriver();
+    const computer = await execution(native.session, "darwin");
+    try {
+      const target = await observeWindow(computer);
+      await expect(
+        computer.act(
+          JSON.stringify({
+            action: "left_click_drag",
+            ...target,
+            fromX: 10,
+            fromY: 15,
+            x: 20,
+            y: 30,
+            modifiers: "cmd",
+          }),
+        ),
+      ).rejects.toThrow("COMPUTER_INVALID_REQUEST");
+      expect(native.callTool).toHaveBeenCalledTimes(2);
+      expect(native.drag).not.toHaveBeenCalled();
+    } finally {
+      await computer.close("completion");
+    }
+  });
+
+  it("preserves macOS background refusal for a modified click", async () => {
+    const native = windowDriver();
+    const computer = await execution(native.session, "darwin");
+    try {
+      const target = await observeWindow(computer);
+      native.callTool.mockResolvedValueOnce(
+        cuaToolResult(
+          { code: "background_unavailable" },
+          { isError: true, errorCode: "background_unavailable", text: "foreground required" },
+        ),
+      );
+      await expect(
+        computer.act(
+          JSON.stringify({
+            action: "left_click",
+            ...target,
+            x: 20,
+            y: 30,
+            modifiers: "cmd",
+            deliveryMode: "background",
+          }),
+        ),
+      ).rejects.toThrow("COMPUTER_REFUSED_background_unavailable");
+      expect(native.callTool).toHaveBeenCalledTimes(3);
+      expect(native.callTool.mock.lastCall?.[1]).toMatchObject({ delivery_mode: "background" });
+    } finally {
+      await computer.close("completion");
+    }
+  });
+});

--- a/extensions/cua-computer/src/commands.test-helpers.ts
+++ b/extensions/cua-computer/src/commands.test-helpers.ts
@@ -134,9 +134,10 @@ export function driver(
   };
 }
 
-export async function execution(session: CuaDriverSession) {
+export async function execution(session: CuaDriverSession, platform: NodeJS.Platform = "linux") {
   return await createCuaComputerProvider({
-    platform: "linux",
+    platform,
+    env: macOsEndpoint(),
     driver: session,
     imageProcessor: {
       encode: vi.fn(async () => ({ data: Buffer.from("jpeg"), width: 100, height: 50 })),

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -233,13 +233,14 @@ function createImageProcessor(env: NodeJS.ProcessEnv): ImageProcessor {
 }
 
 function clickArgs(
+  platform: NodeJS.Platform,
   frame: CuaLastFrame,
   params: CuaComputerActParams,
   button: ClickButton,
   count: 1 | 2 | 3,
 ) {
   const point = scalePoint(frame, params.x, params.y, params.action);
-  const modifiers = normalizeModifiers(params.modifiers);
+  const modifiers = normalizeModifiers(params.modifiers, platform);
   if (modifiers.length > 0) {
     throw new Error(
       "COMPUTER_UNSUPPORTED_ACTION: modifier-held desktop clicks are unsupported by cua-driver",
@@ -267,6 +268,7 @@ async function currentFrame(
 }
 
 async function handleDesktopAct(
+  platform: NodeJS.Platform,
   driver: CuaDriverSession,
   frameState: CuaFrameState,
   params: ComputerActParams,
@@ -305,24 +307,15 @@ async function handleDesktopAct(
       // press_key applies the modifier array on every backend: X11 via XTest,
       // and native Wayland by internally promoting a modifier chord to
       // hotkey_focused. No separate hotkey call is needed for chords.
-      const chord = parseKeyChord(desktopParams.keys);
-      assertToolSuccess(
-        await driver.pressKey(
-          {
-            key: chord.key,
-            modifiers: chord.modifiers,
-          },
-          signal,
-        ),
-        "press_key",
-      );
+      const chord = parseKeyChord(desktopParams.keys, platform);
+      assertToolSuccess(await driver.pressKey(chord, signal), "press_key");
       break;
     }
     case "scroll": {
       if (!desktopParams.scrollDirection) {
         throw new Error("COMPUTER_INVALID_REQUEST: scrollDirection is required for scroll");
       }
-      if (normalizeModifiers(desktopParams.modifiers).length > 0) {
+      if (normalizeModifiers(desktopParams.modifiers, platform).length > 0) {
         throw new Error(
           "COMPUTER_UNSUPPORTED_ACTION: modifier-held scroll is unsupported by cua-driver",
         );
@@ -358,31 +351,46 @@ async function handleDesktopAct(
       switch (desktopParams.action) {
         case "left_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, desktopParams, ClickButton.Left, 1), signal),
+            await driver.click(
+              clickArgs(platform, frame, desktopParams, ClickButton.Left, 1),
+              signal,
+            ),
             "click",
           );
           break;
         case "right_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, desktopParams, ClickButton.Right, 1), signal),
+            await driver.click(
+              clickArgs(platform, frame, desktopParams, ClickButton.Right, 1),
+              signal,
+            ),
             "click",
           );
           break;
         case "middle_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, desktopParams, ClickButton.Middle, 1), signal),
+            await driver.click(
+              clickArgs(platform, frame, desktopParams, ClickButton.Middle, 1),
+              signal,
+            ),
             "click",
           );
           break;
         case "double_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, desktopParams, ClickButton.Left, 2), signal),
+            await driver.click(
+              clickArgs(platform, frame, desktopParams, ClickButton.Left, 2),
+              signal,
+            ),
             "click",
           );
           break;
         case "triple_click":
           assertToolSuccess(
-            await driver.click(clickArgs(frame, desktopParams, ClickButton.Left, 3), signal),
+            await driver.click(
+              clickArgs(platform, frame, desktopParams, ClickButton.Left, 3),
+              signal,
+            ),
             "click",
           );
           break;
@@ -394,13 +402,6 @@ async function handleDesktopAct(
         case "left_click_drag": {
           const from = scalePoint(frame, desktopParams.fromX, desktopParams.fromY, "drag start");
           const to = scalePoint(frame, desktopParams.x, desktopParams.y, "drag end");
-          // The typed desktop drag API has no modifier field. Refuse instead of
-          // silently widening a model request into an unmodified drag.
-          if (normalizeModifiers(desktopParams.modifiers).length > 0) {
-            throw new Error(
-              "COMPUTER_UNSUPPORTED_ACTION: modifier-held drag is unsupported by cua-driver",
-            );
-          }
           assertToolSuccess(
             await driver.drag(
               {

--- a/extensions/cua-computer/src/window-actions.ts
+++ b/extensions/cua-computer/src/window-actions.ts
@@ -75,7 +75,7 @@ async function handleTargetedAct(
             ? "middle"
             : "left";
       const count = params.action === "double_click" ? 2 : params.action === "triple_click" ? 3 : 1;
-      const modifiers = normalizeModifiers(params.modifiers);
+      const modifiers = normalizeModifiers(params.modifiers, platform);
       args = {
         ...base,
         ...(element ?? windowPointArgs(state, params, windowRef, params, "click")),
@@ -99,7 +99,6 @@ async function handleTargetedAct(
         "drag start",
       );
       const to = windowPointArgs(state, params, windowRef, params, "drag end");
-      const modifiers = normalizeModifiers(params.modifiers);
       args = {
         ...base,
         from_x: from.x,
@@ -110,7 +109,6 @@ async function handleTargetedAct(
         ...(params.durationMs === undefined
           ? {}
           : { duration_ms: Math.min(10_000, params.durationMs) }),
-        ...(modifiers.length ? { modifier: modifiers } : {}),
         ...delivery,
       };
       break;
@@ -154,7 +152,7 @@ async function handleTargetedAct(
       if (!params.scrollDirection) {
         throw new Error("COMPUTER_INVALID_REQUEST: scrollDirection is required for scroll");
       }
-      if (normalizeModifiers(params.modifiers).length) {
+      if (normalizeModifiers(params.modifiers, platform).length) {
         throw new Error(
           "COMPUTER_UNSUPPORTED_ACTION: modifier-held scroll is unsupported by cua-driver",
         );
@@ -190,7 +188,7 @@ async function handleTargetedAct(
       break;
     }
     case "key": {
-      const chord = parseKeyChord(params.keys);
+      const chord = parseKeyChord(params.keys, platform);
       tool = "press_key";
       args = {
         ...base,
@@ -198,8 +196,7 @@ async function handleTargetedAct(
           (params.x !== undefined || params.y !== undefined
             ? windowPointArgs(state, params, windowRef, params, "key")
             : {})),
-        key: chord.key,
-        modifiers: chord.modifiers,
+        ...chord,
         ...delivery,
       };
       break;
@@ -224,6 +221,7 @@ export async function handleWindowAct(
   execution: CuaExecutionState,
   params: ComputerActParams,
   handleDesktop: (
+    platform: NodeJS.Platform,
     driver: CuaDriverSession,
     state: CuaFrameState,
     params: ComputerActParams,
@@ -239,7 +237,7 @@ export async function handleWindowAct(
     return await handleTargetedAct(platform, driver, state, input, signal);
   }
   if ((CUA_WIRE_ACTION_NAMES as readonly string[]).includes(input.action)) {
-    return await handleDesktop(driver, state, params, signal);
+    return await handleDesktop(platform, driver, state, params, signal);
   }
   const recordingResult = await handleRecordingAct(
     driver,

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -296,8 +296,9 @@ NODE
 node "$ROOT_DIR/scripts/prepare-apple-mermaid.mjs"
 
 # pnpm build owns the Control UI and content-checked build stamps as well.
-mkdir -p "$(dirname "$APP_DESTINATION")"
-APP_STAGE_DIR="$(mktemp -d "$ROOT_DIR/dist/.openclaw-package.XXXXXX")"
+# Private Swift and worker staging must stay outside the published dist tree.
+mkdir -p "$(dirname "$APP_DESTINATION")" "$ROOT_DIR/.artifacts"
+APP_STAGE_DIR="$(mktemp -d "$ROOT_DIR/.artifacts/.openclaw-package.XXXXXX")"
 APP_ROOT="$APP_STAGE_DIR/OpenClaw.app"
 
 echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [${BUILD_ARCHS[*]}]"

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -564,7 +564,7 @@ fi
 "$ROOT_DIR/scripts/codesign-mac-app.sh" "$APP_ROOT"
 codesign --verify --deep --strict "$APP_ROOT"
 for arch in "${BUILD_ARCHS[@]}"; do
-  env -i HOME="$APP_STAGE_DIR" PATH="/usr/bin:/bin:/usr/sbin:/sbin" TMPDIR="$APP_STAGE_DIR" \
+  env -i HOME="$APP_STAGE_DIR" PATH="/usr/bin:/bin:/usr/sbin:/sbin" TMPDIR="${TMPDIR:-/tmp}" \
     "$APP_ROOT/Contents/Resources/node-worker/$arch/bin/node" \
     "$ROOT_DIR/scripts/verify-mac-node-worker.mjs" \
     "$APP_ROOT/Contents/Resources/node-worker/$arch" "$ROOT_DIR/dist/build-info.json"

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -563,6 +563,30 @@ function isPackedAiRuntimeTarball(filename: string) {
   return /^openclaw-ai-[A-Za-z0-9._-]+\.tgz$/u.test(filename);
 }
 
+function runPackageTar(
+  flags: string[],
+  tarballPath: string,
+  directory: string,
+  args: string[] = [],
+  env?: NodeJS.ProcessEnv,
+) {
+  // Frozen-source harnesses use system tar without their own dependency install.
+  // Basenames avoid GNU tar's drive-as-host parsing; forward slashes prevent
+  // Windows directory separators from becoming -C backslash escapes.
+  return run(
+    "tar",
+    [...flags, path.basename(tarballPath), "-C", directory.replaceAll(path.sep, "/"), ...args],
+    path.dirname(tarballPath),
+    {
+      env,
+      timeoutMs: resolveTimeoutMs(
+        "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
+        DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
+      ),
+    },
+  );
+}
+
 export async function prepareBundledAiRuntimePackage(
   sourceDir: string,
   outputDir: string,
@@ -582,20 +606,7 @@ export async function prepareBundledAiRuntimePackage(
   const extractAiRuntime =
     packageOptions.extractAiRuntime ??
     ((tarballPath: string, destination: string) =>
-      // Source-ref validation runs this trusted harness outside the candidate's dependency tree.
-      // Keep extraction on the system tar contract so only the candidate checkout needs install.
-      // Use an archive basename so GNU tar cannot treat a Windows drive as a remote host.
-      run(
-        "tar",
-        ["-xzf", path.basename(tarballPath), "-C", destination, "--strip-components=1"],
-        path.dirname(tarballPath),
-        {
-          timeoutMs: resolveTimeoutMs(
-            "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
-            DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
-          ),
-        },
-      ));
+      runPackageTar(["-xzf"], tarballPath, destination, ["--strip-components=1"]));
   const prepareManifest = packageOptions.prepareManifest ?? (async () => false);
   const restoreManifest = packageOptions.restoreManifest ?? (async () => false);
   const originalPackageJson = await fs.readFile(packageJsonPath, "utf8");
@@ -774,18 +785,9 @@ async function normalizeOpenClawTarballModes(tarballPath: string) {
   // Rewrite every entry to 0644/0755 the way a umask-022 host would have
   // packed it, keeping executable bits. Stays on the system tar contract like
   // the bundled AI runtime extraction above.
-  const timeoutMs = resolveTimeoutMs(
-    "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",
-    DEFAULT_PACKAGE_PACK_TIMEOUT_MS,
-  );
   const stageDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-package-modes-"));
   try {
-    await run(
-      "tar",
-      ["-xzf", path.basename(tarballPath), "-C", stageDir],
-      path.dirname(tarballPath),
-      { timeoutMs },
-    );
+    await runPackageTar(["-xzf"], tarballPath, stageDir);
     let stagedFileCount = 0;
     const normalizeStagedModes = async (dir: string): Promise<void> => {
       for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
@@ -809,15 +811,13 @@ async function normalizeOpenClawTarballModes(tarballPath: string) {
     const stageRootEntries = await fs.readdir(stageDir);
     const normalizedPath = `${tarballPath}.modes-tmp`;
     await fs.rm(normalizedPath, { force: true });
-    await run(
-      "tar",
-      ["--no-xattrs", "-czf", path.basename(normalizedPath), "-C", stageDir, ...stageRootEntries],
-      path.dirname(normalizedPath),
-      {
-        // BSD tar has separate PAX xattr and AppleDouble (._*) metadata paths.
-        env: { ...process.env, COPYFILE_DISABLE: "1" },
-        timeoutMs,
-      },
+    await runPackageTar(
+      ["--no-xattrs", "-czf"],
+      normalizedPath,
+      stageDir,
+      stageRootEntries,
+      // BSD tar has separate PAX xattr and AppleDouble (._*) metadata paths.
+      { ...process.env, COPYFILE_DISABLE: "1" },
     );
     await fs.rename(normalizedPath, tarballPath);
   } finally {

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -977,17 +977,18 @@ export async function packOpenClawPackageForDocker(
           restoreManifest,
         },
       );
-      const packArgs =
-        packTool === "pnpm"
-          ? ["pack", "--silent", "--config.ignore-scripts=true", "--pack-destination", outputPath]
-          : [
-              "pack",
-              "--silent",
-              "--ignore-scripts",
-              "--pack-destination",
-              outputPath,
-              "--json=false",
-            ];
+      // AI staging materializes the bundled tree; pack must not inherit the
+      // source workspace's isolated linker setting for that prepared bundle.
+      const packArgs = [
+        "pack",
+        "--silent",
+        ...(packTool === "pnpm"
+          ? ["--config.ignore-scripts=true", "--config.node-linker=hoisted"]
+          : ["--ignore-scripts"]),
+        "--pack-destination",
+        outputPath,
+        ...(packTool === "npm" ? ["--json=false"] : []),
+      ];
       packOutput = await runCaptureImpl(packTool, packArgs, sourcePath, {
         timeoutMs: resolveTimeoutMs(
           "OPENCLAW_DOCKER_PACKAGE_PACK_TIMEOUT_MS",

--- a/scripts/stage-mac-node-worker.sh
+++ b/scripts/stage-mac-node-worker.sh
@@ -13,18 +13,21 @@ case "${OPENCLAW_MAC_SIGNING_VARIANT:-standard}" in
   elevation-host) runtime_name=elevation ;;
   *) echo "ERROR: Unknown Mac signing variant" >&2; exit 1 ;;
 esac
-# Keep provisioning and the completed runtime moves on the destination volume.
+# Scratch follows the caller's temp volume; only installed payloads need to
+# share the destination volume so publishing remains a rename, not a copy.
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-mac-worker.XXXXXX")"
+trap 'rm -rf "$SCRATCH"' EXIT
 mkdir -p "$(dirname "$DESTINATION")"
 STAGE="$(cd "$(dirname "$DESTINATION")" && mktemp -d "$PWD/.openclaw-mac-worker.XXXXXX")"
-trap 'rm -rf "$STAGE"' EXIT
-mkdir -p "$STAGE/home" "$STAGE/package"
+trap 'rm -rf "$STAGE" "$SCRATCH"' EXIT
+mkdir -p "$SCRATCH/home" "$SCRATCH/package"
 
 # Lifecycle hooks must never see operator config, credentials, or state;
 # installer main discovers launchd by UID even with a new HOME.
 # Use the build's pinned pnpm packer, not the host npm's expanding file globs.
-TARBALL="$(env -i HOME="$STAGE/home" PATH="$PATH" TMPDIR="$STAGE" \
+TARBALL="$(env -i HOME="$SCRATCH/home" PATH="$PATH" TMPDIR="$SCRATCH" \
   node "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" \
-  --skip-build --pnpm-pack --allow-unreleased-changelog --output-dir "$STAGE/package" \
+  --skip-build --pnpm-pack --allow-unreleased-changelog --output-dir "$SCRATCH/package" \
   --output-name openclaw.tgz)"
 [[ -f "$TARBALL" ]] || { echo "ERROR: Canonical worker package missing" >&2; exit 1; }
 
@@ -34,9 +37,9 @@ for arch in "$@"; do
     x86_64) node_arch=x64 ;;
     *) echo "ERROR: Unsupported Mac worker architecture: $arch" >&2; exit 1 ;;
   esac
-  mkdir -p "$STAGE/$arch/home" "$STAGE/$arch/tmp"
-  env -i HOME="$STAGE/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-    TMPDIR="$STAGE/$arch/tmp" OPENCLAW_INSTALL_CLI_SH_NO_RUN=1 \
+  mkdir -p "$SCRATCH/$arch/home" "$SCRATCH/$arch/tmp"
+  env -i HOME="$SCRATCH/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    TMPDIR="$SCRATCH/$arch/tmp" OPENCLAW_INSTALL_CLI_SH_NO_RUN=1 \
     bash -c '
       set -euo pipefail
       source "$1/scripts/install-cli.sh"
@@ -52,14 +55,14 @@ for arch in "$@"; do
       mv "$(node_dir)" "$2/runtime"
     ' bash "$ROOT_DIR" "$STAGE/$arch" "$TARBALL" "$node_arch"
   if [[ "$runtime_name" == elevation ]]; then
-    env -i HOME="$STAGE/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-      TMPDIR="$STAGE/$arch/tmp" /usr/bin/python3 -B "$ROOT_DIR/scripts/materialize-mac-node-worker.py" \
+    env -i HOME="$SCRATCH/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+      TMPDIR="$SCRATCH/$arch/tmp" /usr/bin/python3 -B "$ROOT_DIR/scripts/materialize-mac-node-worker.py" \
       "$STAGE/$arch/runtime" "$STAGE/$arch/elevation" "$STAGE/$arch" "$arch"
   fi
   # Validate after moving out of its install prefix: absolute wrappers/symlinks
   # cannot accidentally make a non-relocatable payload pass the proof.
-  env -i HOME="$STAGE/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-    TMPDIR="$STAGE/$arch/tmp" \
+  env -i HOME="$SCRATCH/$arch/home" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    TMPDIR="$SCRATCH/$arch/tmp" \
     "$STAGE/$arch/$runtime_name/bin/node" "$ROOT_DIR/scripts/verify-mac-node-worker.mjs" \
     "$STAGE/$arch/$runtime_name" "$ROOT_DIR/dist/build-info.json"
 done

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -1539,34 +1539,69 @@ describe("package-openclaw-for-docker", () => {
     }
   });
 
-  it("uses pnpm pack when requested", async () => {
-    const sourceDir = createPackageSourceFixture("openclaw-package-source-");
-    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pnpm-pack-"));
-    const calls: string[] = [];
-    const packedPath = path.join(outputDir, "openclaw-2026.5.28.tgz");
+  it("packs the bundled AI runtime with isolated workspace configuration", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-pnpm-bundled-source-");
+    const outputDir = tempDirs.make("openclaw-pnpm-bundled-output-");
+    const { packageManager, version } = JSON.parse(fs.readFileSync("package.json", "utf8")) as {
+      packageManager: string;
+      version: string;
+    };
+    const packageJson = JSON.stringify({
+      name: "openclaw",
+      version,
+      packageManager,
+      files: ["dist"],
+      dependencies: { "@openclaw/ai": "workspace:*" },
+      scripts: { prepack: 'node -e "process.exit(91)"' },
+    });
+    const workspace = "packages:\n  - packages/*\nnodeLinker: isolated\n";
+    const aiDir = path.join(sourceDir, "packages/ai");
+    const installedAi = path.join(sourceDir, "node_modules/@openclaw/ai");
+    fs.mkdirSync(path.join(sourceDir, "dist"));
+    fs.mkdirSync(path.join(aiDir, "dist"), { recursive: true });
+    fs.mkdirSync(path.dirname(installedAi), { recursive: true });
+    fs.writeFileSync(path.join(sourceDir, "package.json"), packageJson);
+    fs.writeFileSync(path.join(sourceDir, "pnpm-workspace.yaml"), workspace);
+    fs.writeFileSync(path.join(sourceDir, "dist/entry.js"), "export const worker = true;\n");
+    fs.writeFileSync(
+      path.join(aiDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/ai", version, files: ["dist"] }),
+    );
+    fs.writeFileSync(path.join(aiDir, "dist/index.js"), "export const runtime = true;\n");
+    fs.writeFileSync(path.join(aiDir, "source-only-marker"), "workspace source\n");
+    fs.symlinkSync(aiDir, installedAi, "junction");
 
-    try {
-      const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
-        ...skipDocsMapLifecycle,
-        ...skipTarballModeNormalization,
-        pnpmPack: true,
-        prepareBundledAiRuntime: skipBundledAiRuntime,
-        prepareChangelog: async () => {},
-        restoreChangelog: async () => {},
-        runCaptureImpl: async (command: string, args: string[], cwd: string) => {
-          calls.push(`${command}:${args.join(" ")}:${cwd}`);
-          fs.writeFileSync(packedPath, "package");
-          return `${packedPath}\n`;
-        },
-      });
-
-      expect(tarball).toBe(packedPath);
-      expect(calls).toEqual([
-        `pnpm:pack --silent --config.ignore-scripts=true --pack-destination ${outputDir}:${sourceDir}`,
-      ]);
-    } finally {
-      fs.rmSync(outputDir, { force: true, recursive: true });
-    }
+    const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
+      ...skipDocsMapLifecycle,
+      pnpmPack: true,
+      prepareChangelog: async () => {},
+      restoreChangelog: async () => {},
+    });
+    const extracted = tempDirs.make("openclaw-pnpm-bundled-extracted-");
+    await tar.x({ file: tarball, cwd: extracted });
+    const packedRoot = path.join(extracted, "package");
+    expect(fs.readFileSync(path.join(packedRoot, "dist/entry.js"), "utf8")).toBe(
+      "export const worker = true;\n",
+    );
+    expect(
+      fs.readFileSync(path.join(packedRoot, "node_modules/@openclaw/ai/dist/index.js"), "utf8"),
+    ).toBe("export const runtime = true;\n");
+    expect(
+      JSON.parse(fs.readFileSync(path.join(packedRoot, "package.json"), "utf8")),
+    ).toMatchObject({
+      dependencies: { "@openclaw/ai": version },
+      bundleDependencies: ["@openclaw/ai"],
+    });
+    expect(
+      fs.existsSync(path.join(packedRoot, "node_modules/@openclaw/ai/source-only-marker")),
+    ).toBe(false);
+    expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(packageJson);
+    expect(fs.readFileSync(path.join(sourceDir, "pnpm-workspace.yaml"), "utf8")).toBe(workspace);
+    expect(fs.lstatSync(installedAi).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(path.join(installedAi, "source-only-marker"), "utf8")).toBe(
+      "workspace source\n",
+    );
+    expect(fs.readdirSync(outputDir)).toEqual([path.basename(tarball)]);
   });
 
   it("normalizes npm 12 pack metadata for renamed package artifacts", async () => {

--- a/test/scripts/mac-node-worker-materialization.test-support.ts
+++ b/test/scripts/mac-node-worker-materialization.test-support.ts
@@ -24,6 +24,18 @@ const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
 const materializer = "scripts/materialize-mac-node-worker.py";
 const inventory = "scripts/lib/mac-native-inventory.py";
 
+type WorkerScratchObservation = {
+  phase: "pack" | "install" | "verify";
+  home: string;
+  temporary: string;
+  createdDirectory: string;
+  privateRoot: string | null;
+  privateRootMode: number | null;
+  product: string;
+  productDevice: string;
+  productInode: string;
+};
+
 function snapshot(root: string) {
   const records: { path: string; mode: number; kind: string; content?: string }[] = [];
   function visit(file: string) {
@@ -129,25 +141,69 @@ async function stagingFixture(mac: MacScriptFixture) {
   const scripts = path.join(root, "scripts");
   const destination = path.join(root, "published");
   const calls = path.join(root, "verification-calls");
+  const scratchLog = path.join(root, "scratch-observations");
   const tmp = path.join(root, "tmp");
   await mkdir(scripts);
   await mkdir(tmp);
+  await write(path.join(root, "operator-sentinel"), "ambient home must remain untouched");
+  await write(path.join(tmp, "other-task/sentinel"), "unrelated scratch must survive");
   await cp("scripts/stage-mac-node-worker.sh", path.join(scripts, "stage-mac-node-worker.sh"));
   await cp(materializer, path.join(scripts, path.basename(materializer)));
   await write(path.join(scripts, "lib/mac-native-inventory.py"), readFileSync(inventory));
-  await write(path.join(root, "canonical.tgz"), "inert package mock");
   await write(path.join(root, "dist/build-info.json"), '{"buildId":"unchanged-build"}');
   await write(
+    path.join(scripts, "record-scratch.cjs"),
+    `
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+module.exports = (phase, product) => {
+  const home = fs.realpathSync(process.env.HOME);
+  assert(fs.statSync(home).isDirectory(), 'child HOME must already exist');
+  assert(!fs.existsSync(path.join(home, 'operator-sentinel')), 'ambient HOME leaked');
+  assert.equal(process.env.OPENCLAW_STATE_DIR, undefined, 'ambient state leaked');
+  const temporary = fs.realpathSync(os.tmpdir());
+  const component = path.relative(${JSON.stringify(tmp)}, temporary).split(path.sep)[0];
+  const privateRoot = component && component !== '..' ? path.join(${JSON.stringify(tmp)}, component) : null;
+  const createdDirectory = fs.mkdtempSync(path.join(temporary, 'fixture-scratch-'));
+  fs.writeFileSync(path.join(createdDirectory, 'sentinel'), phase);
+  fs.mkdirSync(path.join(home, '.npm'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.npm/cache'), phase);
+  const info = fs.statSync(product, { bigint: true });
+  fs.appendFileSync(${JSON.stringify(scratchLog)}, JSON.stringify({
+    phase, home, temporary, createdDirectory, privateRoot,
+    privateRootMode: privateRoot === null ? null : fs.statSync(privateRoot).mode & 0o777,
+    product, productDevice: info.dev.toString(), productInode: info.ino.toString(),
+  }) + '\\n');
+};
+if (require.main === module) module.exports(process.argv[2], process.argv[3]);
+`,
+  );
+  await write(
     path.join(scripts, "package-openclaw-for-docker.mjs"),
-    `import assert from 'node:assert/strict';\nassert(process.argv.includes('--pnpm-pack'), 'worker package must use the repository-pinned packer');\nconsole.log(${JSON.stringify(path.join(root, "canonical.tgz"))});\n`,
+    `
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import recordScratch from './record-scratch.cjs';
+assert(process.argv.includes('--pnpm-pack'), 'worker package must use the repository-pinned packer');
+const target = path.join(process.argv[process.argv.indexOf('--output-dir') + 1], process.argv[process.argv.indexOf('--output-name') + 1]);
+fs.writeFileSync(target, 'inert package mock');
+recordScratch('pack', target);
+if (fs.existsSync(${JSON.stringify(path.join(root, "reject-pack"))})) process.exit(41);
+console.log(target);
+`,
   );
   await write(
     path.join(scripts, "verify-mac-node-worker.mjs"),
     `
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import recordScratch from './record-scratch.cjs';
 assert.equal(process.argv[3], ${JSON.stringify(path.join(root, "dist/build-info.json"))});
 assert.equal(fs.readFileSync(process.argv[2]+'/build-info.json', 'utf8'), fs.readFileSync(process.argv[3], 'utf8'));
+recordScratch('verify', process.argv[2]);
 if (process.argv[2].includes('/x86_64/') && fs.existsSync(${JSON.stringify(path.join(root, "reject-verification"))})) process.exit(42);
 `,
   );
@@ -177,6 +233,7 @@ exec ${quote(process.execPath)} "$@"
   await write(
     path.join(scripts, "install-cli.sh"),
     `
+[[ -d "$HOME" ]] || { echo "fixture installer HOME must exist before source" >&2; exit 96; }
 node_dir() { printf '%s' "$PREFIX/node"; }
 node_bin() { printf '%s/bin/node' "$(node_dir)"; }
 install_node() {
@@ -184,15 +241,26 @@ install_node() {
   [[ "$selected" != x64 ]] || selected=x86_64
   mkdir -p "$PREFIX"
   cp -R ${quote(path.join(root, "canonical"))}/"$selected" "$(node_dir)"
+  ${quote(process.execPath)} ${quote(path.join(scripts, "record-scratch.cjs"))} install "$PREFIX"
 }
-install_openclaw() { :; }
+install_openclaw() { [[ "$(cat "$OPENCLAW_VERSION")" == "inert package mock" ]]; }
 `,
   );
   return {
     root,
     destination,
     calls,
+    scratchLog,
     tmp,
+    temporaryBefore: snapshot(tmp),
+    readScratchObservations(): WorkerScratchObservation[] {
+      return existsSync(scratchLog)
+        ? readFileSync(scratchLog, "utf8")
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line) as WorkerScratchObservation)
+        : [];
+    },
     async run(variant: string, tempRoot = tmp) {
       return await mac.run(
         "/bin/bash",
@@ -202,6 +270,7 @@ install_openclaw() { :; }
           env: {
             HOME: root,
             TMPDIR: tempRoot,
+            OPENCLAW_STATE_DIR: path.join(root, "operator-state"),
             PATH: `${path.dirname(process.execPath)}:${systemPath}`,
             OPENCLAW_MAC_SIGNING_VARIANT: variant,
           },
@@ -211,17 +280,54 @@ install_openclaw() { :; }
   };
 }
 
+function expectWorkerScratchCleaned(fixture: Awaited<ReturnType<typeof stagingFixture>>) {
+  for (const observation of fixture.readScratchObservations()) {
+    expect(existsSync(observation.home)).toBe(false);
+    expect(existsSync(observation.createdDirectory)).toBe(false);
+  }
+  expect(snapshot(fixture.tmp)).toEqual(fixture.temporaryBefore);
+}
+
 export function registerMacWorkerMaterializationTests() {
   describe.skipIf(process.platform !== "darwin")("elevation worker materialization", () => {
     const it = createMacScriptTest();
-    it("provisions beside the destination when system temp is unavailable", ({ mac }) =>
-      mac.lifetime.run(async () => {
-        for (const variant of ["standard", "elevation-host"]) {
+    it.for(["standard", "elevation-host"])(
+      "keeps %s worker scratch in caller temp and publishes runtimes by same-volume moves",
+      (variant, { mac }) =>
+        mac.lifetime.run(async () => {
           const fixture = await stagingFixture(mac);
           const before = snapshot(path.join(fixture.root, "canonical"));
-          const result = await fixture.run(variant, path.join(fixture.tmp, "unavailable"));
+          const result = await fixture.run(variant);
           expect(result.status, result.stderr).toBe(0);
           expect(snapshot(path.join(fixture.root, "canonical"))).toEqual(before);
+          const observations = fixture.readScratchObservations();
+          expect(observations.map(({ phase }) => phase)).toEqual([
+            "pack",
+            "install",
+            "verify",
+            "install",
+            "verify",
+          ]);
+          expect(new Set(observations.map(({ privateRoot }) => privateRoot)).size).toBe(1);
+          for (const observation of observations) {
+            expect(observation.privateRoot).not.toBeNull();
+            expect(path.dirname(observation.privateRoot!)).toBe(fixture.tmp);
+            expect(observation.privateRootMode).toBe(0o700);
+            for (const file of [observation.home, observation.temporary]) {
+              expect(path.relative(observation.privateRoot!, file).split(path.sep)[0]).not.toBe(
+                "..",
+              );
+            }
+            expect(observation.createdDirectory.startsWith(`${observation.temporary}/`)).toBe(true);
+            if (observation.phase === "pack") {
+              expect(observation.product.startsWith(`${observation.privateRoot}/`)).toBe(true);
+            } else {
+              expect(observation.product.startsWith(`${fixture.tmp}/`)).toBe(false);
+              expect(observation.productDevice).toBe(
+                statSync(path.dirname(fixture.destination), { bigint: true }).dev.toString(),
+              );
+            }
+          }
           const calls = readFileSync(fixture.calls, "utf8").trim().split("\n");
           expect(calls).toHaveLength(2);
           for (const [index, call] of calls.entries()) {
@@ -235,15 +341,57 @@ export function registerMacWorkerMaterializationTests() {
             const scratch = path.resolve(runtime!, "../..");
             expect(path.dirname(scratch)).toBe(path.dirname(fixture.destination));
             expect(existsSync(scratch)).toBe(false);
+            const verified = observations.find(
+              ({ phase, product }) => phase === "verify" && product === runtime,
+            );
+            expect(verified).toBeDefined();
+            expect(
+              statSync(path.join(fixture.destination, arch), { bigint: true }).ino.toString(),
+            ).toBe(verified!.productInode);
             expect(snapshot(path.join(fixture.destination, arch))).toEqual(
               snapshot(path.join(fixture.root, "canonical", arch)).filter(
                 (entry) => variant === "standard" || entry.path !== "foreign.node",
               ),
             );
           }
-          expect(readdirSync(fixture.tmp)).toEqual([]);
-        }
-      }));
+          expectWorkerScratchCleaned(fixture);
+        }),
+    );
+
+    it.for(["standard", "elevation-host"])(
+      "rejects unavailable worker scratch before %s publication",
+      (variant, { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await stagingFixture(mac);
+          const before = snapshot(fixture.root);
+          const result = await fixture.run(variant, path.join(fixture.tmp, "unavailable"));
+          expect(result.status, result.stderr).not.toBe(0);
+          expect(fixture.readScratchObservations()).toEqual([]);
+          expect(existsSync(fixture.calls)).toBe(false);
+          expect(snapshot(fixture.root)).toEqual(before);
+        }),
+    );
+
+    it.for(["standard", "elevation-host"])(
+      "cleans worker scratch and product staging after %s pack failure",
+      (variant, { mac }) =>
+        mac.lifetime.run(async () => {
+          const fixture = await stagingFixture(mac);
+          await write(path.join(fixture.root, "reject-pack"), "");
+          const before = readdirSync(fixture.root).toSorted();
+          const result = await fixture.run(variant);
+          expect(result.status, result.stderr).toBe(41);
+          expect(fixture.readScratchObservations().map(({ phase }) => phase)).toEqual(["pack"]);
+          expect(existsSync(fixture.calls)).toBe(false);
+          expect(existsSync(fixture.destination)).toBe(false);
+          expectWorkerScratchCleaned(fixture);
+          expect(
+            readdirSync(fixture.root)
+              .filter((name) => name !== path.basename(fixture.scratchLog))
+              .toSorted(),
+          ).toEqual(before);
+        }),
+    );
 
     it.for(
       ["standard", "elevation-host"].flatMap((variant) =>
@@ -274,7 +422,8 @@ export function registerMacWorkerMaterializationTests() {
           expect(existsSync(fixture.destination) ? snapshot(fixture.destination) : []).toEqual(
             before,
           );
-          expect(readdirSync(fixture.tmp)).toEqual([]);
+          expect(fixture.readScratchObservations()).toHaveLength(5);
+          expectWorkerScratchCleaned(fixture);
         }),
     );
 

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1,6 +1,14 @@
 // Package Mac App tests cover package mac app script behavior.
 import { spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { availableParallelism } from "node:os";
 import path from "node:path";
 import { minimatch } from "minimatch";
@@ -1702,42 +1710,126 @@ describe("package-mac-app plist stamping", () => {
     );
   });
 
-  it("passes an explicit signing identity unchanged to the signer", () => {
-    const script = readFileSync(scriptPath, "utf8");
-    const start = script.indexOf('if [[ -n "${SIGN_IDENTITY:-}" ]]');
-    const signingBlock = script.slice(
-      start,
-      script.indexOf("codesign --verify --deep --strict", start),
-    );
-    const tempRoot = tempDirs.make("openclaw-package-signing-identity-");
-    const scriptsDir = path.join(tempRoot, "scripts");
-    const signerPath = path.join(scriptsDir, "codesign-mac-app.sh");
-    const identity = "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)";
-    mkdirSync(scriptsDir, { recursive: true });
-    writeFileSync(
-      signerPath,
-      '#!/usr/bin/env bash\nprintf "identity=%s\\n" "${SIGN_IDENTITY-<unset>}"\n',
-    );
-    chmodSync(signerPath, 0o755);
+  it.skipIf(process.platform === "win32").each(["configured", "unset"] as const)(
+    "passes an explicit signing identity and honors %s TMPDIR during worker verification",
+    (tempMode) => {
+      const script = readFileSync(scriptPath, "utf8");
+      const start = script.indexOf('if [[ -n "${SIGN_IDENTITY:-}" ]]');
+      expect(start).toBeGreaterThanOrEqual(0);
+      const signingBlock = script.slice(start);
+      const tempRoot = tempDirs.make("openclaw-package-signing-identity-");
+      const scriptsDir = path.join(tempRoot, "scripts");
+      const signerPath = path.join(scriptsDir, "codesign-mac-app.sh");
+      const appStage = path.join(tempRoot, "stage");
+      const appRoot = path.join(appStage, "OpenClaw.app");
+      const callerHome = path.join(tempRoot, "caller-home");
+      const callerTemp = path.join(tempRoot, "caller temp [*]");
+      const eventsPath = path.join(tempRoot, "events");
+      const observationsPath = path.join(tempRoot, "worker-scratch.jsonl");
+      const identity = "Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)";
+      for (const directory of [scriptsDir, appRoot, callerHome, callerTemp]) {
+        mkdirSync(directory, { recursive: true });
+      }
+      writeFileSync(path.join(appRoot, "candidate"), "verified replacement");
+      writeFileSync(
+        signerPath,
+        '#!/usr/bin/env bash\nset -euo pipefail\n[[ -d "$1" ]]\nprintf "identity=%s\\n" "${SIGN_IDENTITY-<unset>}"\nprintf "sign\\n" >> "${0%/*}/../events"\n',
+      );
+      chmodSync(signerPath, 0o755);
+      for (const arch of ["arm64", "x86_64"]) {
+        const node = path.join(appRoot, "Contents/Resources/node-worker", arch, "bin/node");
+        mkdirSync(path.dirname(node), { recursive: true });
+        writeFileSync(
+          node,
+          `#!/bin/bash\nexec '${process.execPath.replaceAll("'", "'\\''")}' "$@"\n`,
+        );
+        chmodSync(node, 0o755);
+      }
+      writeFileSync(
+        path.join(scriptsDir, "verify-mac-node-worker.mjs"),
+        `import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+const scratch = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'worker-proof-')));
+try {
+  fs.writeFileSync(path.join(scratch, 'created-by-worker'), 'scratch');
+  fs.appendFileSync(${JSON.stringify(observationsPath)}, JSON.stringify({ home: process.env.HOME, scratch, callerCanary: process.env.OPENCLAW_TEST_CALLER_CANARY ?? null }) + '\\n');
+  fs.appendFileSync(${JSON.stringify(eventsPath)}, 'worker:' + path.basename(process.argv[2]) + '\\n');
+} finally {
+  fs.rmSync(scratch, { recursive: true, force: true });
+}
+`,
+      );
 
-    const result = runHelper(`
+      const result = spawnSync(
+        "/bin/bash",
+        [
+          "-c",
+          `
       set -euo pipefail
-      ROOT_DIR=${JSON.stringify(tempRoot)}
-      APP_ROOT=${JSON.stringify(path.join(tempRoot, "OpenClaw.app"))}
-      APP_DESTINATION="$APP_ROOT"
-      stop_packaged_app_if_running() { :; }
-      replace_mac_app_bundle() { :; }
-      codesign() { :; }
-      SIGN_IDENTITY=${JSON.stringify(identity)}
+      ROOT_DIR="$1"
+      APP_STAGE_DIR="$ROOT_DIR/stage"
+      APP_ROOT="$APP_STAGE_DIR/OpenClaw.app"
+      APP_DESTINATION="$ROOT_DIR/OpenClaw.app"
+      BUILD_ARCHS=(arm64 x86_64)
+      source "$3"
+      stop_packaged_app_if_running() { printf 'stop\\n' >> "$ROOT_DIR/events"; }
+      codesign() {
+        [[ "$1" == --verify && "$2" == --deep && "$3" == --strict && -d "$4" ]]
+        printf 'verify\\n' >> "$ROOT_DIR/events"
+      }
+      SIGN_IDENTITY="$2"
       export SIGN_IDENTITY
       ${signingBlock}
-    `);
+      printf 'published\\n' >> "$ROOT_DIR/events"
+    `,
+          "package-signing",
+          tempRoot,
+          identity,
+          path.resolve("scripts/lib/mac-app-bundle.sh"),
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            HOME: callerHome,
+            PATH: "/usr/bin:/bin",
+            OPENCLAW_TEST_CALLER_CANARY: "must-not-reach-worker",
+            ...(tempMode === "configured" ? { TMPDIR: callerTemp } : {}),
+          },
+        },
+      );
 
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Signing bundle with explicit SIGN_IDENTITY");
-    expect(result.stdout).toContain(`identity=${identity}`);
-    expect(result.stderr).toBe("");
-  });
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("Signing bundle with explicit SIGN_IDENTITY");
+      expect(result.stdout).toContain(`identity=${identity}`);
+      expect(result.stderr).toBe("");
+      expect(readFileSync(eventsPath, "utf8").trim().split("\n")).toEqual([
+        "sign",
+        "verify",
+        "worker:arm64",
+        "worker:x86_64",
+        "verify",
+        "stop",
+        "published",
+      ]);
+      expect(readFileSync(path.join(tempRoot, "OpenClaw.app/candidate"), "utf8")).toBe(
+        "verified replacement",
+      );
+      const observations = readFileSync(observationsPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { home: string; scratch: string; callerCanary: null });
+      expect(observations).toHaveLength(2);
+      for (const observation of observations) {
+        expect(observation.home).toBe(appStage);
+        expect(observation.callerCanary).toBeNull();
+        expect(path.dirname(observation.scratch)).toBe(
+          realpathSync(tempMode === "configured" ? callerTemp : "/tmp"),
+        );
+        expect(existsSync(observation.scratch)).toBe(false);
+      }
+    },
+  );
 
   it("fails when the packaged app survives forced shutdown", () => {
     const result = runStopPackagedAppHarness(0);

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1,9 +1,10 @@
 // Package Mac App tests cover package mac app script behavior.
 import { spawn, spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { availableParallelism } from "node:os";
 import path from "node:path";
 import { minimatch } from "minimatch";
+import * as tar from "tar";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
@@ -130,6 +131,104 @@ touch "$ROOT_DIR/assembled"
 );
 
 describe("packaged worker freshness", () => {
+  it.skipIf(process.platform === "win32")(
+    "keeps private app staging out of package contents and removes it after use",
+    async () => {
+      const root = tempDirs.make("openclaw-package-stage-");
+      const dist = path.join(root, "dist");
+      const output = tempDirs.make("openclaw-package-stage-output-");
+      const previousApp = path.join(dist, "OpenClaw.app/Contents/MacOS/OpenClaw");
+      const { files, packageManager, version } = JSON.parse(
+        readFileSync("package.json", "utf8"),
+      ) as {
+        files: string[];
+        packageManager: string;
+        version: string;
+      };
+      mkdirSync(path.dirname(previousApp), { recursive: true });
+      writeFileSync(previousApp, "previous signed app\n");
+      writeFileSync(path.join(dist, "entry.js"), "export {};\n");
+      writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({ name: "openclaw", version, packageManager, files }),
+      );
+      const script = readFileSync(scriptPath, "utf8");
+      const allocationStart = script.indexOf("# pnpm build owns the Control UI");
+      const allocationEnd = script.indexOf('echo "🔨 Building $PRODUCT', allocationStart);
+      expect(allocationStart).toBeGreaterThanOrEqual(0);
+      expect(allocationEnd).toBeGreaterThan(allocationStart);
+      const allocated = spawnSync(
+        "/bin/bash",
+        [
+          "-c",
+          `set -euo pipefail
+ROOT_DIR="$1"
+APP_DESTINATION="$ROOT_DIR/dist/OpenClaw.app"
+${script.slice(allocationStart, allocationEnd)}
+printf '%s' "$APP_STAGE_DIR"
+`,
+          "package-stage",
+          root,
+        ],
+        {
+          encoding: "utf8",
+          env: { HOME: root, PATH: "/usr/bin:/bin", TMPDIR: path.join(root, "unavailable") },
+        },
+      );
+      expect(allocated.status, allocated.stderr).toBe(0);
+      const stage = allocated.stdout;
+      const swiftResults = path.join(stage, "swift-builds");
+      mkdirSync(path.join(swiftResults, "arm64"), { recursive: true });
+      writeFileSync(path.join(swiftResults, "arm64/peekaboo-commit"), "private stage canary\n");
+      writeFileSync(path.join(swiftResults, "cleanup-complete"), "verified\n");
+      mkdirSync(path.join(stage, "OpenClaw.app/Contents/MacOS"), { recursive: true });
+      writeFileSync(path.join(stage, "OpenClaw.app/Contents/MacOS/OpenClaw"), "candidate app\n");
+      try {
+        expect(statSync(stage).dev).toBe(statSync(dist).dev);
+        expect(statSync(stage).mode & 0o777).toBe(0o700);
+        const packed = spawnSync(
+          "npm",
+          ["pack", "--silent", "--ignore-scripts", "--offline", "--pack-destination", output],
+          { cwd: root, encoding: "utf8", env: { HOME: root, PATH: process.env.PATH } },
+        );
+        expect(packed.status, packed.stderr).toBe(0);
+        const entries: string[] = [];
+        await tar.t({
+          file: path.join(output, `openclaw-${version}.tgz`),
+          onentry: (entry) => {
+            if (entry.type !== "Directory") {
+              entries.push(entry.path);
+            }
+          },
+        });
+        expect(entries.toSorted()).toEqual(["package/dist/entry.js", "package/package.json"]);
+      } finally {
+        const cleanup = script.slice(
+          script.indexOf("cleanup_package_build() {"),
+          script.indexOf("PNPM_CMD=()"),
+        );
+        const cleaned = spawnSync(
+          "/bin/bash",
+          [
+            "-c",
+            `set -euo pipefail
+APP_STAGE_DIR="$1"
+SWIFT_BUILD_RESULTS="$APP_STAGE_DIR/swift-builds"
+SWIFT_BUILD_PID=""
+${cleanup}
+`,
+            "package-stage-cleanup",
+            stage,
+          ],
+          { encoding: "utf8", env: { HOME: root, PATH: "/usr/bin:/bin" } },
+        );
+        expect(cleaned.status, cleaned.stderr).toBe(0);
+        expect(existsSync(stage)).toBe(false);
+        expect(readFileSync(previousApp, "utf8")).toBe("previous signed app\n");
+      }
+    },
+  );
+
   it.each([
     "dist/OpenClaw.app",
     "dist/OpenClaw-proof.app",

--- a/test/scripts/vitest-worker-artifacts.test-support.ts
+++ b/test/scripts/vitest-worker-artifacts.test-support.ts
@@ -179,15 +179,16 @@ export function waitForFixtureFile(
       (expected === undefined || fs.readFileSync(filename, "utf8") === expected);
     const check = () => {
       if (matches()) {
-        fs.unwatchFile(filename, check);
+        clearInterval(poll);
         resolve();
       }
     };
-    // Readiness is the file state, including on hosts without native watch events.
-    fs.watchFile(filename, { interval: 50 }, check);
+    // watchFile can adopt a newly created receipt in its first stat without an event.
+    // Poll the persistent state itself so readiness never depends on that race.
+    const poll = setInterval(check, 50);
     void completion.then(
       () => {
-        fs.unwatchFile(filename, check);
+        clearInterval(poll);
         if (matches()) {
           resolve();
         } else {
@@ -195,7 +196,7 @@ export function waitForFixtureFile(
         }
       },
       (error: unknown) => {
-        fs.unwatchFile(filename, check);
+        clearInterval(poll);
         reject(new Error(`Child failed before writing ${filename}`, { cause: error }));
       },
     );
@@ -297,8 +298,8 @@ export function workerProbe(
           fs.appendFileSync(${JSON.stringify(path.join(directory, "generations.jsonl"))}, JSON.stringify(generation)+'\\n');
           const release = inject('releaseFile');
           if (release) await new Promise(resolve => {
-            const check = () => {if(fs.existsSync(release)){fs.unwatchFile(release,check);resolve();}};
-            fs.watchFile(release,{interval:50},check);
+            const check = () => {if(fs.existsSync(release)){clearInterval(poll);resolve();}};
+            const poll=setInterval(check,50);
             check();
           });
         } finally {prepared.cleanup();}

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -17,7 +17,7 @@ import { createVitestWorkerRun } from "../../scripts/lib/vitest-worker-run.mts";
 import { resolveVitestSpawnParams, spawnWatchedVitestProcess } from "../../scripts/run-vitest.mts";
 import { createVitestProcessCompletion } from "../../scripts/vitest-process-group.mts";
 import { resolveRuntimeWorkerArgv } from "../../src/infra/runtime-worker-url.js";
-import { createDeferred } from "../helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../helpers/promise.js";
 import { copyFsSafePackageFixture } from "./fs-safe-package.test-support.js";
 import {
   createWorkerArtifactTest,
@@ -474,22 +474,45 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       }),
   );
 
-  it("observes readiness when borrower completion wins the file-watch event", ({
-    workerArtifacts,
-  }) =>
-    workerArtifacts.fixtureLifetime.run(async () => {
-      const filename = path.join(workerArtifacts.fixtureDirectory(), "ready");
-      const { promise: completion, resolve: finish } = createDeferred();
-      let ready = false;
-      const waiting = waitForFixtureFile(filename, completion).then(() => {
-        ready = true;
-      });
-      fs.writeFileSync(filename, "ready");
-      finish();
-      await nextTurn();
-      expect(ready).toBe(true);
-      await waiting;
-    }));
+  it.for(["borrower completion", "persistent file"] as const)(
+    "observes readiness from %s without a file-watch event",
+    { concurrent: false },
+    (observation, { workerArtifacts }) =>
+      workerArtifacts.fixtureLifetime.run(async () => {
+        const filename = path.join(workerArtifacts.fixtureDirectory(), "ready");
+        const { promise: completion, resolve: finish } = createDeferred();
+        const watchFile = fs.watchFile;
+        // A successful initial stat establishes a baseline without notifying Node's
+        // watchFile listener. A receipt created during that stat must still be seen.
+        const watcher = vi
+          .spyOn(fs, "watchFile")
+          .mockImplementation((target, ...args) =>
+            target === filename
+              ? watchFile(filename, { interval: 50 }, () => {})
+              : watchFile(target, ...args),
+          );
+        let ready = false;
+        const waiting = waitForFixtureFile(filename, completion).then(() => {
+          ready = true;
+        });
+        try {
+          fs.writeFileSync(filename, "ready");
+          if (observation === "borrower completion") {
+            finish();
+            await nextTurn();
+            expect(ready).toBe(true);
+          }
+          await withTestTimeout(waiting, 10_000, "Persistent readiness was not observed");
+          expect(ready).toBe(true);
+        } finally {
+          finish();
+          await waiting.finally(() => {
+            fs.unwatchFile(filename);
+            watcher.mockRestore();
+          });
+        }
+      }),
+  );
 
   it("keeps standalone configured Vitest on source without a subprocess owner", ({
     workerArtifacts,

--- a/test/scripts/vitest-worker-shutdown.test.ts
+++ b/test/scripts/vitest-worker-shutdown.test.ts
@@ -96,8 +96,9 @@ import fs from 'node:fs';
 import {requestVitestWorkerArtifacts} from ${JSON.stringify(pathToFileURL(path.join(repoRoot, "scripts/lib/vitest-worker-artifacts.mts")).href)};
 const exitFile=${JSON.stringify(borrowerExit)};
 const exitCheck=()=>{if(fs.existsSync(exitFile)) process.exit(1);};
+let exitPoll;
 if(${JSON.stringify(phase)}==='admission') {
-  fs.watchFile(exitFile,{interval:50},exitCheck);
+  exitPoll=setInterval(exitCheck,50);
   exitCheck();
 }
 try {
@@ -105,7 +106,7 @@ try {
   console.log('fixture borrower completed');
 } catch(error) {
   console.error(error);process.exitCode=1;
-} finally {fs.unwatchFile(exitFile,exitCheck);process.disconnect();}
+} finally {clearInterval(exitPoll);process.disconnect();}
 `,
       );
       const preload = writeFixture(
@@ -151,18 +152,18 @@ cp.spawn=(bin,args,options)=>{
 // directly; adding a signal listener could rescue a broken wrapper instead.
 const waitForRelease=()=>new Promise(resolve=>{
   let idle=false, responsive=false;
-  const controls=${JSON.stringify([borrowerClosed, loopRequest, released])};
   const check=()=>{
     if(borrowerClosed && !idle) {idle=true;publish('owner-idle',{owner:process.pid});}
     if(!responsive && fs.existsSync(${JSON.stringify(loopRequest)})) {
       responsive=true;publish('loop-responsive',{owner:process.pid});
     }
     if(fs.existsSync(${JSON.stringify(released)})) {
-      for(const filename of controls) fs.unwatchFile(filename,check);
+      clearInterval(poll);
       resolve();
     }
   };
-  for(const filename of controls) fs.watchFile(filename,{interval:50},check);
+  // Poll state: watchFile's first successful stat can consume a control without notifying.
+  const poll=setInterval(check,50);
   check();
 });
 const readFile=fsp.readFile;


### PR DESCRIPTION
Related: [landed cloud CUA and WebVNC fixes in #135582](https://github.com/openclaw/openclaw/pull/135582).

## What Problem This Solves

Mac CUA shortcuts silently lost Command: `cmd+shift+left` selected one character instead of the line although the action reported success. Building and testing the replacement native app also exposed worker packaging failures: pnpm rejected a prepared bundle under the isolated linker default, temporary Swift files entered the published package, Mac verification ignored the chosen scratch volume, and Windows GNU tar decoded directory separators as escapes.

## Why This Change Was Made

The CUA plugin normalizes modifiers against the provider platform before native dispatch. macOS receives `cmd`; Linux and Windows retain `meta`. Desktop keys, window keys, standalone modifiers and supported window-click modifiers share this owner. Duplicate chord parsing and unreachable drag-modifier handling are removed; the public schema already rejects drag modifiers.

The packaging owner already materializes the private AI runtime as a real bundled directory. Its pnpm pack command now selects the matching hoisted mode without changing installation or workspace configuration. Shared pack arguments preserve the npm path. The Mac builder keeps private Swift staging outside published `dist`, and separates disposable package/cache/HOME/verification files from installed runtime staging. Scratch honors the caller's existing `TMPDIR`; installed payloads stay beside the destination so publication remains a same-volume move. Both private roots are cleaned, isolated homes exist before loading the installer, and the previous app remains untouched until verification succeeds.

One shared tar caller owns bundled-AI extraction and archive-mode normalization. It retains archive basenames and archive-parent working directories, and converts native directory separators to forward slashes before passing `-C`. This prevents GNU tar from interpreting Windows `\n`/`\a` path components as escape sequences. Flags, creation environment, package manager and all deadlines remain unchanged.

Combined production/tooling changes are net +2 lines; tests/support are net +657. The additional Mac allocation lifetime and cleanup are necessary to separate scratch placement from same-volume publication; the tar refactor itself is net zero. There are no OpenClaw configuration, dependency, wire-schema, protocol, store or migration changes. The automated persistence flag does not apply: modifier normalization changes ephemeral native arguments, not stored state.

## User Impact

Documented Command shortcuts reach the Mac with their intended modifier, including window-targeted input. Malformed-input rejection, unsupported actions and background-delivery refusals keep their existing behavior. Native packages include the private AI runtime without temporary Swift files, respect the builder's scratch location and support both Windows tar implementations tested below. No input fallback, permission escalation, larger timeout, skipped verification gate or package-manager substitution is introduced.

## Evidence

- Live Mac RED: screenshot → coordinate click → `cmd+shift+left` → screenshot selected one trailing character without changing the text. The [pinned CUA 0.22 native modifier parser](https://github.com/trycua/cua/blob/ac9b1643acb61e20d5af078215e7d1b8c414db89/libs/cua-driver/rust/crates/platform-macos/src/input/keyboard.rs#L296) accepts `cmd`/`command`; the relevant input modules are unchanged from 0.21. A fresh WebVNC baseline capture was saved and fully inspected before the new build.
- Five intended Darwin failures in the 37-case native-boundary suite became green. The last mechanical refresh passed 283 tests across 23 files: 166 CUA, 106 core computer-tool/result and 11 public-contract tests. Those runtime files are unchanged by the later packaging repairs.
- Both original packaging regressions independently failed before their repairs and passed with identical test bytes afterward. They execute real pack operations and inspect AI payload bytes, manifests, source restoration, temporary-file exclusion, same-volume staging, cleanup and preservation of the previous app. The old pnpm argument-only test was replaced. [pnpm 12.1 source inspection](https://github.com/pnpm/pnpm/blob/6d90c71efdffbc909b499490b64c66badc720327/pnpm/crates/pack/src/lib.rs#L573) and real dependency probes confirm the linker guard and prepared-directory contract.
- Mac scratch regression: six intended failures and eight passes on the prior production code became 14/14 passes with identical tests. Both complete owner test files passed 202/202, covering child-created scratch/cache files, precreated isolated HOME, directory identity across publication, both architectures and signing variants, failure cleanup, and configured/unset post-sign `TMPDIR`.
- Native Windows Node 24.20 reproduced both extraction failures with GNU tar 1.35 on existing backslash paths. Forward-slash paths passed extraction, repacking and independent byte checks with that same executable and with System32 bsdtar 3.8.4. Native paths also passed with bsdtar. The selected binary in the earlier failing CI log is unknown; the independent probe records both exact binaries and did not change PATH. The unchanged real pnpm regression and sibling package/runner tests passed 139 tests locally, with three existing Windows-only skips on macOS.
- The new complete candidate passed the managed Codex P0 review without findings, changed script static gates, root-test typechecking, targeted formatting/lint and shell syntax checks. Reviewed source hashes remained unchanged through normal commit hooks.
- Earlier candidate `1b43b57f` passed its full canonical JavaScript build and Intel Swift compilation, then failed the existing 300-second tar-check deadline after extraction consumed 242.573 seconds on forced destination-volume scratch. Its [CI run](https://github.com/openclaw/openclaw/actions/runs/33606840378) passed both macOS Swift jobs but failed the real Windows bundled-AI test. Both failures are preserved; neither is treated as successful artifact acceptance. The repaired candidate `71df626a` passed its complete canonical JavaScript build in 8m33.1s, including declarations, UI, import/export checks and startup metadata. Its canonical signed Intel app build completed in 20m40s, followed by independent strict verification of the frozen app, CUA 0.22, embedded Node, MLX and required resources. All four native worker startup checks passed before and after signing. The unchanged tar checker completed in 13 seconds, including 1.9 seconds of extraction. The transfer ZIP also passed complete content/mode/link round-trip and strict signature verification. The matching portable package passed canonical integrity, exact build/worker-byte checks, source restoration and native-app exclusion. Both artifacts are accepted. The strictly signed Mac app and the portable Windows package were subsequently installed and their actual source/build/native-driver identities verified; the Windows installation and doctor checks passed.
- Separate historical local diagnostic: the original Mac changed-check had three command timeouts and one cleanup failure in unchanged standalone elevation-artifact verification. The full original CI2 order/concurrency/assertions/deadlines passed those four cases but ended with 559 passes and a different cleanup failure; CI3 passed 355 tests. One retained-input diagnostic later passed unchanged and preserved the original fixture/ownership records. This remains an unresolved local harness diagnostic, not a green full-suite or claimed repair. Neither changed packaging owner is reachable from that standalone `verify` dispatch.
- CI follow-up consumes the existing three-file test repair from [#136036](https://github.com/openclaw/openclaw/pull/136036), commit `827791a4760`, unchanged. Node can adopt a control file during its initial asynchronous stat without delivering a watch notification. The new persistent-file regression failed against the old fixture at its original 10-second deadline, then passed with direct state polling at the unchanged 50 ms cadence. All 20 focused cases plus the real shared-generation release case passed, along with the selected changed checks and independent Codex review. The final head `16fb0f49` differs from the accepted `71df626a` native artifacts only in those three test/support files; all 36,577 other tracked inputs and accepted artifacts are unchanged. No new native-build identity is claimed.
- CI history is preserved: both Windows jobs and Mac release compilation passed on `71df626a`, while security-hook fetching failed before scanning and the receipt-race test failed. That run was superseded by the real test repair. [Exact-head CI for `16fb0f49`](https://github.com/openclaw/openclaw/actions/runs/33619918555) is now successful: both Mac jobs and both Windows jobs passed, followed by the required `openclaw/ci-gate` at 12:15 UTC on September 2. The original security job failed during PR-history fetching before scanning. After the run became terminal, one normal job retry passed history fetching, leaked-credential scanning, private-key detection and dependency auditing on the workflow's GitHub-hosted Ubuntu runner. This proves the retry path, not a repair of the original Blacksmith Git transport failure.
- Live Mac GREEN on the accepted `71df626a` artifact with CUA 0.22: the real placed worker reported `darwin/x64` and its assigned workspace, took a fresh screenshot, clicked using that frame, sent `cmd+shift+left`, and returned a fresh screenshot showing the complete second line selected. Independent WebVNC observation confirmed the selection; the first line was unchanged. A subsequent real typing turn preserved both baseline lines and visibly read back its exact marker. That typing probe did not satisfy its separate physical-line-ordinal expectation because a blank line remained; no newline repair is claimed. Both workers were reclaimed, their known temporary states were removed and workspace proof files reconciled.
- Live Windows CUA 0.22 now passes native screenshot, coordinate click, Ctrl+A, typing and independent WebVNC readback. This ran on accepted follow-up artifact `777b4089`; its CUA plugin and the three packaging owners are byte-identical to `16fb0f49`. The placed worker reported `win32/x64` and its assigned workspace. Native screenshots delivered 1024×768 JPEG images and fresh frame IDs; clicking Increment changed Count 0 to 1. The first model turn supplied an older marker to the type tool and falsely claimed the requested value in its final answer. That failed marker check is preserved: the actual typed text matched the tool argument. One explicitly corrective turn used a fresh screenshot, coordinate click, Ctrl+A and one type action; WebVNC independently confirmed the complete requested marker in both field and display while Count remained 1. Both actual worker processes and their reported temporary state directories were absent after normal reclaim, capacity returned to zero occupied slots, and the unique workspace JSON reconciled byte-for-byte against the actual write serialization. No shell GUI input, clipboard, accessibility write, fixture reset, or native VNC viewer was used.
- A fresh Mac read-only run on the same follow-up worker bundle passed screenshot, window discovery and window accessibility/screenshot observation against the retained accepted `71df626a` native app. Its actual worker and temporary state disappeared after normal reclaim while the native app/node stayed alive. The earlier Mac availability failure and two Windows provider failures remain preserved; this does not establish a network root cause. Shared launch-deadline, provider-error diagnostics and Desktop readiness repairs continue separately in [#136297](https://github.com/openclaw/openclaw/pull/136297).
- Latest review follow-through: personally inspected the pinned CUA 0.22 macOS keyboard and pointer parsers and the complete synthetic Mac/Windows WebVNC captures. Both native parsers accept `cmd`/`command`; their exact Git blobs match the inspected source. This completes the native-contract and visual-artifact Rank-up move. Accept the documented native compatibility evidence under the requested autonomous landing. A fresh independent Codex P0 review of the complete 15-file `16fb0f49` PR patch also passed without findings. The automated stored-data annotation is inapplicable: `actions.ts` normalizes transient native-input arguments and does not change serialization, persistent storage, schemas or migrations.

Named follow-up: **CUA held-pointer modifier contract**. Accepted held-button modifiers and movement semantics need separate ordered gesture/cleanup proof at the CUA boundary. This repair does not change that contract or emulate unsupported input.

## Mac Command proof through WebVNC

Both captures show the same synthetic document and accepted CUA 0.22 app. The first is the baseline immediately before the fresh command; the second shows the complete line selected by that command. No native VNC viewer was used.

Before the fresh Command action:

![Synthetic Mac desktop before the fresh Command action](https://github.com/user-attachments/assets/4a17052e-29c5-43d2-a34d-60fd5a506218)

After `cmd+shift+left`:

![Synthetic Mac desktop with the complete line selected](https://github.com/user-attachments/assets/6e9794c5-7b07-4c8f-8e12-077e106308e1)

## Windows CUA proof through WebVNC

The first capture is the clean synthetic baseline. The second follows the two explicitly described turns above, including the model's corrected marker selection. It is not presented as an uninterrupted first-attempt success.

![Synthetic Windows desktop before CUA input](https://github.com/user-attachments/assets/d6ed0db7-610f-41cc-a691-d90491165dfd)

![Synthetic Windows desktop after verified CUA selection and typing](https://github.com/user-attachments/assets/8bead884-e3d9-4739-84dd-1e955ac75969)
