### PR TITLE
feat(openzoo): add bundled openzoo provider plugin (pay-per-call inference over x402, no API key)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -817,6 +817,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/openshell/**"
+"extensions: openzoo":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/openzoo/**"
 "extensions: parallel":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **openzoo provider:** add the bundled `openzoo` provider plugin for pay-per-call inference over x402 through a local proxy: keyless like LM Studio, with live per-token pricing discovery like Kilo Gateway, app-guided proxy detection, and a `/providers/openzoo` docs page.
 - **macOS releases:** retain signed artifacts and Apple submission IDs so interrupted notarization can resume without rebuilding the app or symbols, while preserving source, hash, signature, and approval checks.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **Developer workflow:** remove the obsolete scoped-commit helper and use standard Git commands in isolated worktrees.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -833,6 +833,7 @@ const config = {
       "models.ts!",
       "oauth.ts!",
     ]),
+    [`${BUNDLED_PLUGIN_ROOT_DIR}/openzoo`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/pixverse`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/qianfan`]: bundledPluginWorkspace(),
     [`${BUNDLED_PLUGIN_ROOT_DIR}/qwen`]: bundledPluginWorkspace(),

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -294,6 +294,7 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 | NovitaAI                                | `novita`                         | `NOVITA_API_KEY`                                     | `novita/deepseek/deepseek-v3-0324`                     |
 | [Ollama Cloud](/providers/ollama-cloud) | `ollama-cloud`                   | `OLLAMA_API_KEY`                                     | `ollama-cloud/kimi-k2.6`                               |
 | OpenRouter                              | `openrouter`                     | OpenRouter OAuth or `OPENROUTER_API_KEY`             | `openrouter/auto`                                      |
+| [openzoo](/providers/openzoo)           | `openzoo`                        | none (local proxy pays per call over x402)           | `openzoo/auto`                                         |
 | Qianfan                                 | `qianfan`                        | `QIANFAN_API_KEY`                                    | `qianfan/deepseek-v3.2`                                |
 | Tencent TokenHub                        | `tencent-tokenhub`               | `TOKENHUB_API_KEY`                                   | `tencent-tokenhub/hy3-preview`                         |
 | Together                                | `together`                       | `TOGETHER_API_KEY`                                   | `together/meta-llama/Llama-3.3-70B-Instruct-Turbo`     |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1695,6 +1695,7 @@
                   "providers/opencode",
                   "providers/opencode-go",
                   "providers/openrouter",
+                  "providers/openzoo",
                   "providers/perplexity-provider",
                   "providers/pixverse",
                   "providers/qianfan",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -174,7 +174,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-90 plugins
+91 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -266,7 +266,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[longcat](/plugins/reference/longcat)** (`@openclaw/longcat-provider`) - npm; ClawHub: `clawhub:@openclaw/longcat-provider`. OpenClaw LongCat provider plugin.
 
-- **[matrix](/plugins/reference/matrix)** (`@openclaw/matrix`) - ClawHub: `clawhub:@openclaw/matrix`; npm. OpenClaw Matrix channel plugin for rooms and direct messages.
+- **[matrix](/plugins/reference/matrix)** (`@openclaw/matrix`) - npm; ClawHub: `clawhub:@openclaw/matrix`. OpenClaw Matrix channel plugin for rooms and direct messages.
 
 - **[mattermost](/plugins/reference/mattermost)** (`@openclaw/mattermost`) - npm; ClawHub: `clawhub:@openclaw/mattermost`. Adds the Mattermost channel surface for sending and receiving OpenClaw messages.
 
@@ -291,6 +291,8 @@ Each entry lists the package, distribution route, and description.
 - **[opencode](/plugins/reference/opencode)** (`@openclaw/opencode-provider`) - npm; ClawHub: `clawhub:@openclaw/opencode-provider`. Adds OpenCode model provider support to OpenClaw.
 
 - **[openshell](/plugins/reference/openshell)** (`@openclaw/openshell-sandbox`) - npm; ClawHub. OpenClaw sandbox backend for the NVIDIA OpenShell CLI with mirrored local workspaces and SSH command execution.
+
+- **[openzoo](/plugins/reference/openzoo)** (`@openclaw/openzoo-provider`) - npm; ClawHub: `clawhub:@openclaw/openzoo-provider`. Adds Openzoo model provider support to OpenClaw.
 
 - **[parallel](/tools/parallel-search)** (`@openclaw/parallel-plugin`) - npm; ClawHub: `clawhub:@openclaw/parallel-plugin`. Adds web search provider support.
 
@@ -344,7 +346,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[vydra](/plugins/reference/vydra)** (`@openclaw/vydra-provider`) - npm; ClawHub: `clawhub:@openclaw/vydra-provider`. Adds Vydra model provider support to OpenClaw.
 
-- **[whatsapp](/plugins/reference/whatsapp)** (`@openclaw/whatsapp`) - ClawHub: `clawhub:@openclaw/whatsapp`; npm. OpenClaw WhatsApp channel plugin for WhatsApp Web chats.
+- **[whatsapp](/plugins/reference/whatsapp)** (`@openclaw/whatsapp`) - npm; ClawHub: `clawhub:@openclaw/whatsapp`. OpenClaw WhatsApp channel plugin for WhatsApp Web chats.
 
 - **[xiaomi](/plugins/reference/xiaomi)** (`@openclaw/xiaomi-provider`) - npm; ClawHub: `clawhub:@openclaw/xiaomi-provider`. Adds Xiaomi, Xiaomi Token Plan model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -16,5 +16,5 @@ Regenerate it with:
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 151
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 152
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/matrix.md
+++ b/docs/plugins/reference/matrix.md
@@ -12,7 +12,7 @@ OpenClaw Matrix channel plugin for rooms and direct messages.
 ## Distribution
 
 - Package: `@openclaw/matrix`
-- Install route: ClawHub: `clawhub:@openclaw/matrix`; npm
+- Install route: npm; ClawHub: `clawhub:@openclaw/matrix`
 
 ## Surface
 

--- a/docs/plugins/reference/openzoo.md
+++ b/docs/plugins/reference/openzoo.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds Openzoo model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the openzoo plugin
+title: "Openzoo plugin"
+---
+
+# Openzoo plugin
+
+Adds Openzoo model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/openzoo-provider`
+- Install route: npm; ClawHub: `clawhub:@openclaw/openzoo-provider`
+
+## Surface
+
+providers: `openzoo`
+
+## Related docs
+
+- [openzoo](/providers/openzoo)

--- a/docs/plugins/reference/whatsapp.md
+++ b/docs/plugins/reference/whatsapp.md
@@ -12,7 +12,7 @@ OpenClaw WhatsApp channel plugin for WhatsApp Web chats.
 ## Distribution
 
 - Package: `@openclaw/whatsapp`
-- Install route: ClawHub: `clawhub:@openclaw/whatsapp`; npm
+- Install route: npm; ClawHub: `clawhub:@openclaw/whatsapp`
 
 ## Surface
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -67,6 +67,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [OpenCode](/providers/opencode)
 - [OpenCode Go](/providers/opencode-go)
 - [OpenRouter](/providers/openrouter)
+- [openzoo (pay per call over x402, no API key)](/providers/openzoo)
 - [Perplexity (web search)](/providers/perplexity-provider)
 - [Qianfan](/providers/qianfan)
 - [Qwen Cloud](/providers/qwen)

--- a/docs/providers/openzoo.md
+++ b/docs/providers/openzoo.md
@@ -1,0 +1,190 @@
+---
+summary: "Pay per call for many models through a local openzoo proxy, no account or API key"
+title: "openzoo"
+read_when:
+  - You want to use many LLMs without creating an account or managing API keys
+  - You want to pay for inference per call over x402 from a local wallet
+  - You want to run models via openzoo in OpenClaw
+---
+
+openzoo is a local proxy that pays for LLM inference per call over x402 (on-chain
+micropayments from a local burner wallet). There is no account and no API key: you run the
+proxy, fund its wallet, and point OpenClaw at `http://localhost:8402/v1`.
+
+| Property | Value                                                |
+| -------- | ---------------------------------------------------- |
+| Provider | `openzoo`                                            |
+| Auth     | none (the proxy pays per call; keys are not checked) |
+| API      | OpenAI-compatible                                    |
+| Base URL | `http://localhost:8402/v1` (local proxy)             |
+
+The public gateway at `https://x402-tokens.fly.dev/v1` answers HTTP 402 to unpaid calls. Only
+the local proxy can pay, so OpenClaw always talks to the proxy, never to the gateway directly.
+
+## Install plugin
+
+```bash
+openclaw plugins install @openclaw/openzoo-provider
+openclaw gateway restart
+```
+
+## Setup
+
+<Steps>
+  <Step title="Start the proxy">
+    In another terminal:
+
+    ```bash
+    npx openzoo
+    ```
+
+    Or install it once with `npm i -g openzoo` and run `openzoo`. The first run creates a
+    burner wallet, prints its funding address, and listens on `http://localhost:8402/v1`.
+    Fund the address with USDC on Solana or Base. Override the port with `OPENZOO_PORT`.
+
+    OpenClaw does not start the proxy for you; it only detects a running one.
+
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice openzoo
+    ```
+
+    Setup probes `GET http://localhost:8402/v1/info` (served by the proxy itself, no
+    upstream call). If the proxy is not running, OpenClaw prints the `npx openzoo` hint and
+    lets you retry.
+
+    Non-interactive:
+
+    ```bash
+    openclaw onboard --non-interactive --accept-risk --skip-health --auth-choice openzoo
+    ```
+
+    Add `--custom-base-url http://host:8402/v1` for a proxy on another host and
+    `--custom-model-id anthropic/claude-sonnet-5` to pick a default other than `auto`.
+
+  </Step>
+  <Step title="Verify the model is available">
+    ```bash
+    openclaw models list --provider openzoo
+    ```
+  </Step>
+</Steps>
+
+## Default model and catalog
+
+The default model is `openzoo/auto`, the gateway's own router row. Routing behind `auto` is
+owned by openzoo.
+
+While the proxy is running, OpenClaw queries `GET http://localhost:8402/v1/models` (free, no
+payment) and merges the discovered models ahead of a static fallback catalog. The static
+fallback contains only `openzoo/auto` (`input: ["text"]`, `reasoning: false`,
+`contextWindow: 128000000`, `maxTokens: 8192`, `cost: { input: 0.1, output: 0.2 }` USD per
+million tokens). When the proxy is not running and `models.providers.openzoo` is not
+configured, the provider is not listed at all.
+
+Any model on the gateway is addressable as `openzoo/<upstream-id>` (for example
+`openzoo/anthropic/claude-sonnet-5`, `openzoo/x-ai/grok-4.6`). Media rows (image and video
+generation) and rows without a price are excluded from the chat catalog.
+
+The discovered `context_length` is the client-usable window: the proxy spills long context
+server-side, so OpenClaw keeps the advertised 128M-token window rather than the upstream
+model's native limit.
+
+## Pricing
+
+Discovered prices are a ceiling. The gateway reports each model on an OpenRouter-direct basis
+(USD per token, converted to USD per million tokens in OpenClaw) and charges at most that,
+often far less through context reuse. The prices you see in `openclaw models list` are the
+most you will pay per token for that model.
+
+Payments settle on chain per call over x402. Receipts live in `~/.openzoo/proxy.log`.
+
+## Config example
+
+```json5
+{
+  models: {
+    providers: {
+      openzoo: {
+        baseUrl: "http://localhost:8402/v1",
+        api: "openai-completions",
+        apiKey: "sk-openzoo", // any placeholder; the zoo takes payment, not keys
+        models: [
+          {
+            id: "auto",
+            name: "auto",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "openzoo/auto" },
+    },
+  },
+}
+```
+
+Omit `apiKey` and OpenClaw synthesizes a local non-secret marker for the provider; set a real
+`apiKey` only when you front the proxy with your own authenticating reverse proxy. Explicit
+`models` rows stay authoritative and live discovery fills in the rest of the catalog.
+
+Set `OPENZOO_BASE_URL` (or `OPENZOO_PORT`) in the Gateway environment to point OpenClaw at a
+proxy that is not on `http://localhost:8402/v1`; `models.providers.openzoo.baseUrl` wins over
+both.
+
+## Behavior notes
+
+<AccordionGroup>
+  <Accordion title="Transport and compatibility">
+    The proxy forwards OpenAI-compatible bodies to OpenRouter-shaped upstreams, so OpenClaw
+    uses the proxy-style OpenAI-compatible request path rather than native OpenAI request
+    shaping.
+
+    - Gemini-backed refs stay on the proxy-Gemini path: OpenClaw sanitizes Gemini thought
+      signatures there but does not enable native Gemini replay validation.
+    - Requests carry a Bearer token built from the placeholder key; the proxy ignores it on
+      localhost.
+
+  </Accordion>
+
+  <Accordion title="Reasoning models">
+    OpenClaw only marks a discovered model as reasoning-capable when its id says so
+    unambiguously (`o1`, `o3`, `o4`, `r1`, `qwq`, `reasoner`, `thinking`). A wrong
+    `reasoning: true` breaks requests; a wrong `false` only hides the thinking toggle. Add an
+    explicit `models` row with `reasoning: true` to override.
+  </Accordion>
+
+  <Accordion title="Troubleshooting">
+    - `openclaw models list --provider openzoo` shows only `openzoo/auto`: the proxy was not
+      reachable at discovery time. Start `npx openzoo` and restart the Gateway.
+    - The provider is missing entirely: the proxy is not running and nothing is configured
+      under `models.providers.openzoo`. Run `openclaw onboard --auth-choice openzoo`.
+    - Requests fail with HTTP 402: the burner wallet is empty. Fund the address the proxy
+      printed at startup.
+    - When the Gateway runs as a daemon, the proxy must be reachable from that process; use
+      `OPENZOO_BASE_URL` or `models.providers.openzoo.baseUrl` for a non-default host.
+
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full OpenClaw configuration reference.
+  </Card>
+  <Card title="openzoo" href="https://openzoo.fun" icon="arrow-up-right-from-square">
+    openzoo site, proxy source, and funding instructions.
+  </Card>
+</CardGroup>

--- a/extensions/openzoo/README.md
+++ b/extensions/openzoo/README.md
@@ -1,0 +1,12 @@
+# OpenClaw openzoo Provider
+
+Official OpenClaw provider plugin for openzoo: pay-per-call inference over x402 through a local proxy, no account and no API key.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/openzoo-provider
+openclaw gateway restart
+```
+
+See <https://docs.openclaw.ai/providers/openzoo> for setup and configuration.

--- a/extensions/openzoo/api.ts
+++ b/extensions/openzoo/api.ts
@@ -1,0 +1,32 @@
+// Openzoo API module exposes the plugin public contract.
+export {
+  hasOpenzooAuthorizationHeader,
+  isOpenzooKeylessApiKey,
+  resolveOpenzooProviderAuthMode,
+  shouldUseOpenzooSyntheticAuth,
+} from "./provider-auth.js";
+export { buildOpenzooProvider, buildOpenzooProviderWithDiscovery } from "./provider-catalog.js";
+export {
+  buildOpenzooModelDefinition,
+  discoverOpenzooModels,
+  normalizeOpenzooBaseUrl,
+  OPENZOO_BASE_URL_ENV_VAR,
+  OPENZOO_DEFAULT_BASE_URL,
+  OPENZOO_DEFAULT_CONTEXT_WINDOW,
+  OPENZOO_DEFAULT_COST,
+  OPENZOO_DEFAULT_MAX_TOKENS,
+  OPENZOO_DEFAULT_MODEL_ID,
+  OPENZOO_DEFAULT_MODEL_NAME,
+  OPENZOO_DEFAULT_MODEL_REF,
+  OPENZOO_DEFAULT_PORT,
+  OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+  OPENZOO_MODEL_CATALOG,
+  OPENZOO_PORT_ENV_VAR,
+  OPENZOO_PROVIDER_ID,
+  OPENZOO_PROVIDER_LABEL,
+  parseOpenzooReasoning,
+  projectOpenzooModels,
+  resolveOpenzooBaseUrl,
+  resolveOpenzooInfoUrl,
+  resolveOpenzooModelsUrl,
+} from "./provider-models.js";

--- a/extensions/openzoo/index.test.ts
+++ b/extensions/openzoo/index.test.ts
@@ -1,0 +1,168 @@
+// Openzoo tests cover index plugin behavior.
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-setup";
+import { expectPassthroughReplayPolicy } from "openclaw/plugin-sdk/provider-test-contracts";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import {
+  buildOpenzooModelDefinition,
+  OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+} from "./provider-models.js";
+
+function createProviderConfig(overrides: Partial<ModelProviderConfig> = {}): ModelProviderConfig {
+  return {
+    baseUrl: "http://localhost:8402/v1",
+    api: "openai-completions",
+    models: [buildOpenzooModelDefinition()],
+    ...overrides,
+  };
+}
+
+describe("openzoo provider plugin", () => {
+  it("registers a keyless custom auth method with app-guided detection", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(provider.id).toBe("openzoo");
+    expect(provider.label).toBe("openzoo");
+    expect(provider.docsPath).toBe("/providers/openzoo");
+    expect(provider.envVars).toBeUndefined();
+    expect(provider.auth.map((method) => [method.id, method.kind])).toEqual([["custom", "custom"]]);
+    const method = provider.auth[0];
+    expect(typeof method?.appGuidedSetup?.detectAvailability).toBe("function");
+    expect(typeof method?.appGuidedSetup?.detect).toBe("function");
+    expect(typeof method?.appGuidedSetup?.prepare).toBe("function");
+    expect(typeof method?.runNonInteractive).toBe("function");
+    expect(typeof method?.validateNonInteractive).toBe("function");
+    expect(provider.wizard?.setup).toMatchObject({ choiceId: "openzoo", methodId: "custom" });
+  });
+
+  it("runs the late catalog and a network-free static catalog", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(provider.catalog?.order).toBe("late");
+    const ctx = {
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    } as ProviderCatalogContext;
+    expect(await provider.staticCatalog?.run(ctx)).toEqual({
+      provider: {
+        baseUrl: "http://localhost:8402/v1",
+        api: "openai-completions",
+        models: [buildOpenzooModelDefinition()],
+      },
+    });
+  });
+
+  it("owns passthrough-gemini replay policy for Gemini-backed models", async () => {
+    await expectPassthroughReplayPolicy({
+      plugin,
+      providerId: "openzoo",
+      modelId: "google/gemini-2.5-pro",
+      sanitizeThoughtSignatures: true,
+    });
+  });
+
+  it("synthesizes local auth only for keyless configured providers", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "openzoo",
+        config: {},
+        providerConfig: createProviderConfig(),
+      }),
+    ).toEqual({
+      apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+      source: "models.providers.openzoo (synthetic local key)",
+      mode: "api-key",
+    });
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "openzoo",
+        config: {},
+        providerConfig: createProviderConfig({ apiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER }),
+      }),
+    ).toMatchObject({ apiKey: CUSTOM_LOCAL_AUTH_MARKER });
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "openzoo",
+        config: {},
+        providerConfig: createProviderConfig({ apiKey: "real-key" }),
+      }),
+    ).toBeUndefined();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "openzoo",
+        config: {},
+        providerConfig: createProviderConfig({ headers: { Authorization: "Bearer token" } }),
+      }),
+    ).toBeUndefined();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "openzoo",
+        config: {},
+        providerConfig: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("defers stored keyless profile auth so real credentials can win", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const base = { provider: "openzoo", config: {}, providerConfig: createProviderConfig() };
+
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({
+        ...base,
+        resolvedApiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+      }),
+    ).toBe(true);
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({
+        ...base,
+        resolvedApiKey: CUSTOM_LOCAL_AUTH_MARKER,
+      }),
+    ).toBe(true);
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({ ...base, resolvedApiKey: "real-key" }),
+    ).toBe(false);
+  });
+
+  it("publishes configured openzoo models through plugin-owned catalog augmentation", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(
+      provider.augmentModelCatalog?.({
+        config: {
+          models: {
+            providers: {
+              openzoo: {
+                models: [
+                  {
+                    id: "anthropic/claude-sonnet-5",
+                    name: "Claude Sonnet 5",
+                    input: ["text", "image"],
+                    reasoning: false,
+                    contextWindow: 128000000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as never),
+    ).toEqual([
+      {
+        provider: "openzoo",
+        id: "anthropic/claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        input: ["text", "image"],
+        reasoning: false,
+        contextWindow: 128000000,
+      },
+    ]);
+  });
+});

--- a/extensions/openzoo/index.ts
+++ b/extensions/openzoo/index.ts
@@ -1,0 +1,117 @@
+// Openzoo plugin entrypoint registers its OpenClaw integration.
+import type {
+  ProviderAuthContext,
+  ProviderAuthMethodNonInteractiveContext,
+  ProviderAuthResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { isOpenzooKeylessApiKey, shouldUseOpenzooSyntheticAuth } from "./provider-auth.js";
+import { buildOpenzooProvider } from "./provider-catalog.js";
+import { OPENZOO_PROVIDER_ID, OPENZOO_PROVIDER_LABEL } from "./provider-models.js";
+
+const PROVIDER_ID = OPENZOO_PROVIDER_ID;
+const OPENZOO_SETUP_HINT =
+  "Pay per call over x402 through a local openzoo proxy (no account, no API key)";
+const OPENZOO_GROUP_HINT = "Pay-per-call inference over x402, no account or API key";
+
+/** Lazily loads setup helpers so provider wiring stays lightweight at startup. */
+async function loadProviderSetup() {
+  return await import("./setup.js");
+}
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "openzoo Provider",
+  description: "Bundled openzoo provider plugin",
+  manifest,
+  provider: {
+    label: OPENZOO_PROVIDER_LABEL,
+    docsPath: "/providers/openzoo",
+    extraAuth: [
+      {
+        id: "custom",
+        label: OPENZOO_PROVIDER_LABEL,
+        hint: OPENZOO_SETUP_HINT,
+        kind: "custom",
+        appGuidedSetup: {
+          detectAvailability: async (ctx) => {
+            const providerSetup = await loadProviderSetup();
+            return await providerSetup.detectAppGuidedOpenzooAvailability(ctx);
+          },
+          detect: async (ctx) => {
+            const providerSetup = await loadProviderSetup();
+            return await providerSetup.detectAppGuidedOpenzooModel(ctx);
+          },
+          prepare: async (ctx) => {
+            const providerSetup = await loadProviderSetup();
+            return await providerSetup.prepareAppGuidedOpenzooSetup(ctx);
+          },
+        },
+        run: async (ctx: ProviderAuthContext): Promise<ProviderAuthResult> => {
+          const providerSetup = await loadProviderSetup();
+          return await providerSetup.promptAndConfigureOpenzooInteractive({
+            config: ctx.config,
+            env: ctx.env,
+            prompter: ctx.prompter,
+            signal: ctx.signal,
+          });
+        },
+        validateNonInteractive: async (ctx) => {
+          const providerSetup = await loadProviderSetup();
+          return await providerSetup.validateOpenzooNonInteractive(ctx);
+        },
+        runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) => {
+          const providerSetup = await loadProviderSetup();
+          return await providerSetup.configureOpenzooNonInteractive(ctx);
+        },
+      },
+    ],
+    catalog: {
+      // Run after early providers so a local proxy does not dominate resolution.
+      order: "late",
+      run: async (ctx) => {
+        const providerSetup = await loadProviderSetup();
+        return await providerSetup.discoverOpenzooProvider(ctx);
+      },
+      staticRun: async () => ({ provider: buildOpenzooProvider() }),
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    // Upstream ids are OpenRouter-shaped, so Gemini-backed refs take the proxy-Gemini path.
+    ...buildProviderReplayFamilyHooks({ family: "passthrough-gemini" }),
+    resolveSyntheticAuth: ({ providerConfig }) => {
+      if (!shouldUseOpenzooSyntheticAuth(providerConfig)) {
+        return undefined;
+      }
+      return {
+        apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+        source: "models.providers.openzoo (synthetic local key)",
+        mode: "api-key" as const,
+      };
+    },
+    shouldDeferSyntheticProfileAuth: ({ resolvedApiKey }) => isOpenzooKeylessApiKey(resolvedApiKey),
+    wizard: {
+      setup: {
+        choiceId: PROVIDER_ID,
+        choiceLabel: OPENZOO_PROVIDER_LABEL,
+        choiceHint: OPENZOO_SETUP_HINT,
+        groupId: PROVIDER_ID,
+        groupLabel: OPENZOO_PROVIDER_LABEL,
+        groupHint: OPENZOO_GROUP_HINT,
+        methodId: "custom",
+      },
+      modelPicker: {
+        label: `${OPENZOO_PROVIDER_LABEL} (local proxy)`,
+        hint: "Detect priced models from the openzoo proxy /v1/models",
+        methodId: "custom",
+      },
+    },
+  },
+});

