### PR TITLE
fix(agent): force reasoning stream control for reasoning-capable models (#134662)

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
@@ -400,3 +400,167 @@ describe("handleMessageUpdate text signatures", () => {
     expect(context.state.deltaBuffer).toBe("Working now");
   });
 });
+
+describe("handleMessageUpdate reasoning stream control for reasoning-capable models", () => {
+  it("opens reasoning stream on text_start for reasoning-capable model with implicit thinkingLevel fallback", async () => {
+    // Issue #134662: Reasoning-capable models fall back to medium thinking without explicit negotiation.
+    // When thinkingLevel falls back implicitly (not via thinking_start event), ensure reasoning stream
+    // is still opened to prevent reasoning leakage into visible message content.
+    const openReasoningStream = vi.fn();
+    const emitReasoningStream = vi.fn();
+    const stripBlockTags = vi.fn((text: string) => text);
+    const context = createMessageUpdateContext({
+      emitReasoningStream,
+      stripBlockTags,
+      state: {
+        reasoningStreamOpen: false,
+      },
+    });
+    // Add openReasoningStream mock to context
+    (context as unknown as Record<string, unknown>).openReasoningStream = openReasoningStream;
+
+    // Simulate a reasoning-capable model (e.g., ollama/glm-5.3:cloud) with implicit thinkingLevel fallback
+    // The session has thinkingLevel set to "medium" via fallback, but no thinking_start event was fired
+    (context.params as unknown as Record<string, unknown>).catalog = [
+      { provider: "ollama", id: "glm-5.3:cloud", reasoning: true },
+    ];
+    (context.params.session as unknown as Record<string, unknown>) = {
+      provider: "ollama",
+      model: "glm-5.3:cloud",
+      thinkingLevel: "medium", // Implicitly set via fallback, not explicit configuration
+      modelCatalogEntry: { provider: "ollama", id: "glm-5.3:cloud", reasoning: true },
+    };
+
+    // Simulate text_start event without prior thinking_start event
+    await updateMessage(
+      context,
+      createTextUpdateEvent({
+        type: "text_start",
+        text: "<thinking>Let me solve this step by step...</thinking>Hello!",
+        delta: "",
+      }),
+    );
+
+    // Reasoning stream should be opened on text_start for reasoning-capable models
+    expect(openReasoningStream).toHaveBeenCalled();
+  });
+
+  it("opens reasoning stream when reasoning tags are detected in chunk for reasoning-capable model", async () => {
+    // Issue #134662: Ensure reasoning stream is opened even when thinking_start event is missing
+    // but reasoning tags are detected in the text chunk
+    const openReasoningStream = vi.fn();
+    const emitReasoningStream = vi.fn();
+    const stripBlockTags = vi.fn((text: string, state: Record<string, unknown>) => {
+      // Simulate stripBlockTags detecting and processing reasoning tags
+      if (text.includes("<thinking>")) {
+        state.thinking = true;
+      }
+      return text.replace(/<\/?thinking>/g, "");
+    });
+    const context = createMessageUpdateContext({
+      emitReasoningStream,
+      stripBlockTags,
+      state: {
+        reasoningStreamOpen: false,
+        partialBlockState: { thinking: false, final: false, inlineCode: { open: false } },
+      },
+    });
+    (context as unknown as Record<string, unknown>).openReasoningStream = openReasoningStream;
+
+    (context.params as unknown as Record<string, unknown>).catalog = [
+      { provider: "ollama", id: "glm-5.3:cloud", reasoning: true },
+    ];
+    (context.params.session as unknown as Record<string, unknown>) = {
+      provider: "ollama",
+      model: "glm-5.3:cloud",
+      thinkingLevel: "medium",
+      modelCatalogEntry: { provider: "ollama", id: "glm-5.3:cloud", reasoning: true },
+    };
+
+    // Simulate text_delta with reasoning tags
+    await updateMessage(
+      context,
+      createTextUpdateEvent({
+        type: "text_delta",
+        text: "<thinking>Solving...</thinking>Answer",
+        delta: "<thinking>Solving...</thinking>Answer",
+      }),
+    );
+
+    // Reasoning stream should be opened when tags are detected
+    expect(openReasoningStream).toHaveBeenCalled();
+  });
+
+  it("does not open reasoning stream for non-reasoning model", async () => {
+    // Verify that non-reasoning models are not affected by the fix
+    const openReasoningStream = vi.fn();
+    const emitReasoningStream = vi.fn();
+    const stripBlockTags = vi.fn((text: string) => text);
+    const context = createMessageUpdateContext({
+      emitReasoningStream,
+      stripBlockTags,
+      state: {
+        reasoningStreamOpen: false,
+      },
+    });
+    (context as unknown as Record<string, unknown>).openReasoningStream = openReasoningStream;
+
+    // Non-reasoning model
+    (context.params.catalog as unknown) = [{ provider: "openai", id: "gpt-4o", reasoning: false }];
+    (context.params.session as unknown as Record<string, unknown>) = {
+      provider: "openai",
+      model: "gpt-4o",
+      thinkingLevel: "off",
+      modelCatalogEntry: { provider: "openai", id: "gpt-4o", reasoning: false },
+    };
+
+    await updateMessage(
+      context,
+      createTextUpdateEvent({
+        type: "text_start",
+        text: "Hello!",
+        delta: "",
+      }),
+    );
+
+    // Reasoning stream should not be opened for non-reasoning models
+    expect(openReasoningStream).not.toHaveBeenCalled();
+  });
+
+  it("does not open reasoning stream when thinkingLevel is 'off'", async () => {
+    // Verify that reasoning-capable models with thinkingLevel='off' don't trigger the fix
+    const openReasoningStream = vi.fn();
+    const emitReasoningStream = vi.fn();
+    const stripBlockTags = vi.fn((text: string) => text);
+    const context = createMessageUpdateContext({
+      emitReasoningStream,
+      stripBlockTags,
+      state: {
+        reasoningStreamOpen: false,
+      },
+    });
+    (context as unknown as Record<string, unknown>).openReasoningStream = openReasoningStream;
+
+    (context.params.catalog as unknown) = [
+      { provider: "ollama", id: "glm-5.3:cloud", reasoning: true },
+    ];
+    (context.params.session as unknown as Record<string, unknown>) = {
+      provider: "ollama",
+      model: "glm-5.3:cloud",
+      thinkingLevel: "off", // Explicitly disabled
+      modelCatalogEntry: { provider: "ollama", id: "glm-5.3:cloud", reasoning: true },
+    };
+
+    await updateMessage(
+      context,
+      createTextUpdateEvent({
+        type: "text_start",
+        text: "Hello!",
+        delta: "",
+      }),
+    );
+
+    // Reasoning stream should not be opened when thinking is disabled
+    expect(openReasoningStream).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -106,6 +106,32 @@ export function handleMessageUpdate(
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
   const suppressMessageToolOnlySourceReplyOutput = hasMessageToolOnlySourceDelivery(ctx);
 
+  // Scheme 2 fix: Force reasoning stream control at streaming entry point for reasoning-capable models.
+  // When a model has native reasoning capability (catalog.reasoning=true) and thinkingLevel is not "off",
+  // ensure reasoning stream is properly isolated regardless of whether thinkingLevel was set explicitly
+  // or via implicit fallback. This prevents reasoning leakage into visible message content.
+  // See: issue #134662 - reasoning-capable models fall back to medium thinking without explicit negotiation.
+  const modelHasReasoningCapability =
+    ctx.session?.modelCatalogEntry?.reasoning === true ||
+    (ctx.session?.provider &&
+      ctx.session?.model &&
+      ctx.params.catalog?.find(
+        (entry) => entry.provider === ctx.session!.provider && entry.id === ctx.session!.model,
+      )?.reasoning === true);
+  const thinkingEnabled = ctx.session?.thinkingLevel && ctx.session.thinkingLevel !== "off";
+  if (
+    evtType === "text_start" &&
+    modelHasReasoningCapability &&
+    thinkingEnabled &&
+    !ctx.state.reasoningStreamOpen
+  ) {
+    // Reasoning-capable model with thinking enabled but stream not yet opened.
+    // This can happen when thinkingLevel falls back implicitly (e.g., to "medium")
+    // without triggering the normal thinking_start event path. Force open the
+    // reasoning stream to ensure proper isolation of reasoning content.
+    openReasoningStream(ctx);
+  }
+
   if (evtType === "thinking_start" || evtType === "thinking_delta" || evtType === "thinking_end") {
     if (
       !suppressMessageToolOnlySourceReplyOutput &&
@@ -396,6 +422,17 @@ export function handleMessageUpdate(
         : recomputedRawText.slice(previousText.length);
       nextRawStreamText = recomputedRawText;
       ctx.state.partialBlockState = recomputeState;
+      // Scheme 2 fix continuation: When reasoning tags are detected in a reasoning-capable model,
+      // ensure reasoning stream is opened even if thinking_start event was not fired.
+      // This handles models that emit reasoning inline without separate thinking_* events.
+      if (
+        modelHasReasoningCapability &&
+        thinkingEnabled &&
+        !ctx.state.reasoningStreamOpen &&
+        recomputeState.thinking
+      ) {
+        openReasoningStream(ctx);
+      }
     } else {
       visibleDelta =
         chunk || evtType === "text_end"


### PR DESCRIPTION
## Summary

Fix reasoning leakage into visible message content for reasoning-capable models when `thinkingLevel` is implicitly set via fallback rather than explicit configuration.

**Root cause**: When using reasoning-capable models (e.g., `ollama/glm-5.3:cloud`) without explicitly configuring `thinkingLevel`, the system falls back to `"medium"` via `resolveThinkingDefaultForModel()`. However, this implicit fallback path did not trigger the normal `thinking_start` event, leaving `reasoningStreamOpen` unset and causing reasoning text to leak into visible message content.

**Fix**: Add two guard points in `handleMessageUpdate()`:
1. On `text_start` event: Check model catalog `reasoning` flag and open reasoning stream if thinking is enabled
2. When `REASONING_TAG_RE` detects reasoning tags in text chunks: Open reasoning stream for reasoning-capable models

This implements **Scheme 2** from the solutions analysis - forcing reasoning stream control at the streaming entry point based on model capability metadata, regardless of explicit vs. implicit `thinkingLevel` configuration.

## Real behavior proof

**Before fix**: Reasoning text appears inline in visible assistant messages
**After fix**: Reasoning text properly isolated in separate reasoning section (to be verified with live gateway test using `ollama/glm-5.3:cloud`)

## Tests and validation

Added test coverage in `embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts`:
- Opens reasoning stream on `text_start` for reasoning-capable model with implicit thinkingLevel fallback
- Opens reasoning stream when reasoning tags detected in chunk
- Does not open reasoning stream for non-reasoning models  
- Does not open reasoning stream when thinkingLevel is 'off'

## Risk checklist

- [x] Changes are minimal and targeted (2 guard points in existing flow)
- [x] No changes to thinking default resolution logic (avoids compatibility risk)
- [x] Explicit thinkingLevel configuration paths unchanged
- [x] Non-reasoning models unaffected
- [x] Format/lint checks pass (oxfmt, oxlint)

## Current review state

Ready for review. Requires live gateway validation with reasoning-capable model to confirm reasoning isolation behavior.

---

🤖 AI-assisted: This PR was developed with AI assistance (co-mind)

Closes #134662