### PR TITLE
Enforce sendPolicy for outbound side effects

### DIFF
--- a/docs/channels/ambient-room-events.md
+++ b/docs/channels/ambient-room-events.md
@@ -68,7 +68,7 @@ With `messages.groupChat.unmentionedInbound: "room_event"`:
 
 Room events use strict visible delivery. Final assistant text is private. The agent must call `message(action=send)` to post in the room.
 
-Typing and lifecycle status reactions stay suppressed for room events. The one explicit receipt exception is `messages.ackReactionScope: "all"`, which sends the configured ack reaction; use any narrower scope or `"off"` when the room must remain completely silent.
+Typing and lifecycle status reactions stay suppressed for room events. The one explicit receipt exception is `messages.ackReactionScope: "all"`, which sends the configured ack reaction unless the destination session's `session.sendPolicy` denies the outbound reaction. Use `sendPolicy` for monitor-only rooms that must remain completely silent across messages, polls, reactions, typing, and read receipts.
 
 ## Discord example
 

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1333,7 +1333,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
   - **`resetByType`**: per-type overrides (`direct`, `group`, `thread`). Doctor migrates legacy `dm` entries to `direct`; the schema rejects `dm`.
 - **`resetByChannel`**: per-channel reset overrides keyed by provider/channel id. When the session's channel has a matching entry, it wins outright over `resetByType`/`reset` for that session. Use only when one channel needs reset behavior different from the type-level policy.
 - **`mainKey`**: accepted but ignored. The per-agent main-session suffix is always `main`; omit this field. Global session scope uses `global` instead.
-- **`sendPolicy`**: match by `channel`, `chatType` (`direct|group|channel`, with legacy `dm` alias), `keyPrefix`, or `rawKeyPrefix`. First deny wins.
+- **`sendPolicy`**: match by `channel`, `chatType` (`direct|group|channel`, with legacy `dm` alias), `keyPrefix`, or `rawKeyPrefix`. First deny wins. Denied sessions suppress durable message delivery and provider-owned outbound side effects such as reactions, typing indicators, polls, and read receipts when the channel has session context for the attempted outbound operation.
 - **`maintenance`**: session-store cleanup + retention controls.
   - `mode`: `enforce` applies cleanup and is the default; `warn` emits warnings only.
   - `pruneAfter`: age cutoff for stale entries (default `30d`).

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -14,6 +14,7 @@ import { resolveWhatsAppGroupSessionRoute } from "../../group-session-key.js";
 import { getPrimaryIdentityId, getSenderIdentity } from "../../identity.js";
 import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
 import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
+import { resolveWhatsAppOutboundPolicy } from "../../outbound-policy.js";
 import { normalizeE164 } from "../../text-runtime.js";
 import { buildMentionConfig } from "../mentions.js";
 import type { MentionConfig } from "../mentions.js";
