### PR TITLE
fix(release): validate numbered draft changelogs

### DIFF
--- a/scripts/package-changelog.mjs
+++ b/scripts/package-changelog.mjs
@@ -40,18 +40,12 @@ function splitLines(content) {
   return content.replace(/^\uFEFF/u, "").split(/\r?\n/u);
 }
 
-function parseLevelTwoHeading(line) {
-  const releaseMatch = RELEASE_HEADING_PATTERN.exec(line);
-  if (releaseMatch) {
-    return releaseMatch[1];
-  }
-  return /^##\s+Unreleased(?:\s+.*)?$/u.test(line) ? UNRELEASED_HEADING : null;
-}
-
 function findLevelTwoHeadings(lines) {
   return lines.flatMap((line, index) => {
-    const version = parseLevelTwoHeading(line);
-    return version ? [{ index, version }] : [];
+    const version =
+      RELEASE_HEADING_PATTERN.exec(line)?.[1] ??
+      (/^##\s+Unreleased(?:\s+.*)?$/u.test(line) ? UNRELEASED_HEADING : null);
+    return version ? [{ index, version, unreleased: /\s+\(Unreleased\)$/u.test(line) }] : [];
   });
 }
 
@@ -76,8 +70,14 @@ export function extractCurrentPackageChangelog(content, packageVersion, options 
   const targetVersions = resolvePackageChangelogVersions(packageVersion, options);
   const lines = splitLines(content);
   const headings = findLevelTwoHeadings(lines);
+  // Keep numbered drafts exact-matchable; their marker only widens the allowed draft fallback.
   const heading = targetVersions
-    .map((version) => headings.find((entry) => entry.version === version))
+    .map((version) =>
+      headings.find(
+        (entry) =>
+          entry.version === version || (version === UNRELEASED_HEADING && entry.unreleased),
+      ),
+    )
     .find((entry) => entry !== undefined);
   if (!heading) {
     throw new Error(

--- a/test/scripts/package-changelog.test.ts
+++ b/test/scripts/package-changelog.test.ts
@@ -96,22 +96,25 @@ Docs: https://docs.openclaw.ai
 `);
   });
 
-  it("uses Unreleased only as a prerelease fallback when no release heading exists", () => {
-    const source = changelog`
+  it.each(["Unreleased", "2026.5.30 (Unreleased)"])(
+    "uses %s only as a prerelease fallback when no release heading exists",
+    (heading) => {
+      const source = changelog`
 # Changelog
-## Unreleased
+## ${heading}
 - Pending beta package notes with enough release detail.
 ## 2026.5.27
 - Older stable.
 `;
 
-    expect(extractCurrentPackageChangelog(source, "2026.5.28-beta.1")).toBe(changelog`
+      expect(extractCurrentPackageChangelog(source, "2026.5.28-beta.1")).toBe(changelog`
 # Changelog
 
-## Unreleased
+## ${heading}
 - Pending beta package notes with enough release detail.
 `);
-  });
+    },
+  );
 
   it("extracts exact correction release sections", () => {
     const source = changelog`
@@ -130,35 +133,43 @@ Docs: https://docs.openclaw.ai
 `);
   });
 
-  it("fails closed when package version has no matching release section", () => {
-    expect(() => extractCurrentPackageChangelog(cumulativeChangelog, "2026.5.29")).toThrow(
-      "CHANGELOG.md does not contain a release section for 2026.5.29.",
-    );
-  });
+  it.each(["Unreleased", "2026.5.30 (Unreleased)", "2026.5.30 (Release notes)"])(
+    "fails closed without a matching release section even with %s notes",
+    (heading) => {
+      const source = cumulativeChangelog.replace("## Unreleased", `## ${heading}`);
+      expect(() => extractCurrentPackageChangelog(source, "2026.5.29")).toThrow(
+        "CHANGELOG.md does not contain a release section for 2026.5.29.",
+      );
+    },
+  );
 
-  it("allows Unreleased notes for explicitly non-publish stable artifacts", () => {
-    const unreleasedChangelog = cumulativeChangelog.replace(
-      "- Pending note.",
-      "- Pending release note with enough detail.",
-    );
-    expect(
-      extractCurrentPackageChangelog(unreleasedChangelog, "2026.5.29", {
-        allowUnreleased: true,
-      }),
-    ).toBe(changelog`
+  it.each(["Unreleased", "2026.5.30 (Unreleased)"])(
+    "allows %s notes for explicitly non-publish stable artifacts",
+    (heading) => {
+      const unreleasedChangelog = cumulativeChangelog
+        .replace("## Unreleased", `## ${heading}`)
+        .replace("- Pending note.", "- Pending release note with enough detail.");
+      expect(
+        extractCurrentPackageChangelog(unreleasedChangelog, "2026.5.29", {
+          allowUnreleased: true,
+        }),
+      ).toBe(changelog`
 # Changelog
 Docs: https://docs.openclaw.ai
 
-## Unreleased
+## ${heading}
 ### Fixes
 - Pending release note with enough detail.
 `);
-  });
+    },
+  );
 
-  it("does not fall back when exact non-publish notes fail safety checks", () => {
-    const source = changelog`
+  it.each(["Unreleased", "2026.5.30 (Unreleased)"])(
+    "does not fall back to %s when exact non-publish notes fail safety checks",
+    (heading) => {
+      const source = changelog`
 # Changelog
-## Unreleased
+## ${heading}
 - Pending development package notes with enough release detail.
 ## 2026.5.29
 - Tiny.
@@ -166,10 +177,11 @@ Docs: https://docs.openclaw.ai
 - Older stable release notes with enough detail.
 `;
 
-    expect(() =>
-      extractCurrentPackageChangelog(source, "2026.5.29", { allowUnreleased: true }),
-    ).toThrow("Packaged changelog section for 2026.5.29 is only 7 body bytes");
-  });
+      expect(() =>
+        extractCurrentPackageChangelog(source, "2026.5.29", { allowUnreleased: true }),
+      ).toThrow("Packaged changelog section for 2026.5.29 is only 7 body bytes");
+    },
+  );
 
   it.each(["", oversizedContributionRecord])(
     "refuses oversized editorial notes even with a contribution record (%#)",
@@ -244,23 +256,25 @@ Docs: https://docs.openclaw.ai
     },
   );
 
-  it("recovers an interrupted ephemeral QA package with the default restore path", async () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-changelog-"));
-    const unreleasedChangelog = cumulativeChangelog.replace(
-      "- Pending note.",
-      "- Pending release note with enough detail.",
-    );
-    try {
-      writeFileSync(path.join(root, "package.json"), '{"version":"2026.5.29"}\n', "utf8");
-      writeFileSync(path.join(root, "CHANGELOG.md"), unreleasedChangelog, "utf8");
+  it.each(["Unreleased", "2026.5.30 (Unreleased)"])(
+    "recovers interrupted %s QA packaging with the default restore path",
+    async (heading) => {
+      const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-changelog-"));
+      const unreleasedChangelog = cumulativeChangelog
+        .replace("## Unreleased", `## ${heading}`)
+        .replace("- Pending note.", "- Pending release note with enough detail.");
+      try {
+        writeFileSync(path.join(root, "package.json"), '{"version":"2026.5.29"}\n', "utf8");
+        writeFileSync(path.join(root, "CHANGELOG.md"), unreleasedChangelog, "utf8");
 
-      await expect(preparePackageChangelog(root, { allowUnreleased: true })).resolves.toBe(true);
-      await expect(restorePackageChangelog(root)).resolves.toBe(true);
-      expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toBe(unreleasedChangelog);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
+        await expect(preparePackageChangelog(root, { allowUnreleased: true })).resolves.toBe(true);
+        await expect(restorePackageChangelog(root)).resolves.toBe(true);
+        expect(readFileSync(path.join(root, "CHANGELOG.md"), "utf8")).toBe(unreleasedChangelog);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each([cumulativeChangelog, oversizedChangelog])(
     "refuses to restore over edits after package preparation (%#)",

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -324,19 +324,21 @@ function runReleaseInputCapture(params: {
 }
 
 describe("package source preflight", () => {
-  it.each(["2026.8.1", "2026.8.1-beta.4", "2026.9.1"])(
-    "accepts aligned %s source manifests with Unreleased notes",
-    (version) => {
-      expect(
-        validatePackageSource({
-          aiManifestContent: aiManifest({ version }),
-          allowUnreleasedChangelog: true,
-          changelogContent: changelog,
-          rootManifestContent: rootManifest({ version }),
-        }),
-      ).toBe(version);
-    },
-  );
+  it.each([
+    ["2026.8.1", "Unreleased"],
+    ["2026.8.1-beta.4", "Unreleased"],
+    ["2026.9.1", "Unreleased"],
+    ["2026.9.1", "2026.8.3 (Unreleased)"],
+  ])("accepts aligned %s source manifests with %s notes", (version, heading) => {
+    expect(
+      validatePackageSource({
+        aiManifestContent: aiManifest({ version }),
+        allowUnreleasedChangelog: true,
+        changelogContent: changelog.replace("## Unreleased", `## ${heading}`),
+        rootManifestContent: rootManifest({ version }),
+      }),
+    ).toBe(version);
+  });
 
   it("uses canonical package changelog validation", () => {
     expect(() =>


### PR DESCRIPTION
Related: #107685, #127019.

<details>
<summary>Additional instructions</summary>

This is a same-repository branch, so maintainers retain repository write access. GitHub only exposes the separate fork-collaboration toggle for cross-repository pull requests.

</details>

## What Problem This Solves

Resolves a problem where maintainers validating a pre-changelog release candidate cannot build its package when the current draft uses a numbered heading, such as `## 2026.8.3 (Unreleased)`, and the candidate version has already been aligned to `2026.9.1`. Source preflight rejects that draft even with the existing explicit allowance for unreleased notes, preventing the Code-SHA validation needed before final release-note generation.

## Why This Change Was Made

The canonical package-changelog parser now retains both the numeric version and the explicit draft marker. Exact-version candidates still take priority; the marker participates only when the existing Unreleased fallback is permitted. Source preflight, npm prepack, Docker packaging and interrupted-pack restoration share this owner, so none needs a separate workaround.

Strict stable missing-version rejection is unchanged, including the existing exact-match behavior for a same-number draft heading. Minimum note length, package-size limits, contribution-record preservation and restore-over-edit protection remain unchanged. There are no new flags, environment variables or configuration fields, and no changelog edits. This is a release-blocking tooling repair, not a change to when release notes are finalized.

## User Impact

Maintainers can validate the pre-changelog Code SHA using the repository's current numbered draft format. Published release notes are still finalized and verified separately before publication. End-user runtime behavior is unchanged.

## Evidence

- Reproduced the real CLI failure against the captured release source with only root/bundled-AI versions aligned to `2026.9.1`: `package-source-preflight --allow-unreleased-changelog` rejected the existing `2026.8.3 (Unreleased)` heading. The same unchanged fixture passes with this owner repair.
- Added cases to the existing tests and fixtures. Before the production edit, four numbered-draft cases failed: source preflight, prerelease fallback, non-publish stable fallback, and interrupted restore. After the fix, `node scripts/run-vitest.mjs run test/scripts/package-changelog.test.ts test/scripts/package-source-preflight.test.ts` passes all 45 tests.
- Exact-note safety failures, strict stable behavior, package-size/credit preservation, dependency alignment and source restoration are covered by the same suite.
- Production LOC is net zero (11 added / 11 removed); tests are net +16. Heading parsing and draft classification now share one helper instead of retaining a redundant single-caller parsing function.
- Changed-file verification passes, including root test typecheck, script/test lint, formatting, dependency and package-boundary guards. Independent Codex autoreview is scoped-clean with no findings.
