### PR TITLE
test(codex): guard source-build dependency ownership

### DIFF
--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -6,6 +6,7 @@ import {
   collectChannelConfigDoctorBuildEntries,
   collectPluginDeclarationSourceEntries,
   collectRootPackageExcludedExtensionDirs,
+  collectSourceCheckoutPluginBuildEntries,
   DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
   listBundledPluginBuildEntries,
   listBundledPluginPackArtifacts,
@@ -138,9 +139,11 @@ describe("bundled plugin build entries", () => {
   it("keeps Codex CLI metadata in bundled build and standalone pack entries", () => {
     const entries = listBundledPluginBuildEntries();
     const artifacts = listBundledPluginPackArtifacts({ includeRootPackageExcludedDirs: true });
+    const sourceEntry = collectSourceCheckoutPluginBuildEntries().find(({ id }) => id === "codex");
 
     expect(entries["extensions/codex/cli-metadata"]).toBe("extensions/codex/cli-metadata.ts");
     expect(artifacts).toContain("dist/extensions/codex/cli-metadata.js");
+    expect(sourceEntry).toMatchObject({ isolated: true, runtimeExtension: ".js" });
   });
 
   it("builds narrow QA runner public surfaces", () => {


### PR DESCRIPTION
Refs #135970

## What Problem This Solves

The Codex source-build path has two distinct packaging requirements:

- its CLI metadata must remain in the bundled core build;
- its plugin-owned runtime dependencies must be staged through the isolated source-checkout path.

A future metadata or package-exclusion change could preserve one side while silently breaking the other, causing the managed Codex app-server launcher to disappear from source builds.

## Why This Change Was Made

The packaging refactor merged in #135478 now provides the canonical fix: root-package exclusions select Codex for isolated source-checkout staging while the bundled build still retains `cli-metadata`.

This PR adds one explicit regression assertion that joins both parts of that contract in the existing Codex packaging test. It does not change production metadata or introduce another dependency-resolution path.

## User Impact

No user-visible behavior changes. The test prevents source-build packaging changes from reintroducing the managed Codex app-server startup failure reported in #135970.

## Evidence

All commands below ran from a standalone clone at exact head `c0fa13bb24d1cd0227a631ce819972ef5f1f7f5a` after `pnpm install --frozen-lockfile`.

### Source build and managed launcher

```text
$ pnpm build
[build-all] phase timings: total 4m 50.7s
exit 0

$ test -x dist/extensions/codex/node_modules/.bin/codex
$ realpath --relative-to="$PWD" dist/extensions/codex/node_modules/@openai/codex
node_modules/.pnpm/@openai+codex@0.151.0/node_modules/@openai/codex

$ dist/extensions/codex/node_modules/.bin/codex --version
codex-cli 0.151.0
```

### Focused test

```text
$ pnpm test -- test/scripts/bundled-plugin-build-entries.test.ts
Test Files  1 passed (1)
Tests       34 passed (34)
```

### Changed-surface checks

```text
$ node scripts/check-changed.mjs -- test/scripts/bundled-plugin-build-entries.test.ts
completed successfully
```

The test-only diff verifies that:

- the source-checkout plan marks Codex as `isolated: true` with a `.js` runtime entry;
- the existing bundled-build assertions continue to require `extensions/codex/cli-metadata.ts` and its packaged artifact.

### Upstream Codex contract

Inspected `openai/codex@eb10d91e48ccbd0930427461fb392337addb1ac0` directly:

- `codex-cli/bin/codex.js` resolves the platform package from the package-owned dependency graph and launches its native binary.
- `codex-rs/app-server/README.md` documents `codex app-server` as a JSONL service whose first request is `initialize` followed by the `initialized` notification.
- `bazel/rules/testing/compat/exec_server_compat_test.rs` exercises the same launcher argument and initialization sequence.
