### PR TITLE
fix(test): keep mixed UI directory runs scoped

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -163,6 +163,12 @@ verify lease cleanup; never stop the operator's Gateway.
 2. `pnpm test <path-or-filter>` for one file, directory, or explicit target.
 3. `pnpm test` only when you intentionally need the full local Vitest suite.
 
+An existing UI directory target stays scoped to that directory, including when
+combined with explicit E2E test files. Tests retain their owning shared, isolated,
+or browser lane. UI source/support-file targets that need whole-lane coverage
+(such as shared styles or setup files) still use that broader fallback; use a
+directory or explicit test files when you want a bounded run.
+
 When a one-shot routed run targets only explicit test-file paths, each selected
 Vitest invocation must discover at least one test file. Excluding every selected
 file fails even when the lane normally permits empty runs. To allow that outcome

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -3763,7 +3763,8 @@ function shouldUseWholeConfigTarget(kind: string, targetArg: string, cwd: string
     return false;
   }
   const relative = toRepoRelativeTarget(targetArg, cwd);
-  if (isTestFileTarget(relative)) {
+  // Source files need whole-project coverage; existing directories already define a test scope.
+  if (isTestFileTarget(relative) || isExistingDirectoryTarget(targetArg, cwd)) {
     return false;
   }
   return relative.startsWith("ui/src/");

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -3221,23 +3221,96 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
-  it("routes changed ui support files to the ui lane without dead include globs", () => {
-    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
-      "ui/src/styles/base.css",
-      "ui/src/test-helpers/lit-warnings.setup.ts",
-    ]);
+  it.each(["changed", "explicit"])(
+    "routes %s ui support files to the ui lane without dead include globs",
+    (mode) => {
+      const targets = ["ui/src/styles/base.css", "ui/src/test-helpers/lit-warnings.setup.ts"];
+      const plans = buildVitestRunPlans(
+        mode === "changed" ? ["--changed", "origin/main"] : targets,
+        process.cwd(),
+        () => targets,
+      );
 
-    expect(plans[0]).toEqual({
-      config: "test/vitest/vitest.ui.config.ts",
-      forwardedArgs: [],
-      includePatterns: null,
-      watchMode: false,
-    });
-    expect(plans[1]?.config).toBe("test/vitest/vitest.ui-browser.config.ts");
-    expect(plans[1]?.includePatterns).toContain(
-      "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
-    );
-  });
+      expect(plans[0]).toEqual({
+        config: "test/vitest/vitest.ui.config.ts",
+        forwardedArgs: [],
+        includePatterns: null,
+        watchMode: false,
+      });
+      expect(plans[1]?.config).toBe("test/vitest/vitest.ui-browser.config.ts");
+      expect(plans[1]?.includePatterns).toContain(
+        "ui/src/components/markdown-mermaid.runtime.browser.test.ts",
+      );
+    },
+  );
+
+  it.each(["relative", "trailing slash", "absolute", "dot segments"])(
+    "keeps an existing nested ui directory and explicit e2es scoped (%s)",
+    (spelling) => {
+      const directory = "ui/src/pages/new-session";
+      const isolated = `${directory}/draft-persistence.test.ts`;
+      const unitFiles = [
+        `${directory}/view.test.ts`,
+        `${directory}/nested/child.test.ts`,
+        isolated,
+      ];
+      const e2es = [
+        "ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts",
+        "ui/src/e2e/new-session-page.projects-places.e2e.test.ts",
+        "ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts",
+      ];
+      withTinyFileTree(
+        Object.fromEntries(
+          [
+            ...unitFiles,
+            ...e2es,
+            "ui/src/pages/other/view.test.ts",
+            "ui/src/pages/workboard/view.test.ts",
+            "ui/src/components/other.browser.test.ts",
+            "ui/src/e2e/other.e2e.test.ts",
+          ].map((file) => [file, ""]),
+        ),
+        (cwd) => {
+          const target =
+            spelling === "absolute"
+              ? path.join(cwd, directory)
+              : spelling === "trailing slash"
+                ? `./${directory}/`
+                : spelling === "dot segments"
+                  ? "ui/src/pages/./new-session/../new-session"
+                  : directory;
+          const plans = buildVitestRunPlans([target, ...e2es], cwd);
+          expect(plans).toEqual([
+            {
+              config: "test/vitest/vitest.ui.config.ts",
+              forwardedArgs: [],
+              includePatterns: [`${directory}/**/*.test.ts`],
+              watchMode: false,
+            },
+            {
+              config: "test/vitest/vitest.ui-isolated.config.ts",
+              forwardedArgs: [],
+              includePatterns: [isolated],
+              watchMode: false,
+            },
+            {
+              config: "test/vitest/vitest.ui-e2e.config.ts",
+              forwardedArgs: [],
+              includePatterns: e2es,
+              watchMode: false,
+            },
+          ]);
+          const includeFile = path.join(cwd, "include.json");
+          const filesByPlan = plans.map((plan) => {
+            writeVitestIncludeFile(includeFile, plan.includePatterns!, { cwd });
+            return JSON.parse(fs.readFileSync(includeFile, "utf8"));
+          });
+          // Shared UI intersects these files with its ownership exclusions.
+          expect(filesByPlan).toEqual([unitFiles.toSorted(), [isolated], e2es]);
+        },
+      );
+    },
+  );
 
   it("keeps mixed Control UI root and source changes in the UI lane", () => {
     const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running a nested UI directory together with explicit E2E files would unexpectedly run the entire shared UI suite and unrelated Chromium-browser tests. On the investigated checkout, the mixed command selected 803 shared UI files and 41 native-browser files instead of the requested 33 shared files, one isolated file, and three E2Es.

Separate tooling follow-up from [lifecycle integration testing (#133747)](https://github.com/openclaw/openclaw/pull/133747). This PR does not change that integration branch or any application lifecycle behavior.

## Why This Change Was Made

The target classifier treated every non-test `ui/src/…` token as a source-file request for whole-config coverage, including existing directories. It now reuses the existing directory classifier to preserve explicit directory scope. The existing include-file, browser ownership, and isolated-test owners do the rest; there is no consumer workaround or new routing path.

Whole-config fallback for UI source/support files remains intentional and unchanged. The regression added in `ead8be96fdd` protects that behavior, and direct inspection of stable tag `v2026.8.1` confirms the fallback exists there. The new regression covers relative, trailing-slash, absolute, and dot-segment directory spellings, plus explicit and changed support-file selection. The testing guide now explains the distinction.

Alternatives rejected: deleting source-file widening would revive dead include globs for support/style changes; preserving scope downstream in the runner would duplicate classifier policy and leave browser selection wrong. Serial failure handling and lifecycle behavior are out of scope.

## User Impact

Developers can use the documented directory-target workflow without expanding test paths in the shell. The reported command now runs exactly 37 files: 33 shared UI files, `draft-persistence.test.ts` in its existing isolated lane, and the three requested E2Es. No unrelated native-browser project starts.

Application runtime LOC: unchanged. Production tooling: +2/-1 (net +1, the explanatory comment; executable LOC neutral). Tests: +89/-16 (net +73). Docs: +6. No dependencies, configuration, baselines, timeouts, mocks, or assertion-strength changes.

## Evidence

### Planner regression, captured before the fix

```bash
OPENCLAW_VITEST_MAX_WORKERS=16 node scripts/run-vitest.mjs test/scripts/test-projects.test.ts -- -t 'keeps an existing nested ui directory|routes (changed|explicit) ui support files'
```

Before the source edit: four directory cases failed because the UI plan had `includePatterns: null` and an extra unrelated browser plan; both source-file fallback cases passed. After the classifier repair: all six selected cases passed.

### Original mixed command, executed after the fix

```bash
OPENCLAW_VITEST_MAX_WORKERS=16 node scripts/run-vitest.mjs ui/src/pages/new-session ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts ui/src/e2e/new-session-page.projects-places.e2e.test.ts ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
```

Passed in 89.38s: shared UI 33 files/372 tests; isolated UI one file/four tests; E2E three files/29 tests. Total: 37 files/405 tests. E2Es ran through real Chromium using the existing mocked-Gateway harness. This is executable test-runner proof, not an application UI change or live authenticated Gateway claim.

### Owner and sibling coverage

```bash
OPENCLAW_VITEST_MAX_WORKERS=16 node scripts/run-vitest.mjs test/scripts/test-projects.test.ts test/scripts/test-projects-routing.test.ts test/scripts/run-vitest.test.ts
```

Three files/649 tests passed. An initial run had 648 passes and one failure in the unchanged residual-process cleanup test: its 5000ms watchdog fired before the startup liveness assertion. The identical command passed on rerun without any source, timeout, mock, or assertion changes; the startup/watchdog race is a separate follow-up, not hidden by this patch.

```bash
node scripts/check-changed.mjs -- scripts/test-projects.test-support.mts test/scripts/test-projects.test.ts docs/reference/test.md
```

Passed selected formatting, script and test-root typechecks, changed-file lint, script erasability, and tooling guards. `git diff --check` passed. Codex autoreview completed with no accepted/actionable findings at its configured P0 threshold.

Dependency contract checked directly in installed Vitest 4.1.11: project discovery uses include/exclude globs and then positional filters. OpenClaw's existing config/include owners retain the shared/isolated/native-browser partition. No dependency behavior is changed.
