### PR TITLE
test(packaging): preserve relocated shared declaration chunks

### DIFF
--- a/test/scripts/write-plugin-sdk-entry-dts.test.ts
+++ b/test/scripts/write-plugin-sdk-entry-dts.test.ts
@@ -189,8 +189,11 @@ describe("write-plugin-sdk-entry-dts", () => {
       writeRelocated(relative, content);
     }
     // SDK publication owns flat entries; historical shared chunks belong to other groups.
-    for (const file of Object.keys(before).filter((entry) => !entry.startsWith("plugin-sdk/"))) {
+    const sharedBefore = Object.keys(before).filter((entry) => !entry.startsWith("plugin-sdk/"));
+    for (const file of sharedBefore) {
       expect(first[file]).toBe(before[file]);
+    }
+    for (const file of Object.keys(first).filter((entry) => !entry.startsWith("plugin-sdk/"))) {
       writeRelocated(`dist/${file}`, fs.readFileSync(path.join(root, "dist", file), "utf8"));
     }
     writeRelocated("dist/plugin-sdk/obsolete.d.ts", "obsolete restored declaration");


### PR DESCRIPTION
## Summary

- preserve the existing assertion that historical non-SDK declaration chunks survive publication
- seed every current non-SDK chunk into the relocated cache fixture
- keep the portable cache restore comparison byte-exact after declaration sources change

## Why

The packaging fixture copied only shared chunks present before declarations changed, then compared the relocated restore with the newer output tree. A newly emitted shared chunk was therefore absent from the relocated fixture, causing `write-plugin-sdk-entry-dts.test.ts` to fail on current `main` and in unrelated PR CI.

## Validation

- `pnpm exec vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/write-plugin-sdk-entry-dts.test.ts` (11/11)
- `pnpm test:changed`
- `pnpm check:changed`
- structured P3 autoreview; accepted preservation finding fixed
