### PR TITLE
refactor(agents): use canonical subagent session rows

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2000,7 +2000,6 @@ src/agents/subagents/registry/subagent-registry.ts	2
 src/agents/subagents/registry/subagent-session-cleanup.ts	2
 src/agents/subagents/spawn/acp-spawn-admission.ts	1
 src/agents/subagents/spawn/acp-spawn-parent-stream.ts	11
-src/agents/subagents/spawn/subagent-depth.ts	1
 src/agents/subagents/spawn/subagent-spawn-cleanup.ts	1
 src/agents/subagents/spawn/subagent-spawn-gateway.ts	3
 src/agents/subagents/spawn/subagent-spawn-session-patch.ts	1

--- a/scripts/lib/type-assertion-guard-scope.mjs
+++ b/scripts/lib/type-assertion-guard-scope.mjs
@@ -120,7 +120,6 @@ export const CHAINED_ASSERTION_EXCLUDED_ROOTS = [
   "src/agents/model-auth-model.ts", // Null Authorization sentinel crosses the SDK's string-only header type.
   "src/agents/model-provider-auth.ts", // Route-fact cache keys cross a config-only hash API.
   "src/agents/modes/interactive/theme/theme.ts", // Global symbol registry and Proxy receiver bridge duplicate module copies.
-  "src/agents/subagents/spawn/subagent-depth.ts", // Generic session projections cross the fixed accessor entry type.
   "src/agents/tool-search-transcript.ts", // Synthetic target turns omit provider-owned assistant metadata.
   "src/channels/plugins/config-schema.ts", // Public SDK Zod generics preserve caller schema identity.
   "src/commands/channel-test-registry.ts", // Test support.

--- a/src/agents/subagents/spawn/subagent-capabilities.ts
+++ b/src/agents/subagents/spawn/subagent-capabilities.ts
@@ -13,6 +13,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../../../config/agent-limits.js";
 import { resolveSessionStorePathCore } from "../../../config/sessions.js";
+import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   isAcpSessionKey,
@@ -40,33 +41,24 @@ const SUBAGENT_SESSION_ROLES: readonly SubagentSessionRole[] = [
 type SubagentControlScope = "children" | "none";
 const SUBAGENT_CONTROL_SCOPES: readonly SubagentControlScope[] = ["children", "none"] as const;
 
+type PersistedSessionCapabilityEntry = Pick<
+  SessionEntry,
+  | "sessionId"
+  | "spawnDepth"
+  | "subagentRole"
+  | "subagentControlScope"
+  | "spawnedBy"
+  | "completionOwnerSessionKey"
+  | "inheritedToolPolicyVersion"
+  | "inheritedToolAllow"
+  | "inheritedToolDeny"
+>;
 type SessionCapabilityEntry = {
-  sessionId?: unknown;
-  spawnDepth?: unknown;
-  subagentRole?: unknown;
-  subagentControlScope?: unknown;
-  spawnedBy?: unknown;
-  completionOwnerSessionKey?: unknown;
-  inheritedToolPolicyVersion?: unknown;
-  inheritedToolAllow?: unknown;
-  inheritedToolDeny?: unknown;
+  [Key in keyof PersistedSessionCapabilityEntry]?: unknown;
 };
 
 /** Minimal persisted session-store shape needed to resolve subagent capabilities. */
-export type SessionCapabilityStore = Record<
-  string,
-  {
-    sessionId?: unknown;
-    spawnDepth?: unknown;
-    subagentRole?: unknown;
-    subagentControlScope?: unknown;
-    spawnedBy?: unknown;
-    completionOwnerSessionKey?: unknown;
-    inheritedToolPolicyVersion?: unknown;
-    inheritedToolAllow?: unknown;
-    inheritedToolDeny?: unknown;
-  }
->;
+export type SessionCapabilityStore = Record<string, SessionCapabilityEntry>;
 
 type PersistedSubagentToolPolicyEnvelope = {
   sessionKey: string;
@@ -137,7 +129,7 @@ function resolveSessionCapabilityEntry(params: {
   const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
     agentId: parsed.agentId,
   });
-  const store = readSubagentSessionStore<SessionCapabilityEntry>(storePath, parsed.agentId);
+  const store = readSubagentSessionStore(storePath, parsed.agentId);
   return store[params.sessionKey] ?? findSubagentSessionEntryById(store, params.sessionKey);
 }
 
@@ -173,7 +165,7 @@ export function resolveSubagentCapabilityStore(
   const storePath = resolveSessionStorePathCore(opts.cfg.session?.store, {
     agentId: parsed.agentId,
   });
-  return readSubagentSessionStore<SessionCapabilityEntry>(storePath, parsed.agentId);
+  return readSubagentSessionStore(storePath, parsed.agentId);
 }
 
 /** Resolve depth-derived role/scope booleans for a subagent position. */

--- a/src/agents/subagents/spawn/subagent-depth.ts
+++ b/src/agents/subagents/spawn/subagent-depth.ts
@@ -7,16 +7,14 @@ import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/numb
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
 import { listSessionEntriesReadOnly } from "../../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizeAgentId } from "../../../routing/session-key.js";
 import { getSubagentDepth, parseAgentSessionKey } from "../../../sessions/session-key-utils.js";
 import { resolveSessionAgentId } from "../../agent-scope.js";
 
-type SessionDepthEntry = {
-  sessionId?: unknown;
-  spawnDepth?: unknown;
-  spawnedBy?: unknown;
-};
+type PersistedSessionDepthEntry = Pick<SessionEntry, "sessionId" | "spawnDepth" | "spawnedBy">;
+type SessionDepthEntry = { [Key in keyof PersistedSessionDepthEntry]?: unknown };
 
 function normalizeSpawnDepth(value: unknown): number | undefined {
   if (typeof value === "number") {
@@ -28,14 +26,14 @@ function normalizeSpawnDepth(value: unknown): number | undefined {
   return undefined;
 }
 
-export function readSubagentSessionStore<T extends SessionDepthEntry = SessionDepthEntry>(
+export function readSubagentSessionStore(
   storePath: string,
   agentId: string,
-): Record<string, T> {
+): Record<string, SessionEntry> {
   try {
     return Object.fromEntries(
       listSessionEntriesReadOnly({ agentId, storePath, clone: false }).map(
-        ({ sessionKey, entry }) => [sessionKey, entry as unknown as T],
+        ({ sessionKey, entry }) => [sessionKey, entry],
       ),
     );
   } catch {
@@ -88,7 +86,7 @@ function resolveEntryForSessionKey(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
   store?: Record<string, SessionDepthEntry>;
-  cache: Map<string, Record<string, SessionDepthEntry>>;
+  cache: Map<string, Record<string, SessionEntry>>;
   agentId?: string;
 }): SessionDepthEntry | undefined {
   const candidates = buildKeyCandidates(params.sessionKey, params.cfg, params.agentId);
@@ -151,7 +149,7 @@ export function getSubagentDepthFromSessionStore(
     return fallbackDepth;
   }
 
-  const cache = new Map<string, Record<string, SessionDepthEntry>>();
+  const cache = new Map<string, Record<string, SessionEntry>>();
   const visited = new Set<string>();
 
   const depthFromStore = (key: string): number | undefined => {


### PR DESCRIPTION
## What Problem This Solves

Subagent depth and capability lookup re-declared partial session-row shapes and cast canonical session accessor results through `unknown`. That weakened the storage contract and let the duplicated projections drift from the canonical `SessionEntry` definition.

## Why This Change Was Made

Persisted subagent session reads now return the canonical `SessionEntry` rows already supplied by `listSessionEntriesReadOnly()`. The narrower depth and capability projections derive their keys from `SessionEntry`, while explicitly injected legacy/test stores retain unknown-valued fields so existing normalization remains exercised and behavior stays unchanged.

The obsolete assertion baseline and chained-assertion exemption are removed with the cast.

## User Impact

No user-visible behavior change. This hardens the type boundary used by subagent depth, tool-policy, persistence, and restart recovery flows and reduces duplicated session schema surface.

## Evidence

- 49 focused tests passed across subagent depth, capabilities, registry persistence, and orphan recovery.
- 11/11 declaration relocation tests passed, including the fresh shared-chunk case exposed by the canonical `SessionEntry` dependency.
- `pnpm check:changed` passed after rebasing onto current `origin/main`, including core and core-test typechecks, lint, dead-export scans, and zero runtime import cycles.
- `pnpm build` passed, including plugin SDK declaration verification and Control UI build.
- Mandatory uncommitted autoreview returned `scoped-clean` with no accepted/actionable findings (0.99 confidence).
- Diff: 25 additions, 37 deletions overall; production TypeScript is net -10 lines and the complete PR is net -12 lines.
