### PR TITLE
fix(backup): find managed schedules by declaration identity

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2422,7 +2422,7 @@ src/commands/auth-choice-prompt.ts	1
 src/commands/auth-choice.apply.api-providers.ts	1
 src/commands/backup-git.ts	1
 src/commands/backup-restore.ts	1
-src/commands/backup-schedule.ts	2
+src/commands/backup-schedule.ts	1
 src/commands/backup-shared.ts	1
 src/commands/backup-verify.ts	2
 src/commands/channel-setup/config-compatibility.ts	2

--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -234,6 +234,8 @@ The interval defaults to `24h` when `--every` is omitted. An explicitly empty or
 
 The default scope is every database. Use `--global-only` or `--agent <id>` to narrow it, and add `--exclude-secrets` for a redacted history. Pushed schedules (`--push`) redact credential-bearing tables and secret-prefixed machine-state rows by default because an unattended recurring push retains them durably in remote history; pass `--include-secrets` for explicit full-fidelity remote backups (restores from redacted history need device re-pairing and provider re-authentication). `--push` also requires the repository to already have an `origin` remote. Re-running `backup enable` updates the existing automation instead of creating a duplicate. `openclaw backup disable` removes it; disabling an already-missing job is a successful no-op. Backup scheduling currently requires a local Gateway because the command job runs on the Gateway host; for a remote Gateway, create the cron job manually with `openclaw cron add`.
 
+Disabling a schedule finds the managed automation across all list pages, even after renaming it. Unrelated automations with the same name are left in place.
+
 ## Recorded runs and freshness
 
 Every real archive, SQLite snapshot, and Git create attempt records a compact outcome in the existing shared state database. Dry runs are not recorded. The log retains the newest 200 attempts, so frequent schedules remain bounded.

