### PR TITLE
test(feishu): scope shared fixtures and join failed downloads

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
@@ -113,21 +114,21 @@ async function withIsolatedHome<T>(run: () => Promise<T>): Promise<T> {
   });
 }
 
+beforeAll(async () => {
+  ({ saveMessageResourceFeishu, sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } =
+    await import("./media.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("./client.js");
+  vi.doUnmock("./accounts.js");
+  vi.doUnmock("./targets.js");
+  vi.doUnmock("./runtime.js");
+  vi.doUnmock("openclaw/plugin-sdk/media-runtime");
+  vi.resetModules();
+});
+
 describe("sendMediaFeishu msg_type routing", () => {
-  beforeAll(async () => {
-    ({ saveMessageResourceFeishu, sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } =
-      await import("./media.js"));
-  });
-
-  afterAll(() => {
-    vi.doUnmock("./client.js");
-    vi.doUnmock("./accounts.js");
-    vi.doUnmock("./targets.js");
-    vi.doUnmock("./runtime.js");
-    vi.doUnmock("openclaw/plugin-sdk/media-runtime");
-    vi.resetModules();
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     mockResolvedFeishuAccount();
@@ -390,32 +391,35 @@ describe("sendMediaFeishu msg_type routing", () => {
 
   it("falls back to file when voice-intent audio cannot be transcoded", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    runFfmpegMock.mockRejectedValueOnce(new Error("ffmpeg missing"));
-    loadWebMediaMock.mockResolvedValueOnce({
-      buffer: Buffer.from("remote-mp3"),
-      fileName: "reply.mp3",
-      kind: "audio",
-      contentType: "audio/mpeg",
-    });
+    try {
+      runFfmpegMock.mockRejectedValueOnce(new Error("ffmpeg missing"));
+      loadWebMediaMock.mockResolvedValueOnce({
+        buffer: Buffer.from("remote-mp3"),
+        fileName: "reply.mp3",
+        kind: "audio",
+        contentType: "audio/mpeg",
+      });
 
-    const result = await sendMediaFeishu({
-      cfg: emptyConfig,
-      to: "user:ou_target",
-      mediaUrl: "https://example.com/reply.mp3",
-      audioAsVoice: true,
-    });
+      const result = await sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaUrl: "https://example.com/reply.mp3",
+        audioAsVoice: true,
+      });
 
-    const fileData = callData<{ file?: Buffer; file_name?: string; file_type?: string }>(
-      fileCreateMock,
-    );
-    expect(fileData.file_type).toBe("stream");
-    expect(fileData.file_name).toBe("reply.mp3");
-    expect(fileData.file).toEqual(Buffer.from("remote-mp3"));
-    expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("file");
-    expect(result.voiceIntentDegradedToFile).toBe(true);
-    expect(mockCallArg<string>(warnSpy, 0, 0)).toContain("audioAsVoice transcode failed");
-    expect(mockCallArg<unknown>(warnSpy, 0, 1)).toBeInstanceOf(Error);
-    warnSpy.mockRestore();
+      const fileData = callData<{ file?: Buffer; file_name?: string; file_type?: string }>(
+        fileCreateMock,
+      );
+      expect(fileData.file_type).toBe("stream");
+      expect(fileData.file_name).toBe("reply.mp3");
+      expect(fileData.file).toEqual(Buffer.from("remote-mp3"));
+      expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("file");
+      expect(result.voiceIntentDegradedToFile).toBe(true);
+      expect(mockCallArg<string>(warnSpy, 0, 0)).toContain("audioAsVoice transcode failed");
+      expect(mockCallArg<unknown>(warnSpy, 0, 1)).toBeInstanceOf(Error);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("configures the media client timeout for image uploads", async () => {
@@ -1064,49 +1068,48 @@ describe("saveMessageResourceFeishu", () => {
 
   it("keeps the shipped 120-second media timeout for stalled stream bodies", async () => {
     vi.useFakeTimers();
-    let markReadStarted: (() => void) | undefined;
-    const readStarted = new Promise<void>((resolve) => {
-      markReadStarted = resolve;
-    });
-    const stalled = new Readable({
-      read() {
-        markReadStarted?.();
-      },
-    });
-    messageResourceGetMock.mockResolvedValueOnce({
-      getReadableStream: () => stalled,
-      headers: { "content-type": "image/jpeg" },
-    });
-
     try {
-      let settled = false;
-      const download = withIsolatedHome(() =>
-        saveMessageResourceFeishu({
+      await withIsolatedHome(async () => {
+        const { promise: readStarted, resolve: markReadStarted } = createDeferred<void>();
+        const stalled = new Readable({
+          read() {
+            markReadStarted();
+          },
+        });
+        messageResourceGetMock.mockResolvedValueOnce({
+          getReadableStream: () => stalled,
+          headers: { "content-type": "image/jpeg" },
+        });
+
+        let settled = false;
+        const download = saveMessageResourceFeishu({
           cfg: emptyConfig,
           messageId: "om_stalled_stream",
           fileKey: "img_key_stalled",
           type: "image",
           maxBytes: 1024,
-        }),
-      );
-      void download.then(
-        () => {
+        });
+        const markSettled = () => {
           settled = true;
-        },
-        () => {
-          settled = true;
-        },
-      );
+        };
+        const downloadSettled = download.then(markSettled, markSettled);
 
-      await readStarted;
-      await vi.advanceTimersByTimeAsync(FEISHU_MEDIA_HTTP_TIMEOUT_MS - 1);
-      expect(settled).toBe(false);
-      await vi.advanceTimersByTimeAsync(1);
-      await expect(download).rejects.toMatchObject({
-        name: "FeishuInboundMediaTimeoutError",
-        chunkTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
+        try {
+          await Promise.race([readStarted, download]);
+          await vi.advanceTimersByTimeAsync(FEISHU_MEDIA_HTTP_TIMEOUT_MS - 1);
+          expect(settled).toBe(false);
+          await vi.advanceTimersByTimeAsync(1);
+          await expect(download).rejects.toMatchObject({
+            name: "FeishuInboundMediaTimeoutError",
+            chunkTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
+          });
+          expect(stalled.destroyed).toBe(true);
+        } finally {
+          // Join the writer before its HOME and directory owners are released on assertion failure.
+          stalled.destroy();
+          await downloadSettled;
+        }
       });
-      expect(stalled.destroyed).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -76,6 +76,49 @@ let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTempl
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
 let sendStructuredCardFeishu: typeof import("./send.js").sendStructuredCardFeishu;
 
+beforeAll(async () => {
+  ({
+    editMessageFeishu,
+    getMessageFeishu,
+    listFeishuThreadMessages,
+    resolveFeishuCardTemplate,
+    sendMessageFeishu,
+    sendStructuredCardFeishu,
+  } = await import("./send.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/markdown-table-runtime");
+  vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+  vi.doUnmock("openclaw/plugin-sdk/text-chunking");
+  vi.doUnmock("./client.js");
+  vi.doUnmock("./accounts.js");
+  vi.doUnmock("./runtime.js");
+  vi.resetModules();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolveMarkdownTableMode.mockReturnValue("preserve");
+  mockConvertMarkdownTables.mockImplementation((text: string) => text);
+  mockRuntimeResolveMarkdownTableMode.mockReturnValue("preserve");
+  mockRuntimeConvertMarkdownTables.mockImplementation((text: string) => text);
+  mockResolveFeishuAccount.mockReturnValue({
+    accountId: "default",
+    configured: true,
+  });
+  mockCreateFeishuClient.mockReturnValue({
+    im: {
+      message: {
+        create: vi.fn(),
+        get: mockClientGet,
+        list: mockClientList,
+        patch: mockClientPatch,
+      },
+    },
+  });
+});
+
 describe("getMessageFeishu", () => {
   function expectTextReceipt(
     result: Awaited<ReturnType<typeof sendMessageFeishu>>,
@@ -108,49 +151,6 @@ describe("getMessageFeishu", () => {
       ...expected,
     });
   }
-
-  beforeAll(async () => {
-    ({
-      editMessageFeishu,
-      getMessageFeishu,
-      listFeishuThreadMessages,
-      resolveFeishuCardTemplate,
-      sendMessageFeishu,
-      sendStructuredCardFeishu,
-    } = await import("./send.js"));
-  });
-
-  afterAll(() => {
-    vi.doUnmock("openclaw/plugin-sdk/markdown-table-runtime");
-    vi.doUnmock("openclaw/plugin-sdk/runtime-env");
-    vi.doUnmock("openclaw/plugin-sdk/text-chunking");
-    vi.doUnmock("./client.js");
-    vi.doUnmock("./accounts.js");
-    vi.doUnmock("./runtime.js");
-    vi.resetModules();
-  });
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockResolveMarkdownTableMode.mockReturnValue("preserve");
-    mockConvertMarkdownTables.mockImplementation((text: string) => text);
-    mockRuntimeResolveMarkdownTableMode.mockReturnValue("preserve");
-    mockRuntimeConvertMarkdownTables.mockImplementation((text: string) => text);
-    mockResolveFeishuAccount.mockReturnValue({
-      accountId: "default",
-      configured: true,
-    });
-    mockCreateFeishuClient.mockReturnValue({
-      im: {
-        message: {
-          create: vi.fn(),
-          get: mockClientGet,
-          list: mockClientList,
-          patch: mockClientPatch,
-        },
-      },
-    });
-  });
 
   it("sends text without requiring Feishu runtime text helpers", async () => {
     mockRuntimeResolveMarkdownTableMode.mockImplementation(() => {
@@ -846,13 +846,8 @@ describe("getMessageFeishu", () => {
 
 describe("editMessageFeishu", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     mockClientPatch.mockReset();
     mockClientUpdate.mockReset();
-    mockResolveFeishuAccount.mockReturnValue({
-      accountId: "default",
-      configured: true,
-    });
     mockCreateFeishuClient.mockReturnValue({
       im: {
         message: {


### PR DESCRIPTION
## Summary
Feishu send and media tests initialized their shared module bindings inside the first test group. Selecting later edit or download cases alone skipped that setup and failed with an undefined function. The same group's teardown also removed shared mocks before sibling groups finished. Move the existing import/unmock ownership to file scope and keep per-group defaults where needed.

The stalled media-download test could also leave its writer, Readable, temporary HOME, and directory alive after an assertion failure. Keep the operation and assertions inside the temporary-home owner, destroy the exact stalled source, then join the existing handled download promise before releasing HOME, the directory, and the clock. Readiness now observes an early download failure rather than waiting for a read that will never start.

All 75 existing cases and 166 assertion sites remain. The 119,999 + 1 ms boundary still checks the actual 120-second media deadline. Production code and provider behavior are unchanged.

## Validation
- Before changes: all 75 send/media cases passed together in 51.70 seconds. Two focused runs failed at the actual edit/download call with undefined functions.
- After changes: all 75 cases plus 2 real chunk-idle/HTTP siblings passed; the final refactored candidate passed in 19.08 seconds. Both formerly broken focused selections pass. These recorded wall times include different warm compilation costs; no fixed whole-suite speedup is claimed. The correction makes focused runs usable without executing unrelated groups.
- Controlled failure after the existing 119999ms assertion: original and candidate each reported 42 passing cases and exactly 1 intentional failure. Original retained the live stream, pending download, HOME override and owned directory until explicit probe rescue. Candidate had already destroyed/closed the stream, joined the download, restored HOME and removed the directory before rescue. Both propagated the identical injected Error. The private instrumentation was removed and the exact candidate hash restored.
- Shared HTTP tests retain timeout-error precedence and observe the server connection close. No deadline inflation, shorter timeout, broader filesystem/stream mock, or skipped assertion.

    node scripts/run-vitest.mjs extensions/feishu/src/send.test.ts extensions/feishu/src/media.test.ts extensions/feishu/src/media-chunk-idle.test.ts

    node scripts/run-vitest.mjs extensions/feishu/src/send.test.ts extensions/feishu/src/media.test.ts -t 'routes card and rich-post edits through their distinct Feishu SDK HTTP methods|does not retry non-fallback download failures'

No live Feishu request is needed for this test-fixture change; the real SDK request mapping, local stream/store/temp operations and local HTTP timeout behavior remain exercised.

Production LOC +0/-0; tests +118/-120 (net -2), mostly ownership moves. Codex P0 autoreview is scoped-clean (0.99).

The first local lint run exposed the existing 1,000-line file cap. The fixture now reuses the shared deferred helper and a single settlement callback, and restores the nearby transcode-warning spy in a finally block. The final candidate again passed all77cases and the controlled failure probe; no lint suppression or limit change was added.

Local changed-scope structural, assertion, boundary and dead-export gates passed. After the small final refactor, formatting, plugin-test typing and focused lint passed again. Final Codex P0 review is scoped-clean at0.99.

Final landing proof: exact-head CI [33597740068](https://github.com/openclaw/openclaw/actions/runs/33597740068) passed. The two documented focused selections also passed on GitHub merge ref ce11c377503 (PR head6b60fc49 plus base8a1dad327);73other cases were intentionally unselected in that supplemental run. ClawSweeper’s request for merge-ref proof is addressed. Its reported later edits to both test files were checked directly: both the reviewed main ebd79690f265 and fetched main110b91e27fc have zero changes to these files from branch base5dd3796. No source conflict or additional test-file changes need a rewrite. The existing autonomous landing instruction supplies the normal maintainer decision.
