### PR TITLE
fix(process): bind lifecycle and output activity to each admission

### DIFF
--- a/src/agents/cli-runner/execute.pending-cancellation.test.ts
+++ b/src/agents/cli-runner/execute.pending-cancellation.test.ts
@@ -34,6 +34,7 @@ function createTestAdapter(): TestAdapter {
   let stderrListener: ((chunk: string) => void) | undefined;
   const adapter: TestAdapter = {
     pid: 1234,
+    supportsRawOutput: false,
     onStdout: (listener) => {
       stdoutListener = listener;
     },

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -505,6 +505,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     pid: child.pid ?? undefined,
     stdin,
     oomScoreWrapperSelected: preparedSpawn.wrapped,
+    supportsRawOutput: true,
     onStdout,
     onStderr,
     wait,

--- a/src/process/supervisor/adapters/pty.ts
+++ b/src/process/supervisor/adapters/pty.ts
@@ -193,6 +193,7 @@ export async function createPtyAdapter(params: {
     pid: pty.pid || undefined,
     stdin,
     oomScoreWrapperSelected: preparedSpawn.wrapped,
+    supportsRawOutput: false,
     onStdout,
     onStderr,
     wait,

--- a/src/process/supervisor/registry.test.ts
+++ b/src/process/supervisor/registry.test.ts
@@ -15,7 +15,7 @@ function addRecord(
     backendId?: string;
   },
 ) {
-  registry.add({
+  return registry.add({
     runId: params.runId,
     sessionId: params.sessionId,
     backendId: params.backendId ?? "b1",
@@ -31,10 +31,10 @@ function addRecord(
 describe("process supervisor run registry", () => {
   it("keeps retrieved snapshots detached while output timestamps advance", () => {
     const registry = createRunRegistry();
-    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
+    const run = addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
     const snapshot = registry.get("r1");
 
-    registry.touchOutput("r1");
+    run.touchOutput();
     const touched = registry.get("r1");
 
     expect(snapshot).toMatchObject({ lastOutputAtMs: 1, updatedAtMs: 1 });
@@ -47,9 +47,9 @@ describe("process supervisor run registry", () => {
 
   it("finalize is idempotent and preserves first terminal metadata", () => {
     const registry = createRunRegistry();
-    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
+    const run = addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
 
-    registry.finalize("r1", {
+    run.finalize({
       reason: "overall-timeout",
       exitCode: null,
       exitSignal: "SIGKILL",
@@ -61,7 +61,7 @@ describe("process supervisor run registry", () => {
       exitSignal: "SIGKILL",
     });
 
-    registry.finalize("r1", {
+    run.finalize({
       reason: "manual-cancel",
       exitCode: 0,
       exitSignal: null,
@@ -76,20 +76,20 @@ describe("process supervisor run registry", () => {
 
   it("prunes the oldest created exited records after out-of-order exits", () => {
     const registry = createRunRegistry({ maxExitedRecords: 2 });
-    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
-    addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2 });
-    addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
-    addRecord(registry, { runId: "r4", sessionId: "s4", startedAtMs: 4 });
+    const r1 = addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
+    const r2 = addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2 });
+    const r3 = addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
+    const r4 = addRecord(registry, { runId: "r4", sessionId: "s4", startedAtMs: 4 });
 
-    registry.finalize("r2", { reason: "exit", exitCode: 0, exitSignal: null });
-    registry.finalize("r3", { reason: "exit", exitCode: 0, exitSignal: null });
-    registry.finalize("r1", { reason: "exit", exitCode: 0, exitSignal: null });
+    r2.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
+    r3.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
+    r1.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
 
     expect(registry.get("r1")).toBeUndefined();
     expect(registry.get("r2")?.state).toBe("exited");
     expect(registry.get("r3")?.state).toBe("exited");
 
-    registry.finalize("r4", { reason: "exit", exitCode: 0, exitSignal: null });
+    r4.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
 
     expect(registry.get("r2")).toBeUndefined();
     expect(registry.get("r3")?.state).toBe("exited");
@@ -99,11 +99,11 @@ describe("process supervisor run registry", () => {
   it("tracks records added or transitioned into the exited state", () => {
     const registry = createRunRegistry({ maxExitedRecords: 2 });
     addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1, state: "exited" });
-    addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2 });
-    addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
+    const r2 = addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2 });
+    const r3 = addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
 
-    registry.updateState("r2", "exited");
-    registry.finalize("r3", { reason: "exit", exitCode: 0, exitSignal: null });
+    r2.updateState("exited");
+    r3.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
 
     expect(registry.get("r1")).toBeUndefined();
     expect(registry.get("r2")?.state).toBe("exited");
@@ -113,16 +113,43 @@ describe("process supervisor run registry", () => {
   it("tracks exited records replaced or transitioned back to a live state", () => {
     const registry = createRunRegistry({ maxExitedRecords: 2 });
     addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1, state: "exited" });
-    addRecord(registry, { runId: "r2", sessionId: "s2", startedAtMs: 2, state: "exited" });
+    const r2 = addRecord(registry, {
+      runId: "r2",
+      sessionId: "s2",
+      startedAtMs: 2,
+      state: "exited",
+    });
 
-    addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
-    registry.updateState("r2", "running");
-    addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
-    registry.finalize("r1", { reason: "exit", exitCode: 0, exitSignal: null });
-    registry.finalize("r3", { reason: "exit", exitCode: 0, exitSignal: null });
+    const r1 = addRecord(registry, { runId: "r1", sessionId: "s1", startedAtMs: 1 });
+    r2.updateState("running");
+    const r3 = addRecord(registry, { runId: "r3", sessionId: "s3", startedAtMs: 3 });
+    r1.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
+    r3.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
 
     expect(registry.get("r1")?.state).toBe("exited");
     expect(registry.get("r2")?.state).toBe("running");
     expect(registry.get("r3")?.state).toBe("exited");
+  });
+
+  it("ignores replaced registrations without corrupting diagnostic retention", () => {
+    const registry = createRunRegistry({ maxExitedRecords: 1 });
+    const older = addRecord(registry, { runId: "r1", sessionId: "older", startedAtMs: 1 });
+    const replacement = addRecord(registry, { runId: "r1", sessionId: "newer", startedAtMs: 2 });
+    const sibling = addRecord(registry, { runId: "r2", sessionId: "sibling", startedAtMs: 3 });
+    const snapshot = registry.get("r1");
+
+    older.updateState("exiting", { pid: 1234, terminationReason: "manual-cancel" });
+    older.touchOutput();
+    older.finalize({ reason: "exit", exitCode: 23, exitSignal: null });
+    expect(registry.get("r1")).toEqual(snapshot);
+
+    sibling.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
+    expect(registry.get("r2")?.state).toBe("exited");
+    replacement.finalize({ reason: "exit", exitCode: 0, exitSignal: null });
+    expect(registry.get("r1")).toBeUndefined();
+    expect(registry.get("r2")?.state).toBe("exited");
+
+    replacement.updateState("running");
+    expect(registry.get("r1")).toBeUndefined();
   });
 });

--- a/src/process/supervisor/registry.ts
+++ b/src/process/supervisor/registry.ts
@@ -1,10 +1,5 @@
 // Supervisor registry tracks active and historical supervised process runs.
-import type { RunRecord, RunState, TerminationReason } from "./types.js";
-
-/** In-memory run index for the supervisor; callers receive detached snapshots. */
-function nowMs() {
-  return Date.now();
-}
+import type { RunExit, RunRecord, RunState } from "./types.js";
 
 const DEFAULT_MAX_EXITED_RECORDS = 2_000;
 
@@ -15,30 +10,24 @@ function resolveMaxExitedRecords(value?: number): number {
   return Math.max(1, Math.floor(value));
 }
 
-type RunRegistry = {
-  add: (record: RunRecord) => void;
-  get: (runId: string) => RunRecord | undefined;
-  updateState: (
-    runId: string,
-    state: RunState,
-    patch?: Partial<Pick<RunRecord, "pid" | "terminationReason" | "exitCode" | "exitSignal">>,
-  ) => RunRecord | undefined;
-  touchOutput: (runId: string) => void;
-  finalize: (
-    runId: string,
-    exit: {
-      reason: TerminationReason;
-      exitCode: number | null;
-      exitSignal: NodeJS.Signals | number | null;
-    },
-  ) => void;
+type RunUpdate = Partial<
+  Pick<
+    RunRecord,
+    "state" | "pid" | "terminationReason" | "exitCode" | "exitSignal" | "lastOutputAtMs"
+  >
+>;
+
+type RunRegistration = {
+  updateState: (state: RunState, patch?: Omit<RunUpdate, "state" | "lastOutputAtMs">) => void;
+  touchOutput: () => void;
+  finalize: (exit: Pick<RunExit, "reason" | "exitCode" | "exitSignal">) => void;
 };
 
 /**
  * Create the supervisor's mutable run registry. Exited records are retained
  * only for diagnostics, so the cap bounds memory without touching live runs.
  */
-export function createRunRegistry(options?: { maxExitedRecords?: number }): RunRegistry {
+export function createRunRegistry(options?: { maxExitedRecords?: number }) {
   const records = new Map<string, RunRecord>();
   const maxExitedRecords = resolveMaxExitedRecords(options?.maxExitedRecords);
   // Keep this exact across every write path so ordinary finalization never scans all records.
@@ -61,79 +50,63 @@ export function createRunRegistry(options?: { maxExitedRecords?: number }): RunR
     }
   };
 
-  const add: RunRegistry["add"] = (record) => {
+  const add = (record: RunRecord): RunRegistration => {
     if (records.get(record.runId)?.state === "exited") {
       exitedRecords -= 1;
     }
-    records.set(record.runId, { ...record });
-    if (record.state === "exited") {
+    const current = { ...record };
+    records.set(current.runId, current);
+    if (current.state === "exited") {
       exitedRecords += 1;
     }
+    const update = (patch: RunUpdate) => {
+      // A run ID is shared by retries. Late output, startup, or completion
+      // belongs to this registration, never the replacement's diagnostics.
+      if (records.get(current.runId) !== current) {
+        return false;
+      }
+      const state = patch.state ?? current.state;
+      if (current.state !== "exited" && state === "exited") {
+        exitedRecords += 1;
+      } else if (current.state === "exited" && state !== "exited") {
+        exitedRecords -= 1;
+      }
+      Object.assign(current, patch, { updatedAtMs: patch.lastOutputAtMs ?? Date.now() });
+      return true;
+    };
+    return {
+      updateState: (state, patch) => {
+        update({ ...patch, state });
+      },
+      touchOutput: () => {
+        update({ lastOutputAtMs: Date.now() });
+      },
+      finalize: (exit) => {
+        // First terminal observation wins; a fallback timer cannot rewrite it.
+        if (current.state === "exited") {
+          return;
+        }
+        if (
+          update({
+            state: "exited",
+            terminationReason: current.terminationReason ?? exit.reason,
+            exitCode: exit.exitCode,
+            exitSignal: exit.exitSignal,
+          })
+        ) {
+          pruneExitedRecords();
+        }
+      },
+    };
   };
 
-  const get: RunRegistry["get"] = (runId) => {
+  const get = (runId: string): RunRecord | undefined => {
     const record = records.get(runId);
     return record ? { ...record } : undefined;
-  };
-
-  const updateState: RunRegistry["updateState"] = (runId, state, patch) => {
-    const current = records.get(runId);
-    if (!current) {
-      return undefined;
-    }
-    if (current.state !== "exited" && state === "exited") {
-      exitedRecords += 1;
-    } else if (current.state === "exited" && state !== "exited") {
-      exitedRecords -= 1;
-    }
-    const updatedAtMs = nowMs();
-    const next: RunRecord = {
-      ...current,
-      ...patch,
-      state,
-      updatedAtMs,
-      lastOutputAtMs: current.lastOutputAtMs,
-    };
-    records.set(runId, next);
-    return { ...next };
-  };
-
-  const touchOutput: RunRegistry["touchOutput"] = (runId) => {
-    const current = records.get(runId);
-    if (!current) {
-      return;
-    }
-    const ts = nowMs();
-    current.lastOutputAtMs = ts;
-    current.updatedAtMs = ts;
-  };
-
-  const finalize: RunRegistry["finalize"] = (runId, exit) => {
-    const current = records.get(runId);
-    if (!current || current.state === "exited") {
-      return;
-    }
-    const ts = nowMs();
-    const next: RunRecord = {
-      ...current,
-      state: "exited",
-      // First terminal observation wins; late fallback timers must not rewrite
-      // the exit reason or signal after a real process exit has been recorded.
-      terminationReason: current.terminationReason ?? exit.reason,
-      exitCode: exit.exitCode,
-      exitSignal: exit.exitSignal,
-      updatedAtMs: ts,
-    };
-    records.set(runId, next);
-    exitedRecords += 1;
-    pruneExitedRecords();
   };
 
   return {
     add,
     get,
-    updateState,
-    touchOutput,
-    finalize,
   };
 }

--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -1,13 +1,16 @@
+import { performance } from "node:perf_hooks";
 import { Duplex } from "node:stream";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
+import * as childAdapter from "./adapters/child.js";
 import { createStubChild, firstMockArg } from "./adapters/child.test-support.js";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorPayload,
 } from "./service-child-protocol.js";
 import { createServiceChildRelayAdapter } from "./service-child-relay-host.js";
+import { createProcessSupervisor } from "./supervisor.js";
 
 const mocks = vi.hoisted(() => ({ spawn: vi.fn() }));
 vi.mock("node:child_process", async (importOriginal) => ({
@@ -29,6 +32,7 @@ afterEach(async () => {
   platformMock?.mockRestore();
   platformMock = undefined;
   mocks.spawn.mockReset();
+  vi.restoreAllMocks();
 });
 
 async function createRelay(platform: "linux" | "win32") {
@@ -88,28 +92,63 @@ async function createRelay(platform: "linux" | "win32") {
       return true;
     });
   }
-  emit({ type: "root-result", code: 0, signal: null });
-  if (platform === "win32") {
-    emit({ type: "output-end", stream: "stdout" });
-    emit({ type: "output-end", stream: "stderr" });
-  } else {
-    stub.child.stdout?.emit("end");
-    stub.child.stderr?.emit("end");
-  }
+  const completeRoot = () => {
+    emit({ type: "root-result", code: 0, signal: null });
+    if (platform === "win32") {
+      emit({ type: "output-end", stream: "stdout" });
+      emit({ type: "output-end", stream: "stderr" });
+    } else {
+      stub.child.stdout?.emit("end");
+      stub.child.stderr?.emit("end");
+    }
+  };
   const close = () => {
     control.destroy();
     stub.disconnectMock();
     stub.emitExit(0);
   };
   cleanups.push(close);
-  return { adapter, cancellations, emit, close };
+  return { adapter, cancellations, emit, completeRoot, close };
 }
+
+it("refreshes the supervisor deadline from text-only Windows Job output", async () => {
+  const { adapter, emit, completeRoot, close } = await createRelay("win32");
+  vi.spyOn(childAdapter, "createChildAdapter").mockResolvedValue(adapter);
+  const nowSpy = vi.spyOn(performance, "now").mockReturnValue(10_000);
+  const supervisor = createProcessSupervisor();
+  const run = await supervisor.spawn({
+    mode: "anchored-shell",
+    command: "synthetic-command",
+    sessionId: "windows-job-output",
+    backendId: "windows-job-output",
+    noOutputTimeoutMs: 1_000,
+  });
+  try {
+    nowSpy.mockReturnValue(10_800);
+    emit({ type: "output", stream: "stdout", chunk: "still running" });
+    nowSpy.mockReturnValue(11_600);
+    completeRoot();
+    await expect(run.wait()).resolves.toMatchObject({
+      reason: "exit",
+      noOutputTimedOut: false,
+      stdout: "still running",
+    });
+  } finally {
+    completeRoot();
+    emit({ type: "closing", reason: "lineage-closed" });
+    close();
+    await run.wait();
+    await run.waitForExtinction!();
+    await supervisor.shutdown();
+  }
+});
 
 describe.each(["linux", "win32"] as const)("service closing authority (%s)", (platform) => {
   it.each(["after receipt", "before receipt"])(
     "preserves confirmed extinction when cancellation starts %s",
     async (order) => {
-      const { adapter, cancellations, emit, close } = await createRelay(platform);
+      const { adapter, cancellations, emit, completeRoot, close } = await createRelay(platform);
+      completeRoot();
       await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
       const extinction = adapter.waitForExtinction();
       const settled = vi.fn();
@@ -135,7 +174,8 @@ describe.each(["linux", "win32"] as const)("service closing authority (%s)", (pl
   it.each(["failed cancellation", "channel close"])(
     "rejects %s without an authoritative closing receipt",
     async (fault) => {
-      const { adapter, cancellations, close } = await createRelay(platform);
+      const { adapter, cancellations, completeRoot, close } = await createRelay(platform);
+      completeRoot();
       const rejected = expect(adapter.waitForExtinction()).rejects.toThrow(
         "service child cleanup identity lost",
       );

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -491,6 +491,7 @@ export async function createServiceChildRelayAdapter(params: {
     pid: commandPid,
     stdin,
     oomScoreWrapperSelected: params.oomScoreWrapperSelected,
+    supportsRawOutput: !useWindowsJobAnchor,
     onStdout: stdoutRelay.subscribe,
     onStderr: stderrRelay.subscribe,
     wait: async () => {

--- a/src/process/supervisor/supervisor.anchored-shell.real.test.ts
+++ b/src/process/supervisor/supervisor.anchored-shell.real.test.ts
@@ -3,11 +3,13 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { isProcessAlive, waitForDead, waitForPidFile } from "../../../test/helpers/process-wait.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { createWindowsOutputDecoder } from "../../infra/windows-encoding.js";
 import { getWindowsCmdExePath } from "../../infra/windows-install-roots.js";
 import { killPidIfAlive } from "../../test-utils/process-tree.js";
 import { createProcessSupervisor } from "./supervisor.js";
+import type { ManagedRun } from "./types.js";
 
 const activePids = new Set<number>();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -149,6 +151,130 @@ async function expectPending(promise: Promise<void>) {
 }
 
 describe("supervisor anchored shell real process ownership", () => {
+  it.each(["exit", "cancel"] as const)(
+    "keeps a replacement's status independent of an older live child's %s",
+    async (completion) => {
+      const supervisor = createProcessSupervisor();
+      const runs: ManagedRun[] = [];
+      const oldOutput = createDeferred();
+      const spawn = async (backendId: string) => {
+        const ready = createDeferred();
+        const run = await supervisor.spawn({
+          mode: "child",
+          runId: "shared-correlation",
+          sessionId: "overlapping-children",
+          backendId,
+          scopeKey: backendId,
+          argv: [
+            process.execPath,
+            "-e",
+            `
+              process.stdout.write("ready\\n");
+              process.stdin.on("data", (data) => {
+                if (data.toString() === "emit") process.stdout.write("older-output\\n");
+                else process.exit(Number(data.toString()));
+              });
+            `,
+          ],
+          stdinMode: "pipe-open",
+          onStdout: (chunk) => {
+            if (chunk.includes("ready")) {
+              ready.resolve();
+            }
+            if (chunk.includes("older-output")) {
+              oldOutput.resolve();
+            }
+          },
+        });
+        runs.push(run);
+        activePids.add(run.pid!);
+        await Promise.race([
+          ready.promise,
+          run.wait().then(() => {
+            throw new Error("child exited before readiness");
+          }),
+        ]);
+        return run;
+      };
+      try {
+        const older = await spawn("older-backend");
+        const replacement = await spawn("replacement-backend");
+        const snapshot = supervisor.getRecord(replacement.runId);
+        older.stdin!.write("emit");
+        await oldOutput.promise;
+        expect(supervisor.getRecord(replacement.runId)).toEqual(snapshot);
+
+        if (completion === "exit") {
+          older.stdin!.write("23");
+        } else {
+          older.cancel();
+        }
+        expect(supervisor.getRecord(replacement.runId)).toEqual(snapshot);
+        await older.wait();
+        expect(isProcessAlive(replacement.pid!)).toBe(true);
+        expect(supervisor.getRecord(replacement.runId)).toEqual(snapshot);
+
+        replacement.stdin!.write("0");
+        await expect(replacement.wait()).resolves.toMatchObject({ reason: "exit", exitCode: 0 });
+        expect(supervisor.getRecord(replacement.runId)).toMatchObject({
+          backendId: "replacement-backend",
+          state: "exited",
+          terminationReason: "exit",
+          exitCode: 0,
+          exitSignal: null,
+        });
+      } finally {
+        for (const run of runs) {
+          run.cancel();
+        }
+        await Promise.all(runs.map((run) => run.wait()));
+        await supervisor.shutdown();
+      }
+    },
+  );
+
+  it("keeps a replacement supervised after an older tree with the same run ID becomes extinct", async () => {
+    const first = await createDescendantScope();
+    const descendantPid = await first.readPid();
+    activePids.add(descendantPid);
+    let replacement: Awaited<ReturnType<typeof first.supervisor.spawn>> | undefined;
+    try {
+      await first.run.wait();
+      expect(isProcessAlive(descendantPid)).toBe(true);
+      const ready = createDeferred();
+      replacement = await first.supervisor.spawn({
+        mode: "child",
+        runId: first.run.runId,
+        sessionId: "fallback-real",
+        backendId: "fallback-real",
+        scopeKey: "fallback-real",
+        argv: [process.execPath, "-e", "process.stdout.write('ready');setInterval(() => {}, 1000)"],
+        stdinMode: "pipe-closed",
+        onStdout: () => ready.resolve(),
+      });
+      const replacementPid = replacement.pid!;
+      activePids.add(replacementPid);
+      await ready.promise;
+      await first.release();
+      await first.run.waitForExtinction!();
+      expect(first.supervisor.getRecord(replacement.runId)).toMatchObject({
+        pid: replacementPid,
+        backendId: "fallback-real",
+        state: "running",
+      });
+      await first.supervisor.shutdown();
+
+      expect(isProcessAlive(replacementPid)).toBe(false);
+      await expect(replacement.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
+    } finally {
+      await first.release();
+      first.run.cancel();
+      replacement?.cancel();
+      await Promise.all([first.run.waitForExtinction!(), replacement?.wait()]);
+      await first.supervisor.shutdown();
+    }
+  });
+
   it.each([
     { name: "cancels retained descendants idempotently", cancel: true },
     { name: "releases ownership after descendants exit naturally", cancel: false },

--- a/src/process/supervisor/supervisor.cancellation-reason.test.ts
+++ b/src/process/supervisor/supervisor.cancellation-reason.test.ts
@@ -35,6 +35,7 @@ function createCancellationTestAdapter(): CancellationTestAdapter {
 
   return {
     pid: 4321,
+    supportsRawOutput: false,
     onStdout: () => undefined,
     onStderr: () => undefined,
     wait: async () => completion.promise,

--- a/src/process/supervisor/supervisor.output-activity.real.test.ts
+++ b/src/process/supervisor/supervisor.output-activity.real.test.ts
@@ -1,0 +1,86 @@
+import { performance } from "node:perf_hooks";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createProcessSupervisor } from "./supervisor.js";
+
+describe("process supervisor byte activity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(["stdout", "stderr"] as const)(
+    "preserves an elapsed byte deadline when %s flushes a partial character at EOF",
+    async (stream) => {
+      const nowSpy = vi.spyOn(performance, "now").mockReturnValue(10_000);
+      const supervisor = createProcessSupervisor();
+      const afterLastByte = () => nowSpy.mockReturnValue(12_000);
+      const run = await supervisor.spawn({
+        mode: "child",
+        argv: [process.execPath, "-e", `process.${stream}.write(Buffer.from([0xe2]))`],
+        sessionId: "decoder-eof",
+        backendId: "decoder-eof",
+        stdinMode: "pipe-closed",
+        noOutputTimeoutMs: 1_000,
+        // Withhold the timer callback while real child pipes close after the deadline.
+        onStdoutRaw: stream === "stdout" ? afterLastByte : undefined,
+        onStderrRaw: stream === "stderr" ? afterLastByte : undefined,
+      });
+      try {
+        const result = await run.wait();
+        expect(result).toMatchObject({ reason: "no-output-timeout", noOutputTimedOut: true });
+        expect(result[stream]).not.toBe("");
+      } finally {
+        run.cancel();
+        await supervisor.shutdown();
+      }
+    },
+  );
+
+  it.each(["stdout", "stderr"] as const)(
+    "keeps a child alive while %s streams an incomplete UTF-8 character",
+    async (stream) => {
+      const supervisor = createProcessSupervisor();
+      const ready = createDeferred();
+      const script = `
+      process.stdout.write("ready\\n");
+      process.stdin.once("data", () => {
+        process.stdin.destroy();
+        const bytes = [0xf0, 0x9f, 0x99, 0x82];
+        let index = 0;
+        const timer = setInterval(() => {
+          process.${stream}.write(Buffer.from([bytes[index++]]));
+          if (index === bytes.length) clearInterval(timer);
+        }, 500);
+      });
+    `;
+      const run = await supervisor.spawn({
+        mode: "child",
+        argv: [process.execPath, "-e", script],
+        sessionId: "byte-activity",
+        backendId: "byte-activity",
+        stdinMode: "pipe-open",
+        noOutputTimeoutMs: 1_500,
+        onStdout: (chunk) => {
+          if (chunk.includes("ready")) {
+            ready.resolve();
+          }
+        },
+      });
+      try {
+        await Promise.race([
+          ready.promise,
+          run.wait().then(() => {
+            throw new Error("child exited before readiness");
+          }),
+        ]);
+        run.stdin!.write("start");
+        const result = await run.wait();
+        expect(result).toMatchObject({ reason: "exit", exitCode: 0, noOutputTimedOut: false });
+        expect(result[stream]).toBe(stream === "stdout" ? "ready\n🙂" : "🙂");
+      } finally {
+        run.cancel();
+        await supervisor.shutdown();
+      }
+    },
+  );
+});

--- a/src/process/supervisor/supervisor.output-fence.test.ts
+++ b/src/process/supervisor/supervisor.output-fence.test.ts
@@ -80,42 +80,54 @@ describe("process supervisor output fence", () => {
     vi.restoreAllMocks();
   });
 
-  it("refreshes the no-output deadline before delivering a raw-only UTF-8 chunk", async () => {
-    vi.useFakeTimers();
-    const adapter = createStubChildAdapter({
-      onKill: (signal, current) => {
-        current.settle(null, signal ?? "SIGKILL");
-      },
-    });
-    createChildAdapterMock.mockResolvedValue(adapter);
+  it.each([false, true])(
+    "refreshes the no-output deadline for raw-only UTF-8 output (raw observer=%s)",
+    async (observeRaw) => {
+      vi.useFakeTimers();
+      const adapter = createStubChildAdapter({
+        onKill: (signal, current) => {
+          current.settle(null, signal ?? "SIGKILL");
+        },
+      });
+      createChildAdapterMock.mockResolvedValue(adapter);
 
-    const supervisor = createProcessSupervisor();
-    const runId = "raw-output-deadline";
-    let callbackOutputAtMs: number | undefined;
-    const run = await spawnChild(supervisor, {
-      runId,
-      sessionId: "s-raw-output-deadline",
-      argv: createSilentIdleArgv(),
-      noOutputTimeoutMs: 10,
-      onStdoutRaw: () => {
-        callbackOutputAtMs = supervisor.getRecord(runId)?.lastOutputAtMs;
-      },
-    });
-    const startedAtMs = supervisor.getRecord(runId)?.startedAtMs;
+      const supervisor = createProcessSupervisor();
+      const runId = "raw-output-deadline";
+      let callbackOutputAtMs: number | undefined;
+      const run = await spawnChild(supervisor, {
+        runId,
+        sessionId: "s-raw-output-deadline",
+        argv: createSilentIdleArgv(),
+        noOutputTimeoutMs: 10,
+        ...(observeRaw
+          ? {
+              onStdoutRaw: () => {
+                callbackOutputAtMs = supervisor.getRecord(runId)?.lastOutputAtMs;
+              },
+            }
+          : {}),
+      });
+      const startedAtMs = supervisor.getRecord(runId)?.startedAtMs;
 
-    await vi.advanceTimersByTimeAsync(9);
-    adapter.emitStdoutRaw(Buffer.from([0xe2]));
+      await vi.advanceTimersByTimeAsync(9);
+      adapter.emitStdoutRaw(Buffer.from([0xe2]));
 
-    expect(callbackOutputAtMs).toBeGreaterThan(startedAtMs ?? Number.POSITIVE_INFINITY);
-    await vi.advanceTimersByTimeAsync(9);
-    expect(adapter.killMock).not.toHaveBeenCalled();
+      expect(supervisor.getRecord(runId)?.lastOutputAtMs).toBeGreaterThan(
+        startedAtMs ?? Number.POSITIVE_INFINITY,
+      );
+      if (observeRaw) {
+        expect(callbackOutputAtMs).toBe(supervisor.getRecord(runId)?.lastOutputAtMs);
+      }
+      await vi.advanceTimersByTimeAsync(9);
+      expect(adapter.killMock).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(1);
-    await expect(run.wait()).resolves.toMatchObject({
-      reason: "no-output-timeout",
-      noOutputTimedOut: true,
-    });
-  });
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(run.wait()).resolves.toMatchObject({
+        reason: "no-output-timeout",
+        noOutputTimedOut: true,
+      });
+    },
+  );
 
   it.each(OUTPUT_LISTENER_KINDS)(
     "stops $name, capture, and the output clock once the run result settles",

--- a/src/process/supervisor/supervisor.queued-cancellation.test.ts
+++ b/src/process/supervisor/supervisor.queued-cancellation.test.ts
@@ -27,6 +27,7 @@ function createStubProcessAdapter(pid = 1234): StubProcessAdapter {
   const killMock = vi.fn();
   return {
     pid,
+    supportsRawOutput: false,
     onStdout: () => undefined,
     onStderr: () => undefined,
     wait: async () => completion.promise,

--- a/src/process/supervisor/supervisor.scope-extinction.test.ts
+++ b/src/process/supervisor/supervisor.scope-extinction.test.ts
@@ -137,42 +137,72 @@ describe("process supervisor scope extinction", () => {
     expect(adapter.killMock).toHaveBeenCalledOnce();
   });
 
-  it("drains cancelled startups and live siblings before reporting ownership failure", async () => {
-    const first = createStubChildAdapter();
-    const sibling = createStubChildAdapter({ pid: 4321 });
-    const [firstExtinction, siblingExtinction] = [createDeferred(), createDeferred()];
-    first.waitForExtinction = async () => await firstExtinction.promise;
-    sibling.waitForExtinction = async () => await siblingExtinction.promise;
+  it.each([false, true])(
+    "drains cancelled startups and live siblings before reporting ownership failure (reused run ID=%s)",
+    async (reuseRunId) => {
+      const first = createStubChildAdapter();
+      const sibling = createStubChildAdapter({ pid: 4321 });
+      const [firstExtinction, siblingExtinction] = [createDeferred(), createDeferred()];
+      first.waitForExtinction = async () => await firstExtinction.promise;
+      sibling.waitForExtinction = async () => await siblingExtinction.promise;
+      const startup = createDeferred<StubChildAdapter>();
+      createChildAdapterMock.mockReturnValueOnce(startup.promise).mockResolvedValueOnce(sibling);
+
+      const supervisor = createProcessSupervisor();
+      const pending = ["failed-owner", "pending-owner"].map((sessionId) =>
+        spawnChild(supervisor, {
+          ...(reuseRunId ? { runId: "same-agent-run" } : {}),
+          sessionId,
+          scopeKey: "scope:failed-drain",
+          argv: createSilentIdleArgv(),
+        }),
+      );
+      supervisor.cancelScope("scope:failed-drain");
+      const drain = supervisor.waitForScope("scope:failed-drain");
+      startup.resolve(first);
+      const runs = await Promise.all(pending);
+      expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
+      expect(sibling.killMock).toHaveBeenCalledWith("SIGTERM");
+      expect(supervisor.getRecord(runs[1]!.runId)).toMatchObject({ pid: sibling.pid });
+      first.settle(0);
+      sibling.settle(0);
+      await Promise.all(runs.map((run) => run.wait()));
+
+      const drained = vi.fn();
+      void drain.then(drained, drained);
+      firstExtinction.reject(new Error("first owner lost authority"));
+      await Promise.resolve();
+      expect(drained).not.toHaveBeenCalled();
+      expect(sibling.disposeMock).not.toHaveBeenCalled();
+
+      siblingExtinction.resolve();
+      await expect(drain).rejects.toThrow("first owner lost authority");
+      expect(sibling.disposeMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("does not finalize a newer admission when an older startup with the same run ID fails", async () => {
     const startup = createDeferred<StubChildAdapter>();
+    const sibling = createStubChildAdapter({ pid: 4321 });
     createChildAdapterMock.mockReturnValueOnce(startup.promise).mockResolvedValueOnce(sibling);
-
     const supervisor = createProcessSupervisor();
-    const pending = ["failed-owner", "pending-owner"].map((sessionId) =>
-      spawnChild(supervisor, {
-        sessionId,
-        scopeKey: "scope:failed-drain",
-        argv: createSilentIdleArgv(),
-      }),
-    );
-    supervisor.cancelScope("scope:failed-drain");
-    const drain = supervisor.waitForScope("scope:failed-drain");
-    startup.resolve(first);
-    const runs = await Promise.all(pending);
-    expect(first.killMock).toHaveBeenCalledWith("SIGTERM");
-    expect(sibling.killMock).toHaveBeenCalledWith("SIGTERM");
-    first.settle(0);
-    sibling.settle(0);
-    await Promise.all(runs.map((run) => run.wait()));
-
-    const drained = vi.fn();
-    void drain.then(drained, drained);
-    firstExtinction.reject(new Error("first owner lost authority"));
-    await Promise.resolve();
-    expect(drained).not.toHaveBeenCalled();
-    expect(sibling.disposeMock).not.toHaveBeenCalled();
-
-    siblingExtinction.resolve();
-    await expect(drain).rejects.toThrow("first owner lost authority");
-    expect(sibling.disposeMock).toHaveBeenCalledTimes(1);
+    const input = {
+      runId: "same-agent-run",
+      sessionId: "overlapping-startups",
+      argv: createSilentIdleArgv(),
+    };
+    const pending = spawnChild(supervisor, input);
+    const replacement = await spawnChild(supervisor, input);
+    try {
+      const snapshot = supervisor.getRecord(replacement.runId);
+      const rejected = expect(pending).rejects.toThrow("older startup failed");
+      startup.reject(new Error("older startup failed"));
+      await rejected;
+      expect(supervisor.getRecord(replacement.runId)).toEqual(snapshot);
+    } finally {
+      sibling.settle(0);
+      await replacement.wait();
+      await supervisor.shutdown();
+    }
   });
 });

--- a/src/process/supervisor/supervisor.test-support.ts
+++ b/src/process/supervisor/supervisor.test-support.ts
@@ -55,6 +55,7 @@ export function createStubChildAdapter(options?: {
   const adapter: StubChildAdapter = {
     pid: options?.pid ?? 1234,
     stdin: undefined,
+    supportsRawOutput: true,
     onStdout: (listener, onRaw) => {
       stdoutSubscribers.push({ listener, ...(onRaw ? { onRaw } : {}) });
     },

--- a/src/process/supervisor/supervisor.timeout-overflow.test.ts
+++ b/src/process/supervisor/supervisor.timeout-overflow.test.ts
@@ -36,6 +36,7 @@ function createTimeoutTestAdapter(): TimeoutTestAdapter {
 
   return {
     pid: 1234,
+    supportsRawOutput: false,
     onStdout: (listener) => {
       stdoutListener = listener;
     },

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -14,22 +14,17 @@ import type {
   ManagedRun,
   ProcessSupervisor,
   RunExit,
-  RunRecord,
   SpawnInput,
   TerminationReason,
 } from "./types.js";
 
-type ActiveRun = {
-  run: ManagedRun;
-  scopeKey?: string;
-  waitForExtinction: () => Promise<void>;
-};
-
-type StartingRun = {
+type OwnedRun = {
+  runId: string;
   scopeKey?: string;
   terminationReason?: TerminationReason;
   cancel?: (reason: TerminationReason) => void;
   pending?: Promise<ManagedRun>;
+  waitForExtinction?: () => Promise<void>;
 };
 
 type StartingScope = {
@@ -101,36 +96,34 @@ export function createProcessSupervisor(): ProcessSupervisor & {
   waitForScope: (scopeKey: string) => Promise<void>;
 } {
   const registry = createRunRegistry();
-  const active = new Map<string, ActiveRun>();
-  const startingRuns = new Map<string, StartingRun>();
+  // Retries share a run ID while an older command can still own descendants.
+  // Keep each admission until its own cleanup completes.
+  const ownedRuns = new Set<OwnedRun>();
   const startingScopes = new Map<string, StartingScope>();
   let shuttingDown = false;
   let shutdownPromise: Promise<void> | null = null;
 
-  const cancel = (runId: string, reason: TerminationReason = "manual-cancel") => {
-    const current = active.get(runId);
-    if (current) {
-      current.run.cancel(reason);
+  const cancelOwner = (current: OwnedRun, reason: TerminationReason) => {
+    if (current.cancel) {
+      current.cancel(reason);
       return;
     }
+    current.terminationReason ??= reason;
+  };
 
-    const starting = startingRuns.get(runId);
-    if (!starting) {
-      return;
+  const cancel = (runId: string, reason: TerminationReason = "manual-cancel") => {
+    for (const current of ownedRuns) {
+      if (current.runId === runId) {
+        cancelOwner(current, reason);
+      }
     }
-    starting.terminationReason ??= reason;
-    registry.updateState(runId, "exiting", {
-      terminationReason: starting.terminationReason,
-    });
-    starting.cancel?.(starting.terminationReason);
   };
 
   const cancelActiveScope = (scopeKey: string, reason: TerminationReason) => {
-    for (const [runId, run] of active.entries()) {
-      if (run.scopeKey !== scopeKey) {
-        continue;
+    for (const current of ownedRuns) {
+      if (current.waitForExtinction && current.scopeKey === scopeKey) {
+        cancelOwner(current, reason);
       }
-      cancel(runId, reason);
     }
   };
 
@@ -138,10 +131,9 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     if (!scopeKey.trim()) {
       return;
     }
-    cancelActiveScope(scopeKey, reason);
-    for (const [runId, starting] of startingRuns.entries()) {
-      if (starting.scopeKey === scopeKey) {
-        cancel(runId, reason);
+    for (const current of ownedRuns) {
+      if (current.scopeKey === scopeKey) {
+        cancelOwner(current, reason);
       }
     }
   };
@@ -152,19 +144,20 @@ export function createProcessSupervisor(): ProcessSupervisor & {
   ): Promise<void> => {
     let firstFailure: PromiseRejectedResult | undefined;
     while (true) {
-      const starts = Array.from(startingRuns.values())
-        .filter((current) => scopeKey === null || current.scopeKey === scopeKey)
-        .flatMap((current) => (current.pending ? [current.pending] : []));
-      const owned = Array.from(active.values())
-        .filter((current) => scopeKey === null || current.scopeKey === scopeKey)
-        .map((current) => current.waitForExtinction());
+      const selected = Array.from(ownedRuns).filter(
+        (current) => scopeKey === null || current.scopeKey === scopeKey,
+      );
+      const starts = selected.flatMap((current) => (current.pending ? [current.pending] : []));
+      const owned = selected.flatMap((current) =>
+        current.waitForExtinction ? [current.waitForExtinction()] : [],
+      );
       if (starts.length === 0 && owned.length === 0) {
         if (firstFailure) {
           throw firstFailure.reason;
         }
         return;
       }
-      // Startup can become active while the snapshot settles; recheck both maps
+      // Startup can become active while the snapshot settles; recheck admissions
       // so shutdown cannot outrun an admitted command or retained descendants.
       const results = await Promise.allSettled([...owned, ...starts]);
       firstFailure ??= results
@@ -174,15 +167,11 @@ export function createProcessSupervisor(): ProcessSupervisor & {
   };
   const waitForScope = (scopeKey: string): Promise<void> => waitForRuns(scopeKey);
 
-  const startRun = async (
-    input: SpawnInput,
-    scopeKey: string | undefined,
-    runId: string,
-    startingRun: StartingRun,
-  ): Promise<ManagedRun> => {
+  const startRun = async (input: SpawnInput, owner: OwnedRun): Promise<ManagedRun> => {
+    const { runId, scopeKey } = owner;
     const startedAtMs = Date.now();
-    const startingTerminationReason = startingRun.terminationReason;
-    const record: RunRecord = {
+    const startingTerminationReason = owner.terminationReason;
+    const registration = registry.add({
       runId,
       sessionId: input.sessionId,
       backendId: input.backendId,
@@ -193,8 +182,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       lastOutputAtMs: startedAtMs,
       createdAtMs: startedAtMs,
       updatedAtMs: startedAtMs,
-    };
-    registry.add(record);
+    });
 
     if (startingTerminationReason) {
       // A replacement can be cancelled behind its scope fence. Never launch
@@ -209,11 +197,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         timedOut: isTimeoutReason(startingTerminationReason),
         noOutputTimedOut: startingTerminationReason === "no-output-timeout",
       };
-      registry.finalize(runId, {
-        reason: exit.reason,
-        exitCode: exit.exitCode,
-        exitSignal: exit.exitSignal,
-      });
+      registration.finalize(exit);
       return {
         runId,
         startedAtMs,
@@ -228,11 +212,10 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       cancelActiveScope(scopeKey, "manual-cancel");
     }
 
-    let forcedReason: TerminationReason | null = startingRun.terminationReason ?? null;
+    let forcedReason: TerminationReason | null = owner.terminationReason ?? null;
     let resultSettled = false;
     let ownershipExtinct = false;
-    let stdout = "";
-    let stderr = "";
+    const captured = { stdout: "", stderr: "" };
     // Forced settlement (kill-wait fallback, Windows forced close) resolves the
     // result while inherited pipes stay open, and callers finalize their own
     // output state from that terminal result. One fence closes every output path
@@ -241,24 +224,17 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     const detachOutput = () => {
       outputDetached = true;
     };
-    let timeoutTimer: NodeJS.Timeout | null = null;
-    let noOutputTimer: NodeJS.Timeout | null = null;
     let forceKillTimer: NodeJS.Timeout | null = null;
     let cancelRequested = false;
     const captureOutput = input.captureOutput !== false;
     const maxCapturedOutputChars = clampCapturedOutputChars(input.maxCapturedOutputChars);
-
-    const overallTimeoutMs = normalizeTimeoutDuration(input.timeoutMs);
-    const noOutputTimeoutMs = normalizeTimeoutDuration(input.noOutputTimeoutMs);
-    let overallTimeoutDeadlineMs: number | null = null;
-    let noOutputTimeoutDeadlineMs: number | null = null;
 
     const setForcedReason = (reason: TerminationReason) => {
       if (forcedReason || resultSettled) {
         return;
       }
       forcedReason = reason;
-      registry.updateState(runId, "exiting", { terminationReason: reason });
+      registration.updateState("exiting", { terminationReason: reason });
     };
 
     let cancelAdapter: ((reason: TerminationReason) => void) | null = null;
@@ -267,48 +243,47 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       setForcedReason(reason);
       cancelAdapter?.(reason);
     };
-    startingRun.cancel = requestCancel;
+    owner.cancel = requestCancel;
 
-    // Node timers cannot hold the full duration of a long-running deadline.
-    // Re-arm bounded intervals so the requested deadline is never shortened.
-    const scheduleTimeout = (
-      reason: "overall-timeout" | "no-output-timeout",
-      remainingMs: number,
-      deadlineMs: number,
-    ): NodeJS.Timeout => {
-      const intervalMs = resolveTimerTimeoutMs(remainingMs, 1);
-      return setTimeout(() => {
-        if (resultSettled) {
-          return;
-        }
-        const nextRemainingMs = Math.min(remainingMs - intervalMs, deadlineMs - performance.now());
-        if (nextRemainingMs <= 0) {
-          requestCancel(reason);
-          return;
-        }
-        const nextTimer = scheduleTimeout(reason, nextRemainingMs, deadlineMs);
-        if (reason === "overall-timeout") {
-          timeoutTimer = nextTimer;
-        } else {
-          noOutputTimer = nextTimer;
-        }
-      }, intervalMs);
+    const createDeadline = (reason: "overall-timeout" | "no-output-timeout", value?: number) => {
+      const durationMs = normalizeTimeoutDuration(value);
+      let deadlineMs: number | null = null;
+      let timer: NodeJS.Timeout | undefined;
+      // Re-arm bounded intervals: a long deadline must not overflow Node's timer cap.
+      const schedule = (remainingMs: number, deadline: number) => {
+        const intervalMs = resolveTimerTimeoutMs(remainingMs, 1);
+        timer = setTimeout(() => {
+          if (resultSettled) {
+            return;
+          }
+          const remaining = Math.min(remainingMs - intervalMs, deadline - performance.now());
+          if (remaining <= 0) {
+            requestCancel(reason);
+          } else {
+            schedule(remaining, deadline);
+          }
+        }, intervalMs);
+      };
+      return {
+        get deadlineMs() {
+          return deadlineMs;
+        },
+        reset: () => {
+          if (!durationMs || resultSettled) {
+            return;
+          }
+          clearTimeout(timer);
+          deadlineMs = performance.now() + durationMs;
+          schedule(durationMs, deadlineMs);
+        },
+        clear: () => clearTimeout(timer),
+      };
     };
-
+    const overallDeadline = createDeadline("overall-timeout", input.timeoutMs);
+    const outputDeadline = createDeadline("no-output-timeout", input.noOutputTimeoutMs);
     const touchOutput = () => {
-      registry.touchOutput(runId);
-      if (!noOutputTimeoutMs || resultSettled) {
-        return;
-      }
-      noOutputTimeoutDeadlineMs = performance.now() + noOutputTimeoutMs;
-      if (noOutputTimer) {
-        clearTimeout(noOutputTimer);
-      }
-      noOutputTimer = scheduleTimeout(
-        "no-output-timeout",
-        noOutputTimeoutMs,
-        noOutputTimeoutDeadlineMs,
-      );
+      registration.touchOutput();
+      outputDeadline.reset();
     };
 
     try {
@@ -341,21 +316,10 @@ export function createProcessSupervisor(): ProcessSupervisor & {
                 secretInput: input.secretInput,
               });
 
-      registry.updateState(runId, forcedReason ? "exiting" : "running", {
+      registration.updateState(forcedReason ? "exiting" : "running", {
         pid: adapter.pid,
         ...(forcedReason ? { terminationReason: forcedReason } : {}),
       });
-
-      const clearResultTimers = () => {
-        if (timeoutTimer) {
-          clearTimeout(timeoutTimer);
-          timeoutTimer = null;
-        }
-        if (noOutputTimer) {
-          clearTimeout(noOutputTimer);
-          noOutputTimer = null;
-        }
-      };
 
       const releaseOwnership = () => {
         if (ownershipExtinct) {
@@ -366,7 +330,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
           clearTimeout(forceKillTimer);
           forceKillTimer = null;
         }
-        active.delete(runId);
+        ownedRuns.delete(owner);
         // Control-channel extinction can precede independently drained output;
         // keep decoder subscriptions alive until the root result also settles.
         if (resultSettled) {
@@ -376,7 +340,8 @@ export function createProcessSupervisor(): ProcessSupervisor & {
 
       const settleResult = () => {
         resultSettled = true;
-        clearResultTimers();
+        overallDeadline.clear();
+        outputDeadline.clear();
         detachOutput();
         if (ownershipExtinct) {
           adapter.dispose();
@@ -419,25 +384,11 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         forceKillTimer.unref?.();
       };
 
-      if (overallTimeoutMs) {
-        overallTimeoutDeadlineMs = performance.now() + overallTimeoutMs;
-        timeoutTimer = scheduleTimeout(
-          "overall-timeout",
-          overallTimeoutMs,
-          overallTimeoutDeadlineMs,
-        );
-      }
-      if (noOutputTimeoutMs) {
-        noOutputTimeoutDeadlineMs = performance.now() + noOutputTimeoutMs;
-        noOutputTimer = scheduleTimeout(
-          "no-output-timeout",
-          noOutputTimeoutMs,
-          noOutputTimeoutDeadlineMs,
-        );
-      }
+      overallDeadline.reset();
+      outputDeadline.reset();
 
       const withOutputFence =
-        <Chunk>(deliver: (chunk: Chunk) => void, recordsOutput = true) =>
+        <Chunk>(deliver?: (chunk: Chunk) => void, recordsOutput = true) =>
         (chunk: Chunk) => {
           if (outputDetached) {
             return;
@@ -445,34 +396,37 @@ export function createProcessSupervisor(): ProcessSupervisor & {
           if (recordsOutput) {
             touchOutput();
           }
-          deliver(chunk);
+          deliver?.(chunk);
         };
       const rawInput = input.mode === "child" ? input : undefined;
-      adapter.onStdout(
-        withOutputFence((chunk: string) => {
-          if (captureOutput) {
-            stdout = appendCapturedOutput(stdout, chunk, "stdout", maxCapturedOutputChars);
-          }
-          input.onStdout?.(chunk);
-        }, !rawInput?.onStdoutRaw),
-        rawInput?.onStdoutRaw && withOutputFence(rawInput.onStdoutRaw),
-      );
-      adapter.onStderr(
-        withOutputFence((chunk: string) => {
-          if (captureOutput) {
-            stderr = appendCapturedOutput(stderr, chunk, "stderr", maxCapturedOutputChars);
-          }
-          input.onStderr?.(chunk);
-        }, !rawInput?.onStderrRaw),
-        rawInput?.onStderrRaw && withOutputFence(rawInput.onStderrRaw),
-      );
+      // Byte transports can flush decoded text at EOF without fresh activity.
+      // PTYs and Windows Job transports report only text.
+      for (const [stream, subscribe, onText, onRaw] of [
+        ["stdout", adapter.onStdout, input.onStdout, rawInput?.onStdoutRaw],
+        ["stderr", adapter.onStderr, input.onStderr, rawInput?.onStderrRaw],
+      ] as const) {
+        subscribe(
+          withOutputFence((chunk: string) => {
+            if (captureOutput) {
+              captured[stream] = appendCapturedOutput(
+                captured[stream],
+                chunk,
+                stream,
+                maxCapturedOutputChars,
+              );
+            }
+            onText?.(chunk);
+          }, !adapter.supportsRawOutput),
+          withOutputFence(onRaw),
+        );
+      }
 
       const waitPromise = (async (): Promise<RunExit> => {
         const result = await adapter.wait();
         const deadlineReason = resolveElapsedTimeoutReason({
           nowMs: performance.now(),
-          overallTimeoutDeadlineMs,
-          noOutputTimeoutDeadlineMs,
+          overallTimeoutDeadlineMs: overallDeadline.deadlineMs,
+          noOutputTimeoutDeadlineMs: outputDeadline.deadlineMs,
         });
         const terminalReason = forcedReason ?? deadlineReason;
         settleResult();
@@ -485,21 +439,16 @@ export function createProcessSupervisor(): ProcessSupervisor & {
           exitSignal: result.signal,
           oomScoreWrapperSelected: adapter.oomScoreWrapperSelected === true,
           durationMs: Date.now() - startedAtMs,
-          stdout,
-          stderr,
+          ...captured,
           timedOut: isTimeoutReason(reason),
           noOutputTimedOut: terminalReason === "no-output-timeout",
         };
-        registry.finalize(runId, {
-          reason: exit.reason,
-          exitCode: exit.exitCode,
-          exitSignal: exit.exitSignal,
-        });
+        registration.finalize(exit);
         return exit;
       })().catch((err: unknown) => {
         if (!resultSettled) {
           settleResult();
-          registry.finalize(runId, {
+          registration.finalize({
             reason: "spawn-error",
             exitCode: null,
             exitSignal: null,
@@ -528,17 +477,13 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         detachOutput,
       };
 
-      active.set(runId, {
-        run: managedRun,
-        scopeKey,
-        waitForExtinction: async () => await extinctionPromise,
-      });
+      owner.waitForExtinction = async () => await extinctionPromise;
       if (forcedReason) {
         managedRun.cancel(forcedReason);
       }
       return managedRun;
     } catch (err) {
-      registry.finalize(runId, {
+      registration.finalize({
         reason: "spawn-error",
         exitCode: null,
         exitSignal: null,
@@ -555,10 +500,10 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     }
     const scopeKey = normalizeOptionalString(input.scopeKey);
     const runId = normalizeOptionalString(input.runId) ?? crypto.randomUUID();
-    const startingRun: StartingRun = { scopeKey };
+    const owner: OwnedRun = { runId, scopeKey };
     // Reserve cancellation before either adapter startup or a replacement
     // fence, so stopping a run cannot silently leave a late child alive.
-    startingRuns.set(runId, startingRun);
+    ownedRuns.add(owner);
 
     const starting = scopeKey
       ? (startingScopes.get(scopeKey) ?? { runs: new Set<Promise<ManagedRun>>() })
@@ -578,17 +523,18 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       : [];
     const pending =
       previous.length > 0
-        ? Promise.allSettled(previous).then(() => startRun(input, scopeKey, runId, startingRun))
-        : startRun(input, scopeKey, runId, startingRun);
-    startingRun.pending = pending;
+        ? Promise.allSettled(previous).then(() => startRun(input, owner))
+        : startRun(input, owner);
+    owner.pending = pending;
     starting?.runs.add(pending);
     if (starting && input.replaceExistingScope) {
       starting.replacement = pending;
     }
 
     const clearPendingStart = () => {
-      if (startingRuns.get(runId) === startingRun) {
-        startingRuns.delete(runId);
+      delete owner.pending;
+      if (!owner.waitForExtinction) {
+        ownedRuns.delete(owner);
       }
       starting?.runs.delete(pending);
       if (starting?.replacement === pending) {
@@ -606,9 +552,9 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     // Publish the admission fence before cancellation can invoke owner callbacks.
     shuttingDown = true;
     return (shutdownPromise ??= Promise.resolve().then(async () => {
-      while (startingRuns.size || active.size) {
-        for (const runId of new Set([...startingRuns.keys(), ...active.keys()])) {
-          cancel(runId);
+      while (ownedRuns.size) {
+        for (const owner of ownedRuns) {
+          cancelOwner(owner, "manual-cancel");
         }
         // A failed startup owns no live process; only failed owner extinction
         // must keep the process-wide supervisor fenced for operator recovery.

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -70,6 +70,8 @@ export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {
   pid?: number;
   stdin?: ManagedRunStdin;
   oomScoreWrapperSelected?: boolean;
+  /** Both output subscriptions observe bytes separately from decoded text. */
+  supportsRawOutput: boolean;
   onStdout: (listener: (chunk: string) => void, onRaw?: (chunk: Buffer) => void) => void;
   onStderr: (listener: (chunk: string) => void, onRaw?: (chunk: Buffer) => void) => void;
   wait: () => Promise<{ code: number | null; signal: WaitSignal }>;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Retries may reuse an admitted run ID while an older process tree still has descendants. Keyed ownership let old cleanup remove the replacement from cancellation/shutdown and let old output or exit overwrite its diagnostics. Separately, an active child emitting partial UTF-8 bytes could hit the idle timeout whenever no optional raw-output observer was registered.

## Why This Change Was Made

Keep every exact admission in one owned set until its own extinction. Bind registry mutations to the exact registration while keeping detached snapshots of the latest registration. This deletes competing run-ID maps and keyed mutation paths.

Always observe byte activity independently of optional delivery. Prepare the adapter’s raw-output capability once; text-only PTY/Windows Job relays use decoded activity. A byte decoder’s EOF flush remains captured and delivered without renewing an expired byte deadline. A shared deadline implementation replaces the duplicated overall/idle timer bookkeeping.

## User Impact

Cancellation and shutdown retain all live retries and descendants. Diagnostics describe the latest registration. Active fragmented UTF-8 stdout/stderr no longer looks silent. Public supervisor/spawn APIs, timeout values, scope fences, terminal ordering, bounded registry retention, and output detachment keep their contracts. No configuration, schema, protocol, or authority change.

## Evidence

Two independently reproduced roots, both present in the stable v2026.8.2 source structure. Real local Node children reproduce the old-root/replacement sequence and continuously emitted fragmented stdout/stderr. The maintained regression cases fail before their owner repairs; raw-observer, ASCII, and ordinary exec controls pass. Every child is cleaned up.

The final process/sibling suite passes **200 tests in16 files**, and the actual CLI caller suite passes **21 tests**. Scope extinction, queued cancellation, adapters, retention, overflow/delayed timers, and output fences are covered. Root independently reran the real-child decoder-EOF proof on the final candidate: the overdue deadline remains a no-output timeout while the replacement character is captured. That proof deliberately controls the monotonic clock and withholds its timer callback; it does not claim a measured wall-clock event-loop stall.

Review caught an EOF-only decoded tail incorrectly refreshing byte activity in the first candidate. The capability-based fix resolves it, with new failing-before stdout/stderr cases and a real Windows Job relay-owner/supervisor composition control. This is part of the output-activity repair, not another issue count. Windows coverage is source/tests; the live child proofs ran on macOS/Node24.19.0.

Production **+187/-263, net -76**. Tests/support **+431/-105, net +326**. Full changed-file checks pass, including types, lint/format, boundaries, dead exports, and architecture guards. A typed CLI fixture needed the new private adapter fact and passed its21 caller tests afterward. Fresh independent Codex review through P2 is scoped-clean with no findings across three evidence passes.

Fixes #136051.
Fixes #136052.
