### PR TITLE
docs(plugin-sdk): correct retained migration paths and deadlines

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -24,8 +24,9 @@ from a single entry point:
   events, heartbeat state, delivery queues, fetch/proxy helpers, file helpers,
   approval types, and unrelated utilities.
 - **`openclaw/plugin-sdk/config-runtime`** - a broad config barrel retained
-  only for its later compatibility window; direct runtime load/write helpers
-  have been removed.
+  for compatibility, including deprecated direct `loadConfig` and
+  `writeConfigFile` exports. Those methods were removed from the injected
+  plugin runtime, not from this retained facade.
 - **`openclaw/extension-api`** - a removed bridge that gave plugins direct
   access to host-side helpers like the embedded agent runner.
 - **`api.registerEmbeddedExtensionFactory(...)`** - a removed embedded-runner-only
@@ -60,8 +61,8 @@ New definitions should use `"tools"`.
   create.
 - **Unclear API surface** - no way to tell stable exports from internal ones.
 
-Each `openclaw/plugin-sdk/<subpath>` is now a small, self-contained module with
-a documented contract.
+The typed public SDK is organized into focused subpaths with documented
+contracts. Not every SDK build entrypoint is a public plugin API.
 
 Legacy provider convenience seams for bundled channels are gone too -
 channel-branded helper shortcuts were private mono-repo conveniences, not
@@ -269,14 +270,20 @@ artifact reader count is zero.
 
 Audit the current migration queue with `pnpm plugins:boundary-report`:
 
-| Flag                                                    | Effect                                                                     |
-| ------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `--summary` (or `pnpm plugins:boundary-report:summary`) | Compact counts instead of full detail.                                     |
-| `--json`                                                | Machine-readable report.                                                   |
-| `--owner <id>`                                          | Filter to one compatibility owner.                                         |
-| `--fail-on-eligible-compat`                             | Exit non-zero on or after a deprecated compat record's `removeAfter` date. |
+| Flag                                                    | Effect                                                                                             |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--summary` (or `pnpm plugins:boundary-report:summary`) | Compact counts instead of full detail.                                                             |
+| `--json`                                                | Machine-readable report.                                                                           |
+| `--owner <id>`                                          | Filter to one compatibility owner.                                                                 |
+| `--fail-on-eligible-compat`                             | Exit non-zero for dated `deprecated` records starting at 00:00 UTC on the day after `removeAfter`. |
 
 `pnpm plugins:boundary-report:ci` runs with the compatibility fail flag.
+For dated `deprecated` records, `removeAfter` is the final compatibility day:
+`2026-09-01` becomes eligible at `2026-09-02T00:00:00Z`, not at the start of
+September 1. `removal-pending` records are separate: they become due for review
+at 00:00 UTC on their `removeAfter` date and are reported with blockers, but do
+not trigger this fail flag. Neither state authorizes automatic removal.
+
 Deprecated records normally have an explicit `removeAfter` date. A contract
 tied to a version boundary instead declares a `removalGate`;
 `next-plugin-sdk-major` is an approved major-version gate, not a pending owner
@@ -377,10 +384,26 @@ For local media read policy, import `getAgentScopedMediaLocalRoots(...)` or
     | Current runtime snapshot reads | `openclaw/plugin-sdk/runtime-config-snapshot` |
     | Config writes | `openclaw/plugin-sdk/config-mutation` |
     | Session store helpers | `openclaw/plugin-sdk/session-store-runtime` |
-    | Markdown table config | `openclaw/plugin-sdk/markdown-table-runtime` |
-    | Group policy runtime helpers | `openclaw/plugin-sdk/runtime-group-policy` |
+    | Markdown table config | `api.runtime.channel.text.resolveMarkdownTableMode` |
+    | Channel group policy, mention requirements, and sender tool policy | `openclaw/plugin-sdk/channel-policy` |
+    | Provider-default group-policy fallback helpers | `openclaw/plugin-sdk/runtime-group-policy` |
     | Secret input resolution | `openclaw/plugin-sdk/secret-input-runtime` |
     | Model/session overrides | `openclaw/plugin-sdk/model-session-runtime` |
+
+    `api.pluginConfig` is registration-scoped, not a live getter. Replacing
+    `resolveLivePluginConfigObject(...)` requires preserving freshness through
+    the current config supplied by the runtime boundary. The injected markdown
+    resolver preserves channel/account precedence and channel defaults;
+    `markdown-table-runtime` is a private, JavaScript-only host export.
+
+    Check named types separately. `config-contracts` does not export `TtsMode`,
+    `TtsPersonaConfig`, `TtsPersonaFallbackPolicy`, or `SessionResetMode`;
+    `session-store-runtime` does not export `SessionResetMode` either. Existing
+    callers needing those names must keep retained type imports or explicitly
+    adapt their types. Talk config, cron-store operations, context-visibility
+    config resolution, and dangerous-name checks also lack a complete modern
+    typed-public mapping. Missing public contracts require an SDK-owner decision,
+    not an import of the private focused implementation.
 
     Bundled plugins and their tests are scanner-guarded against the broad
     barrel so imports and mocks stay local to the behavior they need. The
@@ -483,21 +506,28 @@ For local media read policy, import `getAgentScopedMediaLocalRoots(...)` or
   </Step>
 
   <Step title="Replace with focused imports">
-    Each export from the old surface maps to a specific modern import path:
+    Check the exported name and typed-public contract as well as the import
+    path. Some functions are renamed; not every retained helper or named type
+    has a modern public replacement:
 
     ```typescript
     // Before (deprecated backwards-compatibility layer)
     import {
       createChannelReplyPipeline,
       createPluginRuntimeStore,
-      resolveControlCommandGate,
     } from "openclaw/plugin-sdk/compat";
 
     // After (modern focused imports)
