### PR TITLE
feat(approvals): make Allow Always durable for MCP tools on OpenClaw-configured servers

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -20115,6 +20115,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
     public let scope: ApprovalScope?
     public let toolname: String?
     public let toolcallid: String?
+    public let mcptool: [String: AnyCodable]?
     public let alloweddecisions: [String]?
     public let agentid: String?
     public let sessionkey: String?
@@ -20135,6 +20136,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         scope: ApprovalScope? = nil,
         toolname: String? = nil,
         toolcallid: String? = nil,
+        mcptool: [String: AnyCodable]? = nil,
         alloweddecisions: [String]? = nil,
         agentid: String? = nil,
         sessionkey: String? = nil,
@@ -20154,6 +20156,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         self.scope = scope
         self.toolname = toolname
         self.toolcallid = toolcallid
+        self.mcptool = mcptool
         self.alloweddecisions = alloweddecisions
         self.agentid = agentid
         self.sessionkey = sessionkey
@@ -20175,6 +20178,7 @@ public struct PluginApprovalRequestParams: Codable, Sendable {
         case scope
         case toolname = "toolName"
         case toolcallid = "toolCallId"
+        case mcptool = "mcpTool"
         case alloweddecisions = "allowedDecisions"
         case agentid = "agentId"
         case sessionkey = "sessionKey"

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -421,13 +421,33 @@ warn when a server uses `auto` and none of its tools has safety annotations;
 that warning describes calls under prompting postures.
 
 When offered, **Allow Always** approves the tool, not just the current arguments.
-For servers configured through OpenClaw, the choice currently lasts for the
-current Codex session. Codex can persist it across sessions when the server is
-also saved in its native config. A request that permits only session persistence
-cannot grant a durable approval, and explicit `prompt` mode keeps asking.
+For Gateway-hosted Codex runs on servers configured in `mcp.servers`, OpenClaw
+saves a durable, per-agent server/tool grant in the host approvals document
+when durable persistence is offered and the approval matches one live Gateway-owned
+tool call unambiguously. Missing or ambiguous matches and requests
+that permit only session persistence retain Codex's native/session behavior.
+Codex apps, native plugin servers, and computer-use servers are excluded.
+
+Stored grants apply under `auto` or an unspecified server mode. Explicit
+`prompt` keeps asking, even with a grant; explicit `approve` already bypasses
+approval. A new grant is picked up at the next thread configuration and hook
+registration, such as a new session or restart. The current session continues
+on Codex's remembered decision.
+
+Use `openclaw approvals get --gateway` to inspect grants and
+`openclaw approvals set --gateway --file <file>` to revoke them by editing
+`agents.<agentId>.mcpTools`. Revocation also takes effect on the next
+preparation/registration. Codex can additionally persist its own approval
+when the server is saved in native config; revoke that separately if present.
+See [MCP tool grants](/tools/exec-approvals#mcp-tool-grants) for the document
+shape and export/edit workflow.
 
 For approval delivery through Slack buttons, see
 [Native approvals in Slack](/channels/slack#native-approvals-in-slack).
+
+When an operator denies an MCP tool approval, Codex reports only its generic
+"user rejected MCP tool call" to the model; the remedy is shown on the operator
+card, not to the model.
 
 The optional `codex` block is OpenClaw projection metadata for Codex app-server
 threads only; it does not change ACP sessions, generic Codex harness config, or

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -2,6 +2,7 @@
 summary: "Host exec approvals: policy knobs, allowlists, and the YOLO/strict workflow"
 read_when:
   - Configuring exec approvals or allowlists
+  - Inspecting or revoking durable MCP tool grants
   - Implementing exec approval UX in the macOS app
   - Reviewing sandbox-escape prompts and their implications
 title: "Exec approvals"
@@ -157,6 +158,14 @@ Example schema:
         },
         {
           "pattern": "~/Projects/**/bin/git"
+        }
+      ],
+      "mcpTools": [
+        {
+          "server": "project-docs",
+          "tool": "publish_page",
+          "source": "allow-always",
+          "addedAt": 1737150000000
         }
       ]
     }
@@ -444,6 +453,47 @@ Each allowlist entry supports:
 | `lastUsedAt`       | Last-used timestamp                                                      |
 | `lastUsedCommand`  | Last command that matched; omitted for generated hashed argv entries     |
 | `lastResolvedPath` | Last resolved binary path                                                |
