### PR TITLE
fix(ci): validate frozen releases with target capabilities

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -3,6 +3,11 @@ name: Install Smoke (Reusable)
 on:
   workflow_call:
     inputs:
+      allow_frozen_target_scenario_omissions:
+        description: Allow trusted compatibility omissions for a canonical frozen release target
+        required: false
+        default: false
+        type: boolean
       allow_unreleased_changelog:
         description: Allow Unreleased changelog notes when packaging the current tree
         required: false
@@ -550,8 +555,11 @@ jobs:
 
       - name: Run Docker gateway network e2e
         env:
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}
           OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD: "1"
+          OPENCLAW_SELECTED_SHA: ${{ needs.preflight.outputs.target_sha }}
+          OPENCLAW_TOOLING_SHA: ${{ steps.workflow.outputs.sha }}
         run: bash .release-harness/scripts/e2e/gateway-network-docker.sh
 
       - name: Smoke test Dockerfile with matrix extension build arg

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -4502,7 +4502,9 @@ jobs:
       FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
       OPENCLAW_LIVE_IMAGE: ${{ needs.prepare_live_test_image.outputs.live_image }}
       OPENCLAW_LIVE_REQUIRE_LOCAL_IMAGE: ${{ inputs.shared_image_policy == 'no-push-artifact' && '1' || '0' }}
+      OPENCLAW_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
       OPENCLAW_SKIP_DOCKER_BUILD: "1"
+      OPENCLAW_TOOLING_SHA: ${{ needs.validate_selected_ref.outputs.workflow_sha }}
       OPENCLAW_LIVE_VIDEO_GENERATION_SKIP_PROVIDERS: ""
       OPENCLAW_LIVE_VYDRA_VIDEO: "1"
       OPENCLAW_VITEST_MAX_WORKERS: "2"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1255,6 +1255,7 @@ jobs:
       packages: read
     uses: ./.github/workflows/install-smoke-reusable.yml
     with:
+      allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       run_bun_global_install_smoke: true

--- a/scripts/e2e/gateway-network-docker.sh
+++ b/scripts/e2e/gateway-network-docker.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-gateway-network-e2e" OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD:-0}"
 
@@ -11,6 +12,11 @@ TOKEN="e2e-$(date +%s)-$$"
 NET_NAME="openclaw-net-e2e-$$"
 GW_NAME="openclaw-gateway-e2e-$$"
 SUSPENSION_STATE_PATH="/tmp/gateway-network-suspension.json"
+CAPABILITIES_DIR=""
+CAPABILITIES_PATH=""
+CAPABILITIES_CONTAINER_PATH="/tmp/gateway-network-output/capabilities.json"
+CAPABILITIES_HOST_USER="$(id -u)"
+CAPABILITIES_HOST_GROUP="$(id -g)"
 DOCKER_COMMAND_TIMEOUT="${OPENCLAW_GATEWAY_NETWORK_DOCKER_COMMAND_TIMEOUT:-600s}"
 CLIENT_TIMEOUT="${OPENCLAW_GATEWAY_NETWORK_CLIENT_TIMEOUT:-90s}"
 CLIENT_LIMIT_ENV_ARGS=()
@@ -33,6 +39,8 @@ fi
 cleanup() {
   docker_e2e_docker_cmd rm -f "$GW_NAME" >/dev/null 2>&1 || true
   docker_e2e_docker_cmd network rm "$NET_NAME" >/dev/null 2>&1 || true
+  [[ -z "$CAPABILITIES_PATH" ]] || rm -f "$CAPABILITIES_PATH" >/dev/null 2>&1 || true
+  [[ -z "$CAPABILITIES_DIR" ]] || rmdir "$CAPABILITIES_DIR" >/dev/null 2>&1 || true
 }
 
 run_suspension_phase() {
@@ -77,14 +85,61 @@ if ! docker_e2e_wait_container_bash "$GW_NAME" 180 0.5 "source scripts/lib/openc
 fi
 
 echo "Running client container (connect + health)..."
+CAPABILITIES_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-gateway-network-capabilities.XXXXXX")"
+CAPABILITIES_PATH="$CAPABILITIES_DIR/capabilities.json"
+if [[ ! -O "$CAPABILITIES_DIR" ]]; then
+  echo "Gateway network capability output directory is not owned by the host user." >&2
+  exit 1
+fi
 DOCKER_COMMAND_TIMEOUT="$CLIENT_TIMEOUT" run_logged gateway-network-client docker_e2e_docker_run_cmd run --rm \
   "${DOCKER_E2E_HARNESS_ARGS[@]}" \
+  --user "$CAPABILITIES_HOST_USER:$CAPABILITIES_HOST_GROUP" \
   --network "$NET_NAME" \
   "${CLIENT_LIMIT_ENV_ARGS[@]}" \
+  -v "$CAPABILITIES_DIR:/tmp/gateway-network-output" \
   -e "GW_URL=ws://$GW_NAME:$PORT" \
   -e "GW_TOKEN=$TOKEN" \
+  -e "GW_CAPABILITIES_PATH=$CAPABILITIES_CONTAINER_PATH" \
   "$IMAGE_NAME" \
   node scripts/e2e/lib/gateway-network/client.mts
+
+SUSPENSION_CAPABILITY="$(
+  node -e '
+    const fs = require("node:fs");
+    const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (
+      !value ||
+      typeof value !== "object" ||
+      !["supported", "unsupported"].includes(value.suspension)
+    ) {
+      throw new Error("invalid gateway network capability output");
+    }
+    process.stdout.write(value.suspension);
+  ' "$CAPABILITIES_PATH"
+)"
+if [[ ! -O "$CAPABILITIES_PATH" ]]; then
+  echo "Gateway network capability output is not owned by the host user." >&2
+  exit 1
+fi
+rm "$CAPABILITIES_PATH"
+rmdir "$CAPABILITIES_DIR"
+CAPABILITIES_PATH=""
+CAPABILITIES_DIR=""
+if [[ "$SUSPENSION_CAPABILITY" == "unsupported" ]]; then
+  authorization_status=0
+  if openclaw_frozen_target_omissions_authorized; then
+    echo "Target gateway does not advertise cooperative suspension; authorized frozen-target omission."
+    echo "OK"
+    exit 0
+  else
+    authorization_status=$?
+  fi
+  if ((authorization_status == 2)); then
+    exit "$authorization_status"
+  fi
+  echo "Target gateway does not advertise cooperative suspension and frozen-target omissions are not authorized." >&2
+  exit 1
+fi
 
 phase_started="$SECONDS"
 echo "Running cooperative suspension lifecycle before container stop..."