-    import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
+    import {
+      createChannelMessageReplyPipeline as createChannelReplyPipeline,
+    } from "openclaw/plugin-sdk/channel-outbound";
     import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
-    import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
     ```
+
+    The explicit alias preserves existing `createChannelReplyPipeline(...)`
+    call sites. The modern export is `createChannelMessageReplyPipeline`;
+    see [Retained channel facade mappings](/plugins/sdk-migration#retained-channel-facade-mappings)
+    for the remaining functions and named types.
 
     For host-side helpers, use the injected plugin runtime instead of
     importing directly:
@@ -530,27 +560,42 @@ For local media read policy, import `getAgentScopedMediaLocalRoots(...)` or
     compatibility, but new code should use the supported surface it actually
     needs:
 
-    | Need | Replacement |
+    | Need | Typed-public import or injected API |
     | --- | --- |
     | New system event producers | `api.runtime.system.enqueueSystemEvent` |
-    | Heartbeat wake, event, and visibility helpers | `openclaw/plugin-sdk/heartbeat-runtime` |
-    | Pending delivery queue drain | `openclaw/plugin-sdk/delivery-queue-runtime` |
-    | Channel activity telemetry | `openclaw/plugin-sdk/channel-activity-runtime` |
-    | In-memory and persistent-backed dedupe caches | `openclaw/plugin-sdk/dedupe-runtime` |
-    | Safe local-file/media paths, regular-file checks, and symlink-parent checks | `openclaw/plugin-sdk/security-runtime` |
-    | Dispatcher-aware fetch | `openclaw/plugin-sdk/runtime-fetch` |
-    | Proxy and guarded fetch helpers | `openclaw/plugin-sdk/fetch-runtime` |
-    | SSRF dispatcher policy types | `openclaw/plugin-sdk/ssrf-dispatcher` |
+    | Heartbeat wake requests | `api.runtime.system.requestHeartbeat` |
+    | Channel activity telemetry | `api.runtime.channel.activity.record` and `.get` |
+    | `createDedupeCache`, `resolveGlobalDedupeCache` | `openclaw/plugin-sdk/dedupe-runtime` |
+    | Safe local-file/media paths, regular-file checks, and symlink-parent checks | `openclaw/plugin-sdk/security-runtime` (itself a deprecated broad barrel) |
+    | `fetchWithSsrFGuard`, pinned-dispatcher helpers, `LookupFn`, `SsrFPolicy` | `openclaw/plugin-sdk/ssrf-runtime` |
     | Approval request/resolution types | `openclaw/plugin-sdk/approval-runtime` |
     | Approval reply payload and command helpers | `openclaw/plugin-sdk/approval-reply-runtime` |
-    | Error formatting helpers | `openclaw/plugin-sdk/error-runtime` |
-    | Transport readiness waits | `openclaw/plugin-sdk/transport-ready-runtime` |
-    | Secure token helpers | `openclaw/plugin-sdk/secure-random-runtime` |
-    | Bounded async task concurrency | `openclaw/plugin-sdk/concurrency-runtime` |
-    | Required-value assertions for provable invariants | `openclaw/plugin-sdk/expect-runtime` |
-    | Numeric coercion | `openclaw/plugin-sdk/number-runtime` |
-    | Process-local async lock | `openclaw/plugin-sdk/async-lock-runtime` |
-    | File locks | `openclaw/plugin-sdk/file-lock` |
+    | `collectErrorGraphCandidates`, `extractErrorCode`, `formatErrorMessage`, `formatUncaughtError`, `readErrorName`, `toErrorObject` | `openclaw/plugin-sdk/error-runtime` |
+    | `generateSecureToken`, `generateSecureUuid` | `openclaw/plugin-sdk/core` |
+    | `parseFiniteNumber`, `parseStrictFiniteNumber`, `parseStrictInteger`, `parseStrictNonNegativeInteger`, `parseStrictPositiveInteger` | `openclaw/plugin-sdk/string-coerce-runtime` |
+
+    These are symbol-specific mappings, not replacements for the whole barrel.
+    Private-local entries such as `heartbeat-runtime`, `delivery-queue-runtime`,
+    `fetch-runtime`, `runtime-fetch`, and `file-lock` are JavaScript-only host
+    exports, not typed third-party APIs. Heartbeat event/summary/visibility
+    helpers, pending-delivery drain, transport readiness, concurrency, and file
+    locking do not have equivalent modern typed-public mappings here. Retain
+    existing compatibility imports for those operations pending an SDK-owner
+    decision.
+
+    `fetchWithSsrFGuard` is not a drop-in replacement for dispatcher-aware fetch:
+    it takes an options object and returns `{ response, finalUrl, release, ... }`,
+    not a bare `Response`; callers must release its resources. The named types
+    `PinnedDispatcherPolicy`, `GuardedFetchOptions`, and `GuardedFetchResult`
+    are not exported by `ssrf-runtime`. Similarly, `dedupe-runtime` does not
+    export the legacy `DedupeCache` or `DedupeCacheOptions` names. Migrate type
+    usage explicitly rather than assuming a function move also moves its types.
+
+    The error mapping does not cover `hasErrnoCode`, `isErrno`,
+    `stringifyNonErrorCause`, `ErrorKind`, or `detectErrorKind`; the last helper
+    preserves legacy substring classification. The numeric and random mappings
+    likewise do not cover every timer, expiry, hex, fraction, or integer helper.
+    Keep unsupported retained imports until their public contract is resolved.
 
     System event snapshot inspection and consume helpers remain available only
     through the deprecated `openclaw/plugin-sdk/infra-runtime` compatibility
@@ -601,15 +646,20 @@ For local media read policy, import `getAgentScopedMediaLocalRoots(...)` or
 
 ## Import path reference
 
-The public package export map is the source of truth for importable SDK
-subpaths. Use the topical SDK guides linked from [SDK overview](/plugins/sdk-overview)
-and prefer the narrowest documented public subpath. The compiler inventory in
-`scripts/lib/plugin-sdk-entrypoints.json` also contains private-local entries used
-to build bundled plugins; their presence there does not make them public package exports.
+Use the topical SDK guides linked from [SDK overview](/plugins/sdk-overview)
+and prefer the narrowest documented typed-public subpath. In `package.json`,
+these subpaths have both `types` and `default` export targets.
 
-This table is the common migration subset, not the full SDK surface. The
-compiler entrypoint inventory lives in `scripts/lib/plugin-sdk-entrypoints.json`;
-package exports are generated from the public subset.
+The compiler inventory in `scripts/lib/plugin-sdk-entrypoints.json` also contains
+private-local entries. Their classification is maintained in
+`scripts/lib/plugin-sdk-private-local-only-subpaths.json`. Production-private
+entries may have JavaScript-only `default` exports for bundled or separately
+published official plugins, but their declarations are excluded from the package.
+A runtime export or a source file is not a typed third-party SDK contract.
+
+The mappings on this page are a migration subset, not the full SDK surface.
+Check both the public subpath and its actual named exports before replacing an
+import.
 
 Reserved bundled-plugin helper seams have been retired from the public SDK
 export map except for explicitly documented compatibility facades such as the
@@ -623,13 +673,74 @@ Use the narrowest import that matches the job. If you cannot find an export,
 check the source at `src/plugin-sdk/` or ask maintainers which generic
 contract should own it.
 
+### Retained channel facade mappings
+
+The retained channel facades are not interchangeable with `channel-outbound`.
+Migrate each function and type separately.
+
+For `openclaw/plugin-sdk/channel-reply-pipeline`, use these exports from
+`openclaw/plugin-sdk/channel-outbound`:
+
+| Legacy export                                                                   | Modern export                                  |
+| ------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `createChannelReplyPipeline`                                                    | `createChannelMessageReplyPipeline`            |
+| `resolveChannelSourceReplyDeliveryMode`                                         | `resolveChannelMessageSourceReplyDeliveryMode` |
+| `createReplyPrefixContext`, `createReplyPrefixOptions`, `createTypingCallbacks` | Same names                                     |
+
+These functions share their implementations with the retained facade. The named
+types do not all move with them: `channel-outbound` does not export
+`ChannelReplyPipeline`, `CreateTypingCallbacksParams`, `ReplyPrefixContext`,
+`ReplyPrefixContextBundle`, `ReplyPrefixOptions`, or `TypingCallbacks`.
+`SourceReplyDeliveryMode` is available from the typed-public
+`openclaw/plugin-sdk/reply-runtime` subpath. Callers that still need the other
+named imports must retain their compatibility type imports until an SDK owner
+approves a public replacement; do not import the internal `channel-reply-core`
+source file.
+
+From `openclaw/plugin-sdk/channel-lifecycle`, these functions move unchanged to
+`channel-outbound`: `createAccountStatusSink`, `createChannelRunQueue`,
+`keepHttpServerTaskAlive`, `runPassiveAccountLifecycle`, `waitUntilAbort`,
+`createDraftStreamLoop`, `createFinalizableDraftLifecycle`,
+`createFinalizableDraftStreamControlsForState`, and `takeMessageIdAfterStop`.
+Other lifecycle helpers need more than a path change:
+
+| Retained helper                                       | Migration limit                                                                                                                                                                                                                                                                                                                        |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `deliverFinalizableDraftPreview`                      | Adapt to `defineFinalizableLivePreviewAdapter` and `deliverWithFinalizableLivePreviewAdapter`. Move preview callbacks into `adapter` and handle an object result with `kind` and optional `liveState`, not the legacy string result. The adapter can return `preview-retained`; the legacy wrapper maps that kind to `normal-skipped`. |
+| `createFinalizableDraftStreamControls`                | `createFinalizableDraftStreamControlsForState` requires a shared `{ stopped, final }` object instead of custom state getter/marker callbacks.                                                                                                                                                                                          |
+| `clearFinalizableDraftMessage`                        | Adopting `createFinalizableDraftLifecycle` changes cleanup ownership: it serializes clears and retains failed deletions for retry. `takeMessageIdAfterStop` only takes the ID; it does not delete the message.                                                                                                                         |
+| `createRunStateMachine`, `createArmableStallWatchdog` | No modern public equivalents. Keep retained imports pending an SDK-owner decision.                                                                                                                                                                                                                                                     |
+
+The named types `ChannelRunQueue`, `ChannelRunQueueParams`,
+`ChannelRunQueueTaskContext`, `DraftPreviewFinalizerDraft`,
+`DraftPreviewFinalizerResult`, `DraftStreamLoop`, `FinalizableDraftStreamState`,
+`ArmableStallWatchdog`, and `StallWatchdogTimeoutMeta` are not exported by
+`channel-outbound`. Nor does it export `deliverFinalizableLivePreview`,
+`LivePreviewFinalizerDraft`, or `LivePreviewFinalizerResult`, despite the legacy
+finalizer annotations recommending them. Keep needed compatibility type imports;
+inferred factory results are not necessarily identical to caller-implemented
+legacy interfaces.
+
+For `openclaw/plugin-sdk/channel-message`, move outbound exports unchanged to
+`channel-outbound`, but migrate its three dispatch aliases to
+`openclaw/plugin-sdk/channel-inbound`:
+
+| Legacy export                      | Modern inbound export               |
+| ---------------------------------- | ----------------------------------- |
+| `hasFinalChannelTurnDispatch`      | `hasFinalInboundReplyDispatch`      |
+| `hasVisibleChannelTurnDispatch`    | `hasVisibleInboundReplyDispatch`    |
+| `resolveChannelTurnDispatchCounts` | `resolveInboundReplyDispatchCounts` |
+
+These aliases share their implementations and signatures. See
+[Channel outbound API](/plugins/sdk-channel-outbound) for the outbound contract.
+
 ## Removed compatibility surfaces
 
 The July 2026 sweep removed the root SDK and compat barrels, the extension API
-bridge, the expired SDK subpath aliases, unused SDK subpaths, and the public
-exports for bundled-only SDK modules. Bundled-only modules remain available to
-their repository owners through private-local build mappings; they are not
-importable from the published package.
+bridge, the expired SDK subpath aliases, unused SDK subpaths, and typed-public
+access to bundled-only SDK modules. Private-local build mappings remain for
+repository owners, and production-private JavaScript exports support official
+plugin runtimes. Neither provides typed third-party SDK access.
 
 ### Process-global API-provider publication
 
@@ -1123,12 +1234,13 @@ apps own device capture/playback UX.
 
 ## Removal timeline
 
-| When                                        | What happens                                                                                                                              |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Now**                                     | Warning-capable deprecated surfaces emit runtime warnings; repository guards reject deprecated SDK imports from core and bundled plugins. |
-| **Pending owner decision**                  | Records without `removeAfter` or `removalGate` remain deprecated and ineligible until their owner publishes a gate.                       |
-| **Each compat record's `removeAfter` date** | That dated surface becomes eligible for removal; `pnpm plugins:boundary-report --fail-on-eligible-compat` fails CI on or after that date. |
-| **Next Plugin SDK major**                   | `inbound-reply-dispatch` reaches its explicit `next-plugin-sdk-major` gate; it is not date-eligible before that version boundary.         |
+| When                                                     | What happens                                                                                                                                                                 |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Now**                                                  | Warning-capable deprecated surfaces emit runtime warnings; repository guards reject deprecated SDK imports from core and bundled plugins.                                    |
+| **Pending owner decision**                               | Records without `removeAfter` or `removalGate` remain deprecated and ineligible until their owner publishes a gate.                                                          |
+| **Day after a `deprecated` record's `removeAfter` date** | At 00:00 UTC, that record becomes date-eligible and `pnpm plugins:boundary-report --fail-on-eligible-compat` exits non-zero. The date itself is the final compatibility day. |
+| **A `removal-pending` record's `removeAfter` date**      | At 00:00 UTC, the report marks the record due for review and lists its blockers. It does not trigger the compatibility fail flag.                                            |
+| **Next Plugin SDK major**                                | `inbound-reply-dispatch` reaches its explicit `next-plugin-sdk-major` gate; it is not date-eligible before that version boundary.                                            |
 
 The remaining public SDK subpaths below have registry-backed removal windows.
 The July 30 rows were removed after their early maintainer-authorized sweep:
@@ -1158,9 +1270,12 @@ system-event snapshot inspection and consumption until a modern public replaceme
 exists. This changes compatibility tracking only, not the exported SDK or runtime
 behavior.
 
-All core plugins have already migrated. External plugins should migrate
-before the next major release. Run `pnpm plugins:boundary-report` to see which
-compat records are due soonest for the surfaces your plugin uses.
+Bundled-plugin migration does not prove that every external caller can use a
+path-only replacement. Migrate the functions with verified typed-public mappings;
+keep retained imports where a named type or required behavior still lacks a
+public replacement and ask the SDK owner to resolve that gap. Run
+`pnpm plugins:boundary-report` to see the dates, gates, and blockers for the
+surfaces your plugin uses.
 
 ## Related
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -55,9 +55,11 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
 
 ### Compatibility and private-local helpers
 
-Only the later-window deprecated subpaths remain exported. July 2026 aliases and
-unused subpaths were deleted, while bundled-only helpers were removed from the
-public package and are labeled private-local below. The maintained list is
+Deprecated compatibility subpaths remain exported under their recorded windows
+and retention blockers. July 2026 aliases and unused subpaths were deleted,
+while bundled-only helpers were excluded from the typed public SDK and are
+labeled private-local below. Production-private JavaScript exports remain
+available for official plugin runtimes. The maintained list is
 `scripts/lib/plugin-sdk-deprecated-public-subpaths.json`; CI rejects bundled
 imports of these compatibility-only subpaths. The broad domain barrels
 `plugin-sdk/agent-runtime`, `plugin-sdk/channel-lifecycle`,
@@ -104,16 +106,16 @@ new code; see the per-row notes below.
     | `plugin-sdk/account-helpers` | Narrow account-list/account-action helpers |
     | `plugin-sdk/access-groups` | Private-local after July 2026; Access-group allowlist parsing and redacted group diagnostics helpers |
     | `plugin-sdk/channel-pairing` | `createChannelPairingController` |
-    | `plugin-sdk/channel-reply-pipeline` | Deprecated compatibility facade. Use `plugin-sdk/channel-outbound`. |
+    | `plugin-sdk/channel-reply-pipeline` | Retained compatibility facade. `channel-outbound` exports `createChannelMessageReplyPipeline` and `resolveChannelMessageSourceReplyDeliveryMode`; other function names are unchanged, but named types do not all move. See [retained channel mappings](/plugins/sdk-migration#retained-channel-facade-mappings). |
     | `plugin-sdk/channel-config-helpers` | `createHybridChannelConfigAdapter`, `resolveChannelDmAccess`, `resolveChannelDmAllowFrom`, `resolveChannelDmPolicy`, `normalizeChannelDmPolicy`, `normalizeLegacyDmAliases` |
     | `plugin-sdk/channel-config-schema` | Shared channel config schema primitives plus Zod and direct JSON/TypeBox builders |
     | `plugin-sdk/bundled-channel-config-schema` | Private-local after July 2026; Bundled OpenClaw channel config schemas for maintained bundled plugins only |
     | `plugin-sdk/chat-channel-ids` | Private-local after July 2026; `BUNDLED_CHAT_CHANNEL_IDS`, `BUNDLED_CHAT_CHANNEL_ENVELOPE_PREFIXES`, `ChatChannelId`. Canonical bundled/official chat channel ids plus formatter labels/aliases for plugins that need to recognize envelope-prefixed text without hardcoding their own table. |
     | `plugin-sdk/channel-policy` | `resolveChannelGroupRequireMention` |
     | `plugin-sdk/channel-ingress-runtime` | Experimental high-level channel ingress runtime resolver, implicit-mention policy resolver, and route fact builders for migrated channel receive paths. Prefer this over assembling effective allowlists, command allowlists, and legacy projections in each plugin. See [Channel ingress API](/plugins/sdk-channel-ingress). |
-    | `plugin-sdk/channel-lifecycle` | Deprecated compatibility facade. Use `plugin-sdk/channel-outbound`. |
+    | `plugin-sdk/channel-lifecycle` | Retained compatibility facade. Selected functions move unchanged to `channel-outbound`; other helpers require behavioral migration or an owner-approved public replacement. Named types do not all move. See [retained channel mappings](/plugins/sdk-migration#retained-channel-facade-mappings). |
     | `plugin-sdk/channel-outbound` | Message lifecycle contracts plus reply pipeline options, receipts, live preview/streaming, lifecycle helpers, outbound identity, payload planning, durable sends, and message-send context helpers. See [Channel outbound API](/plugins/sdk-channel-outbound). |
-    | `plugin-sdk/channel-message` | Deprecated compatibility alias for `plugin-sdk/channel-outbound`. |
+    | `plugin-sdk/channel-message` | Retained compatibility facade. Move outbound exports to `channel-outbound` and its three dispatch aliases to their renamed exports in `channel-inbound`. See [retained channel mappings](/plugins/sdk-migration#retained-channel-facade-mappings). |
     | `plugin-sdk/inbound-envelope` | Shared inbound route + envelope builder helpers |
     | `plugin-sdk/inbound-event-delivery` | Process-local correlation between active inbound events and successful channel sends |
     | `plugin-sdk/inbound-reply-dispatch` | Deprecated compatibility shim for `dispatchInboundReplyWithBase`; its compatibility-ledger gate is the next Plugin SDK major, not a calendar date. Use `plugin-sdk/channel-inbound` for inbound runners and `plugin-sdk/channel-outbound` for message delivery helpers. |
@@ -146,10 +148,11 @@ new code; see the per-row notes below.
     | `plugin-sdk/reply-payload` | Reply payload types, normalization, content/media inspection, native question option ordering, chunked send helpers, reasoning detection, and reply fan-out |
   </Accordion>
 
-Later-window channel compatibility subpaths remain public only through their
-registry dates. July aliases such as direct-DM access, reply-options, pairing
-paths, and channel runtime splinters have been removed; bundled-only helpers
-are private-local.
+The September channel facades remain public as `removal-pending` records until
+their recorded blockers are resolved; a registry date does not automatically
+remove an export. See the [removal timeline](/plugins/sdk-migration#removal-timeline).
+July aliases such as direct-DM access, reply-options, pairing paths, and channel
+runtime splinters have been removed; bundled-only helpers are private-local.
 
   <Accordion title="Provider subpaths">
     | Subpath | Key exports |
@@ -270,7 +273,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/gateway-method-runtime` | Reserved Gateway method dispatch helper for plugin HTTP routes that declare `contracts.gatewayMethodDispatch: ["authenticated-request"]` |
     | `plugin-sdk/gateway-runtime` | Gateway client, event-loop-ready client start helper, gateway CLI RPC, gateway protocol errors, advertised LAN host resolution, and channel-status patch helpers |
     | `plugin-sdk/config-contracts` | Focused config surface for plugin config shapes such as `OpenClawConfig` and channel/provider config types, plus the dependency-light runtime helper `resolveGatewayPublicOrigin(cfg)` which returns the normalized `gateway.publicOrigin` (bare http(s) origin, optional reverse-proxy path, no query/hash) or `undefined` when unset, for building links back to the Gateway |