--- a/extensions/openzoo/openclaw.plugin.json
+++ b/extensions/openzoo/openclaw.plugin.json
@@ -1,0 +1,77 @@
+{
+  "id": "openzoo",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["openzoo"],
+  "modelPricing": {
+    "providers": {
+      "openzoo": {
+        "openRouter": {
+          "passthroughProviderModel": true
+        },
+        "liteLLM": {
+          "passthroughProviderModel": true
+        }
+      }
+    }
+  },
+  "nonSecretAuthMarkers": ["sk-openzoo"],
+  "syntheticAuthRefs": ["openzoo"],
+  "setup": {
+    "providers": [
+      {
+        "id": "openzoo",
+        "authMethods": ["custom"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "openzoo",
+      "method": "custom",
+      "choiceId": "openzoo",
+      "appGuidedDiscovery": true,
+      "appGuidedActionLabel": "Connect proxy",
+      "choiceLabel": "openzoo",
+      "choiceHint": "Pay per call over x402 through a local openzoo proxy (no account, no API key)",
+      "website": "https://openzoo.fun",
+      "groupId": "openzoo",
+      "groupLabel": "openzoo",
+      "groupHint": "Pay-per-call inference over x402, no account or API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "modelCatalog": {
+    "providers": {
+      "openzoo": {
+        "baseUrl": "http://localhost:8402/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "auto",
+            "name": "auto",
+            "reasoning": false,
+            "input": ["text"],
+            "cost": {
+              "input": 0.1,
+              "output": 0.2,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 128000000,
+            "maxTokens": 8192
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "openzoo": "refreshable"
+    }
+  }
+}

--- a/extensions/openzoo/package.json
+++ b/extensions/openzoo/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/openzoo-provider",
+  "version": "2026.8.1",
+  "description": "OpenClaw openzoo provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/openzoo-provider",
+      "npmSpec": "@openclaw/openzoo-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.8"
+    },
+    "compat": {
+      "pluginApi": ">=2026.8.1"
+    },
+    "build": {
+      "openclawVersion": "2026.8.1",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/openzoo/provider-auth.test.ts
+++ b/extensions/openzoo/provider-auth.test.ts
@@ -1,0 +1,80 @@
+// Openzoo tests cover provider auth plugin behavior.
+import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { describe, expect, it } from "vitest";
+import {
+  hasOpenzooAuthorizationHeader,
+  isOpenzooKeylessApiKey,
+  resolveOpenzooProviderAuthMode,
+  shouldUseOpenzooSyntheticAuth,
+} from "./provider-auth.js";
+import {
+  buildOpenzooModelDefinition,
+  OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+} from "./provider-models.js";
+
+function createProviderConfig(overrides: Partial<ModelProviderConfig> = {}): ModelProviderConfig {
+  return {
+    baseUrl: "http://localhost:8402/v1",
+    api: "openai-completions",
+    models: [buildOpenzooModelDefinition()],
+    ...overrides,
+  };
+}
+
+describe("openzoo provider auth", () => {
+  it("synthesizes local auth for a keyless configured provider", () => {
+    expect(shouldUseOpenzooSyntheticAuth(createProviderConfig())).toBe(true);
+    expect(
+      shouldUseOpenzooSyntheticAuth(
+        createProviderConfig({ apiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldUseOpenzooSyntheticAuth(createProviderConfig({ apiKey: CUSTOM_LOCAL_AUTH_MARKER })),
+    ).toBe(true);
+    expect(shouldUseOpenzooSyntheticAuth(createProviderConfig({ apiKey: "   " }))).toBe(true);
+  });
+
+  it("does not synthesize auth when a real credential or Authorization header exists", () => {
+    expect(shouldUseOpenzooSyntheticAuth(createProviderConfig({ apiKey: "real-key" }))).toBe(false);
+    expect(
+      shouldUseOpenzooSyntheticAuth(
+        createProviderConfig({ headers: { Authorization: "Bearer proxy-token" } }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseOpenzooSyntheticAuth(
+        createProviderConfig({ headers: { "X-Proxy-Auth": "proxy-token" } }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not synthesize auth without configured models", () => {
+    expect(shouldUseOpenzooSyntheticAuth(createProviderConfig({ models: [] }))).toBe(false);
+    expect(shouldUseOpenzooSyntheticAuth(undefined)).toBe(false);
+  });
+
+  it("treats only real credentials as api-key auth", () => {
+    expect(resolveOpenzooProviderAuthMode("real-key")).toBe("api-key");
+    expect(resolveOpenzooProviderAuthMode(OPENZOO_LOCAL_API_KEY_PLACEHOLDER)).toBeUndefined();
+    expect(resolveOpenzooProviderAuthMode(CUSTOM_LOCAL_AUTH_MARKER)).toBeUndefined();
+    expect(resolveOpenzooProviderAuthMode("")).toBeUndefined();
+    expect(resolveOpenzooProviderAuthMode(undefined)).toBeUndefined();
+  });
+
+  it("recognizes the keyless markers", () => {
+    expect(isOpenzooKeylessApiKey(` ${OPENZOO_LOCAL_API_KEY_PLACEHOLDER} `)).toBe(true);
+    expect(isOpenzooKeylessApiKey(CUSTOM_LOCAL_AUTH_MARKER)).toBe(true);
+    expect(isOpenzooKeylessApiKey("real-key")).toBe(false);
+    expect(isOpenzooKeylessApiKey(undefined)).toBe(false);
+  });
+
+  it("detects Authorization headers case-insensitively", () => {
+    expect(hasOpenzooAuthorizationHeader({ authorization: "Bearer token" })).toBe(true);
+    expect(hasOpenzooAuthorizationHeader({ Authorization: "" })).toBe(false);
+    expect(hasOpenzooAuthorizationHeader({ "X-Other": "1" })).toBe(false);
+    expect(hasOpenzooAuthorizationHeader(undefined)).toBe(false);
+    expect(hasOpenzooAuthorizationHeader(["Authorization"])).toBe(false);
+  });
+});

--- a/extensions/openzoo/provider-auth.ts
+++ b/extensions/openzoo/provider-auth.ts
@@ -1,0 +1,58 @@
+// Openzoo provider module implements model/runtime integration.
+import {
+  CUSTOM_LOCAL_AUTH_MARKER,
+  hasConfiguredSecretInput,
+  normalizeOptionalSecretInput,
+} from "openclaw/plugin-sdk/provider-auth";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { OPENZOO_LOCAL_API_KEY_PLACEHOLDER } from "./provider-models.js";
+
+export function hasOpenzooAuthorizationHeader(headers: unknown): boolean {
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return false;
+  }
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    if (headerName.trim().toLowerCase() !== "authorization") {
+      continue;
+    }
+    if (hasConfiguredSecretInput(headerValue)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Returns `api-key` only for a real operator credential, never for the keyless markers. */
+export function resolveOpenzooProviderAuthMode(
+  apiKey: ModelProviderConfig["apiKey"] | undefined,
+): ModelProviderConfig["auth"] | undefined {
+  const normalized = normalizeOptionalSecretInput(apiKey);
+  if (normalized !== undefined) {
+    const trimmed = normalized.trim();
+    if (
+      !trimmed ||
+      trimmed === OPENZOO_LOCAL_API_KEY_PLACEHOLDER ||
+      trimmed === CUSTOM_LOCAL_AUTH_MARKER
+    ) {
+      return undefined;
+    }
+    return "api-key";
+  }
+  return hasConfiguredSecretInput(apiKey) ? "api-key" : undefined;
+}
+
+export function isOpenzooKeylessApiKey(apiKey: string | undefined): boolean {
+  const trimmed = apiKey?.trim();
+  return trimmed === OPENZOO_LOCAL_API_KEY_PLACEHOLDER || trimmed === CUSTOM_LOCAL_AUTH_MARKER;
+}
+
+export function shouldUseOpenzooSyntheticAuth(
+  providerConfig: ModelProviderConfig | undefined,
+): boolean {
+  const hasModels = Array.isArray(providerConfig?.models) && providerConfig.models.length > 0;
+  return (
+    hasModels &&
+    !resolveOpenzooProviderAuthMode(providerConfig?.apiKey) &&
+    !hasOpenzooAuthorizationHeader(providerConfig?.headers)
+  );
+}

--- a/extensions/openzoo/provider-catalog.test.ts
+++ b/extensions/openzoo/provider-catalog.test.ts
@@ -1,0 +1,59 @@
+// Openzoo tests cover implicit provider plugin behavior.
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const { discoverOpenzooModelsMock } = vi.hoisted(() => ({
+  discoverOpenzooModelsMock: vi.fn(),
+}));
+
+vi.mock("./provider-models.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./provider-models.js")>();
+  return {
+    ...actual,
+    discoverOpenzooModels: (...args: unknown[]) => discoverOpenzooModelsMock(...args),
+  };
+});
+
+import { buildOpenzooProvider, buildOpenzooProviderWithDiscovery } from "./provider-catalog.js";
+
+afterAll(() => {
+  vi.doUnmock("./provider-models.js");
+  vi.resetModules();
+});
+
+describe("openzoo implicit provider", () => {
+  it("publishes the static provider catalog used by implicit provider setup", () => {
+    const provider = buildOpenzooProvider();
+
+    expect(provider.baseUrl).toBe("http://localhost:8402/v1");
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.models).toStrictEqual([
+      {
+        id: "auto",
+        name: "auto",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000000,
+        maxTokens: 8192,
+      },
+    ]);
+  });
+
+  it("builds the discovered provider on the resolved base URL", async () => {
+    const discovered = [{ ...buildOpenzooProvider().models![0]!, id: "anthropic/claude-sonnet-5" }];
+    discoverOpenzooModelsMock.mockResolvedValueOnce(discovered);
+
+    const provider = await buildOpenzooProviderWithDiscovery({
+      baseUrl: "http://proxy-host:8402/v1",
+    });
+
+    expect(discoverOpenzooModelsMock).toHaveBeenCalledWith({
+      baseUrl: "http://proxy-host:8402/v1",
+    });
+    expect(provider).toEqual({
+      baseUrl: "http://proxy-host:8402/v1",
+      api: "openai-completions",
+      models: discovered,
+    });
+  });
+});

--- a/extensions/openzoo/provider-catalog.ts
+++ b/extensions/openzoo/provider-catalog.ts
@@ -1,0 +1,32 @@
+// Openzoo provider module implements model/runtime integration.
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+import {
+  discoverOpenzooModels,
+  OPENZOO_DEFAULT_BASE_URL,
+  OPENZOO_PROVIDER_ID,
+} from "./provider-models.js";
+
+export function buildOpenzooProvider(): ModelProviderConfig {
+  return buildManifestModelProviderConfig({
+    providerId: OPENZOO_PROVIDER_ID,
+    catalog: manifest.modelCatalog.providers.openzoo,
+  });
+}
+
+export async function buildOpenzooProviderWithDiscovery(params?: {
+  baseUrl?: string;
+  signal?: AbortSignal;
+}): Promise<ModelProviderConfig> {
+  const baseUrl = params?.baseUrl ?? OPENZOO_DEFAULT_BASE_URL;
+  const models = await discoverOpenzooModels({
+    baseUrl,
+    ...(params?.signal ? { signal: params.signal } : {}),
+  });
+  return {
+    baseUrl,
+    api: "openai-completions",
+    models,
+  };
+}

--- a/extensions/openzoo/provider-models.test.ts
+++ b/extensions/openzoo/provider-models.test.ts
@@ -1,0 +1,451 @@
+// Openzoo tests cover provider models plugin behavior.
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname: (baseUrl: string) => ({
+    allowedHostnames: [new URL(baseUrl).hostname],
+  }),
+}));
+
+import {
+  discoverOpenzooModels,
+  normalizeOpenzooBaseUrl,
+  OPENZOO_DEFAULT_BASE_URL,
+  OPENZOO_DEFAULT_COST,
+  parseOpenzooReasoning,
+  projectOpenzooModels,
+  resolveOpenzooBaseUrl,
+  resolveOpenzooInfoUrl,
+  resolveOpenzooModelsUrl,
+} from "./provider-models.js";
+
+type MockOpenzooFetch = ((url: string, init?: RequestInit) => Promise<Response>) & {
+  mock: { calls: unknown[][] };
+};
+
+const OPENZOO_MODELS_URL = `${OPENZOO_DEFAULT_BASE_URL}/models`;
+
+const EXPECTED_STATIC_OPENZOO_MODELS = [
+  {
+    id: "auto",
+    name: "auto",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0.1, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128000000,
+    maxTokens: 8192,
+  },
+];
+
+function requireModelById(
+  models: Awaited<ReturnType<typeof discoverOpenzooModels>>,
+  id: string,
+): Awaited<ReturnType<typeof discoverOpenzooModels>>[number] {
+  const model = models.find((candidate) => candidate.id === id);
+  if (!model) {
+    throw new Error(`expected openzoo model ${id}`);
+  }
+  return model;
+}
+
+const requireRecord = createRequireRecord("record", "expected-label-record");
+
+function requireFirstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): unknown[] {
+  const [call] = mock.mock.calls;
+  if (!call) {
+    throw new Error(`expected ${label}`);
+  }
+  return call;
+}
+
+/** Mirrors a live proxy row: no name, no architecture, numeric per-token prices. */
+function makeProxyModel(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "anthropic/claude-opus-4.1",
+    object: "model",
+    owned_by: "openrouter",
+    pricing: {
+      prompt: 0.000015,
+      completion: 0.000075,
+      unit: "USD",
+      markup: 1,
+    },
+    context_length: 128000000,
+    top_provider: {
+      context_length: 128000000,
+      max_completion_tokens: 32000,
+      is_moderated: false,
+    },
+    architecture: null,
+    supported_parameters: null,
+    ...overrides,
+  };
+}
+
+function makeAutoModel(overrides: Record<string, unknown> = {}) {
+  return makeProxyModel({
+    id: "auto",
+    owned_by: "openzoo",
+    pricing: {
+      prompt: 1e-7,
+      completion: 2e-7,
+      unit: "USD",
+      markup: 1,
+    },
+    top_provider: {
+      context_length: 128000000,
+      max_completion_tokens: null,
+      is_moderated: false,
+    },
+    ...overrides,
+  });
+}
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+async function withFetchPathTest(mockFetch: MockOpenzooFetch, runAssertions: () => Promise<void>) {
+  const release = vi.fn(async () => {});
+
+  fetchWithSsrFGuardMock.mockReset();
+  const callMockFetch = mockFetch as unknown as (
+    url: string,
+    init?: RequestInit,
+  ) => Promise<unknown>;
+  fetchWithSsrFGuardMock.mockImplementation(
+    async (params: { url: string; init?: RequestInit }) => ({
+      response: await callMockFetch(params.url, params.init),
+      release,
+    }),
+  );
+
+  try {
+    await runAssertions();
+    return release;
+  } finally {
+    fetchWithSsrFGuardMock.mockReset();
+  }
+}
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+  vi.resetModules();
+});
+
+describe("discoverOpenzooModels (fetch path)", () => {
+  it("parses proxy rows with per-token pricing converted to USD per million", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        object: "list",
+        data: [makeAutoModel(), makeProxyModel()],
+      }),
+    );
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+      const [guardedFetchParams] = requireFirstMockCall(
+        fetchWithSsrFGuardMock,
+        "guarded fetch call",
+      );
+      const guardedFetch = requireRecord(guardedFetchParams, "guarded fetch params");
+      expect(guardedFetch.url).toBe(OPENZOO_MODELS_URL);
+      const guardedInit = requireRecord(guardedFetch.init, "guarded fetch init");
+      expect(Object.fromEntries(new Headers(guardedInit.headers as HeadersInit))).toEqual({
+        accept: "application/json",
+      });
+      expect(guardedFetch.policy).toEqual({ allowedHostnames: ["localhost"] });
+      expect(guardedFetch.timeoutMs).toBeGreaterThan(0);
+      expect(guardedFetch.timeoutMs).toBeLessThanOrEqual(5000);
+      expect(guardedFetch.auditContext).toBe("openzoo.model_discovery");
+
+      expect(models.length).toBe(2);
+
+      const opus = requireModelById(models, "anthropic/claude-opus-4.1");
+      expect(opus.name).toBe("anthropic/claude-opus-4.1");
+      expect(opus.cost.input).toBeCloseTo(15);
+      expect(opus.cost.output).toBeCloseTo(75);
+      expect(opus.cost.cacheRead).toBe(0);
+      expect(opus.cost.cacheWrite).toBe(0);
+      expect(opus.input).toEqual(["text"]);
+      expect(opus.reasoning).toBe(false);
+      expect(opus.contextWindow).toBe(128000000);
+      expect(opus.maxTokens).toBe(32000);
+
+      const auto = requireModelById(models, "auto");
+      expect(auto.cost.input).toBeCloseTo(0.1);
+      expect(auto.cost.output).toBeCloseTo(0.2);
+      expect(auto.maxTokens).toBe(8192);
+      expect(auto.contextWindow).toBe(128000000);
+    });
+  });
+
+  it("accepts string prices, cache prices, names, and image modality", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          makeProxyModel({
+            id: "anthropic/claude-sonnet-5",
+            name: "Anthropic: Claude Sonnet 5",
+            pricing: {
+              prompt: "0.000003",
+              completion: "0.000015",
+              input_cache_read: "0.0000003",
+              input_cache_write: "0.00000375",
+            },
+            architecture: {
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
+            },
+          }),
+        ],
+      }),
+    );
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      const sonnet = requireModelById(models, "anthropic/claude-sonnet-5");
+      expect(sonnet.name).toBe("Anthropic: Claude Sonnet 5");
+      expect(sonnet.cost.input).toBeCloseTo(3);
+      expect(sonnet.cost.output).toBeCloseTo(15);
+      expect(sonnet.cost.cacheRead).toBeCloseTo(0.3);
+      expect(sonnet.cost.cacheWrite).toBeCloseTo(3.75);
+      expect(sonnet.input).toEqual(["text", "image"]);
+    });
+  });
+
+  it("skips media rows and rows without a price", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          makeProxyModel({ id: "google/veo-3.1", kind: "video" }),
+          makeProxyModel({ id: "black-forest-labs/flux-2", kind: "image" }),
+          makeProxyModel({ id: "claude-sonnet-5", pricing: { prompt: 0, completion: 0 } }),
+          makeProxyModel({ id: "some/unpriced", pricing: { unit: "USD" } }),
+          makeProxyModel({ id: "some/negative", pricing: { prompt: "-1", completion: "-1" } }),
+          makeProxyModel(),
+        ],
+      }),
+    );
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      expect(models.map((model) => model.id)).toEqual(["auto", "anthropic/claude-opus-4.1"]);
+    });
+  });
+
+  it("keeps a row that is priced on only one side", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          makeProxyModel({ id: "some/free-prompt", pricing: { prompt: 0, completion: 2e-6 } }),
+        ],
+      }),
+    );
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      expect(requireModelById(models, "some/free-prompt").cost).toEqual({
+        input: 0,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
+    });
+  });
+
+  it("preserves default auto pricing when the live auto row is unpriced", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [makeAutoModel({ pricing: { prompt: "unavailable", completion: "-1" } })],
+      }),
+    );
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      expect(models).toHaveLength(1);
+      expect(requireModelById(models, "auto").cost).toEqual(OPENZOO_DEFAULT_COST);
+    });
+  });
+
+  it("falls back to static catalog on network error", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("connection refused"));
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      expect(models).toStrictEqual(EXPECTED_STATIC_OPENZOO_MODELS);
+    });
+  });
+
+  it("falls back to static catalog on HTTP error", async () => {
+    const response = new Response("payment required", { status: 402 });
+    const cancelSpy = vi.spyOn(response.body!, "cancel").mockResolvedValue(undefined);
+    const mockFetch = vi.fn().mockResolvedValue(response);
+
+    const release = await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      expect(models).toStrictEqual(EXPECTED_STATIC_OPENZOO_MODELS);
+    });
+
+    expect(cancelSpy).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to static catalog for malformed successful model list payloads", async () => {
+    for (const payload of [[], { data: {} }, { data: [null] }]) {
+      const mockFetch = vi.fn().mockResolvedValue(jsonResponse(payload));
+      await withFetchPathTest(mockFetch, async () => {
+        const models = await discoverOpenzooModels();
+        expect(models).toStrictEqual(EXPECTED_STATIC_OPENZOO_MODELS);
+      });
+    }
+  });
+
+  it("falls back from malformed live token metadata", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [
+          makeProxyModel({
+            id: "some/bad-window",
+            context_length: -1,
+            top_provider: { context_length: null, max_completion_tokens: 8192.5 },
+          }),
+          makeProxyModel({
+            id: "some/bad-output",
+            context_length: Number.POSITIVE_INFINITY,
+            top_provider: { context_length: 0, max_completion_tokens: 0 },
+          }),
+        ],
+      }),
+    );
+
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+
+      for (const id of ["some/bad-window", "some/bad-output"]) {
+        expect(requireModelById(models, id)).toMatchObject({
+          contextWindow: 128000000,
+          maxTokens: 8192,
+        });
+      }
+    });
+  });
+
+  it("ensures auto is present even when the proxy omits it", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ data: [makeProxyModel()] }));
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      expect(models.map((model) => model.id)).toEqual(["auto", "anthropic/claude-opus-4.1"]);
+      expect(requireModelById(models, "auto")).toStrictEqual(EXPECTED_STATIC_OPENZOO_MODELS[0]);
+    });
+  });
+
+  it("keeps a later valid duplicate when an earlier entry is malformed", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [makeAutoModel({ pricing: undefined }), makeAutoModel(), makeProxyModel()],
+      }),
+    );
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverOpenzooModels();
+      expect(models.map((model) => model.id)).toEqual(["auto", "anthropic/claude-opus-4.1"]);
+      expect(requireModelById(models, "auto").cost.input).toBeCloseTo(0.1);
+    });
+  });
+
+  it("discovers from an operator-supplied base URL", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ data: [makeAutoModel()] }));
+    await withFetchPathTest(mockFetch, async () => {
+      await discoverOpenzooModels({ baseUrl: "http://127.0.0.1:9402/v1" });
+
+      const [guardedFetchParams] = requireFirstMockCall(
+        fetchWithSsrFGuardMock,
+        "guarded fetch call",
+      );
+      const guardedFetch = requireRecord(guardedFetchParams, "guarded fetch params");
+      expect(guardedFetch.url).toBe("http://127.0.0.1:9402/v1/models");
+      expect(guardedFetch.policy).toEqual({ allowedHostnames: ["127.0.0.1"] });
+    });
+  });
+});
+
+describe("parseOpenzooReasoning", () => {
+  it.each([
+    ["openai/o3-pro", true],
+    ["openai/o1", true],
+    ["openai/o4-mini-high", true],
+    ["deepseek/deepseek-r1-0528", true],
+    ["deepseek/deepseek-reasoner", true],
+    ["qwen/qwq-32b", true],
+    ["qwen/qwen3-max-thinking", true],
+    ["anthropic/claude-3.7-sonnet:thinking", true],
+    ["sao10k/l3.3-euryale-70b", false],
+    ["upstage/solar-pro4", false],
+    ["openai/gpt-4o", false],
+    ["x-ai/grok-4.6", false],
+    ["anthropic/claude-sonnet-5", false],
+    ["auto", false],
+  ])("flags %s as reasoning=%s only on unambiguous id tokens", (id, expected) => {
+    expect(parseOpenzooReasoning(id)).toBe(expected);
+    const models = projectOpenzooModels([makeProxyModel({ id })]);
+    expect(requireModelById(models, id).reasoning).toBe(expected);
+  });
+});
+
+describe("openzoo base URL resolution", () => {
+  it("defaults to the local proxy", () => {
+    expect(resolveOpenzooBaseUrl({ env: {} })).toBe("http://localhost:8402/v1");
+    expect(OPENZOO_DEFAULT_BASE_URL).toBe("http://localhost:8402/v1");
+  });
+
+  it("prefers configured base URL over environment overrides", () => {
+    expect(
+      resolveOpenzooBaseUrl({
+        env: { OPENZOO_BASE_URL: "http://proxy-host:8402/v1", OPENZOO_PORT: "9402" },
+        configuredBaseUrl: "http://127.0.0.1:8500/v1/",
+      }),
+    ).toBe("http://127.0.0.1:8500/v1");
+  });
+
+  it("honours OPENZOO_BASE_URL and appends the /v1 path when missing", () => {
+    expect(resolveOpenzooBaseUrl({ env: { OPENZOO_BASE_URL: "http://proxy-host:8402" } })).toBe(
+      "http://proxy-host:8402/v1",
+    );
+    expect(resolveOpenzooBaseUrl({ env: { OPENZOO_BASE_URL: "http://proxy-host:8402/v1/" } })).toBe(
+      "http://proxy-host:8402/v1",
+    );
+  });
+
+  it("honours OPENZOO_PORT and ignores unusable ports", () => {
+    expect(resolveOpenzooBaseUrl({ env: { OPENZOO_PORT: "9402" } })).toBe(
+      "http://localhost:9402/v1",
+    );
+    for (const port of ["0", "70000", "abc", "84.02", ""]) {
+      expect(resolveOpenzooBaseUrl({ env: { OPENZOO_PORT: port } })).toBe(
+        "http://localhost:8402/v1",
+      );
+    }
+  });
+
+  it("ignores non-http base URLs", () => {
+    expect(normalizeOpenzooBaseUrl("ftp://proxy-host:8402/v1")).toBeUndefined();
+    expect(normalizeOpenzooBaseUrl("not a url")).toBeUndefined();
+    expect(normalizeOpenzooBaseUrl("   ")).toBeUndefined();
+    expect(resolveOpenzooBaseUrl({ env: { OPENZOO_BASE_URL: "ftp://proxy-host" } })).toBe(
+      "http://localhost:8402/v1",
+    );
+  });
+
+  it("derives the models and info endpoints from the base URL", () => {
+    expect(resolveOpenzooModelsUrl("http://localhost:8402/v1/")).toBe(
+      "http://localhost:8402/v1/models",
+    );
+    expect(resolveOpenzooInfoUrl("http://localhost:8402/v1")).toBe("http://localhost:8402/v1/info");
+  });
+});

