### PR TITLE
docs: record which settings contain apply_patch to the workspace

### DIFF
--- a/docs/gateway/permission-modes.md
+++ b/docs/gateway/permission-modes.md
@@ -28,7 +28,11 @@ Managed worktree sessions use the worktree checkout as `sessionRoot`. A nested w
 
 File tools recognize aliases of the session's trusted root and working directory, including absolute paths using those aliases. This does not expand the boundary: unrelated external symlinks pointing inward remain denied, as do symlinks and raw `symlink/..` traversal that escape the root. In `read-only` mode, OpenClaw-managed mutation tools remain omitted.
 
-New sessions, including managed worktree sessions, inherit the configured global or per-agent tool/exec policy when no mode is specified. Creating a worktree pins the working directory without selecting a permission mode. Explicit modes and modes already saved on existing sessions remain unchanged.
+New sessions, including managed worktree sessions, inherit the configured global or per-agent tool/exec policy when no mode is specified. That configured policy is not one setting. `tools.exec.mode` governs `exec` only; file tools are governed separately by `tools.fs.workspaceOnly`, and `apply_patch` is contained by that setting or by `tools.exec.applyPatch.workspaceOnly`. Because `tools.exec.applyPatch.workspaceOnly` defaults to `true`, `apply_patch` stays workspace-contained on a session with no mode even when `tools.exec.mode` is `full`.
+
+Creating a worktree pins the working directory without selecting a permission mode. Explicit modes and modes already saved on existing sessions remain unchanged.
+
+Worker placements do not read those file settings at all: with no permission mode they contain `apply_patch` whenever the tool is available, so only an explicit `full` mode lifts the boundary there.
 
 The Control UI permission picker labels Default with the agent's resolved exec posture when it matches a session mode, for example **Default (Guarded)** for `tools.exec.mode: "ask"` without a stricter host approval policy. Resolution includes global settings, agent overrides, and host approval floors. Without those settings or sandboxing, the default is full access. Allowlist-only policy and non-equivalent `security`/`ask` pairs, including `ask: "always"`, keep the plain **Default** label. Agents whose sandbox configuration could apply to their sessions also keep plain **Default**, because effective policy cannot be stated at agent scope. This is display metadata, not an authorization decision or a filesystem-access guarantee; tool policy still applies. Selecting Default clears the session override; it does not save the displayed mode into the session.
 

--- a/docs/tools/apply-patch.md
+++ b/docs/tools/apply-patch.md
@@ -43,7 +43,7 @@ The tool accepts a single `input` string that wraps one or more file operations:
   to disable it, or restrict it to specific models with
   `tools.exec.applyPatch.allowModels` (accepts raw ids like `gpt-5.4` or full
   ids like `openai/gpt-5.4`).
-- Config lives under `tools.exec.applyPatch.*`.
+- The tool's own enablement and model settings live under `tools.exec.applyPatch.*`. Containment is not exclusive to that section: `tools.fs.workspaceOnly` and the session permission mode also apply, as described above.
 
 ## Example
 

--- a/docs/tools/apply-patch.md
+++ b/docs/tools/apply-patch.md
@@ -32,6 +32,10 @@ The tool accepts a single `input` string that wraps one or more file operations:
 
 - Patch paths support relative paths (from the workspace directory) and absolute paths.
 - `tools.exec.applyPatch.workspaceOnly` defaults to `true` (workspace-contained). Set it to `false` only if you intentionally want `apply_patch` to write/delete outside the workspace directory.
+- This setting is independent of `tools.exec.mode`. Setting `tools.exec.mode: "full"` opens `exec` and does not lift the `apply_patch` workspace boundary.
+- `tools.fs.workspaceOnly` contains `apply_patch` independently, so clearing one setting can leave the other in force.
+- A session permission mode overrides both settings: `full` lifts the boundary, `guarded` and `workspace` contain `apply_patch` regardless of them, and `read-only` omits the tool.
+- Worker placements ignore both settings. With no permission mode a worker contains `apply_patch` whenever the tool is available, and only an explicit `full` mode lifts the boundary there.
 - `*** Add File:` and a non-self `*** Move to:` require the destination path to be absent. To intentionally replace a path, delete it earlier in the same patch before adding or moving the replacement.
 - Use `*** Move to:` within an `*** Update File:` hunk to rename files.
 - `*** End of File` marks an EOF-only insert when needed.


### PR DESCRIPTION
Related: #131434

## What Problem This Solves

Operators who want `apply_patch` to write outside the workspace set `tools.exec.mode: "full"` and find that it still cannot. The documentation never said which setting actually owns that boundary, so `tools.exec.mode` looks like the one knob that governs it.

## Why This Change Was Made

Explain the independent file settings and explicit session-mode precedence in the apply_patch reference. Required roots and sandbox restrictions still apply in full mode. Memory-flush runs omit apply_patch. Distinguish whole-agent workers from workers used only for remote commands, and link the detailed rules from the session guide.

## User Impact

Operators can identify the applicable boundary without being sent to a setting that cannot lift it. Runtime behavior and defaults stay unchanged.

## Evidence

Docs-to-source audit against the local tool-policy owner, session-mode resolver, worker tool construction, and final memory-flush tool filtering. The audit covers configured full, explicit full with and without required roots, and worker defaults.

`pnpm check:docs`, changed-page spelling, and `git diff --check` passed on the corrected content. The docs suite ran on a fresh merge with main. Full-tree spelling reproduces the same two errors on main in `docs/ci/runners.md` and `docs/cli/fleet.md`.

Production types, all test type groups, and protocol checks passed. No runtime behavior changes or runtime test results are claimed.

## Consumers

Operator docs only. No runtime symbols, state writers, dependencies, config keys, or schemas change. Existing routes and headings remain stable; the session guide links the existing patch Notes anchor.
