### PR TITLE
fix(ui): keep sent images visible during history handoff

### DIFF
--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -50,8 +50,10 @@ waits in durable pending-input custody, including during workspace preparation.
 An optional `messageSeq` comes only from a committed transcript receipt; clients
 must not predict it from history length or treat `status: "started"` as persistence.
 The Control UI replaces its provisional source with accepted custody, then with
-the canonical row. Retained initial attachment bytes may enrich that exact row
-without recreating a pending bubble on later snapshots or pane remounts.
+the canonical row. Its renderer keeps a loaded local preview in the same image
+element during this handoff while canonical media metadata and image bytes load.
+Authoritative text, media replacements, and removals still win; unavailable or
+access-denied media shows a visible reason.
 Once custody, a consumption record, or a committed user-message receipt retires
 a local source, replayed terminal events cannot bring it back, even when its row
 is absent from a later history page. Submission identity stays separate from the

--- a/src/agents/cli-executable-identity.test.ts
+++ b/src/agents/cli-executable-identity.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeTempDir } from "../../test/helpers/temp-dir.js";
 import type { CliBackendRuntimeArtifactPolicy } from "../plugins/cli-backend.types.js";
 import { resolveCliExecutableIdentity } from "./cli-executable-identity.js";
 
@@ -68,11 +69,12 @@ describe("CLI executable implementation identity", () => {
   it.runIf(process.platform === "win32")(
     "rejects mixed-case relative PATH entries and accepts mixed-case absolute entries",
     async () => {
-      // Keep the relative PATH fixture on the same Windows drive as cwd.
+      // Keep the PATH fixture on cwd's drive, outside concurrent compiler input scans.
+      const artifactRoot = path.join(process.cwd(), ".artifacts");
+      fs.mkdirSync(artifactRoot, { recursive: true });
       const root = fs.realpathSync.native(
-        fs.mkdtempSync(path.join(process.cwd(), "openclaw-cli-path-case-")),
+        makeTempDir(tempDirs, "openclaw-cli-path-case-", artifactRoot),
       );
-      tempDirs.push(root);
       const binDir = path.join(root, "bin");
       const executable = path.join(binDir, "mixed-identity.exe");
       fs.mkdirSync(binDir);

--- a/ui/src/e2e/chat-flow.image-handoff.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.image-handoff.e2e.test.ts
@@ -1,0 +1,244 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  captureUiProofEnabled,
+  createChatFlowE2eSuite,
+  expectDefined,
+  installMockGateway,
+  requireRecord,
+  requireString,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("keeps a submitted image visible through custody and canonical history loading", async () => {
+    const proofDir = captureUiProofEnabled ? suite.artifactDir : undefined;
+    const imageBytes = await readFile(path.join(process.cwd(), "ui/public/apple-touch-icon.png"));
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(proofDir ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } } : {}),
+      },
+      async ({ page }) => {
+        const sessionKey = "agent:main:main";
+        const sessionId = "image-handoff-session";
+        const source = "media://inbound/stable-preview.png";
+        const prompt = "Keep this image visible while the prompt is accepted.";
+        let releaseMetadata!: () => void;
+        let releaseImage!: () => void;
+        const metadataGate = new Promise<void>((resolve) => {
+          releaseMetadata = resolve;
+        });
+        const imageGate = new Promise<void>((resolve) => {
+          releaseImage = resolve;
+        });
+        let metadataRequested = false;
+        let imageRequested = false;
+        await page.route("**/__openclaw__/assistant-media?**", async (route) => {
+          const request = route.request();
+          const url = new URL(request.url());
+          expect(url.searchParams.get("source")).toBe(source);
+          if (url.searchParams.get("meta") === "1") {
+            metadataRequested = true;
+            expect(request.headers().authorization).toBe("Bearer e2e-device-token");
+            await metadataGate;
+            await route.fulfill({
+              json: {
+                available: true,
+                mediaTicket: "stable-image-ticket",
+                mediaTicketExpiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+              },
+            });
+          } else {
+            imageRequested = true;
+            expect(url.searchParams.get("mediaTicket")).toBe("stable-image-ticket");
+            expect(request.headers().authorization).toBeUndefined();
+            await imageGate;
+            await route.fulfill({ contentType: "image/png", body: imageBytes });
+          }
+        });
+        const initialHistory = {
+          messages: [],
+          sessionId,
+          sessionInfo: { key: sessionKey, kind: "direct", hasActiveRun: false, status: "done" },
+        };
+        const gateway = await installMockGateway(page, {
+          historyMessages: [],
+          methodResponses: { "chat.startup": initialHistory, "chat.history": initialHistory },
+        });
+        const capture = async (stage: string) => {
+          if (proofDir) {
+            await page.screenshot({ path: path.join(proofDir, `${stage}.png`), fullPage: true });
+          }
+        };
+
+        try {
+          await page.goto(`${suite.server.baseUrl}chat`);
+          await gateway.waitForRequest("chat.startup");
+          await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+          await page.locator(".agent-chat__file-input").setInputFiles({
+            name: "stable-preview.png",
+            mimeType: "image/png",
+            buffer: imageBytes,
+          });
+          await page.getByRole("img", { name: "stable-preview.png" }).waitFor();
+          await gateway.deferNext("chat.send");
+          await page.getByRole("button", { name: "Send message" }).click();
+          const request = await gateway.waitForRequest("chat.send");
+          expect(request.params).toMatchObject({
+            message: prompt,
+            attachments: [{ fileName: "stable-preview.png", mimeType: "image/png" }],
+          });
+          const runId = requireString(
+            requireRecord(request.params).idempotencyKey,
+            "image send identity",
+          );
+          const userImage = page.locator(".chat-group.user img.chat-message-image");
+          await expect
+            .poll(() =>
+              userImage.evaluate((image) =>
+                image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
+              ),
+            )
+            .toBe(180);
+          expect(await userImage.getAttribute("src")).toMatch(/^blob:/u);
+          const displayed = expectDefined(await userImage.elementHandle(), "submitted image");
+          const initialPixels = await userImage.screenshot({ animations: "disabled" });
+          const continuity = await displayed.evaluateHandle((image) => {
+            const frames: boolean[] = [];
+            const initialBounds = image.getBoundingClientRect();
+            let frame = 0;
+            const sample = () => {
+              const bounds = image.getBoundingClientRect();
+              frames.push(
+                image.isConnected &&
+                  bounds.width > 0 &&
+                  bounds.height > 0 &&
+                  bounds.width === initialBounds.width &&
+                  bounds.height === initialBounds.height &&
+                  document.querySelectorAll(".chat-group.user img.chat-message-image").length ===
+                    1 &&
+                  document.querySelector(".chat-group.user [aria-busy='true']") === null,
+              );
+              frame = requestAnimationFrame(sample);
+            };
+            sample();
+            return {
+              stop: () => {
+                cancelAnimationFrame(frame);
+                return frames;
+              },
+            };
+          });
+          const expectImageStillVisible = async (stage: string) => {
+            await capture(stage);
+            expect(await displayed.evaluate((image) => image.isConnected)).toBe(true);
+            expect(await userImage.count()).toBe(1);
+            // Native pending sources may report zero dimensions while the browser
+            // still paints the current decoded image. Compare the actual pixels.
+            expect(
+              (await userImage.screenshot({ animations: "disabled" })).equals(initialPixels),
+              `${stage} preserves the displayed image pixels`,
+            ).toBe(true);
+            expect(await page.locator(".chat-group.user [aria-busy='true']").count()).toBe(0);
+          };
+          await expectImageStillVisible("01-submitted");
+          const acceptedAt = Date.now();
+          const pendingInput = {
+            id: "accepted-image-input",
+            runId,
+            acceptedAt,
+            state: "queued",
+            message: {
+              role: "user",
+              content: prompt,
+              timestamp: acceptedAt,
+              __openclaw: {
+                id: "pending:accepted-image-input",
+                mediaImageLayout: { slots: [{ kind: "inline", factIndex: 0 }] },
+                media: [{ path: source, contentType: "image/png", fileName: "stable-preview.png" }],
+              },
+            },
+          };
+          const sessionInfo = {
+            key: sessionKey,
+            kind: "direct",
+            activeRunIds: [runId],
+            hasActiveRun: true,
+            status: "running",
+          };
+          const custodyHistory = {
+            messages: [],
+            sessionId,
+            sessionInfo,
+            pendingInputs: { items: [pendingInput], total: 1 },
+          };
+          await gateway.setMethodResponse("chat.history", custodyHistory);
+          const histories = (await gateway.getRequests("chat.history")).length;
+          await gateway.emitGatewayEvent("sessions.changed", {
+            sessionKey,
+            sessionId,
+            reason: "send",
+            hasActiveRun: true,
+            session: sessionInfo,
+          });
+          await gateway.waitForRequest("chat.history", { after: histories });
+          await expect.poll(() => page.locator(".chat-send-status").count()).toBe(0);
+          await expectImageStillVisible("02-custody");
+          await gateway.resolveDeferred("chat.send", { runId, status: "started" });
+
+          const canonical = {
+            ...pendingInput.message,
+            __openclaw: {
+              ...pendingInput.message["__openclaw"],
+              id: pendingInput.id,
+              seq: 1,
+              idempotencyKey: `${runId}:user`,
+            },
+          };
+          await gateway.setMethodResponse("chat.history", {
+            ...custodyHistory,
+            messages: [canonical],
+            pendingInputs: { items: [], total: 0 },
+          });
+          await gateway.emitGatewayEvent("session.message", {
+            sessionKey,
+            sessionId,
+            hasActiveRun: true,
+            messageId: pendingInput.id,
+            messageSeq: 1,
+            message: canonical,
+          });
+          await page.locator('.chat-bubble[data-entry-id="accepted-image-input"]').waitFor();
+          await expect.poll(() => metadataRequested).toBe(true);
+          await expectImageStillVisible("03-canonical-metadata-loading");
+          releaseMetadata();
+          await expect.poll(() => imageRequested).toBe(true);
+          await expectImageStillVisible("04-canonical-image-loading");
+          releaseImage();
+          await expect.poll(() => userImage.getAttribute("src")).toContain("stable-image-ticket");
+          await expect
+            .poll(() =>
+              userImage.evaluate((image) =>
+                image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
+              ),
+            )
+            .toBe(180);
+          await expectImageStillVisible("05-canonical-image-ready");
+          const frames = await continuity.evaluate((sampler) => sampler.stop());
+          await continuity.dispose();
+          expect(frames.length).toBeGreaterThan(1);
+          expect(frames.every(Boolean)).toBe(true);
+        } finally {
+          releaseMetadata();
+          releaseImage();
+          await capture("06-final");
+        }
+      },
+    );
+  });
+});

--- a/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
@@ -152,10 +152,13 @@ suite.define(() => {
     const mediaBlocked = new Promise<void>((resolve) => {
       releaseMedia = resolve;
     });
+    let metadataRequested = false;
     await page.route("**/__openclaw__/assistant-media?**", async (route) => {
+      const metadata = new URL(route.request().url()).searchParams.has("meta");
+      metadataRequested ||= metadata;
       await mediaBlocked;
       await route.fulfill(
-        new URL(route.request().url()).searchParams.has("meta")
+        metadata
           ? { json: { available: true } }
           : { contentType: "image/png", body: Buffer.from(ONE_PIXEL_PNG_B64, "base64") },
       );
@@ -181,6 +184,7 @@ suite.define(() => {
               fileName: "synthetic.png",
             },
           ],
+          mediaImageLayout: { slots: [{ kind: "inline", factIndex: 0 }] },
         },
       },
     };
@@ -367,9 +371,7 @@ suite.define(() => {
         };
       });
       await gateway.resolveDeferred("chat.startup");
