### PR TITLE
fix(qa): format IPv6 listener URLs at their owners

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1260,6 +1260,11 @@ The baseline list should stay broad enough to cover:
   protocol, fixture, record/replay, and chaos coverage. It is additive and
   does not replace the `mock-openai` scenario dispatcher.
 
+For an IPv6 loopback server, run `pnpm openclaw qa mock-openai --host ::1`.
+The printed URL includes brackets, such as `http://[::1]:<port>`; use that URL
+when configuring a client. QA Lab also brackets IPv6 hosts in its listen and
+advertised URLs. Pass the bare address to `--host`.
+
 Provider-lane implementation lives under `extensions/qa-lab/src/providers/`.
 Each provider owns its defaults, local server startup, gateway model config,
 auth-profile staging needs, and live/mock capability flags. Shared suite and

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -1,4 +1,5 @@
 // Qa Lab plugin module implements bus server behavior.
+import { once } from "node:events";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -487,10 +488,7 @@ export function createQaBusServer(state: QaBusState): Server {
 
 export async function startQaBusServer(params: { state: QaBusState; port?: number }) {
   const server = createQaBusServer(params.state);
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(params.port ?? 0, "127.0.0.1", () => resolve());
-  });
+  await once(server.listen(params.port ?? 0, "127.0.0.1"), "listening");
   const address = server.address();
   if (!address || typeof address === "string") {
     throw new Error("qa-bus failed to bind");

--- a/extensions/qa-lab/src/lab-server-ui.ts
+++ b/extensions/qa-lab/src/lab-server-ui.ts
@@ -7,7 +7,7 @@ import net from "node:net";
 import path from "node:path";
 import type { Duplex } from "node:stream";
 import tls from "node:tls";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, format as formatUrl } from "node:url";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { writeError } from "./bus-server.js";
 
