### PR TITLE
fix(e2e): prevent macOS tooling from breaking Linux upgrade proofs

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -838,14 +838,9 @@ seed_state() {
 }
 
 apply_baseline_config_recipe() {
-  local tsx_import="${OPENCLAW_UPGRADE_SURVIVOR_TSX_IMPORT:-tsx}"
-  local recipe_runner=(
-    node --import "$tsx_import" scripts/e2e/lib/upgrade-survivor/config-recipe.mts
-  )
-  if [ ! -f scripts/e2e/lib/upgrade-survivor/config-recipe.mts ]; then
-    recipe_runner=(node scripts/e2e/lib/upgrade-survivor/config-recipe.mjs)
-  fi
-  "${recipe_runner[@]}" apply \
+  # Source recipes need the runner's native tsx, not a host dependency mount.
+  openclaw_e2e_run_script_entrypoint \
+    scripts/e2e/lib/upgrade-survivor/config-recipe apply \
     --summary "$CONFIG_COVERAGE_JSON" \
     --baseline-version "$baseline_version"
 }

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -234,12 +234,6 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
   fi
 
   OPENCLAW_TEST_STATE_FUNCTION_B64="$(docker_e2e_test_state_function_b64)"
-  TRUSTED_TSX_NODE_MODULES="$HARNESS_ROOT_DIR/node_modules"
-  TRUSTED_TSX_IMPORT="$TRUSTED_TSX_NODE_MODULES/tsx/dist/loader.mjs"
-  if [ ! -f "$TRUSTED_TSX_IMPORT" ]; then
-    echo "Trusted upgrade-survivor tsx loader not found: $TRUSTED_TSX_IMPORT" >&2
-    exit 1
-  fi
 
   docker_e2e_build_or_reuse "$IMAGE_NAME" upgrade-survivor "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" "bare" "$SKIP_BUILD"
 
@@ -260,7 +254,6 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -e OPENCLAW_UPGRADE_SURVIVOR_VOLUME_IDEMPOTENCE_BUDGET_SECONDS="${OPENCLAW_UPGRADE_SURVIVOR_VOLUME_IDEMPOTENCE_BUDGET_SECONDS:-60}" \
     -e OPENCLAW_UPGRADE_SURVIVOR_LEGACY_RUNTIME_DEPS_SYMLINK="${OPENCLAW_UPGRADE_SURVIVOR_LEGACY_RUNTIME_DEPS_SYMLINK:-}" \
     -e OPENCLAW_UPGRADE_SURVIVOR_ROOT_MANAGED_VPS="$ROOT_MANAGED_VPS" \
-    -e OPENCLAW_UPGRADE_SURVIVOR_TSX_IMPORT=/tmp/openclaw-release-harness/node_modules/tsx/dist/loader.mjs \
     -e OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON=/tmp/openclaw-upgrade-survivor-artifacts/summary.json \
     -e OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS="$START_BUDGET_SECONDS" \
     -e OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS="$STATUS_BUDGET_SECONDS" \