-    | `plugin-sdk/config-runtime` | Deprecated broad config compatibility facade; prefer `plugin-config-runtime`, `config-mutation`, `runtime-config-snapshot`, and other focused config subpaths |
+    | `plugin-sdk/config-runtime` | Retained broad config compatibility facade; prefer passed config, `api.pluginConfig`, `config-contracts`, `config-mutation`, and `runtime-config-snapshot` where they cover the needed contract. Named types and private-runtime helpers are not blanket replacements; see [migration guidance](/plugins/sdk-migration#how-to-migrate). |
     | `plugin-sdk/plugin-config-runtime` | Deprecated compatibility facade for runtime plugin-config helpers; new plugins use `api.pluginConfig` plus focused config contracts, snapshots, and mutation helpers |
     | `plugin-sdk/config-mutation` | Transactional config mutation helpers such as `mutateConfigFile`, `replaceConfigFile`, and `logConfigUpdated` |
     | `plugin-sdk/message-tool-delivery-hints` | Private-local after July 2026; Shared message-tool delivery metadata hint strings |


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** is enabled through this branch in the main repository.

</details>

## What Problem This Solves

Fixes an issue where plugin authors following the SDK migration guide would select a removal-pending facade as the modern destination, import unavailable names or types, or expect the compatibility fail gate to activate one UTC day early.

The adjacent subpath catalog also implied that the five retained facades could be replaced wholesale, even though some functions are renamed, some helpers require behavioral migration, and fourteen recommended destinations are private JavaScript-only host exports rather than typed-public SDK APIs.

## Why This Change Was Made

Document the contracts that actually exist instead of expanding the SDK to match inaccurate documentation. The reply-pipeline example imports `createChannelMessageReplyPipeline` from `channel-outbound` with an explicit alias preserving the old caller spelling. The guide separates exact public mappings, injected runtime alternatives, and owner-gated gaps, and explains lifecycle/fetch migrations whose result or ownership semantics differ.

The gate documentation now treats `removeAfter` as the final compatibility day for `deprecated` records. Eligibility starts at midnight UTC the next day. `removal-pending` records become due for review on the recorded date and are reported with blockers without triggering that fail flag.

No SDK exports, compatibility dates/statuses, runtime behavior, or gate implementation change.

## User Impact

Plugin authors can follow the supported migrations without confusing runtime-only imports with typed-public contracts or assuming that moved functions also export their old named types. Existing callers retain compatibility imports where no public replacement exists; missing APIs still require SDK-owner decisions.

Remaining owner-gated areas include reply/lifecycle named types and state-machine/watchdog helpers; named TTS/reset types and some config operations; and system-event inspection/consumption, heartbeat observation, queue drain, readiness/concurrency/locking, and selected infra helper/type contracts. This PR records those gaps rather than adding exports or changing removal policy.

Documentation: [SDK migration](https://docs.openclaw.ai/plugins/sdk-migration) and [SDK subpaths](https://docs.openclaw.ai/plugins/sdk-subpaths).

## Evidence

Source evidence includes the canonical package export generator and private-local inventory, all five retained facades and their public destinations, the reply/lifecycle implementations, and `scripts/plugin-boundary-report.ts` with its existing final-compatibility-day regression coverage. Current-main refreshes showed no changes to these audited contracts.

Validation completed:

- `pnpm docs:list`
- `node scripts/check-docs-mdx.mjs docs/plugins/sdk-migration.md docs/plugins/sdk-subpaths.md` — both pages pass.
- `pnpm docs:check-links` — 7,243 internal links checked; zero broken links.
- `pnpm docs:check-i18n-glossary`
- Canonical Oxfmt plus Mintlify accordion formatting, checked for idempotence on both edited pages.
- `git diff --check`
- Codex autoreview of the complete uncommitted documentation diff: scoped-clean at the configured P0 scope, with no findings. Independent source audits also checked migration-name, type, and semantic correctness.
- Compiler export inspection: 43 documented names present and 37 explicitly documented name gaps absent; 20 recommended destinations match the canonical typed-public export map, while all 14 former private-runtime recommendations lack public declaration exports.
- Direct boundary-report probes: September 1 at `23:59:59.999Z` is still compatible, September 2 at `00:00:00Z` is eligible, and the five due removal-pending records are reported with blockers without failing the flag.

Production LOC: +0/-0. Tests: +0/-0. Only the two English documentation pages change. No runtime build or live channel test is needed for this docs-only correction; localized output remains owned by the documentation publishing pipeline.