@@ -172,6 +173,44 @@ export function createWebOnMessageHandler(params: {
     // Bound route facts intentionally feed group activation/mention policy.
     // Side-effectful ACP readiness still waits until the group turn is admitted.
     const route = configuredRoute.route;
+    const readReceiptPolicy = resolveWhatsAppOutboundPolicy({
+      cfg,
+      target: msg.platform.chatJid,
+      sessionKey: route.sessionKey,
+      action: "read_receipt",
+    });
+    if (readReceiptPolicy.status === "deny") {
+      msg.readReceiptSuppressed = true;
+    }
+    const messagePolicy = resolveWhatsAppOutboundPolicy({
+      cfg,
+      target: msg.platform.chatJid,
+      sessionKey: route.sessionKey,
+      action: "message",
+    });
+    if (messagePolicy.status === "deny") {
+      msg.platform.reply = async () => ({
+        kind: "text",
+        messageId: "",
+        keys: [],
+        providerAccepted: false,
+      });
+      msg.platform.sendMedia = async () => ({
+        kind: "media",
+        messageId: "",
+        keys: [],
+        providerAccepted: false,
+      });
+    }
+    const typingPolicy = resolveWhatsAppOutboundPolicy({
+      cfg,
+      target: msg.platform.chatJid,
+      sessionKey: route.sessionKey,
+      action: "typing",
+    });
+    if (typingPolicy.status === "deny") {
+      msg.platform.sendComposing = async () => undefined;
+    }
     const groupHistoryKey =
       conversationKind === "group"
         ? buildGroupHistoryKey({

--- a/extensions/whatsapp/src/auto-reply/monitor/reaction-eligibility.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/reaction-eligibility.ts
@@ -2,6 +2,7 @@ import { shouldAckReaction } from "openclaw/plugin-sdk/channel-feedback";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
 import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
+import { resolveWhatsAppOutboundPolicy } from "../../outbound-policy.js";
 import { resolveWhatsAppReactionLevel } from "../../reaction-level.js";
 import type { sendReactionWhatsApp } from "../../send.js";
 import { resolveWhatsAppAckEmoji } from "./ack-emoji.js";
@@ -39,6 +40,15 @@ export async function resolveWhatsAppReactionEligibility(params: {
     ackConfig: params.cfg.messages?.ackReaction,
   });
   const isGroup = admission.conversation.kind === "group";
+  const sendPolicy = resolveWhatsAppOutboundPolicy({
+    cfg: params.cfg,
+    target: params.msg.platform.chatJid,
+    sessionKey: params.sessionKey,
+    action: "reaction",
+  });
+  if (sendPolicy.status === "deny") {
+    return DISABLED_REACTION;
+  }
   const activation = isGroup
     ? await resolveGroupActivationFor({
         cfg: params.cfg,

--- a/extensions/whatsapp/src/auto-reply/monitor/reactions.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/reactions.test.ts
@@ -212,6 +212,37 @@ describe("maybeSendAckReaction", () => {
     expect(hoisted.sendReactionWhatsApp).not.toHaveBeenCalled();
   });
 
+  it("suppresses ack reactions when session.sendPolicy denies group reactions", async () => {
+    const cfg = {
+      ...createConfig("ack"),
+      session: {
+        sendPolicy: {
+          rules: [{ action: "deny", match: { channel: "whatsapp", chatType: "group" } }],
+        },
+      },
+    } as OpenClawConfig;
+    const ackReaction = await runAckReaction({
+      cfg,
+      msg: createMessage({
+        platform: {
+          chatJid: "120363000000000000@g.us",
+          recipientJid: "15559876543",
+          fromMe: false,
+        },
+        admission: {
+          accountId: "default",
+          conversation: { kind: "group", id: "120363000000000000@g.us" },
+          sender: { id: "15551234567" },
+        },
+        groupMention: { wasMentioned: true, requireMention: true },
+      }),
+      sessionKey: "agent:agent:whatsapp:group:120363000000000000@g.us",
+    });
+
+    expect(ackReaction).toBeNull();
+    expect(hoisted.sendReactionWhatsApp).not.toHaveBeenCalled();
+  });
+
   it("uses the active account reactionLevel override for ack gating", async () => {
     const cfg = createConfig("off", {
       accounts: {

--- a/extensions/whatsapp/src/inbound/message-debounce.ts
+++ b/extensions/whatsapp/src/inbound/message-debounce.ts
@@ -94,7 +94,13 @@ export function createWhatsAppInboundMessageDebouncer(options: {
             if (orderedEntries.length === 1) {
               await options.onMessage(attachWhatsAppIngressLifecycle(last, admissionLifecycle));
               await settle();
-              await Promise.all(orderedEntries.map((entry) => options.markRead(entry.readReceipt)));
+              await Promise.all(
+                orderedEntries.map((entry) =>
+                  entry.readReceiptSuppressed === true
+                    ? Promise.resolve()
+                    : options.markRead(entry.readReceipt),
+                ),
+              );
               return;
             }
             const mentioned = new Set<string>();
@@ -134,8 +140,19 @@ export function createWhatsAppInboundMessageDebouncer(options: {
               admissionLifecycle,
             );
             await options.onMessage(combinedMessage);
+            if (combinedMessage.readReceiptSuppressed === true) {
+              for (const entry of orderedEntries) {
+                entry.readReceiptSuppressed = true;
+              }
+            }
             await settle();
-            await Promise.all(orderedEntries.map((entry) => options.markRead(entry.readReceipt)));
+            await Promise.all(
+              orderedEntries.map((entry) =>
+                entry.readReceiptSuppressed === true
+                  ? Promise.resolve()
+                  : options.markRead(entry.readReceipt),
+              ),
+            );
           } catch (error) {
             await abandon();
             throw error;

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -9,6 +9,7 @@ import { defaultRuntime, createSubsystemLogger } from "openclaw/plugin-sdk/runti
 import { maybeResolveWhatsAppApprovalReaction } from "../approval-reactions.js";
 import { resolveComparableIdentity } from "../identity.js";
 import { addWhatsAppImagePreviewFields } from "../image-preview.js";
+import { resolveWhatsAppOutboundPolicy } from "../outbound-policy.js";
 import { maybeResolveWhatsAppQuestionReaction } from "../question-reactions.js";
 import { cacheInboundMessageMeta } from "../quoted-message.js";
 import { formatError } from "../session.js";
@@ -152,6 +153,14 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
 
   const maybeMarkInboundAsRead = async (target: WhatsAppReadReceiptTarget | undefined) => {
     if (!target || options.sendReadReceipts === false) {
+      return;
+    }
+    const policy = resolveWhatsAppOutboundPolicy({
+      cfg: options.loadConfig?.() ?? options.cfg,
+      target: target.remoteJid,
+      action: "read_receipt",
+    });
+    if (policy.status === "deny") {
       return;
     }
     const { id, remoteJid, participant } = target;

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -9,6 +9,7 @@ import type { PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import type { WhatsAppIdentity, WhatsAppReplyContext, WhatsAppSelfIdentity } from "../identity.js";
 import type { WhatsAppQuotedMessageKey } from "../quoted-message.js";
 import type { WhatsAppInboundAdmission } from "./admission.js";
+import type { WhatsAppReadReceiptTarget } from "./durable-receive.js";
 import type { WhatsAppSendResult } from "./send-result.js";
 
 export type WebListenerCloseReason = {
@@ -136,6 +137,8 @@ export type WebInboundCallbackMessage = {
     wasMentioned: boolean;
     requireMention: boolean;
   };
+  readReceipt?: WhatsAppReadReceiptTarget;
+  readReceiptSuppressed?: boolean;
 };
 
 export type WebInboundMessage = WebInboundCallbackMessage;

--- a/extensions/whatsapp/src/monitor-inbox.policy.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.policy.test.ts
@@ -236,6 +236,37 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("delivery coordinator skips group read receipts denied by session.sendPolicy", async () => {
+    const { onMessage, listener, sock } = await startWebInboxMonitor({
+      config: {
+        channels: { whatsapp: { groupPolicy: "open" } },
+        messages: DEFAULT_MESSAGES_CFG,
+        session: {
+          sendPolicy: {
+            rules: [{ action: "deny", match: { channel: "whatsapp", chatType: "group" } }],
+          },
+        },
+      },
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      createNotifyUpsert(
+        createGroupMessage({
+          id: "rr-policy-1",
+          participant: "15551234567@s.whatsapp.net",
+          conversation: "read receipt should stay silent",
+        }),
+      ),
+    );
+    await waitForMessageCalls(onMessage, 1);
+    await waitForInboundWorkDrained(listener);
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(sock.readMessages).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
   it.each([
     {
       name: "lets group messages through even when sender not in allowFrom",

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -109,6 +109,7 @@ export function createWhatsAppOutboundBase({
       cfg: params.cfg,
       ...mediaOptions,
       accountId: params.accountId ?? undefined,
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       gifPlayback: params.gifPlayback,
       ...mediaDeliveryOptions,
       replyToIdSource: params.replyToIdSource,
@@ -161,10 +162,11 @@ export function createWhatsAppOutboundBase({
           },
           { forceDocument: params.forceDocument },
         ),
-      sendPoll: async ({ cfg, to, poll, accountId }) =>
+      sendPoll: async ({ cfg, to, poll, accountId, sessionKey }) =>
         await sendPollWhatsApp(to, poll, {
           verbose: shouldLogVerbose(),
           accountId: accountId ?? undefined,
+          ...(sessionKey ? { sessionKey } : {}),
           cfg,
         }),
     }),

--- a/extensions/whatsapp/src/outbound-policy.ts
+++ b/extensions/whatsapp/src/outbound-policy.ts
@@ -1,0 +1,51 @@
+// WhatsApp side effects share the host session.sendPolicy decision.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import {
+  resolveSessionOutboundPolicy,
+  type SessionOutboundPolicyAction,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import { isWhatsAppGroupJid, isWhatsAppNewsletterJid } from "./normalize.js";
+import { toWhatsappJid } from "./text-runtime.js";
+
+function resolveWhatsAppChatType(target: string): "direct" | "group" | "channel" {
+  const jid = toWhatsappJid(target);
+  if (isWhatsAppGroupJid(jid)) {
+    return "group";
+  }
+  if (isWhatsAppNewsletterJid(jid)) {
+    return "channel";
+  }
+  return "direct";
+}
+
+export function resolveWhatsAppOutboundPolicy(params: {
+  cfg: OpenClawConfig;
+  target: string;
+  sessionKey?: string;
+  action: SessionOutboundPolicyAction;
+}) {
+  return resolveSessionOutboundPolicy({
+    cfg: params.cfg,
+    action: params.action,
+    sessionKey: params.sessionKey,
+    channel: "whatsapp",
+    chatType: resolveWhatsAppChatType(params.target),
+  });
+}
+
+export function assertWhatsAppOutboundPolicyAllowed(params: {
+  cfg: OpenClawConfig;
+  target: string;
+  sessionKey?: string;
+  action: SessionOutboundPolicyAction;
+}): void {
+  const decision = resolveWhatsAppOutboundPolicy(params);
+  if (decision.status === "allow") {
+    return;
+  }
+  throw new PlatformMessageNotDispatchedError(
+    `session.sendPolicy denied WhatsApp ${params.action}`,
+    { cause: new Error(decision.reason), retryable: false },
+  );
+}

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -27,6 +27,14 @@ let setLoggerOverride: typeof import("openclaw/plugin-sdk/runtime-env").setLogge
 const WHATSAPP_TEST_CFG: OpenClawConfig = {
   channels: { whatsapp: {} },
 };
+const WHATSAPP_GROUP_SEND_DENIED_CFG: OpenClawConfig = {
+  session: {
+    sendPolicy: {
+      rules: [{ action: "deny", match: { channel: "whatsapp", chatType: "group" } }],
+    },
+  },
+  channels: { whatsapp: {} },
+};
 
 vi.mock("./connection-controller-runtime-context.js", async () => {
   const actual = await vi.importActual<typeof import("./connection-controller-runtime-context.js")>(
@@ -145,6 +153,64 @@ describe("web outbound", () => {
     });
     expect(sendComposingTo).toHaveBeenCalledWith("+1555");
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
+  });
+
+  it.each([
+    {
+      name: "messages",
+      run: async () =>
+        await sendMessageWhatsApp("120363401234567890@g.us", "hi", {
+          verbose: false,
+          cfg: WHATSAPP_GROUP_SEND_DENIED_CFG,
+          sessionKey: "agent:main:whatsapp:group:120363401234567890@g.us",
+        }),
+      expectNoSend: () => {
+        expect(sendComposingTo).not.toHaveBeenCalled();
+        expect(sendMessage).not.toHaveBeenCalled();
+      },
+    },
+    {
+      name: "typing",
+      run: async () =>
+        await sendTypingWhatsApp("120363401234567890@g.us", {
+          cfg: WHATSAPP_GROUP_SEND_DENIED_CFG,
+          sessionKey: "agent:main:whatsapp:group:120363401234567890@g.us",
+        }),
+      expectNoSend: () => {
+        expect(sendComposingTo).not.toHaveBeenCalled();
+      },
+    },
+    {
+      name: "polls",
+      run: async () =>
+        await sendPollWhatsApp(
+          "120363401234567890@g.us",
+          { question: "Lunch?", options: ["Pizza", "Sushi"] },
+          {
+            verbose: false,
+            cfg: WHATSAPP_GROUP_SEND_DENIED_CFG,
+            sessionKey: "agent:main:whatsapp:group:120363401234567890@g.us",
+          },
+        ),
+      expectNoSend: () => {
+        expect(sendPoll).not.toHaveBeenCalled();
+      },
+    },
+    {
+      name: "reactions",
+      run: async () =>
+        await sendReactionWhatsApp("120363401234567890@g.us", "msg123", "👀", {
+          verbose: false,
+          cfg: WHATSAPP_GROUP_SEND_DENIED_CFG,
+          sessionKey: "agent:main:whatsapp:group:120363401234567890@g.us",
+        }),
+      expectNoSend: () => {
+        expect(sendReaction).not.toHaveBeenCalled();
+      },
+    },
+  ])("blocks WhatsApp group $name denied by session.sendPolicy", async ({ run, expectNoSend }) => {
+    await expect(run()).rejects.toBeInstanceOf(PlatformMessageNotDispatchedError);
+    expectNoSend();
   });
 
   it.each([

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -36,6 +36,7 @@ import {
   prepareWhatsAppOutboundMedia,
   resolveAdditiveWhatsAppMediaUrls,
 } from "./outbound-media-contract.js";
+import { assertWhatsAppOutboundPolicyAllowed } from "./outbound-policy.js";
 import type { WhatsAppQuotedMessageKey } from "./quoted-message.js";
 import { markdownToWhatsAppChunks, toWhatsappJid } from "./text-runtime.js";
 
@@ -154,6 +155,7 @@ export async function sendMessageWhatsApp(
     audioAsVoice?: boolean;
     forceDocument?: boolean;
     accountId?: string;
+    sessionKey?: string;
     quotedMessageKey?: WhatsAppQuotedMessageKey;
     preserveLeadingWhitespace?: boolean;
     /** Report each accepted internal platform send before the next fallible send. */
@@ -197,6 +199,12 @@ async function sendMessageWhatsAppInActivityScope(
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
   const cfg = requireRuntimeConfig(options.cfg, "WhatsApp send");
+  assertWhatsAppOutboundPolicyAllowed({
+    cfg,
+    target: jid,
+    sessionKey: options.sessionKey,
+    action: "message",
+  });
   const { listener: active, accountId: resolvedAccountId } = requireOutboundActiveWebListener({
     cfg,
     accountId: options.accountId,
@@ -378,9 +386,16 @@ export async function sendTypingWhatsApp(
   options: {
     cfg: OpenClawConfig;
     accountId?: string;
+    sessionKey?: string;
   },
 ): Promise<void> {
   const cfg = requireRuntimeConfig(options.cfg, "WhatsApp typing send");
+  assertWhatsAppOutboundPolicyAllowed({
+    cfg,
+    target: to,
+    sessionKey: options.sessionKey,
+    action: "typing",
+  });
   const { listener: active } = requireOutboundActiveWebListener({
     cfg,
     accountId: options.accountId,
@@ -400,11 +415,18 @@ export async function sendReactionWhatsApp(
     fromMe?: boolean;
     participant?: string;
     accountId?: string;
+    sessionKey?: string;
     cfg: OpenClawConfig;
   },
 ): Promise<void> {
   const correlationId = generateSecureUuid();
   const cfg = requireRuntimeConfig(options.cfg, "WhatsApp reaction");
+  assertWhatsAppOutboundPolicyAllowed({
+    cfg,
+    target: chatJid,
+    sessionKey: options.sessionKey,
+    action: "reaction",
+  });
   const { listener: active } = requireOutboundActiveWebListener({
     cfg,
     accountId: options.accountId,
@@ -442,11 +464,17 @@ export async function sendReactionWhatsApp(
 export async function sendPollWhatsApp(
   to: string,
   poll: PollInput,
-  options: { verbose: boolean; accountId?: string; cfg: OpenClawConfig },
+  options: { verbose: boolean; accountId?: string; sessionKey?: string; cfg: OpenClawConfig },
 ): Promise<{ messageId: string; toJid: string }> {
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
   const cfg = requireRuntimeConfig(options.cfg, "WhatsApp poll");
+  assertWhatsAppOutboundPolicyAllowed({
+    cfg,
+    target: to,
+    sessionKey: options.sessionKey,
+    action: "poll",
+  });
   const { listener: active } = requireOutboundActiveWebListener({
     cfg,
     accountId: options.accountId,

--- a/packages/gateway-protocol/src/schema/audit-activity.ts
+++ b/packages/gateway-protocol/src/schema/audit-activity.ts
@@ -384,6 +384,7 @@ const outboundSuppressedReasonSchema = Type.Union([
   Type.Literal("empty_after_message_sending_hook"),
   Type.Literal("empty_after_reply_payload_sending_hook"),
   Type.Literal("no_visible_payload"),
+  Type.Literal("send_policy_denied"),
 ]);
 
 const outboundFailureStageSchema = Type.Union([
@@ -613,7 +614,8 @@ type AuditActivityOutboundMessageV1Terminal =
         | "cancelled_by_reply_payload_sending_hook"
         | "empty_after_message_sending_hook"
         | "empty_after_reply_payload_sending_hook"
-        | "no_visible_payload";
+        | "no_visible_payload"
+        | "send_policy_denied";
       failureStage?: never;
       deliveryKind?: never;
     }

--- a/src/audit/audit-event-types.ts
+++ b/src/audit/audit-event-types.ts
@@ -51,6 +51,7 @@ export const AUDIT_OUTBOUND_MESSAGE_SUPPRESSED_REASONS = [
   "empty_after_message_sending_hook",
   "empty_after_reply_payload_sending_hook",
   "no_visible_payload",
+  "send_policy_denied",
 ] as const;
 
 export type AuditOutboundMessageSuppressedReasonCode =

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -37,6 +37,8 @@ export type ChannelOutboundContext = {
   formatting?: OutboundDeliveryFormattingOptions;
   threadId?: string | number | null;
   accountId?: string | null;
+  /** Trusted originating turn context for channel-owned side-effect policy. */
+  sessionKey?: string;
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -554,6 +554,7 @@ const createChannelOutboundContextBase = (params: ChannelHandlerParams) => ({
   cfg: params.cfg,
   to: params.to,
   accountId: params.accountId,
+  sessionKey: params.session?.policyKey ?? params.session?.key,
   replyToId: params.replyToId,
   replyToIdSource: undefined,
   replyToMode: params.replyToMode,

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -140,6 +140,8 @@ export type ChannelHandlerParams = {
   channel: string;
   to: string;
   accountId?: string;
+  /** Trusted originating turn context for channel-owned side-effect policy. */
+  session?: OutboundSessionContext;
   replyToId?: string | null;
   replyToMode?: ReplyToMode;
   formatting?: OutboundDeliveryFormattingOptions;

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -80,6 +80,7 @@ export async function deliverOutboundPayloadsCore(
       to,
       deps,
       accountId,
+      session: params.session,
       replyToId: reply?.replyToId,
       replyToMode: reply?.source === "implicit" ? reply.mode : undefined,
       formatting: params.formatting,

--- a/src/infra/outbound/deliver-prepare.ts
+++ b/src/infra/outbound/deliver-prepare.ts
@@ -2,6 +2,7 @@ import { copyReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 // Finalizes outbound modifying policy before durable queue custody is created.
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { resolveSessionOutboundPolicy } from "../../sessions/send-policy.js";
 import { throwIfAborted } from "./abort.js";
 import { createChannelHandler, resolveChannelOutboundDirectiveOptions } from "./deliver-channel.js";
 import type { DeliverOutboundPayloadsParams } from "./deliver-contracts.js";
@@ -54,6 +55,7 @@ async function createPreparationHandler(params: DeliverOutboundPayloadsParams) {
     to: params.to,
     deps: params.deps,
     accountId: params.accountId,
+    session: params.session,
     replyToId: reply?.replyToId,
     replyToMode: reply?.source === "implicit" ? reply.mode : undefined,
     formatting: params.formatting,
@@ -121,6 +123,35 @@ export async function prepareOutboundPayloadBatch(
   params: DeliverOutboundPayloadsParams,
   options?: { onBeforeFirstModifier?: () => void },
 ): Promise<PreparedOutboundBatch> {
+  const policy = resolveSessionOutboundPolicy({
+    cfg: params.cfg,
+    action: "message",
+    sessionKey: params.session?.policyKey ?? params.session?.key,
+    channel: params.channel,
+    chatType:
+      params.session?.conversationKind ??
+      (params.session?.conversationType === "direct" || params.session?.conversationType === "group"
+        ? params.session.conversationType
+        : undefined),
+  });
+  if (policy.status === "deny") {
+    return {
+      schemaVersion: PREPARED_OUTBOUND_BATCH_SCHEMA_VERSION,
+      sourcePayloadCount: params.payloads.length,
+      channelNormalized: true,
+      ...((params.runId ?? params.replyPayloadSendingHook?.runId)
+        ? { runId: params.runId ?? params.replyPayloadSendingHook?.runId }
+        : {}),
+      ...(params.executionIdentityToken
+        ? { executionIdentityToken: params.executionIdentityToken }
+        : {}),
+      entries: params.payloads.map((_, sourceIndex) => ({
+        sourceIndex,
+        status: "suppressed",
+        reason: policy.reason,
+      })),
+    };
+  }
   const directiveOptions = await resolveChannelOutboundDirectiveOptions({
     cfg: params.cfg,
     agentId: params.session?.agentId,

--- a/src/infra/outbound/deliver-types.ts
+++ b/src/infra/outbound/deliver-types.ts
@@ -45,6 +45,7 @@ export type OutboundPayloadDeliverySuppressionReason =
   | "empty_after_message_sending_hook"
   | "empty_after_reply_payload_sending_hook"
   | "no_visible_payload"
+  | "send_policy_denied"
   | "adapter_returned_no_send"
   | "adapter_returned_no_identity";
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1170,6 +1170,38 @@ describe("deliverOutboundPayloads", () => {
     expect(hookMocks.runner.runMessageSending).not.toHaveBeenCalled();
   });
 
+  it("suppresses durable payload preparation when session.sendPolicy denies delivery", async () => {
+    const onBeforeFirstModifier = vi.fn();
+
+    await expect(
+      prepareOutboundPayloadBatch(
+        {
+          cfg: {
+            session: {
+              sendPolicy: {
+                rules: [{ action: "deny", match: { channel: "matrix", chatType: "group" } }],
+              },
+            },
+          } as OpenClawConfig,
+          channel: "matrix",
+          to: "!room:example",
+          payloads: [{ text: "blocked" }],
+          deps: { matrix: vi.fn() },
+          session: {
+            key: "agent:main:matrix:group:!room:example",
+            conversationKind: "group",
+          },
+        },
+        { onBeforeFirstModifier },
+      ),
+    ).resolves.toMatchObject({
+      entries: [{ sourceIndex: 0, status: "suppressed", reason: "send_policy_denied" }],
+    });
+    expect(onBeforeFirstModifier).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runReplyPayloadSending).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runMessageSending).not.toHaveBeenCalled();
+  });
+
   it("revalidates conversation authority after queue admission and before the adapter", async () => {
     const order: string[] = [];
     queueMocks.enqueueDelivery.mockImplementationOnce(async () => {

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -26,9 +26,13 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { OutboundMediaAccess, OutboundMediaReadFile } from "../../media/load-options.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
+import {
+  resolveSessionOutboundPolicy,
+  type SessionOutboundPolicyAction,
+} from "../../sessions/send-policy.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
-import type { OutboundDeliveryResult } from "./deliver-types.js";
+import { PlatformMessageNotDispatchedError, type OutboundDeliveryResult } from "./deliver-types.js";
 import type { NormalizedOutboundPayload, OutboundSendDeps } from "./deliver.js";
 import type { DurableDeliveryCompletion } from "./delivery-completion.js";
 import type { MessageActionGateway } from "./message-action-contracts.js";
@@ -107,6 +111,29 @@ type PluginHandledResult = {
 };
 
 type SendMessageParams = Parameters<typeof sendMessage>[0];
+
+function assertOutboundSendPolicyAllowed(params: {
+  ctx: OutboundSendContext;
+  action: SessionOutboundPolicyAction;
+}): void {
+  if (params.ctx.dryRun) {
+    return;
+  }
+  const decision = resolveSessionOutboundPolicy({
+    cfg: params.ctx.cfg,
+    action: params.action,
+    sessionKey: params.ctx.sessionKey ?? params.ctx.mirror?.sessionKey,
+    channel: params.ctx.channel,
+    chatType: params.ctx.conversationType,
+  });
+  if (decision.status === "allow") {
+    return;
+  }
+  throw new PlatformMessageNotDispatchedError(
+    `Session sendPolicy denied outbound ${params.action} on ${params.ctx.channel}`,
+    { cause: new Error(decision.reason), retryable: false },
+  );
+}
 
 export function materializeMessagePresentationFallback(params: {
   payload: Pick<ReplyPayload, "presentation" | "text">;
@@ -354,6 +381,7 @@ export async function executeSendAction(params: {
   sendResult?: MessageSendResult;
 }> {
   throwIfAborted(params.ctx.abortSignal);
+  assertOutboundSendPolicyAllowed({ ctx: params.ctx, action: "message" });
   const defaultPayload: ReplyPayload = params.payload ?? {
     text: params.message,
     mediaUrl: params.mediaUrl,
@@ -513,6 +541,7 @@ export async function executePollAction(params: {
   toolResult?: AgentToolResult<unknown>;
   pollResult?: MessagePollResult;
 }> {
+  assertOutboundSendPolicyAllowed({ ctx: params.ctx, action: "poll" });
   const pluginHandled = await tryHandleWithPluginAction({
     ctx: params.ctx,
     action: "poll",

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -625,6 +625,11 @@ export {
   resolveSessionResetType,
   resolveThreadFlag,
 } from "../config/sessions/reset.js";
-export { resolveSendPolicy } from "../sessions/send-policy.js";
+export {
+  resolveSendPolicy,
+  resolveSessionOutboundPolicy,
+  type SessionOutboundPolicyAction,
+  type SessionOutboundPolicyDecision,
+} from "../sessions/send-policy.js";
 export type { SessionEntry } from "../config/sessions/types.js";
 export type { SessionScope } from "../config/sessions/types.js";

--- a/src/sessions/send-policy.test.ts
+++ b/src/sessions/send-policy.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { buildAgentPeerSessionKey } from "../routing/session-key.js";
-import { resolveSendPolicy } from "./send-policy.js";
+import { resolveSendPolicy, resolveSessionOutboundPolicy } from "./send-policy.js";
 
 describe("resolveSendPolicy", () => {
   const cfgWithRules = (
@@ -204,5 +204,31 @@ describe("resolveSendPolicy", () => {
     } as OpenClawConfig;
 
     expect(resolveSendPolicy({ cfg, sessionKey })).toBe("deny");
+  });
+});
+
+describe("resolveSessionOutboundPolicy", () => {
+  it("uses sendPolicy as the shared outbound side-effect decision", () => {
+    const cfg = {
+      session: {
+        sendPolicy: {
+          default: "allow",
+          rules: [{ action: "deny", match: { channel: "whatsapp", chatType: "group" } }],
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveSessionOutboundPolicy({
+        cfg,
+        action: "reaction",
+        sessionKey: "agent:main:whatsapp:group:1203630@g.us",
+      }),
+    ).toEqual({
+      status: "deny",
+      sendPolicy: "deny",
+      action: "reaction",
+      reason: "send_policy_denied",
+    });
   });
 });

--- a/src/sessions/send-policy.ts
+++ b/src/sessions/send-policy.ts
@@ -16,6 +16,23 @@ import { deriveSessionChatType } from "./session-chat-type.js";
 /** Session send-policy decision after config and per-session overrides are evaluated. */
 export type SessionSendPolicyDecision = "allow" | "deny";
 
+export type SessionOutboundPolicyAction =
+  | "message"
+  | "poll"
+  | "reaction"
+  | "typing"
+  | "read_receipt"
+  | "system";
+
+export type SessionOutboundPolicyDecision =
+  | { status: "allow"; sendPolicy: "allow"; action: SessionOutboundPolicyAction }
+  | {
+      status: "deny";
+      sendPolicy: "deny";
+      action: SessionOutboundPolicyAction;
+      reason: "send_policy_denied";
+    };
+
 /** Normalizes raw send-policy text into a decision. */
 export function normalizeSendPolicy(raw?: string | null): SessionSendPolicyDecision | undefined {
   const value = normalizeOptionalLowercaseString(raw);
@@ -156,4 +173,24 @@ export function resolveSendPolicy(params: {
 
   const fallback = normalizeSendPolicy(policy.default);
   return fallback ?? "allow";
+}
+
+export function resolveSessionOutboundPolicy(params: {
+  cfg: OpenClawConfig;
+  entry?: SessionEntry;
+  sessionKey?: string;
+  channel?: string;
+  chatType?: SessionChatType;
+  action: SessionOutboundPolicyAction;
+}): SessionOutboundPolicyDecision {
+  const sendPolicy = resolveSendPolicy(params);
+  if (sendPolicy === "deny") {
+    return {
+      status: "deny",
+      sendPolicy,
+      action: params.action,
+      reason: "send_policy_denied",
+    };
+  }
+  return { status: "allow", sendPolicy, action: params.action };
 }


### PR DESCRIPTION
## What Problem This Solves

Monitor-only sessions can currently rely on `session.sendPolicy` for durable replies, but channel-owned side effects can still happen outside that durable message path. That leaves room for outbound signals such as WhatsApp ack reactions, typing/presence, polls, or read receipts even when a room is meant to be read-only.

## Why This Change Was Made

This makes `session.sendPolicy` the shared outbound source of truth instead of adding a WhatsApp-specific special case. Durable outbound batches, plugin send/poll actions, and WhatsApp provider-owned side effects now resolve the same policy decision before dispatch.

The WhatsApp adapter is wired through the new helper for its high-risk side-effect paths: messages, polls, reactions, typing/presence, and read receipts. The SDK also exposes the shared resolver so other channel adapters can enforce the same invariant for their own provider-owned effects.

## User Impact

Operators can configure monitor-only group bindings with `session.sendPolicy` and expect denied outbound to suppress more than ordinary text replies. For WhatsApp, monitor-only group policies now also suppress ack reactions and read receipts, preventing visible or protocol-level acknowledgement signals from those groups.

Suppressed durable payloads are audited with the new `send_policy_denied` reason.

## Evidence

Passed:

- `PATH=/home/nehor/.nvm/versions/node/v24.15.0/bin:$PATH corepack pnpm test src/sessions/send-policy.test.ts src/infra/outbound/deliver.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/auto-reply/monitor/reactions.test.ts extensions/whatsapp/src/monitor-inbox.policy.test.ts`
- `PATH=/home/nehor/.nvm/versions/node/v24.15.0/bin:$PATH corepack pnpm test extensions/whatsapp/src/monitor-inbox.policy.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/auto-reply/monitor/reactions.test.ts`
- `PATH=/home/nehor/.nvm/versions/node/v24.15.0/bin:$PATH corepack pnpm docs:check-mdx`
- `PATH=/home/nehor/.nvm/versions/node/v24.15.0/bin:$PATH corepack pnpm format:check -- docs/channels/ambient-room-events.md docs/gateway/config-agents.md`
- `PATH=/home/nehor/.nvm/versions/node/v24.15.0/bin:$PATH corepack pnpm plugin-sdk:check-exports`
- `git diff --check`

Checked:

- `PATH=/home/nehor/.nvm/versions/node/v24.15.0/bin:$PATH corepack pnpm tsgo:core:test`

`tsgo:core:test` still fails on existing unrelated errors in `packages/ai`, `packages/markdown-core`, and `src/tui`. The errors introduced by this branch were fixed before opening the PR.
