### PR TITLE
test(msteams): batch pre-existing retention fixture rows

### DIFF
--- a/extensions/msteams/doctor-contract-api.retention.test.ts
+++ b/extensions/msteams/doctor-contract-api.retention.test.ts
@@ -3,6 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import {
   createPluginStateKeyedStoreForTests,
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  openOpenClawStateDatabase,
+  type OpenClawStateKyselyDatabaseForTests,
   resetPluginStateStoreForTests,
   setMaxPluginStateEntriesPerPluginForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
@@ -89,23 +93,49 @@ describe("Teams custom migration retention", () => {
       if (surface === "vote buckets") {
         setMaxPluginStateEntriesPerPluginForTests(capacity + 1);
       }
-      for (let index = 0; index < capacity; index++) {
+      const rows = Array.from({ length: capacity }, (_, index) => {
         const id = `existing-${index}`;
+        const row = {
+          plugin_id: "msteams",
+          namespace,
+          created_at: Date.now(),
+          expires_at: null,
+        };
         if (conversations) {
-          await store.register(buildMSTeamsConversationStateKey(id), { conversation: { id } });
-        } else if (surface === "polls") {
+          return {
+            ...row,
+            entry_key: buildMSTeamsConversationStateKey(id),
+            value_json: JSON.stringify({ conversation: { id } }),
+          };
+        }
+        if (surface === "polls") {
           const { votes: _votes, ...metadata } = makePoll(id);
-          await store.register(buildMSTeamsPollStateKey(id), metadata);
-        } else {
-          const bucket = selectMSTeamsPollVoteBucket(id, "voter");
-          await store.register(buildMSTeamsPollVoteBucketKey(id, bucket), {
+          return {
+            ...row,
+            entry_key: buildMSTeamsPollStateKey(id),
+            value_json: JSON.stringify(metadata),
+          };
+        }
+        const bucket = selectMSTeamsPollVoteBucket(id, "voter");
+        return {
+          ...row,
+          entry_key: buildMSTeamsPollVoteBucketKey(id, bucket),
+          value_json: JSON.stringify({
             pollId: id,
             bucket,
             votes: { voter: ["1"] },
             updatedAt: new Date().toISOString(),
-          });
-        }
-      }
+          }),
+        };
+      });
+      // Seed pre-existing rows together; migration below still owns real limit enforcement.
+      const { db } = openOpenClawStateDatabase({ env });
+      executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<OpenClawStateKyselyDatabaseForTests>(db)
+          .insertInto("plugin_state_entries")
+          .values(rows),
+      );
       const before = new Set((await store.entries()).map((entry) => entry.key));
       const poll = {
         ...makePoll("legacy"),


### PR DESCRIPTION
## Summary
Three Teams migration-retention tests built pre-existing state through 4,032 individual registrations. Each registration opened a write transaction and repeated expiry, lookup and capacity work even though these fixed fixture rows cannot expire, collide or overflow during setup.

Seed the same 2,000 conversation rows, 2,000 poll rows and32vote-bucket rows with three typed inserts through the existing private test SDK. The migration then runs unchanged against the real database and enforces its actual namespace and plugin limits. No production, schema, SDK, capacity, timeout or assertion changes.

## Validation
A fresh baseline and candidate used the same base and canonical runner. All10 cases and53 expanded assertions remain.

| Measurement | Before | After |
| --- | ---: | ---: |
| Summed case execution |4.413s|2.026s|
| Three affected cases |2.990s|0.431s|
| Vitest including imports/setup |11.76s|8.43s|

    node scripts/run-vitest.mjs extensions/msteams/doctor-contract-api.retention.test.ts

A separate observational probe froze only Date during setup, then restored real time before migration. It compared all4,032 raw six-column rows, schema columns and schema version between original and candidate. Every row matched. The actual SQLite3.53.3 runtime executed the12,000/12,000/192-binding inserts and reported MAX_VARIABLE_NUMBER=32766. Both full10-case probe runs passed, closed all three captured seed database handles and removed all10 owned directories.

A private fault removed only the migration's three pre-existing-key snapshots. The original eviction checks still passed, followed by the three expected source/archive failures; the other seven cases passed. All10 directories were removed and captured handles closed despite those failures. This proves the bulk seed still detects the retention regression that originally motivated these tests. All instrumentation and the fault were removed; exact candidate and owner hashes were restored.

The seven untouched cases still cover imported-row eviction, real age/count selection and archival, repeat migration, and empty/malformed SSO imports. Production LOC+0/-0; tests+40/-10. No live channel or credentials are involved.

Local changed-scope formatting, plugin-test typing, lint, boundary/coercion/deprecation guards and all three dead-export scans passed. Final Codex P0 autoreview is scoped-clean (0.99).

Exact-head [CI33599324723](https://github.com/openclaw/openclaw/actions/runs/33599324723) passed. The completed ClawSweeper review reports no findings, before-merge items or rank-up actions. The requested autonomous batch supplies the ordinary maintainer landing decision.
