### PR TITLE
refactor(agents): reuse canonical SHA helper

### DIFF
--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -4,8 +4,8 @@
  * Session metadata uses this report to account for prompt size, bootstrap file
  * injection, skills, and tool schema footprint without storing raw prompt text.
  */
-import { createHash } from "node:crypto";
 import type { SessionSystemPromptReport } from "../config/sessions/types.js";
+import { sha256Hex } from "../infra/crypto-digest.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { BootstrapInjectionStat } from "./bootstrap-budget.types.js";
 import type { AgentTool } from "./runtime/index.js";
@@ -21,10 +21,6 @@ const toolSchemaStatsCache = new WeakMap<
   object,
   Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash">
 >();
-
-function sha256(input: string): string {
-  return createHash("sha256").update(input).digest("hex");
-}
 
 function extractBetween(input: string, startMarker: string, endMarker: string): string {
   const start = input.indexOf(startMarker);
@@ -55,7 +51,7 @@ function buildToolSchemaStats(
   parameters: AgentTool["parameters"],
 ): Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash"> {
   if (!parameters || typeof parameters !== "object") {
-    return { schemaChars: 0, schemaHash: sha256(""), propertiesCount: null };
+    return { schemaChars: 0, schemaHash: sha256Hex(""), propertiesCount: null };
   }
   const cached = toolSchemaStatsCache.get(parameters);
   if (cached) {
@@ -69,7 +65,7 @@ function buildToolSchemaStats(
   }
   const stats = {
     schemaChars: schemaJson.length,
-    schemaHash: sha256(schemaJson),
+    schemaHash: sha256Hex(schemaJson),
     propertiesCount: (() => {
       const schema = parameters as Record<string, unknown>;
       const props = typeof schema.properties === "object" ? schema.properties : null;
@@ -87,13 +83,13 @@ function buildToolSchemaStats(
 
 function resolveSummaryHash(summary: string): string {
   if (summary.length > MAX_CACHED_TOOL_SUMMARY_CHARS) {
-    return sha256(summary);
+    return sha256Hex(summary);
   }
   const cached = toolSummaryHashCache.get(summary);
   if (cached !== undefined) {
     return cached;
   }
-  const hash = sha256(summary);
+  const hash = sha256Hex(summary);
   toolSummaryHashCache.set(summary, hash);
   pruneMapToMaxSize(toolSummaryHashCache, MAX_TOOL_SUMMARY_HASHES);
   return hash;
@@ -152,7 +148,7 @@ export function buildSystemPromptReport(params: {
     sandbox: params.sandbox,
     systemPrompt: {
       chars: systemPromptChars,
-      hash: sha256(params.systemPrompt),
+      hash: sha256Hex(params.systemPrompt),
       projectContextChars,
       nonProjectContextChars: Math.max(0, systemPromptChars - projectContextChars),
     },
@@ -160,7 +156,7 @@ export function buildSystemPromptReport(params: {
     injectedWorkspaceFiles: params.injectedWorkspaceFiles,
     skills: {
       promptChars: params.skillsPrompt.length,
-      hash: sha256(params.skillsPrompt),
+      hash: sha256Hex(params.skillsPrompt),
       entries: skillsEntries,
     },
     tools: {


### PR DESCRIPTION
## What Problem This Solves

This is part of an explicitly maintainer-directed function-duplication cleanup campaign. The system prompt report kept a private SHA-256 wrapper even though core already owns the same string/byte digest contract.

## Why This Change Was Made

Route all six report hash operations through the canonical core `sha256Hex` helper and remove the duplicate private implementation. Hash bytes, lowercase hexadecimal output, call ordering, prompt determinism, and cache behavior remain unchanged. No SDK, export, config, persistence, protocol, or security seam changes.

## User Impact

No user-visible behavior change. Core has one fewer duplicate digest implementation and one canonical owner for this hashing contract.

## Evidence

- Production LOC: `+7/-11` (net `-4`); tests: `0`.
- Focused baseline and exact-head proof: 19/19 tests passed across `system-prompt-report.test.ts`, `system-prompt-report.tool-digest-cache.test.ts`, and `crypto-digest.test.ts`.
- Formatting and diff checks passed.
- Blacksmith Testbox `tbx_01m1ggmegwhwpr6atjpfwem6a8`: `tsgo:core`, `check:changed`, and standalone `check:import-cycles` passed; 0 runtime value cycles. The one-shot lease completed and was released.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/33604235651
- Required Sol autoreview: scoped clean, 0.99 confidence.
- Independent read-only exact-commit Sol review: no findings, 0.99 confidence.
- Codex source gate inspected at `codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; unrelated to the digest contract.
- Live overlap recheck found no PR implementing this refactor. PR #133910 touches stale history in the same file, but its target/helper blobs equal current `main` and its active hunk is semantically disjoint.