-      await page
-        .locator('[data-chat-row-key="group:user:pending-input:accepted-project-input"]')
-        .waitFor();
+      await expect.poll(() => metadataRequested).toBe(true);
       expect(await page.locator(".chat-notice").count()).toBe(0);
       const working = page.locator('.chat-working-indicator[role="status"]');
       await pollLocatorText(working).toContain("Preparing workspace…");

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -471,20 +471,41 @@ suite.define(() => {
       const sessionKey = "agent:main:single-image-prompt";
       const runId = "initial-image-send";
       const message = "testing if dual prompts show";
+      const source = "media://inbound/initial-prompt.png";
+      const imageBytes = await readFile(path.join(process.cwd(), "ui/public/apple-touch-icon.png"));
+      let releaseMedia!: () => void;
+      const mediaGate = new Promise<void>((resolve) => {
+        releaseMedia = resolve;
+      });
+      let metadataRequested = false;
+      await page.route("**/__openclaw__/assistant-media?**", async (route) => {
+        const url = new URL(route.request().url());
+        expect(url.searchParams.get("source")).toBe(source);
+        const metadata = url.searchParams.get("meta") === "1";
+        metadataRequested ||= metadata;
+        await mediaGate;
+        await route.fulfill(
+          metadata
+            ? {
+                json: {
+                  available: true,
+                  mediaTicket: "initial-prompt-ticket",
+                  mediaTicketExpiresAt: new Date(Date.now() + 5 * 60_000).toISOString(),
+                },
+              }
+            : { contentType: "image/png", body: imageBytes },
+        );
+      });
       const authoritative = {
         role: "user",
-        content: [
-          {
-            type: "image",
-            source: { type: "url", url: "/persisted-image.png" },
-          },
-          { type: "text", text: message },
-        ],
+        content: [{ type: "text", text: message }],
         timestamp: Date.now(),
         __openclaw: {
           id: "persisted-image-prompt",
           idempotencyKey: `${runId}:user`,
           seq: 1,
+          media: [{ path: source, contentType: "image/png", fileName: "pixel.png" }],
+          mediaImageLayout: { slots: [{ kind: "inline", factIndex: 0 }] },
         },
       };
       const gateway = await installMockGateway(page, {
@@ -509,62 +530,98 @@ suite.define(() => {
           },
         },
       });
-      await page.goto(`${suite.server.baseUrl}new`);
-      const composer = page.locator(".new-session-page__message");
-      await composer.fill(message);
-      await pastePng(composer);
-      await page.getByRole("button", { name: "Start session" }).click();
-      await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
-        timeout: 30_000,
-      });
-      await gateway.waitForRequest("chat.startup");
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        const composer = page.locator(".new-session-page__message");
+        await composer.fill(message);
+        await page.locator(".agent-chat__file-input").setInputFiles({
+          name: "pixel.png",
+          mimeType: "image/png",
+          buffer: imageBytes,
+        });
+        await page.getByRole("button", { name: "Start session" }).click();
+        await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey), {
+          timeout: 30_000,
+        });
+        await gateway.waitForRequest("chat.startup");
 
-      const userRow = page.locator(".chat-group.user");
-      const userImage = userRow.locator("img.chat-message-image");
-      await expect.poll(() => userRow.count()).toBe(1);
-      await expect.poll(() => userImage.count()).toBe(1);
-      await expect.poll(() => userImage.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
-      const initialImageSrc = await userImage.getAttribute("src");
-      await userImage.evaluate((image) => image.setAttribute("data-initial-image-node", "true"));
-      await pollLocatorText(userRow).toContain(message);
-      await pollLocatorText(userRow).not.toContain("Attached image");
+        const userRow = page.locator(".chat-group.user");
+        const userImage = userRow.locator("img.chat-message-image");
+        await expect.poll(() => userRow.count()).toBe(1);
+        await expect.poll(() => userImage.count()).toBe(1);
+        await expect.poll(() => userImage.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
+        await expect
+          .poll(() =>
+            userImage.evaluate((image) =>
+              image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
+            ),
+          )
+          .toBe(180);
+        const initialImageSrc = await userImage.getAttribute("src");
+        const initialPixels = await userImage.screenshot({ animations: "disabled" });
+        await userImage.evaluate((image) => image.setAttribute("data-initial-image-node", "true"));
+        await pollLocatorText(userRow).toContain(message);
+        await pollLocatorText(userRow).not.toContain("Attached image");
 
-      const promptBubbles = page.locator(".chat-bubble").filter({ hasText: message });
-      const durableBubble = page.locator('.chat-bubble[data-entry-id="persisted-image-prompt"]');
-      await expect.poll(() => promptBubbles.count()).toBe(1);
-      await gateway.emitGatewayEvent("session.message", {
-        activeRunIds: [runId],
-        clientRunId: runId,
-        hasActiveRun: true,
-        message: authoritative,
-        messageId: "persisted-image-prompt",
-        messageSeq: 1,
-        session: {
+        const promptBubbles = page.locator(".chat-bubble").filter({ hasText: message });
+        const durableBubble = page.locator('.chat-bubble[data-entry-id="persisted-image-prompt"]');
+        await expect.poll(() => promptBubbles.count()).toBe(1);
+        await gateway.emitGatewayEvent("session.message", {
           activeRunIds: [runId],
+          clientRunId: runId,
           hasActiveRun: true,
-          key: sessionKey,
-          kind: "direct",
-          status: "running",
-          updatedAt: Date.now(),
-        },
-        sessionKey,
-      });
-      await durableBubble.waitFor({ timeout: 10_000 });
-      await expect.poll(() => durableBubble.count()).toBe(1);
-      await expect.poll(() => promptBubbles.count()).toBe(1);
-      await expect.poll(() => userImage.getAttribute("data-initial-image-node")).toBe("true");
-      await expect.poll(() => userImage.getAttribute("src")).toBe(initialImageSrc);
+          message: authoritative,
+          messageId: "persisted-image-prompt",
+          messageSeq: 1,
+          session: {
+            activeRunIds: [runId],
+            hasActiveRun: true,
+            key: sessionKey,
+            kind: "direct",
+            status: "running",
+            updatedAt: Date.now(),
+          },
+          sessionKey,
+        });
+        await durableBubble.waitFor({ timeout: 10_000 });
+        await expect.poll(() => durableBubble.count()).toBe(1);
+        await expect.poll(() => promptBubbles.count()).toBe(1);
+        await expect.poll(() => metadataRequested).toBe(true);
+        await expect.poll(() => userImage.getAttribute("data-initial-image-node")).toBe("true");
+        await expect.poll(() => userImage.getAttribute("src")).toBe(initialImageSrc);
+        expect((await userImage.screenshot({ animations: "disabled" })).equals(initialPixels)).toBe(
+          true,
+        );
+        expect(await userRow.locator('[aria-busy="true"]').count()).toBe(0);
+        await captureUiProof(suite, page, "initial-image-metadata-loading.png");
 
-      await gateway.resolveDeferred("chat.startup");
+        await gateway.resolveDeferred("chat.startup");
 
-      await expect.poll(() => userRow.count()).toBe(1);
-      await expect.poll(() => userImage.count()).toBe(1);
-      await expect.poll(() => userImage.getAttribute("data-initial-image-node")).toBe("true");
-      await expect.poll(() => userImage.getAttribute("src")).toBe(initialImageSrc);
-      await expect.poll(() => promptBubbles.count()).toBe(1);
-      await expect.poll(() => durableBubble.count()).toBe(1);
-      await pollLocatorText(userRow).toContain(message);
-      await pollLocatorText(userRow).not.toContain("Attached image");
+        await expect.poll(() => userRow.count()).toBe(1);
+        await expect.poll(() => userImage.count()).toBe(1);
+        await expect.poll(() => userImage.getAttribute("data-initial-image-node")).toBe("true");
+        await expect.poll(() => userImage.getAttribute("src")).toBe(initialImageSrc);
+        await expect.poll(() => promptBubbles.count()).toBe(1);
+        await expect.poll(() => durableBubble.count()).toBe(1);
+        await pollLocatorText(userRow).toContain(message);
+        await pollLocatorText(userRow).not.toContain("Attached image");
+        releaseMedia();
+        await expect.poll(() => userImage.getAttribute("src")).toContain("initial-prompt-ticket");
+        await expect
+          .poll(() =>
+            userImage.evaluate((image) =>
+              image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
+            ),
+          )
+          .toBe(180);
+        expect(await userImage.getAttribute("data-initial-image-node")).toBe("true");
+        expect((await userImage.screenshot({ animations: "disabled" })).equals(initialPixels)).toBe(
+          true,
+        );
+        await captureUiProof(suite, page, "initial-image-canonical-ready.png");
+      } finally {
+        releaseMedia();
+      }
     });
   });
 

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -38,18 +38,19 @@ async function withNewSessionPage(run: (page: Page) => Promise<void>): Promise<v
   }
 }
 
