### PR TITLE
test(ui): unify shared fixture cleanup ownership

### DIFF
--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -483,9 +483,13 @@ suite.define(() => {
             await expect.poll(() => thread.evaluate((element) => element.scrollTop)).toBe(0);
           }
           await expect.poll(() => bubble.count()).toBe(0);
-          await thread.evaluate((element, offset) => {
-            element.scrollTop = offset;
-          }, final.returnOffset);
+          // Returning is reader input: retire any still-reconciling latest command.
+          await thread.hover();
+          const returnDelta = await thread.evaluate(
+            (element, offset) => offset - element.scrollTop,
+            final.returnOffset,
+          );
+          await page.mouse.wheel(0, returnDelta);
           await bubble
             .getByText("Recovered paragraph 1.", { exact: false })
             .waitFor({ state: "visible" });

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -1,5 +1,6 @@
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, inject } from "vitest";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   captureControlUiE2eFailureDiagnostics,
@@ -102,11 +103,19 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
   let artifactDir: string | undefined;
 
   const closeBrowserContext = async (context: BrowserContext): Promise<void> => {
+    // Retain failed closes for the final browser teardown owner.
+    await context.close();
     openBrowserContexts.delete(context);
-    await context.close().catch(() => {});
   };
   const closeOpenBrowserContexts = async (): Promise<void> => {
-    await Promise.all([...openBrowserContexts].map((context) => closeBrowserContext(context)));
+    const [first, ...remaining] = openBrowserContexts;
+    if (!first) {
+      return;
+    }
+    await runQaGatewayFixture(
+      () => closeBrowserContext(first),
+      ...remaining.map((context) => () => closeBrowserContext(context)),
+    );
   };
   const newBrowserContext = async (
     contextOptions: Parameters<Browser["newContext"]>[0],
@@ -153,33 +162,25 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
           const startServer = options.startServer ?? startControlUiE2eServer;
           if (options.startServerBeforeBrowser) {
             server = await startServer();
-            try {
-              browser = await chromium.launch({
-                ...options.browserLaunchOptions,
-                executablePath: chromiumExecutablePath,
-              });
-            } catch (error) {
-              await server.close();
-              throw error;
-            }
+            browser = await chromium.launch({
+              ...options.browserLaunchOptions,
+              executablePath: chromiumExecutablePath,
+            });
           } else {
             browser = await chromium.launch({
               ...options.browserLaunchOptions,
               executablePath: chromiumExecutablePath,
             });
-            try {
-              server = await startServer();
-            } catch (error) {
-              await browser.close();
-              throw error;
-            }
+            server = await startServer();
           }
         });
 
         afterAll(async () => {
-          await closeOpenBrowserContexts();
-          await browser?.close();
-          await server?.close();
+          await runQaGatewayFixture(
+            closeOpenBrowserContexts,
+            () => browser?.close(),
+            () => server?.close(),
+          );
         });
 
         if (options.trackBrowserContexts) {
@@ -190,22 +191,28 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
       });
     },
     newBrowserContext,
