### PR TITLE
refactor(plugin-sdk): share session visibility types

### DIFF
--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -13,6 +13,10 @@ import {
   renderSessionVisibilityDenial,
   resolveIncognitoSessionAccessDecision,
   sessionOwnershipLookupDenied,
+  type SessionVisibilityDecisionAction,
+  type SessionVisibilityDecisionMode,
+  type SessionVisibilityDecisionPolicy,
+  type SessionVisibilityDecisionRow,
   type SessionVisibilityDecision,
   type SessionOwnershipLookupFailure,
 } from "./session-visibility-internal.js";
@@ -20,17 +24,15 @@ import {
 type GatewayCaller = typeof defaultCallGateway;
 
 /** Configured visibility mode for session tools and session-related commands. */
-export type SessionToolsVisibility = "self" | "tree" | "agent" | "all";
+export type SessionToolsVisibility = SessionVisibilityDecisionMode;
 
 /** Agent-to-agent access policy compiled from `tools.agentToAgent` config. */
-export type AgentToAgentPolicy = {
-  enabled: boolean;
+export type AgentToAgentPolicy = SessionVisibilityDecisionPolicy & {
   matchesAllow: (agentId: string) => boolean;
-  isAllowed: (requesterAgentId: string, targetAgentId: string) => boolean;
 };
 
 /** Session operation whose visibility error copy should be rendered. */
-export type SessionAccessAction = "history" | "send" | "list" | "status";
+export type SessionAccessAction = SessionVisibilityDecisionAction;
 
 /** Result of checking whether one session operation may target a session. */
 export type SessionAccessResult =
@@ -79,13 +81,7 @@ function resolveScopedSessionAccess(
 }
 
 /** Minimal session row metadata needed to evaluate ownership and cross-agent access. */
-export type SessionVisibilityRow = {
-  key: string;
-  agentId?: string;
-  ownerSessionKey?: string;
-  spawnedBy?: string;
-  parentSessionKey?: string;
-};
+export type SessionVisibilityRow = SessionVisibilityDecisionRow;
 
 /** Public compatibility wrapper; direct guards use the richer private result. */
 export async function listSpawnedSessionKeys(params: {


### PR DESCRIPTION
## What Problem This Solves

The public session-visibility SDK repeated the internal visibility mode, action, policy, and row types even though both surfaces feed the same decision checker. Future changes could therefore update one copy without updating the other, leaving plugin-facing declarations inconsistent with the policy owner.

## Why This Change Was Made

The public names now alias the canonical internal primitives, and the public agent-to-agent policy extends the internal policy with its public `matchesAllow` helper. This preserves the existing public names, emitted declaration shape, runtime behavior, and SDK entrypoint surface while removing duplicate type definitions.

## User Impact

No user-visible runtime behavior changes. Plugin developers keep the same public type names and contracts, while future session-visibility changes have one canonical type owner.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-sdk/session-visibility.test.ts src/agents/tools/sessions-access.test.ts src/agents/openclaw-tools.sessions.test.ts` — 117 tests passed across 3 shards, repeated after the final rebase.
- `pnpm check:changed` — passed core and extension production/test typechecks, lint, SDK checks, dead-export scans, guards, and import-cycle validation.
- `pnpm plugin-sdk:check-exports` — plugin SDK registration synced.
- `pnpm plugin-sdk:surface:check` — 345 entrypoints and 7,426 exports; passed before and after the final rebase.
- `pnpm build` — passed, including all 149 public Plugin SDK subpaths and packaged declaration validation.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — scoped-clean, no accepted/actionable findings, correctness 0.99.
- Production LOC: +8/-12 (net -4). Tests: +0/-0.
