### PR TITLE
perf: reuse captured model-catalog visibility state

### DIFF
--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -40,9 +40,8 @@ describe("resolveLogicalVisibleModelCatalog", () => {
     input: ["text"],
   };
 
-  const evaluateAvailableEntry = async (entry: ModelCatalogEntry) =>
+  const evaluateAvailableEntry = async () =>
     resolveLogicalModelCatalogEntryState({
-      entry,
       evaluation: { availability: true, routeResolution: null },
       routePolicy: openAIModelCatalogRoutePolicy,
     });
@@ -101,9 +100,8 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       defaultProvider: "openai",
       view: "all",
       routePolicy: openAIModelCatalogRoutePolicy,
-      evaluateEntry: async (entry) =>
+      evaluateEntry: async () =>
         resolveLogicalModelCatalogEntryState({
-          entry,
           evaluation: {
             availability: true,
             routeResolution: { kind: "routes", routes: [selectedRoute] },
@@ -160,39 +158,45 @@ describe("resolveLogicalVisibleModelCatalog", () => {
     expect(result.map((entry) => entry.id)).toEqual(["alias-key", "primary"]);
   });
 
-  it("dedupes physical routes after selected-route projection", async () => {
-    const catalog = [platform, chatGPT];
-    const result = await resolveLogicalVisibleModelCatalog({
-      cfg: {} as OpenClawConfig,
-      catalog,
-      defaultProvider: "openai",
-      view: "all",
-      routePolicy: openAIModelCatalogRoutePolicy,
-      evaluateEntry: async (entry) =>
-        resolveLogicalModelCatalogEntryState({
-          entry,
-          evaluation: {
-            availability: true,
-            routeResolution: { kind: "routes", routes: [selectedRoute] },
-            selectedRoute,
-          },
-          routePolicy: openAIModelCatalogRoutePolicy,
-        }),
-    });
+  it.each(["all", "default", "configured"] as const)(
+    "dedupes physical routes after selected-route projection in the %s view",
+    async (view) => {
+      const catalog = [
+        { ...platform, alias: "platform" },
+        { ...chatGPT, alias: "selected" },
+      ];
+      const result = await resolveLogicalVisibleModelCatalog({
+        cfg: {} as OpenClawConfig,
+        catalog,
+        defaultProvider: "openai",
+        view,
+        routePolicy: openAIModelCatalogRoutePolicy,
+        evaluateEntry: async () =>
+          resolveLogicalModelCatalogEntryState({
+            evaluation: {
+              availability: true,
+              routeResolution: { kind: "routes", routes: [selectedRoute] },
+              selectedRoute,
+            },
+            routePolicy: openAIModelCatalogRoutePolicy,
+          }),
+      });
 
-    expect(result).toEqual([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "ChatGPT GPT-5.5",
-        api: "openai-chatgpt-responses",
-        baseUrl: "https://chatgpt.com/backend-api/codex",
-        contextWindow: 400_000,
-        reasoning: false,
-        input: ["text"],
-      },
-    ]);
-  });
+      expect(result).toEqual([
+        {
+          provider: "openai",
+          id: "gpt-5.5",
+          name: "ChatGPT GPT-5.5",
+          alias: view === "all" ? "platform" : "selected",
+          api: "openai-chatgpt-responses",
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          contextWindow: 400_000,
+          reasoning: false,
+          input: ["text"],
+        },
+      ]);
+    },
+  );
 
   it.each([
     ["deprecated", []],
@@ -207,9 +211,8 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       routeVariants: catalog,
       defaultProvider: "openai",
       routePolicy: openAIModelCatalogRoutePolicy,
-      evaluateEntry: async (entry) =>
+      evaluateEntry: async () =>
         resolveLogicalModelCatalogEntryState({
-          entry,
           evaluation: {
             availability: true,
             routeResolution: { kind: "routes", routes: [selectedRoute] },
@@ -229,9 +232,8 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       defaultProvider: "openai",
       view: "all",
       routePolicy: openAIModelCatalogRoutePolicy,
-      evaluateEntry: async (entry) =>
+      evaluateEntry: async () =>
         resolveLogicalModelCatalogEntryState({
-          entry,
           evaluation: {
             availability: false,
             routeResolution: { kind: "indeterminate", defaultRuntimeId: "codex" },
@@ -258,9 +260,8 @@ describe("resolveLogicalVisibleModelCatalog", () => {
       };
       const routeVariants = reverse ? [platformNano, chatGPTNano] : [chatGPTNano, platformNano];
       const evaluateEntry = vi.fn(
-        async (entry: ModelCatalogEntry, _variants: readonly ModelCatalogEntry[]) =>
+        async (_entry: ModelCatalogEntry, _variants: readonly ModelCatalogEntry[]) =>
           resolveLogicalModelCatalogEntryState({
-            entry,
             evaluation: {
               availability: true,
               routeResolution: { kind: "routes", routes: [selectedRoute] },

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -36,14 +36,12 @@ export type ModelCatalogAuthChecker = (
 type LogicalModelCatalogEntryState = {
   authBacked: boolean;
   compatible: boolean;
-  preferred: boolean;
   routeManaged: boolean;
   routeProjection: ModelCatalogRouteProjection;
 };
 
 /** Maps one shared auth evaluation into logical catalog selection state. */
 export function resolveLogicalModelCatalogEntryState(params: {
-  entry: ModelCatalogEntry;
   evaluation: ModelAuthAvailabilityEvaluation;
   authBacked?: boolean;
   routePolicy: ModelCatalogRoutePolicy;
@@ -58,7 +56,6 @@ export function resolveLogicalModelCatalogEntryState(params: {
   return {
     authBacked: params.authBacked ?? params.evaluation.availability === true,
     compatible: params.evaluation.routeResolution?.kind !== "incompatible",
-    preferred: selectedRoute ? params.routePolicy.matchesRoute(params.entry, selectedRoute) : false,
     routeManaged,
     routeProjection,
   };
@@ -208,21 +205,16 @@ export async function prepareLogicalVisibleModelCatalog(
   return () => {
     // Membership and row availability consume this one observation after every await.
     const states = new Map([...readers].map(([key, read]) => [key, read()]));
-    const evaluateEntry = (entry: ModelCatalogEntry) => {
+    const getEntryState = (entry: ModelCatalogEntry) => {
       const state = states.get(keyOf(entry));
       if (!state) {
         throw new Error("Model catalog publication omitted prepared entry state");
       }
-      const selected =
-        state.routeProjection.kind === "selected" ? state.routeProjection.route : undefined;
-      return {
-        ...state,
-        preferred: selected ? params.routePolicy.matchesRoute(entry, selected) : false,
-      };
+      return state;
     };
     const projectEntries = (entries: readonly ModelCatalogEntry[]) => {
       const projected = entries.map((entry) => {
-        const projection = evaluateEntry(entry).routeProjection;
+        const projection = getEntryState(entry).routeProjection;
         let cached = projections.get(entry);
         if (!cached) {
           cached = {
@@ -259,7 +251,7 @@ export async function prepareLogicalVisibleModelCatalog(
       ? sortModelCatalogEntries(
           dedupeModelCatalogEntries([
             ...configuredCatalog,
-            ...params.catalog.filter((entry) => evaluateEntry(entry).authBacked),
+            ...params.catalog.filter((entry) => getEntryState(entry).authBacked),
           ]),
         )
       : [];
@@ -285,11 +277,15 @@ export async function prepareLogicalVisibleModelCatalog(
       if (!preferredKey && !wildcardRoute) {
         continue;
       }
-      const state = evaluateEntry(entry);
+      const state = getEntryState(entry);
       if (!state.compatible && !configuredKeys.has(key)) {
         continue;
       }
-      if (state.preferred && preferredKey) {
+      if (
+        preferredKey &&
+        state.routeProjection.kind === "selected" &&
+        params.routePolicy.matchesRoute(entry, state.routeProjection.route)
+      ) {
         preferred.push(entry);
       }
       if (wildcardRoute && state.routeManaged && state.authBacked) {
@@ -297,7 +293,7 @@ export async function prepareLogicalVisibleModelCatalog(
       }
     }
     const kept = visible.filter((entry) => {
-      const state = evaluateEntry(entry);
+      const state = getEntryState(entry);
       const configured = configuredKeys.has(keyOf(entry));
       return (
         (state.compatible || configured) &&

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -270,7 +270,6 @@ async function buildPreparedDataForConfig(
         incompatibleModelKeys.add(logicalModelKey(entry));
       }
       return resolveLogicalModelCatalogEntryState({
-        entry,
         evaluation,
         authBacked: options.view === "all" || evaluation.availability === true,
         routePolicy: openAIModelCatalogRoutePolicy,

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -277,7 +277,6 @@ async function resolvePickerLogicalCatalog(params: {
         })),
       });
       return resolveLogicalModelCatalogEntryState({
-        entry,
         evaluation,
         routePolicy: openAIModelCatalogRoutePolicy,
       });

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -237,7 +237,6 @@ export function createGatewayAgentModelCatalogProjector(params: {
           const routeVariants = resolveRouteVariants(entry);
           const evaluation = evaluateNative(entry, await evaluateEntry(entry, routeVariants));
           const state = resolveLogicalModelCatalogEntryState({
-            entry,
             evaluation,
             routePolicy: openAIModelCatalogRoutePolicy,
           });
@@ -680,7 +679,6 @@ export async function prepareModelsListResult(
           evaluation.availability === undefined &&
           evaluation.evidence === "synthetic";
         return resolveLogicalModelCatalogEntryState({
-          entry,
           evaluation,
           authBacked: evaluation.availability === true || syntheticLocal,
           routePolicy: openAIModelCatalogRoutePolicy,


### PR DESCRIPTION
## What Problem This Solves

Publishing a model list for the picker, model commands and Gateway does unnecessary allocation and provider-route matching for repeated lookups of the same prepared state.

## Why This Change Was Made

Reuse the state captured for each logical model within one publication. Compute physical-row preference only where a row enters the preferred list, and remove the producer's overwritten preference field and unused row argument from all four callers. Every revocable reader still runs once per logical key on each publication; configured membership, selected-route precedence, cached-row identity, ordering and rejection behavior retain their existing owners.

Production **−8 lines**, tests **+1**, total **−7**. This uses the ordinary data records returned by all production callers; it does not promise equivalence for arbitrary accessor-bearing synthetic state. No new cache or public configuration, storage, provider policy or SDK surface.

## User Impact

The same model rows, availability and capabilities appear in each view, with less temporary work during publication. The measured source-owner loops run faster; no general RSS reduction or end-to-end Gateway latency improvement is established.

## Evidence

The before/after actual-source proof preserves identical complete semantic output across 12 combinations of default/configured/all views, variant order and exact/wildcard policy, with route switches, unresolved/revoked/recovered state and errors. All 840 canonical state observations remain; temporary state copies fall **2,190 → 0** and matcher calls **2,088 → 452**. The existing selected-route test now distinguishes physical-row precedence in all three views while preserving its original capability assertions.

The proof invokes the real public provider-artifact matcher and prepared Gateway result builder with synthetic catalog and host facts. The latter retains eight preparations and forty revocable observations across five publications, verifies private fields are omitted, and invalidates the prepared result when config changes. It is not a listening Gateway or real provider request.

Eight fresh Node 26.8.1 processes used the fixed B-C-C-B-B-C-C-B schedule: 128 logical models, 256 physical route variants, 16 warmups and 128 measured reads per lane. Each process runs the three lanes in fixed order. The table reports separate arm medians and median paired changes; these are descriptive results from four pairs.

| Source-owner lane | Seconds / 128 reads, baseline → candidate | Paired elapsed change | Sampled max RSS MiB, baseline → candidate | Paired RSS change MiB |
| --- | ---: | ---: | ---: | ---: |
| Default publication | 0.718336 → 0.667310 | -7.36% | 593.164 → 599.969 | +7.844 |
| All-model publication | 0.123299 → 0.105305 | -14.63% | 593.203 → 599.984 | +7.906 |
| Prepared Gateway projection | 0.839231 → 0.782773 | -6.40% | 593.781 → 600.539 | +7.883 |

All four elapsed pairs improved in each lane. RSS includes the owner process and loader threads; its sampled maximum is not an instantaneous peak. Most of the between-process RSS difference was already present before measured reads. The all-model lane's uncollected heap endpoint has a **+8.99 MB** median paired difference; after clearing the eight-output ring and requesting GC, the difference is **+6,308 bytes**, with both signs across pairs. No GC event trace, retained-object or steady-state memory claim is made. Imports and preparation are outside the timed reads, and the Gateway composition includes the artifact's metadata-scope wrapper.

**198 canonical tests across eight files**, the exact changed-file gate including core/core-test typechecks, and managed Codex review at its configured P0 scope pass. An independent reviewer checked the owner, callers, physical-route semantics, all raw process receipts and all 426 aggregate cells; the parent also replayed the offline assertions. All observed process groups exited, lifecycle cleanup completed and private roots were removed.

The initial pre-edit fixture assertion was too broad about wildcard membership after auth revocation; its failure and corrected expected-presence/absence cases remain preserved and are not counted as a passing run. The proof rejects unexpected global fetch calls and performs no intentional network operation; it is not comprehensive egress prevention or credential/native-runtime validation. Public API, model-policy and readiness contracts are unchanged.
