### PR TITLE
fix: show requester titles on projected approval cards

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -370,6 +370,11 @@ Sidebar visibility belongs to the current tab and is not remembered across tabs,
 Pending approvals also contribute an attention chip above the sidebar footer;
 select it to open the owning Approvals page.
 
+When an approval appears inline in a different session, **Approval requested by session**
+uses the requesting session's loaded title, not the open conversation's title. If that
+metadata is unavailable, the normal session-name fallback remains until it loads.
+This label does not change which request the approval buttons resolve.
+
 ## What it can do (today)
 
 <AccordionGroup>

--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -3,6 +3,7 @@ import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { formatApprovalDisplayPath } from "../../../src/infra/approval-display-paths.ts";
 import type { ApprovalScope } from "../../../src/infra/approval-scope.ts";
+import type { GatewaySessionRow } from "../api/types.ts";
 import type {
   ExecApprovalDecision,
   ExecApprovalRequest,
@@ -23,6 +24,7 @@ const DEFAULT_EXEC_APPROVAL_DECISIONS = [
 
 type ExecApprovalCardProps = {
   approval: ExecApprovalRequest;
+  sourceSession?: GatewaySessionRow;
   busy: boolean;
   canGrant: boolean;
   error: string | null;
@@ -384,7 +386,7 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
     ${props.variant === "inline" && active.sourceSessionKey
       ? html`<div class="exec-approval-warning" role="note">
           ${t("execApproval.requestedBySession", {
-            session: resolveSessionDisplayName(active.sourceSessionKey),
+            session: resolveSessionDisplayName(active.sourceSessionKey, props.sourceSession),
           })}
         </div>`
       : nothing}

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -1,6 +1,5 @@
 /* @vitest-environment jsdom */
 
-import { html } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -22,42 +21,20 @@ import {
   nativeHistorySeq,
   stagedPagesRequest,
 } from "./chat-pane-history.test-support.ts";
-import { ChatPane } from "./chat-pane-render.ts";
 import {
   createInitializationContext,
+  createRenderTestChatPane,
   createSessionCapabilityFixture,
 } from "./chat-pane.test-support.ts";
 import { applyChatPendingInputs } from "./chat-pending-inputs.ts";
-import { createPageState } from "./chat-state-page.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
-import type { ChatProps } from "./chat-view.ts";
 import { reduceChatSessionProjection } from "./history-merge.ts";
 import { applySessionMessagePayload } from "./session-message-apply.ts";
 import { cacheChatSessionSnapshot, readChatSessionSnapshot } from "./session-message-cache.ts";
 
 describe("chat pane native history pagination", () => {
-  class RefreshChatPane extends ChatPane {
-    chatProps: ChatProps | undefined;
-
-    initialize(context: ApplicationContext) {
-      this.context = context;
-      this.state = createPageState(
-        context,
-        { afterCommit: () => () => {}, invalidate: () => {} },
-        this,
-      );
-      return this.state;
-    }
-
-    protected override renderChatPaneLayout(params: { chatProps: ChatProps }) {
-      this.chatProps = params.chatProps;
-      return html``;
-    }
-  }
-  customElements.define("openclaw-chat-refresh-regression", RefreshChatPane);
-
   it("passes only a proven profile viewer identity to transcript rendering", () => {
-    const pane = document.createElement("openclaw-chat-refresh-regression") as RefreshChatPane;
+    const pane = createRenderTestChatPane();
     const context: ApplicationContext = {
       ...createInitializationContext(),
       sessions: createSessionCapabilityFixture({
@@ -78,7 +55,7 @@ describe("chat pane native history pagination", () => {
   });
 
   it("preserves the steer split through the refresh callback and later cumulative deltas", async () => {
-    const pane = document.createElement("openclaw-chat-refresh-regression") as RefreshChatPane;
+    const pane = createRenderTestChatPane();
     const history = createDeferred<ChatHistoryResult>();
     const request = vi.fn(() => history.promise);
     const client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/pages/chat/chat-pane-identity.test.ts
+++ b/ui/src/pages/chat/chat-pane-identity.test.ts
@@ -1,16 +1,25 @@
 /* @vitest-environment jsdom */
 
+import { html, render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { t } from "../../i18n/index.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
+  createInitializationContext,
+  createRenderTestChatPane,
   createSessionCapabilityFixture,
   createSessionContext,
   createTestChatPane,
   type TestChatPane,
 } from "./chat-pane.test-support.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { cancelChatStreamRenderFrame } from "./chat-state-render.ts";
+import { renderChat } from "./chat-view.ts";
+import { projectSessionApprovalReplay } from "./session-approval-projection.ts";
 
 describe("chat pane assistant identity snapshots", () => {
   it("keeps an explicitly owned global Home pane on its agent across work selection", () => {
@@ -213,5 +222,140 @@ describe("chat pane assistant identity snapshots", () => {
     });
 
     expect(state.assistantName).toBe(pane.context.config.current.assistantIdentity.name);
+  });
+});
+
+describe("chat pane approval requester identity", () => {
+  it("renders projected approval requester titles from reactive session metadata without changing decision routing", async () => {
+    const pane = createRenderTestChatPane();
+    const host = {
+      key: "agent:main:dashboard:approval-host",
+      kind: "direct",
+      updatedAt: 1,
+      label: "Presentation session label",
+      displayName: "Presentation session display name",
+      derivedTitle: "Presentation session derived title",
+    } satisfies GatewaySessionRow;
+    const source = {
+      key: "agent:main:dashboard:11111111-2222-4333-8444-555555555555",
+      kind: "direct",
+      updatedAt: 1,
+    } satisfies GatewaySessionRow;
+    const decideApproval = vi.fn();
+    const context: ApplicationContext = {
+      ...createInitializationContext(),
+      overlays: {
+        snapshot: {
+          approvalQueue: [],
+          approvalBusy: false,
+          approvalCanGrant: true,
+          approvalErrors: new Map(),
+        },
+        decideApproval,
+      } as unknown as ApplicationContext["overlays"],
+      sessions: createSessionCapabilityFixture({
+        state: {
+          result: null,
+          agentId: "main",
+          modelOverrides: {},
+          deletedSessions: [],
+          loading: false,
+          error: null,
+          groups: [],
+          groupSettings: [],
+          sectionOrder: [],
+        },
+        think: () => undefined,
+        reconcile: vi.fn(),
+      }),
+    };
+    const state = pane.initialize(context);
+    state.sessionKey = host.key;
+    pane.paneTitle = "Unrelated pane title";
+    const now = Date.now();
+    state.chatSessionApprovalQueue = projectSessionApprovalReplay(
+      {
+        sessionKey: host.key,
+        updatedAtMs: now,
+        truncated: false,
+        approvals: [
+          {
+            id: "plugin:requester-title",
+            status: "pending",
+            sourceSessionKey: source.key,
+            createdAtMs: now,
+            expiresAtMs: now + 60_000,
+            urlPath: "/approve/plugin%3Arequester-title",
+            presentation: {
+              kind: "plugin",
+              title: "Review requested action",
+              description: "A synthetic child-session request",
+              severity: "warning",
+              pluginId: "test-plugin",
+              toolName: null,
+              agentId: "main",
+              allowedDecisions: ["allow-once", "deny"],
+            },
+          },
+        ],
+      },
+      host.key,
+    );
+    const approval = state.chatSessionApprovalQueue[0]!;
+    expect(approval).toMatchObject({
+      id: "plugin:requester-title",
+      kind: "plugin",
+      sourceSessionKey: source.key,
+      request: { sessionKey: host.key },
+    });
+    Object.freeze(approval.request);
+    Object.freeze(approval);
+    const container = document.createElement("div");
+    const redraw = vi.fn(() => {
+      pane.render();
+      render(renderChat(pane.chatProps!), container);
+    });
+    state.requestUpdate = redraw;
+    const publications: Array<[GatewaySessionRow | undefined, string]> = [
+      [undefined, "New session"],
+      [
+        { ...source, derivedTitle: "Requesting session derived title" },
+        "Requesting session derived title",
+      ],
+      [
+        { ...source, displayName: "Requesting session display name" },
+        "Requesting session display name",
+      ],
+      [{ ...source, label: "Requesting session label" }, "Requesting session label"],
+      [{ ...source, label: "Renamed requesting session" }, "Renamed requesting session"],
+      [undefined, "New session"],
+    ];
+
+    try {
+      for (const [row, title] of publications) {
+        redraw.mockClear();
+        pane.applySessionsState({
+          ...context.sessions.state,
+          result: {
+            ts: now,
+            path: "",
+            count: row ? 2 : 1,
+            defaults: { modelProvider: null, model: null, contextTokens: null },
+            sessions: row ? [host, row] : [host],
+          },
+        });
+        await vi.waitFor(() => expect(redraw).toHaveBeenCalled());
+        const card = container.querySelector(".chat-inline-approval .exec-approval-card");
+        expect(card?.getAttribute("data-approval-id")).toBe(approval.id);
+        expect
+          .soft(card?.querySelector('[role="note"]')?.textContent?.trim())
+          .toBe(t("execApproval.requestedBySession", { session: title }));
+      }
+      container.querySelector<HTMLButtonElement>(".exec-approval-actions .primary")!.click();
+      expect(decideApproval).toHaveBeenCalledExactlyOnceWith("allow-once", approval.id, approval);
+    } finally {
+      cancelChatStreamRenderFrame(state);
+      render(html``, container);
+    }
   });
 });

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -1,4 +1,4 @@
-import type { TemplateResult } from "lit";
+import { html, type TemplateResult } from "lit";
 import { vi } from "vitest";
 import type {
   SessionSuggestion,
@@ -32,8 +32,11 @@ import {
   SESSION_MUTATION_TEST_METHODS,
   sessionMutationGatewayHello,
 } from "../../test-helpers/gateway-methods.ts";
+import { ChatPane } from "./chat-pane-render.ts";
 import { attachChatRealtimeActions, createInitialChatRealtimeState } from "./chat-realtime.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { createPageState } from "./chat-state-page.ts";
+import type { ChatProps } from "./chat-view.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
 import type { HeaderMenuAction } from "./components/chat-header-session-menu.ts";
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
@@ -437,4 +440,34 @@ export function offlineDeviceSession(): GatewaySessionRow & { placement: ActiveP
       runner: { kind: "device", status: "offline" },
     },
   };
+}
+
+class RenderTestChatPane extends ChatPane {
+  chatProps: ChatProps | undefined;
+
+  initialize(context: ApplicationContext) {
+    this.context = context;
+    this.state = createPageState(
+      context,
+      { afterCommit: () => () => {}, invalidate: () => {} },
+      this,
+    );
+    return this.state;
+  }
+
+  protected override renderChatPaneLayout(params: { chatProps: ChatProps }) {
+    this.chatProps = params.chatProps;
+    return html``;
+  }
+
+  override applySessionsState(state: ApplicationContext["sessions"]["state"]) {
+    super.applySessionsState(state);
+  }
+}
+
+export function createRenderTestChatPane() {
+  if (!customElements.get("openclaw-chat-render-regression")) {
+    customElements.define("openclaw-chat-render-regression", RenderTestChatPane);
+  }
+  return document.createElement("openclaw-chat-render-regression") as RenderTestChatPane;
 }

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -21,6 +21,7 @@ import {
   KEYBOARD_SHORTCUT_COMBOS,
   matchesShortcutCombo,
 } from "../../lib/keyboard-shortcut-catalog.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { getChatHistoryLoadState } from "./chat-history-state.ts";
 import { retryChatHistoryLoad } from "./chat-history.ts";
 import { getChatPendingInputs, loadChatPendingInputs } from "./chat-pending-inputs.ts";
@@ -128,6 +129,13 @@ export type ChatProps = Omit<
   };
 
 export function renderChat(props: ChatProps) {
+  // The request session hosts the card; only sourceSessionKey names the requester.
+  const approvalSourceSessionKey = props.inlineApproval?.sourceSessionKey;
+  const approvalSourceSession = approvalSourceSessionKey
+    ? props.sessions?.sessions.find((row) =>
+        areUiSessionKeysEquivalent(row.key, approvalSourceSessionKey),
+      )
+    : undefined;
   const pendingInputs = props.historyState ? getChatPendingInputs(props.historyState) : undefined;
   const requestUpdate = props.onRequestUpdate ?? (() => {});
   const canCompose = props.canSend;
@@ -344,6 +352,7 @@ export function renderChat(props: ChatProps) {
                     ? html`<div class="chat-inline-approval">
                         ${renderExecApprovalCard({
                           approval: props.inlineApproval,
+                          sourceSession: approvalSourceSession,
                           busy: props.approvalBusy === true,
                           canGrant: props.approvalCanGrant,
                           error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,


### PR DESCRIPTION
Closes #136083 — projected approval cards show “New session” for named requesting sessions.

<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** is enabled through a branch in this repository.

</details>

## What Problem This Solves

Fixes an issue where operators reviewing an approval in a different session would see “Approval requested by session New session” even though the requesting dashboard session already had a name. In the reproduced case, the sidebar correctly showed “Release checklist” while the card showed “New session.”

## Why This Change Was Made

The chat renderer already receives current canonical session rows. It now passes the row matching `sourceSessionKey` separately to the approval card, which supplies it to the existing session display resolver. The resolver still owns title precedence and the fallback when metadata is genuinely unavailable.

The approval projection, presentation routing, request object, permission checks, available decisions, and decision RPCs are unchanged. Inferring a name from the session key or the currently open pane would name the wrong thing; copying a title into approval state would become stale on rename. No new fetch, cache, dependency, configuration, protocol, or storage was added.

## User Impact

Projected inline approvals identify the requesting session by its loaded title and follow metadata updates and renames. A genuinely unknown source keeps the existing fallback until its metadata arrives. This is a label-only repair, not a change to approval policy or authority.

The [Control UI documentation](https://docs.openclaw.ai/web/control-ui) is updated in source to explain the distinction.

## Evidence

### Before and after

The attached screenshots show the same synthetic Control UI scenario before and after the repair. The open presentation session is “Project review”; the requesting session is “Release checklist.” Before, the card incorrectly says “New session.” After, it correctly says “Release checklist.” Both complete captures were visually inspected for the asserted state and incidental sensitive data before upload.

This used the real Vite Control UI with the repository's mocked Gateway installed before boot, an isolated Chromium context, and external requests blocked. No real Gateway, operator state, credentials, or provider inference were used. In both runs, clicking **Allow once** emitted exactly `plugin.approval.resolve` with the original synthetic approval ID and `decision: allow-once`; both had zero browser page errors.

### Regression and checks

The new pane-boundary regression failed before the production edit: four named-source states incorrectly rendered “New session,” while the unknown fallback and original decision routing still passed. The final regression exercises missing metadata → derived title → display name → label → rename → missing metadata through the existing reactive publication path, with the approval and request frozen.

Focused proof: **177 tests passed**.

```bash
node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-history.test.ts ui/src/pages/chat/chat-pane-identity.test.ts ui/src/pages/chat/session-approval-projection.test.ts ui/src/components/exec-approval-card.test.ts
```

```bash
node scripts/run-vitest.mjs ui/src/app/approval-presentation.test.ts ui/src/app/exec-approval.test.ts ui/src/components/exec-approval.test.ts ui/src/lib/session-display.test.ts ui/src/lib/sessions/session-key.test.ts
```

```bash
node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts -t 'inline approval card'
```

The filtered chat-view run intentionally skipped 328 unrelated cases. The complete changed gate passed for the six changed files, including formatting, core test/UI types, i18n, dead exports, lint/styles, and applicable guards. `git diff --check` passed. Independent blocking review found no accepted/actionable findings.

```bash
node scripts/check-changed.mjs -- docs/web/control-ui.md ui/src/components/exec-approval-card.ts ui/src/pages/chat/chat-pane-history.test.ts ui/src/pages/chat/chat-pane-identity.test.ts ui/src/pages/chat/chat-pane.test-support.ts ui/src/pages/chat/chat-view.ts
```

Two test-only gate failures were corrected before the final green run: readonly fixture initialization and the history test file's line limit. The regression now lives in the existing pane-identity suite, and the original render fixture is shared rather than duplicated. No suppression or baseline was added.

### Scope and size

Production: **+12/-1 (net +11)**. Tests/support: **+181/-27 (net +154)**. Documentation: **+5/-0**. The production growth is the missing canonical metadata handoff, its type, and the ownership comment; the old key-only call is replaced rather than retained as another path.

Separate follow-up: the Inbox approval title selector currently prefers `displayName` before `label` and omits `derivedTitle`. That source-level inconsistency needs its own behavioral proof and is not mixed into this projected-requester-label repair.

![Before - named requester incorrectly shown as New session](https://github.com/user-attachments/assets/8dcac0bf-6ea7-4078-abbc-a1676119b211)

![After - canonical requester title shown](https://github.com/user-attachments/assets/9bda7faf-eeb0-414e-ab21-17bd03113b30)

### Maintainer review follow-through

The current ClawSweeper review found no actionable patch findings. Both advisory items are addressed: the requester-title card, chat renderer, pane caller/publication owner, approval projection, display resolver, and key comparator were directly compared through repaired base `5e552100ac4176c0b6ba3142723f300491021444`, with no owner-file drift. The net +11 production lines are the missing canonical metadata handoff, type, and ownership comment; they replace the key-only call without storing stale titles or adding a fetch, cache, fallback, or decision path.

The branch was rebased onto that repaired main. Its delta remains exactly the original six title-fix files; no SDK or config-reload patch is duplicated here. All 177 focused UI tests passed again, and `pnpm ui:build` passed with 796 finalized sidecars and all performance budgets.

### CI history and repaired base

[Initial CI run 33602075737, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33602075737) failed at old head `a545d7b2adda8e51d672f74a72971afff27079d3` in two unchanged owners:

- [SDK declaration restoration](https://github.com/openclaw/openclaw/actions/runs/33602075737/job/100157958155): an independent reproduction confirmed the exact 355/356 mismatch. The fixture omitted a historical root chunk from an earlier QA build, not a current cache output. A local bounded fixture repair passed all 24 SDK/publication tests after one focused run hit the unchanged 120-second deadline. That alternative is retained only as local ignored evidence. The canonical repair landed in [PR #135831](https://github.com/openclaw/openclaw/pull/135831), commit [5e6117d17d92](https://github.com/openclaw/openclaw/commit/5e6117d17d92dcac2ef6da6d609eb423b089a77a), and is included in this branch's base. It seeds only non-owned historical root chunks excluded from the current cache manifest, preserving full filename/hash equality and requiring actual cache restoration of current outputs. The duplicate SDK-only PR was closed; no additional SDK commit is needed here.
- [Included-config reload](https://github.com/openclaw/openclaw/actions/runs/33602075737/job/100157958128): the two include-file cases passed locally (2 passed, 221 intentionally skipped), then the full file passed in its original order (223 passed). The nested-include case took 1331 ms and 1796 ms respectively. Timeouts and watcher settings were unchanged. Direct owner and Chokidar source inspection did not establish a production defect, so no speculative config repair was added. The older watcher PR is not claimed as this failure's fix.

```bash
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts -t 'startGatewayConfigReloader include files'
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts
```

No timeout, assertion, baseline, or CI gate was weakened. The original broad local diagnostic was stopped before completion and is not passing/failing reproduction evidence; the subsequent complete results above supersede that diagnostic. Repaired-head CI must be green before native preparation and merge.


### Repaired-head validation

At `e00adabb23fd32fd15aaeb9b50f3afe1c89a03fc`, all 177 focused UI tests, `pnpm ui:build`, the complete six-file changed gate, and a fresh isolated Codex review against actual base `5e552100ac4176c0b6ba3142723f300491021444` passed. The review was scoped-clean with no accepted/actionable finding. No source changed during the CI investigation.

[Run 33606408577, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33606408577/attempts/1) passed the prior SDK/config lanes but failed one of 123 cases in UI E2E shard 5/14: the normal-motion wheel disclosure scenario stopped 398 pixels from the bottom during its leave-and-return step. The recovered-row height/adjacency assertions had already passed. The failed log and retained screenshot/diagnostics were inspected once; no page error was reported. Direct inspection covered the transcript virtualizer, scroll policy, TanStack reconciliation, and Playwright clock implementation. No production defect was established.

All eight cases in the unchanged disclosure file then passed locally, including all four interruption variants, with the same assertions and deadlines:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
```

Blacksmith Testbox diagnostic warmup failed at workflow dispatch with HTTP 500 before returning a lease; it is not test proof. A single failed-jobs retry of the existing exact-head CI run was requested to exercise the original Linux shard/order. No source, timeout, assertion, baseline, or gate was changed for that retry.

[CI run 33606408577, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33606408577/attempts/2) completed successfully for exact head `e00adabb23fd32fd15aaeb9b50f3afe1c89a03fc`. The retried Linux UI shard passed (job 100174935996); all relevant checks and the required `openclaw/ci-gate` are green.
