### PR TITLE
fix(qa): retain bootstrap diagnostics after timeouts

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1131,7 +1131,10 @@ commands run against the active Gateway. Each CLI command has a two-minute
 execution limit. Stop closes admission immediately and settles all owned process
 groups; leader exit does not bypass shutdown or the bounded wait for inherited
 stdio to close. On POSIX, CLI commands use their own process groups, so concurrent
-commands do not replace the active Gateway's identity.
+commands do not replace the active Gateway's identity. CLI failures, including
+timeouts, cancellations, and stream faults, retain bounded, redacted stderr and
+stdout captured through shutdown. Packaged plugin setup errors distinguish
+`update repair --help` from `update repair`.
 
 Transport adapters drain their driver work in
 `cleanup()` and release Gateway-backed credentials in

--- a/extensions/qa-lab/src/gateway-child-bootstrap.test.ts
+++ b/extensions/qa-lab/src/gateway-child-bootstrap.test.ts
@@ -48,13 +48,22 @@ if (command === "descendant") {
     : command === "update" ? (args.includes("--help") ? "help" : "repair") : command;
   write(current);
   if (current === phase) {
-    process.on("SIGTERM", () => {});
+    process.on("SIGTERM", () => {
+      if (mode === "running") for (const [fd, label] of [[1, "stdout"], [2, "stderr"]]) {
+        try { fs.writeSync(fd, "\nshutdown " + label + " diagnostic apiKey=synthetic-drain-secret\n"); }
+        catch { /* The fault matrix can close either parent-side pipe. */ }
+      }
+    });
     setTimeout(() => process.exit(20), 30_000);
     const child = spawn(process.execPath, [process.argv[1], record, phase, mode, "descendant"],
       { stdio: ["ignore", mode === "closed-pipes" ? "ignore" : "inherit", mode === "closed-pipes" ? "ignore" : "inherit", "ipc"] });
     await once(child, "message");
     write("ready", { descendant: child.pid, tempRoot: process.env.OPENCLAW_QA_TEMP_ROOT,
       ...(mode === "failure" ? { submittedKey: input.trim() } : {}) });
+    if (mode === "running") {
+      fs.writeSync(2, "plugin registry still pending apiKey=synthetic-stderr-secret\n::error::stderr diagnostic\nstderr ready\n");
+      fs.writeSync(1, "diagnostic ".repeat(400) + "\nplugin scan still pending Authorization: Bearer synthetic-stdout-secret\n##[error]stdout diagnostic\nstdout ready\n");
+    }
     if (mode !== "running") {
       if (mode === "failure") fs.writeSync(2, "Authorization: Bearer " + input.trim() + "\ncontext retained\n" + "diagnostic ".repeat(400));
       process.stdout.write("fixture-output");
@@ -277,8 +286,8 @@ describe.skipIf(process.platform === "win32")("packaged QA bootstrap lifetime", 
     },
   );
 
-  it.each(["timeout", "stdout", "stderr", "process"] as const)(
-    "settles a real CLI tree after %s failure without retaining raw error graphs",
+  it.each(["timeout", "cancel", "stdout", "stderr", "stdin", "process"] as const)(
+    "retains bounded redacted diagnostics after %s failure and settles the real CLI tree",
     async (failure) => {
       const f = await fixture("probe", "running");
       const lifetime = new QaGatewayChildLifecycle();
@@ -290,38 +299,88 @@ describe.skipIf(process.platform === "win32")("packaged QA bootstrap lifetime", 
         runQaGatewayCliCommand({
           ...f.command,
           lifetime,
-          args: ["probe"],
+          args: ["probe", "unlabeled-argv-secret"],
           cwd: f.root,
-          env: { HOME: f.root },
+          env: { HOME: f.root, QA_SYNTHETIC_SECRET: "unlabeled-env-secret" },
+          stdin: failure === "stdin" ? "unlabeled-stdin-secret" : undefined,
         }),
       );
       cleanups.push(async () => {
         await lifetime.stop();
       });
-      await f.ready();
       const child = registration.mock.calls[0]![0];
+      const observed = { stdout: "", stderr: "" };
+      for (const stream of ["stdout", "stderr"] as const) {
+        child[stream]!.on("data", (chunk) => (observed[stream] += String(chunk)));
+      }
+      await f.ready();
+      await vi.waitFor(() => {
+        expect(observed.stdout).toContain("stdout ready");
+        expect(observed.stderr).toContain("stderr ready");
+      });
+      let stopping: Promise<unknown> | undefined;
       if (failure === "timeout") {
         await vi.advanceTimersByTimeAsync(120_000);
+      } else if (failure === "cancel") {
+        stopping = f.track(lifetime.stop());
       } else {
-        const error = new AggregateError(
-          [new Error("unlabeled-nested-secret")],
-          "apiKey=synthetic-stream-secret",
-          { cause: new Error("unlabeled-cause-secret") },
+        const error = Object.assign(
+          new AggregateError(
+            [new Error("unlabeled-nested-secret")],
+            "apiKey=synthetic-stream-secret",
+            { cause: new Error("unlabeled-cause-secret") },
+          ),
+          { spawnargs: ["unlabeled-spawnargs-secret"], env: { key: "unlabeled-error-env-secret" } },
         );
         if (failure === "process") {
           child.emit("error", error);
+        } else if (failure === "stdin") {
+          child.stdin!.emit("error", error);
         } else {
-          child[failure]!.destroy(error);
+          await bounded(
+            new Promise<void>((resolve) => {
+              child[failure]!.once("error", () => resolve());
+              child[failure]!.destroy(error);
+            }),
+          );
         }
       }
+      (failure === "process" ? child.stderr! : child).emit("error", new Error("later failure"));
       const error = await bounded(command);
       expect(error).toBeInstanceOf(Error);
-      expect(String(error)).toContain(
-        failure === "timeout" ? "exceeded 120000ms" : `${failure} failed`,
+      if (!(error instanceof Error)) {
+        throw new Error("expected CLI failure");
+      }
+      expect(error.message).toContain(
+        failure === "timeout"
+          ? "exceeded 120000ms"
+          : failure === "cancel"
+            ? "CLI cancelled"
+            : `${failure} failed`,
       );
+      expect(error.message).not.toContain("later failure");
+      expect(error.message).toContain("plugin registry still pending apiKey=<redacted>");
+      expect(error.message).toContain("plugin scan still pending Authorization: Bearer <redacted>");
+      expect(error.message.indexOf("plugin registry")).toBeLessThan(
+        error.message.indexOf("plugin scan"),
+      );
+      for (const stream of ["stdout", "stderr"] as const) {
+        if (failure !== stream) {
+          expect(error.message).toContain(`shutdown ${stream} diagnostic apiKey=<redacted>`);
+        }
+      }
+      expect(error.message.length).toBeLessThanOrEqual(2_048);
+      expect(error.message).toContain(": :error::stderr diagnostic");
+      expect(error.message).toContain("# #[error]stdout diagnostic");
+      expect(error.message).not.toMatch(/(^|[\r\n])[^\S\r\n]*::/u);
+      expect(error).not.toHaveProperty("cause");
+      expect(error).not.toHaveProperty("errors");
       const diagnostic = inspect(error, { depth: null });
-      expect(diagnostic).not.toMatch(/synthetic-stream-secret|unlabeled-(nested|cause)-secret/u);
+      expect(diagnostic).not.toMatch(/synthetic-[\w-]+-secret|unlabeled-[\w-]+-secret/u);
       f.assertStopped();
+      if (stopping) {
+        expect(await bounded(stopping)).toEqual({ process: "confirmed-stopped", errors: [] });
+      }
       await expect(lifetime.stop()).resolves.toEqual({ process: "confirmed-stopped", errors: [] });
     },
   );

--- a/extensions/qa-lab/src/gateway-child-command.ts
+++ b/extensions/qa-lab/src/gateway-child-command.ts
@@ -143,10 +143,12 @@ async function readQaGatewayCliCommand(
     child.stderr?.destroy();
   }
   const stdoutText = readQaChildOutput(stdout);
-  if (exitCode !== 0 && !failure) {
+  if (failure || exitCode !== 0) {
+    // Preserve the first failure's reason, but include output drained during shutdown.
+    const reason = failure?.message ?? `OpenClaw CLI exited ${exitCode}`;
     const stderrText = formatQaChildOutputTail(stderr, "stderr");
     failure = createQaGatewayCliError(
-      `OpenClaw CLI exited ${exitCode}: ${[stderrText, stdoutText].filter(Boolean).join("\n")}`,
+      `${reason}: ${[stderrText, stdoutText].filter(Boolean).join("\n")}`,
     );
   }
   if (stopped.errors.length) {

--- a/extensions/qa-lab/src/gateway-child-setup.ts
+++ b/extensions/qa-lab/src/gateway-child-setup.ts
@@ -109,12 +109,12 @@ function createQaPackagedMockApiKey(): string {
   return `${prefix}-${["qa", "mock", randomUUID().replaceAll("-", "")].join("-")}`;
 }
 
-async function runQaPackagedBootstrap(
+async function runQaPackagedBootstrap<T>(
   failureMessage: string,
-  operation: () => Promise<unknown>,
-): Promise<void> {
+  operation: () => Promise<T>,
+): Promise<T> {
   try {
-    await operation();
+    return await operation();
   } catch (error) {
     const details = createQaGatewayCliError(error).message;
     // oxlint-disable-next-line preserve-caught-error -- Candidate CLI output can contain credentials; only the bounded redacted message crosses this boundary, never its raw cause.
@@ -441,23 +441,25 @@ export async function prepareQaGatewayChild(
             cwd: gatewayCwd,
             env,
           };
-          await runQaPackagedBootstrap("installed package plugin setup failed", async () => {
-            // The separate onboarding smoke cannot prepare this child's state.
-            // Converge every freshly written config; a new-port retry can otherwise
-            // restore plugin entries the candidate removed before verify-only startup.
-            // Published candidates such as 2026.7.1-2 predate capability consent.
-            const help = await runQaGatewayCliCommand({
-              ...command,
-              args: ["update", "repair", "--help"],
-            });
-            const consentArgs = help.includes("--accept-capabilities")
-              ? ["--accept-capabilities"]
-              : [];
-            await runQaGatewayCliCommand({
-              ...command,
-              args: ["update", "repair", ...consentArgs, "--yes", "--no-restart", "--json"],
-            });
-          });
+          // The separate onboarding smoke cannot prepare this child's state.
+          // Converge every freshly written config; a new-port retry can otherwise
+          // restore plugin entries the candidate removed before verify-only startup.
+          // Published candidates such as 2026.7.1-2 predate capability consent.
+          const help = await runQaPackagedBootstrap(
+            "installed package plugin setup failed (update repair --help)",
+            () => runQaGatewayCliCommand({ ...command, args: ["update", "repair", "--help"] }),
+          );
+          const consentArgs = help.includes("--accept-capabilities")
+            ? ["--accept-capabilities"]
+            : [];
+          await runQaPackagedBootstrap(
+            "installed package plugin setup failed (update repair)",
+            () =>
+              runQaGatewayCliCommand({
+                ...command,
+                args: ["update", "repair", ...consentArgs, "--yes", "--no-restart", "--json"],
+              }),
+          );
         }
       }
       if (!env) {

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1767,7 +1767,7 @@ describe("buildQaRuntimeEnv", () => {
       }
       const prefix = provider
         ? `installed package mock auth bootstrap failed for ${provider}: `
-        : "installed package plugin setup failed: ";
+        : `installed package plugin setup failed (update repair${phase === "help" ? " --help" : ""}): `;
       const detail = provider
         ? "OpenClaw CLI exited 9: Authorization: Bearer <redacted>"
         : "OpenClaw CLI exited 8: plugin fixture rejected: Authorization: Bearer <redacted>";


### PR DESCRIPTION
Closes #136102 — QA bootstrap drops captured diagnostics on timeout and earlier failures.

## What Problem This Solves

Fixes an issue where QA operators would lose useful child stdout/stderr when bootstrap or a post-start CLI command timed out, was cancelled, or failed through a process/stream error. Installed-package plugin setup also reported the same failure prefix for `update repair --help` and the actual repair, hiding which phase failed.

## Why This Change Was Made

Finalize the diagnostic in the existing CLI command owner after process-tree settlement and bounded pipe draining, preserving the first failure reason and appending captured stderr then stdout through the canonical redactor. Let the existing private bootstrap wrapper return its operation result so help and repair can have separate fixed phase labels; no raw argv/environment logging or parallel logging path is added.

Lifecycle ownership, admission/cancellation, cleanup aggregation, successful stdout, capability-consent negotiation, the 120000ms execution deadline, and the 1000ms drain deadline are unchanged. The existing 2048-character redacted error bound, stdout 1MiB cap, and stderr 64KiB tail are unchanged. No configuration, dependency, schema, protocol, or test-only production seam is added.

This repairs diagnostic loss only. The original isolated UI setup's timed-out invocation is unknown; nonempty output in that attempt was not established. Neither the underlying bootstrap timeout nor the pending-notice UI bug is claimed fixed. Separate scenario-command diagnostic gaps use different result/settlement owners and were recorded as follow-up work rather than bundled here.

## User Impact

QA failures retain meaningful sanitized diagnostics, including output emitted during shutdown, while preserving the earliest failure reason and normal cleanup. Packaged setup errors identify the repair-help probe or actual repair. QA overview documentation describes the diagnostic behavior.

Production LOC: +27/-23 (net +4). Tests: +74/-15 (net +59). Docs: +4/-1. The small production increase buys final output retention and phase-specific attribution by reusing the existing owners; no alternative runtime flow was introduced.

## Evidence

### Failing before, passing after

The extended existing real-child fixture writes meaningful synthetic diagnostics to both pipes and hangs. The parent observes both streams before injecting failures. Timeout uses the existing fake-timer control; child spawning, output, descendant liveness, termination, and cleanup remain real.

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child-bootstrap.test.ts
```

Pre-fix: **6 expected diagnostic failures, 8 passes**. Post-fix: **14 passes**. Coverage includes timeout, cancellation, stdout, stderr, stdin, process errors, first-failure precedence, shutdown-emitted output, redaction, workflow-command neutralization, the 2048-character bound, and removal of raw argv/env/stdin/cause/error-graph data.

```text
Before:
Expected: plugin registry still pending apiKey=<redacted>
Received: qa gateway CLI exceeded 120000ms

After:
qa gateway CLI exceeded 120000ms: plugin registry still pending apiKey=<redacted>
[bounded synthetic output]
plugin scan still pending Authorization: Bearer <redacted>
shutdown stdout diagnostic apiKey=<redacted>
```

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child.test.ts --testNamePattern 'blocks packaged gateway spawn with bounded redacted diagnostics'
```

Pre-fix: **2 expected phase-label failures, 2 passes**. Post-fix: **4 passes**. Help and repair are now independently attributed; auth phase labeling and canonical-config behavior are unchanged.

### Owner and sibling coverage

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child-bootstrap.test.ts extensions/qa-lab/src/gateway-child.test.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts extensions/qa-lab/src/gateway-log-redaction.test.ts extensions/qa-lab/src/child-output.test.ts
```

**138 passed, 1 skipped** on macOS/Node 24.20.0. The skipped case is Linux-only. Existing coverage includes overlapping post-start commands, successful leader exits with descendants, cleanup failures/retries, artifacts, legacy capability-help behavior, output byte bounds, and redaction.

### Real-clock timeout proof

A separate source-owner probe launched an isolated synthetic Node child, emitted stdout/stderr, and waited for the unchanged real deadline without fake timers or a timeout override. It completed at **120052ms** with a **2048-character** error containing both sanitized diagnostic markers, no raw secrets/argv/environment data, and **confirmed-stopped** cleanup. Its isolated temporary directory was removed.

```text
qa gateway CLI exceeded 120000ms: synthetic registry diagnostic apiKey=<redacted>
[bounded synthetic padding; output omitted marker]
synthetic scan diagnostic Authorization: Bearer <redacted>
```

This is real child-process boundary proof, not proof of successful packaged installation, a live-provider run, or the original UI bootstrap. No UI rendering changed, so there is no before/after UI capture.

### Static checks and review

```bash
node scripts/check-changed.mjs --base HEAD -- extensions/qa-lab/src/gateway-child-command.ts extensions/qa-lab/src/gateway-child-setup.ts extensions/qa-lab/src/gateway-child-bootstrap.test.ts extensions/qa-lab/src/gateway-child.test.ts docs/concepts/qa-e2e-automation.md
```

Passed: production/test type checks, targeted lint/format, doctor contract tests (5 passed), plugin boundaries, dead exports, import cycles, and selected guards. The first check attempt found missing browser parser types already declared by refreshed main; `pnpm install` refreshed the stale install, and unchanged checks then passed. No manifest/lockfile edits.

Independent Codex autoreview: scoped-clean at the default P0 threshold. The lead separately inspected the full command/setup/lifecycle/capture/redaction owners, callers, tests, docs, current main, raw historical patches, and Node's exit/close contract. `git diff --check` passed. Full-suite, package, provider, and cross-platform campaigns were not run for this diagnostic-only owner change; hosted exact-head CI is the remaining landing gate.

### Maintainer review follow-through

The [current ClawSweeper review](https://github.com/openclaw/openclaw/pull/136111#issuecomment-5506170625) found no correctness or security findings and judged this the owner-level fix. Its remaining items are addressed as follows:

- **Production net +4:** accepted. The four lines provide final diagnostic retention and distinguish help/repair while replacing the old nonzero-only branch. Reducing the count by inlining the reason or duplicating the formatter would make the boundary less clear; no new abstraction, runtime path, or configurable policy was added.
- **Stored-data classification:** not applicable. The `gateway-child-setup.ts` change returns a private helper's existing operation result and splits fixed error labels. Auth configuration, capability detection, repair arguments, persistence operations, representations, and migrations are unchanged. No schema/store change or new upgrade step exists to migrate. Existing auth/config, legacy-help, retry, and lifecycle tests passed.

The refreshed 08:05 UTC review adds a Rank-up move: refresh onto current main and obtain green exact-head CI. The mechanical refresh below incorporates the canonical fixture fix; the new exact-head CI result remains mandatory before merge. No additional diagnostic source change is requested by the review.

### CI correction

[Initial exact-head CI 33603899100](https://github.com/openclaw/openclaw/actions/runs/33603899100) failed in `checks-node-compact-small-49`: the unrelated `write-plugin-sdk-entry-dts.test.ts` cache-relocation fixture expected a historical root chunk that it had not seeded. The actual tested merge used main parent `331d8a2265ff07d5db51e459c32d38c10fc7dc24`.

Main subsequently fixed that premise in [5e6117d17d92 — scoped external channels and CI fixture repair](https://github.com/openclaw/openclaw/commit/5e6117d17d92dcac2ef6da6d609eb423b089a77a). The fixture now pre-seeds only unowned historical chunks from the current snapshot, while cache-owned outputs must still be restored and the complete tree must remain byte-identical. The diagnostic patch was mechanically rebased onto `4fc24e6e0f81121cef0fb4395db29fb87700e7f6`, which contains that fix. Range-diff and patch hashing confirm the same five-file patch, byte-for-byte. No duplicate fixture patch, assertion weakening, timeout increase, or CI bypass was added. Prepare/merge were not invoked on the failed head.

Rebased head: `020d3683c1828ff2d56a3b1d658817008f550aa7`. The focused bootstrap suite passed **14/14** again on Node 24.20.0, and fresh branch autoreview was scoped-clean at P0. The previous complete changed checks and 138-test owner/sibling proof apply to the identical repair; fresh hosted exact-head CI remains required before merge.

A supplemental local SDK sweep on Node 26.8.1 reported three passing cases but was explicitly interrupted by the maintainer after approximately 19 minutes; it has no cache-relocation verdict and is **not passing proof**. A concurrently started QA retry was also stopped, then replaced by the completed 14-test Node 24.20.0 run above. The canonical upstream fixture was verified by the new exact-head Linux CI run, not by treating the interrupted sweep as success.

### Final exact-head validation

[CI run 33609123436](https://github.com/openclaw/openclaw/actions/runs/33609123436) completed **success** for `020d3683c1828ff2d56a3b1d658817008f550aa7`; the required `openclaw/ci-gate` is **SUCCESS**. The previously failing `checks-node-compact-small-49` shard passed with the inherited canonical fixture correction. The native CI watcher completed `GREEN`, and native review artifacts validate for this exact head.

The latest ClawSweeper review at 08:40 UTC covers this head, reports no correctness/security findings and no before-merge items. The prior refresh-and-green-CI Rank-up move is completed. The stored-data classification remains inapplicable for the unchanged persistence contract, as explained above. All remaining proof limitations are unchanged; this is ready for repository-native prepare/merge, not a claim that the original bootstrap timeout or UI bug is repaired.
