### PR TITLE
fix: restore SDK declaration CI after QA builds

### DIFF
--- a/test/scripts/write-plugin-sdk-entry-dts.test.ts
+++ b/test/scripts/write-plugin-sdk-entry-dts.test.ts
@@ -150,7 +150,9 @@ describe("write-plugin-sdk-entry-dts", () => {
     expect(
       (privateQa.stdout + privateQa.stderr).match(/\[tsdown-build\] invocation \d\/2 finished/gu),
     ).toHaveLength(2);
-    expectOutputs(root, qa, Object.keys(treeHashes(path.join(root, "dist"))));
+    // QA may add root chunks that the later source change must retain as history.
+    const beforeChange = treeHashes(path.join(root, "dist"));
+    expectOutputs(root, qa, Object.keys(beforeChange));
     expectStagingClean(root);
 
     writeDeclarations("after");
@@ -189,8 +191,10 @@ describe("write-plugin-sdk-entry-dts", () => {
       writeRelocated(relative, content);
     }
     // SDK publication owns flat entries; historical shared chunks belong to other groups.
-    for (const file of Object.keys(before).filter((entry) => !entry.startsWith("plugin-sdk/"))) {
-      expect(first[file]).toBe(before[file]);
+    for (const file of Object.keys(beforeChange).filter(
+      (entry) => !entry.startsWith("plugin-sdk/"),
+    )) {
+      expect(first[file]).toBe(beforeChange[file]);
       writeRelocated(`dist/${file}`, fs.readFileSync(path.join(root, "dist", file), "utf8"));
     }
     writeRelocated("dist/plugin-sdk/obsolete.d.ts", "obsolete restored declaration");


### PR DESCRIPTION
## What Problem This Solves

Fixes the main-side SDK declaration restore test failure blocking #136067, #136090, and #136091: restoration yielded 355 files while the reference tree contained 356, including one historical root declaration chunk missing from the relocated fixture.

Related: #136067, #136090, #136091. Discovered while completing the follow-up to Elton Lau's node-exec report in #135966; this fixture failure is independent of that runtime fix.

## Why This Change Was Made

The consolidated proof introduced in #135976 compared different build histories. Its reference tree went through production, private-QA, and changed-source builds, but its relocated fixture seeded historical chunks from the initial production snapshot. The public-only production declaration selection in #135478 lets the private-QA build produce an additional root chunk that the later build intentionally retains.

Capture the history after private-QA compilation and before the source change, then seed that history in the relocated fixture. Current changed-source chunks still have to come from the cache. The full filename/hash equality assertion, nominal type checks, stale-output cleanup, and unrelated-artifact preservation remain intact. No generator or runtime behavior changes.

## User Impact

Restores meaningful CI coverage of SDK cache portability and byte-stable output restoration. No configuration, dependency, protocol, schema, or public SDK changes.

## Evidence

The unchanged test failed on fresh main `9e6912ca0d2e0200bdcbcfc32bde2d27db262464` with the same 355/356 mismatch and missing `actual-xIWKef-Q.d.ts` chunk as the hosted failures. This was the intended equality assertion, not a timeout.

```text
node scripts/run-vitest.mjs test/scripts/write-plugin-sdk-entry-dts.test.ts \
  -t 'publishes fresh canonical partitions with stable bytes and public nominal identity'
Before: 1 failed, 10 skipped; full-tree equality differed by one historical chunk.
```

Canonical changed-file checks passed, including test-root typechecking, typed lint, formatting, and selected guards. Independent pre-commit Autoreview is scoped-clean at its configured P0 threshold.

Full SDK and unified-declaration suites are still running locally. The unchanged unified cache-reuse test hit its existing 120-second timeout during host CPU contention (load 103 on 32 logical CPUs, no memory pressure); it will be rerun alone with unchanged settings. The repaired SDK case has not yet completed in the serialized run. These pending results are not claimed as passes; final proof and exact-head hosted CI are required before landing.

Production/tooling delta: 0. Test delta: +7/-3 (net +4). No assertions, timeouts, cache guards, or baselines were weakened. Proof uses the actual compiler, publication owner, and cache restoration against synthetic isolated filesystem fixtures; it does not need an application Gateway or live provider.
