### PR TITLE
fix(gateway): bound retained Control UI asset memory

### DIFF
--- a/src/gateway/control-ui-asset-retention.cancellation.test.ts
+++ b/src/gateway/control-ui-asset-retention.cancellation.test.ts
@@ -28,7 +28,9 @@ describe.each(["signal", "predicate"] as const)(
         const build =
           boundary === "refresh"
             ? old
-            : await writeRetentionBuild(path.join(root, "current"), "current");
+            : await writeRetentionBuild(path.join(root, "current"), "current", {
+                size: 128 * 1024,
+              });
         const target = path.join(cache, build.manifest.generation);
         const stale = [".staging-1-aaaa", ".staging-2-bbbb"].map((name) => path.join(cache, name));
         for (const directory of stale) {
@@ -39,6 +41,7 @@ describe.each(["signal", "predicate"] as const)(
         const controller = new AbortController();
         let cancelled = false;
         let published = false;
+        const closed = new Set<string>();
         const pruned = new Set<string>();
         const cancel = () => {
           cancelled = true;
@@ -56,37 +59,60 @@ describe.each(["signal", "predicate"] as const)(
         };
         vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
           const result = await original.readFile(...args);
-          if (
-            (boundary === "retained-read" && args[0] === path.join(old.target, old.assetPath)) ||
-            (boundary === "refresh" && args[0] === path.join(build.root, "asset-manifest.json"))
-          ) {
+          if (boundary === "refresh" && args[0] === path.join(build.root, "asset-manifest.json")) {
             cancel();
           }
           return result;
         });
         vi.spyOn(fs, "open").mockImplementation(async (...args) => {
           const handle = await original.open(...args);
-          const read = handle.readFile.bind(handle);
-          vi.spyOn(handle, "readFile").mockImplementation(async (...readArgs) => {
-            const result = await read(...readArgs);
-            if (boundary === "source-read") {
+          const file = args[0];
+          if (typeof file !== "string") {
+            return handle;
+          }
+          const read = handle.read.bind(handle);
+          vi.spyOn(handle, "read").mockImplementation((async (
+            buffer: Buffer,
+            offset: number,
+            length: number,
+            position: number | null,
+          ) => {
+            const result = await read(buffer, offset, length, position);
+            if (
+              (boundary === "retained-read" && file === path.join(old.target, old.assetPath)) ||
+              (boundary === "source-read" && file === path.join(build.root, build.assetPath))
+            ) {
               cancel();
             }
             return result;
+          }) as typeof handle.read);
+          const write = handle.write.bind(handle);
+          vi.spyOn(handle, "write").mockImplementation((async (
+            buffer: Buffer,
+            offset: number,
+            length: number,
+            position: number | null,
+          ) => {
+            const result = await write(buffer, offset, length, position);
+            if (
+              boundary === "asset-write" &&
+              file.includes(".staging-") &&
+              file.endsWith(build.assetPath)
+            ) {
+              cancel();
+            }
+            return result;
+          }) as typeof handle.write);
+          const close = handle.close.bind(handle);
+          vi.spyOn(handle, "close").mockImplementation(async () => {
+            await close();
+            closed.add(file);
           });
           return handle;
         });
         vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
           await original.writeFile(...args);
           const file = args[0];
-          if (
-            boundary === "asset-write" &&
-            typeof file === "string" &&
-            file.includes(".staging-") &&
-            file.endsWith(build.assetPath)
-          ) {
-            cancel();
-          }
           if (
             boundary === "manifest-write" &&
             typeof file === "string" &&
@@ -138,6 +164,14 @@ describe.each(["signal", "predicate"] as const)(
         expect(refreshes).toHaveBeenCalledTimes(
           ["prune-issued", "projection"].includes(boundary) ? 1 : 0,
         );
+        if (boundary === "source-read" || boundary === "asset-write") {
+          expect(closed).toContain(path.join(build.root, build.assetPath));
+          expect(
+            [...closed].some(
+              (file) => file.includes(".staging-") && file.endsWith(build.assetPath),
+            ),
+          ).toBe(true);
+        }
         vi.restoreAllMocks();
         expect(
           (await fs.readdir(cache)).filter(

--- a/src/gateway/control-ui-asset-retention.integrity.test.ts
+++ b/src/gateway/control-ui-asset-retention.integrity.test.ts
@@ -81,10 +81,13 @@ describe("Control UI retained integrity", () => {
     "refuses source %s before publication",
     async (fault) => {
       await withRetentionFixture(async ({ root, cache }) => {
-        const build = await writeRetentionBuild(path.join(root, "build"), "source");
+        const build = await writeRetentionBuild(path.join(root, "build"), "source", {
+          size: fault === "inode-swap" ? 128 * 1024 : undefined,
+        });
         const source = path.join(build.root, build.assetPath);
         const outside = path.join(root, "outside");
         await fs.cp(build.root, outside, { recursive: true });
+        const outsideContents = await fs.readFile(path.join(outside, build.assetPath));
         if (fault === "leaf-symlink") {
           await fs.rm(source);
           await fs.symlink(path.join(outside, build.assetPath), source);
@@ -95,8 +98,25 @@ describe("Control UI retained integrity", () => {
           const open = fs.open;
           vi.spyOn(fs, "open").mockImplementation(async (...args) => {
             const handle = await open(...args);
-            await fs.rename(source, `${source}.old`);
-            await fs.copyFile(path.join(outside, build.assetPath), source);
+            if (args[0] !== source) {
+              return handle;
+            }
+            const read = handle.read.bind(handle);
+            let replaced = false;
+            vi.spyOn(handle, "read").mockImplementation((async (
+              buffer: Buffer,
+              offset: number,
+              length: number,
+              position: number | null,
+            ) => {
+              const result = await read(buffer, offset, length, position);
+              if (!replaced && result.bytesRead > 0) {
+                replaced = true;
+                await fs.rename(source, `${source}.old`);
+                await fs.copyFile(path.join(outside, build.assetPath), source);
+              }
+              return result;
+            }) as typeof handle.read);
             return handle;
           });
         }
@@ -106,8 +126,47 @@ describe("Control UI retained integrity", () => {
         );
         expect(owner.resolveAsset(build.assetPath)).toBeNull();
         expect(await fs.readdir(cache)).toEqual([]);
-        expect(await fs.readFile(path.join(outside, build.assetPath), "utf8")).toContain("source");
+        expect(await fs.readFile(path.join(outside, build.assetPath))).toEqual(outsideContents);
       });
     },
   );
+
+  it("rejects a cached asset replaced after its handle opens", async () => {
+    await withRetentionFixture(async ({ root, cache, seed }) => {
+      const cached = await seed("cached", { size: 128 * 1024 });
+      const asset = path.join(cached.target, cached.assetPath);
+      const current = await writeRetentionBuild(path.join(root, "current"), "current");
+      const open = fs.open;
+      let replaced = false;
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        if (args[0] !== asset) {
+          return handle;
+        }
+        const read = handle.read.bind(handle);
+        vi.spyOn(handle, "read").mockImplementation((async (
+          buffer: Buffer,
+          offset: number,
+          length: number,
+          position: number | null,
+        ) => {
+          const result = await read(buffer, offset, length, position);
+          if (!replaced && result.bytesRead > 0) {
+            replaced = true;
+            await fs.rename(asset, `${asset}.old`);
+            await fs.writeFile(asset, Buffer.alloc(cached.manifest.assets[0]!.size, 120));
+          }
+          return result;
+        }) as typeof handle.read);
+        return handle;
+      });
+      const owner = createControlUiAssetRetention(current.root);
+      await owner.prepare();
+      expect(replaced).toBe(true);
+      expect(owner.resolveAsset(cached.assetPath)).toBeNull();
+      expect(owner.resolveAsset(current.assetPath)).not.toBeNull();
+      await expect(fs.access(cached.target)).rejects.toMatchObject({ code: "ENOENT" });
+      expect((await fs.readdir(cache)).some((entry) => entry.startsWith(".staging-"))).toBe(false);
+    });
+  });
 });

--- a/src/gateway/control-ui-asset-retention.publication.test.ts
+++ b/src/gateway/control-ui-asset-retention.publication.test.ts
@@ -22,20 +22,25 @@ describe("Control UI retained publication", () => {
         const contents = await fs.readFile(path.join(current.root, current.assetPath));
         const targetAsset = path.join(current.target, current.assetPath);
         const siblingAsset = path.join(sibling.target, sibling.assetPath);
-        const reads = new Map([
+        const opens = new Map([
           [targetAsset, 0],
           [siblingAsset, 0],
         ]);
-        const refreshReads: number[] = [];
+        const refreshOpens: number[] = [];
         const readFile = fs.readFile;
+        const open = fs.open;
         const utimes = fs.utimes;
         let mutated = false;
+        vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const file = args[0];
+          if (typeof file === "string" && opens.has(file)) {
+            opens.set(file, opens.get(file)! + 1);
+          }
+          return open(...args);
+        });
         vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
           const result = await readFile(...args);
           const file = args[0];
-          if (typeof file === "string" && reads.has(file)) {
-            reads.set(file, reads.get(file)! + 1);
-          }
           if (!mutated && file === path.join(current.root, "asset-manifest.json")) {
             mutated = true;
             if (mutation === "removed") {
@@ -53,22 +58,22 @@ describe("Control UI retained publication", () => {
         });
         vi.spyOn(fs, "utimes").mockImplementation(async (...args) => {
           if (args[0] === current.target) {
-            refreshReads.push(reads.get(targetAsset)!);
+            refreshOpens.push(opens.get(targetAsset)!);
           }
           return utimes(...args);
         });
         const owner = createControlUiAssetRetention(current.root);
         if (mutation === "symlink") {
           await expect(owner.prepare()).rejects.toThrow();
-          expect(refreshReads).toEqual([]);
+          expect(refreshOpens).toEqual([]);
         } else {
           await owner.prepare();
           expect(owner.resolveAsset(current.assetPath)?.filePath).toBe(targetAsset);
-          expect(refreshReads).toEqual([2]);
-          expect(reads.get(targetAsset)).toBe(2);
+          expect(refreshOpens).toEqual([2]);
+          expect(opens.get(targetAsset)).toBe(2);
         }
         expect(mutated).toBe(true);
-        expect(reads.get(siblingAsset)).toBe(1);
+        expect(opens.get(siblingAsset)).toBe(1);
         vi.restoreAllMocks();
         expect(await fs.readFile(targetAsset)).toEqual(contents);
         expect(await fs.readFile(path.join(outside, current.assetPath))).toEqual(contents);
@@ -133,6 +138,60 @@ describe("Control UI retained publication", () => {
             1,
           );
         }
+      });
+    },
+  );
+
+  it.each(["partial", "zero-progress"] as const)(
+    "handles %s destination writes without adopting incomplete bytes",
+    async (behavior) => {
+      await withRetentionFixture(async ({ root, cache }) => {
+        const build = await writeRetentionBuild(path.join(root, "build"), "write", {
+          size: 128 * 1024,
+        });
+        const source = path.join(build.root, build.assetPath);
+        const open = fs.open;
+        let intercepted = false;
+        vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const handle = await open(...args);
+          const file = args[0];
+          if (
+            typeof file !== "string" ||
+            !file.includes(".staging-") ||
+            !file.endsWith(build.assetPath)
+          ) {
+            return handle;
+          }
+          const write = handle.write.bind(handle);
+          vi.spyOn(handle, "write").mockImplementation((async (
+            buffer: Buffer,
+            offset: number,
+            length: number,
+            position: number | null,
+          ) => {
+            intercepted = true;
+            if (behavior === "zero-progress") {
+              return { buffer, bytesWritten: 0 };
+            }
+            return await write(buffer, offset, Math.min(length, 17), position);
+          }) as typeof handle.write);
+          return handle;
+        });
+        const owner = createControlUiAssetRetention(build.root);
+        if (behavior === "zero-progress") {
+          await expect(owner.prepare()).rejects.toThrow("write made no progress");
+          expect(owner.resolveAsset(build.assetPath)).toBeNull();
+          expect(await fs.readdir(cache)).toEqual([]);
+        } else {
+          await owner.prepare();
+          expect(await fs.readFile(owner.resolveAsset(build.assetPath)!.filePath)).toEqual(
+            await fs.readFile(source),
+          );
+        }
+        expect(intercepted).toBe(true);
+        expect((await fs.readdir(cache)).some((entry) => entry.startsWith(".staging-"))).toBe(
+          false,
+        );
       });
     },
   );

--- a/src/gateway/control-ui-asset-retention.test.ts
+++ b/src/gateway/control-ui-asset-retention.test.ts
@@ -1,6 +1,4 @@
-import crypto from "node:crypto";
 import fs from "node:fs/promises";
-import { syncBuiltinESMExports } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -14,7 +12,7 @@ import {
 } from "./control-ui-asset-retention.test-support.js";
 
 describe("Control UI asset retention", () => {
-  it("verifies each retained asset once per preparation", async () => {
+  it("verifies retained assets through one bounded scratch buffer", async () => {
     const fixture = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-retention-io-")),
     );
@@ -25,71 +23,62 @@ describe("Control UI asset retention", () => {
         let root = "";
         for (const label of ["a", "b", "c"]) {
           root = path.join(fixture, label);
-          const { assetPath: asset } = await writeRetentionBuild(root, label);
+          const { assetPath: asset } = await writeRetentionBuild(root, label, {
+            size: 128 * 1024 + label.charCodeAt(0),
+          });
           const owner = createControlUiAssetRetention(root);
           await owner.prepare();
           const retained = owner.resolveAsset(asset)!;
           retainedPaths.add(retained.filePath);
           expectedBytes += (await fs.stat(retained.filePath)).size;
         }
-        const counts = { lstats: 0, reads: 0, readBytes: 0, hashes: 0, hashBytes: 0 };
-        const buffers = new WeakSet<object>();
+        const buffers = new Set<Buffer>();
+        let readBytes = 0;
+        let wholeFileReads = 0;
         const readFile = fs.readFile;
-        const lstat = fs.lstat;
-        const hash = crypto.createHash;
-        vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-          if (typeof args[0] === "string" && retainedPaths.has(args[0])) {
-            counts.lstats++;
-          }
-          return lstat(...args);
-        });
+        const open = fs.open;
         vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
           const result = await readFile(...args);
-          if (
-            typeof args[0] === "string" &&
-            retainedPaths.has(args[0]) &&
-            Buffer.isBuffer(result)
-          ) {
-            counts.reads++;
-            counts.readBytes += result.byteLength;
-            buffers.add(result);
+          if (typeof args[0] === "string" && retainedPaths.has(args[0])) {
+            wholeFileReads++;
           }
           return result;
         });
-        vi.spyOn(crypto, "createHash").mockImplementation((...args) => {
-          const instance = hash(...args);
-          const update = instance.update.bind(instance);
-          instance.update = (data, ...rest) => {
-            if (typeof data === "object" && buffers.has(data)) {
-              counts.hashes++;
-              counts.hashBytes += data.byteLength;
-            }
-            return update(data, ...rest);
-          };
-          return instance;
+        vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const handle = await open(...args);
+          if (typeof args[0] !== "string" || !retainedPaths.has(args[0])) {
+            return handle;
+          }
+          const read = handle.read.bind(handle);
+          vi.spyOn(handle, "read").mockImplementation((async (
+            buffer: Buffer,
+            offset: number,
+            length: number,
+            position: number | null,
+          ) => {
+            expect(length).toBeLessThanOrEqual(64 * 1024);
+            buffers.add(buffer);
+            const result = await read(buffer, offset, length, position);
+            readBytes += result.bytesRead;
+            return result;
+          }) as typeof handle.read);
+          return handle;
         });
-        syncBuiltinESMExports();
         const owner = createControlUiAssetRetention(root);
         try {
           await owner.prepare();
         } finally {
           vi.restoreAllMocks();
-          syncBuiltinESMExports();
         }
-        expect(counts).toEqual({
-          lstats: 3,
-          reads: 3,
-          readBytes: expectedBytes,
-          hashes: 3,
-          hashBytes: expectedBytes,
-        });
+        expect(wholeFileReads).toBe(0);
+        expect(readBytes).toBe(expectedBytes);
+        expect(buffers.size).toBe(1);
         for (const retained of retainedPaths) {
           expect(owner.resolveAsset(`assets/${path.basename(retained)}`)?.filePath).toBe(retained);
         }
       });
     } finally {
       vi.restoreAllMocks();
-      syncBuiltinESMExports();
       await fs.rm(fixture, { recursive: true, force: true });
     }
   });
@@ -175,9 +164,11 @@ describe("Control UI asset retention", () => {
       expect(owner.resolveAsset(old.assetPath)).toBeNull();
       const open = fs.open;
       const observed = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
-        expect(owner.resolveAsset(old.assetPath)?.filePath).toBe(
-          path.join(old.target, old.assetPath),
-        );
+        if (args[0] === path.join(current.root, current.assetPath)) {
+          expect(owner.resolveAsset(old.assetPath)?.filePath).toBe(
+            path.join(old.target, old.assetPath),
+          );
+        }
         return open(...args);
       });
       const preparing = owner.prepare();

--- a/src/gateway/control-ui-asset-retention.ts
+++ b/src/gateway/control-ui-asset-retention.ts
@@ -20,6 +20,7 @@ const CONTROL_UI_GENERATION_PATTERN = /^[a-f0-9]{64}$/u;
 const CONTROL_UI_STAGING_PATTERN = /^\.staging-[0-9]+-[a-f0-9-]+$/u;
 const CONTROL_UI_STAGING_MAX_AGE_MS = 60 * 60 * 1000;
 const CONTROL_UI_MANIFEST_MAX_BYTES = 4 * 1024 * 1024;
+const CONTROL_UI_ASSET_IO_BUFFER_BYTES = 64 * 1024;
 
 type RetainedGeneration = {
   assetPaths: ReadonlySet<string>;
@@ -50,6 +51,8 @@ type RetentionOperation = {
   signal?: AbortSignal;
 };
 
+type RetentionIo = RetentionOperation & { scratch: Buffer };
+
 function throwIfCancelled(operation?: RetentionOperation): void {
   operation?.signal?.throwIfAborted();
   if (operation?.isCancelled?.()) {
@@ -59,7 +62,7 @@ function throwIfCancelled(operation?: RetentionOperation): void {
 
 async function readCachedGeneration(
   directory: string,
-  operation?: RetentionOperation,
+  operation: RetentionIo,
 ): Promise<RetainedGeneration | null> {
   try {
     throwIfCancelled(operation);
@@ -76,20 +79,12 @@ async function readCachedGeneration(
       return null;
     }
     for (const asset of manifest.assets) {
-      throwIfCancelled(operation);
-      const assetPath = path.join(realPath, asset.path);
-      const assetStats = await fs.lstat(assetPath);
-      throwIfCancelled(operation);
-      if (
-        assetStats.isSymbolicLink() ||
-        !assetStats.isFile() ||
-        assetStats.size !== asset.size ||
-        createHash("sha256")
-          .update(await fs.readFile(assetPath, { signal: operation?.signal }))
-          .digest("hex") !== asset.sha256
-      ) {
-        return null;
-      }
+      await verifyAsset({
+        entry: asset,
+        operation,
+        root: realPath,
+        rootRealPath: realPath,
+      });
     }
     const currentStats = await fs.lstat(directory);
     throwIfCancelled(operation);
@@ -127,7 +122,7 @@ function compareGenerations(left: RetainedGeneration, right: RetainedGeneration)
 
 async function readCacheInventory(
   cacheDir: string,
-  operation?: RetentionOperation,
+  operation: RetentionIo,
   verified: RetainedGeneration[] = [],
 ) {
   const generations: RetainedGeneration[] = [];
@@ -193,12 +188,13 @@ async function readAssetManifest(
   return manifest;
 }
 
-async function readVerifiedAsset(params: {
+async function verifyAsset(params: {
+  destination?: string;
   entry: ControlUiAssetManifestEntry;
-  operation?: RetentionOperation;
+  operation: RetentionIo;
   root: string;
   rootRealPath: string;
-}): Promise<Buffer> {
+}): Promise<void> {
   throwIfCancelled(params.operation);
   const sourcePath = path.resolve(params.root, params.entry.path);
   if (!isWithinDir(params.root, sourcePath)) {
@@ -212,28 +208,75 @@ async function readVerifiedAsset(params: {
   if (initialStats.isSymbolicLink() || !initialStats.isFile()) {
     throw new Error(`Unsafe Control UI asset: ${params.entry.path}`);
   }
-  const handle = await fs.open(sourcePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+  const source = await fs.open(sourcePath, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
+  let destination: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
-    const openedStats = await handle.stat();
-    const contents = await handle.readFile({ signal: params.operation?.signal });
+    if (params.destination) {
+      destination = await fs.open(
+        params.destination,
+        fsConstants.O_WRONLY |
+          fsConstants.O_CREAT |
+          fsConstants.O_EXCL |
+          (fsConstants.O_NOFOLLOW ?? 0),
+        0o600,
+      );
+    }
+    const hash = createHash("sha256");
+    let offset = 0;
+    for (;;) {
+      throwIfCancelled(params.operation);
+      const { bytesRead } = await source.read(
+        params.operation.scratch,
+        0,
+        params.operation.scratch.length,
+        offset,
+      );
+      throwIfCancelled(params.operation);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+      if (offset > params.entry.size) {
+        throw new Error(`Control UI asset changed while being retained: ${params.entry.path}`);
+      }
+      hash.update(params.operation.scratch.subarray(0, bytesRead));
+      if (!destination) {
+        continue;
+      }
+      for (let written = 0; written < bytesRead;) {
+        throwIfCancelled(params.operation);
+        const { bytesWritten } = await destination.write(
+          params.operation.scratch,
+          written,
+          bytesRead - written,
+          offset - bytesRead + written,
+        );
+        throwIfCancelled(params.operation);
+        if (bytesWritten === 0) {
+          throw new Error(`Control UI asset write made no progress: ${params.entry.path}`);
+        }
+        written += bytesWritten;
+      }
+    }
+    const openedStats = await source.stat();
     const currentStats = await fs.lstat(sourcePath);
     const currentRealPath = await fs.realpath(sourcePath);
     if (
       !openedStats.isFile() ||
+      openedStats.size !== params.entry.size ||
       currentStats.isSymbolicLink() ||
       !currentStats.isFile() ||
       currentRealPath !== expectedRealPath ||
       currentStats.dev !== openedStats.dev ||
       currentStats.ino !== openedStats.ino ||
-      contents.byteLength !== params.entry.size ||
-      createHash("sha256").update(contents).digest("hex") !== params.entry.sha256
+      offset !== params.entry.size ||
+      hash.digest("hex") !== params.entry.sha256
     ) {
       throw new Error(`Control UI asset changed while being retained: ${params.entry.path}`);
     }
     throwIfCancelled(params.operation);
-    return contents;
   } finally {
-    await handle.close();
+    await Promise.allSettled([source.close(), destination?.close()]);
   }
 }
 
@@ -241,7 +284,7 @@ async function publishGeneration(params: {
   cacheDir: string;
   manifest: ControlUiAssetManifest;
   verified?: RetainedGeneration;
-  operation?: RetentionOperation;
+  operation: RetentionIo;
   root: string;
 }): Promise<RetainedGeneration> {
   const target = path.join(await fs.realpath(params.cacheDir), params.manifest.generation);
@@ -271,24 +314,19 @@ async function publishGeneration(params: {
     let preparedDirectory: string | undefined;
     for (const entry of params.manifest.assets) {
       throwIfCancelled(params.operation);
-      const contents = await readVerifiedAsset({
-        entry,
-        operation: params.operation,
-        root: params.root,
-        rootRealPath,
-      });
       const destination = path.join(staging, entry.path);
-      throwIfCancelled(params.operation);
       const directory = path.dirname(destination);
       // This preparer owns staging; adjacent assets can reuse its last created directory.
       if (directory !== preparedDirectory) {
         await fs.mkdir(directory, { recursive: true, mode: 0o700 });
         preparedDirectory = directory;
       }
-      throwIfCancelled(params.operation);
-      await fs.writeFile(destination, contents, {
-        mode: 0o600,
-        signal: params.operation?.signal,
+      await verifyAsset({
+        destination,
+        entry,
+        operation: params.operation,
+        root: params.root,
+        rootRealPath,
       });
     }
     throwIfCancelled(params.operation);
@@ -326,7 +364,7 @@ async function pruneRetainedGenerations(params: {
   currentGeneration?: string;
   verified: RetainedGeneration[];
   now: number;
-  operation?: RetentionOperation;
+  operation: RetentionIo;
 }): Promise<RetainedGeneration[]> {
   const inventory = await readCacheInventory(params.cacheDir, params.operation, params.verified);
   const generations = inventory.generations.toSorted((left, right) => {
@@ -398,7 +436,8 @@ export function createControlUiAssetRetention(root: string): ControlUiAssetReten
         throwIfCancelled(operation);
         await fs.mkdir(cacheDir, { recursive: true, mode: 0o700 });
         await fs.chmod(cacheDir, 0o700);
-        const inventory = await readCacheInventory(cacheDir, operation);
+        const io = { ...operation, scratch: Buffer.allocUnsafe(CONTROL_UI_ASSET_IO_BUFFER_BYTES) };
+        const inventory = await readCacheInventory(cacheDir, io);
         throwIfCancelled(operation);
         generations = inventory.generations;
         const verified = [...generations];
@@ -408,7 +447,7 @@ export function createControlUiAssetRetention(root: string): ControlUiAssetReten
           const published = await publishGeneration({
             cacheDir,
             manifest,
-            operation,
+            operation: io,
             root,
             verified: verified.find((entry) => entry.generation === manifest.generation),
           });
@@ -420,7 +459,7 @@ export function createControlUiAssetRetention(root: string): ControlUiAssetReten
           currentGeneration:
             manifestBytes <= CONTROL_UI_RETAINED_ASSET_MAX_BYTES ? manifest.generation : undefined,
           now: Date.now(),
-          operation,
+          operation: io,
         });
         throwIfCancelled(operation);
         generations = survivors;


### PR DESCRIPTION
Closes #136106

## What Problem This Solves

Fixes an issue where constrained hosts experienced a deterministic post-ready memory spike while the Gateway verified and retained Control UI assets. On a 512 MiB ARM64 host without swap, the Gateway reached readiness but was then killed when a routine `gateway status` process overlapped it.

## Why This Change Was Made

Control UI retention previously materialized complete asset files as temporary `Buffer` objects during verification and publication. This change streams every retained asset through one shared 64 KiB scratch buffer, hashes and optionally writes the same bytes, handles partial writes, and preserves source/path identity and post-publication integrity checks.

The fix is deliberately scoped to the Control UI retention owner. It does not claim that 512 MiB is now a supported no-swap configuration; install residue, the core Gateway graph, and concurrent CLI processes remain material.

Production LOC: +81 / -42 (net +39). The growth implements descriptor-pinned streaming, partial-write handling, cancellation, and integrity validation that cannot be preserved by a simple whole-file helper. It remains one canonical verifier rather than adding a parallel copy path. Tests: +220 / -77 (net +143).

ClawSweeper merge-risk decision: accept the +39 production lines. Compressing this back into the former whole-file helper would either restore the allocation spike or drop descriptor, cancellation, partial-write, or integrity guarantees.

## User Impact

Gateway startup has lower transient and settled memory pressure on small ARM64 systems. In matched exact-source package tests:

- 1 GiB, no swap: Gateway max RSS fell from 424,356 to 398,520 KiB; +5s RSS fell from 411,284 to 391,300 KiB.
- 768 MiB, no swap: Gateway max RSS fell from 412,680 to 390,508 KiB; +5s RSS fell from 396,788 to 382,728 KiB.
- 512 MiB, no swap: both packages still OOM during `gateway status`; the patch lowers pressure but does not make this tier reliable.

## Evidence

- Pre-fix regression proof: the bounded-buffer test failed on unchanged `main` because retention performed three whole-file asset reads.
- Focused tests after final rebase: 58/58 passed across the retention owner, integrity, publication, and cancellation suites.
- Exact-head CI exposed an unrelated declaration-cache fixture regression introduced by #135976. A stronger owner-aware repair landed independently in `5e6117d17d9`; this branch is rebased onto it, and all 11 fixture cases pass without carrying an unrelated test diff.
- The exact hosted core test-types stripe (`4/5`) passes in a full checkout.
- Oxlint and repository formatting gates passed.
- `check:changed` passed through formatting, plugin boundaries, dependency guards, and the core graph boundary. It stopped at `tsgo:core` because the shared worktree install lacks unrelated markdown/GFM and phone-normalization dependencies.
- A task-owned normal checkout completed all build phases through the final CLI import guard. Current `main` then failed the existing worker artifact check because `dist/worker/worker.mjs` retains `yargs-parser`.
- Exact ARM64 package A/B used Node.js 24.15.0, Debian 12, one CPU, cold page cache, no swap, and package source SHA `8492d2c7de50e3bc0798ad9c8594eda16ac16f90`.
- Independent autoreview on the amended exact head found no actionable correctness, security, or regression issues.
