### PR TITLE
feat: show every mounted local disk in Control UI

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2803,6 +2803,7 @@ public struct SystemInfoResult: Codable, Sendable {
     public let disktotalbytes: Int?
     public let diskavailablebytes: Int?
     public let diskpath: String?
+    public let disks: [[String: AnyCodable]]?
     public let defaultagentutilitymodel: AnyCodable?
 
     public init(
@@ -2826,6 +2827,7 @@ public struct SystemInfoResult: Codable, Sendable {
         disktotalbytes: Int? = nil,
         diskavailablebytes: Int? = nil,
         diskpath: String? = nil,
+        disks: [[String: AnyCodable]]? = nil,
         defaultagentutilitymodel: AnyCodable? = nil)
     {
         self.machinename = machinename
@@ -2848,6 +2850,7 @@ public struct SystemInfoResult: Codable, Sendable {
         self.disktotalbytes = disktotalbytes
         self.diskavailablebytes = diskavailablebytes
         self.diskpath = diskpath
+        self.disks = disks
         self.defaultagentutilitymodel = defaultagentutilitymodel
     }
 
@@ -2872,6 +2875,7 @@ public struct SystemInfoResult: Codable, Sendable {
         case disktotalbytes = "diskTotalBytes"
         case diskavailablebytes = "diskAvailableBytes"
         case diskpath = "diskPath"
+        case disks
         case defaultagentutilitymodel = "defaultAgentUtilityModel"
     }
 }

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -504,7 +504,7 @@ This label does not change which request the approval buttons resolve.
 
   </Accordion>
   <Accordion title="Debug, logs, update">
-    - Debug: status/health/models snapshots, event log, manual RPC calls, and a System busyness overlay with live CPU, memory, and event-loop delay graphs (`status`, `health`, `models.list`).
+    - Debug: status/health/models snapshots, event log, manual RPC calls, and a System busyness overlay with live CPU, memory, event-loop delay, and per-disk free-space graphs (`status`, `health`, `models.list`, `system.info`). Connection also shows each mounted local storage volume separately, labeled by its mount path. Disk snapshots refresh every ten seconds; memory-backed filesystems and hidden macOS system volumes are excluded.
     - Lane tables omit disabled, empty lanes, including `hook-dispatch` when HTTP hooks are off. Disabled lanes remain visible while work is running or queued.
     - The event log includes Control UI refresh/RPC timings, slow chat/config render timings, and browser responsiveness entries for long animation frames or long tasks when the browser exposes those PerformanceObserver entry types.
     - Logs: live tail of gateway file logs with filter/export (`logs.tail`).

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -182,7 +182,7 @@ Local agent avatars use [authenticated avatar URLs](#avatar-route-auth) in this 
 
 ## Gateway host status
 
-Open **Settings → Connection** to see the **Gateway Host** card with the Gateway machine, LAN address, operating system, runtime, uptime, CPU load, memory, and state-volume disk space. The card refreshes every 10 seconds while visible through the `system.info` Gateway RPC, which requires the `operator.read` scope. Older Gateways and connections without that scope omit the card.
+Open **Settings → Connection** to see the **Gateway Host** card with the Gateway machine, LAN address, operating system, runtime, uptime, CPU load, memory, and space for each mounted local disk. The card refreshes every 10 seconds while visible through the `system.info` Gateway RPC, which requires the `operator.read` scope. If mounted-disk discovery is unavailable, the card retains the state-directory disk reading when available. Connections without the required scope omit the card.
 
 ## Language support
 

--- a/packages/gateway-protocol/src/schema/system-info.test.ts
+++ b/packages/gateway-protocol/src/schema/system-info.test.ts
@@ -23,6 +23,10 @@ const validSystemInfo = {
   diskTotalBytes: 994_662_584_320,
   diskAvailableBytes: 497_331_292_160,
   diskPath: "/Users/operator/.openclaw",
+  disks: [
+    { path: "/", totalBytes: 994_662_584_320, availableBytes: 497_331_292_160 },
+    { path: "/data", totalBytes: 2_000_000_000_000, availableBytes: 1_000_000_000_000 },
+  ],
 };
 
 describe("SystemInfoResultSchema", () => {
@@ -32,5 +36,13 @@ describe("SystemInfoResultSchema", () => {
 
   it("rejects extra properties", () => {
     expect(Value.Check(SystemInfoResultSchema, { ...validSystemInfo, extra: true })).toBe(false);
+  });
+
+  it.each([
+    { path: "/", totalBytes: 0, availableBytes: 0 },
+    { path: "/", totalBytes: 100, availableBytes: -1 },
+    { path: "", totalBytes: 100, availableBytes: 1 },
+  ])("rejects invalid disk metrics: %j", (disk) => {
+    expect(Value.Check(SystemInfoResultSchema, { ...validSystemInfo, disks: [disk] })).toBe(false);
   });
 });

--- a/packages/gateway-protocol/src/schema/system-info.ts
+++ b/packages/gateway-protocol/src/schema/system-info.ts
@@ -36,6 +36,15 @@ export const SystemInfoResultSchema = closedObject({
   diskTotalBytes: Type.Optional(Type.Integer()),
   diskAvailableBytes: Type.Optional(Type.Integer()),
   diskPath: Type.Optional(Type.String()),
+  disks: Type.Optional(
+    Type.Array(
+      closedObject({
+        path: Type.String({ minLength: 1 }),
+        totalBytes: Type.Integer({ minimum: 1 }),
+        availableBytes: Type.Integer({ minimum: 0 }),
+      }),
+    ),
+  ),
   /** Resolved utility model for the configured default agent. */
   defaultAgentUtilityModel: Type.Optional(UtilityModelStatusSchema),
 });

--- a/src/gateway/server-methods/system-info.test.ts
+++ b/src/gateway/server-methods/system-info.test.ts
@@ -2,26 +2,30 @@
 
 import os from "node:os";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { validateSystemInfoResult } from "../../../packages/gateway-protocol/src/index.js";
+import * as diskSpace from "../../infra/disk-space.js";
 import { getGatewayProcessInstanceId } from "../process-instance.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   resolveAdvertisedLanHostCore: vi.fn(async () => "192.168.1.20"),
+  runCommandWithTimeout: vi.fn(),
 }));
 
 vi.mock("../../process/exec.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../process/exec.js")>()),
-  runCommandWithTimeout: vi.fn(async (argv: string[]) => ({
-    code: 0,
-    stdout:
-      argv[0] === "mount"
-        ? "/dev/root on / (apfs, local)\n/dev/data on /Volumes/Data (apfs, local)\n"
-        : "/dev/root 1000 600 400 60% /\n/dev/data 2000 500 1500 25% /Volumes/Data\n",
-    stderr: "",
-  })),
+  runCommandWithTimeout: mocks.runCommandWithTimeout,
 }));
+
+const mountedVolumeOutput = (argv: string[]) => ({
+  code: 0,
+  stdout:
+    argv[0] === "mount"
+      ? "/dev/root on / (apfs, local)\n/dev/data on /Volumes/Data (apfs, local)\n"
+      : "/dev/root 1000 600 400 60% /\n/dev/data 2000 500 1500 25% /Volumes/Data\n",
+  stderr: "",
+});
 
 // Keep every real export available: other modules in the import graph may pull
 // parse/select helpers from this module, and a partial factory would break them.
@@ -33,10 +37,16 @@ vi.mock("../../infra/advertised-lan-host.js", async (importOriginal) => ({
 import { systemHandlers } from "./system.js";
 
 describe("system.info", () => {
+  let sampleTime = Date.now();
+  beforeEach(() => {
+    sampleTime += 10_001;
+    vi.spyOn(Date, "now").mockReturnValue(sampleTime);
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
+    mocks.runCommandWithTimeout.mockReset().mockImplementation(mountedVolumeOutput);
+  });
   afterEach(() => vi.restoreAllMocks());
 
   it("returns a schema-valid host resource snapshot", async () => {
-    vi.spyOn(os, "platform").mockReturnValue("darwin");
     const respond = vi.fn();
 
     const request = {
@@ -74,4 +84,47 @@ describe("system.info", () => {
       { path: "/Volumes/Data", totalBytes: 2_048_000, availableBytes: 1_536_000 },
     ]);
   });
+
+  it.each(["throw", "mount-exit", "df-exit", "empty"])(
+    "preserves the state-directory snapshot only when discovery is unavailable (%s)",
+    async (failure) => {
+      vi.spyOn(diskSpace, "tryReadDiskSpace").mockImplementation((targetPath) => ({
+        targetPath,
+        checkedPath: targetPath,
+        totalBytes: 2048,
+        availableBytes: 1024,
+      }));
+      if (failure === "throw") {
+        mocks.runCommandWithTimeout.mockRejectedValueOnce(new Error("unavailable"));
+      } else {
+        if (failure === "df-exit") {
+          mocks.runCommandWithTimeout.mockImplementationOnce(mountedVolumeOutput);
+        }
+        mocks.runCommandWithTimeout.mockResolvedValueOnce({
+          code: failure === "empty" ? 0 : 1,
+          stdout: "",
+          stderr: "",
+        });
+      }
+      const respond = vi.fn();
+      await expectDefined(
+        systemHandlers["system.info"],
+        "system.info handler",
+      )({
+        params: {},
+        respond,
+        context: { getRuntimeConfig: () => ({}) },
+      } as unknown as GatewayRequestHandlerOptions);
+      const [ok, payload] = respond.mock.calls[0] ?? [];
+      expect(ok).toBe(true);
+      if (!validateSystemInfoResult(payload)) {
+        throw new Error("system.info returned an invalid payload");
+      }
+      expect(payload.disks).toEqual(
+        failure === "empty"
+          ? []
+          : [{ path: payload.diskPath, totalBytes: 2048, availableBytes: 1024 }],
+      );
+    },
+  );
 });

--- a/src/gateway/server-methods/system-info.test.ts
+++ b/src/gateway/server-methods/system-info.test.ts
@@ -1,13 +1,26 @@
 /** Gateway system.info method tests. */
 
+import os from "node:os";
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateSystemInfoResult } from "../../../packages/gateway-protocol/src/index.js";
 import { getGatewayProcessInstanceId } from "../process-instance.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   resolveAdvertisedLanHostCore: vi.fn(async () => "192.168.1.20"),
+}));
+
+vi.mock("../../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/exec.js")>()),
+  runCommandWithTimeout: vi.fn(async (argv: string[]) => ({
+    code: 0,
+    stdout:
+      argv[0] === "mount"
+        ? "/dev/root on / (apfs, local)\n/dev/data on /Volumes/Data (apfs, local)\n"
+        : "/dev/root 1000 600 400 60% /\n/dev/data 2000 500 1500 25% /Volumes/Data\n",
+    stderr: "",
+  })),
 }));
 
 // Keep every real export available: other modules in the import graph may pull
