### PR TITLE
fix(release): reuse prepared artifacts on failed-job retries

### DIFF
--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -51,7 +51,8 @@ Same-parent continuation requires the original root to have been dispatched
 with `fail_fast=false`. The controller verifies that exact logged input before
 any rerun mutation.
 It is also unavailable when that parent produced the sealed candidate or
-publication artifacts, because GitHub reruns make those prior-attempt artifacts unavailable.
+publication artifacts: the continuation controller does not rebind those
+artifacts to a later parent attempt.
 Keep the candidate and Tooling SHAs frozen, supersede the parent, and start a
 fresh all-group Full Release Validation.
 
@@ -321,6 +322,13 @@ sharing the target snapshot. Publication selects its channel's report and
 acknowledgement without rebuilding. Alpha, beta prerelease, and extended-stable
 targets keep their required channel.
 
+If npm qualification fails after source checks and package preparation succeed,
+rerun the failed qualification job. It reuses the exact successful producer jobs
+and package bytes from the earlier attempt, even if that attempt failed or was
+cancelled. Failed or unfinished producer jobs remain ineligible. Final npm
+publication still requires the qualified preflight attempt to complete
+successfully.
+
 `docker-release-prepare.yml` builds both native architectures, retains OCI
 indexes and their SBOM/provenance, and runs image smoke checks before approval.
 OCI export uses gzip level 1 for new layers and reuses cached layers without
@@ -340,6 +348,12 @@ then promotes those bytes to GHCR and Docker Hub. The publication lock covers
 registry writes and selector promotion. Historical evidence without prepared
 images uses the same preparation workflow before promotion. Alpha targets
 retain their existing npm-only preparation contract.
+
+If Docker preparation succeeds but publication fails in the same workflow run,
+rerun the failed publication job. The new publisher attempt verifies the original
+successful preparation job and sealed artifacts without rebuilding. A separate
+publisher run still requires the original producer attempt to be active or
+successful; it cannot adopt a failed producer attempt through this retry path.
 
 Fresh package-facing validation passes the prepared root/core bundle to the
 `Full Release Candidate` reusable workflow. Its registry carries the exact

--- a/scripts/docker-release-artifacts.mjs
+++ b/scripts/docker-release-artifacts.mjs
@@ -508,12 +508,8 @@ export function validateDockerReleaseManifest(manifest, expected) {
   return manifest;
 }
 
