### PR TITLE
test(ui): share browser lifetime across isolated contexts

### DIFF
--- a/ui/src/e2e/chat-composer-pointer-activation.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-pointer-activation.e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI E2E tests cover pointer activation near the mobile safe area.
-import { chromium, type Locator, type Page } from "playwright";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -27,6 +28,7 @@ type PointerTraceEntry = {
 };
 
 let server: ControlUiE2eServer;
+let browser: Browser;
 
 async function installPointerTrace(page: Page, button: Locator): Promise<void> {
   await button.evaluate((element) => {
@@ -114,27 +116,31 @@ async function clickMouseAtCurrentCenter(page: Page, button: Locator): Promise<v
 describeControlUiE2e("Control UI composer pointer controls", () => {
   beforeAll(async () => {
     server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
 
   afterAll(async () => {
-    await server?.close();
+    await runQaGatewayFixture(
+      async () => {
+        await browser?.close();
+      },
+      () => server?.close(),
+    );
   });
 
   it("sends and stops without moving the action out from under an Android-like tap", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({
       hasTouch: true,
       isMobile: true,
       serviceWorkers: "block",
       viewport: { width: 393, height: 852 },
     });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      assistantName: "OpenClaw",
-      deferredMethods: ["chat.send"],
-    });
-
     try {
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        assistantName: "OpenClaw",
+        deferredMethods: ["chat.send"],
+      });
       await page.goto(`${server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       await page.addStyleTag({
@@ -202,25 +208,22 @@ describeControlUiE2e("Control UI composer pointer controls", () => {
       await expect.poll(() => stop.count()).toBe(0);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("sends and stops in a narrow desktop viewport without moving under the mouse", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({
       hasTouch: false,
       isMobile: false,
       serviceWorkers: "block",
       viewport: { width: 393, height: 852 },
     });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      assistantName: "OpenClaw",
-      deferredMethods: ["chat.send"],
-    });
-
     try {
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        assistantName: "OpenClaw",
+        deferredMethods: ["chat.send"],
+      });
       await page.goto(`${server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       await page.addStyleTag({
@@ -280,25 +283,22 @@ describeControlUiE2e("Control UI composer pointer controls", () => {
         .toBe(true);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("keeps wide desktop mouse activation and keyboard activation working", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({
       hasTouch: false,
       isMobile: false,
       serviceWorkers: "block",
       viewport: { width: 1280, height: 900 },
     });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      assistantName: "OpenClaw",
-      deferredMethods: ["chat.send"],
-    });
-
     try {
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        assistantName: "OpenClaw",
+        deferredMethods: ["chat.send"],
+      });
       await page.goto(`${server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       const textarea = page.locator(".agent-chat__input textarea");
@@ -362,22 +362,19 @@ describeControlUiE2e("Control UI composer pointer controls", () => {
       await expect.poll(async () => (await gateway.getRequests("chat.send")).length).toBe(2);
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 
   it("does not send when a mouse gesture leaves the button before release", async () => {
-    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({
       hasTouch: false,
       isMobile: false,
       serviceWorkers: "block",
       viewport: { width: 393, height: 852 },
     });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, { assistantName: "OpenClaw" });
-
     try {
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, { assistantName: "OpenClaw" });
       await page.goto(`${server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
       await page.addStyleTag({
@@ -406,7 +403,6 @@ describeControlUiE2e("Control UI composer pointer controls", () => {
       await expect.poll(() => textarea.inputValue()).toBe("Do not send this draft");
     } finally {
       await context.close();
-      await browser.close();
     }
   });
 });

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 
 let artifactDir: string | undefined;
@@ -23,11 +24,9 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 
 let server: ControlUiE2eServer;
-const openBrowsers = new Set<Browser>();
+let browser: Browser;
 
 async function newBrowserContext(): Promise<BrowserContext> {
-  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-  openBrowsers.add(browser);
   return browser.newContext({
     colorScheme: "light",
     locale: "en-US",
@@ -36,9 +35,14 @@ async function newBrowserContext(): Promise<BrowserContext> {
   });
 }
 
-async function closeBrowsers(): Promise<void> {
-  await Promise.all([...openBrowsers].map((browser) => browser.close().catch(() => {})));
-  openBrowsers.clear();
+async function closeContexts(): Promise<void> {
+  const [first, ...remaining] = browser?.contexts() ?? [];
+  await runQaGatewayFixture(
+    async () => {
+      await first?.close();
+    },
+    ...remaining.map((context) => () => context.close()),
+  );
 }
 
 async function expectText(locator: Locator, text: string): Promise<void> {
@@ -138,14 +142,18 @@ describeControlUiE2e("GitHub link hover cards", () => {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
     server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
 
   afterAll(async () => {
-    await closeBrowsers();
-    await server?.close();
+    await runQaGatewayFixture(
+      closeContexts,
+      () => browser?.close(),
+      () => server?.close(),
+    );
   });
 
-  afterEach(closeBrowsers);
+  afterEach(closeContexts);
 
   it.each([
     { theme: "light", reducedMotion: "no-preference", width: 1180, fails: false },


### PR DESCRIPTION
## Summary
The hovercard and composer pointer E2Es launched Chromium once per case even though their scenario settings already belonged to fresh browser contexts. Each file now owns one browser, and every case still owns a new context and page. Hovercard teardown uses Playwright's existing context inventory and the canonical ordered cleanup helper; pointer setup now acquires its page and installs the Gateway inside its cleanup boundary.

This also repairs a demonstrated setup-failure leak. When the first real page creation rejected after acquiring a page, the original pointer fixture left one browser, context and page alive. The candidate closes all three, preserves the induced failure and runs the next three cases successfully.

## Validation
Both complete files ran on the same pinned source and Blacksmith Testbox, through the canonical bundled UI E2E runner. Private observation forwarded actual Playwright operations; all 11 cases and 94 static assertion sites were preserved.

| Measurement | Before | After |
| --- | ---: | ---: |
| Actual Chromium launches / exits | 11 / 11 | 2 / 2 |
| Distinct contexts, all closed | 11 | 11 |
| Pages including popups, all closed | 13 | 13 |
| Vitest including setup and hooks | 19.18s | 18.00s |
| Test execution including hooks | 19.44s | 17.28s |
| Complete runner | 19.91s | 18.57s |

The elapsed improvement is modest; the deterministic reduction is nine process launches. Fresh contexts retain page-local preview caches, Gateway state, cookies and storage isolation. Native launch PIDs all reached process exit, and each candidate context was closed before the next context was acquired.

    node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/github-link-hovercard.e2e.test.ts ui/src/e2e/chat-composer-pointer-activation.e2e.test.ts

The separate first-page failure probe produced exactly one intended failure and three passes on both versions. Before rescue, the original retained one live browser/context/page; the candidate retained none. Exact-object rescue joined the original browser afterward. Both versions' native PIDs exited. All instrumentation was removed and source hashes restored.

The first observational attempt failed before the cases because its private artifact path accidentally retained a macOS /private prefix on Linux. Correcting only that probe path produced the results above; no test implementation or environment workaround was required.

The shared bundled preview remains owned by invocation setup; these suites borrow its lease. Hovercard request counts, physical pointer traversal, 300ms negative windows, keyboard/ARIA/navigation checks, mobile safe-area geometry, send/abort traffic and canceled gestures remain unchanged. Production LOC +0/-0; test LOC +44/-40. No product behavior, deadlines, mocks or configuration surfaces changed.

Provider: Blacksmith Testbox, lease tbx_01m1gec58nmbcdp93mta6jrv5p, [hydration run](https://github.com/openclaw/openclaw/actions/runs/33601011730). Lease stopped after proof.

A nearby native-link-routing fixture still swallows context-close errors; that separate cleanup follow-up remains outside this change.

Measured source pin: 22905b1e9698123013144f6b446cfac2eaf51b65. The patch was refreshed onto 9e6912ca0d2e0200bdcbcfc32bde2d27db262464; both target tests, the cleanup owner, shared fixture owner and UI E2E configuration are unchanged. Lockfile changes concern unrelated plugin dependencies; Playwright remains1.62.1.

Local validation: formatting, graph-boundary, i18n and preceding changed-file guards passed. The UI E2E type graph stops on the worktree’s existing missing Mermaid dependency in packages/mermaid-renderer/src/renderer.ts; clean exact-head hosted CI remains required. The final scoped Codex P0 review reported no actionable findings.

Remaining local typed lint, coercion guard and dead-export scans passed.

ClawSweeper's completed review found no actionable defect and identified a reviewer-environment gap: Playwright was absent from its sparse checkout. Maintainer inspection resolves that gap with the installed Playwright1.62.1 implementation and types. The client creates fresh contexts through its non-reuse channel, tracks them in its own Set, removes them only on the close event, and awaits context/browser closure. The Chromium owner issues Target.createBrowserContext, and browser close awaits its native browser process. These contracts were also exercised in the retained Testbox observation:11 distinct contexts,13 closed pages and all native process exits, including the deliberate setup failure. No rank-up implementation changes were requested. Exact-head CI33603283532 is green.
