### PR TITLE
fix(release): tolerate historical npm preflight targets

### DIFF
--- a/.github/workflows/openclaw-npm-preflight.yml
+++ b/.github/workflows/openclaw-npm-preflight.yml
@@ -353,27 +353,16 @@ jobs:
           OPENCLAW_CONTROL_UI_RELEASE_BUILD: "1"
         run: pnpm build
 
-      - name: Build Control UI only when the target full build does not own it
+      - name: Ensure Control UI release artifact
         if: steps.dist_build_cache.outputs.cache-hit != 'true'
         env:
           OPENCLAW_CONTROL_UI_RELEASE_BUILD: "1"
         run: |
           set -euo pipefail
-          build_has_ui="$(node --import ./scripts/tsx.mjs --input-type=module <<'NODE'
-          import { existsSync, readFileSync } from "node:fs";
-          import { pathToFileURL } from "node:url";
-          import { resolve } from "node:path";
-          const pkg = JSON.parse(readFileSync("package.json", "utf8"));
-          const owner = ["scripts/build-all.mts", "scripts/build-all.mjs"].find(
-            (path) => pkg.scripts?.build?.includes(path) && existsSync(path),
-          );
-          const build = owner ? await import(pathToFileURL(resolve(owner)).href) : null;
-          console.log(build?.resolveBuildAllSteps?.("full").some((step) => step.label === "ui:build") === true);
-          NODE
-          )"
-          if [[ "$build_has_ui" != true ]]; then
+          if [[ ! -f dist/control-ui/index.html ]]; then
             pnpm ui:build
           fi
+          test -f dist/control-ui/index.html
 
       - name: Save preflight build outputs
         if: steps.setup-node-env.outputs.cache-mode == 'read-write' && steps.dist_build_cache.outputs.cache-hit != 'true'

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -1,4 +1,15 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
@@ -56,6 +67,63 @@ function step(job: Job | undefined, name: string): Step {
     throw new Error(`Missing workflow step: ${name}`);
   }
   return found;
