### PR TITLE
improve(gateway): reuse verified metadata during startup

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -5,6 +5,14 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../../packages/terminal-core/src/note.js";
 import type { ConfigSnapshotReadMeasure } from "../../config/io.js";
+import { getGatewayPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-state.js";
+import {
+  adoptProcessPluginCache,
+  createPluginCache,
+  getProcessPluginCache,
+  withPluginCache,
+} from "../../plugins/plugin-cache.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { ExitError } from "../../runtime.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { VERSION } from "../../version.js";
@@ -82,6 +90,9 @@ describe("ensureConfigReady", () => {
   const resetConfigGuardStateForTests = testApi.resetConfigGuardStateForTests;
   const tempRoots: string[] = [];
   let envSnapshot: ReturnType<typeof captureEnv> | undefined;
+  let processCache: ReturnType<typeof getProcessPluginCache>;
+  let preflightCache: ReturnType<typeof createPluginCache>;
+  let preflightMetadata: ReturnType<typeof createPluginMetadataSnapshotFixture>;
 
   async function runEnsureConfigReady(commandPath: string[], suppressDoctorStdout = false) {
     const runtime = makeRuntime();
@@ -101,6 +112,7 @@ describe("ensureConfigReady", () => {
     loadAndMaybeMigrateDoctorConfigMock.mockResolvedValue({
       snapshot,
       baseConfig: {},
+      pluginMetadataSnapshot: preflightMetadata,
     });
     return snapshot;
   }
@@ -135,6 +147,9 @@ describe("ensureConfigReady", () => {
   }
 
   beforeEach(() => {
+    processCache = getProcessPluginCache();
+    preflightCache = createPluginCache();
+    preflightMetadata = withPluginCache(preflightCache, createPluginMetadataSnapshotFixture);
     envSnapshot = captureEnv([
       "HOME",
       "OPENCLAW_HOME",
@@ -152,10 +167,12 @@ describe("ensureConfigReady", () => {
     loadAndMaybeMigrateDoctorConfigMock.mockImplementation(async () => ({
       snapshot: makeSnapshot(),
       baseConfig: {},
+      pluginMetadataSnapshot: preflightMetadata,
     }));
   });
 
   afterEach(() => {
+    adoptProcessPluginCache(processCache);
     envSnapshot?.restore();
     envSnapshot = undefined;
     for (const root of tempRoots.splice(0)) {
@@ -252,6 +269,7 @@ describe("ensureConfigReady", () => {
   ])("$name", async ({ commandPath, expectedDoctorCalls }) => {
     await runEnsureConfigReady(commandPath);
     expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledTimes(expectedDoctorCalls);
+    expect(getProcessPluginCache()).toBe(processCache);
     if (expectedDoctorCalls > 0) {
       expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
         migrateState: true,
@@ -377,15 +395,37 @@ describe("ensureConfigReady", () => {
     });
   });
 
-  it("requires a startup migration checkpoint for foreground gateway startup", async () => {
-    await runEnsureConfigReady(["gateway"]);
+  it.each([
+    { commandPath: ["gateway"], suppressDoctorStdout: false },
+    { commandPath: ["gateway"], suppressDoctorStdout: true },
+    { commandPath: ["gateway", "run"], suppressDoctorStdout: false },
+    { commandPath: ["gateway", "run"], suppressDoctorStdout: true },
+  ])(
+    "retains accepted startup facts for $commandPath (suppressed: $suppressDoctorStdout)",
+    async ({ commandPath, suppressDoctorStdout }) => {
+      await runEnsureConfigReady(commandPath, suppressDoctorStdout);
 
-    expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
-      migrateState: true,
-      migrateLegacyConfig: false,
-      invalidConfigNote: false,
-      requireStartupMigrationCheckpoint: true,
+      expect(loadAndMaybeMigrateDoctorConfigMock).toHaveBeenCalledWith({
+        migrateState: true,
+        migrateLegacyConfig: false,
+        invalidConfigNote: false,
+        requireStartupMigrationCheckpoint: true,
+      });
+      expect(getProcessPluginCache() === preflightCache).toBe(true);
+      // Cache reuse must not freeze the Gateway inventory before its final config read.
+      expect(getGatewayPluginMetadataSnapshot()).toBeUndefined();
+    },
+  );
+
+  it("keeps the process owner when accepted config preparation fails", async () => {
+    const error = new Error("runtime config preparation failed");
+    setRuntimeConfigSnapshotMock.mockImplementationOnce(() => {
+      throw error;
     });
+
+    await expect(runEnsureConfigReady(["gateway", "run"])).rejects.toThrow(error);
+
+    expect(getProcessPluginCache()).toBe(processCache);
   });
 
   it("honors a deferred migration exit after preflight resources unwind", async () => {
@@ -407,6 +447,7 @@ describe("ensureConfigReady", () => {
     ).rejects.toMatchObject({ name: "ExitError", code: 78 });
 
     expect(runtime.exit).toHaveBeenCalledWith(78);
+    expect(getProcessPluginCache()).toBe(processCache);
   });
 
   it("uses only the state migration checkpoint for gateway probes", async () => {
@@ -418,6 +459,7 @@ describe("ensureConfigReady", () => {
       invalidConfigNote: false,
       requireStateMigrationCheckpoint: true,
     });
+    expect(getProcessPluginCache()).toBe(processCache);
   });
 
   it("runs doctor flow for legacy sessions without task sidecars", async () => {
@@ -973,6 +1015,7 @@ describe("ensureConfigReady", () => {
     const doctorRuntime = await runEnsureConfigReady(["doctor", "fix"]);
     expect(doctorRuntime.exit).not.toHaveBeenCalled();
     expect(doctorRuntime.error).toHaveBeenCalledWith(expect.stringContaining("agentRuntime"));
+    expect(getProcessPluginCache()).toBe(processCache);
   });
 
   it("allows an explicit invalid-config override", async () => {
@@ -1002,6 +1045,7 @@ describe("ensureConfigReady", () => {
 
     expect(confirm).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
+    expect(getProcessPluginCache()).toBe(processCache);
   });
 
   it("runs doctor migration flow only once per module instance", async () => {

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { withSuppressedNotes } from "../../../packages/terminal-core/src/note.js";
+import type { DoctorConfigPreflightResult } from "../../commands/doctor-config-preflight.js";
 import { readConfigFileSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import { createInvalidConfigError } from "../../config/io.invalid-config.js";
 import type { ConfigSnapshotReadMeasure } from "../../config/io.js";
@@ -15,6 +16,10 @@ import {
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { resolveExecApprovalsPath } from "../../infra/exec-approvals-config.js";
 import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
+import {
+  adoptProcessPluginCache,
+  getPluginMetadataSnapshotCache,
+} from "../../plugins/plugin-cache.js";
 import { ExitError, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import type { InvalidConfigRecoveryDeps } from "../invalid-config-recovery.js";
 
@@ -234,7 +239,7 @@ export async function ensureConfigReady(
   const subcommandName = commandPath[1];
   const isRestartController =
     (commandName === "gateway" || commandName === "daemon") && subcommandName === "restart";
-  let preflightSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>> | null = null;
+  let preflightResult: DoctorConfigPreflightResult | null = null;
   const shouldConsiderStateMigration =
     !params.validateConfigOnly &&
     commandName !== "config" &&
@@ -272,8 +277,8 @@ export async function ensureConfigReady(
       });
     try {
       return !params.suppressDoctorStdout
-        ? (await runDoctorConfigPreflight()).snapshot
-        : (await withSuppressedNotes(runDoctorConfigPreflight)).snapshot;
+        ? await runDoctorConfigPreflight()
+        : await withSuppressedNotes(runDoctorConfigPreflight);
     } catch (error) {
       if (error instanceof ExitError) {
         // The migration owner has unwound its lease and heartbeat before this handoff.
@@ -287,7 +292,7 @@ export async function ensureConfigReady(
     shouldConsiderStateMigration &&
     (!requiresLegacyStateInput || hasLegacyStateMigrationInputs())
   ) {
-    preflightSnapshot = await runStateMigrationPreflight();
+    preflightResult = await runStateMigrationPreflight();
   }
 
   // Read-only diagnostics must not record config health. Core-only validation
@@ -302,17 +307,17 @@ export async function ensureConfigReady(
         ? ({ observe: false } as const)
         : undefined;
   let snapshot =
-    preflightSnapshot ?? (await getConfigSnapshot(configSnapshotOptions, params.measure));
+    preflightResult?.snapshot ?? (await getConfigSnapshot(configSnapshotOptions, params.measure));
   if (
-    !preflightSnapshot &&
+    !preflightResult &&
     !didRunDoctorConfigFlow &&
     shouldConsiderStateMigration &&
     requiresLegacyStateInput &&
     snapshot.valid &&
     snapshotHasConfiguredSessionStore(snapshot)
   ) {
-    preflightSnapshot = await runStateMigrationPreflight();
-    snapshot = preflightSnapshot;
+    preflightResult = await runStateMigrationPreflight();
+    snapshot = preflightResult.snapshot;
   }
   const isBareGatewayForegroundRun =
     commandName === "gateway" && (subcommandName === undefined || subcommandName.trim() === "");
@@ -341,8 +346,15 @@ export async function ensureConfigReady(
   const invalid = snapshot.exists && !snapshot.valid;
   if (!invalid) {
     setRuntimeConfigSnapshot(snapshot.runtimeConfig ?? snapshot.config, snapshot.sourceConfig);
-  }
-  if (!invalid) {
+    if (
+      shouldRequireStartupMigrationCheckpoint(commandPath) &&
+      preflightResult?.pluginMetadataSnapshot
+    ) {
+      // Carry verified package facts into the final config reread without publishing Gateway policy.
+      adoptProcessPluginCache(
+        getPluginMetadataSnapshotCache(preflightResult.pluginMetadataSnapshot),
+      );
+    }
     return;
   }
 

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -1,7 +1,5 @@
 import { note } from "../../packages/terminal-core/src/note.js";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
-import type { ConfigFileSnapshot } from "../config/types.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
@@ -40,9 +38,8 @@ type MigrationCheckpoint = {
   }) => void;
 };
 
-/** Completes startup checkpointing and plugin verification after state migration has run. */
+/** Completes startup verification and returns the accepted config and metadata generation. */
 export async function completeStartupMigrationPreflight(params: {
-  baseConfig: OpenClawConfig;
   freshConfigGuardAllowed: boolean | undefined;
   gatewayStartupCheckpointRequired: boolean;
   migrationCheckpoint: MigrationCheckpoint | undefined;
@@ -53,13 +50,16 @@ export async function completeStartupMigrationPreflight(params: {
   ) => Promise<DoctorConfigPreflightPluginSnapshotRead>;
   shouldRecordStartupCheckpoint: boolean;
   shouldRecordStateCheckpoint: boolean;
-  snapshot: ConfigFileSnapshot;
+  snapshotRead: DoctorConfigPreflightPluginSnapshotRead;
   startupMigrationEnv: NodeJS.ProcessEnv;
   startupMigrationHeartbeatError: unknown;
   startupMigrationLease: StartupMigrationLease | undefined;
   startupMigrationWarnings: readonly string[];
   stateMigrationsAllowed: boolean | undefined;
-}): Promise<void> {
+}): Promise<DoctorConfigPreflightPluginSnapshotRead> {
+  let snapshotRead = params.snapshotRead;
+  const snapshot = snapshotRead.snapshot;
+  const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
   if (
     (params.shouldRecordStateCheckpoint || params.shouldRecordStartupCheckpoint) &&
     params.startupMigrationHeartbeatError
@@ -73,7 +73,7 @@ export async function completeStartupMigrationPreflight(params: {
     params.stateMigrationsAllowed &&
     params.freshConfigGuardAllowed &&
     params.startupMigrationWarnings.length === 0 &&
-    params.snapshot.valid
+    snapshot.valid
   ) {
     if (!params.migrationCheckpoint) {
       throw new Error("OpenClaw state migration checkpoint module was not loaded.");
@@ -85,7 +85,7 @@ export async function completeStartupMigrationPreflight(params: {
     });
   }
   if (params.gatewayStartupCheckpointRequired) {
-    if (params.shouldRecordStartupCheckpoint && !params.snapshot.valid) {
+    if (params.shouldRecordStartupCheckpoint && !snapshot.valid) {
       throwStartupMigrationRefusal(
         formatStartupMigrationFailure([
           'OpenClaw config is invalid; run "openclaw doctor --fix" before startup.',
@@ -93,15 +93,15 @@ export async function completeStartupMigrationPreflight(params: {
       );
     }
     setActiveDegradedPlugins([]);
-    if (params.snapshot.valid) {
+    if (snapshot.valid) {
       const pluginConvergence = params.shouldRecordStartupCheckpoint
         ? await runStartupUpgradeConvergence({
-            cfg: params.baseConfig,
+            cfg: baseConfig,
             env: process.env,
             ...(params.measure ? { measure: params.measure } : {}),
           })
         : await refreshStartupPluginQuarantine({
-            cfg: params.baseConfig,
+            cfg: baseConfig,
             env: process.env,
             ...(params.measure ? { measure: params.measure } : {}),
           });
@@ -127,6 +127,7 @@ export async function completeStartupMigrationPreflight(params: {
         ) {
           throwStartupMigrationIdentityChanged();
         }
+        snapshotRead = convergedSnapshotRead;
       }
     }
     recordStartupMigrationWarnings(params.startupMigrationWarnings);
@@ -142,6 +143,7 @@ export async function completeStartupMigrationPreflight(params: {
       lease: params.startupMigrationLease,
     });
   }
+  return snapshotRead;
 }
 
 export function noteStateMigrationResult(result: MigrationMessages): void {

--- a/src/commands/doctor-config-preflight.plugin-persistence.test.ts
+++ b/src/commands/doctor-config-preflight.plugin-persistence.test.ts
@@ -436,6 +436,36 @@ describe("Doctor plugin persistence", () => {
       });
     });
   });
+
+  it("returns the final accepted startup read with its metadata producer", async () => {
+    await withPreflightPluginFixture(async (_writeVersion, config) => {
+      const initial = await readPluginPreflight();
+      config.plugins!.entries = { "preflight-fixture": { enabled: false } };
+      await fs.writeFile(initial.snapshot.path, JSON.stringify(config));
+      let acceptedRead: DoctorConfigPreflightPluginSnapshotRead | undefined;
+      const result = await runDoctorConfigPreflight({
+        migrateState: false,
+        migrateLegacyConfig: false,
+        requireStartupMigrationCheckpoint: true,
+        preparePluginMetadataSnapshot: true,
+        observe: false,
+        measure: async (name, operation) => {
+          const measured = await operation();
+          if (name === "doctor.config-preflight.config-snapshot") {
+            acceptedRead = measured as DoctorConfigPreflightPluginSnapshotRead;
+          }
+          return measured;
+        },
+      });
+      expect(acceptedRead?.pluginMetadataSnapshot?.registrySource).toBe("persisted");
+      // The post-convergence generation, not the preceding persistence read, owns startup.
+      expect(result.snapshot === acceptedRead?.snapshot).toBe(true);
+      expect(result.baseConfig === acceptedRead?.snapshot.sourceConfig).toBe(true);
+      expect(result.pluginMetadataSnapshot === acceptedRead?.pluginMetadataSnapshot).toBe(true);
+      expect(migrationCheckpoint.hasActiveStartupMigrationLease({ env: process.env })).toBe(false);
+    });
+  });
+
   it("refuses persistence verification when package facts change before the durable reread", async () => {
     const fixturePluginId = "preflight-\u001b[31mfixture";
     await withPreflightPluginFixture(

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -683,8 +683,7 @@ export async function runDoctorConfigPreflight(
       configSnapshotRead = persistedSnapshotRead;
       migrationCheckpointIdentity = persistedIdentity;
     }
-    await completeStartupMigrationPreflight({
-      baseConfig,
+    configSnapshotRead = await completeStartupMigrationPreflight({
       freshConfigGuardAllowed,
       gatewayStartupCheckpointRequired,
       migrationCheckpoint,
@@ -693,13 +692,15 @@ export async function runDoctorConfigPreflight(
       readConfigSnapshotForPreflight,
       shouldRecordStartupCheckpoint,
       shouldRecordStateCheckpoint,
-      snapshot,
+      snapshotRead: configSnapshotRead,
       startupMigrationEnv,
       startupMigrationHeartbeatError,
       startupMigrationLease,
       startupMigrationWarnings,
       stateMigrationsAllowed,
     });
+    snapshot = configSnapshotRead.snapshot;
+    baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
 
     return {
       snapshot,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This same-repository branch is available for maintainer edits.

</details>

## What Problem This Solves

Resolves repeated work during foreground Gateway startup: the final configuration read rebuilt plugin metadata that startup preflight had just verified. Baseline medians for this final read ranged from roughly 124–207 ms.

This is a bounded startup cache-ownership repair requested by a maintainer. No related issue is claimed fixed.

## Why This Change Was Made

Startup preflight now returns its final accepted config/metadata generation instead of discarding the post-convergence read. After successful foreground config preparation, the CLI carries that generation's existing cache into the final config reread. It does not publish Gateway activation policy early or introduce a second cache.

Config-file rereads, fresh persistence/convergence verification, migration leases, fingerprint/package checks, quarantine, and readiness work remain intact. Ordinary Doctor calls, service management, read-only diagnostics, invalid-config overrides, and failed preparation do not adopt the startup cache.

## User Impact

Foreground Gateway startup avoids one redundant plugin-metadata rebuild. The final config-read phase improved in all 40 measured A/B pairs, with medians falling to 3–4 ms. There are no new settings, environment variables, dependencies, schema changes, protocol changes, or operator steps.

**Overall startup and CPU improvement are not established.** Whole-startup results were mixed on the busy measurement host, and the unfavorable measurements are retained below. This PR claims the observed final-read improvement, not a startup-wide percentage reduction.

## Evidence

Measured the built Gateway before and after the patch against source baseline `ebd79690f2652eb24eb509d63d0fecc01af16baf`, using matched full builds and Node v24.19.0 on macOS arm64. There were **80 measured starts plus 12 excluded warmups**, using fresh temporary state and isolated loopback ports. Every start reached HTTP 200 on both `/healthz` and `/readyz`; loaded inventories matched at 17 plugins for default and 51 for the 50-fixture-plugin case. No runs were selectively retried or removed; the operator Gateway was not touched.

The readiness-only block retained ten paired measurements per fixture, with no CPU/RSS polling, preloads, or profiling:

| Fixture | Final config-read p50, before → after | Readiness p50, before → after | Faster readiness pairs |
| --- | ---: | ---: | ---: |
| Default | 194.7 → 4.35 ms (−97.8%) | 5.153 → 4.365 s (−15.3%) | 5/10 |
| 50 fixture plugins | 206.6 → 3.4 ms (−98.4%) | 4.950 → 4.725 s (−4.5%) | 6/10 |

Readiness means changed −6.3% for default but **+3.4%** for the 50-plugin fixture. Two retained process-stat blocks, pooled to ten pairs per fixture, showed worse readiness medians (+8.1%/+9.3%) and CPU medians (+2.1%/**+12.3%**, default/50 plugins). Their final config-read medians still improved from 124.35 → 4.25 ms and 184.2 → 3.5 ms. These blocks are not discarded or treated as proof of a total CPU benefit.

Separate main-thread Inspector profiles captured real startup through readiness and showed approximately 18% less weighted sampled time with visible plugin-metadata ancestry in both fixtures. That metric is neither OS CPU time nor a complete asynchronous phase duration. Diagnostic cache counts also confirmed that the 50-plugin fixture's early handoff did not discard populated SDK/module-loader memos; this does not explain away the adverse CPU result.

The new regression cases failed on the original code. After the fix, **138 tests across four files passed**, covering the final accepted generation, foreground variants, convergence drift, persistence, lease cleanup, invalid config, management/diagnostic isolation, and failed runtime-config preparation:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node --import ./scripts/tsx.mjs scripts/test-projects.mts \
  src/cli/program/config-guard.test.ts \
  src/commands/doctor-config-preflight.plugin-persistence.test.ts \
  src/commands/doctor-config-preflight.state-migration.test.ts \
  src/commands/doctor-config-preflight.state-migration-input.test.ts
```

Both revisions passed full `pnpm build`. Changed-file checks passed, including production/test typechecking, formatting, lint, dead exports, import cycles, plugin boundaries, and state/database guards:

```sh
node scripts/check-changed.mjs -- \
  src/cli/program/config-guard.ts \
  src/cli/program/config-guard.test.ts \
  src/commands/doctor-config-preflight-startup.ts \
  src/commands/doctor-config-preflight.ts \
  src/commands/doctor-config-preflight.plugin-persistence.test.ts
git diff --check
```

The same 138 focused tests and a full `pnpm build` also passed after moving the byte-identical five-file patch onto main `331d8a2265ff07d5db51e459c32d38c10fc7dc24`. Two additional isolated live startup smoke runs reached HTTP 200 on both endpoints, retained the expected 17/51-plugin inventories, and exited normally. Those two runs are correctness smoke tests, not part of the 80 measured starts above. That base includes the separate prepared-normalizer optimization in #136063; the A/B percentages above are tied to their original measured baseline, not presented as measurements against the newer main.

```sh
node --import ./scripts/tsx.mjs scripts/bench-gateway-startup.ts \
  --case default --case fiftyPlugins --runs 1 --warmup 0 \
  --output .artifacts/startup-performance/live-main-refresh.json
```

Refreshed changed-file checks also passed, including production/test typechecks, formatting, lint, all three dead-export scans, import cycles, plugin boundaries, and state/database guards. [Exact-head CI run 33606750778](https://github.com/openclaw/openclaw/actions/runs/33606750778) completed successfully for `345688564ebcce7e9a1d9ac57d0de69ada6dbf40`, including the required `openclaw/ci-gate`.

Production delta is **+15 lines** (39 added/24 removed); tests are **+74 lines** (81 added/7 removed). The production growth carries the accepted config/metadata owner across the existing preflight boundary; redundant parameters and duplicate success blocks were removed.

### Measurement limits and follow-up

These are source-checkout fixtures, not installed-package or OS-cold benchmarks. Host contention, synchronous process-stat sampling on the probe event loop, and CPU capture after readiness limit end-to-end conclusions. A quiet-host run with a defined CPU boundary is still needed before claiming startup-wide savings. The measurement tooling should move process-stat collection off the probe loop and avoid inherited worker profile-file collisions; this patch does not change those tools or weaken startup verification.
