### PR TITLE
perf: reuse prepared plugin metadata normalizers

### DIFF
--- a/src/config/io.plugin-metadata.ts
+++ b/src/config/io.plugin-metadata.ts
@@ -4,11 +4,11 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { createPluginCache, getPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import {
+  finalizePluginMetadataSnapshot,
   projectPluginMetadataSnapshot,
   rebasePluginMetadataSnapshotManifestRegistry,
   resolvePluginMetadataSnapshot,
   resolvePluginMetadataSnapshotCacheKey,
-  restorePluginMetadataSnapshot,
   type PluginMetadataSnapshot,
 } from "../plugins/plugin-metadata-snapshot.js";
 import { normalizePluginPolicyId } from "../plugins/plugin-policy-id.js";
@@ -151,7 +151,7 @@ function resolveConfigWidePluginMetadataSnapshotImpl(
     : undefined;
   const sumMetric = (key: keyof PluginMetadataSnapshot["metrics"]) =>
     snapshots.reduce((total, snapshot) => total + snapshot.metrics[key], 0);
-  return restorePluginMetadataSnapshot(
+  return finalizePluginMetadataSnapshot(
     rebasePluginMetadataSnapshotManifestRegistry(
       {
         ...firstSnapshot,

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -107,18 +107,25 @@ function indexesMatch(
   );
 }
 
+/** Freezes prepared process-local facts; worker transfers must use restorePluginMetadataSnapshot. */
+export function finalizePluginMetadataSnapshot(
+  snapshot: PluginMetadataSnapshot,
+): PluginMetadataSnapshot {
+  freezeSnapshotValue(snapshot);
+  bindPluginMetadataSnapshotCache(snapshot);
+  return snapshot;
+}
+
 /** Restores process-local behavior and immutability after a snapshot crosses a worker boundary. */
 export function restorePluginMetadataSnapshot(
   snapshot: Omit<PluginMetadataSnapshot, "normalizePluginId">,
 ): PluginMetadataSnapshot {
-  const restored = freezeSnapshotValue({
+  return finalizePluginMetadataSnapshot({
     ...snapshot,
     normalizePluginId: createPluginRegistryIdNormalizer(snapshot.index, {
       manifestRegistry: snapshot.manifestRegistry,
     }),
   });
-  bindPluginMetadataSnapshotCache(restored);
-  return restored;
 }
 
 export function isPluginMetadataSnapshotCompatible(params: {
@@ -443,53 +450,45 @@ export function completePluginMetadataSnapshot(params: {
     return completed;
   }
   return withPluginCache(cache, () => {
-    const completed = completePluginMetadataSnapshotImpl({ ...params, snapshot });
+    const inputs = { ...params, snapshot };
+    const workspaceDir = inputs.workspaceDir ?? inputs.snapshot.workspaceDir;
+    const manifestStartedAt = performance.now();
+    const manifestRegistry =
+      inputs.snapshot.pluginIds === undefined
+        ? inputs.snapshot.manifestRegistry
+        : loadPluginManifestRegistryForInstalledIndex({
+            index: inputs.snapshot.index,
+            config: inputs.config,
+            env: inputs.env ?? process.env,
+            ...(workspaceDir ? { workspaceDir } : {}),
+            includeDisabled: true,
+          });
+    // Bundled fallback contracts cannot come from a same-id external winner.
+    // Capture their separately validated roots before runtime readers lose discovery access.
+    const bundledManifestRegistry =
+      inputs.snapshot.bundledManifestRegistry ??
+      loadBundledPluginManifestRegistry({ env: inputs.env });
+    const manifestRegistryMs = performance.now() - manifestStartedAt;
+    const rebased = rebasePluginMetadataSnapshotManifestRegistry(inputs.snapshot, manifestRegistry);
+    const { pluginIds: _pluginIds, ...unscoped } = rebased;
+    const completed = finalizePluginMetadataSnapshot({
+      ...unscoped,
+      bundledManifestRegistry,
+      configFingerprint: resolvePluginControlPlaneFingerprint({
+        config: inputs.config,
+        env: inputs.env,
+        index: rebased.index,
+        policyHash: rebased.policyHash,
+        workspaceDir,
+      }),
+      metrics: {
+        ...rebased.metrics,
+        manifestRegistryMs,
+        totalMs: rebased.metrics.totalMs + manifestRegistryMs,
+      },
+    });
     cache.metadata.completions.set(snapshot, completed);
     return completed;
-  });
-}
-
-function completePluginMetadataSnapshotImpl(params: {
-  snapshot: PluginMetadataSnapshot;
-  config: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  workspaceDir?: string;
-}): PluginMetadataSnapshot {
-  const workspaceDir = params.workspaceDir ?? params.snapshot.workspaceDir;
-  const manifestStartedAt = performance.now();
-  const manifestRegistry =
-    params.snapshot.pluginIds === undefined
-      ? params.snapshot.manifestRegistry
-      : loadPluginManifestRegistryForInstalledIndex({
-          index: params.snapshot.index,
-          config: params.config,
-          env: params.env ?? process.env,
-          ...(workspaceDir ? { workspaceDir } : {}),
-          includeDisabled: true,
-        });
-  // Bundled fallback contracts cannot come from a same-id external winner.
-  // Capture their separately validated roots before runtime readers lose discovery access.
-  const bundledManifestRegistry =
-    params.snapshot.bundledManifestRegistry ??
-    loadBundledPluginManifestRegistry({ env: params.env });
-  const manifestRegistryMs = performance.now() - manifestStartedAt;
-  const completed = rebasePluginMetadataSnapshotManifestRegistry(params.snapshot, manifestRegistry);
-  const { pluginIds: _pluginIds, ...unscoped } = completed;
-  return restorePluginMetadataSnapshot({
-    ...unscoped,
-    bundledManifestRegistry,
-    configFingerprint: resolvePluginControlPlaneFingerprint({
-      config: params.config,
-      env: params.env,
-      index: completed.index,
-      policyHash: completed.policyHash,
-      workspaceDir,
-    }),
-    metrics: {
-      ...completed.metrics,
-      manifestRegistryMs,
-      totalMs: completed.metrics.totalMs + manifestRegistryMs,
-    },
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Plugin metadata completion and multi-workspace composition build an alias normalizer during rebase, then immediately discard it through the worker-restoration path. This repeats preparation of the same immutable plugin inventory.

## Why This Change Was Made

Finalize prepared local snapshots through the existing recursive-freeze and cache-binding owners. Worker restoration still unconditionally rebuilds its process-local normalizer, including when the input carries a stale function. Inlining the one-call completion wrapper absorbs this distinction while retaining parameter capture order, projection caching, and source/receiving-cache ownership.

Production: **49 additions / 50 deletions, net −1**. Tests unchanged. No configuration, persistence, schema, plugin API, or dependency changes.

## User Impact

Metadata values, alias precedence, disabled membership, workspace collision rejection, and snapshot immutability are preserved. Completion and workspace composition each avoid one 184-entry alias Map and one 151-reference sorted array on the current 151-plugin fixture. These are observed preparation counts, not an RSS or latency claim.

## Evidence

- The existing four-file, **78-test** suite passed before and after, including complete freeze rewalks, prototype-based Map/Set mutation, accessors, projection/source-cache ownership, and config composition. The canonical changed gate passed.
- Actual source-module probes produced **23,160,363 identical canonical semantic bytes**, SHA-256 `59673aa2cfff7b3aaa5a86aa03d73f71532cda951c12d5bff8243bb72e6f9959`, and the same 370 alias answers. Object and collection ordering, undefined/functions, reference contracts, and parameter read order are checked. Two measured timing fields, an independently asserted fingerprint, and the private test-home prefix are normalized.
- An actual `WorkerTaskPool` / `serveWorkerTasks` exchange uses Node structured-clone transport. Both arms receive native Maps without the function, restore exactly once, bind the receiving cache, retain shared graph references, reject mutation, and replace an injected stale normalizer. Both pool closes were awaited.
- Scoped projection and worker restoration retain one normalizer construction; cached completion remains zero. The full freeze walker is unchanged. This exercises the metadata and worker boundaries, not a complete Gateway request.
- Managed Codex review passed at the default P0 floor with no findings. Independent parent review inspected the full owner, cache, worker producers/consumers, tests, and the history introducing cache binding. All owned proof processes and private runtime roots were cleaned up.