--- a/scripts/e2e/lib/gateway-network/client.mts
+++ b/scripts/e2e/lib/gateway-network/client.mts
@@ -32,6 +32,7 @@ type GatewayPayload = Record<string, unknown> & {
   defaultAgentId?: string;
   durationMs?: number;
   expiresAtMs?: number;
+  features?: Record<string, unknown>;
   ok?: boolean;
   ready?: boolean;
   resumed?: boolean;
@@ -57,7 +58,13 @@ type GatewayRequestContext = {
   token: string;
   url: string;
 };
-type GatewayClientOptions = { statePath?: string; timeoutMs?: number; token: string; url: string };
+type GatewayClientOptions = {
+  capabilitiesPath?: string;
+  statePath?: string;
+  timeoutMs?: number;
+  token: string;
+  url: string;
+};
 type GatewayFetchDeps = { fetchImpl?: typeof fetch };
 type GatewayNetworkDeps = {
   delay?: (ms: number) => Promise<void>;
@@ -105,6 +112,28 @@ function hasGatewayHealthSummaryPayload(
     Array.isArray(payload.channelOrder) &&
     isRecord(payload.sessions)
   );
+}
+
+const SUSPENSION_METHODS = [
+  "gateway.suspend.prepare",
+  "gateway.suspend.status",
+  "gateway.suspend.resume",
+] as const;
+
+function classifySuspensionCapability(connectResponse: GatewayFrame) {
+  const features = connectResponse.payload?.features;
+  const methods = isRecord(features) ? features.methods : undefined;
+  if (!Array.isArray(methods) || methods.some((method) => typeof method !== "string")) {
+    throw new Error("connect hello suspension methods are malformed");
+  }
+  const availableCount = SUSPENSION_METHODS.filter((method) => methods.includes(method)).length;
+  if (availableCount === 0) {
+    return "unsupported" as const;
+  }
+  if (availableCount === SUSPENSION_METHODS.length) {
+    return "supported" as const;
+  }
+  throw new Error("connect hello contains partial suspension methods");
 }
 
 function httpUrl(url: string, pathname = "/") {
@@ -503,7 +532,12 @@ async function readProtocolVersion() {
 }
 
 export async function runGatewayNetworkClient(
-  { token, url, timeoutMs = readGatewayNetworkClientConnectTimeoutMs() }: GatewayClientOptions,
+  {
+    capabilitiesPath,
+    token,
+    url,
+    timeoutMs = readGatewayNetworkClientConnectTimeoutMs(),
+  }: GatewayClientOptions,
   deps: GatewayNetworkDeps = {},
 ) {
   const deadline = Date.now() + timeoutMs;
@@ -550,6 +584,13 @@ export async function runGatewayNetworkClient(
           throw lastError;
         }
       } else {
+        let suspension: "supported" | "unsupported" | undefined;
+        let capabilityError: Error | undefined;
+        try {
+          suspension = classifySuspensionCapability(connectRes);
+        } catch (error) {
+          capabilityError = error instanceof Error ? error : new Error(String(error));
+        }
         ws.send(JSON.stringify({ type: "req", id: "h1", method: "health" }));
         const healthRes = await onceFrameImpl(
           ws,
@@ -560,8 +601,16 @@ export async function runGatewayNetworkClient(
           if (!hasGatewayHealthSummaryPayload(healthRes)) {
             throw new Error("health failed: missing health summary payload");
           }
+          if (capabilityError) {
+            throw capabilityError;
+          }
+          assert(suspension, "connect hello suspension capability must be classified");
+          const capabilities = { suspension };
+          if (capabilitiesPath) {
+            await writeFile(capabilitiesPath, JSON.stringify(capabilities));
+          }
           stdout("ok");
-          return;
+          return capabilities;
         }
 
         throw responseError("health", healthRes);
@@ -592,7 +641,11 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   }
   const mode = process.env.GW_MODE ?? "network";
   if (mode === "network") {
-    await runGatewayNetworkClient({ token, url });
+    await runGatewayNetworkClient({
+      capabilitiesPath: process.env.GW_CAPABILITIES_PATH,
+      token,
+      url,
+    });
   } else {
     const statePath = process.env.GW_STATE_PATH;
     if (!statePath) {

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+openclaw_frozen_target_omissions_authorized() {
+  case "${OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS:-0}" in
+    0 | "")
+      return 1
+      ;;
+    1) ;;
+    *)
+      echo "invalid OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: expected 0 or 1" >&2
+      return 2
+      ;;
+  esac
+
+  if [[ ! "${OPENCLAW_SELECTED_SHA:-}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "OPENCLAW_SELECTED_SHA must be a full lowercase commit SHA" >&2
+    return 2
+  fi
+  if [[ ! "${OPENCLAW_TOOLING_SHA:-}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "OPENCLAW_TOOLING_SHA must be a full lowercase commit SHA" >&2
+    return 2
+  fi
+  if [[ "$OPENCLAW_SELECTED_SHA" == "$OPENCLAW_TOOLING_SHA" ]]; then
+    echo "frozen-target omissions require distinct selected and tooling SHAs" >&2
+    return 2
+  fi
+}

--- a/scripts/lib/live-docker-stage.sh
+++ b/scripts/lib/live-docker-stage.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+live_docker_stage_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$live_docker_stage_dir/frozen-target-compat.sh"
+unset live_docker_stage_dir
+
 openclaw_live_stage_mounted_auth() {
   if [ "${OPENCLAW_DOCKER_AUTH_PRESTAGED:-0}" = "1" ]; then
     return 0
@@ -98,6 +102,139 @@ openclaw_live_prepare_cli_backend() {
     echo "ERROR: CLI backend executable was not provisioned: $command_path (package=${package:-none})." >&2
     return 127
   fi
+}
+
+openclaw_live_prepare_cli_backend_docker_packages() {
+  local requested_providers="${1:-}"
+  local requested_models="${2:-}"
+  local metadata_json
+
+  metadata_json="$(
+    OPENCLAW_REQUESTED_PROVIDERS="$requested_providers" \
+      OPENCLAW_REQUESTED_MODELS="$requested_models" \
+      node --import tsx --input-type=module <<'NODE'
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+
+const modulePath = pathToFileURL(
+  path.resolve("scripts/print-cli-backend-live-metadata.ts"),
+).href;
+const specParserPath = pathToFileURL(path.resolve("src/infra/npm-registry-spec.ts")).href;
+const metadata = await import(modulePath);
+const specParser = await import(specParserPath);
+if (typeof specParser.parseRegistryNpmSpec !== "function") {
+  throw new Error("staged target is missing parseRegistryNpmSpec");
+}
+let result;
+if (!Object.prototype.hasOwnProperty.call(metadata, "resolveCliBackendDockerPackages")) {
+  result = { kind: "missing-export", packages: [] };
+} else {
+  if (typeof metadata.resolveCliBackendDockerPackages !== "function") {
+    throw new Error("resolveCliBackendDockerPackages export must be a function");
+  }
+  const splitCsv = (value) => (value ?? "").split(",").map((part) => part.trim()).filter(Boolean);
+  const packages = await metadata.resolveCliBackendDockerPackages(
+    splitCsv(process.env.OPENCLAW_REQUESTED_PROVIDERS),
+    splitCsv(process.env.OPENCLAW_REQUESTED_MODELS),
+  );
+  if (!Array.isArray(packages)) {
+    throw new Error("resolveCliBackendDockerPackages must return an array");
+  }
+  const seen = new Set();
+  for (const npmPackage of packages) {
+    if (typeof npmPackage !== "string" || !specParser.parseRegistryNpmSpec(npmPackage)) {
+      throw new Error(`invalid Docker CLI package: ${JSON.stringify(npmPackage)}`);
+    }
+    if (seen.has(npmPackage)) {
+      throw new Error(`duplicate Docker CLI package: ${npmPackage}`);
+    }
+    seen.add(npmPackage);
+  }
+  result = { kind: "supported", packages };
+}
+process.stdout.write(JSON.stringify(result));
+NODE
+  )" || return $?
+
+  local capability
+  capability="$(
+    printf '%s' "$metadata_json" | node -e '
+      const fs = require("node:fs");
+      const value = JSON.parse(fs.readFileSync(0, "utf8"));
+      if (
+        !value ||
+        typeof value !== "object" ||
+        !["missing-export", "supported"].includes(value.kind) ||
+        !Array.isArray(value.packages)
+      ) {
+        throw new Error("invalid staged Docker package capability output");
+      }
+      process.stdout.write(value.kind);
+    '
+  )" || return $?
+
+  if [[ "$capability" == "missing-export" ]]; then
+    local authorization_status
+    if openclaw_frozen_target_omissions_authorized; then
+      echo "Staged target does not export resolveCliBackendDockerPackages; preserving historical no-package-setup behavior."
+      return 0
+    else
+      authorization_status=$?
+    fi
+    if ((authorization_status == 2)); then
+      return "$authorization_status"
+    fi
+    echo "staged target does not export resolveCliBackendDockerPackages and frozen-target omissions are not authorized" >&2
+    return 1
+  fi
+
+  local packages
+  packages="$(
+    printf '%s' "$metadata_json" | node -e '
+      const fs = require("node:fs");
+      const value = JSON.parse(fs.readFileSync(0, "utf8"));
+      process.stdout.write(value.packages.join("\n"));
+    '
+  )" || return $?
+  while IFS= read -r npm_package; do
+    [[ -n "$npm_package" ]] || continue
+    openclaw_live_run_setup_command 180 "live CLI backend setup" npm install -g "$npm_package" ||
+      return $?
+  done <<<"$packages"
+}
+
+openclaw_live_resolve_unique_staged_file() {
+  local root_dir="${1:?staged root required}"
+  local basename="${2:?staged file basename required}"
+  if [[ ! -d "$root_dir" ]]; then
+    echo "no staged file matched basename: $basename" >&2
+    return 1
+  fi
+  local matches
+  matches="$(
+    find "$root_dir" \
+      \( -path "$root_dir/.git" -o -path "$root_dir/dist" -o -path "$root_dir/node_modules" \) \
+      -prune -o -type f -name "$basename" -print |
+      LC_ALL=C sort
+  )" || return $?
+
+  local count=0
+  local match=""
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+    count=$((count + 1))
+    match="$candidate"
+  done <<<"$matches"
+
+  if ((count == 0)); then
+    echo "no staged file matched basename: $basename" >&2
+    return 1
+  fi
+  if ((count != 1)); then
+    echo "multiple staged files matched basename: $basename" >&2
+    return 1
+  fi
+  printf '%s\n' "${match#"$root_dir"/}"
 }
 
 openclaw_live_run_staged_script() {

--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -54,12 +54,9 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
-docker_packages="$(node --import tsx scripts/print-cli-backend-live-metadata.ts \
-  --docker-packages "${OPENCLAW_LIVE_GATEWAY_PROVIDERS:-}" "${OPENCLAW_LIVE_GATEWAY_MODELS:-}")"
-while IFS= read -r docker_package; do
-  [ -n "$docker_package" ] || continue
-  openclaw_live_run_setup_command 180 "live CLI backend setup" npm install -g "$docker_package"
-done <<<"$docker_packages"
+openclaw_live_prepare_cli_backend_docker_packages \
+  "${OPENCLAW_LIVE_GATEWAY_PROVIDERS:-}" \
+  "${OPENCLAW_LIVE_GATEWAY_MODELS:-}"
 openclaw_live_stage_gemini_auth
 openclaw_live_run_staged_script scripts/test-live -- src/gateway/gateway-models.profiles.live.test.ts
 EOF
@@ -104,6 +101,9 @@ DOCKER_RUN_ARGS+=(--rm -t \
   -e OPENCLAW_DOCKER_AUTH_PRESTAGED="$DOCKER_AUTH_PRESTAGED" \
   -e OPENCLAW_DOCKER_AUTH_DIRS_RESOLVED="$AUTH_DIRS_CSV" \
   -e OPENCLAW_DOCKER_AUTH_FILES_RESOLVED="$AUTH_FILES_CSV" \
+  -e OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS="${OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS:-0}" \
+  -e OPENCLAW_SELECTED_SHA="${OPENCLAW_SELECTED_SHA:-}" \
+  -e OPENCLAW_TOOLING_SHA="${OPENCLAW_TOOLING_SHA:-}" \
   -e OPENCLAW_LIVE_DOCKER_SCRIPTS_DIR="${DOCKER_TRUSTED_HARNESS_CONTAINER_DIR}/scripts" \
   -e OPENCLAW_LIVE_DOCKER_SOURCE_STAGE_MODE="${OPENCLAW_LIVE_DOCKER_SOURCE_STAGE_MODE:-copy}" \
   -e OPENCLAW_LIVE_TEST=1 \

--- a/scripts/test-live-subagent-announce-docker.sh
+++ b/scripts/test-live-subagent-announce-docker.sh
@@ -82,10 +82,14 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
+announce_relative="$(
+  openclaw_live_resolve_unique_staged_file "$tmp_dir/src/agents" subagent-announce.live.test.ts
+)"
+announce_test="src/agents/$announce_relative"
 OPENCLAW_LIVE_TEST=1 \
 OPENCLAW_LIVE_SUBAGENT_E2E=1 \
 OPENCLAW_VITEST_MAX_WORKERS="${OPENCLAW_VITEST_MAX_WORKERS:-1}" \
-openclaw_live_run_staged_script scripts/test-live -- src/agents/subagents/announce/subagent-announce.live.test.ts -- --reporter=verbose
+openclaw_live_run_staged_script scripts/test-live -- "$announce_test" -- --reporter=verbose
 EOF
 
 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$ROOT_DIR" "$TRUSTED_HARNESS_DIR/scripts/test-live-build-docker.sh"
@@ -98,7 +102,7 @@ if openclaw_live_uses_managed_bind_dirs; then
 fi
 
 echo "==> Run subagent announce live test in Docker"
-echo "==> Target: src/agents/subagents/announce/subagent-announce.live.test.ts"
+echo "==> Target: unique staged subagent-announce.live.test.ts"
 echo "==> Model: ${OPENCLAW_LIVE_SUBAGENT_E2E_MODEL:-openai/gpt-5.6-luna}"
 echo "==> Profile file: $PROFILE_STATUS"
 DOCKER_RUN_ARGS=()

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -5104,6 +5104,10 @@ server.listen(0, "127.0.0.1", () => {
       releaseChecks.jobs.validate_repo_e2e_gateway,
       releaseChecks.jobs.validate_repo_e2e_runtime,
     ];
+    expect(releaseChecks.jobs.validate_live_docker_provider_suites.env).toMatchObject({
+      OPENCLAW_SELECTED_SHA: "${{ needs.validate_selected_ref.outputs.selected_sha }}",
+      OPENCLAW_TOOLING_SHA: "${{ needs.validate_selected_ref.outputs.workflow_sha }}",
+    });
     const repoE2eRows = pipelines.flatMap((pipeline) => JSON.parse(pipeline.with.suites)) as Array<{
       name: string;
       command: string;

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6634,8 +6634,23 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
   it("proves gateway suspension across a same-container process restart", () => {
     const runner = readFileSync(GATEWAY_NETWORK_DOCKER_E2E_PATH, "utf8");
     expectTextToIncludeAll(runner, [
+      'source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"',
       "plugins enable admin-http-rpc",
       "/tmp/gateway-network-configured",
+      'CAPABILITIES_DIR="$(mktemp -d',
+      "GW_CAPABILITIES_PATH=$CAPABILITIES_CONTAINER_PATH",
+      'CAPABILITIES_HOST_USER="$(id -u)"',
+      'CAPABILITIES_HOST_GROUP="$(id -g)"',
+      'if [[ ! -O "$CAPABILITIES_DIR" ]]',
+      '--user "$CAPABILITIES_HOST_USER:$CAPABILITIES_HOST_GROUP"',
+      "trap cleanup EXIT",
+      '[[ -z "$CAPABILITIES_PATH" ]] || rm -f "$CAPABILITIES_PATH"',
+      '[[ -z "$CAPABILITIES_DIR" ]] || rmdir "$CAPABILITIES_DIR"',
+      'if [[ ! -O "$CAPABILITIES_PATH" ]]',
+      'rm "$CAPABILITIES_PATH"',
+      'rmdir "$CAPABILITIES_DIR"',
+      'if [[ "$SUSPENSION_CAPABILITY" == "unsupported" ]]',
+      "openclaw_frozen_target_omissions_authorized",
       "run_suspension_phase() {",
       "GW_MODE=suspension-$stage-restart",
       "run_suspension_phase pre",
@@ -6650,6 +6665,27 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
       'run_logged_print "gateway-network-suspension-$stage"',
       '"phase":"container-restart","durationMs":%d',
     ]);
+    expect(runner).not.toContain('source "$ROOT_DIR/scripts/lib/live-docker-auth.sh"');
+    expect(runner).not.toContain("openclaw_live_chown_bind_dirs_for_container_user");
+    expect(runner).not.toContain("gateway-network-capabilities-dir");
+    expect(runner).not.toContain("IMAGE_USER=");
+    expect(runner).not.toContain("--user 0:0");
+    expect(runner).not.toContain("chown");
+    expect(runner).not.toContain("chmod");
+    expect(runner).not.toContain('rm -rf "$CAPABILITIES_DIR"');
+
+    const parseIndex = runner.indexOf('SUSPENSION_CAPABILITY="$(');
+    const ownershipIndex = runner.indexOf('if [[ ! -O "$CAPABILITIES_PATH" ]]');
+    const unlinkIndex = runner.indexOf('rm "$CAPABILITIES_PATH"', ownershipIndex);
+    const rmdirIndex = runner.indexOf('rmdir "$CAPABILITIES_DIR"', ownershipIndex);
+    const capabilityBranchIndex = runner.indexOf(
+      'if [[ "$SUSPENSION_CAPABILITY" == "unsupported" ]]',
+    );
+    expect(parseIndex).toBeGreaterThanOrEqual(0);
+    expect(ownershipIndex).toBeGreaterThan(parseIndex);
+    expect(unlinkIndex).toBeGreaterThan(ownershipIndex);
+    expect(rmdirIndex).toBeGreaterThan(unlinkIndex);
+    expect(capabilityBranchIndex).toBeGreaterThan(rmdirIndex);
   });
 
   it.each([

--- a/test/scripts/gateway-network-client.test.ts
+++ b/test/scripts/gateway-network-client.test.ts
@@ -1,6 +1,6 @@
 // Gateway Network Client tests cover gateway network client script behavior.
 import { EventEmitter } from "node:events";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -45,6 +45,21 @@ describe("gateway network client", () => {
         ok: true,
         sessions: { count: 0, path: "/state/sessions", recent: [] },
         ts: Date.now(),
+      },
+    };
+  }
+
+  function connectResponse(
+    methods: unknown = [
+      "gateway.suspend.prepare",
+      "gateway.suspend.status",
+      "gateway.suspend.resume",
+    ],
+  ) {
+    return {
+      ok: true,
+      payload: {
+        features: { methods },
       },
     };
   }
@@ -300,9 +315,7 @@ describe("gateway network client", () => {
     await expect(frame).rejects.toThrow();
   });
 
-  function createNetworkClientHarness(
-    responses: Array<{ error?: { message?: string }; ok: boolean }>,
-  ) {
+  function createNetworkClientHarness(responses: GatewayFrame[]) {
     const frames = [...responses];
     const sentMethods: string[] = [];
     const stdout: string[] = [];
@@ -329,10 +342,13 @@ describe("gateway network client", () => {
           predicate: (frame: GatewayFrame) => boolean,
           _timeoutMs?: number,
         ) => {
+          const response = frames.shift();
           const frame = {
             type: "res",
             id: sentMethods.at(-1) === "connect" ? "c1" : "h1",
-            ...frames.shift(),
+            ...(sentMethods.at(-1) === "connect" && response?.ok && !response.payload
+              ? connectResponse()
+              : response),
           };
           expect(predicate(frame)).toBe(true);
           return frame;
@@ -357,6 +373,52 @@ describe("gateway network client", () => {
     expect(harness.sentMethods).toEqual(["connect", "health"]);
     expect(harness.stdout).toEqual(["ok"]);
     expect(harness.closeCount).toBe(1);
+  });
+
+  it.each([
+    {
+      methods: ["gateway.suspend.prepare", "gateway.suspend.status", "gateway.suspend.resume"],
+      expected: "supported",
+    },
+    { methods: ["health", "status"], expected: "unsupported" },
+  ])("records $expected suspension support from connect hello methods", async (testCase) => {
+    const workDir = tempDirs.make("openclaw-gateway-network-capabilities-");
+    const capabilitiesPath = join(workDir, "capabilities.json");
+    const harness = createNetworkClientHarness([
+      connectResponse(testCase.methods),
+      healthResponse(),
+    ]);
+
+    await expect(
+      runGatewayNetworkClient(
+        {
+          capabilitiesPath,
+          token: "test-token",
+          url: "ws://127.0.0.1:12345",
+          timeoutMs: 1000,
+        },
+        harness.deps,
+      ),
+    ).resolves.toEqual({ suspension: testCase.expected });
+    expect(JSON.parse(readFileSync(capabilitiesPath, "utf8"))).toEqual({
+      suspension: testCase.expected,
+    });
+    expect(harness.sentMethods).toEqual(["connect", "health"]);
+  });
+
+  it.each([
+    ["partial", ["gateway.suspend.prepare", "gateway.suspend.status"]],
+    ["malformed", "gateway.suspend.prepare"],
+  ])("rejects %s suspension methods only after baseline health", async (_label, methods) => {
+    const harness = createNetworkClientHarness([connectResponse(methods), healthResponse()]);
+
+    await expect(
+      runGatewayNetworkClient(
+        { token: "test-token", url: "ws://127.0.0.1:12345", timeoutMs: 1000 },
+        harness.deps,
+      ),
+    ).rejects.toThrow(/suspension methods/u);
+    expect(harness.sentMethods).toEqual(["connect", "health"]);
   });
 
   it("bounds socket and frame waits by the client deadline", async () => {

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -102,6 +102,12 @@ describe("install smoke no-push root image transport", () => {
       default: false,
       type: "boolean",
     });
+    expect(
+      workflow.on?.workflow_call?.inputs?.allow_frozen_target_scenario_omissions,
+    ).toMatchObject({
+      default: false,
+      type: "boolean",
+    });
     expect(workflow.on?.workflow_call?.inputs?.root_image_transport).toBeUndefined();
     expect(workflow.permissions).toEqual({
       actions: "read",
@@ -364,11 +370,27 @@ describe("install smoke no-push root image transport", () => {
       const requireLocal = step(consumer, "Require local root Dockerfile image");
       expect(requireLocal.if, jobName).toBeUndefined();
       expect(requireLocal.run, jobName).toBe('docker image inspect "$IMAGE_REF" >/dev/null');
+
+      const gatewayNetwork = step(consumer, "Run Docker gateway network e2e");
+      expect(gatewayNetwork.env, jobName).toMatchObject({
+        OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS:
+          "${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}",
+        OPENCLAW_SELECTED_SHA: "${{ needs.preflight.outputs.target_sha }}",
+        OPENCLAW_TOOLING_SHA: "${{ steps.workflow.outputs.sha }}",
+      });
     }
 
     const text = readFileSync(INSTALL_SMOKE_REUSABLE, "utf8");
     expect(text.match(/verify-upload "Root image"/g)).toHaveLength(1);
     expect(text).not.toContain("gh api");
+  });
+
+  it("forwards frozen-target omission authority from the release coordinator", () => {
+    const workflow = readWorkflow(RELEASE_CHECKS);
+    expect(job(workflow, "install_smoke_release_checks").with).toMatchObject({
+      allow_frozen_target_scenario_omissions:
+        "${{ inputs.allow_frozen_target_scenario_omissions }}",
+    });
   });
 
   it("binds independent installer producer-consumer pairs to immutable artifact tuples", () => {

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -1,6 +1,6 @@
 // Live Docker Stage tests cover live docker stage script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -12,6 +12,25 @@ const stageScriptPath = path.join(repoRoot, "scripts/lib/live-docker-stage.sh");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("live Docker state staging", () => {
+  function linkFixtureNodeModules(root: string) {
+    symlinkSync(path.join(repoRoot, "node_modules"), path.join(root, "node_modules"));
+  }
+
+  function writeFixturePackageSpecParser(root: string) {
+    const parserPath = path.join(root, "src", "infra", "npm-registry-spec.ts");
+    mkdirSync(path.dirname(parserPath), { recursive: true });
+    writeFileSync(
+      parserPath,
+      String.raw`
+export function parseRegistryNpmSpec(spec: string) {
+  return /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*(?:@[a-z0-9][a-z0-9._-]*)?$/u.test(spec)
+    ? { raw: spec }
+    : null;
+}
+`,
+    );
+  }
+
   it.each([
     { geminiKey: "test-gemini-key", googleKey: "", expectedType: "gemini-api-key" },
     { geminiKey: "", googleKey: "test-google-key", expectedType: "vertex-ai" },
@@ -59,11 +78,17 @@ describe("live Docker state staging", () => {
     const binDir = path.join(root, "bin");
     mkdirSync(binDir);
     const npmPath = path.join(binDir, "npm");
+    const timeoutPath = path.join(binDir, "timeout");
     writeFileSync(
       npmPath,
       '#!/usr/bin/env bash\nset -eu\nprintf "%s\\n" "$3" >> "$INSTALL_LOG"\nprintf "#!/usr/bin/env bash\\nprintf fixture-ok" > "$CLI_PATH"\nchmod +x "$CLI_PATH"\n',
     );
     chmodSync(npmPath, 0o755);
+    writeFileSync(
+      timeoutPath,
+      '#!/usr/bin/env bash\nset -euo pipefail\nwhile [[ "$1" == --* ]]; do shift; done\nshift\nexec "$@"\n',
+    );
+    chmodSync(timeoutPath, 0o755);
     const installLog = path.join(root, "installs.log");
     const result = spawnSync(
       "bash",
@@ -162,6 +187,223 @@ describe("live Docker state staging", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("staged OpenClaw script entrypoint not found");
+  });
+
+  it("installs validated Docker packages from the staged metadata export", () => {
+    const root = tempDirs.make("openclaw-live-stage-packages-");
+    const binDir = path.join(root, "bin");
+    const installLog = path.join(root, "installs.log");
+    mkdirSync(path.join(root, "scripts"), { recursive: true });
+    mkdirSync(binDir);
+    linkFixtureNodeModules(root);
+    writeFixturePackageSpecParser(root);
+    writeFileSync(
+      path.join(root, "scripts", "print-cli-backend-live-metadata.ts"),
+      'export async function resolveCliBackendDockerPackages() { return ["@fixture/cli@1.2.3", "fixture-cli"]; }\n',
+    );
+    writeFileSync(
+      path.join(binDir, "timeout"),
+      '#!/usr/bin/env bash\nset -euo pipefail\nwhile [[ "$1" == --* ]]; do shift; done\nshift\nexec "$@"\n',
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      path.join(binDir, "npm"),
+      '#!/usr/bin/env bash\nset -euo pipefail\nprintf "%s\\n" "$*" >> "$INSTALL_LOG"\n',
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set -euo pipefail; cd "$1"; source "$2"; openclaw_live_prepare_cli_backend_docker_packages "fixture-provider" "fixture-provider/model"',
+        "test",
+        root,
+        stageScriptPath,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          INSTALL_LOG: installLog,
+          PATH: `${binDir}:${process.env.PATH}`,
+        },
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(installLog, "utf8").trim().split("\n")).toEqual([
+      "install -g @fixture/cli@1.2.3",
+      "install -g fixture-cli",
+    ]);
+  });
+
+  it("omits historical package setup only with explicit frozen-target authorization", () => {
+    const root = tempDirs.make("openclaw-live-stage-packages-missing-");
+    mkdirSync(path.join(root, "scripts"), { recursive: true });
+    linkFixtureNodeModules(root);
+    writeFixturePackageSpecParser(root);
+    writeFileSync(
+      path.join(root, "scripts", "print-cli-backend-live-metadata.ts"),
+      "export const legacyMetadata = true;\n",
+    );
+    const command = [
+      "-c",
+      'set -euo pipefail; cd "$1"; source "$2"; openclaw_live_prepare_cli_backend_docker_packages "" ""',
+      "test",
+      root,
+      stageScriptPath,
+    ];
+    const baseEnv = {
+      ...process.env,
+      OPENCLAW_SELECTED_SHA: "a".repeat(40),
+      OPENCLAW_TOOLING_SHA: "b".repeat(40),
+    };
+
+    const denied = spawnSync("bash", command, {
+      encoding: "utf8",
+      env: { ...baseEnv, OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "0" },
+    });
+    expect(denied.status).not.toBe(0);
+    expect(denied.stderr).toContain("does not export resolveCliBackendDockerPackages");
+
+    const authorized = spawnSync("bash", command, {
+      encoding: "utf8",
+      env: { ...baseEnv, OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1" },
+    });
+    expect(authorized.status, authorized.stderr).toBe(0);
+    expect(authorized.stdout).toContain("preserving historical no-package-setup behavior");
+  });
+
+  it("lets staged metadata output flush through normal Node completion", () => {
+    const source = readFileSync(stageScriptPath, "utf8");
+    const moduleStart = source.indexOf("node --import tsx --input-type=module <<'NODE'");
+    const moduleEnd = source.indexOf("\nNODE\n", moduleStart);
+    expect(moduleStart).toBeGreaterThanOrEqual(0);
+    expect(moduleEnd).toBeGreaterThan(moduleStart);
+    const moduleSource = source.slice(moduleStart, moduleEnd);
+    expect(moduleSource).not.toContain("process.exit(");
+    expect(moduleSource.match(/process\.stdout\.write/gu)).toHaveLength(1);
+  });
+
+  it("rejects malformed staged package metadata before npm runs", () => {
+    const root = tempDirs.make("openclaw-live-stage-packages-malformed-");
+    const binDir = path.join(root, "bin");
+    const installLog = path.join(root, "installs.log");
+    mkdirSync(path.join(root, "scripts"), { recursive: true });
+    mkdirSync(binDir);
+    linkFixtureNodeModules(root);
+    writeFixturePackageSpecParser(root);
+    writeFileSync(
+      path.join(root, "scripts", "print-cli-backend-live-metadata.ts"),
+      'export async function resolveCliBackendDockerPackages() { return ["--force"]; }\n',
+    );
+    writeFileSync(
+      path.join(binDir, "npm"),
+      '#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$INSTALL_LOG"\n',
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set -euo pipefail; cd "$1"; source "$2"; openclaw_live_prepare_cli_backend_docker_packages "" ""',
+        "test",
+        root,
+        stageScriptPath,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          INSTALL_LOG: installLog,
+          PATH: `${binDir}:${process.env.PATH}`,
+        },
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("invalid Docker CLI package");
+    expect(() => readFileSync(installLog, "utf8")).toThrow();
+  });
+
+  it("defaults frozen-target omissions closed and rejects invalid identity", () => {
+    const command = [
+      "-c",
+      'set -euo pipefail; source "$1"; openclaw_frozen_target_omissions_authorized',
+      "test",
+      stageScriptPath,
+    ];
+    const run = (env: Record<string, string>) =>
+      spawnSync("bash", command, { encoding: "utf8", env: { ...process.env, ...env } });
+
+    expect(run({}).status).toBe(1);
+    const sameSha = run({
+      OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
+      OPENCLAW_SELECTED_SHA: "a".repeat(40),
+      OPENCLAW_TOOLING_SHA: "a".repeat(40),
+    });
+    expect(sameSha.status).toBe(2);
+    expect(sameSha.stderr).toContain("require distinct selected and tooling SHAs");
+
+    const malformed = run({
+      OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "yes",
+      OPENCLAW_SELECTED_SHA: "a".repeat(40),
+      OPENCLAW_TOOLING_SHA: "b".repeat(40),
+    });
+    expect(malformed.status).toBe(2);
+    expect(malformed.stderr).toContain("invalid OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
+  });
+
+  it.each([
+    "src/agents/subagent-announce.live.test.ts",
+    "src/agents/subagents/announce/subagent-announce.live.test.ts",
+  ])("resolves the staged announce test by unique basename: %s", (relativePath) => {
+    const root = tempDirs.make("openclaw-live-stage-announce-");
+    mkdirSync(path.join(root, path.dirname(relativePath)), { recursive: true });
+    writeFileSync(path.join(root, relativePath), "");
+
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set -euo pipefail; source "$2"; relative="$(openclaw_live_resolve_unique_staged_file "$1/src/agents" subagent-announce.live.test.ts)"; printf "src/agents/%s\\n" "$relative"',
+        "test",
+        root,
+        stageScriptPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe(relativePath);
+  });
+
+  it("rejects missing or ambiguous staged announce tests", () => {
+    const root = tempDirs.make("openclaw-live-stage-announce-invalid-");
+    const command = [
+      "-c",
+      'set -euo pipefail; source "$2"; openclaw_live_resolve_unique_staged_file "$1/src/agents" subagent-announce.live.test.ts',
+      "test",
+      root,
+      stageScriptPath,
+    ];
+
+    const missing = spawnSync("bash", command, { encoding: "utf8" });
+    expect(missing.status).not.toBe(0);
+    expect(missing.stderr).toContain("no staged file matched");
+
+    for (const directory of ["old", "current"]) {
+      mkdirSync(path.join(root, "src", "agents", directory), { recursive: true });
+      writeFileSync(
+        path.join(root, "src", "agents", directory, "subagent-announce.live.test.ts"),
+        "",
+      );
+    }
+    const ambiguous = spawnSync("bash", command, { encoding: "utf8" });
+    expect(ambiguous.status).not.toBe(0);
+    expect(ambiguous.stderr).toContain("multiple staged files matched");
   });
 
   it("keeps repo-local generated artifacts out of the source copy", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could report false release failures when current trusted harness code validated the frozen release target `659df8107ce37c07a4cd4364c76ece55a7124e22`.

Release-check child run 33597892284 exposed three target/tooling skew failures:

- gateway network job 100147459445 required current suspension RPCs after baseline connect and health succeeded, even though the target did not advertise them;
- provider jobs 100148303193, 100148303213, 100148303259, and 100148303272 invoked a current-only metadata CLI mode from the target, then passed its JSON to npm and failed with `EINVALIDTAGNAME` before provider calls;
- announce job 100148303298 hardcoded the current test path, while the frozen target retained the historical path.

These were trusted-harness failures, not product regressions in the frozen release.

## Why This Change Was Made

The trusted harness now discovers capabilities and paths from the staged target instead of assuming current-only contracts:

- gateway suspension support comes from the existing WebSocket connect hello methods; all three methods are required for the lifecycle, none permits omission only for an explicitly authorized frozen target, and partial or malformed capability data fails closed;
- Docker package setup imports the staged target's structured metadata export and validates package specs with the target's `parseRegistryNpmSpec`; an authorized historical target without the export preserves its historical no-package-setup behavior;
- announce resolves one unique live-test basename under staged `src/agents`, supporting both historical and current layouts while rejecting zero or ambiguous matches;
- workflows forward exact selected/tooling SHAs plus a default-deny omission authorization flag;
- the gateway capability client runs as the numeric host UID/GID, verifies host ownership, and removes its private output file and directory without a root preparation container or recursive `chown`.

The architectural owner is the trusted release harness. No product fallback, timeout increase, retry, or product-code change was added. The false current-only CLI and hardcoded-path assumptions are bypassed only through target-owned capability/path discovery.

## User Impact

Release operators can validate a frozen target with current trusted tooling without false gateway, provider, announce, or bind-output ownership failures caused by harness evolution. Current/capable targets still run the full package setup and gateway suspension lifecycle.

No product runtime behavior changes. No release, publish, tag, registry mutation, or full FRV graph was run.

## Evidence

- Exact repaired head: `32cf1b36c58d9f54d2ec1ac22fd30fea4fa0be97`
- Frozen target: `659df8107ce37c07a4cd4364c76ece55a7124e22`
- Regression provenance:
  - pre-fix target failed 7 metadata/path cases, 4 gateway hello-method cases, 1 workflow propagation case, and 1 Docker source-integrity case;
  - pre-amend head `03635db69530c6c0c315c21c1ab4063337e9ded2` failed the stdout-flush regression because the missing-export branch called `process.exit()` after writing;
  - the ownership regression failed the committed pre-fix source contract because it inspected the image user, ran a root preparation container, and recursively changed bind ownership;
  - the repaired source runs the client as `$(id -u):$(id -g)`, asserts directory and output-file ownership with Bash `-O`, and unlinks both outputs before continuing.
- Focused local:
  - ownership source contract failed on pre-fix and passed on the repaired working tree;
  - `test/scripts/docker-build-helper.test.ts`: 273 passed, 2 skipped;
  - `test/scripts/gateway-network-client.test.ts`: 23 passed;
  - shell syntax, targeted formatting, targeted oxlint, `git diff --check`, and `scripts/check-changed.mjs --dry-run` passed;
  - the actual changed-file gate passed all preceding lanes, then the broad test-root tsgo lane hit the known incomplete shared-dependency baseline (`smol-toml`, OpenTelemetry, Discord, Slack, and other unrelated packages);
  - Codex autoreview: scoped-clean, no accepted P0 findings or exposed credentials.
- Pre-fix hosted ownership receipt:
  - Testbox `tbx_01m1gmb2fkv3nfqtdx7w37mqm3`;
  - Actions run https://github.com/openclaw/openclaw/actions/runs/33609842690;
  - tooling `cd0007d7e4f98cda4df4573ecd4325d1a146b43d`, target `659df8107ce37c07a4cd4364c76ece55a7124e22`;
  - root image build passed, then gateway connect+health produced the capability file but the host read failed with `EACCES` and cleanup reported `Operation not permitted`;
  - provider and announce scenarios did not run; total 360.489 seconds, exit 1.
- Repaired exact-head hosted proof:
  - Testbox `tbx_01m1gnext9gezmwv1z4h4sy5x9`;
  - Actions run https://github.com/openclaw/openclaw/actions/runs/33611589793;
  - tooling `32cf1b36c58d9f54d2ec1ac22fd30fea4fa0be97`, target `659df8107ce37c07a4cd4364c76ece55a7124e22`;
  - root image build passed in 215 seconds and live image build passed in 289 seconds;
  - gateway baseline passed in 9 seconds with connect+health and the authorized historical suspension omission;
  - OpenAI passed in 59 seconds;
  - Anthropic passed in 50 seconds;
  - Google passed in 33 seconds;
  - MiniMax and MiniMax Portal passed in 37 seconds;
  - historical announce path resolution and live test passed in 73 seconds;
  - overall timing: `commandMs=946460`, `totalMs=949035`, `exitCode=0`, `runStatus=succeeded`;
  - the one-shot Testbox stopped with state `completed`.
- Provider admission accounting:
  - the first repaired-head acquisition attempt returned HTTP 429 before a lease existed (`run_b7596d33d0ac`, `commandMs=0`);
  - after the authorized 120-second cooldown, the single acquisition retry produced the successful receipt above;
  - no FRV campaign or release retry was consumed.
- LOC:
  - trusted harness/workflows: `+299/-12` (net `+287`);
  - tests/test support: `+372/-6` (net `+366`);
  - product runtime: `0`.

Sibling coverage includes all gateway hello capability shapes, all provider Docker lanes through the shared package owner, both announce layouts, workflow propagation/default deny, canonical Docker E2E ownership/timeout wiring, and the hosted frozen-target execution of every supported release-harness scenario.
