### PR TITLE
fix(cli): keep secrets JSON failures machine-readable

### DIFF
--- a/src/cli/secrets-cli-output.ts
+++ b/src/cli/secrets-cli-output.ts
@@ -1,0 +1,29 @@
+import { defaultRuntime } from "../runtime.js";
+import { formatCliJsonFailure } from "./failure-output.js";
+import { exitCliAfterOutput } from "./one-shot-exit.js";
+
+/** Keep each secrets command's payload, failure envelope, and exit code in one path. */
+export async function runSecretsCommand<T>(
+  json: boolean | undefined,
+  run: () => Promise<T>,
+  renderHumanFailure: (error: unknown) => void,
+  failureExit: number | ((error: unknown) => { error: unknown; exitCode: number }),
+  jsonResult?: (result: T) => unknown,
+): Promise<T> {
+  try {
+    const result = await run();
+    if (json) {
+      defaultRuntime.writeJson(jsonResult ? jsonResult(result) : result);
+    }
+    return result;
+  } catch (error) {
+    const failure =
+      typeof failureExit === "function" ? failureExit(error) : { error, exitCode: failureExit };
+    if (json) {
+      defaultRuntime.writeJson(formatCliJsonFailure(failure.error));
+    } else {
+      renderHumanFailure(failure.error);
+    }
+    return exitCliAfterOutput(defaultRuntime, failure.exitCode);
+  }
+}

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -14,6 +14,7 @@ import {
 import { registerSecretsCli } from "./secrets-cli.js";
 
 const execFileAsync = promisify(execFile);
+const missingPlan = path.join(os.tmpdir(), "openclaw-secrets-cli-missing-plan.json");
 
 const mocks = await vi.hoisted(async () => {
   const { createCliRuntimeMock } = await import("./test-runtime-mock.js");
@@ -49,6 +50,11 @@ vi.mock("./gateway-rpc.js", () => ({
 
 vi.mock("../runtime.js", () => ({
   defaultRuntime: mocks.defaultRuntime,
+}));
+
+vi.mock("./one-shot-exit.js", () => ({
+  exitCliAfterOutput: (runtime: typeof mocks.defaultRuntime, exitCode: number) =>
+    runtime.exit(exitCode),
 }));
 
 vi.mock("../secrets/audit.js", () => ({
@@ -212,16 +218,50 @@ describe("secrets CLI", () => {
     expect(runtimeLogs.at(-1)).toContain('"ok": true');
   });
 
-  it("prints a JSON failure when reload fails in JSON mode", async () => {
-    callGatewayFromCli.mockRejectedValue(new Error("reload failed"));
+  it.each([
+    {
+      name: "reload",
+      prepare: () => callGatewayFromCli.mockRejectedValue(new Error("reload failed")),
+      args: ["secrets", "reload", "--json"],
+      exitCode: 1,
+      message: "reload failed",
+    },
+    {
+      name: "audit",
+      prepare: () => runSecretsAudit.mockRejectedValue(new Error("audit failed")),
+      args: ["secrets", "audit", "--json"],
+      exitCode: 2,
+      message: "audit failed",
+    },
+    {
+      name: "configure",
+      prepare: () =>
+        runSecretsConfigureInteractive.mockRejectedValue(new Error("configure failed")),
+      args: ["secrets", "configure", "--json"],
+      exitCode: 1,
+      message: "configure failed",
+    },
+    {
+      name: "apply",
+      prepare: async () => {
+        await fs.rm(missingPlan, { force: true });
+      },
+      args: ["secrets", "apply", "--from", missingPlan, "--json"],
+      exitCode: 1,
+      message: `Secrets plan file not found: ${missingPlan}`,
+    },
+  ])("prints one JSON failure when $name fails", async (testCase) => {
+    await testCase.prepare();
 
-    await expect(
-      createProgram().parseAsync(["secrets", "reload", "--json"], { from: "user" }),
-    ).rejects.toThrow("__exit__:1");
+    await expect(createProgram().parseAsync(testCase.args, { from: "user" })).rejects.toThrow(
+      `__exit__:${testCase.exitCode}`,
+    );
 
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+    expect(defaultRuntime.writeJson).toHaveBeenCalledTimes(1);
+    expect(runtimeLogs).toHaveLength(1);
+    expect(JSON.parse(runtimeLogs[0] ?? "")).toEqual({
       ok: false,
-      error: { type: "cli_error", message: "reload failed" },
+      error: { type: "cli_error", message: testCase.message },
     });
     expect(runtimeErrors).toHaveLength(0);
   });
@@ -245,8 +285,8 @@ describe("secrets CLI", () => {
     expect(runtimeErrors.at(-1)).not.toContain("diagnostics..");
   });
 
-  it("runs secrets audit and exits via check code", async () => {
-    runSecretsAudit.mockResolvedValue({
+  it("writes one audit report before exiting with the check code", async () => {
+    const report = {
       version: 1,
       status: "findings",
       filesScanned: [],
@@ -263,31 +303,53 @@ describe("secrets CLI", () => {
         resolvabilityComplete: true,
       },
       findings: [],
-    });
+    };
+    runSecretsAudit.mockResolvedValue(report);
     resolveSecretsAuditExitCode.mockReturnValue(1);
 
     await expect(
-      createProgram().parseAsync(["secrets", "audit", "--check"], { from: "user" }),
-    ).rejects.toThrow("__exit__:2");
+      createProgram().parseAsync(["secrets", "audit", "--check", "--json"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
     expect(mockFirstObjectArg(runSecretsAudit).allowExec).toBe(false);
     const exitCodeCall = mockCall(resolveSecretsAuditExitCode);
     if (exitCodeCall[0] === undefined) {
       throw new Error("Expected secrets audit result for exit-code resolution");
     }
     expect(exitCodeCall[1]).toBe(true);
+    expect(defaultRuntime.writeJson).toHaveBeenCalledTimes(1);
+    expect(mockFirstObjectArg(defaultRuntime.writeJson)).toBe(report);
+    expect(runtimeLogs).toHaveLength(1);
+    expect(runtimeErrors).toHaveLength(0);
   });
 
-  it("prints a JSON failure when audit fails in JSON mode", async () => {
-    runSecretsAudit.mockRejectedValue(new Error("audit failed"));
+  it("keeps an unresolved audit report intact at exit 2", async () => {
+    const report = {
+      version: 1,
+      status: "unresolved",
+      filesScanned: [],
+      summary: {
+        plaintextCount: 0,
+        unresolvedRefCount: 1,
+        shadowedRefCount: 0,
+        storeResidueCount: 0,
+        legacyResidueCount: 0,
+      },
+      resolution: {
+        refsChecked: 1,
+        skippedExecRefs: 0,
+        resolvabilityComplete: true,
+      },
+      findings: [],
+    };
+    runSecretsAudit.mockResolvedValue(report);
+    resolveSecretsAuditExitCode.mockReturnValue(2);
 
     await expect(
       createProgram().parseAsync(["secrets", "audit", "--json"], { from: "user" }),
     ).rejects.toThrow("__exit__:2");
 
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
-      ok: false,
-      error: { type: "cli_error", message: "audit failed" },
-    });
+    expect(defaultRuntime.writeJson).toHaveBeenCalledTimes(1);
+    expect(mockFirstObjectArg(defaultRuntime.writeJson)).toBe(report);
     expect(runtimeErrors).toHaveLength(0);
   });
 
@@ -352,40 +414,6 @@ describe("secrets CLI", () => {
       path: "skills.entries.qa-secret-test.apiKey",
     });
     expect(runtimeLogs.at(-1)).toContain("Secrets applied");
-  });
-
-  it("prints a JSON failure when configure fails in JSON mode", async () => {
-    runSecretsConfigureInteractive.mockRejectedValue(new Error("configure failed"));
-
-    await expect(
-      createProgram().parseAsync(["secrets", "configure", "--json"], { from: "user" }),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
-      ok: false,
-      error: { type: "cli_error", message: "configure failed" },
-    });
-    expect(runtimeErrors).toHaveLength(0);
-  });
-
-  it("prints a JSON failure when apply cannot read its plan in JSON mode", async () => {
-    const missingPlan = path.join(os.tmpdir(), "openclaw-secrets-cli-missing-plan.json");
-    await fs.rm(missingPlan, { force: true });
-
-    await expect(
-      createProgram().parseAsync(["secrets", "apply", "--from", missingPlan, "--json"], {
-        from: "user",
-      }),
-    ).rejects.toThrow("__exit__:1");
-
-    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
-      ok: false,
-      error: {
-        type: "cli_error",
-        message: `Secrets plan file not found: ${missingPlan}`,
-      },
-    });
-    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("emits one JSON document when --yes applies configure output", async () => {

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -212,6 +212,20 @@ describe("secrets CLI", () => {
     expect(runtimeLogs.at(-1)).toContain('"ok": true');
   });
 
+  it("prints a JSON failure when reload fails in JSON mode", async () => {
+    callGatewayFromCli.mockRejectedValue(new Error("reload failed"));
+
+    await expect(
+      createProgram().parseAsync(["secrets", "reload", "--json"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: "reload failed" },
+    });
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
   it("explains Gateway reload failures without duplicate doctor noise", async () => {
     callGatewayFromCli.mockRejectedValue(
       new Error(
@@ -261,6 +275,20 @@ describe("secrets CLI", () => {
       throw new Error("Expected secrets audit result for exit-code resolution");
     }
     expect(exitCodeCall[1]).toBe(true);
+  });
+
+  it("prints a JSON failure when audit fails in JSON mode", async () => {
+    runSecretsAudit.mockRejectedValue(new Error("audit failed"));
+
+    await expect(
+      createProgram().parseAsync(["secrets", "audit", "--json"], { from: "user" }),
+    ).rejects.toThrow("__exit__:2");
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: "audit failed" },
+    });
+    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("forwards --allow-exec to secrets audit", async () => {
@@ -324,6 +352,40 @@ describe("secrets CLI", () => {
       path: "skills.entries.qa-secret-test.apiKey",
     });
     expect(runtimeLogs.at(-1)).toContain("Secrets applied");
+  });
+
+  it("prints a JSON failure when configure fails in JSON mode", async () => {
+    runSecretsConfigureInteractive.mockRejectedValue(new Error("configure failed"));
+
+    await expect(
+      createProgram().parseAsync(["secrets", "configure", "--json"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: "configure failed" },
+    });
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("prints a JSON failure when apply cannot read its plan in JSON mode", async () => {
+    const missingPlan = path.join(os.tmpdir(), "openclaw-secrets-cli-missing-plan.json");
+    await fs.rm(missingPlan, { force: true });
+
+    await expect(
+      createProgram().parseAsync(["secrets", "apply", "--from", missingPlan, "--json"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: {
+        type: "cli_error",
+        message: `Secrets plan file not found: ${missingPlan}`,
+      },
+    });
+    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("emits one JSON document when --yes applies configure output", async () => {

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -9,8 +9,10 @@ import type { SecretsApplyPlan } from "../secrets/plan.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { formatCliCommand } from "./command-format.js";
 import { formatGatewayCommandFailure } from "./error-format.js";
-import { formatCliJsonFailure, rethrowExpectedCliError } from "./failure-output.js";
+import { rethrowExpectedCliError } from "./failure-output.js";
 import { addGatewayClientOptions, callGatewayFromCli, type GatewayRpcOpts } from "./gateway-rpc.js";
+import { exitCliAfterOutput } from "./one-shot-exit.js";
+import { runSecretsCommand } from "./secrets-cli-output.js";
 import { registerSecretStoreCli } from "./secrets-store-cli.js";
 
 type FsModule = typeof import("node:fs");
@@ -127,26 +129,13 @@ export function registerSecretsCli(program: Command): void {
       .description("Re-resolve secret references and atomically swap runtime snapshot")
       .option("--json", "Output JSON", false),
   ).action(async (opts: SecretsReloadOptions) => {
-    try {
-      const result = await callGatewayFromCli("secrets.reload", opts, undefined, {
-        expectFinal: false,
-      });
-      if (opts.json) {
-        defaultRuntime.writeJson(result);
-        return;
-      }
-      const warningCount = Number(
-        (result as { warningCount?: unknown } | undefined)?.warningCount ?? 0,
-      );
-      if (Number.isFinite(warningCount) && warningCount > 0) {
-        defaultRuntime.log(`Secrets reloaded with ${warningCount} warning(s).`);
-        return;
-      }
-      defaultRuntime.log("Secrets reloaded.");
-    } catch (err) {
-      if (opts.json) {
-        defaultRuntime.writeJson(formatCliJsonFailure(err));
-      } else {
+    const result = await runSecretsCommand(
+      opts.json,
+      () =>
+        callGatewayFromCli("secrets.reload", opts, undefined, {
+          expectFinal: false,
+        }),
+      (err) => {
         rethrowExpectedCliError(err);
         defaultRuntime.error(
           danger(
@@ -157,9 +146,20 @@ export function registerSecretsCli(program: Command): void {
             }),
           ),
         );
-      }
-      defaultRuntime.exit(1);
+      },
+      1,
+    );
+    if (opts.json) {
+      return;
     }
+    const warningCount = Number(
+      (result as { warningCount?: unknown } | undefined)?.warningCount ?? 0,
+    );
+    defaultRuntime.log(
+      Number.isFinite(warningCount) && warningCount > 0
+        ? `Secrets reloaded with ${warningCount} warning(s).`
+        : "Secrets reloaded.",
+    );
   });
 
   secrets
@@ -173,49 +173,49 @@ export function registerSecretsCli(program: Command): void {
     )
     .option("--json", "Output JSON", false)
     .action(async (opts: SecretsAuditOptions) => {
-      try {
-        const { resolveSecretsAuditExitCode, runSecretsAudit } =
-          await import("../secrets/audit.js");
-        const report = await runSecretsAudit({
-          allowExec: Boolean(opts.allowExec),
-        });
-        if (opts.json) {
-          defaultRuntime.writeJson(report);
-        } else {
-          defaultRuntime.log(
-            `Secrets audit: ${report.status}. plaintext=${report.summary.plaintextCount}, unresolved=${report.summary.unresolvedRefCount}, shadowed=${report.summary.shadowedRefCount}, storeResidue=${report.summary.storeResidueCount}, legacy=${report.summary.legacyResidueCount}.`,
-          );
-          if (report.findings.length > 0) {
-            for (const finding of report.findings.slice(0, 20)) {
-              defaultRuntime.log(
-                `- [${finding.code}] ${finding.file}:${finding.jsonPath} ${finding.message}`,
-              );
-            }
-            if (report.findings.length > 20) {
-              defaultRuntime.log(`... ${report.findings.length - 20} more finding(s).`);
-            }
-          }
-          if (report.resolution.skippedExecRefs > 0) {
-            defaultRuntime.log(
-              `Audit note: skipped ${report.resolution.skippedExecRefs} exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during audit.`,
-            );
-          }
-        }
-        const exitCode = resolveSecretsAuditExitCode(report, Boolean(opts.check));
-        if (exitCode !== 0) {
-          defaultRuntime.exit(exitCode);
-        }
-      } catch (err) {
-        if (opts.json) {
-          defaultRuntime.writeJson(formatCliJsonFailure(err));
-        } else {
+      const { report, exitCode } = await runSecretsCommand(
+        opts.json,
+        async () => {
+          const { resolveSecretsAuditExitCode, runSecretsAudit } =
+            await import("../secrets/audit.js");
+          const auditReport = await runSecretsAudit({
+            allowExec: Boolean(opts.allowExec),
+          });
+          return {
+            report: auditReport,
+            exitCode: resolveSecretsAuditExitCode(auditReport, Boolean(opts.check)),
+          };
+        },
+        (err) => {
           defaultRuntime.error(
             danger(
               `Secrets audit failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw doctor")} to inspect config and credential state.`,
             ),
           );
+        },
+        2,
+        (outcome) => outcome.report,
+      );
+      if (!opts.json) {
+        defaultRuntime.log(
+          `Secrets audit: ${report.status}. plaintext=${report.summary.plaintextCount}, unresolved=${report.summary.unresolvedRefCount}, shadowed=${report.summary.shadowedRefCount}, storeResidue=${report.summary.storeResidueCount}, legacy=${report.summary.legacyResidueCount}.`,
+        );
+        for (const finding of report.findings.slice(0, 20)) {
+          defaultRuntime.log(
+            `- [${finding.code}] ${finding.file}:${finding.jsonPath} ${finding.message}`,
+          );
         }
-        defaultRuntime.exit(2);
+        if (report.findings.length > 20) {
+          defaultRuntime.log(`... ${report.findings.length - 20} more finding(s).`);
+        }
+        if (report.resolution.skippedExecRefs > 0) {
+          defaultRuntime.log(
+            `Audit note: skipped ${report.resolution.skippedExecRefs} exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during audit.`,
+          );
+        }
+      }
+      if (exitCode !== 0) {
+        exitCliAfterOutput(defaultRuntime, exitCode);
       }
     });
 
@@ -242,111 +242,104 @@ export function registerSecretsCli(program: Command): void {
     .option("--plan-out <path>", "Write generated plan JSON to a file (max 16 MiB)")
     .option("--json", "Output JSON", false)
     .action(async (opts: SecretsConfigureOptions) => {
-      try {
-        const { runSecretsConfigureInteractive } = await import("../secrets/configure.js");
-        const configured = await runSecretsConfigureInteractive({
-          providersOnly: Boolean(opts.providersOnly),
-          skipProviderSetup: Boolean(opts.skipProviderSetup),
-          agentId: typeof opts.agent === "string" ? opts.agent : undefined,
-          allowExecInPreflight: Boolean(opts.allowExec),
-        });
-        if (opts.planOut) {
-          const { writeFileSync } = await fsModuleLoader.load();
-          writeFileSync(opts.planOut, serializePlanFile(configured.plan, opts.planOut), "utf8");
-        }
-
-        let shouldApply = Boolean(opts.apply || opts.yes);
-        if (opts.json) {
-          if (!shouldApply) {
-            defaultRuntime.writeJson({
-              plan: configured.plan,
-              preflight: configured.preflight,
-            });
+      await runSecretsCommand(
+        opts.json,
+        async () => {
+          const { runSecretsConfigureInteractive } = await import("../secrets/configure.js");
+          const configured = await runSecretsConfigureInteractive({
+            providersOnly: Boolean(opts.providersOnly),
+            skipProviderSetup: Boolean(opts.skipProviderSetup),
+            agentId: typeof opts.agent === "string" ? opts.agent : undefined,
+            allowExecInPreflight: Boolean(opts.allowExec),
+          });
+          if (opts.planOut) {
+            const { writeFileSync } = await fsModuleLoader.load();
+            writeFileSync(opts.planOut, serializePlanFile(configured.plan, opts.planOut), "utf8");
           }
-        } else {
-          defaultRuntime.log(
-            `Preflight: changed=${configured.preflight.changed}, files=${configured.preflight.changedFiles.length}, warnings=${configured.preflight.warningCount}.`,
-          );
-          if (configured.preflight.warningCount > 0) {
-            for (const warning of configured.preflight.warnings) {
-              defaultRuntime.log(`- warning: ${warning}`);
+
+          let shouldApply = Boolean(opts.apply || opts.yes);
+          if (!opts.json) {
+            defaultRuntime.log(
+              `Preflight: changed=${configured.preflight.changed}, files=${configured.preflight.changedFiles.length}, warnings=${configured.preflight.warningCount}.`,
+            );
+            if (configured.preflight.warningCount > 0) {
+              for (const warning of configured.preflight.warnings) {
+                defaultRuntime.log(`- warning: ${warning}`);
+              }
+            }
+            if (
+              !configured.preflight.checks.resolvabilityComplete &&
+              configured.preflight.skippedExecRefs > 0
+            ) {
+              defaultRuntime.log(
+                `Preflight note: skipped ${configured.preflight.skippedExecRefs} exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during preflight.`,
+              );
+            }
+            const providerUpserts = Object.keys(configured.plan.providerUpserts ?? {}).length;
+            const providerDeletes = configured.plan.providerDeletes?.length ?? 0;
+            defaultRuntime.log(
+              `Plan: targets=${configured.plan.targets.length}, providerUpserts=${providerUpserts}, providerDeletes=${providerDeletes}.`,
+            );
+            if (opts.planOut) {
+              defaultRuntime.log(`Plan written to ${opts.planOut}`);
             }
           }
-          if (
-            !configured.preflight.checks.resolvabilityComplete &&
-            configured.preflight.skippedExecRefs > 0
-          ) {
-            defaultRuntime.log(
-              `Preflight note: skipped ${configured.preflight.skippedExecRefs} exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during preflight.`,
-            );
-          }
-          const providerUpserts = Object.keys(configured.plan.providerUpserts ?? {}).length;
-          const providerDeletes = configured.plan.providerDeletes?.length ?? 0;
-          defaultRuntime.log(
-            `Plan: targets=${configured.plan.targets.length}, providerUpserts=${providerUpserts}, providerDeletes=${providerDeletes}.`,
-          );
-          if (opts.planOut) {
-            defaultRuntime.log(`Plan written to ${opts.planOut}`);
-          }
-        }
 
-        if (!shouldApply && !opts.json) {
-          const { confirm } = await clackPromptsLoader.load();
-          const approved = await confirm({
-            message: "Apply this plan now?",
-            initialValue: true,
-          });
-          if (typeof approved === "boolean") {
-            shouldApply = approved;
-          }
-        }
-        if (shouldApply) {
-          // Show the irreversibility warning whenever we are about to apply,
-          // including when the user opted in through the interactive "Apply
-          // this plan now?" confirm. Previously this checked opts.apply, so the
-          // one-way-migration warning was silently skipped on the interactive
-          // path (only --apply surfaced it). See #83883.
-          const needsIrreversiblePrompt = shouldApply;
-          if (needsIrreversiblePrompt && !opts.yes && !opts.json) {
+          if (!shouldApply && !opts.json) {
             const { confirm } = await clackPromptsLoader.load();
-            const confirmed = await confirm({
-              message:
-                "This migration is one-way for migrated plaintext values. Continue with apply?",
+            const approved = await confirm({
+              message: "Apply this plan now?",
               initialValue: true,
             });
-            if (confirmed !== true) {
-              defaultRuntime.log("Apply cancelled.");
-              return;
+            if (typeof approved === "boolean") {
+              shouldApply = approved;
             }
           }
-          const { runSecretsApply } = await secretsApplyLoader.load();
-          const result = await runSecretsApply({
-            plan: configured.plan,
-            write: true,
-            allowExec: Boolean(opts.allowExec),
-          });
-          if (opts.json) {
-            defaultRuntime.writeJson(result);
-            return;
+          if (shouldApply) {
+            // Show the irreversibility warning whenever we are about to apply,
+            // including when the user opted in through the interactive "Apply
+            // this plan now?" confirm. Previously this checked opts.apply, so the
+            // one-way-migration warning was silently skipped on the interactive
+            // path (only --apply surfaced it). See #83883.
+            if (!opts.yes && !opts.json) {
+              const { confirm } = await clackPromptsLoader.load();
+              const confirmed = await confirm({
+                message:
+                  "This migration is one-way for migrated plaintext values. Continue with apply?",
+                initialValue: true,
+              });
+              if (confirmed !== true) {
+                defaultRuntime.log("Apply cancelled.");
+                return { plan: configured.plan, preflight: configured.preflight };
+              }
+            }
+            const { runSecretsApply } = await secretsApplyLoader.load();
+            const result = await runSecretsApply({
+              plan: configured.plan,
+              write: true,
+              allowExec: Boolean(opts.allowExec),
+            });
+            if (!opts.json) {
+              defaultRuntime.log(
+                result.changed
+                  ? `Secrets applied. Updated ${result.changedFiles.length} file(s).`
+                  : "Secrets apply: no changes.",
+              );
+            }
+            return result;
           }
-          defaultRuntime.log(
-            result.changed
-              ? `Secrets applied. Updated ${result.changedFiles.length} file(s).`
-              : "Secrets apply: no changes.",
-          );
-        }
-      } catch (err) {
-        if (opts.json) {
-          defaultRuntime.writeJson(formatCliJsonFailure(err));
-        } else {
+
+          return { plan: configured.plan, preflight: configured.preflight };
+        },
+        (err) => {
           defaultRuntime.error(
             danger(
               `Secrets configure failed: ${formatErrorMessage(err)}. Re-run ${formatCliCommand("openclaw secrets audit")} before applying changes.`,
             ),
           );
-        }
-        defaultRuntime.exit(1);
-      }
+        },
+        1,
+      );
     });
 
   secrets
@@ -357,53 +350,52 @@ export function registerSecretsCli(program: Command): void {
     .option("--allow-exec", "Allow exec SecretRef checks (may execute provider commands)", false)
     .option("--json", "Output JSON", false)
     .action(async (opts: SecretsApplyOptions) => {
-      try {
-        const [{ runSecretsApply }, plan] = await Promise.all([
-          secretsApplyLoader.load(),
-          readPlanFile(opts.from),
-        ]);
-        const result = await runSecretsApply({
-          plan,
-          write: !opts.dryRun,
-          allowExec: Boolean(opts.allowExec),
-        });
-        if (opts.json) {
-          defaultRuntime.writeJson(result);
-          return;
-        }
-        if (opts.dryRun) {
-          defaultRuntime.log(
-            result.changed
-              ? `Secrets apply dry run: ${result.changedFiles.length} file(s) would change.`
-              : "Secrets apply dry run: no changes.",
-          );
-          if (!result.checks.resolvabilityComplete && result.skippedExecRefs > 0) {
-            defaultRuntime.log(
-              `Secrets apply dry-run note: skipped ${result.skippedExecRefs} exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during dry-run.`,
-            );
-          }
-          return;
-        }
-        defaultRuntime.log(
-          result.changed
-            ? `Secrets applied. Updated ${result.changedFiles.length} file(s).`
-            : "Secrets apply: no changes.",
-        );
-      } catch (err) {
-        // The missing-plan wrapper already carries a user-facing message. Keep its
-        // ENOENT cause available to diagnostics without rendering the raw filesystem error.
-        const message =
-          err instanceof SecretsPlanFileNotFoundError ? err.message : formatErrorMessage(err);
-        if (opts.json) {
-          defaultRuntime.writeJson(formatCliJsonFailure(err));
-        } else {
+      const result = await runSecretsCommand(
+        opts.json,
+        async () => {
+          const [{ runSecretsApply }, plan] = await Promise.all([
+            secretsApplyLoader.load(),
+            readPlanFile(opts.from),
+          ]);
+          return runSecretsApply({
+            plan,
+            write: !opts.dryRun,
+            allowExec: Boolean(opts.allowExec),
+          });
+        },
+        (err) => {
+          // The missing-plan wrapper already carries a user-facing message. Keep its
+          // ENOENT cause available to diagnostics without rendering the raw filesystem error.
+          const message =
+            err instanceof SecretsPlanFileNotFoundError ? err.message : formatErrorMessage(err);
           defaultRuntime.error(
             danger(
               `Secrets apply failed: ${message}. Re-run ${formatCliCommand("openclaw secrets apply --from <path> --dry-run")} to inspect the plan without writing.`,
             ),
           );
-        }
-        defaultRuntime.exit(1);
+        },
+        1,
+      );
+      if (opts.json) {
+        return;
       }
+      if (opts.dryRun) {
+        defaultRuntime.log(
+          result.changed
+            ? `Secrets apply dry run: ${result.changedFiles.length} file(s) would change.`
+            : "Secrets apply dry run: no changes.",
+        );
+        if (!result.checks.resolvabilityComplete && result.skippedExecRefs > 0) {
+          defaultRuntime.log(
+            `Secrets apply dry-run note: skipped ${result.skippedExecRefs} exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during dry-run.`,
+          );
+        }
+        return;
+      }
+      defaultRuntime.log(
+        result.changed
+          ? `Secrets applied. Updated ${result.changedFiles.length} file(s).`
+          : "Secrets apply: no changes.",
+      );
     });
 }

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -9,7 +9,7 @@ import type { SecretsApplyPlan } from "../secrets/plan.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { formatCliCommand } from "./command-format.js";
 import { formatGatewayCommandFailure } from "./error-format.js";
-import { rethrowExpectedCliError } from "./failure-output.js";
+import { formatCliJsonFailure, rethrowExpectedCliError } from "./failure-output.js";
 import { addGatewayClientOptions, callGatewayFromCli, type GatewayRpcOpts } from "./gateway-rpc.js";
 import { registerSecretStoreCli } from "./secrets-store-cli.js";
 
@@ -144,16 +144,20 @@ export function registerSecretsCli(program: Command): void {
       }
       defaultRuntime.log("Secrets reloaded.");
     } catch (err) {
-      rethrowExpectedCliError(err);
-      defaultRuntime.error(
-        danger(
-          formatGatewayCommandFailure({
-            action: "reload secrets",
-            error: err,
-            inspectCommand: "openclaw gateway status --deep",
-          }),
-        ),
-      );
+      if (opts.json) {
+        defaultRuntime.writeJson(formatCliJsonFailure(err));
+      } else {
+        rethrowExpectedCliError(err);
+        defaultRuntime.error(
+          danger(
+            formatGatewayCommandFailure({
+              action: "reload secrets",
+              error: err,
+              inspectCommand: "openclaw gateway status --deep",
+            }),
+          ),
+        );
+      }
       defaultRuntime.exit(1);
     }
   });
@@ -202,11 +206,15 @@ export function registerSecretsCli(program: Command): void {
           defaultRuntime.exit(exitCode);
         }
       } catch (err) {
-        defaultRuntime.error(
-          danger(
-            `Secrets audit failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw doctor")} to inspect config and credential state.`,
-          ),
-        );
+        if (opts.json) {
+          defaultRuntime.writeJson(formatCliJsonFailure(err));
+        } else {
+          defaultRuntime.error(
+            danger(
+              `Secrets audit failed: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw doctor")} to inspect config and credential state.`,
+            ),
+          );
+        }
         defaultRuntime.exit(2);
       }
     });
@@ -328,11 +336,15 @@ export function registerSecretsCli(program: Command): void {
           );
         }
       } catch (err) {
-        defaultRuntime.error(
-          danger(
-            `Secrets configure failed: ${formatErrorMessage(err)}. Re-run ${formatCliCommand("openclaw secrets audit")} before applying changes.`,
-          ),
-        );
+        if (opts.json) {
+          defaultRuntime.writeJson(formatCliJsonFailure(err));
+        } else {
+          defaultRuntime.error(
+            danger(
+              `Secrets configure failed: ${formatErrorMessage(err)}. Re-run ${formatCliCommand("openclaw secrets audit")} before applying changes.`,
+            ),
+          );
+        }
         defaultRuntime.exit(1);
       }
     });
@@ -382,11 +394,15 @@ export function registerSecretsCli(program: Command): void {
         // ENOENT cause available to diagnostics without rendering the raw filesystem error.
         const message =
           err instanceof SecretsPlanFileNotFoundError ? err.message : formatErrorMessage(err);
-        defaultRuntime.error(
-          danger(
-            `Secrets apply failed: ${message}. Re-run ${formatCliCommand("openclaw secrets apply --from <path> --dry-run")} to inspect the plan without writing.`,
-          ),
-        );
+        if (opts.json) {
+          defaultRuntime.writeJson(formatCliJsonFailure(err));
+        } else {
+          defaultRuntime.error(
+            danger(
+              `Secrets apply failed: ${message}. Re-run ${formatCliCommand("openclaw secrets apply --from <path> --dry-run")} to inspect the plan without writing.`,
+            ),
+          );
+        }
         defaultRuntime.exit(1);
       }
     });

--- a/src/cli/secrets-store-cli.test.ts
+++ b/src/cli/secrets-store-cli.test.ts
@@ -21,6 +21,10 @@ const mocks = await vi.hoisted(async () => {
 });
 
 vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
+vi.mock("./one-shot-exit.js", () => ({
+  exitCliAfterOutput: (runtime: typeof mocks.defaultRuntime, exitCode: number) =>
+    runtime.exit(exitCode),
+}));
 vi.mock("../secrets/store/secret-store.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../secrets/store/secret-store.js")>();
   return {
@@ -75,6 +79,31 @@ beforeEach(() => {
 });
 
 describe("secrets store CLI", () => {
+  it("writes JSON results for list and get", async () => {
+    mocks.list.mockReturnValueOnce([
+      { name: "SERVICE_MODE", kind: "env", valuePreview: "production" },
+    ]);
+    await createProgram().parseAsync(["secrets", "store", "list", "--json"], { from: "user" });
+
+    mocks.list.mockReturnValueOnce([{ name: "SERVICE_MODE", kind: "env" }]);
+    mocks.read.mockReturnValueOnce({ ok: true, value: "production" });
+    await createProgram().parseAsync(["secrets", "store", "get", "SERVICE_MODE", "--json"], {
+      from: "user",
+    });
+
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledTimes(2);
+    expect(mocks.runtimeLogs).toHaveLength(2);
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenNthCalledWith(1, [
+      { name: "SERVICE_MODE", kind: "env", valuePreview: "production" },
+    ]);
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenNthCalledWith(2, {
+      name: "SERVICE_MODE",
+      kind: "env",
+      value: "production",
+    });
+    expect(mocks.runtimeErrors).toHaveLength(0);
+  });
+
   it("shows non-secret allowed-host metadata in list output", async () => {
     mocks.list.mockReturnValue([
       {
@@ -237,20 +266,38 @@ describe("secrets store CLI", () => {
     expect(mocks.updateHosts).not.toHaveBeenCalled();
   });
 
-  it("returns exit 3 for a missing get and exit 1 for a database failure", async () => {
-    mocks.list.mockReturnValueOnce([]);
-    await expect(
-      createProgram().parseAsync(["secrets", "store", "get", "MISSING_VALUE"], {
-        from: "user",
-      }),
-    ).rejects.toThrow("__exit__:3");
+  it.each([
+    {
+      name: "missing get",
+      prepare: () => mocks.list.mockReturnValueOnce([]),
+      args: ["secrets", "store", "get", "MISSING_VALUE", "--json"],
+      exitCode: 3,
+      message: 'Secret store entry "MISSING_VALUE" was not found.',
+    },
+    {
+      name: "database failure",
+      prepare: () =>
+        mocks.list.mockImplementationOnce(() => {
+          throw new Error("database unavailable");
+        }),
+      args: ["secrets", "store", "list", "--json"],
+      exitCode: 1,
+      message: "database unavailable",
+    },
+  ])("writes one JSON failure for $name", async (testCase) => {
+    testCase.prepare();
 
-    mocks.list.mockImplementationOnce(() => {
-      throw new Error("database unavailable");
+    await expect(createProgram().parseAsync(testCase.args, { from: "user" })).rejects.toThrow(
+      `__exit__:${testCase.exitCode}`,
+    );
+
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledTimes(1);
+    expect(mocks.runtimeLogs).toHaveLength(1);
+    expect(JSON.parse(mocks.runtimeLogs[0] ?? "")).toEqual({
+      ok: false,
+      error: { type: "cli_error", message: testCase.message },
     });
-    await expect(
-      createProgram().parseAsync(["secrets", "store", "list"], { from: "user" }),
-    ).rejects.toThrow("__exit__:1");
+    expect(mocks.runtimeErrors).toHaveLength(0);
   });
 
   it("keeps rm idempotent when entries are already missing", async () => {

--- a/src/cli/secrets-store-cli.ts
+++ b/src/cli/secrets-store-cli.ts
@@ -10,6 +10,7 @@ import type {
   SecretStoreEntryMetadata,
   SecretStoreValidationError,
 } from "../secrets/store/secret-store.js";
+import { runSecretsCommand } from "./secrets-cli-output.js";
 
 type OutputOptions = { json?: boolean; plain?: boolean; scope?: string };
 type SetOptions = {
@@ -84,25 +85,26 @@ function mapStoreError(error: unknown): SecretStoreCliFailure {
   return new SecretStoreCliFailure(1, formatErrorMessage(error));
 }
 
-async function runStoreAction(action: () => Promise<void>): Promise<void> {
-  let failure: SecretStoreCliFailure | undefined;
-  try {
-    await action();
-  } catch (error) {
-    failure = mapStoreError(error);
+async function runStoreAction<T>(
+  action: () => Promise<T>,
+  json?: boolean,
+  renderHumanSuccess?: (result: T) => void,
+): Promise<void> {
+  const result = await runSecretsCommand(
+    json,
+    action,
+    (error) => defaultRuntime.error(danger(formatErrorMessage(error))),
+    (error) => {
+      const failure = mapStoreError(error);
+      return { error: failure, exitCode: failure.exitCode };
+    },
+  );
+  if (!json) {
+    renderHumanSuccess?.(result);
   }
-  if (!failure) {
-    return;
-  }
-  defaultRuntime.error(danger(failure.message));
-  defaultRuntime.exit(failure.exitCode);
 }
 
 function renderList(entries: SecretStoreEntryMetadata[], options: OutputOptions): void {
-  if (options.json) {
-    defaultRuntime.writeJson(entries);
-    return;
-  }
   if (options.plain) {
     for (const entry of entries) {
       defaultRuntime.writeStdout(
@@ -174,12 +176,16 @@ export function registerSecretStoreCli(secrets: Command): void {
     .option("--json", "Output JSON", false)
     .option("--plain", "Output tab-separated rows", false)
     .action((options: OutputOptions) =>
-      runStoreAction(async () => {
-        assertOutputMode(options);
-        const scope = teamScope(options.scope);
-        const { listSecretStoreEntries } = await import("../secrets/store/secret-store.js");
-        renderList(listSecretStoreEntries({ scope }), options);
-      }),
+      runStoreAction(
+        async () => {
+          assertOutputMode(options);
+          const scope = teamScope(options.scope);
+          const { listSecretStoreEntries } = await import("../secrets/store/secret-store.js");
+          return listSecretStoreEntries({ scope });
+        },
+        options.json,
+        (entries) => renderList(entries, options),
+      ),
     );
 
   store
@@ -292,37 +298,41 @@ export function registerSecretStoreCli(secrets: Command): void {
     .option("--json", "Output JSON", false)
     .option("--plain", "Output only the env value", false)
     .action((name: string, options: OutputOptions) =>
-      runStoreAction(async () => {
-        assertOutputMode(options);
-        assertStoreName(name);
-        const scope = teamScope(options.scope);
-        const { listSecretStoreEntries, readSecretStoreValue } =
-          await import("../secrets/store/secret-store.js");
-        const metadata = listSecretStoreEntries({ scope }).find((entry) => entry.name === name);
-        if (!metadata) {
-          throw new SecretStoreCliFailure(3, `Secret store entry "${name}" was not found.`);
-        }
-        if (metadata.kind === "secret") {
-          throw new SecretStoreCliFailure(
-            2,
-            `Secret store entry "${name}" is write-only by design. Reference it from config with a store SecretRef.`,
-          );
-        }
-        const result = readSecretStoreValue({ scope, name });
-        if (!result.ok) {
-          throw new SecretStoreCliFailure(
-            result.error.code === "SECRET_STORE_NOT_FOUND" ? 3 : 1,
-            result.error.message,
-          );
-        }
-        if (options.json) {
-          defaultRuntime.writeJson({ name, kind: metadata.kind, value: result.value });
-        } else if (options.plain) {
-          defaultRuntime.writeStdout(result.value);
-        } else {
-          defaultRuntime.log(`${name}=${result.value}`);
-        }
-      }),
+      runStoreAction(
+        async () => {
+          assertOutputMode(options);
+          assertStoreName(name);
+          const scope = teamScope(options.scope);
+          const { listSecretStoreEntries, readSecretStoreValue } =
+            await import("../secrets/store/secret-store.js");
+          const metadata = listSecretStoreEntries({ scope }).find((entry) => entry.name === name);
+          if (!metadata) {
+            throw new SecretStoreCliFailure(3, `Secret store entry "${name}" was not found.`);
+          }
+          if (metadata.kind === "secret") {
+            throw new SecretStoreCliFailure(
+              2,
+              `Secret store entry "${name}" is write-only by design. Reference it from config with a store SecretRef.`,
+            );
+          }
+          const result = readSecretStoreValue({ scope, name });
+          if (!result.ok) {
+            throw new SecretStoreCliFailure(
+              result.error.code === "SECRET_STORE_NOT_FOUND" ? 3 : 1,
+              result.error.message,
+            );
+          }
+          return { name, kind: metadata.kind, value: result.value };
+        },
+        options.json,
+        (result) => {
+          if (options.plain) {
+            defaultRuntime.writeStdout(result.value);
+          } else {
+            defaultRuntime.log(`${name}=${result.value}`);
+          }
+        },
+      ),
     );
 
   store

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -57,7 +57,8 @@ describe("cli json stdout contract", () => {
           const endpoint =
             env.OPENCLAW_TELEMETRY_ENDPOINT ?? "https://telemetry.openclaw.ai/api/latest-version";
           if (format === "JSON") {
-            expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+            expect(result.stdout, result.stderr).not.toContain("\u001B");
+            expect(result.stdout, result.stderr).not.toContain("\u0007");
             const payload = JSON.parse(result.stdout);
             expect(payload).toEqual({
               featureStatsEnabled: false,
@@ -212,7 +213,8 @@ describe("cli json stdout contract", () => {
           if ("human" in testCase) {
             expect(result.stdout).toBe("");
           } else {
-            expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+            expect(result.stdout, result.stderr).not.toContain("\u001B");
+            expect(result.stdout, result.stderr).not.toContain("\u0007");
             expect(JSON.parse(result.stdout)).toEqual({
               ok: false,
               error: { type: "cli_error", message: testCase.message },
@@ -245,6 +247,44 @@ describe("cli json stdout contract", () => {
         });
       },
       { prefix: "openclaw-json-failure-e2e-" },
+    );
+  });
+
+  it.each([
+    {
+      name: "secrets apply",
+      args: (tempHome: string) => [
+        "secrets",
+        "apply",
+        "--from",
+        path.join(tempHome, "missing-plan.json"),
+        "--json",
+      ],
+      status: 1,
+      message: (tempHome: string) =>
+        `Secrets plan file not found: ${path.join(tempHome, "missing-plan.json")}`,
+    },
+    {
+      name: "secrets store get",
+      args: () => ["secrets", "store", "get", "MISSING_VALUE", "--json"],
+      status: 3,
+      message: () => 'Secret store entry "MISSING_VALUE" was not found.',
+    },
+  ])("keeps $name failures machine-readable", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runBuiltCli(tempHome, testCase.args(tempHome), {
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+        });
+
+        expect(result.status, result.stderr).toBe(testCase.status);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: { type: "cli_error", message: testCase.message(tempHome) },
+        });
+        expect(result.stdout).not.toContain("[openclaw]");
+      },
+      { prefix: "openclaw-secrets-json-failure-e2e-" },
     );
   });
 
@@ -470,7 +510,8 @@ describe("cli json stdout contract", () => {
         expect(payload.error.message).toBe(
           'OpenClaw sessions has no command "lst".\nDid you mean this?\n  openclaw sessions list\nTry: openclaw sessions --help\nDocs: https://docs.openclaw.ai/cli',
         );
-        expect(payload.error.message).not.toMatch(/[\u001B\u0007]/u);
+        expect(payload.error.message).not.toContain("\u001B");
+        expect(payload.error.message).not.toContain("\u0007");
         expect(result.stdout).not.toContain("\\u001b");
         expect(result.stderr).toContain("\u001B[");
       },


### PR DESCRIPTION
## What Problem This Solves

`openclaw secrets ... --json` wrote plain-text terminal errors for command failures. Scripts received no JSON document on stdout.

The same defect also affected `secrets store list/get --json`. Valid `secrets audit --check --json` reports could be caught as operational failures in non-exiting runtimes.

## Root Cause

Each secrets command owned success and failure output separately. The store commands had another failure owner. Audit performed its nonzero result exit inside the operational catch.

## Fix

- Route secrets JSON success and failure through one result owner.
- Reuse the canonical sanitized CLI failure envelope.
- Exit only after the selected result is written and stdout can drain.
- Preserve human output and documented exit codes, including audit exits `1` and `2` and store-get exit `3`.
- Cover `reload`, `audit`, `configure`, `apply`, and store `list/get`.

No secret values are added to failures. No configuration, persistence schema, or security policy changes.

## Evidence

- Current main `0f553a2d60752dbc739812e4dcad92f3cf5281de`: missing-plan apply exited `1`, wrote empty stdout, and wrote plain text to stderr.
- Anti-cheat: changing the missing plan path changed the plain-text terminal failure.
- Exact head `980a5f9be0c40943bf52f38942fcdcc6ffbecc5a`: missing-plan apply exits `1` with one parsed JSON failure and empty stderr.
- Exact head: missing store get exits `3` with one parsed JSON failure and empty stderr.
- Exact head: empty store list exits `0` with one parsed JSON array and empty stderr.
- Human apply and store failures keep their prior text and exit codes.
- Regression tests fail eight cases on the recorded baseline and pass 43/43 on the repaired source.
- Focused formatting, lint, assertion-safety, dead-export, import-cycle, coercion, deprecated-API, and diff checks pass.

## Review Note

The ClawSweeper rank-up move is applied: the repeated mode guards were replaced with one result owner. Production growth creates that owner and covers the previously omitted store commands and audit outcome sequencing.
