### PR TITLE
perf: avoid materializing text and media for presence checks

### DIFF
--- a/src/agents/tools/message-tool-visible-content.ts
+++ b/src/agents/tools/message-tool-visible-content.ts
@@ -296,45 +296,43 @@ function readFirstStringParam(params: Record<string, unknown>, keys: readonly st
   return "";
 }
 
-function readStructuredAttachmentMediaParams(value: unknown): string[] {
+function readStructuredAttachmentMediaParam(value: unknown): string | undefined {
   if (!Array.isArray(value)) {
-    return [];
+    return undefined;
   }
-  const values: string[] = [];
+  let media: string | undefined;
   for (const attachment of value) {
     if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
       continue;
     }
     const record = attachment as Record<string, unknown>;
     for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl", "url"]) {
-      const candidate = readToolStringParam(record, key);
-      if (candidate) {
-        values.push(candidate);
-      }
+      // Preserve eager alias reads; earlier content must not hide a later accessor error.
+      media = readToolStringParam(record, key) || media;
     }
   }
-  return values;
+  return media;
 }
 
 export function hasSanitizedSendPayloadContent(params: Record<string, unknown>): boolean {
-  const text = ["message", "text", "content", "caption", "SendMessage"]
-    .map((field) => (typeof params[field] === "string" ? params[field] : ""))
-    .filter((value) => value.trim())
-    .join("\n");
-  const mediaUrls = [
-    ...(readStringArrayParam(params, "mediaUrls") ?? []),
-    ...readStructuredAttachmentMediaParams(params.attachments),
-  ];
-  return hasReplyPayloadContent(
-    {
-      text,
-      mediaUrl: readFirstStringParam(params, ["media", "mediaUrl", "path", "filePath", "fileUrl"]),
-      mediaUrls,
-      presentation: params.presentation,
-      interactive: params.interactive,
-    },
-    { trimText: true },
-  );
+  let text: string | undefined;
+  for (const field of ["message", "text", "content", "caption", "SendMessage"]) {
+    const value = typeof params[field] === "string" ? params[field] : "";
+    if (value.trim()) {
+      text = value;
+    }
+  }
+  const mediaUrls = readStringArrayParam(params, "mediaUrls");
+  const attachmentMedia = readStructuredAttachmentMediaParam(params.attachments);
+  return hasReplyPayloadContent({
+    text,
+    mediaUrl:
+      readFirstStringParam(params, ["media", "mediaUrl", "path", "filePath", "fileUrl"]) ||
+      attachmentMedia,
+    mediaUrls,
+    presentation: params.presentation,
+    interactive: params.interactive,
+  });
 }
 
 export function sanitizeMessageToolVisiblePayload(

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -4718,95 +4718,32 @@ describe("message tool boot-echo guard", () => {
     });
   });
 