-/** A reusable workflow can finish while its FRV parent remains active. Trust the
- * exact completed seal job, never infer successful preparation from parent state. */
-export function verifyDockerReleaseProducer(manifest, { publisherSha, readApi = ghJson }) {
+function verifyDockerProducerRun(runInfo, manifest, runAttempt) {
   const { repository, toolingSha, producer } = manifest;
-  requireValue(SHA.test(publisherSha), "Invalid Docker publisher tooling SHA.");
-  const runInfo = readApi(`repos/${repository}/actions/runs/${producer.runId}`);
   const workflowPath = String(runInfo.path).split("@", 1)[0];
   const prefix = `${repository}/${workflowPath}@`;
   requireValue(
@@ -533,22 +529,63 @@ export function verifyDockerReleaseProducer(manifest, { publisherSha, readApi = 
       fullRef === "refs/heads/main");
   requireValue(
     String(runInfo.id) === producer.runId &&
-      String(runInfo.run_attempt) === producer.runAttempt &&
+      String(runInfo.run_attempt) === runAttempt &&
       runInfo.head_sha === toolingSha &&
       runInfo.repository?.full_name === repository &&
       runInfo.head_repository?.full_name === repository &&
       trustedEvent,
     "Docker producer run/attempt/source mismatch.",
   );
+  return { workflowPath, fullRef };
+}
+
+/** Preparation belongs to its exact successful seal job. A publisher retry
+ * advances the parent attempt without rebuilding that immutable payload. */
+export function verifyDockerReleaseProducer(
+  manifest,
+  { publisherSha, publisherRunId = "", publisherRunAttempt = "", readApi = ghJson },
+) {
+  const { repository, toolingSha, producer } = manifest;
+  requireValue(SHA.test(publisherSha), "Invalid Docker publisher tooling SHA.");
+  const currentRun = readApi(`repos/${repository}/actions/runs/${producer.runId}`);
+  const currentAttempt = String(currentRun.run_attempt);
   requireValue(
-    (runInfo.status === "completed" && runInfo.conclusion === "success") ||
-      (runInfo.status === "in_progress" && runInfo.conclusion === null),
+    POSITIVE_INTEGER.test(currentAttempt) && BigInt(currentAttempt) >= BigInt(producer.runAttempt),
+    "Docker producer attempt is not available.",
+  );
+  const { workflowPath, fullRef } = verifyDockerProducerRun(currentRun, manifest, currentAttempt);
+  requireValue(
+    (currentRun.status === "completed" && currentRun.conclusion === "success") ||
+      (currentRun.status === "in_progress" && currentRun.conclusion === null),
     "Docker producer is neither active nor successfully completed.",
   );
+  let preparedRun = currentRun;
+  if (currentAttempt !== producer.runAttempt) {
+    preparedRun = readApi(
+      `repos/${repository}/actions/runs/${producer.runId}/attempts/${producer.runAttempt}`,
+    );
+    verifyDockerProducerRun(preparedRun, manifest, producer.runAttempt);
+    // Failed publication may reuse its own successful seal; unrelated publishers
+    // still require a successful producer parent, even when that run is retried.
+    const resumingOwnPublication =
+      producer.runId === publisherRunId &&
+      currentAttempt === publisherRunAttempt &&
+      currentRun.head_sha === publisherSha &&
+      currentRun.status === "in_progress" &&
+      preparedRun.status === "completed" &&
+      ["failure", "cancelled", "timed_out"].includes(preparedRun.conclusion);
+    requireValue(
+      (preparedRun.status === "completed" && preparedRun.conclusion === "success") ||
+        resumingOwnPublication,
+      "Historical Docker producer did not qualify for this publication.",
+    );
+  }
+  // Preparation linkage belongs to its recorded attempt; a publisher-only retry
+  // need not list that completed reusable workflow in its current attempt.
   requireValue(
     producer.preparationWorkflowRef === `${repository}/${WORKFLOW_PATH}@${fullRef}` &&
       (workflowPath === WORKFLOW_PATH ||
-        runInfo.referenced_workflows?.some(
+        preparedRun.referenced_workflows?.some(
           (workflow) =>
             workflow.path === `${repository}/${WORKFLOW_PATH}@${toolingSha}` &&
             workflow.sha === toolingSha &&
@@ -604,7 +641,11 @@ function loadPreparedManifest(values, env) {
     runId: values["run-id"],
     runAttempt: values["run-attempt"],
   });
-  return verifyDockerReleaseProducer(manifest, { publisherSha: env.GITHUB_WORKFLOW_SHA });
+  return verifyDockerReleaseProducer(manifest, {
+    publisherSha: env.GITHUB_WORKFLOW_SHA,
+    publisherRunId: env.GITHUB_RUN_ID,
+    publisherRunAttempt: env.GITHUB_RUN_ATTEMPT,
+  });
 }
 
 function verifyFinalTag(manifest, readApi = ghJson) {

--- a/scripts/npm-prepared-bundle.mjs
+++ b/scripts/npm-prepared-bundle.mjs
@@ -277,12 +277,10 @@ export function verifyNpmBundleProducer({
   ) {
     throw new Error("npm bundle producer run identity mismatch.");
   }
-  const succeeded = run.status === "completed" && run.conclusion === "success";
-  const active =
-    ["in_progress", "pending", "queued", "requested", "waiting"].includes(run.status) &&
-    run.conclusion === null;
-  if (!succeeded && (requireCompletedParent || !active)) {
-    throw new Error("npm bundle producer parent must be successful or still qualifying.");
+  // Qualification retries reuse completed producer jobs from failed attempts.
+  // Publication additionally requires the complete producer attempt to succeed.
+  if (requireCompletedParent && (run.status !== "completed" || run.conclusion !== "success")) {
+    throw new Error("npm publication requires a successful producer parent.");
   }
   const matches = readAttemptJobs(repository, producer, runGh).filter(
     (job) => job.name === producer.jobName,

--- a/test/scripts/docker-release-artifacts.test.ts
+++ b/test/scripts/docker-release-artifacts.test.ts
@@ -174,6 +174,7 @@ async function createPreparedRelease(includeBrowser = true, version = "2026.8.1-
       },
     ],
   };
+  const attemptRun = structuredClone(run);
   const readApi = (endpoint: string) => {
     if (endpoint.includes("/artifacts?")) {
       return { artifacts: artifacts.filter((artifact) => endpoint.includes(artifact.name)) };
@@ -196,6 +197,9 @@ async function createPreparedRelease(includeBrowser = true, version = "2026.8.1-
         ],
         total_count: 2,
       };
+    }
+    if (endpoint.endsWith(`/actions/runs/${runId}/attempts/${runAttempt}`)) {
+      return attemptRun;
     }
     if (endpoint.endsWith(`/actions/runs/${runId}`)) {
       return run;
@@ -227,7 +231,27 @@ async function createPreparedRelease(includeBrowser = true, version = "2026.8.1-
     checkRunId: "7",
     readApi,
   });
-  return { root, manifest, run, job, artifacts, readApi };
+  return { root, manifest, run, attemptRun, job, artifacts, readApi };
+}
+
+async function createPublicationRetry(conclusion = "failure") {
+  const fixture = await createPreparedRelease(false);
+  const workflow = ".github/workflows/openclaw-release-publish.yml";
+  fixture.manifest.producer.workflowRef = `${repository}/${workflow}@refs/heads/main`;
+  fixture.run.path = fixture.attemptRun.path = workflow;
+  fixture.attemptRun.status = "completed";
+  fixture.attemptRun.conclusion = conclusion;
+  fixture.run.run_attempt += 1;
+  fixture.run.referenced_workflows = [];
+  return {
+    ...fixture,
+    publisher: {
+      publisherSha: toolingSha,
+      publisherRunId: runId,
+      publisherRunAttempt: String(fixture.run.run_attempt),
+      readApi: fixture.readApi,
+    },
+  };
 }
 
 describe("prepared Docker publication", () => {
@@ -253,10 +277,73 @@ describe("prepared Docker publication", () => {
     ).toBe(manifest);
   });
 
+  it.each(["failure", "cancelled", "timed_out"])(
+    "reuses its successful preparation when retrying a %s publication attempt",
+    async (conclusion) => {
+      const fixture = await createPublicationRetry(conclusion);
+      expect(verifyDockerReleaseProducer(fixture.manifest, fixture.publisher)).toBe(
+        fixture.manifest,
+      );
+    },
+  );
+
+  it.each([
+    "unrelated publisher",
+    "stale publisher attempt",
+    "different publisher source",
+    "failed current parent",
+    "changed historical source",
+    "wrong historical attempt",
+    "changed historical workflow",
+    "missing historical preparation",
+    "failed seal",
+    "replaced artifact",
+  ])("rejects a publication retry with %s", async (failure) => {
+    const fixture = await createPublicationRetry();
+    if (failure === "unrelated publisher") {
+      fixture.publisher.publisherRunId = "200";
+    }
+    if (failure === "stale publisher attempt") {
+      fixture.publisher.publisherRunAttempt = runAttempt;
+    }
+    if (failure === "different publisher source") {
+      fixture.publisher.publisherSha = sourceSha;
+    }
+    if (failure === "failed current parent") {
+      fixture.run.status = "completed";
+      fixture.run.conclusion = "failure";
+    }
+    if (failure === "changed historical source") {
+      fixture.attemptRun.head_sha = sourceSha;
+    }
+    if (failure === "wrong historical attempt") {
+      fixture.attemptRun.run_attempt += 1;
+    }
+    if (failure === "changed historical workflow") {
+      fixture.attemptRun.path = ".github/workflows/ci.yml";
+    }
+    if (failure === "missing historical preparation") {
+      fixture.attemptRun.referenced_workflows = [];
+    }
+    if (failure === "failed seal") {
+      fixture.job.conclusion = "failure";
+    }
+    if (failure === "replaced artifact") {
+      fixture.artifacts[0]!.id += 100;
+    }
+    expect(() => verifyDockerReleaseProducer(fixture.manifest, fixture.publisher)).toThrow();
+  });
+
+  it("retains successful historical preparation for an unrelated publisher", async () => {
+    const fixture = await createPublicationRetry("success");
+    fixture.publisher.publisherRunId = "200";
+    expect(verifyDockerReleaseProducer(fixture.manifest, fixture.publisher)).toBe(fixture.manifest);
+  });
+
   it.each([
     "unfinished job",
     "failed parent",
-    "new attempt",
+    "unfinished historical attempt",
     "different tooling",
     "replaced artifact",
     "wrong workflow",
@@ -269,7 +356,7 @@ describe("prepared Docker publication", () => {
       fixture.run.status = "completed";
       fixture.run.conclusion = "failure";
     }
-    if (failure === "new attempt") {
+    if (failure === "unfinished historical attempt") {
       fixture.run.run_attempt += 1;
     }
     if (failure === "different tooling") {

--- a/test/scripts/npm-prepared-bundle.test.ts
+++ b/test/scripts/npm-prepared-bundle.test.ts
@@ -13,6 +13,7 @@ import {
   prepareNpmPackageBundle,
   qualifyNpmPackageBundle,
   validatePreparedNpmBundleDescriptor,
+  verifyNpmBundleProducer,
   verifyPreparedNpmBundleFiles,
   verifyNpmSourceCheck,
 } from "../../scripts/npm-prepared-bundle.mjs";
@@ -26,10 +27,10 @@ const toolingSha = "b".repeat(40);
 const workflowPath = ".github/workflows/full-release-validation.yml";
 const hash = (bytes: Buffer) => createHash("sha256").update(bytes).digest("hex");
 
-function packageProducer() {
+function packageProducer(callerWorkflowPath = workflowPath) {
   return {
     repository,
-    workflowRef: `${repository}/${workflowPath}@refs/heads/main`,
+    workflowRef: `${repository}/${callerWorkflowPath}@refs/heads/main`,
     workflowSha: toolingSha,
     runId: "12",
     runAttempt: "2",
@@ -96,8 +97,8 @@ function packageSourceFixture(
   };
 }
 
-async function bundleFixture() {
-  const producer = packageProducer();
+async function bundleFixture(callerWorkflowPath = workflowPath) {
+  const producer = packageProducer(callerWorkflowPath);
   const tarball = Buffer.from("exact publishable root archive");
   const aiTarball = Buffer.from("exact publishable AI archive");
   const corePackage = {
@@ -158,7 +159,7 @@ async function bundleFixture() {
     id: 12,
     run_attempt: 2,
     head_sha: toolingSha,
-    path: workflowPath,
+    path: callerWorkflowPath,
     head_branch: "main",
     event: "workflow_dispatch",
     repository: { full_name: repository },
@@ -210,6 +211,60 @@ async function bundleFixture() {
 }
 
 describe("prepared npm bundle", () => {
+  it.each(["failure", "cancelled"])(
+    "reuses successful preparation and source jobs after parent %s",
+    async (conclusion) => {
+      const fixture = await bundleFixture(".github/workflows/openclaw-npm-release.yml");
+      Object.assign(fixture.run, { status: "completed", conclusion });
+      const downloaded = await downloadPreparedNpmBundle({
+        ...fixture,
+        repository,
+        sourceSha,
+        toolingSha,
+        outputDir: join(tempDirs.make("npm-retry-"), "prepared"),
+        token: "test-token",
+        npmDistTag: "beta",
+        releaseTag: fixture.manifest.releaseTag,
+      });
+      expect(readFileSync(downloaded.tarballPath)).toEqual(
+        fixture.files.get(fixture.manifest.tarballName),
+      );
+      const descriptor = {
+        schema: NPM_SOURCE_CHECK_SCHEMA,
+        source: { sha: sourceSha },
+        producer: { ...fixture.descriptor.producer, jobName: "Check npm release source" },
+      };
+      fixture.job.name = descriptor.producer.jobName;
+      const source = { descriptor, repository, sourceSha, toolingSha, runGh: fixture.runGh };
+      expect(verifyNpmSourceCheck(source).job.id).toBe(fixture.job.id);
+      fixture.job.run_attempt += 1;
+      expect(() => verifyNpmSourceCheck(source)).toThrow("unique exact completed producer job");
+    },
+  );
+
+  it.each([
+    ["completed", "failure"],
+    ["completed", "cancelled"],
+    ["in_progress", null],
+  ])("requires a successful parent for publication (%s/%s)", async (status, conclusion) => {
+    const fixture = await bundleFixture(".github/workflows/openclaw-npm-release.yml");
+    Object.assign(fixture.run, { status, conclusion });
+    fixture.job.name = "Qualify prepared npm package";
+    const options = {
+      producer: { ...fixture.descriptor.producer, jobName: fixture.job.name },
+      repository,
+      toolingSha,
+      qualified: true,
+      requireCompletedParent: true,
+      runGh: fixture.runGh,
+    };
+    expect(() => verifyNpmBundleProducer(options)).toThrow("parent");
+    Object.assign(fixture.run, { status: "completed", conclusion: "success" });
+    expect(verifyNpmBundleProducer(options).job.id).toBe(fixture.job.id);
+    fixture.job.conclusion = "failure";
+    expect(() => verifyNpmBundleProducer(options)).toThrow("unique exact completed producer job");
+  });
+
   it.each([
     ["2026.8.1", "v2026.8.1-2", "same-source"],
     ["2026.8.1-2", "v2026.8.1-2", undefined],

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1046,6 +1046,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/openclaw-npm-extended-stable-workflow.test.ts",
         "test/scripts/package-acceptance-workflow.test.ts",
         "test/scripts/authorized-beta-focused-evidence.test.ts",
+        "test/scripts/npm-prepared-bundle.test.ts",
         "test/scripts/openclaw-npm-resume-run.test.ts",
         "test/scripts/release-candidate-checklist.test.ts",
         "test/scripts/ci-workflow-guards.test.ts",


### PR DESCRIPTION
Related: #135639 (prepare publication artifacts during validation)

## What Problem This Solves

Fixes an issue where release operators could not retry failed npm qualification or Docker publication after package/image preparation had already succeeded. The retry rejected its retained inputs because the overall earlier attempt had failed or the current attempt number had advanced, forcing unnecessary preparation work.

## Why This Change Was Made

Successful preparation belongs to its exact producer job and immutable artifact. npm qualification now verifies those recorded jobs without requiring unrelated jobs in the same attempt to succeed. Final npm publication still requires a completed, successful qualification attempt.

Docker publication verifies the current run separately from the recorded preparation attempt. Only the same active publisher run, current attempt, and tooling source may recover its own failed historical parent. Separate publishers still require successful historical preparation. The original workflow linkage, successful seal job, artifact IDs and digests, source, and ancestry checks remain enforced. Preparation linkage is read from its original attempt even when a publisher-only retry omits that reusable workflow from current metadata.

## User Impact

Operators can retry qualification or publication with the prepared package/image bytes instead of rebuilding them. The release guide explains both recovery paths and distinguishes them from the still-restricted full-validation continuation controller.

## Evidence

- npm: two new retained-input regressions failed before the repair; 121 tests passed across the prepared-bundle and extended-stable release/workflow suites afterward.
- Docker: three new publication-retry regressions failed before the repair; 64 artifact/promotion tests passed afterward, including wrong publisher, stale attempt, changed source, failed seal, replaced artifact, and missing historical preparation-link rejection.
- Latest-main sparse tooling repair: all 12 existing FRV continuation workflow tests pass, including six isolated imports and the real sparse metadata preflight. That separate blocker was already fixed by #135902 and #135983 before this branch was created.
- Scoped changed checks passed, including root test types and the producer scripts. The new Docker test cases needed braces; the affected lint check passed after correction.
- Final Codex autoreview found no actionable P0–P2 findings.
- Read-only live GitHub API checks against run [33579008526](https://github.com/openclaw/openclaw/actions/runs/33579008526) confirmed a later successful attempt coexists with a cancelled original attempt and its successful jobs. No release or registry publication was dispatched for this repair.

Tooling grows by 39 lines to separate current publisher authority from historical preparation identity; tests grow by 143 lines. Existing verification remains the canonical path, with the incorrect aggregate-state veto removed for npm and the mutable latest-attempt comparison replaced for Docker.

CI follow-through: the initial run exposed a stale npm workflow test-target expectation and an unrelated SDK relocation fixture mismatch. The expectation now includes the new prepared-bundle regression (failed locally before correction, passed afterward). The SDK fixture repair is inherited from main commit `5e6117d17d92dcac2ef6da6d609eb423b089a77a`; it seeds only unowned historical chunks and retains full cache-output equality.

Historical retry proof: [the attached live API trace](https://github.com/openclaw/openclaw/pull/136112#issuecomment-5506229476) verifies that FRV run 33465912522 retains exact reusable-workflow references and successful original jobs in failed attempt 1 after attempt 2 succeeds. A new deliberately failed Docker workflow was not dispatched; controlled nonpublishing verifier regressions cover the Docker-specific decision, while the real Actions trace checks the external API contract.

Named follow-ups: uppercase SHA preflight inputs still need consistent normalization; retrying an incomplete Docker architecture build remains separate from resuming publication of an already sealed image set.
