### PR TITLE
fix(i18n): avoid duplicate Android locale resources

### DIFF
--- a/scripts/android-app-i18n.ts
+++ b/scripts/android-app-i18n.ts
@@ -386,11 +386,15 @@ function lineNumber(source: string, offset: number): number {
 }
 
 function decodeKotlinLiteral(value: string): string {
-  return value
-    .replaceAll("\\n", "\n")
-    .replaceAll('\\"', '"')
-    .replaceAll("\\$", "$")
-    .replaceAll("\\\\", "\\");
+  return value.replace(
+    /\\(?:u([0-9a-fA-F]{4})|[n"$\\])/gu,
+    (escape, codeUnit: string | undefined) => {
+      if (codeUnit) {
+        return String.fromCharCode(Number.parseInt(codeUnit, 16));
+      }
+      return escape === "\\n" ? "\n" : escape.slice(1);
+    },
+  );
 }
 
 function collectExplicitRuntimeSources(

--- a/test/scripts/android-app-i18n.test.ts
+++ b/test/scripts/android-app-i18n.test.ts
@@ -350,6 +350,19 @@ describe("Android app i18n resources", () => {
     );
   });
 
+  it("decodes Kotlin Unicode escapes without collapsing escaped backslashes", () => {
+    const source = String.raw`
+      Text("Progress \u00b7 ready")
+      Text("Literal \\u00b7 marker")
+    `;
+    const findings = findUnlocalizedAndroidUiLiterals(
+      source,
+      "apps/android/app/src/main/java/ai/openclaw/app/ui/Example.kt",
+    ).map((finding) => finding.source);
+
+    expect(findings).toEqual(["Progress · ready", String.raw`Literal \u00b7 marker`]);
+  });
+
   it("inventories command, attention, and overview model display literals", () => {
     const source = `
       data class CommandItem(


### PR DESCRIPTION
Related: #136144

## What Problem This Solves

Fixes an issue where Android locale generation treated a Kotlin Unicode escape such as `\u00b7` as a different source string from the decoded middle dot, producing an unused duplicate resource during native locale refresh.

## Why This Change Was Made

The Android i18n generator now decodes supported Kotlin escapes in one left-to-right pass. This canonicalizes Unicode code units to their runtime string while preserving escaped backslash literals such as `\\u00b7`.

Architectural owner: `scripts/android-app-i18n.ts`. The generated locale files in #136144 are intentionally not patched here; they should be regenerated after this fix lands.

## User Impact

Native locale refreshes no longer emit phantom Android resources for Kotlin Unicode escapes. Product runtime code is unchanged.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs test/scripts/android-app-i18n.test.ts` failed only the new Unicode case, returning `Progress \u00b7 ready` instead of `Progress · ready` (26 passed, 1 failed).
- Post-fix regression: the same command passes all 27 tests, including preservation of `\\u00b7` as a literal backslash sequence.
- `node scripts/check-changed.mjs -- scripts/android-app-i18n.ts test/scripts/android-app-i18n.test.ts` passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/android-app-i18n.ts test/scripts/android-app-i18n.test.ts` passed.
- Script and test-root oxlint passed.
- `pnpm check:script-erasability`, `pnpm tsgo:scripts`, and `pnpm tsgo:test:root` passed.
- Structured autoreview: scoped clean, no accepted P0 findings.
- `pnpm native:i18n:check` and `pnpm android:i18n:check` currently report the pre-existing managed artifact drift already captured by #136144. The focused suite's tolerant Android owner check passes.

LOC: product runtime `+0/-0`; generator tooling `+9/-5` (net `+4`); tests `+13/-0`.
