### PR TITLE
refactor(ui): consolidate shared session menu rendering

### DIFF
--- a/ui/src/components/session-icon-picker.ts
+++ b/ui/src/components/session-icon-picker.ts
@@ -54,10 +54,7 @@ function renderCustomSessionIconEntry(props: SessionIconPickerProps) {
   const normalized = normalizeSessionIconValue(props.customIconValue);
   const shortcut = sessionEmojiPickerShortcut();
   return html`
-    <div
-      slot=${props.inline ? nothing : "submenu"}
-      class="session-menu__icon-picker session-menu__icon-custom-entry"
-    >
+    <div class="session-menu__icon-picker session-menu__icon-custom-entry">
       <div class="session-menu__icon-custom-header">
         <button
           type="button"
@@ -101,11 +98,26 @@ function renderSessionIconGrid(props: SessionIconPickerProps) {
   if (props.mode === "custom") {
     return renderCustomSessionIconEntry(props);
   }
-  const tabStop = [...SESSION_ICON_EMOJI_CHOICES, ...SESSION_ICON_GLYPH_IDS].find(
-    (icon) => icon === props.currentIcon,
-  );
+  const tabStop =
+    [...SESSION_ICON_EMOJI_CHOICES, ...SESSION_ICON_GLYPH_IDS].find(
+      (icon) => icon === props.currentIcon,
+    ) ?? SESSION_ICON_EMOJI_CHOICES[0];
+  const renderChoice = (icon: string, glyph = false) => html`
+    <button
+      type="button"
+      class=${`session-menu__icon-choice${glyph ? " session-menu__icon-choice--glyph" : ""}`}
+      aria-label=${glyph ? icon : nothing}
+      aria-pressed=${String(props.currentIcon === icon)}
+      tabindex=${icon === tabStop ? "0" : "-1"}
+      ?disabled=${props.disabled}
+      title=${props.disabledReason ?? nothing}
+      @click=${(event: MouseEvent) => props.onSelect(event, icon)}
+    >
+      ${glyph ? resolveSessionIconGlyph(icon) : icon}
+    </button>
+  `;
   return html`
-    <div slot=${props.inline ? nothing : "submenu"} class="session-menu__icon-picker">
+    <div class="session-menu__icon-picker">
       <div
         class="session-menu__icon-options"
         role="group"
@@ -114,22 +126,7 @@ function renderSessionIconGrid(props: SessionIconPickerProps) {
       >
         <div class="session-menu__icon-section-label">${t("sessionsView.iconEmojiSection")}</div>
         <div class="session-menu__icon-grid">
-          ${SESSION_ICON_EMOJI_CHOICES.map((icon, index) => {
-            const checked = props.currentIcon === icon;
-            return html`
-              <button
-                type="button"
-                class="session-menu__icon-choice"
-                aria-pressed=${String(checked)}
-                tabindex=${icon === tabStop || (!tabStop && index === 0) ? "0" : "-1"}
-                ?disabled=${props.disabled}
-                title=${props.disabledReason ?? nothing}
-                @click=${(event: MouseEvent) => props.onSelect(event, icon)}
-              >
-                ${icon}
-              </button>
-            `;
-          })}
+          ${SESSION_ICON_EMOJI_CHOICES.map((icon) => renderChoice(icon))}
           <button
             type="button"
             class="session-menu__icon-choice session-menu__icon-choice--custom"
@@ -145,23 +142,7 @@ function renderSessionIconGrid(props: SessionIconPickerProps) {
         </div>
         <div class="session-menu__icon-section-label">${t("sessionsView.iconGlyphSection")}</div>
         <div class="session-menu__icon-grid">
-          ${SESSION_ICON_GLYPH_IDS.map((icon) => {
-            const checked = props.currentIcon === icon;
-            return html`
-              <button
-                type="button"
-                class="session-menu__icon-choice session-menu__icon-choice--glyph"
-                aria-label=${icon}
-                aria-pressed=${String(checked)}
-                tabindex=${icon === tabStop ? "0" : "-1"}
-                ?disabled=${props.disabled}
-                title=${props.disabledReason ?? nothing}
-                @click=${(event: MouseEvent) => props.onSelect(event, icon)}
-              >
-                ${resolveSessionIconGlyph(icon)}
-              </button>
-            `;
-          })}
+          ${SESSION_ICON_GLYPH_IDS.map((icon) => renderChoice(icon, true))}
         </div>
       </div>
     </div>
@@ -177,7 +158,7 @@ export function renderSessionAppearancePicker(props: SessionIconPickerProps) {
       disabledReason: props.colorDisabledReason,
       onSelect: props.onSelectColor,
     })}
-    ${renderSessionIconGrid({ ...props, inline: true })}
+    ${renderSessionIconGrid(props)}
     <div class="session-menu__separator" role="separator"></div>
     <button
       type="button"

--- a/ui/src/components/session-menu-actions.ts
+++ b/ui/src/components/session-menu-actions.ts
@@ -6,14 +6,15 @@ import { icons } from "./icons.ts";
 import { menuShortcutHint } from "./menu-shortcuts.ts";
 import { renderSessionAppearancePicker } from "./session-icon-picker.ts";
 import {
+  renderCompactSessionMenuFrame,
   renderCompactSessionMenuNavigationItem,
-  renderCompactSessionMenuView,
   type CompactSessionMenuView,
 } from "./session-menu-compact.ts";
 import { renderSessionEditorOptions, renderSessionGroupOptions } from "./session-menu-options.ts";
 import type { SessionOwnerOption } from "./session-owner-chip.ts";
 import {
   renderSessionOwnerAssignmentMenu,
+  renderSessionOwnerAssignmentOptions,
   sessionOwnerAssignmentFromMenuValue,
 } from "./session-owner-menu.ts";
 
@@ -305,23 +306,24 @@ export class SessionMenuActions {
     view: Exclude<CompactSessionMenuView, "root">,
     label: string,
     icon: TemplateResult,
-    body: () => TemplateResult,
     disabled = false,
+    title?: string,
   ) {
     if (this.readState().compact) {
-      return renderCompactSessionMenuNavigationItem({ view, label, icon, disabled });
+      return renderCompactSessionMenuNavigationItem({ view, label, icon, disabled, title });
     }
+    const shortcut = view === "icon" ? "i" : view === "copy" ? "c" : undefined;
     return html`<wa-dropdown-item
       class="session-menu__item"
       ?disabled=${disabled}
-      data-shortcut=${view === "icon" ? "i" : view === "copy" ? "c" : nothing}
-      aria-keyshortcuts=${view === "icon" ? "I" : view === "copy" ? "C" : nothing}
+      title=${title ?? nothing}
+      data-shortcut=${shortcut ?? nothing}
+      aria-keyshortcuts=${shortcut?.toUpperCase() ?? nothing}
       @submenu-opening=${view === "icon" ? this.focusAppearanceOnOpen : nothing}
     >
       <span slot="icon" class="session-menu__icon" aria-hidden="true">${icon}</span>
       <span class="session-menu__text">${label}</span>
-      ${view === "icon" ? menuShortcutHint("i") : view === "copy" ? menuShortcutHint("c") : nothing}
-      ${body()}
+      ${shortcut ? menuShortcutHint(shortcut) : nothing} ${this.renderSubmenuBody(view)}
     </wa-dropdown-item>`;
   }
 
@@ -386,7 +388,6 @@ export class SessionMenuActions {
             "icon",
             t("sessionsView.setIconColorMenu"),
             icons.palette,
-            () => this.renderAppearancePicker(),
             this.actionDisabled("set-icon") && this.actionDisabled("set-color"),
           )}
       ${this.renderGroupAction()}