@@ -20,7 +33,10 @@ vi.mock("../../infra/advertised-lan-host.js", async (importOriginal) => ({
 import { systemHandlers } from "./system.js";
 
 describe("system.info", () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it("returns a schema-valid host resource snapshot", async () => {
+    vi.spyOn(os, "platform").mockReturnValue("darwin");
     const respond = vi.fn();
 
     const request = {
@@ -53,5 +69,9 @@ describe("system.info", () => {
     expect(payload.processInstanceId).toBe(getGatewayProcessInstanceId());
     expect(payload.uptimeMs).toBeGreaterThanOrEqual(0);
     expect(payload.defaultAgentUtilityModel).toEqual({ status: "unavailable" });
+    expect(payload).toHaveProperty("disks", [
+      { path: "/", totalBytes: 1_024_000, availableBytes: 409_600 },
+      { path: "/Volumes/Data", totalBytes: 2_048_000, availableBytes: 1_536_000 },
+    ]);
   });
 });

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -102,7 +102,13 @@ async function collectSystemInfo(context: GatewayRequestContext): Promise<System
     ...(loadAverage.some((value) => value !== 0) ? { loadAverage } : {}),
     memoryTotalBytes: os.totalmem(),
     memoryFreeBytes: os.freemem(),
-    ...(disks ? { disks } : {}),
+    // Keep the existing state-volume reading when native discovery is unavailable;
+    // an empty successful discovery intentionally stays empty.
+    disks:
+      disks ??
+      (disk?.totalBytes != null && disk.totalBytes > 0
+        ? [{ path: stateDir, totalBytes: disk.totalBytes, availableBytes: disk.availableBytes }]
+        : undefined),
     ...(disk?.totalBytes != null
       ? {
           diskTotalBytes: disk.totalBytes,

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -34,6 +34,7 @@ import { getLastHeartbeatEvent } from "../../infra/heartbeat-events.js";
 import { requestHeartbeat, setHeartbeatsEnabled } from "../../infra/heartbeat-wake.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
+import { readSystemDisks } from "../../infra/system-disks.js";
 import { withSystemEventOwner } from "../../infra/system-event-ownership.js";
 import { enqueueSystemEvent, isSystemEventContextChanged } from "../../infra/system-events.js";
 import { listSystemPresence, updateSystemPresence } from "../../infra/system-presence.js";
@@ -64,7 +65,10 @@ async function collectSystemInfo(context: GatewayRequestContext): Promise<System
   const disk = tryReadDiskSpace(stateDir);
   const config = context.getRuntimeConfig();
   const port = resolveGatewayPort(config);
-  const lanAddress = (await resolveCachedAdvertisedLanHost()) ?? undefined;
+  const [lanAddress, disks] = await Promise.all([
+    resolveCachedAdvertisedLanHost(),
+    readSystemDisks(),
+  ]);
   const soleAgentId = tryResolveLegacyCompatibilityAgentId(config);
   const defaultAgentUtilityModel = soleAgentId
     ? (() => {
@@ -98,6 +102,7 @@ async function collectSystemInfo(context: GatewayRequestContext): Promise<System
     ...(loadAverage.some((value) => value !== 0) ? { loadAverage } : {}),
     memoryTotalBytes: os.totalmem(),
     memoryFreeBytes: os.freemem(),
+    ...(disks ? { disks } : {}),
     ...(disk?.totalBytes != null
       ? {
           diskTotalBytes: disk.totalBytes,

--- a/src/infra/system-disks.test.ts
+++ b/src/infra/system-disks.test.ts
@@ -70,6 +70,17 @@ describe("system disk snapshots", () => {
     ]);
   });
 
+  it.each(["tmpfs tmpfs", "nfs server:/root", "nfs4 server:/root"])(
+    "excludes a non-local Linux root (%s) without hiding local data disks",
+    async (filesystem) => {
+      mocks.readFile.mockResolvedValue(
+        `1 0 0:5 / / rw - ${filesystem} rw\n2 1 8:1 / /data rw - ext4 /dev/sdb rw`,
+      );
+      const { readSystemDisks } = await import("./system-disks.js");
+      expect((await readSystemDisks())?.map((disk) => disk.path)).toEqual(["/data"]);
+    },
+  );
+
   it("keeps macOS root and browsable volumes without duplicating hidden APFS volumes", async () => {
     mocks.platform.mockReturnValue("darwin");
     mocks.runCommandWithTimeout.mockResolvedValueOnce({

--- a/src/infra/system-disks.test.ts
+++ b/src/infra/system-disks.test.ts
@@ -146,18 +146,16 @@ describe("system disk snapshots", () => {
     expect(await readSystemDisks()).toHaveLength(1);
   });
 
-  it("keeps completed disk rows when a later filesystem probe times out", async () => {
+  it("returns unavailable when df times out before printing its table", async () => {
     mocks.readFile.mockResolvedValue(
       "1 0 8:1 / / rw - ext4 /dev/sda1 rw\n2 1 8:2 / /data rw - xfs /dev/sdb1 rw",
     );
     mocks.runCommandWithTimeout.mockResolvedValue({
       code: 124,
       termination: "timeout",
-      stdout: "/dev/sda1 2000 1000 1000 50% /\n",
+      stdout: "",
     });
     const { readSystemDisks } = await import("./system-disks.js");
-    expect(await readSystemDisks()).toEqual([
-      { path: "/", totalBytes: 2_048_000, availableBytes: 1_024_000 },
-    ]);
+    expect(await readSystemDisks()).toBeUndefined();
   });
 });

--- a/src/infra/system-disks.test.ts
+++ b/src/infra/system-disks.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  platform: vi.fn(() => "linux"),
+  readFile: vi.fn(),
+  runCommandWithTimeout: vi.fn(),
+}));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, default: { ...actual, platform: mocks.platform } };
+});
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    default: { ...actual, readFile: mocks.readFile },
+  };
+});
+vi.mock("../process/exec.js", () => ({ runCommandWithTimeout: mocks.runCommandWithTimeout }));
+
+describe("system disk snapshots", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    mocks.platform.mockReturnValue("linux");
+    mocks.runCommandWithTimeout.mockImplementation(async (argv: string[]) => ({
+      code: 0,
+      stdout: argv
+        .slice(2)
+        .map((mountPath) => `/dev/disk 2000 1000 1000 50% ${mountPath}`)
+        .join("\n"),
+    }));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("reports distinct Linux storage mounts, not bind aliases or memory and image filesystems", async () => {
+    mocks.readFile.mockResolvedValue(
+      [
+        "1 0 8:1 / / rw - ext4 /dev/sda1 rw",
+        "2 1 8:2 /work /srv/bind rw - xfs /dev/sdb1 rw",
+        "3 1 8:2 / /mnt/data\\040disk rw - xfs /dev/sdb1 rw",
+        "4 1 0:1 / /run rw - tmpfs tmpfs rw",
+        "5 1 7:0 / /snap/package ro - squashfs /dev/loop0 ro",
+        "6 1 0:2 / /tank rw - zfs tank rw",
+      ].join("\n"),
+    );
+    const { readSystemDisks } = await import("./system-disks.js");
+    expect(await readSystemDisks()).toEqual([
+      { path: "/", totalBytes: 2_048_000, availableBytes: 1_024_000 },
+      { path: "/mnt/data disk", totalBytes: 2_048_000, availableBytes: 1_024_000 },
+      { path: "/tank", totalBytes: 2_048_000, availableBytes: 1_024_000 },
+    ]);
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      ["df", "-kP", "/", "/mnt/data disk", "/tank"],
+      expect.objectContaining({ timeoutMs: 3_000, maxOutputBytes: 1024 * 1024 }),
+    );
+  });
+
+  it("keeps container root storage and omits a volume that disappears while sampling", async () => {
+    mocks.readFile.mockResolvedValue(
+      "1 0 0:5 / / rw - overlay overlay rw\n2 1 8:1 / /data rw - ext4 /dev/sdb rw",
+    );
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 1,
+      stdout: "overlay 2000 2001 -1 101% /\n",
+    });
+    const { readSystemDisks } = await import("./system-disks.js");
+    expect(await readSystemDisks()).toEqual([
+      { path: "/", totalBytes: 2_048_000, availableBytes: 0 },
+    ]);
+  });
+
+  it("keeps macOS root and browsable volumes without duplicating hidden APFS volumes", async () => {
+    mocks.platform.mockReturnValue("darwin");
+    mocks.runCommandWithTimeout.mockResolvedValueOnce({
+      code: 0,
+      stdout: [
+        "/dev/disk3s1s1 on / (apfs, sealed, local, read-only, journaled)",
+        "/dev/disk3s5 on /System/Volumes/Data (apfs, local, journaled, nobrowse, root data)",
+        "/dev/disk3s6 on /System/Volumes/VM (apfs, local, nobrowse)",
+        "/dev/disk7s1 on /Volumes/Data Disk (apfs, local, nodev, nosuid)",
+        "devfs on /dev (devfs, local, nobrowse)",
+        "server:/share on /Volumes/Network (nfs)",
+      ].join("\n"),
+    });
+    const { readSystemDisks } = await import("./system-disks.js");
+    expect((await readSystemDisks())?.map((disk) => disk.path)).toEqual([
+      "/",
+      "/Volumes/Data Disk",
+    ]);
+  });
+
+  it.each([
+    [[{ Path: "C:\\", Capacity: 1000, FreeSpace: 200 }], ["C:\\"]],
+    [
+      [
+        { Path: "C:\\", Capacity: 1000, FreeSpace: 200 },
+        { Path: "C:\\Data\\", Capacity: 2000, FreeSpace: 1500 },
+        { Path: "E:\\", Capacity: null, FreeSpace: null },
+      ],
+      ["C:\\", "C:\\Data\\"],
+    ],
+  ])("reports ready Windows volumes including folder-mounted storage: %j", async (rows, paths) => {
+    mocks.platform.mockReturnValue("win32");
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: JSON.stringify(rows.length === 1 ? rows[0] : rows),
+    });
+    const { readSystemDisks } = await import("./system-disks.js");
+    expect((await readSystemDisks())?.map((disk) => disk.path)).toEqual(paths);
+  });
+
+  it("shares in-flight probes and refreshes mount membership after the sample expires", async () => {
+    vi.useFakeTimers();
+    mocks.readFile.mockResolvedValue("1 0 8:1 / / rw - ext4 /dev/sda1 rw");
+    const { readSystemDisks } = await import("./system-disks.js");
+    const pending = readSystemDisks();
+    expect(readSystemDisks()).toBe(pending);
+    await pending;
+    mocks.readFile.mockResolvedValue(
+      "1 0 8:1 / / rw - ext4 /dev/sda1 rw\n2 1 8:2 / /data rw - xfs /dev/sdb1 rw",
+    );
+    expect(await readSystemDisks()).toHaveLength(1);
+    vi.advanceTimersByTime(10_001);
+    expect(await readSystemDisks()).toHaveLength(2);
+  });
+
+  it("returns unavailable on probe failure and recovers on the next sample", async () => {
+    vi.useFakeTimers();
+    mocks.readFile.mockRejectedValueOnce(new Error("unavailable"));
+    const { readSystemDisks } = await import("./system-disks.js");
+    expect(await readSystemDisks()).toBeUndefined();
+    mocks.readFile.mockResolvedValue("1 0 8:1 / / rw - ext4 /dev/sda1 rw");
+    vi.advanceTimersByTime(10_001);
+    expect(await readSystemDisks()).toHaveLength(1);
+  });
+
+  it("keeps completed disk rows when a later filesystem probe times out", async () => {
+    mocks.readFile.mockResolvedValue(
+      "1 0 8:1 / / rw - ext4 /dev/sda1 rw\n2 1 8:2 / /data rw - xfs /dev/sdb1 rw",
+    );
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 124,
+      termination: "timeout",
+      stdout: "/dev/sda1 2000 1000 1000 50% /\n",
+    });
+    const { readSystemDisks } = await import("./system-disks.js");
+    expect(await readSystemDisks()).toEqual([
+      { path: "/", totalBytes: 2_048_000, availableBytes: 1_024_000 },
+    ]);
+  });
+});

