### PR TITLE
fix(qa): honor nonstreaming Responses contracts

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -88,6 +88,7 @@ export type StreamEvent =
       type: "response.completed";
       response: {
         id: string;
+        object: "response";
         status: "completed";
         output: Array<Record<string, unknown>>;
         usage: {
@@ -97,6 +98,24 @@ export type StreamEvent =
         };
       };
     };
+
+export function buildCompletedResponseEvent(
+  id: string,
+  output: Array<Record<string, unknown>>,
+  outputTokens: number,
+): Extract<StreamEvent, { type: "response.completed" }> {
+  return {
+    type: "response.completed",
+    response: {
+      id,
+      // SDK clients use this discriminator to expose output_text.
+      object: "response",
+      status: "completed",
+      output,
+      usage: { input_tokens: 64, output_tokens: outputTokens, total_tokens: 64 + outputTokens },
+    },
+  };
+}
 
 /**
  * Provider variant tag for `body.model`. The mock previously ignored
@@ -479,15 +498,7 @@ export function buildRemoteCompactionV2Events(): [
   };
   return [
     { type: "response.output_item.done", item },
-    {
-      type: "response.completed",
-      response: {
-        id: "resp_mock_compaction_1",
-        status: "completed",
-        output: [item],
-        usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
-      },
-    },
+    buildCompletedResponseEvent("resp_mock_compaction_1", [item], 16),
   ];
 }
 

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
@@ -1,6 +1,6 @@
 // QA Lab mock provider output event builders.
 
-import type { StreamEvent } from "./mock-openai-contracts.js";
+import { buildCompletedResponseEvent, type StreamEvent } from "./mock-openai-contracts.js";
 import { buildMockFunctionCall } from "./mock-openai-tooling.js";
 
 export function buildFailedResponseEvents(): StreamEvent[] {
@@ -290,9 +290,8 @@ export function buildAssistantThenToolCallEvents(
   args: Record<string, unknown>,
 ): StreamEvent[] {
   const call = buildMockFunctionCall(name, args);
-  const message = buildAssistantOutputItem(spec);
   const events: StreamEvent[] = [];
-  appendAssistantMessageEvents(events, spec, 0);
+  const message = appendAssistantMessageEvents(events, spec, 0);
   events.push({
     type: "response.output_item.added",
     output_index: 1,
@@ -315,15 +314,7 @@ export function buildAssistantThenToolCallEvents(
     output_index: 1,
     item: call.item,
   });
-  events.push({
-    type: "response.completed",
-    response: {
-      id: call.responseId,
-      status: "completed",
-      output: [message, call.item],
-      usage: { input_tokens: 64, output_tokens: 32, total_tokens: 96 },
-    },
-  });
+  events.push(buildCompletedResponseEvent(call.responseId, [message, call.item], 32));
   return events;
 }
 
@@ -339,23 +330,11 @@ export function buildAssistantEvents(
           },
         ]
       : specsOrText;
-  const renderedSpecs = specs.map((spec) => ({ spec, item: buildAssistantOutputItem(spec) }));
-  const output = renderedSpecs.map(({ item }) => item);
   const events: StreamEvent[] = [];
-
-  for (const [outputIndex, { spec }] of renderedSpecs.entries()) {
-    appendAssistantMessageEvents(events, spec, outputIndex);
-  }
-
-  events.push({
-    type: "response.completed",
-    response: {
-      id: "resp_mock_msg_1",
-      status: "completed",
-      output,
-      usage: { input_tokens: 64, output_tokens: 24, total_tokens: 88 },
-    },
-  });
+  const output = specs.map((spec, outputIndex) =>
+    appendAssistantMessageEvents(events, spec, outputIndex),
+  );
+  events.push(buildCompletedResponseEvent("resp_mock_msg_1", output, 24));
   return events;
 }
 
@@ -395,15 +374,7 @@ export function buildReasoningOnlyEvents(summaryText: string, id: string): Strea
       output_index: 0,
       item: reasoningItem,
     },
-    {
-      type: "response.completed",
-      response: {
-        id: `resp_${id}`,
-        status: "completed",
-        output: [reasoningItem],
-        usage: { input_tokens: 64, output_tokens: 8, total_tokens: 72 },
-      },
-    },
+    buildCompletedResponseEvent(`resp_${id}`, [reasoningItem], 8),
   ];
 }
 
@@ -443,14 +414,8 @@ export function buildReasoningAndAssistantEvents(params: {
     },
     1,
   );
-  events.push({
-    type: "response.completed",
-    response: {
-      id: `resp_${params.reasoningId}`,
-      status: "completed",
-      output: [reasoningItem, answerItem],
-      usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
-    },
-  });
+  events.push(
+    buildCompletedResponseEvent(`resp_${params.reasoningId}`, [reasoningItem, answerItem], 16),
+  );
   return events;
 }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY } from "../../qa-web-search-provider.js";
-import type { StreamEvent } from "./mock-openai-contracts.js";
+import { buildCompletedResponseEvent, type StreamEvent } from "./mock-openai-contracts.js";
 
 let mockFunctionCallSequence = 0;
 
@@ -124,15 +124,7 @@ export function buildToolCallEventsWithArgs(
       type: "response.output_item.done",
       item: call.item,
     },
-    {
-      type: "response.completed",
-      response: {
-        id: call.responseId,
-        status: "completed",
-        output: [call.item],
-        usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
-      },
-    },
+    buildCompletedResponseEvent(call.responseId, [call.item], 16),
   ];
 }
 
@@ -168,15 +160,7 @@ export function buildCustomToolCallEventsWithInput(
       delta: input,
     },
     { type: "response.output_item.done", item },
-    {
-      type: "response.completed",
-      response: {
-        id: call.responseId,
-        status: "completed",
-        output: [item],
-        usage: { input_tokens: 64, output_tokens: 16, total_tokens: 80 },
-      },
-    },
+    buildCompletedResponseEvent(call.responseId, [item], 16),
   ];
 }
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.responses-contract.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.responses-contract.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { startQaMockOpenAiServer } from "./server.js";
+
+describe("mock Responses contract", () => {
+  it.each([undefined, false])("returns a JSON Response when stream is %s", async (stream) => {
+    const server = await startQaMockOpenAiServer({ host: "127.0.0.1", port: 0 });
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "qa-model",
+          ...(stream === undefined ? {} : { stream }),
+          input: [
+            {
+              role: "user",
+              content: [{ type: "input_text", text: "Reply exactly: QA-RESPONSE-CONTRACT" }],
+            },
+          ],
+        }),
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("application/json");
+      expect(await response.json()).toMatchObject({
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "QA-RESPONSE-CONTRACT" }],
+          },
+        ],
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -6570,6 +6570,7 @@ Update and merge these partial structured summaries.`,
         type: "response.completed",
         response: {
           id: "response_mock",
+          object: "response",
           status: "completed",
           output: [
             { type: "function_call", name: "read", call_id: nativeId, arguments: "{}" },

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -2911,7 +2911,7 @@ export async function startQaMockOpenAiServer(params?: {
         if (dispatched.responsePauseMs !== undefined) {
           await sleep(dispatched.responsePauseMs);
         }
-        if (body.stream === false) {
+        if (body.stream !== true) {
           const completion = events.at(-1);
           if (!completion || completion.type !== "response.completed") {
             writeJson(res, 500, { error: "mock completion failed" });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

QA Lab's mock Responses endpoint breaks two ordinary SDK calls. Omitting `stream` returns SSE when the SDK expects JSON and causes a TypeError. Explicitly setting `stream: false` returns JSON, but the response lacks `object: "response"`, so the SDK never exposes its `output_text` property.

## Why This Change Was Made

The HTTP route now reserves SSE for `stream: true`. One completed-response builder adds the required discriminator for text, tool, reasoning, and compaction replies across HTTP and WebSocket transports. It replaces seven repeated envelopes and preserves their IDs, output, and usage. Assistant replies also reuse the message item already built for the output event.

## User Impact

Standard nonstreaming SDK calls return a Response and expose its text. Explicit streaming keeps the existing event framing, completion behavior, pauses, and errors.

## Evidence

Both maintained HTTP regressions fail on the starting head: omitted streaming returns the wrong content type, and explicit nonstreaming omits the required discriminator. The selected provider, event, WebSocket, memory, and regression suites pass **304 tests** after the fix.

The real OpenAI SDK 7.5.0 reproduces both failures over loopback HTTP with synthetic credentials. After the repair, omitted, false, and true streaming modes all pass, and the separate explicit-false check returns the expected `output_text`. Nine comparisons against the original Git-object builders preserve event order, IDs, content, and usage, with only the added discriminator differing.

Production TypeScript: **+35/-75, net -40**. Tests: **+40/-0**. Both defects are present in the v2026.8.2 tagged source; QA Lab is a source-checkout plugin.

The acting agent inspected the pinned SDK's create/parse/output-text code and Codex at `94cbbddafc1776d5e377bca1b05932c697e82238`: `codex-rs/core/src/client.rs:1014-1029` explicitly requests streaming, and `codex-rs/codex-api/src/sse/responses.rs:116-126,479-496` consumes completion ID and usage without requiring the discriminator. No native Codex execution is claimed.

Fresh independent Codex review through P2 is scoped-clean with no findings (confidence 0.98).

Full changed-file checks exited 0, including extension and extension-test type checks, formatting, changed lint, boundary guards, dead-export scans, storage guards, and runtime import-cycle checks.

Integration verification: mechanically rebased onto the merged Anthropic terminal repair. Root reran the actual SDK omitted/false/true modes, the separate output_text check, and all six Responses/Anthropic HTTP regressions; all pass.

Fixes #136058.
Fixes #136060.
