### PR TITLE
fix(ui): limit sidebar catalog groups to five sessions

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -54,6 +54,7 @@ type SessionCatalogGroupsParams = {
   mainKey: string;
   collapsedSections: ReadonlySet<string>;
   loadingMoreCatalogIds: ReadonlySet<string>;
+  visibleSessionLimits: ReadonlyMap<string, number>;
   projectGrouping: CatalogProjectGrouping;
   liveRows: readonly GatewaySessionRow[];
   ownerId?: string | null;
@@ -74,6 +75,7 @@ type SessionCatalogGroupsParams = {
     position?: { x: number; y: number },
   ) => void;
   onLoadMore: (catalogId: string) => void;
+  onSetVisibleSessionLimit: (sectionId: string, limit: number) => void;
   onOpenNewSession?: (agentId: string, target?: NewSessionTarget) => void;
   newSessionDisabledReason?: string;
   sectionDragDisabledReason?: string;
@@ -90,6 +92,8 @@ type SessionCatalogGroupsParams = {
   onCatalogMenuTriggerRendered: (key: CatalogSessionKey, element: Element | undefined) => void;
   isMenuOpen: (key: CatalogSessionKey) => boolean;
 };
+
+const CATALOG_SESSION_GROUP_LIMIT = 5;
 
 const CATALOG_CONTROL_SELECTORS = [
   ".sidebar-recent-session__link",
@@ -378,6 +382,45 @@ function renderCatalogHostGroup(
       (session) =>
         renderCatalogSessionRow(catalog, host, session, liveRowsByKey, params, projectChild),
     );
+  const renderVisibleRows = (
+    sessions: readonly SessionCatalogSession[],
+    sectionId: string,
+    projectChild = false,
+  ) => {
+    const expanded =
+      (params.visibleSessionLimits.get(sectionId) ?? CATALOG_SESSION_GROUP_LIMIT) >
+      CATALOG_SESSION_GROUP_LIMIT;
+    return renderRows(
+      expanded ? sessions : sessions.slice(0, CATALOG_SESSION_GROUP_LIMIT),
+      projectChild,
+    );
+  };
+  const renderPagination = (sessions: readonly SessionCatalogSession[], sectionId: string) => {
+    if (sessions.length <= CATALOG_SESSION_GROUP_LIMIT) {
+      return nothing;
+    }
+    const visibleLimit = params.visibleSessionLimits.get(sectionId) ?? CATALOG_SESSION_GROUP_LIMIT;
+    const expanded = visibleLimit > CATALOG_SESSION_GROUP_LIMIT;
+    const label = expanded ? t("chat.messages.showLess") : t("chat.messages.showMore");
+    return html`<div class="sidebar-session-pagination sidebar-session-pagination--catalog">
+      <button
+        type="button"
+        class="sidebar-session-pagination__button"
+        aria-label=${label}
+        @click=${() =>
+          params.onSetVisibleSessionLimit(
+            sectionId,
+            expanded ? CATALOG_SESSION_GROUP_LIMIT : sessions.length,
+          )}
+      >
+        ${label}
+      </button>
+    </div>`;
+  };
+  const flatSessions = projectGroups?.ungrouped ?? host.sessions;
+  const flatSectionId = projectGroups
+    ? `catalog-${params.projectGrouping}-ungrouped:${catalog.id}:${host.hostId}`
+    : `catalog-host:${catalog.id}:${host.hostId}`;
   // Gateway errors stay on the catalog header; node headings remain so remote rows keep their owner.
   const showHostHeading = host.kind !== "gateway";
   return html`
@@ -438,19 +481,21 @@ function renderCatalogHostGroup(
                     ${collapsed
                       ? nothing
                       : html`<div
-                          class="sidebar-session-catalog-project__sessions"
-                          role="list"
-                          aria-label=${`${host.label}: ${group.label}`}
-                        >
-                          ${renderRows(group.sessions, true)}
-                        </div>`}
+                            class="sidebar-session-catalog-project__sessions"
+                            role="list"
+                            aria-label=${`${host.label}: ${group.label}`}
+                          >
+                            ${renderVisibleRows(group.sessions, sectionId, true)}
+                          </div>
+                          ${renderPagination(group.sessions, sectionId)}`}
                   </div>
                 `;
               },
             )}
-            ${renderRows(projectGroups.ungrouped)}`
-          : renderRows(host.sessions)}
+            ${renderVisibleRows(flatSessions, flatSectionId)}`
+          : renderVisibleRows(flatSessions, flatSectionId)}
       </div>
+      ${renderPagination(flatSessions, flatSectionId)}
     </section>
   `;
 }

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -357,6 +357,7 @@ function renderSessionCatalog(params: {
       mainKey: snapshot.mainKey,
       collapsedSections: host.collapsedSessionSections,
       loadingMoreCatalogIds: snapshot.loadingMoreCatalogIds,
+      visibleSessionLimits: host.sessionData.visibleSessionLimits,
       projectGrouping: snapshot.projectGrouping,
       liveRows: snapshot.liveRows,
       ownerId: snapshot.ownerId,
@@ -384,6 +385,7 @@ function renderSessionCatalog(params: {
         host.sidebarMenus.toggleCatalogViewMenu(catalogId, trigger);
       },
       onLoadMore: (catalogId) => void host.sessionData.loadMoreSessionCatalog(catalogId),
+      onSetVisibleSessionLimit: (sectionId, limit) => host.setVisibleSessionLimit(sectionId, limit),
       onOpenNewSession: (agentId, target) => host.requestOpenNewSession(agentId, target),
       newSessionDisabledReason: newSessionAccess.allowed ? undefined : newSessionAccess.reason,
       sectionDragDisabledReason: groupWriteAccess.allowed ? undefined : groupWriteAccess.reason,

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -72,6 +72,7 @@ export interface SessionListHost {
     | "retryChildSessions"
     | "sessionCatalogRefreshStatus"
     | "sessionMutationError"
+    | "visibleSessionLimits"
   >;
   readonly sessionsGrouping: SidebarSessionsGrouping;
   readonly collapsedSessionSections: ReadonlySet<string>;

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -10,6 +10,7 @@ import "../test-helpers/app-sidebar-cases/catalog-live-events.ts";
 import "../test-helpers/app-sidebar-cases/catalog-project-activity.ts";
 import "../test-helpers/app-sidebar-cases/catalog-row-lifecycle.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live.ts";
+import "../test-helpers/app-sidebar-cases/catalog-pagination-visibility.ts";
 import "../test-helpers/app-sidebar-cases/catalog-reconnect.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live-errors.ts";
 import "../test-helpers/app-sidebar-cases/catalog-live-state.ts";

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1798,6 +1798,10 @@ openclaw-settings-save-indicator:empty {
   text-align: center;
 }
 
+.sidebar-session-catalog-project > .sidebar-session-pagination--catalog {
+  padding-left: calc(var(--sidebar-text-offset) + var(--sidebar-lead));
+}
+
 .sidebar-session-pagination {
   display: flex;
   justify-content: flex-start;

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-pagination-visibility.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-pagination-visibility.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
+import "../../components/app-sidebar.ts";
+
+describe("AppSidebar catalog session visibility", () => {
+  const mountCatalog = async (grouping: "project" | "none", sessionCount = 7) => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    (
+      sidebar as typeof sidebar & {
+        catalogProjectGrouping: "project" | "none";
+      }
+    ).catalogProjectGrouping = grouping;
+    sidebar.sessionData.sessionCatalogs = [
+      {
+        id: "codex",
+        label: "Codex",
+        capabilities: { continueSession: true, archive: false },
+        hosts: [
+          {
+            hostId: "gateway:local",
+            label: "Local Codex",
+            kind: "gateway",
+            connected: true,
+            sessions: Array.from({ length: sessionCount }, (_, index) => ({
+              threadId: `thread-${index + 1}`,
+              name: `Session ${index + 1}`,
+              cwd: "/workspace/openclaw",
+              status: "stored" as const,
+              archived: false,
+              canContinue: true,
+              canArchive: false,
+            })),
+          },
+        ],
+      },
+    ];
+    sidebar.sessionData.requestSessionDataUpdate();
+    await sidebar.updateComplete;
+    return sidebar;
+  };
+
+  const verifyExpansion = async (
+    container: HTMLElement,
+    sidebar: HTMLElement & { updateComplete: Promise<boolean> },
+  ) => {
+    const rows = () => container.querySelectorAll("[data-session-key]").length;
+    const pagingButton = () =>
+      container.querySelector<HTMLButtonElement>(".sidebar-session-pagination__button");
+
+    expect(rows()).toBe(5);
+    expect(pagingButton()?.getAttribute("aria-label")).toBe("Show more");
+
+    pagingButton()?.click();
+    await sidebar.updateComplete;
+
+    expect(rows()).toBe(7);
+    expect(pagingButton()?.getAttribute("aria-label")).toBe("Show less");
+
+    pagingButton()?.click();
+    await sidebar.updateComplete;
+
+    expect(rows()).toBe(5);
+    expect(pagingButton()?.getAttribute("aria-label")).toBe("Show more");
+  };
+
+  it("limits project groups until the user expands them", async () => {
+    const sidebar = await mountCatalog("project");
+
+    const project = sidebar.querySelector<HTMLElement>(
+      '[data-session-catalog-project="project:/workspace/openclaw"]',
+    );
+    const projectGroup = project?.closest<HTMLElement>(".sidebar-session-catalog-project");
+    expect(projectGroup).not.toBeNull();
+    await verifyExpansion(projectGroup!, sidebar);
+  });
+
+  it("limits flat host groups until the user expands them", async () => {
+    const sidebar = await mountCatalog("none");
+    const host = sidebar.querySelector<HTMLElement>(".sidebar-session-catalog-host");
+    expect(host).not.toBeNull();
+    await verifyExpansion(host!, sidebar);
+  });
+
+  it("omits the control when a group has five sessions", async () => {
+    const sidebar = await mountCatalog("none", 5);
+    const host = sidebar.querySelector<HTMLElement>(".sidebar-session-catalog-host");
+
+    expect(host?.querySelectorAll("[data-session-key]")).toHaveLength(5);
+    expect(host?.querySelector(".sidebar-session-pagination__button")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with more than five loaded sessions in a sidebar catalog subgroup would see every row at once, making the session catalog unnecessarily tall and harder to scan.

## Why This Change Was Made

Catalog project and flat host groups now reuse the sidebar's existing visibility-limit state. Each subgroup shows five sessions by default, **Show more** reveals all loaded rows, and **Show less** restores the five-row limit. Pagination controls stay outside elements with `role="list"`, and groups with five or fewer sessions do not render a control.

## User Impact

Session catalog subgroups stay compact by default while preserving one-click access to every loaded session. Expansion state is independent per subgroup.

## Evidence

### Before

Seven loaded Codex sessions rendered at once with no disclosure control:

![Before: all seven catalog sessions visible](https://github.com/user-attachments/assets/4cf5a902-8e5c-4794-983d-056f317488a1)

### After

Five rows by default with **Show more**:

![After: five catalog sessions visible with Show more](https://github.com/user-attachments/assets/051bdf2d-43b6-4f32-9da8-4aecd4e23681)

All seven loaded rows after expansion with **Show less**:

![After expansion: all seven catalog sessions visible with Show less](https://github.com/user-attachments/assets/3d7287e8-72ac-434d-9516-d1fe49afde96)

Five rows again after collapsing:

![After collapsing again: five catalog sessions visible with Show more](https://github.com/user-attachments/assets/a3f7b7eb-21ab-4732-8c0d-ce0fd2319d55)

[Browser interaction recording](https://github.com/user-attachments/assets/081066f7-f3e1-4efe-a8d4-d670d642f970)

### Validation

- Isolated OCM environment: `sidebar-five-proof`, separate state root `/Users/jsy/.ocm/envs/sidebar-five-proof/.openclaw`, loopback port `19020`; the operator Gateway was not used.
- Real Codex app-server catalog provider with seven representative rollout sessions under an isolated Codex home, all grouped under `/workspace/openclaw`.
- Browser assertions: `5 + Show more` → `7 + Show less` → `5 + Show more`.
- Baseline browser assertion: `7` rows and no disclosure control.
- `pnpm test ui/src/components/app-sidebar.test.ts` — 326 passed.
- `pnpm check:changed` — passed on the synchronized branch base.
- `pnpm build` — passed, including Control UI performance limits and 812 precompressed sidecars.
- Fresh Codex autoreview — scoped clean, no accepted or actionable findings.

Crabbox was not used for the UI pass: the isolated local OCM environment exercised the real browser, Gateway, provider, and catalog data path, so a remote clean-machine run would not add platform-specific coverage.

## Worked on by

- @fuller-stack-dev