+
+## MCP tool grants
+
+For Gateway-hosted Codex runs, **Allow Always** can save a durable grant for one
+MCP tool on a server configured in `mcp.servers`. The Gateway writes the grant
+to `agents.<agentId>.mcpTools` in this same approvals document. It covers the
+exact agent, configured server name, and tool name, **with any arguments**;
+it does not grant access to other agents, servers, or tools.
+
+Each entry has `server`, `tool`, `source: "allow-always"`, and `addedAt`
+(Unix milliseconds). `lastUsedAt` is optional. Codex apps, native plugin
+servers, and computer-use servers do not receive OpenClaw MCP tool grants.
+OpenClaw only mints when durable persistence is offered and it can unambiguously
+match the approval to a live Gateway-owned tool call. Missing or ambiguous
+correlation retains Codex's existing native/session behavior instead.
+
+Grants apply when the server's `codex.defaultToolsApprovalMode` is `auto` or
+unspecified. Explicit `prompt` wins over a stored grant and keeps asking;
+explicit `approve` already bypasses per-call approval. See
+[Codex tool approvals](/cli/mcp#codex-tool-approvals).
+
+The durable grant is read when OpenClaw next prepares the Codex thread
+configuration and hook registration, such as for a new session or after a
+restart. The current session continues using Codex's remembered decision;
+OpenClaw does not reload grants for every tool call.
+
+To inspect grants, run `openclaw approvals get --gateway`. To revoke one,
+export the document, remove its entry from `agents.<agentId>.mcpTools`, and
+replace the document with the existing `set` command:
+
+```bash
+openclaw approvals get --gateway --json | jq '.file' > approvals.json
+# Edit approvals.json, preserving other settings, allowlists, and grants.
+openclaw approvals set --gateway --file approvals.json
+```
+
+Omit `--gateway` from both commands to edit local approvals. Revocation takes
+effect at the next thread preparation/registration too; start a new session
+or restart to discard the active session's remembered approval. If Codex also
+persisted a separate approval in its native config, remove that native grant
+there as well.
 
 ## Standing grants for automations
 

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -95,7 +95,18 @@ An enabled server needs either a command (stdio) or a URL (SSE or Streamable HTT
 
 ## Approvals
 
-Codex MCP tool approvals follow the session permission posture: the default full-permission posture does not prompt, while stricter modes check tools without safety annotations (`workspace` can use automatic review; `guarded` and `read-only` can prompt the operator). When offered, **Allow Always** remembers the tool, even when its arguments change. For servers configured through OpenClaw, this lasts for the current Codex session; Codex can persist the choice across sessions when the server is also saved in its native config. Override a server with `openclaw mcp configure <server> --approval approve|prompt|auto`; an explicit mode takes precedence over the posture-derived default. See [Codex tool approvals](/cli/mcp#codex-tool-approvals) for details and [Native approvals in Slack](/channels/slack#native-approvals-in-slack) for Slack button delivery.
+Codex MCP tool approvals follow the session permission posture: the default full-permission posture does not prompt, while stricter modes check tools without safety annotations (`workspace` can use automatic review; `guarded` and `read-only` can prompt the operator).
+
+When durable persistence is offered, **Allow Always** saves a per-agent grant
+for the exact configured server and tool, even when its arguments change.
+This applies to Gateway-hosted Codex runs when OpenClaw can unambiguously match
+the approval to a live Gateway-owned tool call; missing or ambiguous matches retain
+Codex's native/session behavior. Codex apps, native plugin servers, and
+computer-use servers are excluded. Grants survive restarts and apply at the
+next thread configuration and hook registration, such as a new session or
+restart; the current session uses Codex's remembered decision.
+
+Override a server with `openclaw mcp configure <server> --approval approve|prompt|auto`; an explicit mode takes precedence over the posture-derived default. Stored grants apply only under `auto` or an unspecified server mode; explicit `prompt` keeps asking. Inspect or revoke grants through [MCP tool grants](/tools/exec-approvals#mcp-tool-grants). See [Codex tool approvals](/cli/mcp#codex-tool-approvals) for details and [Native approvals in Slack](/channels/slack#native-approvals-in-slack) for Slack button delivery.
 
 ## Troubleshooting
 

--- a/extensions/codex/src/app-server/canonical-fork-preparation.ts
+++ b/extensions/codex/src/app-server/canonical-fork-preparation.ts
@@ -131,6 +131,7 @@ export async function prepareCanonicalCodexFork(params: {
   });
   const bundleMcp = await loadCodexBundleMcpThreadConfig({
     workspaceDir,
+    agentId: created.agentId,
     cfg: config,
     toolOverrides,
     preparationOnly: true,

--- a/extensions/codex/src/app-server/canonical-fork.test-support.ts
+++ b/extensions/codex/src/app-server/canonical-fork.test-support.ts
@@ -224,6 +224,7 @@ export async function createCanonicalForkFixture(params: {
         const startupBinding = await bindingStore.read(session);
         const bundleMcpThreadConfig = await loadCodexBundleMcpThreadConfig({
           workspaceDir,
+          agentId: attempt.agentId,
           cfg: config,
           toolsEnabled: true,
         });

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -391,6 +391,94 @@ describe("Codex app-server elicitation bridge", () => {
     },
   );
 
+  it.each([
+    {
+      name: "raw tool identity",
+      display: [{ name: "repo", value: "openclaw/openclaw" }],
+      grant: true,
+    },
+    { name: "absent display metadata", display: undefined, grant: true },
+    { name: "numeric string form", display: [{ name: "limit", value: "3" }], grant: true },
+    {
+      name: "mismatched display value",
+      display: [{ name: "repo", value: "another/repo" }],
+      grant: false,
+    },
+    { name: "unknown display key", display: [{ name: "other", value: "x" }], grant: false },
+    { name: "malformed display metadata", display: "repo", grant: false },
+    {
+      name: "ambiguous or missing active item",
+      display: undefined,
+      missingItem: true,
+      grant: false,
+    },
+    { name: "unconfigured server", display: undefined, unconfigured: true, grant: false },
+    { name: "explicit prompt", display: undefined, prompt: true, grant: false },
+    { name: "session-only hint", display: undefined, sessionOnly: true, grant: false },
+    { name: "missing active turn", display: undefined, missingTurn: true, grant: false },
+    { name: "computer use", display: undefined, computerUse: true, grant: false },
+    { name: "Codex apps", display: undefined, apps: true, grant: false },
+  ])("binds durable MCP intent only for $name", async (testCase) => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:durable", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:durable", decision: "allow-always" });
+    const server = testCase.apps ? "codex_apps" : "raw-server";
+    const item = {
+      id: "raw-call",
+      server,
+      tool: "_create.issue-v2",
+      arguments: { repo: "openclaw/openclaw", limit: 3 },
+    };
+    let activeItem: typeof item | undefined = testCase.missingItem ? undefined : item;
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: {
+        ...buildCurrentCodexApprovalElicitation(),
+        serverName: server,
+        ...(testCase.missingTurn ? { turnId: null } : {}),
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          persist: testCase.sessionOnly ? "session" : ["session", "always"],
+          tool_title: "This is not the tool identity",
+          ...(testCase.display === undefined ? {} : { tool_params_display: testCase.display }),
+        },
+      },
+      paramsForRun: {
+        ...createParams(),
+        config: {
+          mcp: {
+            servers: testCase.unconfigured
+              ? {}
+              : {
+                  [server]: {
+                    url: "https://mcp.example.test",
+                    ...(testCase.prompt ? { codex: { defaultToolsApprovalMode: "prompt" } } : {}),
+                  },
+                },
+          },
+        },
+      },
+      getActiveMcpToolCall: () => activeItem,
+      ...(testCase.computerUse ? { computerUseMcpServerName: server } : {}),
+      ...codexTestTurnIds(),
+    });
+    const request = gatewayToolArg(0, 2) as {
+      mcpTool?: unknown;
+      toolCallId?: string;
+      isMcpToolApprovalActive?: () => boolean;
+    };
+    expect(request.mcpTool).toEqual(testCase.grant ? { server, tool: item.tool } : undefined);
+    if (testCase.grant) {
+      expect(request.toolCallId).toBe(item.id);
+      expect(request.isMcpToolApprovalActive?.()).toBe(true);
+      activeItem = undefined;
+      expect(request.isMcpToolApprovalActive?.()).toBe(false);
+    }
+    expect(result?.action).toBe("accept");
+    if (!testCase.prompt) {
+      expect(result?._meta).toEqual({ persist: testCase.sessionOnly ? "session" : "always" });
+    }
+  });
+
   it("does not trust request-time decisions for two-phase MCP approvals", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -15,6 +15,7 @@ import {
   createCodexElicitationResponse,
   type CodexElicitationResponse,
 } from "./elicitation-response.js";
+import type { CodexActiveMcpToolCall } from "./event-projector-native-tool-lifecycle.js";
 import {
   approvalRequestExplicitlyUnavailable,
   mapExecDecisionToOutcome,
@@ -94,6 +95,7 @@ export async function routeCodexAppServerElicitationRequest(params: {
   computerUseMcpServerName?: string;
   autoApproveMcpTools?: boolean;
   projectedMcpServers?: NonNullable<CodexBundleMcpThreadConfig["configPatch"]>["mcp_servers"];
+  getActiveMcpToolCall?: (serverName: string) => CodexActiveMcpToolCall | undefined;
   signal?: AbortSignal;
 }): Promise<CodexApprovalElicitationResult> {
   const requestParams = isJsonObject(params.requestParams) ? params.requestParams : undefined;
@@ -152,6 +154,12 @@ export async function routeCodexAppServerElicitationRequest(params: {
   if (!approvalPrompt) {
     return handled(createCodexElicitationResponse("decline"));
   }
+  let persistence:
+    | Pick<
+        Parameters<typeof requestPluginApproval>[0],
+        "mcpTool" | "toolCallId" | "isMcpToolApprovalActive"
+      >
+    | undefined;
   if (!computerUsePrompt) {
     // App elicitation delegation changes Codex's policy; custom MCP servers still
     // follow the original operator posture unless their server config overrides it.
@@ -168,6 +176,36 @@ export async function routeCodexAppServerElicitationRequest(params: {
       params.paramsForRun.hostCapabilities.assertActive();
       return handled(buildElicitationResponse(approvalPrompt, "approved-once"));
     }
+    // Explicit prompt is per-call consent, even if stale persistence hints arrive.
+    if (mode === "prompt") {
+      approvalPrompt.allowedDecisions = ["allow-once", "deny"];
+    } else if (
+      serverName &&
+      serverName !== CODEX_APPS_SERVER_NAME &&
+      Object.hasOwn(params.paramsForRun.config?.mcp?.servers ?? {}, serverName) &&
+      requestTurnId === params.turnId &&
+      readPersistHints(approvalPrompt.meta, "explicit").includes("always")
+    ) {
+      const resolveItem = () => {
+        const item = params.getActiveMcpToolCall?.(serverName);
+        return item?.server === serverName && matchesMcpApprovalDisplay(item, approvalPrompt.meta)
+          ? item
+          : undefined;
+      };
+      const item = resolveItem();
+      if (item) {
+        persistence = {
+          mcpTool: { server: serverName, tool: item.tool },
+          toolCallId: item.id,
+          // Recheck at the gateway's mint boundary: another call may start or
+          // this item may finish while the operator's approval card is pending.
+          isMcpToolApprovalActive: () => {
+            const current = resolveItem();
+            return current?.id === item.id && current.tool === item.tool;
+          },
+        };
+      }
+    }
   }
 
   const outcome = await requestPluginApprovalOutcome({
@@ -175,9 +213,34 @@ export async function routeCodexAppServerElicitationRequest(params: {
     title: approvalPrompt.title,
     description: approvalPrompt.description,
     allowedDecisions: approvalPrompt.allowedDecisions,
+    ...persistence,
     signal: params.signal,
   });
   return handled(buildElicitationResponse(approvalPrompt, outcome));
+}
+
+function matchesMcpApprovalDisplay(item: CodexActiveMcpToolCall, meta: JsonObject): boolean {
+  if (!Object.hasOwn(meta, MCP_TOOL_APPROVAL_TOOL_PARAMS_DISPLAY_KEY)) {
+    return true;
+  }
+  const display = meta[MCP_TOOL_APPROVAL_TOOL_PARAMS_DISPLAY_KEY];
+  if (!Array.isArray(display)) {
+    return false;
+  }
+  const args = item.arguments;
+  return display.every((param) => {
+    if (!isJsonObject(param) || typeof param.name !== "string" || !isJsonObject(args)) {
+      return false;
+    }
+    if (!Object.hasOwn(args, param.name)) {
+      return false;
+    }
+    const value = args[param.name];
+    return (
+      typeof param.value !== "string" ||
+      param.value === (typeof value === "string" ? value : JSON.stringify(value))
+    );
+  });
 }
 
 function handled(response: CodexElicitationResponse): CodexApprovalElicitationResult {
@@ -713,6 +776,9 @@ async function requestPluginApprovalOutcome(params: {
   title: string;
   description: string;
   allowedDecisions?: ExecApprovalDecision[];
+  mcpTool?: { server: string; tool: string };
+  toolCallId?: string;
+  isMcpToolApprovalActive?: () => boolean;
   signal?: AbortSignal;
 }): Promise<ElicitationApprovalOutcome> {
   try {
@@ -724,6 +790,9 @@ async function requestPluginApprovalOutcome(params: {
       severity: "warning",
       toolName: "codex_mcp_tool_approval",
       allowedDecisions: params.allowedDecisions,
+      mcpTool: params.mcpTool,
+      toolCallId: params.toolCallId,
+      isMcpToolApprovalActive: params.isMcpToolApprovalActive,
     });
 
     const approvalId = requestResult?.id;

--- a/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
+++ b/extensions/codex/src/app-server/event-projector-native-tool-lifecycle.ts
@@ -26,6 +26,7 @@ import {
   type CodexServerNotification,
   type CodexThreadItem,
   type JsonObject,
+  type JsonValue,
 } from "./protocol.js";
 
 type CodexNativeToolLifecycleContext = Pick<
@@ -42,12 +43,31 @@ type CodexNativePreToolUseFailureRecord = {
   terminalReason: CodexNativePreToolUseFailure["disposition"];
 };
 
-/** Projects metadata-only lifecycle diagnostics for native tool items. */
+export type CodexActiveMcpToolCall = {
+  id: string;
+  server: string;
+  tool: string;
+  arguments: JsonValue;
+};
+
+function isMcpToolCallItemNotification(method: string, params: JsonObject): boolean {
+  return (
+    (method === "item/started" || method === "item/completed") &&
+    isJsonObject(params.item) &&
+    params.item.type === "mcpToolCall"
+  );
+}
+
+/** Owns native item lifetimes for diagnostics and MCP approval correlation. */
 export class CodexNativeToolLifecycleProjector {
   private readonly startedAtByItem = new Map<string, number>();
   private readonly activeItems = new Map<
     string,
-    { toolName: string; unfinishedStatus: CodexNativeToolUnfinishedStatus }
+    {
+      toolName: string;
+      unfinishedStatus: CodexNativeToolUnfinishedStatus;
+      mcpToolCall?: CodexThreadItem;
+    }
   >();
   private readonly webSearchCompletionByItem = new Map<
     string,
@@ -60,6 +80,8 @@ export class CodexNativeToolLifecycleProjector {
   >();
   private readonly preToolUseFailureByItem = new Map<string, CodexNativePreToolUseFailureRecord>();
   private finalized = false;
+  private turnCompleted = false;
+  private pendingMcpNotifications = 0;
 
   constructor(
     private readonly context: CodexNativeToolLifecycleContext,
@@ -68,16 +90,82 @@ export class CodexNativeToolLifecycleProjector {
     private readonly options: CodexNativeToolLifecycleProjectorOptions = {},
   ) {}
 
+  getActiveMcpToolCall(serverName: string): CodexActiveMcpToolCall | undefined {
+    if (
+      this.finalized ||
+      this.turnCompleted ||
+      this.pendingMcpNotifications > 0 ||
+      this.options.runAbortSignal?.aborted
+    ) {
+      return undefined;
+    }
+    let candidate: CodexThreadItem | undefined;
+    for (const { mcpToolCall } of this.activeItems.values()) {
+      if (mcpToolCall?.server !== serverName) {
+        continue;
+      }
+      // Count before validating: excluding an app/plugin or malformed item first
+      // could falsely make another call on the same server look unambiguous.
+      if (candidate) {
+        return undefined;
+      }
+      candidate = mcpToolCall;
+    }
+    if (
+      !candidate ||
+      candidate.status !== "inProgress" ||
+      typeof candidate.server !== "string" ||
+      !candidate.server.trim() ||
+      typeof candidate.tool !== "string" ||
+      !candidate.tool.trim() ||
+      candidate.arguments === undefined ||
+      candidate.appContext != null ||
+      candidate.pluginId != null
+    ) {
+      return undefined;
+    }
+    return {
+      id: candidate.id,
+      server: candidate.server,
+      tool: candidate.tool,
+      arguments: candidate.arguments,
+    };
+  }
+
+  recordMcpToolCallReceipt(notification: CodexServerNotification): void {
+    const params = isJsonObject(notification.params) ? notification.params : undefined;
+    if (!params || !isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
+      return;
+    }
+    // The route's receipt hook precedes its FIFO projection queue. Refuse stale
+    // correlation while queued MCP events wait behind asynchronous presentation.
+    if (isMcpToolCallItemNotification(notification.method, params)) {
+      this.pendingMcpNotifications += 1;
+    } else if (
+      notification.method === "turn/completed" &&
+      readCodexTurn(params.turn)?.id === this.turnId
+    ) {
+      this.turnCompleted = true;
+    }
+  }
+
   handleNotification(notification: CodexServerNotification): void {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
     if (!params || !isCodexNotificationForTurn(params, this.threadId, this.turnId)) {
       return;
+    }
+    if (
+      this.pendingMcpNotifications > 0 &&
+      isMcpToolCallItemNotification(notification.method, params)
+    ) {
+      this.pendingMcpNotifications -= 1;
     }
     if (notification.method === "turn/completed") {
       const turn = readCodexTurn(params.turn);
       if (!turn || turn.id !== this.turnId) {
         return;
       }
+      this.turnCompleted = true;
       for (const item of turn.items ?? []) {
         this.recordSnapshotItem(item);
       }
@@ -111,7 +199,10 @@ export class CodexNativeToolLifecycleProjector {
     item: CodexThreadItem;
     sourceTimestampMs?: number;
   }): void {
-    const toolName = auditNativeToolName(params.item);
+    // Malformed MCP starts must still block ambiguous approval correlation.
+    const toolName =
+      auditNativeToolName(params.item) ??
+      (params.item.type === "mcpToolCall" ? params.item.type : undefined);
     if (!toolName || this.completedItemIds.has(params.item.id)) {
       return;
     }
@@ -121,6 +212,7 @@ export class CodexNativeToolLifecycleProjector {
         toolName,
         auditNativeToolUnfinishedStatus(params.item),
         params.sourceTimestampMs,
+        params.item.type === "mcpToolCall" ? params.item : undefined,
       );
       return;
     }
@@ -345,12 +437,13 @@ export class CodexNativeToolLifecycleProjector {
     toolName: string,
     unfinishedStatus: CodexNativeToolUnfinishedStatus,
     sourceTimestampMs?: number,
+    mcpToolCall?: CodexThreadItem,
   ): void {
     if (this.activeItems.has(toolCallId)) {
       return;
     }
     this.startedAtByItem.set(toolCallId, sourceTimestampMs ?? Date.now());
-    this.activeItems.set(toolCallId, { toolName, unfinishedStatus });
+    this.activeItems.set(toolCallId, { toolName, unfinishedStatus, mcpToolCall });
     emitTrustedDiagnosticEvent({
       type: "tool.execution.started",
       ...this.buildBase(toolCallId, toolName),

--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -23,6 +23,116 @@ import {
 registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector native tool finalization", () => {
+  const mcpItem = {
+    type: "mcpToolCall",
+    id: "mcp-grant-item",
+    server: "docs/raw-name",
+    tool: "lookup.raw",
+    arguments: { query: "exact argument", limit: 3 },
+    status: "inProgress",
+    appContext: null,
+    pluginId: null,
+    readOnlyHint: false,
+    result: null,
+    error: null,
+    durationMs: null,
+  };
+
+  it("correlates only a unique active MCP item using raw server and tool identities", async () => {
+    const projector = await createProjector();
+    expect(projector.getActiveMcpToolCall(mcpItem.server)).toBeUndefined();
+    await projector.handleNotification(forCurrentTurn("item/started", { item: mcpItem }));
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { ...mcpItem, id: "other-server-item", server: "other-server" },
+      }),
+    );
+    expect(projector.getActiveMcpToolCall(mcpItem.server)).toEqual({
+      id: mcpItem.id,
+      server: mcpItem.server,
+      tool: mcpItem.tool,
+      arguments: mcpItem.arguments,
+    });
+
+    const concurrentItem = { ...mcpItem, id: "concurrent-item", tool: "different.tool" };
+    await projector.handleNotification(forCurrentTurn("item/started", { item: concurrentItem }));
+    expect(projector.getActiveMcpToolCall(mcpItem.server)).toBeUndefined();
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", { item: { ...concurrentItem, status: "completed" } }),
+    );
+    expect(projector.getActiveMcpToolCall(mcpItem.server)?.id).toBe(mcpItem.id);
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", { item: { ...mcpItem, status: "completed" } }),
+    );
+    expect(projector.getActiveMcpToolCall(mcpItem.server)).toBeUndefined();
+  });
+
+  it.each([
+    { label: "another thread", params: { threadId: "other-thread" } },
+    { label: "another turn", params: { turnId: "other-turn" } },
+    { label: "completed status", item: { status: "completed" } },
+    { label: "missing raw arguments", item: { arguments: undefined } },
+    { label: "blank raw tool", item: { tool: " " } },
+    { label: "app context", item: { appContext: { resourceUri: "ui://app/view" } } },
+    { label: "plugin context", item: { pluginId: "external-plugin" } },
+  ])("does not correlate an MCP item from $label", async (testCase) => {
+    const projector = await createProjector();
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        ...("params" in testCase ? testCase.params : {}),
+        item: { ...mcpItem, ...("item" in testCase ? testCase.item : {}) },
+      }),
+    );
+    expect(projector.getActiveMcpToolCall(mcpItem.server)).toBeUndefined();
+  });
+
+  it.each([
+    { label: "plugin", item: { pluginId: "external-plugin" } },
+    { label: "app", item: { appContext: { resourceUri: "ui://app/view" } } },
+    { label: "missing tool", item: { tool: undefined } },
+  ])(
+    "counts a $label item before deciding whether same-server correlation is unique",
+    async ({ item }) => {
+      const projector = await createProjector();
+      await projector.handleNotification(forCurrentTurn("item/started", { item: mcpItem }));
+      await projector.handleNotification(
+        forCurrentTurn("item/started", {
+          item: { ...mcpItem, ...item, id: "other-item" },
+        }),
+      );
+      expect(projector.getActiveMcpToolCall(mcpItem.server)).toBeUndefined();
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: { ...mcpItem, ...item, id: "other-item", status: "completed" },
+        }),
+      );
+      expect(projector.getActiveMcpToolCall(mcpItem.server)?.id).toBe(mcpItem.id);
+    },
+  );
+
+  it.each(["closed", "finalized", "turn completed", "aborted", "timed out"])(
+    "does not correlate MCP items after the turn is %s",
+    async (ending) => {
+      const projector = await createProjector();
+      await projector.handleNotification(forCurrentTurn("item/started", { item: mcpItem }));
+      if (ending === "closed") {
+        await projector.closeProjection();
+      } else if (ending === "finalized") {
+        projector.buildResult(buildEmptyToolTelemetry());
+      } else if (ending === "turn completed") {
+        await projector.handleNotification(turnCompleted());
+      } else if (ending === "aborted") {
+        projector.markAborted();
+      } else {
+        projector.markTimedOut();
+      }
+      await projector.handleNotification(
+        forCurrentTurn("item/started", { item: { ...mcpItem, id: "late-item" } }),
+      );
+      expect(projector.getActiveMcpToolCall(mcpItem.server)).toBeUndefined();
+    },
+  );
+
   it("marks only explicitly completed native tool metadata with false", async () => {
     const projector = await createProjector();
     const command = {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -157,6 +157,19 @@ export class CodexAppServerEventProjector {
     return this.completedTurn?.status;
   }
 
+  getActiveMcpToolCall(serverName: string) {
+    if (this.projectionClosed || this.aborted) {
+      return undefined;
+    }
+    return this.nativeToolLifecycleProjector.getActiveMcpToolCall(serverName);
+  }
+
+  recordMcpToolCallReceipt(notification: CodexServerNotification): void {
+    if (!this.projectionClosed) {
+      this.nativeToolLifecycleProjector.recordMcpToolCallReceipt(notification);
+    }
+  }
+
   buildSteeringTranscriptPrefix(): AgentMessage[] {
     const snapshot = buildCodexSteeringMessagesSnapshot({
       runParams: this.params,
@@ -604,18 +617,13 @@ export class CodexAppServerEventProjector {
     const unsettledAsyncDeliveries = this.asyncDeliveryProjection.pending();
     // The final snapshot is authoritative when item notifications were omitted.
     // Only its last relevant tool may change the terminal presentation.
-    for (let index = turnItems.length - 1; index >= 0; index -= 1) {
-      const item = turnItems[index];
-      if (!item || !matchesCodexSnapshotTurn(item, this.turnId)) {
-        continue;
-      }
-      if (item?.type === "dynamicToolCall") {
-        break;
-      }
-      if (shouldClearTerminalPresentationForNativeItem(item)) {
-        this.clearTerminalPresentationForNativeItem(item);
-        break;
-      }
+    const lastToolItem = turnItems.findLast(
+      (item) =>
+        matchesCodexSnapshotTurn(item, this.turnId) &&
+        (item.type === "dynamicToolCall" || shouldClearTerminalPresentationForNativeItem(item)),
+    );
+    if (lastToolItem?.type !== "dynamicToolCall") {
+      this.clearTerminalPresentationForNativeItem(lastToolItem);
     }
     for (const item of turnItems) {
       if (!this.asyncDeliveryProjection.allows(item)) {

--- a/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
+++ b/extensions/codex/src/app-server/plugin-approval-roundtrip.ts
@@ -68,6 +68,8 @@ export async function requestPluginApproval(params: {
   toolName: string;
   toolCallId?: string;
   allowedDecisions?: ExecApprovalDecision[];
+  mcpTool?: { server: string; tool: string };
+  isMcpToolApprovalActive?: () => boolean;
 }): Promise<ApprovalRequestResult | undefined> {
   const timeoutMs = DEFAULT_CODEX_APPROVAL_TIMEOUT_MS;
   return params.hostCapabilities.requestApproval({
@@ -80,6 +82,9 @@ export async function requestPluginApproval(params: {
     severity: params.severity,
     toolName: params.toolName,
     toolCallId: params.toolCallId,
+    ...(params.mcpTool
+      ? { mcpTool: params.mcpTool, isMcpToolApprovalActive: params.isMcpToolApprovalActive }
+      : {}),
     timeoutMs,
     transportTimeoutMs: resolveCodexGatewayTimeoutWithGraceMs(timeoutMs),
     ...(params.allowedDecisions ? { allowedDecisions: params.allowedDecisions } : {}),

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -171,6 +171,7 @@ export function createCodexAttemptNotificationController(
     if (!projector || !turnId || state.projectionClosed) {
       return;
     }
+    projector.recordMcpToolCallReceipt(notification);
     if (isTerminalTurnNotificationForTurn(notification, turnId)) {
       state.terminalTurnNotificationQueued = true;
       steeringQueueRef.current?.sealAdmission();

--- a/extensions/codex/src/app-server/run-attempt-runtime.ts
+++ b/extensions/codex/src/app-server/run-attempt-runtime.ts
@@ -172,6 +172,7 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
   );
   const bundleMcpThreadConfig = await loadCodexBundleMcpThreadConfig({
     workspaceDir: effectiveWorkspace,
+    agentId: sessionAgentId,
     cfg: params.config,
     toolsEnabled: usesSupervisionConnection || supportsModelTools(params.model),
     disableTools: params.disableTools,

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -101,6 +101,7 @@ export function createCodexAttemptServerRequestController(
           turnId,
           autoApproveMcpTools: autoApprove,
           projectedMcpServers: runtime.bundleMcpThreadConfig.configPatch?.mcp_servers,
+          getActiveMcpToolCall: (serverName) => projector?.getActiveMcpToolCall(serverName),
           pluginAppPolicyContext: resourceState.thread.pluginAppPolicyContext,
           ...(computerUseConfig.enabled
             ? { computerUseMcpServerName: computerUseConfig.mcpServerName }

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -826,6 +826,7 @@ async function runSharedClientRestartTest(closeCount: number) {
   await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
   const requests: string[][] = [];
   const clients: Array<ReturnType<typeof createCodexLifecycleHarness>> = [];
+  const turnStarted = createDeferred<ReturnType<typeof createCodexLifecycleHarness>>();
   onTestFinished(async () => {
     await Promise.all(clients.map(({ client }) => client.closeAndWait()));
   });
@@ -840,6 +841,7 @@ async function runSharedClientRestartTest(closeCount: number) {
           return threadStartResult("thread-existing");
         }
         if (method === "turn/start") {
+          turnStarted.resolve(wire);
           return turnStartResult();
         }
         return {};
@@ -878,16 +880,18 @@ async function runSharedClientRestartTest(closeCount: number) {
       }),
   );
   const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
-  await Promise.race([
-    run,
-    vi.waitFor(() => expect(requests[closeCount]).toContain("turn/start"), fastWait),
+  const readyClient = await Promise.race([
+    turnStarted.promise,
+    run.then(() => {
+      throw new Error("Codex startup retry ended before turn/start");
+    }),
   ]);
-  clients[closeCount]!.notify({
+  readyClient.notify({
     method: "turn/completed",
     params: { threadId: "thread-existing", turn: { id: "turn-1", status: "completed" } },
   });
   const result = await run;
-  return { result, requests, client: clients[closeCount]!.client };
+  return { result, requests, client: readyClient.client };
 }
 
 async function expectRetainedSuccessfulThread(client: CodexAppServerClient, threadId: string) {
@@ -5873,6 +5877,18 @@ describe("runCodexAppServerAttempt", () => {
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(createRunParams());
     await harness.waitForMethod("turn/start");
+    const mcpItem = {
+      type: "mcpToolCall",
+      id: "raw-item",
+      server: "raw-server",
+      tool: "_raw.tool",
+      arguments: { query: "exact" },
+      status: "inProgress",
+    };
+    await harness.notify({
+      method: "item/started",
+      params: { threadId: "thread-1", turnId: "turn-1", item: mcpItem },
+    });
 
     const params = {
       threadId: "thread-1",
@@ -5890,6 +5906,13 @@ describe("runCodexAppServerAttempt", () => {
       }),
     ).resolves.toEqual({ action: "accept", content: { name: "Ada" }, _meta: null });
     expect(approvalSpy).toHaveBeenCalledWith(expect.objectContaining({ requestParams: params }));
+    const getActiveMcpToolCall = approvalSpy.mock.calls[0]?.[0].getActiveMcpToolCall;
+    expect(getActiveMcpToolCall?.("raw-server")).toEqual({
+      id: mcpItem.id,
+      server: mcpItem.server,
+      tool: mcpItem.tool,
+      arguments: mcpItem.arguments,
+    });
     expect(ordinaryHandler).toHaveBeenCalledWith({ id: "ordinary-1", params });
     const approvalOrder = approvalSpy.mock.invocationCallOrder.at(0);
     const ordinaryOrder = ordinaryHandler.mock.invocationCallOrder.at(0);
@@ -5900,7 +5923,87 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+    expect(getActiveMcpToolCall?.("raw-server")).toBeUndefined();
   });
+  it.each(["competing item", "terminal turn"])(
+    "fences MCP persistence correlation when a %s receipt is behind a slow projection",
+    async (receipt) => {
+      const approvalSpy = vi
+        .spyOn(elicitationBridge, "routeCodexAppServerElicitationRequest")
+        .mockResolvedValue({
+          kind: "handled",
+          response: { action: "accept", content: {}, _meta: { persist: "always" } },
+        });
+      const projectionEntered = createDeferred<void>();
+      const projectionRelease = createDeferred<void>();
+      const params = createRunParams();
+      params.onAssistantMessageStart = async () => {
+        projectionEntered.resolve();
+        await projectionRelease.promise;
+      };
+      const harness = createStartedThreadHarness();
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      const item = {
+        type: "mcpToolCall",
+        id: "active-mcp",
+        server: "configured-server",
+        tool: "raw-tool",
+        arguments: {},
+        status: "inProgress",
+      };
+      await harness.notify({
+        method: "item/started",
+        params: { threadId: "thread-1", turnId: "turn-1", item },
+      });
+      await harness.handleServerRequest({
+        id: "pending-mcp-approval",
+        method: "mcpServer/elicitation/request",
+        params: { threadId: "thread-1", turnId: "turn-1", serverName: item.server },
+      });
+      const correlate = approvalSpy.mock.calls[0]?.[0].getActiveMcpToolCall;
+      expect(correlate?.(item.server)?.id).toBe(item.id);
+      const slowProjection = harness.notify({
+        method: "item/agentMessage/delta",
+        params: { threadId: "thread-1", turnId: "turn-1", itemId: "slow", delta: "Waiting" },
+      });
+      await projectionEntered.promise;
+      const queuedReceipt = harness.notify(
+        receipt === "terminal turn"
+          ? turnCompleted({ id: "turn-1", status: "completed" })
+          : {
+              method: "item/started",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                item: { ...item, id: "competing-mcp" },
+              },
+            },
+      );
+      try {
+        expect(correlate?.(item.server)).toBeUndefined();
+      } finally {
+        projectionRelease.resolve();
+        await Promise.all([slowProjection, queuedReceipt]);
+        if (receipt !== "terminal turn") {
+          try {
+            await harness.notify({
+              method: "item/completed",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                item: { ...item, id: "competing-mcp", status: "completed" },
+              },
+            });
+            expect(correlate?.(item.server)?.id).toBe(item.id);
+          } finally {
+            await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+          }
+        }
+        await run;
+      }
+    },
+  );
   it("routes Computer Use MCP elicitations through the native bridge", async () => {
     const bridgeSpy = vi
       .spyOn(elicitationBridge, "routeCodexAppServerElicitationRequest")

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -23,6 +23,7 @@ import {
   createFakeCodexAppServerClient,
 } from "./codex-app-server.test-fixtures.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
+import * as elicitationBridge from "./elicitation-bridge.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import {
   isJsonObject,
@@ -841,12 +842,26 @@ describe("runCodexAppServerSideQuestion", () => {
   );
 
   it("returns an explicit unsupported decline for ordinary MCP input", async () => {
+    const approvalSpy = vi.spyOn(elicitationBridge, "routeCodexAppServerElicitationRequest");
     const client = createFakeClient({ completeTurn: false });
     getSharedCodexAppServerClientMock.mockResolvedValue(client);
     const run = runCodexAppServerSideQuestion(sideParams());
     await vi.waitFor(() =>
       expect(client.request.mock.calls.map(([method]) => method)).toContain("turn/start"),
     );
+
+    const item = {
+      type: "mcpToolCall",
+      id: "side-mcp",
+      server: "configured-server",
+      tool: "raw-tool",
+      arguments: { query: "side query" },
+      status: "inProgress",
+    };
+    client.emit({
+      method: "item/started",
+      params: { threadId: "side-thread", turnId: "turn-1", item },
+    });
 
     await expect(
       handleClientRequestWhenReady(client, {
@@ -869,9 +884,20 @@ describe("runCodexAppServerSideQuestion", () => {
       },
     });
 
-    client.emit(agentDelta("side-thread", "turn-1", "Side answer."));
-    client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
-    await expect(run).resolves.toEqual({ text: "Side answer." });
+    const correlate = approvalSpy.mock.calls[0]?.[0].getActiveMcpToolCall;
+    try {
+      expect(correlate?.(item.server)).toEqual({
+        id: item.id,
+        server: item.server,
+        tool: item.tool,
+        arguments: item.arguments,
+      });
+    } finally {
+      client.emit(agentDelta("side-thread", "turn-1", "Side answer."));
+      client.emit(turnCompleted("side-thread", "turn-1", "Side answer."));
+      await expect(run).resolves.toEqual({ text: "Side answer." });
+    }
+    expect(correlate?.(item.server)).toBeUndefined();
   });
 
   it("routes a remote-exec side question through the injected sandbox environment", async () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -581,6 +581,8 @@ export async function runCodexAppServerSideQuestion(
             turnId,
             autoApproveMcpTools,
             projectedMcpServers,
+            getActiveMcpToolCall: (serverName) =>
+              nativeToolLifecycleProjector?.getActiveMcpToolCall(serverName),
             pluginAppPolicyContext: binding.pluginAppPolicyContext,
             signal: runAbortController.signal,
           });

--- a/packages/gateway-protocol/src/exec-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/exec-approvals-validators.test.ts
@@ -19,6 +19,9 @@ describe("exec approvals protocol validators", () => {
       version: 1 as const,
       agents: {
         main: {
+          mcpTools: [
+            { server: "project.docs", tool: "write_note", source: "allow-always", addedAt: 123 },
+          ],
           allowlist: [
             {
               id: "entry-1",

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -56,6 +56,17 @@ const ExecApprovalsDefaultsSchema = closedObject(ExecApprovalsPolicyFields);
 const ExecApprovalsAgentSchema = closedObject({
   ...ExecApprovalsPolicyFields,
   allowlist: Type.Optional(Type.Array(ExecApprovalsAllowlistEntrySchema)),
+  mcpTools: Type.Optional(
+    Type.Array(
+      closedObject({
+        server: Type.String({ minLength: 1, pattern: "\\S" }),
+        tool: Type.String({ minLength: 1, pattern: "\\S" }),
+        source: Type.Literal("allow-always"),
+        addedAt: Type.Number({ minimum: 0 }),
+        lastUsedAt: Type.Optional(Type.Number({ minimum: 0 })),
+      }),
+    ),
+  ),
 });
 
 /** Versioned exec approvals config file edited through gateway APIs. */

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -53,6 +53,12 @@ export const PluginApprovalRequestParamsSchema = closedObject({
   ),
   toolName: Type.Optional(nullableMetadata(Type.String())),
   toolCallId: Type.Optional(nullableMetadata(Type.String())),
+  mcpTool: Type.Optional(
+    closedObject({
+      server: Type.String({ minLength: 1, pattern: "\\S" }),
+      tool: Type.String({ minLength: 1, pattern: "\\S" }),
+    }),
+  ),
   allowedDecisions: Type.Optional(
     nullableMetadata(
       Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {

--- a/src/agents/cli-runner/bundle-mcp-codex.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.ts
@@ -4,6 +4,7 @@
 import { normalizeConfiguredMcpServers } from "../../config/mcp-config-normalize.js";
 import type { SessionToolOverrides } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadMcpToolGrants } from "../../infra/exec-approvals-mcp.js";
 import type { BundleMcpConfig, BundleMcpServerConfig } from "../../plugins/bundle-mcp.js";
 import { isValidAgentId, normalizeAgentId } from "../../routing/session-key.js";
 import { getOrCreateSessionMcpRuntime } from "../agent-bundle-mcp-manager-api.js";
@@ -168,6 +169,7 @@ export function buildCodexUserMcpServersThreadConfigPatch(
   if (entries.length === 0) {
     return undefined;
   }
+  const grants = options?.agentId ? loadMcpToolGrants(options.agentId) : [];
   // Collected as entries: a server literally named `__proto__` would hit the
   // prototype setter under plain assignment and vanish from the patch.
   const projected: [string, CodexThreadConfigObject][] = [];
@@ -177,6 +179,7 @@ export function buildCodexUserMcpServersThreadConfigPatch(
       normalizeCodexMcpServerConfig(
         name,
         applyCodexSessionMcpToolDenials(name, server, options?.toolOverrides),
+        grants,
       ) as CodexThreadConfigObject,
     ]);
   }
@@ -207,6 +210,7 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
   if (Object.keys(allowedServers).length === 0) {
     return undefined;
   }
+  const grants = options?.agentId ? loadMcpToolGrants(options.agentId) : [];
   const resolvedConfig = await resolveMcpBearerBundleConfig({
     config: { mcpServers: allowedServers },
     cfg,
@@ -221,6 +225,7 @@ export async function buildCodexUserMcpServersThreadConfigPatchForRuntime(
       normalizeCodexMcpServerConfig(
         name,
         applyCodexSessionMcpToolDenials(name, server, options?.toolOverrides),
+        grants,
       ) as CodexThreadConfigObject,
     ]),
   );

--- a/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
+++ b/src/agents/cli-runner/bundle-mcp-codex.user-config.test.ts
@@ -7,9 +7,14 @@ import {
 } from "./bundle-mcp-codex.js";
 
 const authMocks = vi.hoisted(() => ({
+  loadExecApprovalsReadOnly: vi.fn(),
   loadAuthProfileStoreForSecretsRuntime: vi.fn(),
   resolveApiKeyForProfile: vi.fn(),
   resolveMcpOAuthAccessToken: vi.fn(),
+}));
+
+vi.mock("../../infra/exec-approvals-store.js", () => ({
+  loadExecApprovalsReadOnly: authMocks.loadExecApprovalsReadOnly,
 }));
 
 vi.mock("../auth-profiles/store.js", () => ({
@@ -26,10 +31,69 @@ vi.mock("../mcp-oauth.js", () => ({
 
 describe("buildCodexUserMcpServersThreadConfigPatch", () => {
   beforeEach(() => {
+    authMocks.loadExecApprovalsReadOnly.mockReset().mockReturnValue({ version: 1, agents: {} });
     authMocks.loadAuthProfileStoreForSecretsRuntime.mockReset();
     authMocks.resolveApiKeyForProfile.mockReset();
     authMocks.resolveMcpOAuthAccessToken.mockReset();
   });
+
+  it.each(["configured", "runtime"])(
+    "projects exact-agent durable grants with server policy precedence in %s preparation",
+    async (preparation) => {
+      const grants = ["auto", "unspecified", "prompt", "approve", "missing"].map((server) => ({
+        server,
+        tool: "write.raw_tool",
+        source: "allow-always",
+        addedAt: 1,
+      }));
+      authMocks.loadExecApprovalsReadOnly.mockReturnValue({
+        version: 1,
+        agents: {
+          main: { mcpTools: grants },
+          other: { mcpTools: [{ ...grants[0], tool: "other_tool" }] },
+          "*": { mcpTools: [{ ...grants[0], tool: "wildcard_tool" }] },
+        },
+      });
+      const cfg = {
+        mcp: {
+          servers: {
+            auto: { command: "mcp", codex: { defaultToolsApprovalMode: "auto" } },
+            unspecified: { command: "mcp", toolFilter: { exclude: ["write.raw_tool"] } },
+            prompt: { command: "mcp", codex: { defaultToolsApprovalMode: "prompt" } },
+            approve: { command: "mcp", codex: { defaultToolsApprovalMode: "approve" } },
+          },
+        },
+      } satisfies OpenClawConfig;
+      const prepare =
+        preparation === "runtime"
+          ? buildCodexUserMcpServersThreadConfigPatchForRuntime
+          : buildCodexUserMcpServersThreadConfigPatch;
+
+      const patch = await prepare(cfg, { agentId: "main" });
+
+      expect(patch?.mcp_servers.auto).toEqual({
+        command: "mcp",
+        default_tools_approval_mode: "auto",
+        tools: { "write.raw_tool": { approval_mode: "approve" } },
+      });
+      expect(patch?.mcp_servers.unspecified).toEqual({
+        command: "mcp",
+        disabled_tools: ["write.raw_tool"],
+        tools: { "write.raw_tool": { approval_mode: "approve" } },
+      });
+      expect(patch?.mcp_servers.prompt).toEqual({
+        command: "mcp",
+        default_tools_approval_mode: "prompt",
+      });
+      expect(patch?.mcp_servers.approve).toEqual({
+        command: "mcp",
+        default_tools_approval_mode: "approve",
+      });
+      expect(patch?.mcp_servers.missing).toBeUndefined();
+      expect(authMocks.loadExecApprovalsReadOnly).toHaveBeenCalledTimes(1);
+      expect((await prepare(cfg))?.mcp_servers.auto).not.toHaveProperty("tools");
+    },
+  );
 
   it("returns undefined when cfg has no mcp.servers (regression: #80814)", () => {
     expect(buildCodexUserMcpServersThreadConfigPatch(undefined)).toBeUndefined();

--- a/src/agents/codex-mcp-config.test.ts
+++ b/src/agents/codex-mcp-config.test.ts
@@ -12,6 +12,7 @@ import {
 import { testing as resolverTesting } from "./mcp-connection-resolver.js";
 
 const mocks = vi.hoisted(() => ({
+  loadExecApprovalsReadOnly: vi.fn(),
   loadCalls: [] as Array<Record<string, unknown>>,
   bundleMcp: {
     config: {
@@ -22,6 +23,10 @@ const mocks = vi.hoisted(() => ({
 }));
 const tempDirs: string[] = [];
 
+vi.mock("../infra/exec-approvals-store.js", () => ({
+  loadExecApprovalsReadOnly: mocks.loadExecApprovalsReadOnly,
+}));
+
 vi.mock("../plugins/bundle-mcp.js", () => ({
   loadEnabledBundleMcpConfig: (params: Record<string, unknown>) => {
     mocks.loadCalls.push(params);
@@ -30,6 +35,7 @@ vi.mock("../plugins/bundle-mcp.js", () => ({
 }));
 
 beforeEach(() => {
+  mocks.loadExecApprovalsReadOnly.mockReset().mockReturnValue({ version: 1, agents: {} });
   mocks.loadCalls.length = 0;
   mocks.bundleMcp = {
     config: {
@@ -99,6 +105,52 @@ describe("buildCodexMcpServersConfig", () => {
 });
 
 describe("loadCodexBundleMcpThreadConfigCore", () => {
+  it("projects durable grants only for configured bundle names and fingerprints their removal", () => {
+    mocks.bundleMcp.config.mcpServers = {
+      configured: { command: "mcp" },
+      prompt: { command: "mcp" },
+      pluginOnly: { command: "mcp" },
+    };
+    mocks.loadExecApprovalsReadOnly.mockReturnValue({
+      version: 1,
+      agents: {
+        main: {
+          mcpTools: ["configured", "prompt", "pluginOnly"].map((server) => ({
+            server,
+            tool: "write.raw_tool",
+            source: "allow-always",
+            addedAt: 1,
+          })),
+        },
+      },
+    });
+    const params = {
+      workspaceDir: "/workspace",
+      agentId: "main",
+      cfg: {
+        mcp: {
+          servers: {
+            configured: { command: "mcp" },
+            prompt: { command: "mcp", codex: { defaultToolsApprovalMode: "prompt" as const } },
+          },
+        },
+      },
+    };
+
+    const granted = loadCodexBundleMcpThreadConfigCore(params);
+
+    expect(granted.configPatch?.mcp_servers).toEqual({
+      configured: { command: "mcp", tools: { "write.raw_tool": { approval_mode: "approve" } } },
+      prompt: { command: "mcp" },
+      pluginOnly: { command: "mcp" },
+    });
+    expect(mocks.loadExecApprovalsReadOnly).toHaveBeenCalledTimes(1);
+    mocks.loadExecApprovalsReadOnly.mockReturnValue({ version: 1, agents: {} });
+    const revoked = loadCodexBundleMcpThreadConfigCore(params);
+    expect(revoked.configPatch?.mcp_servers.configured).not.toHaveProperty("tools");
+    expect(revoked.fingerprint).not.toBe(granted.fingerprint);
+  });
+
   it("forwards a prepared manifest registry to bundle loading", () => {
     const manifestRegistry = { plugins: [] };
 

--- a/src/agents/codex-mcp-config.ts
+++ b/src/agents/codex-mcp-config.ts
@@ -8,6 +8,7 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
 import type { SessionToolOverrides } from "../config/sessions/types.js";
+import { loadMcpToolGrants, type McpToolGrant } from "../infra/exec-approvals-mcp.js";
 import {
   loadEnabledBundleMcpConfig,
   type BundleMcpConfig,
@@ -90,12 +91,24 @@ export function applyCodexSessionMcpToolDenials(
 export function normalizeCodexMcpServerConfig(
   name: string,
   server: BundleMcpServerConfig,
+  grants: readonly McpToolGrant[] = [],
 ): Record<string, unknown> {
   const next = normalizeBundleMcpServerConfig(server);
   applyCodexToolFilter(next, name, server);
   const defaultToolsApprovalMode = resolveProjectedMcpCodexToolApprovalMode(name, server);
   if (defaultToolsApprovalMode) {
     next.default_tools_approval_mode = defaultToolsApprovalMode;
+  }
+  // Codex downgrades remembered approvals under explicit prompt; only auto
+  // (including its default) accepts durable grants. Server-wide approve is already sufficient.
+  if (defaultToolsApprovalMode === undefined || defaultToolsApprovalMode === "auto") {
+    const tools = grants
+      .filter((grant) => grant.server === name)
+      .map((grant) => [grant.tool, { approval_mode: "approve" }] as const)
+      .toSorted(([left], [right]) => left.localeCompare(right));
+    if (tools.length > 0) {
+      next.tools = Object.fromEntries(tools);
+    }
   }
   const httpHeaders = normalizeMcpStringRecord(server.headers);
   if (httpHeaders) {
@@ -129,12 +142,15 @@ export function normalizeCodexMcpServerConfig(
  * Requester-scoped servers are excluded: harness-native MCP clients are
  * session-shared and must never dial placeholder or requester-bound URLs.
  */
-export function buildCodexMcpServersConfig(config: BundleMcpConfig): CodexMcpServersConfig {
+export function buildCodexMcpServersConfig(
+  config: BundleMcpConfig,
+  grants: readonly McpToolGrant[] = [],
+): CodexMcpServersConfig {
   const { staticServers } = partitionMcpServersByConnectionScope(config.mcpServers);
   return Object.fromEntries(
     Object.entries(staticServers).map(([name, server]) => [
       name,
-      normalizeCodexMcpServerConfig(name, server),
+      normalizeCodexMcpServerConfig(name, server, grants),
     ]),
   );
 }
@@ -270,7 +286,18 @@ export function loadCodexBundleMcpThreadConfigCore(
     prepareDataDirsByServer: bundleMcp.prepareDataDirsByServer ?? {},
   });
   const diagnostics = [...bundleMcp.diagnostics, ...preparedDataDirs.diagnostics];
-  const mcpServers = buildCodexMcpServersConfig(preparedDataDirs.config);
+  const grants = params.agentId ? loadMcpToolGrants(params.agentId) : [];
+  const configuredGrants = grants.filter((grant) => {
+    const server = Object.hasOwn(configuredMcp, grant.server)
+      ? configuredMcp[grant.server]
+      : undefined;
+    if (!server) {
+      return false;
+    }
+    const mode = resolveProjectedMcpCodexToolApprovalMode(grant.server, server);
+    return mode === undefined || mode === "auto";
+  });
+  const mcpServers = buildCodexMcpServersConfig(preparedDataDirs.config, configuredGrants);
   if (Object.keys(mcpServers).length === 0) {
     return {
       diagnostics,

--- a/src/agents/codex-mcp-config.types.ts
+++ b/src/agents/codex-mcp-config.types.ts
@@ -26,6 +26,7 @@ export type CodexBundleMcpThreadConfig = {
 /** Inputs used to load a Codex bundle-MCP thread config patch. */
 export type LoadCodexBundleMcpThreadConfigParams = {
   workspaceDir: string;
+  agentId?: string;
   /** Read-only initialization cannot provision data directories or requester transports. */
   preparationOnly?: true;
   cfg?: OpenClawConfig;

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -83,6 +83,9 @@ export type AgentHarnessHostCapabilities = Readonly<{
     severity: "info" | "warning";
     toolName: string;
     toolCallId?: string;
+    mcpTool?: { server: string; tool: string };
+    /** Persistence-only proof; loss of correlation does not cancel a one-shot approval. */
+    isMcpToolApprovalActive?: () => boolean;
     allowedDecisions?: AgentHarnessHostApprovalDecision[];
     timeoutMs: number;
     transportTimeoutMs?: number;

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -12,6 +12,7 @@ import {
   validateAgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
 import { withInstallationTarget } from "../../infra/installation-target-context.js";
+import { takeMcpToolApprovalBinding } from "../../infra/mcp-tool-approval-binding.js";
 import {
   bindGatewayContextResolver,
   withPluginRuntimeGatewayRequestScope,
@@ -686,6 +687,48 @@ describe("agent harness host capability", () => {
     expect(scopes.every((signal) => signal.aborted)).toBe(true);
     expect(() => host.capabilities.assertActive()).not.toThrow();
     host.close();
+  });
+
+  it("hands off MCP persistence proof once without serializing the callback", async () => {
+    const { attempt } = await admittedAttempt("mcp-persistence-proof");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+    const authority = getAdmittedRunDelegatedAuthority(attempt.admittedRunContext)!;
+    const scope = {
+      authority,
+      agentId: "main",
+      toolCallId: "item-1",
+      server: "docs",
+      tool: "write_note",
+    };
+    let active = true;
+    let proof: (() => boolean) | undefined;
+    mockCallGatewayTool.mockImplementationOnce(async (_method, _opts, payload) => {
+      expect(payload).toMatchObject({
+        mcpTool: { server: "docs", tool: "write_note" },
+        toolCallId: "item-1",
+      });
+      expect(payload).not.toHaveProperty("isMcpToolApprovalActive");
+      expect(takeMcpToolApprovalBinding({ ...scope, agentId: "other" })).toBeUndefined();
+      proof = takeMcpToolApprovalBinding(scope);
+      expect(takeMcpToolApprovalBinding(scope)).toBeUndefined();
+      return { id: "approval-1" };
+    });
+    await host.capabilities.requestApproval({
+      title: "MCP approval",
+      description: "Write a note",
+      severity: "warning",
+      toolName: "codex_mcp_tool_approval",
+      toolCallId: "item-1",
+      timeoutMs: 1_000,
+      mcpTool: { server: "docs", tool: "write_note" },
+      isMcpToolApprovalActive: () => active,
+    });
+    expect(proof?.()).toBe(true);
+    active = false;
+    expect(proof?.()).toBe(false);
+    active = true;
+    host.close();
+    expect(proof?.()).toBe(false);
   });
 
   it("revokes a retained bound tool when the same run id gets a replacement owner", async () => {

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -7,6 +7,7 @@ import {
   installationTargetEnv,
   withInstallationTarget,
 } from "../../infra/installation-target-context.js";
+import { registerMcpToolApprovalBinding } from "../../infra/mcp-tool-approval-binding.js";
 import { prepareSystemRunMutableFileApproval } from "../../infra/system-run-approval-binding.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import {
@@ -555,36 +556,54 @@ export function createAgentHarnessHostCapabilities(params: {
     requestApproval: async (request) => {
       assertActive();
       request.signal?.throwIfAborted();
-      const result = await withCaller(
-        async () =>
-          await withGatewayToolApprovalOwner(
-            params.pluginId,
-            async () =>
-              await callGatewayTool(
-                "plugin.approval.request",
-                { timeoutMs: request.transportTimeoutMs ?? request.timeoutMs },
-                {
-                  title: request.title,
-                  description: request.description,
-                  severity: request.severity,
-                  toolName: request.toolName,
-                  toolCallId: request.toolCallId,
-                  timeoutMs: request.timeoutMs,
-                  twoPhase: true,
-                  ...(request.allowedDecisions
-                    ? { allowedDecisions: request.allowedDecisions }
-                    : {}),
-                },
-                { expectFinal: false, requireAgentRuntimeIdentity: true, signal: request.signal },
-              ),
-          ),
-        request.signal,
-      );
-      // Gateway approval calls may outlive their owning attempt. A late
-      // request result must not escape after exact authority has closed.
-      assertActive();
-      request.signal?.throwIfAborted();
-      return result;
+      const releaseMcpBinding =
+        request.mcpTool && request.toolCallId && request.isMcpToolApprovalActive && attempt.agentId
+          ? registerMcpToolApprovalBinding({
+              authority: delegatedAuthority,
+              agentId: attempt.agentId,
+              toolCallId: request.toolCallId,
+              ...request.mcpTool,
+              isActive: () => {
+                assertActive();
+                return !request.signal?.aborted && request.isMcpToolApprovalActive!();
+              },
+            })
+          : undefined;
+      try {
+        const result = await withCaller(
+          async () =>
+            await withGatewayToolApprovalOwner(
+              params.pluginId,
+              async () =>
+                await callGatewayTool(
+                  "plugin.approval.request",
+                  { timeoutMs: request.transportTimeoutMs ?? request.timeoutMs },
+                  {
+                    title: request.title,
+                    description: request.description,
+                    severity: request.severity,
+                    toolName: request.toolName,
+                    toolCallId: request.toolCallId,
+                    ...(request.mcpTool ? { mcpTool: request.mcpTool } : {}),
+                    timeoutMs: request.timeoutMs,
+                    twoPhase: true,
+                    ...(request.allowedDecisions
+                      ? { allowedDecisions: request.allowedDecisions }
+                      : {}),
+                  },
+                  { expectFinal: false, requireAgentRuntimeIdentity: true, signal: request.signal },
+                ),
+            ),
+          request.signal,
+        );
+        // Gateway approval calls may outlive their owning attempt. A late
+        // request result must not escape after exact authority has closed.
+        assertActive();
+        request.signal?.throwIfAborted();
+        return result;
+      } finally {
+        releaseMcpBinding?.();
+      }
     },
     waitForApproval: async (request) => {
       assertActive();

--- a/src/agents/harness/native-hook-relay.approval-wait.test.ts
+++ b/src/agents/harness/native-hook-relay.approval-wait.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { callGatewayTool } from "../tools/gateway.js";
 import { invokeNativeHookRelay, registerNativeHookRelay, testing } from "./native-hook-relay.js";
 
@@ -7,6 +7,15 @@ vi.mock("../tools/gateway.js", () => ({
 }));
 
 const mockCallGatewayTool = vi.mocked(callGatewayTool);
+const approvalMocks = vi.hoisted(() => ({ loadExecApprovalsReadOnly: vi.fn() }));
+
+vi.mock("../../infra/exec-approvals-store.js", () => ({
+  loadExecApprovalsReadOnly: approvalMocks.loadExecApprovalsReadOnly,
+}));
+
+beforeEach(() => {
+  approvalMocks.loadExecApprovalsReadOnly.mockReset().mockReturnValue({ version: 1, agents: {} });
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -15,6 +24,65 @@ afterEach(() => {
 });
 
 describe("native hook relay approval wait handling", () => {
+  it("defers all native MCP names to Codex when the exact agent has a prepared durable grant", async () => {
+    const grant = { server: "raw-server_", tool: "_raw.tool", source: "allow-always", addedAt: 1 };
+    approvalMocks.loadExecApprovalsReadOnly.mockReturnValue({
+      version: 1,
+      agents: { main: { mcpTools: [grant] }, "*": { mcpTools: [grant] } },
+    });
+    mockCallGatewayTool.mockResolvedValue({ id: "unexpected-approval", decision: "deny" });
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      agentId: "main",
+      sessionId: "session-1",
+      runId: "run-1",
+    });
+    approvalMocks.loadExecApprovalsReadOnly.mockReturnValue({ version: 1, agents: {} });
+    for (const toolName of [
+      "mcp__raw_server__raw_tool",
+      "mcp__hashed_a13e__shortened",
+      "mcp__codex_apps__write",
+    ]) {
+      for (const query of ["first", "different arguments"]) {
+        const result = await invokeNativeHookRelay({
+          provider: "codex",
+          relayId: relay.relayId,
+          event: "permission_request",
+          rawPayload: {
+            hook_event_name: "PermissionRequest",
+            tool_name: toolName,
+            tool_input: { query },
+          },
+        });
+        expect(result).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+      }
+    }
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(approvalMocks.loadExecApprovalsReadOnly).toHaveBeenCalledTimes(1);
+    relay.unregister();
+    approvalMocks.loadExecApprovalsReadOnly.mockReturnValue({
+      version: 1,
+      agents: { "*": { mcpTools: [grant] } },
+    });
+    const nextRelay = registerNativeHookRelay({
+      provider: "codex",
+      agentId: "main",
+      sessionId: "session-2",
+      runId: "run-2",
+    });
+    const result = await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: nextRelay.relayId,
+      event: "permission_request",
+      rawPayload: {
+        hook_event_name: "PermissionRequest",
+        tool_name: "mcp__raw_server__raw_tool",
+        tool_input: {},
+      },
+    });
+    expect(JSON.parse(result.stdout).hookSpecificOutput.decision.behavior).toBe("deny");
+  });
+
   it.each(
     [
       { fullPermission: true, mode: undefined, decision: "defer" },

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -4,6 +4,7 @@ import {
   MAX_TIMER_TIMEOUT_MS,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { loadMcpToolGrants } from "../../infra/exec-approvals-mcp.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { resolveProjectedMcpCodexToolApprovalMode } from "../mcp-codex-tool-approval.js";
@@ -202,6 +203,8 @@ function registerNativeHookRelayInternal(
       ...(params.config ? { config: params.config } : {}),
       deferMcpToolApprovals:
         params.autoApproveMcpTools === true ||
+        // Native hook names lose raw identity; let Codex apply the prepared per-tool config.
+        (params.agentId ? loadMcpToolGrants(params.agentId).length > 0 : false) ||
         Object.keys({ ...params.projectedMcpServers, ...params.config?.mcp?.servers }).some(
           (serverName) =>
             resolveProjectedMcpCodexToolApprovalMode(

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -97,6 +97,10 @@ const localSnapshot = {
   file: { version: 1, agents: {} } as ExecApprovalsFile,
 };
 
+function createMcpToolGrant(tool = "publish_page") {
+  return { server: "project-docs", tool, source: "allow-always" as const, addedAt: Date.now() };
+}
+
 const requireRecord = createRequireRecord("record", "expected-label-capitalized");
 
 function requireArray(value: unknown, label: string): unknown[] {
@@ -273,37 +277,20 @@ describe("exec approvals CLI", () => {
     defaultRuntime.exit.mockClear();
   });
 
-  it("routes get command to local, gateway, and node modes", async () => {
-    await runApprovalsCommand(["approvals", "get"]);
+  it.each([
+    ["local", [], null],
+    ["gateway", ["--gateway"], "exec.approvals.get"],
+    ["node", ["--node", "macbook"], "exec.approvals.node.get"],
+  ] as const)("routes get command to %s mode", async (target, args, method) => {
+    await runApprovalsCommand(["approvals", "get", ...args]);
 
-    expect(callGatewayFromCli).not.toHaveBeenCalled();
-    expect(readBestEffortConfig).toHaveBeenCalledTimes(1);
-    expect(
-      defaultRuntime.log.mock.calls.filter(([line]) =>
-        String(line ?? "").includes(SESSION_EXEC_OVERRIDES_NOTE),
-      ),
-    ).toHaveLength(1);
-    expect(runtimeErrors).toHaveLength(0);
-    callGatewayFromCli.mockClear();
-    defaultRuntime.log.mockClear();
-
-    await runApprovalsCommand(["approvals", "get", "--gateway"]);
-
-    expectGatewayCall(0, "exec.approvals.get", {});
-    expectGatewayCall(1, "config.get", {});
-    expect(
-      defaultRuntime.log.mock.calls.filter(([line]) =>
-        String(line ?? "").includes(SESSION_EXEC_OVERRIDES_NOTE),
-      ),
-    ).toHaveLength(1);
-    expect(runtimeErrors).toHaveLength(0);
-    callGatewayFromCli.mockClear();
-    defaultRuntime.log.mockClear();
-
-    await runApprovalsCommand(["approvals", "get", "--node", "macbook"]);
-
-    expectGatewayCall(0, "exec.approvals.node.get", { nodeId: "node-1" });
-    expectGatewayCall(1, "config.get", {});
+    if (method) {
+      expectGatewayCall(0, method, target === "node" ? { nodeId: "node-1" } : {});
+      expectGatewayCall(1, "config.get", {});
+    } else {
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+      expect(readBestEffortConfig).toHaveBeenCalledTimes(1);
+    }
     expect(
       defaultRuntime.log.mock.calls.filter(([line]) =>
         String(line ?? "").includes(SESSION_EXEC_OVERRIDES_NOTE),
@@ -368,6 +355,23 @@ describe("exec approvals CLI", () => {
     const file = requireRecord(output.file, "JSON approvals file");
     expect(file.socket).toEqual({ path: "/tmp/local-exec-approvals.sock" });
     expect(JSON.stringify(output)).not.toContain('"token"');
+  });
+
+  it("lists MCP tool grants without exec allowlist entries in human and JSON output", async () => {
+    const grant = createMcpToolGrant();
+    localSnapshot.file = { version: 1, agents: { main: { mcpTools: [grant] } } };
+
+    await runApprovalsCommand(["approvals", "get"]);
+
+    const output = loggedOutput();
+    expect(output).toContain("MCP tool grants");
+    expect(output).toContain("main");
+    expect(output).toContain(grant.server);
+    expect(output).toContain(grant.tool);
+
+    await runApprovalsCommand(["approvals", "get", "--json"]);
+
+    expect(writtenJson().file).toEqual(localSnapshot.file);
   });
 
   it("redacts the socket token from local write JSON while preserving its path", async () => {
@@ -748,87 +752,45 @@ describe("exec approvals CLI", () => {
     expect(runtimeErrors[0]).toContain("do not support allowlist mutations");
   });
 
-  it("keeps gateway approvals output when config.get fails", async () => {
-    callGatewayFromCli.mockImplementation(
-      async (method: string, _opts: unknown, params?: unknown) => {
-        if (method === "config.get") {
-          throw new Error("gateway config unavailable");
-        }
-        if (method === "exec.approvals.get") {
-          return {
-            path: "/tmp/exec-approvals.json",
-            exists: true,
-            hash: "hash-1",
-            file: { version: 1, agents: {} },
-          };
-        }
-        return { method, params };
-      },
-    );
-
-    await runApprovalsCommand(["approvals", "get", "--gateway", "--json"]);
-
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(writtenJson(), 0);
-    expect(effectivePolicy()).toEqual({
+  it.each([
+    {
+      label: "keeps gateway approvals output when config.get fails",
+      args: ["--gateway"],
+      method: "exec.approvals.get",
+      error: "gateway config unavailable",
       note: "Config unavailable.",
-      scopes: [],
-    });
-    expect(runtimeErrors).toHaveLength(0);
-  });
-
-  it("reports gateway config timeout explicitly", async () => {
-    callGatewayFromCli.mockImplementation(
-      async (method: string, _opts: unknown, params?: unknown) => {
-        if (method === "config.get") {
-          throw new Error("gateway timeout after 10000ms\u001b[2K\u0007\nRPC config.get");
-        }
-        if (method === "exec.approvals.get") {
-          return {
-            path: "/tmp/exec-approvals.json",
-            exists: true,
-            hash: "hash-1",
-            file: { version: 1, agents: {} },
-          };
-        }
-        return { method, params };
-      },
-    );
-
-    await runApprovalsCommand(["approvals", "get", "--gateway", "--timeout", "10000", "--json"]);
-
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(writtenJson(), 0);
-    expect(effectivePolicy()).toEqual({
+    },
+    {
+      label: "reports gateway config timeout explicitly",
+      args: ["--gateway", "--timeout", "10000"],
+      method: "exec.approvals.get",
+      error: "gateway timeout after 10000ms\u001b[2K\u0007\nRPC config.get",
       note: "Config fetch timed out. Re-run with a higher --timeout to inspect Effective Policy.",
-      scopes: [],
-    });
-    expect(runtimeErrors).toHaveLength(0);
-  });
-
-  it("keeps node approvals output when gateway config is unavailable", async () => {
+    },
+    {
+      label: "keeps node approvals output when gateway config is unavailable",
+      args: ["--node", "macbook"],
+      method: "exec.approvals.node.get",
+      error: "gateway config unavailable",
+      note: "Gateway config unavailable. Node output above shows host approvals state only, and final runtime policy still intersects with gateway tools.exec.",
+    },
+  ])("$label", async ({ args, method: snapshotMethod, error, note }) => {
     callGatewayFromCli.mockImplementation(
       async (method: string, _opts: unknown, params?: unknown) => {
         if (method === "config.get") {
-          throw new Error("gateway config unavailable");
+          throw new Error(error);
         }
-        if (method === "exec.approvals.node.get") {
-          return {
-            path: "/tmp/node-exec-approvals.json",
-            exists: true,
-            hash: "hash-node-1",
-            file: { version: 1, agents: {} },
-          };
+        if (method === snapshotMethod) {
+          return localSnapshot;
         }
         return { method, params };
       },
     );
 
-    await runApprovalsCommand(["approvals", "get", "--node", "macbook", "--json"]);
+    await runApprovalsCommand(["approvals", "get", ...args, "--json"]);
 
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(writtenJson(), 0);
-    expect(effectivePolicy()).toEqual({
-      note: "Gateway config unavailable. Node output above shows host approvals state only, and final runtime policy still intersects with gateway tools.exec.",
-      scopes: [],
-    });
+    expect(effectivePolicy()).toEqual({ note, scopes: [] });
     expect(runtimeErrors).toHaveLength(0);
   });
 
@@ -1032,6 +994,51 @@ describe("exec approvals CLI", () => {
     });
     expect(loggedOutput()).toContain("Writing local approvals.");
     expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("keeps MCP tool grants when removing the last exec allowlist entry", async () => {
+    readBestEffortConfig.mockResolvedValue({ agents: { list: [{ id: "main" }] } });
+    const grant = createMcpToolGrant();
+    localSnapshot.file = {
+      version: 1,
+      agents: { main: { allowlist: [{ pattern: "/usr/bin/uname" }], mcpTools: [grant] } },
+    };
+
+    await runApprovalsCommand([
+      "approvals",
+      "allowlist",
+      "remove",
+      "/usr/bin/uname",
+      "--agent",
+      "main",
+    ]);
+
+    expect(localSnapshot.file.agents).toEqual({ main: { mcpTools: [grant] } });
+  });
+
+  it("revokes one MCP tool grant through approvals set while preserving the others", async () => {
+    const retainedGrant = createMcpToolGrant("read_page");
+    localSnapshot.file = {
+      version: 1,
+      agents: {
+        main: { mcpTools: [retainedGrant, { ...retainedGrant, tool: "publish_page" }] },
+      },
+    };
+    const filePath = path.join(tempDirs.make("openclaw-mcp-grants-revoke-"), "approvals.json");
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        agents: { main: { mcpTools: [retainedGrant] } },
+      }),
+    );
+
+    await runApprovalsCommand(["approvals", "set", "--file", filePath, "--json"]);
+
+    expect(localSnapshot.file.agents).toEqual({ main: { mcpTools: [retainedGrant] } });
+    expect(requireRecord(writtenJson().file, "JSON approvals file").agents).toEqual(
+      localSnapshot.file.agents,
+    );
   });
 
   it("bounds approvals JSON read from stdin", async () => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -967,6 +967,14 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
       });
     }
   }
+  const mcpToolRows = Object.entries(agents).flatMap(([agentId, agent]) =>
+    (agent.mcpTools ?? []).map((grant) => ({
+      Agent: agentId,
+      Server: grant.server,
+      Tool: grant.tool,
+      Added: formatTimeAgo(Math.max(0, now - grant.addedAt)),
+    })),
+  );
 
   const summaryRows = [
     { Field: "Target", Value: targetLabel },
@@ -981,6 +989,7 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
     { Field: "Defaults", Value: defaultsParts.length > 0 ? defaultsParts.join(", ") : "none" },
     { Field: "Agents", Value: String(Object.keys(agents).length) },
     { Field: "Allowlist", Value: String(allowlistRows.length) },
+    { Field: "MCP tool grants", Value: String(mcpToolRows.length) },
   ];
 
   defaultRuntime.log(heading("Approvals"));
@@ -995,24 +1004,39 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
     }).trimEnd(),
   );
 
-  if (allowlistRows.length === 0) {
-    defaultRuntime.log("");
+  defaultRuntime.log("");
+  if (allowlistRows.length > 0) {
+    defaultRuntime.log(heading("Allowlist"));
+    defaultRuntime.log(
+      renderTerminalSafeTable({
+        width: tableWidth,
+        columns: [
+          { key: "Target", header: "Target", minWidth: 10 },
+          { key: "Agent", header: "Agent", minWidth: 8 },
+          { key: "Pattern", header: "Pattern", minWidth: 20, flex: true },
+          { key: "LastUsed", header: "Last Used", minWidth: 10 },
+        ],
+        rows: allowlistRows,
+      }).trimEnd(),
+    );
+  } else {
     defaultRuntime.log(muted("No allowlist entries."));
+  }
+  if (mcpToolRows.length === 0) {
     return;
   }
-
   defaultRuntime.log("");
-  defaultRuntime.log(heading("Allowlist"));
+  defaultRuntime.log(heading("MCP tool grants"));
   defaultRuntime.log(
     renderTerminalSafeTable({
       width: tableWidth,
       columns: [
-        { key: "Target", header: "Target", minWidth: 10 },
         { key: "Agent", header: "Agent", minWidth: 8 },
-        { key: "Pattern", header: "Pattern", minWidth: 20, flex: true },
-        { key: "LastUsed", header: "Last Used", minWidth: 10 },
+        { key: "Server", header: "Server", minWidth: 16, flex: true },
+        { key: "Tool", header: "Tool", minWidth: 16, flex: true },
+        { key: "Added", header: "Added", minWidth: 10 },
       ],
-      rows: allowlistRows,
+      rows: mcpToolRows,
     }).trimEnd(),
   );
 }
@@ -1105,6 +1129,7 @@ function isEmptyAgent(agent: ExecApprovalsAgent): boolean {
     !agent.ask &&
     !agent.askFallback &&
     agent.autoAllowSkills === undefined &&
+    !agent.mcpTools?.length &&
     allowlist.length === 0
   );
 }

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -117,6 +117,8 @@ export type ExecApprovalRecord<TPayload = ExecApprovalRequestPayload> = {
   /** Closure-bound authority for approvals created by in-process delegated tools. */
   approvalAuthority?: () => boolean | void;
   approvalSignals?: readonly AbortSignal[];
+  /** Process-local persistence proof; never serialized with approval presentation. */
+  mcpToolApprovalActive?: () => boolean;
 };
 
 type OperatorApprovalPersistenceRuntime = {
@@ -126,6 +128,7 @@ type OperatorApprovalPersistenceRuntime = {
 
 export type OperatorStandingGrantMintSpec =
   | ({ kind: "cron" } & CronStandingGrantMintSpec)
+  | { kind: "mcp-tool"; agentId: string; server: string; tool: string }
   | ({ kind: "placement" } & PlacementStandingGrantMintSpec);
 
 type ExecApprovalManagerOptions<TPayload> = {
@@ -577,10 +580,16 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       return { outcome: "not-found" };
     }
 
-    const standingGrantSpec =
+    let standingGrantSpec =
       decision === "allow-always" && localEntry
         ? (this.options.resolveStandingGrantMint?.(localEntry.record.request) ?? undefined)
         : undefined;
+    if (
+      standingGrantSpec?.kind === "mcp-tool" &&
+      localEntry?.record.mcpToolApprovalActive?.() !== true
+    ) {
+      standingGrantSpec = undefined;
+    }
     const standingGrant = standingGrantSpec
       ? {
           ...standingGrantSpec,
@@ -600,6 +609,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
         runtimeEpoch: persistence.runtimeEpoch,
         databaseOptions: persistence.databaseOptions,
         ...(standingGrant?.kind === "cron" ? { standingGrant } : {}),
+        ...(standingGrant?.kind === "mcp-tool" ? { mcpToolGrant: standingGrant } : {}),
       });
     } catch (error) {
       this.settleLocalStorageFailure(recordId);
@@ -857,6 +867,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     pending.record.runtimeEpoch = this.runtimeEpoch ?? undefined;
     pending.record.consumedAtMs = params.consumedAtMs ?? null;
     pending.record.consumedBy = params.consumedBy ?? null;
+    delete pending.record.mcpToolApprovalActive;
     pending.retainForManagerLifetime ||= params.retainForManagerLifetime === true;
     pending.admissionContinuation?.release();
     pending.admissionContinuation = null;

--- a/src/gateway/operator-approval-mcp-grants.test.ts
+++ b/src/gateway/operator-approval-mcp-grants.test.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { buildCodexUserMcpServersThreadConfigPatch } from "../agents/cli-runner/bundle-mcp-codex.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.js";
+import {
+  claimAgentRunDelegatedAuthority,
+  releaseAgentRunDelegatedAuthority,
+  resetAgentRunRegistryForTest,
+  validateAgentRunDelegatedAuthority,
+} from "../infra/agent-run-registry.js";
+import { loadExecApprovalsReadOnly } from "../infra/exec-approvals-store.js";
+import { registerMcpToolApprovalBinding } from "../infra/mcp-tool-approval-binding.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createGatewayAuxHandlers } from "./server-aux-handlers.js";
+import { createPluginApprovalHandlers } from "./server-methods/plugin-approval.js";
+import type { GatewayRequestHandlerOptions } from "./server-methods/types.js";
+
+const dirs = useAutoCleanupTempDirTracker(afterEach);
+const auxiliaries: ReturnType<typeof createGatewayAuxHandlers>[] = [];
+const cfg: OpenClawConfig = {
+  agents: { list: [{ id: "main" }, { id: "other" }] },
+  mcp: { servers: { "project.docs": { command: "docs-mcp" } } },
+};
+
+function gateway() {
+  const aux = createGatewayAuxHandlers({
+    log: {},
+    activateRuntimeSecrets: async () => {
+      throw new Error("unexpected secrets reload");
+    },
+    sharedGatewaySessionGenerationState: { current: undefined, required: null },
+    resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+    clients: [],
+    channelManager: {
+      startChannel: async () => new Map(),
+      stopChannel: async () => {},
+      isManuallyStopped: () => false,
+      resolveRuntimeAccountId: (_channel, accountId) => accountId,
+    },
+    logChannels: { info: () => {} },
+    validateAgentRuntimeDelegatedAuthority: validateAgentRunDelegatedAuthority,
+  });
+  auxiliaries.push(aux);
+  return aux;
+}
+
+beforeEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.stubEnv("OPENCLAW_STATE_DIR", fs.realpathSync(dirs.make("mcp-tool-grants-")));
+  setRuntimeConfigSnapshot(cfg);
+});
+afterEach(() => {
+  for (const aux of auxiliaries.splice(0)) {
+    aux.unregisterApprovalAuthorityObserver();
+    aux.questionManager.reset();
+  }
+  resetAgentRunRegistryForTest();
+  closeOpenClawStateDatabaseForTest();
+  clearRuntimeConfigSnapshot();
+  vi.unstubAllEnvs();
+});
+
+async function requestGrant(
+  options: {
+    server?: string;
+    agentId?: string;
+    trusted?: boolean;
+    allowedDecisions?: string[];
+    isActive?: () => boolean;
+    binding?: boolean;
+  } = {},
+) {
+  const aux = gateway();
+  const authority = claimAgentRunDelegatedAuthority({
+    instanceId: "mcp-instance",
+    runId: "mcp-run",
+  });
+  const request = {
+    title: "MCP tool approval",
+    description: "Write a note",
+    toolName: "codex_mcp_tool_approval",
+    toolCallId: "raw-item-1",
+    mcpTool: { server: options.server ?? "project.docs", tool: "write_note" },
+    agentId: options.agentId ?? "main",
+    allowedDecisions: options.allowedDecisions ?? ["allow-once", "allow-always", "deny"],
+    twoPhase: true,
+  };
+  const releaseBinding =
+    options.binding === false
+      ? undefined
+      : registerMcpToolApprovalBinding({
+          authority,
+          agentId: "main",
+          toolCallId: request.toolCallId,
+          ...request.mcpTool,
+          isActive: options.isActive ?? (() => true),
+        });
+  const args = {
+    req: { method: "plugin.approval.request", params: request, id: "request-1" },
+    params: request,
+    client: {
+      connId: "runtime-1",
+      connect: { client: { id: "test-client" } },
+      ...(options.trusted === false
+        ? {}
+        : {
+            internal: {
+              agentRuntimeIdentity: {
+                kind: "agentRuntime",
+                agentId: "main",
+                operationalRunInstance: authority.operationalRunInstance,
+                delegatedAuthority: { ...authority, kind: "local" },
+                approvalOwnerPluginId: "codex",
+              },
+            },
+          }),
+    },
+    respond: vi.fn(),
+    isWebchatConnect: () => false,
+    context: {
+      broadcast: vi.fn(),
+      getRuntimeConfig: () => cfg,
+      logGateway: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+      hasExecApprovalClients: () => true,
+      validateAgentRuntimeApprovalAuthority: () => validateAgentRunDelegatedAuthority(authority),
+    },
+  } as unknown as GatewayRequestHandlerOptions;
+  const pending = createPluginApprovalHandlers(aux.pluginApprovalManager)[
+    "plugin.approval.request"
+  ]!(args);
+  await vi.waitFor(() => expect(args.respond).toHaveBeenCalled());
+  releaseBinding?.();
+  const record = aux.pluginApprovalManager.listPendingRecords()[0];
+  if (!record) {
+    await pending;
+    throw new Error("MCP approval request did not register");
+  }
+  return { aux, authority, pending, record };
+}
+
+describe("gateway MCP tool grants", () => {
+  it("mints once for the authenticated agent and projects the grant after gateway restart", async () => {
+    const { aux, pending, record } = await requestGrant({ agentId: "other" });
+    expect(aux.pluginApprovalManager.resolve(record.id, "allow-always")).toBe(true);
+    await pending;
+    const expected = {
+      server: "project.docs",
+      tool: "write_note",
+      source: "allow-always",
+      addedAt: expect.any(Number),
+    };
+    expect(loadExecApprovalsReadOnly().agents).toEqual({ main: { mcpTools: [expected] } });
+    expect(aux.pluginApprovalManager.resolve(record.id, "allow-always")).toBe(false);
+    closeOpenClawStateDatabaseForTest();
+    const restarted = gateway();
+    expect(restarted.pluginApprovalManager.runtimeEpoch).not.toBe(
+      aux.pluginApprovalManager.runtimeEpoch,
+    );
+    expect(loadExecApprovalsReadOnly().agents).toEqual({ main: { mcpTools: [expected] } });
+    expect(buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "main" })).toMatchObject({
+      mcp_servers: { "project.docs": { tools: { write_note: { approval_mode: "approve" } } } },
+    });
+    expect(buildCodexUserMcpServersThreadConfigPatch(cfg, { agentId: "other" })).not.toMatchObject({
+      mcp_servers: { "project.docs": { tools: { write_note: { approval_mode: "approve" } } } },
+    });
+  });
+
+  it.each([
+    { name: "unconfigured apps", server: "codex_apps" },
+    { name: "unconfigured computer use", server: "computer" },
+    { name: "untrusted caller", trusted: false },
+    { name: "remote or missing live proof", binding: false },
+    { name: "allow once", decision: "allow-once" as const },
+    { name: "deny", decision: "deny" as const },
+    { name: "explicit prompt", prompt: true },
+    { name: "native prompt spelling", nativePrompt: true },
+    { name: "removed server", removed: true },
+    { name: "closed authority", closed: true },
+  ])("does not mint for $name", async (options) => {
+    const { aux, authority, pending, record } = await requestGrant(options);
+    if (options.prompt) {
+      setRuntimeConfigSnapshot({
+        ...cfg,
+        mcp: {
+          servers: {
+            "project.docs": { command: "docs-mcp", codex: { defaultToolsApprovalMode: "prompt" } },
+          },
+        },
+      });
+    }
+    if (options.removed) {
+      setRuntimeConfigSnapshot({ ...cfg, mcp: { servers: {} } });
+    }
+    if (options.nativePrompt) {
+      setRuntimeConfigSnapshot({
+        ...cfg,
+        mcp: {
+          servers: {
+            "project.docs": { command: "docs-mcp", default_tools_approval_mode: "prompt" },
+          },
+        },
+      });
+    }
+    if (options.closed) {
+      releaseAgentRunDelegatedAuthority(authority);
+    }
+    aux.pluginApprovalManager.resolve(record.id, options.decision ?? "allow-always");
+    await pending;
+    expect(loadExecApprovalsReadOnly().agents).toEqual({});
+  });
+
+  it("keeps one-shot approval when correlation is lost while the prompt is pending", async () => {
+    let active = true;
+    const { aux, pending, record } = await requestGrant({ isActive: () => active });
+    active = false;
+    expect(aux.pluginApprovalManager.resolve(record.id, "allow-always")).toBe(true);
+    await pending;
+    expect(loadExecApprovalsReadOnly().agents).toEqual({});
+    expect(aux.pluginApprovalManager.getSnapshot(record.id)?.mcpToolApprovalActive).toBeUndefined();
+  });
+
+  it("rejects an unadvertised allow-always without minting", async () => {
+    const { aux, pending, record } = await requestGrant({
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    expect(aux.pluginApprovalManager.resolve(record.id, "allow-always")).toBe(false);
+    expect(loadExecApprovalsReadOnly().agents).toEqual({});
+    aux.pluginApprovalManager.resolve(record.id, "deny");
+    await pending;
+  });
+});

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -16,6 +16,7 @@ import {
   buildApprovalResolutionRef,
   isApprovalResolutionRef,
 } from "../infra/approval-resolution-ref.js";
+import { mintMcpToolGrantLocked } from "../infra/exec-approvals-sqlite.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -1682,6 +1683,7 @@ export function resolveOperatorApproval(params: {
   runtimeEpoch?: string;
   nowMs?: number;
   databaseOptions?: OpenClawStateDatabaseOptions;
+  mcpToolGrant?: { agentId: string; server: string; tool: string };
   /** Cron-context allow-always mints this scoped grant in the same transaction. */
   standingGrant?: { kind: "cron" } & CronStandingGrantMintSpec & {
       expiresAtMs: number | null;
@@ -1755,6 +1757,14 @@ export function resolveOperatorApproval(params: {
     }
     record = requireDecodedRecord(row);
     if (result.numAffectedRows === 1n) {
+      if (
+        params.decision === "allow-always" &&
+        params.mcpToolGrant &&
+        record.kind === "plugin" &&
+        record.source.agentId === params.mcpToolGrant.agentId
+      ) {
+        mintMcpToolGrantLocked(database.db, params.mcpToolGrant, auditTimestampMs);
+      }
       if (params.decision === "allow-always" && params.standingGrant) {
         // Same-transaction mint: the just-resolved approval row is the sole
         // authorization owner; the grant is its derivative cron re-execution scope.

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -1,6 +1,7 @@
 // Gateway auxiliary method handlers.
 // Wires reload, secrets, exec approval, and plugin approval RPC handlers.
 import { randomUUID } from "node:crypto";
+import { resolveProjectedMcpCodexToolApprovalMode } from "../agents/mcp-codex-tool-approval.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
   type AgentRunDelegatedAuthority,
@@ -196,11 +197,25 @@ export function createGatewayAuxHandlers(
     "plugin",
     resolveCanonicalPluginApprovalRequestAllowedDecisions,
     (request) => {
-      if (!request.placementGrant) {
-        return null;
-      }
       // Abort-wins for plugin approvals matches the cron mint boundary.
       if (request.runId && params.hasRunAbortMarker?.(request.runId) === true) {
+        return null;
+      }
+      if (request.mcpTool && request.agentId && request.agentId !== "*") {
+        const servers = getRuntimeConfig().mcp?.servers;
+        const server =
+          servers && Object.hasOwn(servers, request.mcpTool.server)
+            ? servers[request.mcpTool.server]
+            : undefined;
+        // Explicit prompt always asks, even after an earlier operator grant.
+        const mode =
+          server &&
+          resolveProjectedMcpCodexToolApprovalMode(request.mcpTool.server, server, server);
+        if (server && server.enabled !== false && (mode === undefined || mode === "auto")) {
+          return { kind: "mcp-tool", agentId: request.agentId, ...request.mcpTool };
+        }
+      }
+      if (!request.placementGrant) {
         return null;
       }
       return { kind: "placement", ...request.placementGrant };

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -14,6 +14,7 @@ import {
   sanitizeExecApprovalDisplayText,
   sanitizeExecApprovalWarningText,
 } from "../../infra/exec-approval-text-sanitize.js";
+import { takeMcpToolApprovalBinding } from "../../infra/mcp-tool-approval-binding.js";
 import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../../infra/plugin-approval-canonical-decisions.js";
 import type {
   PluginApprovalRequest,
@@ -93,6 +94,7 @@ export function createPluginApprovalHandlers(
         scope?: ApprovalScope | null;
         toolName?: string | null;
         toolCallId?: string | null;
+        mcpTool?: { server: string; tool: string };
         allowedDecisions?: string[] | null;
         agentId?: string | null;
         sessionKey?: string | null;
@@ -199,6 +201,7 @@ export function createPluginApprovalHandlers(
         severity: (p.severity as PluginApprovalRequestPayload["severity"]) ?? null,
         toolName: sanitizeMeta(p.toolName),
         toolCallId: p.toolCallId ?? null,
+        ...(trustedAgentRuntime && p.mcpTool ? { mcpTool: { ...p.mcpTool } } : {}),
         ...(Array.isArray(p.allowedDecisions)
           ? {
               allowedDecisions: resolveCanonicalPluginApprovalRequestAllowedDecisions({
@@ -230,6 +233,14 @@ export function createPluginApprovalHandlers(
       const record = manager.create(request, timeoutMs, `plugin:${randomUUID()}`);
       if (trustedAgentRuntime) {
         record.agentRuntimeDelegatedAuthority = trustedAgentRuntime.delegatedAuthority;
+        if (request.mcpTool && request.toolCallId) {
+          record.mcpToolApprovalActive = takeMcpToolApprovalBinding({
+            authority: trustedAgentRuntime.delegatedAuthority,
+            agentId: trustedAgentRuntime.agentId,
+            toolCallId: request.toolCallId,
+            ...request.mcpTool,
+          });
+        }
       }
       if (
         trustedAgentRuntime?.executionIdentity &&

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -180,6 +180,35 @@ describe("exec approvals default agent migration", () => {
 });
 
 describe("persisted exec approvals schema", () => {
+  it("round-trips exact MCP grants and tolerates unrelated future agent metadata", () => {
+    const mcpTools = [
+      { server: "project.docs", tool: "write_note", source: "allow-always", addedAt: 123 },
+    ];
+    const file = { version: 1, agents: { main: { mcpTools, futurePolicy: { enabled: true } } } };
+    const parsed = tryParsePersistedExecApprovals(JSON.stringify(file));
+    expect(parsed?.agents?.main).toMatchObject(file.agents.main);
+    expect(tryParsePersistedExecApprovals(JSON.stringify(parsed))?.agents?.main).toMatchObject(
+      file.agents.main,
+    );
+  });
+
+  it("retains MCP grants when merging legacy default and canonical main policy", () => {
+    const grant = {
+      server: "project.docs",
+      tool: "write_note",
+      source: "allow-always",
+      addedAt: 123,
+    };
+    const parsed = tryParsePersistedExecApprovals(
+      JSON.stringify({
+        version: 1,
+        agents: { main: { mcpTools: [grant] }, default: { ask: "off" } },
+      }),
+    );
+    expect(parsed?.agents?.main).toMatchObject({ mcpTools: [grant], ask: "off" });
+    expect(parsed?.agents?.default).toBeUndefined();
+  });
+
   it("keeps legacy string allowlist entries while normalizing them", () => {
     const parsed = tryParsePersistedExecApprovals(
       JSON.stringify({
@@ -194,6 +223,15 @@ describe("persisted exec approvals schema", () => {
   });
 
   it.each([
+    ...[
+      { server: "", tool: "write_note", source: "allow-always", addedAt: 123 },
+      { server: "project.docs", tool: "", source: "allow-always", addedAt: 123 },
+      { server: "project.docs", tool: "write_note", source: "other", addedAt: 123 },
+      { server: "project.docs", tool: "write_note", source: "allow-always", addedAt: -1 },
+    ].map((grant, index) => ({
+      name: `MCP grant ${index}`,
+      value: { version: 1, agents: { main: { mcpTools: [grant] } } },
+    })),
     { name: "version", value: { version: 2 } },
     { name: "socket token", value: { version: 1, socket: { token: 42 } } },
     { name: "policy enum", value: { version: 1, defaults: { security: "none" } } },

--- a/src/infra/exec-approvals-config.ts
+++ b/src/infra/exec-approvals-config.ts
@@ -52,6 +52,17 @@ const persistedExecAllowlistEntrySchema = z
   );
 const persistedExecApprovalsAgentSchema = persistedExecApprovalPolicySchema.extend({
   allowlist: z.array(persistedExecAllowlistEntrySchema).optional(),
+  mcpTools: z
+    .array(
+      z.looseObject({
+        server: z.string().refine((value) => value.trim().length > 0),
+        tool: z.string().refine((value) => value.trim().length > 0),
+        source: z.literal("allow-always"),
+        addedAt: z.number().finite().nonnegative(),
+        lastUsedAt: z.number().finite().nonnegative().optional(),
+      }),
+    )
+    .optional(),
 });
 const persistedExecApprovalsAgentsSchema = z
   .unknown()
@@ -142,6 +153,10 @@ const diagnosticFields = new Set([
   "askFallback",
   "autoAllowSkills",
   "allowlist",
+  "mcpTools",
+  "server",
+  "tool",
+  "addedAt",
   "pattern",
   "id",
   "source",
@@ -174,7 +189,7 @@ function formatPersistedExecApprovalsIssue(issue: z.core.$ZodIssue, parsed: unkn
       location += ` entry #${ordinal}`;
     } else if (
       index === 3 &&
-      issuePath[2] === "allowlist" &&
+      (issuePath[2] === "allowlist" || issuePath[2] === "mcpTools") &&
       typeof segment === "number" &&
       Number.isSafeInteger(segment) &&
       segment >= 0
@@ -289,11 +304,25 @@ function mergeLegacyAgent(
   }
 
   return {
+    ...legacy,
+    ...current,
     security: current.security ?? legacy.security,
     ask: current.ask ?? legacy.ask,
     askFallback: current.askFallback ?? legacy.askFallback,
     autoAllowSkills: current.autoAllowSkills ?? legacy.autoAllowSkills,
     allowlist: allowlist.length > 0 ? allowlist : undefined,
+    mcpTools:
+      current.mcpTools || legacy.mcpTools
+        ? [
+            ...(current.mcpTools ?? []),
+            ...(legacy.mcpTools ?? []).filter(
+              (grant) =>
+                !current.mcpTools?.some(
+                  (entry) => entry.server === grant.server && entry.tool === grant.tool,
+                ),
+            ),
+          ]
+        : undefined,
   };
 }
 

--- a/src/infra/exec-approvals-core.ts
+++ b/src/infra/exec-approvals-core.ts
@@ -3,7 +3,7 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import type { ApprovalScope } from "./approval-scope.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
 import type { ExecApprovalPolicySnapshot } from "./exec-approval-policy-snapshot.js";
-import type { ExecAllowlistEntry } from "./exec-approvals.types.js";
+import type { ExecAllowlistEntry, McpToolGrant } from "./exec-approvals.types.js";
 
 export type ExecHost = "sandbox" | "gateway" | "node";
 export type ExecTarget = "auto" | ExecHost;
@@ -244,6 +244,7 @@ export type ExecApprovalsDefaults = {
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecAllowlistEntry[];
+  mcpTools?: McpToolGrant[];
 };
 
 export type ExecApprovalsFile = {

--- a/src/infra/exec-approvals-mcp.ts
+++ b/src/infra/exec-approvals-mcp.ts
@@ -1,0 +1,9 @@
+import { loadExecApprovalsReadOnly } from "./exec-approvals-store.js";
+import type { McpToolGrant } from "./exec-approvals.types.js";
+
+export type { McpToolGrant } from "./exec-approvals.types.js";
+
+/** Snapshot exact-agent grants at thread/registration preparation, never on tool calls. */
+export function loadMcpToolGrants(agentId: string): readonly McpToolGrant[] {
+  return agentId === "*" ? [] : (loadExecApprovalsReadOnly().agents?.[agentId]?.mcpTools ?? []);
+}

--- a/src/infra/exec-approvals-sqlite.ts
+++ b/src/infra/exec-approvals-sqlite.ts
@@ -220,3 +220,44 @@ export function deleteExecApprovalsConfigRow(db: DatabaseSync): void {
       .where("config_key", "=", EXEC_APPROVALS_CONFIG_KEY),
   );
 }
+
+/** Called only inside the approval owner's winning resolution transaction. */
+export function mintMcpToolGrantLocked(
+  db: DatabaseSync,
+  grant: { agentId: string; server: string; tool: string },
+  nowMs: number,
+): void {
+  const row = readExecApprovalsConfigRow(db);
+  const current: ExecApprovalsFile | null = row
+    ? tryParsePersistedExecApprovals(row.raw_json)
+    : { version: 1 };
+  if (!current) {
+    throw new Error("Cannot save MCP tool grant: invalid exec approvals document");
+  }
+  const agent = current.agents?.[grant.agentId];
+  if (
+    agent?.mcpTools?.some((entry) => entry.server === grant.server && entry.tool === grant.tool)
+  ) {
+    return;
+  }
+  const next = {
+    ...current,
+    agents: {
+      ...current.agents,
+      [grant.agentId]: {
+        ...agent,
+        mcpTools: [
+          ...(agent?.mcpTools ?? []),
+          {
+            server: grant.server,
+            tool: grant.tool,
+            source: "allow-always" as const,
+            addedAt: nowMs,
+          },
+        ],
+      },
+    },
+  };
+  assertExecApprovalsMutationAllowed({ db, current, next });
+  writeExecApprovalsConfigRow({ db, file: next, now: nowMs });
+}

--- a/src/infra/exec-approvals.types.ts
+++ b/src/infra/exec-approvals.types.ts
@@ -1,3 +1,11 @@
+export type McpToolGrant = {
+  server: string;
+  tool: string;
+  source: "allow-always";
+  addedAt: number;
+  lastUsedAt?: number;
+};
+
 // Serialized allowlist entries stored with enough command context to explain
 // why an approval can be reused later.
 export type ExecAllowlistEntry = {

--- a/src/infra/mcp-tool-approval-binding.ts
+++ b/src/infra/mcp-tool-approval-binding.ts
@@ -1,0 +1,67 @@
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import {
+  getActiveAgentRunDelegatedAuthority,
+  validateAgentRunDelegatedAuthority,
+  type AgentRunDelegatedAuthority,
+} from "./agent-run-registry.js";
+
+type McpToolApprovalBinding = {
+  authority: AgentRunDelegatedAuthority;
+  agentId: string;
+  toolCallId: string;
+  server: string;
+  tool: string;
+  isActive: () => boolean;
+};
+
+// The authoritative owner object, not a copied token/run id, owns this one-shot
+// handoff across the local RPC. Separate host processes have no entry and cannot mint.
+const bindings = resolveGlobalSingleton(
+  Symbol.for("openclaw.mcpToolApprovalBindings"),
+  () => new WeakMap<AgentRunDelegatedAuthority, Set<McpToolApprovalBinding>>(),
+);
+
+export function registerMcpToolApprovalBinding(binding: McpToolApprovalBinding): () => void {
+  const owner = getActiveAgentRunDelegatedAuthority(binding.authority.operationalRunInstance);
+  if (!owner || !validateAgentRunDelegatedAuthority(binding.authority)) {
+    return () => {};
+  }
+  const entries = bindings.get(owner) ?? new Set<McpToolApprovalBinding>();
+  entries.add(binding);
+  bindings.set(owner, entries);
+  return () => entries.delete(binding);
+}
+
+export function takeMcpToolApprovalBinding(
+  scope: Omit<McpToolApprovalBinding, "isActive">,
+): (() => boolean) | undefined {
+  if (!validateAgentRunDelegatedAuthority(scope.authority)) {
+    return undefined;
+  }
+  const owner = getActiveAgentRunDelegatedAuthority(scope.authority.operationalRunInstance);
+  const entries = owner && bindings.get(owner);
+  const matches = [...(entries ?? [])].filter(
+    (entry) =>
+      entry.agentId === scope.agentId &&
+      entry.toolCallId === scope.toolCallId &&
+      entry.server === scope.server &&
+      entry.tool === scope.tool,
+  );
+  if (matches.length !== 1) {
+    return undefined;
+  }
+  const binding = matches[0]!;
+  entries!.delete(binding);
+  return () => {
+    try {
+      return (
+        validateAgentRunDelegatedAuthority(binding.authority) &&
+        binding.isActive() &&
+        validateAgentRunDelegatedAuthority(binding.authority) &&
+        validateAgentRunDelegatedAuthority(scope.authority)
+      );
+    } catch {
+      return false;
+    }
+  };
+}

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -41,6 +41,8 @@ export type PluginApprovalRequestPayload = {
   scope?: ApprovalScope | null;
   toolName?: string | null;
   toolCallId?: string | null;
+  /** Exact MCP persistence intent; the host separately binds live tool-call proof. */
+  mcpTool?: { server: string; tool: string };
   allowedDecisions?: readonly ExecApprovalDecision[] | null;
   /** Trusted in-process metadata; public Gateway callers cannot submit this field. */
   externalResolution?: {


### PR DESCRIPTION
## What Problem This Solves

After #135812, "Allow Always" on a Codex MCP tool approval was honest but session-scoped for servers configured in OpenClaw (`mcp.servers`): Codex can only persist a per-tool approval when the server lives in a writable native Codex config or plugin (`codex-rs/core/src/mcp_tool_call.rs` `persist_non_app_mcp_tool_approval`, verified at `rust-v0.151.0`), and OpenClaw projects these servers through the thread config. Operators who approved a Linear-style tool "always" were asked again in the next session.

Two hard constraints shaped the design (both verified upstream at `rust-v0.151.0` and HEAD): the approval elicitation carries **no canonical tool name** (only display `tool_title`/`tool_params_display`), and hook tool names are sanitized/hashed — so an exact per-tool grant cannot be minted from the approval alone without risking authorizing the wrong tool.

## Why This Change Was Made

Maintainer decision (@steipete): store grants in the **existing exec-approvals document**, not a new table.

- **Identity, fail closed.** Upstream emits the `mcpToolCall` thread item (`item/started`, raw `server`/`tool`/`arguments`) *before* requesting approval (`handle_mcp_tool_call`: `notify_mcp_tool_call_started` precedes `maybe_request_mcp_tool_approval`). The bridge correlates the approval with the **single** active `mcpToolCall` item on that server in the current turn and requires its arguments to agree with the card's `tool_params_display`. Zero or several candidates, a display mismatch, a queued-but-unprojected MCP lifecycle notification (receipt fence), a completed turn, or any Codex app / native plugin / computer-use context → **no durable mint**; Codex's session memory still applies.
- **Authority.** The persistence intent travels with the plugin approval request as typed `mcpTool` data plus a process-local one-shot binding keyed on the authoritative run object (`WeakMap`, never a bearer token). The Gateway accepts it only from the trusted agent runtime, redeems the binding once, and re-checks liveness at the winning `allow-always` resolution; settlement releases it.
- **Storage.** `agents.<agentId>.mcpTools[{server, tool, source: "allow-always", addedAt}]` in the `exec_approvals_config` document, minted inside the same synchronous SQLite transaction as the approval resolution, deduplicated, exact agent/server/tool. Additive field in the closed gateway schema; the loader tolerates older documents and preserves grants through the legacy `default`→`main` merge. **No DDL, no new table, no config/env option, no doctor migration.**
- **Consumers.** Both Codex thread projections (bundle loader and user-configured servers, sync and runtime) read the exact agent's grants once at preparation and project `tools.<tool>.approval_mode = "approve"` — only under `auto`/unspecified server mode (explicit `prompt` keeps asking, matching Codex's own downgrade of remembered decisions; explicit `approve` already bypasses). The hook relay defers `mcp__*` requests to Codex's native gate when the agent has grants instead of parsing lossy hook names. Grants take effect at the next thread preparation / relay registration (new session or restart); the current session keeps Codex's remembered decision.
- **Operator surface.** `openclaw approvals get` lists grants; revocation uses the existing `approvals set` document-edit path (documented recipe); grant-only agents are no longer pruned when the last exec allowlist entry is removed.

Alternatives rejected: seeding a Codex `config.toml` so upstream persists (two owners of a server definition = drift); a new SQLite grants table (more surface; the exec-approvals document already is the durable "Always allow" store); minting from `tool_title` prose or parsing `mcp__server__tool` hook names (can authorize the wrong tool).

## User Impact

- Stricter-posture sessions (`workspace`, `guarded`, `read-only`, or servers left in `auto`): clicking **Allow Always** on an MCP tool card now sticks across sessions and gateway restarts for that agent/server/tool, for any arguments.
- Explicit `codex.defaultToolsApprovalMode: "prompt"` still asks every time and no longer offers Allow Always; `approve` unchanged.
- `openclaw approvals get` shows an "MCP tool grants" table; docs cover shape, precedence, take-effect timing, and revocation.
- Default full-permission posture is unaffected (it never prompts).

## Evidence

- Regression tests written first, failing pre-fix (37 failed / 235 passed across 9 files), then passing: bridge correlation and exclusions, receipt-race fence, gateway mint (once-only, authenticated agent, untrusted caller rejected, removed/disabled server, explicit prompt, closed authority, lost correlation), protocol schema, loader round-trip incl. legacy merge and older documents, both projection paths and agent isolation, relay deferral, CLI rendering and grant-only agent retention, host-capability rendezvous.
- **Restart persistence** (`src/gateway/operator-approval-mcp-grants.test.ts`): real gateway aux manager + plugin approval handler + operator approval store + SQLite document — mint on allow-always, reject duplicate resolution, close the DB, construct a fresh manager with a new runtime epoch, reload the grant, prepare the next thread config, observe `mcp_servers["project.docs"].tools.write_note.approval_mode === "approve"` for `main` but not `other`.
- Scoped matrix: 1,021 passing cases across the recorded shards (23-file owner/sibling matrix; the one broad-run failure was a load-sensitive fixed 5 s poll in `attempt-startup-retry`, replaced with a readiness wait — no production change). `pnpm check:changed` passed (all typecheck lanes, lint, SDK budget, dead exports, 0 import cycles, schema v15 unchanged). `pnpm build` passed, zero `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- Blacksmith Testbox (Linux) run of every test file touched — see comment.
- Live real-session proof (isolated dev gateway, real Codex app-server 0.151.0, real model turns, unannotated MCP fixture) — all four scenarios PASS (details in the PR comment): Allow Always minted exactly one `tickets/lookup_ticket` grant; after a gateway restart a new session with different arguments ran with 0 approval requests across 330 polls; explicit `--approval prompt` prompted again offering only allow-once/deny; a different agent was prompted and its denial kept the fixture untouched. Scenario E (authority boundary): the source run aborted before the operator resolved `allow-always` → approval cancelled `run-aborted`, late resolution rejected, approvals document byte-identical, next call prompted again.
- Codex-backed autoreview — see comment.
- Second commit regenerates the Swift gateway protocol model (`GatewayModels.swift`) for the additive schema fields; `pnpm protocol:check` (the `checks-fast-bundled-protocol` lane) and `pnpm test:bundled` (207 tests) pass locally on the final head.
- LOC: production +485 / −63 (net +422, 29 files); tests +948 / −109; docs +82 / −5. Growth is deliberate: an authorization-path feature whose identity must stay valid across an asynchronous operator approval and the host/Gateway boundary (correlation + receipt fence ~100, bridge argument matching ~70, one-shot live binding ~67, additive document/protocol shape + same-transaction mint ~60, two projection paths + relay ~45, CLI rendering ~33). Existing exec argv-pattern persistence cannot express MCP identity; no parallel store, hook-name parser, or migration fallback was added.
