### PR TITLE
perf: project model catalog runtime capabilities once

### DIFF
--- a/src/agents/prepared-model-runtime.configured-catalog.ts
+++ b/src/agents/prepared-model-runtime.configured-catalog.ts
@@ -6,13 +6,11 @@ import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   toStaticCatalogEntry,
   type PreparedConfiguredRuntimeModel,
-  type PreparedRuntimeCapabilityModel,
 } from "./prepared-model-runtime.configured.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
 
 type ConfiguredCatalogAgentFacts = {
   configuredModelRefs: readonly ModelCatalogRef[];
-  runtimeCapabilityModels: readonly PreparedRuntimeCapabilityModel[];
 };
 
 type ConfiguredCatalogWorkspaceFacts = {
@@ -57,57 +55,14 @@ function createConfiguredModelCatalogSnapshot(params: {
     }
   }
   const configuredEntries = [...entries.values()];
-  const materializedEntries = materializeRuntimeCapabilities(
-    configuredEntries,
-    params.agentFacts.runtimeCapabilityModels,
-  );
-  const staticEntries = materializeRuntimeCapabilities(
-    params.configuredRuntimeModels.map(({ model }) => toStaticCatalogEntry(model)),
-    params.agentFacts.runtimeCapabilityModels,
+  const staticEntries = params.configuredRuntimeModels.map(({ model }) =>
+    toStaticCatalogEntry(model),
   );
   return {
-    entries: materializedEntries,
-    routeVariants: materializedEntries,
+    entries: configuredEntries,
+    routeVariants: configuredEntries,
     ...(staticEntries.length > 0 ? { staticEntries } : {}),
   };
-}
-
-/**
- * Configured views omit runtime-only rows. Retain the concrete route's
- * capabilities on the logical row so downstream projections do not rediscover
- * or depend on an absent runtime sibling.
- */
-export function materializeRuntimeCapabilities(
-  entries: readonly ModelCatalogEntry[],
-  runtimeCapabilityModels: readonly PreparedRuntimeCapabilityModel[],
-): ModelCatalogEntry[] {
-  const runtimeByKey = new Map(
-    runtimeCapabilityModels.map(({ provider, modelId, model }) => [
-      modelCatalogEntryKey({ provider, id: modelId }),
-      toStaticCatalogEntry(model),
-    ]),
-  );
-  return entries.map((entry) => {
-    const runtime = runtimeByKey.get(modelCatalogEntryKey(entry));
-    if (!runtime) {
-      return entry;
-    }
-    const thinkingPolicyProvider = runtime.provider;
-    if (entry.configuredReasoning !== undefined) {
-      return { ...entry, thinkingPolicyProvider };
-    }
-    const params =
-      runtime.params || entry.params ? { ...runtime.params, ...entry.params } : undefined;
-    const compat =
-      runtime.compat || entry.compat ? { ...runtime.compat, ...entry.compat } : undefined;
-    return {
-      ...entry,
-      thinkingPolicyProvider,
-      ...(runtime.reasoning !== undefined ? { reasoning: runtime.reasoning } : {}),
-      ...(params ? { params } : {}),
-      ...(compat ? { compat } : {}),
-    };
-  });
 }
 
 export function prepareConfiguredRuntimeFacts(params: {

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -11,10 +11,7 @@ import type {
   PreparedModelRuntimeCatalogFacts,
   PreparedModelRuntimeCatalogSource,
 } from "./prepared-model-runtime.catalog-contract.js";
-import {
-  materializeRuntimeCapabilities,
-  modelCatalogEntryKey,
-} from "./prepared-model-runtime.configured-catalog.js";
+import { modelCatalogEntryKey } from "./prepared-model-runtime.configured-catalog.js";
 import {
   toStaticCatalogEntry,
   type PreparedRuntimeCapabilityModel,
@@ -90,14 +87,42 @@ export function materializePreparedModelCatalog(
   snapshot: ModelCatalogSnapshot,
   runtimeCapabilityModels: readonly PreparedRuntimeCapabilityModel[],
 ): ModelCatalogSnapshot {
+  // Preserve inventory reads before capability preparation when the snapshot has accessors.
+  const materialized = { ...snapshot };
+  const sourceEntries = snapshot.entries;
+  const runtimeByKey = new Map(
+    runtimeCapabilityModels.map(({ provider, modelId, model }) => [
+      modelCatalogEntryKey({ provider, id: modelId }),
+      toStaticCatalogEntry(model),
+    ]),
+  );
   const project = (entries: ModelCatalogSnapshot["entries"]) =>
-    materializeRuntimeCapabilities(entries, runtimeCapabilityModels);
-  const materialized = {
-    ...snapshot,
-    entries: project(snapshot.entries),
-    routeVariants: project(snapshot.routeVariants),
-    ...(snapshot.staticEntries ? { staticEntries: project(snapshot.staticEntries) } : {}),
-  };
+    entries.map((entry) => {
+      const runtime = runtimeByKey.get(modelCatalogEntryKey(entry));
+      if (!runtime) {
+        return entry;
+      }
+      const thinkingPolicyProvider = runtime.provider;
+      if (entry.configuredReasoning !== undefined) {
+        return { ...entry, thinkingPolicyProvider };
+      }
+      const params =
+        runtime.params || entry.params ? { ...runtime.params, ...entry.params } : undefined;
+      const compat =
+        runtime.compat || entry.compat ? { ...runtime.compat, ...entry.compat } : undefined;
+      return {
+        ...entry,
+        thinkingPolicyProvider,
+        ...(runtime.reasoning !== undefined ? { reasoning: runtime.reasoning } : {}),
+        ...(params ? { params } : {}),
+        ...(compat ? { compat } : {}),
+      };
+    });
+  materialized.entries = project(sourceEntries);
+  materialized.routeVariants = project(snapshot.routeVariants);
+  if (snapshot.staticEntries) {
+    materialized.staticEntries = project(snapshot.staticEntries);
+  }
   if (isPreparedModelCatalogFull(snapshot)) {
     markPreparedModelCatalogFull(materialized);
   }

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../agents/auth-profiles.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import type { PreparedModelRuntimeAuth } from "../../agents/prepared-model-runtime-auth.js";
-import { materializeRuntimeCapabilities } from "../../agents/prepared-model-runtime.configured-catalog.js";
+import { materializePreparedModelCatalog } from "../../agents/prepared-model-runtime.full-catalog.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
@@ -644,8 +644,11 @@ describe("models.list", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    const materializedCatalog = materializeRuntimeCapabilities(
-      [{ id: modelId, name: modelId, provider: "anthropic", reasoning: false }],
+    const materializedCatalog = materializePreparedModelCatalog(
+      {
+        entries: [{ id: modelId, name: modelId, provider: "anthropic", reasoning: false }],
+        routeVariants: [],
+      },
       [
         {
           provider: "anthropic",
@@ -658,7 +661,7 @@ describe("models.list", () => {
           } as never,
         },
       ],
-    );
+    ).entries;
     const { request, respond } = requestModelsList({
       view: "configured",
       runtimeConfig,
@@ -755,8 +758,11 @@ describe("models.list", () => {
         },
       },
     } as unknown as OpenClawConfig;
-    const materializedCatalog = materializeRuntimeCapabilities(
-      [{ id: modelId, name: "Claude Mythos 5", provider: "anthropic" }],
+    const materializedCatalog = materializePreparedModelCatalog(
+      {
+        entries: [{ id: modelId, name: "Claude Mythos 5", provider: "anthropic" }],
+        routeVariants: [],
+      },
       [
         {
           provider: "anthropic",
@@ -769,7 +775,7 @@ describe("models.list", () => {
           } as never,
         },
       ],
-    );
+    ).entries;
     const { request, respond } = requestModelsList({
       view: "configured",
       runtimeConfig,


### PR DESCRIPTION
## What Problem This Solves

Configured model inventories apply runtime capabilities before final snapshot construction applies them again. Finalization then rebuilds the same lookup for each catalog array, repeating model conversion during publication and reload.

## Why This Change Was Made

Keep configured inventory raw until the shared final materializer, matching full discovery and retained inventory. Prepare one capability lookup for entries, route variants, and static entries, and delete the old helper and its early callers. Each output row still receives its own mutable params and compatibility objects; snapshot read order, logical model keys, and full-catalog/auth provenance are preserved.

Production **40 additions / 60 deletions, net −20**; tests **+6**; total **−14**. The two direct Gateway test callers now use the final owner with their original assertions. No new cache, configuration, environment variable, provider API, protocol, persistence, or dependency change.

## User Impact

Model rows, thinking opt-outs, runtime override changes, and retained discovery behave the same with less repeated preparation. On the actual composed configured/final path with two capability models, lookup Maps fall **5 → 1**, converted rows **10 → 2**, context-window arrays **10 → 2**, and copied option objects **20 → 4**. Retained full inventory also uses one lookup instead of three. These are observed source operations, not measured RSS or allocation bytes.

## Evidence

- **93 existing tests pass before and after**: 36 prepared-runtime publication cases, seven scoped-refresh cases, and 50 Gateway-model cases. They cover adding/removing runtime overrides without rediscovery, retained paired auth, thinking levels, and explicit opt-outs. The canonical changed gate passed.
- The actual-source probe produces **10,074 identical semantic bytes**, SHA-256 `3b45fb7f9fc53df1208c3da9dbdaccfbe05497af64685a7b534806f43919afdc`. It checks row/parameter precedence, output/property order, snapshot access order, sparse and optional arrays, normalized duplicate last-wins behavior, full/auth markers, and removal of an override from raw inventory.
- Mutation checks confirm independent params and compatibility objects across output arrays. Explicit opt-outs and unmatched rows retain the same source references as before. Frozen source rows and capability facts remain unchanged.
- Existing publication/refresh harnesses execute production owners with mocked discovery and worker requests. The additional actual-owner benchmark below measures elapsed time and process RSS; it is not a listening Gateway or real-provider run.
- Managed isolated Codex review is scoped-clean at the default P0 floor. Parent review inspected the configured/final owners, fact preparation, publication/retained-inventory consumers, converter, scoped reload tests, changed Gateway cases, and full probe, then verified the raw paired semantic hashes. All owned proof processes joined and temporary runtime roots were removed.

## Elapsed-time and RSS follow-up

This resolves the benchmark finding and Rank-up move in [ClawSweeper review](https://github.com/openclaw/openclaw/pull/136080#issuecomment-5505843682).

Fresh elapsed-time/RSS evidence for this PR: exact base `e6f50858d04ac12dd13630ff5310b0fc36163425` versus head `41587c37cec1c834593b2f57ef9b139d12c71e15`, four fixed pairs in B→C, C→B, B→C, C→B order. All eight actual-owner Node processes exited0 with matching input/semantic/final-output hashes, no replacement runs, no forced cleanup and no observed survivors. Node26.8.1, flags, owned dependencies, warmup, GC requests and synthetic workload matched. The benchmark calls actual source owners; these numbers are not Vitest or wrapper RSS.

| Actual-source workload | Baseline seconds, median [min, max] | Candidate seconds, median [min, max] | Paired change, median [min, max] |
| --- | ---: | ---: | ---: |
| Configured + final projection + thinking capture, 2,048 calls | 0.353048 [0.352046, 0.354520] | 0.234261 [0.233676, 0.235094] | −33.611% [−33.851%, −33.528%] |
| Retained inventory + final projection + thinking capture, 2,048 calls | 1.204846 [1.174421, 1.210785] | 1.134770 [1.118225, 1.146000] | −6.267% [−6.752%, −2.420%] |
| Configured composition + real preloaded Gateway models-list builder, 128 calls | 31.647947 [31.434117, 32.061529] | 31.716949 [31.632685, 31.990985] | +0.269% [−0.957%, +1.281%] |

| Workload | Baseline sampled process RSS MiB, median | Candidate sampled process RSS MiB, median | Paired difference MiB, median [min, max] |
| --- | ---: | ---: | ---: |
| Configured | 1041.719 | 1007.492 | −24.211 [−82.000, +97.203] |
| Retained | 1042.219 | 1007.422 | −24.516 [−81.953, +96.656] |
| Gateway builder | 631.172 | 631.289 | +0.117 [−6.281, +1.656] |

Configured and retained timings improved in every pair. Gateway timings were mixed. **This run does not establish a process-RSS or retained-heap reduction.** The early RSS differences were already present before timed work; RSS includes source initialization, loader threads and allocator state, excludes the supervisor/separate children, and is sampled rather than an exact peak. The 16-output ring's retained-GC minus pre-lane heapUsed paired differences were slightly positive: +0.016861 MiB configured, +0.005241 MiB retained and +0.008995 MiB Gateway. External/arrayBuffers paired medians were unchanged. These GC observations are not dominator retained sizes. No explicit GC is requested within timed batches; automatic V8 GC is included.

Inputs are bounded synthetic prepared facts: 64 authored rows, 32 configured runtime models/overrides and eight registry refs; retained inventory contains 1,024 entries, 1,280 route variants and 128 static rows. The third lane uses the real builder/browse/visibility/public projection with existing preloaded-catalog/projector seams. Metadata/auth and availability/native-ready evaluations are fixtures. No listening Gateway, provider request, credential resolver, private retained-publication lifecycle or scoped full-facts preparation was executed. Canonical source initialization imported/cached provider artifacts, all in the owned temporary runtime removed after each leg. Four pairs are descriptive; batches are not independent replicates. All source blobs and dependency-link ownership were rechecked after the run.

Named follow-up: profile the surrounding preloaded models-list builder work, which is still about 247 ms/call in this synthetic case, with imported/cached provider artifacts present. Its cause is unproven, and this is not evidence of a real-operator regression. No extra profiling or favorable rerun was performed.

The full protocol, raw eight-leg results, source/cleanup receipts and offline analyzer are retained in `.artifacts/memory-round3-20260901/capability-projection-benchmark/`. Benchmark SHA256: `80daa745015da489c13323c764acc58d3821d63c7265cbdf3f4a641753ff0b8a`; analysis SHA256: `0d12bdaae9ffc9faa09d5b911b5e7b212efad0c75ba79f60af578e3c135a05bb`. Replay arithmetic without executing product code: `python3.14 .artifacts/memory-round3-20260901/capability-projection-benchmark/analyze.py --check`.