@@ -127,7 +127,8 @@ export function resolveAdvertisedBaseUrl(params: {
     typeof params.advertisePort === "number" && Number.isFinite(params.advertisePort)
       ? params.advertisePort
       : params.bindPort;
-  return `http://${advertisedHost}:${advertisedPort}`;
+  // Keep explicit zero ports: url.format drops numeric zero.
+  return formatUrl({ protocol: "http", hostname: advertisedHost, port: String(advertisedPort) });
 }
 
 export function isControlUiProxyPath(pathname: string) {

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -403,6 +403,17 @@ async function createQaLabSuiteResultFixture(params?: {
 }
 
 describe("qa-lab server", () => {
+  it("returns reachable IPv6 listen and advertised URLs", async () => {
+    const lab = await startQaLabServerForTest({ host: "::1", port: 0 });
+    cleanups.push(async () => await lab.stop());
+
+    for (const baseUrl of [lab.listenUrl, lab.baseUrl]) {
+      const response = await fetch(`${baseUrl}/healthz`);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true, status: "live" });
+    }
+  });
+
   it("returns a 500 JSON response when a shared bus route rejects", async () => {
     const lab = await startQaLabServerForTest();
     cleanups.push(async () => await lab.stop());

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -1,4 +1,5 @@
 // Qa Lab plugin module implements lab server behavior.
+import { once } from "node:events";
 import fs from "node:fs";
 import { createServer, type IncomingMessage } from "node:http";
 import path from "node:path";
@@ -962,10 +963,7 @@ export async function startQaLabServer(
   };
 
   try {
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(params?.port ?? 0, params?.host ?? "127.0.0.1", () => resolve());
-    });
+    await once(server.listen(params?.port ?? 0, params?.host ?? "127.0.0.1"), "listening");
     serverListening = true;
     const address = server.address();
     if (!address || typeof address === "string") {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1,6 +1,8 @@
 // QA Lab mock Responses dispatcher, HTTP transport, and debug endpoints.
+import { once } from "node:events";
 import { createServer } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
+import { format as formatUrl } from "node:url";
 import {
   closeQaHttpServer,
   dispatchQaHttpRequest,
@@ -2944,10 +2946,7 @@ export async function startQaMockOpenAiServer(params?: {
     dispatch: dispatchResponses,
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(params?.port ?? 0, host, () => resolve());
-  });
+  await once(server.listen(params?.port ?? 0, host), "listening");
 
   const address = server.address();
   if (!address || typeof address === "string") {
@@ -2955,7 +2954,7 @@ export async function startQaMockOpenAiServer(params?: {
   }
 
   return {
-    baseUrl: `http://${host}:${address.port}`,
+    baseUrl: formatUrl({ protocol: "http", hostname: host, port: address.port }),
     async stop() {
       await responsesWebSocket.close();
       await closeQaHttpServer(server);

--- a/extensions/qa-lab/src/providers/server-runtime.test.ts
+++ b/extensions/qa-lab/src/providers/server-runtime.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from "vitest";
+import { startQaProviderServer } from "./server-runtime.js";
+
+it("returns a reachable IPv6 URL for the mock provider", async () => {
+  const server = await startQaProviderServer("mock-openai", { host: "::1", port: 0 });
+  if (!server) {
+    throw new Error("mock provider did not start");
+  }
+  try {
+    const response = await fetch(`${server.baseUrl}/healthz`);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, status: "live" });
+  } finally {
+    await server.stop();
+  }
+});

--- a/extensions/qa-lab/src/providers/server-runtime.ts
+++ b/extensions/qa-lab/src/providers/server-runtime.ts
@@ -1,37 +1,20 @@
 // Qa Lab plugin module implements server runtime behavior.
 import { getQaProvider, type QaMockProviderServer, type QaProviderModeInput } from "./index.js";
 
-type QaProviderServerParams = {
-  host: string;
-  port: number;
-  modelRefs?: readonly string[];
-};
-
-async function startMockOpenAiProviderServer(params: QaProviderServerParams) {
-  const { startQaMockOpenAiServer } = await import("./mock-openai/server.js");
-  return await startQaMockOpenAiServer(params);
-}
-
-async function startAimockProviderServer(params: QaProviderServerParams) {
-  const { startQaAimockServer } = await import("./aimock/server.js");
-  return await startQaAimockServer(params);
-}
-
 export async function startQaProviderServer(
   input: QaProviderModeInput,
   params?: { host?: string; port?: number; modelRefs?: readonly string[] },
 ): Promise<QaMockProviderServer | null> {
   const provider = getQaProvider(input);
-  const serverParams = {
-    host: params?.host ?? "127.0.0.1",
-    port: params?.port ?? 0,
-    modelRefs: params?.modelRefs,
-  };
   switch (provider.mode) {
-    case "mock-openai":
-      return await startMockOpenAiProviderServer(serverParams);
-    case "aimock":
-      return await startAimockProviderServer(serverParams);
+    case "mock-openai": {
+      const { startQaMockOpenAiServer } = await import("./mock-openai/server.js");
+      return await startQaMockOpenAiServer(params);
+    }
+    case "aimock": {
+      const { startQaAimockServer } = await import("./aimock/server.js");
+      return await startQaAimockServer(params);
+    }
     default:
       return null;
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

`openclaw qa mock-openai --host ::1` starts a working IPv6 listener but prints an invalid URL such as `http://::1:58146`. Clients cannot parse it. QA Lab's listen and advertised URLs have the same defect.

## Why This Change Was Made

The two URL producers now use Node's hostname-aware URL formatter. Local QA servers use `events.once` for listen/error ownership, and provider dispatch forwards startup parameters to the existing default owners. This removes three hand-written startup promises, two one-use wrappers, and duplicated defaults.

## User Impact

The printed mock-provider URL and both QA Lab URLs can be consumed directly on IPv6. Existing IPv4, DNS, wildcard, bracketed advertisement, explicit port, and ephemeral port behavior is preserved. Explicit advertised port zero remains present. The documentation shows the existing IPv6 command.

## Evidence

Both maintained IPv6 regressions fail on the starting head with `ERR_INVALID_URL`. All **79 tests** in seven focused suites now pass, including HTTP error/shutdown and Responses WebSocket siblings. A real Commander CLI run with OpenAI SDK 7.5.0 fails on the original printed URL and passes with the corrected URL; the explicitly bracketed control passes in both runs, and both CLI processes exit cleanly on SIGINT.

Another **23 checks** exercise actual mock, Lab, and bus servers: IPv4/DNS/IPv6/wildcard and default addresses, port selection, bracketed advertisement, occupied-port rejection, foreign-listener preservation, and released-port reuse. AIMock's default IPv4 dispatcher path and the live-provider non-server path also pass. All proof state and listeners are cleaned up.

Production TypeScript: **+19/-40, net -21**. Tests: **+27/-0**. Documentation: **+5/-0**. The invalid URL construction is also present at stable v2026.8.2. Fresh independent Codex review through P2 is scoped-clean with zero findings (confidence 0.95).

Full changed-file checks exited 0, including extension and extension-test types, formatting, extension lint, plugin boundaries, assertion and coercion guards, dead-export scans, storage guards, and runtime import-cycle checks.

## Follow-up

AIMock 1.39.0 constructs its own IPv6 URL incorrectly inside its upstream server. That is a separate upstream-owner follow-up; this change preserves its current IPv4 path and does not rewrite dependency-returned URLs.

Root verification also passed the actual registered CLI and pinned SDK request against its printed IPv6 URL, with clean SIGINT shutdown. One concurrent local run reached the existing30-second startup deadline; the unchanged standalone rerun passed with the same deadline. The branch is mechanically refreshed onto current main, including its SDK declaration fixture correction.

Fixes #136117.
