### PR TITLE
fix(test): prevent cyclic subprocess errors from breaking cleanup

### DIFF
--- a/scripts/lib/dist-artifact-ownership.mts
+++ b/scripts/lib/dist-artifact-ownership.mts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { acquireFileLock } from "@openclaw/fs-safe/file-lock";
 import { root as openLockRoot } from "@openclaw/fs-safe/root";
 import { isDirectRunUrl } from "./direct-run.mjs";
+import { hasUnjoinedWork } from "./managed-child-process.mts";
 import { findRepoRoot } from "./repo-root.mjs";
 
 const DIST_ARTIFACT_LOCK_PATH = ".artifacts/dist-artifacts.lock";
@@ -15,19 +16,6 @@ export function resolveDistArtifactLockPath(rootDir: string) {
   // Compiler inputs can resolve outside cwd. Subdirectories share checkout
   // ownership; standalone non-checkout work owns its directory.
   return path.join(findRepoRoot(rootDir) ?? rootDir, DIST_ARTIFACT_LOCK_PATH);
-}
-
-function hasUnjoinedWork(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-  if ("processTreeState" in error && error.processTreeState !== "terminated") {
-    return true;
-  }
-  if (error instanceof AggregateError && error.errors.some(hasUnjoinedWork)) {
-    return true;
-  }
-  return "cause" in error && hasUnjoinedWork(error.cause);
 }
 
 function retainUnjoinedDistArtifactWork(directory: string, error: unknown) {

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -76,6 +76,35 @@ type ManagedCommandOutcome =
 const managedChildren = new Set<(signal: NodeJS.Signals) => void>();
 const signalHandlers = new Map<NodeJS.Signals, () => void>();
 
+/** Nested command failures retain their owner's inputs until process cleanup is verified. */
+export function hasUnjoinedWork(value: unknown): boolean {
+  const pending: unknown[] = [value];
+  const seen = new Set<object>();
+  for (const current of pending) {
+    if (!current || typeof current !== "object" || seen.has(current)) {
+      continue;
+    }
+    // Native execFileSync errors can point .error back to themselves. Skip only
+    // that identity; other aggregate members and wrapper edges still need checking.
+    seen.add(current);
+    if ("processTreeState" in current && current.processTreeState !== "terminated") {
+      return true;
+    }
+    if (current instanceof AggregateError) {
+      for (const error of current.errors) {
+        pending.push(error);
+      }
+    }
+    if ("cause" in current) {
+      pending.push(current.cause);
+    }
+    if ("error" in current) {
+      pending.push(current.error);
+    }
+  }
+  return false;
+}
+
 /** Return the conventional shell exit code for a signal. */
 export function signalExitCode(signal: NodeJS.Signals) {
   const signalNumber = signalNumberFor(signal);

--- a/test/helpers/fixture-lifetime.ts
+++ b/test/helpers/fixture-lifetime.ts
@@ -1,22 +1,7 @@
 import fs from "node:fs";
+import { hasUnjoinedWork } from "../../scripts/lib/managed-child-process.mts";
 import { findVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { makeTempDir } from "./temp-dir.js";
-
-function hasUnjoinedWork(value: unknown): boolean {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  if ("processTreeState" in value && value.processTreeState !== "terminated") {
-    return true;
-  }
-  if (value instanceof AggregateError && value.errors.some(hasUnjoinedWork)) {
-    return true;
-  }
-  return (
-    ("cause" in value && hasUnjoinedWork(value.cause)) ||
-    ("error" in value && hasUnjoinedWork(value.error))
-  );
-}
 
 /** Own whole fixture bodies; an explicit root scopes deliberate retention without changing env. */
 export function createFixtureLifetime(ownerRoot?: string) {

--- a/test/scripts/dist-artifact-ownership.test.ts
+++ b/test/scripts/dist-artifact-ownership.test.ts
@@ -1,10 +1,14 @@
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveDistArtifactLockPath,
+  withDistArtifactOwnership,
+} from "../../scripts/lib/dist-artifact-ownership.mts";
 import {
   TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
   TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS,
@@ -292,6 +296,51 @@ async function runWithProcesses(
 // Native TypeScript emits the declarations. Only
 // process completion is gated; ordering never depends on sleeps or host speed.
 describe.skipIf(process.platform === "win32")("dist artifact ownership", () => {
+  it("releases ownership after a native execFileSync ENOENT error", async () => {
+    const root = createCheckout();
+    const error = await withDistArtifactOwnership(root, async () =>
+      execFileSync(path.join(root, "absent-command"), [], { stdio: "pipe" }),
+    ).catch((cause: unknown) => cause);
+    expect(error).toHaveProperty("code", "ENOENT");
+    expect(error).toHaveProperty("error", error);
+    expect(fs.existsSync(path.join(resolveDistArtifactLockPath(root), "owner.json"))).toBe(false);
+    expect(fs.existsSync(path.join(resolveDistArtifactLockPath(root), "unjoined"))).toBe(false);
+  });
+
+  it.for(["cause", "error", "cyclic aggregate"])(
+    "retains ownership for unjoined work nested in %s",
+    async (kind, { signal }) => {
+      // Retention deliberately keeps lock handles open; a joined child owns
+      // their disposal rather than leaking them into the shared Vitest worker.
+      await withProcesses(async ({ start }) => {
+        const root = createCheckout();
+        const probe = write(
+          root,
+          "retained-error.mts",
+          `
+          import assert from 'node:assert/strict';
+          import { withDistArtifactOwnership } from ${JSON.stringify(path.join(sourceRoot, "scripts/lib/dist-artifact-ownership.mts"))};
+          const kind = ${JSON.stringify(kind)};
+          const uncertainty = { processTreeState: 'indeterminate' };
+          const aggregate = new AggregateError([], 'sibling cleanup');
+          aggregate.errors.push(aggregate, new Error('command failed', { cause: uncertainty }));
+          const error = kind === 'cyclic aggregate' ? aggregate
+            : new Error('command failed', { cause: kind === 'cause' ? uncertainty : { error: uncertainty } });
+          const outcome = await withDistArtifactOwnership(process.cwd(), async () => {
+            throw error;
+          }).catch(cause => cause);
+          assert.equal(outcome, error);
+        `,
+        );
+        const result = await start(root, probe).done;
+        const directory = resolveDistArtifactLockPath(root);
+        expect(fs.existsSync(path.join(directory, "owner.json"))).toBe(true);
+        expect(fs.existsSync(path.join(directory, "unjoined"))).toBe(true);
+        expect(result.code, result.output).toBe(0);
+      }, signal);
+    },
+  );
+
   it.for([
     { script: "prepare-extension-package-boundary-artifacts.mts", failStagingCleanup: false },
     { script: "write-plugin-sdk-entry-dts.ts", failStagingCleanup: false },

--- a/test/scripts/fixture-lifetime.test.ts
+++ b/test/scripts/fixture-lifetime.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { getEventListeners } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
@@ -23,6 +24,30 @@ beforeEach(() => {
 afterEach(() => vi.unstubAllEnvs());
 const fixture = createFixtureLifetime();
 afterEach(() => fixture.cleanup());
+
+it("releases inputs and claims after a native execFileSync ENOENT error", async () => {
+  const lifetime = createFixtureLifetime();
+  const root = lifetime.createTempDir("fixture-missing-command-");
+  const error = await lifetime
+    .run(async () => execFileSync(path.join(root, "absent-command"), [], { stdio: "pipe" }))
+    .catch((cause: unknown) => cause);
+  expect(error).toHaveProperty("code", "ENOENT");
+  expect(error).toHaveProperty("error", error);
+  await lifetime.cleanup();
+  expect(fs.existsSync(root)).toBe(false);
+  expect(() => owner.assertReleased()).not.toThrow();
+});
+
+it("releases cyclic joined results without treating repeated objects as uncertainty", async () => {
+  const lifetime = createFixtureLifetime();
+  const root = lifetime.createTempDir("fixture-joined-cycle-");
+  const result = new AggregateError([], "joined failures");
+  result.errors.push(result, { cause: result }, { error: result, processTreeState: "terminated" });
+  await lifetime.run(async () => result);
+  await lifetime.cleanup();
+  expect(fs.existsSync(root)).toBe(false);
+  expect(() => owner.assertReleased()).not.toThrow();
+});
 
 it("registers fresh fixture work after clean release and module reset", async () => {
   const first = fixture.createTempDir("fixture-first-");
@@ -366,7 +391,7 @@ it
   },
 );
 
-it.each(["cause", "aggregate", "cleanup"])(
+it.each(["cause", "error", "aggregate", "cyclic aggregate", "cleanup"])(
   "retains inputs and reports unverified %s cleanup even when the body handled its rejection",
   async (kind) => {
     const root = fixture.createTempDir("fixture-lifetime-retained-");
@@ -374,12 +399,19 @@ it.each(["cause", "aggregate", "cleanup"])(
       code: "EPROCESSGROUP_CLEANUP_FAILED",
       processTreeState: "indeterminate",
     });
+    const aggregate = new AggregateError([], "sibling cleanup");
+    aggregate.errors.push(
+      kind === "cyclic aggregate" ? aggregate : new Error("primary failure"),
+      new Error("command failed", { cause: { error: uncertainty } }),
+    );
     const error =
       kind === "cause"
         ? new Error("command failed", { cause: uncertainty })
-        : kind === "aggregate"
-          ? new AggregateError([new Error("primary failure"), uncertainty], "sibling cleanup")
-          : new Error("orphan verification failed");
+        : kind === "error"
+          ? Object.assign(new Error("command failed"), { error: uncertainty })
+          : kind === "cleanup"
+            ? new Error("orphan verification failed")
+            : aggregate;
     const run = kind === "cleanup" ? fixture.verifyCleanup : fixture.run;
     await expect(
       run(async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/135647 — follow-up to the nested Vitest fixture-retention repair; this cyclic-error traversal bug predates that change.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where developers running fixture-owned subprocess work get `RangeError: Maximum call stack size exceeded` during cleanup after an ordinary native `execFileSync` spawn failure. A nonexistent executable produces an `ENOENT` error whose `.error` refers to itself; no executable starts, but cleanup cannot finish.

The invariant-sharing dist-artifact owner also mishandles cyclic aggregates: traversal can throw before recording unjoined work, after which `finally` releases the lock. Its separate walker additionally misses uncertainty nested through `.error`.

## Why This Change Was Made

One small iterative, identity-tracked traversal now lives beside the managed process-state producer and replaces both recursive copies. It examines `AggregateError.errors`, `.cause`, and `.error`; repeated identities are skipped without hiding other siblings. Cycles alone are not uncertainty, and no depth cutoff or error-message matching is used.

The existing `processTreeState !== "terminated"` condition, process-tree inspection, signals, deadlines, positive fixture-release receipts, and lock-retention mechanisms are unchanged. No application configuration, persistence schema, dependency, or published API changes are introduced.

## User Impact

Ordinary failed subprocess work can finish verified fixture cleanup without a secondary stack overflow. Genuine nested cleanup uncertainty still retains the original fixture inputs, pending claims, and dist-artifact ownership. This repairs developer/test/build tooling; application runtime behavior is unchanged.

## Evidence

- Inspected the actual Node 24.20.0 `child_process` source: `checkExecSyncError()` takes `ret.error` and copies `ret` onto it, creating the native self-reference. Node 26.8.1 exhibits the same behavior.
- Before the repair, the native repository-launcher reproduction returned `{originalCode:"ENOENT", selfError:true, cleanupError:"RangeError"}`. Afterward on Node 24.20.0, cleanup completes, the fixture is removed, and the positive ownership claim is released.
- Regression tests failed against pre-fix code for the native error, harmless cyclic result, cyclic aggregate with an unjoined sibling, and dist `.error`/cyclic-aggregate retention. The final isolated dist tests were rerun against the exact baseline owner and failed because `owner.json` was incorrectly removed.
- Final local affected-owner and sibling run: **117 passed, one Linux-only skip**, on macOS / Node 24.20.0. Coverage includes real detached children, cancellation, output drainage, nested writer retention, asynchronous fixture removal, and claims retained across cleanup/reuse. Synthetic retained-lock tests run in joined child processes so they do not leak lock handles into shared Vitest workers.

```bash
node scripts/run-vitest.mjs test/scripts/fixture-lifetime.test.ts test/scripts/dist-artifact-ownership.test.ts test/helpers/run-node-script.test.ts test/scripts/managed-child-process.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/lib/managed-child-process.mts scripts/lib/dist-artifact-ownership.mts test/helpers/fixture-lifetime.ts test/scripts/fixture-lifetime.test.ts test/scripts/dist-artifact-ownership.test.ts
```

The changed-file typecheck/lint/guard plan, formatting, and `git diff --check` passed. Independent isolated autoreview found no actionable P0 findings. One earlier Node 26 declaration-concurrency case exceeded its unchanged 30-second deadline; it passed its focused retry and the complete final Node 24 run without deadline changes. No native Linux/Windows or product UI/live-provider execution is claimed by this local evidence; hosted CI is recorded separately before landing.

Scope: tooling **+30/-13 (net +17)**; fixture test support **+1/-16 (net -15)**; regression tests **+86/-5 (net +81)**. Removing both duplicate walkers leaves only **two net additional implementation lines** for identity tracking and iterative traversal. Application-runtime production LOC is unchanged.

Integration verification on `848578477744e2a3393a613e66b5ac8aaa9731ec`, mechanically rebased onto `a7ecbcc2221ef0c0b1dcae319504433dbbd0405c`: the reviewed patch remained byte-identical. `pnpm build` passed on Node 24.20.0 (18m 16s), the same four-file test command passed again (117 passed, one Linux-only skip, 4m 33s), and the same five-file changed-check command plus `git diff --check` passed. No source changes or retries were needed during integration. The full build included frozen declaration generation, native built-module/doctor-closure checks, SDK export validation, and the UI build.

### Maintainer follow-through on ClawSweeper review

The [exact-head review](https://github.com/openclaw/openclaw/pull/136057#issuecomment-5505594785) found no correctness defect and identified two pre-merge evidence/risk items. Both are resolved without source changes:

- **Single owner / LOC:** `hasUnjoinedWork` has one definition in `scripts/lib/managed-child-process.mts`, consumed by fixture lifetime and dist ownership; both prior recursive definitions were deleted. Tooling is +17 and fixture support is -15, so only two net implementation lines remain. No parallel cleanup-policy path was added.
- **Direct Node contract:** the acting maintainer agent personally inspected the installed Node 24.20.0 embedded `lib/child_process.js:932–944` (`checkExecSyncError`) and `967–971` (`execFileSync` → `spawnSync`). The native source assigns `err = ret.error` then `ObjectAssign(err, ret)`, so `.error` refers to the same object. This independently closes the reviewer's source-access limitation, alongside the real ENOENT regression and positive cleanup proof above.

The refreshed 06:53 UTC review adds a rank-up move asking for an explicit maintainer proof-sufficiency decision. **Maintainer decision: accept the recorded Node 24 native source inspection and before/after cleanup proof, together with the passing boundary regressions and exact-head CI.** This is the evidence accepted for the exact-head landing; the reviewer-environment source-access limitation does not leave an unresolved implementation or proof gap. No source change or additional re-review was needed.
