### PR TITLE
refactor(gateway): preserve required agent selection fields

### DIFF
--- a/src/commands/status.agent-local.ts
+++ b/src/commands/status.agent-local.ts
@@ -72,8 +72,8 @@ export async function getAgentLocalStatuses(
     // The gateway keeps a projected first id for wire compatibility. Local status must
     // preserve the selection state so read-only consumers never treat that id as an owner.
     defaultId: agentList.selectionRequired ? null : agentList.defaultId,
-    ownership: agentList.ownership ?? (agentList.selectionRequired === true ? "explicit" : "sole"),
-    selectionRequired: agentList.selectionRequired === true,
+    ownership: agentList.ownership,
+    selectionRequired: agentList.selectionRequired,
     agents: statuses,
     totalSessions: sessionStores.count,
     bootstrapPendingCount,

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -288,6 +288,8 @@ describe("getStatusSummary", () => {
     vi.mocked(resolveSessionStorePathCore).mockReturnValue("/tmp/sessions.json");
     vi.mocked(listGatewayAgentsBasic).mockReturnValue({
       defaultId: "main",
+      ownership: "sole",
+      selectionRequired: false,
       mainKey: "main",
       scope: "per-sender",
       agents: [{ id: "main" }],
@@ -821,6 +823,8 @@ describe("getStatusSummary", () => {
   it("passes agent scope when listing configured agent session stores", async () => {
     vi.mocked(listGatewayAgentsBasic).mockReturnValue({
       defaultId: "main",
+      ownership: "sole",
+      selectionRequired: false,
       mainKey: "main",
       scope: "per-sender",
       agents: [{ id: "main" }, { id: "ops" }],

--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -68,10 +68,7 @@ export function resolveGatewayAgentSelectionState(cfg: OpenClawConfig): GatewayA
 }
 
 /** Lists gateway-visible agents with canonical membership, ordering, and semantic kind. */
-export function listGatewayAgentsBasic(cfg: OpenClawConfig): {
-  defaultId: string;
-  ownership?: GatewayAgentOwnership;
-  selectionRequired?: boolean;
+export function listGatewayAgentsBasic(cfg: OpenClawConfig): GatewayAgentSelectionState & {
   mainKey: string;
   scope: SessionScope;
   agents: GatewayAgentListRow[];

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -445,8 +445,8 @@ export function listAgentsForGateway(
   });
   return {
     defaultId: basic.defaultId,
-    ownership: basic.ownership!,
-    selectionRequired: basic.selectionRequired!,
+    ownership: basic.ownership,
+    selectionRequired: basic.selectionRequired,
     mainKey: basic.mainKey,
     scope: basic.scope,
     agents,


### PR DESCRIPTION
## What Problem This Solves

The lightweight gateway agent list guaranteed ownership and selection state at runtime but exposed both fields as optional. Downstream callers therefore carried impossible fallback paths and non-null assertions, weakening compile-time protection when the selection contract evolves.

## Why This Change Was Made

The list result now composes the canonical required selection-state type. Callers consume those guarantees directly, removing stale fallbacks and assertions without changing serialized behavior.

## User Impact

No user-visible behavior changes. Maintainers get a stricter agent-selection contract, with invalid optional states no longer representable.

## Evidence

- `pnpm test src/gateway/agent-list.test.ts` — 8 passed
- `pnpm test src/gateway/session-utils.test.ts` — 231 passed
- `pnpm test src/commands/status.agent-local.test.ts` — 2 passed
- `pnpm test src/commands/status.test.ts` — 20 passed
- `pnpm test src/commands/status.summary.test.ts` — 41 passed
- `node scripts/run-tsgo-core-test-shards.mjs --stripe '2/5' --concurrency 2` — passed
- `pnpm check:changed` — passed after rebasing onto current `origin/main`
- `pnpm check` — passed, including production/test typechecks, lint, formatting, policy guards, and import-cycle check
- `pnpm check:assertion-safety` — passed
- Autoreview: scoped clean, no accepted/actionable findings
- Production LOC: 5 additions, 8 deletions (net −3); test LOC: +4/−0; total net +1
