### PR TITLE
fix(subagents): settle rejected requester wake

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -288,7 +288,6 @@ export function scheduleRequesterSettleWake(
   // A replayed lifecycle start can retain an older endedAt; require both
   // terminal status and end evidence so a live child never wakes its requester.
   if (
-    !admittedWake ||
     entry.collect ||
     entry.execution.status === "running" ||
     !hasSubagentRunEnded(entry) ||
@@ -340,7 +339,7 @@ export function scheduleRequesterSettleWake(
           requesterSessionKey: maskLifecycleIdentifier(requesterSessionKey, "session"),
         });
         const current = params.runs.get(runId);
-        if (current !== entry || current.requesterSettleWake !== admittedWake) {
+        if (!admittedWake || current !== entry || current.requesterSettleWake !== admittedWake) {
           return;
         }
         try {

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -220,7 +220,7 @@ const persistRequesterSettleWakePending = (
 // blocks on the wake, but the wake must run as tracked root work: a live
 // cleanup parent reserves the root synchronously, so restart or suspend
 // cannot reach quiescence between scheduling and the wake's gateway turn.
-// Failures are logged only.
+// Failures settle only the exact admitted wake so a newer requester-yield rearm survives.
 function retainScheduledRequesterSettleWakeTimer(
   context: SubagentLifecycleWakeContext,
   runId: string,
@@ -283,10 +283,12 @@ export function scheduleRequesterSettleWake(
   entry: SubagentRunRecord,
 ): void {
   const params = context.options;
+  const admittedWake = entry.requesterSettleWake;
   const requesterSessionKey = entry.requesterSessionKey?.trim();
   // A replayed lifecycle start can retain an older endedAt; require both
   // terminal status and end evidence so a live child never wakes its requester.
   if (
+    !admittedWake ||
     entry.collect ||
     entry.execution.status === "running" ||
     !hasSubagentRunEnded(entry) ||
@@ -331,11 +333,30 @@ export function scheduleRequesterSettleWake(
       "subagents:lifecycle-wake",
     )
       .catch((error: unknown) => {
+        const safeError = buildSafeLifecycleErrorMeta(error);
         params.warn("requester settle wake failed", {
-          error: buildSafeLifecycleErrorMeta(error),
+          error: safeError,
           runId: maskLifecycleIdentifier(runId, "run"),
           requesterSessionKey: maskLifecycleIdentifier(requesterSessionKey, "session"),
         });
+        const current = params.runs.get(runId);
+        if (current !== entry || current.requesterSettleWake !== admittedWake) {
+          return;
+        }
+        try {
+          completeRequesterSettleWakeBatch(
+            context,
+            admittedWake.batchRunIds ?? [runId],
+            admittedWake.rearmGeneration,
+            { delivered: false, path: "none", error: safeError.message },
+          );
+        } catch (settleError) {
+          params.warn("failed to persist requester settle wake rejection", {
+            error: buildSafeLifecycleErrorMeta(settleError),
+            runId: maskLifecycleIdentifier(runId, "run"),
+            requesterSessionKey: maskLifecycleIdentifier(requesterSessionKey, "session"),
+          });
+        }
       })
       .finally(() => {
         context.unmarkRequesterSettleWakeRunScheduled(runId);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -17,6 +17,7 @@ import {
   tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../../../process/gateway-work-admission.js";
+import { createDeferredCore } from "../../../shared/deferred.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "../../../tasks/detached-task-runtime-contract.js";
 import {
   buildAnnounceIdFromChildRun,
@@ -5500,7 +5501,7 @@ describe("requester settle wake trigger", () => {
     expect(settleWake).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps settle bookkeeping resilient to a rejecting wake", () => {
+  it("settles bookkeeping after a wake rejects before attempt admission", async () => {
     const entry = createRunEntry({ endedAt: 4_000 });
     const warn = vi.fn();
     const settleWake = vi.fn(async () => {
@@ -5521,9 +5522,69 @@ describe("requester settle wake trigger", () => {
       }),
     ).not.toThrow();
 
-    return waitForLifecycleState(() => {
+    await waitForLifecycleState(() => {
       expect(warn).toHaveBeenCalledWith("requester settle wake failed", expect.anything());
     });
+    expect(entry.requesterSettleWake).toBeUndefined();
+  });
+
+  it("preserves a newer yielded batch when an admitted wake rejects", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      delivery: { status: "delivered" },
+    });
+    const admittedWake = createDeferredCore<boolean>();
+    let wakeCount = 0;
+    const settleWake = vi.fn(
+      async (
+        params: Parameters<
+          LifecycleControllerParams["maybeWakeRequesterAfterAllChildrenSettled"]
+        >[0],
+      ) => {
+        wakeCount += 1;
+        if (wakeCount === 1) {
+          return await admittedWake.promise;
+        }
+        params.completeBatch([entry.runId], entry.requesterSettleWake?.rearmGeneration, {
+          delivered: true,
+          path: "direct",
+        });
+        return true;
+      },
+    );
+    const controller = createLifecycleController({
+      entry,
+      maybeWakeRequesterAfterAllChildrenSettled: settleWake,
+    });
+
+    controller.completeCleanupBookkeeping({
+      runId: entry.runId,
+      entry,
+      cleanup: "keep",
+      completedAt: 5_000,
+    });
+    await waitForLifecycleState(() => expect(settleWake).toHaveBeenCalledOnce());
+
+    entry.requesterTurnRunId = "run-requester";
+    entry.requesterTurnYielded = true;
+    expect(
+      controller.settleRequesterTurnAfterSessionSpawns({
+        requesterSessionKey: entry.requesterSessionKey,
+        requesterTurnRunId: "run-requester",
+        requesterYielded: true,
+        acceptedSessionSpawns: [{ runId: entry.runId, childSessionKey: entry.childSessionKey }],
+      }),
+    ).toBe(true);
+    expect(entry.requesterSettleWake).toMatchObject({
+      requesterYieldBatch: true,
+      afterRequesterYield: true,
+      rearmGeneration: 1,
+    });
+
+    admittedWake.reject(new Error("wake exploded"));
+    await waitForLifecycleState(() => expect(settleWake).toHaveBeenCalledTimes(2));
+    await waitForLifecycleState(() => expect(entry.requesterSettleWake).toBeUndefined());
   });
 
   it("holds the settle wake as tracked root work so restart drain waits for its turn", async () => {

--- a/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
@@ -2,7 +2,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { isPathInside } from "../../../infra/path-guards.js";
 import { getGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { listOpenClawAgentDatabasesForTest as listSeedAgentDatabases } from "../../../state/openclaw-agent-db.js";
@@ -24,6 +25,7 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 const { announceSpy } = vi.hoisted(() => ({
   announceSpy: vi.fn(async () => "delivered" as const),
 }));
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 vi.mock("../announce/subagent-announce.js", () => ({
   runSubagentAnnounceFlow: announceSpy,
 }));
@@ -387,7 +389,7 @@ describe("subagent registry persistence resume", () => {
   });
 
   it("settles a restored delivered wake rejected before attempt admission", async () => {
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    const stateDir = tempDirs.make("openclaw-subagent-");
     await withRegistryState(stateDir, async () => {
       const endedAt = Date.now();
       const run: SubagentRunRecord = {

--- a/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.resume.test.ts
@@ -386,6 +386,64 @@ describe("subagent registry persistence resume", () => {
     });
   });
 
+  it("settles a restored delivered wake rejected before attempt admission", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
+    await withRegistryState(stateDir, async () => {
+      const endedAt = Date.now();
+      const run: SubagentRunRecord = {
+        runId: "run-rejected-requester-wake",
+        childSessionKey: "agent:main:subagent:rejected-requester-wake",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "settle one rejected requester wake",
+        cleanup: "keep",
+        createdAt: endedAt - 1_000,
+        endedReason: "subagent-complete",
+        execution: {
+          status: "terminal",
+          startedAt: endedAt - 500,
+          endedAt,
+          outcome: { status: "ok" },
+        },
+        expectsCompletionMessage: true,
+        completion: { required: true, resultText: "done", capturedAt: endedAt },
+        delivery: { status: "delivered", deliveredAt: endedAt },
+        cleanupHandled: true,
+        cleanupCompletedAt: endedAt,
+        requesterSettleWake: {
+          status: "pending",
+          attemptCount: 0,
+          batchRunIds: ["run-rejected-requester-wake"],
+          requesterYieldBatch: true,
+          afterRequesterYield: true,
+          rearmGeneration: 1,
+        },
+      };
+      const wakeRequester = vi.fn(async () => {
+        throw new Error("requester wake rejected before attempt admission");
+      });
+      mod.testing.setDepsForTest({
+        ...createSubagentRegistryTestDeps({
+          callGateway: vi.mocked(callGatewayModule.callGateway),
+          maybeWakeRequesterAfterAllChildrenSettled: wakeRequester,
+        }),
+      });
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      mod.initSubagentRegistry();
+      activateRegistry();
+
+      await vi.waitFor(() => expect(wakeRequester).toHaveBeenCalledOnce());
+      await vi.waitFor(() => {
+        const restored = loadSubagentRegistryFromSqlite().get(run.runId);
+        expect(restored?.delivery).toMatchObject({ status: "delivered" });
+        expect(restored?.requesterSettleWake).toBeUndefined();
+      });
+      await mod.testing.sweepOnceForTests();
+      expect(wakeRequester).toHaveBeenCalledOnce();
+    });
+  });
+
   it.each([
     { status: "suspended" as const, disposition: undefined, queueId: undefined },
     { status: "in_progress" as const, disposition: "session_queued" as const, queueId: "queue-1" },

--- a/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
@@ -1,0 +1,363 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionDeliveryState } from "../../../config/sessions/types.js";
+import type { CallGatewayOptions } from "../../../gateway/call.js";
+import type { AgentEventPayload } from "../../../infra/agent-events.js";
+import type { AgentRunTerminalReplySnapshot } from "../../agent-run-terminal-reply.js";
+import { maybeSpawnVisibleSession } from "../../tools/sessions-spawn-visible.js";
+import { createSessionsYieldTool } from "../../tools/sessions-yield-tool.js";
+import { testing as subagentAnnounceDeliveryTesting } from "../announce/subagent-announce-delivery.test-support.js";
+import { testing as subagentAnnounceOutputTesting } from "../announce/subagent-announce-output.test-support.js";
+import { testing as subagentAnnounceTesting } from "../announce/subagent-announce.js";
+import { maybeWakeRequesterAfterAllChildrenSettled } from "../announce/subagent-announce.requester-settle-wake.js";
+import * as registry from "./subagent-registry.test-helpers.js";
+
+const MAIN_REQUESTER_SESSION_KEY = "agent:main:main";
+
+type LifecycleData = {
+  phase?: string;
+  endedAt?: number;
+  terminalReply?: AgentRunTerminalReplySnapshot;
+};
+type LifecycleEvent = Pick<AgentEventPayload, "runId"> &
+  Partial<Omit<AgentEventPayload, "runId" | "data">> & { data?: LifecycleData };
+type SessionStoreEntry = {
+  sessionId: string;
+  updatedAt: number;
+  delivery?: SessionDeliveryState;
+};
+type GatewayRequest = Omit<CallGatewayOptions, "params"> & {
+  params?: {
+    sessionKey?: string;
+    inputProvenance?: { sourceSessionKey?: string };
+    idempotencyKey?: string;
+  };
+};
+
+let lifecycleHandler: ((event: LifecycleEvent) => void) | undefined;
+let agentCallGates = new Map<string, Promise<void>>();
+let chatHistoryBySessionKey = new Map<string, Array<Record<string, unknown>>>();
+let sessionStore: Record<string, SessionStoreEntry> = {};
+let rejectNextRequesterWake = false;
+
+const callGatewayMock = vi.fn(async (request: GatewayRequest) => {
+  if (request.method === "agent.wait") {
+    return { status: "pending" };
+  }
+  if (request.method === "chat.history") {
+    return { messages: chatHistoryBySessionKey.get(request.params?.sessionKey ?? "") ?? [] };
+  }
+  if (request.method === "agent") {
+    const sourceSessionKey = request.params?.inputProvenance?.sourceSessionKey;
+    const gate = sourceSessionKey ? agentCallGates.get(sourceSessionKey) : undefined;
+    if (gate) {
+      await gate;
+    }
+    return { result: { payloads: [{ text: "completion delivered" }] } };
+  }
+  return {};
+});
+
+const loadConfigMock = vi.fn(() => ({
+  agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+  session: { mainKey: "main", scope: "per-sender" },
+}));
+
+vi.mock("../../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => sessionStore),
+  resolveAgentIdFromSessionKey: (key: string) => key.match(/^agent:([^:]+)/)?.[1] ?? "main",
+  resolveSessionStorePathCore: () => "/tmp/test-store",
+  resolveMainSessionKey: () => MAIN_REQUESTER_SESSION_KEY,
+  updateSessionStore: vi.fn(),
+}));
+
+vi.mock("../../../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../config/sessions/session-accessor.js")>()),
+  loadSessionEntry: (scope: { sessionKey: string }) => sessionStore[scope.sessionKey],
+  listSessionEntriesReadOnly: () =>
+    Object.entries(sessionStore).map(([sessionKey, entry]) => ({ sessionKey, entry })),
+}));
+
+vi.mock("../../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+vi.mock("../../../browser-lifecycle-cleanup.js", () => ({
+  cleanupBrowserSessionsForLifecycleEnd: vi.fn(async () => {}),
+}));
+
+vi.mock("../spawn/subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 0,
+}));
+
+const loadSubagentRegistryRuntimeForTest = async () =>
+  ({
+    replaceSubagentRunAfterSteer: registry.replaceSubagentRunAfterSteerCore,
+  }) as unknown as typeof import("./subagent-registry-runtime.js");
+
+describe("requester settle wake product flow", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "1";
+    vi.useFakeTimers();
+    callGatewayMock.mockClear();
+    agentCallGates = new Map();
+    chatHistoryBySessionKey = new Map();
+    rejectNextRequesterWake = false;
+    sessionStore = {
+      [MAIN_REQUESTER_SESSION_KEY]: {
+        sessionId: "sess-main",
+        updatedAt: 1,
+        delivery: {
+          kind: "external",
+          route: { channel: "discord", accountId: "default", target: { to: "user-1" } },
+          context: { channel: "discord", to: "user-1", accountId: "default" },
+          origin: { provider: "discord", to: "user-1", accountId: "default" },
+        },
+      },
+    };
+    registry.testing.setDepsForTest({
+      callGateway: callGatewayMock as typeof import("../../../gateway/call.js").callGateway,
+      getRuntimeConfig:
+        loadConfigMock as typeof import("../../../config/config.js").getRuntimeConfig,
+      loadAgentRuntimePluginRegistryHandle: () => undefined,
+      onAgentEvent: ((handler: typeof lifecycleHandler) => {
+        lifecycleHandler = handler;
+        return () => {};
+      }) as unknown as typeof import("../../../infra/agent-events.js").onAgentEvent,
+      persistSubagentRunsToDisk: () => {},
+      persistSubagentRunsToDiskOrThrow: () => {},
+      restoreSubagentRunsFromDisk: () => 0,
+      maybeWakeRequesterAfterAllChildrenSettled: async (params) => {
+        if (rejectNextRequesterWake) {
+          rejectNextRequesterWake = false;
+          throw new Error("requester wake rejected before attempt admission");
+        }
+        return await maybeWakeRequesterAfterAllChildrenSettled(params);
+      },
+    });
+    subagentAnnounceTesting.setDepsForTest({
+      callGateway: callGatewayMock as typeof import("../../../gateway/call.js").callGateway,
+      getRuntimeConfig:
+        loadConfigMock as typeof import("../../../config/config.js").getRuntimeConfig,
+      loadSubagentRegistryRuntime: loadSubagentRegistryRuntimeForTest,
+    });
+    subagentAnnounceDeliveryTesting.setDepsForTest({
+      callGateway: callGatewayMock as typeof import("../../../gateway/call.js").callGateway,
+      getRuntimeConfig:
+        loadConfigMock as typeof import("../../../config/config.js").getRuntimeConfig,
+      loadSessionEntry: ({ sessionKey }) => sessionStore[sessionKey],
+      getRequesterSessionActivity: (requesterSessionKey: string) => ({
+        sessionId: sessionStore[requesterSessionKey]?.sessionId,
+        isActive: false,
+      }),
+    });
+    subagentAnnounceOutputTesting.setDepsForTest({
+      callGateway: callGatewayMock as typeof import("../../../gateway/call.js").callGateway,
+      getRuntimeConfig:
+        loadConfigMock as typeof import("../../../config/config.js").getRuntimeConfig,
+      readSubagentSessionEntry: (_storePath, sessionKey) => sessionStore[sessionKey],
+      resolveAgentIdFromSessionKey: (key) => key?.match(/^agent:([^:]+)/)?.[1] ?? "main",
+      resolveSessionStorePathCore: () => "/tmp/test-store",
+    });
+  });
+
+  afterEach(() => {
+    lifecycleHandler = undefined;
+    subagentAnnounceDeliveryTesting.setDepsForTest();
+    subagentAnnounceOutputTesting.setDepsForTest();
+    subagentAnnounceTesting.setDepsForTest();
+    registry.testing.setDepsForTest();
+    registry.resetSubagentRegistryForTests({ persist: false });
+    vi.useRealTimers();
+    if (previousFastTestEnv === undefined) {
+      delete process.env.OPENCLAW_TEST_FAST;
+    } else {
+      process.env.OPENCLAW_TEST_FAST = previousFastTestEnv;
+    }
+  });
+
+  const flushAsync = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  const getAgentCalls = () =>
+    (callGatewayMock.mock.calls as [GatewayRequest][])
+      .map(([request]) => request)
+      .filter((request) => request.method === "agent");
+
+  const getRequesterWakeCalls = () =>
+    getAgentCalls().filter((request) =>
+      request.params?.idempotencyKey?.startsWith("announce:requester-settle:"),
+    );
+
+  const waitForAgentCallCount = async (expectedCount: number) => {
+    for (let attempt = 0; attempt < 80; attempt += 1) {
+      if (getAgentCalls().length >= expectedCount) {
+        return;
+      }
+      await vi.advanceTimersByTimeAsync(100);
+      await flushAsync();
+    }
+    throw new Error(`expected ${expectedCount} agent calls, got ${getAgentCalls().length}`);
+  };
+
+  const waitForDeliveredCleanup = async (runId: string) => {
+    for (let attempt = 0; attempt < 80; attempt += 1) {
+      const run = registry.getSubagentRunByRunId(runId);
+      if (
+        run?.delivery?.status === "delivered" &&
+        typeof run.cleanupCompletedAt === "number" &&
+        run.requesterSettleWake === undefined
+      ) {
+        return;
+      }
+      await vi.advanceTimersByTimeAsync(1);
+      await flushAsync();
+    }
+    throw new Error(`run ${runId} did not finish delivered cleanup`);
+  };
+
+  const spawnVisibleChild = async (params: {
+    runId: string;
+    childSessionKey: string;
+    requesterTurnRunId: string;
+  }) => {
+    const result = await maybeSpawnVisibleSession({
+      raw: { visible: true },
+      task: `finish ${params.runId}`,
+      label: params.runId,
+      runtime: "subagent",
+      sandbox: "inherit",
+      options: {
+        agentSessionKey: MAIN_REQUESTER_SESSION_KEY,
+        requesterTurnRunId: params.requesterTurnRunId,
+        requesterAgentIdOverride: "main",
+        config: {
+          agents: { list: [{ id: "main" }] },
+          session: { mainKey: "main", scope: "per-sender" },
+        },
+        callGateway: vi.fn(async () => ({
+          key: params.childSessionKey,
+          runStarted: true,
+          runId: params.runId,
+        })) as never,
+        registerRun: registry.registerSubagentRun,
+        countActiveRuns: () => 0,
+      },
+    });
+    expect(result).toMatchObject({ status: "accepted", runId: params.runId });
+  };
+
+  const emitCompleted = (runId: string, childSessionKey: string, text: string) => {
+    chatHistoryBySessionKey.set(childSessionKey, [{ role: "assistant", content: text }]);
+    lifecycleHandler?.({
+      stream: "lifecycle",
+      runId,
+      sessionKey: childSessionKey,
+      data: {
+        phase: "end",
+        endedAt: Date.now(),
+        terminalReply: { disposition: "visible", text },
+      },
+    });
+  };
+
+  it.each([
+    { name: "delivers the visible requester final", rejectRequesterWake: false },
+    { name: "settles the rejected delivered-row wake", rejectRequesterWake: true },
+  ])("$name", async ({ rejectRequesterWake }) => {
+    const requesterTurnRunId = "run-requester-yield";
+    const alpha = {
+      runId: "run-alpha",
+      childSessionKey: "agent:main:subagent:alpha",
+      expectsCompletionMessage: true,
+    };
+    const beta = {
+      runId: "run-beta",
+      childSessionKey: "agent:main:subagent:beta",
+      expectsCompletionMessage: true,
+    };
+    await spawnVisibleChild({ ...alpha, requesterTurnRunId });
+    await spawnVisibleChild({ ...beta, requesterTurnRunId });
+
+    let releaseBetaDelivery: (() => void) | undefined;
+    agentCallGates.set(
+      beta.childSessionKey,
+      new Promise<void>((resolve) => {
+        releaseBetaDelivery = resolve;
+      }),
+    );
+    emitCompleted(alpha.runId, alpha.childSessionKey, "alpha complete");
+    await waitForAgentCallCount(1);
+    emitCompleted(beta.runId, beta.childSessionKey, "beta complete");
+    await waitForAgentCallCount(2);
+
+    const betaBeforeYield = registry.getSubagentRunByRunId(beta.runId);
+    if (!betaBeforeYield) {
+      throw new Error("expected beta run before requester yield");
+    }
+    betaBeforeYield.delivery = rejectRequesterWake
+      ? {
+          ...betaBeforeYield.delivery,
+          status: "delivered",
+          disposition: "delivered",
+          deliveredAt: Date.now(),
+        }
+      : { ...betaBeforeYield.delivery, status: "in_progress" };
+
+    const yieldTool = createSessionsYieldTool({
+      sessionId: "sess-main",
+      claimYield: () =>
+        registry.markRequesterTurnYielded({
+          requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
+          requesterAgentId: "main",
+          requesterTurnRunId,
+        }) > 0,
+      onYield: () => {},
+    });
+    await expect(
+      yieldTool.execute("yield-requester-wake", { message: "Wait for visible children" }),
+    ).resolves.toMatchObject({ details: { status: "yielded" } });
+
+    rejectNextRequesterWake = rejectRequesterWake;
+    const { withLocalSessionPlacementTurnSettlement } =
+      await import("../../session-placement-admission.js");
+    await withLocalSessionPlacementTurnSettlement(
+      {
+        sessionId: "sess-main",
+        sessionKey: MAIN_REQUESTER_SESSION_KEY,
+        agentId: "main",
+        runId: requesterTurnRunId,
+      },
+      async () => ({
+        acceptedSessionSpawns: [alpha, beta],
+        meta: {
+          durationMs: 1,
+          yielded: true,
+          executionTrace: { runner: "cli", attempts: [], fallbackUsed: false },
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    await flushAsync();
+
+    await waitForAgentCallCount(rejectRequesterWake ? 2 : 3);
+    expect(getRequesterWakeCalls()).toHaveLength(rejectRequesterWake ? 0 : 1);
+    for (const child of [alpha, beta]) {
+      expect(registry.getSubagentRunByRunId(child.runId)).toMatchObject({
+        delivery: { status: "delivered" },
+        requesterSettleWake: undefined,
+      });
+    }
+
+    agentCallGates.delete(beta.childSessionKey);
+    releaseBetaDelivery?.();
+    await waitForDeliveredCleanup(alpha.runId);
+    await waitForDeliveredCleanup(beta.runId);
+    await registry.testing.sweepOnceForTests();
+    expect(getRequesterWakeCalls()).toHaveLength(rejectRequesterWake ? 0 : 1);
+  });
+});

--- a/src/agents/subagents/registry/subagent-registry.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.test.ts
@@ -2022,7 +2022,7 @@ describe("subagent registry seam flow", () => {
     expect(mod.getSubagentRunByRunId(runId)?.execution.endedAt).toBeUndefined();
   });
 
-  it("requeues durable requester-settle obligations after a worker error", async () => {
+  it("settles a requester-settle wake rejected before attempt admission", async () => {
     const endedAt = Date.now() - 1_000;
     mod.addSubagentRunForTests({
       runId: "run-settle-retry",
@@ -2043,10 +2043,13 @@ describe("subagent registry seam flow", () => {
     );
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
 
+    expect(mod.getSubagentRunByRunId("run-settle-retry")).toMatchObject({
+      delivery: { status: "delivered" },
+      requesterSettleWake: undefined,
+    });
+
     await mod.testing.sweepOnceForTests();
-    await waitForFast(() =>
-      expect(mocks.maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledTimes(2),
-    );
+    expect(mocks.maybeWakeRequesterAfterAllChildrenSettled).toHaveBeenCalledTimes(1);
   });
 
   it("keeps runs active instead of terminally failing on recoverable wait transport errors", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #135692.

A requester-settle wake can reject before it durably admits a delivery attempt. The persisted row then stays `pending` with zero attempts and no retry deadline, so the registry sweeper re-drives it every 60 seconds forever.

## Why This Change Was Made

The lifecycle catch previously logged the rejection without resolving the durable wake obligation. It now completes the exact unchanged admitted wake through the existing durable batch-completion owner.

The identity check prevents a stale rejection from clearing a newer requester-yield generation. This preserves the valid path where an already-delivered child still owes the requester a visible final response.

The sweeper, SQLite schema, persisted shape, migration behavior, and compact console renderer are unchanged.

Production delta is +22/-2. The growth records exact wake ownership, reuses canonical durable completion, and contains a failed settlement write without claiming success.

## User Impact

Gateways no longer retry the same pre-admission requester-settle rejection forever. A newer yielded requester still receives its required final-response wake.

## Evidence

- Baseline `07cac7a3b6644e3dadef56cf3f4dc08372e330d9`: the regression assertion failed because the wake remained `{ status: "pending", attemptCount: 0 }` after rejection.
- Anti-cheat: a second explicit sweep called the wake a second time on baseline.
- Baseline SQLite restart proof: the persisted delivered row retained `requesterSettleWake` with zero attempts and `rearmGeneration: 1` after the injected rejection.
- Head `e4936aca69c5f9ffb97b89795a905ea086757d6f`: the full SQLite persistence suite passed with 15 tests; owner and sibling suites passed with 353 tests.
- Head proof covers durable SQLite reopen, terminal settlement, no second sweep call, delivered-child preservation, and a newer yielded generation surviving a stale rejection.
- Blacksmith Testbox `tbx_01m1gfb5tczbvbnsenzpm6bd87`: the dedicated visible-session spawn and `sessions_yield` flow passed both end-to-end cases against the owner repair.
- Focused Oxlint, max-lines ratchet, assertion-safety ratchet, test temporary-directory report, and `git diff --check` passed.
- Local type-check and build were not run because repository policy forbids them on this host; CI owns those gates.