@@ -269,7 +262,6 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     "${PROBE_ENV_ARGS[@]}" \
     ${LIVE_OPENAI_ENV_ARGS[@]+"${LIVE_OPENAI_ENV_ARGS[@]}"} \
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
-    -v "$TRUSTED_TSX_NODE_MODULES:/tmp/openclaw-release-harness/node_modules:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/config-parking.mjs:/tmp/openclaw-config-parking.mjs:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro" \

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -6,12 +6,12 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CONFIG_COMMAND_MAX_BUFFER_BYTES,
@@ -30,69 +30,88 @@ const RUN_PATH = "scripts/e2e/lib/upgrade-survivor/run.sh";
 const DOCKER_RUNNER_PATH = "scripts/e2e/upgrade-survivor-docker.sh";
 
 describe("upgrade survivor config recipe command resolution", () => {
-  it("uses trusted tsx or the candidate compiled config recipe entrypoint", () => {
+  it("selects the prerelease update channel for the plugin registry", () => {
     const runner = readFileSync(RUN_PATH, "utf8");
-    const dockerRunner = readFileSync(DOCKER_RUNNER_PATH, "utf8");
-    expect(runner).toContain("OPENCLAW_UPGRADE_SURVIVOR_TSX_IMPORT:-tsx");
-    expect(runner).toContain(
-      'node --import "$tsx_import" scripts/e2e/lib/upgrade-survivor/config-recipe.mts',
-    );
-    expect(runner).toContain(
-      "recipe_runner=(node scripts/e2e/lib/upgrade-survivor/config-recipe.mjs)",
-    );
     expect(runner).toContain('OPENCLAW_UPGRADE_SURVIVOR_UPDATE_CHANNEL="beta"');
     expect(runner).toContain("OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION");
-    expect(runner).toContain('"${recipe_runner[@]}" apply');
-    expect(dockerRunner).toContain(
-      'TRUSTED_TSX_IMPORT="$TRUSTED_TSX_NODE_MODULES/tsx/dist/loader.mjs"',
-    );
   });
 
-  it("keeps trusted tsx dependencies resolvable at the Docker mount target", () => {
-    const dockerRunner = readFileSync(DOCKER_RUNNER_PATH, "utf8");
-    const loaderTarget = dockerRunner.match(
-      /OPENCLAW_UPGRADE_SURVIVOR_TSX_IMPORT=(\/tmp\/\S+\/loader\.mjs)/u,
-    )?.[1];
-    const mountTarget = dockerRunner.match(
-      /-v "\$TRUSTED_TSX_NODE_MODULES:(\/tmp\/[^:"]+):ro"/u,
-    )?.[1];
-    expect(loaderTarget).toBeTruthy();
-    expect(mountTarget).toBeTruthy();
-    if (!loaderTarget || !mountTarget) {
-      return;
-    }
+  it.skipIf(process.platform === "win32")(
+    "launches the published baseline with trusted sources and no host dependencies",
+    () => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "openclaw-upgrade-docker-boundary-")));
+      const harnessRoot = realpathSync(process.cwd());
+      try {
+        const candidateRoot = join(root, "candidate");
+        const binDir = join(root, "bin");
+        const candidate = join(candidateRoot, "candidate.tgz");
+        const stateScript = "scripts/lib/openclaw-test-state.mts";
+        mkdirSync(join(candidateRoot, dirname(stateScript)), { recursive: true });
+        cpSync(stateScript, join(candidateRoot, stateScript));
+        writeFileSync(candidate, "unused by the Docker boundary stub");
+        mkdirSync(binDir);
+        writeFileSync(
+          join(binDir, "docker"),
+          `#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  image) test "$2" = inspect ;;
+  run) printf '%s\\0' "$@" >"$TMPDIR/docker-args" ;;
+  *) echo "Unexpected Docker command: $1" >&2; exit 1 ;;
+esac
+`,
+          { mode: 0o755 },
+        );
 
-    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-tsx-mount-"));
-    try {
-      const mountedNodeModules = join(root, mountTarget.slice(1));
-      mkdirSync(mountedNodeModules, { recursive: true });
-      const tsxManifest = createRequire(import.meta.url).resolve("tsx/package.json");
-      const esbuildManifest = createRequire(tsxManifest).resolve("esbuild/package.json");
-      const nativePackage = `@esbuild/${process.platform}-${process.arch}`;
-      const nativeManifest = createRequire(esbuildManifest).resolve(
-        `${nativePackage}/package.json`,
-      );
-      for (const [packageName, manifest] of [
-        ["tsx", tsxManifest],
-        ["esbuild", esbuildManifest],
-        [nativePackage, nativeManifest],
-      ] as const) {
-        cpSync(dirname(manifest), join(mountedNodeModules, packageName), {
-          dereference: true,
-          recursive: true,
+        const result = spawnSync("bash", [join(harnessRoot, DOCKER_RUNNER_PATH)], {
+          cwd: root,
+          encoding: "utf8",
+          env: {
+            HOME: root,
+            TMPDIR: root,
+            PATH: [binDir, dirname(process.execPath), process.env.PATH ?? ""].join(delimiter),
+            OPENCLAW_SKIP_DOCKER_BUILD: "1",
+            OPENCLAW_DOCKER_E2E_REPO_ROOT: candidateRoot,
+            OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR: join(root, "artifacts"),
+            OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE: "1",
+            OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: "openclaw@2026.7.1-2",
+            OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE: candidate,
+          },
         });
+        expect(result.status, result.stdout + result.stderr).toBe(0);
+        const args = readFileSync(join(root, "docker-args"), "utf8").split("\0").slice(0, -1);
+        const mounts = args.filter((_, index) => args[index - 1] === "-v");
+        expect(mounts.filter((mount) => mount.includes("node_modules"))).toEqual([]);
+        expect(args.some((arg) => arg.startsWith("OPENCLAW_UPGRADE_SURVIVOR_TSX_IMPORT="))).toBe(
+          false,
+        );
+        expect(mounts).toEqual(
+          expect.arrayContaining([
+            `${harnessRoot}/scripts/e2e:/app/scripts/e2e:ro`,
+            `${harnessRoot}/scripts/lib:/app/scripts/lib:ro`,
+            `${harnessRoot}/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro`,
+            `${harnessRoot}/${RUN_PATH}:/tmp/openclaw-upgrade-survivor-run.sh:ro`,
+            `${candidate}:/tmp/openclaw-current.tgz:ro`,
+          ]),
+        );
+        expect(mounts.filter((mount) => mount.startsWith(`${candidateRoot}/`))).toEqual([
+          `${candidate}:/tmp/openclaw-current.tgz:ro`,
+        ]);
+        expect(args).toContain(
+          "OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE_SPEC=/tmp/openclaw-current.tgz",
+        );
+        expect(args.slice(-5)).toEqual([
+          "timeout",
+          "--kill-after=30s",
+          "1200s",
+          "bash",
+          "/tmp/openclaw-upgrade-survivor-run.sh",
+        ]);
+      } finally {
+        rmSync(root, { force: true, recursive: true });
       }
-
-      const loaderPath = join(root, loaderTarget.slice(1));
-      const result = spawnSync(process.execPath, ["--import", loaderPath, "-e", ""], {
-        cwd: root,
-        encoding: "utf8",
-      });
-      expect(result.status, result.stderr).toBe(0);
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
+    },
+  );
 
   it("compares baseline versions with the shared release parser", () => {
     expect(isReleaseBefore("2026.3.31", "2026.4.0")).toBe(true);
@@ -320,34 +339,36 @@ describe("upgrade survivor config recipe command resolution", () => {
     });
   });
 
-  it("skips ACPX bridge config on baselines before the bridge field existed", () => {
-    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-recipe-acpx-"));
-    try {
-      const binDir = join(root, "bin");
-      const logPath = join(root, "openclaw-argv.jsonl");
-      const summaryPath = join(root, "summary.json");
-      mkdirSync(binDir, { recursive: true });
-      const openclawLogPath = join(binDir, "openclaw-log.js");
-      const openclawPath = join(binDir, "openclaw");
-      const openclawCmdPath = join(binDir, "openclaw.cmd");
-      writeFileSync(
-        openclawLogPath,
-        `
+  it.each(process.platform === "win32" ? ["recipe CLI"] : ["recipe CLI", "survivor shell"])(
+    "skips unsupported ACPX bridge config through the %s",
+    (entrypoint) => {
+      const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-recipe-acpx-"));
+      try {
+        const binDir = join(root, "bin");
+        const logPath = join(root, "openclaw-argv.jsonl");
+        const summaryPath = join(root, "summary.json");
+        mkdirSync(binDir, { recursive: true });
+        const openclawLogPath = join(binDir, "openclaw-log.js");
+        const openclawPath = join(binDir, "openclaw");
+        const openclawCmdPath = join(binDir, "openclaw.cmd");
+        writeFileSync(
+          openclawLogPath,
+          `
 const fs = require("node:fs");
 fs.appendFileSync(${JSON.stringify(logPath)}, JSON.stringify(process.argv.slice(2)) + "\\n");
 process.exit(0);
 `,
-      );
-      writeFileSync(openclawPath, `#!/usr/bin/env node\nrequire("./openclaw-log.js");\n`);
-      chmodSync(openclawPath, 0o755);
-      writeFileSync(
-        openclawCmdPath,
-        `@echo off\r\n"${process.execPath}" "%~dp0openclaw-log.js" %*\r\n`,
-      );
+        );
+        writeFileSync(openclawPath, `#!/usr/bin/env node\nrequire("./openclaw-log.js");\n`);
+        chmodSync(openclawPath, 0o755);
+        writeFileSync(
+          openclawCmdPath,
+          `@echo off\r\n"${process.execPath}" "%~dp0openclaw-log.js" %*\r\n`,
+        );
 
-      execFileSync(
-        process.execPath,
-        [
+        let command = process.execPath;
+        let cwd = process.cwd();
+        let args = [
           "--import",
           "tsx",
           RECIPE_PATH,
@@ -356,32 +377,62 @@ process.exit(0);
           summaryPath,
           "--baseline-version",
           "2026.4.21",
-        ],
-        {
+        ];
+        if (entrypoint === "survivor shell") {
+          // Source mounts contain the recipe closure, but no host dependency tree.
+          for (const file of [
+            RECIPE_PATH,
+            "scripts/e2e/lib/upgrade-survivor/config-recipe",
+            "scripts/lib/release-version.mjs",
+            "scripts/windows-cmd-helpers.mjs",
+          ]) {
+            mkdirSync(dirname(join(root, file)), { recursive: true });
+            cpSync(file, join(root, file), { recursive: true });
+          }
+          const launcher = readFileSync(RUN_PATH, "utf8").match(
+            /^apply_baseline_config_recipe\(\) \{[\s\S]*?^\}/mu,
+          )?.[0];
+          expect(launcher).toBeTruthy();
+          command = "bash";
+          cwd = root;
+          args = [
+            "-c",
+            `set -euo pipefail\nsource "$1"\n${launcher}\nCONFIG_COVERAGE_JSON="$2"\nbaseline_version=2026.4.21\napply_baseline_config_recipe`,
+            "survivor-recipe",
+            join(process.cwd(), "scripts/lib/openclaw-e2e-instance.sh"),
+            summaryPath,
+          ];
+        }
+        execFileSync(command, args, {
+          cwd,
           env: {
             ...process.env,
             OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "acpx-openclaw-tools-bridge",
-            PATH: `${binDir}${process.platform === "win32" ? ";" : ":"}${process.env.PATH ?? ""}`,
+            PATH: [binDir, join(process.cwd(), "node_modules/.bin"), process.env.PATH ?? ""].join(
+              delimiter,
+            ),
           },
           stdio: "pipe",
-        },
-      );
+        });
 
-      const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
-      const loggedArgs = readFileSync(logPath, "utf8")
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line));
-      expect(summary.skippedIntents).toContain("acpx-openclaw-tools-bridge");
-      expect(loggedArgs).not.toContainEqual(
-        expect.arrayContaining([
-          "set",
-          "plugins",
-          expect.stringContaining("openClawToolsMcpBridge"),
-        ]),
-      );
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
+        const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+        const loggedArgs = readFileSync(logPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(summary.skippedIntents).toContain("acpx-openclaw-tools-bridge");
+        expect(summary.baselineVersion).toBe("2026.4.21");
+        expect(loggedArgs.at(-1)).toEqual(["config", "validate"]);
+        expect(loggedArgs).not.toContainEqual(
+          expect.arrayContaining([
+            "set",
+            "plugins",
+            expect.stringContaining("openClawToolsMcpBridge"),
+          ]),
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
 });

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -262,10 +262,10 @@ esac
   it.each([null, "2026.8.1-beta.2", "2026.8.1"])(
     "authors a schema-valid explicit agent roster for baseline %s",
     (version) => {
-      const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
+      const agentStep = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
         (step) => step.id === "agents",
       );
-      const agents = JSON.parse(step?.argv[3] ?? "{}");
+      const agents = JSON.parse(agentStep?.argv[3] ?? "{}");
       expect(AgentsSchema.safeParse(agents).success).toBe(true);
       expect(agents.ownership).toBe("explicit");
       expect(agents.defaults.heartbeat.every).toBe("0m");
@@ -277,10 +277,10 @@ esac
   it.each(["2026.3.13", "2026.4.1", "2026.8.1-beta.1"])(
     "preserves the legacy agent contract for baseline %s",
     (version) => {
-      const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
+      const agentStep = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
         (step) => step.id === "agents",
       );
-      const agents = JSON.parse(step?.argv[3] ?? "{}");
+      const agents = JSON.parse(agentStep?.argv[3] ?? "{}");
       expect(agents.ownership).toBeUndefined();
       expect(agents.entries).toBeUndefined();
       expect(agents.list.map((agent: { id: string }) => agent.id)).toEqual(["main", "ops"]);


### PR DESCRIPTION
Closes #136128 — published-baseline upgrade proofs fail on macOS hosts before exercising the updater.

<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where developers running published upgrade-survivor proofs from macOS hit an esbuild platform error inside the Linux container after baseline installation, before the update is exercised. The old same-host loader-import test did not detect this cross-platform failure.

## Why This Change Was Made

Use the Linux-native tsx already installed by the shared Docker runner instead of binding the host's `node_modules` into Linux. Reuse the existing source/compiled script-entrypoint launcher, preserving frozen `.mjs` support, trusted source mounts, candidate/harness separation, and failure propagation. No additional dependency installation, new option, product change, or weakened scenario assertion is needed.

## User Impact

Mac-host/Linux-container published upgrade validation reaches the real updater instead of failing in harness tooling. No application runtime or operator configuration changes. The original failure was a harness defect, not evidence that the package updater failed at that point.

Tooling: **+3/-16, net -13**. Product/runtime: **0**. Tests: **+157/-106, net +51**, including table-driven setup reindentation and two pre-existing shadowed-variable names corrected for the newer test-root lint gate.

## Evidence

- Actual outer shell entrypoint regression with Docker mocked only at its process boundary and distinct harness/candidate roots; no host dependency mount, trusted source mounts retained. A source-only recipe case also exercises the real launcher without fixture-local `node_modules`.
- Before repair: **2 failed / 25 passed**, specifically the host dependency mount and package-local tsx resolution. After repair and integration with current main: **27 passed**.
- **4 selected shared-helper tests passed**, covering source/frozen entrypoints, source mounts, and host-only diagnostics/failure propagation. The remaining cases were intentionally outside the selection.
- Real Darwin/ARM64-host → Linux/ARM64-container reproduction failed with `@esbuild/darwin-arm64` where `@esbuild/linux-arm64` was required. The same image's native tsx executed the typed module successfully; its esbuild binary was verified as ELF.
- Prior complete actual outer-wrapper proof passed for published `2026.7.1-2 → 2026.8.1` (`base`, manual restart), including the existing explicit capability-consent recovery, state/config survival, Gateway health/readiness, and RPC status. No operator state, host ports, or live provider/channel credentials were used.
- Fresh complete outer-wrapper proof for published **`2026.7.1-2 → 2026.8.2` passed, exit 0**. The strengthened automatic-migration and exec-approvals assertions from main passed before standalone Doctor; the existing explicit capability-consent recovery, state/config survival, Gateway startup, health/readiness, and RPC status also passed. Startup 9s; health/readiness 1s each; RPC 2s. Source hashes were unchanged during proof, and all task containers were removed. The tested harness bytes at `6b0c8bd4cbc646f9375fd6c1e56ce927b4edc4a2` are identical at PR head `b9659f91549a615a754b4286bf5ddc14fcafbde6`; the subsequent commit only renames two test variables.
- Final scoped checks, including test-root types/lint and Docker boundary guards, passed. The first integrated check exposed two existing name-shadow lint errors; they were corrected without changing assertions and all 27 tests/checks rerun successfully. Fresh independent autoreview was scoped-clean at its default P0 threshold.

The fresh real run used the checked-in outer entrypoint, a new shared-runner image, published packages, and isolated synthetic state—not a replacement driver of the inner scenario:

```bash
env -i PATH="$PATH" HOME="$HOME" TMPDIR=/tmp \
  OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 \
  OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.7.1-2 \
  OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE=openclaw@2026.8.2 \
  OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=base \
  OPENCLAW_UPGRADE_SURVIVOR_E2E_IMAGE=openclaw-upgrade-harness:landing-6b0c8bd4 \
  OPENCLAW_UPGRADE_SURVIVOR_E2E_SKIP_BUILD=1 \
  OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE=1 \
  OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_DIR="$PWD/.artifacts/upgrade-harness-portability/landing-live-6b0c8bd4/published-baseline" \
  OPENCLAW_DOCKER_ALL_LOG_DIR="$PWD/.artifacts/upgrade-harness-portability/landing-live-6b0c8bd4/diagnostics" \
  bash scripts/e2e/upgrade-survivor-docker.sh
```

```bash
node scripts/run-vitest.mjs test/scripts/upgrade-survivor-config-recipe.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts -t 'runs current TypeScript and frozen JavaScript Docker harness entrypoints|mounts root helper modules imported by bare Docker E2E scripts|publishes only on the host and preserves Docker outcomes'
```

```bash
node scripts/check-changed.mjs -- scripts/e2e/upgrade-survivor-docker.sh scripts/e2e/lib/upgrade-survivor/run.sh test/scripts/upgrade-survivor-config-recipe.test.ts
```

Proof scope is the cross-platform harness and selected package-upgrade scenario, not all historical baselines, live provider/channel traffic, volume idempotence, or automatic system-service restart. No UI surface changed.