@@ -422,49 +423,30 @@ export class SessionMenuActions {
         shortcut: "f",
         title: state.forkFromLastCompleted ? t("sessionsView.forkFromLastCompleted") : undefined,
       })}
-      ${this.renderSubmenu("copy", t("common.copy"), icons.copy, () => this.renderCopySubmenu())}
+      ${this.renderSubmenu("copy", t("common.copy"), icons.copy)}
       ${state.navigationAllowed || state.worktreePath || state.renderOpenInExtra
-        ? this.renderSubmenu(
-            "open-in",
-            t("sessionsView.openInEditorMenu"),
-            icons.externalLink,
-            () => this.renderOpenSubmenu(),
-          )
+        ? this.renderSubmenu("open-in", t("sessionsView.openInEditorMenu"), icons.externalLink)
         : nothing}
     `;
   }
 
-  renderGroupAction() {
+  private renderGroupAction() {
     const state = this.readState();
     const batch = state.selectionCount > 1;
     const count = String(state.selectionCount);
     if (state.session.isChild === true) {
       return nothing;
     }
-    if (state.compact) {
-      return renderCompactSessionMenuNavigationItem({
-        view: "group",
-        label: batch
-          ? t("sessionsView.moveToGroupMenuCount", { count })
-          : t("sessionsView.moveToGroupMenu"),
-        icon: icons.folder,
-        disabled: this.actionDisabled("move-to-group"),
-        title: state.actionDisabledReasons["move-to-group"],
-      });
-    }
-    return html`<wa-dropdown-item
-      class="session-menu__item"
-      ?disabled=${this.actionDisabled("move-to-group")}
-      title=${this.actionTitle("move-to-group")}
-    >
-      <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
-      <span class="session-menu__text"
-        >${batch
-          ? t("sessionsView.moveToGroupMenuCount", { count })
-          : t("sessionsView.moveToGroupMenu")}</span
-      >
-      ${this.renderGroupSubmenu()}
-    </wa-dropdown-item>`;
+    const label = batch
+      ? t("sessionsView.moveToGroupMenuCount", { count })
+      : t("sessionsView.moveToGroupMenu");
+    return this.renderSubmenu(
+      "group",
+      label,
+      icons.folder,
+      this.actionDisabled("move-to-group"),
+      state.actionDisabledReasons["move-to-group"],
+    );
   }
 
   renderDeleteAction() {
@@ -477,19 +459,36 @@ export class SessionMenuActions {
   }
 
   renderCompactView(view: CompactSessionMenuView) {
+    return view === "root"
+      ? nothing
+      : renderCompactSessionMenuFrame(this.renderSubmenuBody(view, true));
+  }
+
+  private renderSubmenuBody(view: Exclude<CompactSessionMenuView, "root">, inline = false) {
     const state = this.readState();
-    return renderCompactSessionMenuView({
-      view,
-      ownerOptions: state.ownerOptions,
-      selfOwner: state.selfOwner,
-      currentOwnerId: state.currentOwnerId,
-      assignOwnerDisabled: this.actionDisabled("assign-owner"),
-      assignOwnerDisabledReason: state.actionDisabledReasons["assign-owner"],
-      renderOpenIn: () => this.renderOpenSubmenu(true),
-      renderCopy: () => this.renderCopySubmenu(true),
-      renderIcon: () => this.renderAppearancePicker(true),
-      renderGroup: () => this.renderGroupSubmenu(true),
-    });
+    switch (view) {
+      case "copy":
+        return this.renderCopySubmenu(inline);
+      case "open-in":
+        return this.renderOpenSubmenu(inline);
+      case "icon":
+        return this.renderAppearancePicker(inline);
+      case "group":
+        return this.renderGroupSubmenu(inline);
+      case "assign-owner":
+        return renderSessionOwnerAssignmentOptions(
+          {
+            ownerOptions: state.ownerOptions,
+            selfOwner: state.selfOwner,
+            currentOwnerId: state.currentOwnerId,
+            disabled: this.actionDisabled("assign-owner"),
+            disabledReason: state.actionDisabledReasons["assign-owner"],
+          },
+          inline,
+        );
+      default:
+        return view satisfies never;
+    }
   }
 
   private renderCopySubmenu(inline = false) {

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -1,8 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../i18n/index.ts";
 import { icons } from "./icons.ts";
-import type { SessionOwnerOption } from "./session-owner-chip.ts";
-import { renderSessionOwnerAssignmentOptions } from "./session-owner-menu.ts";
 
 export type CompactSessionMenuView =
   | "root"
@@ -57,41 +55,4 @@ export function renderCompactSessionMenuFrame(body: TemplateResult | readonly Te
     <div class="session-menu__separator" role="separator"></div>
     ${body}
   `;
