### PR TITLE
refactor(amazon-bedrock): consolidate Opus 4.7 and 4.8 policy

### DIFF
--- a/extensions/amazon-bedrock/provider-policy-api.test.ts
+++ b/extensions/amazon-bedrock/provider-policy-api.test.ts
@@ -87,6 +87,22 @@ describe("amazon-bedrock provider-policy-api", () => {
   });
 
   it.each([
+    "global.anthropic.claude-opus-4-70",
+    "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-80",
+  ])("does not treat numeric Opus version prefixes as supported models: %s", (modelId) => {
+    const profile = resolveThinkingProfile({ provider: "amazon-bedrock", modelId });
+
+    expect(profile?.levels.map((level) => level.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(profile?.defaultLevel).toBeUndefined();
+  });
+
+  it.each([
     {
       canonicalModelId: "claude-fable-5",
       defaultLevel: "high",

--- a/extensions/amazon-bedrock/thinking-policy.ts
+++ b/extensions/amazon-bedrock/thinking-policy.ts
@@ -28,8 +28,8 @@ function isOpus5BedrockModelRef(modelRef: string): boolean {
   );
 }
 
-function isOpus48BedrockModelRef(modelRef: string): boolean {
-  return /(?:^|[/.:])(?:(?:us|eu|ap|apac|au|jp|global)\.)?(?:anthropic\.)?claude-opus-4[.-]8(?:$|[-.:/])/i.test(
+function isOpus47Or48BedrockModelRef(modelRef: string): boolean {
+  return /(?:^|[/.:])(?:(?:us|eu|ap|apac|au|jp|global)\.)?(?:anthropic\.)?claude-opus-4[.-][78](?:$|[-.:/])/i.test(
     modelRef,
   );
 }
@@ -40,20 +40,9 @@ function isOpus46BedrockModelRef(modelRef: string): boolean {
   );
 }
 
-/** Return whether a Bedrock model ref names Claude Opus 4.7. */
-function isOpus47BedrockModelRef(modelRef: string): boolean {
-  return /(?:^|[/.:])(?:(?:us|eu|ap|apac|au|jp|global)\.)?(?:anthropic\.)?claude-opus-4[.-]7(?:$|[-.:/])/i.test(
-    modelRef,
-  );
-}
-
 /** Return whether a Bedrock model ref names Claude Opus 4.7 or newer. */
 export function isOpus47OrNewerBedrockModelRef(modelRef: string): boolean {
-  return (
-    isOpus5BedrockModelRef(modelRef) ||
-    isOpus47BedrockModelRef(modelRef) ||
-    isOpus48BedrockModelRef(modelRef)
-  );
+  return isOpus5BedrockModelRef(modelRef) || isOpus47Or48BedrockModelRef(modelRef);
 }
 
 function isMythosPreviewBedrockModelRef(modelRef: string): boolean {
@@ -150,13 +139,7 @@ export function resolveBedrockClaudeThinkingProfile(
       defaultLevel: "high",
     };
   }
-  if (modelRefs.some(isOpus48BedrockModelRef)) {
-    return {
-      levels: [...BASE_CLAUDE_THINKING_LEVELS, { id: "xhigh" }, { id: "adaptive" }, { id: "max" }],
-      defaultLevel: "off",
-    };
-  }
-  if (modelRefs.some(isOpus47BedrockModelRef)) {
+  if (modelRefs.some(isOpus47Or48BedrockModelRef)) {
     return {
       levels: [...BASE_CLAUDE_THINKING_LEVELS, { id: "xhigh" }, { id: "adaptive" }, { id: "max" }],
       defaultLevel: "off",


### PR DESCRIPTION
## What Problem This Solves

The Amazon Bedrock thinking policy maintained separate Opus 4.7 and 4.8 matchers and profile branches even though both versions have identical behavior. That duplication can drift when future policy changes touch only one branch.

This is an explicitly maintainer-directed function-duplication cleanup.

## Why This Change Was Made

Use one private, bounded Opus 4.7/4.8 matcher and one shared profile branch while preserving the exported `isOpus47OrNewerBedrockModelRef` contract. Opus 5 remains a distinct branch with its existing `high` default.

The API-boundary tests also pin two numeric-prefix negatives so `4-70` and `4-80` do not accidentally match `4.7` or `4.8`. These are contract guards for the refactor, not regression tests that failed before the change.

## User Impact

No user-visible behavior changes. Existing Opus 4.7, 4.8, and 5 thinking levels and defaults remain unchanged.

## Evidence

- Pre-edit focused Testbox baseline: 2 files, 73 tests passed.
- Exact-head Testbox proof: focused policy/API tests passed (2 files, 75 tests); full Amazon Bedrock extension suite passed; `pnpm check:changed` passed; runtime import-cycle checks reported 0 cycles.
- Exact-head Testbox run: https://github.com/openclaw/openclaw/actions/runs/33602490654
- Required local autoreview: scoped clean, 0 actionable findings, correctness confidence 0.99.
- Production delta: +4/-21 (net -17). Test delta: +16/-0. Total: +20/-21.
- Diff is limited to `extensions/amazon-bedrock/thinking-policy.ts` and `extensions/amazon-bedrock/provider-policy-api.test.ts`.
- Live open-PR overlap checks found no PR touching either scoped file.
- `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870` were inspected as required; those CLI surfaces are unrelated to this provider-local refactor.
- No SDK, barrel, manifest, catalog, docs, or changelog changes.
