### PR TITLE
fix: declaration cache restore test drops preexisting chunks

### DIFF
--- a/test/scripts/write-plugin-sdk-entry-dts.test.ts
+++ b/test/scripts/write-plugin-sdk-entry-dts.test.ts
@@ -152,6 +152,7 @@ describe("write-plugin-sdk-entry-dts", () => {
     ).toHaveLength(2);
     expectOutputs(root, qa, Object.keys(treeHashes(path.join(root, "dist"))));
     expectStagingClean(root);
+    const beforeChanged = treeHashes(path.join(root, "dist"));
 
     writeDeclarations("after");
     fs.rmSync(path.join(root, "contracts/before.ts"));
@@ -189,8 +190,10 @@ describe("write-plugin-sdk-entry-dts", () => {
       writeRelocated(relative, content);
     }
     // SDK publication owns flat entries; historical shared chunks belong to other groups.
-    for (const file of Object.keys(before).filter((entry) => !entry.startsWith("plugin-sdk/"))) {
-      expect(first[file]).toBe(before[file]);
+    for (const file of Object.keys(beforeChanged).filter(
+      (entry) => !entry.startsWith("plugin-sdk/"),
+    )) {
+      expect(first[file]).toBe(beforeChanged[file]);
       writeRelocated(`dist/${file}`, fs.readFileSync(path.join(root, "dist", file), "utf8"));
     }
     writeRelocated("dist/plugin-sdk/obsolete.d.ts", "obsolete restored declaration");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the root tooling CI suite fails after the plugin SDK declaration fixture runs a Private QA build. That build can leave additional shared root declaration chunks, but the relocated cache-restore fixture only seeds chunks captured before the Private QA build and then incorrectly reports the preexisting chunk as missing.

## Why This Change Was Made

The fixture now snapshots the live declaration tree immediately after the Private QA build and seeds every preexisting non-SDK chunk into the relocated checkout. This preserves the production ownership boundary: the SDK declaration cache owns flat `plugin-sdk` entries, while shared root chunks remain inputs owned by other declaration groups.

## User Impact

There is no runtime behavior change. Contributors no longer receive a deterministic false CI failure from `write-plugin-sdk-entry-dts.test.ts` on current `main`.

## Evidence

- Reproduced on upstream `main` at `331d8a2265ff07d5db51e459c32d38c10fc7dc24` with:
  - `pnpm test -- test/scripts/write-plugin-sdk-entry-dts.test.ts`
  - Failure: restored output omitted preexisting `actual-xIWKef-Q.d.ts`.
- Verified on current upstream `main` at `905f810622b0b9b3c56146b52e66141c78a05957`:
  - `pnpm test -- test/scripts/write-plugin-sdk-entry-dts.test.ts` — 11/11 tests passed.
  - `node scripts/check-changed.mjs -- test/scripts/write-plugin-sdk-entry-dts.test.ts` — passed.
