### PR TITLE
fix(qa): accept string content in Responses messages

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1045,7 +1045,7 @@ extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts	3
 extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts	2
 extensions/qa-lab/src/providers/mock-openai/mock-openai-directives.ts	4
 extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts	4
-extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts	11
+extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts	6
 extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts	2
 extensions/qa-lab/src/providers/mock-openai/server.ts	16
 extensions/qa-lab/src/providers/shared/auth-store.ts	1

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-input.ts
@@ -12,27 +12,18 @@ import {
   QA_WHATSAPP_BATCHED_FINAL_MARKER_RE,
 } from "./mock-openai-contracts.js";
 export function extractLastUserText(input: ResponsesInputItem[]) {
-  for (const item of input.toReversed()) {
-    if (item.role !== "user" || !Array.isArray(item.content)) {
-      continue;
-    }
-    const text = extractInputText(item.content);
-    if (text && !isInternalRuntimeContextCarrierText(text)) {
-      return text;
-    }
-  }
-  return "";
+  return extractLastMatchingUserTurn(input)?.text ?? "";
 }
 
-export function extractLastMatchingUserTurn(input: ResponsesInputItem[], pattern: RegExp) {
-  const matcher = new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
+export function extractLastMatchingUserTurn(input: ResponsesInputItem[], pattern?: RegExp) {
+  const matcher = pattern && new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
   for (let index = input.length - 1; index >= 0; index -= 1) {
     const item = input[index];
-    if (item?.role !== "user" || !Array.isArray(item.content)) {
+    if (item?.role !== "user") {
       continue;
     }
     const text = extractInputText(item.content);
-    if (text && !isInternalRuntimeContextCarrierText(text) && matcher.test(text)) {
+    if (text && !isInternalRuntimeContextCarrierText(text) && (!matcher || matcher.test(text))) {
       return { index, text };
     }
   }
@@ -75,12 +66,12 @@ export function extractMockSubagentContext(input: ResponsesInputItem[]) {
   return { task, inheritedUserTexts };
 }
 
-function findLastUserIndex(input: ResponsesInputItem[]) {
-  return input.findLastIndex(
-    (item) =>
-      item.role === "user" &&
-      Array.isArray(item.content) &&
-      !isInternalRuntimeContextCarrierText(extractInputText(item.content)),
+function isUserTurn(item: ResponsesInputItem) {
+  // Empty user messages still fence old tool output; runtime carriers do not.
+  return (
+    item.role === "user" &&
+    (typeof item.content === "string" || Array.isArray(item.content)) &&
+    !isInternalRuntimeContextCarrierText(extractInputText(item.content))
   );
 }
 
@@ -163,7 +154,7 @@ function extractFunctionCallOutputText(item: ResponsesInputItem) {
 }
 
 function findCurrentToolOutput(input: ResponsesInputItem[]): ResponsesInputItem | undefined {
-  const lastUserIndex = findLastUserIndex(input);
+  const lastUserIndex = input.findLastIndex(isUserTurn);
   for (const item of input.slice(lastUserIndex + 1).toReversed()) {
     if (isResponsesToolCallOutput(item)) {
       return item;
@@ -175,9 +166,8 @@ function findCurrentToolOutput(input: ResponsesInputItem[]): ResponsesInputItem 
     }
     const laterUserTexts = input
       .slice(candidateIndex + 1)
-      .filter((laterItem) => laterItem.role === "user" && Array.isArray(laterItem.content))
-      .map((laterItem) => extractInputText(laterItem.content as unknown[]))
-      .filter(Boolean);
+      .filter(isUserTurn)
+      .map((laterItem) => extractInputText(laterItem.content));
     if (laterUserTexts.length > 0 && laterUserTexts.every(isContinuationUserText)) {
       return candidateItem;
     }
@@ -237,13 +227,19 @@ export function extractUserTextAfterLatestToolOutput(input: ResponsesInputItem[]
   }
   return input
     .slice(latestToolOutputIndex + 1)
-    .filter((item) => item.role === "user" && Array.isArray(item.content))
-    .map((item) => extractInputText(item.content as unknown[]))
+    .filter((item) => item.role === "user")
+    .map((item) => extractInputText(item.content))
     .filter(Boolean)
     .join("\n");
 }
 
-function extractInputText(content: unknown[]): string {
+function extractInputText(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
   return content
     .filter(
       (entry): entry is { type: "input_text"; text: string } =>
@@ -258,17 +254,10 @@ function extractInputText(content: unknown[]): string {
 }
 
 export function extractAllUserTexts(input: ResponsesInputItem[]) {
-  const texts: string[] = [];
-  for (const item of input) {
-    if (item.role !== "user" || !Array.isArray(item.content)) {
-      continue;
-    }
-    const text = extractInputText(item.content);
-    if (text) {
-      texts.push(text);
-    }
-  }
-  return texts;
+  return input
+    .filter((item) => item.role === "user")
+    .map((item) => extractInputText(item.content))
+    .filter(Boolean);
 }
 
 export function extractSlackMpimRetainedBotNonce(
@@ -307,20 +296,13 @@ export function extractSlackMpimRetainedBotNonce(
 }
 
 function extractAllInputTexts(input: ResponsesInputItem[]) {
-  const texts: string[] = [];
-  for (const item of input) {
-    if (typeof item.output === "string" && item.output.trim()) {
-      texts.push(item.output.trim());
-    }
-    if (!Array.isArray(item.content)) {
-      continue;
-    }
-    const text = extractInputText(item.content);
-    if (text) {
-      texts.push(text);
-    }
-  }
-  return texts.join("\n");
+  return input
+    .flatMap((item) => [
+      typeof item.output === "string" ? item.output.trim() : "",
+      extractInputText(item.content),
+    ])
+    .filter(Boolean)
+    .join("\n");
 }
 
 export function extractInstructionsText(body: Record<string, unknown>) {
@@ -328,16 +310,7 @@ export function extractInstructionsText(body: Record<string, unknown>) {
 }
 
 export function extractAllRequestTexts(input: ResponsesInputItem[], body: Record<string, unknown>) {
-  const texts: string[] = [];
-  const instructions = extractInstructionsText(body);
-  if (instructions) {
-    texts.push(instructions);
-  }
-  const inputText = extractAllInputTexts(input);
-  if (inputText) {
-    texts.push(inputText);
-  }
-  return texts.join("\n");
+  return [extractInstructionsText(body), extractAllInputTexts(input)].filter(Boolean).join("\n");
 }
 
 export function buildWhatsAppPendingHistoryReply(prompt: string, input: ResponsesInputItem[]) {
@@ -365,9 +338,9 @@ export function buildWhatsAppPendingHistoryReply(prompt: string, input: Response
 
 function extractWhatsAppPendingHistoryRuntimeContext(input: ResponsesInputItem[]) {
   return input
-    .filter((item) => item.role === "user" && Array.isArray(item.content))
+    .filter((item) => item.role === "user")
     .map((item) => {
-      const text = extractInputText(item.content as unknown[]);
+      const text = extractInputText(item.content);
       return isInternalRuntimeContextCarrierText(text) ? text : undefined;
     })
     .filter((block): block is string => Boolean(block))
@@ -447,7 +420,7 @@ export function countImageInputs(value: unknown): number {
 }
 
 function extractLatestImageUserTurn(input: ResponsesInputItem[]) {
-  const latestUserIndex = findLastUserIndex(input);
+  const latestUserIndex = input.findLastIndex(isUserTurn);
   if (latestUserIndex < 0) {
     return { text: "", imageInputCount: 0 };
   }
@@ -464,7 +437,7 @@ function extractLatestImageUserTurn(input: ResponsesInputItem[]) {
   }
   return {
     text: imageTurnItems
-      .map((item) => extractInputText(item.content as unknown[]))
+      .map((item) => extractInputText(item.content))
       .filter(Boolean)
       .join("\n"),
     imageInputCount,
@@ -482,8 +455,8 @@ export function extractCurrentImageRequest(
     return imageUserTurn;
   }
   const developerInstructions = input
-    .filter((item) => item.role === "developer" && Array.isArray(item.content))
-    .map((item) => extractInputText(item.content as unknown[]))
+    .filter((item) => item.role === "developer")
+    .map((item) => extractInputText(item.content))
     .filter(Boolean);
   return {
     text: [extractInstructionsText(body), ...developerInstructions, imageUserTurn.text]

--- a/extensions/qa-lab/src/providers/mock-openai/server.responses-input.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.responses-input.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { startQaMockOpenAiServer } from "./server.js";
+
+const prompt = "Reply exactly: QA-MESSAGE-CONTENT";
+
+describe("mock Responses input text", () => {
+  it.each([
+    { name: "plain input", input: prompt },
+    { name: "string message", input: [{ role: "user", content: prompt }] },
+    {
+      name: "text-block message",
+      input: [{ role: "user", content: [{ type: "input_text", text: prompt }] }],
+    },
+  ])("reads $name", async ({ input }) => {
+    const server = await startQaMockOpenAiServer({ host: "127.0.0.1", port: 0 });
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "qa-model", stream: false, input }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        output: [
+          {
+            type: "message",
+            content: [{ type: "output_text", text: "QA-MESSAGE-CONTENT" }],
+          },
+        ],
+      });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it.each([
+    {
+      name: "ignores a runtime carrier before continuation",
+      laterInput: [
+        {
+          role: "user",
+          content: [
+            "OpenClaw runtime event.",
+            "This context is runtime-generated, not user-authored. Keep internal details private.",
+            "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+            "Runtime: synthetic metadata.",
+            "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+          ].join("\n"),
+        },
+        { role: "user", content: [{ type: "input_text", text: "Continue." }] },
+      ],
+      requestKind: "tool-continuation",
+    },
+    {
+      name: "fences completed tools with an empty user message after continuation",
+      laterInput: [
+        { role: "user", content: "Continue." },
+        { role: "user", content: [] },
+      ],
+      requestKind: "agent-initial",
+    },
+  ])("$name", async ({ laterInput, requestKind }) => {
+    const server = await startQaMockOpenAiServer({ host: "127.0.0.1", port: 0 });
+    try {
+      const response = await fetch(`${server.baseUrl}/v1/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "qa-model",
+          stream: false,
+          input: [
+            {
+              role: "user",
+              content: [{ type: "input_text", text: "Summarize the fixture result." }],
+            },
+            {
+              type: "function_call",
+              id: "fc_fixture",
+              call_id: "fixture_call",
+              name: "read",
+              arguments: '{"path":"QA.md"}',
+            },
+            { type: "function_call_output", call_id: "fixture_call", output: "fixture result" },
+            ...laterInput,
+          ],
+        }),
+      });
+      expect(response.status).toBe(200);
+      await response.arrayBuffer();
+      const snapshot = await fetch(`${server.baseUrl}/debug/last-request`).then((res) =>
+        res.json(),
+      );
+      expect(snapshot).toMatchObject({ requestKind });
+    } finally {
+      await server.stop();
+    }
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

QA Lab silently ignores valid Responses messages whose `content` is a string. A normal SDK request such as `input: [{ role: "user", content: "Reply exactly: QA-MESSAGE-CONTENT" }]` returns the mock readiness message and records an empty prompt. The equivalent top-level string and text-block forms work.

## Why This Change Was Made

One text decoder now handles both SDK-supported content forms. The existing latest-user selector owns prompt selection, while a shared user-turn predicate owns tool and image boundaries. Protected runtime context stays outside continuation checks, and valid empty user messages still fence completed tools. This removes repeated array gates, text-projection loops, and five casts.

## User Impact

String-content messages follow the same scenario, role, context, and tool behavior as their text-block equivalents. Mixed-format continuations retain completed tools across protected context messages and respect a later empty user turn.

## Evidence

The maintained string-message regression fails on the starting head, with both existing forms passing. Independent review also caught two continuation regressions during implementation; each failed through actual HTTP and the official SDK before the shared predicate repair. All **307 tests** in the five focused suites now pass.

OpenAI SDK 7.5.0 passes all three input forms over loopback HTTP. Additional real-wire checks pass for both mixed continuation cases, SDK SSE, Responses WebSocket, and Anthropic SDK JSON. Twelve comparisons against the original Git-object owner preserve existing block behavior and verify equivalent string projections, including roles, empty turns, tool identities, runtime context, and image/developer instructions.

Production TypeScript: **+41/-68, net -27**. Tests: **+98/-0**. Tooling: **+1/-1**, tightening the existing assertion baseline from 11 to 6 after removing five casts. The array-only gate is present in stable v2026.8.2; QA Lab is a source-checkout plugin.

The acting agent inspected the pinned SDK's `EasyInputMessage` contract and Codex at `94cbbddafc1776d5e377bca1b05932c697e82238`: `codex-rs/protocol/src/models.rs:814-823,853-869,975-989` uses content arrays. Native Codex validation here is direct source inspection plus the existing array-form wire controls.

Fresh independent Codex review through P2 is scoped-clean with zero findings (confidence 0.95). The two initial review findings are fixed and covered by maintained HTTP regressions.

Full changed-file checks exited 0, including extension and extension-test types, formatting, extension/scripts lint, boundary and assertion guards, dead-export scans, storage guards, and runtime import-cycle checks.


After rebasing onto merged #136062, the production owner and new maintained test retain their reviewed hashes; the assertion baseline retains the reviewed five-cast reduction and inherits three unrelated main decreases. The actual SDK three-form probe passes again, and all11 Responses input/default-mode/Anthropic terminal HTTP regressions pass together.

Fixes #136087.
