### PR TITLE
test(parallel): remove private helper test facade

### DIFF
--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -131,7 +131,7 @@ export async function executeParallelSearchRequest(params: {
   return payload;
 }
 
-export function resolveParallelSearchCount(
+function resolveParallelSearchCount(
   args: Record<string, unknown>,
   configuredCount: unknown,
 ): number {
@@ -148,7 +148,7 @@ export function resolveParallelSearchCount(
   });
 }
 
-export function normalizeParallelObjective(value: string | undefined): string | undefined {
+function normalizeParallelObjective(value: string | undefined): string | undefined {
   const trimmed = normalizeOptionalString(value);
   if (!trimmed) {
     return undefined;
@@ -158,7 +158,7 @@ export function normalizeParallelObjective(value: string | undefined): string | 
     : truncateUtf16Safe(trimmed, PARALLEL_MAX_OBJECTIVE_CHARS);
 }
 
-export function normalizeParallelClientModel(value: string | undefined): string | undefined {
+function normalizeParallelClientModel(value: string | undefined): string | undefined {
   const trimmed = normalizeOptionalString(value);
   if (!trimmed) {
     return undefined;
@@ -172,7 +172,7 @@ export function normalizeParallelClientModel(value: string | undefined): string 
 // trim, drop empties/duplicates, truncate over-long entries to the API's hard
 // limit, and cap to the API's maximum so a malformed call from the model
 // doesn't 422 the request. See https://docs.parallel.ai/search/best-practices.
-export function normalizeParallelSearchQueries(value: unknown): string[] {
+function normalizeParallelSearchQueries(value: unknown): string[] {
   const candidates = Array.isArray(value) ? value : [];
   const seen = new Set<string>();
   const out: string[] = [];
@@ -209,7 +209,7 @@ function invalidSearchQueriesPayload() {
   };
 }
 
-export function normalizeParallelResults(payload: unknown): ParallelSearchResult[] {
+function normalizeParallelResults(payload: unknown): ParallelSearchResult[] {
   if (!payload || typeof payload !== "object") {
     return [];
   }
@@ -301,7 +301,7 @@ function stripParallelGeneratedSessionId(
   return rest;
 }
 
-export function buildParallelCacheKey(params: {
+function buildParallelCacheKey(params: {
   endpoint: string;
   objective?: string;
   searchQueries: readonly string[];

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -16,14 +16,8 @@ import {
 import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
-  buildParallelCacheKey,
   executeParallelSearchRequest,
-  normalizeParallelClientModel,
-  normalizeParallelObjective,
-  normalizeParallelResults,
-  normalizeParallelSearchQueries,
   type ParallelSearchResponse,
-  resolveParallelSearchCount,
 } from "./parallel-search-normalize.js";
 
 const PARALLEL_BASE_URL = "https://api.parallel.ai";
@@ -209,16 +203,3 @@ export async function executeParallelWebSearchProviderTool(
       }),
   });
 }
-
-export const testing = {
-  buildParallelCacheKey,
-  missingParallelKeyPayload,
-  normalizeParallelClientModel,
-  normalizeParallelObjective,
-  normalizeParallelResults,
-  normalizeParallelSearchQueries,
-  resolveParallelApiKey,
-  resolveParallelSearchCount,
-  resolveParallelSearchEndpoint,
-  PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES,
-} as const;

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -39,7 +39,6 @@ vi.mock("openclaw/plugin-sdk/provider-web-search", async (importOriginal) => {
     ),
   };
 });
-import { testing } from "../test-api.js";
 import { createParallelWebSearchProvider as createContractParallelWebSearchProvider } from "../web-search-contract-api.js";
 import { createParallelFreeWebSearchProvider } from "./parallel-free-web-search-provider.js";
 import { runParallelMcpSearch } from "./parallel-mcp-search.runtime.js";
@@ -114,15 +113,6 @@ function cancelTrackedResponse(text: string, init: ResponseInit) {
     wasCanceled: () => canceled,
   };
 }
-type CacheKeyParams = Parameters<typeof testing.buildParallelCacheKey>[0];
-const CACHE_KEY_BASE: CacheKeyParams = {
-  endpoint: "https://api.parallel.ai/v1/search",
-  objective: "Find OpenClaw on GitHub",
-  searchQueries: ["openclaw github"],
-  count: 5,
-};
-const cacheKey = (overrides: Partial<CacheKeyParams> = {}) =>
-  testing.buildParallelCacheKey({ ...CACHE_KEY_BASE, ...overrides });
 beforeEach(() => {
   endpointMockState.calls = [];
   endpointMockState.effects = [];
@@ -224,131 +214,73 @@ describe("parallel web search provider", () => {
       true,
     );
   });
-  it("prefers scoped configured api keys over environment fallbacks", () => {
-    expect(testing.resolveParallelApiKey({ apiKey: "par-secret" })).toBe("par-secret");
-  });
-  it("resolves Parallel search base URL overrides", () => {
-    expect(testing.resolveParallelSearchEndpoint()).toEqual({
-      endpoint: "https://api.parallel.ai/v1/search",
-    });
-    expect(
-      testing.resolveParallelSearchEndpoint({ baseUrl: "https://proxy.example/parallel" }),
-    ).toEqual({ endpoint: "https://proxy.example/parallel/v1/search" });
-    expect(
-      testing.resolveParallelSearchEndpoint({ baseUrl: "proxy.example/parallel/v1/search/" }),
-    ).toEqual({ endpoint: "https://proxy.example/parallel/v1/search" });
-    expect(
-      testing.resolveParallelSearchEndpoint({ baseUrl: "ftp://proxy.example/parallel" }),
-    ).toEqual({
-      docs: "https://docs.openclaw.ai/tools/parallel-search",
-      error: "invalid_base_url",
-      message:
-        "plugins.entries.parallel.config.webSearch.baseUrl must be a valid http(s) URL. Got: ftp://proxy.example/parallel",
-    });
-  });
-  it("partitions Parallel cache keys by resolved endpoint", () => {
-    expect(cacheKey()).not.toBe(cacheKey({ endpoint: "https://proxy.example/parallel/v1/search" }));
-  });
-  it("partitions Parallel cache keys by resolved result count", () => {
-    expect(cacheKey()).not.toBe(cacheKey({ count: 10 }));
-  });
-  it("partitions Parallel cache keys by objective and by search_queries set", () => {
-    expect(cacheKey()).not.toBe(cacheKey({ objective: "Find the OpenClaw release notes" }));
-    expect(cacheKey()).not.toBe(
-      cacheKey({ searchQueries: ["openclaw github", "openclaw repository"] }),
-    );
-  });
-  it("partitions Parallel cache keys by caller-provided session id", () => {
-    expect(cacheKey({ sessionId: "session-a" })).not.toBe(cacheKey({ sessionId: "session-b" }));
-    expect(cacheKey()).not.toBe(cacheKey({ sessionId: "session-a" }));
-  });
-  it("partitions Parallel cache keys by client_model so per-model results never bleed", () => {
-    expect(cacheKey({ clientModel: "claude-opus-4-7" })).not.toBe(
-      cacheKey({ clientModel: "gpt-5.5" }),
-    );
-    expect(cacheKey()).not.toBe(cacheKey({ clientModel: "claude-opus-4-7" }));
-  });
-  it("normalizes objectives by trimming and capping at 5000 chars", () => {
-    expect(testing.normalizeParallelObjective("  Find OpenClaw  ")).toBe("Find OpenClaw");
-    expect(testing.normalizeParallelObjective(undefined)).toBeUndefined();
-    expect(testing.normalizeParallelObjective("")).toBeUndefined();
-    expect((testing.normalizeParallelObjective("x".repeat(6000)) ?? "").length).toBe(5000);
-    expect(testing.normalizeParallelObjective(`${"x".repeat(4999)}🚀tail`)).toBe("x".repeat(4999));
-  });
-  it("normalizes search_queries: trim, drop blanks, dedupe, cap length, cap count", () => {
-    expect(
-      testing.normalizeParallelSearchQueries([
-        "openclaw github",
-        "  openclaw github  ",
-        "",
-        " ",
-        42,
-        "openclaw releases",
-      ]),
-    ).toEqual(["openclaw github", "openclaw releases"]);
-    expect(testing.normalizeParallelSearchQueries(undefined)).toEqual([]);
-    expect(testing.normalizeParallelSearchQueries("openclaw github")).toEqual([]);
-    expect(testing.normalizeParallelSearchQueries(["x".repeat(250)])).toEqual(["x".repeat(200)]);
-    expect(testing.normalizeParallelSearchQueries([`${"x".repeat(199)}🚀tail`])).toEqual([
-      "x".repeat(199),
-    ]);
-    expect(testing.normalizeParallelSearchQueries(["a", "b", "c", "d", "e", "f"])).toEqual([
-      "a",
-      "b",
-      "c",
-      "d",
-      "e",
-    ]);
-  });
-  it("normalizes client_model identifiers", () => {
-    expect(testing.normalizeParallelClientModel("claude-opus-4-7")).toBe("claude-opus-4-7");
-    expect(testing.normalizeParallelClientModel("  gpt-5.5  ")).toBe("gpt-5.5");
-    expect(testing.normalizeParallelClientModel(undefined)).toBeUndefined();
-    expect((testing.normalizeParallelClientModel("a".repeat(200)) ?? "").length).toBe(100);
-    expect(testing.normalizeParallelClientModel(`${"m".repeat(99)}🚀tail`)).toBe("m".repeat(99));
-  });
-  it("normalizes the Parallel /v1/search response shape", () => {
-    expect(
-      testing.normalizeParallelResults({
-        results: [
-          {
-            url: "https://example.com/a",
-            title: "Sample",
-            publish_date: "2026-04-01",
-            excerpts: ["first", "second"],
-          },
-          "not-an-object",
-        ],
-      }),
-    ).toEqual([
-      {
-        url: "https://example.com/a",
-        title: "Sample",
-        publish_date: "2026-04-01",
-        excerpts: ["first", "second"],
-      },
-    ]);
-    expect(testing.normalizeParallelResults({})).toEqual([]);
-    expect(testing.normalizeParallelResults(null)).toEqual([]);
-  });
-  it("resolves configured counts while strictly validating the tool schema range", () => {
-    expect(testing.resolveParallelSearchCount({}, undefined)).toBe(5);
-    expect(testing.resolveParallelSearchCount({}, 120)).toBe(40);
-    expect(testing.resolveParallelSearchCount({}, 0)).toBe(1);
-    expect(testing.resolveParallelSearchCount({ count: 40 }, 5)).toBe(40);
-    for (const count of [0, 4.5, "3abc", 41]) {
-      expect(() => testing.resolveParallelSearchCount({ count }, 5)).toThrow(
-        "count must be an integer from 1 to 40.",
-      );
-    }
-  });
-  it("returns a stable missing-key payload that points at the real config path", () => {
-    expect(testing.missingParallelKeyPayload()).toEqual({
+  it("returns a stable missing-key payload that points at the real config path", async () => {
+    await expect(paidTool({}).execute({ search_queries: ["openclaw"] })).resolves.toEqual({
       error: "missing_parallel_api_key",
       message:
         "web_search (parallel) needs a Parallel API key. Set PARALLEL_API_KEY in the Gateway environment, or configure plugins.entries.parallel.config.webSearch.apiKey.",
       docs: "https://docs.openclaw.ai/tools/parallel-search",
     });
+    expect(endpointMockState.calls).toHaveLength(0);
+  });
+  it("resolves and validates configured search endpoints at the request boundary", async () => {
+    enqueueJson();
+    await paidTool({
+      parallel: { apiKey: "par-secret", baseUrl: "proxy.example/parallel/v1/search/" },
+    }).execute({ search_queries: ["openclaw"] });
+    expect(endpointCall(0).url).toBe("https://proxy.example/parallel/v1/search");
+    await expect(
+      paidTool({
+        parallel: { apiKey: "par-secret", baseUrl: "ftp://proxy.example/parallel" },
+      }).execute({ search_queries: ["openclaw"] }),
+    ).resolves.toMatchObject({ error: "invalid_base_url" });
+    expect(endpointMockState.calls).toHaveLength(1);
+  });
+  it("normalizes bounded request fields before sending them", async () => {
+    enqueueJson();
+    await paidTool().execute({
+      objective: `  ${"x".repeat(4999)}🚀tail  `,
+      search_queries: [
+        "  alpha  ",
+        "alpha",
+        "",
+        42,
+        `${"q".repeat(199)}🚀tail`,
+        "c",
+        "d",
+        "e",
+        "f",
+      ],
+      client_model: `  ${"m".repeat(99)}🚀tail  `,
+    });
+    expect(readBody()).toMatchObject({
+      objective: "x".repeat(4999),
+      search_queries: ["alpha", "q".repeat(199), "c", "d", "e"],
+      client_model: "m".repeat(99),
+    });
+  });
+  it("partitions cached searches by every request input", async () => {
+    const seed = `parallel-cache-key-${Date.now()}-${Math.random()}`;
+    const base = { objective: seed, search_queries: [seed], count: 5 };
+    const tool = paidTool();
+    enqueueJson();
+    await tool.execute(base);
+    await tool.execute(base);
+    for (const args of [
+      { ...base, count: 6 },
+      { ...base, objective: `${seed}-objective` },
+      { ...base, search_queries: [`${seed}-query`] },
+      { ...base, session_id: `${seed}-session` },
+      { ...base, client_model: `${seed}-model` },
+    ]) {
+      enqueueJson();
+      await tool.execute(args);
+    }
+    enqueueJson();
+    await paidTool({
+      parallel: { apiKey: "par-secret", baseUrl: "https://proxy.example/parallel" },
+    }).execute(base);
+    expect(endpointMockState.calls).toHaveLength(7);
   });
   it("treats objective as optional and omits it from the request when absent", async () => {
     enqueueJson();
@@ -436,7 +368,7 @@ describe("parallel web search provider", () => {
     enqueueJson({
       search_id: "search_test",
       session_id: "session_test",
-      results: [{ url: "https://example.com/a", title: "A", excerpts: ["alpha"] }],
+      results: [{ url: "https://example.com/a", title: "A", excerpts: ["alpha"] }, "invalid"],
     });
     const result = await paidTool({
       parallel: { apiKey: "par-secret" },
@@ -462,6 +394,7 @@ describe("parallel web search provider", () => {
       provider: "parallel",
       searchId: "search_test",
       sessionId: "session_test",
+      count: 1,
     });
   });
   it("threads caller-supplied session_id and client_model through to Parallel", async () => {
@@ -604,9 +537,7 @@ describe("parallel web search provider", () => {
       .catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toMatch(
-      new RegExp(
-        `Parallel API: JSON response exceeds ${testing.PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES} bytes`,
-      ),
+      new RegExp("Parallel API: JSON response exceeds 16777216 bytes"),
     );
     expect(streamed.getReadCount()).toBeLessThan(200);
     expect(streamed.wasCanceled()).toBe(true);

--- a/extensions/parallel/test-api.ts
+++ b/extensions/parallel/test-api.ts
@@ -1,1 +1,0 @@
-export { testing } from "./src/parallel-web-search-provider.runtime.js";


### PR DESCRIPTION
## What Problem This Solves

The Parallel extension exposed private normalization helpers through a test-only facade and tested those helpers directly, duplicating coverage already available through the real REST and MCP provider boundaries.

## Why This Change Was Made

Remove the private testing facade, make its helper exports module-private, and consolidate the same endpoint, normalization, cache-partition, response-filtering, and response-cap contracts around public provider execution.

## User Impact

No user-visible behavior changes. Provider requests and responses are unchanged.

## Evidence

- `pnpm check:changed`
- `pnpm test:changed` — 48 passed
- Structured autoreview: scoped clean, 0.96 confidence, no accepted/actionable findings
