### PR TITLE
perf(agents): speed up concurrent final-answer streaming

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.test.ts
@@ -321,7 +321,7 @@ describe("handleMessageEnd", () => {
       const ctx = createMessageEndContext({
         onBlockReply,
         state: {
-          lastStreamedAssistantCleaned: "Hello world",
+          assistantStream: { raw: "", text: "Hello world" },
           blockReplyBreak: "text_end",
           deltaBuffer: "",
         },
@@ -373,7 +373,7 @@ describe("handleMessageEnd", () => {
     const ctx = createMessageEndContext({
       onBlockReply,
       state: {
-        lastStreamedAssistantCleaned: "Caption [[oops",
+        assistantStream: { raw: "", text: "Caption [[oops" },
         blockReplyBreak: "message_end",
       },
     });
@@ -478,7 +478,7 @@ describe("handleMessageEnd", () => {
         onAgentEvent,
         bufferedText: previousText,
         state: {
-          lastStreamedAssistantCleaned: previousText,
+          assistantStream: { raw: "", text: previousText },
           deltaBuffer: previousText,
         },
       });
@@ -512,7 +512,7 @@ describe("handleMessageEnd", () => {
     const ctx = createMessageEndContext({
       onAgentEvent,
       state: {
-        lastStreamedAssistantCleaned: "Working...",
+        assistantStream: { raw: "", text: "Working..." },
         blockReplyBreak: "text_end",
         deltaBuffer: "",
       },

--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -239,8 +239,7 @@ export function handleMessageEnd(
     // Late text_end events still use the partial lane's tag/inline state.
     const { thinking, final, inlineCode } = ctx.state.partialBlockState;
     ctx.state.partialBlockState = { thinking, final, inlineCode };
-    ctx.state.lastStreamedAssistant = undefined;
-    ctx.state.lastStreamedAssistantCleaned = undefined;
+    ctx.state.assistantStream = undefined;
     ctx.state.reasoningStreamOpen = false;
   };
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
@@ -350,22 +350,14 @@ export function resolveAssistantTextChunk(params: {
   return "";
 }
 
-export function resolveTextAppendDelta(previousText: string, nextText: string): string {
-  if (nextText.startsWith(previousText)) {
-    return nextText.slice(previousText.length);
-  }
-  return previousText.startsWith(nextText) ? "" : nextText;
-}
-
 export function resolveStreamingReply(params: {
   evtType: "text_delta" | "text_start" | "text_end";
   next: string;
-  previousRawText: string;
+  previousText: string;
   previousCleaned: string;
   visibleDelta: string;
-  rawTextIsAppend: boolean;
+  textIsAppend: boolean;
   parsedStreamDirectives: ReplyDirectiveParseResult | null;
-  shouldUsePhaseAwareBlockReply: boolean;
 }): { text: string; delta: string; replace: boolean; hasText: boolean } {
   if (!params.parsedStreamDirectives && params.evtType === "text_delta") {
     const text = params.previousCleaned;
@@ -383,26 +375,20 @@ export function resolveStreamingReply(params: {
     !/(?:^|\n)\s*MEDIA:\s*\S[^\n]*(?:\n|$)/i.test(params.visibleDelta) &&
     params.parsedStreamDirectives.text === params.visibleDelta
   ) {
-    if (
-      !params.shouldUsePhaseAwareBlockReply &&
-      params.rawTextIsAppend &&
-      params.previousRawText === params.previousCleaned
-    ) {
+    if (params.textIsAppend && params.previousText === params.previousCleaned) {
       // Reuse the normalized prefix and small delta. Trimming the cumulative
       // snapshot can flatten it; slicing can retain it in queued updates.
       delta = params.previousCleaned ? params.visibleDelta.trimEnd() : params.visibleDelta.trim();
       text = delta === params.visibleDelta ? params.next : `${params.previousCleaned}${delta}`;
       isAppend = true;
-    } else if (
-      !params.shouldUsePhaseAwareBlockReply &&
-      params.previousCleaned === params.previousRawText.trim()
-    ) {
+    } else if (params.textIsAppend && params.previousCleaned === params.previousText.trim()) {
       text = params.next.trim();
-      isAppend = params.rawTextIsAppend;
+      isAppend = true;
     } else {
       const candidate = `${params.previousCleaned}${params.parsedStreamDirectives.text}`.trim();
-      if (candidate === params.next.trim()) {
-        text = candidate;
+      const normalizedNext = params.next.trim();
+      if (candidate === normalizedNext) {
+        text = normalizedNext;
         // Appending cannot alter the prior prefix unless trimming removed its whitespace.
         isAppend =
           candidate.length >= params.previousCleaned.length &&

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
@@ -103,15 +103,13 @@ describe("handleMessageUpdate text signatures", () => {
       onPartialReply,
       state: {
         deltaBuffer: "First block",
-        lastStreamedAssistant: "First block",
-        lastStreamedAssistantCleaned: "First block",
+        assistantStream: { raw: "First block", text: "First block" },
         lastAssistantStreamContentIndex: 0,
       },
     });
     const resetAssistantMessageState = vi.fn(() => {
       context.state.deltaBuffer = "";
-      context.state.lastStreamedAssistant = undefined;
-      context.state.lastStreamedAssistantCleaned = undefined;
+      context.state.assistantStream = undefined;
     });
     context.resetAssistantMessageState = resetAssistantMessageState;
     context.params.onAssistantMessageStart = onAssistantMessageStart;
@@ -166,7 +164,7 @@ describe("handleMessageUpdate text signatures", () => {
       stream: "assistant",
       data: { text: "Hello", delta: "Hello" },
     });
-    expect(context.state.lastStreamedAssistantCleaned).toBe("Hello");
+    expect(context.state.assistantStream?.text).toBe("Hello");
   });
 
   it.each([
@@ -197,7 +195,7 @@ describe("handleMessageUpdate text signatures", () => {
       assistantMessageEvent: { type: "text_end", content: text },
     });
 
-    expect(context.state.lastStreamedAssistantCleaned).toBe(text);
+    expect(context.state.assistantStream?.text).toBe(text);
     expect(firstMockArg(onAgentEvent, "final assistant event")).toMatchObject({
       stream: "assistant",
       data: { text },

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-phases.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-phases.test.ts
@@ -96,45 +96,79 @@ describe("handleMessageUpdate text signatures", () => {
       ],
       updates: [{ text: "Done.", delta: "Done." }],
     },
-  ])("uses append events for same-item phased streams ($name)", async ({ chunks, updates }) => {
-    const onAgentEvent = vi.fn();
-    const context = createMessageUpdateContext({ onAgentEvent });
-    const signature = JSON.stringify({ v: 1, id: "item-final", phase: "final_answer" });
-    const partial = {
-      role: "assistant",
-      phase: "final_answer",
-      content: [
-        {
-          type: "text",
-          textSignature: signature,
-          get text() {
-            throw new Error("full partial text should not be read");
-          },
-        },
+    {
+      name: "split voice directive",
+      chunks: ["[[audio_as_", "voice]]Hello", " world"],
+      updates: [
+        { text: "Hello", delta: "Hello" },
+        { text: "Hello world", delta: " world" },
       ],
-    };
+      reply: { audioAsVoice: true },
+    },
+    {
+      name: "split reply target",
+      chunks: ["[[reply_to:", "message-7]]Hello", " world"],
+      updates: [
+        { text: "Hello", delta: "Hello" },
+        { text: "Hello world", delta: " world" },
+      ],
+      reply: { replyToId: "message-7", replyToTag: true },
+    },
+    {
+      name: "duplicate paragraph becomes distinct",
+      chunks: ["One.\n\n", "One.", " More."],
+      updates: [
+        { text: "One.", delta: "One." },
+        { text: "One.\n\nOne. More.", delta: "\n\nOne. More." },
+      ],
+    },
+  ])(
+    "uses append events for same-item phased streams ($name)",
+    async ({ chunks, updates, reply }) => {
+      const onAgentEvent = vi.fn();
+      const context = createMessageUpdateContext({ onAgentEvent });
+      const signature = JSON.stringify({ v: 1, id: "item-final", phase: "final_answer" });
+      const partial = {
+        role: "assistant",
+        phase: "final_answer",
+        content: [
+          {
+            type: "text",
+            textSignature: signature,
+            get text() {
+              throw new Error("full partial text should not be read");
+            },
+          },
+        ],
+      };
 
-    const createPhasedDelta = (delta: string) =>
-      ({
-        message: { role: "assistant", content: [] },
-        assistantMessageEvent: {
-          type: "text_delta",
-          delta,
-          partial,
-        },
-      }) as never;
+      const createPhasedDelta = (delta: string) =>
+        ({
+          message: { role: "assistant", content: [] },
+          assistantMessageEvent: {
+            type: "text_delta",
+            delta,
+            partial,
+          },
+        }) as never;
 
-    for (const chunk of chunks) {
-      await updateMessage(context, createPhasedDelta(chunk));
-    }
+      for (const chunk of chunks) {
+        await updateMessage(context, createPhasedDelta(chunk));
+      }
 
-    expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject(
-      updates.map((data) => ({
-        stream: "assistant",
-        data: { ...data, replace: undefined, phase: "final_answer" },
-      })),
-    );
-  });
+      expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject(
+        updates.map((data) => ({
+          stream: "assistant",
+          data: { ...data, replace: undefined, phase: "final_answer" },
+        })),
+      );
+      if (reply) {
+        expect(
+          consumePendingAssistantReplyDirectivesIntoReply(context.state, { text: "Hello world" }),
+        ).toMatchObject(reply);
+      }
+    },
+  );
 
   it.each(["Hello", ""])(
     "replaces a phased reply with the final snapshot %j",
@@ -203,7 +237,7 @@ describe("handleMessageUpdate text signatures", () => {
               phase: "final_answer",
             }),
             createOpenAiResponsesTextBlock({
-              text: "Second block",
+              text: "Second block [[reply_to_current]]",
               id: "item-2",
               phase: "final_answer",
             }),
@@ -311,8 +345,7 @@ describe("handleMessageUpdate text signatures", () => {
       onPartialReply,
       state: {
         deltaBuffer: "First block",
-        lastStreamedAssistant: "First block",
-        lastStreamedAssistantCleaned: "First block",
+        assistantStream: { raw: "First block", text: "First block" },
         lastAssistantStreamContentIndex: 0,
         lastAssistantStreamItemId: "item-1",
       },

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -32,7 +32,6 @@ import {
   resolveAssistantTextChunk,
   resolveCurrentSourceMessagingToolPartial,
   resolveStreamingReply,
-  resolveTextAppendDelta,
   scopeAssistantMessageToStreamBlock,
   shouldSuppressDeterministicApprovalOutput,
 } from "./embedded-agent-subscribe.handlers.messages.stream.js";
@@ -308,7 +307,8 @@ export function handleMessageUpdate(
   );
   const wasThinking = ctx.state.partialBlockState.thinking;
   let visibleDelta = "";
-  let rawTextIsAppend = false;
+  let textIsAppend = false;
+  let previousText = ctx.state.assistantStream?.raw ?? "";
   // A text_start partial may already contain text that the following text_delta replays.
   // Use starts only for lifecycle boundaries; consume their text from delta/end events.
   const shouldReadPartialText =
@@ -348,10 +348,12 @@ export function handleMessageUpdate(
   if (!next && evtType !== "text_end") {
     next = undefined;
   }
-  let nextRawStreamText = next;
+  let nextRawStreamText = next ?? "";
+  let sanitized: NonNullable<EmbeddedAgentSubscribeState["assistantStream"]>["sanitized"];
   if (next === undefined && deliveryPhase === "final_answer" && (reprojectBlockReply || chunk)) {
     // A late phase can reveal inline examples; retain already scoped snapshots above.
-    const previousRawText = reprojectBlockReply ? "" : (ctx.state.lastStreamedAssistant ?? "");
+    const previousStream = reprojectBlockReply ? undefined : ctx.state.assistantStream;
+    const previousRawText = previousStream?.raw ?? "";
     visibleDelta = reprojectBlockReply
       ? ctx.state.deltaBuffer
       : ctx.params.enforceFinalTag
@@ -360,10 +362,17 @@ export function handleMessageUpdate(
     nextRawStreamText = `${previousRawText}${visibleDelta}`;
     const sanitizerPhase = ctx.params.enforceFinalTag ? undefined : deliveryPhase;
     next = sanitizeAssistantVisibleStreamText(nextRawStreamText, sanitizerPhase).trim();
-    visibleDelta = resolveTextAppendDelta(
-      sanitizeAssistantVisibleStreamText(previousRawText, sanitizerPhase).trim(),
-      next,
-    );
+    sanitized = { phase: sanitizerPhase, text: next };
+    previousText =
+      previousStream?.sanitized && previousStream.sanitized.phase === sanitizerPhase
+        ? previousStream.sanitized.text
+        : sanitizeAssistantVisibleStreamText(previousRawText, sanitizerPhase).trim();
+    textIsAppend = next.startsWith(previousText);
+    visibleDelta = textIsAppend
+      ? next.slice(previousText.length)
+      : previousText.startsWith(next)
+        ? ""
+        : next;
     if (reprojectBlockReply) {
       ctx.resetPartialReplyDirectives();
     }
@@ -379,13 +388,12 @@ export function handleMessageUpdate(
       const recomputedRawText = ctx.stripBlockTags(ctx.state.deltaBuffer, recomputeState, {
         final: finalText,
       });
-      const previousRawText = ctx.state.lastStreamedAssistant ?? "";
-      const isFullStreamReplacement = !recomputedRawText.startsWith(previousRawText);
-      rawTextIsAppend = !isFullStreamReplacement;
+      const isFullStreamReplacement = !recomputedRawText.startsWith(previousText);
+      textIsAppend = !isFullStreamReplacement;
       next = recomputedRawText.trim();
       visibleDelta = isFullStreamReplacement
         ? recomputedRawText
-        : recomputedRawText.slice(previousRawText.length);
+        : recomputedRawText.slice(previousText.length);
       nextRawStreamText = recomputedRawText;
       ctx.state.partialBlockState = recomputeState;
     } else {
@@ -397,12 +405,12 @@ export function handleMessageUpdate(
           : "";
       if (ctx.state.partialBlockState.pendingTagFragment) {
         visibleDelta = "";
-        next = ctx.state.lastStreamedAssistantCleaned ?? "";
-        nextRawStreamText = ctx.state.lastStreamedAssistant ?? "";
+        next = ctx.state.assistantStream?.text ?? "";
+        nextRawStreamText = ctx.state.assistantStream?.raw ?? "";
       } else {
-        nextRawStreamText = `${ctx.state.lastStreamedAssistant ?? ""}${visibleDelta}`;
+        nextRawStreamText = `${ctx.state.assistantStream?.raw ?? ""}${visibleDelta}`;
         next = nextRawStreamText;
-        rawTextIsAppend = true;
+        textIsAppend = true;
       }
     }
   } else if (!isTerminalSnapshot && next !== undefined && (chunk || evtType === "text_end")) {
@@ -437,7 +445,7 @@ export function handleMessageUpdate(
     if (shouldUsePhaseAwareBlockReply || isTerminalSnapshot) {
       recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
     }
-    const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
+    const previousCleaned = ctx.state.assistantStream?.text ?? "";
     const {
       text: cleanedText,
       delta: replyDelta,
@@ -446,12 +454,11 @@ export function handleMessageUpdate(
     } = resolveStreamingReply({
       evtType,
       next,
-      previousRawText: ctx.state.lastStreamedAssistant ?? "",
+      previousText,
       previousCleaned,
       visibleDelta,
-      rawTextIsAppend,
+      textIsAppend,
       parsedStreamDirectives,
-      shouldUsePhaseAwareBlockReply,
     });
     const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
     const managedMediaUrls = resolveManagedStreamMediaUrls(ctx.state, mediaUrls);
@@ -522,8 +529,8 @@ export function handleMessageUpdate(
       ctx.state.streamBlockText = content;
     }
 
-    ctx.state.lastStreamedAssistant = nextRawStreamText;
-    ctx.state.lastStreamedAssistantCleaned = cleanedText;
+    // Snapshot recovery must not seed the next streaming sanitizer result.
+    ctx.state.assistantStream = { raw: nextRawStreamText, text: cleanedText, sanitized };
 
     if (
       ctx.params.silentExpected ||

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -155,8 +155,11 @@ export type EmbeddedAgentSubscribeState = {
   hasFlushedPartialText: boolean;
   blockState: StreamBlockState & { inlineCode: InlineCodeState };
   partialBlockState: StreamBlockState & { inlineCode: InlineCodeState };
-  lastStreamedAssistant?: string;
-  lastStreamedAssistantCleaned?: string;
+  assistantStream?: {
+    raw: string;
+    text: string;
+    sanitized?: { phase: AssistantPhase | undefined; text: string };
+  };
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   lastDeliveredBlockReplyText?: string;

--- a/src/agents/embedded-agent-subscribe.run-state.ts
+++ b/src/agents/embedded-agent-subscribe.run-state.ts
@@ -42,8 +42,7 @@ export function createEmbeddedAgentSubscribeState(
     // Track if a streamed chunk opened a <think> block (stateful across chunks).
     blockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
     partialBlockState: { thinking: false, final: false, inlineCode: createInlineCodeState() },
-    lastStreamedAssistant: undefined,
-    lastStreamedAssistantCleaned: undefined,
+    assistantStream: undefined,
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
     lastDeliveredBlockReplyText: undefined,

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -627,8 +627,7 @@ export function createStreamRendering({
       final: false,
       inlineCode: createInlineCodeState(),
     };
-    state.lastStreamedAssistant = undefined;
-    state.lastStreamedAssistantCleaned = undefined;
+    state.assistantStream = undefined;
     state.currentSourceMessagingToolHeldPartial = undefined;
     state.lastBlockReplyText = undefined;
     state.lastStreamedReasoning = undefined;

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -37,14 +37,15 @@ export function parseReplyDirectives(
   });
   let text = split.text ?? "";
 
-  const replyParsed = parseInlineDirectives(text, {
-    currentMessageId: options.currentMessageId,
-    stripAudioTag: false,
-    stripReplyTags: true,
-  });
+  const replyParsed = text.includes("[[")
+    ? parseInlineDirectives(text, {
+        currentMessageId: options.currentMessageId,
+        stripAudioTag: false,
+      })
+    : undefined;
 
   text = stripInlineDirectiveTagsForDelivery(
-    replyParsed.hasReplyTag ? replyParsed.text : text,
+    replyParsed?.hasReplyTag ? replyParsed.text : text,
   ).text;
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
@@ -55,9 +56,9 @@ export function parseReplyDirectives(
     text: isSilent ? "" : text,
     // Keep native path conversion outside the browser-shared parser and before reply policy.
     mediaUrls: split.mediaUrls?.map((source) => trySafeFileURLToPath(source) ?? source),
-    replyToId: replyParsed.replyToId,
-    replyToCurrent: replyParsed.replyToCurrent || undefined,
-    replyToTag: replyParsed.hasReplyTag,
+    replyToId: replyParsed?.replyToId,
+    replyToCurrent: replyParsed?.replyToCurrent || undefined,
+    replyToTag: replyParsed?.hasReplyTag ?? false,
     audioAsVoice: split.audioAsVoice,
     isSilent,
   };

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -19,10 +19,6 @@ type PendingReplyState = {
   hasTag: boolean;
 };
 
-type ParsedChunk = ReplyDirectiveParseResult & {
-  replyToExplicitId?: string;
-};
-
 type ConsumeOptions = {
   final?: boolean;
   silentToken?: string;
@@ -31,8 +27,7 @@ type ConsumeOptions = {
 // TRANSITIONAL(marker-retirement): streaming tail-buffering exists only because
 // live drafts still carry inline markers mid-run. Delete alongside the marker
 // parser when the visibleReplies default flips to "message_tool".
-// Holds back incomplete inline directive tails so parseChunk only ever sees
-// complete reply/audio tags.
+// Hold incomplete tails until the inline parser can read complete reply/audio tags.
 export const splitTrailingDirective = (text: string): { text: string; tail: string } => {
   let bufferStart = text.length;
   let trimTextBeforeTail = false;
@@ -79,39 +74,6 @@ export const splitTrailingDirective = (text: string): { text: string; tail: stri
   };
 };
 
-const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChunk => {
-  let text = raw ?? "";
-  const replyParsed = parseInlineDirectives(text, {
-    stripAudioTag: true,
-    stripReplyTags: true,
-  });
-  if (replyParsed.hasReplyTag || replyParsed.hasAudioTag) {
-    text = replyParsed.text;
-  }
-
-  const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
-  const isSilent =
-    isSilentReplyText(text, silentToken) || isSilentReplyPrefixText(text, silentToken);
-  if (isSilent) {
-    text = "";
-  } else if (startsWithSilentToken(text, silentToken)) {
-    text = stripLeadingSilentToken(text, silentToken);
-  }
-
-  return {
-    text,
-    replyToId: replyParsed.replyToId,
-    replyToExplicitId: replyParsed.replyToExplicitId,
-    replyToCurrent: replyParsed.replyToCurrent,
-    replyToTag: replyParsed.hasReplyTag,
-    audioAsVoice: replyParsed.audioAsVoice,
-    isSilent,
-  };
-};
-
-const hasRenderableContent = (parsed: ReplyDirectiveParseResult): boolean =>
-  hasOutboundReplyContent(parsed) || Boolean(parsed.audioAsVoice);
-
 export function createStreamingDirectiveAccumulator() {
   let pendingTail = "";
   let pendingSeparator = "";
@@ -127,14 +89,14 @@ export function createStreamingDirectiveAccumulator() {
     hasReturnedText = false;
   };
 
-  const consume = (raw: string, options: ConsumeOptions = {}): ReplyDirectiveParseResult | null => {
+  const consume = (raw: string, options?: ConsumeOptions): ReplyDirectiveParseResult | null => {
     const hadPendingTail = pendingTail.length > 0;
     const heldSeparator = pendingSeparator;
     let combined = `${pendingTail}${raw ?? ""}`;
     pendingTail = "";
     pendingSeparator = "";
 
-    if (!options.final) {
+    if (!options?.final) {
       const split = splitTrailingDirective(combined);
       if (split.tail) {
         const tailStart = combined.length - split.tail.length;
@@ -152,29 +114,41 @@ export function createStreamingDirectiveAccumulator() {
       return null;
     }
 
-    const parsed = parseChunk(combined, { silentToken: options.silentToken });
-    if (hadPendingTail && heldSeparator && parsed.text.startsWith("[")) {
-      parsed.text = `${heldSeparator}${parsed.text}`;
+    const parsed = combined.includes("[[") ? parseInlineDirectives(combined) : undefined;
+    let text = parsed && (parsed.hasReplyTag || parsed.hasAudioTag) ? parsed.text : combined;
+    const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
+    const isSilent =
+      isSilentReplyText(text, silentToken) || isSilentReplyPrefixText(text, silentToken);
+    if (isSilent) {
+      text = "";
+    } else if (startsWithSilentToken(text, silentToken)) {
+      text = stripLeadingSilentToken(text, silentToken);
+    }
+    if (hadPendingTail && heldSeparator && text.startsWith("[")) {
+      text = heldSeparator + text;
     }
     // Only a message-leading malformed marker is delivery control. Once text has
     // streamed, a later marker is literal content whose Markdown opener may be gone.
-    if (options.final && !hasReturnedText) {
-      parsed.text = stripInlineDirectiveTagsForDelivery(parsed.text).text;
+    if (options?.final && !hasReturnedText) {
+      text = stripInlineDirectiveTagsForDelivery(text).text;
     }
-    const hasTag = activeReply.hasTag || pendingReply.hasTag || parsed.replyToTag;
+    const hasTag = activeReply.hasTag || pendingReply.hasTag || parsed?.hasReplyTag === true;
     const sawCurrent =
-      activeReply.sawCurrent || pendingReply.sawCurrent || parsed.replyToCurrent === true;
+      activeReply.sawCurrent || pendingReply.sawCurrent || parsed?.replyToCurrent === true;
     const explicitId =
-      parsed.replyToExplicitId ?? pendingReply.explicitId ?? activeReply.explicitId;
+      parsed?.replyToExplicitId ?? pendingReply.explicitId ?? activeReply.explicitId;
 
-    const combinedResult: ReplyDirectiveParseResult = {
-      ...parsed,
+    const combinedResult = {
+      text,
       replyToId: explicitId,
+      replyToExplicitId: parsed?.replyToExplicitId,
       replyToCurrent: sawCurrent,
       replyToTag: hasTag,
+      audioAsVoice: parsed?.audioAsVoice ?? false,
+      isSilent,
     };
 
-    if (!hasRenderableContent(combinedResult)) {
+    if (!hasOutboundReplyContent(combinedResult) && !combinedResult.audioAsVoice) {
       if (hasTag) {
         pendingReply = {
           explicitId,


### PR DESCRIPTION
Related: #135956

## What Problem This Solves

Concurrent long replies explicitly marked as final answers consume avoidable CPU. The subscriber sanitizes both the new cumulative reply and the previous cumulative reply on each delta, then repeats delivery normalization. Profiling the latest-main baseline identified these repeated full-text passes on the busy path.

## Why This Change Was Made

The subscriber owns one reply projection containing raw text, delivered text, and the prepared sanitizer result for its phase. Each update sanitizes the new cumulative reply and reuses the previous result. Phase mismatches, snapshot recovery, and existing message/item/run boundaries invalidate that prepared fact. The full sanitizer remains necessary because later text can change an earlier visible prefix.

Phased and ordinary streams now share the append path when the producer has established that the text is an append. Directive accumulation skips unused no-marker parsing and no longer creates an intermediate parse result. This removes the two independently reset stream-text fields, the one-use append helper, and duplicated phase-specific normalization branches.

Production: **81 added / 113 removed, net −32 LOC**. Tests: **net +31**. Total: **160 added / 161 removed, net −1 LOC**.

## User Impact

The built-in runtime spends roughly one-third less CPU on concurrent long final-answer streams in this local workload. Ordinary unphased streaming is effectively unchanged in the control measurements. This is a throughput/CPU improvement; it does not establish lower live-model latency or memory savings.

## Evidence

Compared baseline `b485d4d3e76fa4ea408fde6d3fc1a39536751101` with candidate `b84bd9de914d8c43fed39beb0a1028d4b4591275`, using independent frozen-lock builds, Node 24.19.0, and pnpm 12.1.0 on a 32-core M3 Ultra with 512 GiB RAM. Three alternating baseline/candidate pairs per row; values below are medians. The shared host had varying background load. Each final response contains 4,096 deterministic stream chunks (about 90 KB); the two provider fixtures differ only in whether they declare `final_answer` from the start.

| Concurrent workload | Elapsed seconds, before → after | Process-tree CPU seconds, before → after | Sampled Gateway peak RSS MiB, before → after |
|---|---:|---:|---:|
| 8 sessions, final-answer phase | 29.235 → 19.982 | 25.86 → 17.28 | 2,215 → 2,341 |
| 16 sessions, final-answer phase | 52.128 → 35.163 | 53.35 → 36.01 | 3,618 → 3,684 |
| 8 sessions, unphased control | 3.277 → 3.339 | 4.19 → 4.21 | 1,216 → 1,228 |

Phased elapsed ranges were 25.24–30.15 → 16.37–22.14 seconds at eight sessions and 50.06–79.20 → 32.66–38.06 seconds at sixteen. CPU ranges were 25.39–25.91 → 16.02–17.43 and 52.06–56.03 → 34.27–36.31 seconds respectively. No statistical-significance claim follows from these three pairs.

The concurrent-phase RSS medians increased 5.7% at eight sessions and 1.8% at sixteen. The median largest RSS sample across all five measured phases was 2,410 → 2,409 MiB and 3,788 → 3,835 MiB respectively. The cache has one replaceable owner slot, but RSS does not establish retained heap or the cause of the transient peak difference. Memory reduction is not claimed.

Client-observed readiness/session-RPC p95 also did not improve: 46.7/43.4 → 55.2/56.1 ms at eight phased sessions and 18.5/24.5 → 26.6/29.5 ms at sixteen. These probes include client scheduling and synchronous end-of-work sampling, and faster runs yield fewer samples. Follow-up measurement of delivery bursts and control latency remains useful; these figures are not isolated server tail latency.

- **18 complete local Gateway runs:** 282 exact full durable replies and 864 local provider requests verified independently, including real file/command tools, same-session serialization, cancellation, child termination, reuse, and clean shutdown. Full replies were checked from private SQLite copies; capped chat-history previews were not treated as full-content proof. Source, dependencies, native bindings, build output, and helper inventories matched before and after the experiment.
- **Real OpenAI proof:** seven successful turns through `openai/gpt-5.6-luna`, 21 recorded model calls with ordered usage, full durable replies, cancellation/reuse, and clean Gateway exit. All seven final replies retained provider-declared final-answer signatures by completion. This does not prove when the live phase appeared or that the cache was hit; the phased fixture establishes the streaming input condition. The key was supplied through the child environment, and the credential window was closed afterward.
- **Focused verification:** 1,058 tests across 38 files, the complete changed-file static gate, and one clean Codex autoreview round. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33598409430): 203 successful jobs, 17 skipped.

ClawSweeper's no-marker-normalization finding and first Rank-up move are not accepted: [the baseline caller](https://github.com/openclaw/openclaw/blob/b485d4d3e76fa4ea408fde6d3fc1a39536751101/src/auto-reply/reply/reply-directives.ts#L47) already used the inline parser's normalized text only when `hasReplyTag` was true. For plain text, that flag is false and the normalized intermediate result was discarded. Both revisions return `"hello  world"` from `parseReplyDirectives("hello  world")`, while the unchanged direct `parseInlineDirectives` call returns `"hello world"`. An executable differential probe found identical text and metadata for 12 cases through terminal parsing, streaming accumulation, and the public inline parser. Restoring normalization at this caller would introduce the formatting change alleged by the review. The requested benchmark evidence is included above.

<details>
<summary>Local proof provenance</summary>

Artifacts are retained locally under `.artifacts/threading/performance-20260902`; these are content hashes, not public artifact-download links.

- Paired verification summary SHA-256: `d92aff3a2036fa717eaca5e677066763d65e4beed24dc76da8bd8b7f0896cb4a`
- Live proof receipt SHA-256: `0070bf217112598c0ba8e76251defe8be1d77a65ba1303cfb4676ab872384dac`
- Direct parser comparison SHA-256: `99c953c7dc53c839ce2d527c1aaee2982792b28b3a7216677372706fef78e6dd`

Elapsed time covers admitted turns, tools, completion, and history checks against a local deterministic provider. CPU snapshots can omit short-lived child processes. RSS samples cover the Gateway, including workers, and exclude provider/harness/tool subprocesses; brief peaks may be missed. Live proof establishes behavior and recorded usage, not independent provider billing or a live-service speedup.

</details>
