### PR TITLE
fix(codex): restore Ultra for configured native account models

### DIFF
--- a/extensions/codex/src/app-server/model-catalog.test.ts
+++ b/extensions/codex/src/app-server/model-catalog.test.ts
@@ -98,7 +98,11 @@ describe("Codex app-server model catalog", () => {
         },
       },
     ]);
-    expect(listModelsMock).toHaveBeenCalledExactlyOnceWith({ request: rpc.request, limit: 100 });
+    expect(listModelsMock).toHaveBeenCalledExactlyOnceWith({
+      request: rpc.request,
+      limit: 100,
+      includeHidden: true,
+    });
   });
 
   it("returns no rows without a live call when discovery is disabled", async () => {
@@ -106,6 +110,45 @@ describe("Codex app-server model catalog", () => {
       await loadCodexAppServerModelCatalog(catalogParams, { discovery: { enabled: false } }),
     ).toEqual([]);
     expect(listModelsMock).not.toHaveBeenCalled();
+  });
+
+  it("discovers configured hidden models without exposing other hidden models or readiness", async () => {
+    const models = ["visible", "configured", "other-agent", "unconfigured", "other-provider"].map(
+      (name) => ({
+        id: `synthetic-${name}`,
+        model: `synthetic-${name}`,
+        hidden: name !== "visible",
+        inputModalities: ["text"],
+        supportedReasoningEfforts: ["high", "ultra"],
+      }),
+    );
+    listModelsMock.mockImplementation(async (options) => ({
+      models: models.filter((model) => options?.includeHidden || !model.hidden),
+    }));
+    const params = {
+      ...catalogParams,
+      configuredModelRefs: [
+        { provider: "openai", model: "synthetic-configured" },
+        { provider: "another", model: "synthetic-other-provider" },
+      ],
+    };
+    const catalog = await owner.load(params, undefined);
+    expect(catalog.map((model) => model.id)).toEqual(["synthetic-visible", "synthetic-configured"]);
+    expect(catalog[1]).toMatchObject({
+      nativeRuntime: "codex",
+      reasoning: true,
+      compat: { supportedReasoningEfforts: ["high", "ultra"] },
+    });
+    expect(catalog[1]?.api).toBeUndefined();
+    for (const model of models) {
+      expect(read({ modelId: model.id })).toEqual(
+        model.id === "synthetic-visible" || model.id === "synthetic-configured"
+          ? { accountType: "apiKey" }
+          : undefined,
+      );
+    }
+    await owner.load({ ...params, configuredModelRefs: [] }, undefined);
+    expect(read({ modelId: "synthetic-configured" })).toBeUndefined();
   });
 
   it("bounds the live call with the configured discovery timeout", async () => {

--- a/extensions/codex/src/app-server/model-catalog.ts
+++ b/extensions/codex/src/app-server/model-catalog.ts
@@ -99,7 +99,18 @@ export function createCodexAppServerModelCatalog(runtime: string) {
         { startOptions: start, config: params.config, agentDir: params.agentDir, timeoutMs },
         async (request, client) => {
           const isCurrent = captureSharedCodexAppServerCatalogLifetime(client);
-          const listed = await listAllCodexAppServerModels({ request, limit: 100 });
+          const listed = await listAllCodexAppServerModels({
+            request,
+            limit: 100,
+            includeHidden: true,
+          });
+          const models = listed.models.filter(
+            (model) =>
+              !model.hidden ||
+              params.configuredModelRefs?.some(
+                (ref) => ref.provider === "openai" && ref.model === model.id,
+              ),
+          );
           const account = await request<CodexGetAccountResponse>({
             method: "account/read",
             requestParams: { refreshToken: false },
@@ -111,7 +122,7 @@ export function createCodexAppServerModelCatalog(runtime: string) {
                 ? observedType
                 : undefined
               : undefined;
-          return { models: listed.models, isCurrent, accountType } as const;
+          return { models, isCurrent, accountType } as const;
         },
       );
       // Publish only after the bounded operation settles; a late timed-out callback cannot publish.

--- a/extensions/openai/thinking-policy.test.ts
+++ b/extensions/openai/thinking-policy.test.ts
@@ -14,6 +14,18 @@ function levelIds(params: {
 }
 
 describe("OpenAI thinking route provenance", () => {
+  it.each([
+    { efforts: ["low", "high", "ultra"], expected: ["off", "low", "high", "ultra"] },
+    { efforts: ["low", "high", "max"], expected: ["off", "low", "high", "max"] },
+    { efforts: [], expected: ["off"] },
+  ])("uses native account efforts without a host transport: $efforts", ({ efforts, expected }) => {
+    expect(
+      resolveUnifiedOpenAIThinkingProfile("account-model", "codex", {
+        supportedReasoningEfforts: efforts,
+      }).levels.map((level) => level.id),
+    ).toEqual(expected);
+  });
+
   it("keeps native fallback capabilities for a direct OpenAI route", () => {
     expect(
       levelIds({

--- a/extensions/openai/thinking-policy.ts
+++ b/extensions/openai/thinking-policy.ts
@@ -94,7 +94,7 @@ function buildOpenAIThinkingProfile(params: {
   const agentRuntime = normalizeModelId(params.agentRuntime ?? "");
   const codexEfforts = params.compat?.supportedReasoningEfforts?.map(normalizeModelId);
   const resolvedCodexEfforts =
-    params.api === "openai-chatgpt-responses"
+    params.api === undefined || params.api === "openai-chatgpt-responses"
       ? resolveOpenAICodexReasoningEfforts(modelId, codexEfforts)
       : undefined;
   const knownCodexEfforts = resolveOpenAICodexReasoningEfforts(modelId, undefined);
@@ -104,7 +104,7 @@ function buildOpenAIThinkingProfile(params: {
     modelId.startsWith("gpt-5.6") && (agentRuntime !== "codex" || codexSupportsMax);
   const codexSupportsUltra = (resolvedCodexEfforts ?? knownCodexEfforts)?.includes("ultra");
   // OpenClaw owns its logical Ultra orchestration. Native Codex capabilities
-  // come only from the selected ChatGPT route's catalog metadata.
+  // come from native discovery or the selected ChatGPT route's catalog metadata.
   const supportsUltra =
     (modelId === OPENAI_GPT_56_MODEL_ID || isGpt56Variant) &&
     (agentRuntime === "openclaw" ||

--- a/src/agents/harness/model-catalog.test.ts
+++ b/src/agents/harness/model-catalog.test.ts
@@ -212,6 +212,50 @@ describe("agent harness model catalog", () => {
       agentId: "main",
       agentDir: "/tmp/main-agent",
       workspaceDir: "/tmp/workspace",
+      configuredModelRefs: [
+        { provider: "openai", model: "gpt-5.6-sol" },
+        { provider: "openai", model: "gpt-5.6-sol" },
+      ],
+    });
+  });
+
+  it("prepares configured refs for the selected agent without including other agents", async () => {
+    const selectedConfig: OpenClawConfig = {
+      agents: {
+        defaults: cfg.agents?.defaults,
+        entries: {
+          main: {
+            models: {
+              "openai/gpt-5.6-sol": { agentRuntime: { id: "codex" } },
+              "openai/synthetic-configured": {},
+            },
+          },
+          another: { model: { primary: "openai/synthetic-other-agent" } },
+        },
+      },
+    };
+    const loadModelCatalog = vi.fn(async () => []);
+    await augmentModelCatalogWithAgentHarness({
+      cfg: selectedConfig,
+      agentId: "main",
+      agentDir: "/tmp/main-agent",
+      workspaceDir: "/tmp/workspace",
+      defaultProvider: "anthropic",
+      defaultModel: "openai/gpt-5.6-sol",
+      snapshot,
+      pluginRegistry: registryWithCatalog(loadModelCatalog),
+    });
+
+    expect(loadModelCatalog).toHaveBeenCalledExactlyOnceWith({
+      config: selectedConfig,
+      agentId: "main",
+      agentDir: "/tmp/main-agent",
+      workspaceDir: "/tmp/workspace",
+      configuredModelRefs: [
+        { provider: "openai", model: "gpt-5.6-sol" },
+        { provider: "openai", model: "gpt-5.6-sol" },
+        { provider: "openai", model: "synthetic-configured" },
+      ],
     });
   });
 

--- a/src/agents/harness/model-catalog.ts
+++ b/src/agents/harness/model-catalog.ts
@@ -11,6 +11,7 @@ import { DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../model-catalog.types.js";
 import { resolveModelRefFromString } from "../model-selection-shared.js";
 import { resolveModelCatalogIdentityKey } from "../openai-model-routes.js";
+import { collectPreparedModelRuntimeConfiguredRefs } from "../prepared-model-runtime.configured.js";
 import type { PreparedModelRuntimeInput } from "../prepared-model-runtime.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../workspace.js";
 import { resolveAgentHarnessPolicy } from "./policy.js";
@@ -152,11 +153,26 @@ export async function augmentModelCatalogWithAgentHarness(params: {
     return params.snapshot;
   }
   try {
+    const configuredModelRefs = collectPreparedModelRuntimeConfiguredRefs(
+      params.cfg,
+      params.agentId,
+    ).flatMap(({ value }) => {
+      const resolved = resolveModelRefFromString({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        raw: value,
+        defaultProvider: params.defaultProvider,
+        allowManifestNormalization: true,
+        allowPluginNormalization: true,
+      })?.ref;
+      return resolved ? [resolved] : [];
+    });
     const listedRows = await harness.loadModelCatalog({
       config: params.cfg,
       agentId: params.agentId,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
+      configuredModelRefs,
     });
     if (!params.pluginRegistry && getActivePluginRegistry() !== pluginRegistry) {
       return params.snapshot;

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -516,6 +516,7 @@ export type AgentHarnessModelCatalogParams = {
   agentId: string;
   agentDir: string;
   workspaceDir: string;
+  configuredModelRefs?: readonly import("../model-ref-shared.js").ModelRef[];
 };
 
 type AgentHarnessModelCatalogCapability = {


### PR DESCRIPTION
Closes #135991

## What Problem This Solves

Fixes an issue where users selecting a configured native Codex account model could not choose its supported reasoning effort in the Control UI. Hidden-but-explicitly-configured models lost discovery metadata and could appear unavailable; API-less native rows also lost their account-advertised Ultra, Maximum, or explicit no-effort capabilities in the OpenAI effort policy.

## Why This Change Was Made

The native catalog is the capability and readiness owner. Core prepares normalized configured model references using its existing selected-agent collector; the Codex plugin requests hidden metadata but publishes only visible models and models explicitly configured for that agent. The OpenAI plugin then consumes native effort metadata without inventing a host transport.

This replaces the incomplete discovery/policy path rather than changing the slider, adding model-name exceptions, or copying host API capabilities into native rows. Discovery refresh still revokes stale readiness; other agents' hidden models and unrelated hidden models stay excluded. Explicit direct Responses routing remains unchanged.

## User Impact

- Configured native models expose their actual account-supported effort choices, including Ultra.
- Models advertising no reasoning effort remain off-only.
- No new configuration, environment setting, persistence format, or static model catalog row is introduced.

## Evidence

### Regression and sibling coverage

- Pre-fix native-catalog regression: 1 failed / 8 passed; the explicitly configured hidden row was absent.
- Pre-fix native-policy regressions: 3 failed; API-less unknown account models ignored Ultra, Maximum, and explicit empty effort metadata.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/model-catalog.test.ts src/agents/harness/model-catalog.test.ts`: 14 passed. Covers selected-agent scoping, hidden-model filtering, readiness refresh/revocation, and native/host ownership.
- `node scripts/run-vitest.mjs extensions/openai/thinking-policy.test.ts extensions/openai/provider-policy-api.test.ts`: 64 passed. Covers native metadata, explicit empty effort lists, known model contracts, and direct API siblings.
- Fresh structured Autoreview: scoped-clean, no accepted/actionable P0 findings. Manual owner-boundary review also completed.
- `node scripts/check-changed.mjs -- <the seven changed files>`: passed, including formatting, core and plugin production/test typechecks, dead exports, lint, import cycles, and selected architectural guards.

### Dependency contract

Personally inspected sibling Codex at `5f49aba876922d6f2f55caa153bbb0ed1b46feba`: `codex-rs/app-server/src/request_processors/catalog_processor.rs:254` defaults `include_hidden` to false; `codex-rs/app-server/src/models.rs:22` filters hidden models and `:46` projects hidden status with supported efforts. Also checked `codex-rs/protocol/src/openai_models.rs:833` for effort projection and `codex-rs/core/src/client.rs:182` for Ultra's wire-level mapping. The proof distinguishes native app-server Ultra selection from the downstream wire representation.

### Real Control UI and native runtime proof

Built the full candidate with `pnpm build` (passed), then ran a real isolated development gateway, separate state directory and port, real browser, and native Codex 0.151.0. No mock gateway, injected DOM state, or changes to the operator's running gateway/configuration.

- Before: the configured hidden account model was omitted from discovery, marked unavailable, and its composer had no effort control.
- After: live `models.list` / `chat.metadata` exposed that configured model as available with `off,low,medium,high,xhigh,max,ultra`; the real slider selected Ultra and retained it after session reload.
- Observed native `codex_app_server.lifecycle` / `turn_starting` with both `effort: "ultra"` and `collaborationEffort: "ultra"`.
- The account advertised the hidden model but rejected its completion request with upstream `model_not_found`. This is not claimed as a successful hidden-model completion.
- Repeated the complete UI flow with runnable `gpt-5.6-sol`: select Ultra, submit "Reply exactly ULTRA_OK. Do not use tools.", receive `ULTRA_OK` in 8 seconds / 7 output tokens, observe terminal Done, reload, and verify Ultra remains selected. Both native effort fields were `ultra`.

Before/after screenshots and a sanitized 33-second video were captured, personally inspected, and uploaded through GitHub's authenticated browser UI after command-line artifact publication failed. No proof assets or live configuration are committed.

**Before: configured hidden model, missing effort control**

![Before: no effort control](https://github.com/user-attachments/assets/181dad56-b5df-48ff-982d-22c14e55da7e)

**After: Ultra selected from the account-advertised effort list**

![After: Ultra selected](https://github.com/user-attachments/assets/b181b560-66e7-4b35-8f1d-75e1470fda3a)

**After: completed native turn and persisted Ultra**

![Completed turn and persisted Ultra](https://github.com/user-attachments/assets/0a0b3ec2-6181-47fe-a748-90f72a26602f)

**Real flow: selection, completion, reload, persistence**

https://github.com/user-attachments/assets/ee2163f6-b5ef-4548-9b6f-89e9678865df

Recorded runnable-flow result:

```json
{"model":"gpt-5.6-sol","nativeEvents":[{"stream":"codex_app_server.lifecycle","phase":"turn_starting","effort":"ultra","collaborationEffort":"ultra"}],"reply":"ULTRA_OK","terminal":true,"reloadEffort":"ultra","sourceCommit":"31595153cd974cf15b23ff65910061448a5497f3"}
```

### Scope and implementation cost

Production: +32/-4, net +28 lines. Tests: +100/-1, net +99 lines. The growth supplies a missing generic prepared-reference handoff and the native owner's filtering; it reuses the canonical collector/resolver and adds no helper, configuration option, transport tag, or parallel discovery path. The policy repair itself is net-neutral. Existing readiness lifecycle and catalog conversion are reused unchanged.

Related but distinct: #135867 addresses fallback-harness discovery; #134524 addresses readiness across worker publication. Neither is superseded by this configured-hidden-model/effort-policy repair.

No owning manifest's static model definitions changed, so this runtime discovery repair does not require a static catalog publication.