-    async withPage(contextOptions, run) {
+    async withPage<T>(
+      contextOptions: Parameters<Browser["newContext"]>[0],
+      run: (fixture: ControlUiE2ePage) => Promise<T>,
+    ) {
       const context = await newBrowserContext(contextOptions);
-      try {
-        const page = await context.newPage();
-        try {
-          return await run({ context, page });
-        } catch (error) {
-          await captureControlUiE2eFailureDiagnostics(page, {
-            error: error instanceof Error ? error : new Error(String(error)),
-            label: options.name,
-          });
-          throw error;
-        }
-      } finally {
-        await closeBrowserContext(context);
-      }
+      let result!: T;
+      await runQaGatewayFixture(
+        async () => {
+          const page = await context.newPage();
+          try {
+            result = await run({ context, page });
+          } catch (error) {
+            await captureControlUiE2eFailureDiagnostics(page, {
+              error: error instanceof Error ? error : new Error(String(error)),
+              label: options.name,
+            });
+            throw error;
+          }
+        },
+        () => closeBrowserContext(context),
+      );
+      return result;
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves
The shared Control UI E2E fixture could leave its source Vite server listening when browser teardown rejected. It also swallowed context-close failures and duplicated counterpart cleanup in startup catches, masking the original setup error when cleanup failed.

## Why This Change Was Made

Use the existing ordered fixture cleanup helper for contexts, browser and server. Keep failed context closes owned until final teardown, retain both callback and cleanup errors, and let Vitest's existing `afterAll` guarantee own partial startup cleanup. Both acquisition orders and successful `withPage` return values remain intact.

## User Impact

Test infrastructure only. Cleanup failures stay visible, all acquired owners receive cleanup, and the transcript geometry test returns through native reader input instead of competing with a still-active scroll command.

## Evidence
Same pinned Linux Testbox, canonical UI E2E runner, installed Playwright 1.62.1 and Vitest 4.1.11:

- Approval bootstrap, all settings skeleton cases and tracked Home-attention context: 18/18 before and after, identical case names/order. Complete runner 29.66s before, 30.14s after; no ordinary speed improvement claimed.
- Browser-close rejection after real Chromium closure: original left the real Vite listener open; candidate closed it and propagated the same error.
- Callback failure plus context-close rejection after real closure: original lost the close error; candidate retained both exact error identities and final ownership.
- Both startup orders, with second acquisition rejected and acquired-owner close rejected: original masked startup and closed the counterpart twice; candidate retained separate setup/teardown failures and closed once.

All eight deliberate fault runs failed as expected. Existing approval assertions completed before body/teardown faults; setup failures kept the original case present and skipped. Exact native browser/context/page and Vite handles were observed before rescue; original leaked owners were then closed through saved native handles. Every command group exited, all private instrumentation was removed, and all source hashes were restored.

    node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/approval-bootstrap.e2e.test.ts ui/src/e2e/settings-loading-skeletons.e2e.test.ts ui/src/e2e/home-attention.e2e.test.ts

The installed Vitest runner calls `afterAll` from `finally` after a failed `beforeAll`, and appends each phase's error. Playwright awaits native context/browser closure; Vite closes its owned listener. These dependency contracts were read directly and exercised above. No new mirrored cleanup-loop tests, product behavior, mocks, timeouts or configuration surfaces are introduced. Production LOC +0/-0; test support +42/-35.

The separate Vite acquisition gap before `startControlUiE2eServer` returns remains a follow-up; this change owns resources after acquisition. Failed or timed-out in-flight acquisition is not claimed as covered.

Local formatting, guard ratchets, graph boundary, i18n, typed lint, coercion and dead-export checks passed. The full local UI type graph stops on the existing missing Mermaid dependency in this worktree; exact-head hosted CI must pass before landing. The final scoped Codex P0 review reported no actionable findings.

ClawSweeper found no actionable code defect; its remaining concern was inability to install Vitest in its review environment. Maintainer inspection verified the installed `@vitest/runner` 4.1.11 implementation directly: `dist/chunk-artifact.js:3139-3144` records setup failure, `:3168-3180` executes `afterAll` inside `finally`, and `:3059-3076` appends each phase error. The real Testbox receipts for both removed startup catches were:

```json
[
  {
    "variant": "before-setup-server-first",
    "rejectedPhases": [
      {
        "phase": "beforeAll",
        "errorIdentity": "close"
      }
    ],
    "closeCalls": 2,
    "serverListenersClosed": true,
    "browsersDisconnected": true
  },
  {
    "variant": "after-setup-server-first",
    "rejectedPhases": [
      {
        "phase": "beforeAll",
        "errorIdentity": "startup"
      },
      {
        "phase": "afterAll",
        "errorIdentity": "close"
      }
    ],
    "closeCalls": 1,
    "serverListenersClosed": true,
    "browsersDisconnected": true
  },
  {
    "variant": "before-setup-browser-first",
    "rejectedPhases": [
      {
        "phase": "beforeAll",
        "errorIdentity": "close"
      }
    ],
    "closeCalls": 2,
    "serverListenersClosed": true,
    "browsersDisconnected": true
  },
  {
    "variant": "after-setup-browser-first",
    "rejectedPhases": [
      {
        "phase": "beforeAll",
        "errorIdentity": "startup"
      },
      {
        "phase": "afterAll",
        "errorIdentity": "close"
      }
    ],
    "closeCalls": 1,
    "serverListenersClosed": true,
    "browsersDisconnected": true
  }
]
```

All eight fault runs retained their expected nonzero exit; all 118 receipt checks passed. The reviewer environment gap is covered by direct installed-source inspection and real owner observations. No rank-up implementation change was requested. Exact-head CI must complete before merge.

## CI repair and branch refresh

The initial exact-head CI at `83ba15d2e1d93cd1eb34bfa27945ae997ec840e9` exposed two existing test problems. The SDK declaration relocation fixture failed identically on Linux and Windows; rebasing onto main includes its upstream repair in `5e6117d17d92dcac2ef6da6d609eb423b089a77a`. No duplicate SDK change is part of this PR. The superseded run was cancelled after recording these failures; fresh CI is required on the final head.

The disclosure-anchor test reached its recovered row after a raw `scrollTop` assignment, then lost it before the return-geometry assertion. The current virtualizer intentionally retains smooth-scroll ownership until settled or interrupted by reader input. Replace that return assignment with a real wheel delta so its normal input owner cancels the earlier command. All eight cases, reduced-motion variants, pointer checks, the 5.5-second reconciliation check, exact returned height, and adjacency assertions remain.

Complete real-browser proof at rebased `b810df78f84b878b50d66de1e2f9eea7f16b29ce`: original 8/8 passed in 29.135s; candidate 8/8 passed in 31.774s. The CI race did not recur in that original run, and this repair claims no speed gain. Both command groups exited and the temporary source overlay was restored. A fresh worker initially lacked FFmpeg; the recorded-video tests were rerun after installing Playwright’s FFmpeg dependency, with the failed prerequisite runs retained separately.

The final two-file scope is test/test-support +49/-38 and application production +0/-0. Formatting, scoped typed lint and fresh Codex review passed. Source inspection covers the complete virtualizer host, its cancellation/near-end sibling tests, and installed TanStack 3.17.8 and Playwright 1.62.1 input contracts. No production owner, deadline, assertion, or browser motion setting changed.

### CI follow-up

The full manual run on this final head passed. Native preparation also identified an earlier failed PR-triggered run (33610520774): `update-managed-service-handoff-lifecycle.test.ts` returned helper exit 1 instead of 7 in the launchd recovery/relative-input case. Its failure branch reports stderr but omits the helper log, so the retained output does not establish the cause. This is outside the UI fixture change; the same head later passed its complete infra lane. The failed scheduled job and dependent CI gate passed on attempt 2 through the normal failed-job rerun (33610520774). Named follow-up: preserve helper-log diagnostics for the transferred-control branch and investigate the unexpected recovery exit if it recurs.