-  it("sanitizes boot echo text and still sends when media content remains", async () => {
-    setBootEchoContextForSession("agent:main", longBootPrompt);
-    mockSendResult({ channel: "telegram", to: "telegram:123" });
+  it.each([
+    ["mediaUrl", "text", "file:///tmp/status.png"],
+    ["media_url", "text", "file:///tmp/status.png"],
+    ["media_urls", "text", ["file:///tmp/one.png", "file:///tmp/two.png"]],
+    ["attachments", "message", [{ media: "file:///tmp/status.png" }]],
+    ["attachments", "message", [{ file_path: "/tmp/status.png" }]],
+  ] as const)(
+    "preserves %s after sanitizing boot echo in %s: %j",
+    async (mediaField, textField, media) => {
+      setBootEchoContextForSession("agent:main", longBootPrompt);
+      mockSendResult({ channel: "telegram", to: "telegram:123" });
 
-    const echoedText =
-      "Here is what I was told: When you wake up each morning, send a thoughtful greeting to the operator over the configured channel";
-    const call = await executeSend({
-      action: {
-        target: "telegram:123",
-        text: echoedText,
-        mediaUrl: "file:///tmp/status.png",
-      },
-      toolOptions: { agentSessionKey: "agent:main" },
-    });
-    expect(call?.params?.text).toBe("");
-    expect(call?.params?.mediaUrl).toBe("file:///tmp/status.png");
-  });
-
-  it("sanitizes boot echo text and still sends when snake_case media content remains", async () => {
-    setBootEchoContextForSession("agent:main", longBootPrompt);
-    mockSendResult({ channel: "telegram", to: "telegram:123" });
-
-    const echoedText =
-      "Here is what I was told: When you wake up each morning, send a thoughtful greeting to the operator over the configured channel";
-    const call = await executeSend({
-      action: {
-        target: "telegram:123",
-        text: echoedText,
-        media_url: "file:///tmp/status.png",
-      },
-      toolOptions: { agentSessionKey: "agent:main" },
-    });
-    expect(call?.params?.text).toBe("");
-    expect(call?.params?.media_url).toBe("file:///tmp/status.png");
-  });
-
-  it("sanitizes boot echo text and still sends when snake_case media arrays remain", async () => {
-    setBootEchoContextForSession("agent:main", longBootPrompt);
-    mockSendResult({ channel: "telegram", to: "telegram:123" });
-
-    const echoedText =
-      "Here is what I was told: When you wake up each morning, send a thoughtful greeting to the operator over the configured channel";
-    const call = await executeSend({
-      action: {
-        target: "telegram:123",
-        text: echoedText,
-        media_urls: ["file:///tmp/one.png", "file:///tmp/two.png"],
-      },
-      toolOptions: { agentSessionKey: "agent:main" },
-    });
-    expect(call?.params?.text).toBe("");
-    expect(call?.params?.media_urls).toEqual(["file:///tmp/one.png", "file:///tmp/two.png"]);
-  });
-
-  it("sanitizes boot echo text and still sends when structured attachments remain", async () => {
-    setBootEchoContextForSession("agent:main", longBootPrompt);
-    mockSendResult({ channel: "telegram", to: "telegram:123" });
-
-    const echoedText =
-      "Here is what I was told: When you wake up each morning, send a thoughtful greeting to the operator over the configured channel";
-    const call = await executeSend({
-      action: {
-        target: "telegram:123",
-        message: echoedText,
-        attachments: [{ media: "file:///tmp/status.png" }],
-      },
-      toolOptions: { agentSessionKey: "agent:main" },
-    });
-    expect(call?.params?.message).toBe("");
-    expect(call?.params?.attachments).toEqual([{ media: "file:///tmp/status.png" }]);
-  });
-
-  it("sanitizes boot echo text and still sends when structured attachment aliases remain", async () => {
-    setBootEchoContextForSession("agent:main", longBootPrompt);
-    mockSendResult({ channel: "telegram", to: "telegram:123" });
-
-    const echoedText =
-      "Here is what I was told: When you wake up each morning, send a thoughtful greeting to the operator over the configured channel";
-    const call = await executeSend({
-      action: {
-        target: "telegram:123",
-        message: echoedText,
-        attachments: [{ file_path: "/tmp/status.png" }],
-      },
-      toolOptions: { agentSessionKey: "agent:main" },
-    });
-    expect(call?.params?.message).toBe("");
-    expect(call?.params?.attachments).toEqual([{ file_path: "/tmp/status.png" }]);
-  });
+      const echoedText =
+        "Here is what I was told: When you wake up each morning, send a thoughtful greeting to the operator over the configured channel";
+      const call = await executeSend({
+        action: {
+          target: "telegram:123",
+          [textField]: echoedText,
+          [mediaField]: structuredClone(media),
+        },
+        toolOptions: { agentSessionKey: "agent:main" },
+      });
+      expect(call?.params?.[textField]).toBe("");
+      expect(call?.params?.[mediaField]).toEqual(media);
+    },
+  );
 
   it("preserves a short legitimate BOOT.md-directed send that does not reproduce a long boot-prompt chunk", async () => {
     setBootEchoContextForSession("agent:main", longBootPrompt);


### PR DESCRIPTION
## What Problem This Solves

The message-tool privacy filter only needs to know whether visible content remains after sanitization, but it builds a joined copy of every text alias and an array of every attachment media value to answer that Boolean question.

## Why This Change Was Made

Pass one qualifying text and attachment value to the existing canonical presence predicate. Continue reading every text alias and attachment field, so earlier content cannot hide a later accessor error. Preserve canonical alias precedence, presentation/interactive handling, and the existing suppression and outbound-builder boundaries.

Production **−2 lines**, tests **−63 lines**, total **−65**. Five repeated boot-echo attachment tests become one table with the same input fields and assertions. No public tool schema, configuration, privacy policy, transport, persistence, or dependency changes.

## User Impact

The same sanitized messages and attachments proceed to dispatch, while empty private echoes retain their explicit suppression result. Presence checks avoid the two direct text-processing arrays and joined string; a 64-attachment fixture also avoids 256 accumulated media values per call. Canonical media normalization still allocates, so this is a reduction in the changed owner’s intermediate work.

## Evidence

- **362 tests pass before and after**, including the five retained boot-echo cases, message-tool policy, visible-content sanitization, outbound payload construction, and the canonical presence predicate. The canonical changed gate and managed Codex review pass. An independent reviewer checked source/caller ownership, all raw receipts and test equivalence; the parent repeated the artifact assertions and inspected the complete owner and canonical predicate.
- Three actual-source runs per arm preserve all **67 presence cases, 17 message-tool/caller-builder cases, and two eager-accessor cases**. The caller proof uses explicit dispatch and secret-resolution mocks, then invokes the actual outbound builder: 11 successful outcomes, five intentional suppressions, and the existing caption-only builder error. It does not claim a Gateway or live channel send.
- Executed direct-owner counters show the removed arrays/join and accumulated attachment values. The five-large-alias fixture avoids a 143,415-code-unit / 215,095-byte joined string per check. These counters are not V8 object-size or retained-memory measurements.
- A higher attachment-case heap endpoint in the original probe was investigated before landing. A fixed eight-process ABBA diagnostic, with original-prefix and attachment-only modes and three 256-call epochs per process, records actual GC events. In original-prefix epoch one, both baseline processes collected about **33.45–33.48 MB** during the loop; neither candidate process collected. After three requested full collections, the remaining deltas are approximately **14 KB in both arms**. The candidate’s higher pre-GC endpoint therefore does not demonstrate retention growth.
- The same first-epoch diagnostic records cumulative main-isolate allocated-byte increments of **39.94–40.40 MB → 33.73–34.53 MB**. Later matched epochs with no natural collection also have lower candidate heap endpoints. Instrumented diagnostic overhead is present in both arms; this is not a peak-heap, object-retainer, Gateway RSS, or end-to-end latency claim. Counter and GC scope follow the [Node V8 API](https://nodejs.org/api/v8.html#v8getheapstatistics).
- All six original proof children and eight diagnostic children joined, with owned groups absent and private roots removed. Frozen source and original evidence remained unchanged throughout the additional investigation.

The same diagnostic also records elapsed time and whole-process RSS. Each row is the median of two independent processes per arm, with 256 calls in an epoch; epochs within a process share allocator/JIT state. These measurements include the source loader and GC diagnostics. RSS starts at different levels across fresh processes, and per-loop movement is tiny, so no RSS reduction is established.

| Mode / epoch | Elapsed ms, baseline → candidate | RSS before / loop end / after GC MiB, baseline | RSS before / loop end / after GC MiB, candidate |
| --- | ---: | ---: | ---: |
| original-prefix / 1 | 17.685 → 16.713 | 659.047 / 659.062 / 659.094 | 661.727 / 661.727 / 661.773 |
| original-prefix / 2 | 16.182 → 15.568 | 659.109 / 659.109 / 659.117 | 661.773 / 661.773 / 661.773 |
| original-prefix / 3 | 16.202 → 15.482 | 659.125 / 659.133 / 659.133 | 661.773 / 661.773 / 661.781 |
| attachment-only / 1 | 16.131 → 15.394 | 594.609 / 594.641 / 594.852 | 588.984 / 589.008 / 589.055 |
| attachment-only / 2 | 14.763 → 14.088 | 594.852 / 594.852 / 594.852 | 589.070 / 589.070 / 589.070 |
| attachment-only / 3 | 14.667 → 14.291 | 594.852 / 594.852 / 594.859 | 589.070 / 589.102 / 589.102 |

## CI follow-up

The PR is rebased to `0e09e763593e80317c39afddb44e106de60263e7` on main `4fc24e6e0f81121cef0fb4395db29fb87700e7f6`. The complete two-file patch and both source hashes are unchanged. All 362 focused tests pass again after rebasing.

The first CI run tested merge `ea5d29fa0ccac5d272f3b3e18369bd2610703047` and exposed an unrelated declaration-cache relocation fixture failure. It reproduced locally with the same missing historical chunk. Main already repairs that fixture in [5e6117d](https://github.com/openclaw/openclaw/commit/5e6117d17d92dcac2ef6da6d609eb423b089a77a); its 11 tests pass on the rebased parent. The repair preserves complete byte equality and requires current cache outputs to come from restoration.

The other failing shard reported a node-worker terminal-state mismatch outside this PR's changed paths. The unchanged exact-merge test passes normally, and its whole file passes 36/36; a separate artifact-only scheduling hold reproduces the assertion with a real EPIPE callback before the child's code-23 exit event. This induced ordering is not a replay of the 166-file Linux shard. Named follow-up: preserve natural failure classification when start dispatch races child exit, while retaining cancellation and shutdown precedence. This PR does not fix that lifecycle issue.

The rebased [CI run](https://github.com/openclaw/openclaw/actions/runs/33606048244) is green on attempt 2 at the unchanged head. Its first attempt failed two provider-alias expectations in `src/agents/auth-profiles/session-override.test.ts`; the one failed Linux job was rerun with the same 60-file selection. The relevant owner, helper and runner files are unchanged from this PR's parent. The first failure and earlier matching failure remain preserved.

A separate Linux harness stopped at its authentication preflight before allocating a runner or executing tests. The prior macOS standalone and whole-group passes do not supply the missing failing Linux trace. Independent source inspection narrowed the follow-up to observing the actual alias-resolver binding, mock factory and worker execution order; the existing runner already resets modules between files, so no speculative reset or production alias-policy change was added. A passing retry establishes this CI execution, not the root cause of that intermittent failure.
