### PR TITLE
fix(cron): paginate history after session visibility filtering

### DIFF
--- a/src/cron/task-run-history.ts
+++ b/src/cron/task-run-history.ts
@@ -33,6 +33,8 @@ type ReadCronTaskRunHistoryPageOptions = {
   query?: string;
   sortDir?: CronRunHistorySortDir;
   jobNameById?: Record<string, string>;
+  /** Filter before paging so hidden runs cannot consume page slots or inflate totals. */
+  entryFilter?: (entry: CronRunLogEntry) => boolean;
 };
 
 type CronTaskRunHistoryPage = {
@@ -149,8 +151,9 @@ export function readCronTaskRunHistoryPage(
         return false;
       }
       return (
-        !query ||
-        normalizeLowercaseStringOrEmpty(queryText(entry, options.jobNameById)).includes(query)
+        (!query ||
+          normalizeLowercaseStringOrEmpty(queryText(entry, options.jobNameById)).includes(query)) &&
+        (!options.entryFilter || options.entryFilter(entry))
       );
     })
     .toSorted((left, right) => compareHistoryRows(left, right, sortDir));

--- a/src/gateway/server-methods/cron.runs.test.ts
+++ b/src/gateway/server-methods/cron.runs.test.ts
@@ -1,0 +1,253 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import type { CronRunLogEntry } from "../../cron/run-log-types.js";
+import { CronService } from "../../cron/service.js";
+import { createNoopLogger } from "../../cron/service.test-harness.js";
+import { cronStoreKey } from "../../cron/store/key.js";
+import {
+  cronRunLogEntryToTaskDetail,
+  cronRunStatusToTaskStatus,
+} from "../../cron/task-run-detail.js";
+import { saveTaskRegistryStateToSqlite } from "../../tasks/task-registry.store.sqlite.js";
+import type { TaskRecord } from "../../tasks/task-registry.types.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import { roleClient, rolePolicyConfig } from "../session-sharing.test-utils.js";
+import { cronHandlers } from "./cron.js";
+import type { GatewayClient, RespondFn } from "./types.js";
+
+async function withCronHistory(
+  run: (fixture: {
+    jobId: string;
+    foreignJobId: string;
+    cron: CronService;
+    query: (
+      params: Record<string, unknown>,
+      client?: GatewayClient,
+    ) => Promise<ReturnType<typeof vi.fn<RespondFn>>>;
+    viewer: GatewayClient;
+  }) => Promise<void>,
+) {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const cfg = {
+      ...rolePolicyConfig(),
+      agents: { entries: { main: { workspace: state.workspaceDir } } },
+    };
+    await state.writeConfig(cfg);
+    const owner = roleClient("none", "history-owner");
+    const foreign = roleClient("none", "history-foreign");
+    const viewer = roleClient("view", "history-viewer");
+    const ownKey = "agent:main:history-own";
+    const foreignKey = "agent:main:history-foreign";
+    for (const [sessionKey, client] of [
+      [ownKey, owner],
+      [foreignKey, foreign],
+    ] as const) {
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: sessionKey,
+          updatedAt: Date.now(),
+          createdActor: {
+            type: "human",
+            source: "profile",
+            id: expectDefined(client.authenticatedUserProfile, "fixture profile").profileId,
+          },
+        },
+      );
+    }
+    const storePath = state.path("cron", "jobs.json");
+    const cron = new CronService({
+      storePath,
+      defaultAgentId: "main",
+      cronEnabled: false,
+      log: createNoopLogger(),
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(),
+    });
+    try {
+      const jobs = [];
+      for (const sessionKey of [ownKey, foreignKey]) {
+        const result = await cron.add({
+          name: sessionKey,
+          agentId: "main",
+          owner: { agentId: "main", sessionKey },
+          enabled: false,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "fixture" },
+          delivery: { mode: "none" },
+        });
+        jobs.push("job" in result ? result.job : result);
+      }
+      const jobId = expectDefined(jobs[0], "own job").id;
+      const foreignJobId = expectDefined(jobs[1], "foreign job").id;
+      const rows: Array<Pick<CronRunLogEntry, "sessionKey" | "status" | "summary" | "jobId">> = [
+        { jobId, sessionKey: foreignKey, status: "error", summary: "needle hidden" },
+        { jobId, sessionKey: ownKey, status: "error", summary: "needle first" },
+        { jobId, sessionKey: foreignKey, status: "ok", summary: "other hidden" },
+        { jobId, status: "error", summary: "needle second" },
+        { jobId, sessionKey: ownKey, status: "ok", summary: "other third" },
+        { jobId: foreignJobId, sessionKey: ownKey, status: "error", summary: "needle foreign job" },
+      ];
+      const now = Date.now();
+      const tasks = rows.map((row, index): TaskRecord => {
+        const entry: CronRunLogEntry = {
+          ...row,
+          action: "finished",
+          ts: now + index,
+          runId: `history-run-${index}`,
+          deliveryStatus: row.status === "error" ? "not-delivered" : "delivered",
+        };
+        return {
+          taskId: `history-task-${index}`,
+          runtime: "cron",
+          sourceId: entry.jobId,
+          requesterSessionKey: "",
+          ownerKey: "",
+          scopeKind: "system",
+          childSessionKey: entry.sessionKey,
+          agentId: "main",
+          task: "history fixture",
+          status: cronRunStatusToTaskStatus(entry),
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          createdAt: entry.ts,
+          endedAt: entry.ts,
+          detail: cronRunLogEntryToTaskDetail(entry, { storeKey: cronStoreKey(storePath) }),
+        };
+      });
+      saveTaskRegistryStateToSqlite({
+        tasks: new Map(tasks.map((task) => [task.taskId, task])),
+        deliveryStates: new Map(),
+      });
+      const context = createDirectChatContext({
+        cron,
+        cronStorePath: storePath,
+        getRuntimeConfig: () => cfg,
+      });
+      const query = async (params: Record<string, unknown>, client = owner) => {
+        const respond = vi.fn<RespondFn>();
+        await expectDefined(
+          cronHandlers["cron.runs"],
+          "cron.runs handler",
+        )({
+          req: { type: "req", id: "history-request", method: "cron.runs", params },
+          params,
+          client,
+          respond,
+          context,
+          isWebchatConnect: () => false,
+        });
+        return respond;
+      };
+      await run({ jobId, foreignJobId, cron, query, viewer });
+    } finally {
+      cron.stop();
+    }
+  });
+}
+
+describe("cron.runs session visibility", () => {
+  it.each(["job", "all"] as const)(
+    "paginates visible %s history before counting and slicing",
+    async (scope) => {
+      await withCronHistory(async ({ jobId, query }) => {
+        const selector = scope === "job" ? { id: jobId } : { scope };
+        for (const [offset, summary] of [
+          "needle first",
+          "needle second",
+          "other third",
+        ].entries()) {
+          const respond = await query({
+            ...selector,
+            agentId: "MAIN",
+            limit: 1,
+            offset,
+            sortDir: "asc",
+          });
+          expect(respond).toHaveBeenCalledWith(
+            true,
+            {
+              entries: [expect.objectContaining({ summary })],
+              total: 3,
+              offset,
+              limit: 1,
+              hasMore: offset < 2,
+              nextOffset: offset < 2 ? offset + 1 : null,
+            },
+            undefined,
+          );
+        }
+        expect(await query({ ...selector, offset: 99, limit: 1 })).toHaveBeenCalledWith(
+          true,
+          {
+            entries: [],
+            total: 3,
+            offset: 3,
+            limit: 1,
+            hasMore: false,
+            nextOffset: null,
+          },
+          undefined,
+        );
+      });
+    },
+  );
+
+  it.each(["job", "all"] as const)("combines %s visibility with history filters", async (scope) => {
+    await withCronHistory(async ({ jobId, query }) => {
+      const respond = await query({
+        ...(scope === "job" ? { id: jobId } : { scope }),
+        agentId: "MAIN",
+        statuses: ["error"],
+        deliveryStatuses: ["not-delivered"],
+        query: "needle",
+        sortDir: "asc",
+        offset: 1,
+        limit: 1,
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          entries: [expect.objectContaining({ summary: "needle second" })],
+          total: 2,
+          offset: 1,
+          limit: 1,
+          hasMore: false,
+          nextOffset: null,
+        },
+        undefined,
+      );
+    });
+  });
+
+  it("keeps foreign jobs hidden and retained deleted-job history available to viewers", async () => {
+    await withCronHistory(async ({ jobId, foreignJobId, cron, query, viewer }) => {
+      expect(await query({ id: foreignJobId })).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ details: { code: "CRON_JOB_NOT_FOUND", jobId: foreignJobId } }),
+      );
+      await cron.remove(jobId);
+      expect(await query({ id: jobId })).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ details: { code: "CRON_JOB_NOT_FOUND", jobId } }),
+      );
+      expect(
+        await query({ id: jobId, limit: 1, runId: "history-run-1" }, viewer),
+      ).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          entries: [expect.objectContaining({ summary: "needle first" })],
+          total: 1,
+        }),
+        undefined,
+      );
+    });
+  });
+});

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -1399,51 +1399,18 @@ export const cronHandlers: GatewayRequestHandlers = {
           .filter((job) => typeof job.id === "string" && typeof job.name === "string")
           .map((job) => [job.id, job.name]),
       );
