### PR TITLE
fix(memory): avoid unnecessary full rebuilds during memory search

### DIFF
--- a/docs/concepts/memory-builtin.md
+++ b/docs/concepts/memory-builtin.md
@@ -116,6 +116,10 @@ which support selective deletion after promotion. For coverage and limits, see
   See [provider selection](/reference/memory-config#provider-selection).
 - **Reindex on demand:** `openclaw memory index --force --agent <id>`
 
+Search-triggered maintenance applies pending memory and session changes
+incrementally while searches remain available. A failed full rebuild retains
+its full-retry state; ordinary dirty content does not itself force a rebuild.
+
 Full reindexes build a replacement in a temporary database and publish the
 memory tables atomically. Concurrent searches and status reads keep using the
 published index; a failed rebuild leaves that index intact. The embedding cache

--- a/extensions/memory-core/src/memory/manager-search-maintenance.ts
+++ b/extensions/memory-core/src/memory/manager-search-maintenance.ts
@@ -1,8 +1,9 @@
 // Memory Core owns detached search-time index maintenance lifecycle.
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 
-type MemorySearchMaintenanceManager = {
-  sync(params: { reason: string; force: true }): Promise<void>;
+type MemorySearchMaintenanceManager<DirtyGeneration> = {
+  adoptReindexRetryState(generation: DirtyGeneration): void;
+  sync(params: { reason: string }): Promise<void>;
   status(): { dirty?: boolean; lastSyncError?: string };
   close(): Promise<void>;
 };
@@ -11,10 +12,10 @@ export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
   reason: string;
   takeDirtyGeneration: () => DirtyGeneration;
   restoreDirtyGeneration: (generation: DirtyGeneration) => void;
-  acquireManager: () => Promise<MemorySearchMaintenanceManager | null>;
+  acquireManager: () => Promise<MemorySearchMaintenanceManager<DirtyGeneration> | null>;
 }): Promise<string | undefined> {
   const dirtyGeneration = params.takeDirtyGeneration();
-  let manager: MemorySearchMaintenanceManager | null;
+  let manager: MemorySearchMaintenanceManager<DirtyGeneration> | null;
   try {
     manager = await params.acquireManager();
   } catch (err) {
@@ -29,9 +30,10 @@ export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
   let maintenanceError: Error | undefined;
   let incompleteReason: string | undefined;
   try {
-    // The transient manager has no watcher state. Force every source represented
-    // by the handed-off generation while the default manager serves published reads.
-    await manager.sync({ reason: params.reason, force: true });
+    // The transient manager owns exactly this handed-off generation, merged with
+    // its initial repair state. Full-retry flags still select rebuilds in runSync.
+    manager.adoptReindexRetryState(dirtyGeneration);
+    await manager.sync({ reason: params.reason });
     const status = manager.status();
     if (status.dirty === true) {
       // A provider fallback may deliberately resolve in keyword-only mode while

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -565,72 +565,128 @@ describe("memory index", () => {
     await pendingSync;
   });
 
-  it("keeps the published index searchable while dirty maintenance builds", async () => {
-    providerFixture.forceNoProvider = true;
-    const manager = await getPersistentManager(
-      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
-    );
-    await manager.sync({ reason: "test" });
-    await fs.writeFile(
-      path.join(fixture.paths.memory, "search-sync.md"),
-      "Current memory appears only after the dirty search sync.",
-    );
-    await vi.waitFor(() => expect(manager.status().dirty).toBe(true));
-
-    const maintenanceReady = createDeferred<void>();
-    const releaseMaintenance = createDeferred<void>();
-    const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
-    let maintenanceClosed = false;
-    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
-      const acquired = await originalGet(params);
-      if (params.purpose !== "maintenance" || !acquired) {
-        return acquired;
-      }
-      const closeMaintenance = acquired.close.bind(acquired);
-      vi.spyOn(acquired, "close").mockImplementation(async () => {
-        await closeMaintenance();
-        maintenanceClosed = true;
-      });
-      const fields = acquired as unknown as {
-        syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
-      };
-      const syncMemoryFiles = fields.syncMemoryFiles.bind(acquired);
-      vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (syncParams) => {
-        const result = await syncMemoryFiles(syncParams);
-        maintenanceReady.resolve();
-        await releaseMaintenance.promise;
-        return result;
-      });
-      return acquired;
-    });
-
-    try {
-      const firstSearch = manager.search("zebra", { maxResults: 5, minScore: 0 });
-      await maintenanceReady.promise;
-      expect(manager.status()).toMatchObject({ dirty: true });
-
-      const publishedResults = await manager.search("zebra", { maxResults: 5, minScore: 0 });
-      expect(publishedResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
-      await expect(
-        manager.search("current dirty search sync", { maxResults: 5, minScore: 0 }),
-      ).resolves.toEqual([]);
-
-      releaseMaintenance.resolve();
-      await firstSearch;
-      await (manager as unknown as { awaitManagerIdle: () => Promise<void> }).awaitManagerIdle();
-      expect(manager.status().dirty).toBe(false);
-
-      const refreshedResults = await manager.search("current dirty search sync", {
-        maxResults: 5,
+  it.each([
+    { name: "dirty memory", source: "memory", fullRetry: false },
+    { name: "one dirty session", source: "sessions", fullRetry: false },
+    { name: "full memory retry", source: "memory", fullRetry: true },
+  ] as const)(
+    "keeps search usable while maintenance syncs $name",
+    async ({ source, fullRetry }) => {
+      providerFixture.forceNoProvider = true;
+      const cfg = createCfg({
+        provider: "none",
+        sources: ["memory", "sessions"],
+        sessionMemory: true,
         minScore: 0,
+        onSearch: true,
+        hybrid: { enabled: true },
       });
-      expect(refreshedResults.some((entry) => entry.path === "memory/search-sync.md")).toBe(true);
-      expect(maintenanceClosed).toBe(true);
-    } finally {
-      releaseMaintenance.resolve();
-      getSpy.mockRestore();
-    }
-  });
+      const manager = await getPersistentManager(cfg);
+      await manager.sync({ reason: "test", force: true });
+      // This fixture supplies one exact dirty generation, without later native
+      // watcher notifications adding another generation during the handoff.
+      (
+        manager as unknown as { closeNativeMemoryWatchPairs: () => void }
+      ).closeNativeMemoryWatchPairs();
+      const content = "Current memory appears only after the dirty search sync.";
+      if (source === "memory") {
+        await fs.writeFile(path.join(fixture.paths.memory, "search-sync.md"), content);
+      } else {
+        await seedMemoryIndexSessionTranscript({
+          sessionId: "search-sync",
+          messages: [{ role: "assistant", timestamp: Date.now(), content }],
+        });
+      }
+      const servingFields = manager as unknown as {
+        dirty: boolean;
+        memoryFullRetryDirty: boolean;
+        sessionsDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+        listSessionCorpusEntries: () => Promise<Array<{ sessionFile: string }>>;
+        awaitManagerIdle: () => Promise<void>;
+      };
+      servingFields.dirty = source === "memory";
+      servingFields.memoryFullRetryDirty = fullRetry;
+      servingFields.sessionsDirty = source === "sessions";
+      if (source === "sessions") {
+        const entries = await servingFields.listSessionCorpusEntries();
+        expect(entries).toHaveLength(1);
+        servingFields.sessionsDirtyFiles = new Set(entries.map((entry) => entry.sessionFile));
+      }
+
+      const maintenanceReady = createDeferred<void>();
+      const releaseMaintenance = createDeferred<void>();
+      const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
+      let maintenanceClosed = false;
+      let maintenanceFields:
+        | {
+            runInPlaceReindex: (params: unknown) => Promise<void>;
+            syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+            syncArchiveFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+          }
+        | undefined;
+      const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
+        const acquired = await originalGet(params);
+        if (params.purpose !== "maintenance" || !acquired) {
+          return acquired;
+        }
+        const closeMaintenance = acquired.close.bind(acquired);
+        vi.spyOn(acquired, "close").mockImplementation(async () => {
+          await closeMaintenance();
+          maintenanceClosed = true;
+        });
+        const fields = acquired as unknown as NonNullable<typeof maintenanceFields>;
+        maintenanceFields = fields;
+        vi.spyOn(fields, "runInPlaceReindex");
+        const sourceSync = source === "memory" ? "syncMemoryFiles" : "syncArchiveFiles";
+        const syncSource = fields[sourceSync].bind(acquired);
+        vi.spyOn(fields, sourceSync).mockImplementation(async (syncParams) => {
+          // Full retries hold completed shadow writes; incremental sync holds before
+          // its live writes so both cases prove reads remain available during work.
+          const result = fullRetry ? await syncSource(syncParams) : undefined;
+          maintenanceReady.resolve();
+          await releaseMaintenance.promise;
+          return fullRetry ? result : await syncSource(syncParams);
+        });
+        return acquired;
+      });
+
+      try {
+        const firstSearch = manager.search("zebra", { maxResults: 5, minScore: 0 });
+        await maintenanceReady.promise;
+        expect(manager.status()).toMatchObject({ dirty: true });
+        expect(maintenanceFields!.runInPlaceReindex).toHaveBeenCalledTimes(fullRetry ? 1 : 0);
+        expect(
+          maintenanceFields![source === "memory" ? "syncMemoryFiles" : "syncArchiveFiles"],
+        ).toHaveBeenCalledWith(expect.objectContaining({ needsFullReindex: fullRetry }));
+
+        const publishedResults = await firstSearch;
+        expect(publishedResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+        await expect(
+          manager.search("current dirty search sync", { maxResults: 5, minScore: 0 }),
+        ).resolves.toEqual([]);
+
+        releaseMaintenance.resolve();
+        await servingFields.awaitManagerIdle();
+        expect(manager.status().dirty).toBe(false);
+
+        const refreshedResults = await manager.search("current dirty search sync", {
+          maxResults: 5,
+          minScore: 0,
+        });
+        expect(refreshedResults).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ source, snippet: expect.stringContaining(content) }),
+          ]),
+        );
+        expect(maintenanceClosed).toBe(true);
+      } finally {
+        releaseMaintenance.resolve();
+        await servingFields.awaitManagerIdle();
+        getSpy.mockRestore();
+      }
+    },
+  );
 
   it("keeps transient CLI search off the serving manager write path", async () => {
     providerFixture.forceNoProvider = true;
@@ -720,6 +776,7 @@ describe("memory index", () => {
     await manager.sync({ reason: "test" });
     const syncError = new Error("maintenance failed");
     const maintenance = {
+      adoptReindexRetryState: vi.fn(),
       sync: vi.fn(async () => {
         throw syncError;
       }),
@@ -742,7 +799,15 @@ describe("memory index", () => {
         ).syncPublishedIndexInBackground({ reason: "search" }),
       ).rejects.toThrow(syncError);
 
-      expect(maintenance.sync).toHaveBeenCalledWith({ reason: "search", force: true });
+      expect(maintenance.adoptReindexRetryState).toHaveBeenCalledWith({
+        dirty: true,
+        memoryFullRetryDirty: true,
+        sessionsDirty: true,
+        sessionsFullRetryDirty: true,
+        sessionsReconcileDirty: true,
+        sessionsDirtyFiles: new Set(["session.jsonl"]),
+      });
+      expect(maintenance.sync).toHaveBeenCalledWith({ reason: "search" });
       expect(maintenance.close).toHaveBeenCalledTimes(1);
       expect(manager.status().lastSyncError).toContain("maintenance failed");
       expect(Reflect.get(manager, "dirty")).toBe(true);
@@ -792,6 +857,7 @@ describe("memory index", () => {
     const maintenanceStarted = createDeferred<void>();
     const releaseMaintenance = createDeferred<void>();
     const maintenance = {
+      adoptReindexRetryState: vi.fn(),
       sync: vi.fn(async () => {
         maintenanceStarted.resolve();
         await releaseMaintenance.promise;

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -84,7 +84,7 @@ export type MemorySourceSyncPlan = {
   finalize: () => Promise<void> | void;
 };
 
-type MemoryReindexRetryState = {
+export type MemoryReindexRetryState = {
   dirty: boolean;
   memoryFullRetryDirty: boolean;
   sessionsDirty: boolean;
@@ -98,7 +98,9 @@ const META_KEY = MEMORY_INDEX_META_KEY;
 const VECTOR_TABLE = MEMORY_INDEX_VECTOR_TABLE;
 const LEGACY_VECTOR_TABLE = "chunks_vec";
 const EMBEDDING_CACHE_TABLE = MEMORY_EMBEDDING_CACHE_TABLE;
-const EMBEDDING_CACHE_SEED_BATCH_SIZE = 1_000;
+// Production embeddings measured ~28 KB/row; 1,000-row synchronous commits
+// blocked the event loop for seconds. Keep each commit small between yields.
+const EMBEDDING_CACHE_SEED_BATCH_SIZE = 100;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const log = createSubsystemLogger("memory");
 

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -289,7 +289,7 @@ describe("embedding cache seed responsiveness", () => {
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
       );
       sourceDb.exec("BEGIN");
-      for (let index = 0; index < 1_001; index += 1) {
+      for (let index = 0; index < 101; index += 1) {
         insert.run("test", "model", "key", `hash-${index}`, "[0.5]", 1, index);
       }
       sourceDb.exec("COMMIT");
@@ -320,9 +320,9 @@ describe("embedding cache seed responsiveness", () => {
       expect(duringYield).toEqual({
         sourceInTransaction: false,
         targetInTransaction: false,
-        rows: 1_000,
+        rows: 100,
       });
-      expect(countCacheRows(targetDb)).toBe(1_001);
+      expect(countCacheRows(targetDb)).toBe(101);
     } finally {
       sourceDb.close();
       targetDb.close();

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -53,6 +53,7 @@ import {
   resolveInitialMemoryDirty,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
+import type { MemoryReindexRetryState } from "./manager-sync-base.js";
 import {
   enqueueMemoryTargetedSessionSync,
   hasTargetedSessionSyncParams,
@@ -278,6 +279,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
 
   async sync(params?: MemorySyncParams): Promise<void> {
     return await this.withPublishedDatabase(() => this.syncPublished(params));
+  }
+
+  adoptReindexRetryState(snapshot: MemoryReindexRetryState): void {
+    this.restoreReindexRetryState(snapshot);
   }
 
   private async syncPublished(params?: MemorySyncParams): Promise<void> {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where searching a dirty builtin memory index repeatedly launches a full shadow rebuild instead of indexing pending changes. On busy agents with session indexing, this wastes embedding/cache work and can keep incremental session updates waiting on the reindex lock. Observed on a production Gateway: every dirty search started a multi-minute full rebuild whose 1,000-row embedding-cache seed commits blocked the event loop for 1-10 s each, while `session-delta` syncs failed with "Memory reindex lock is held" more than 100 times per hour.

Closes #134337 (thanks @ThatGuySizemore for the report and the diagnosis). Overlaps #134338, which also addresses forced dirty-search maintenance through source inspection and CLI lifecycle changes. This work follows the maintainer-requested dirty-generation handoff instead; it does not modify that PR. Revision-conflict retry work in #134333 remains separate.

## Why This Change Was Made

The serving manager already owns a complete dirty-generation snapshot. The transient maintenance manager now adopts it through the existing OR/union restoration logic and syncs without `force`, preserving constructor repair state and letting `runSync` choose incremental work or a genuine full retry. Embedding-cache seed commits are reduced from 1,000 to 100 rows, retaining the per-batch event-loop yield; reported production rows were about 28 KB and 1,000-row synchronous commits took seconds.

No Plugin SDK exports, configuration options, schemas, revision fences, reindex locks, or publication-generation leases change. The small production increase is the required plugin-local adoption method/type contract; the existing restoration owner remains canonical.

## User Impact

Memory searches can refresh dirty memory files and session transcripts without rebuilding the entire index. Searches remain available during maintenance, dirty content becomes searchable afterward, and full-retry generations still receive the required rebuild. Failed or incomplete maintenance still restores the handed-off state and closes its transient manager.

## Evidence

The existing published-index availability fixture was extended rather than duplicated. It now exercises memory dirtiness, a single dirty session, and a full-memory retry against real SQLite indexing and searches. The cache-yield fixture now checks the 100-row boundary and that neither database holds a transaction during the yield.

Pre-fix command:

```sh
pnpm test extensions/memory-core/src/memory/manager-search-orchestration.test.ts
```

Both incremental regression cases failed for the intended reason:

```text
FAIL memory index > keeps search usable while maintenance syncs 'dirty memory'
FAIL memory index > keeps search usable while maintenance syncs 'one dirty session'
AssertionError: expected "runInPlaceReindex" to be called +0 times, but got 1 times
```

The full-memory-retry case passed before the fix. The changed adoption-contract assertion also failed because no generation was adopted. With the old seed limit, `pnpm test extensions/memory-core/src/memory/manager-sync-yield.test.ts` failed with `rows: 100` expected and `rows: 101` received before the first yield.

Final validation:

- `pnpm test extensions/memory-core/src/memory/manager-search-orchestration.test.ts` — 23 passed.
- `pnpm test extensions/memory-core/src/memory/manager-sync-ops` — 36 passed across 2 files.
- `pnpm test extensions/memory-core/src/memory/manager.reindex-recovery.test.ts` — 17 passed.
- `pnpm test extensions/memory-core` — 1,409 passed, 3 Windows-only tests skipped; 102 files passed, 1 skipped (313.34s wrapper duration).
- `node scripts/check-changed.mjs` — passed, including formatting, production/test typechecks, lint, plugin doctor contracts, ownership guards, dead-export scans, and zero runtime import cycles.
- `git diff --check` — passed.
- Codex autoreview — scoped-clean at the configured P0 threshold.

An initial fixed-code fixture run exposed a late native watcher notification after manually seeding dirty state. The fixture now closes its native watchers before supplying the exact test generation; no runtime guard, timeout increase, or weakened assertion was added.

LOC: production +18/-9 (net +9); tests +132/-66 (net +66); docs +4/-0. No production-scale latency benchmark or operator-Gateway modification was performed. The deterministic proof uses isolated test state and real SQLite with fixture-controlled embedding providers, not live provider inference. Clean CLI search behavior and revision-conflict retry policy are outside this change.