-}
-
-export function renderCompactSessionMenuView(params: {
-  view: CompactSessionMenuView;
-  ownerOptions: readonly SessionOwnerOption[];
-  selfOwner: SessionOwnerOption | null;
-  currentOwnerId: string | null;
-  assignOwnerDisabled: boolean;
-  assignOwnerDisabledReason?: string;
-  renderOpenIn: () => TemplateResult;
-  renderCopy: () => TemplateResult;
-  renderIcon: () => TemplateResult;
-  renderGroup: () => TemplateResult;
-}) {
-  if (params.view === "root") {
-    return nothing;
-  }
-  const body =
-    params.view === "copy"
-      ? params.renderCopy()
-      : params.view === "open-in"
-        ? params.renderOpenIn()
-        : params.view === "assign-owner"
-          ? renderSessionOwnerAssignmentOptions(
-              {
-                ownerOptions: params.ownerOptions,
-                selfOwner: params.selfOwner,
-                currentOwnerId: params.currentOwnerId,
-                disabled: params.assignOwnerDisabled,
-                disabledReason: params.assignOwnerDisabledReason,
-              },
-              true,
-            )
-          : params.view === "icon"
-            ? params.renderIcon()
-            : params.renderGroup();
-  return renderCompactSessionMenuFrame(body);
 }


