### PR TITLE
fix(exec): reduce cold-start delays for shell commands

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -26,7 +26,12 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
+import {
+  claimExecApprovalFollowupRuntimeHandoff,
+  finalizeExecApprovalFollowupRuntimeHandoff,
+} from "./bash-tools.exec-approval-followup-state.js";
 import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import { sendExecApprovalFollowupResult } from "./bash-tools.exec-host-shared.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const tempStoreDirs: string[] = [];
@@ -973,21 +978,45 @@ describe("exec approval followup", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("carries the runtime handoff separately from idempotency without exposing elevated defaults", async () => {
-    await sendExecApprovalFollowup({
+  it("registers the runtime handoff before default followup dispatch without exposing elevated defaults", async () => {
+    const target = {
       approvalId: "req-elevated-75832",
       sessionKey: "agent:main:telegram:direct:123",
       turnSourceChannel: "telegram",
-      resultText: "Exec finished (gateway id=req-elevated-75832, code 0)\nok",
-      internalRuntimeHandoffId: "handoff-75832",
-      idempotencyKey: "exec-approval-followup:req-elevated-75832:nonce:nonce-75832",
+      bashElevated: { enabled: true, allowed: true, defaultLevel: "on" as const },
+    };
+    const resultText = "Exec finished (gateway id=req-elevated-75832, code 0)\nok";
+    let handoff: ReturnType<typeof claimExecApprovalFollowupRuntimeHandoff>;
+    vi.mocked(callGatewayTool).mockImplementationOnce(async (_method, _options, rawParams) => {
+      const params = requireRecord(rawParams, "followup dispatch params");
+      const handoffId = String(params.internalRuntimeHandoffId);
+      handoff = claimExecApprovalFollowupRuntimeHandoff({
+        handoffId,
+        approvalId: target.approvalId,
+        sessionKey: target.sessionKey,
+        idempotencyKey: String(params.idempotencyKey),
+        claimId: "followup-default-dispatch",
+      });
+      finalizeExecApprovalFollowupRuntimeHandoff({
+        handoffId,
+        claimId: "followup-default-dispatch",
+      });
+      return { status: "ok" };
     });
+    await sendExecApprovalFollowupResult(target, resultText);
 
     const agentArgs = expectGatewayAgentFollowup({
       sessionKey: "agent:main:telegram:direct:123",
       channel: "telegram",
-      idempotencyKey: "exec-approval-followup:req-elevated-75832:nonce:nonce-75832",
-      internalRuntimeHandoffId: "handoff-75832",
+    });
+    expectAuthenticatedHandoff(agentArgs, target);
+    expect(handoff).toEqual({
+      kind: "exec-approval-followup",
+      approvalId: target.approvalId,
+      sessionKey: target.sessionKey,
+      idempotencyKey: agentArgs.idempotencyKey,
+      bashElevated: target.bashElevated,
+      resultText,
     });
     expect(agentArgs.message).toContain("ok");
     expect(agentArgs.inputProvenance).toEqual({

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./bash-tools.exec-host-shared.js";
 
 const mocks = vi.hoisted(() => ({
+  followupImports: 0,
   resolveExecApprovals: vi.fn(async () => ({
     defaults: {
       security: "allowlist",
@@ -40,6 +41,11 @@ const mocks = vi.hoisted(() => ({
   approvalRunAbortedError: new Error("approval owning run aborted"),
   resolveRegisteredExecApprovalDecision: vi.fn(async (): Promise<string | null> => "allow-once"),
 }));
+
+vi.mock("./bash-tools.exec-approval-followup.js", async (importOriginal) => {
+  mocks.followupImports += 1;
+  return importOriginal<typeof import("./bash-tools.exec-approval-followup.js")>();
+});
 
 vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
   const mod = await importOriginal<typeof import("../infra/exec-approvals.js")>();
@@ -104,6 +110,31 @@ describe("sendExecApprovalFollowupResult", () => {
         }
       | undefined;
   }
+
+  it("does not load delivery when importing shared approval helpers", () => {
+    expect(mocks.followupImports).toBe(0);
+  });
+
+  it("logs default delivery import failures through the deduplicated dispatch handler", async () => {
+    const loadDelivery = vi.fn(() => {
+      throw new Error("synthetic delivery import failure");
+    });
+    vi.doMock("./bash-tools.exec-approval-followup.js", loadDelivery);
+    try {
+      const target = { approvalId: "approval-import-failure" };
+      await sendExecApprovalFollowupResult(target, "Exec finished", { logWarn });
+      await sendExecApprovalFollowupResult(target, "Exec finished", { logWarn });
+
+      expect(loadDelivery).toHaveBeenCalled();
+      expect(logWarn).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(
+          "exec approval followup dispatch failed (id=approval-import-failure):",
+        ),
+      );
+    } finally {
+      vi.doUnmock("./bash-tools.exec-approval-followup.js");
+    }
+  });
 
   it("logs repeated followup dispatch failures once per approval id and error message", async () => {
     sendExecApprovalFollowup.mockRejectedValue(new Error("Channel is required"));

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -25,7 +25,7 @@ import {
 } from "../infra/exec-approvals.js";
 import { logWarn } from "../logger.js";
 import { registerExecApprovalFollowupRuntimeHandoff } from "./bash-tools.exec-approval-followup-state.js";
-import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import type { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
 import {
   type ExecApprovalRegistration,
   isExecApprovalRunAbortedError,
@@ -540,7 +540,12 @@ export async function sendExecApprovalFollowupResult(
   resultText: string,
   deps: ExecApprovalFollowupResultDeps = {},
 ): Promise<void> {
-  const send = deps.sendExecApprovalFollowup ?? sendExecApprovalFollowup;
+  const send: typeof sendExecApprovalFollowup =
+    deps.sendExecApprovalFollowup ??
+    (async (params) => {
+      const { sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js");
+      return sendExecApprovalFollowup(params);
+    });
   const warn = deps.logWarn ?? logWarn;
   const runtimeHandoff =
     target.direct === true || !target.sessionKey || isExecDeniedResultText(resultText)

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -14,6 +14,7 @@ import {
   resolveExecApprovalsFromFile,
   resolveExecModePolicy,
 } from "../infra/exec-approvals.js";
+import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import {
   rejectUnsafeExecControlShellCommand,
   rejectUnsafeExecLiveStateSqliteShellCommand,
@@ -61,6 +62,7 @@ import {
   attachExecApprovalReview,
   buildExecForegroundResult,
   createExecHostResolver,
+  resolveExecElevatedMode,
   resolveExecReviewerDefaults,
 } from "./bash-tools.exec-support.js";
 import {
@@ -75,7 +77,6 @@ import type {
 } from "./bash-tools.exec-types.js";
 import { formatUnavailableWorkdirFailure, resolveExecWorkdir } from "./bash-tools.exec-workdir.js";
 import { clampWithDefault, readEnvInt, truncateMiddle } from "./bash-tools.shared.js";
-import { createModelExecAutoReviewer } from "./exec-auto-reviewer.js";
 import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import type { AgentToolWithMeta } from "./tools/common.js";
 import { withoutGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
@@ -202,15 +203,20 @@ export function createExecTool(
     execute: async (toolCallId, args, signal, onUpdate) => {
       signal?.throwIfAborted();
       assertSupportedExecParams(args);
-      // Review cancellation belongs to this execution, never another call on the shared tool.
-      const autoReviewer =
-        defaults?.autoReviewer ??
-        createModelExecAutoReviewer({
+      // Capture settings and cancellation per execution; unused reviewers must not load model runtime.
+      let autoReviewer: ExecAutoReviewer | undefined = defaults?.autoReviewer;
+      if (!autoReviewer) {
+        const reviewerParams = {
           cfg: defaults?.config,
           agentId,
           reviewer: resolveExecReviewerDefaults({ defaults, agentId }),
           signal,
-        });
+        };
+        autoReviewer = async (input) => {
+          const { createModelExecAutoReviewer } = await import("./exec-auto-reviewer.js");
+          return createModelExecAutoReviewer(reviewerParams)(input);
+        };
+      }
       let params = requestPreparation.normalizeParams(args);
       const resolveExecEnvPrepared = requestPreparation.isResolveExecEnvPrepared(
         args as ExecToolArgs,
@@ -245,25 +251,7 @@ export function createExecTool(
             )
         : null;
       const elevatedDefaults = defaults?.elevated;
-      const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);
-      const elevatedDefaultMode =
-        elevatedDefaults?.defaultLevel === "full"
-          ? "full"
-          : elevatedDefaults?.defaultLevel === "ask"
-            ? "ask"
-            : elevatedDefaults?.defaultLevel === "on"
-              ? "ask"
-              : "off";
-      const effectiveDefaultMode =
-        elevatedAllowed && !defaults?.sandboxRequired ? elevatedDefaultMode : "off";
-      const elevatedMode =
-        typeof params.elevated === "boolean"
-          ? params.elevated
-            ? elevatedDefaultMode === "full"
-              ? "full"
-              : "ask"
-            : "off"
-          : effectiveDefaultMode;
+      const elevatedMode = resolveExecElevatedMode(defaults, params.elevated);
       const elevatedRequested = elevatedMode !== "off";
       if (elevatedRequested) {
         if (!elevatedDefaults?.enabled || !elevatedDefaults.allowed) {

--- a/src/agents/bash-tools.exec-support.ts
+++ b/src/agents/bash-tools.exec-support.ts
@@ -82,28 +82,27 @@ export function resolveExecReviewerDefaults(params: {
   return agentExec?.reviewer ?? cfg?.tools?.exec?.reviewer;
 }
 
+// Preparation and execution must interpret elevation identically before host policy runs.
+export function resolveExecElevatedMode(
+  defaults: ExecToolDefaults | undefined,
+  requested: unknown,
+) {
+  const elevated = defaults?.elevated;
+  const defaultMode =
+    elevated?.defaultLevel === "full"
+      ? "full"
+      : elevated?.defaultLevel === "ask" || elevated?.defaultLevel === "on"
+        ? "ask"
+        : "off";
+  if (typeof requested === "boolean") {
+    return requested ? (defaultMode === "full" ? "full" : "ask") : "off";
+  }
+  return elevated?.enabled && elevated.allowed && !defaults?.sandboxRequired ? defaultMode : "off";
+}
+
 export function createExecHostResolver(defaults?: ExecToolDefaults) {
   return (params: ExecToolArgs): ExecHost => {
-    const elevatedDefaults = defaults?.elevated;
-    const elevatedAllowed = Boolean(elevatedDefaults?.enabled && elevatedDefaults.allowed);
-    const elevatedDefaultMode =
-      elevatedDefaults?.defaultLevel === "full"
-        ? "full"
-        : elevatedDefaults?.defaultLevel === "ask"
-          ? "ask"
-          : elevatedDefaults?.defaultLevel === "on"
-            ? "ask"
-            : "off";
-    const effectiveDefaultMode =
-      elevatedAllowed && !defaults?.sandboxRequired ? elevatedDefaultMode : "off";
-    const elevatedMode =
-      typeof params.elevated === "boolean"
-        ? params.elevated
-          ? elevatedDefaultMode === "full"
-            ? "full"
-            : "ask"
-          : "off"
-        : effectiveDefaultMode;
+    const elevatedMode = resolveExecElevatedMode(defaults, params.elevated);
     const requestedTarget = requireValidExecTarget(params.host);
     return resolveExecTarget({
       configuredTarget: defaults?.host,

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -7,6 +7,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { saveExecApprovals, type ExecApprovalsFile } from "../infra/exec-approvals.js";
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
@@ -14,11 +16,37 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createExecTool as createExecToolImpl } from "./bash-tools.exec-run.js";
+import { makeProviderModelFixture } from "./test-helpers/provider-model-fixture.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const createExecTool = (
   defaults?: Parameters<typeof createExecToolImpl>[0],
 ): ReturnType<typeof createExecToolImpl> => createExecToolImpl({ agentId: "main", ...defaults });
+
+const optionalRuntimeImports = vi.hoisted(() => ({ reviewer: 0, followup: 0 }));
+const reviewerRuntime = vi.hoisted(() => ({
+  prepare:
+    vi.fn<typeof import("./simple-completion-runtime.js").prepareSimpleCompletionModelForAgent>(),
+  complete:
+    vi.fn<
+      typeof import("./simple-completion-runtime.js").completeWithPreparedSimpleCompletionModel
+    >(),
+}));
+
+vi.mock("./simple-completion-runtime.js", () => ({
+  prepareSimpleCompletionModelForAgent: reviewerRuntime.prepare,
+  completeWithPreparedSimpleCompletionModel: reviewerRuntime.complete,
+}));
+
+vi.mock("./exec-auto-reviewer.js", async (importOriginal) => {
+  optionalRuntimeImports.reviewer += 1;
+  return importOriginal<typeof import("./exec-auto-reviewer.js")>();
+});
+
+vi.mock("./bash-tools.exec-approval-followup.js", async (importOriginal) => {
+  optionalRuntimeImports.followup += 1;
+  return importOriginal<typeof import("./bash-tools.exec-approval-followup.js")>();
+});
 
 vi.mock("./tools/gateway.js", () => ({
   callGatewayTool: vi.fn(),
@@ -110,6 +138,8 @@ describe("exec security floor", () => {
     }
     resetProcessRegistryForTests();
     vi.mocked(callGatewayTool).mockReset();
+    reviewerRuntime.prepare.mockReset();
+    reviewerRuntime.complete.mockReset();
   });
 
   afterEach(() => {
@@ -140,6 +170,15 @@ describe("exec security floor", () => {
     expect(text).not.toMatch(/exec denied/i);
     expect(text).not.toMatch(/allowlist miss/i);
     expect(text.trim()).toContain("hello");
+  });
+
+  it("does not load optional review or delivery runtimes for full/off execution", async () => {
+    const tool = createExecTool({ host: "gateway", mode: "full" });
+
+    const result = await tool.execute("call-unused-optional-runtimes", { command: "echo hello" });
+
+    expect(result.details.status).toBe("completed");
+    expect(optionalRuntimeImports).toEqual({ reviewer: 0, followup: 0 });
   });
 
   it("enforces configured allowlist security when model also passes allowlist", async () => {
@@ -363,6 +402,7 @@ describe("exec security floor", () => {
     }
 
     expect(liveReviews).toEqual([]);
+    expect(reviewerRuntime.prepare).not.toHaveBeenCalled();
     expect(result.details).toMatchObject({
       status: "completed",
       approvalReviewOutcome: "approved",
@@ -566,4 +606,105 @@ describe("exec security floor", () => {
       expect(calls).toContain("exec.approval.request");
     },
   );
+
+  it("keeps default reviewer settings and cancellation scoped to each execution", async () => {
+    const reviewer = { model: "synthetic/reviewer-first" };
+    const config: OpenClawConfig = {
+      tools: { exec: { reviewer: { model: "synthetic/reviewer-global" } } },
+      agents: { entries: { main: { tools: { exec: { reviewer } } } } },
+    };
+    reviewerRuntime.prepare.mockResolvedValue({
+      selection: { provider: "synthetic", modelId: "reviewer", agentDir: tempRoot ?? os.tmpdir() },
+      model: makeProviderModelFixture({
+        provider: "synthetic",
+        id: "reviewer",
+        api: "openai-responses",
+        baseUrl: "https://example.invalid",
+      }),
+      auth: { source: "synthetic", mode: "aws-sdk" },
+    });
+    const completion = createDeferred<never>();
+    const completionEntered = createDeferred();
+    reviewerRuntime.complete
+      .mockImplementationOnce(() => {
+        completionEntered.resolve();
+        return completion.promise;
+      })
+      .mockRejectedValueOnce(new Error("synthetic completion unavailable"));
+    vi.mocked(callGatewayTool).mockResolvedValue({ decision: "deny" });
+    const tool = createExecTool({
+      host: "gateway",
+      mode: "auto",
+      safeBins: [],
+      config,
+      messageProvider: "webchat",
+    });
+    const first = new AbortController();
+    const second = new AbortController();
+    const firstRun = tool.execute(
+      "default-review-first",
+      { command: "node --version" },
+      first.signal,
+    );
+    try {
+      await Promise.race([completionEntered.promise, firstRun]);
+      first.abort(new Error("first execution cancelled"));
+      await expect(firstRun).rejects.toThrow("first execution cancelled");
+      expect(reviewerRuntime.complete.mock.calls[0]?.[0].options?.signal?.aborted).toBe(true);
+
+      reviewer.model = "synthetic/reviewer-second";
+      const result = await tool.execute(
+        "default-review-second",
+        { command: "node --version" },
+        second.signal,
+      );
+      expect(reviewerRuntime.prepare.mock.calls.map(([params]) => params.modelRef)).toEqual([
+        "synthetic/reviewer-first",
+        "synthetic/reviewer-second",
+      ]);
+      expect(reviewerRuntime.prepare).toHaveBeenLastCalledWith(
+        expect.objectContaining({ cfg: config, agentId: "main" }),
+      );
+      expect(reviewerRuntime.complete.mock.calls[1]?.[0].options?.signal?.aborted).toBe(false);
+      expect(result.details).toMatchObject({
+        status: "failed",
+        approvalReviewOutcome: "denied",
+        approvalReviews: [{ rationale: "exec reviewer failed: synthetic completion unavailable" }],
+      });
+    } finally {
+      first.abort();
+      completion.reject(new Error("review fixture closed"));
+      await firstRun.catch(() => undefined);
+    }
+  });
+
+  it("defers to human approval when the default reviewer import fails", async () => {
+    const loadReviewer = vi.fn(() => {
+      throw new Error("synthetic reviewer import failure");
+    });
+    vi.doMock("./exec-auto-reviewer.js", loadReviewer);
+    vi.mocked(callGatewayTool).mockResolvedValue({ decision: "deny" });
+    try {
+      const tool = createExecTool({
+        host: "gateway",
+        mode: "auto",
+        safeBins: [],
+        messageProvider: "webchat",
+      });
+      const result = await tool.execute("default-review-import-failure", {
+        command: "node --version",
+      });
+      expect(loadReviewer).toHaveBeenCalled();
+      expect(result.details).toMatchObject({
+        status: "failed",
+        approvalReviewOutcome: "denied",
+        approvalReviews: [
+          { riskLevel: "unknown", rationale: expect.stringContaining("exec reviewer failed:") },
+        ],
+      });
+      expect(reviewerRuntime.prepare).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("./exec-auto-reviewer.js");
+    }
+  });
 });

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -99,6 +99,10 @@ vi.mock("./browser-runtime.js", () => {
   return { createWorkerBrowserToolRuntime: browserRuntimeMocks.createWorkerBrowserToolRuntime };
 });
 
+// Compile the real lazy runtimes during collection, not inside the first turn.
+// Cold imports must not consume these integration cases' lifecycle deadlines.
+await Promise.all([import("./embedded-agent.runtime.js"), import("../agents/bash-tools.js")]);
+
 function waitForFast<T>(
   callback: () => T | Promise<T>,
   options: { timeout?: number; interval?: number } = {},


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary cold-start work when agents execute ordinary shell commands: the exec tool eagerly loaded model-review and approval-followup delivery runtimes even when neither capability was used. This also made worker lifecycle integration tests spend their result deadlines compiling unrelated lazy dependencies.

The investigation started with one local `keeps completed-turn background processes controllable in the managed environment (running)` failure at baseline `1e93009a9659ea88ca410c13ad11842afbd8770b`, followed by unchanged passing runs. A cold isolated reproduction reached the same empty first-result assertion **before child spawn**, while imports were still pending. This is not a claim that CI was red or that production background-process retention was broken; the original historical log does not identify its exact stalled phase.

## Why This Change Was Made

Load the default model reviewer at the review callback, and default approval-followup delivery at dispatch. Preserve injected implementations, per-execution reviewer settings/cancellation, authenticated handoff registration before delivery, human fallback, and existing delivery-error handling. Preparation and execution now share their previously duplicated elevation-mode calculation.

The worker integration suite awaits its real lazy runtimes during collection, outside individual lifecycle deadlines. It retains the real exec/process/supervisor composition, all 65 cases, existing process lifetimes, assertions and timeout values. Both performance samples below use this identical fixture preparation, so the gain is not merely moving work outside the measured command.

## User Impact

Ordinary exec no longer pays to load unused model-review and outbound-delivery code. Operators keep the same approval, elevation, cancellation and background-process behavior; no configuration, migration, dependency, schema or public API changes are required.

Production: **+39/-47, net -8 lines**. Tests: **+212/-7, net +205 lines**. The reduction comes from removing duplicated policy, not suppressing the file-size guard.

## Evidence

### Same-host cold comparison

Separate fresh Vitest transform caches, same command, **65/65 tests in both samples**:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Whole-command wall time | 206.35 s | 81.31 s | -60.6% |
| Vitest duration | 173.86 s | 75.86 s | -56.4% |
| Import time | 122.05 s | 54.20 s | -55.6% |
| Test bodies | 41.49 s | 19.43 s | -53.2% |
| CPU user + system | 87.73 s | 67.42 s | -23.1% |
| Peak RSS | 2,006,925,312 B | 1,903,656,960 B | -5.1% |

One cold sample per side, not a universal or CI speedup guarantee. These samples precede the behavior-equivalent elevation deduplication; final-candidate verification is recorded below.

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<fresh-task-cache> /usr/bin/time -l node scripts/run-vitest.mjs src/worker/worker.runtime.test.ts --maxWorkers=1 --no-file-parallelism
```

### Regression and sibling proof

Two new lazy-import assertions fail against original production code. The fixed focused tests passed; the full reviewer, shared-host, delivery, security-floor, gateway, node, node cancellation, integration and phase suites passed **405/405**. The default delivery test invokes the real sender through its existing Gateway boundary and verifies the handoff exists before dispatch. Fault-injection tests retain human fallback, per-execution cancellation/settings and warning deduplication.

```bash
node scripts/run-vitest.mjs src/agents/exec-auto-reviewer.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-approval-followup.test.ts src/agents/bash-tools.exec.security-floor.test.ts src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-host-node.cancellation.test.ts src/agents/bash-tools.exec-host-node.integration.test.ts src/agents/bash-tools.exec-host-node-phases.test.ts --maxWorkers=1 --no-file-parallelism
```

The consolidated elevation policy matched both exact original source calculations in **1,918 executed comparisons** covering documented levels, enabled/allowed flags, required sandbox and explicit/absent inputs. No policy change was intended or observed.

### Live provider and process proof

A real isolated Gateway using `openai/gpt-5.6-luna` and the OpenClaw runtime (not a mock provider) started a real background child. After the first agent turn completed, the child was still alive. A fresh turn polled it, killed it, observed terminal `manual-cancel`, and independent PID/signal checks verified physical exit. A subsequent real model-backed default reviewer approved and executed `/usr/bin/git --version`.

The fixture uses an explicit readiness marker and parent-controlled lifetime, not a fixed sleep. Only task-owned Gateway/state/home/processes were used and cleaned up; operator state was untouched. This is live provider/Gateway/tool proof, not desktop proof or an unbiased Gateway startup benchmark. Followup delivery's default wiring and import-failure behavior are covered by the boundary tests; no external channel message was sent.

### Final candidate validation

Final cold worker run: **65/65, 69.83 seconds wall**, 66.34 seconds Vitest, 49.65 seconds imports, 58.04 seconds CPU, 1,915,600,896 B peak RSS. Final target/support/resolve-env/security-floor tests: **77/77**.

```bash
node scripts/run-vitest.mjs src/agents/bash-tools.exec.security-floor.test.ts src/agents/bash-tools.exec-target.test.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts src/agents/bash-tools.exec-support.test.ts --maxWorkers=1 --no-file-parallelism
```

Full `pnpm build` passed for the lazy-boundary change. After the equivalent elevation deduplication, `pnpm build qaRuntime` rebuilt the final runtime successfully. Neither build reported ineffective dynamic imports. A fresh isolated Codex autoreview at its default P0 threshold returned scoped-clean, with no findings or filtered findings.

The refreshed live run against the final runtime also passed, including actual default model review and complete cleanup:

```json
{"model":"openai/gpt-5.6-luna","runtime":"openclaw","mockProvider":false,"aliveAfterCompletedTurn":true,"terminalCancellationObserved":true,"physicalExitObserved":true,"liveDefaultReviewerApproved":true,"ok":true,"cleanedUp":true}
```

Final complete changed-scope gate **passed**, including core/core-test types, formatting, lint, all three dead-export scans, schema/store/sidecar guards and import-cycle checks. The first attempt hit the exec file's 700-line limit; shared elevation-policy consolidation fixed it without a suppression or weakened limit.

```bash
node scripts/check-changed.mjs -- src/agents/bash-tools.exec-run.ts src/agents/bash-tools.exec-support.ts src/agents/bash-tools.exec-host-shared.ts src/agents/bash-tools.exec.security-floor.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/bash-tools.exec-approval-followup.test.ts src/worker/worker.runtime.test.ts
```

No changelog or release changes. Existing exec/background-process documentation remains accurate; this changes loading cost, not the documented behavior.
