### PR TITLE
test: batch npm fixture packing by install scenario

### DIFF
--- a/src/plugins/install.npm-spec.e2e.test.ts
+++ b/src/plugins/install.npm-spec.e2e.test.ts
@@ -19,8 +19,8 @@ import {
 } from "./install.npm-spec.test-support.js";
 import { runPluginPayloadSmokeCheck } from "./payload-verification.js";
 import {
-  packPlugin,
-  registryPackage,
+  packPlugins,
+  registryPackages,
   startStaticRegistry,
   startMutableRegistry,
   type RegistryPackage,
@@ -122,7 +122,7 @@ describe("installPluginFromNpmSpec e2e", () => {
   it("relocates a bundled plugin through real npm only after artifact consent", async () => {
     const { rootDir, npmRoot } = await makeInstallFixture("relocation-e2e");
     const packageName = uniquePackageName("relocated-plugin");
-    await useStaticRegistry([await registryPackage({ packageName, rootDir })]);
+    await useStaticRegistry(await registryPackages(rootDir, [{ packageName }]));
     const bundledPath = path.join(rootDir, "old", "extensions", packageName);
     const config: OpenClawConfig = {
       plugins: {
@@ -191,13 +191,12 @@ describe("installPluginFromNpmSpec e2e", () => {
       const packageName = uniquePackageName("delegated-install");
       const downloadBarrier = { requested: createDeferred(), released: createDeferred() };
       const registry = await startStaticRegistry(
-        [
-          await registryPackage({
+        await registryPackages(rootDir, [
+          {
             packageName,
-            rootDir,
             ...(kind === "hook pack" ? { hookName: "cancel-test-hook" } : {}),
-          }),
-        ],
+          },
+        ]),
         servers,
         downloadBarrier,
       );
@@ -371,20 +370,18 @@ describe("installPluginFromNpmSpec e2e", () => {
       install: { minHostVersion: ">=2026.4.25" },
       compat: { pluginApi: ">=2026.5.27" },
     };
-    const versions = [
-      await packPlugin({
+    const versions = await packPlugins(rootDir, [
+      {
         packageName,
         version: "2026.5.26",
-        rootDir,
         openclaw: compatibleOpenClaw,
-      }),
-      await packPlugin({
+      },
+      {
         packageName,
         version: "2026.5.27",
-        rootDir,
         openclaw: incompatibleOpenClaw,
-      }),
-    ];
+      },
+    ]);
     await useStaticRegistry([{ packageName, latest: "2026.5.27", versions }]);
     const previousHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
     process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = "2026.5.10-beta.1";
@@ -421,20 +418,20 @@ describe("installPluginFromNpmSpec e2e", () => {
   it("scrubs root openclaw materialized by required npm peers", async () => {
     const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-required-peer-e2e");
     const packageName = uniquePackageName("required-peer-plugin");
-    const registry = await useStaticRegistry([
-      await registryPackage({
-        packageName,
-        peerDependencies: { openclaw: ">=2026.0.0" },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-      await registryPackage({
-        packageName: "openclaw",
-        pluginId: "registry-openclaw-copy",
-        version: "2026.0.0",
-        rootDir,
-      }),
-    ]);
+    const registry = await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          packageName,
+          peerDependencies: { openclaw: ">=2026.0.0" },
+          peerDependenciesMeta: {},
+        },
+        {
+          packageName: "openclaw",
+          pluginId: "registry-openclaw-copy",
+          version: "2026.0.0",
+        },
+      ]),
+    );
 
     const rawNpmRoot = path.join(rootDir, "raw-managed-npm");
     await fs.mkdir(rawNpmRoot, { recursive: true });
@@ -497,16 +494,17 @@ describe("installPluginFromNpmSpec e2e", () => {
     const pluginWithRuntimePeer = uniquePackageName("runtime-peer-plugin");
     const laterPlugin = uniquePackageName("later-plugin");
     const runtimePeer = uniquePackageName("runtime-peer");
-    await useStaticRegistry([
-      await registryPackage({
-        packageName: pluginWithRuntimePeer,
-        peerDependencies: { [runtimePeer]: "^1.0.0" },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-      await registryPackage({ packageName: laterPlugin, rootDir }),
-      await registryPackage({ packageName: runtimePeer, rootDir }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          packageName: pluginWithRuntimePeer,
+          peerDependencies: { [runtimePeer]: "^1.0.0" },
+          peerDependenciesMeta: {},
+        },
+        { packageName: laterPlugin },
+        { packageName: runtimePeer },
+      ]),
+    );
 
     const first = await installNpmPlugin({
       spec: `${pluginWithRuntimePeer}@1.0.0`,
@@ -538,20 +536,20 @@ describe("installPluginFromNpmSpec e2e", () => {
     const pluginWithOptionalDependency = uniquePackageName("optional-owner-plugin");
     const optionalDependency = uniquePackageName("optional-dep");
     const runtimePeer = uniquePackageName("optional-peer");
-    await useStaticRegistry([
-      await registryPackage({
-        packageName: pluginWithOptionalDependency,
-        optionalDependencies: { [optionalDependency]: "1.0.0" },
-        rootDir,
-      }),
-      await registryPackage({
-        packageName: optionalDependency,
-        peerDependencies: { [runtimePeer]: "^1.0.0" },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-      await registryPackage({ packageName: runtimePeer, rootDir }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          packageName: pluginWithOptionalDependency,
+          optionalDependencies: { [optionalDependency]: "1.0.0" },
+        },
+        {
+          packageName: optionalDependency,
+          peerDependencies: { [runtimePeer]: "^1.0.0" },
+          peerDependenciesMeta: {},
+        },
+        { packageName: runtimePeer },
+      ]),
+    );
 
     const result = await installNpmPlugin({
       spec: `${pluginWithOptionalDependency}@1.0.0`,
@@ -581,16 +579,17 @@ describe("installPluginFromNpmSpec e2e", () => {
     const pluginWithRuntimePeer = uniquePackageName("existing-peer-plugin");
     const laterPlugin = uniquePackageName("later-plugin");
     const runtimePeer = uniquePackageName("runtime-peer");
-    await useStaticRegistry([
-      await registryPackage({
-        packageName: pluginWithRuntimePeer,
-        peerDependencies: { [runtimePeer]: "^1.0.0" },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-      await registryPackage({ packageName: laterPlugin, rootDir }),
-      await registryPackage({ indexJs: "eval('1');\n", packageName: runtimePeer, rootDir }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          packageName: pluginWithRuntimePeer,
+          peerDependencies: { [runtimePeer]: "^1.0.0" },
+          peerDependenciesMeta: {},
+        },
+        { packageName: laterPlugin },
+        { indexJs: "eval('1');\n", packageName: runtimePeer },
+      ]),
+    );
 
     await installProjectDependencies(npmRoot, { [pluginWithRuntimePeer]: "1.0.0" });
     await expect(
@@ -625,10 +624,12 @@ describe("installPluginFromNpmSpec e2e", () => {
     const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-cycle-e2e");
     const existingPlugin = uniquePackageName("existing-plugin");
     const laterPlugin = uniquePackageName("later-plugin");
-    await useStaticRegistry([
-      await registryPackage({ packageName: existingPlugin, rootDir }),
-      await registryPackage({ packageName: laterPlugin, rootDir }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        { packageName: existingPlugin },
+        { packageName: laterPlugin },
+      ]),
+    );
 
     await installProjectDependencies(npmRoot, { [existingPlugin]: "1.0.0" });
     const existingPluginDir = path.join(npmRoot, "node_modules", existingPlugin);
@@ -658,16 +659,17 @@ describe("installPluginFromNpmSpec e2e", () => {
     const policyExec = await createInstalledPackageTreePolicyExec(rootDir);
     const blockedPlugin = uniquePackageName("blocked-plugin");
     const runtimePeer = uniquePackageName("runtime-peer");
-    await useStaticRegistry([
-      await registryPackage({
-        indexJs: "eval('1');\n",
-        packageName: blockedPlugin,
-        peerDependencies: { [runtimePeer]: "^1.0.0" },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-      await registryPackage({ packageName: runtimePeer, rootDir }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          indexJs: "eval('1');\n",
+          packageName: blockedPlugin,
+          peerDependencies: { [runtimePeer]: "^1.0.0" },
+          peerDependenciesMeta: {},
+        },
+        { packageName: runtimePeer },
+      ]),
+    );
 
     const result = await installNpmPlugin({
       config: configWithInstalledPackageTreeBlockPolicy(policyExec),
@@ -705,14 +707,15 @@ describe("installPluginFromNpmSpec e2e", () => {
     const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-plan-fallback-e2e");
     const blockedPlugin = uniquePackageName("missing-peer-plugin");
     const missingPeer = uniquePackageName("missing-peer");
-    await useStaticRegistry([
-      await registryPackage({
-        packageName: blockedPlugin,
-        peerDependencies: { [missingPeer]: "^1.0.0" },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          packageName: blockedPlugin,
+          peerDependencies: { [missingPeer]: "^1.0.0" },
+          peerDependenciesMeta: {},
+        },
+      ]),
+    );
 
     const result = await installNpmPlugin({
       spec: `${blockedPlugin}@1.0.0`,
@@ -739,20 +742,21 @@ describe("installPluginFromNpmSpec e2e", () => {
     const existingRootDependency = uniquePackageName("existing-root");
     const blockedPlugin = uniquePackageName("blocked-plugin");
     const runtimePeer = uniquePackageName("runtime-peer");
-    await useStaticRegistry([
-      await registryPackage({ packageName: existingRootDependency, rootDir }),
-      await registryPackage({
-        indexJs: "eval('1');\n",
-        packageName: blockedPlugin,
-        peerDependencies: {
-          [existingRootDependency]: "^1.0.0",
-          [runtimePeer]: "^1.0.0",
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        { packageName: existingRootDependency },
+        {
+          indexJs: "eval('1');\n",
+          packageName: blockedPlugin,
+          peerDependencies: {
+            [existingRootDependency]: "^1.0.0",
+            [runtimePeer]: "^1.0.0",
+          },
+          peerDependenciesMeta: {},
         },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-      await registryPackage({ packageName: runtimePeer, rootDir }),
-    ]);
+        { packageName: runtimePeer },
+      ]),
+    );
 
     const blockedProjectRoot = pluginNpmProjectRoot(npmRoot, blockedPlugin);
     await installProjectDependencies(blockedProjectRoot, {
@@ -799,26 +803,25 @@ describe("installPluginFromNpmSpec e2e", () => {
     const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-sibling-peer-e2e");
     const codexName = uniquePackageName("codex-peer-plugin");
     const opikName = uniquePackageName("opik-peer-plugin");
-    await useStaticRegistry([
-      await registryPackage({
-        packageName: codexName,
-        peerDependencies: { openclaw: ">=2026.5.5-beta.2" },
-        peerDependenciesMeta: { openclaw: { optional: true } },
-        rootDir,
-      }),
-      await registryPackage({
-        packageName: opikName,
-        peerDependencies: { openclaw: ">=2026.3.2" },
-        peerDependenciesMeta: {},
-        rootDir,
-      }),
-      await registryPackage({
-        packageName: "openclaw",
-        pluginId: "registry-openclaw-copy",
-        version: "2026.5.4",
-        rootDir,
-      }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          packageName: codexName,
+          peerDependencies: { openclaw: ">=2026.5.5-beta.2" },
+          peerDependenciesMeta: { openclaw: { optional: true } },
+        },
+        {
+          packageName: opikName,
+          peerDependencies: { openclaw: ">=2026.3.2" },
+          peerDependenciesMeta: {},
+        },
+        {
+          packageName: "openclaw",
+          pluginId: "registry-openclaw-copy",
+          version: "2026.5.4",
+        },
+      ]),
+    );
 
     const first = await installNpmPlugin({
       spec: `${codexName}@1.0.0`,
@@ -863,14 +866,15 @@ describe("installPluginFromNpmSpec e2e", () => {
     const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-peer-e2e");
     const peerPackageName = uniquePackageName("peer-plugin");
     const laterPackageName = uniquePackageName("later-plugin");
-    await useStaticRegistry([
-      await registryPackage({
-        packageName: peerPackageName,
-        peerDependencies: { openclaw: ">=2026.0.0" },
-        rootDir,
-      }),
-      await registryPackage({ packageName: laterPackageName, rootDir }),
-    ]);
+    await useStaticRegistry(
+      await registryPackages(rootDir, [
+        {
+          packageName: peerPackageName,
+          peerDependencies: { openclaw: ">=2026.0.0" },
+        },
+        { packageName: laterPackageName },
+      ]),
+    );
 
     const first = await installNpmPlugin({
       spec: `${peerPackageName}@1.0.0`,
@@ -905,10 +909,10 @@ describe("installPluginFromNpmSpec e2e", () => {
   it("pins a mutable npm tag to the version resolved before install", async () => {
     const { rootDir, npmRoot } = await makeInstallFixture("npm-plugin-e2e");
     const packageName = uniquePackageName("mutable-plugin");
-    const versions = [
-      await packPlugin({ packageName, version: "1.0.0", rootDir }),
-      await packPlugin({ packageName, version: "2.0.0", rootDir }),
-    ];
+    const versions = await packPlugins(rootDir, [
+      { packageName, version: "1.0.0" },
+      { packageName, version: "2.0.0" },
+    ]);
     const registry = await startMutableRegistry(
       {
         packageName,

--- a/src/plugins/test-helpers/npm-registry-fixtures.ts
+++ b/src/plugins/test-helpers/npm-registry-fixtures.ts
@@ -4,7 +4,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
-import { resolveNpmJsonEntries } from "../../infra/npm-registry-spec.js";
+import { expectDefined } from "@openclaw/normalization-core";
 import type { Deferred } from "../../shared/deferred.js";
 
 type PackedVersion = {
@@ -30,7 +30,6 @@ type PackPluginParams = {
   peerDependencies?: Record<string, string>;
   peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   pluginId?: string;
-  rootDir: string;
   version?: string;
 };
 
@@ -40,107 +39,123 @@ export type RegistryPackage = {
   versions: PackedVersion[];
 };
 
-export async function packPlugin(params: PackPluginParams): Promise<PackedVersion> {
-  const version = params.version ?? "1.0.0";
-  const packageDir = path.join(params.rootDir, `package-${params.packageName}-${version}`);
-  const peerDependenciesMeta = params.peerDependencies
-    ? (params.peerDependenciesMeta ??
-      Object.fromEntries(
-        Object.keys(params.peerDependencies).map((name) => [name, { optional: true }]),
-      ))
-    : undefined;
-  await fs.mkdir(path.join(packageDir, "dist"), { recursive: true });
-  await fs.writeFile(
-    path.join(packageDir, "package.json"),
-    `${JSON.stringify(
-      {
-        name: params.packageName,
-        version,
-        type: "module",
-        openclaw:
-          params.openclaw ??
-          (params.hookName
-            ? { hooks: [`./hooks/${params.hookName}`] }
-            : { extensions: ["./dist/index.js"] }),
-        ...(params.dependencies ? { dependencies: params.dependencies } : {}),
-        ...(params.optionalDependencies
-          ? { optionalDependencies: params.optionalDependencies }
-          : {}),
-        ...(params.peerDependencies
-          ? {
-              peerDependencies: params.peerDependencies,
-              ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
-            }
-          : {}),
-      },
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  );
-  if (params.hookName) {
-    const hookDir = path.join(packageDir, "hooks", params.hookName);
-    await fs.mkdir(hookDir, { recursive: true });
+export async function packPlugins(
+  rootDir: string,
+  packages: [PackPluginParams, ...PackPluginParams[]],
+): Promise<PackedVersion[]> {
+  const prepared = [];
+  for (const params of packages) {
+    const version = params.version ?? "1.0.0";
+    const packageDir = path.join(rootDir, `package-${params.packageName}-${version}`);
+    const peerDependenciesMeta = params.peerDependencies
+      ? (params.peerDependenciesMeta ??
+        Object.fromEntries(
+          Object.keys(params.peerDependencies).map((name) => [name, { optional: true }]),
+        ))
+      : undefined;
+    await fs.mkdir(path.join(packageDir, "dist"), { recursive: true });
     await fs.writeFile(
-      path.join(hookDir, "HOOK.md"),
-      `---\nname: ${params.hookName}\ndescription: Install cancellation fixture\nmetadata: {"openclaw":{"events":["command:new"]}}\n---\n`,
-    );
-    await fs.writeFile(path.join(hookDir, "handler.js"), "export default async () => {};\n");
-  } else {
-    await fs.writeFile(
-      path.join(packageDir, "openclaw.plugin.json"),
+      path.join(packageDir, "package.json"),
       `${JSON.stringify(
         {
-          id: params.pluginId ?? params.packageName,
-          name: params.pluginId ?? params.packageName,
-          configSchema: { type: "object" },
+          name: params.packageName,
+          version,
+          type: "module",
+          openclaw:
+            params.openclaw ??
+            (params.hookName
+              ? { hooks: [`./hooks/${params.hookName}`] }
+              : { extensions: ["./dist/index.js"] }),
+          ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+          ...(params.optionalDependencies
+            ? { optionalDependencies: params.optionalDependencies }
+            : {}),
+          ...(params.peerDependencies
+            ? {
+                peerDependencies: params.peerDependencies,
+                ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
+              }
+            : {}),
         },
         null,
         2,
       )}\n`,
       "utf8",
     );
+    if (params.hookName) {
+      const hookDir = path.join(packageDir, "hooks", params.hookName);
+      await fs.mkdir(hookDir, { recursive: true });
+      await fs.writeFile(
+        path.join(hookDir, "HOOK.md"),
+        `---\nname: ${params.hookName}\ndescription: Install cancellation fixture\nmetadata: {"openclaw":{"events":["command:new"]}}\n---\n`,
+      );
+      await fs.writeFile(path.join(hookDir, "handler.js"), "export default async () => {};\n");
+    } else {
+      await fs.writeFile(
+        path.join(packageDir, "openclaw.plugin.json"),
+        `${JSON.stringify(
+          {
+            id: params.pluginId ?? params.packageName,
+            name: params.pluginId ?? params.packageName,
+            configSchema: { type: "object" },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+    }
+    await fs.writeFile(
+      path.join(packageDir, "dist", "index.js"),
+      params.indexJs ?? "export {};\n",
+      "utf8",
+    );
+    prepared.push({ params, packageDir, peerDependenciesMeta, version });
   }
-  await fs.writeFile(
-    path.join(packageDir, "dist", "index.js"),
-    params.indexJs ?? "export {};\n",
-    "utf8",
-  );
 
-  const packOutput = execFileSync(
+  execFileSync(
     "npm",
-    ["pack", "--json", "--ignore-scripts", "--pack-destination", params.rootDir],
-    { cwd: packageDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    [
+      "pack",
+      "--ignore-scripts",
+      "--pack-destination",
+      rootDir,
+      ...prepared.map(({ packageDir }) => packageDir),
+    ],
+    { cwd: rootDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
   );
-  const parsed = resolveNpmJsonEntries(JSON.parse(packOutput)) as Array<{ filename: string }>;
-  const tarballName = parsed[0]?.filename;
-  if (!tarballName) {
-    throw new Error(`npm pack did not return a tarball for ${params.packageName}`);
+  const versions: PackedVersion[] = [];
+  for (const { params, peerDependenciesMeta, version } of prepared) {
+    // npm 12 keys JSON output by name, which collapses two versions of one package.
+    // Read each manifest-named archive instead; a missing artifact remains a fixture failure.
+    const tarballName = `${params.packageName.replace(/^@/, "").replaceAll("/", "-")}-${version}.tgz`;
+    const archive = await fs.readFile(path.join(rootDir, tarballName));
+    versions.push({
+      archive,
+      ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+      integrity: `sha512-${crypto.createHash("sha512").update(archive).digest("base64")}`,
+      ...(params.openclaw ? { openclaw: params.openclaw } : {}),
+      ...(params.optionalDependencies ? { optionalDependencies: params.optionalDependencies } : {}),
+      ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
+      ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
+      shasum: crypto.createHash("sha1").update(archive).digest("hex"),
+      tarballName,
+      version,
+    });
   }
-  const archive = await fs.readFile(path.join(params.rootDir, tarballName));
-  return {
-    archive,
-    ...(params.dependencies ? { dependencies: params.dependencies } : {}),
-    integrity: `sha512-${crypto.createHash("sha512").update(archive).digest("base64")}`,
-    ...(params.openclaw ? { openclaw: params.openclaw } : {}),
-    ...(params.optionalDependencies ? { optionalDependencies: params.optionalDependencies } : {}),
-    ...(params.peerDependencies ? { peerDependencies: params.peerDependencies } : {}),
-    ...(peerDependenciesMeta ? { peerDependenciesMeta } : {}),
-    shasum: crypto.createHash("sha1").update(archive).digest("hex"),
-    tarballName,
-    version,
-  };
+  return versions;
 }
 
-export async function registryPackage(
-  params: PackPluginParams & { latest?: string },
-): Promise<RegistryPackage> {
-  const version = params.version ?? "1.0.0";
-  return {
+export async function registryPackages(
+  rootDir: string,
+  packages: [PackPluginParams & { latest?: string }, ...(PackPluginParams & { latest?: string })[]],
+): Promise<RegistryPackage[]> {
+  const versions = await packPlugins(rootDir, packages);
+  return packages.map((params, index) => ({
     packageName: params.packageName,
-    latest: params.latest ?? version,
-    versions: [await packPlugin({ ...params, version })],
-  };
+    latest: params.latest ?? params.version ?? "1.0.0",
+    versions: [expectDefined(versions[index], "packed fixture version")],
+  }));
 }
 
 export async function startStaticRegistry(


### PR DESCRIPTION
## Summary
The npm install E2E fixtures spawned npm separately for every package, including packages that belong to the same installation scenario. Prepare those package directories together and use npm's native multi-directory pack operation. The 15 scenarios still build31real archives, with15npm invocations instead of31.

The fixture owner now exposes plural pack/registry helpers and all callers use that one path. Archive names come from the same package name/version rule used by npm: npm12JSON output keys packages by name and cannot represent both fixture versions reliably. Reading the expected archive preserves a missing-artifact failure instead of silently losing one version.

## Validation
On the same clean Linux Testbox, Node24.19.0 and npm11.17.0:
- Before:15/15passed,29.728seconds summed case execution,34.64seconds Vitest.
- After:the same ordered15/15passed,29.299seconds summed case execution,33.09seconds Vitest.
- Both ran the normal build and actual npm installation/loopback registry flows. Build wall time varied and is excluded from the claim. Real installation/cancellation costs dominate the suite, so no large whole-suite speedup is claimed.
- All86existing assertion sites remain, including delegated-authority cancellation, artifact consent, compatible-version selection, peers, rollback, isolated project ownership and mutable-tag pinning.

    node scripts/run-vitest.mjs src/plugins/install.npm-spec.e2e.test.ts

A separate real npm12.0.2 contract probe compared sequential and batched archives across names/scopes, two versions of one package, peers, optional dependencies, hooks and workspace defaults. It compared complete tar entry contents/types/modes, manifests, registry metadata, and hashes/integrity. Missing-manifest and missing-archive fault pairs propagated the actual errors and cleaned every owned temporary root; all21observed npm commands finished. An initial supplemental assumption that a declared bin must be executable was false even in the original fixture; that probe assertion was corrected to compare the observed archive modes, retaining the full before/after mode comparison.

Changed-scope structural/boundary/format guards, production typing, plugin-platform test typing, focused lint and all three dead-export scans passed locally. Broad core-test typing is blocked locally by the checkout's missing Mermaid package; exact-head hosted CI is required before landing. Codex P0 autoreview is scoped-clean(0.98).

Production LOC+0/-0. Tests/support+236/-217(net+19), primarily moving the existing fixture preparation into a batch and formatting its callsites. No runtime, schema, dependency, SDK, timeout, assertion or mock expansion. No live external provider is involved.

Final landing checks: exact-head [CI33598648940](https://github.com/openclaw/openclaw/actions/runs/33598648940) passed, including all five core-test type shards. The completed ClawSweeper review has no findings or before-merge items. Its generic serialized-data notice applies to temporary npm/registry fixture artifacts only: this PR changes no operator state, data schema or upgrade contract, so no migration is applicable. Normal maintainer landing is covered by the requested autonomous batch.
