### PR TITLE
refactor(cron): derive run history type from wire schema

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2742,7 +2742,6 @@ src/cron/store/quarantine.ts	1
 src/cron/store/row-codec.ts	4
 src/cron/store/transaction-hooks.ts	1
 src/cron/task-run-detail.ts	2
-src/cron/task-run-history.ts	1
 src/daemon/arg-split.ts	2
 src/daemon/launchd-install.ts	7
 src/daemon/launchd-lifecycle.ts	4

--- a/src/cron/run-log-types.ts
+++ b/src/cron/run-log-types.ts
@@ -1,38 +1,8 @@
 /** Stable cron run-history wire shape and legacy JSONL migration input. */
-import type { FailoverReason } from "../agents/failover/signal.js";
+import type { CronRunLogEntry as CronRunLogWireEntry } from "../../packages/gateway-protocol/src/schema/cron.types.js";
 import type { NormalizeReplySkipReason } from "../auto-reply/reply/normalize-reply-skip-reason.js";
-import type {
-  CronCompletionStatus,
-  CronDeliveryStatus,
-  CronDeliveryTrace,
-  CronFailureNotificationDelivery,
-  CronRunDiagnostics,
-  CronRunStatus,
-  CronRunTelemetry,
-} from "./types.js";
 
 /** Run-history record for a completed cron job execution. */
-export type CronRunLogEntry = {
-  ts: number;
-  jobId: string;
-  action: "finished";
-  status?: CronRunStatus;
-  completionStatus?: CronCompletionStatus;
-  error?: string;
-  errorReason?: FailoverReason;
-  summary?: string;
-  diagnostics?: CronRunDiagnostics;
-  delivered?: boolean;
-  deliveryStatus?: CronDeliveryStatus;
-  deliveryError?: string;
+export type CronRunLogEntry = Omit<CronRunLogWireEntry, "deliverySuppressionReason"> & {
   deliverySuppressionReason?: NormalizeReplySkipReason;
-  failureNotificationDelivery?: CronFailureNotificationDelivery;
-  delivery?: CronDeliveryTrace;
-  sessionId?: string;
-  sessionKey?: string;
-  runId?: string;
-  runAtMs?: number;
-  durationMs?: number;
-  nextRunAtMs?: number;
-  triggerFired?: boolean;
-} & CronRunTelemetry;
+};

--- a/src/cron/task-run-history.ts
+++ b/src/cron/task-run-history.ts
@@ -112,7 +112,7 @@ function attachJobNames(entries: CronRunLogEntry[], jobNameById?: Record<string,
   for (const entry of entries) {
     const jobName = jobNameById?.[entry.jobId];
     if (jobName) {
-      (entry as CronRunLogEntry & { jobName?: string }).jobName = jobName;
+      entry.jobName = jobName;
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Cron run history maintained a second handwritten copy of the gateway wire type. The copies had already diverged: the protocol included `jobName`, while cron added it through an intersection assertion.

## Why This Change Was Made

Derive the cron run-history type from the gateway-protocol leaf type and override only the narrower cron-owned `deliverySuppressionReason`. This keeps the existing runtime schema and behavior unchanged while making protocol additions visible to cron at compile time.

## User Impact

No user-visible behavior changes. Maintainers get one canonical static contract for cron run-history responses and one fewer unsafe assertion.

## Evidence

- `pnpm test src/cron/task-run-history.test.ts src/cron/cron-protocol-conformance.test.ts packages/gateway-protocol/src/cron-validators.test.ts` — 65 tests passed
- `node scripts/check-changed.mjs -- src/cron/run-log-types.ts src/cron/task-run-history.ts config/assertion-safety-baseline.txt` — passed
- `pnpm check:import-cycles` — 0 runtime value cycles
- `pnpm build` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — scoped-clean, no accepted/actionable findings

Production LOC: +4/-34 (net -30). Tests: +0/-0. Tooling baseline: +0/-1.