-async function expectDecodedThumbnail(image: Locator) {
+async function expectDecodedThumbnail(image: Locator, expectedNaturalWidth?: number) {
   await image.waitFor({ state: "visible" });
   await image.scrollIntoViewIfNeeded();
   await expect
     .poll(() =>
-      image.evaluate(async (element) => {
+      image.evaluate(async (element, expectedWidth) => {
         if (!(element instanceof HTMLImageElement)) {
           return false;
         }
         await element.decode();
         const bounds = element.getBoundingClientRect();
         return (
+          (expectedWidth === undefined || element.naturalWidth === expectedWidth) &&
           Math.min(element.naturalWidth, element.naturalHeight, bounds.width, bounds.height) >=
             32 &&
           bounds.top >= 0 &&
@@ -57,7 +58,7 @@ async function expectDecodedThumbnail(image: Locator) {
           bounds.bottom <= window.innerHeight &&
           bounds.right <= window.innerWidth
         );
-      }),
+      }, expectedNaturalWidth),
     )
     .toBe(true);
 }
@@ -550,13 +551,7 @@ suite.define(() => {
         await expect.poll(() => userRow.count()).toBe(1);
         await expect.poll(() => userImage.count()).toBe(1);
         await expect.poll(() => userImage.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
-        await expect
-          .poll(() =>
-            userImage.evaluate((image) =>
-              image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
-            ),
-          )
-          .toBe(180);
+        await expectDecodedThumbnail(userImage, 180);
         const initialImageSrc = await userImage.getAttribute("src");
         const initialPixels = await userImage.screenshot({ animations: "disabled" });
         await userImage.evaluate((image) => image.setAttribute("data-initial-image-node", "true"));
@@ -607,13 +602,7 @@ suite.define(() => {
         await pollLocatorText(userRow).not.toContain("Attached image");
         releaseMedia();
         await expect.poll(() => userImage.getAttribute("src")).toContain("initial-prompt-ticket");
-        await expect
-          .poll(() =>
-            userImage.evaluate((image) =>
-              image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
-            ),
-          )
-          .toBe(180);
+        await expectDecodedThumbnail(userImage, 180);
         expect(await userImage.getAttribute("data-initial-image-node")).toBe("true");
         expect((await userImage.screenshot({ animations: "disabled" })).equals(initialPixels)).toBe(
           true,

--- a/ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts
+++ b/ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts
@@ -1,4 +1,6 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { IDBFactory } from "fake-indexeddb";
+import { render } from "lit";
 /* @vitest-environment jsdom */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
@@ -11,8 +13,14 @@ import {
 } from "./chat-pane.test-support.ts";
 import { applyChatPendingInputs, getChatPendingInputs } from "./chat-pending-inputs.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import { buildChatItems } from "./chat-thread-build.ts";
-import { extractImages } from "./components/chat-message-media.ts";
+import { createTestTranscript } from "./chat-view.test-helpers.ts";
+import { releaseChatMediaResourceSubscriber } from "./components/chat-message-media.ts";
+import { renderChatThread } from "./components/chat-thread.ts";
+import {
+  installTranscriptDomMocks,
+  resetTranscriptTestDom,
+  threadProps,
+} from "./components/chat-transcript.test-support.ts";
 import {
   observeChatCache,
   readChatSessionSnapshot,
@@ -24,9 +32,7 @@ import { buildInitialChatSubmission } from "./user-message-content.ts";
 import "./chat-pane.ts";
 
 describe("stored chat snapshot hydration", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+  afterEach(resetTranscriptTestDom);
 
   function createMountedPane(targetSessionKey: string, sharedMessages: ChatMessageCache) {
     const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
@@ -58,7 +64,13 @@ describe("stored chat snapshot hydration", () => {
   )(
     "keeps one attributed initial source through $cacheMode remount, custody, and promotion ($senderName)",
     async ({ cacheMode, senderName }) => {
+      installTranscriptDomMocks();
       vi.stubGlobal("indexedDB", new IDBFactory());
+      const mediaResponse = createDeferred<Response>();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => mediaResponse.promise),
+      );
       const targetSessionKey = "agent:main:cached-initial";
       const runId = "cached-initial-send";
       const dataUrl = "data:image/png;base64,iVBORw0KGgo=";
@@ -104,22 +116,6 @@ describe("stored chat snapshot hydration", () => {
         expect(() => pane.connectedCallback()).toThrow(stopAfterAttach);
         return pane;
       };
-      const renderedUsers = (state: ChatPageHost) =>
-        buildChatItems({
-          paneId: "cached-initial-pane",
-          sessionKey: targetSessionKey,
-          messages: state.chatMessages,
-          pendingInputs: getChatPendingInputs(state)?.page.items,
-          toolMessages: [],
-          streamSegments: [],
-          stream: null,
-          streamStartedAt: null,
-          showToolCalls: true,
-        }).flatMap((item) =>
-          item.kind === "group" && item.role === "user"
-            ? item.messages.map(({ message }) => message)
-            : [],
-        );
       const first = mount();
       try {
         // A stale network response commits the still-visible local prompt to cache.
@@ -138,6 +134,24 @@ describe("stored chat snapshot hydration", () => {
         sharedMessages.clear();
       }
       const remounted = mount(cacheMode === "stored");
+      const transcript = createTestTranscript();
+      const container = document.body.appendChild(document.createElement("div"));
+      const renderPane = () => {
+        render(
+          renderChatThread(
+            {
+              ...threadProps("cached-initial-pane", targetSessionKey, remounted.state.chatMessages),
+              pendingInputs: getChatPendingInputs(remounted.state)?.page.items,
+              assistantAttachmentAuthToken: "test-auth-token",
+              connectionEpoch: 1,
+              onRequestUpdate: renderPane,
+            },
+            transcript,
+          ),
+          container,
+        );
+        transcript.hostUpdated();
+      };
       try {
         await vi.waitFor(() =>
           expect(
@@ -146,15 +160,34 @@ describe("stored chat snapshot hydration", () => {
             }),
           ).not.toBeNull(),
         );
-        expect(renderedUsers(remounted.state)).toHaveLength(1);
+        renderPane();
+        transcript.hostConnected();
+        const displayed = expectDefined(
+          container.querySelector<HTMLImageElement>(".chat-message-image"),
+          "remounted initial image",
+        );
+        // jsdom has no decoder; deliver the loaded-preview boundary before custody.
+        Object.defineProperty(displayed, "naturalWidth", { value: 1 });
+        displayed.dispatchEvent(new Event("load"));
+        const expectRenderedInput = (text: string, author: string) => {
+          expect(container.querySelectorAll(".chat-bubble")).toHaveLength(1);
+          expect(container.querySelectorAll(".chat-message-image")).toHaveLength(1);
+          expect(container.querySelector(".chat-message-image")).toBe(displayed);
+          expect(displayed.getAttribute("src")).toBe(dataUrl);
+          expect(container.querySelector('[aria-busy="true"]')).toBeNull();
+          expect(container.textContent).toContain(text);
+          expect(container.querySelector(".chat-sender-name")?.textContent?.trim()).toBe(author);
+        };
+        expectRenderedInput("Keep the attributed initial image", "Local Author");
         const metadata = {
           id: "pending:cached-input",
           ...(senderName ? { senderName } : {}),
           media: [{ url: "media://inbound/cached-image", contentType: "image/png" }],
+          mediaImageLayout: { slots: [{ kind: "inline", factIndex: 0 }] },
         };
         const custodyMessage = {
           role: "user",
-          content: "Keep the attributed initial image",
+          content: "Gateway accepted the initial image",
           __openclaw: metadata,
         };
         applyChatPendingInputs(remounted.state, {
@@ -163,42 +196,40 @@ describe("stored chat snapshot hydration", () => {
             { id: "cached-input", runId, acceptedAt: 1, state: "queued", message: custodyMessage },
           ],
         });
-        const custodyUsers = renderedUsers(remounted.state);
-        expect(custodyUsers).toHaveLength(1);
+        renderPane();
         expect(remounted.state.chatMessages).toEqual([]);
-        expect(extractImages(custodyUsers[0]).map((image) => image.url)).toEqual([dataUrl]);
-        expect(custodyUsers[0]).toMatchObject({
-          __openclaw: { id: "pending:cached-input", ...(senderName ? { senderName } : {}) },
-        });
-        expect(custodyUsers[0]).not.toHaveProperty("__openclaw.senderId");
-        expect(custodyUsers[0]).not.toHaveProperty("__openclaw.media");
-        if (!senderName) {
-          expect(custodyUsers[0]).not.toHaveProperty("__openclaw.senderName");
-        }
+        expect(
+          getChatPendingInputs(remounted.state)?.page.items.map((item) => item.message),
+        ).toEqual([custodyMessage]);
+        expectRenderedInput(custodyMessage.content, senderName ?? "You");
+        expect(container.textContent).not.toContain("Keep the attributed initial image");
         expect(custodyMessage["__openclaw"]).toBe(metadata);
+        const canonicalMessage = {
+          ...custodyMessage,
+          content: "Gateway persisted the initial image",
+          __openclaw: {
+            ...metadata,
+            id: "cached-input",
+            seq: 1,
+            idempotencyKey: `${runId}:user`,
+            runId: "execution-run",
+          },
+        };
         request.mockResolvedValue({
           sessionId: "cached-initial-session",
-          messages: [
-            {
-              ...custodyMessage,
-              __openclaw: {
-                ...metadata,
-                id: "cached-input",
-                seq: 1,
-                idempotencyKey: `${runId}:user`,
-                runId: "execution-run",
-              },
-            },
-          ],
+          messages: [canonicalMessage],
           pendingInputs: { items: [], total: 0 },
         });
         await loadChatHistory(remounted.state);
-        const canonicalUsers = renderedUsers(remounted.state);
-        expect(canonicalUsers).toHaveLength(1);
-        expect(canonicalUsers[0]).toMatchObject({ __openclaw: { id: "cached-input", seq: 1 } });
-        expect(extractImages(canonicalUsers[0]).map((image) => image.url)).toEqual([dataUrl]);
+        renderPane();
+        expect(remounted.state.chatMessages).toEqual([canonicalMessage]);
+        expectRenderedInput(canonicalMessage.content, senderName ?? "You");
+        expect(container.textContent).not.toContain(custodyMessage.content);
         expect(request.mock.calls.every(([method]) => method === "chat.history")).toBe(true);
       } finally {
+        render(null, container);
+        releaseChatMediaResourceSubscriber(renderPane);
+        transcript.hostDisconnected();
         remounted.disconnectedCallback();
         await store.flush();
         await clearStoredChatSnapshots();

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -31,7 +31,6 @@ import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
 import { resetChatThreadState } from "./chat-thread.ts";
-import { extractImages } from "./components/chat-message-media.ts";
 import { listStoredChatOutboxes, loadChatComposerSnapshot } from "./composer-persistence.ts";
 import {
   admitChatSubmission,
@@ -462,32 +461,14 @@ describe("server-owned pending input display", () => {
       expect(host.chatStream).toBe("Still working");
       expect(host.chatToolMessages).toEqual([tool]);
       const displayed = getChatPendingInputs(host)?.page;
-      if (source === "initial" && custody !== "consumed") {
-        expect(displayed).toMatchObject({
-          total: acceptedPage.total,
-          items: [
-            { id: input.id, runId: input.runId, state: custody, acceptedAt: input.acceptedAt },
-          ],
-        });
+      expect(displayed).toEqual(acceptedPage);
+      if (custody !== "consumed") {
         const displayedMessage = displayed!.items[0]!.message;
-        expect(displayedMessage).toMatchObject({
-          timestamp: 90,
-          __openclaw: { id: `pending:${input.id}`, senderName: "Authoritative Author" },
-        });
         expect(readSessionMessageIdentity(displayedMessage)).toMatchObject({
           id: `pending:${input.id}`,
           sequence: null,
           sendId: null,
         });
-        expect(extractImages(displayedMessage).map((image) => image.url)).toEqual([
-          "data:image/png;base64,iVBORw0KGgo=",
-        ]);
-        expect(acceptedPage.items[0]?.message).toMatchObject({
-          content: "Keep my accepted input",
-          __openclaw: { media: [{ url: "media://inbound/initial.png" }] },
-        });
-      } else {
-        expect(displayed).toEqual(acceptedPage);
       }
       // Empty later snapshots and a fresh pane must not turn retained image bytes back into input.
       reduceChatSessionProjection(
@@ -504,7 +485,7 @@ describe("server-owned pending input display", () => {
       });
       expect(admitChatSubmission(remounted)).toBe(false);
       expect(remounted.chatMessages).toEqual([]);
-      // Retirement still permits display adoption, but only for the exact source.
+      // Retirement does not hide distinct or uncorrelated server-owned inputs.
       const otherInputs = ["other-accepted-source", undefined].map((runId) => ({
         id: `other-${runId ?? "uncorrelated"}`,
         acceptedAt: input.acceptedAt,
@@ -525,8 +506,7 @@ describe("server-owned pending input display", () => {
       expect(getChatPendingInputs(host)?.page.items.slice(0, -2)).toEqual(displayed?.items);
       applyChatPendingInputs(host, { items: [], total: 0 });
       expect(host.chatMessages).toEqual([...history, unrelated]);
-      if (source === "initial" && custody !== "consumed") {
-        const localContent = chatSubmissions.readInitial(sessionKey, host.client)!.message.content;
+      if (custody !== "consumed") {
         const promoted = {
           role: "user",
           content: "authoritative projection",
@@ -539,16 +519,12 @@ describe("server-owned pending input display", () => {
           },
         };
         reduceChatSessionProjection(host, { type: "messagePersisted", message: promoted });
-        expect(host.chatMessages).toHaveLength(2);
-        expect(host.chatMessages.find((message) => message !== unrelated)).toMatchObject({
-          content: localContent,
-          __openclaw: {
-            id: input.id,
-            seq: 4,
-            runId: "execution-run",
-            senderName: "Authoritative Author",
-          },
-        });
+        expect(host.chatMessages).toHaveLength(history.length + 2);
+        expect(host.chatMessages).toContain(promoted);
+        expect(host.chatMessages.filter((message) => message !== promoted)).toEqual([
+          ...history,
+          unrelated,
+        ]);
         expect(admitChatSubmission(host)).toBe(false);
       }
     },

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -12,7 +12,7 @@ import { formatUiError } from "../../lib/format-error.ts";
 import { resolveUiSelectedSessionAgentId } from "../../lib/sessions/session-key.ts";
 import { removeQueuedMessage } from "./chat-queue.ts";
 import type { ChatState } from "./chat-state-contract.ts";
-import { messageMatchesSearchQuery } from "./chat-thread-items.ts";
+import { buildMessageItems, messageMatchesSearchQuery } from "./chat-thread-items.ts";
 import {
   getChatSessionProjection,
   readChatSessionProjectionScope,
@@ -43,7 +43,13 @@ export function buildPendingInputItems(
     if (searchQuery?.trim() && !messageMatchesSearchQuery(input.message, searchQuery)) {
       continue;
     }
-    items.push({ kind: "message", key: `pending-input:${input.id}`, message: input.message });
+    // Custody keeps submission correlation outside the message; use it for
+    // presentation without inventing transcript or execution identity.
+    items.push(
+      ...buildMessageItems([input.message], () =>
+        input.runId ? `send:${input.runId}` : `pending-input:${input.id}`,
+      ),
+    );
     if (input.state === "queued") {
       continue;
     }

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -367,8 +367,9 @@ function messageProjectionDigest(message: unknown): string {
 
 export function buildMessageItems<Message>(
   messages: Message[],
+  resolveSourceKey: (message: Message) => string | null = transcriptMessageSourceKey,
 ): Array<Extract<ChatItem, { kind: "message" }> & { message: Message }> {
-  const sourceKeys = messages.map(transcriptMessageSourceKey);
+  const sourceKeys = messages.map(resolveSourceKey);
   const sourceCounts = new Map<string, number>();
   for (const sourceKey of sourceKeys) {
     if (sourceKey) {

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -73,15 +73,17 @@ function renderChatIcon(name: string) {
   return icons[name as IconName] ?? icons.zap;
 }
 
-function canonicalImageMessageKey(message: unknown, sessionKey: string | undefined) {
+function imageMessageIdentity(message: unknown, sessionKey: string | undefined) {
   const identity = readSessionMessageIdentity(message);
-  return identity?.role === "user" &&
-    identity.id &&
-    !identity.isImported &&
-    !isPendingSendMessage(message) &&
-    !identity.id.startsWith(CHAT_PENDING_INPUT_MESSAGE_PREFIX)
-    ? JSON.stringify([sessionKey, identity.id, identity.sequence])
-    : undefined;
+  if (identity?.role !== "user" || identity.isImported) {
+    return { localSubmission: false };
+  }
+  if (!identity.id || isPendingSendMessage(message)) {
+    return { localSubmission: Boolean(identity.sendId) };
+  }
+  return identity.id.startsWith(CHAT_PENDING_INPUT_MESSAGE_PREFIX)
+    ? {}
+    : { canonicalMessageKey: JSON.stringify([sessionKey, identity.id, identity.sequence]) };
 }
 
 function renderInlineToolCards(
@@ -262,7 +264,7 @@ export function renderGroupedMessage(
   const images = extractImages(message);
   const hasImages = images.length > 0;
   const imageRenderOptions = {
-    canonicalMessageKey: hasImages ? canonicalImageMessageKey(message, opts.sessionKey) : undefined,
+    ...(hasImages ? imageMessageIdentity(message, opts.sessionKey) : {}),
     connectionEpoch: opts.connectionEpoch,
     localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
     resourceBasePath: opts.resourceBasePath,

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -1,5 +1,6 @@
 import { html, noChange, nothing } from "lit";
 import { AsyncDirective, directive } from "lit/async-directive.js";
+import { Directive } from "lit/directive.js";
 import { keyed } from "lit/directives/keyed.js";
 import { repeat } from "lit/directives/repeat.js";
 import { until } from "lit/directives/until.js";
@@ -13,6 +14,7 @@ import {
 } from "../../../lib/open-external-url.ts";
 import { showToast } from "../../../lib/toast.ts";
 import {
+  isManagedOutgoingMediaSource,
   resolveAssistantAttachmentAvailability,
   resolveManagedOutgoingMediaSessionKey,
 } from "./chat-message-attachment-availability.ts";
@@ -47,15 +49,13 @@ type ManagedImageVariant = "full" | "thumbnail";
 
 type RetainedInlineImage = {
   status: "retaining";
-  source: string;
   previewUrl: string;
-  preparation?: {
-    url: string;
-    image: HTMLImageElement;
-    decoded: boolean;
-    cancel: () => void;
-  };
+  timeout?: ReturnType<typeof setTimeout>;
 };
+
+function isInlineImageSource(source: string): boolean {
+  return source.startsWith("data:image/") || source.startsWith("blob:");
+}
 
 class MessageImageResourceDirective extends AsyncDirective {
   private image: ImageBlock | undefined;
@@ -89,19 +89,24 @@ class MessageImageResourceDirective extends AsyncDirective {
     const previous = this.image;
     if (previous?.url !== image.url || previous?.artifactId !== image.artifactId) {
       this.releaseRetainedImage();
-      // Bind once, only from an actually displayed inline image to its exact
-      // persisted slot. A later source replacement cannot borrow that preview.
+      // The gallery binds the exact submission/slot. Retain only pixels this
+      // mounted IMG has loaded, never another pane's cached preview.
       this.retained =
-        options?.canonicalMessageKey &&
         image.factIndex !== undefined &&
-        previous?.url.startsWith("data:image/") &&
+        previous &&
+        isInlineImageSource(previous.url) &&
         previous.artifactId === image.artifactId &&
         isCanonicalInboundMediaSource(image.url) &&
         this.element?.getAttribute("src") === previous.url &&
         this.element.naturalWidth > 0
-          ? { status: "retaining", source: image.url, previewUrl: previous.url }
+          ? { status: "retaining", previewUrl: previous.url }
           : undefined;
-      if (!this.retained) {
+      const inlineReplacement =
+        options?.localSubmission &&
+        previous &&
+        isInlineImageSource(previous.url) &&
+        isInlineImageSource(image.url);
+      if (!this.retained && !inlineReplacement) {
         this.element = undefined;
         this.presentationKey = Symbol("image-presentation");
       }
@@ -163,13 +168,17 @@ class MessageImageResourceDirective extends AsyncDirective {
       availability.mediaTicket,
     );
     const renderable = { ...image, displayUrl };
-    if (!isManagedOutgoingImageSource(displayUrl)) {
+    if (!isManagedOutgoingMediaSource(displayUrl)) {
       const retained = this.retained;
-      const previewUrl =
-        retained?.status === "retaining" && !this.prepareRetainedImage(retained, displayUrl).decoded
-          ? retained.previewUrl
-          : displayUrl;
-      return this.present(this.renderImageElement(renderable, previewUrl, options));
+      if (retained?.status === "retaining" && retained.timeout === undefined) {
+        // IMG keeps its current decoded request while the new src loads. One
+        // native load/error boundary replaces the detached decode preloader.
+        retained.timeout = setTimeout(
+          () => this.failRetainedImage(),
+          CANONICAL_IMAGE_HANDOFF_TIMEOUT_MS,
+        );
+      }
+      return this.present(this.renderImageElement(renderable, displayUrl, options));
     }
     // Keep this render's callbacks when the image resolves, not later directive options.
     const preview = resolveManagedOutgoingImageBlobUrl(
@@ -188,7 +197,7 @@ class MessageImageResourceDirective extends AsyncDirective {
     opts: ImageRenderOptions | undefined,
   ) {
     const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
-    const managed = isManagedOutgoingImageSource(img.displayUrl);
+    const managed = isManagedOutgoingMediaSource(img.displayUrl);
     // Upscale genuinely tiny sources enough to read and operate without
     // stretching every transcript image into a fixed-size tile.
     const imageClass =
@@ -221,49 +230,6 @@ class MessageImageResourceDirective extends AsyncDirective {
     `;
   }
 
-  private prepareRetainedImage(retained: RetainedInlineImage, url: string) {
-    if (retained.preparation?.url === url) {
-      return retained.preparation;
-    }
-    retained.preparation?.cancel();
-    const image = new Image();
-    const preparation = {
-      url,
-      image,
-      decoded: false,
-      cancel: () => {
-        clearTimeout(timeout);
-        image.removeAttribute("src");
-      },
-    };
-    const finish = (decoded: boolean) => {
-      if (
-        !this.isConnected ||
-        this.retained !== retained ||
-        retained.preparation !== preparation ||
-        this.image?.url !== retained.source
-      ) {
-        return;
-      }
-      if (!decoded) {
-        this.failRetainedImage();
-        return;
-      }
-      preparation.decoded = true;
-      this.refreshImage();
-    };
-    // Metadata proves access, not decoded pixels. Keep this preloader alive
-    // through the displayed IMG's load; the deadline bounds both requests.
-    const timeout = setTimeout(() => finish(false), CANONICAL_IMAGE_HANDOFF_TIMEOUT_MS);
-    retained.preparation = preparation;
-    image.src = url;
-    void image.decode().then(
-      () => finish(true),
-      () => finish(false),
-    );
-    return preparation;
-  }
-
   private releaseRetainedImage() {
     const retained = this.retained;
     this.retained = undefined;
@@ -271,7 +237,7 @@ class MessageImageResourceDirective extends AsyncDirective {
       this.element = undefined;
     }
     if (retained?.status === "retaining") {
-      retained.preparation?.cancel();
+      clearTimeout(retained.timeout);
     }
   }
 
@@ -313,7 +279,7 @@ function openMessageImage(
 ) {
   const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
   const requestVersion = opts?.onRequestOpenImage?.();
-  if (!isManagedOutgoingImageSource(img.displayUrl)) {
+  if (!isManagedOutgoingMediaSource(img.displayUrl)) {
     openResolvedImage(opts?.onOpenImage, previewUrl, title, undefined, requestVersion);
     return;
   }
@@ -365,52 +331,77 @@ function openMessageImage(
     .catch(() => showToast({ message: t("chat.imageLightbox.loadFailed") }));
 }
 
-export function renderMessageImages(images: ImageBlock[], opts?: ImageRenderOptions) {
-  if (images.length === 0) {
-    return nothing;
-  }
+class MessageImagesDirective extends Directive {
+  private slots: { image: ImageBlock; key: symbol }[] = [];
+  private scope = "";
+  private canonicalMessageKey: string | undefined;
+  private localSubmission = false;
 
-  const layoutClasses = [
-    "chat-message-images",
-    images.length === 1 ? "chat-message-images--single" : "chat-message-images--gallery",
-    images.length === 2 || images.length === 4 ? "chat-message-images--two-column" : "",
-    images.length === 5 ? "chat-message-images--five" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const scope = JSON.stringify([
-    opts?.connectionEpoch,
-    opts?.authToken?.trim(),
-    opts?.resourceBasePath,
-  ]);
-  return html`<div class=${layoutClasses}>
-    ${repeat(
-      images,
-      // Canonical identity scopes persisted slots, not unchanged initial-send
-      // images: adopting their message ID must not remount their inline pixels.
-      (img, index) =>
-        `${scope}:${img.factIndex === undefined ? `image:${index}` : `${opts?.canonicalMessageKey}:fact:${img.factIndex}`}`,
-      // The template owns the directive so repeat removal disconnects it.
-      (img) => html`${renderMessageImageResource(img, opts)}`,
-    )}
-  </div>`;
-}
-
-function isManagedOutgoingImageSource(source: string): boolean {
-  const trimmed = source.trim();
-  if (trimmed.startsWith("/api/chat/media/outgoing/")) {
-    return true;
-  }
-  try {
-    const parsed = new URL(trimmed, window.location.origin);
-    return (
-      parsed.origin === window.location.origin &&
-      parsed.pathname.startsWith("/api/chat/media/outgoing/")
+  override render(images: ImageBlock[], opts?: ImageRenderOptions) {
+    const scope = JSON.stringify([
+      opts?.connectionEpoch,
+      opts?.authToken?.trim(),
+      opts?.resourceBasePath,
+    ]);
+    // Custody keeps local ownership; imported history must end it even when
+    // the outer row reuses the same submission key.
+    const continuing =
+      this.scope === scope &&
+      (!this.localSubmission || opts?.localSubmission !== false) &&
+      (this.canonicalMessageKey === opts?.canonicalMessageKey ||
+        (this.localSubmission && !this.canonicalMessageKey));
+    const localSubmission = continuing ? this.localSubmission : opts?.localSubmission === true;
+    // Fact positions preserve selected image order, even when hooks reorder
+    // content blocks. Partial/ambiguous receipts cannot borrow pixels.
+    const adoptingSlots =
+      continuing &&
+      localSubmission &&
+      images.length === this.slots.length &&
+      this.slots.every(({ image }) => isInlineImageSource(image.url)) &&
+      images.every((image) => image.factIndex !== undefined);
+    const previousImages = adoptingSlots
+      ? images.toSorted((left, right) => (left.factIndex ?? 0) - (right.factIndex ?? 0))
+      : this.slots.map(({ image }) => image);
+    const previousSlots = new Map(
+      previousImages.map((image, index) => [image.factIndex, this.slots[index]?.key]),
     );
-  } catch {
-    return false;
+    this.slots = images.map((image, index) => {
+      const slot = this.slots[index];
+      const previous =
+        image.factIndex !== undefined
+          ? previousSlots.get(image.factIndex)
+          : slot?.image.factIndex === undefined
+            ? slot?.key
+            : undefined;
+      return { image, key: (continuing && previous) || Symbol("image-slot") };
+    });
+    this.scope = scope;
+    this.canonicalMessageKey = opts?.canonicalMessageKey;
+    this.localSubmission =
+      localSubmission &&
+      !(opts?.canonicalMessageKey && images.every((image) => image.factIndex !== undefined));
+    if (!images.length) {
+      return nothing;
+    }
+    const layoutClasses = [
+      "chat-message-images",
+      images.length === 1 ? "chat-message-images--single" : "chat-message-images--gallery",
+      images.length === 2 || images.length === 4 ? "chat-message-images--two-column" : "",
+      images.length === 5 ? "chat-message-images--five" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+    return html`<div class=${layoutClasses}>
+      ${repeat(
+        this.slots,
+        ({ key }) => key,
+        ({ image }) => html`${renderMessageImageResource(image, opts)}`,
+      )}
+    </div>`;
   }
 }
+
+export const renderMessageImages = directive(MessageImagesDirective);
 
 function resolveManagedOutgoingImageBlobUrlCacheKey(
   source: string,

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -37,6 +37,7 @@ export type ArtifactDownloadResolver = (params: {
 
 export type ImageRenderOptions = {
   canonicalMessageKey?: string;
+  localSubmission?: boolean;
   connectionEpoch?: number;
   localMediaPreviewRoots?: readonly string[];
   resourceBasePath?: string;
@@ -462,6 +463,7 @@ export function extractImages(message: unknown): ImageBlock[] {
         continue;
       }
       const b = block as Record<string, unknown>;
+      const blockImages: ImageBlock[] = [];
 
       if (b.type === "image") {
         // Handle source object format from optimistic user sends.
@@ -479,7 +481,7 @@ export function extractImages(message: unknown): ImageBlock[] {
         };
         inlineIndex += 1;
         if (source?.type === "base64" && typeof source.data === "string") {
-          appendImageBlock(images, {
+          appendImageBlock(blockImages, {
             url: buildBase64ImageUrl({
               data: source.data,
               mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
@@ -488,7 +490,7 @@ export function extractImages(message: unknown): ImageBlock[] {
           });
         } else if (typeof b.data === "string") {
           // Direct tool-result image block from imageResult() / read tool.
-          appendImageBlock(images, {
+          appendImageBlock(blockImages, {
             url: buildBase64ImageUrl({
               data: b.data,
               mediaType: typeof b.mimeType === "string" ? b.mimeType : undefined,
@@ -499,7 +501,7 @@ export function extractImages(message: unknown): ImageBlock[] {
           typeof b.url === "string" &&
           !crossOriginStructuredSvgAttachment(b.url, b.mimeType ?? source?.media_type, b)
         ) {
-          appendImageBlock(images, { url: b.url, ...imageMeta });
+          appendImageBlock(blockImages, { url: b.url, ...imageMeta });
         }
       } else if (b.type === "image_url") {
         // OpenAI format
@@ -508,7 +510,7 @@ export function extractImages(message: unknown): ImageBlock[] {
           typeof imageUrl?.url === "string" &&
           !crossOriginStructuredSvgAttachment(imageUrl.url, undefined)
         ) {
-          appendImageBlock(images, { url: imageUrl.url });
+          appendImageBlock(blockImages, { url: imageUrl.url });
         }
       } else if (b.type === "input_image") {
         const imageUrl = b.image_url;
@@ -516,11 +518,11 @@ export function extractImages(message: unknown): ImageBlock[] {
           typeof imageUrl === "string" &&
           !crossOriginStructuredSvgAttachment(imageUrl, undefined)
         ) {
-          appendImageBlock(images, { url: imageUrl });
+          appendImageBlock(blockImages, { url: imageUrl });
         } else if (imageUrl && typeof imageUrl === "object") {
           const url = (imageUrl as Record<string, unknown>).url;
           if (typeof url === "string" && !crossOriginStructuredSvgAttachment(url, undefined)) {
-            appendImageBlock(images, { url });
+            appendImageBlock(blockImages, { url });
           }
         }
         const source = b.source as Record<string, unknown> | undefined;
@@ -528,9 +530,9 @@ export function extractImages(message: unknown): ImageBlock[] {
           typeof source?.url === "string" &&
           !crossOriginStructuredSvgAttachment(source.url, source.media_type)
         ) {
-          appendImageBlock(images, { url: source.url });
+          appendImageBlock(blockImages, { url: source.url });
         } else if (typeof source?.data === "string") {
-          appendImageBlock(images, {
+          appendImageBlock(blockImages, {
             url: buildBase64ImageUrl({
               data: source.data,
               mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
@@ -543,12 +545,14 @@ export function extractImages(message: unknown): ImageBlock[] {
         }
         const imageUrl = b.image_url;
         if (typeof imageUrl === "string") {
-          appendImageBlock(images, {
+          appendImageBlock(blockImages, {
             url: imageUrl,
             alt: typeof b.alt === "string" ? b.alt : undefined,
           });
         }
       }
+      // Separate blocks are separate attachments, including identical uploads.
+      images.push(...blockImages);
     }
   }
 

--- a/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
@@ -3,7 +3,10 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createChatSubmissions } from "../../../app/chat-submissions.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { admitChatSubmission, reduceChatSessionProjection } from "../history-merge.ts";
+import { buildInitialChatSubmission, buildLocalUserMessage } from "../user-message-content.ts";
 import { releaseChatMediaResourceSubscriber } from "./chat-message-media.ts";
 import { renderChatThread } from "./chat-thread.ts";
 import {
@@ -58,19 +61,8 @@ function mountTranscriptPane(props: Parameters<typeof renderChatThread>[0]) {
 function createCanonicalImageTranscript(
   factIndexes = [0],
   inlineUrls = ["data:image/png;base64,aW5saW5l"],
+  origin: "canonical" | "queued" | "submitted" | "initial receipt" = "canonical",
 ) {
-  const decodes: Array<{ image: HTMLImageElement; resolve: () => void; reject: () => void }> = [];
-  vi.stubGlobal(
-    "Image",
-    vi.fn(function () {
-      const image = document.createElement("img");
-      const decoded = new Promise<void>((resolve, reject) => {
-        decodes.push({ image, resolve, reject: () => reject(new Error("Image decode failed")) });
-      });
-      image.decode = vi.fn(() => decoded);
-      return image;
-    }),
-  );
   const requests: Array<{ resolve: (response: Response) => void; signal?: AbortSignal | null }> =
     [];
   vi.stubGlobal(
@@ -84,28 +76,54 @@ function createCanonicalImageTranscript(
   const canonical = {
     id: crypto.randomUUID(),
     seq: 1,
-    idempotencyKey: "canonical-image-send",
+    idempotencyKey: "canonical-image-send:user",
     mediaImageLayout: { slots: factIndexes.map((factIndex) => ({ kind: "inline", factIndex })) },
   };
-  const cached = {
-    role: "user",
-    timestamp: 1_000,
-    content: [
-      { type: "text", text: "Cached text" },
-      ...inlineUrls.map((url) => ({ type: "image", url })),
-    ],
-    __openclaw: canonical,
+  const input = {
+    text: "Cached text",
+    createdAt: 1_000,
+    runId: "canonical-image-send",
+    attachments: inlineUrls.map((dataUrl, index) => ({
+      id: `image-${index}`,
+      mimeType: "image/png",
+      dataUrl,
+    })),
   };
+  const local = expectDefined(buildLocalUserMessage(input), "submitted image message");
+  const cached = origin === "canonical" ? { ...local, __openclaw: canonical } : local;
+  const owner = {
+    sessionKey: "agent:main:main",
+    client: {},
+    chatSubmissions: createChatSubmissions(),
+    chatMessages: [] as unknown[],
+  };
+  if (origin === "initial receipt") {
+    owner.chatSubmissions.retain(
+      buildInitialChatSubmission(owner.sessionKey, input, owner.client, input.runId),
+    );
+    admitChatSubmission(owner);
+  } else if (origin === "submitted") {
+    reduceChatSessionProjection(owner, { type: "sendPending", runId: input.runId, message: local });
+  }
   const media = Array.from({ length: Math.max(...factIndexes) + 1 }, (_, index) =>
     factIndexes.includes(index)
       ? { path: `media://inbound/${crypto.randomUUID()}.png`, contentType: "image/png" }
       : null,
   );
   const props = {
-    ...threadProps(`pane-${crypto.randomUUID()}`, "agent:main:main", [cached]),
+    ...threadProps(
+      `pane-${crypto.randomUUID()}`,
+      owner.sessionKey,
+      origin === "canonical" ? [cached] : owner.chatMessages,
+    ),
     assistantAttachmentAuthToken: "test-auth-token",
     connectionEpoch: 1,
   };
+  if (origin === "queued") {
+    props.queue = [
+      { ...input, id: input.runId, sendRunId: input.runId, sendState: "sending", sendAttempts: 1 },
+    ];
+  }
   const { container, renderPane, root } = mountTranscriptPane(props);
   const images = () => [...container.querySelectorAll<HTMLImageElement>(".chat-message-image")];
   const displayed = images();
@@ -119,14 +137,25 @@ function createCanonicalImageTranscript(
     metadata: Record<string, unknown> = {},
     nextMedia = media,
     text = "Fresh authoritative text",
+    content: unknown[] = [],
   ) => {
-    props.messages = [
+    const messages = [
       {
         ...cached,
-        content: [{ type: "text", text }],
+        content: [{ type: "text", text }, ...content],
         __openclaw: { ...canonical, media: nextMedia, ...metadata },
       },
     ];
+    if (origin === "canonical") {
+      props.messages = messages;
+    } else {
+      reduceChatSessionProjection(
+        owner,
+        { type: "snapshotLoaded", messages },
+        { runActive: false },
+      );
+      props.messages = owner.chatMessages;
+    }
     renderPane();
   };
   return {
@@ -136,7 +165,6 @@ function createCanonicalImageTranscript(
     inlineUrls,
     media,
     requests,
-    decodes,
     images,
     publish,
     renderPane,
@@ -148,36 +176,34 @@ describe("canonical image presentation handoff", () => {
   beforeEach(installTranscriptDomMocks);
   afterEach(resetTranscriptTestDom);
 
-  it("keeps the displayed canonical inline image while fresh history text and media metadata arrive", async () => {
-    const fixture = createCanonicalImageTranscript();
-    const displayed = expectDefined(fixture.displayed[0], "displayed inline image");
-    fixture.publish();
+  it.each(["canonical", "submitted", "initial receipt"] as const)(
+    "keeps the displayed %s image while fresh history text and media metadata arrive",
+    async (origin) => {
+      const fixture = createCanonicalImageTranscript(undefined, undefined, origin);
+      const displayed = expectDefined(fixture.displayed[0], "displayed inline image");
+      if (origin === "initial receipt") {
+        fixture.publish();
+        expectSameImageNodes(fixture.images(), [displayed]);
+      }
+      fixture.publish();
 
-    expect(fixture.container.textContent).toContain("Fresh authoritative text");
-    expect(fixture.container.textContent).not.toContain("Cached text");
-    expectSameImageNodes(fixture.images(), [displayed]);
-    expect(displayed.getAttribute("src")).toBe(fixture.inlineUrls[0]);
+      expect(fixture.container.textContent).toContain("Fresh authoritative text");
+      expect(fixture.container.textContent).not.toContain("Cached text");
+      expectSameImageNodes(fixture.images(), [displayed]);
+      expect(displayed.getAttribute("src")).toBe(fixture.inlineUrls[0]);
 
-    fixture.requests[0]?.resolve(mediaMetadataResponse());
-    await flushDeferredRowPrune();
-    expectSameImageNodes(fixture.images(), [displayed]);
-    expect(displayed.getAttribute("src")).toBe(fixture.inlineUrls[0]);
-    const prepared = expectDefined(fixture.decodes[0], "canonical decode request");
-    expect(prepared.image.getAttribute("src")).toContain(
-      encodeURIComponent(expectDefined(fixture.media[0], "canonical media fact").path),
-    );
-    fixture.renderPane();
-    expect(fixture.decodes).toHaveLength(1);
-    prepared.resolve();
-    await flushDeferredRowPrune();
-    expectSameImageNodes(fixture.images(), [displayed]);
-    expect(displayed.getAttribute("src")).toContain(
-      encodeURIComponent(expectDefined(fixture.media[0], "canonical media fact").path),
-    );
-    expect(prepared.image.getAttribute("src")).not.toBeNull();
-    displayed.dispatchEvent(new Event("load"));
-    expect(prepared.image.getAttribute("src")).toBeNull();
-  });
+      fixture.requests[0]?.resolve(mediaMetadataResponse());
+      await flushDeferredRowPrune();
+      expectSameImageNodes(fixture.images(), [displayed]);
+      expect(displayed.getAttribute("src")).toContain(
+        encodeURIComponent(expectDefined(fixture.media[0], "canonical media fact").path),
+      );
+      fixture.renderPane();
+      expectSameImageNodes(fixture.images(), [displayed]);
+      displayed.dispatchEvent(new Event("load"));
+      expectSameImageNodes(fixture.images(), [displayed]);
+    },
+  );
 
   it.each([
     {
@@ -187,6 +213,15 @@ describe("canonical image presentation handoff", () => {
     { name: "different canonical sequence", metadata: { seq: 2 } },
     { name: "missing persisted ID", metadata: { id: undefined } },
     { name: "imported message identity", metadata: { importedFrom: "external" } },
+    {
+      name: "imported message replacing a queued send",
+      metadata: {
+        importedFrom: "external",
+        cliSessionId: "imported-session",
+        externalId: "imported-image",
+      },
+      origin: "queued" as const,
+    },
     { name: "pending message identity", metadata: { id: "pending:input" } },
     { name: "missing layout", metadata: { mediaImageLayout: undefined } },
     {
@@ -200,8 +235,8 @@ describe("canonical image presentation handoff", () => {
         },
       },
     },
-  ])("does not borrow an inline preview for $name", ({ metadata }) => {
-    const fixture = createCanonicalImageTranscript();
+  ])("does not borrow an inline preview for $name", ({ metadata, origin }) => {
+    const fixture = createCanonicalImageTranscript(undefined, undefined, origin);
     fixture.publish(metadata, fixture.media, "Cached text");
     expect(fixture.images()).toHaveLength(0);
     expect(fixture.container.querySelector('[aria-busy="true"]')).not.toBeNull();
@@ -223,6 +258,62 @@ describe("canonical image presentation handoff", () => {
     expectSameImageNodes(fixture.images(), fixture.displayed);
     expect(container.querySelector(".chat-message-image")).toBeNull();
     expect(fixture.requests).toHaveLength(1);
+  });
+
+  it.each(["complete", "partial"] as const)(
+    "handles a %s receipt for duplicate submitted attachments",
+    (receipt) => {
+      const fixture = createCanonicalImageTranscript(
+        [0, 1, 2],
+        ["data:image/png;base64,YQ==", "data:image/png;base64,YQ==", "data:image/png;base64,Yg=="],
+        "submitted",
+      );
+      fixture.media[1] = fixture.media[0] ?? null;
+      const media = receipt === "partial" ? fixture.media.slice(0, 2) : fixture.media;
+      fixture.publish(
+        {
+          mediaImageLayout: { slots: media.map((_, factIndex) => ({ kind: "inline", factIndex })) },
+        },
+        media,
+      );
+      expectSameImageNodes(fixture.images(), receipt === "complete" ? fixture.displayed : []);
+    },
+  );
+
+  it("binds local previews by fact position when inline blocks reorder mixed image receipts", () => {
+    const fixture = createCanonicalImageTranscript(
+      [0, 1],
+      ["data:image/png;base64,aW1hZ2VB", "data:image/png;base64,aW1hZ2VC"],
+      "queued",
+    );
+    fixture.publish(
+      {
+        mediaImageLayout: {
+          slots: [
+            { kind: "offloaded", factIndex: 0 },
+            { kind: "inline", factIndex: 1 },
+          ],
+        },
+      },
+      fixture.media,
+      "Fresh authoritative text",
+      [{ type: "image", url: expectDefined(fixture.media[1], "inline image fact").path }],
+    );
+
+    expectSameImageNodes(fixture.images(), fixture.displayed.toReversed());
+    expect(fixture.images().map((image) => image.getAttribute("src"))).toEqual(
+      fixture.inlineUrls.toReversed(),
+    );
+  });
+
+  it("adopts submitted images across interleaved non-image fact slots", () => {
+    const fixture = createCanonicalImageTranscript(
+      [1, 3],
+      ["data:image/png;base64,YQ==", "data:image/png;base64,Yg=="],
+      "submitted",
+    );
+    fixture.publish();
+    expectSameImageNodes(fixture.images(), fixture.displayed);
   });
 
   it.each([
@@ -271,9 +362,8 @@ describe("canonical image presentation handoff", () => {
         await flushDeferredRowPrune();
         expectSameImageNodes(fixture.images(), expected);
       }
-      for (const prepared of fixture.decodes.toReversed()) {
-        prepared.resolve();
-        await flushDeferredRowPrune();
+      for (const image of expected.toReversed()) {
+        image.dispatchEvent(new Event("load"));
         expectSameImageNodes(fixture.images(), expected);
       }
       for (const [index, { factIndex }] of order.entries()) {
@@ -347,13 +437,13 @@ describe("canonical image presentation handoff", () => {
   );
 
   it.each(["removal", "auth", "replacement", "disconnect"] as const)(
-    "discards a pending decode on %s and ignores its late completion",
+    "retires a pending native image on %s and ignores its late load and error",
     async (change) => {
       const fixture = createCanonicalImageTranscript();
       fixture.publish();
       fixture.requests[0]?.resolve(mediaMetadataResponse());
       await flushDeferredRowPrune();
-      const prepared = expectDefined(fixture.decodes[0], "pending decode");
+      const displayed = expectDefined(fixture.displayed[0], "pending native image");
       expectSameImageNodes(fixture.images(), fixture.displayed);
       if (change === "removal") {
         fixture.publish({}, []);
@@ -367,10 +457,9 @@ describe("canonical image presentation handoff", () => {
       } else {
         fixture.root().setConnected(false);
       }
-      expect(prepared.image.getAttribute("src")).toBeNull();
-      prepared.resolve();
+      displayed.dispatchEvent(new Event("load"));
+      displayed.dispatchEvent(new Event("error"));
       await flushDeferredRowPrune();
-      expect(fixture.displayed[0]?.getAttribute("src")).toBe(fixture.inlineUrls[0]);
       if (change === "disconnect") {
         fixture.root().setConnected(true);
       }
@@ -379,7 +468,7 @@ describe("canonical image presentation handoff", () => {
   );
 
   it.each(["renewal", "denial"] as const)(
-    "discards the old decode after metadata ticket %s",
+    "updates native image presentation after metadata ticket %s",
     async (change) => {
       vi.useFakeTimers();
       try {
@@ -387,24 +476,19 @@ describe("canonical image presentation handoff", () => {
         fixture.publish();
         fixture.requests[0]?.resolve(mediaMetadataResponse(true, "before-refresh"));
         await vi.advanceTimersByTimeAsync(0);
-        const old = expectDefined(fixture.decodes[0], "old ticket decode");
+        const displayed = expectDefined(fixture.displayed[0], "displayed image");
         await vi.advanceTimersByTimeAsync(1_000);
         fixture.requests[1]?.resolve(mediaMetadataResponse(change === "renewal", "after-refresh"));
         await vi.advanceTimersByTimeAsync(0);
-        expect(old.image.getAttribute("src")).toBeNull();
-        old.reject();
-        await vi.advanceTimersByTimeAsync(0);
         if (change === "denial") {
+          displayed.dispatchEvent(new Event("load"));
+          displayed.dispatchEvent(new Event("error"));
           expect(fixture.images()).toHaveLength(0);
           expect(fixture.container.textContent).toContain("Attachment removed");
         } else {
           expectSameImageNodes(fixture.images(), fixture.displayed);
-          expect(fixture.displayed[0]?.getAttribute("src")).toBe(fixture.inlineUrls[0]);
-          const current = expectDefined(fixture.decodes[1], "renewed ticket decode");
-          current.resolve();
-          await vi.advanceTimersByTimeAsync(0);
-          expectSameImageNodes(fixture.images(), fixture.displayed);
-          expect(fixture.displayed[0]?.getAttribute("src")).toContain("mediaTicket=after-refresh");
+          expect(displayed.getAttribute("src")).toContain("mediaTicket=after-refresh");
+          displayed.dispatchEvent(new Event("load"));
         }
       } finally {
         vi.clearAllTimers();
@@ -413,7 +497,7 @@ describe("canonical image presentation handoff", () => {
     },
   );
 
-  it.each(["decode rejection", "decode deadline", "display load deadline"] as const)(
+  it.each(["native load error", "display load deadline"] as const)(
     "ends the retained handoff visibly on %s without retrying or resurrecting it",
     async (failure) => {
       vi.useFakeTimers();
@@ -422,33 +506,45 @@ describe("canonical image presentation handoff", () => {
         fixture.publish();
         fixture.requests[0]?.resolve(mediaMetadataResponse());
         await vi.advanceTimersByTimeAsync(0);
-        const prepared = expectDefined(fixture.decodes[0], "pending decode");
-        if (failure === "decode rejection") {
-          prepared.reject();
+        const displayed = expectDefined(fixture.displayed[0], "pending native image");
+        if (failure === "native load error") {
+          displayed.dispatchEvent(new Event("error"));
           await vi.advanceTimersByTimeAsync(0);
         } else {
-          if (failure === "display load deadline") {
-            prepared.resolve();
-            await vi.advanceTimersByTimeAsync(0);
-          }
           await vi.advanceTimersByTimeAsync(29_999);
           expectSameImageNodes(fixture.images(), fixture.displayed);
           await vi.advanceTimersByTimeAsync(1);
         }
-        expect(prepared.image.getAttribute("src")).toBeNull();
         expect(fixture.images()).toHaveLength(0);
         expect(
           fixture.container.querySelector(".chat-assistant-attachment-card--definitive"),
         ).not.toBeNull();
-        prepared.resolve();
+        displayed.dispatchEvent(new Event("load"));
         fixture.renderPane();
         await vi.advanceTimersByTimeAsync(0);
         expect(fixture.images()).toHaveLength(0);
-        expect(fixture.decodes).toHaveLength(1);
       } finally {
         vi.clearAllTimers();
         vi.useRealTimers();
       }
     },
   );
+
+  it("keeps a successfully loaded native image after the handoff deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const fixture = createCanonicalImageTranscript();
+      fixture.publish();
+      fixture.requests[0]?.resolve(mediaMetadataResponse());
+      await vi.advanceTimersByTimeAsync(0);
+      const displayed = expectDefined(fixture.displayed[0], "pending native image");
+      displayed.dispatchEvent(new Event("load"));
+      await vi.advanceTimersByTimeAsync(30_000);
+      expectSameImageNodes(fixture.images(), [displayed]);
+      expect(fixture.container.querySelector('[aria-busy="true"]')).toBeNull();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -90,7 +90,7 @@ function createInitialHandoffFixture() {
 function createAuthoritativeInitialMessage(sequence = 1) {
   return {
     role: "user",
-    content: [{ type: "image", source: { type: "url", url: "/persisted.png" } }],
+    content: "Inspect this persisted image",
     timestamp: 456,
     serverField: "authoritative",
     __openclaw: {
@@ -98,7 +98,8 @@ function createAuthoritativeInitialMessage(sequence = 1) {
       idempotencyKey: "initial-run:user",
       runId: "initial-execution",
       seq: sequence,
-      media: [{ path: "/persisted.png", contentType: "image/png" }],
+      media: [{ url: "media://inbound/image-1.png", contentType: "image/png" }],
+      mediaImageLayout: { slots: [{ kind: "inline", factIndex: 0 }] },
     },
   };
 }
@@ -292,29 +293,15 @@ describe("pane-owned canonical session projection", () => {
       );
       expect(owner.chatMessages).toEqual([handoff.message]);
     }
-    const localContent = handoff.message.content;
     const authoritative = createAuthoritativeInitialMessage();
     const event =
       eventType === "messagePersisted"
         ? ({ type: eventType, message: authoritative } as const)
         : ({ type: eventType, messages: [authoritative] } as const);
     const projection = reduceChatSessionProjection(owner, event, { runActive: admitFirst });
-    const adopted = owner.chatMessages[0] as Record<string, unknown>;
 
-    expect(owner.chatMessages).toHaveLength(1);
-    expect(projection.messages[0]).toBe(adopted);
-    expect(adopted.content).toBe(localContent);
-    expect(adopted).toMatchObject({
-      role: "user",
-      timestamp: 456,
-      serverField: "authoritative",
-      __openclaw: {
-        id: "persisted-initial-user",
-        idempotencyKey: "initial-run:user",
-        seq: 1,
-      },
-    });
-    expect((adopted["__openclaw"] as Record<string, unknown>).media).toBeUndefined();
+    expect(owner.chatMessages).toEqual([authoritative]);
+    expect(projection.messages[0]).toBe(authoritative);
 
     if (admitFirst) {
       expect(chatSubmissions.readInitial(sessionKey, client)).not.toBeNull();
@@ -335,7 +322,6 @@ describe("pane-owned canonical session projection", () => {
 
   it("adopts the exact submission at its actual committed position", () => {
     const { client, chatSubmissions, owner, sessionKey } = createInitialHandoffFixture();
-    const localContent = chatSubmissions.readInitial(sessionKey, client)!.message.content;
     admitChatSubmission(owner);
     const authoritative = createAuthoritativeInitialMessage(4);
     reduceChatSessionProjection(
@@ -343,11 +329,7 @@ describe("pane-owned canonical session projection", () => {
       { type: "snapshotLoaded", messages: [authoritative] },
       { runActive: false },
     );
-    expect(owner.chatMessages).toHaveLength(1);
-    expect(owner.chatMessages[0]).toMatchObject({
-      content: localContent,
-      __openclaw: { id: "persisted-initial-user", seq: 4, runId: "initial-execution" },
-    });
+    expect(owner.chatMessages).toEqual([authoritative]);
     expect(chatSubmissions.readInitial(sessionKey, client)).toBeNull();
   });
 

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -85,13 +85,8 @@ function readChatSubmissionBatch(owner: ChatSessionProjectionOwner, scope: Sessi
         handoff.pending = false;
       }
     },
-    receive: (
-      message: unknown,
-      identity: SessionMessageIdentity | null,
-      persisted = false,
-      acceptedRunId?: string,
-    ) => {
-      const runId = acceptedRunId ?? identity?.idempotencyKey?.replace(/:user$/u, "");
+    receive: (message: unknown, identity: SessionMessageIdentity | null, persisted = false) => {
+      const runId = identity?.idempotencyKey?.replace(/:user$/u, "");
       if (identity?.role !== "user" || !runId) {
         return message;
       }
@@ -105,20 +100,11 @@ function readChatSubmissionBatch(owner: ChatSessionProjectionOwner, scope: Sessi
       // Cached bytes for this retained submission are not a receipt. Omit
       // that snapshot copy; the pane admits the recorded local owner through
       // sendPending, preserving provenance even with sender/reply metadata.
-      if (!receipt && !acceptedRunId) {
+      if (!receipt) {
         return undefined;
       }
       handoff.pending = false;
-      const authoritative = asNullableRecord(message) ?? {};
-      // Initial inline bytes replace managed media, never duplicate it. The
-      // received object and its authoritative sender attribution stay intact.
-      const { media: _media, ...metadata } = asNullableRecord(authoritative["__openclaw"]) ?? {};
-      return {
-        ...handoff.message,
-        ...authoritative,
-        content: handoff.message.content,
-        __openclaw: metadata,
-      };
+      return message;
     },
   };
 }
@@ -360,21 +346,7 @@ export function reconcileChatInputCustody(
   }
   return {
     acceptedRunIds,
-    page:
-      page && submissions?.initial
-        ? {
-            ...page,
-            items: page.items.map((input) => ({
-              ...input,
-              message: submissions.receive(
-                input.message,
-                readSessionMessageIdentity(input.message),
-                false,
-                input.runId,
-              ),
-            })),
-          }
-        : (page ?? { items: [], total: 0 }),
+    page: page ?? { items: [], total: 0 },
   };
 }
 


### PR DESCRIPTION
Related: #134310 (hard-refresh image hydration) and #124839 (sent-image history handoff).

<details>
<summary>Additional instructions</summary>

This branch is in the main repository and is editable by maintainers.

</details>

## Current Landing Status

Final head **`1e6e2dede0b6bd051acf90593894b9a031d3e8c1`**, based on inspected main `3e94877fec4a`, includes the conflict rebase and an 11-line test-helper simplification. The actual SDK conflict is resolved by dropping our superseded test commit and keeping main’s stronger repair; the message-bubble and initial-prompt auto-merges were inspected and tested. ClawSweeper’s latest review inspected this exact head at 09:33 UTC, found no actionable correctness or security issue, and requested final green exact-head CI. That gate is now satisfied, with no product, schema, or protocol expansion.

Fresh local proof: **600 unit/boundary tests and 27 Chromium E2E cases pass** on the rebased candidate; the unchanged native-wheel case and main’s pending-submit preview are included. Fresh whole-branch Codex review is **P0 scoped-clean**, not an all-priority audit. The broad structural/type/dead-export checks and final lint/style/format gates pass. Normal exact-head [CI 33613603298](https://github.com/openclaw/openclaw/actions/runs/33613603298) and its [required merge gate](https://github.com/openclaw/openclaw/actions/runs/33613603298/job/100205454084) are **successful** after one unchanged failed-job retry. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 136072` passed on the same head and skipped an unnecessary push. **Merged** through the native wrapper at 10:06 UTC as [34fcc9cf3055](https://github.com/openclaw/openclaw/commit/34fcc9cf30557bb8afb7430eba7beb0f6a4be580). The canonical main checkout was fast-forwarded and verified clean with that commit present.

New main compaction/history and lazy-stylesheet changes were separately inspected and tested without restarting PR CI. Combining main `40a01c9744c2` with the exact PR head produced conflict-free merge tree `f070220c1354ec667c4f5868c09e661e844476e0`. That isolated combined checkout passed **603 owner/neighbor tests, 23 isolated transcript-render tests, and 28 Chromium cases**, including both image handoffs, initial-submit failure/retry, scrolling, cold sidebar loading, and dashboard selection after reload. The tested index exactly matches the merge-tree result. This is additional local integration proof, not a new PR commit or a new real-Gateway cache-upgrade claim.

## What Problem This Solves

Fixes an issue where users sending an image in the Control UI would see their image, then a loading placeholder or empty space, then the image again as the submission moved through accepted input custody and saved history. Initial prompts and ordinary conversation sends used different presentation paths.

## Why This Change Was Made

Keep presentation ownership in the existing transcript and image renderer. Custody uses the same submission-derived row key without inventing transcript identity; the gallery adopts exact image slots when a complete canonical receipt arrives. It binds local attachment order to persisted fact positions, including duplicate uploads and mixed inline/offloaded blocks whose display order can differ.

The same loaded image element remains mounted while metadata and authorized image bytes load. Native image load/error events and the existing bounded deadline replace the detached decode preloader. Initial prompts now keep authoritative text and media instead of overwriting them with local attachment content. Imported identity changes, partial/ambiguous receipts, removals, replacements, denial, and connection/auth changes cannot borrow unrelated previews.

Production LOC: **+137/-161 (net -24)**. Tests: **+640/-261 (net +379)**. Docs: **+4/-2**. No dependency, configuration, protocol, database, or provider changes.

## User Impact

An image that has already appeared stays visible and keeps its space while the send is accepted and history catches up. Unavailable or denied media still has a visible failure outcome. No operator action or new setting is needed.

## Evidence

The original ordinary-send browser reproduction failed on the unmodified baseline when custody replaced the uploaded image with a loading card. The fixed built Control UI passes separately paused custody, metadata-loading, and image-byte-loading stages, preserving the original image element, its geometry, and pixel-identical screenshots. A request-animation-frame sampler also checks image continuity and absence of a replacement loading card.

**Before: the already visible upload becomes a loading placeholder during custody.**

![Before: sent image replaced by a loading card](https://github.com/user-attachments/assets/0c35d3ff-fcb9-430d-9e4d-df79c8949d42)

**After: the same image remains visible while canonical image bytes are still loading.**

![After: sent image stays visible while canonical bytes load](https://github.com/user-attachments/assets/4f9ccaed-da67-40bf-8b6d-a77ae6ddcdb3)

Both complete captures were inspected and contain only synthetic task data. This is real Chromium running the built UI with a mocked Gateway, not a live external-provider claim. The earlier work in #134310 rejected a same-node-only implementation, so this repair is checked against rendered pixels rather than DOM identity or `naturalWidth` alone; a browser can paint its current decoded request while a pending replacement reports zero intrinsic dimensions.

**The existing-cache hard-refresh boundary also passed against an isolated real Gateway.** A local mock provider was the only external-service substitute. Baseline `58af1daa457` naturally wrote a canonical inline-image cache through the normal initial-image UI; candidate `09ee4adbdcc` then hard-reloaded on the same origin and browser storage. A 164 ms delay of the actual, unmodified startup response let that cached image paint before authoritative history arrived. Real metadata and raw-image responses were then held and forwarded unchanged. The same image element and 180×180 geometry persisted through all stages, with pixel-identical stage screenshots, 33 sampled animation frames, zero continuity violations or page errors, then successful native canonical load. The follow-up commits change tests only. The six-file image repair remains unchanged after the conflict rebase onto main; this earlier capture proves the original image repair, while the combined rebased UI has fresh unit and browser proof below.

![Real Gateway: cached image remains visible while canonical bytes are held](https://github.com/user-attachments/assets/d88bd151-8ecd-4962-ab5b-235547b4f66b)

All five full-page captures from that run were inspected and contain only synthetic data; the pictured pending-byte stage was independently inspected before upload. The owned Gateway and browser stopped cleanly. An earlier ungated attempt let history win before the cache painted and is explicitly not counted as continuity proof or a product failure.

**600 focused and neighboring unit tests passed again on rebased head `37fcb2ecde26`**, including canonical history hydration, ordinary/initial sends, duplicate uploads, partial receipts, mixed inline/offloaded ordering, imported queue identity boundaries, reverse completion, ticket renewal, denial, timeouts, and cleanup:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/chat-pending-inputs.test.ts ui/src/pages/chat/history-merge.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/chat-pane-snapshot-hydration.test.ts
```

**27 Chromium E2E cases passed across four specs on final candidate `1e6e2dede0b6`** (37.82 s), covering ordinary sends, initial-prompt attachments, GitHub project/worktree creation, and transcript disclosure/scroll interruption. This includes main’s new submitted-preview/failure/retry scenario and the native-wheel case that failed in the older normal CI run:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.image-handoff.e2e.test.ts ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts ui/src/e2e/new-session-page.github-projects.e2e.test.ts ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts --reporter=verbose
```

The added ordinary-send/initial handoff, duplicate-attachment, imported queue, and mixed-receipt regressions were demonstrated failing before their respective repairs. The rebased full changed-file check passed all core-test/UI typechecks, graph, i18n, coercion, dependency, ratchet, format, and dead-export checks, then found the combined initial-prompt specification five lines over its 1,000-line lint limit. The final test-only cleanup reuses the existing decoded-thumbnail helper for both exact-180-pixel handoff assertions, removing 11 lines without suppressions or lost assertions. The E2E type graph, all four remaining selected Oxlint/Stylelint batches, formatting, `git diff --check`, all 27 browser cases, and a fresh whole-candidate P0-scoped review pass after that cleanup. The earlier `37fcb2ecde26` CI run was automatically cancelled when this final head was pushed.

Fresh whole-patch Codex autoreview is scoped-clean at the repository's P0 threshold; this is not represented as an all-priority audit. The actual merge conflict was confined to the SDK relocation fixture. Rebase onto inspected main `3e94877fec4a` kept main’s stronger dedicated prior-output inventory and cache-output exclusions, dropping our now-redundant SDK commit entirely. No SDK file remains in this PR’s diff. Both the upstream submitted-preview browser scenario and this PR’s image handoff scenario survived the automatic merge and pass. Main’s reasoning-only empty-bubble guard remains orthogonal because image-bearing rows are excluded; source inspection also confirms its settled-input/history lifecycle changes preserve submission custody until canonical consumption. A fresh whole-branch Codex review of the rebased candidate is P0 scoped-clean; this is not an all-priority audit. Introducing commit/release is unknown; related earlier image repairs are context, not attribution of this remaining bug.

The first hosted run failed only on two stale handoff test surfaces (one duplicated across UI and core shards): snapshot assertions expected the removed history overwrite, and project-creation E2E waited for the retired custody row key and omitted current image-slot metadata. The test-only follow-up preserves sender checks and asserts same-image continuity plus canonical authority. Its seven snapshot tests, all 19 browser cases, complete changed-file checks, and fresh scoped review pass.

ClawSweeper found no correctness or security finding. Earlier reviews requested current-main conflict resolution and fresh focused/browser plus exact-head validation; its latest exact-head review retained only the final CI gate. Conflict resolution, focused/browser proof, additional current-main integration, and exact-head CI are now complete. The maintainer explicitly requested this landing. Its stored-data heuristic is not a schema change: image identity is ephemeral renderer state, and history reconciliation now retains the existing authoritative message shape; no storage writer, schema, migration, persistent-store retention, or format changed. The real-Gateway cache replay above covers the upgrade boundary.

[Run 33601860739](https://github.com/openclaw/openclaw/actions/runs/33601860739) passed all formerly failing image checks. Its SDK declaration cache-relocation fixture exposed a deterministic setup defect after a main-branch test consolidation: historical root chunks were seeded from the initial production build, omitting an intermediate QA build. The test-only correction captures the last pre-change QA inventory without prepopulating the changed outputs under test. All 11 declaration tests pass on the exact failed CI merge snapshot with that correction, as do the changed-file type/lint/structural checks and fresh P0-scoped Codex review. That temporary one-line test repair is no longer in this PR: main’s stronger equivalent superseded it during the conflict rebase.

```bash
node scripts/run-vitest.mjs test/scripts/write-plugin-sdk-entry-dts.test.ts
```

That run also failed two auth-alias assertions and one browser-relay tab-navigation case outside this change. The auth suite passed alone (28 cases) and after runtime-plugin tests in a one-worker ordered pair (71 cases total); that bounded diagnostic does not recreate the original two-reusable-worker CI lifecycle. Browser source was byte-identical across its passing and failing runs; the diagnostic record shows the real Chrome tab remained open while its Playwright page retired. Neither observation justifies a speculative production fix. Named follow-ups if they recur: **auth-profile alias expectations in a shared agents-support worker**, and **browser-relay initial navigation retiring the Playwright page while Chrome stays open**.

[Run 33603749918](https://github.com/openclaw/openclaw/actions/runs/33603749918) cleared those SDK, auth, and browser failures, then exposed one Windows-only fixture collision: the CLI PATH test deleted a checkout-root temporary directory while the declaration snapshot traversed the checkout through installed workspace links. The fixture now uses the existing `.artifacts` scratch boundary on the same drive, via the canonical temp-directory helper. All Windows PATH/native-owner assertions remain unchanged, and no compiler catch, retry, namespace narrowing, or production behavior was added.

A deterministic real-filesystem ordering probe reproduced the original `ENOENT/scandir` after directory enumeration, then passed with an identical before/during/after snapshot signature when the fixture lived under `.artifacts`. This probe ran on macOS and is not a Windows PATH claim. The existing cache, temp-helper, and CLI suites passed 56 portable tests locally, with seven Windows-only cases skipped on macOS. Both hosted Windows jobs subsequently passed on pre-rebase head `cfdb880f4adb` in run 33606518366, including the Windows-only PATH cases.

```bash
node scripts/run-vitest.mjs src/agents/cli-executable-identity.test.ts test/helpers/temp-dir.test.ts test/scripts/build-artifact-cache.test.ts
```

While normal PR CI was not yet visible, the repository’s native `scripts/pr ci-dispatch 136072` recovery accepted head `cfdb880f4adbdf23df42991c0230f586bd989ca8` and started [manual CI run 33606518366](https://github.com/openclaw/openclaw/actions/runs/33606518366). Normal PR CI did attach later; the final preflight caught it, so no close/reopen recovery was performed. This is CI validation, not publication or a merge-gate bypass. Its normal hosted Windows lane runs the unchanged PATH cases with serial project execution; the original scan/delete interleaving is covered by the separate deterministic ordering probe. All changed-file gates and fresh P0-scoped review passed. Native landing results will be recorded before merge.

That run's first attempt also exposed two unrelated test failures; neither test or owner is changed by this PR. [UI shard 3](https://github.com/openclaw/openclaw/actions/runs/33606518366/job/100172198283) reached no observed hide animation-start event in the dropdown test, before its pointer-dismissal action (4,586 other tests passed). Both complete dropdown suites passed unchanged locally, 49/49. The short default animation and the event/class observation window explain what the test depends on, but the log does not identify why that window was missed. Named follow-up: **dropdown animation-start observation can miss the hide phase under the full UI shard**.

[Gateway-methods](https://github.com/openclaw/openclaw/actions/runs/33606518366/job/100172207723) failed with `ENOTEMPTY` while removing the abort-registry fixture's state directory, not a cancellation assertion (4,309 other tests passed). The complete six-case incarnation suite passed unchanged locally in its original case order; that does not reproduce the original two-worker shard lifecycle. Existing teardown already drains registry/session/reconcile/file-lock owners and closes databases, including the current-main cleanup repair. No surviving writer is identified by this log. Named follow-up: **abort registry fixture: identify state-file recreation after teardown drain**. Both the [UI shard](https://github.com/openclaw/openclaw/actions/runs/33606518366/job/100181134013) and [Gateway-methods shard](https://github.com/openclaw/openclaw/actions/runs/33606518366/job/100181151633) passed unchanged in the single accepted failed-job retry. No timing limit, assertion, isolation, or cleanup retry has been weakened; passing the retry is not a claim that those test-lifecycle issues are fixed.

The first attempt also reported [Android build-play](https://github.com/openclaw/openclaw/actions/runs/33606518366/job/100172198883) as **cancelled**, rather than failed. Its check annotation confirms the 20-minute job deadline. Both phone variants assembled and passed lint before the deadline interrupted benchmark APK compilation. This job intentionally covers both phone variants, benchmark, and Wear-shared tasks in three separate Gradle processes to release memory on hosted runners. Setup took about 2m24; the first two build phases took 10m45 and 6m37. The Gradle cache was cold and read-only, so the first attempt did not publish a warmed cache. Named follow-up: **hosted Android build-play exceeds its 20-minute cold-cache job budget**. Android code and CI configuration are unchanged by this PR; its existing task coverage, memory separation, and deadline remain intact. The same cancelled job hit its 20-minute deadline again on the one accepted failed-job retry. No further retry, timeout increase, task removal, or Android/workflow change was made.

[Normal PR CI run 33606652598](https://github.com/openclaw/openclaw/actions/runs/33606652598) attached later to pre-rebase head `cfdb880f4adb`. Its sole failed test was the native-wheel/no-reduced-motion transcript recovery case: scrolling stopped 112 px above the requested top before the held recovery response was released. The fixture contains only canonical text messages and no send, custody, or attachment transition; the scroll test, owner, and helper are unchanged between that head and the inspected main. All eight cases in the unchanged disclosure suite pass alongside the 19 image/project cases on the rebased candidate. This is a bounded local diagnostic, not reproduction of the original full Linux shard. Named follow-up: **native wheel interruption leaves the transcript 112 px from the top before recovery**; event/frame evidence is needed before classifying it as input observation or a cancellation/measurement defect. The conflicted pre-rebase head is superseded; final native landing remains gated on fresh exact-head CI.

Final-head CI attempt 1 completed with 152 successful jobs, 11 skipped jobs, and two substantive browser failures plus the aggregate gate. [Browser-extension bootstrap](https://github.com/openclaw/openclaw/actions/runs/33613603298/job/100194708982) passed pairing, transport recovery, injected detach recovery and all-tab creation, then rejected selected-tab creation with `Page.navigate: access was revoked`. Native navigation reached the destination; the route’s owned-page cleanup explains the subsequent empty tab inventory. The extension subtree is unchanged between this head and inspected main `719cac4f964d`; the earlier stale-group replay repair is already present. The detailed diagnostic ended before this creation phase, so it cannot identify the event that revoked authority. The exact `pnpm test:e2e:browser-extension` package command passes locally with its complete ordered lifecycle, both access modes, pinned Chromium, and successful relay/MCP/HTTP cleanup. This macOS result is not a Linux reproduction. Named follow-up: **selected-tab creation: identify access-epoch revocation after native navigation**; do not weaken access checks or retry the product command without identifying that owner failure.

[Control UI E2E shard 12](https://github.com/openclaw/openclaw/actions/runs/33613603298/job/100194708904) passed 116 cases and timed out restoring the dashboard’s selected side-panel tab after reload. Its initial Terminal selection and Board chat activation succeeded, then the Board chat tab was absent after reload. That test sends no prompts or images; the sidebar selection/persistence owner and fixture are unchanged, and the existing restoration repair is present. The complete one-case specification passes unchanged locally in 10.85 seconds. Named follow-up: **dashboard reload: capture board readiness and side-panel projection when the selected chat tab is absent**. Neither local pass proves the full Linux shard’s original ordering. The single unchanged failed-job retry passed both [browser extension bootstrap](https://github.com/openclaw/openclaw/actions/runs/33613603298/job/100203942097) and [Control UI shard 12](https://github.com/openclaw/openclaw/actions/runs/33613603298/job/100203942101), and the full run and required gate are successful. No extra delay, timeout, assertion relaxation, production workaround, or CI-scope change was added. Passing the retry does not establish that the recorded lifecycle observations are fixed.
