### PR TITLE
fix(browser): prevent unreviewed Chrome MCP upgrades

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -801,7 +801,7 @@ Agent use:
 - If you use a custom existing-session profile, pass that explicit profile name.
 - Only choose this mode when the user is at the computer to approve the attach
   prompt.
-- The Gateway or node host can spawn `npx chrome-devtools-mcp@latest --autoConnect`.
+- The Gateway or node host can spawn `npx -y chrome-devtools-mcp@1.8.0 --autoConnect`.
 
 Notes:
 
@@ -827,8 +827,10 @@ Notes:
 ### Custom Chrome MCP launch
 
 Override the spawned Chrome DevTools MCP server per profile when the default
-`npx chrome-devtools-mcp@latest` flow is not what you want (offline hosts,
-pinned versions, vendored binaries):
+`npx -y chrome-devtools-mcp@1.8.0` flow is not what you want (offline hosts,
+different versions, vendored binaries). OpenClaw pins the default server to the
+version validated with its endpoint-policy parser. Custom executables and versions
+are operator-managed and must preserve Chrome MCP's connection-argument semantics.
 
 | Field        | What it does                                                                                                                    |
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -836,7 +838,7 @@ pinned versions, vendored binaries):
 | `mcpArgs`    | Extra arguments passed unchanged to `mcpCommand`. Connection options override the generated endpoint or auto-connect arguments. |
 
 Using `mcpArgs` does not replace the package prefix: when `mcpCommand` is `npx`,
-OpenClaw still prepends `-y chrome-devtools-mcp@latest`.
+OpenClaw still prepends `-y chrome-devtools-mcp@1.8.0`.
 
 When `mcpArgs` does not set a connection option, OpenClaw forwards a configured
 `cdpUrl` to Chrome MCP instead of generating `--autoConnect`:

