### PR TITLE
fix(cli): hide remote exec without an executable node

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -346,6 +346,13 @@ When bundle MCP is enabled, OpenClaw:
 - loads enabled bundle-MCP servers for the current workspace and merges them with any existing backend MCP config/settings shape;
 - rewrites the launch config using the backend-owned integration mode from the owning plugin.
 
+The node-only `exec` tool is offered only when policy permits it and a connected
+node advertises `system.run`. Offline paired devices and approval-only phones do
+not make remote execution available. A configured node binding must identify an
+eligible node; it never redirects to another device. When several eligible nodes
+are connected, select one explicitly. When local execution is allowed by policy,
+use the CLI's native shell for local work.
+
 `tools.allow` and `tools.deny` also constrain configured native MCP servers.
 OpenClaw lists each server through its session-scoped runtime, assigns the same
 provider-safe `<safe-server>__<safe-tool>` identities used by embedded tools,

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -54,7 +54,7 @@ import { createCodexTestModel } from "./test-support.js";
 const hoisted = vi.hoisted(() => ({
   normalizeAgentRuntimeTools: vi.fn(),
   resolveWebSearchToolPolicy: vi.fn(),
-  listNodes: vi.fn(),
+  loadNodeExecAvailability: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-harness", async (importOriginal) => {
@@ -75,12 +75,17 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
   return {
     ...actual,
-    listNodes: hoisted.listNodes,
     normalizeAgentRuntimeTools: (...args: Parameters<typeof actual.normalizeAgentRuntimeTools>) => {
       hoisted.normalizeAgentRuntimeTools(...args);
       return actual.normalizeAgentRuntimeTools(...args);
     },
   };
+});
+
+vi.mock("openclaw/plugin-sdk/node-selection-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/node-selection-runtime")>();
+  return { ...actual, loadNodeExecAvailability: hoisted.loadNodeExecAvailability };
 });
 
 let tempDir: string;
@@ -529,13 +534,10 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   beforeEach(async () => {
-    hoisted.listNodes.mockResolvedValue(
-      ["mac-mini", "worker-1", "bound-mac-mini"].map((nodeId) => ({
-        nodeId,
-        connected: true,
-        commands: ["system.run"],
-      })),
-    );
+    hoisted.loadNodeExecAvailability.mockResolvedValue({
+      cacheKey: "eligible",
+      isAvailable: () => true,
+    });
     hoisted.normalizeAgentRuntimeTools.mockClear();
     hoisted.resolveWebSearchToolPolicy.mockClear();
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-tools-"));
@@ -1679,96 +1681,71 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shellTestToolNames(tools)).toEqual(testCase.expected);
   });
 
