### PR TITLE
fix(ui): copy chat errors without expanding details

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -625,7 +625,7 @@ They are generated separately from the agent's work, so a title is not a complet
 status or a report of tool access. Existing titles and manual names are left
 unchanged; click a title to rename it.
 
-Chat error banners, including cloud runner failures, show short messages in full. Use **Copy error** to copy the complete diagnostic received by the UI. **Error details** appears only when the complete diagnostic adds information beyond the preview, such as additional lines or text shortened for the preview; repeated lines and whitespace-only differences do not add details. Open it to read and select the complete diagnostic. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Expanding or copying an error does not retry the failed operation. Retry and other recovery actions remain separate from the disclosure.
+Chat error banners, including cloud runner failures, show short messages in full. Use **Copy error** beside **Details** in the header to copy the complete diagnostic received by the UI, even while collapsed. **Details** appears only when the complete diagnostic adds information beyond the preview, such as additional lines or text shortened for the preview; repeated lines and whitespace-only differences do not add details. Open it to read and select the complete diagnostic. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Copying does not open or close the details, and neither copying nor expanding an error retries the failed operation. Retry and other recovery actions remain separate from the disclosure.
 
 <AccordionGroup>
   <Accordion title="Send and history semantics">

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -496,7 +496,9 @@ suite.define(() => {
         await summary.focus();
         await page.keyboard.press("Enter");
         await alert.locator("pre").waitFor({ timeout: 10_000 });
-        expect(await alert.locator("pre").textContent()).toBe(errorText);
+        const diagnostic = alert.getByLabel("Error details", { exact: true });
+        expect(await diagnostic.count()).toBe(1);
+        expect(await diagnostic.textContent()).toBe(errorText);
         expect(await summary.getByText("Details", { exact: true }).count()).toBe(1);
         if (artifactDir) {
           await page.screenshot({ path: path.join(artifactDir, `terminal-details-${label}.png`) });

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -6,6 +6,7 @@ import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-ar
 import {
   chatThreadDistanceFromBottom,
   createChatFlowE2eSuite,
+  expectRequestCountStable,
   installMockGateway,
   requireRecord,
   requireString,
@@ -392,7 +393,10 @@ suite.define(() => {
         ? createControlUiE2eArtifactDir("chat-flow.streaming", artifactDirParent)
         : undefined;
       const context = await suite.newBrowserContext({
+        hasTouch: label === "mobile",
+        isMobile: label === "mobile",
         locale: "en-US",
+        permissions: ["clipboard-read", "clipboard-write"],
         serviceWorkers: "block",
         viewport,
         ...(artifactDir
@@ -448,8 +452,8 @@ suite.define(() => {
         });
 
         const gatewayErrorText =
-          "⚠️ Model login expired on the gateway for openai. Send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth with `openclaw models auth login --provider openai` in a terminal, then try again.";
-        const errorText = gatewayErrorText.replace(/^⚠️\s*/u, "");
+          "Agent failed before reply: Session became active in another runner; wait for it to finish before continuing.\nTo view logs, run `openclaw logs --follow` in a terminal.";
+        const errorText = `Error: ${gatewayErrorText}`;
         await gateway.emitGatewayEvent("chat", {
           errorMessage: gatewayErrorText,
           message: {
@@ -469,13 +473,51 @@ suite.define(() => {
         expect(
           await page.locator(".chat-thread-inner").getByText(partialText, { exact: true }).count(),
         ).toBe(1);
+        const alert = page.locator(".chat-error");
+        await alert.waitFor();
         if (artifactDir) {
           await page.screenshot({ path: path.join(artifactDir, `terminal-partial-${label}.png`) });
         }
-        const alert = page.locator(".chat-error");
-        await alert.getByText("Error details", { exact: true }).click();
-        await alert.getByText(errorText, { exact: true }).waitFor({ timeout: 10_000 });
-        await alert.getByText("Error details", { exact: true }).click();
+        const details = alert.locator("details");
+        const summary = alert.locator("summary");
+        const copy = alert.getByRole("button", { name: "Copy error", exact: true });
+        expect(await copy.count()).toBe(1);
+        expect(await copy.isVisible()).toBe(true);
+        expect(await details.getAttribute("open")).toBeNull();
+        if (label === "mobile") {
+          await copy.tap();
+        } else {
+          await copy.click();
+        }
+        await expect
+          .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+          .toBe(errorText);
+        expect(await details.getAttribute("open")).toBeNull();
+        await summary.focus();
+        await page.keyboard.press("Enter");
+        await alert.locator("pre").waitFor({ timeout: 10_000 });
+        expect(await alert.locator("pre").textContent()).toBe(errorText);
+        expect(await summary.getByText("Details", { exact: true }).count()).toBe(1);
+        if (artifactDir) {
+          await page.screenshot({ path: path.join(artifactDir, `terminal-details-${label}.png`) });
+        }
+        const headerCopy = summary.getByRole("button");
+        await page.evaluate(() => navigator.clipboard.writeText("Before expanded copy."));
+        await headerCopy.press("Enter");
+        await expect
+          .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+          .toBe(errorText);
+        expect(await details.getAttribute("open")).not.toBeNull();
+        expect(await alert.getByRole("button").count()).toBe(1);
+        await summary.press("Space");
+        await alert.locator("pre").waitFor({ state: "hidden" });
+        if (label === "mobile") {
+          await summary.getByText("Details", { exact: true }).tap();
+          await alert.locator("pre").waitFor();
+          await summary.getByText("Details", { exact: true }).tap();
+          await alert.locator("pre").waitFor({ state: "hidden" });
+        }
+        await expectRequestCountStable(gateway, "chat.send", 1);
         expect(await alert.getByRole("button", { name: "Dismiss error" }).count()).toBe(0);
         expect(await alert.getByRole("button", { name: "Retry", exact: true }).count()).toBe(0);
         expect(await page.locator(".chat-thread-inner").getByText(errorText).count()).toBe(0);
@@ -493,6 +535,13 @@ suite.define(() => {
           ),
         ).toBeLessThan(1);
         expect(alertBox?.width ?? 0).toBeLessThanOrEqual(composerBox?.width ?? 0);
+        const copyBox = await headerCopy.boundingBox();
+        expect(copyBox).not.toBeNull();
+        expect(copyBox!.x).toBeGreaterThan(alertBox!.x);
+        expect(copyBox!.x + copyBox!.width).toBeLessThanOrEqual(alertBox!.x + alertBox!.width);
+        expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+          viewport.width,
+        );
 
         await page.locator(".agent-chat__composer-combobox textarea").fill("retry after error");
         await page.getByRole("button", { name: "Send message" }).click();

--- a/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
+++ b/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
@@ -336,6 +336,7 @@ describeControlUiE2e("Control UI cloud workspace conflict recovery", () => {
         expect(await alert.textContent()).not.toContain("stale terminal worker failure");
         await capture(page, `05-${failedState}-collapsed-error.png`);
         const summary = alert.locator("summary");
+        const copy = alert.getByRole("button", { name: "Copy error", exact: true });
         const diagnostic = alert.locator("pre");
         const expected = `${failedState === "request" ? "" : "Runner failed: "}${workerFailureDiagnostic}`;
         expect(await summary.count()).toBe(1);
@@ -369,6 +370,8 @@ describeControlUiE2e("Control UI cloud workspace conflict recovery", () => {
           expect(bounds.scrollWidth).toBeLessThanOrEqual(bounds.clientWidth + 1);
           expect(bounds.scrollHeight).toBeGreaterThan(bounds.clientHeight);
           await page.keyboard.press("Tab");
+          expect(await copy.evaluate((node) => node === document.activeElement)).toBe(true);
+          await page.keyboard.press("Tab");
           expect(await diagnostic.evaluate((node) => node === document.activeElement)).toBe(true);
           await page.keyboard.press("PageDown");
           await expect.poll(() => diagnostic.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
@@ -382,7 +385,6 @@ describeControlUiE2e("Control UI cloud workspace conflict recovery", () => {
               return selection?.toString();
             }),
           ).toBe(expected);
-          const copy = alert.getByRole("button", { name: "Copy error", exact: true });
           await copy.focus();
           await page.keyboard.press("Enter");
           await expect

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5116,7 +5116,7 @@ export const en: TranslationMap & {
   },
   chat: {
     cloudWorkerFailed: "Runner failed: {error}",
-    errorDetails: "Error details",
+    errorDetails: "Details",
     copyError: "Copy error",
     diskSpace: {
       warningTitle: "Cloud session disk space is low",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5116,7 +5116,8 @@ export const en: TranslationMap & {
   },
   chat: {
     cloudWorkerFailed: "Runner failed: {error}",
-    errorDetails: "Details",
+    errorDetails: "Error details",
+    details: "Details",
     copyError: "Copy error",
     diskSpace: {
       warningTitle: "Cloud session disk space is low",

--- a/ui/src/pages/chat/chat-view-notices.ts
+++ b/ui/src/pages/chat/chat-view-notices.ts
@@ -92,7 +92,7 @@ function renderErrorNotice(
         ? html`<details class="chat-error__content">
             <summary class="chat-error__summary">
               <strong>${summary}</strong>
-              <span>${t("chat.errorDetails")}</span>
+              <span>${t("chat.details")}</span>
               <span class="chat-error__chevron" aria-hidden="true">${icons.chevronDown}</span>
               ${renderCopyButton(error, t("chat.copyError"))}
             </summary>

--- a/ui/src/pages/chat/chat-view-notices.ts
+++ b/ui/src/pages/chat/chat-view-notices.ts
@@ -94,10 +94,10 @@ function renderErrorNotice(
               <strong>${summary}</strong>
               <span>${t("chat.errorDetails")}</span>
               <span class="chat-error__chevron" aria-hidden="true">${icons.chevronDown}</span>
+              ${renderCopyButton(error, t("chat.copyError"))}
             </summary>
             <pre class="chat-error__diagnostic" tabindex="0" aria-label=${t("chat.errorDetails")}>
 ${displayError}</pre>
-            ${renderCopyButton(error, t("chat.copyError"))}
           </details>`
         : html`<span class="chat-error__content"
             ><strong>${summary}</strong>${renderCopyButton(error, t("chat.copyError"))}</span

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1151,9 +1151,9 @@ describe("chat run error", () => {
       expect(alert.getAttribute("role")).toBe("alert");
       const details = requireElement(alert, "details", "error disclosure");
       expect(details.hasAttribute("open")).toBe(false);
-      expect(requireElement(details, "pre", "full diagnostic").textContent).toBe(
-        renderedDiagnostic,
-      );
+      const fullDiagnostic = requireElement(details, "pre", "full diagnostic");
+      expect(fullDiagnostic.textContent).toBe(renderedDiagnostic);
+      expect(fullDiagnostic.getAttribute("aria-label")).toBe("Error details");
       expect(alert.textContent).not.toMatch(/[⚠🛠]/u);
       expect(alert.textContent).toContain("🧭");
       expect(alert.querySelector("img")).toBeNull();
@@ -1217,6 +1217,10 @@ describe("chat run error", () => {
     );
     expect(alert.textContent).not.toContain("⚠");
     const details = requireElement(alert, "details", "startup disclosure");
+    expect(requireElement(details, "summary", "startup header").textContent).toContain("Details");
+    expect(requireElement(details, "pre", "startup diagnostic").getAttribute("aria-label")).toBe(
+      "Error details",
+    );
     const copy = details.querySelector<HTMLButtonElement>('summary [aria-label="Copy error"]');
     expect(copy).not.toBeNull();
     copy?.click();

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -994,7 +994,8 @@ describe("chat run error", () => {
           message,
         );
         expect(alert.querySelector("details")).toBeNull();
-        expect(alert.textContent).not.toContain("Error details");
+        expect(alert.textContent).not.toContain("Details");
+        expect(alert.querySelectorAll(".chat-copy-btn")).toHaveLength(1);
         alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')?.click();
         await Promise.resolve();
         expect(writeText).toHaveBeenLastCalledWith(diagnostic);
@@ -1138,9 +1139,13 @@ describe("chat run error", () => {
         "⚠️ 🛠️ Error:  gateway disconnected near 🧭\n  indented\tdetail\n<img src=x onerror=alert(1)>\nFinal diagnostic line  ";
       const renderedDiagnostic =
         "  Error:  gateway disconnected near 🧭\n  indented\tdetail\n<img src=x onerror=alert(1)>\nFinal diagnostic line  ";
-      const container = renderChatView(
-        source === "run" ? { runError: { summary: diagnostic } } : { error: diagnostic },
-      );
+      const onDismissError = vi.fn();
+      const onRetrySessionPlacementStartup = vi.fn();
+      const container = renderChatView({
+        ...(source === "run" ? { runError: { summary: diagnostic } } : { error: diagnostic }),
+        onDismissError,
+        onRetrySessionPlacementStartup,
+      });
 
       const alert = requireElement(container, ".chat-error", "chat run error");
       expect(alert.getAttribute("role")).toBe("alert");
@@ -1152,14 +1157,31 @@ describe("chat run error", () => {
       expect(alert.textContent).not.toMatch(/[⚠🛠]/u);
       expect(alert.textContent).toContain("🧭");
       expect(alert.querySelector("img")).toBeNull();
-      alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')?.click();
-      await waitForFast(() => expect(writeText).toHaveBeenCalledWith(diagnostic));
+      const summary = requireElement(details, "summary", "error header");
+      expect(summary.textContent).toContain("Details");
+      expect(summary.textContent).not.toContain("Error details");
+      expect(alert.querySelectorAll(".chat-copy-btn")).toHaveLength(1);
+      const copy = summary.querySelector<HTMLButtonElement>('[aria-label="Copy error"]');
+      expect(copy).not.toBeNull();
+      for (const open of [false, true]) {
+        details.toggleAttribute("open", open);
+        copy?.click();
+        await waitForFast(() => expect(copy?.disabled).toBe(false));
+        await waitForFast(() => expect(writeText).toHaveBeenCalledTimes(open ? 2 : 1));
+        expect(writeText).toHaveBeenLastCalledWith(diagnostic);
+        expect(details.hasAttribute("open")).toBe(open);
+      }
+      (summary as HTMLElement).click();
+      expect(onDismissError).not.toHaveBeenCalled();
+      expect(onRetrySessionPlacementStartup).not.toHaveBeenCalled();
       expect(alert.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]') !== null).toBe(
         source === "request",
       );
       expect(
         alert.closest(source === "run" ? ".agent-chat__composer-overlay" : ".chat-topbar-notices"),
       ).not.toBeNull();
+      alert.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]')?.click();
+      expect(onDismissError).toHaveBeenCalledTimes(source === "request" ? 1 : 0);
     },
   );
 
@@ -1194,12 +1216,16 @@ describe("chat run error", () => {
       "The session was created, but runner startup failed:  Provisioning failed\n  Final diagnostic line  ",
     );
     expect(alert.textContent).not.toContain("⚠");
-    alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')?.click();
+    const details = requireElement(alert, "details", "startup disclosure");
+    const copy = details.querySelector<HTMLButtonElement>('summary [aria-label="Copy error"]');
+    expect(copy).not.toBeNull();
+    copy?.click();
     await waitForFast(() =>
       expect(writeText).toHaveBeenCalledWith(
         "The session was created, but runner startup failed: ⚠️ Provisioning failed\n  Final diagnostic line  ",
       ),
     );
+    expect(details.hasAttribute("open")).toBe(false);
     alert.querySelector<HTMLElement>("summary")?.click();
     expect(onRetrySessionPlacementStartup).not.toHaveBeenCalled();
     const retry = Array.from(alert.querySelectorAll("button")).find(

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -369,6 +369,7 @@ describe("chat transcript controller", () => {
     { behavior: "smooth", resizeBefore: false, deltaY: -100, observerLate: false },
     { behavior: "smooth", resizeBefore: true, deltaY: 100, observerLate: false },
     { behavior: "smooth", resizeBefore: true, deltaY: -100, observerLate: true },
+    { behavior: "smooth", resizeBefore: true, deltaY: -100_000, observerLate: "after-wheel" },
   ] as const)(
     "recovers $behavior measurements with resizeBeforeInterruption=$resizeBefore, wheel=$deltaY, and late offset=$observerLate",
     async ({ behavior, resizeBefore, deltaY, observerLate }) => {
@@ -422,12 +423,17 @@ describe("chat transcript controller", () => {
         if (resizeBefore) {
           resize();
         }
-        if (observerLate) {
+        if (observerLate === true) {
           // Native wheel movement can precede both input delivery and the
           // offset observer. Remeasurement must use this viewport, not 135.
           container.scrollTop = 0;
         }
         container.dispatchEvent(new WheelEvent("wheel", { deltaY }));
+        if (observerLate === "after-wheel") {
+          // The wheel's native default action can land before its offset observer,
+          // but after the input callback queued skipped row measurements.
+          container.scrollTop = 0;
+        }
         if (!observerLate) {
           container.scrollTop = 0;
           container.dispatchEvent(new Event("scroll"));
@@ -438,7 +444,7 @@ describe("chat transcript controller", () => {
         flushFrames();
         renderRows(rows);
         expect(transcriptSize(container)).toBe(initialSize + 80);
-        expect(container.scrollTop).toBe(0);
+        expect.soft(container.scrollTop).toBe(0);
         if (observerLate) {
           container.dispatchEvent(new Event("scroll"));
           flushFrames();

--- a/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
+++ b/ui/src/pages/chat/components/chat-transcript-virtualizer-host.ts
@@ -112,6 +112,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
   private readonly measureRowRefs = new Map<string, (element?: Element) => void>();
   private pruneDetachedRowsQueued = false;
   private pendingRowMeasureFrame: number | null = null;
+  private syncNativeOffset: (() => void) | null = null;
   private pendingInteractionAnchor: ChatTranscriptInteractionAnchor | null = null;
   private readonly captureInteractionResize = (event: Event) => {
     const anchor = resolveChatTranscriptInteractionAnchor(event);
@@ -122,6 +123,9 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
     queueMicrotask(() => this.pendingInteractionAnchor === anchor && this.host.requestUpdate());
   };
   private measureConnectedRows(): void {
+    // Native input can land after takeover but before its offset observer.
+    // Refresh the offset and direction before compensating deferred row growth.
+    this.syncNativeOffset?.();
     measureConnectedTranscriptRows(this.scrollElement, this.virtualizerController.getVirtualizer());
   }
   private readonly handleGeometryCommit = (event: Event) => {
@@ -245,6 +249,16 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
         }),
       observeElementOffset: (instance, callback) => {
         const element = this.scrollElement;
+        const syncOffset = () => {
+          if (!element || element !== this.scrollElement || instance.scrollElement !== element) {
+            return;
+          }
+          const offset = element.scrollTop;
+          if (offset !== instance.scrollOffset) {
+            callback(offset, instance.isScrolling);
+          }
+        };
+        this.syncNativeOffset = syncOffset;
         const interrupt = (event: Event) => {
           if (!element || element !== this.scrollElement || instance.scrollElement !== element) {
             return;
@@ -260,12 +274,7 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
           }
           this.pendingInteractionAnchor = null;
           this.cancelScroll();
-          // Native input can move the viewport before its scroll event. Publish
-          // that offset before queued remeasurement compensates against a stale fold.
-          const offset = element.scrollTop;
-          if (offset !== instance.scrollOffset) {
-            callback(offset, instance.isScrolling);
-          }
+          syncOffset();
           this.callbacks.onReaderScroll?.();
         };
         for (const type of ["wheel", "touchstart", "keydown", "pointerdown"]) {
@@ -292,6 +301,9 @@ export class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatT
           }
         });
         return () => {
+          if (this.syncNativeOffset === syncOffset) {
+            this.syncNativeOffset = null;
+          }
           cleanup?.();
           for (const type of ["wheel", "touchstart", "keydown", "pointerdown"]) {
             element?.removeEventListener(type, interrupt);


### PR DESCRIPTION
Closes #136070

## What Problem This Solves

Fixes an issue where Control UI users have to expand an error before they can copy its full diagnostic. The longer **Error details** label also consumes space in the compact header.

CI additionally exposed a transcript scroll-offset ordering defect. This PR reuses the already-verified, two-file UI repair from #136036 so landing this UI change does not depend on that PR's unrelated approval work.

## Why This Change Was Made

Move the existing Copy error control into the native disclosure header and show **Details** beside it. There is still one copy control, using the existing clipboard handling and feedback. The focusable diagnostic retains its separate, descriptive **Error details** accessible name. The shared renderer covers run, request, and startup errors; it does not change the underlying failure or retry behavior.

The scroll fix is the exact patch from [`d1913719e52c`](https://github.com/openclaw/openclaw/commit/d1913719e52c18061ba27110092dc61360a290bc), adopted with author, date, message, and cherry-pick trace preserved. It publishes the actual native offset through the existing observer callback before deferred connected-row measurement. This preserves direction, adjustment, and notification semantics instead of writing the virtualizer cache directly. The callback remains bound to its exact element and is cleared only by its own cleanup. No Full Access or authorization changes are included.

## User Impact

Copy a complete error directly from its collapsed header. Expanding Details still reveals selectable diagnostic text. Copy does not toggle the disclosure or retry the failed operation; retry and dismiss remain separate actions.

Deferred transcript remeasurement also uses the current browser scroll position, avoiding incorrect compensation against a stale forward offset after wheel interruption.

## Evidence

- Regression-first error proof: collapsed Copy and the separate accessible-name assertions failed before their respective fixes and pass afterward. Desktop/mobile browser checks exercise actual clipboard bytes, native Enter/Space and touch behavior, one copy action, and independent recovery controls.
- Regression-first scroll proof: with the new test and old production code, **39 controller cases passed and one failed**, with both assertions observing **215 instead of 0**. The scenario holds cached offset 135, lets the wheel's native action reach 0, then measures 80 px of row growth before the delayed offset observer. The exact adopted repair fixes that owner ordering.
- Integrated candidate: **385 unit tests passed**, plus **all eight original transcript disclosure/interruption browser cases and two desktop/mobile Copy cases**. No E2E assertion, wheel retry, forced scrolling, timeout, browser requirement, or environment relaxation was introduced.
- Complete changed-file gate passed: formatting, keyless i18n, core-test/UI typechecks, guards, dead-export scans, lint, and UI style checks. Fresh isolated complete-candidate Codex autoreview is P0 scoped-clean, with no findings; the owner, caller, geometry callee, lifecycle siblings, and actual installed TanStack source/dist contracts were also inspected directly.
- Browser proof uses the real isolated Chromium Control UI with synthetic mocked Gateway data, not a live provider. Exact numerical provenance of the earlier 112 px CI trace, and a separate second-Latest 581 px failure, are not claimed fixed by the deterministic 215 px regression.

```bash
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-transcript-controller.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/lib/clipboard.test.ts ui/src/app/route-transition.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts ui/src/e2e/chat-flow.streaming.e2e.test.ts -t 'Control UI transcript disclosure anchoring|keeps streamed text visible when a chat error'
```

### Before and after

Captured from the running Control UI using synthetic session/error data. All attached screenshots were visually inspected. The later accessibility correction preserves this visible layout.

**Desktop, expanded**

| Before | After |
| --- | --- |
| ![Before: Error details with Copy below the diagnostic](https://github.com/user-attachments/assets/1907d5e4-ea9d-4529-957d-cf697102ff59) | ![After: Details and Copy together in the header, showing copy confirmation](https://github.com/user-attachments/assets/d33c7e4d-969b-425f-96bd-82ce356575c4) |

**Mobile, collapsed**

| Before | After |
| --- | --- |
| ![Before: collapsed error has no accessible Copy action](https://github.com/user-attachments/assets/752f2069-657a-403b-826b-7e918a98ed35) | ![After: collapsed error exposes Copy beside Details](https://github.com/user-attachments/assets/72c2f929-d690-4c11-9335-07c26481a445) |

The exact reused scroll repair has separate [inspected before/after proof](https://github.com/openclaw/openclaw/pull/136036#issuecomment-5506790018). Its two complete synthetic screenshots were also inspected during this adoption; fresh candidate disclosure/interruption captures were retained locally and inspected.

### Review and CI follow-through

ClawSweeper's P2 accessible-name finding and matching rank-up move are addressed: compact **Details** and descriptive **Error details** now use separate localized keys with independent assertions. Its canonical-scroll-repair and current-main comparison requests are addressed by the exact patch adoption and native main-baseline review. Native review artifacts validate with zero findings.

The initial CI caught an old keyboard-tab-order assumption; the sibling test now verifies **summary → Copy → diagnostic** without weakening focus, scroll, or clipboard assertions. Subsequent SDK fixture, Inbox readiness, and new-session animation failures were investigated; their canonical repairs are now on the rebased main ([SDK fixture repair](https://github.com/openclaw/openclaw/pull/135831), [new-session transition repair](https://github.com/openclaw/openclaw/pull/136069), and the landed Inbox readiness change). Duplicate test repairs were removed from this PR rather than maintained twice.

GitHub's [zero-job startup failure](https://github.com/openclaw/openclaw/actions/runs/33612182848) was retriggered on the unchanged head. The integrated [CI run 33626320082](https://github.com/openclaw/openclaw/actions/runs/33626320082) initially failed before private-key scanning because Git could not fetch the public pre-commit hook repository; no key finding was reported. Only the failed setup/check jobs were retried without source changes. **[Attempt 2 is green](https://github.com/openclaw/openclaw/actions/runs/33626320082/attempts/2)** on exact head `0369b8d5e6977879528514387e84b0632f9b3865`; the completed run and current MERGEABLE head were independently verified before native preparation.

### Scope and size

Eight files. Production **+21/-8 (net +13)**: one locale line separates visual/accessibility wording, and the exact scroll repair adds **+18/-6** for its single lifecycle-bound canonical callback. Tests/support **+108/-19**; documentation **+1/-1**. No new configuration, dependency, protocol, storage, or authorization surface.