--- a/src/infra/system-disks.test.ts
+++ b/src/infra/system-disks.test.ts
@@ -56,19 +56,26 @@ describe("system disk snapshots", () => {
     );
   });
 
-  it("keeps container root storage and omits a volume that disappears while sampling", async () => {
-    mocks.readFile.mockResolvedValue(
-      "1 0 0:5 / / rw - overlay overlay rw\n2 1 8:1 / /data rw - ext4 /dev/sdb rw",
-    );
-    mocks.runCommandWithTimeout.mockResolvedValue({
-      code: 1,
-      stdout: "overlay 2000 2001 -1 101% /\n",
-    });
-    const { readSystemDisks } = await import("./system-disks.js");
-    expect(await readSystemDisks()).toEqual([
-      { path: "/", totalBytes: 2_048_000, availableBytes: 0 },
-    ]);
-  });
+  it.each([
+    { directory: "removed", code: 1, stdout: "overlay 2000 2001 -1 101% /\n" },
+    {
+      directory: "remaining",
+      code: 0,
+      stdout: "overlay 2000 2001 -1 101% /\noverlay 2000 2001 -1 101% /\n",
+    },
+  ])(
+    "keeps one container root when a volume disappears with its directory $directory",
+    async ({ code, stdout }) => {
+      mocks.readFile.mockResolvedValue(
+        "1 0 0:5 / / rw - overlay overlay rw\n2 1 8:1 / /data rw - ext4 /dev/sdb rw",
+      );
+      mocks.runCommandWithTimeout.mockResolvedValue({ code, stdout });
+      const { readSystemDisks } = await import("./system-disks.js");
+      expect(await readSystemDisks()).toEqual([
+        { path: "/", totalBytes: 2_048_000, availableBytes: 0 },
+      ]);
+    },
+  );
 
   it.each(["tmpfs tmpfs", "nfs server:/root", "nfs4 server:/root"])(
     "excludes a non-local Linux root (%s) without hiding local data disks",

--- a/src/infra/system-disks.ts
+++ b/src/infra/system-disks.ts
@@ -14,7 +14,7 @@ const windowsVolumeSchema = z.object({
 const commandOptions = { timeoutMs: 3_000, maxOutputBytes: 1024 * 1024 };
 let snapshot: { expiresAt: number; pending: Promise<SystemDisk[] | undefined> } | undefined;
 
-async function readMountedDiskPaths(platform: NodeJS.Platform): Promise<string[]> {
+async function readMountedDiskPaths(platform: NodeJS.Platform): Promise<string[] | undefined> {
   if (platform === "linux") {
     const mounts = await fs.readFile("/proc/self/mountinfo", "utf8");
     const devices = new Map<string, { path: string; root: string }>();
@@ -26,7 +26,10 @@ async function readMountedDiskPaths(platform: NodeJS.Platform): Promise<string[]
         continue;
       }
       const mountPath = decodeMountInfoPath(encodedPath);
-      if (mountPath !== "/" && !source.startsWith("/dev/") && type !== "zfs") {
+      // Containers expose their writable storage through overlay at /; other
+      // roots must meet the same local-disk predicate as ordinary mounts.
+      const localDisk = source.startsWith("/dev/") || type === "zfs";
+      if (!localDisk && !(mountPath === "/" && type === "overlay")) {
         continue;
       }
       const existing = devices.get(device);
@@ -45,7 +48,10 @@ async function readMountedDiskPaths(platform: NodeJS.Platform): Promise<string[]
     return [...devices.values()].map((entry) => entry.path);
   }
 
-  const { stdout } = await runCommandWithTimeout(["mount"], commandOptions);
+  const { stdout, code } = await runCommandWithTimeout(["mount"], commandOptions);
+  if (code !== 0) {
+    return undefined;
+  }
   return stdout.split("\n").flatMap((line) => {
     const match = /^\/dev\/\S+ on (.+) \(([^)]+)\)$/.exec(line);
     if (!match) {
@@ -100,14 +106,14 @@ async function collectSystemDisks(): Promise<SystemDisk[] | undefined> {
     return undefined;
   }
   const paths = await readMountedDiskPaths(platform);
-  if (paths.length === 0) {
-    return [];
+  if (!paths?.length) {
+    return paths ? [] : undefined;
   }
-  const { stdout } = await runCommandWithTimeout(["df", "-kP", ...paths], {
+  const { stdout, code } = await runCommandWithTimeout(["df", "-kP", ...paths], {
     ...commandOptions,
     env: { LC_ALL: "C" },
   });
-  return stdout.split("\n").flatMap((line) => {
+  const disks = stdout.split("\n").flatMap((line) => {
     const match = /^.+?\s+(\d+)\s+\d+\s+(-?\d+)\s+\d+%\s+(.+)$/.exec(line);
     if (!match) {
       return [];
@@ -123,6 +129,9 @@ async function collectSystemDisks(): Promise<SystemDisk[] | undefined> {
       ? [{ path: mountPath, totalBytes, availableBytes }]
       : [];
   });
+  // Preserve completed rows from a partial df failure, but distinguish a
+  // failed probe from successful discovery of no eligible disks.
+  return code !== 0 && disks.length === 0 ? undefined : disks;
 }
 
 export function readSystemDisks(): Promise<SystemDisk[] | undefined> {

--- a/src/infra/system-disks.ts
+++ b/src/infra/system-disks.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import { decodeMountInfoPath } from "@openclaw/normalization-core/mountinfo-path";
+import { z } from "zod";
+import { runCommandWithTimeout } from "../process/exec.js";
+
+type SystemDisk = { path: string; totalBytes: number; availableBytes: number };
+
+const windowsVolumeSchema = z.object({
+  Path: z.string().min(1),
+  Capacity: z.number().int().positive(),
+  FreeSpace: z.number().int().nonnegative(),
+});
+const commandOptions = { timeoutMs: 3_000, maxOutputBytes: 1024 * 1024 };
+let snapshot: { expiresAt: number; pending: Promise<SystemDisk[] | undefined> } | undefined;
+
+async function readMountedDiskPaths(platform: NodeJS.Platform): Promise<string[]> {
+  if (platform === "linux") {
+    const mounts = await fs.readFile("/proc/self/mountinfo", "utf8");
+    const devices = new Map<string, { path: string; root: string }>();
+    for (const line of mounts.split("\n")) {
+      const [mount, filesystem] = line.split(" - ");
+      const [device, root, encodedPath] = (mount ?? "").split(" ").slice(2, 5);
+      const [type, source] = (filesystem ?? "").split(" ");
+      if (!device || !root || !encodedPath || !source || type === "squashfs") {
+        continue;
+      }
+      const mountPath = decodeMountInfoPath(encodedPath);
+      if (mountPath !== "/" && !source.startsWith("/dev/") && type !== "zfs") {
+        continue;
+      }
+      const existing = devices.get(device);
+      const wholeFilesystem = root === "/";
+      const existingWholeFilesystem = existing?.root === "/";
+      if (
+        !existing ||
+        (wholeFilesystem && !existingWholeFilesystem) ||
+        (wholeFilesystem === existingWholeFilesystem &&
+          (mountPath.length < existing.path.length ||
+            (mountPath.length === existing.path.length && mountPath < existing.path)))
+      ) {
+        devices.set(device, { path: mountPath, root });
+      }
+    }
+    return [...devices.values()].map((entry) => entry.path);
+  }
+
+  const { stdout } = await runCommandWithTimeout(["mount"], commandOptions);
+  return stdout.split("\n").flatMap((line) => {
+    const match = /^\/dev\/\S+ on (.+) \(([^)]+)\)$/.exec(line);
+    if (!match) {
+      return [];
+    }
+    const [, mountPath, flags] = match;
+    return mountPath &&
+      flags?.split(", ").includes("local") &&
+      (mountPath === "/" || !flags.split(", ").includes("nobrowse"))
+      ? [mountPath]
+      : [];
+  });
+}
+
+async function collectSystemDisks(): Promise<SystemDisk[] | undefined> {
+  const platform = os.platform();
+  if (platform === "win32") {
+    const { stdout, code } = await runCommandWithTimeout(
+      [
+        "powershell.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "[Console]::OutputEncoding=[Text.UTF8Encoding]::new($false); " +
+          "Get-CimInstance Win32_Volume -Filter 'DriveType=2 OR DriveType=3' | ForEach-Object { " +
+          "$volume = $_; $mount = if ($volume.DriveLetter) { $volume.DriveLetter + '\\' } else { " +
+          "Get-CimAssociatedInstance -InputObject $volume -Association Win32_MountPoint " +
+          "-ResultClassName Win32_Directory | Select-Object -ExpandProperty Name | Sort-Object | Select-Object -First 1 }; " +
+          "if ($mount) { [pscustomobject]@{Path=$mount;Capacity=$volume.Capacity;FreeSpace=$volume.FreeSpace} } " +
+          "} | ConvertTo-Json -Compress",
+      ],
+      commandOptions,
+    );
+    if (code !== 0) {
+      return undefined;
+    }
+    const parsed: unknown = stdout.trim() ? JSON.parse(stdout) : [];
+    return (Array.isArray(parsed) ? parsed : [parsed]).flatMap((row) => {
+      const result = windowsVolumeSchema.safeParse(row);
+      return result.success
+        ? [
+            {
+              path: result.data.Path,
+              totalBytes: result.data.Capacity,
+              availableBytes: result.data.FreeSpace,
+            },
+          ]
+        : [];
+    });
+  }
+  if (platform !== "linux" && platform !== "darwin") {
+    return undefined;
+  }
+  const paths = await readMountedDiskPaths(platform);
+  if (paths.length === 0) {
+    return [];
+  }
+  const { stdout } = await runCommandWithTimeout(["df", "-kP", ...paths], {
+    ...commandOptions,
+    env: { LC_ALL: "C" },
+  });
+  return stdout.split("\n").flatMap((line) => {
+    const match = /^.+?\s+(\d+)\s+\d+\s+(-?\d+)\s+\d+%\s+(.+)$/.exec(line);
+    if (!match) {
+      return [];
+    }
+    const [, total, available, mountPath] = match;
+    const totalBytes = Number(total) * 1024;
+    const availableBytes = Math.max(0, Number(available) * 1024);
+    return mountPath &&
+      paths.includes(mountPath) &&
+      Number.isSafeInteger(totalBytes) &&
+      totalBytes > 0 &&
+      Number.isSafeInteger(availableBytes)
+      ? [{ path: mountPath, totalBytes, availableBytes }]
+      : [];
+  });
+}
+
+export function readSystemDisks(): Promise<SystemDisk[] | undefined> {
+  const now = Date.now();
+  if (!snapshot || now >= snapshot.expiresAt) {
+    const next = {
+      expiresAt: Infinity,
+      pending: collectSystemDisks()
+        .then((disks) => disks?.toSorted((left, right) => left.path.localeCompare(right.path)))
+        .catch(() => undefined)
+        .finally(() => {
+          next.expiresAt = Date.now() + 10_000;
+        }),
+    };
+    snapshot = next;
+  }
+  return snapshot.pending;
+}

--- a/src/infra/system-disks.ts
+++ b/src/infra/system-disks.ts
@@ -113,25 +113,30 @@ async function collectSystemDisks(): Promise<SystemDisk[] | undefined> {
     ...commandOptions,
     env: { LC_ALL: "C" },
   });
-  const disks = stdout.split("\n").flatMap((line) => {
+  // An unmounted volume's directory can resolve to another sampled filesystem.
+  // Key by the returned mount path so df's repeated rows remain one disk.
+  const disks = new Map<string, SystemDisk>();
+  for (const line of stdout.split("\n")) {
     const match = /^.+?\s+(\d+)\s+\d+\s+(-?\d+)\s+\d+%\s+(.+)$/.exec(line);
     if (!match) {
-      return [];
+      continue;
     }
     const [, total, available, mountPath] = match;
     const totalBytes = Number(total) * 1024;
     const availableBytes = Math.max(0, Number(available) * 1024);
-    return mountPath &&
+    if (
+      mountPath &&
       paths.includes(mountPath) &&
       Number.isSafeInteger(totalBytes) &&
       totalBytes > 0 &&
       Number.isSafeInteger(availableBytes)
-      ? [{ path: mountPath, totalBytes, availableBytes }]
-      : [];
-  });
+    ) {
+      disks.set(mountPath, { path: mountPath, totalBytes, availableBytes });
+    }
+  }
   // Preserve completed rows from a partial df failure, but distinguish a
   // failed probe from successful discovery of no eligible disks.
-  return code !== 0 && disks.length === 0 ? undefined : disks;
+  return code !== 0 && disks.size === 0 ? undefined : [...disks.values()];
 }
 
 export function readSystemDisks(): Promise<SystemDisk[] | undefined> {

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -205,6 +205,59 @@ describe("channels section order", () => {
   });
 });
 
+describe("channel row actions", () => {
+  it.each([
+    { list: "connected", action: "details", update: "reorder" },
+    { list: "available", action: "details", update: "reorder" },
+    { list: "available", action: "setup", update: "reorder" },
+    { list: "available", action: "details", update: "connect" },
+    { list: "available", action: "setup", update: "connect" },
+  ])(
+    "keeps $list $action clicks on their channel after a status $update",
+    ({ list, action, update }) => {
+      const configured = list === "connected";
+      const snapshot = {
+        ts: 1,
+        channelOrder: ["whatsapp", "telegram"],
+        channelLabels: { whatsapp: "WhatsApp", telegram: "Telegram" },
+        channels: { whatsapp: { configured }, telegram: { configured } },
+        channelAccounts: {},
+        channelDefaultAccountId: {},
+      };
+      const props = createProps(snapshot);
+      const onAction = vi.fn();
+      if (action === "setup") {
+        props.onStartSetup = onAction;
+      } else {
+        props.onShowDetail = onAction;
+      }
+      const container = document.createElement("div");
+      render(renderChannels(props), container);
+      const row = Array.from(container.querySelectorAll<HTMLElement>(".channels-item")).find(
+        (element) => element.querySelector(".settings-row__title")?.textContent === "Telegram",
+      )!;
+      const button = row.matches("button")
+        ? (row as HTMLButtonElement)
+        : row.querySelector<HTMLButtonElement>(
+            action === "setup" ? ".btn" : ".channels-item__detail",
+          )!;
+
+      props.snapshot = {
+        ...snapshot,
+        ts: 2,
+        ...(update === "connect"
+          ? { channels: { ...snapshot.channels, whatsapp: { configured: true } } }
+          : { channelOrder: ["telegram", "whatsapp"] }),
+      };
+      render(renderChannels(props), container);
+      expect(container.contains(button)).toBe(true);
+      button.click();
+
+      expect(onAction).toHaveBeenCalledExactlyOnceWith("telegram");
+    },
+  );
+});
+
 function createWhatsAppStatus(overrides: Partial<WhatsAppStatus> = {}): WhatsAppStatus {
   return {
     configured: true,

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -1,6 +1,7 @@
 // Channels hub: connected-channel rows, add-a-channel gallery, setup wizard,
 // and a per-channel detail overlay with the full config form.
 import { html, nothing } from "lit";
+import { repeat } from "lit/directives/repeat.js";
 import "../../styles/channels.css";
 import type {
   ChannelsStatusSnapshot,
@@ -51,6 +52,7 @@ const RECOMMENDED_CHANNEL_ORDER: ChannelKey[] = [
 
 export function renderChannels(props: ChannelsProps) {
   const channelOrder = resolveChannelOrder(props.snapshot);
+  // Key both lists so status updates cannot retarget an in-flight channel click.
   const connected = channelOrder.filter((key) => channelEnabled(key, props));
   const available = channelOrder.filter((key) => !channelEnabled(key, props));
   const showingStaleSnapshot = Boolean(props.loading && props.snapshot && props.lastSuccessAt);
@@ -96,7 +98,11 @@ export function renderChannels(props: ChannelsProps) {
                 ${renderSettingsEmpty(t("channels.hub.noneConnected"))}
               </div>
             `
-          : connected.map((key) => renderConnectedRow(key, props)),
+          : repeat(
+              connected,
+              (key) => key,
+              (key) => renderConnectedRow(key, props),
+            ),
       )}
       ${renderSettingsSection(
         {
@@ -106,7 +112,11 @@ export function renderChannels(props: ChannelsProps) {
         html`
           ${!props.canAdmin
             ? html`<div class="callout info" role="note">${t("channels.hub.adminRequired")}</div>`
-            : html`${available.map((key) => renderAvailableRow(key, props))}
+            : html`${repeat(
+                available,
+                (key) => key,
+                (key) => renderAvailableRow(key, props),
+              )}
               ${renderBrowseAllRow(props)}`}
         `,
       )}

--- a/ui/src/pages/connection/system-section.ts
+++ b/ui/src/pages/connection/system-section.ts
@@ -22,6 +22,7 @@ type SystemStat = {
   detail?: string;
   /** Used share of the resource (0..1); renders the meter bar when present. */
   usedFraction?: number;
+  path?: string;
   title?: string;
 };
 
@@ -57,15 +58,20 @@ function renderSystemMeter(label: string, fraction: number) {
 }
 
 function renderSystemStat(stat: SystemStat) {
+  const label = stat.path ? `${stat.label} ${stat.path}` : stat.label;
   return html`
-    <div class="config-host__stat" title=${stat.title ?? ""}>
-      <div class="config-host__stat-label">${stat.label}</div>
+    <div class="config-host__stat" title=${stat.path ?? stat.title ?? ""}>
+      <div class="config-host__stat-label">
+        ${stat.label}${stat.path
+          ? html` <span class="config-host__stat-path">${stat.path}</span>`
+          : nothing}
+      </div>
       <div class="config-host__stat-value">
         ${stat.value}${stat.unit
           ? html` <span class="config-host__stat-unit">${stat.unit}</span>`
           : nothing}
       </div>
-      ${stat.usedFraction == null ? nothing : renderSystemMeter(stat.label, stat.usedFraction)}
+      ${stat.usedFraction == null ? nothing : renderSystemMeter(label, stat.usedFraction)}
       ${stat.detail ? html`<div class="config-host__stat-detail">${stat.detail}</div>` : nothing}
     </div>
   `;
@@ -123,19 +129,21 @@ function buildSystemStats(info: SystemInfoResult): SystemStat[] {
     usedFraction: memoryUsed,
   };
   const stats = [cpu, memory];
-  const diskUsed = usedFraction(info.diskTotalBytes, info.diskAvailableBytes);
-  // Disk info is optional in the protocol; skip the tile instead of showing an empty gauge.
-  if (diskUsed != null) {
+  for (const disk of info.disks ?? []) {
+    const diskUsed = usedFraction(disk.totalBytes, disk.availableBytes);
+    if (diskUsed == null) {
+      continue;
+    }
     stats.push({
       label: t("quickSettings.system.disk"),
       value: formatUsedPercent(diskUsed),
       unit: t("quickSettings.system.used"),
       detail: t("quickSettings.system.freeOf", {
-        free: formatBytes(info.diskAvailableBytes),
-        total: formatBytes(info.diskTotalBytes),
+        free: formatBytes(disk.availableBytes),
+        total: formatBytes(disk.totalBytes),
       }),
       usedFraction: diskUsed,
-      title: info.diskPath,
+      path: disk.path,
     });
   }
   return stats;

--- a/ui/src/pages/connection/view.render.test.ts
+++ b/ui/src/pages/connection/view.render.test.ts
@@ -2,6 +2,7 @@
 
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
+import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayHelloOk } from "../../api/gateway.ts";
 import { renderConnection } from "./view.ts";
 
@@ -53,7 +54,10 @@ function accessRowTitles(container: HTMLElement): string[] {
 function expectStatByLabel(container: Element, text: string): HTMLElement {
   const stat = Array.from(container.querySelectorAll<HTMLElement>(".config-host__stat")).find(
     (candidate) =>
-      candidate.querySelector(".config-host__stat-label")?.textContent?.trim() === text,
+      candidate
+        .querySelector(".config-host__stat-label")
+        ?.textContent?.replace(/\s+/g, " ")
+        .trim() === text,
   );
   if (!(stat instanceof HTMLElement)) {
     throw new Error(`Expected system stat "${text}"`);
@@ -129,34 +133,40 @@ describe("connection view rendering", () => {
 
   it("renders Gateway host identity and resources between access and snapshot", async () => {
     const container = document.createElement("div");
-    render(
-      renderConnection(
-        createConnectionProps({
-          systemInfo: {
-            machineName: "Gateway Mac",
-            hostname: "gateway.local",
-            platform: "darwin",
-            release: "25.5.0",
-            arch: "arm64",
-            osLabel: "macOS 26.5.0",
-            lanAddress: "192.168.1.20",
-            port: 18789,
-            nodeVersion: "v24.1.0",
-            pid: 1234,
-            uptimeMs: 3_600_000,
-            cpuCount: 10,
-            cpuModel: "Apple M4",
-            loadAverage: [1.2, 1.1, 0.9],
-            memoryTotalBytes: 34_359_738_368,
-            memoryFreeBytes: 17_179_869_184,
-            diskTotalBytes: 994_662_584_320,
-            diskAvailableBytes: 497_331_292_160,
-            diskPath: "/Users/operator/.openclaw",
-          },
-        }),
-      ),
-      container,
-    );
+    const systemInfo = {
+      machineName: "Gateway Mac",
+      hostname: "gateway.local",
+      platform: "darwin",
+      release: "25.5.0",
+      arch: "arm64",
+      osLabel: "macOS 26.5.0",
+      lanAddress: "192.168.1.20",
+      port: 18789,
+      nodeVersion: "v24.1.0",
+      pid: 1234,
+      uptimeMs: 3_600_000,
+      cpuCount: 10,
+      cpuModel: "Apple M4",
+      loadAverage: [1.2, 1.1, 0.9],
+      memoryTotalBytes: 34_359_738_368,
+      memoryFreeBytes: 17_179_869_184,
+      diskTotalBytes: 994_662_584_320,
+      diskAvailableBytes: 497_331_292_160,
+      diskPath: "/Users/operator/.openclaw",
+      disks: [
+        {
+          path: "/",
+          totalBytes: 994_662_584_320,
+          availableBytes: 497_331_292_160,
+        },
+        {
+          path: "/Volumes/Archive",
+          totalBytes: 2_199_023_255_552,
+          availableBytes: 549_755_813_888,
+        },
+      ],
+    } satisfies SystemInfoResult;
+    render(renderConnection(createConnectionProps({ systemInfo })), container);
     await Promise.resolve();
 
     const sections = [...container.querySelectorAll(".settings-section__heading")].map((node) =>
@@ -196,15 +206,37 @@ describe("connection view rendering", () => {
       "16 GB free of 32 GB",
     );
 
-    const disk = expectStatByLabel(container, "Disk");
+    const disk = expectStatByLabel(container, "Disk /");
     expect(
       disk.querySelector(".config-host__stat-value")?.textContent?.replace(/\s+/g, " ").trim(),
     ).toBe("50% used");
     expect(disk.querySelector(".config-host__stat-detail")?.textContent?.trim()).toBe(
       "463 GB free of 926 GB",
     );
-    expect(disk.getAttribute("title")).toBe("/Users/operator/.openclaw");
+    expect(disk.getAttribute("title")).toBe("/");
+    expect(disk.querySelector('[role="meter"]')?.getAttribute("aria-label")).toBe("Disk / usage");
+    const archive = expectStatByLabel(container, "Disk /Volumes/Archive");
+    expect(archive.querySelector(".config-host__stat-detail")?.textContent?.trim()).toBe(
+      "512 GB free of 2.0 TB",
+    );
+    expect(archive.querySelector('[role="meter"]')?.getAttribute("aria-valuenow")).toBe("75");
+    expect(archive.querySelector('[role="meter"]')?.getAttribute("aria-label")).toBe(
+      "Disk /Volumes/Archive usage",
+    );
+    expect(container.querySelectorAll(".config-host__stat")).toHaveLength(4);
     expect(container.textContent).not.toContain("Uptime");
+
+    for (const disks of [systemInfo.disks.slice(0, 1), [], undefined]) {
+      render(
+        renderConnection(createConnectionProps({ systemInfo: { ...systemInfo, disks } })),
+        container,
+      );
+      expect(container.querySelectorAll(".config-host__stat")).toHaveLength(
+        2 + (disks?.length ?? 0),
+      );
+      expect(container.textContent).not.toContain("/Volumes/Archive");
+      expect(container.textContent).not.toContain("/Users/operator/.openclaw");
+    }
   });
 
   it("escalates host meter tones and hides the section when the RPC is unavailable", async () => {
@@ -226,8 +258,13 @@ describe("connection view rendering", () => {
             loadAverage: [9.8, 9.1, 8.4],
             memoryTotalBytes: 34_359_738_368,
             memoryFreeBytes: 2_147_483_648,
-            diskTotalBytes: 994_662_584_320,
-            diskAvailableBytes: 198_932_516_864,
+            disks: [
+              {
+                path: "/",
+                totalBytes: 994_662_584_320,
+                availableBytes: 198_932_516_864,
+              },
+            ],
           },
         }),
       ),
@@ -239,7 +276,7 @@ describe("connection view rendering", () => {
       expectStatByLabel(container, label).querySelector(".config-host__meter-fill")?.classList[1];
     expect(tone("CPU")).toBe("config-host__meter-fill--critical");
     expect(tone("Memory")).toBe("config-host__meter-fill--critical");
-    expect(tone("Disk")).toBe("config-host__meter-fill--warn");
+    expect(tone("Disk /")).toBe("config-host__meter-fill--warn");
 
     render(
       renderConnection(createConnectionProps({ systemInfo: null, systemInfoUnavailable: true })),

--- a/ui/src/pages/debug/debug-overlay-sections.ts
+++ b/ui/src/pages/debug/debug-overlay-sections.ts
@@ -1,6 +1,7 @@
 import { formatByteSize } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type TemplateResult } from "lit";
+import { repeat } from "lit/directives/repeat.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGateway } from "../../app/gateway.ts";
@@ -62,11 +63,7 @@ export type DebugOverlayStatusSnapshot = {
     heapUsedBytes: number;
     heapTotalBytes: number;
   };
-  diskSpace?: {
-    availableBytes: number;
-    totalBytes: number;
-    path?: string;
-  };
+  disks?: SystemInfoResult["disks"];
   uptimeMs?: number;
 };
 
@@ -109,6 +106,8 @@ function collectSamples(
     const value = read(entry.status);
     if (typeof value === "number" && Number.isFinite(value)) {
       samples.push({ value, at: entry.at });
+    } else {
+      samples.length = 0;
     }
   }
   return samples;
@@ -159,10 +158,6 @@ function renderStatus(
     typeof eventLoop?.delayMaxMs === "number"
       ? t("debug.overlay.maxShort", { value: formatDelayMs(eventLoop.delayMaxMs) })
       : "";
-  const diskTotalSub =
-    typeof status.diskSpace?.totalBytes === "number"
-      ? t("debug.overlay.totalShort", { value: formatStorageBytes(status.diskSpace.totalBytes) })
-      : "";
   return html`
     <div class="debug-overlay__vitals">
       <openclaw-debug-sparkline
@@ -191,18 +186,27 @@ function renderStatus(
         .format=${formatDelayMs}
         .floorMax=${20}
       ></openclaw-debug-sparkline>
-      ${status.diskSpace
-        ? html`<openclaw-debug-sparkline
-            class="debug-overlay__vital debug-overlay__vital--disk"
-            title=${status.diskSpace.path ?? ""}
-            .label=${t("debug.overlay.disk")}
-            .sub=${diskTotalSub}
-            .samples=${collectSamples(history, (sample) => sample.diskSpace?.availableBytes)}
-            .format=${formatFreeBytes}
-            autorange
-          ></openclaw-debug-sparkline>`
-        : nothing}
     </div>
+    ${status.disks?.length
+      ? html`<div class="debug-overlay__vitals debug-overlay__disks">
+          ${repeat(
+            status.disks ?? [],
+            (disk) => disk.path,
+            (disk) => html`<openclaw-debug-sparkline
+              class="debug-overlay__vital debug-overlay__vital--disk"
+              title=${disk.path}
+              .label=${`${t("debug.overlay.disk")} ${disk.path}`}
+              .sub=${t("debug.overlay.totalShort", { value: formatStorageBytes(disk.totalBytes) })}
+              .samples=${collectSamples(
+                history,
+                (sample) => sample.disks?.find((entry) => entry.path === disk.path)?.availableBytes,
+              )}
+              .format=${formatFreeBytes}
+              autorange
+            ></openclaw-debug-sparkline>`,
+          )}
+        </div>`
+      : nothing}
     ${typeof status.uptimeMs === "number"
       ? html`<div class="debug-overlay__vitals-footer mono">
           ${t("debug.overlay.uptime")} ${formatDurationHuman(status.uptimeMs)}
@@ -257,19 +261,10 @@ export const DEBUG_OVERLAY_SECTIONS: readonly DebugOverlaySectionDescriptor[] = 
         context.client.request<DebugOverlayStatusSnapshot>("status", {}, { signal }),
         context.client.request<SystemInfoResult>("system.info", {}, { signal }).catch(() => null),
       ]);
-      const diskSpace =
-        typeof systemInfo?.diskAvailableBytes === "number" &&
-        typeof systemInfo.diskTotalBytes === "number"
-          ? {
-              availableBytes: systemInfo.diskAvailableBytes,
-              totalBytes: systemInfo.diskTotalBytes,
-              ...(systemInfo.diskPath ? { path: systemInfo.diskPath } : {}),
-            }
-          : undefined;
       return {
         eventLoop: value.eventLoop,
         processMemory: value.processMemory,
-        ...(diskSpace ? { diskSpace } : {}),
+        disks: systemInfo?.disks,
         ...(typeof value.uptimeMs === "number" ? { uptimeMs: value.uptimeMs } : {}),
       } satisfies DebugOverlayStatusSnapshot;
     },

--- a/ui/src/pages/debug/debug-overlay.ts
+++ b/ui/src/pages/debug/debug-overlay.ts
@@ -3,8 +3,10 @@ import { html, nothing } from "lit";
 import { state as litState } from "lit/decorators.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
+import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/debug.css";
 import {
   DEBUG_OVERLAY_SECTIONS,
@@ -32,24 +34,25 @@ export class DebugOverlay extends OpenClawLightDomElement {
   private requestActive = false;
   private requestGeneration = 0;
   private statusHistory: DebugOverlayStatusSample[] = [];
-  private eventLogSource: ApplicationContext["gateway"] | null = null;
-  private unsubscribeEventLog: (() => void) | null = null;
   private readonly polling = new PollController(
     this,
     DEBUG_OVERLAY_POLL_INTERVAL_MS,
     () => void this.refreshSections(),
     false,
   );
+  private readonly gateway = new GatewayPageController(this, {
+    getGateway: () => this.context?.gateway,
+    invalidateRequests: () => this.resetSections(),
+    ensureInitialData: () => void this.refreshSections(),
+  });
+  private readonly subscriptions = new SubscriptionsController(this).watch(
+    () => (this.open ? this.context?.gateway : null),
+    (gateway, notify) => gateway.subscribeEventLog(notify),
+  );
 
   override disconnectedCallback(): void {
     this.close();
     super.disconnectedCallback();
-  }
-
-  protected override updated(): void {
-    if (this.open) {
-      this.syncEventLogSubscription();
-    }
   }
 
   toggle(): void {
@@ -58,9 +61,7 @@ export class DebugOverlay extends OpenClawLightDomElement {
       return;
     }
     this.open = true;
-    this.statusHistory = [];
     document.addEventListener("keydown", this.handleKeydown, true);
-    this.syncEventLogSubscription();
     this.sections = new Map(
       DEBUG_OVERLAY_SECTIONS.map((section) => [section.id, { status: "loading" }]),
     );
@@ -77,34 +78,33 @@ export class DebugOverlay extends OpenClawLightDomElement {
   };
 
   private readonly close = (): void => {
-    if (!this.open && !this.requestController && !this.unsubscribeEventLog) {
+    if (!this.open && !this.requestController) {
       return;
     }
     this.open = false;
     this.polling.stop();
     document.removeEventListener("keydown", this.handleKeydown, true);
+    this.resetSections();
+    this.subscriptions.clear();
+  };
+
+  private resetSections(): void {
     this.requestGeneration += 1;
     this.requestController?.abort();
     this.requestController = null;
     this.requestActive = false;
-    this.unsubscribeEventLog?.();
-    this.unsubscribeEventLog = null;
-    this.eventLogSource = null;
-  };
-
-  private syncEventLogSubscription(): void {
-    const gateway = this.context?.gateway ?? null;
-    if (!this.open || gateway === this.eventLogSource) {
-      return;
-    }
-    this.unsubscribeEventLog?.();
-    this.eventLogSource = gateway;
-    this.unsubscribeEventLog = gateway?.subscribeEventLog(() => this.requestUpdate()) ?? null;
+    this.statusHistory = [];
+    this.sections = new Map(
+      DEBUG_OVERLAY_SECTIONS.map((section) => [
+        section.id,
+        { status: this.gateway.connected ? "loading" : "unavailable" },
+      ]),
+    );
   }
 
   private async refreshSections(): Promise<void> {
-    const gateway = this.context?.gateway;
-    const client = gateway?.snapshot.phase === "connected" ? gateway.snapshot.client : null;
+    const gateway = this.gateway.gateway;
+    const client = this.gateway.connected ? this.gateway.client : null;
     if (!this.open || this.requestActive) {
       return;
     }

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -7,6 +7,7 @@ import { i18n } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import "./debug-overlay.ts";
 import "./debug-page.ts";
+import type { SparklineSample } from "./sparkline-tile.ts";
 import { renderDebug } from "./view.ts";
 
 type DebugProps = Parameters<typeof renderDebug>[0];
@@ -35,11 +36,19 @@ type TestDebugPage = HTMLElement & {
   loadDiagnostics: () => Promise<void>;
 };
 
-type TestDebugOverlay = HTMLElement & {
-  readonly updateComplete: Promise<boolean>;
+type TestDebugOverlay = LitElement & {
   context: ApplicationContext;
   toggle: () => void;
 };
+
+type TestSparkline = LitElement & { samples: readonly SparklineSample[] };
+
+async function updateOverlayVitals(overlay: TestDebugOverlay): Promise<void> {
+  await overlay.updateComplete;
+  for (const tile of overlay.querySelectorAll<TestSparkline>("openclaw-debug-sparkline")) {
+    await tile.updateComplete;
+  }
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -354,7 +363,8 @@ describe("DebugOverlay", () => {
   it("graphs bounded status samples without clamping CPU and resets history on reopen", async () => {
     vi.useFakeTimers();
     let sampleCount = 0;
-    let diskResponse: "available" | "missing" | "rejected" = "available";
+    let diskResponse: "available" | "single" | "empty" | "legacy" | "missing" | "rejected" =
+      "available";
     const request = vi.fn(async (method: string) => {
       if (method === "status") {
         sampleCount += 1;
@@ -376,13 +386,30 @@ describe("DebugOverlay", () => {
         if (diskResponse === "rejected") {
           throw new Error("system info unavailable");
         }
-        return diskResponse === "available"
-          ? {
-              diskAvailableBytes: (700 - sampleCount) * 1_073_741_824,
-              diskTotalBytes: 1_000 * 1_073_741_824,
-              diskPath: "/var/lib/openclaw",
-            }
-          : {};
+        if (diskResponse === "legacy") {
+          return { diskAvailableBytes: 500, diskTotalBytes: 1000, diskPath: "/legacy" };
+        }
+        if (diskResponse === "missing") {
+          return {};
+        }
+        const disks = [
+          {
+            availableBytes: (700 - sampleCount) * 1_073_741_824,
+            totalBytes: 1_000 * 1_073_741_824,
+            path: "/",
+          },
+          {
+            availableBytes: (300 - sampleCount * 2) * 1_073_741_824,
+            totalBytes: 500 * 1_073_741_824,
+            path: "/Volumes/Archive",
+          },
+        ];
+        if (diskResponse === "single") {
+          disks.pop();
+        } else if (diskResponse === "empty") {
+          disks.length = 0;
+        }
+        return { disks: sampleCount % 2 ? disks : disks.toReversed() };
       }
       if (method === "sessions.list") {
         return { sessions: [] };
@@ -398,16 +425,15 @@ describe("DebugOverlay", () => {
       await vi.advanceTimersByTimeAsync(0);
       await overlay.updateComplete;
 
-      const vitalUpdated = async () => {
-        await overlay.updateComplete;
-        for (const tile of overlay.querySelectorAll("openclaw-debug-sparkline")) {
-          await (tile as LitElement).updateComplete;
-        }
-      };
+      const vitalUpdated = () => updateOverlayVitals(overlay);
       await vitalUpdated();
+      const diskTile = (mountPath: string) =>
+        overlay.querySelector<TestSparkline>(`.debug-overlay__vital--disk[title="${mountPath}"]`);
+      const rootDisk = diskTile("/");
+      const archiveDisk = diskTile("/Volumes/Archive");
 
       // One sample: tiles show current values, charts wait for a second point.
-      expect(overlay.querySelectorAll(".debug-overlay__vital")).toHaveLength(4);
+      expect(overlay.querySelectorAll(".debug-overlay__vital")).toHaveLength(5);
       expect(normalizedText(overlay.querySelector(".debug-overlay__vital--cpu"))).toContain(
         "loop 42%",
       );
@@ -429,16 +455,21 @@ describe("DebugOverlay", () => {
       expect(normalizedText(overlay.querySelector(".debug-overlay__vital--delay"))).toContain(
         "max 87ms",
       );
-      expect(normalizedText(overlay.querySelector(".debug-overlay__vital--disk"))).toContain(
-        "698 GB free",
-      );
-      expect(normalizedText(overlay.querySelector(".debug-overlay__vital--disk"))).toContain(
-        "1000 GB total",
-      );
-      expect(overlay.querySelector(".debug-overlay__vital--disk")?.getAttribute("title")).toBe(
-        "/var/lib/openclaw",
-      );
-      expect(overlay.querySelectorAll(".debug-vital__chart")).toHaveLength(4);
+      expect(normalizedText(diskTile("/"))).toContain("698 GB free");
+      expect(normalizedText(diskTile("/"))).toContain("1000 GB total");
+      expect(normalizedText(diskTile("/")?.querySelector(".debug-vital__label"))).toBe("Disk /");
+      expect(
+        normalizedText(diskTile("/Volumes/Archive")?.querySelector(".debug-vital__label")),
+      ).toBe("Disk /Volumes/Archive");
+      expect(normalizedText(diskTile("/Volumes/Archive"))).toContain("296 GB free");
+      expect(normalizedText(diskTile("/Volumes/Archive"))).toContain("500 GB total");
+      expect(diskTile("/")).toBe(rootDisk);
+      expect(diskTile("/Volumes/Archive")).toBe(archiveDisk);
+      expect(rootDisk?.samples.map((sample) => sample.value / 1_073_741_824)).toEqual([699, 698]);
+      expect(archiveDisk?.samples.map((sample) => sample.value / 1_073_741_824)).toEqual([
+        298, 296,
+      ]);
+      expect(overlay.querySelectorAll(".debug-vital__chart")).toHaveLength(5);
       // Healthy event loop: no tile carries the degraded tint.
       expect(overlay.querySelector(".debug-overlay__vital[data-degraded]")).toBeNull();
 
@@ -456,10 +487,21 @@ describe("DebugOverlay", () => {
       await vi.advanceTimersByTimeAsync(0);
       await vitalUpdated();
 
-      expect(overlay.querySelectorAll(".debug-overlay__vital")).toHaveLength(4);
+      expect(overlay.querySelectorAll(".debug-overlay__vital")).toHaveLength(5);
       expect(overlay.querySelector(".debug-vital__chart")).toBeNull();
 
-      for (const response of ["missing", "rejected"] as const) {
+      diskResponse = "single";
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vitalUpdated();
+      expect(overlay.querySelectorAll(".debug-overlay__vital--disk")).toHaveLength(1);
+      expect(diskTile("/")?.samples).toHaveLength(2);
+      diskResponse = "available";
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vitalUpdated();
+      expect(diskTile("/")?.samples).toHaveLength(3);
+      expect(diskTile("/Volumes/Archive")?.samples).toHaveLength(1);
+
+      for (const response of ["empty", "legacy", "missing", "rejected"] as const) {
         diskResponse = response;
         await vi.advanceTimersByTimeAsync(2_000);
         await vitalUpdated();
@@ -475,4 +517,109 @@ describe("DebugOverlay", () => {
       vi.useRealTimers();
     }
   });
+
+  it.each(["same-client reconnect", "client replacement", "Gateway source replacement"])(
+    "discards pending samples and prior disk history on %s",
+    async (transition) => {
+      vi.useFakeTimers();
+      const listeners = new Set<(snapshot: ApplicationGatewaySnapshot) => void>();
+      const pending = deferred<unknown>();
+      const firstInfo = {
+        disks: [
+          { path: "/", totalBytes: 1000 * 1_073_741_824, availableBytes: 700 * 1_073_741_824 },
+        ],
+        diskPath: "/",
+        diskTotalBytes: 1000 * 1_073_741_824,
+        diskAvailableBytes: 700 * 1_073_741_824,
+      };
+      let infoResponse: unknown = firstInfo;
+      const request = vi.fn(async (method: string) => {
+        if (method === "system.info") {
+          return infoResponse;
+        }
+        if (method === "sessions.list") {
+          return { sessions: [] };
+        }
+        return diagnosticResponse(method);
+      });
+      const context = createDebugApplicationContext(request);
+      let snapshot = context.gateway.snapshot;
+      const gateway = {
+        ...context.gateway,
+        get snapshot() {
+          return snapshot;
+        },
+        subscribe(listener: (snapshot: ApplicationGatewaySnapshot) => void) {
+          listeners.add(listener);
+          return () => {
+            listeners.delete(listener);
+          };
+        },
+      };
+      const publishSnapshot = (next: ApplicationGatewaySnapshot) => {
+        snapshot = next;
+        for (const listener of listeners) {
+          listener(snapshot);
+        }
+      };
+      const overlay = document.createElement("openclaw-debug-overlay") as TestDebugOverlay;
+      overlay.context = { ...context, gateway };
+      document.body.append(overlay);
+      try {
+        overlay.toggle();
+        await vi.advanceTimersByTimeAsync(2_000);
+        await updateOverlayVitals(overlay);
+        expect(
+          overlay.querySelector<TestSparkline>(".debug-overlay__vital--disk")?.samples,
+        ).toHaveLength(2);
+
+        infoResponse = pending.promise;
+        await vi.advanceTimersByTimeAsync(2_000);
+        const callsBeforeTransition = request.mock.calls.filter(
+          ([method]) => method === "system.info",
+        ).length;
+        infoResponse = {
+          disks: [{ ...firstInfo.disks[0], availableBytes: 200 * 1_073_741_824 }],
+          diskPath: "/",
+          diskTotalBytes: firstInfo.diskTotalBytes,
+          diskAvailableBytes: 200 * 1_073_741_824,
+        };
+        if (transition === "same-client reconnect") {
+          publishSnapshot({ ...snapshot, phase: "reconnecting" });
+          await overlay.updateComplete;
+          expect(overlay.querySelector(".debug-overlay__vital--disk")).toBeNull();
+          publishSnapshot({ ...snapshot, phase: "connected" });
+        } else if (transition === "client replacement") {
+          publishSnapshot({
+            ...snapshot,
+            client: createDebugApplicationContext(request).gateway.snapshot.client,
+          });
+        } else {
+          overlay.context = { ...context, gateway: { ...gateway } };
+          overlay.requestUpdate();
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        await updateOverlayVitals(overlay);
+        expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(
+          callsBeforeTransition + 1,
+        );
+
+        pending.resolve(firstInfo);
+        await vi.advanceTimersByTimeAsync(0);
+        await updateOverlayVitals(overlay);
+        const disk = overlay.querySelector<TestSparkline>(".debug-overlay__vital--disk");
+        expect(normalizedText(disk)).toContain("200 GB free");
+        expect(disk?.samples.map((sample) => sample.value / 1_073_741_824)).toEqual([200]);
+        expect(disk?.querySelector("polyline")).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(2_000);
+        await updateOverlayVitals(overlay);
+        expect(disk?.samples.map((sample) => sample.value / 1_073_741_824)).toEqual([200, 200]);
+      } finally {
+        overlay.remove();
+        vi.useRealTimers();
+      }
+      expect(listeners.size).toBe(0);
+    },
+  );
 });

--- a/ui/src/styles/connection.css
+++ b/ui/src/styles/connection.css
@@ -70,6 +70,13 @@
   font-variant-numeric: tabular-nums;
 }
 
+.config-host__stat-path {
+  font-family: var(--mono);
+  letter-spacing: normal;
+  text-transform: none;
+  overflow-wrap: anywhere;
+}
+
 .config-host__stat-unit {
   font-size: var(--control-ui-text-xs);
   font-weight: 500;

--- a/ui/src/styles/debug.css
+++ b/ui/src/styles/debug.css
@@ -134,6 +134,10 @@ openclaw-debug-overlay {
   gap: 8px;
 }
 
+.debug-overlay__disks {
+  margin-top: 8px;
+}
+
 .debug-overlay__vital {
   position: relative;
   display: flex;
@@ -160,6 +164,18 @@ openclaw-debug-overlay {
   letter-spacing: 0.08em;
   white-space: nowrap;
   text-transform: uppercase;
+}
+
+.debug-overlay__vital--disk .debug-vital__head {
+  display: grid;
+  gap: 2px;
+}
+
+.debug-overlay__vital--disk .debug-vital__label {
+  letter-spacing: normal;
+  white-space: normal;
+  text-transform: none;
+  overflow-wrap: anywhere;
 }
 
 .debug-vital__sub {


### PR DESCRIPTION
Closes #136074. Related: #128383, the original single-disk diagnostics feature.

## What Problem This Solves

System busyness and Connection settings show only the filesystem containing the Gateway state directory, hiding other mounted local disks such as a separate worktree disk. Both surfaces now show a labeled capacity/free-space display for each mounted local volume, with independent disk histories in System busyness.

## Implementation

The `system.info` owner supplies one canonical `disks` collection from bounded native Linux, macOS, and Windows probes. Discovery excludes network, memory, duplicate, and hidden system mounts; concurrent callers share a probe and completed results are cached in memory for ten seconds. Native facilities avoid a new dependency or configuration option. The shipped scalar disk fields remain available to external protocol clients.

Unavailable discovery uses the valid state-directory snapshot at the Gateway owner; successful empty discovery remains empty. Completed rows survive an ordinary partial `df` failure. Deduplication uses returned mount paths, preventing duplicate root entries when a disappearing mount leaves a directory that resolves to another sampled filesystem. The overlay uses the existing Gateway lifecycle controller, clears history on reconnect/source replacement, and keeps each disk's graph associated with its path. The old singular UI projection and manual subscription lifecycle are removed.

CI exposed a separate, bounded channel-picker defect twice: an initial WhatsApp click opened Telegram as channel status arrived. Lit's unkeyed arrays reused a row's DOM for another channel and replaced its action callback. Both connected and available lists now use the existing keyed `repeat` directive with unique channel IDs. Five deterministic regressions failed with wrong-channel callbacks before this repair; all pass afterward. This fixes the rendering owner without waits, retries, longer timeouts, or test-only production hooks. A channel moving between lists is removed/recreated; remaining rows retain their identities.

There is no new permission, configuration, dependency, persistent store, migration, or protocol-version bump. The maintainer explicitly requested this bounded local-volume telemetry under existing `operator.read` access. No production deployment is included.

## Before / after

Disk captures use the same macOS host with two mounted local volumes and a task-owned isolated Gateway. The before capture uses the original single-disk UI; the after capture shows this feature. Only the diagnostics panel is captured. Later main changes to lane visibility and lazy diagnostics English are retained and covered by integration tests; this PR has no localization/catalog delta.

| Before: state-directory disk only | After: both mounted local disks |
| --- | --- |
| ![Before: one disk](https://github.com/user-attachments/assets/02836486-14a7-4cc2-a738-9c2f9b1ed16b) | ![After: separate disk labels and graphs](https://github.com/user-attachments/assets/dd7da1dd-a132-459e-b342-23d37dd0c5c8) |

Channel captures are synthetic mock-Gateway browser evidence. The before capture is the retained CI failure from the WhatsApp login test; after repair, that same scenario opens WhatsApp and reaches the expected rejected-login feedback.

| Before: WhatsApp click opened Telegram | After: correct WhatsApp dialog and feedback |
| --- | --- |
| ![Wrong channel before repair](https://github.com/user-attachments/assets/0293380c-bd88-428c-b406-8f9dd575b983) | ![Correct channel after repair](https://github.com/user-attachments/assets/8e3d8b49-737c-4003-822f-08ed81b887c3) |

## Validation

- **120 focused tests across eleven files passed**, covering disk discovery, state-disk collection, Gateway RPC/protocol, Connection/Debug rendering and lifecycle, diagnostics loading/lane ownership, catalog tooling, and channel actions. Missing collection, duplicate returned mount paths, and wrong-channel callbacks were reproduced before their repairs.
- **Five Chromium mock-Gateway E2E scenarios passed**, including both CI failures, rejected configuration saves, login rejection, logout confirmation/reconnect ownership, and the complete Telegram setup flow. Existing assertions and timeouts are unchanged.
- Real macOS collection and the isolated dashboard agree on two volumes. Both also appear in narrow layout, with no observed browser page errors.
- The final collector and actual command runner were replayed on a multi-volume Linux host: root, EFI, and data filesystems appeared once each, with capacities and free bytes exactly matching adjacent native `df` output. The read-only probe took **18.94 ms**. Its isolated bundle resolves the process barrel to the existing exported runner to avoid unrelated logger initialization; no command/filesystem mocks were used. Collector source is unchanged through the final integration and channel repair.
- Changed-file type, lint, formatting, guard, i18n, and dead-code checks passed. Full-candidate independent P0–P2 autoreview is clean; a second direct review confirms the channel repair against installed Lit's identity contract.

Focused browser command:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
```

Final reviewed head: `32e6a41ad3d2f3ed831372a5b66b4b2557f0de0c`. [Exact-head CI run33717286355](https://github.com/openclaw/openclaw/actions/runs/33717286355) completed successfully, including the required `openclaw/ci-gate`, every browser shard, and native iOS jobs. This final head needed no retry. Previous head `16e39800` passed its real-Gateway UI lane, but a browser shard reproduced the channel-picker defect; that run was canceled after the failure because this repair supersedes it. The earlier unchanged retry had passed, but recurrence led to the deterministic owner-level repair above.

## Review decisions and limits

ClawSweeper's review of final head `32e6a41ad3d` reports no correctness findings in disk discovery or channel rendering. Its reviewer could not inspect installed dependencies; the acting maintainer review did: `lit-html/development/lit-html.js` (`_commitIterable` and `EventPart`) reuses ordinary array parts by index and updates their callbacks, while `directives/repeat.js` guarantees key-to-DOM identity with unique keys. `resolveChannelOrder` already provides unique IDs. Installed Zod 4.4.3 `safeParse` and number/integer bounds were directly inspected and exercised for valid capacities plus malformed/null/fractional/negative inputs. This resolves the dependency-source limitation. Its exact-head CI rank-up move is satisfied by the completed green run. The automated persistent-data warning is inapplicable: the ten-second snapshot is only an in-memory Promise/cache and writes no database or file. A UI fallback for mismatched Gateway versions was rejected against the supported one-install/one-version Control UI contract; scalar external protocol fields retain compatibility.

Native Windows execution remains a declared follow-up: the CIM invocation and drive-letter/folder-mounted, singleton/array cases were source-reviewed and fixture-tested, but no approved native Windows backend was accessible. This bounded additive diagnostics risk is accepted for landing because unavailable discovery preserves the existing state-volume metrics. Linux proof exercises the collector/runner; macOS supplies the real Gateway/UI proof. No native Windows success or deployed Linux Gateway change is claimed.

Overall diff: production **+281/-68 (net +213)**, tests **+554/-64 (net +490)**, generated Swift **+4**, docs **+2/-2 (net 0)**. The feature accounts for +203 production lines; the channel identity repair adds +10 through canonical keyed rendering. Growth provides the native discovery boundary, per-disk presentation/lifecycle, and correct channel action identity. Release-note context belongs here; no changelog is edited.
