### PR TITLE
feat(config): add conditional set expectations

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -180,6 +180,26 @@ openclaw config set models.providers.ollama.models '[{"id":"llama3.2","name":"Ll
 
 Use `--replace` only when the provided value should intentionally become the complete target value.
 
+### Conditional writes
+
+Use a conditional expectation when automation must update one authored path only if it has not
+changed since the caller last observed it:
+
+```bash
+openclaw config set gateway.port 19001 --strict-json --expect-current-json 18789
+openclaw config set gateway.port 19001 --strict-json --expect-current-absent
+```
+
+`--expect-current-json <json>` uses strict JSON and compares the value by JSON type and structure.
+`null` is an authored value, so it does not satisfy `--expect-current-absent`. The comparison uses
+the effective authored config after includes and environment substitution, before runtime defaults
+are applied.
+
+The two expectation flags are mutually exclusive. They apply only to a single `config set`
+operation and cannot be combined with batch mode or `--dry-run`. A mismatch exits with status 1,
+writes nothing, and does not print either the expected or current value. OpenClaw's config snapshot
+guard still rejects a later race between the expectation check and the final file replacement.
+
 ## `config set` modes
 
 <Tabs>

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -196,9 +196,12 @@ the effective authored config after includes and environment substitution, befor
 are applied.
 
 The two expectation flags are mutually exclusive. They apply only to a single `config set`
-operation and cannot be combined with batch mode or `--dry-run`. A mismatch exits with status 1,
-writes nothing, and does not print either the expected or current value. OpenClaw's config snapshot
-guard still rejects a later race between the expectation check and the final file replacement.
+operation, require a direct non-redirected config path, and cannot be combined with batch mode or
+`--dry-run`. If input or roster resolution would write a different path than the caller requested,
+such as a sibling `*Ref` path, the command exits with status 1 instead of retargeting the
+expectation. A mismatch exits with status 1, writes nothing, and does not print either the expected
+or current value. OpenClaw's config snapshot guard still rejects a later race between the
+expectation check and the final file replacement.
 
 ## `config set` modes
 

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -264,6 +264,15 @@ function assertConfigSetCurrentExpectation(params: {
   }
 }
 