--- a/extensions/browser/src/browser/chrome-mcp-options.ts
+++ b/extensions/browser/src/browser/chrome-mcp-options.ts
@@ -9,7 +9,8 @@ import type {
 import { BrowserProfileUnavailableError } from "./errors.js";
 
 const DEFAULT_CHROME_MCP_COMMAND = "npx";
-const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "chrome-devtools-mcp@latest"];
+// Endpoint policy below must match the launched CLI's argument grammar.
+const DEFAULT_CHROME_MCP_PACKAGE_ARGS = ["-y", "chrome-devtools-mcp@1.8.0"];
 const DEFAULT_CHROME_MCP_FEATURE_ARGS = [
   "--no-usage-statistics",
   // Direct chrome-devtools-mcp launches do not enable structuredContent by default.

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -244,13 +244,21 @@ describe("chrome MCP page parsing", () => {
     vi.unstubAllEnvs();
   });
 
-  it("passes HTTP CDP endpoints to Chrome MCP as browserUrl discovery endpoints", () => {
-    const { args } = normalizeChromeMcpOptions({ cdpUrl: "http://127.0.0.1:9222" });
+  it.each([undefined, "npx"])(
+    "uses pinned Chrome MCP for HTTP endpoints with command %s",
+    (mcpCommand) => {
+      const { command, args } = normalizeChromeMcpOptions({
+        cdpUrl: "http://127.0.0.1:9222",
+        mcpCommand,
+      });
 
-    expect(args).toContain("--browserUrl");
-    expect(args).toContain("http://127.0.0.1:9222");
-    expect(args).not.toContain("--wsEndpoint");
-  });
+      expect(command).toBe("npx");
+      expect(args.slice(0, 2)).toEqual(["-y", "chrome-devtools-mcp@1.8.0"]);
+      expect(args).toContain("--browserUrl");
+      expect(args).toContain("http://127.0.0.1:9222");
+      expect(args).not.toContain("--wsEndpoint");
+    },
+  );
 
   it("passes direct WebSocket CDP endpoints to Chrome MCP as wsEndpoint attachments", () => {
     const { args } = normalizeChromeMcpOptions({
@@ -339,8 +347,13 @@ describe("chrome MCP page parsing", () => {
     const options = normalizeChromeMcpOptions({ mcpCommand: "custom-chrome-mcp", mcpArgs });
 
     expect(options.command).toBe("custom-chrome-mcp");
-    expect(options.args.slice(-mcpArgs.length)).toEqual(mcpArgs);
-    expect(options.args).not.toContain("chrome-devtools-mcp@latest");
+    expect(options.args).toEqual([
+      "--autoConnect",
+      "--no-usage-statistics",
+      "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
+      ...mcpArgs,
+    ]);
   });
 
   it("keeps document-bound evaluations on one pinned target and raw snapshot uid", async () => {


### PR DESCRIPTION
Related: #135857, #135845.

## What Problem This Solves

Resolves a problem where existing-session Browser profiles could launch an unreviewed Chrome MCP release without an OpenClaw update. The endpoint-policy repair in #135857 interprets Chrome MCP's connection arguments before starting its subprocess; a floating `@latest` executable could later change that grammar independently. This addresses the [late version-drift finding](https://github.com/openclaw/openclaw/pull/135857#issuecomment-5505314936), not a newly demonstrated bypass in version 1.8.0.

## Why This Change Was Made

Pin the built-in launcher to `chrome-devtools-mcp@1.8.0` at the existing options owner. That is the public package used for the endpoint-parser and real-browser verification. Its Yargs and parser implementation are bundled in the package, not floating runtime dependencies. Keep the current custom-executable contract and document that those executables and versions remain operator-managed.

No additional launch path, compatibility shim, configuration key, schema, RPC, migration, dependency override, or lockfile change is introduced. The existing default executable-version surface changes once: `@latest` to `1.8.0`.

## User Impact

The default Browser attachment flow no longer silently adopts a newer Chrome MCP release. Hosts need the pinned package available through npm or their npm cache; this does not make the launcher offline or hermetic. Explicit `mcpCommand: "npx"` uses the same pin. A custom command still receives the existing connection/feature arguments and the operator's extra arguments without an npm package prefix.

## Evidence

- Regression proof: the implicit/default `npx` and explicit `npx` cases both failed against the old `@latest` default, then passed with the pin. The custom-command argument contract passed before and after.
- Focused Chrome MCP, Browser config, existing-session, and CDP blocklist suites: **244 passed, one existing skip**.
- Changed-file gate passed, including extension production/test typechecks, lint, boundary/dependency guards, dead-code checks, and runtime import-cycle checks. MDX passed for the changed page; **7,246 internal links checked, zero broken**.
- Local `pnpm build qaRuntime` passed, including plugin assets, runtime bundles, native control-plane imports, and postbuild checks. Source remained clean at `44ad75b4d1161ca6fb98c3da5c319055fbdf9475`.
- Fresh independent Codex autoreview: **scoped-clean through P2** on the complete three-file change.
- Live proof used the real default options owner and real `npx`, with `mcpCommand` omitted. npm installed the package from an integrity-verified public cache into a fresh task-owned executable directory; the normal seven-day package cooldown stayed enabled. All **345 installed files** matched the public tarball, and the live MCP handshake reported **1.8.0**.

The actual signed Chrome 152 flow passed attachment, tab listing, owned-tab creation, navigation, DOM read, and owned-tab close. Initial and final tab counts were both one. Blocking that same endpoint produced the expected visible error before any new subprocess, TCP connection, HTTP request, WebSocket upgrade, or page request:

```text
default command: npx -y chrome-devtools-mcp@1.8.0
MCP handshake: chrome_devtools 1.8.0
public package files verified: 345
allowed: attach / list / open / navigate / DOM read / owned close PASS
denied deltas: processes=0 npx=0 tcp=0 http=0 ws=0 page=0
cleanup: Chrome exit=0; remaining task/MCP pids=0;
         cached/pending/retained sessions=0; errors=0
```

The first live attempt exposed a proof-host constraint: macOS refuses its setuid `/bin/ps` inside the inherited sandbox. A path-specific exception for that native read-only helper let the real process-owner checks run; Node, npm, Chrome MCP, and Chrome retained the loopback-only outbound fence. Parent and child Node network-denial probes both passed. No fake launcher, process-list mock, operator browser profile, production Gateway, or product-code workaround was used. The failed attempt was retained, all its processes were checked closed, and the successful run used a fresh browser profile and npm executable directory.

Public dependency provenance: [Chrome MCP 1.8.0 tarball](https://registry.npmjs.org/chrome-devtools-mcp/-/chrome-devtools-mcp-1.8.0.tgz), upstream revision `45f187b1e3202c9f32ddba913be5d68751c3caa3`; SHA-256 `ac0334410cea75d11a5ebb555fbb0139a4a394de35d98cc2a3bc0a959f004cdd`. The inspected connection grammar is in `build/src/config/mcp-options.js`, connection selection in `build/src/index.js` and `build/src/browser.js`, and the parser bytes in `build/src/third_party/index.js`. The successful live report SHA-256 is `59ac0568e9acd02921a91ea1fa1ef1c48dd2e0f9d2fd9ce5e8003cb4f0d69cc2`.

Production delta: **+2/-1, net +1** (the extra line is the parser/launcher invariant comment); tests **+21/-8, net +13**; docs **+6/-4, net +2**. Existing owner and sibling coverage was extended; no test-only production seam was added.

### Maintainer review dispositions

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/136121#issuecomment-5506277719) found no actionable code or security defect and raised two merge considerations. The exact-version cache tradeoff is intentional and accepted under the explicit maintainer direction to pin 1.8.0 and land this change. An offline host needs that version cached or an operator-managed executable; no floating fallback is added. The reviewer's DNS failure to reopen the dependency is a reviewer-environment limitation: the acting maintainer agent personally inspected the exact published package, verified its bundled parser and integrity, and ran the real default executable. This does not claim the reviewer independently performed those checks.

### CI refresh

[Initial CI](https://github.com/openclaw/openclaw/actions/runs/33604711343) failed one SDK declaration-cache relocation test, not a Browser assertion. The same missing historical QA chunk was reproduced locally. [PR #135831](https://github.com/openclaw/openclaw/pull/135831) had already repaired that fixture on main by seeding only unowned history while requiring current cache outputs to restore. This branch was mechanically rebased onto that fix; its three changed files are byte-for-byte unchanged.

On refreshed head `145a91983eb761673c9fc06b6e8b5489afecb51f`, the exact SDK regression passes, the 244 Browser tests pass again, fresh independent review is clean through P2, and the genuine default-npx live Chrome flow passes again with zero denied-endpoint activity and complete cleanup. Refreshed live report SHA-256: `71ba347d9ceab77837ff04019b863bfd6a853f70a4540b206e81a81c033f6cec`. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33606864847) is green: **135 jobs passed, 16 skipped**, on this exact source head. The refreshed ClawSweeper review at `2026-09-02T08:10:39.236Z` covers this same head, has no code/security finding, and its cache-availability decision and rank-up request are addressed by the explicit maintainer acceptance above.
