### PR TITLE
refactor(agents): type sessions yield stream contract

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1789,7 +1789,7 @@ src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts	1
 src/agents/embedded-agent-runner/run/attempt-setup.ts	1
 src/agents/embedded-agent-runner/run/attempt-stop-reason-recovery.ts	3
 src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts	3
-src/agents/embedded-agent-runner/run/attempt-stream.ts	9
+src/agents/embedded-agent-runner/run/attempt-stream.ts	8
 src/agents/embedded-agent-runner/run/attempt-subscription-cleanup.ts	2
 src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts	17
 src/agents/embedded-agent-runner/run/attempt-tool-call-stream-normalization.ts	4

--- a/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
@@ -1,3 +1,4 @@
+import type { AssistantMessage, AssistantMessageEventStreamLike } from "../../../llm/types.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { SessionManager } from "../../sessions/index.js";
@@ -33,36 +34,11 @@ export function createYieldAbortedResponse(model: {
   api?: string;
   provider?: string;
   id?: string;
-}): {
-  [Symbol.asyncIterator]: () => AsyncGenerator<never, void, unknown>;
-  result: () => Promise<{
-    role: "assistant";
-    content: Array<{ type: "text"; text: string }>;
-    stopReason: "aborted";
-    api: string;
-    provider: string;
-    model: string;
-    usage: {
-      input: number;
-      output: number;
-      cacheRead: number;
-      cacheWrite: number;
-      totalTokens: number;
-      cost: {
-        input: number;
-        output: number;
-        cacheRead: number;
-        cacheWrite: number;
-        total: number;
-      };
-    };
-    timestamp: number;
-  }>;
-} {
-  const message = {
-    role: "assistant" as const,
-    content: [{ type: "text" as const, text: "" }],
-    stopReason: "aborted" as const,
+}): AssistantMessageEventStreamLike {
+  const message: AssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "" }],
+    stopReason: "aborted",
     api: model.api ?? "",
     provider: model.provider ?? "",
     model: model.id ?? "",

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -243,9 +243,7 @@ export function installEmbeddedAttemptStreamGuards(input: {
   session.agent.streamFn = (model, context, options) => {
     const signal = input.abortSignal as AbortSignal & { reason?: unknown };
     if (input.isYieldDetected() && signal.aborted && isSessionsYieldAbortReason(signal.reason)) {
-      return createYieldAbortedResponse(model) as unknown as Awaited<
-        ReturnType<typeof innerStreamFn>
-      >;
+      return createYieldAbortedResponse(model);
     }
     return innerStreamFn(model, context, options);
   };


### PR DESCRIPTION
## What Problem This Solves

Resolves a type-safety gap where the sessions-yield synthetic response duplicated the LLM stream contract and required an unchecked double assertion at the embedded stream boundary.

## Why This Change Was Made

The synthetic response now uses the canonical `AssistantMessage` and `AssistantMessageEventStreamLike` contracts exported by the LLM layer. This removes the duplicated structural type and double cast without changing runtime values or control flow, and shrinks the assertion-safety baseline.

## User Impact

There is no user-visible behavior change. Future drift between the sessions-yield response and the canonical LLM stream/message contracts is now caught by TypeScript.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts` — 2 files, 23 tests passed after rebasing onto current `origin/main`.
- `node scripts/check-changed.mjs` — passed, including core/core-test typechecks, lint, assertion ratchet, dead-export scans, and zero runtime import cycles.
- `pnpm check:madge-import-cycles` — 0 cycles.
- `pnpm build` — passed, including runtime module verification, public plugin-SDK export checks, and UI build.
- Fresh autoreview (`--mode uncommitted`) — scoped-clean, no actionable findings, correctness 0.99.
- Production TypeScript: +7/-33 (net -26); tests: unchanged; assertion baseline: +1/-1.