+function assertConfigSetCurrentExpectationPath(params: {
+  operation: ConfigSetOperation;
+  writePath: readonly PathSegment[];
+}): void {
+  if (!pathEquals(params.operation.requestedPath, params.writePath)) {
+    throw new Error("conditional config set requires a direct, non-redirected config path");
+  }
+}
+
 export async function runConfigOperations(params: {
   runtime: RuntimeEnv;
   operations: ConfigSetOperation[];
@@ -328,6 +337,12 @@ export async function runConfigOperations(params: {
     const merge =
       operation.mutation === "merge" || (options.merge && operation.mutation !== "replace");
     roster.prepare(operation, Boolean(merge));
+    if (currentExpectation) {
+      assertConfigSetCurrentExpectationPath({
+        operation,
+        writePath: roster.writePath(operation.setPath),
+      });
+    }
     if (operation.mutation === "delete") {
       const writePath = recordOperation(operation);
       const unsetResult = unsetAtPath(next, operation.setPath);

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -47,6 +47,7 @@ import {
   printConfigDryRunResult,
   type ConfigSetDryRunResult,
 } from "./config-set-dryrun.js";
+import type { ConfigSetCurrentExpectation } from "./config-set-input.js";
 import { exitCliAfterOutput } from "./one-shot-exit.js";
 
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
@@ -245,11 +246,30 @@ async function loadMutationSchema(): Promise<JsonSchemaRecord | undefined> {
   }
 }
 
+function assertConfigSetCurrentExpectation(params: {
+  authoredConfig: OpenClawConfig;
+  operation: ConfigSetOperation;
+  expectation: ConfigSetCurrentExpectation;
+}): void {
+  const current = getAtPath(params.authoredConfig, params.operation.setPath);
+  const matches =
+    params.expectation.kind === "absent"
+      ? !current.found
+      : current.found && isDeepStrictEqual(current.value, params.expectation.value);
+  if (!matches) {
+    throw new ConfigMutationConflictError(
+      "conditional config set expectation did not match the authored config",
+      { retryable: false },
+    );
+  }
+}
+
 export async function runConfigOperations(params: {
   runtime: RuntimeEnv;
   operations: ConfigSetOperation[];
   options: ConfigMutationOptions;
   successMode: "set" | "patch";
+  currentExpectation?: ConfigSetCurrentExpectation;
   beforePersistentApply?: () => void;
 }) {
   const { runtime, operations, options } = params;
@@ -266,6 +286,21 @@ export async function runConfigOperations(params: {
   }
   const mutationStart = await loadValidConfigForWrite(runtime);
   const { snapshot } = mutationStart;
+  const currentExpectation = params.currentExpectation;
+  let assertCurrentExpectation: (() => void) | undefined;
+  if (currentExpectation) {
+    const expectationOperation = operations[0];
+    if (!expectationOperation) {
+      throw new Error("conditional config set requires one resolved operation");
+    }
+    assertCurrentExpectation = () => {
+      assertConfigSetCurrentExpectation({
+        authoredConfig: snapshot.resolved,
+        operation: expectationOperation,
+        expectation: currentExpectation,
+      });
+    };
+  }
   // Mutate resolved config so runtime defaults never leak into the authored file.
   const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
   const currentConfig = normalizeConfigMutationModelRefs(snapshot.resolved);
@@ -382,6 +417,7 @@ export async function runConfigOperations(params: {
     return;
   }
   if (validation.kind === "unchanged") {
+    assertCurrentExpectation?.();
     runtime.log(info("No change"));
     return;
   }
@@ -393,10 +429,11 @@ export async function runConfigOperations(params: {
     writeOptions: {
       ...mutationStart.writeOptions,
       auditOrigin: "cli",
-      ...(params.beforePersistentApply
+      ...(assertCurrentExpectation || params.beforePersistentApply
         ? {
             assertConfigPathForWrite: () => {
               mutationStart.writeOptions.assertConfigPathForWrite?.();
+              assertCurrentExpectation?.();
               params.beforePersistentApply?.();
             },
           }

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -177,6 +177,92 @@ describe("config cli integration", () => {
     });
   });
 
+  it("accepts absent and exact authored expectations", async () => {
+    await withConfigFileHarness(
+      "openclaw-config-cli-conditional-success-",
+      "{ gateway: { port: 18789 } }\n",
+      async ({ configPath }) => {
+        const absentOutput = createTestRuntime();
+        await runConfigSet({
+          path: "gateway.bind",
+          value: '"loopback"',
+          cliOptions: { strictJson: true, expectCurrentAbsent: true },
+          runtime: absentOutput.runtime,
+        });
+        expect(absentOutput.errors).toStrictEqual([]);
+
+        const exactOutput = createTestRuntime();
+        await runConfigSet({
+          path: "gateway.port",
+          value: "19001",
+          cliOptions: { strictJson: true, expectCurrentJson: "18789" },
+          runtime: exactOutput.runtime,
+        });
+        expect(exactOutput.errors).toStrictEqual([]);
+        expect(JSON5.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({
+          gateway: { bind: "loopback", port: 19001 },
+        });
+      },
+    );
+  });
+
+  it("rejects a conditional set when the authored value changed before CLI load", async () => {
+    await withConfigFileHarness(
+      "openclaw-config-cli-conditional-preload-conflict-",
+      "{ gateway: { port: 19002 } }\n",
+      async ({ configPath }) => {
+        const before = fs.readFileSync(configPath, "utf8");
+        const output = createTestRuntime();
+
+        await expect(
+          runConfigSet({
+            path: "gateway.port",
+            value: "19001",
+            cliOptions: { strictJson: true, expectCurrentJson: "18789" },
+            runtime: output.runtime,
+          }),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(configPath, "utf8")).toBe(before);
+        expect(output.logs).toStrictEqual([]);
+        expect(output.errors.join("\n")).toContain(
+          "conditional config set expectation did not match the authored config",
+        );
+        expect(output.errors.join("\n")).not.toContain("18789");
+        expect(output.errors.join("\n")).not.toContain("19002");
+      },
+    );
+  });
+
+  it("keeps the snapshot hash guard after a matching conditional preflight", async () => {
+    await withConfigFileHarness(
+      "openclaw-config-cli-conditional-postload-race-",
+      "{ gateway: { port: 18789 } }\n",
+      async ({ configPath }) => {
+        const concurrentRaw = "{ gateway: { port: 19002 } }\n";
+        const output = createTestRuntime();
+
+        await expect(
+          runConfigSet({
+            path: "gateway.port",
+            value: "19001",
+            cliOptions: { strictJson: true, expectCurrentJson: "18789" },
+            runtime: output.runtime,
+            beforePersistentApply: () => {
+              fs.writeFileSync(configPath, concurrentRaw, "utf8");
+            },
+          }),
+        ).rejects.toThrow("__exit__:1");
+
+        expect(fs.readFileSync(configPath, "utf8")).toBe(concurrentRaw);
+        expect(output.logs).toStrictEqual([]);
+        expect(output.errors.join("\n")).toContain("config changed since last load");
+        expect(output.errors.join("\n")).not.toContain("18789");
+        expect(output.errors.join("\n")).not.toContain("19002");
+      },
+    );
+  });
+
   it("preserves exact JSON5 bytes while rejecting an absent authored unset", async () => {
     const raw =
       '{\n  // preserve this comment and order\n  gateway: { port: 18789 },\n  logging: { level: "info" },\n}\n';

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1366,6 +1366,82 @@ describe("config cli", () => {
       ).rejects.toMatchObject({ name: "ExitError", code: 1 });
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
+
+    it("rejects an absent expectation when a SecretRef redirects away from the caller path", async () => {
+      const existingValue = "caller-value-present";
+      const refId = "REDIRECTED_REF_ID";
+      const resolved = {
+        channels: { discord: { accounts: [{ token: existingValue }] } },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigSet(
+          "channels.discord.accounts[0].token",
+          "--ref-provider",
+          "default",
+          "--ref-source",
+          "env",
+          "--ref-id",
+          refId,
+          "--expect-current-absent",
+        ),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("conditional config set requires a direct, non-redirected config path");
+      const output = JSON.stringify([...mockLog.mock.calls, ...mockError.mock.calls]);
+      expect(output).not.toContain(existingValue);
+      expect(output).not.toContain(refId);
+    });
+
+    it("rejects an exact expectation when a SecretRef value redirects the write path", async () => {
+      const existingValue = "caller-exact-value";
+      const refId = "REDIRECTED_EXACT_REF_ID";
+      const resolved = {
+        channels: { discord: { accounts: [{ token: existingValue }] } },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigSet(
+          "channels.discord.accounts[0].token",
+          JSON.stringify({ source: "env", provider: "default", id: refId }),
+          "--strict-json",
+          "--expect-current-json",
+          JSON.stringify(existingValue),
+        ),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("conditional config set requires a direct, non-redirected config path");
+      const output = JSON.stringify([...mockLog.mock.calls, ...mockError.mock.calls]);
+      expect(output).not.toContain(existingValue);
+      expect(output).not.toContain(refId);
+    });
+
+    it("rejects an exact expectation when roster normalization redirects the write path", async () => {
+      const existingValue = "existing-agent-name";
+      const resolved: OpenClawConfig = {
+        agents: { entries: { main: { name: existingValue } } },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigSet(
+          "agents.list[0].name",
+          "updated-agent-name",
+          "--expect-current-json",
+          JSON.stringify(existingValue),
+        ),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("conditional config set requires a direct, non-redirected config path");
+      const output = JSON.stringify([...mockLog.mock.calls, ...mockError.mock.calls]);
+      expect(output).not.toContain(existingValue);
+      expect(output).not.toContain("updated-agent-name");
+    });
   });
 
   describe("config get", () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -118,8 +118,12 @@ vi.mock("../config/config.js", () => ({
       auditOrigin?: "cli";
       unsetPaths?: string[][];
       explicitSetPaths?: string[][];
+      assertConfigPathForWrite?: () => void;
     };
-  }) => mockWriteConfigFile(params.nextConfig, params.writeOptions),
+  }) => {
+    params.writeOptions?.assertConfigPathForWrite?.();
+    return mockWriteConfigFile(params.nextConfig, params.writeOptions);
+  },
 }));
 
 vi.mock("../secrets/resolve.js", () => ({
@@ -1306,6 +1310,62 @@ describe("config cli", () => {
       });
       expectLogIncludes("Removed inactive gateway.auth.password for gateway.auth.mode=token");
     });
+
+    it("conditionally writes when the authored path is absent or exactly matches JSON", async () => {
+      const absent: OpenClawConfig = { gateway: {} };
+      setSnapshot(absent, { gateway: { port: 18789 } });
+
+      await runConfigSet("gateway.port", "19001", "--strict-json", "--expect-current-absent");
+
+      expect(firstWrittenConfig().gateway?.port).toBe(19001);
+      vi.clearAllMocks();
+      setSnapshot({ gateway: { port: 19001 } }, { gateway: { port: 19001 } });
+
+      await runConfigSet(
+        "gateway.port",
+        "19002",
+        "--strict-json",
+        "--expect-current-json",
+        "19001",
+      );
+
+      expect(firstWrittenConfig().gateway?.port).toBe(19002);
+    });
+
+    it("distinguishes an authored null from an absent path", async () => {
+      const resolved = { gateway: { port: null } } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigSet("gateway.port", "19001", "--strict-json", "--expect-current-absent"),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("conditional config set expectation did not match the authored config");
+    });
+
+    it("uses deep type-exact comparison for authored expectations", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789, bind: "loopback" },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigSet(
+        "gateway",
+        '{"port":19001,"bind":"loopback"}',
+        "--strict-json",
+        "--expect-current-json",
+        '{"port":18789,"bind":"loopback"}',
+      );
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+
+      vi.clearAllMocks();
+      setSnapshot({ gateway: { port: 1 } }, { gateway: { port: 1 } });
+      await expect(
+        runConfigSet("gateway.port", "2", "--strict-json", "--expect-current-json", '"1"'),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
   });
 
   describe("config get", () => {
@@ -1941,6 +2001,8 @@ describe("config cli", () => {
       expect(helpText).not.toContain("--provider-allow-insecure-path");
       expect(helpText).not.toContain("--provider-allow-symlink-command");
       expect(helpText).toContain("--batch-json");
+      expect(helpText).toContain("--expect-current-absent");
+      expect(helpText).toContain("--expect-current-json <json>");
       expect(helpText).toContain("--dry-run");
       expect(helpText).toContain("--allow-exec");
       // Ignore Commander line wrapping and env-injected CLI prefixes.
@@ -2788,6 +2850,51 @@ describe("config cli", () => {
       expectErrorIncludes(
         "config set mode error: batch mode (--batch-json/--batch-file) cannot be combined",
       );
+    });
+
+    it.each([
+      {
+        name: "both expectation flags",
+        args: [
+          "gateway.port",
+          "19001",
+          "--expect-current-absent",
+          "--expect-current-json",
+          "18789",
+        ],
+      },
+      {
+        name: "malformed expected JSON",
+        args: ["gateway.port", "19001", "--expect-current-json", "{bad"],
+      },
+      {
+        name: "batch mode",
+        args: [
+          "--batch-json",
+          '[{"path":"gateway.port","value":19001}]',
+          "--expect-current-absent",
+        ],
+      },
+      {
+        name: "dry-run",
+        args: ["gateway.port", "19001", "--expect-current-absent", "--dry-run"],
+      },
+    ])("rejects conditional config set with $name before loading config", async ({ args }) => {
+      await expect(runConfigSet(...args)).rejects.toThrow(ExitError);
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("checks a conditional expectation before reporting No change", async () => {
+      setGatewaySnapshot();
+
+      await expect(
+        runConfigSet("gateway.port", "18789", "--strict-json", "--expect-current-json", "19001"),
+      ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectLogExcludes("No change");
     });
 
     it("rejects empty inline batches before reading or rewriting config", async () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -39,7 +39,7 @@ import {
   strictlyValidateConfigSnapshotForCli,
 } from "./config-cli-validation.js";
 import { isConfigMachineOutput, isConfigSetJsonParseOnly } from "./config-output-mode.js";
-import type { ConfigSetOptions } from "./config-set-input.js";
+import { parseConfigSetCurrentExpectation, type ConfigSetOptions } from "./config-set-input.js";
 import { formatCliJsonFailure } from "./failure-output.js";
 import { exitCliAfterOutput } from "./one-shot-exit.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
@@ -77,15 +77,23 @@ export async function runConfigSet(opts: {
 }) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
+    const currentExpectation = parseConfigSetCurrentExpectation(opts.cliOptions);
+    const operations = buildConfigSetOperations({
+      path: opts.path,
+      value: opts.value,
+      opts: opts.cliOptions,
+    });
+    if (currentExpectation && operations.length !== 1) {
+      throw new Error(
+        "config set mode error: conditional expectations require exactly one resolved operation.",
+      );
+    }
     await runConfigOperations({
       runtime,
-      operations: buildConfigSetOperations({
-        path: opts.path,
-        value: opts.value,
-        opts: opts.cliOptions,
-      }),
+      operations,
       options: opts.cliOptions,
       successMode: "set",
+      ...(currentExpectation ? { currentExpectation } : {}),
       ...(opts.beforePersistentApply ? { beforePersistentApply: opts.beforePersistentApply } : {}),
     });
   } catch (err) {
@@ -339,6 +347,11 @@ export function registerConfigCli(program: Command) {
     .argument("[value]", "Value (JSON/JSON5 or raw string)")
     .option("--strict-json", "Strict JSON parsing (error instead of raw string fallback)", false)
     .option("--json", "Legacy alias for --strict-json", false)
+    .option("--expect-current-absent", "Write only when the authored path is absent", false)
+    .option(
+      "--expect-current-json <json>",
+      "Write only when the authored path exactly matches this strict JSON value",
+    )
     .option(
       "--dry-run",
       "Validate changes without writing openclaw.json (checks run in builder/json/batch modes; exec SecretRefs are skipped unless --allow-exec is set)",

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   hasProviderBuilderOptions,
   parseBatchSource,
+  parseConfigSetCurrentExpectation,
   type ConfigSetOptions,
 } from "./config-set-input.js";
 
@@ -29,6 +30,52 @@ describe("config set input parsing", () => {
 
     expect(hasProviderBuilderOptions(retired)).toBe(false);
     expect(hasProviderBuilderOptions({ providerTrustedDir: ["/usr/local/bin"] })).toBe(true);
+  });
+
+  it("parses absent and strict JSON current-value expectations", () => {
+    expect(parseConfigSetCurrentExpectation({ expectCurrentAbsent: true })).toEqual({
+      kind: "absent",
+    });
+    expect(parseConfigSetCurrentExpectation({ expectCurrentJson: "null" })).toEqual({
+      kind: "json",
+      value: null,
+    });
+    expect(
+      parseConfigSetCurrentExpectation({ expectCurrentJson: '{"enabled":true,"ports":[1,2]}' }),
+    ).toEqual({
+      kind: "json",
+      value: { enabled: true, ports: [1, 2] },
+    });
+  });
+
+  it.each([
+    {
+      name: "both expectation flags",
+      options: { expectCurrentAbsent: true, expectCurrentJson: "null" },
+      message: "choose either --expect-current-absent or --expect-current-json",
+    },
+    {
+      name: "malformed expected JSON",
+      options: { expectCurrentJson: "{enabled:true}" },
+      message: "--expect-current-json must be valid JSON",
+    },
+    {
+      name: "non-finite expected number",
+      options: { expectCurrentJson: "1e999" },
+      message: "--expect-current-json must be valid JSON",
+    },
+    {
+      name: "batch mode",
+      options: { expectCurrentAbsent: true, batchJson: "[]" },
+      message: "cannot be combined with batch mode",
+    },
+    {
+      name: "dry-run",
+      options: { expectCurrentAbsent: true, dryRun: true },
+      message: "cannot be combined with --dry-run",
+    },
+  ] as const)("rejects $name with a current-value expectation", ({ options, message }) => {
+    expect(() => parseConfigSetCurrentExpectation(options)).toThrow(message);
   });
 
   it("returns null when no batch options are provided", () => {

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -36,6 +36,8 @@ export type ConfigSetOptions = {
   providerTrustedDir?: string[];
   batchJson?: string;
   batchFile?: string;
+  expectCurrentAbsent?: boolean;
+  expectCurrentJson?: string;
 };
 
 export type ConfigSetBatchEntry = {
@@ -44,6 +46,8 @@ export type ConfigSetBatchEntry = {
   ref?: unknown;
   provider?: unknown;
 };
+
+export type ConfigSetCurrentExpectation = { kind: "absent" } | { kind: "json"; value: unknown };
 
 const CONFIG_MUTATION_FILE_MAX_BYTES = 8 * 1024 * 1024;
 
@@ -161,6 +165,48 @@ function parseBatchEntries(raw: string, sourceLabel: string): ConfigSetBatchEntr
     });
   }
   return out;
+}
+
+export function parseConfigSetCurrentExpectation(
+  opts: ConfigSetOptions,
+): ConfigSetCurrentExpectation | undefined {
+  const expectAbsent = opts.expectCurrentAbsent === true;
+  const hasExpectedJson = opts.expectCurrentJson !== undefined;
+  if (!expectAbsent && !hasExpectedJson) {
+    return undefined;
+  }
+  if (expectAbsent && hasExpectedJson) {
+    throw new Error(
+      "config set mode error: choose either --expect-current-absent or --expect-current-json, not both.",
+    );
+  }
+  if (opts.dryRun) {
+    throw new Error(
+      "config set mode error: conditional expectations cannot be combined with --dry-run.",
+    );
+  }
+  if (opts.batchJson !== undefined || opts.batchFile !== undefined) {
+    throw new Error(
+      "config set mode error: conditional expectations require one path operation and cannot be combined with batch mode.",
+    );
+  }
+  if (expectAbsent) {
+    return { kind: "absent" };
+  }
+  const expectedJson = opts.expectCurrentJson;
+  if (expectedJson === undefined) {
+    throw new Error("config set mode error: missing conditional expectation.");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(expectedJson) as unknown;
+    rejectConfigNonFiniteNumbers(value);
+  } catch (error) {
+    throw new Error("config set mode error: --expect-current-json must be valid JSON.", {
+      cause: error,
+    });
+  }
+  return { kind: "json", value };
 }
 
 export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] | null {


### PR DESCRIPTION
## What Problem This Solves

Automation that performs a read-modify-write through `openclaw config set` cannot currently assert that the authored value is still the value it inspected. A concurrent edit can therefore make the automation's intended precondition stale before persistence.

## Why This Change Was Made

Adds mutually exclusive `--expect-current-absent` and `--expect-current-json <json>` flags to single-operation `config set`. The expectation compares the effective authored value after includes and environment substitution but before runtime defaults, runs immediately before persistence, and returns a non-retryable mutation conflict without disclosing values or writing when it does not match. Conditional sets also require the final persistent write path to match the caller-requested path; SecretRef, provider, or roster redirects are rejected before mutation rather than silently retargeting the expectation. The existing snapshot hash remains the later race guard.

## User Impact

Operators and automation can now make conditional config updates with compare-and-set semantics on direct, non-redirected paths. Authored `null` remains distinct from an absent path, JSON comparison is deep and type-exact, and existing `config set` behavior is unchanged when neither flag is supplied.

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/config-set-input.test.ts src/cli/config-cli.test.ts src/cli/config-cli.integration.test.ts` (273 tests passed)
- `pnpm check:changed` (passed in isolated AWS Crabbox lease `cbx_7da6e7bf691f`)
- `pnpm build` (passed in the same isolated Linux checkout)
- Regression coverage proves both SecretRef builder forms and roster normalization reject redirected conditional writes before mutation, preserve zero writes, and do not disclose caller, expected, or replacement values
- Built `dist` CLI proof against temporary configs covered exact-value and absent-value success; same-value expectation mismatch; malformed JSON; mutually exclusive flags; batch and dry-run rejection; roster redirect rejection; exit code 1; unchanged config bytes; and expected/current value non-disclosure
- Integration coverage proves a change before CLI load is rejected and a post-load/pre-rename change is caught by the existing snapshot hash guard
