### PR TITLE
fix(ci): recover native locale refresh from malformed translations

### DIFF
--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -756,7 +756,10 @@ type TranslationBatchContext = LocaleRunContext & {
   locale: string;
   splitDepth?: number;
   segmentLabel?: string;
+  validateTranslation?: TranslationValidator;
 };
+
+type TranslationValidator = (source: string, target: string, key: string, locale: string) => void;
 
 type ClientAccess = {
   getClient: () => Promise<TranslationClient>;
@@ -927,6 +930,7 @@ export function parseTranslationBatchReply(
   raw: string,
   items: readonly TranslationBatchItem[],
   locale: string,
+  validateTranslation?: TranslationValidator,
 ): Map<string, string> {
   const parsed = parseTranslationReply(raw);
   const translated = new Map<string, string>();
@@ -935,6 +939,7 @@ export function parseTranslationBatchReply(
     if (typeof value !== "string" || !value.trim()) {
       throw new Error(`missing translation for ${item.key}`);
     }
+    validateTranslation?.(item.text, value, item.key, locale);
     translated.set(item.key, value);
   }
   assertPlaceholderParity(new Map(items.map((item) => [item.key, item.text])), translated, locale);
@@ -961,7 +966,12 @@ async function translateBatch(
         await clientAccess.getClient()
       ).prompt(buildBatchPrompt(items, validationError), attemptLabel);
       promptCompleted = true;
-      const translated = parseTranslationBatchReply(raw, items, context.locale);
+      const translated = parseTranslationBatchReply(
+        raw,
+        items,
+        context.locale,
+        context.validateTranslation,
+      );
       logProgress(`${attemptLabel}: done (${formatDuration(Date.now() - startedAt)})`);
       return translated;
     } catch (error) {
@@ -1013,6 +1023,7 @@ export async function translateNativeEntries(
   entries: readonly NativeTranslationEntry[],
   targetLocale: string,
   glossary: readonly GlossaryEntry[] = [],
+  validateTranslation?: TranslationValidator,
 ): Promise<Map<string, string>> {
   if (!hasTranslationProvider()) {
     throw new Error("native app translation requires OPENAI_API_KEY or ANTHROPIC_API_KEY");
@@ -1034,6 +1045,7 @@ export async function translateNativeEntries(
         localeIndex: 1,
         batchCount: batches.length,
         batchIndex: batchIndex + 1,
+        validateTranslation,
       });
       for (const [id, value] of result) {
         translated.set(id, value);

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -719,6 +719,21 @@ function structuralTokenSignature(source: string): string {
   return JSON.stringify({ swift, kotlin, nativeFormat, buildSettings, lineBreaks });
 }
 
+function formatNativeTranslationStructureError(locale: string, id: string): string {
+  return `native translation changed placeholders or line breaks for ${locale}:${id}`;
+}
+
+function validateNativeTranslationStructure(
+  source: string,
+  translated: string,
+  id: string,
+  locale: string,
+): void {
+  if (structuralTokenSignature(source) !== structuralTokenSignature(translated)) {
+    throw new Error(formatNativeTranslationStructureError(locale, id));
+  }
+}
+
 function addCandidate(
   entries: Candidate[],
   surface: NativeI18nSurface,
@@ -1493,7 +1508,7 @@ export function validateNativeLocaleArtifact(
     } else if (!translated.trim()) {
       errors.push(`translation must be nonempty for ${entry.id}`);
     } else if (structuralTokenSignature(entry.source) !== structuralTokenSignature(translated)) {
-      errors.push(`translation changed structural tokens or line breaks for ${entry.id}`);
+      errors.push(formatNativeTranslationStructureError(locale, entry.id));
     }
   }
   if (errors.length > 0) {
@@ -1604,7 +1619,12 @@ export async function syncNativeLocale(
     }));
   const translated =
     pending.length && !migratingV1
-      ? await (options.translate ?? translateNativeEntries)(pending, locale, glossary)
+      ? await (options.translate ?? translateNativeEntries)(
+          pending,
+          locale,
+          glossary,
+          validateNativeTranslationStructure,
+        )
       : new Map<string, string>();
   const translations = Object.fromEntries(
     entries
@@ -1623,21 +1643,7 @@ export async function syncNativeLocale(
     glossaryHash: currentGlossaryHash,
     translations,
   };
-  try {
-    validateNativeLocaleArtifact(locale, entries, artifact, glossary);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const structural = message.match(
-      /translation changed structural tokens or line breaks for ([^\s]+)/u,
-    );
-    if (structural?.[1]) {
-      throw new Error(
-        `native translation changed placeholders or line breaks for ${locale}:${structural[1]}`,
-        { cause: error },
-      );
-    }
-    throw error;
-  }
+  validateNativeLocaleArtifact(locale, entries, artifact, glossary);
   const rendered = `${JSON.stringify(artifact, null, 2)}\n`;
   const changed = previousRaw !== rendered;
   if (changed) {

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -350,6 +350,30 @@ describe("control-ui-i18n process runner", () => {
     ).toEqual(new Map([["configView.viewPendingChange", "Pending change ({count})"]]));
   });
 
+  it("runs an optional result validator before accepting a batch reply", () => {
+    const items = [
+      {
+        cacheKey: "cache-key",
+        key: "native.apple.progress",
+        text: "Processed %lld of %@",
+        textHash: "text-hash",
+      },
+    ];
+
+    expect(() =>
+      parseTranslationBatchReply(
+        JSON.stringify({ "native.apple.progress": "Bearbetade %@" }),
+        items,
+        "sv",
+        (source, translated, key, locale) => {
+          if (source.includes("%lld") && !translated.includes("%lld")) {
+            throw new Error(`invalid structural tokens for ${locale}:${key}`);
+          }
+        },
+      ),
+    ).toThrow("invalid structural tokens for sv:native.apple.progress");
+  });
+
   it("makes placeholder-incompatible existing copy pending for bot repair", () => {
     const reusable = filterPlaceholderCompatibleTranslations(
       new Map([

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -779,6 +779,33 @@ describe("native app i18n inventory", () => {
       cleanupTempDirs(tempDirs);
     }
   });
+  it("rejects invalid native placeholders inside the translation batch", async () => {
+    const tempDirs: string[] = [];
+    const translationsDir = makeTempDir(tempDirs, "openclaw-native-i18n-");
+    const entry = testEntry("native.apple.progress", "apple", "Processed %lld of %@");
+    let translatorReturned = false;
+
+    try {
+      await expect(
+        syncNativeLocale("sv", [entry], {
+          glossary: [],
+          translationsDir,
+          translate: async (_pending, locale, _glossary, validateTranslation) => {
+            const translated = "Bearbetade %@";
+            validateTranslation?.(entry.source, translated, entry.id, locale);
+            translatorReturned = true;
+            return new Map([[entry.id, translated]]);
+          },
+        }),
+      ).rejects.toThrow(
+        `native translation changed placeholders or line breaks for sv:${entry.id}`,
+      );
+      expect(translatorReturned).toBe(false);
+    } finally {
+      cleanupTempDirs(tempDirs);
+    }
+  });
+
   it("rejects native printf placeholder drift", async () => {
     const tempDirs: string[] = [];
     const translationsDir = makeTempDir(tempDirs, "openclaw-native-i18n-");
@@ -882,14 +909,14 @@ describe("native app i18n inventory", () => {
         }),
       },
       {
-        expected: "translation changed structural tokens or line breaks",
+        expected: `native translation changed placeholders or line breaks for sv:${greeting.id}`,
         mutate: (artifact) => ({
           ...artifact,
           translations: { ...artifact.translations, [greeting.id]: "Hej\nNästa" },
         }),
       },
       {
-        expected: "translation changed structural tokens or line breaks",
+        expected: `native translation changed placeholders or line breaks for sv:${greeting.id}`,
         mutate: (artifact) => ({
           ...artifact,
           translations: { ...artifact.translations, [greeting.id]: "Hej ${name} Nästa" },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where native locale refresh could exhaust every translation provider attempt and fail when a provider returned parseable text that changed native placeholders such as `%lld` or `%@`.

Failed workflow evidence:
- https://github.com/openclaw/openclaw/actions/runs/33595364598
- https://github.com/openclaw/openclaw/actions/runs/33595364598/job/100141940982

## Why This Change Was Made

Native placeholder and line-break validation now runs inside the existing translation batch retry loop. The shared batch parser accepts an optional validator, while native i18n continues to own native structural-token semantics and final stored-artifact validation.

This does not change provider routing, retry counts, timeout behavior, workflow configuration, or credentials.

## User Impact

Maintainers can refresh native locale artifacts without a single malformed provider response aborting the whole locale after all fallback providers have run. Invalid stored or carried translations remain rejected by final artifact validation.

## Evidence

Pre-fix regressions, run with test changes only:
- control batch parser accepted a translation that dropped `%lld`
- native sync returned from the translator before detecting placeholder drift

Post-fix:
- `test/scripts/control-ui-i18n.test.ts`: 21 passed
- `test/scripts/native-app-i18n.test.ts`: 15 passed
- `pnpm native:i18n:verify`: 4,473 entries, unchanged
- `pnpm ui:i18n:verify`: 6,147 source keys verified
- `pnpm check:import-cycles`: 0 runtime value cycles
- changed-file verification: passed
- `git diff --check`: passed
- Autoreview: scoped clean, no accepted/actionable findings

LOC:
- production/tooling: +36/-18
- tests: +53/-2

The production growth adds the native validation callback needed to move failure detection into the existing retry owner; the final artifact validator remains the independent stored-data backstop.

## Maintainer Review Decisions

- Current-main comparison: clean through `9e6912ca0d2e0200bdcbcfc32bde2d27db262464`; no newer commit touches the four changed files, and the candidate merge has no conflict.
- Production LOC: the net +18 tooling lines are accepted because the generic callback is the minimal seam between native structural-token ownership and the existing shared retry owner. A native-specific retry loop would duplicate provider orchestration.
- Stored data: no artifact schema, persisted field, or migration behavior changes. This only moves validation timing earlier while retaining final artifact validation.
- Decision: approve the retry-boundary fix for native locale refresh.
