### PR TITLE
refactor: remove disposable plugin metadata test fixtures

### DIFF
--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -67,6 +67,25 @@ vi.mock("./manifest-registry-installed.js", async (importOriginal) => {
   };
 });
 
+function mockSchemaSnapshotSource(
+  index: ReturnType<typeof makeIndex>,
+  properties: Record<string, unknown>,
+) {
+  const registry = makeManifestRegistry();
+  const plugin = registry.plugins[0];
+  if (!plugin) {
+    throw new Error("expected manifest plugin fixture");
+  }
+  plugin.configSchema = { type: "object", properties };
+  loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+    source: "provided",
+    snapshot: index,
+    diagnostics: [],
+  });
+  loadPluginManifestRegistryForInstalledIndex.mockReturnValue(registry);
+  return registry;
+}
+
 describe("plugin metadata snapshot", () => {
   beforeEach(() => {
     loadPluginRegistrySnapshotWithMetadata.mockReset();
@@ -328,25 +347,11 @@ describe("plugin metadata snapshot", () => {
 
   it("rewalks collection-bearing manifest graphs after prototype mutation", () => {
     const index = makeIndex();
-    const registry = makeManifestRegistry();
-    const plugin = registry.plugins[0];
-    if (!plugin) {
-      throw new Error("expected manifest plugin fixture");
-    }
     const initialMapValue = { nested: { value: "initial-map" } };
     const initialSetValue = { nested: { value: "initial-set" } };
     const sharedMap = new Map([["initial", initialMapValue]]);
     const sharedSet = new Set([initialSetValue]);
-    plugin.configSchema = {
-      type: "object",
-      properties: { sharedMap, sharedSet },
-    };
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
-    loadPluginManifestRegistryForInstalledIndex.mockReturnValue(registry);
+    const registry = mockSchemaSnapshotSource(index, { sharedMap, sharedSet });
 
     const first = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
     expect(Object.isFrozen(initialMapValue.nested)).toBe(true);
@@ -387,27 +392,13 @@ describe("plugin metadata snapshot", () => {
 
   it("rewalks enumerable accessor graphs when their closure-backed values change", () => {
     const index = makeIndex();
-    const registry = makeManifestRegistry();
-    const plugin = registry.plugins[0];
-    if (!plugin) {
-      throw new Error("expected manifest plugin fixture");
-    }
     let accessorValue = { nested: { value: "initial" } };
     const accessor = {} as { current: typeof accessorValue };
     Object.defineProperty(accessor, "current", {
       enumerable: true,
       get: () => accessorValue,
     });
-    plugin.configSchema = {
-      type: "object",
-      properties: { accessor },
-    };
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
-    loadPluginManifestRegistryForInstalledIndex.mockReturnValue(registry);
+    const registry = mockSchemaSnapshotSource(index, { accessor });
 
     const first = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
     expect(Object.isFrozen(accessor)).toBe(true);
@@ -433,11 +424,6 @@ describe("plugin metadata snapshot", () => {
 
   it("rewalks proxy graphs that forge safe descriptors before their values change", () => {
     const index = makeIndex();
-    const registry = makeManifestRegistry();
-    const plugin = registry.plugins[0];
-    if (!plugin) {
-      throw new Error("expected manifest plugin fixture");
-    }
     let currentValue = { nested: { value: "decoy" } };
     const target = {} as { current: typeof currentValue };
     Object.defineProperty(target, "current", {
@@ -468,16 +454,7 @@ describe("plugin metadata snapshot", () => {
         return Reflect.get(proxyTarget, key, receiver);
       },
     });
-    plugin.configSchema = {
-      type: "object",
-      properties: { proxy },
-    };
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
-    loadPluginManifestRegistryForInstalledIndex.mockReturnValue(registry);
+    const registry = mockSchemaSnapshotSource(index, { proxy });
 
     const first = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
     expect(forgedDescriptors).toBe(1);

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -260,7 +260,10 @@ export function listPluginOriginsFromMetadataSnapshot(
 
 /** Rebuilds every manifest-derived snapshot fact from one authoritative registry. */
 export function rebasePluginMetadataSnapshotManifestRegistry(
-  snapshot: PluginMetadataSnapshot,
+  snapshot: Omit<
+    PluginMetadataSnapshot,
+    "manifestRegistry" | "plugins" | "diagnostics" | "byPluginId" | "owners"
+  >,
   manifestRegistry: PluginManifestRegistry,
 ): PluginMetadataSnapshot {
   const plugins = manifestRegistry.plugins;

--- a/src/plugins/plugin-metadata.test-support.ts
+++ b/src/plugins/plugin-metadata.test-support.ts
@@ -52,27 +52,12 @@ export function createPluginMetadataSnapshotFixture(
     })),
     diagnostics: manifestRegistry.diagnostics,
   };
-  const snapshot: PluginMetadataSnapshot = {
+  const snapshot: Parameters<typeof rebasePluginMetadataSnapshotManifestRegistry>[0] = {
     policyHash: "test-policy",
     index,
     registryIndex: index,
     registryDiagnostics: [],
-    manifestRegistry,
-    plugins,
-    diagnostics: manifestRegistry.diagnostics,
-    byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId) => pluginId.trim().toLowerCase(),
-    owners: {
-      channels: new Map(),
-      channelConfigs: new Map(),
-      providers: new Map(),
-      modelCatalogProviders: new Map(),
-      cliBackends: new Map(),
-      setupProviders: new Map(),
-      commandAliases: new Map(),
-      contracts: new Map(),
-      modelIdNormalizationPolicies: new Map(),
-    },
     metrics: {
       registrySnapshotMs: 0,
       manifestRegistryMs: 0,


### PR DESCRIPTION
## What Problem This Solves

The shared metadata test fixture built lookup maps that canonical preparation immediately replaced. Three immutability cases also repeated their schema and mock setup.

## Why This Change Was Made

Allow the existing rebase input type to omit facts that rebase always rebuilds, remove the disposable fixture indexes, and share the repeated setup. All cases and assertions remain. Production typing grows by 3 lines, test/support code shrinks by 38, and total code shrinks by 35 lines. The emitted production JavaScript is byte-identical.

## User Impact

There is no runtime behavior change. Metadata tests allocate fewer disposable containers and use the same preparation owner as production.

## Evidence

The actual fixture falls from 23 to 13 Map constructions per call and removes one mapped input array plus 151 tuples for the 151-plugin case. Value/reference, alias, projection, cache-generation and worker-restore checks pass. Ordinary top-level fixture key order changes and is recorded separately; production callers are unchanged.

All 77 focused tests and canonical changed checks pass. Isolated Codex autoreview is scoped-clean at P0. The fixed timing sample shows no speedup, and no RSS or Gateway performance claim is made.
