### PR TITLE
fix(agents): avoid unused discovery for read-only catalog queries

### DIFF
--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -375,19 +375,22 @@ async function buildSnapshotBatch(
     );
     const preferBuiltPluginArtifacts =
       pluginGeneration?.preferBuiltPluginArtifacts ?? prepareInboundPluginRegistry;
-    const config = groupCandidates[0]!.input.config;
-    let configuredHarnessRuntimes = configuredHarnessRuntimesByConfig.get(config);
-    if (!configuredHarnessRuntimes) {
-      configuredHarnessRuntimes = collectConfiguredAgentHarnessRuntimes(config);
-      configuredHarnessRuntimesByConfig.set(config, configuredHarnessRuntimes);
-    }
+    const getConfiguredHarnessRuntimes = () => {
+      const config = groupCandidates[0]!.input.config;
+      let runtimes = configuredHarnessRuntimesByConfig.get(config);
+      if (!runtimes) {
+        runtimes = collectConfiguredAgentHarnessRuntimes(config);
+        configuredHarnessRuntimesByConfig.set(config, runtimes);
+      }
+      return runtimes;
+    };
     const prepared = await prepareWorkspaceBuildGroup(
       groupCandidates.map(({ input }) => input),
       catalogMode,
       {
         preferBuiltPluginArtifacts,
         includeCredentialProviders,
-        configuredHarnessRuntimes,
+        getConfiguredHarnessRuntimes,
       },
       prepareInboundPluginRegistry ? loadInboundPluginRegistry : undefined,
       pluginGeneration,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -163,7 +163,7 @@ export async function prepareWorkspaceBuildGroup(
     providerDiscoveryProviderIds?: readonly string[];
     preferBuiltPluginArtifacts?: boolean;
     includeCredentialProviders?: boolean;
-    configuredHarnessRuntimes?: readonly string[];
+    getConfiguredHarnessRuntimes?: () => readonly string[];
   } = {},
   loadInboundPluginRegistry?: PreparedInboundRegistryLoader,
   reusablePluginGeneration?: PreparedModelRuntimePluginGeneration,
@@ -204,7 +204,7 @@ export async function prepareWorkspaceBuildGroup(
     loadInboundPluginRegistry,
     preferBuiltPluginArtifacts,
     reusablePluginGeneration,
-    options.configuredHarnessRuntimes,
+    options.getConfiguredHarnessRuntimes,
   );
   const reuseRuntimeFacts =
     reusablePluginGeneration && runtimePluginRegistry === reusablePluginGeneration.pluginRegistry;

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -127,7 +127,7 @@ export function prepareWorkspacePluginRegistries(
   loadInboundRegistry?: PreparedInboundRegistryLoader,
   preferBuiltPluginArtifacts = false,
   reusableGeneration?: PreparedModelRuntimePluginGeneration,
-  configuredHarnessRuntimes?: readonly string[],
+  getConfiguredHarnessRuntimes?: () => readonly string[],
 ): {
   runtimePluginRegistry?: PluginRegistry;
   inboundPluginRegistry?: PluginRegistry;
@@ -137,10 +137,11 @@ export function prepareWorkspacePluginRegistries(
   if (input.readOnly && !input.loadRuntimePlugins && !input.runtimePluginSelections) {
     return {};
   }
+  // Resolve batch facts only for a registry load; read-only and reused registries need no scan.
   const inboundPluginRegistry = input.readOnly
     ? undefined
     : (reusableGeneration?.inboundPluginRegistry ??
-      loadInboundRegistry?.(input, metadataSnapshot, configuredHarnessRuntimes));
+      loadInboundRegistry?.(input, metadataSnapshot, getConfiguredHarnessRuntimes?.()));
   const baseRegistry = reusableGeneration?.pluginRegistry ?? inboundPluginRegistry;
   const runtimePluginRegistry =
     input.runtimePluginSelections || !baseRegistry
@@ -160,7 +161,7 @@ export function prepareWorkspacePluginRegistries(
           metadataSnapshot,
           ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
           selections: input.runtimePluginSelections,
-          configuredHarnessRuntimes,
+          configuredHarnessRuntimes: getConfiguredHarnessRuntimes?.(),
         })
       : baseRegistry;
   return {

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -15,6 +15,7 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
+import * as harnessRuntimes from "./harness-runtimes.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
 import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
 import {
@@ -723,6 +724,10 @@ describe("prepared model runtime snapshots", () => {
 
   it("allows a read-only draft owner while the gateway lifecycle is active", async () => {
     await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+    const collectHarnessRuntimes = vi.spyOn(
+      harnessRuntimes,
+      "collectConfiguredAgentHarnessRuntimes",
+    );
     const draftConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
 
     await expect(
@@ -740,6 +745,7 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
     expect(mocks.planOpenClawModelsJsonSource).not.toHaveBeenCalled();
     expect(mocks.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalled();
+    expect(collectHarnessRuntimes).not.toHaveBeenCalled();
   });
 
   it("builds credential-free command owners separately from runtime owners", async () => {
@@ -1071,5 +1077,6 @@ describe("prepared model runtime snapshots", () => {
 });
 
 afterEach(async ({ task }) => {
+  vi.restoreAllMocks();
   await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");
 });


### PR DESCRIPTION
Related: #135743. Follow-up to #135773; does not close #135893.

## What Problem This Solves

Fixes an issue where read-only model catalog preparation unnecessarily scanned the fleet's configured harnesses even when it would not load a runtime registry. The large-roster repair in #135773 introduced this eager work before the existing runtime-free early return.

## Why This Change Was Made

Keep the existing per-build, per-config cache, but carry a synchronous getter to the registry owner and invoke it only when a registry must actually load. Runtime-free reads and fully reused registries do not request the facts. Executable read-only probes and normal startup still receive the same prepared array, and subsequent publications still get fresh facts.

No new config, environment, persistence, protocol, dependency, or public API surface. No persistent config cache and no duplicated read-only policy. Production +16/-12 (net +4); the four lines pay for lazy evaluation of the existing batch fact and its ownership comment. Tests +7/-0, extending the existing read-only lifecycle test rather than adding a new harness.

## User Impact

Read-only catalog work avoids discovery it cannot use, without changing model-policy precedence or executable probe behavior. The original roster repair is already on main as e7ec39fe54ec90df2fa4a422c7d74d6a48857aab. This follow-up does not claim all large-fleet startup costs are gone: #135893 tracks remaining model-auth/plugin planning stalls.

The doctor setup/install callers use the shared collector and inherit the original optimization. #134331 is a distinct, already-closed workspace migration conflict, not the same performance defect. Thanks @609NFT for the original report and @LiuwqGit for the original repair direction.

## Evidence

- Regression red on main: the existing read-only draft lifecycle test fails because `collectConfiguredAgentHarnessRuntimes` is called once.
- Regression green and siblings: 121 tests passed across harness discovery, model policy, prepared runtime lifecycle/owner selection, and runtime plugin loading. The existing 300-agent x 40-model test still bounds roster reads and checks freshness after config mutations.
- Two local Codex autoreview passes reported scoped-clean at the configured P0 threshold. Final branch review and exact-head CI are recorded below before landing.

Live proof is synthetic-only, on a temporary state directory and OS-selected loopback port; no operator state or port 18789. Baseline built from 9fbf676ef1a26fc0c008c0e3c549d0b74726a598 with 100 agents and 40 model refs per agent. Listener observed at 110.573s; first completed `/health` HTTP 200 at 144.682s (34.109s after listen). A later independent request returned `{"ok":true,"status":"live"}` in 0.001482s. The full observation recorded 248 HTTP 200 responses and 28 two-second timeouts, including intermittent post-first-response stalls. This is a liveness smoke, not a controlled performance comparison: concurrent build activity varied.

The baseline `models list --json --agent proof-0` did not finish within 180 seconds; its detached child was verified against the temporary working directory and cleaned up. This failure is retained as a proof limitation, not described as passing.

Candidate gateway smoke from commit 22025fe1f4245a9d8ff01e297d524c46491de927, again 100 agents x 40 refs on a fresh state/port:

```text
listener observed: 135.153s
gateway ready observed: 161.867s
first completed GET /health: 170.980s (35.827s after listener)
HTTP 200 {"ok":true,"status":"live"}
```

The similar post-listen delay is expected: this patch avoids unused read-only discovery, not the remaining startup bottleneck. The candidate was built through the normal incremental `pnpm openclaw --help` path after one full baseline build. The final branch Codex autoreview is scoped-clean. All changed-file checks passed (format/lint, core and test types, dead-export scans, import cycles, and repository guards).

The candidate `models list --json --agent proof-0` also timed out at 180 seconds on the 100-agent state. A separate fresh one-agent / 40-model state returned exit 0 and all 40 models in 6.321 seconds. The large catalog stall is not claimed fixed by this patch; both timed-out children were cleaned up after verifying their temporary working directories.

Commands used:

```text
node scripts/run-vitest.mjs src/agents/prepared-model-runtime.test.ts -t 'allows a read-only draft owner'
# Before: FAIL, collector invoked once; after included in the passing suite below.
node scripts/run-vitest.mjs src/agents/prepared-model-runtime.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/runtime-plugins.test.ts src/agents/harness-runtimes.test.ts src/agents/model-runtime-policy.test.ts
# PASS: 121 tests
node scripts/check-changed.mjs -- src/agents/prepared-model-runtime.build.ts src/agents/prepared-model-runtime.facts.ts src/agents/prepared-model-runtime.inbound-registry.ts src/agents/prepared-model-runtime.test.ts
# PASS
pnpm build
pnpm openclaw --help
# Baseline full build and candidate incremental CLI build: PASS
OPENCLAW_STATE_DIR=<fresh-temp-dir> OPENCLAW_CONFIG_PATH=<synthetic-config> node openclaw.mjs gateway run --port <OS-selected-free-port> --bind loopback --auth none
# Candidate: gateway ready; GET /health -> HTTP 200 {"ok":true,"status":"live"}
OPENCLAW_STATE_DIR=<fresh-one-agent-temp-dir> node openclaw.mjs models list --json --agent proof-0
# Candidate: exit 0, 40 models, 6.321 seconds
```

The subprocesses also used an isolated home and a minimal environment. Fixture agents use explicit ownership, unique temporary workspaces, `openai/proof-model-0` through `openai/proof-model-39`, and only OpenAI/Codex plugins; no inference, real channels, credentials, or user data were used. Exact-head CI will be verified before landing.