-  it.each([
-    { label: "no nodes", nodes: [], available: false },
-    {
-      label: "offline executor",
-      nodes: [{ nodeId: "worker", connected: false, commands: ["system.run"] }],
-      available: false,
-    },
-    {
-      label: "connected approval device",
-      nodes: [{ nodeId: "phone", connected: true, commands: [] }],
-      available: false,
-    },
-    {
-      label: "unknown capabilities",
-      nodes: [{ nodeId: "phone", connected: true }],
-      available: false,
-    },
-    {
-      label: "eligible executor",
-      nodes: [{ nodeId: "worker", connected: true, commands: ["system.run"] }],
-      available: true,
-    },
-    {
-      label: "multiple executors",
-      nodes: ["one", "two"].map((nodeId) => ({
-        nodeId,
-        connected: true,
-        commands: ["system.run"],
-      })),
-      available: true,
-    },
-    {
-      label: "offline binding beside eligible executor",
-      node: "phone",
-      nodes: [
-        { nodeId: "phone", connected: false, commands: [] },
-        { nodeId: "worker", connected: true, commands: ["system.run"] },
-      ],
-      available: false,
-    },
-    {
-      label: "eligible named binding",
-      node: "Build Worker",
-      nodes: [
-        {
-          nodeId: "worker",
-          displayName: "Build Worker",
-          connected: true,
-          commands: ["system.run"],
-        },
-      ],
-      available: true,
-    },
-    {
-      label: "ambiguous binding",
-      node: "Build Worker",
-      nodes: [
-        { nodeId: "phone", displayName: "Build Worker", connected: true, commands: [] },
-        {
-          nodeId: "worker",
-          displayName: "Build Worker",
-          connected: true,
-          commands: ["system.run"],
-        },
-      ],
-      available: false,
-    },
-  ])(
-    "gates node_exec on live execution eligibility: $label",
-    async ({ nodes, node, available }) => {
-      hoisted.listNodes.mockResolvedValue(nodes);
-      setOpenClawCodingToolsFactoryForTests(() => [
-        createRuntimeDynamicTool("exec"),
-        createRuntimeDynamicTool("message"),
-      ]);
-      const workspaceDir = path.join(tempDir, "workspace");
-      const params = createParams(path.join(tempDir, "eligibility.jsonl"), workspaceDir);
-      params.disableTools = false;
-      params.runtimePlan = createCodexRuntimePlanFixture();
-      for (const host of ["auto", "node"] as const) {
-        params.execOverrides = { host, node };
-        const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params);
+  it.each([false, true])("projects node exec when availability is %s", async (available) => {
+    hoisted.loadNodeExecAvailability.mockResolvedValue({
+      cacheKey: String(available),
+      isAvailable: () => available,
+    });
+    setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "eligibility.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    for (const host of ["auto", "node"] as const) {
+      params.execOverrides = { host };
+      const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(params);
+      const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+        nativeToolSurfaceEnabled,
+      });
+      expect(tools.some((tool) => tool.name === "node_exec")).toBe(available);
+      expect(nativeToolSurfaceEnabled).toBe(host === "auto");
+    }
+  });
+
+  it("shares discovery across attempt catalogs but refreshes the next attempt", async () => {
+    setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("exec")]);
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "catalog-discovery.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    hoisted.loadNodeExecAvailability.mockClear();
+    for (const available of [true, false]) {
+      hoisted.loadNodeExecAvailability.mockResolvedValue({
+        cacheKey: String(available),
+        isAvailable: () => available,
+      });
+      const nodeExecAvailability = {};
+      for (const ignoreRuntimePlan of [false, true]) {
         const tools = await buildDynamicToolsForTest(params, workspaceDir, {
-          nativeToolSurfaceEnabled,
+          nodeExecAvailability,
+          ignoreRuntimePlan,
         });
         expect(tools.some((tool) => tool.name === "node_exec")).toBe(available);
-        expect(nativeToolSurfaceEnabled).toBe(host === "auto");
       }
-    },
-  );
+    }
+    expect(hoisted.loadNodeExecAvailability).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates cancellation during node discovery without publishing tools", async () => {
+    setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("exec")]);
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "cancel-discovery.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const runAbortController = new AbortController();
+    const reason = new Error("synthetic attempt cancelled");
+    hoisted.loadNodeExecAvailability.mockImplementationOnce(async (signal: AbortSignal) => {
+      expect(signal).toBe(runAbortController.signal);
+      runAbortController.abort(reason);
+      return { cacheKey: "eligible", isAvailable: () => true };
+    });
+    await expect(
+      buildDynamicToolsForTest(params, workspaceDir, { runAbortController }),
+    ).rejects.toBe(reason);
+  });
 
   it("exposes pinned node shell tools for node-targeted Codex app-server runs", async () => {
     const execTool = {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -54,6 +54,7 @@ import {
   createGatewayProcessProjection,
   createNodeExecAliasDynamicTool,
   isCodexDynamicToolExcluded,
+  type NodeExecAvailabilityRef,
 } from "./shell-dynamic-tools.js";
 import { filterCodexVisionTools } from "./vision-tools.js";
 import { resolveCodexWebSearchPlan, type CodexNativeWebSearchSupport } from "./web-search.js";
@@ -132,6 +133,7 @@ type DynamicToolBuildParams = {
   nativeToolSurfaceEnabled?: boolean;
   nativeProviderWebSearchSupport?: CodexNativeWebSearchSupport;
   runAbortController: AbortController;
+  nodeExecAvailability?: NodeExecAvailabilityRef;
   sessionAgentId: string;
   policyAgentId: string;
   pluginConfig: CodexPluginConfig;
@@ -911,6 +913,7 @@ async function addNodeShellDynamicToolsIfNeeded(
     execTool,
     nodePolicy.node,
     input.runAbortController.signal,
+    input.nodeExecAvailability,
   );
   return nodeExec ? [...filteredTools, nodeExec] : filteredTools;
 }

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -198,6 +198,8 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     | undefined;
   const runtimeYieldCompletionClaim: { current?: () => boolean } = {};
   const commonToolParams = {
+    // Both catalogs describe one attempt; a later attempt discovers fresh connections.
+    nodeExecAvailability: {},
     params: dynamicToolParams,
     resolvedWorkspace,
     effectiveWorkspace,

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,8 +1,8 @@
-import { listNodes, resolveNodeIdFromList } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   pinExecToolTarget,
   type CodexScheduledToolProjectionFactory,
 } from "openclaw/plugin-sdk/codex-mcp-projection";
+import { loadNodeExecAvailability } from "openclaw/plugin-sdk/node-selection-runtime";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
@@ -27,30 +27,21 @@ export function isCodexDynamicToolExcluded(
   );
 }
 
+/** Shared only by the runtime and registered catalogs of one attempt. */
+export type NodeExecAvailabilityRef = { current?: ReturnType<typeof loadNodeExecAvailability> };
+
 export async function createNodeExecAliasDynamicTool(
   execTool: OpenClawDynamicTool,
   node?: string,
   discoverySignal?: AbortSignal,
+  availabilityRef?: NodeExecAvailabilityRef,
 ): Promise<OpenClawDynamicTool | undefined> {
   const pinnedNode = node?.trim();
-  try {
-    const nodes = await listNodes({}, discoverySignal);
-    // Resolve bindings before filtering: an unavailable or ambiguous target must
-    // never redirect execution to another device that happens to support shell.
-    const nodeId = pinnedNode ? resolveNodeIdFromList(nodes, pinnedNode) : undefined;
-    if (
-      !nodes.some(
-        (candidate) =>
-          (!nodeId || candidate.nodeId === nodeId) &&
-          candidate.connected === true &&
-          candidate.commands?.includes("system.run") === true,
-      )
-    ) {
-      return undefined;
-    }
-  } catch {
-    discoverySignal?.throwIfAborted();
-    // Discovery failure hides the optional remote shell, not the working local shell.
+  const availability = await (availabilityRef
+    ? (availabilityRef.current ??= loadNodeExecAvailability(discoverySignal))
+    : loadNodeExecAvailability(discoverySignal));
+  discoverySignal?.throwIfAborted();
+  if (!availability.isAvailable(pinnedNode)) {
     return undefined;
   }
   const pinnedTool = pinExecToolTarget(execTool, {
@@ -77,8 +68,8 @@ export async function createNodeExecAliasDynamicTool(
     ...pinnedTool,
     name: CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
     description: pinnedNode
-      ? "Run a shell command to completion on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
-      : "Run a shell command to completion on an OpenClaw remote node. The sole connected node that can execute commands is selected automatically; select by name or id when several can. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work.",
+      ? "Run a shell command to completion on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work when it is available."
+      : "Run a shell command to completion on an OpenClaw remote node. The sole connected node that can execute commands is selected automatically; select by name or id when several can. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work when it is available.",
     execute,
   };
 }

--- a/src/agents/bash-tools.exec-host-node-phases.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
 import {
   formatNodeInvokeFailureFollowup,
   invokeNodeSystemRun,
@@ -121,6 +122,25 @@ describe("invokeNodeSystemRun failure classification", () => {
 describe("node execution target resolution", () => {
   beforeEach(() => {
     callGatewayToolMock.mockReset();
+  });
+
+  it("rejects legacy paired-node records without execution capabilities", async () => {
+    callGatewayToolMock
+      .mockRejectedValueOnce(
+        new GatewayClientRequestError({
+          code: "INVALID_REQUEST",
+          message: "unknown method: node.list",
+        }),
+      )
+      .mockResolvedValueOnce({ paired: [{ nodeId: "legacy-node", platform: "linux" }] });
+
+    await expect(resolveNodeExecutionTarget(createDirectNodeRun().request)).rejects.toThrow(
+      /supports system.run/,
+    );
+    expect(callGatewayToolMock.mock.calls.map(([method]) => method)).toEqual([
+      "node.list",
+      "node.pair.list",
+    ]);
   });
 
   it("requires an explicit target when multiple connected nodes support system.run", async () => {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1085,13 +1085,15 @@ export async function prepareCliRunContext(
   const projectedToolsBeforePromptBuild =
     (bundleMcpEnabled || shouldMaterializeRuntimePolicy || nodeWorkshopEnabled) &&
     mcpProjectionContext
-      ? resolveProjectedTools({
-          cfg: runConfig,
-          ...mcpProjectionContext,
-          ...(skillWorkshop ? { skillWorkshop } : {}),
-          ...(mcpToolAuth ? { authProfileStore: mcpToolAuth.store } : {}),
-          ...(mcpToolAuth?.agentDir ? { authProfileStoreAgentDir: mcpToolAuth.agentDir } : {}),
-        }).tools
+      ? (
+          await resolveProjectedTools({
+            cfg: runConfig,
+            ...mcpProjectionContext,
+            ...(skillWorkshop ? { skillWorkshop } : {}),
+            ...(mcpToolAuth ? { authProfileStore: mcpToolAuth.store } : {}),
+            ...(mcpToolAuth?.agentDir ? { authProfileStoreAgentDir: mcpToolAuth.agentDir } : {}),
+          })
+        ).tools
       : [];
   const hookFilteredProjectedTools = applyEmbeddedAttemptToolsAllow(
     projectedToolsBeforePromptBuild,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1088,6 +1088,7 @@ export async function prepareCliRunContext(
       ? (
           await resolveProjectedTools({
             cfg: runConfig,
+            signal: params.abortSignal,
             ...mcpProjectionContext,
             ...(skillWorkshop ? { skillWorkshop } : {}),
             ...(mcpToolAuth ? { authProfileStore: mcpToolAuth.store } : {}),

--- a/src/agents/node-exec-availability.ts
+++ b/src/agents/node-exec-availability.ts
@@ -1,0 +1,39 @@
+import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
+
+/** Prepares current node facts for tool discovery without caching connection state. */
+export async function loadNodeExecAvailability(signal?: AbortSignal) {
+  const nodes = await listNodes({}, signal).catch(() => {
+    signal?.throwIfAborted();
+    return [];
+  });
+  return {
+    // Only matching and execution facts invalidate a cached tool catalog.
+    cacheKey: JSON.stringify(
+      nodes
+        .toSorted((a, b) => a.nodeId.localeCompare(b.nodeId))
+        .map(({ nodeId, displayName, remoteIp, clientId, connected, commands }) => [
+          nodeId,
+          displayName,
+          remoteIp,
+          clientId,
+          connected === true,
+          commands?.includes("system.run") === true,
+        ]),
+    ),
+    isAvailable: (node?: string): boolean => {
+      try {
+        // Bind against the full inventory: an offline or ambiguous name must not
+        // redirect execution to another eligible device with the same name.
+        const nodeId = node?.trim() ? resolveNodeIdFromList(nodes, node) : undefined;
+        return nodes.some(
+          (entry) =>
+            (!nodeId || entry.nodeId === nodeId) &&
+            entry.connected === true &&
+            entry.commands?.includes("system.run") === true,
+        );
+      } catch {
+        return false;
+      }
+    },
+  };
+}

--- a/src/agents/node-exec-availability.ts
+++ b/src/agents/node-exec-availability.ts
@@ -6,6 +6,7 @@ export async function loadNodeExecAvailability(signal?: AbortSignal) {
     signal?.throwIfAborted();
     return [];
   });
+  signal?.throwIfAborted();
   return {
     // Only matching and execution facts invalidate a cached tool catalog.
     cacheKey: JSON.stringify(

--- a/src/gateway/mcp-http.oauth-tools.test.ts
+++ b/src/gateway/mcp-http.oauth-tools.test.ts
@@ -14,7 +14,7 @@ vi.mock("../plugins/tools.js", async (importOriginal) => ({
 }));
 
 describe("MCP loopback OAuth tools", () => {
-  it("exposes a plugin tool backed by a prepared OAuth profile", () => {
+  it("exposes a plugin tool backed by a prepared OAuth profile", async () => {
     pluginTools.resolve.mockImplementation(
       (params: {
         context?: { activeModel?: { provider?: string; modelId?: string } };
@@ -35,7 +35,7 @@ describe("MCP loopback OAuth tools", () => {
           : [],
     );
 
-    const result = resolveMcpLoopbackScopedTools({
+    const result = await resolveMcpLoopbackScopedTools({
       cfg: {
         auth: { order: { xai: ["xai:oauth"] } },
         plugins: { allow: ["xai"] },

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { loadNodeExecAvailability } from "../agents/node-exec-availability.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
@@ -8,6 +10,16 @@ import {
 } from "./mcp-http.runtime.js";
 
 const resolveGatewayScopedTools = vi.hoisted(() => vi.fn());
+const listNodes = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/tools/gateway.js", () => ({
+  callGatewayTool: async (
+    _method: string,
+    _opts: unknown,
+    _args: unknown,
+    options: { signal?: AbortSignal },
+  ) => ({ nodes: await listNodes(options.signal) }),
+}));
 
 vi.mock("./tool-resolution.js", () => ({
   resolveGatewayScopedTools,
@@ -38,6 +50,8 @@ function scopeParams(overrides: Record<string, unknown> = {}) {
 }
 
 beforeEach(() => {
+  listNodes.mockReset();
+  listNodes.mockResolvedValue([]);
   resolveGatewayScopedTools.mockReset();
   resolveGatewayScopedTools.mockReturnValue(
     scopedToolFixture(["memory_search", "memory_get", "message", "cron"]),
@@ -48,9 +62,116 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
+describe("node execution discovery", () => {
+  it("treats an unavailable Gateway as unavailable node execution", async () => {
+    listNodes.mockRejectedValueOnce(new Error("synthetic transport failure"));
+    const availability = await loadNodeExecAvailability();
+    expect(availability.isAvailable()).toBe(false);
+  });
+
+  it("preserves the abort reason when discovery also reports a transport failure", async () => {
+    const controller = new AbortController();
+    const reason = new Error("synthetic attempt cancelled");
+    listNodes.mockImplementationOnce((signal: AbortSignal) => {
+      expect(signal).toBe(controller.signal);
+      controller.abort(reason);
+      throw new Error("synthetic transport failure");
+    });
+    await expect(loadNodeExecAvailability(controller.signal)).rejects.toBe(reason);
+  });
+});
+
 describe("resolveMcpLoopbackScopedTools", () => {
-  it("keeps the full session scope without a grant allowlist", () => {
-    const scoped = resolveMcpLoopbackScopedTools(scopeParams());
+  it.each([
+    { name: "no nodes", nodes: [], exposed: false },
+    {
+      name: "offline executor",
+      nodes: [{ nodeId: "worker", connected: false, commands: ["system.run"] }],
+      exposed: false,
+    },
+    {
+      name: "approval-only phone",
+      nodes: [{ nodeId: "phone", connected: true, commands: ["canvas.present"] }],
+      exposed: false,
+    },
+    {
+      name: "unknown capabilities",
+      nodes: [{ nodeId: "phone", connected: true }],
+      exposed: false,
+    },
+    {
+      name: "eligible named binding",
+      node: "Build Worker",
+      nodes: [
+        {
+          nodeId: "worker",
+          displayName: "Build Worker",
+          connected: true,
+          commands: ["system.run"],
+        },
+      ],
+      exposed: true,
+    },
+    {
+      name: "ambiguous binding",
+      node: "Build Worker",
+      nodes: [
+        { nodeId: "phone", displayName: "Build Worker", connected: true, commands: [] },
+        {
+          nodeId: "worker",
+          displayName: "Build Worker",
+          connected: true,
+          commands: ["system.run"],
+        },
+      ],
+      exposed: false,
+    },
+    {
+      name: "eligible executor",
+      nodes: [{ nodeId: "worker", connected: true, commands: ["system.run"] }],
+      exposed: true,
+    },
+    {
+      name: "multiple executors",
+      nodes: ["one", "two"].map((nodeId) => ({
+        nodeId,
+        connected: true,
+        commands: ["system.run"],
+      })),
+      exposed: true,
+    },
+    {
+      name: "offline binding beside executor",
+      node: "phone",
+      nodes: [
+        { nodeId: "phone", connected: false, commands: [] },
+        { nodeId: "worker", connected: true, commands: ["system.run"] },
+      ],
+      exposed: false,
+    },
+  ])(
+    "advertises remote exec only with an eligible target: $name",
+    async ({ nodes, node, exposed }) => {
+      listNodes.mockResolvedValue(nodes);
+      resolveGatewayScopedTools.mockImplementation(
+        ({ includeNodeExecTool, nodeExecAvailable, execOverrides }) =>
+          scopedToolFixture(
+            includeNodeExecTool && nodeExecAvailable?.(execOverrides?.node) ? ["exec"] : [],
+          ),
+      );
+      const scoped = await resolveMcpLoopbackScopedTools(
+        scopeParams({
+          senderIsOwner: true,
+          nodeExecAllowed: true,
+          execOverrides: { mode: "full", node },
+        }),
+      );
+      expect(scoped.tools.map((tool) => tool.name)).toEqual(exposed ? ["exec"] : []);
+    },
+  );
+
+  it("keeps the full session scope without a grant allowlist", async () => {
+    const scoped = await resolveMcpLoopbackScopedTools(scopeParams());
     expect(scoped.tools.map((tool) => (tool as { name: string }).name)).toEqual([
       "memory_search",
       "memory_get",
@@ -59,8 +180,8 @@ describe("resolveMcpLoopbackScopedTools", () => {
     ]);
   });
 
-  it("hard-filters the surface to the grant allowlist", () => {
-    const scoped = resolveMcpLoopbackScopedTools(
+  it("hard-filters the surface to the grant allowlist", async () => {
+    const scoped = await resolveMcpLoopbackScopedTools(
       scopeParams({ toolsAllow: ["memory_search", "memory_get"] }),
     );
     expect(scoped.tools.map((tool) => (tool as { name: string }).name)).toEqual([
@@ -69,10 +190,10 @@ describe("resolveMcpLoopbackScopedTools", () => {
     ]);
   });
 
-  it("keeps exact grant names exact instead of reinterpreting policy shorthand", () => {
+  it("keeps exact grant names exact instead of reinterpreting policy shorthand", async () => {
     resolveGatewayScopedTools.mockReturnValue(scopedToolFixture(["write", "apply_patch"]));
 
-    const scoped = resolveMcpLoopbackScopedTools(scopeParams({ toolsAllow: ["write"] }));
+    const scoped = await resolveMcpLoopbackScopedTools(scopeParams({ toolsAllow: ["write"] }));
 
     expect(scoped.tools.map((tool) => (tool as { name: string }).name)).toEqual(["write"]);
     expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).toMatchObject({
@@ -80,12 +201,12 @@ describe("resolveMcpLoopbackScopedTools", () => {
     });
   });
 
-  it("fails closed on an empty grant allowlist", () => {
-    const scoped = resolveMcpLoopbackScopedTools(scopeParams({ toolsAllow: [] }));
+  it("fails closed on an empty grant allowlist", async () => {
+    const scoped = await resolveMcpLoopbackScopedTools(scopeParams({ toolsAllow: [] }));
     expect(scoped.tools).toEqual([]);
   });
 
-  it("forwards the exact Skill Workshop revision into loopback tool construction", () => {
+  it("forwards the exact Skill Workshop revision into loopback tool construction", async () => {
     const proposalRevision = {
       agentId: "proposal-owner",
       workspaceDir: "/proposal-workspace",
@@ -93,7 +214,7 @@ describe("resolveMcpLoopbackScopedTools", () => {
       expectedRevisionHash: "1".repeat(64),
     };
 
-    resolveMcpLoopbackScopedTools(
+    await resolveMcpLoopbackScopedTools(
       scopeParams({
         toolsAllow: ["skill_workshop"],
         skillWorkshop: { proposalRevision },
@@ -105,10 +226,10 @@ describe("resolveMcpLoopbackScopedTools", () => {
     );
   });
 
-  it("exposes explicitly granted coding tools through the mediated loopback surface", () => {
+  it("exposes explicitly granted coding tools through the mediated loopback surface", async () => {
     resolveGatewayScopedTools.mockReturnValue(scopedToolFixture(["read", "exec", "browser"]));
 
-    const scoped = resolveMcpLoopbackScopedTools(
+    const scoped = await resolveMcpLoopbackScopedTools(
       scopeParams({
         toolsAllow: ["read", "exec", "browser"],
         nodeExecAllowed: true,
@@ -141,7 +262,7 @@ describe("resolveMcpLoopbackScopedTools", () => {
     { allow: ["unknown"], expected: [] },
   ])(
     "materializes policy expressions into concrete loopback tools: $allow",
-    ({ allow, expected }) => {
+    async ({ allow, expected }) => {
       resolveGatewayScopedTools.mockReturnValue(
         scopedToolFixture([
           "read",
@@ -154,7 +275,7 @@ describe("resolveMcpLoopbackScopedTools", () => {
         ]),
       );
 
-      const scoped = resolveMcpLoopbackPolicyTools(scopeParams({ toolsAllow: allow }));
+      const scoped = await resolveMcpLoopbackPolicyTools(scopeParams({ toolsAllow: allow }));
 
       expect(scoped.tools.map((tool) => (tool as { name: string }).name)).toEqual(expected);
     },
@@ -163,7 +284,7 @@ describe("resolveMcpLoopbackScopedTools", () => {
   it.each([
     { allow: ["group:plugins"], expected: ["memory_search", "memory_get"] },
     { allow: ["active-memory"], expected: ["memory_search", "memory_get"] },
-  ])("materializes plugin policy selectors: $allow", ({ allow, expected }) => {
+  ])("materializes plugin policy selectors: $allow", async ({ allow, expected }) => {
     const pluginTools = ["memory_search", "memory_get"].map((name) => ({
       name,
       description: `${name} tool`,
@@ -176,40 +297,107 @@ describe("resolveMcpLoopbackScopedTools", () => {
       tools: [...pluginTools, { name: "message", description: "message tool" }],
     });
 
-    const scoped = resolveMcpLoopbackPolicyTools(scopeParams({ toolsAllow: allow }));
+    const scoped = await resolveMcpLoopbackPolicyTools(scopeParams({ toolsAllow: allow }));
 
     expect(scoped.tools.map((tool) => (tool as { name: string }).name)).toEqual(expected);
   });
 });
 
 describe("McpLoopbackToolCache", () => {
-  it("expires at the ttl boundary and partitions rows by config identity", () => {
+  it("rechecks execution availability before reusing cached schemas", async () => {
+    const cache = new McpLoopbackToolCache();
+    const params = scopeParams({ senderIsOwner: true, nodeExecAllowed: true });
+    resolveGatewayScopedTools.mockImplementation(({ includeNodeExecTool, nodeExecAvailable }) =>
+      scopedToolFixture(includeNodeExecTool && nodeExecAvailable?.() ? ["exec"] : []),
+    );
+    for (const connected of [false, true, false]) {
+      listNodes.mockResolvedValue([{ nodeId: "worker", connected, commands: ["system.run"] }]);
+      const result = await cache.resolve(params);
+      expect(result.tools.map((tool) => tool.name)).toEqual(connected ? ["exec"] : []);
+    }
+  });
+
+  it.each(["evict", "clear"])(
+    "does not resurrect cache rows when %s overtakes discovery",
+    async (action) => {
+      const cache = new McpLoopbackToolCache();
+      const params = scopeParams({ nodeExecAllowed: true, grantToken: "pending-grant" });
+      const entered = createDeferred();
+      const inventory = createDeferred<unknown[]>();
+      listNodes.mockImplementationOnce(() => {
+        entered.resolve();
+        return inventory.promise;
+      });
+      const pending = cache.resolve(params);
+      await entered.promise;
+      if (action === "evict") {
+        cache.evictGrant("pending-grant");
+      } else {
+        cache.clear();
+      }
+      inventory.resolve([]);
+      await pending;
+      expect(cache.evictGrant("pending-grant")).toBe(false);
+      await cache.resolve(params);
+      expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("refreshes cached bound tools when node matching preferences change", async () => {
+    const cache = new McpLoopbackToolCache();
+    const params = scopeParams({ nodeExecAllowed: true, execOverrides: { node: "shared-name" } });
+    resolveGatewayScopedTools.mockImplementation(({ nodeExecAvailable, execOverrides }) =>
+      scopedToolFixture(nodeExecAvailable(execOverrides.node) ? ["exec"] : []),
+    );
+    for (const eligibleIsCurrent of [false, true, false]) {
+      listNodes.mockResolvedValue([
+        {
+          nodeId: "phone",
+          displayName: "shared-name",
+          connected: true,
+          commands: [],
+          clientId: eligibleIsCurrent ? "clawdbot-node" : "openclaw-node",
+        },
+        {
+          nodeId: "worker",
+          displayName: "shared-name",
+          connected: true,
+          commands: ["system.run"],
+          clientId: eligibleIsCurrent ? "openclaw-node" : "clawdbot-node",
+        },
+      ]);
+      const scoped = await cache.resolve(params);
+      expect(scoped.tools.map((tool) => tool.name)).toEqual(eligibleIsCurrent ? ["exec"] : []);
+    }
+  });
+
+  it("expires at the ttl boundary and partitions rows by config identity", async () => {
     vi.useFakeTimers();
     const cache = new McpLoopbackToolCache();
     const cfgA = {} as OpenClawConfig;
     const cfgB = {} as OpenClawConfig;
     const paramsA = scopeParams({ cfg: cfgA });
 
-    cache.resolve(paramsA);
-    cache.resolve(paramsA);
+    await cache.resolve(paramsA);
+    await cache.resolve(paramsA);
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(1);
 
     vi.advanceTimersByTime(30_000);
-    cache.resolve(paramsA);
+    await cache.resolve(paramsA);
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
 
-    cache.resolve(scopeParams({ cfg: cfgB }));
-    cache.resolve(paramsA);
+    await cache.resolve(scopeParams({ cfg: cfgB }));
+    await cache.resolve(paramsA);
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
   });
 
-  it("does not share cache rows across different grant allowlists", () => {
+  it("does not share cache rows across different grant allowlists", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
 
-    const unrestricted = cache.resolve(scopeParams({ cfg }));
-    const restricted = cache.resolve(scopeParams({ cfg, toolsAllow: ["memory_search"] }));
-    const denied = cache.resolve(scopeParams({ cfg, toolsAllow: [] }));
+    const unrestricted = await cache.resolve(scopeParams({ cfg }));
+    const restricted = await cache.resolve(scopeParams({ cfg, toolsAllow: ["memory_search"] }));
+    const denied = await cache.resolve(scopeParams({ cfg, toolsAllow: [] }));
 
     expect(unrestricted.tools).toHaveLength(4);
     expect(restricted.tools).toHaveLength(1);
@@ -217,28 +405,28 @@ describe("McpLoopbackToolCache", () => {
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
 
     // Same allowlist reuses the cached row.
-    cache.resolve(scopeParams({ cfg, toolsAllow: ["memory_search"] }));
+    await cache.resolve(scopeParams({ cfg, toolsAllow: ["memory_search"] }));
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
   });
 
-  it("does not share cache rows across different runtime policy agents", () => {
+  it("does not share cache rows across different runtime policy agents", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
 
-    cache.resolve(scopeParams({ cfg, runtimePolicyAgentId: "main" }));
-    cache.resolve(scopeParams({ cfg, runtimePolicyAgentId: "worker" }));
-    cache.resolve(scopeParams({ cfg, runtimePolicyAgentId: "main" }));
+    await cache.resolve(scopeParams({ cfg, runtimePolicyAgentId: "main" }));
+    await cache.resolve(scopeParams({ cfg, runtimePolicyAgentId: "worker" }));
+    await cache.resolve(scopeParams({ cfg, runtimePolicyAgentId: "main" }));
 
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
   });
 
-  it("does not share loopback tools across prepared vision capabilities", () => {
+  it("does not share loopback tools across prepared vision capabilities", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
 
-    cache.resolve(scopeParams({ cfg, modelHasVision: true }));
-    cache.resolve(scopeParams({ cfg, modelHasVision: false }));
-    cache.resolve(scopeParams({ cfg, modelHasVision: true }));
+    await cache.resolve(scopeParams({ cfg, modelHasVision: true }));
+    await cache.resolve(scopeParams({ cfg, modelHasVision: false }));
+    await cache.resolve(scopeParams({ cfg, modelHasVision: true }));
 
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
     expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).toMatchObject({
@@ -249,56 +437,56 @@ describe("McpLoopbackToolCache", () => {
     });
   });
 
-  it("does not share loopback message tools across prepared reply modes", () => {
+  it("does not share loopback message tools across prepared reply modes", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
 
-    cache.resolve(scopeParams({ cfg, replyToMode: "all" }));
-    cache.resolve(scopeParams({ cfg, replyToMode: "off" }));
-    cache.resolve(scopeParams({ cfg, replyToMode: "all" }));
+    await cache.resolve(scopeParams({ cfg, replyToMode: "all" }));
+    await cache.resolve(scopeParams({ cfg, replyToMode: "off" }));
+    await cache.resolve(scopeParams({ cfg, replyToMode: "all" }));
 
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
     expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).toMatchObject({ replyToMode: "all" });
     expect(resolveGatewayScopedTools.mock.calls[1]?.[0]).toMatchObject({ replyToMode: "off" });
   });
 
-  it("evicts only the revoked grant's cached tool closures", () => {
+  it("evicts only the revoked grant's cached tool closures", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
 
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-a" }));
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-b" }));
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-a" }));
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-b" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-a" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-b" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-a" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-b" }));
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
 
     expect(cache.evictGrant("grant-a")).toBe(true);
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-a" }));
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-b" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-a" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-b" }));
 
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
   });
 
-  it("preserves the global 256-entry cache cap across grants", () => {
+  it("preserves the global 256-entry cache cap across grants", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
 
     for (let index = 0; index < 256; index += 1) {
-      cache.resolve(
+      await cache.resolve(
         scopeParams({ cfg, grantToken: "grant-a", currentMessageId: `message-${index}` }),
       );
     }
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-b", currentMessageId: "message-b" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-b", currentMessageId: "message-b" }));
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(257);
 
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-a", currentMessageId: "message-0" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-a", currentMessageId: "message-0" }));
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(258);
 
-    cache.resolve(scopeParams({ cfg, grantToken: "grant-b", currentMessageId: "message-b" }));
+    await cache.resolve(scopeParams({ cfg, grantToken: "grant-b", currentMessageId: "message-b" }));
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(258);
   });
 
-  it("never reuses ordinary private-mode tools for a source-reply-only grant", () => {
+  it("never reuses ordinary private-mode tools for a source-reply-only grant", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
     const params = scopeParams({
@@ -309,22 +497,22 @@ describe("McpLoopbackToolCache", () => {
       toolsAllow: ["message"],
     });
 
-    cache.resolve(params);
-    cache.resolve({ ...params, sourceReplyOnly: true });
-    cache.resolve(params);
-    cache.resolve({ ...params, sourceReplyOnly: true });
+    await cache.resolve(params);
+    await cache.resolve({ ...params, sourceReplyOnly: true });
+    await cache.resolve(params);
+    await cache.resolve({ ...params, sourceReplyOnly: true });
 
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
     expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).not.toHaveProperty("sourceReplyOnly");
     expect(resolveGatewayScopedTools.mock.calls[1]?.[0]).toMatchObject({ sourceReplyOnly: true });
   });
 
-  it("does not share cache rows across delegation capabilities", () => {
+  it("does not share cache rows across delegation capabilities", async () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;
 
-    cache.resolve(scopeParams({ cfg }));
-    cache.resolve(scopeParams({ cfg, delegationCapability: "report_only" }));
+    await cache.resolve(scopeParams({ cfg }));
+    await cache.resolve(scopeParams({ cfg, delegationCapability: "report_only" }));
 
     // A restricted attempt must neither read nor seed the full-capability row
     // for the same session context.
@@ -333,7 +521,7 @@ describe("McpLoopbackToolCache", () => {
       delegationCapability: "report_only",
     });
 
-    cache.resolve(scopeParams({ cfg, delegationCapability: "report_only" }));
+    await cache.resolve(scopeParams({ cfg, delegationCapability: "report_only" }));
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -343,6 +343,34 @@ describe("McpLoopbackToolCache", () => {
     },
   );
 
+  it("does not cache tools when cancellation overtakes discovery", async () => {
+    const cache = new McpLoopbackToolCache();
+    const params = scopeParams({ nodeExecAllowed: true, grantToken: "cancelled-grant" });
+    const controller = new AbortController();
+    const reason = new Error("synthetic request cancelled");
+    const entered = createDeferred();
+    const inventory = createDeferred<unknown[]>();
+    listNodes.mockImplementationOnce(() => {
+      entered.resolve();
+      return inventory.promise;
+    });
+    const rejected = expect(cache.resolve({ ...params, signal: controller.signal })).rejects.toBe(
+      reason,
+    );
+    await entered.promise;
+    expect(listNodes).toHaveBeenCalledWith(controller.signal);
+    controller.abort(reason);
+    inventory.resolve([]);
+    await rejected;
+    expect(cache.evictGrant("cancelled-grant")).toBe(false);
+    const next = new AbortController();
+    await cache.resolve({ ...params, signal: next.signal });
+    next.abort();
+    await cache.resolve({ ...params, signal: new AbortController().signal });
+    expect(resolveGatewayScopedTools).toHaveBeenCalledOnce();
+    expect(resolveGatewayScopedTools.mock.calls[0]?.[0]).not.toHaveProperty("signal");
+  });
+
   it("refreshes cached bound tools when node matching preferences change", async () => {
     const cache = new McpLoopbackToolCache();
     const params = scopeParams({ nodeExecAllowed: true, execOverrides: { node: "shared-name" } });

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -2,6 +2,7 @@ import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 // MCP loopback runtime scope cache.
 // Resolves Gateway-visible tools for MCP clients with short-lived schema caching.
 import { applyEmbeddedAttemptToolsAllow } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import { loadNodeExecAvailability } from "../agents/node-exec-availability.js";
 import { normalizeToolPolicyName } from "../agents/tool-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DirectoryCache } from "../infra/outbound/directory-cache.js";
@@ -42,6 +43,7 @@ type McpLoopbackScopeParams = Omit<McpLoopbackRequestContext, "senderIsOwner" | 
   senderIsOwner: boolean | undefined;
   yieldContextCacheKey?: string;
   onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
+  nodeExecAvailability?: Awaited<ReturnType<typeof loadNodeExecAvailability>>;
 };
 
 type LoopbackToolsAllowMode = "exact" | "policy";
@@ -71,6 +73,19 @@ function resolveMediatedNativeTools(
   );
 }
 
+async function resolveNodeExecScope(
+  params: McpLoopbackScopeParams,
+  mode: LoopbackToolsAllowMode,
+): Promise<McpLoopbackScopeParams> {
+  if (
+    params.nodeExecAllowed !== true ||
+    resolveMediatedNativeTools(params.toolsAllow, mode).size > 0
+  ) {
+    return params;
+  }
+  return { ...params, nodeExecAvailability: await loadNodeExecAvailability() };
+}
+
 function resolveMcpLoopbackTools(
   params: McpLoopbackScopeParams,
   mode: LoopbackToolsAllowMode,
@@ -94,6 +109,7 @@ function resolveMcpLoopbackTools(
     toolsAllow: _toolsAllow,
     authProfileStoreAgentDir,
     grantToken: _grantToken,
+    nodeExecAvailability,
     ...scopeParams
   } = params;
   const scoped = resolveGatewayScopedTools({
@@ -104,6 +120,7 @@ function resolveMcpLoopbackTools(
     excludeToolNames,
     mediatedToolNames: mediatedNativeTools,
     includeNodeExecTool,
+    nodeExecAvailable: nodeExecAvailability?.isAvailable,
   });
   return {
     agentId: scoped.agentId,
@@ -116,20 +133,20 @@ function resolveMcpLoopbackTools(
 }
 
 /** Resolves loopback-visible tools from the exact names carried by a minted grant. */
-export function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): {
+export async function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): Promise<{
   agentId: string | undefined;
   workspaceDir?: string;
   tools: McpLoopbackTool[];
-} {
-  return resolveMcpLoopbackTools(params, "exact");
+}> {
+  return resolveMcpLoopbackTools(await resolveNodeExecScope(params, "exact"), "exact");
 }
 
 /** Materializes runtime policy expressions against the concrete loopback catalog. */
-export function resolveMcpLoopbackPolicyTools(params: McpLoopbackScopeParams): {
+export async function resolveMcpLoopbackPolicyTools(params: McpLoopbackScopeParams): Promise<{
   agentId: string | undefined;
   tools: McpLoopbackTool[];
-} {
-  return resolveMcpLoopbackTools(params, "policy");
+}> {
+  return resolveMcpLoopbackTools(await resolveNodeExecScope(params, "policy"), "policy");
 }
 
 /**
@@ -175,8 +192,12 @@ export class McpLoopbackToolCache {
   #entries = new DirectoryCache<CachedScopedTools>(TOOL_CACHE_TTL_MS, TOOL_CACHE_MAX_ENTRIES);
   // Revocation needs the config scopes where one grant may have cached tools.
   #grantConfigScopes = new Map<string, Set<OpenClawConfig>>();
+  #epoch = 0;
 
-  resolve(params: McpLoopbackScopeParams): CachedScopedTools {
+  async resolve(input: McpLoopbackScopeParams): Promise<CachedScopedTools> {
+    const epoch = this.#epoch;
+    // Availability belongs to the current connection, not the schema TTL.
+    const params = await resolveNodeExecScope(input, "exact");
     // Callers differing only in capabilities must not share cached tool lists.
     const clientCapsCacheKey = [...new Set(params.clientCaps ?? [])].toSorted().join(",");
     const cacheKey = [
@@ -215,6 +236,7 @@ export class McpLoopbackToolCache {
       params.delegationCapability === "report_only" ? "delegation:report_only" : "",
       JSON.stringify(params.scheduledToolPolicy ?? null),
       params.nodeExecAllowed === true ? "node-exec" : "",
+      params.nodeExecAvailability?.cacheKey ?? "",
       params.execSession?.execHost ?? "",
       params.execSession?.execNode ?? "",
       params.execSession?.permissionMode ?? "",
@@ -255,13 +277,17 @@ export class McpLoopbackToolCache {
       return cached;
     }
 
-    const next = resolveMcpLoopbackScopedTools(params);
+    const next = resolveMcpLoopbackTools(params, "exact");
     const nextEntry: CachedScopedTools = {
       agentId: next.agentId,
       workspaceDir: next.workspaceDir,
       tools: next.tools,
       toolSchema: buildMcpToolSchema(next.tools),
     };
+    // Revocation may overtake discovery before a grant owns any cached rows.
+    if (epoch !== this.#epoch) {
+      return nextEntry;
+    }
     this.#entries.set(cacheKey, nextEntry, params.cfg);
     if (params.grantToken) {
       const scopes = this.#grantConfigScopes.get(params.grantToken) ?? new Set<OpenClawConfig>();
@@ -272,6 +298,7 @@ export class McpLoopbackToolCache {
   }
 
   evictGrant(token: string): boolean {
+    this.#epoch += 1;
     const scopes = this.#grantConfigScopes.get(token);
     if (!scopes) {
       return false;
@@ -285,6 +312,7 @@ export class McpLoopbackToolCache {
   }
 
   clear(): void {
+    this.#epoch += 1;
     this.#entries.clear();
     this.#grantConfigScopes.clear();
   }

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -44,6 +44,7 @@ type McpLoopbackScopeParams = Omit<McpLoopbackRequestContext, "senderIsOwner" | 
   yieldContextCacheKey?: string;
   onYield?: (message: string, acknowledgment?: string) => Promise<void> | void;
   nodeExecAvailability?: Awaited<ReturnType<typeof loadNodeExecAvailability>>;
+  signal?: AbortSignal;
 };
 
 type LoopbackToolsAllowMode = "exact" | "policy";
@@ -83,7 +84,7 @@ async function resolveNodeExecScope(
   ) {
     return params;
   }
-  return { ...params, nodeExecAvailability: await loadNodeExecAvailability() };
+  return { ...params, nodeExecAvailability: await loadNodeExecAvailability(params.signal) };
 }
 
 function resolveMcpLoopbackTools(
@@ -94,6 +95,7 @@ function resolveMcpLoopbackTools(
   workspaceDir?: string;
   tools: McpLoopbackTool[];
 } {
+  params.signal?.throwIfAborted();
   const excludeToolNames = new Set(NATIVE_TOOL_EXCLUDE);
   // Restricted CLI grants use OpenClaw's implementations for coding tools;
   // native CLI tools bypass path, approval, sandbox, and exec policy.
@@ -110,6 +112,7 @@ function resolveMcpLoopbackTools(
     authProfileStoreAgentDir,
     grantToken: _grantToken,
     nodeExecAvailability,
+    signal: _signal,
     ...scopeParams
   } = params;
   const scoped = resolveGatewayScopedTools({
@@ -198,6 +201,7 @@ export class McpLoopbackToolCache {
     const epoch = this.#epoch;
     // Availability belongs to the current connection, not the schema TTL.
     const params = await resolveNodeExecScope(input, "exact");
+    input.signal?.throwIfAborted();
     // Callers differing only in capabilities must not share cached tool lists.
     const clientCapsCacheKey = [...new Set(params.clientCaps ?? [])].toSorted().join(",");
     const cacheKey = [

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -99,6 +99,10 @@ const resolveGatewayScopedToolsMock = vi.hoisted(() =>
   })),
 );
 
+const loadNodeExecAvailabilityMock = vi.hoisted(() =>
+  vi.fn(async () => ({ cacheKey: "eligible", isAvailable: (): boolean => true })),
+);
+
 const logWarnMock = vi.hoisted(() => vi.fn<(message: string) => void>());
 const sessionEntries = vi.hoisted(() => new Map<string, Record<string, unknown>>());
 
@@ -131,6 +135,10 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
 vi.mock("../agents/agent-tools.before-tool-call.js", () => ({
   runBeforeToolCallHook: (...args: Parameters<typeof runBeforeToolCallHookMock>) =>
     runBeforeToolCallHookMock(...args),
+}));
+
+vi.mock("../agents/node-exec-availability.js", () => ({
+  loadNodeExecAvailability: loadNodeExecAvailabilityMock,
 }));
 
 vi.mock("./tool-resolution.js", () => ({
@@ -644,6 +652,9 @@ function makeMcpToolCacheParams(overrides: Partial<McpToolCacheParams> = {}): Mc
 }
 
 beforeEach(() => {
+  loadNodeExecAvailabilityMock
+    .mockReset()
+    .mockResolvedValue({ cacheKey: "eligible", isAvailable: () => true });
   logWarnMock.mockClear();
   sessionEntries.clear();
   resolveGatewayScopedToolsMock.mockClear();
@@ -1622,6 +1633,40 @@ describe("mcp loopback server", () => {
     },
   );
 
+  it("rejects a grant revoked while node availability is being resolved", async () => {
+    const entered = createDeferred();
+    const availability = createDeferred<{ cacheKey: string; isAvailable: () => boolean }>();
+    loadNodeExecAvailabilityMock.mockImplementationOnce(() => {
+      entered.resolve();
+      return availability.promise;
+    });
+    const { runtime } = await startLoopbackServerForTest();
+    const captureKey = "node-availability-revoked";
+    const grant = mintMcpLoopbackClientGrant({
+      context: {
+        sessionKey: "agent:main:node-availability",
+        senderIsOwner: true,
+        nodeExecAllowed: true,
+      },
+      runtimeOwnerToken: runtime.ownerToken,
+      admittedRunContext: await activeAdmission("node-availability-revoked"),
+      toolAuth: { store: { version: 1, profiles: {} } },
+    });
+    activateMcpLoopbackClientGrantCapture({
+      token: grant.token,
+      runtimeOwnerToken: runtime.ownerToken,
+      captureKey,
+    });
+    const response = sendLoopbackToolsList({
+      token: grant.token,
+      headers: { "x-openclaw-cli-capture-key": captureKey },
+    });
+    await entered.promise;
+    expect(revokeMcpLoopbackClientGrant(grant.token)).toBe(true);
+    availability.resolve({ cacheKey: "eligible", isAvailable: () => true });
+    expect((await response).status).toBe(401);
+  });
+
   it("carries callable personal Workshop authority outside cloned grant context", async () => {
     const { runtime } = await startLoopbackServerForTest();
     const admittedRunContext = await activeAdmission("run-library-grant");
@@ -1913,7 +1958,7 @@ describe("mcp loopback server", () => {
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps explicit non-owner and unknown-owner loopback cache entries separate", () => {
+  it("keeps explicit non-owner and unknown-owner loopback cache entries separate", async () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = makeMcpToolCacheParams({
       cfg: { session: { mainKey: "main" } } as never,
@@ -1937,21 +1982,21 @@ describe("mcp loopback server", () => {
       };
     });
 
-    const unknownFirst = cache.resolve({ ...baseParams, senderIsOwner: undefined });
-    const nonOwnerSecond = cache.resolve({ ...baseParams, senderIsOwner: false });
+    const unknownFirst = await cache.resolve({ ...baseParams, senderIsOwner: undefined });
+    const nonOwnerSecond = await cache.resolve({ ...baseParams, senderIsOwner: false });
     expect(unknownFirst.toolSchema.map((tool) => tool.name)).toContain("cron");
     expect(nonOwnerSecond.toolSchema.map((tool) => tool.name)).not.toContain("cron");
 
     const secondCache = new McpLoopbackToolCache();
-    const nonOwnerFirst = secondCache.resolve({ ...baseParams, senderIsOwner: false });
-    const unknownSecond = secondCache.resolve({ ...baseParams, senderIsOwner: undefined });
+    const nonOwnerFirst = await secondCache.resolve({ ...baseParams, senderIsOwner: false });
+    const unknownSecond = await secondCache.resolve({ ...baseParams, senderIsOwner: undefined });
     expect(nonOwnerFirst.toolSchema.map((tool) => tool.name)).not.toContain("cron");
     expect(unknownSecond.toolSchema.map((tool) => tool.name)).toContain("cron");
 
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(4);
   });
 
-  it("keeps CLI node-exec capability and session defaults cache-bound", () => {
+  it("keeps CLI node-exec capability and session defaults cache-bound", async () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = makeMcpToolCacheParams();
     resolveGatewayScopedToolsMock.mockImplementation((input: unknown) => {
@@ -1964,13 +2009,13 @@ describe("mcp loopback server", () => {
       };
     });
 
-    const withoutExec = cache.resolve({ ...baseParams, nodeExecAllowed: false });
-    const withExec = cache.resolve({
+    const withoutExec = await cache.resolve({ ...baseParams, nodeExecAllowed: false });
+    const withExec = await cache.resolve({
       ...baseParams,
       nodeExecAllowed: true,
       execSession: { execHost: "node", execNode: "mac-a" },
     });
-    cache.resolve({
+    await cache.resolve({
       ...baseParams,
       nodeExecAllowed: true,
       execSession: { execHost: "node", execNode: "mac-b" },
@@ -1981,7 +2026,7 @@ describe("mcp loopback server", () => {
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(3);
   });
 
-  it("never reuses loopback tools across session permissions or effective exec modes", () => {
+  it("never reuses loopback tools across session permissions or effective exec modes", async () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = makeMcpToolCacheParams();
     resolveGatewayScopedToolsMock.mockImplementation((input: unknown) => {
@@ -1996,29 +2041,31 @@ describe("mcp loopback server", () => {
       };
     });
 
-    const readOnly = cache.resolve({
+    const readOnly = await cache.resolve({
       ...baseParams,
       execSession: { permissionMode: "read-only" },
     });
-    const fullSession = cache.resolve({
+    const fullSession = await cache.resolve({
       ...baseParams,
       execSession: { permissionMode: "full" },
     });
-    const deniedOverride = cache.resolve({ ...baseParams, execOverrides: { mode: "deny" } });
-    const fullOverride = cache.resolve({ ...baseParams, execOverrides: { mode: "full" } });
+    const deniedOverride = await cache.resolve({ ...baseParams, execOverrides: { mode: "deny" } });
+    const fullOverride = await cache.resolve({ ...baseParams, execOverrides: { mode: "full" } });
 
     expect(readOnly.toolSchema.map((tool) => tool.name)).not.toContain("exec");
     expect(fullSession.toolSchema.map((tool) => tool.name)).toContain("exec");
     expect(deniedOverride.toolSchema.map((tool) => tool.name)).not.toContain("exec");
     expect(fullOverride.toolSchema.map((tool) => tool.name)).toContain("exec");
-    expect(cache.resolve({ ...baseParams, execSession: { permissionMode: "read-only" } })).toBe(
-      readOnly,
+    expect(
+      await cache.resolve({ ...baseParams, execSession: { permissionMode: "read-only" } }),
+    ).toBe(readOnly);
+    expect(await cache.resolve({ ...baseParams, execOverrides: { mode: "deny" } })).toBe(
+      deniedOverride,
     );
-    expect(cache.resolve({ ...baseParams, execOverrides: { mode: "deny" } })).toBe(deniedOverride);
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(4);
   });
 
-  it("keeps model policy identity cache-bound", () => {
+  it("keeps model policy identity cache-bound", async () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = makeMcpToolCacheParams({
       nodeExecAllowed: true,
@@ -2032,22 +2079,22 @@ describe("mcp loopback server", () => {
       };
     });
 
-    const openAi = cache.resolve({
+    const openAi = await cache.resolve({
       ...baseParams,
       modelProvider: "openai",
       modelId: "gpt-5.5",
     });
-    const blockedAnthropic = cache.resolve({
+    const blockedAnthropic = await cache.resolve({
       ...baseParams,
       modelProvider: "anthropic",
       modelId: "claude-opus-4-7",
     });
-    const allowedAnthropic = cache.resolve({
+    const allowedAnthropic = await cache.resolve({
       ...baseParams,
       modelProvider: "anthropic",
       modelId: "claude-sonnet-4-6",
     });
-    cache.resolve({ ...baseParams, modelProvider: "openai", modelId: "gpt-5.5" });
+    await cache.resolve({ ...baseParams, modelProvider: "openai", modelId: "gpt-5.5" });
 
     expect(openAi.toolSchema.map((tool) => tool.name)).toContain("exec");
     expect(blockedAnthropic.toolSchema.map((tool) => tool.name)).not.toContain("exec");
@@ -2055,7 +2102,7 @@ describe("mcp loopback server", () => {
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(3);
   });
 
-  it("keeps exec overrides and sender identities cache-bound", () => {
+  it("keeps exec overrides and sender identities cache-bound", async () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = makeMcpToolCacheParams({
       messageProvider: "discord",
@@ -2063,42 +2110,42 @@ describe("mcp loopback server", () => {
       nodeExecAllowed: true,
     });
 
-    cache.resolve(baseParams);
-    cache.resolve({ ...baseParams, execOverrides: { host: "gateway" } });
-    cache.resolve({ ...baseParams, senderName: "Guest Name" });
-    cache.resolve({ ...baseParams, senderUsername: "guest-user" });
-    cache.resolve({ ...baseParams, senderE164: "+15550001111" });
-    cache.resolve({ ...baseParams, groupId: "group-a" });
-    cache.resolve({ ...baseParams, groupChannel: "ops" });
-    cache.resolve({ ...baseParams, groupSpace: "guild-a" });
-    cache.resolve({ ...baseParams, spawnedBy: "agent:main:discord:channel:parent" });
-    cache.resolve({
+    await cache.resolve(baseParams);
+    await cache.resolve({ ...baseParams, execOverrides: { host: "gateway" } });
+    await cache.resolve({ ...baseParams, senderName: "Guest Name" });
+    await cache.resolve({ ...baseParams, senderUsername: "guest-user" });
+    await cache.resolve({ ...baseParams, senderE164: "+15550001111" });
+    await cache.resolve({ ...baseParams, groupId: "group-a" });
+    await cache.resolve({ ...baseParams, groupChannel: "ops" });
+    await cache.resolve({ ...baseParams, groupSpace: "guild-a" });
+    await cache.resolve({ ...baseParams, spawnedBy: "agent:main:discord:channel:parent" });
+    await cache.resolve({
       ...baseParams,
       runtimePolicySessionKey: "agent:main:discord:default:direct:guest",
     });
-    cache.resolve({ ...baseParams, agentId: "worker" });
-    cache.resolve(baseParams);
+    await cache.resolve({ ...baseParams, agentId: "worker", sessionKey: "agent:worker:main" });
+    await cache.resolve(baseParams);
 
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(11);
   });
 
-  it("keeps every elevated-exec authority field cache-bound", () => {
+  it("keeps every elevated-exec authority field cache-bound", async () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = makeMcpToolCacheParams({
       messageProvider: "discord",
       nodeExecAllowed: true,
     });
 
-    cache.resolve(baseParams);
-    cache.resolve({
+    await cache.resolve(baseParams);
+    await cache.resolve({
       ...baseParams,
       bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
     });
-    cache.resolve({
+    await cache.resolve({
       ...baseParams,
       bashElevated: { enabled: true, allowed: true, defaultLevel: "ask" },
     });
-    cache.resolve({
+    await cache.resolve({
       ...baseParams,
       bashElevated: {
         enabled: true,
@@ -2107,7 +2154,7 @@ describe("mcp loopback server", () => {
         fullAccessAvailable: true,
       },
     });
-    cache.resolve({
+    await cache.resolve({
       ...baseParams,
       bashElevated: {
         enabled: true,
@@ -2117,12 +2164,12 @@ describe("mcp loopback server", () => {
         fullAccessBlockedReason: "runtime",
       },
     });
-    cache.resolve(baseParams);
+    await cache.resolve(baseParams);
 
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(5);
   });
 
-  it("caps loopback tool cache cardinality by evicting oldest contexts", () => {
+  it("caps loopback tool cache cardinality by evicting oldest contexts", async () => {
     const cache = new McpLoopbackToolCache();
     const baseParams = makeMcpToolCacheParams({
       cfg: { session: { mainKey: "main" } } as never,
@@ -2135,20 +2182,20 @@ describe("mcp loopback server", () => {
     });
 
     for (let index = 0; index < 257; index += 1) {
-      cache.resolve({
+      await cache.resolve({
         ...baseParams,
         currentMessageId: `message-${index}`,
       });
     }
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(257);
 
-    cache.resolve({
+    await cache.resolve({
       ...baseParams,
       currentMessageId: "message-0",
     });
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(258);
 
-    cache.resolve({
+    await cache.resolve({
       ...baseParams,
       currentMessageId: "message-256",
     });

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1,6 +1,7 @@
 // MCP HTTP tests cover gateway-scoped tool listing and invocation over the
 // JSON-RPC surface, including hook filtering and context propagation.
-import { request } from "node:http";
+import { EventEmitter } from "node:events";
+import { request, ServerResponse } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import {
@@ -1665,6 +1666,78 @@ describe("mcp loopback server", () => {
     expect(revokeMcpLoopbackClientGrant(grant.token)).toBe(true);
     availability.resolve({ cacheKey: "eligible", isAvailable: () => true });
     expect((await response).status).toBe(401);
+  });
+
+  it("does not dispatch after the HTTP client disconnects during node discovery", async () => {
+    const entered = createDeferred();
+    const availability = createDeferred<{ cacheKey: string; isAvailable: () => boolean }>();
+    loadNodeExecAvailabilityMock.mockImplementationOnce(() => {
+      entered.resolve();
+      return availability.promise;
+    });
+    const execute = vi.fn<MockGatewayTool["execute"]>(async () => ({ content: [] }));
+    mockScopedTools([makeMessageTool({ execute })]);
+    const { runtime, port } = await startLoopbackServerForTest();
+    const captureKey = "node-discovery-disconnect";
+    const grant = mintMcpLoopbackClientGrant({
+      context: {
+        sessionKey: "agent:main:disconnected",
+        senderIsOwner: true,
+        nodeExecAllowed: true,
+      },
+      runtimeOwnerToken: runtime.ownerToken,
+      admittedRunContext: await activeAdmission(captureKey),
+      toolAuth: { store: { version: 1, profiles: {} } },
+    });
+    activateMcpLoopbackClientGrantCapture({
+      token: grant.token,
+      runtimeOwnerToken: runtime.ownerToken,
+      captureKey,
+    });
+    beginMcpLoopbackToolCallCapture({ captureKey, onToolCallResult: vi.fn() });
+    const disconnected = createDeferred();
+    const responseEvents = vi.spyOn(ServerResponse.prototype, "emit").mockImplementation(function (
+      this: ServerResponse,
+      event,
+      ...args
+    ) {
+      const emitted = EventEmitter.prototype.emit.call(this, event, ...args);
+      if (event === "close") {
+        disconnected.resolve();
+      }
+      return emitted;
+    });
+    const req = request({
+      hostname: "127.0.0.1",
+      port,
+      path: "/mcp",
+      method: "POST",
+      headers: jsonHeaders({
+        authorization: `Bearer ${grant.token}`,
+        "x-openclaw-cli-capture-key": captureKey,
+      }),
+    });
+    req.on("error", () => {});
+    req.end(mcpToolCallBody("message"));
+    try {
+      await entered.promise;
+      req.destroy();
+      // Observe the server's close event before releasing discovery, not a timed delay.
+      await disconnected.promise;
+      availability.resolve({ cacheKey: "eligible", isAvailable: () => true });
+      expect(
+        await waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
+          timeoutMs: 1_000,
+          admissionGraceMs: 0,
+        }),
+      ).toBe(true);
+      expect(execute).not.toHaveBeenCalled();
+    } finally {
+      responseEvents.mockRestore();
+      req.destroy();
+      availability.resolve({ cacheKey: "eligible", isAvailable: () => true });
+      clearMcpLoopbackToolCallCapture(captureKey);
+    }
   });
 
   it("carries callable personal Workshop authority outside cloned grant context", async () => {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -295,7 +295,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           return;
         }
         const yieldContext = resolveMcpLoopbackYieldContext(cliRequestCaptureHandle);
-        const scopedTools = toolCache.resolve({
+        const scopedTools = await toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
           runtimePolicySessionKey: requestContext.runtimePolicySessionKey,
@@ -351,6 +351,13 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           groupSpace: requestContext.groupSpace,
           spawnedBy: requestContext.spawnedBy,
         });
+
+        // Node discovery awaited transport state; a closed grant must not publish its tools.
+        if (boundClientGrant && !boundClientGrant.isCurrent()) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "unauthorized" }));
+          return;
+        }
 
         logMcpLoopbackTraffic("request", {
           batchSize: messages.length,

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -297,6 +297,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
         const yieldContext = resolveMcpLoopbackYieldContext(cliRequestCaptureHandle);
         const scopedTools = await toolCache.resolve({
           cfg,
+          signal: requestAbort.signal,
           sessionKey: requestContext.sessionKey,
           runtimePolicySessionKey: requestContext.runtimePolicySessionKey,
           runtimePolicyAgentId: requestContext.runtimePolicyAgentId,
@@ -352,7 +353,8 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           spawnedBy: requestContext.spawnedBy,
         });
 
-        // Node discovery awaited transport state; a closed grant must not publish its tools.
+        // Discovery may outlive the requesting connection or grant.
+        requestAbort.signal.throwIfAborted();
         if (boundClientGrant && !boundClientGrant.isCurrent()) {
           res.writeHead(401, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "unauthorized" }));

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -386,6 +386,33 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     expect(args.inheritedToolDenylist).toEqual(["exec"]);
   });
 
+  it.each([
+    { available: false, expected: false },
+    { available: true, expected: true },
+  ])(
+    "gates node exec with the runtime policy agent binding: $available",
+    ({ available, expected }) => {
+      const result = resolveGatewayScopedTools({
+        cfg: {
+          agents: {
+            list: [
+              { id: "main", tools: { exec: { node: "outer-node" } } },
+              { id: "worker", tools: { exec: { node: "worker-node" } } },
+            ],
+          },
+        } as OpenClawConfig,
+        sessionKey: "agent:main:direct:test",
+        runtimePolicySessionKey: "agent:worker:direct:test",
+        runtimePolicyAgentId: "worker",
+        surface: "loopback",
+        senderIsOwner: true,
+        includeNodeExecTool: true,
+        nodeExecAvailable: (node) => available && node === "worker-node",
+      });
+      expect(result.tools.some((tool) => tool.name === "exec")).toBe(expected);
+    },
+  );
+
   it("adds a synchronous node-forced exec tool to allowed owner loopback scopes", () => {
     hoisted.createOpenClawToolsMock.mockReturnValueOnce([
       hoisted.makeTool("read"),
@@ -398,6 +425,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       bashElevated: {
         enabled: true,
         allowed: true,
@@ -448,6 +476,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       execSession: { execHost: "gateway" },
     });
     hoisted.createOpenClawToolsMock.mockReturnValueOnce([
@@ -461,6 +490,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       execSession: { execHost: "node" },
       execOverrides: { host: "gateway" },
     });
@@ -475,6 +505,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(gatewayOnly.tools.map((tool) => tool.name)).not.toContain("exec");
@@ -494,6 +525,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
@@ -515,6 +547,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
     const worker = resolveGatewayScopedTools({
       cfg,
@@ -523,6 +556,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(defaultAgent.tools.map((tool) => tool.name)).toContain("exec");
@@ -542,6 +576,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "http",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
@@ -555,6 +590,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
@@ -574,6 +610,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       senderIsOwner: true,
       messageProvider: "node",
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).toEqual(["canvas", "web_search"]);
@@ -595,6 +632,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       messageProvider: "discord",
       channelContext: { sender: { id: "blocked-sender" } },
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
@@ -631,6 +669,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
         senderIsOwner: false,
         messageProvider: "discord",
         includeNodeExecTool: true,
+        nodeExecAvailable: () => true,
       });
 
       expect(result.tools.map((tool) => tool.name)).toEqual(
@@ -666,6 +705,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       senderIsOwner: false,
       messageProvider: "discord",
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(resolveToolPolicy).toHaveBeenCalledWith(
@@ -698,6 +738,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       senderIsOwner: false,
       messageProvider: "discord",
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       [field]: value,
     });
 
@@ -724,6 +765,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
         senderIsOwner,
         messageProvider,
         includeNodeExecTool: true,
+        nodeExecAvailable: () => true,
       });
 
       expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
@@ -745,6 +787,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       senderIsOwner: true,
       messageProvider: "webchat",
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).toContain("exec");
@@ -765,6 +808,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       modelProvider: "anthropic",
       modelId: "claude-opus-4-7",
     });
@@ -774,6 +818,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       modelProvider: "openai",
       modelId: "gpt-5.5",
     });
@@ -803,6 +848,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       modelProvider: "anthropic",
       modelId: "claude-opus-4-7",
     });
@@ -812,6 +858,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
       modelProvider: "anthropic",
       modelId: "claude-sonnet-4-6",
     });
@@ -841,6 +888,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       messageProvider: "telegram",
       channelContext: { sender: { id: "blocked-sender" } },
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).not.toContain("exec");
@@ -854,6 +902,7 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
       surface: "loopback",
       senderIsOwner: true,
       includeNodeExecTool: true,
+      nodeExecAvailable: () => true,
     });
 
     expect(result.tools.map((tool) => tool.name)).toContain("exec");

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -115,6 +115,8 @@ export function resolveGatewayScopedTools(params: {
   gatewayRequestedTools?: string[];
   /** Add the CLI-only, node-forced exec tool before applying the shared policy pipeline. */
   includeNodeExecTool?: boolean;
+  /** Current node inventory predicate; evaluated with the resolved exec binding. */
+  nodeExecAvailable?: (node?: string) => boolean;
   execSession?: ExecSessionDefaults;
   execOverrides?: ExecPolicyOverrides & { mode?: ExecMode };
   bashElevated?: ExecElevatedDefaults;
@@ -370,7 +372,11 @@ export function resolveGatewayScopedTools(params: {
         })
       : undefined;
   const nodeExecDefaults =
-    nodeExecSurface && execDefaults?.canRequestNode === true ? execDefaults : undefined;
+    nodeExecSurface &&
+    execDefaults?.canRequestNode === true &&
+    params.nodeExecAvailable?.(execDefaults.node) === true
+      ? execDefaults
+      : undefined;
   const includeNodeExecTool = nodeExecDefaults !== undefined;
   const execConfig = includeNodeExecTool
     ? resolveExecToolConfig({ cfg: params.cfg, agentId: policyAgentId })
@@ -504,7 +510,7 @@ export function resolveGatewayScopedTools(params: {
           },
           {
             description:
-              "Execute a shell command on a connected OpenClaw node. This tool is node-only; use the CLI native shell for Gateway-local commands. Commands run synchronously. The sole connected node that can execute commands is selected automatically; set node when several can.",
+              "Execute a shell command on a connected OpenClaw node. This tool is node-only; use the CLI native shell for Gateway-local commands when it is available. Commands run synchronously. The sole connected node that can execute commands is selected automatically; set node when several can.",
             displaySummary: "Run commands on a connected node",
             parameters: nodeExecSchema,
           },

--- a/src/plugin-sdk/node-selection-runtime.ts
+++ b/src/plugin-sdk/node-selection-runtime.ts
@@ -2,3 +2,9 @@
 
 export type { EligibleNodeMessages } from "../shared/node-resolve.js";
 export { resolveEligibleNodeFromList } from "../shared/node-resolve.js";
+
+/** Loads current exec eligibility only when a harness is building its tool catalog. */
+export async function loadNodeExecAvailability(signal?: AbortSignal) {
+  const runtime = await import("../agents/node-exec-availability.js");
+  return runtime.loadNodeExecAvailability(signal);
+}

--- a/src/plugin-sdk/node-selection-runtime.ts
+++ b/src/plugin-sdk/node-selection-runtime.ts
@@ -1,10 +1,15 @@
 // Shared node-selection policy for bundled plugin runtime code.
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+
+const loadNodeExecRuntime = createLazyRuntimeModule(
+  () => import("../agents/node-exec-availability.js"),
+);
 
 export type { EligibleNodeMessages } from "../shared/node-resolve.js";
 export { resolveEligibleNodeFromList } from "../shared/node-resolve.js";
 
 /** Loads current exec eligibility only when a harness is building its tool catalog. */
 export async function loadNodeExecAvailability(signal?: AbortSignal) {
-  const runtime = await import("../agents/node-exec-availability.js");
+  const runtime = await loadNodeExecRuntime();
   return runtime.loadNodeExecAvailability(signal);
 }


### PR DESCRIPTION
Related: #136000, #135966

## What Problem This Solves

Fixes an issue where CLI-backend agents would see remote `exec` even when their only paired devices were offline or could not execute shell commands. This is the sibling-surface follow-up to the Codex repair in #136000. Thanks to Elton Lau for the original field report.

Native `auto` execution already selects the Gateway or sandbox. The unusable node-forced alias was exposed beside the native shell, allowing the model to select it; this change repairs advertising, not native `auto` host routing.

## Why This Change Was Made

CLI loopback discovery now supplies current node facts to the Gateway's existing policy owner, which checks the effective node binding without duplicating agent/session or exec-policy resolution. Codex and CLI discovery share the same connected-`system.run` predicate. Codex's runtime and registered catalogs share one lazy discovery result per attempt; later attempts read fresh facts.

MCP schema caching includes the node matching/execution facts, and HTTP revalidates the request and grant after awaited discovery. Cache eviction and clearing also fence pending discovery so revoked grants cannot resurrect cached rows. Cancellation reaches inventory discovery; aborted requests cannot seed the cache or dispatch a tool, and request signals never enter cached tool closures. Execution-time routing and approval guards remain authoritative. The shared helper uses the existing private `node-selection-runtime` seam behind the canonical lazy-module facade: no public SDK export or budget changes. No configuration, environment, database, protocol, or dependency changes.

## User Impact

Offline and approval-only devices no longer advertise a remote shell. Explicit node bindings remain explicit, multiple eligible nodes allow selection, and policy-permitted local native shell access is unchanged. Discovery failures hide optional remote execution; cancellation still cancels the attempt.

## Evidence

The final real-owner regression was run against the pre-follow-up `tool-resolution.ts`: the unavailable bound-node case failed with `expected true to be false`, while the available case passed. Restoring the candidate made all 34 Gateway owner tests pass.

Focused wrapper tests passed: 148 MCP tests (including OAuth), 109 Codex dynamic-tool tests plus four focused projection/cancellation reruns, 34 Gateway tool-resolution tests, 22 node-execution phase tests, and 131 CLI preparation tests. Two deferred-discovery regressions failed before the cache epoch fence and passed afterward, proving eviction and clearing cannot be overtaken by an in-flight resolution. The node-execution suite now also verifies that legacy paired-node fallback records without command capabilities cannot execute; stable v2026.8.2 already rejects this state: its [paired-node fallback](https://github.com/openclaw/openclaw/blob/v2026.8.2/src/agents/tools/nodes-utils.ts#L39) omits command facts and its [execution owner](https://github.com/openclaw/openclaw/blob/v2026.8.2/src/agents/bash-tools.exec-host-node-phases.ts#L336) requires `system.run`. See the [parent review disposition](https://github.com/openclaw/openclaw/pull/136000#issuecomment-5505240984).

Addressed the [ClawSweeper cancellation finding and rank-up move](https://github.com/openclaw/openclaw/pull/136067#issuecomment-5505701310). The new real-HTTP disconnect regression failed before the repair: after server-side connection close, the tool executed once with an already-aborted signal. It now proves zero executions after deferred discovery resumes. A second red/green regression proves cancelled discovery cannot populate the cache and a later request on the same grant works without retaining the old signal. The review's persistence heuristic does not apply: these are in-process catalog/cache keys, not persisted state or a database schema.

Live proof passed on clean source commit `1d06fedb1fff51782f5493ca2d07a3424cb0d00c`, using this worktree's existing Gateway build from `774249b759a9eef931cfc5cae6a8affeff8b37ef` on port 54008 with an isolated temporary state directory. That Gateway supplies real node inventory; the actual source MCP and Codex tool builders and core local exec tool run from the final source head. The HTTP disconnect regression separately exercises the final source HTTP server. There were no model calls, operator state, or live provider credentials. Synthetic nodes were mock protocol clients; the coding-tool factory used its existing seam with the real core exec tool. Inventory and eligibility were not mocked. Condensed transcript:

```text
sourceWorktreeDirty=false; gatewayChild=true; isolatedState=true; modelCalls=0
scenario                              Codex node_exec   CLI exec
no nodes                              hidden            hidden
connected phone without system.run    hidden            hidden
offline paired phone                  hidden            hidden
eligible connected executor           offered           offered
offline phone bound beside executor   hidden            hidden
eligible named binding                offered           offered
executor disconnected, rebuilt        hidden            hidden
auto local shell: completed, exitCode=0, nodeRouted=false
nativeSurfaceEnabled=true throughout
verdict=pass; process exit=0; fixture cleaned up
```

Autoreview passed with no accepted/actionable findings at its configured P0 threshold. The single own-worktree `pnpm build sourcePerformance` produced the runtime/CLI, then failed its final control-plane check against stale borrowed `@openclaw/ai` artifacts. One frozen-lockfile, task-local install repaired dependency resolution without changing source, lockfile, or shared Git hooks; the existing built CLI then passed live proof. No blanket rebuild was repeated. The full changed-check runner subsequently passed on `774249b759a9eef931cfc5cae6a8affeff8b37ef` with isolated dependencies, closing the earlier environment gaps. The later increment passed focused formatting, typed lint, production/test type checks, the export-collision guard, regression proof, and review. Hosted exact-head CI remains required before landing. The CI export-name collision was reproduced locally and resolved with the existing lazy-module forwarding mechanism, without weakening its guard.

Production delta: +136/-39 (net +97). Test delta: +586/-204 (net +382). Docs: +7. Production growth supplies current inventory preparation/cache identity, async revocation/cancellation-safe discovery, and a lazy private SDK facade; duplicated Codex eligibility logic is removed and Gateway policy remains the single owner.

Remaining limitations: a node can disconnect after discovery; existing execution-time guards still reject that race. The per-attempt Codex snapshot is not a process cache. Live proof exercises real inventory and model-visible projection, but does not execute a remote command on the synthetic node or invoke a live model.


### Main-side CI repair and refreshed head

The earlier exact-head run was blocked by an independently broken SDK declaration fixture on main, not node execution. That fixture was repaired in #135831 (`5e6117d17d92dcac2ef6da6d609eb423b089a77a`) with its SDK shard and CI gate green. The parallel test-only alternative #136115 was closed as superseded after its own red/green proof.

This branch was rebased onto that actual repair. `git range-diff` confirms both commits are patch-identical; the new head is `1d06fedb1fff51782f5493ca2d07a3424cb0d00c`. Fresh isolated live proof and branch review passed on this head. All 444 refreshed tests passed: 182 Gateway/MCP owner tests, 22 node-execution phase tests, 131 CLI preparation tests, and 109 Codex dynamic-tool tests. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33605050567), including build artifacts, production/test types, lint, and the repaired declaration shard.

The fresh local changed-file runner passed its guards, SDK budgets, core types, and core-test types, then stopped at `extensions/browser/src/browser/chrome-mcp-options.ts:3` because this pre-rebase install lacks the browser-local `yargs-parser`/`@types/yargs-parser` dependencies added on main by #135857. The plugin-test type phase reproduced the same single dependency diagnostic. Both packages are correctly declared and locked; no source workaround, dependency override, or second install was added. The remaining 14 selected checks passed, including all three typed-lint batches, export scans, schema/storage/media/import-cycle and webhook/auth guards. The exact-head [production-type job](https://github.com/openclaw/openclaw/actions/runs/33605050567/job/100167191201) runs `pnpm tsgo:prod`, including plugin types; it and the [test-type job](https://github.com/openclaw/openclaw/actions/runs/33605050567/job/100167191257) passed. Thus the local full runner is explicitly not claimed green, while complete installed-dependency CI is green.

The refreshed ClawSweeper review found no actionable code/security finding. The [maintainer disposition](https://github.com/openclaw/openclaw/pull/136067#issuecomment-5506091221) accepts the bounded process-cache complexity needed for accurate catalogs and the proved cancellation/revocation races; no persistent-store change is involved.
