### PR TITLE
fix: release completed log payloads during slow writes

### DIFF
--- a/src/logging/log-file-size-cap.test.ts
+++ b/src/logging/log-file-size-cap.test.ts
@@ -109,41 +109,34 @@ describe("log file size cap", () => {
     });
   });
 
-  it("keeps cached default rolling loggers on the current-day file", async () => {
-    const logDir = path.dirname(logPath);
-    const firstDay = path.join(logDir, "openclaw-2026-01-01.log");
-    const secondDay = path.join(logDir, "openclaw-2026-01-02.log");
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T08:00:00Z"));
-    setLoggerOverride({ level: "info", file: firstDay });
-    const logger = getLogger();
+  it.each([
+    { name: "default rolling", prefix: "openclaw", rolls: true },
+    { name: "explicit profile-shaped", prefix: "openclaw-dev", rolls: false },
+  ])(
+    "keeps cached $name loggers on the expected files across date changes",
+    async ({ prefix, rolls }) => {
+      const logDir = path.dirname(logPath);
+      const firstDay = path.join(logDir, `${prefix}-2026-01-01.log`);
+      const secondDay = path.join(logDir, `${prefix}-2026-01-02.log`);
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T08:00:00Z"));
+      setLoggerOverride({ level: "info", file: firstDay });
+      const logger = getLogger();
 
-    logger.info({ message: "first day" });
-    vi.setSystemTime(new Date("2026-01-02T08:00:00Z"));
-    logger.info({ message: "second day" });
-    await testApi.flushFileLogQueueForTests();
+      logger.info({ message: "first day" });
+      vi.setSystemTime(new Date("2026-01-02T08:00:00Z"));
+      logger.info({ message: "second day" });
+      await testApi.flushFileLogQueueForTests();
 
-    expect(fs.readFileSync(firstDay, "utf8")).toContain("first day");
-    expect(fs.readFileSync(secondDay, "utf8")).toContain("second day");
-    expect(fs.readFileSync(firstDay, "utf8")).not.toContain("second day");
-  });
-
-  it("keeps an explicit profile-shaped log path stable across date changes", async () => {
-    const logDir = path.dirname(logPath);
-    const configured = path.join(logDir, "openclaw-dev-2026-01-01.log");
-    const inferredNextDay = path.join(logDir, "openclaw-dev-2026-01-02.log");
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T08:00:00Z"));
-    setLoggerOverride({ level: "info", file: configured });
-    const logger = getLogger();
-
-    logger.info({ message: "first day" });
-    vi.setSystemTime(new Date("2026-01-02T08:00:00Z"));
-    logger.info({ message: "second day" });
-    await testApi.flushFileLogQueueForTests();
-
-    expect(fs.readFileSync(configured, "utf8")).toContain("first day");
-    expect(fs.readFileSync(configured, "utf8")).toContain("second day");
-    expect(fs.existsSync(inferredNextDay)).toBe(false);
-  });
+      const firstContent = fs.readFileSync(firstDay, "utf8");
+      expect(firstContent).toContain("first day");
+      if (rolls) {
+        expect(fs.readFileSync(secondDay, "utf8")).toContain("second day");
+        expect(firstContent).not.toContain("second day");
+      } else {
+        expect(firstContent).toContain("second day");
+        expect(fs.existsSync(secondDay)).toBe(false);
+      }
+    },
+  );
 });

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -187,8 +187,7 @@ function rotateIfNeeded(entry: FileLogQueueEntry, cursor: FileCursor, synchronou
 
 async function writeEntries(entries: FileLogQueueEntry[], generation: number): Promise<void> {
   const cursors = new Map<string, FileCursor>();
-  let index = 0;
-  while (index < entries.length) {
+  for (let index = 0; index < entries.length; index += 1) {
     if (generation !== drainGeneration || processExiting) {
       return;
     }
@@ -216,17 +215,16 @@ async function writeEntries(entries: FileLogQueueEntry[], generation: number): P
       warnAboutAppendFailure(entry, false);
     } finally {
       activeAppendInFlight = false;
+      // Drains share entries; release settled text even while a later append is still pending.
+      entry.payload = "";
     }
     activeIndex = index + 1;
-    index += 1;
   }
 }
 
 function writeEntriesSync(entries: FileLogQueueEntry[]): void {
   const cursors = new Map<string, FileCursor>();
-  let index = 0;
-  while (index < entries.length) {
-    const entry = entries[index];
+  for (const entry of entries) {
     if (!entry) {
       return;
     }
@@ -245,7 +243,7 @@ function writeEntriesSync(entries: FileLogQueueEntry[]): void {
       // Match the old best-effort transport: a failed append must not stop later records.
       warnAboutAppendFailure(entry, true);
     }
-    index += 1;
+    entry.payload = "";
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

File logging kept completed log text in memory until the slowest append in a batch finished. A forced drain also left its already-written tail reachable through the older asynchronous batch.

## Why This Change Was Made

Clear each transport-owned payload after its append attempt settles, so both batch references release consumed text while cursor, rotation, failure and in-flight rules remain intact. Production is net -2 lines; a two-case rollover fixture consolidation preserves all assertions and brings total net to -9.

## User Impact

A slow append no longer keeps the batch's completed payloads alive. File contents, ordering and shutdown behavior remain unchanged.

## Evidence

The held-append probe releases 33.56 MB of earlier payload text and another 8.39 MB after a forced tail drain. This is scoped owner retention evidence, not a Gateway RSS claim. Four real logger/file lifecycle scenarios and natural, forced and in-flight child shutdown modes preserve exact bytes and record order. The 18-test neighboring suite passes before and after.

The canonical changed gate passed. Managed Codex autoreview was scoped-clean at default P0 priority with no accepted/actionable findings; it reviewed the supplied source and evidence without rerunning tests. The first gate caught a prefer-for-of lint issue in the synchronous loop; the corrected loop and all final proof runs passed. All owned test, proof and review processes have joined.

The requested [inspectable retention trace and exact runnable drivers](https://github.com/openclaw/openclaw/pull/136030#issuecomment-5505634353) are published in the PR. Parent review replayed the underlying evidence; ClawSweeper's durable-evidence item and Rank-up request are addressed.