+}
+
+function runControlUiArtifactStep(options: { artifactPresent: boolean }) {
+  const root = mkdtempSync(join(tmpdir(), "openclaw-npm-preflight-ui-"));
+  const binDir = join(root, "bin");
+  const artifactPath = join(root, "dist", "control-ui", "index.html");
+  const invocationPath = join(root, "pnpm-invocation.txt");
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  mkdirSync(binDir);
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({
+      version: "2026.6.35",
+      scripts: {
+        build: "node scripts/build-all.mjs",
+        "ui:build": "node scripts/ui.js build",
+      },
+    }),
+  );
+  writeFileSync(join(root, "scripts", "build-all.mjs"), "");
+  if (options.artifactPresent) {
+    mkdirSync(join(root, "dist", "control-ui"), { recursive: true });
+    writeFileSync(artifactPath, "<!doctype html>\n");
+  }
+  const fakePnpm = join(binDir, "pnpm");
+  writeFileSync(
+    fakePnpm,
+    `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == "ui:build" ]]
+printf '%s\\n' "$*" > "${invocationPath}"
+mkdir -p "${join(root, "dist", "control-ui")}"
+printf '<!doctype html>\\n' > "${artifactPath}"
+`,
+  );
+  chmodSync(fakePnpm, 0o755);
+
+  const ensureControlUi = step(
+    workflow(preflightWorkflowPath).jobs?.prepare_openclaw_npm,
+    "Ensure Control UI release artifact",
+  );
+  const result = spawnSync("bash", ["--noprofile", "--norc", "-c", ensureControlUi.run ?? ""], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OPENCLAW_CONTROL_UI_RELEASE_BUILD: "1",
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    },
+  });
+  const invocation = existsSync(invocationPath)
+    ? readFileSync(invocationPath, "utf8").trim()
+    : null;
+  const artifactExists = existsSync(artifactPath);
+  const targetHasTsxLoader = existsSync(join(root, "scripts", "tsx.mjs"));
+  rmSync(root, { force: true, recursive: true });
+  return { artifactExists, invocation, result, targetHasTsxLoader };
 }
 
 describe("minimal npm extended-stable workflow", () => {
@@ -344,10 +412,7 @@ describe("minimal npm extended-stable workflow", () => {
     // Only the build producers skip on a cache hit; every validation step
     // still runs against the restored artifacts.
     const build = step(preflight, "Build");
-    const buildControlUi = step(
-      preflight,
-      "Build Control UI only when the target full build does not own it",
-    );
+    const buildControlUi = step(preflight, "Ensure Control UI release artifact");
     expect(build.if).toBe("steps.dist_build_cache.outputs.cache-hit != 'true'");
     expect(build.env?.OPENCLAW_CONTROL_UI_RELEASE_BUILD).toBe("1");
     expect(buildControlUi.if).toBe("steps.dist_build_cache.outputs.cache-hit != 'true'");
@@ -368,6 +433,26 @@ describe("minimal npm extended-stable workflow", () => {
     expect(save.uses).toContain("actions/cache/save@");
     expect(save.if).toContain("steps.setup-node-env.outputs.cache-mode == 'read-write'");
     expect(save.with?.key).toBe("${{ steps.dist_build_cache.outputs.cache-primary-key }}");
+  });
+
+  it("accepts the historical full-build artifact without a target tsx loader", () => {
+    const { artifactExists, invocation, result, targetHasTsxLoader } = runControlUiArtifactStep({
+      artifactPresent: true,
+    });
+    expect(targetHasTsxLoader).toBe(false);
+    expect(result.status, result.stderr).toBe(0);
+    expect(invocation).toBeNull();
+    expect(artifactExists).toBe(true);
+  });
+
+  it("builds a missing Control UI release artifact through the target package script", () => {
+    const { artifactExists, invocation, result, targetHasTsxLoader } = runControlUiArtifactStep({
+      artifactPresent: false,
+    });
+    expect(targetHasTsxLoader).toBe(false);
+    expect(result.status, result.stderr).toBe(0);
+    expect(invocation).toBe("ui:build");
+    expect(artifactExists).toBe(true);
   });
 
   it("uses the trusted Full Validation evidence verifier", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could not prepare npm artifacts for an older exact SHA when that target's full build produced the required Control UI bundle but predated `scripts/tsx.mjs`.

The failure was observed in https://github.com/openclaw/openclaw/actions/runs/33597852879/job/100144945644 against frozen target `659df8107ce37c07a4cd4364c76ece55a7124e22` (`2026.6.35`).

## Why This Change Was Made

The npm preflight now owns the package output boundary: it reuses `dist/control-ui/index.html` when the target build produced it, otherwise runs the target's public `pnpm ui:build` script, then requires the artifact. This removes cross-version introspection through a target-owned TypeScript loader.

## User Impact

Release operators can validate historical exact SHAs without the trusted preflight assuming that those targets contain current release-tooling loaders. Current targets still avoid a duplicate Control UI build when the full build already produced the artifact.

## Evidence

- Pre-fix reproduction: exact `2026.6.35` package shape, `dist/control-ui/index.html` present, `scripts/tsx.mjs` absent; the actual workflow step exited `1` with `ERR_MODULE_NOT_FOUND`.
- Focused executable workflow test: 16 passed, including artifact-present/no-loader and artifact-missing/build cases.
- `actionlint .github/workflows/openclaw-npm-preflight.yml`
- `pnpm check:coercion-helpers`
- `pnpm lint:scripts`
- Targeted oxlint, formatting, workflow owner guards, and `git diff --check`
- Sol/high autoreview: scoped clean.
- Workflow delta: `+3/-14` (net `-11`); test delta: `+90/-5`.

Local `pnpm check:workflows` reached its external pre-commit bootstrap but the configured Python index does not yet expose pinned `pre-commit==4.6.2`. `pnpm check:changed` reached the test-root typecheck but the shared worktree install lacks current optional/plugin packages. Exact-head CI is the authoritative proof for both environment-dependent gates.

No Full Release Validation campaign was rerun for this focused repair.
