### PR TITLE
fix(cli): use Gateway ages and clean up heartbeat status

### DIFF
--- a/docs/cli/health.md
+++ b/docs/cli/health.md
@@ -33,6 +33,7 @@ openclaw health --debug
 - Without `--verbose`, the Gateway can return a cached snapshot (fresh for up to 60 seconds and unchanged from live channel runtime state) and refresh it in the background for the next caller.
 - `--verbose` forces a live probe (per-channel account probes), prints Gateway connection details, and expands human-readable output across all configured accounts and agents instead of just the default agent.
 - `--json` always returns the full snapshot: channels, per-account probes, plugin load state, context-engine quarantine state, model-pricing cache state, event-loop health, delivery-queue warnings, and per-agent session stores.
+- Session ages in text and JSON use the Gateway's clock.
 - Top-level `ok: true` means the health RPC succeeded and the Gateway produced a snapshot. Queue warnings do not change it to `false`.
 - When outbound or session deliveries, or inbound channel events, are dead-lettered, text output reports their counts and oldest failure age. Inbound counts are grouped by channel account; inspect or recover individual events with [`openclaw channels dead-letters`](/cli/channels#inbound-dead-letters).
 - Optional `deliveryQueues.ingressPressure` summarizes durable inbound lanes that may be blocking later events. It is grouped by channel account and never exposes event, lane, payload, error, owner, token, session, or target identifiers. See [Gateway health](/gateway/health#queue-warnings) for the exact qualification and counting semantics.

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -494,55 +494,77 @@ describe("healthCommand", () => {
     expect(output).not.toContain("Config hot reload");
   });
 
-  it("prints the rich text summary and verbose gateway details", async () => {
-    const recent = [
-      { key: "main", updatedAt: Date.now() - 60_000, age: 60_000 },
-      { key: "foo", updatedAt: null, age: null },
-    ];
-    const snapshot = createHealthSummary({
-      channels: {
-        whatsapp: { accountId: "default", linked: true, authAgeMs: 5 * 60_000 },
-        telegram: {
-          accountId: "default",
-          configured: true,
-          probe: {
-            ok: true,
-            elapsedMs: 7,
-            bot: { username: "bot" },
-            webhook: { url: "https://example.com/h" },
+  it.each(
+    [0, -600_000, 600_000].flatMap((clockSkewMs) =>
+      ["agent", "top-level"].map((surface) => ({ clockSkewMs, surface })),
+    ),
+  )(
+    "prints $surface gateway ages with $clockSkewMs ms client clock skew",
+    async ({ clockSkewMs, surface }) => {
+      const gatewayNow = Date.now();
+      const recent = [
+        { key: "main", updatedAt: gatewayNow - 60_000, age: 60_000 },
+        { key: "fresh", updatedAt: gatewayNow, age: 0 },
+        { key: "foo", updatedAt: null, age: null },
+      ];
+      const snapshot = createHealthSummary({
+        channels: {
+          whatsapp: { accountId: "default", linked: true, authAgeMs: 5 * 60_000 },
+          telegram: {
+            accountId: "default",
+            configured: true,
+            probe: {
+              ok: true,
+              elapsedMs: 7,
+              bot: { username: "bot" },
+              webhook: { url: "https://example.com/h" },
+            },
           },
+          discord: { accountId: "default", configured: false },
         },
-        discord: { accountId: "default", configured: false },
-      },
-      channelOrder: ["whatsapp", "telegram", "discord"],
-      channelLabels: {
-        whatsapp: "WhatsApp",
-        telegram: "Telegram",
-        discord: "Discord",
-      },
-      sessions: {
-        path: "/tmp/sessions.json",
-        count: 2,
-        recent,
-      },
-    });
-    callGatewayMock.mockResolvedValueOnce(snapshot);
+        channelOrder: ["whatsapp", "telegram", "discord"],
+        channelLabels: {
+          whatsapp: "WhatsApp",
+          telegram: "Telegram",
+          discord: "Discord",
+        },
+        sessions: {
+          path: "/tmp/sessions.json",
+          count: recent.length,
+          recent,
+        },
+      });
+      if (surface === "top-level") {
+        snapshot.agents = [];
+      }
+      callGatewayMock.mockResolvedValueOnce(snapshot);
+      const clock = vi.spyOn(Date, "now").mockReturnValue(gatewayNow + clockSkewMs);
+      try {
+        await healthCommand(
+          {
+            json: false,
+            verbose: true,
+            timeoutMs: 1000,
+            config: { agents: { ownership: "explicit", entries: {} } },
+          },
+          runtime as never,
+        );
+      } finally {
+        clock.mockRestore();
+      }
 
-    await healthCommand(
-      { json: false, verbose: true, timeoutMs: 1000, config: {} },
-      runtime as never,
-    );
-
-    expect(runtime.exit).not.toHaveBeenCalled();
-    const output = stripAnsi(runtime.log.mock.calls.map((c) => String(c[0])).join("\n"));
-    expect(output).toMatch(/WhatsApp: linked/i);
-    expect(runtime.log.mock.calls.slice(0, 3)).toEqual([
-      ["Gateway connection:"],
-      ["  Gateway mode: local"],
-      [`  Gateway target: ${TEST_GATEWAY_URL}`],
-    ]);
-    expect(buildGatewayConnectionDetailsMock).toHaveBeenCalled();
-  });
+      expect(runtime.exit).not.toHaveBeenCalled();
+      const output = stripAnsi(runtime.log.mock.calls.map((c) => String(c[0])).join("\n"));
+      expect(output).toContain("- main (1m ago)\n- fresh (0m ago)\n- foo (no activity)");
+      expect(output).toMatch(/WhatsApp: linked/i);
+      expect(runtime.log.mock.calls.slice(0, 3)).toEqual([
+        ["Gateway connection:"],
+        ["  Gateway mode: local"],
+        [`  Gateway target: ${TEST_GATEWAY_URL}`],
+      ]);
+      expect(buildGatewayConnectionDetailsMock).toHaveBeenCalled();
+    },
+  );
 
   it("passes explicit gateway credentials through to the gateway call", async () => {
     const snapshot = createHealthSummary();

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -452,31 +452,18 @@ export async function healthCommand(
     if (heartbeatParts.length > 0) {
       runtime.log(info(`Heartbeat interval: ${heartbeatParts.join(", ")}`));
     }
-    if (displayAgents.length === 0) {
-      runtime.log(
-        info(`Session store: ${summary.sessions.path} (${summary.sessions.count} entries)`),
-      );
-      if (summary.sessions.recent.length > 0) {
-        for (const r of summary.sessions.recent) {
-          runtime.log(
-            `- ${r.key} (${r.updatedAt ? `${Math.round((Date.now() - r.updatedAt) / 60000)}m ago` : "no activity"})`,
-          );
-        }
-      }
-    } else {
-      for (const agent of displayAgents) {
+    const sessionGroups =
+      displayAgents.length > 0
+        ? displayAgents
+        : [{ agentId: undefined, sessions: summary.sessions }];
+    for (const { agentId, sessions } of sessionGroups) {
+      const label = agentId ? `Session store (${agentId})` : "Session store";
+      runtime.log(info(`${label}: ${sessions.path} (${sessions.count} entries)`));
+      for (const { key, age } of sessions.recent) {
+        // A remote Gateway owns these ages; the CLI clock may differ.
         runtime.log(
-          info(
-            `Session store (${agent.agentId}): ${agent.sessions.path} (${agent.sessions.count} entries)`,
-          ),
+          `- ${key} (${age === null ? "no activity" : `${Math.round(age / 60000)}m ago`})`,
         );
-        if (agent.sessions.recent.length > 0) {
-          for (const r of agent.sessions.recent) {
-            runtime.log(
-              `- ${r.key} (${r.updatedAt ? `${Math.round((Date.now() - r.updatedAt) / 60000)}m ago` : "no activity"})`,
-            );
-          }
-        }
       }
     }
   }

--- a/src/commands/status.command-report-data.test.ts
+++ b/src/commands/status.command-report-data.test.ts
@@ -10,7 +10,48 @@ describe("buildStatusCommandReportData", () => {
     vi.stubEnv("OPENCLAW_PROFILE", undefined);
     vi.stubEnv("OPENCLAW_CONTAINER_HINT", undefined);
   });
-  afterEach(() => vi.unstubAllEnvs());
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      ageMs: 300_000,
+      channel: "quietchat",
+      accountId: "acct",
+      expected: "ok-token · 5m ago · quietchat · account acct",
+    },
+    {
+      ageMs: 15_000,
+      channel: "quietchat",
+      accountId: "acct",
+      expected: "ok-token · just now · quietchat · account acct",
+    },
+    { ageMs: 300_000, expected: "ok-token · 5m ago" },
+  ])(
+    "formats the last heartbeat age once for $ageMs ms",
+    async ({ ageMs, channel, accountId, expected }) => {
+      const now = Date.parse("2026-09-01T12:00:00.000Z");
+      vi.spyOn(Date, "now").mockReturnValue(now);
+      const result = await buildStatusCommandReportData(
+        createStatusCommandReportDataParams({
+          lastHeartbeat: {
+            ts: now - ageMs,
+            status: "ok-token",
+            channel,
+            accountId,
+          },
+        }),
+      );
+
+      const row = expectDefined(
+        result.overviewRows.find(({ Item }) => Item === "Last heartbeat"),
+        "last heartbeat row",
+      );
+      expect(stripAnsi(row.Value)).toBe(expected);
+    },
+  );
 
   it("builds report inputs from shared status surfaces", async () => {
     const baseParams = createStatusCommandReportDataParams();

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -142,11 +142,10 @@ export function buildStatusLastHeartbeatValue(params: {
     return params.muted("none");
   }
   const age = params.formatTimeAgo(Date.now() - params.lastHeartbeat.ts);
-  const channel = params.lastHeartbeat.channel ?? "unknown";
   const accountLabel = params.lastHeartbeat.accountId
     ? `account ${params.lastHeartbeat.accountId}`
     : null;
-  return [params.lastHeartbeat.status, `${age} ago`, channel, accountLabel]
+  return [params.lastHeartbeat.status, age, params.lastHeartbeat.channel, accountLabel]
     .filter(Boolean)
     .join(" · ");
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

A remote `openclaw health` command can print `-9m ago` or `11m ago` for a session the Gateway reports as one minute old. Both text renderers discarded the recorded age and recalculated it using the CLI clock. Deep status also prints `5m ago ago` or `just now ago`, and invents an `unknown` channel for valid silent heartbeats without delivery metadata.

## Why This Change Was Made

One health-rendering loop consumes the Gateway-owned age for top-level and per-agent snapshots, removing duplicate rendering. The last-heartbeat row uses the complete shared relative-time label and includes only supplied channel/account metadata. Status already uses recorded session ages; health now follows the same ownership boundary.

## User Impact

Clock differences between the CLI and Gateway no longer distort session ages. Existing headings, minute rounding, zero-age and no-activity output, ordering, agent selection, JSON and RPC behavior remain. Deep status shows the heartbeat age once and keeps missing optional delivery fields absent.

This completes the original heartbeat report #46932 and the intent of closed, unmerged #46933. Thanks to @jeffrey4341 for the original report and patch. That stale fork does not allow maintainer edits, so this repair targets the current shared renderer and preserves its contributor credit.

## Evidence

Four clock-skew regressions fail before the health repair while two matching-clock controls pass. Both duplicate-suffix examples fail through complete status report assembly with the real formatter. A further no-channel report case fails before removing the fallback. All124 tests across six owner/sibling suites pass after the final change. A separate actual health-command entry-point matrix passes all six synthetic snapshot/clock cases, preserving zero/null controls.

The display proof invokes the real command/report owners with synthetic RPC/plugin-list boundaries and controlled time; no live Gateway or credential is needed to make the clock skew deterministic. Both defects are present in stablev2026.8.2. No configuration, schema, persistence or authorization change.

Production **+11/-25, net -14 LOC**; tests **+110/-47, net +63**; docs **+1**. Fresh independent Codex review through P2 is scoped-clean with zero findings. The complete changed-file gate passed, including core/test types, formatting, lint, architecture/storage guards, dead exports and import cycles.

CI exposed an unrelated SDK declaration fixture failure. Main now contains the canonical historical-chunk seeding repair in commit5e6117d17d92; this branch incorporates it through a mechanical refresh. Its own diff remains the five health/status files above. All five source hashes match the verified repair, and a post-refresh health/status run passed50 tests. The temporary local fixture repair also passed the failing cache test with byte equality intact and was superseded by main.

Fixes #136089.
Fixes #46932.
Refs #46933.
