### PR TITLE
refactor(scripts): inline positive integer env adapters

### DIFF
--- a/scripts/lib/docker-e2e-json-artifacts.mts
+++ b/scripts/lib/docker-e2e-json-artifacts.mts
@@ -9,7 +9,10 @@ export function readDockerE2eJsonArtifact(file: string): unknown {
 }
 
 function readDockerE2eJsonArtifactText(file: string): string {
-  const maxBytes = readPositiveIntEnv(JSON_ARTIFACT_MAX_BYTES_ENV, DEFAULT_JSON_ARTIFACT_MAX_BYTES);
+  const maxBytes = parsePositiveInt(
+    process.env[JSON_ARTIFACT_MAX_BYTES_ENV] || String(DEFAULT_JSON_ARTIFACT_MAX_BYTES),
+    JSON_ARTIFACT_MAX_BYTES_ENV,
+  );
   const stat = fs.statSync(file);
   if (!stat.isFile()) {
     throw new Error(`JSON artifact is not a file: ${file}`);
@@ -23,9 +26,4 @@ function readDockerE2eJsonArtifactText(file: string): string {
     throw new Error(`JSON artifact exceeded ${maxBytes} bytes: ${file} (${bytes} bytes)`);
   }
   return text;
-}
-
-function readPositiveIntEnv(name: string, fallback: number): number {
-  const raw = process.env[name];
-  return raw === undefined || raw === "" ? fallback : parsePositiveInt(raw, name);
 }

--- a/scripts/lib/plugin-gateway-gauntlet.mts
+++ b/scripts/lib/plugin-gateway-gauntlet.mts
@@ -31,11 +31,6 @@ const ANSI_PATTERN = new RegExp(String.raw`\u001B\[[0-9;]*m`, "gu");
 const QA_SUMMARY_MAX_BYTES_ENV = "OPENCLAW_PLUGIN_GATEWAY_GAUNTLET_QA_SUMMARY_MAX_BYTES";
 const DEFAULT_QA_SUMMARY_MAX_BYTES = 2 * 1024 * 1024;
 
-function readPositiveIntEnv(name: string, fallback: number) {
-  const raw = process.env[name];
-  return raw === undefined || raw === "" ? fallback : parsePositiveInt(raw, name);
-}
-
 function normalizeStringOrEmpty(value: unknown) {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -583,7 +578,10 @@ function readQaSuiteSummary(summaryPath: string) {
 }
 
 function readQaSuiteSummaryText(summaryPath: string) {
-  const maxBytes = readPositiveIntEnv(QA_SUMMARY_MAX_BYTES_ENV, DEFAULT_QA_SUMMARY_MAX_BYTES);
+  const maxBytes = parsePositiveInt(
+    process.env[QA_SUMMARY_MAX_BYTES_ENV] || String(DEFAULT_QA_SUMMARY_MAX_BYTES),
+    QA_SUMMARY_MAX_BYTES_ENV,
+  );
   const stat = fs.statSync(summaryPath);
   if (!stat.isFile()) {
     throw new Error(`QA suite summary is not a file: ${summaryPath}`);


### PR DESCRIPTION
## What Problem This Solves

Two script helpers each maintained a private one-caller adapter for the same positive-integer environment parsing behavior. That duplicated fallback dispatch next to the canonical parser and made the tooling carry extra concepts without adding a distinct contract.

## Why This Change Was Made

The Docker E2E artifact reader and plugin gateway gauntlet now apply their existing defaults at the call site and invoke `parsePositiveInt` directly. Ownership remains with the two `scripts/lib` call sites and the existing numeric-options parser. The private adapters are deleted; no shared helper, SDK seam, dependency, test, or runtime surface is added.

Contract behavior is unchanged:

- missing and empty values still use the existing defaults;
- whitespace-only values still reach `parsePositiveInt` and fail;
- leading-zero positive integers remain accepted;
- zero, negative, decimal, and unsafe integers remain rejected;
- labels and error messages still come from the same `parsePositiveInt` calls.

`readPositiveEnvInt` is intentionally not used because it has different whitespace, leading-zero, and diagnostic behavior.

## User Impact

No observable caller behavior changes. Missing and empty environment values
continue to use the existing defaults; every nonempty `ProcessEnv` string
continues through `parsePositiveInt` with the same label and error message.

The `||` fallback is intentional: replacing it with `??` would send an empty
string to the parser instead of applying the default.

Invalid-value stacks lose the deleted adapter frame. The Docker CLI prints only
the error message, while the plugin gateway gauntlet records only that message,
so their observable output is unchanged.

## Evidence

- Refreshed exact signed head:
  `921999342ccc158dde1164f02c5b3ae3c57ca8f6`.
- Refresh parent/current main:
  `507e5faf28500d12b8b43c8d0ad7996190e27d5d`.
- The refresh preserved the exact two-file diff and patch IDs:
  aggregate `001303d91c2ec07c7fd44aa72449106fd9134d2a`,
  `docker-e2e-json-artifacts.mts`
  `e8dca4ebd750c0a30eb6e49cfa8d1ce0ff0d8f51`, and
  `plugin-gateway-gauntlet.mts`
  `18365eed44ddffd8701e660a2abbf38ed905bed8`.
- `node scripts/run-vitest.mjs test/scripts/docker-e2e-helper-cli.test.ts
  test/scripts/plugin-gateway-gauntlet.test.ts
  test/scripts/numeric-options.test.ts`: 3 files, 108 tests passed.
- An independent input matrix confirmed equivalent results and messages for
  missing, empty, whitespace, leading-zero, signed, decimal, exponent, hex,
  zero, negative, and unsafe-integer values.
- Exact-head structured autoreview completed scoped-clean at 0.99.
- `git diff --check` passed.
- Tooling diff: `+8/-12`, net `-4`; production and test LOC: `0`.
- Current main has no changes to either touched file or the canonical parser.
- A live open-PR file scan found no competing PR touching either changed file.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 136034` completed at
  `2026-09-03T03:44:54Z` and selected exact-head hosted gates for
  `921999342ccc158dde1164f02c5b3ae3c57ca8f6`.
- Exact-head CI passed:
  https://github.com/openclaw/openclaw/actions/runs/33710507490
- Exact-head Workflow Sanity passed:
  https://github.com/openclaw/openclaw/actions/runs/33710507479
- The native gate receipt classified Blacksmith Testbox, Blacksmith ARM
  Testbox, and Blacksmith Build Artifacts Testbox as not applicable for this
  script-only change, so no `tbx_` lease was minted.
- Codex gate: inspected `../codex/codex-rs/cli/src/main.rs:220-245` and
  `:2840-2870`; those CLI and completion paths are unrelated.
