### PR TITLE
fix(hooks): install optional hook-pack dependencies

### DIFF
--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -192,9 +192,11 @@ non-latest tag such as `@beta` or `@rc`. Use `npm:` to select npm explicitly; th
 unified installer supports other plugin sources described in
 [`openclaw plugins`](/cli/plugins).
 
-Supported local archives are `.zip`, `.tgz`, `.tar.gz`, and `.tar`. npm pack and
-project-local dependency installation use `--ignore-scripts`; this does not
-sandbox the installed handler.
+Supported local archives are `.zip`, `.tgz`, `.tar.gz`, and `.tar`. Copied hook
+packs resolve runtime packages from `dependencies` and `optionalDependencies`,
+including packs with only optional dependencies. Packages listed only in
+`devDependencies` are omitted. npm pack and dependency installation use
+`--ignore-scripts`; this does not sandbox the installed handler.
 
 ### Install options and trust
 

--- a/src/hooks/install.runtime.ts
+++ b/src/hooks/install.runtime.ts
@@ -7,10 +7,7 @@ import {
   resolveInstallModeOptions,
   resolveTimedInstallModeOptions,
 } from "../infra/install-mode-options.js";
-import {
-  installPackageDir,
-  installPackageDirWithManifestDeps,
-} from "../infra/install-package-dir.js";
+import { installPackageDir } from "../infra/install-package-dir.js";
 import {
   type NpmIntegrityDrift,
   type NpmSpecResolution,
@@ -32,7 +29,6 @@ export {
   pathExists as fileExists,
   installFromValidatedNpmSpecArchive,
   installPackageDir,
-  installPackageDirWithManifestDeps,
   isPathInside,
   isPathInsideWithRealpath,
   readJson as readJsonFile,

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -121,6 +121,7 @@ function writeHookPackManifest(params: {
   pkgDir: string;
   hooks: string[];
   dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
   extensions?: string[];
 }) {
   fs.writeFileSync(
@@ -133,6 +134,7 @@ function writeHookPackManifest(params: {
         ...(params.extensions ? { extensions: params.extensions } : {}),
       },
       ...(params.dependencies ? { dependencies: params.dependencies } : {}),
+      ...(params.optionalDependencies ? { optionalDependencies: params.optionalDependencies } : {}),
     }),
     "utf-8",
   );
@@ -152,10 +154,14 @@ function writeHookPackFiles(params: {
   hookName: string;
   hookDescription: string;
   heading: string;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
 }) {
   writeHookPackManifest({
     pkgDir: params.pkgDir,
     hooks: [`./hooks/${params.hookName}`],
+    dependencies: params.dependencies,
+    optionalDependencies: params.optionalDependencies,
   });
   const hookDir = path.join(params.pkgDir, "hooks", params.hookName);
   fs.mkdirSync(hookDir, { recursive: true });
@@ -390,45 +396,33 @@ describe("installHooksFromPath", () => {
     }
   });
 
-  it("uses --ignore-scripts for dependency install", async () => {
-    const workDir = makeTempDir();
-    const stateDir = makeTempDir();
-    const pkgDir = path.join(workDir, "package");
-    fs.mkdirSync(path.join(pkgDir, "hooks", "one-hook"), { recursive: true });
-    writeHookPackManifest({
-      pkgDir,
-      hooks: ["./hooks/one-hook"],
-      dependencies: { "left-pad": "1.3.0" },
-    });
-    fs.writeFileSync(
-      path.join(pkgDir, "hooks", "one-hook", "HOOK.md"),
-      [
-        "---",
-        "name: one-hook",
-        "description: One hook",
-        'metadata: {"openclaw":{"events":["command:new"]}}',
-        "---",
-        "",
-        "# One Hook",
-      ].join("\n"),
-      "utf-8",
-    );
-    fs.writeFileSync(
-      path.join(pkgDir, "hooks", "one-hook", "handler.ts"),
-      "export default async () => {};\n",
-      "utf-8",
-    );
+  it.each(["dependencies", "optionalDependencies"] as const)(
+    "installs %s with lifecycle scripts disabled",
+    async (dependencyField) => {
+      const workDir = makeTempDir();
+      const stateDir = makeTempDir();
+      const pkgDir = path.join(workDir, "package");
+      fs.mkdirSync(pkgDir, { recursive: true });
+      writeHookPackFiles({
+        pkgDir,
+        packageName: "@openclaw/test-hooks",
+        hookName: "one-hook",
+        hookDescription: "One hook",
+        heading: "One Hook",
+        [dependencyField]: { "left-pad": "1.3.0" },
+      });
 
-    const run = runCommandWithTimeoutMock;
-    await expectInstallUsesIgnoreScripts({
-      run,
-      install: async () =>
-        await installHooksFromPath({
-          path: pkgDir,
-          hooksDir: path.join(stateDir, "hooks"),
-        }),
-    });
-  });
+      const run = runCommandWithTimeoutMock;
+      await expectInstallUsesIgnoreScripts({
+        run,
+        install: async () =>
+          await installHooksFromPath({
+            path: pkgDir,
+            hooksDir: path.join(stateDir, "hooks"),
+          }),
+      });
+    },
+  );
 
   it("installs a single hook directory", async () => {
     const stateDir = makeTempDir();

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -3,7 +3,10 @@
 import path from "node:path";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
-import { copyPackageDirInstallTransactionRequest } from "../infra/install-package-dir.js";
+import {
+  copyPackageDirInstallTransactionRequest,
+  hasPackageRuntimeDependencies,
+} from "../infra/install-package-dir.js";
 import { resolveSafeInstallDir, unscopedPackageName } from "../infra/install-safe-path.js";
 import type { NpmIntegrityDrift, NpmSpecResolution } from "../infra/install-source-utils.js";
 import { readRegularFile } from "../infra/regular-file.js";
@@ -35,6 +38,7 @@ type HookPackageManifest = {
   name?: string;
   version?: string;
   dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
 } & Partial<Record<typeof MANIFEST_KEY, { extensions?: string[]; hooks?: string[] }>>;
 
 export type InstallHooksResult =
@@ -520,7 +524,8 @@ async function installHookPackageFromDir(
     };
   }
 
-  const installRes = await runtime.installPackageDirWithManifestDeps(
+  const hasDeps = hasPackageRuntimeDependencies(manifest);
+  const installRes = await runtime.installPackageDir(
     copyPackageDirInstallTransactionRequest(params, {
       sourceDir: params.packageDir,
       targetDir,
@@ -529,7 +534,8 @@ async function installHookPackageFromDir(
       logger,
       copyErrorPrefix: "failed to copy hook pack",
       depsLogMessage: "Installing hook pack dependencies…",
-      manifestDependencies: manifest.dependencies,
+      hasDeps,
+      sourceHardlinks: hasDeps ? "package-manager" : "reject",
       beforePersistentApply: params.beforePersistentApply,
       afterInstall: async (installedDir) => {
         const dependencyPolicyFailure = await runHookInstalledDependencyPolicy({

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -30,6 +30,16 @@ type HiddenProjectConfigFile = {
 type InstallPackageDirFailure = { ok: false; error: string };
 type InstallPackageDirSuccess = { ok: true };
 
+export function hasPackageRuntimeDependencies(manifest: {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}): boolean {
+  return (
+    Object.keys(manifest.dependencies ?? {}).length > 0 ||
+    Object.keys(manifest.optionalDependencies ?? {}).length > 0
+  );
+}
+
 async function sanitizeManifestForNpmInstall(targetDir: string): Promise<void> {
   const manifestPath = path.join(targetDir, "package.json");
   const parsed = await tryReadJson<unknown>(manifestPath);
@@ -477,32 +487,4 @@ export async function installPackageDir<
       },
     },
   );
-}
-
-/**
- * Installs a manifest-backed package directory while deriving whether npm
- * dependencies must be installed and which hardlink policy is safe to use.
- */
-export async function installPackageDirWithManifestDeps<
-  TAfterInstallFailure extends InstallPackageDirFailure = InstallPackageDirFailure,
->(params: {
-  sourceDir: string;
-  targetDir: string;
-  mode: "install" | "update";
-  timeoutMs: number;
-  logger?: { info?: (message: string) => void; warn?: (message: string) => void };
-  copyErrorPrefix: string;
-  depsLogMessage: string;
-  manifestDependencies?: Record<string, unknown>;
-  afterCopy?: (installedDir: string) => void | Promise<void>;
-  afterInstall?: (installedDir: string) => Promise<InstallPackageDirSuccess | TAfterInstallFailure>;
-  afterBackup?: (backupDir: string) => Promise<InstallPackageDirSuccess | TAfterInstallFailure>;
-  beforePersistentApply?: () => void;
-}): Promise<InstallPackageDirSuccess | InstallPackageDirFailure | TAfterInstallFailure> {
-  const hasDeps = Object.keys(params.manifestDependencies ?? {}).length > 0;
-  return installPackageDir<TAfterInstallFailure>({
-    ...params,
-    hasDeps,
-    sourceHardlinks: hasDeps ? "package-manager" : "reject",
-  });
 }

--- a/src/plugins/install-installed-package.ts
+++ b/src/plugins/install-installed-package.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasPackageRuntimeDependencies } from "../infra/install-package-dir.js";
 import { packageNameMatchesId } from "../infra/install-safe-path.js";
 import type { InstallPolicySource } from "../security/install-policy.js";
 import { matchesExpectedPluginId, validatePluginId } from "./install-paths.js";
@@ -11,7 +12,6 @@ import {
   emitSuccessfulPluginInstallSecurityEvent,
   ensureOpenClawExtensions,
   formatUnresolvedOpenClawPeerLinkError,
-  hasPackageRuntimeDependencies,
   loadPluginInstallRuntime,
   readOptionalPackageManifest,
   runInstallSourceScan,

--- a/src/plugins/install-shared.ts
+++ b/src/plugins/install-shared.ts
@@ -213,13 +213,6 @@ export function emitSuccessfulPluginInstallSecurityEvent(
   });
 }
 
-export function hasPackageRuntimeDependencies(manifest: PackageManifest): boolean {
-  return (
-    Object.keys(manifest.dependencies ?? {}).length > 0 ||
-    Object.keys(manifest.optionalDependencies ?? {}).length > 0
-  );
-}
-
 function buildBlockedInstallResult(params: {
   blocked: NonNullable<NonNullable<InstallSecurityScanResult>["blocked"]>;
 }): Extract<InstallPluginResult, { ok: false }> {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Hook packs with only optional runtime dependencies reported success without installing those packages, so their handlers always lost the optional capability. The hook owner passed only ordinary dependencies to a one-use installer wrapper.

## Why This Change Was Made

Move the existing ordinary-plus-optional predicate from plugin installation to the generic package installer and use it from both owners. Delete the one-use manifest wrapper and its runtime export. The installed npm12 dependency contract and real offline installs confirm the intended behavior.

## User Impact

Copied hook packs now attempt optional runtime dependencies, including optional-only packs. Ordinary hook installs and plugin-local copies retain their behavior. Npm still owns optional-package failure semantics; lifecycle scripts remain disabled and dev-only packages omitted. Source/dependency scans, hardlink decisions, staged publication, and deferred rollback retain their contracts. No configuration, schema, protocol, dependency, or public API surface is added.

## Evidence

The new optional-only regression fails on the starting owner while the ordinary dependency control passes. After the repair, 189 hook/plugin/shared-installer tests pass; the final hook file passes35 and the two targeted cases pass independently again.

Real offline npm12.0.2 proof used the same synthetic dependency tarball before and after, actual filesystem staging, real scanners, and imported/invoked the installed handler. Directory and archive ordinary-dependency controls pass throughout. Both optional-only installs return the unavailable fallback before; all four installs materialize the dependency and return the expected handler value after. No registry, credentials, or operator state was used.

Production **+21/-44, net -23**; tests **+32/-38, net -6**; docs **+5/-3**. The deletion comes from the redundant manifest wrapper, beyond moving the shared predicate.

Full changed-file checks pass, including typechecks, lint/format, boundaries, dead exports, storage guards, and runtime cycles. An initial test-file line-limit failure was fixed by reusing its existing fixture; the unweakened full gate passed afterward. Independent Codex review through P2 is scoped-clean with no findings.

Fixes #136046.