### PR DESCRIPTION
Related: #133490 (session-menu redesign).
Related: #133002 (separate menu-scope work; its header cleanup is deliberately excluded here).

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

The session-menu redesign left duplicate rendering paths for desktop and compact menus, plus separate copies of the emoji and glyph buttons. This maintainer-requested cleanup reduces the maintenance burden without changing the menu's layout or actions.

## Why This Change Was Made

Keep submenu selection with `SessionMenuActions`, the owner of the action state, rather than passing rendering callbacks through a second compact-menu dispatcher. Both layouts now use the same closed submenu switch and group-action renderer. The icon picker uses one button renderer and leaves submenu-slot ownership with the outer appearance picker.

The deleted paths are the callback-heavy `renderCompactSessionMenuView`, duplicate group-action markup, duplicate emoji/glyph button templates, and redundant inner submenu slots. Existing owner-assignment, child-session, batch-label, disabled-reason, and keyboard behavior is preserved. The header cleanup already proposed in #133002 is not duplicated.

Production LOC: +74 / -133, net **-59** across three files. Tests: +0 / -0; existing behavioral coverage is reused. No dependency, configuration, protocol, persistence, or translated-copy changes.

## User Impact

No intended user-visible change. Sidebar, header, and compact menus retain their current appearance, keyboard traversal, owner assignment, icon/color selection, and reset behavior. This is a behavior-neutral refactor, not another menu redesign.

## Evidence

- 64 existing menu unit tests pass: `node scripts/run-vitest.mjs ui/src/components/session-menu.test.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts`.
- 9 real-Chromium checks pass against the mocked Gateway: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-color.e2e.test.ts ui/src/e2e/session-owner-assignment.e2e.test.ts`. Coverage includes sidebar/header/compact keyboard access; color set/reset; self/named owner selection; and visible assignment errors.
- `pnpm ui:build` passes, including Control UI asset/performance budgets.
- `node scripts/check-changed.mjs --base HEAD -- ui/src/components/session-icon-picker.ts ui/src/components/session-menu-actions.ts ui/src/components/session-menu-compact.ts` covers formatting, i18n, test/UI types, coercion/import guards, unused exports, and lint.
- Fresh Codex autoreview of the final uncommitted scope reports no accepted/actionable P0 findings; manual owner/caller and installed Web Awesome submenu-contract inspection supplements that priority-scoped review.

Proof boundary: browser checks use a mocked Gateway, not the operator's running Gateway. No new real-Gateway session flow or screenshot claim is made; this bounded behavior-neutral refactor uses focused tests/checks. No live service restart is part of this PR.