-      let page = readCronTaskRunHistoryPage({
+      const visibleJobIds = new Set(jobs.map((job) => job.id));
+      const page = readCronTaskRunHistoryPage({
         storeKey: cronStoreKey(context.cronStorePath),
         ...cronRunLogPageFilters(p),
         agentId: p.agentId,
         jobNameById,
+        entryFilter: cronVisibility
+          ? (entry) =>
+              visibleJobIds.has(entry.jobId) &&
+              (!entry.sessionKey || cronVisibility(entry.sessionKey, p.agentId))
+          : undefined,
       });
-      if (cronVisibility) {
-        const visibleJobIds = new Set(jobs.map((job) => job.id));
-        const visibleEntries: typeof page.entries = [];
-        let sourceOffset = 0;
-        for (;;) {
-          const sourcePage = readCronTaskRunHistoryPage({
-            storeKey: cronStoreKey(context.cronStorePath),
-            ...cronRunLogPageFilters(p),
-            offset: sourceOffset,
-            limit: 200,
-            agentId: p.agentId,
-            jobNameById,
-          });
-          visibleEntries.push(
-            ...sourcePage.entries.filter(
-              (entry) =>
-                visibleJobIds.has(entry.jobId) &&
-                (!entry.sessionKey || cronVisibility(entry.sessionKey, p.agentId)),
-            ),
-          );
-          if (!sourcePage.hasMore || sourcePage.nextOffset === null) {
-            break;
-          }
-          sourceOffset = sourcePage.nextOffset;
-        }
-        const total = visibleEntries.length;
-        const offset = Math.max(0, Math.min(total, Math.floor(p.offset ?? 0)));
-        const limit = Math.max(1, Math.min(200, Math.floor(p.limit ?? 50)));
-        const entries = visibleEntries.slice(offset, offset + limit);
-        const nextOffset = offset + entries.length;
-        page = {
-          entries,
-          total,
-          offset,
-          limit,
-          hasMore: nextOffset < total,
-          nextOffset: nextOffset < total ? nextOffset : null,
-        };
-      }
       respond(true, page, undefined);
       return;
     }
@@ -1479,26 +1446,15 @@ export const cronHandlers: GatewayRequestHandlers = {
         matchedJob && typeof matchedJob.name === "string"
           ? { [jobId]: matchedJob.name }
           : undefined;
-      let page = readCronTaskRunHistoryPage({
+      const page = readCronTaskRunHistoryPage({
         storeKey,
         jobId,
         ...cronRunLogPageFilters(p),
         jobNameById,
+        entryFilter: cronVisibility
+          ? (entry) => !entry.sessionKey || cronVisibility(entry.sessionKey, matchedJob?.agentId)
+          : undefined,
       });
-      if (cronVisibility) {
-        const visibleEntries = page.entries.filter(
-          (entry) => !entry.sessionKey || cronVisibility(entry.sessionKey, matchedJob?.agentId),
-        );
-        const total = visibleEntries.length;
-        page = {
-          ...page,
-          entries: visibleEntries,
-          total,
-          offset: Math.min(page.offset, total),
-          hasMore: false,
-          nextOffset: null,
-        };
-      }
       respond(true, page, undefined);
     } catch (err) {
       if (!isInvalidCronTaskRunJobIdError(err)) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Operators restricted to their own sessions can receive an empty or truncated cron history page even when more visible runs exist. The per-job `cron.runs` path filtered only the requested raw page, reported that page's survivors as the entire history, and always disabled further paging.

## Why This Change Was Made

The canonical history reader now applies the existing caller-supplied visibility predicate before sorting, counting, and slicing. Both per-job and all-job history use that one pager. This removes the per-job metadata rewrite and the all-job loop that repeatedly read and filtered 200-row pages.

## User Impact

Visible runs fill the requested page, totals count the full visible history, and continuation offsets reach the remaining results. Session ownership, hidden-job checks, caller capabilities, and retained deleted-job history keep their existing policy.

## Evidence

Two maintained per-job regressions fail on the starting source; the three all-job and ownership controls pass. After the repair, the selected history, gateway validation, run-filter, and session-sharing suites pass **264 tests**. All five focused regressions pass again after the final fixture cleanup.

An isolated real Gateway with synthetic authenticated profiles, real session records, and SQLite task history reproduced both failures through `GatewayClient`. Before the fix, a first page returned no rows and `total: 0` despite three visible runs, and an overlapping-filter page returned the wrong visible run. After the fix, all six client checks pass, including unrestricted-role and exact-run controls. The Gateway and clients close cleanly.

Production TypeScript: **+16/-57, net -41**. Tests: **+253/-0**. The change is an internal read projection; it adds no schema, store design, configuration, or protocol surface.

Fresh independent Codex review through P2 is scoped-clean with no findings (confidence 0.98).

Full changed-file checks exited 0, including core and test type checks, formatting, changed lint, boundaries, dead-export scans, storage guards, and runtime import-cycle checks.

Fixes #136042.