--- a/extensions/openzoo/provider-models.ts
+++ b/extensions/openzoo/provider-models.ts
@@ -1,0 +1,277 @@
+// Openzoo provider module implements model/runtime integration.
+import { buildLiveModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  asOptionalRecord,
+  asPositiveSafeInteger,
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export const OPENZOO_PROVIDER_ID = "openzoo";
+export const OPENZOO_PROVIDER_LABEL = "openzoo";
+export const OPENZOO_DEFAULT_PORT = 8402;
+export const OPENZOO_PORT_ENV_VAR = "OPENZOO_PORT";
+export const OPENZOO_BASE_URL_ENV_VAR = "OPENZOO_BASE_URL";
+export const OPENZOO_DEFAULT_BASE_URL = `http://localhost:${OPENZOO_DEFAULT_PORT}/v1`;
+// The proxy takes payment, not keys; this placeholder only satisfies the Bearer transport.
+export const OPENZOO_LOCAL_API_KEY_PLACEHOLDER = "sk-openzoo";
+export const OPENZOO_DEFAULT_MODEL_ID = "auto";
+export const OPENZOO_DEFAULT_MODEL_REF = `${OPENZOO_PROVIDER_ID}/${OPENZOO_DEFAULT_MODEL_ID}`;
+export const OPENZOO_DEFAULT_MODEL_NAME = "auto";
+
+type OpenzooModelCatalogEntry = {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: Array<"text" | "image">;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+export const OPENZOO_MODEL_CATALOG: OpenzooModelCatalogEntry[] = [
+  {
+    id: OPENZOO_DEFAULT_MODEL_ID,
+    name: OPENZOO_DEFAULT_MODEL_NAME,
+    input: ["text"],
+    reasoning: false,
+  },
+];
+
+// The proxy spills long context server-side, so the client-usable window really is ~128M.
+export const OPENZOO_DEFAULT_CONTEXT_WINDOW = 128_000_000;
+export const OPENZOO_DEFAULT_MAX_TOKENS = 8192;
+// USD per million tokens, matching the live `auto` row (1e-7 / 2e-7 per token).
+export const OPENZOO_DEFAULT_COST = {
+  input: 0.1,
+  output: 0.2,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+const DISCOVERY_TIMEOUT_MS = 5000;
+const PER_TOKEN_TO_PER_MILLION = 1_000_000;
+// Reasoning is only advertised when the id unambiguously says so: a wrong `true`
+// breaks requests, a wrong `false` only hides a toggle. Tokens are matched on
+// id boundaries so `sao10k` (o1) and `solar-pro4` (o4) do not false-positive.
+const REASONING_ID_TOKEN_RE = /(?:^|[^a-z0-9])(?:o1|o3|o4|r1|qwq|reasoner|thinking)(?:[^a-z0-9]|$)/;
+
+/** Normalizes an operator-supplied proxy URL to `<origin>[/path]` with a `/v1` default path. */
+export function normalizeOpenzooBaseUrl(value: string | undefined): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return undefined;
+  }
+  const path = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = path === "" ? "/v1" : path;
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+function resolveOpenzooPort(raw: string | undefined): number {
+  const trimmed = normalizeOptionalString(raw);
+  if (!trimmed || !/^\d{1,5}$/.test(trimmed)) {
+    return OPENZOO_DEFAULT_PORT;
+  }
+  const port = Number(trimmed);
+  return port >= 1 && port <= 65535 ? port : OPENZOO_DEFAULT_PORT;
+}
+
+/** Resolves the proxy base URL: configured value, then OPENZOO_BASE_URL, then OPENZOO_PORT. */
+export function resolveOpenzooBaseUrl(params?: {
+  env?: NodeJS.ProcessEnv;
+  configuredBaseUrl?: string;
+}): string {
+  const env = params?.env ?? process.env;
+  const configured = normalizeOpenzooBaseUrl(params?.configuredBaseUrl);
+  if (configured) {
+    return configured;
+  }
+  const fromEnv = normalizeOpenzooBaseUrl(env[OPENZOO_BASE_URL_ENV_VAR]);
+  if (fromEnv) {
+    return fromEnv;
+  }
+  const port = resolveOpenzooPort(env[OPENZOO_PORT_ENV_VAR]);
+  return port === OPENZOO_DEFAULT_PORT ? OPENZOO_DEFAULT_BASE_URL : `http://localhost:${port}/v1`;
+}
+
+export function resolveOpenzooModelsUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/models`;
+}
+
+export function resolveOpenzooInfoUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/info`;
+}
+
+function toPricePerMillion(perToken: unknown): number | undefined {
+  let num: number;
+  if (typeof perToken === "number") {
+    num = perToken;
+  } else if (typeof perToken === "string") {
+    const trimmed = perToken.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    num = Number(trimmed);
+  } else {
+    return undefined;
+  }
+  return Number.isFinite(num) && num >= 0 ? num * PER_TOKEN_TO_PER_MILLION : undefined;
+}
+
+function parseModality(row: Record<string, unknown>): Array<"text" | "image"> {
+  const modalities = asOptionalRecord(row.architecture)?.input_modalities;
+  if (!Array.isArray(modalities)) {
+    return ["text"];
+  }
+  const hasImage = modalities.some(
+    (entry) => typeof entry === "string" && normalizeLowercaseStringOrEmpty(entry) === "image",
+  );
+  return hasImage ? ["text", "image"] : ["text"];
+}
+
+export function parseOpenzooReasoning(modelId: string): boolean {
+  return REASONING_ID_TOKEN_RE.test(normalizeLowercaseStringOrEmpty(modelId));
+}
+
+function readRowId(row: unknown): string {
+  const id = asOptionalRecord(row)?.id;
+  return typeof id === "string" ? id.trim() : "";
+}
+
+type ProjectedRow =
+  | { kind: "model"; model: ModelDefinitionConfig }
+  | { kind: "skip" }
+  | { kind: "malformed" };
+
+function projectRow(row: unknown, id: string): ProjectedRow {
+  const record = asOptionalRecord(row);
+  const pricing = record ? asOptionalRecord(record.pricing) : undefined;
+  if (!record || !pricing) {
+    return { kind: "malformed" };
+  }
+  // `kind` marks media rows (image/video); they are not chat models.
+  if (normalizeOptionalString(record.kind)) {
+    return { kind: "skip" };
+  }
+  const fallbackCost = id === OPENZOO_DEFAULT_MODEL_ID ? OPENZOO_DEFAULT_COST : undefined;
+  const input = toPricePerMillion(pricing.prompt) ?? fallbackCost?.input;
+  const output = toPricePerMillion(pricing.completion) ?? fallbackCost?.output;
+  // Unpriced rows cannot be metered honestly; the gateway never serves them for free.
+  if (!(input !== undefined && input > 0) && !(output !== undefined && output > 0)) {
+    return { kind: "skip" };
+  }
+  const topProvider = asOptionalRecord(record.top_provider);
+  const name = normalizeOptionalString(record.name);
+  return {
+    kind: "model",
+    model: {
+      id,
+      name: name ?? id,
+      reasoning: parseOpenzooReasoning(id),
+      input: parseModality(record),
+      cost: {
+        input: input ?? 0,
+        output: output ?? 0,
+        cacheRead: toPricePerMillion(pricing.input_cache_read) ?? 0,
+        cacheWrite: toPricePerMillion(pricing.input_cache_write) ?? 0,
+      },
+      // The primary provider window bounds real requests; the catalog-wide value can be larger.
+      contextWindow:
+        asPositiveSafeInteger(topProvider?.context_length) ??
+        asPositiveSafeInteger(record.context_length) ??
+        OPENZOO_DEFAULT_CONTEXT_WINDOW,
+      maxTokens:
+        asPositiveSafeInteger(topProvider?.max_completion_tokens) ?? OPENZOO_DEFAULT_MAX_TOKENS,
+    },
+  };
+}
+
+function buildStaticCatalog(): ModelDefinitionConfig[] {
+  return OPENZOO_MODEL_CATALOG.map((model) => ({
+    id: model.id,
+    name: model.name,
+    reasoning: model.reasoning,
+    input: model.input,
+    cost: OPENZOO_DEFAULT_COST,
+    contextWindow: model.contextWindow ?? OPENZOO_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: model.maxTokens ?? OPENZOO_DEFAULT_MAX_TOKENS,
+  }));
+}
+
+function readGatewayModelRows(body: unknown): readonly unknown[] {
+  const data = asOptionalRecord(body)?.data;
+  if (!Array.isArray(data)) {
+    throw new Error("openzoo model list: malformed JSON response");
+  }
+  return data;
+}
+
+export function projectOpenzooModels(rows: readonly unknown[]): ModelDefinitionConfig[] {
+  const models: ModelDefinitionConfig[] = [];
+  const discoveredIds = new Set<string>();
+  for (const rawEntry of rows) {
+    const id = readRowId(rawEntry);
+    if (!id || discoveredIds.has(id)) {
+      continue;
+    }
+    const projected = projectRow(rawEntry, id);
+    if (projected.kind !== "model") {
+      // A malformed or skipped row must not hide a later valid row with the same id.
+      continue;
+    }
+    models.push(projected.model);
+    discoveredIds.add(id);
+  }
+  for (const staticModel of buildStaticCatalog()) {
+    if (!discoveredIds.has(staticModel.id)) {
+      models.unshift(staticModel);
+    }
+  }
+  return models;
+}
+
+export async function discoverOpenzooModels(params?: {
+  baseUrl?: string;
+  signal?: AbortSignal;
+}): Promise<ModelDefinitionConfig[]> {
+  const baseUrl = params?.baseUrl ?? OPENZOO_DEFAULT_BASE_URL;
+  const provider = await buildLiveModelProviderConfig({
+    providerId: OPENZOO_PROVIDER_ID,
+    endpoint: resolveOpenzooModelsUrl(baseUrl),
+    providerConfig: { baseUrl, api: "openai-completions" },
+    models: buildStaticCatalog(),
+    timeoutMs: DISCOVERY_TIMEOUT_MS,
+    ttlMs: 0,
+    ...(params?.signal ? { signal: params.signal } : {}),
+    readRows: readGatewayModelRows,
+    buildRequestHeaders: () => ({ Accept: "application/json" }),
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(baseUrl),
+    auditContext: "openzoo.model_discovery",
+    projectRows: projectOpenzooModels,
+  });
+  return provider.models;
+}
+
+export function buildOpenzooModelDefinition(): ModelDefinitionConfig {
+  return {
+    id: OPENZOO_DEFAULT_MODEL_ID,
+    name: OPENZOO_DEFAULT_MODEL_NAME,
+    reasoning: false,
+    input: ["text"],
+    cost: OPENZOO_DEFAULT_COST,
+    contextWindow: OPENZOO_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: OPENZOO_DEFAULT_MAX_TOKENS,
+  };
+}

--- a/extensions/openzoo/setup.test.ts
+++ b/extensions/openzoo/setup.test.ts
@@ -1,0 +1,536 @@
+// Openzoo tests cover setup plugin behavior.
+import {
+  createNonExitingRuntimeEnv,
+  createQueuedWizardPrompter,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { CUSTOM_LOCAL_AUTH_MARKER, type OpenClawConfig } from "openclaw/plugin-sdk/provider-auth";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
+import type {
+  ProviderAuthMethodNonInteractiveContext,
+  ProviderCatalogContext,
+} from "openclaw/plugin-sdk/provider-setup";
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname: (baseUrl: string) => ({
+    allowedHostnames: [new URL(baseUrl).hostname],
+  }),
+}));
+
+import {
+  buildOpenzooModelDefinition,
+  OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+} from "./provider-models.js";
+import {
+  configureOpenzooNonInteractive,
+  detectAppGuidedOpenzooAvailability,
+  detectAppGuidedOpenzooModel,
+  discoverOpenzooProvider,
+  fetchOpenzooInfo,
+  mergeOpenzooModels,
+  prepareAppGuidedOpenzooSetup,
+  promptAndConfigureOpenzooInteractive,
+  selectOpenzooDefaultModelRef,
+  validateOpenzooNonInteractive,
+} from "./setup.js";
+
+const DEFAULT_BASE_URL = "http://localhost:8402/v1";
+const STATIC_AUTO = buildOpenzooModelDefinition();
+const requireRecord = createRequireRecord("record", "expected-label-record");
+
+type ProxyState = {
+  reachable: boolean;
+  identity?: string;
+  infoStatus?: number;
+  models?: unknown[];
+  modelsStatus?: number;
+};
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeProxyModel(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    pricing: { prompt: 0.000003, completion: 0.000015 },
+    context_length: 128000000,
+    top_provider: { context_length: 128000000, max_completion_tokens: 8192 },
+    ...overrides,
+  };
+}
+
+function installProxy(state: ProxyState) {
+  const release = vi.fn(async () => {});
+  fetchWithSsrFGuardMock.mockReset();
+  fetchWithSsrFGuardMock.mockImplementation(async (params: { url: string }) => {
+    if (!state.reachable) {
+      throw new Error("connection refused");
+    }
+    if (params.url.endsWith("/info")) {
+      return {
+        response: jsonResponse(
+          { youAreTalkingTo: state.identity ?? "openzoo proxy", yourEndpoint: DEFAULT_BASE_URL },
+          state.infoStatus ?? 200,
+        ),
+        release,
+      };
+    }
+    if (params.url.endsWith("/models")) {
+      return {
+        response: jsonResponse(
+          {
+            object: "list",
+            data: state.models ?? [
+              makeProxyModel("auto", { pricing: { prompt: 1e-7, completion: 2e-7 } }),
+              makeProxyModel("anthropic/claude-sonnet-5"),
+            ],
+          },
+          state.modelsStatus ?? 200,
+        ),
+        release,
+      };
+    }
+    throw new Error(`unexpected url ${params.url}`);
+  });
+  return release;
+}
+
+function buildConfig(
+  provider?: Partial<import("openclaw/plugin-sdk/provider-model-shared").ModelProviderConfig>,
+  config: Omit<OpenClawConfig, "models"> = {},
+): OpenClawConfig {
+  if (!provider) {
+    return { ...config };
+  }
+  return {
+    ...config,
+    models: {
+      providers: {
+        openzoo: {
+          baseUrl: DEFAULT_BASE_URL,
+          api: "openai-completions",
+          models: [],
+          ...provider,
+        },
+      },
+    },
+  };
+}
+
+function buildDiscoveryContext(params?: {
+  config?: OpenClawConfig;
+  apiKey?: string;
+  env?: NodeJS.ProcessEnv;
+}): ProviderCatalogContext {
+  return {
+    config: params?.config ?? {},
+    env: params?.env ?? {},
+    resolveProviderApiKey: () => ({ apiKey: params?.apiKey }),
+    resolveProviderAuth: () => ({
+      apiKey: params?.apiKey,
+      mode: "none" as const,
+      source: "none" as const,
+    }),
+  };
+}
+
+function buildNonInteractiveContext(params?: {
+  config?: OpenClawConfig;
+  customBaseUrl?: string;
+  customModelId?: string;
+}) {
+  const runtime = createNonExitingRuntimeEnv();
+  return {
+    authChoice: "openzoo",
+    config: params?.config ?? {},
+    baseConfig: params?.config ?? {},
+    opts: {
+      customBaseUrl: params?.customBaseUrl,
+      customModelId: params?.customModelId,
+    } as ProviderAuthMethodNonInteractiveContext["opts"],
+    runtime,
+    resolveApiKey: vi.fn(async () => null),
+    toApiKeyCredential: vi.fn(),
+  } satisfies ProviderAuthMethodNonInteractiveContext;
+}
+
+function requireOpenzooProvider(config: OpenClawConfig | null | undefined) {
+  const provider = config?.models?.providers?.openzoo;
+  if (!provider) {
+    throw new Error("expected openzoo provider config");
+  }
+  return provider;
+}
+
+beforeEach(() => {
+  fetchWithSsrFGuardMock.mockReset();
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+  vi.resetModules();
+});
+
+describe("fetchOpenzooInfo", () => {
+  it("probes /info with a short local timeout and recognizes the proxy", async () => {
+    installProxy({ reachable: true });
+
+    const probe = await fetchOpenzooInfo({ baseUrl: DEFAULT_BASE_URL });
+
+    expect(probe.reachable).toBe(true);
+    const [guardedFetchParams] = fetchWithSsrFGuardMock.mock.calls[0] ?? [];
+    const guardedFetch = requireRecord(guardedFetchParams, "guarded fetch params");
+    expect(guardedFetch.url).toBe(`${DEFAULT_BASE_URL}/info`);
+    expect(guardedFetch.timeoutMs).toBeLessThanOrEqual(2000);
+    expect(guardedFetch.policy).toEqual({ allowedHostnames: ["localhost"] });
+    expect(guardedFetch.auditContext).toBe("openzoo.info_probe");
+  });
+
+  it("treats other servers, HTTP errors, and network failures as unreachable", async () => {
+    installProxy({ reachable: true, identity: "some other proxy" });
+    expect((await fetchOpenzooInfo({ baseUrl: DEFAULT_BASE_URL })).reachable).toBe(false);
+
+    const release = installProxy({ reachable: true, infoStatus: 503 });
+    expect(await fetchOpenzooInfo({ baseUrl: DEFAULT_BASE_URL })).toEqual({
+      reachable: false,
+      status: 503,
+    });
+    expect(release).toHaveBeenCalledOnce();
+
+    installProxy({ reachable: false });
+    expect((await fetchOpenzooInfo({ baseUrl: DEFAULT_BASE_URL })).reachable).toBe(false);
+  });
+});
+
+describe("discoverOpenzooProvider", () => {
+  it("returns null when the proxy is down and nothing is configured", async () => {
+    installProxy({ reachable: false });
+
+    expect(await discoverOpenzooProvider(buildDiscoveryContext())).toBeNull();
+  });
+
+  it("falls back to the static catalog when the proxy is down but configured", async () => {
+    installProxy({ reachable: false });
+
+    const result = await discoverOpenzooProvider(
+      buildDiscoveryContext({ config: buildConfig({}) }),
+    );
+
+    expect(result?.provider).toEqual({
+      baseUrl: DEFAULT_BASE_URL,
+      api: "openai-completions",
+      apiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+      models: [STATIC_AUTO],
+    });
+  });
+
+  it("publishes the discovered priced catalog with the local marker when the proxy answers", async () => {
+    installProxy({ reachable: true });
+
+    const result = await discoverOpenzooProvider(buildDiscoveryContext());
+
+    expect(result?.provider.baseUrl).toBe(DEFAULT_BASE_URL);
+    expect(result?.provider.apiKey).toBe(OPENZOO_LOCAL_API_KEY_PLACEHOLDER);
+    expect(result?.provider).not.toHaveProperty("auth");
+    expect(result?.provider.models.map((model) => model.id)).toEqual([
+      "auto",
+      "anthropic/claude-sonnet-5",
+    ]);
+    expect(result?.provider.models[1]?.cost.input).toBeCloseTo(3);
+  });
+
+  it("keeps explicit rows authoritative and appends discovered rows", async () => {
+    installProxy({ reachable: true });
+    const pinned: ModelDefinitionConfig = { ...STATIC_AUTO, name: "Zoo router" };
+
+    const result = await discoverOpenzooProvider(
+      buildDiscoveryContext({ config: buildConfig({ models: [pinned] }) }),
+    );
+
+    expect(result?.provider.models[0]).toEqual(pinned);
+    expect(result?.provider.models.map((model) => model.id)).toEqual([
+      "auto",
+      "anthropic/claude-sonnet-5",
+    ]);
+  });
+
+  it("uses the configured base URL, then OPENZOO_BASE_URL, for discovery", async () => {
+    installProxy({ reachable: true });
+    await discoverOpenzooProvider(
+      buildDiscoveryContext({
+        config: buildConfig({ baseUrl: "http://proxy-host:8402" }),
+        env: { OPENZOO_BASE_URL: "http://ignored:1/v1" },
+      }),
+    );
+    expect(
+      fetchWithSsrFGuardMock.mock.calls.map((call) => requireRecord(call[0], "call").url),
+    ).toEqual(["http://proxy-host:8402/v1/info", "http://proxy-host:8402/v1/models"]);
+
+    installProxy({ reachable: true });
+    const result = await discoverOpenzooProvider(
+      buildDiscoveryContext({ env: { OPENZOO_BASE_URL: "http://env-host:9402/v1" } }),
+    );
+    expect(result?.provider.baseUrl).toBe("http://env-host:9402/v1");
+  });
+
+  it("preserves a real operator credential and downgrades synthetic markers", async () => {
+    installProxy({ reachable: true });
+    const real = await discoverOpenzooProvider(
+      buildDiscoveryContext({ config: buildConfig({ apiKey: "real-key" }), apiKey: "real-key" }),
+    );
+    expect(real?.provider).toMatchObject({ auth: "api-key", apiKey: "real-key" });
+
+    installProxy({ reachable: true });
+    const synthetic = await discoverOpenzooProvider(
+      buildDiscoveryContext({ apiKey: CUSTOM_LOCAL_AUTH_MARKER }),
+    );
+    expect(synthetic?.provider.apiKey).toBe(OPENZOO_LOCAL_API_KEY_PLACEHOLDER);
+  });
+});
+
+describe("mergeOpenzooModels and default selection", () => {
+  it("dedupes by id with explicit rows first", () => {
+    const explicit: ModelDefinitionConfig = { ...STATIC_AUTO, name: "pinned" };
+    const discovered = [STATIC_AUTO, { ...STATIC_AUTO, id: "x-ai/grok-4.6" }];
+    expect(mergeOpenzooModels([explicit], discovered).map((model) => model.name)).toEqual([
+      "pinned",
+      "auto",
+    ]);
+    expect(mergeOpenzooModels(undefined, discovered)).toEqual(discovered);
+  });
+
+  it("prefers auto, then the first row, and validates requested ids", () => {
+    const other = { ...STATIC_AUTO, id: "x-ai/grok-4.6" };
+    expect(selectOpenzooDefaultModelRef([other, STATIC_AUTO])).toBe("openzoo/auto");
+    expect(selectOpenzooDefaultModelRef([other])).toBe("openzoo/x-ai/grok-4.6");
+    expect(selectOpenzooDefaultModelRef([])).toBeUndefined();
+    expect(selectOpenzooDefaultModelRef([other, STATIC_AUTO], "x-ai/grok-4.6")).toBe(
+      "openzoo/x-ai/grok-4.6",
+    );
+    expect(selectOpenzooDefaultModelRef([STATIC_AUTO], "missing/model")).toBeUndefined();
+  });
+});
+
+describe("promptAndConfigureOpenzooInteractive", () => {
+  it("confirms the proxy and seeds config with the static catalog", async () => {
+    installProxy({ reachable: true });
+    const { prompter, text, note } = createQueuedWizardPrompter({ textValues: [""] });
+
+    const result = await promptAndConfigureOpenzooInteractive({
+      config: {},
+      env: {},
+      prompter,
+    });
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: DEFAULT_BASE_URL, placeholder: DEFAULT_BASE_URL }),
+    );
+    expect(note).not.toHaveBeenCalled();
+    expect(result.profiles).toEqual([]);
+    expect(result.defaultModel).toBe("openzoo/auto");
+    expect(result.configPatch?.models).toEqual({
+      mode: "merge",
+      providers: {
+        openzoo: {
+          baseUrl: DEFAULT_BASE_URL,
+          api: "openai-completions",
+          apiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+          models: [STATIC_AUTO],
+        },
+      },
+    });
+    expect(result.configPatch?.agents?.defaults?.models).toEqual({
+      "openzoo/auto": { alias: "openzoo" },
+    });
+  });
+
+  it("normalizes a typed base URL and keeps an existing real credential", async () => {
+    installProxy({ reachable: true });
+    const { prompter } = createQueuedWizardPrompter({ textValues: ["http://proxy-host:9402"] });
+
+    const result = await promptAndConfigureOpenzooInteractive({
+      config: buildConfig({ apiKey: "real-key", headers: { "X-Proxy-Auth": "1" } }),
+      env: {},
+      prompter,
+    });
+
+    expect(requireOpenzooProvider(result.configPatch as OpenClawConfig)).toEqual({
+      baseUrl: "http://proxy-host:9402/v1",
+      api: "openai-completions",
+      auth: "api-key",
+      apiKey: "real-key",
+      headers: { "X-Proxy-Auth": "1" },
+      models: [STATIC_AUTO],
+    });
+  });
+
+  it("prints the npx openzoo hint and cancels when the proxy stays down", async () => {
+    installProxy({ reachable: false });
+    const { prompter, note, confirm } = createQueuedWizardPrompter({
+      textValues: [""],
+      confirmValues: [false],
+    });
+
+    await expect(
+      promptAndConfigureOpenzooInteractive({ config: {}, env: {}, prompter }),
+    ).rejects.toThrow("openzoo proxy not reachable");
+
+    expect(note).toHaveBeenCalledWith(
+      `openzoo proxy could not be reached at ${DEFAULT_BASE_URL}.\nStart it in another terminal with \`npx openzoo\` (it prints a funding address; fund it with USDC on Solana or Base), then retry.`,
+      "openzoo",
+    );
+    expect(confirm).toHaveBeenCalledWith({
+      message: "Retry the openzoo proxy connection now?",
+      initialValue: true,
+    });
+  });
+
+  it("retries the probe after the proxy comes up", async () => {
+    let attempts = 0;
+    fetchWithSsrFGuardMock.mockImplementation(async (params: { url: string }) => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("connection refused");
+      }
+      const payload = params.url.endsWith("/info")
+        ? { youAreTalkingTo: "openzoo proxy" }
+        : { data: [makeProxyModel("auto", { pricing: { prompt: 1e-7, completion: 2e-7 } })] };
+      return { response: jsonResponse(payload), release: async () => {} };
+    });
+    const { prompter, confirm } = createQueuedWizardPrompter({
+      textValues: [""],
+      confirmValues: [true],
+    });
+
+    const result = await promptAndConfigureOpenzooInteractive({ config: {}, env: {}, prompter });
+
+    expect(confirm).toHaveBeenCalledOnce();
+    expect(result.defaultModel).toBe("openzoo/auto");
+  });
+});
+
+describe("non-interactive setup", () => {
+  it("writes the provider and default model when the proxy answers", async () => {
+    installProxy({ reachable: true });
+    const ctx = buildNonInteractiveContext();
+
+    const result = await configureOpenzooNonInteractive(ctx);
+
+    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe("openzoo/auto");
+    expect(requireOpenzooProvider(result)).toEqual({
+      baseUrl: DEFAULT_BASE_URL,
+      api: "openai-completions",
+      apiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+      models: [STATIC_AUTO],
+    });
+    expect(result?.models?.mode).toBe("merge");
+    expect(result?.agents?.defaults?.models).toEqual({ "openzoo/auto": { alias: "openzoo" } });
+    expect(ctx.runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("honours --custom-base-url and --custom-model-id", async () => {
+    installProxy({ reachable: true });
+    const ctx = buildNonInteractiveContext({
+      customBaseUrl: "http://proxy-host:8402",
+      customModelId: "anthropic/claude-sonnet-5",
+    });
+
+    const result = await configureOpenzooNonInteractive(ctx);
+
+    expect(resolveAgentModelPrimaryValue(result?.agents?.defaults?.model)).toBe(
+      "openzoo/anthropic/claude-sonnet-5",
+    );
+    expect(requireOpenzooProvider(result).baseUrl).toBe("http://proxy-host:8402/v1");
+  });
+
+  it("fails closed with the setup hint when the proxy is down", async () => {
+    installProxy({ reachable: false });
+    const ctx = buildNonInteractiveContext();
+
+    expect(await configureOpenzooNonInteractive(ctx)).toBeNull();
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Start it in another terminal with `npx openzoo`"),
+    );
+    expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects a requested model the proxy does not list", async () => {
+    installProxy({ reachable: true });
+    const ctx = buildNonInteractiveContext({ customModelId: "missing/model" });
+
+    expect(await configureOpenzooNonInteractive(ctx)).toBeNull();
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("openzoo model missing/model was not found"),
+    );
+  });
+
+  it("validates without mutating config", async () => {
+    installProxy({ reachable: true });
+    expect(await validateOpenzooNonInteractive(buildNonInteractiveContext())).toBe(true);
+
+    installProxy({ reachable: false });
+    const ctx = buildNonInteractiveContext();
+    expect(await validateOpenzooNonInteractive(ctx)).toBe(false);
+    expect(ctx.runtime.error).toHaveBeenCalledOnce();
+  });
+});
+
+describe("app-guided setup", () => {
+  it("reports availability from the info probe", async () => {
+    installProxy({ reachable: true });
+    expect(await detectAppGuidedOpenzooAvailability({ config: {}, env: {} })).toBe(true);
+
+    installProxy({ reachable: false });
+    expect(await detectAppGuidedOpenzooAvailability({ config: {}, env: {} })).toBe(false);
+  });
+
+  it("offers the router row when the proxy answers", async () => {
+    installProxy({ reachable: true });
+    expect(await detectAppGuidedOpenzooModel({ config: {}, env: {} })).toEqual({
+      modelRef: "openzoo/auto",
+      detail: `auto at ${DEFAULT_BASE_URL}`,
+    });
+
+    installProxy({ reachable: false });
+    expect(await detectAppGuidedOpenzooModel({ config: {}, env: {} })).toBeNull();
+  });
+
+  it("prepares config for a detected model and rejects foreign refs", async () => {
+    installProxy({ reachable: true });
+    const prepared = await prepareAppGuidedOpenzooSetup({
+      config: {},
+      env: {},
+      modelRef: "openzoo/anthropic/claude-sonnet-5",
+    });
+    expect(prepared?.defaultModel).toBe("openzoo/anthropic/claude-sonnet-5");
+    expect(requireOpenzooProvider(prepared?.configPatch as OpenClawConfig).apiKey).toBe(
+      OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+    );
+
+    installProxy({ reachable: true });
+    expect(
+      await prepareAppGuidedOpenzooSetup({ config: {}, env: {}, modelRef: "lmstudio/qwen" }),
+    ).toBeNull();
+
+    installProxy({ reachable: true });
+    expect(
+      await prepareAppGuidedOpenzooSetup({ config: {}, env: {}, modelRef: "openzoo/missing" }),
+    ).toBeNull();
+
+    installProxy({ reachable: false });
+    expect(
+      await prepareAppGuidedOpenzooSetup({ config: {}, env: {}, modelRef: "openzoo/auto" }),
+    ).toBeNull();
+  });
+});

--- a/extensions/openzoo/setup.ts
+++ b/extensions/openzoo/setup.ts
@@ -1,0 +1,387 @@
+// Openzoo setup module handles plugin onboarding behavior.
+import type { ProviderAppGuidedSetupContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  normalizeOptionalSecretInput,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { withAgentModelAliases } from "openclaw/plugin-sdk/provider-onboard";
+import {
+  applyProviderDefaultModel,
+  type ProviderAuthMethodNonInteractiveContext,
+  type ProviderAuthResult,
+  type ProviderCatalogContext,
+} from "openclaw/plugin-sdk/provider-setup";
+import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveOpenzooProviderAuthMode } from "./provider-auth.js";
+import { buildOpenzooProvider } from "./provider-catalog.js";
+import {
+  discoverOpenzooModels,
+  normalizeOpenzooBaseUrl,
+  OPENZOO_DEFAULT_MODEL_ID,
+  OPENZOO_DEFAULT_MODEL_REF,
+  OPENZOO_LOCAL_API_KEY_PLACEHOLDER,
+  OPENZOO_PROVIDER_ID,
+  OPENZOO_PROVIDER_LABEL,
+  resolveOpenzooBaseUrl,
+  resolveOpenzooInfoUrl,
+} from "./provider-models.js";
+
+const PROVIDER_ID = OPENZOO_PROVIDER_ID;
+const INFO_PROBE_TIMEOUT_MS = 2000;
+const OPENZOO_PROXY_IDENTITY = "openzoo proxy";
+
+export type OpenzooInfoProbe =
+  | { reachable: true; info: Record<string, unknown> }
+  | { reachable: false; status?: number; error?: unknown };
+
+export type OpenzooAppGuidedCandidate = {
+  modelRef: string;
+  detail?: string;
+};
+
+export function isOpenzooProxyInfo(info: Record<string, unknown>): boolean {
+  return normalizeOptionalLowercaseString(info.youAreTalkingTo) === OPENZOO_PROXY_IDENTITY;
+}
+
+/** Read-only reachability probe; `/v1/info` is served by the proxy itself and never touches upstream. */
+export async function fetchOpenzooInfo(params: {
+  baseUrl: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  /** Injectable fetch implementation; defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+}): Promise<OpenzooInfoProbe> {
+  try {
+    const { response, release } = await fetchWithSsrFGuard({
+      url: resolveOpenzooInfoUrl(params.baseUrl),
+      init: { headers: { Accept: "application/json" } },
+      timeoutMs: params.timeoutMs ?? INFO_PROBE_TIMEOUT_MS,
+      ...(params.signal ? { signal: params.signal } : {}),
+      ...(params.fetchImpl ? { fetchImpl: params.fetchImpl } : {}),
+      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(params.baseUrl),
+      auditContext: "openzoo.info_probe",
+    });
+    try {
+      if (!response.ok) {
+        return { reachable: false, status: response.status };
+      }
+      const info = await readProviderJsonObjectResponse(response, "openzoo info");
+      return isOpenzooProxyInfo(info)
+        ? { reachable: true, info }
+        : { reachable: false, status: response.status };
+    } finally {
+      // A capture tee must not delay the guard's bounded dispatcher release.
+      if (!response.bodyUsed) {
+        void response.body?.cancel().catch(() => undefined);
+      }
+      await release();
+    }
+  } catch (error) {
+    return { reachable: false, error };
+  }
+}
+
+export function buildOpenzooUnreachableNote(baseUrl: string): string[] {
+  return [
+    `${OPENZOO_PROVIDER_LABEL} proxy could not be reached at ${baseUrl}.`,
+    "Start it in another terminal with `npx openzoo` (it prints a funding address; fund it with USDC on Solana or Base), then retry.",
+  ];
+}
+
+function readConfiguredOpenzooProvider(config: OpenClawConfig): ModelProviderConfig | undefined {
+  return config.models?.providers?.[PROVIDER_ID];
+}
+
+/** Explicit rows stay authoritative; live rows fill in the rest of the catalog. */
+export function mergeOpenzooModels(
+  explicit: readonly ModelDefinitionConfig[] | undefined,
+  discovered: readonly ModelDefinitionConfig[],
+): ModelDefinitionConfig[] {
+  const explicitRows = explicit ?? [];
+  const explicitIds = new Set(explicitRows.map((model) => model.id));
+  return [...explicitRows, ...discovered.filter((model) => !explicitIds.has(model.id))];
+}
+
+export function selectOpenzooDefaultModelRef(
+  models: readonly ModelDefinitionConfig[],
+  requestedModelId?: string,
+): string | undefined {
+  if (requestedModelId) {
+    return models.some((model) => model.id === requestedModelId)
+      ? `${PROVIDER_ID}/${requestedModelId}`
+      : undefined;
+  }
+  if (models.some((model) => model.id === OPENZOO_DEFAULT_MODEL_ID)) {
+    return OPENZOO_DEFAULT_MODEL_REF;
+  }
+  const first = models[0];
+  return first ? `${PROVIDER_ID}/${first.id}` : undefined;
+}
+
+function buildOpenzooSetupProviderConfig(params: {
+  existingProvider: ModelProviderConfig | undefined;
+  baseUrl: string;
+  models: ModelDefinitionConfig[];
+}): ModelProviderConfig {
+  const existing = params.existingProvider;
+  const existingWithoutAuth = existing
+    ? (({ auth: _auth, apiKey: _apiKey, ...rest }) => rest)(existing)
+    : undefined;
+  const existingAuth = resolveOpenzooProviderAuthMode(existing?.apiKey);
+  return {
+    ...existingWithoutAuth,
+    baseUrl: params.baseUrl,
+    api: existing?.api ?? "openai-completions",
+    // A real operator credential survives; otherwise persist the non-secret local marker.
+    ...(existingAuth && existing?.apiKey !== undefined
+      ? { auth: existingAuth, apiKey: existing.apiKey }
+      : { apiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER }),
+    models: params.models,
+  };
+}
+
+function buildOpenzooSetupState(params: { config: OpenClawConfig; baseUrl: string }) {
+  return {
+    modelsMode: params.config.models?.mode ?? "merge",
+    agentModels: withAgentModelAliases(params.config.agents?.defaults?.models, [
+      { modelRef: OPENZOO_DEFAULT_MODEL_REF, alias: OPENZOO_PROVIDER_LABEL },
+    ]),
+    // Only the static seed is persisted; refreshable discovery publishes the live catalog.
+    providerConfig: buildOpenzooSetupProviderConfig({
+      existingProvider: readConfiguredOpenzooProvider(params.config),
+      baseUrl: params.baseUrl,
+      models: buildOpenzooProvider().models ?? [],
+    }),
+  };
+}
+
+function buildOpenzooAuthResult(params: {
+  config: OpenClawConfig;
+  baseUrl: string;
+  defaultModel: string;
+}): ProviderAuthResult {
+  const state = buildOpenzooSetupState(params);
+  return {
+    profiles: [],
+    defaultModel: params.defaultModel,
+    configPatch: {
+      agents: { defaults: { models: state.agentModels } },
+      models: {
+        mode: state.modelsMode,
+        providers: { [PROVIDER_ID]: state.providerConfig },
+      },
+    },
+  };
+}
+
+/** Interactive setup: confirm the proxy answers, then seed config with the static catalog. */
+export async function promptAndConfigureOpenzooInteractive(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  prompter: WizardPrompter;
+  signal?: AbortSignal;
+}): Promise<ProviderAuthResult> {
+  const existingProvider = readConfiguredOpenzooProvider(params.config);
+  const defaultBaseUrl = resolveOpenzooBaseUrl({
+    env: params.env,
+    configuredBaseUrl: existingProvider?.baseUrl,
+  });
+  const baseUrlRaw = await params.prompter.text({
+    message: `${OPENZOO_PROVIDER_LABEL} proxy base URL`,
+    initialValue: defaultBaseUrl,
+    placeholder: defaultBaseUrl,
+    validate: (value) => (normalizeOpenzooBaseUrl(value) ? undefined : "Enter an http(s) URL"),
+  });
+  const baseUrl = normalizeOpenzooBaseUrl(baseUrlRaw) ?? defaultBaseUrl;
+  let probe = await fetchOpenzooInfo({ baseUrl, signal: params.signal });
+  while (!probe.reachable) {
+    params.signal?.throwIfAborted();
+    await params.prompter.note(
+      buildOpenzooUnreachableNote(baseUrl).join("\n"),
+      OPENZOO_PROVIDER_LABEL,
+    );
+    const retry = await params.prompter.confirm({
+      message: `Retry the ${OPENZOO_PROVIDER_LABEL} proxy connection now?`,
+      initialValue: true,
+    });
+    if (!retry) {
+      throw new WizardCancelledError(`${OPENZOO_PROVIDER_LABEL} proxy not reachable`);
+    }
+    probe = await fetchOpenzooInfo({ baseUrl, signal: params.signal });
+  }
+  const models = await discoverOpenzooModels({ baseUrl, signal: params.signal });
+  const defaultModel = selectOpenzooDefaultModelRef(models) ?? OPENZOO_DEFAULT_MODEL_REF;
+  return buildOpenzooAuthResult({ config: params.config, baseUrl, defaultModel });
+}
+
+async function validateNonInteractiveOpenzooDiscovery(
+  ctx: Omit<ProviderAuthMethodNonInteractiveContext, "toApiKeyCredential">,
+): Promise<{ baseUrl: string; defaultModel: string } | null> {
+  const existingProvider = readConfiguredOpenzooProvider(ctx.config);
+  const customBaseUrl = normalizeOpenzooBaseUrl(
+    normalizeOptionalSecretInput(ctx.opts.customBaseUrl),
+  );
+  const baseUrl =
+    customBaseUrl ??
+    resolveOpenzooBaseUrl({ env: process.env, configuredBaseUrl: existingProvider?.baseUrl });
+  const requestedModelId = normalizeOptionalSecretInput(ctx.opts.customModelId);
+  const probe = await fetchOpenzooInfo({ baseUrl });
+  if (!probe.reachable) {
+    ctx.runtime.error(buildOpenzooUnreachableNote(baseUrl).join("\n"));
+    ctx.runtime.exit(1);
+    return null;
+  }
+  const models = await discoverOpenzooModels({ baseUrl });
+  const defaultModel = selectOpenzooDefaultModelRef(models, requestedModelId);
+  if (!defaultModel) {
+    ctx.runtime.error(
+      [
+        `${OPENZOO_PROVIDER_LABEL} model ${requestedModelId ?? "(none)"} was not found at ${baseUrl}.`,
+        `Run openclaw models list --provider ${PROVIDER_ID} to see the discovered catalog.`,
+      ].join("\n"),
+    );
+    ctx.runtime.exit(1);
+    return null;
+  }
+  return { baseUrl, defaultModel };
+}
+
+/** Checks proxy reachability and the requested model without mutating config. */
+export async function validateOpenzooNonInteractive(
+  ctx: Omit<ProviderAuthMethodNonInteractiveContext, "toApiKeyCredential">,
+): Promise<boolean> {
+  return Boolean(await validateNonInteractiveOpenzooDiscovery(ctx));
+}
+
+/** Non-interactive setup path used by `openclaw onboard --auth-choice openzoo`. */
+export async function configureOpenzooNonInteractive(
+  ctx: ProviderAuthMethodNonInteractiveContext,
+): Promise<OpenClawConfig | null> {
+  const validated = await validateNonInteractiveOpenzooDiscovery(ctx);
+  if (!validated) {
+    return null;
+  }
+  const state = buildOpenzooSetupState({ config: ctx.config, baseUrl: validated.baseUrl });
+  return applyProviderDefaultModel(
+    {
+      ...ctx.config,
+      agents: {
+        ...ctx.config.agents,
+        defaults: {
+          ...ctx.config.agents?.defaults,
+          models: state.agentModels,
+        },
+      },
+      models: {
+        ...ctx.config.models,
+        mode: state.modelsMode,
+        providers: {
+          ...ctx.config.models?.providers,
+          [PROVIDER_ID]: state.providerConfig,
+        },
+      },
+    },
+    validated.defaultModel,
+  );
+}
+
+/** Live catalog: merges explicit config rows with the proxy's priced model list. */
+export async function discoverOpenzooProvider(ctx: ProviderCatalogContext): Promise<{
+  provider: ModelProviderConfig;
+} | null> {
+  const explicit = readConfiguredOpenzooProvider(ctx.config);
+  const baseUrl = resolveOpenzooBaseUrl({ env: ctx.env, configuredBaseUrl: explicit?.baseUrl });
+  const probe = await fetchOpenzooInfo({ baseUrl });
+  if (!probe.reachable && !explicit) {
+    // An unconfigured proxy that is not running is not a provider.
+    return null;
+  }
+  const discovered = probe.reachable
+    ? await discoverOpenzooModels({ baseUrl })
+    : (buildOpenzooProvider().models ?? []);
+  const models = mergeOpenzooModels(explicit?.models, discovered);
+  const { apiKey } = ctx.resolveProviderApiKey(PROVIDER_ID);
+  const resolvedApiKey = apiKey ?? explicit?.apiKey;
+  const auth = resolveOpenzooProviderAuthMode(resolvedApiKey);
+  const explicitWithoutAuth = explicit
+    ? (({ auth: _auth, apiKey: _apiKey, models: _models, ...rest }) => rest)(explicit)
+    : undefined;
+  return {
+    provider: {
+      ...explicitWithoutAuth,
+      baseUrl,
+      api: explicit?.api ?? "openai-completions",
+      ...(auth && resolvedApiKey !== undefined
+        ? { auth, apiKey: resolvedApiKey }
+        : { apiKey: OPENZOO_LOCAL_API_KEY_PLACEHOLDER }),
+      models,
+    },
+  };
+}
+
+function resolveAppGuidedOpenzooBaseUrl(ctx: ProviderAppGuidedSetupContext): string {
+  return resolveOpenzooBaseUrl({
+    env: ctx.env,
+    configuredBaseUrl: readConfiguredOpenzooProvider(ctx.config)?.baseUrl,
+  });
+}
+
+/** Read-only reachability probe for app-guided setup. */
+export async function detectAppGuidedOpenzooAvailability(
+  ctx: ProviderAppGuidedSetupContext,
+): Promise<boolean> {
+  const probe = await fetchOpenzooInfo({
+    baseUrl: resolveAppGuidedOpenzooBaseUrl(ctx),
+    signal: ctx.signal,
+  });
+  return probe.reachable;
+}
+
+/** Offers the gateway's own router row when the proxy answers. */
+export async function detectAppGuidedOpenzooModel(
+  ctx: ProviderAppGuidedSetupContext,
+): Promise<OpenzooAppGuidedCandidate | null> {
+  const baseUrl = resolveAppGuidedOpenzooBaseUrl(ctx);
+  const probe = await fetchOpenzooInfo({ baseUrl, signal: ctx.signal });
+  if (!probe.reachable) {
+    return null;
+  }
+  return {
+    modelRef: OPENZOO_DEFAULT_MODEL_REF,
+    detail: `${OPENZOO_DEFAULT_MODEL_ID} at ${baseUrl}`,
+  };
+}
+
+/** Rechecks one detected model and returns the config required for a live probe. */
+export async function prepareAppGuidedOpenzooSetup(
+  ctx: ProviderAppGuidedSetupContext & { modelRef?: string },
+): Promise<ProviderAuthResult | null> {
+  const baseUrl = resolveAppGuidedOpenzooBaseUrl(ctx);
+  const requestedPrefix = `${PROVIDER_ID}/`;
+  const requestedModelId = ctx.modelRef?.startsWith(requestedPrefix)
+    ? ctx.modelRef.slice(requestedPrefix.length)
+    : undefined;
+  if (ctx.modelRef && !requestedModelId) {
+    return null;
+  }
+  const probe = await fetchOpenzooInfo({ baseUrl, signal: ctx.signal });
+  if (!probe.reachable) {
+    return null;
+  }
+  const models = await discoverOpenzooModels({ baseUrl, signal: ctx.signal });
+  const defaultModel = selectOpenzooDefaultModelRef(models, requestedModelId);
+  if (!defaultModel) {
+    return null;
+  }
+  return buildOpenzooAuthResult({ config: ctx.config, baseUrl, defaultModel });
+}

--- a/extensions/openzoo/tsconfig.json
+++ b/extensions/openzoo/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json"
+}

--- a/package.json
+++ b/package.json
@@ -327,6 +327,7 @@
     "!dist/extensions/qa-channel/**",
     "!dist/extensions/qa-lab/**",
     "!dist/extensions/openshell/**",
+    "!dist/extensions/openzoo/**",
     "!dist/extensions/qwen/**",
     "!dist/extensions/searxng/**",
     "!dist/extensions/signal/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1743,6 +1743,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/openzoo:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/parallel:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -1188,6 +1188,45 @@
       }
     },
     {
+      "name": "@openclaw/openzoo-provider",
+      "description": "OpenClaw openzoo provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "openzoo",
+          "label": "openzoo"
+        },
+        "providers": [
+          {
+            "id": "openzoo",
+            "name": "openzoo",
+            "docs": "/providers/openzoo",
+            "categories": ["local", "llm"],
+            "envVars": [],
+            "authChoices": [
+              {
+                "method": "custom",
+                "choiceId": "openzoo",
+                "choiceLabel": "openzoo",
+                "choiceHint": "Pay per call over x402 through a local openzoo proxy (no account, no API key)",
+                "groupId": "openzoo",
+                "groupLabel": "openzoo",
+                "groupHint": "Pay-per-call inference over x402, no account or API key",
+                "onboardingScopes": ["text-inference"]
+              }
+            ]
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/openzoo-provider",
+          "npmSpec": "@openclaw/openzoo-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.6.8"
+        }
+      }
+    },
+    {
       "name": "@openclaw/opencode-go-provider",
       "description": "OpenClaw OpenCode Go provider plugin",
       "source": "official",

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -65,6 +65,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "opencode",
   "opencode-go",
   "openrouter",
+  "openzoo",
   "qianfan",
   "qwen",
   "qwen-token-plan",

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1997,6 +1997,7 @@ describe("official external plugin catalog", () => {
       ["longcat", "@openclaw/longcat-provider"],
       ["kilocode", "@openclaw/kilocode-provider"],
       ["kimi", "@openclaw/kimi-provider"],
+      ["openzoo", "@openclaw/openzoo-provider"],
       ["qianfan", "@openclaw/qianfan-provider"],
       ["qwen", "@openclaw/qwen-provider"],
     ] as const;

--- a/test/vitest/vitest.extension-misc-paths.mjs
+++ b/test/vitest/vitest.extension-misc-paths.mjs
@@ -15,6 +15,7 @@ export const miscExtensionTestRoots = [
   "extensions/opencode",
   "extensions/opencode-go",
   "extensions/openshell",
+  "extensions/openzoo",
   "extensions/parallel",
   "extensions/perplexity",
   "extensions/searxng",


### PR DESCRIPTION
## What Problem This Solves

OpenClaw users who want pay-per-call inference without creating an account or managing an API key have no bundled provider for it. openzoo (npm `openzoo`, https://openzoo.fun) is a local proxy that pays for each LLM call over x402 from a local burner wallet and exposes an OpenAI-compatible endpoint at `http://localhost:8402/v1`; today it can only be wired in by hand as a generic custom provider, with no discovery, no pricing, and no onboarding.

## Why This Change Was Made

Adds a bundled provider plugin `extensions/openzoo/` (provider id `openzoo`, package `@openclaw/openzoo-provider`) plus `docs/providers/openzoo.md`, shipped the same way every provider ships in 2026.8: as a plugin.

Design, in one line: keyless and local like `lmstudio`, discovery-priced like `kilocode`.

- Auth shape follows LM Studio: `nonSecretAuthMarkers: ["sk-openzoo"]`, `syntheticAuthRefs: ["openzoo"]`, a `custom` auth method with app-guided "Connect proxy" detection, `resolveSyntheticAuth` returning `CUSTOM_LOCAL_AUTH_MARKER` for keyless configured providers, and `shouldDeferSyntheticProfileAuth` for the local markers. The proxy takes payment, not keys; the placeholder only satisfies the Bearer transport.
- Catalog shape follows Kilo Gateway: `defineSingleProviderPluginEntry`, `openclaw.plugin.json` with `modelCatalog.discovery: refreshable`, and live discovery through `buildLiveModelProviderConfig` against the proxy's free `GET /v1/models`. Rows are OpenRouter-shaped; `pricing.prompt`/`completion` (USD per token, numbers or strings) become OpenClaw `cost` in USD per million. Rows with `kind` (media) and rows with no price on either side are skipped. `reasoning` is set only when the id carries an unambiguous token (`o1`/`o3`/`o4`/`r1`/`qwq`/`reasoner`/`thinking`, matched on id boundaries so `sao10k` and `solar-pro4` do not false-positive). Input modality is `["text"]` unless `architecture.input_modalities` lists `image`. `contextWindow` keeps the advertised 128M window (the proxy spills long context server-side); `maxTokens` falls back to 8192 when `top_provider.max_completion_tokens` is null.
- Static fallback is only `openzoo/auto` (0.1 / 0.2 USD per Mtok, the live row's values); no prices are invented for other models. Docs state that discovered prices are a ceiling (OpenRouter-direct basis; the gateway charges at most that).
- Detection probes `GET /v1/info` with a 2 s timeout and accepts `youAreTalkingTo: "openzoo proxy"`. The plugin never spawns the proxy; when it is down, setup prints the `npx openzoo` hint (fund with USDC on Solana or Base) and offers a retry. An unconfigured, unreachable proxy is not published as a provider; a configured one falls back to the static seed.
- Base URL: `models.providers.openzoo.baseUrl` wins, then `OPENZOO_BASE_URL`, then `OPENZOO_PORT` (default `http://localhost:8402/v1`).
- Registered everywhere `kilocode` is: official external provider catalog JSON, package dist excludes, knip workspace, labeler, misc extension test roots, built-in overlay ids, docs nav/index/provider table, generated plugin inventory and reference page, CHANGELOG.

Non-goals: no stream wrapper (the proxy forwards plain OpenAI bodies), no cache-TTL eligibility claim, no Control UI cover art.

## User Impact

- `openclaw onboard --auth-choice openzoo` (interactive or `--non-interactive`) and the app-guided "Connect proxy" flow set up openzoo with no account and no key; `openclaw models list --provider openzoo` shows the proxy's live, priced catalog, and any gateway model is addressable as `openzoo/<upstream-id>` (default `openzoo/auto`).
- Receipts stay in `~/.openzoo/proxy.log`; payments settle on chain per call.

## Evidence

Run in a clone of upstream `main` (`pnpm install` clean, lockfile gains the `extensions/openzoo` importer):

- `pnpm test extensions/openzoo`: 5 files, 68 tests passed (discovery parsing incl. `kind`/zero-price skipping, pricing conversion, static fallback, reasoning token matching, base URL override, synthetic auth, interactive/non-interactive/app-guided setup, plugin registration and passthrough-gemini replay policy).
- `pnpm test src/plugins/official-external-plugin-catalog.test.ts src/plugins/official-external-provider-endpoints.test.ts test/release-check.test.ts test/plugin-npm-package-manifest.test.ts test/plugin-clawhub-release.test.ts src/plugins/copy-bundled-plugin-metadata.test.ts src/plugins/providers.test.ts`: 334 tests passed across 2 shards.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test`: clean.
- `node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/openzoo`: clean.
- `oxfmt --check` on all touched code/JSON, `pnpm format:docs:check`, `pnpm lint:docs`, `pnpm docs:check-links`, `pnpm docs:check-mdx`, `pnpm docs:check-config-examples`, `pnpm docs:check-i18n-glossary`: clean.
- `pnpm plugins:inventory:gen` + `pnpm plugins:inventory:check`, `pnpm plugins:sync:check`, `pnpm check:assertion-safety`, `pnpm check:coercion-helpers`: clean. The generator also refreshed the matrix/whatsapp install-route lines, which had drifted from their `package.json` `defaultChoice: "npm"` on `main`.
- Live, free endpoints of a running proxy were inspected to shape the parser (`/v1/info` identity, `/v1/models` with 397 rows: no `name`, no `architecture`, numeric per-token prices, `max_completion_tokens: null` on `auto`, six unpriced bare ids). No paid completion was sent as part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