--- a/src/commands/backup-schedule.test.ts
+++ b/src/commands/backup-schedule.test.ts
@@ -2,7 +2,16 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerCronCli } from "../cli/cron-cli.js";
+import { registerBackupCommand } from "../cli/program/register.backup.js";
+import { CronService } from "../cron/service.js";
+import { createCronStoreHarness, createNoopLogger } from "../cron/service.test-harness.js";
+import type { CronListPageOptions } from "../cron/service/list-page-types.js";
+import type { CronJobCreate, CronJobPatch } from "../cron/types.js";
+import { defaultRuntime } from "../runtime.js";
 import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const gatewayRpc = vi.hoisted(() => ({
@@ -31,8 +40,17 @@ import { GIT_BACKUP_PUSH_CREDENTIAL_WARNING } from "./backup-git.js";
 import { backupDisableCommand, backupEnableCommand } from "./backup-schedule.js";
 
 const BACKUP_CRON_JOB_NAME = "openclaw-backup-scheduled";
+const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-backup-lookup-" });
 
 const roots: string[] = [];
+
+async function runCli(args: string[]) {
+  const program = new Command();
+  program.exitOverride();
+  registerBackupCommand(program);
+  registerCronCli(program);
+  await program.parseAsync(args, { from: "user" });
+}
 
 // enable --push preflights an origin remote, so push fixtures need a real repo.
 async function pushReadyRepository(): Promise<string> {
@@ -55,6 +73,7 @@ describe("scheduled backups", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(
       roots.splice(0).map(async (root) => await fs.rm(root, { recursive: true, force: true })),
     );
@@ -150,56 +169,116 @@ describe("scheduled backups", () => {
     expect(gatewayRpc.call).not.toHaveBeenCalled();
   });
 
-  it("atomically converges an existing declaration and removes it idempotently", async () => {
-    gatewayRpc.call.mockResolvedValueOnce({
-      created: false,
-      updated: true,
-      job: { id: "existing" },
-    });
-    const runtime = createTestRuntime();
-    await expect(
-      backupEnableCommand(runtime, {
-        repository: "/tmp/openclaw-backups",
-        globalOnly: true,
-      }),
-    ).resolves.toEqual({ id: "existing", updated: true });
-    expect(gatewayRpc.call).toHaveBeenCalledOnce();
-    expect(gatewayRpc.call).toHaveBeenCalledWith(
-      "cron.add",
-      expect.anything(),
-      expect.objectContaining({
-        declarationKey: BACKUP_CRON_JOB_NAME,
-        schedule: { kind: "every", everyMs: 86_400_000 },
-        payload: expect.objectContaining({ argv: expect.arrayContaining(["--global"]) }),
-      }),
-    );
+  it.each([
+    { scenario: "ordinary", renamed: false, decoys: 1, disabled: false },
+    { scenario: "renamed", renamed: true, decoys: 1, disabled: false },
+    { scenario: "beyond the first page", renamed: false, decoys: 200, disabled: false },
+    { scenario: "already disabled", renamed: false, decoys: 1, disabled: true },
+  ])(
+    "removes the $scenario managed declaration through the CLI",
+    async ({ renamed, decoys, disabled }) => {
+      const { storePath } = await makeStorePath();
+      const runJob = vi.fn(async () => {
+        throw new Error("Scheduled execution is outside this lookup test");
+      });
+      const cron = new CronService({
+        storePath,
+        cronEnabled: false,
+        log: createNoopLogger(),
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: runJob,
+        runCommandJob: runJob,
+      });
+      gatewayRpc.call.mockImplementation(
+        async (method: string, _options: unknown, params: unknown) => {
+          switch (method) {
+            case "cron.add":
+              return await cron.add(params as CronJobCreate);
+            case "cron.list":
+              return await cron.listPage(params as CronListPageOptions);
+            case "cron.get":
+              return await cron.readJob((params as { id: string }).id);
+            case "cron.update": {
+              const { id, patch } = params as { id: string; patch: CronJobPatch };
+              return await cron.update(id, patch);
+            }
+            case "cron.remove":
+              return await cron.remove((params as { id: string }).id);
+            default:
+              throw new Error(`Unexpected test RPC: ${method}`);
+          }
+        },
+      );
+      const runtime = createTestRuntime();
+      vi.spyOn(defaultRuntime, "log").mockImplementation(runtime.log);
+      vi.spyOn(defaultRuntime, "error").mockImplementation(runtime.error);
+      vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+      vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+        throw new Error(`Unexpected CLI exit ${code}`);
+      });
+      try {
+        const decoyIds: string[] = [];
+        for (let index = 0; index < decoys; index += 1) {
+          const job = await cron.add({
+            name: BACKUP_CRON_JOB_NAME,
+            enabled: true,
+            schedule: { kind: "every", everyMs: 60_000 },
+            sessionTarget: "isolated",
+            wakeMode: "next-heartbeat",
+            payload: { kind: "command", argv: ["synthetic-command"] },
+            delivery: { mode: "none" },
+          });
+          decoyIds.push(job.id);
+        }
+        const enableArgs = [
+          "backup",
+          "enable",
+          "--repository",
+          path.dirname(storePath),
+          "--global-only",
+        ];
+        await runCli(enableArgs);
+        const managed = expectDefined(
+          (await cron.list({ includeDisabled: true })).find(
+            (job) => job.declarationKey === BACKUP_CRON_JOB_NAME,
+          ),
+          "created managed backup",
+        );
+        await runCli([...enableArgs, "--every", "6h"]);
+        expect(await cron.readJob(managed.id)).toMatchObject({
+          schedule: { everyMs: 21_600_000 },
+          payload: { argv: expect.arrayContaining(["--global"]) },
+        });
+        if (renamed) {
+          await runCli(["cron", "edit", managed.id, "--name", "Nightly operator backup"]);
+        }
+        if (disabled) {
+          await cron.update(managed.id, { enabled: false });
+        }
+        const page = await cron.listPage({ includeDisabled: true, limit: 200 });
+        expect(page.total).toBe(decoys + 1);
+        if (decoys === 200) {
+          expect(page.jobs.some((job) => job.id === managed.id)).toBe(false);
+          expect(page.hasMore).toBe(true);
+        }
 
-    gatewayRpc.call.mockReset();
-    gatewayRpc.call.mockImplementation(async (method: string) => {
-      if (method === "cron.list") {
-        return {
-          jobs: [
-            { id: "decoy", name: BACKUP_CRON_JOB_NAME },
-            {
-              id: "existing",
-              name: "operator display name",
-              declarationKey: BACKUP_CRON_JOB_NAME,
-            },
-          ],
-        };
+        await runCli(["backup", "disable"]);
+
+        expect(await cron.readJob(managed.id)).toBeUndefined();
+        expect(runtime.log).toHaveBeenLastCalledWith("Scheduled Git backups disabled.");
+        expect(
+          (await cron.list({ includeDisabled: true })).map((job) => job.id).toSorted(),
+        ).toEqual(decoyIds.toSorted());
+        await runCli(["backup", "disable"]);
+        expect(runtime.log).toHaveBeenLastCalledWith("Scheduled Git backups are already disabled.");
+        expect(runtime.error).not.toHaveBeenCalled();
+        expect(runJob).not.toHaveBeenCalled();
+      } finally {
+        cron.stop();
       }
-      return { ok: true };
-    });
-    await expect(backupDisableCommand(runtime, {})).resolves.toEqual({ removed: true });
-    expect(gatewayRpc.call).toHaveBeenCalledWith("cron.remove", {}, { id: "existing" });
-    expect(gatewayRpc.call).not.toHaveBeenCalledWith("cron.remove", {}, { id: "decoy" });
-
-    gatewayRpc.call.mockReset();
-    gatewayRpc.call.mockResolvedValueOnce({
-      jobs: [{ id: "decoy", name: BACKUP_CRON_JOB_NAME }],
-    });
-    await expect(backupDisableCommand(runtime, {})).resolves.toEqual({ removed: false });
-  });
+    },
+  );
 
   it("redacts pushed schedules by default and warns only on explicit full fidelity", async () => {
     const runtime = createTestRuntime();

--- a/src/commands/backup-schedule.ts
+++ b/src/commands/backup-schedule.ts
@@ -1,4 +1,5 @@
 import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
+import { listCronJobsFromGateway } from "../cli/cron-cli/list-jobs.js";
 import {
   callGatewayFromCli,
   isImplicitLocalGatewayTargetFromCli,
@@ -6,7 +7,6 @@ import {
 } from "../cli/gateway-rpc.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import { getRuntimeConfig } from "../config/config.js";
-import type { CronJob } from "../cron/types.js";
 import { executeGitCommand } from "../infra/git-exec.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -73,16 +73,6 @@ function buildScheduledArgv(
     ...(options.push ? ["--push"] : []),
     ...(redactSecrets ? ["--exclude-secrets"] : []),
   ];
-}
-
-async function findScheduledBackup(options: GatewayRpcOpts): Promise<CronJob | undefined> {
-  const response = (await callGatewayFromCli("cron.list", options, {
-    includeDisabled: true,
-    query: BACKUP_CRON_JOB_NAME,
-    limit: 200,
-    offset: 0,
-  })) as { jobs?: CronJob[] };
-  return response.jobs?.find((job) => job.declarationKey === BACKUP_CRON_JOB_NAME);
 }
 
 async function assertLocalGatewayScheduleTarget(options: GatewayRpcOpts): Promise<void> {
@@ -153,7 +143,8 @@ export async function backupDisableCommand(
   options: GatewayRpcOpts,
 ): Promise<{ removed: boolean }> {
   await assertLocalGatewayScheduleTarget(options);
-  const existing = await findScheduledBackup(options);
+  const { jobs } = await listCronJobsFromGateway(options, { includeDisabled: true });
+  const existing = jobs.find((job) => job.declarationKey === BACKUP_CRON_JOB_NAME);
   if (!existing) {
     runtime.log("Scheduled Git backups are already disabled.");
     return { removed: false };


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

After a scheduled backup is renamed with `openclaw cron edit`, `openclaw backup disable` can report that backups are already disabled while the managed job remains enabled. A managed job beyond the first 200 matching-name rows is missed by the same lookup.

## Why This Change Was Made

The private finder filtered by display name and inspected one page before checking declaration identity. Disabling now uses the existing canonical Gateway inventory reader and selects the stable declaration key. This deletes the incomplete private lookup and its unchecked result cast. The shared reader already owns bounded pagination, snapshot consistency, older-Gateway capability handling and visible failures for incomplete inventories.

## User Impact

Managed backups are removed after a rename or on a later list page. Unrelated jobs with the same name remain intact. Repeated enable/disable behavior, local-Gateway validation and pushed-backup redaction remain unchanged. No configuration, database schema or persistence behavior changes.

## Evidence

The maintained real Commander/CronService regression failed for renamed and later-page jobs before the fix, while ordinary and already-disabled controls passed. All **76 tests across six owner/sibling suites** pass afterward. The test drives enable, repeated enable, actual cron rename and disable against private canonical SQLite state; it asserts the managed row is gone, decoys remain and no scheduled job executes. Existing local-target and redaction cases remain covered.

A separate actual command probe with real configuration and target resolution also failed before and passed after. Root review reran all **14 backup command tests** successfully. The faulty lookup is present at stable v2026.8.2. A mechanical refresh incorporates current main's SDK declaration fixture correction; the production and regression sources retain their reviewed hashes.

Production **+3/-12, net -9 LOC**; tests **+127/-48, net +79**; docs **+2**; assertion baseline **+1/-1**, reducing the owner allowance from two casts to one. The complete changed-file gate passed, including core/test types, lint, formatting, boundaries, dead-code checks and import cycles. Fresh independent Codex review through P2 is clean, confidence 0.96.

Fixes #136118.
