### PR TITLE
fix(acp): keep configured aliases as session owners

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -287,7 +287,7 @@ Examples:
     - `--bind here` and `--thread ...` are mutually exclusive.
     - `--bind here` only works on channels that advertise current-conversation binding; OpenClaw returns a clear unsupported message otherwise. Bindings persist across gateway restarts.
     - On Discord, `spawnSessions` gates child thread creation for `--thread auto|here` - not `--bind here`.
-    - If you spawn to a different ACP agent without `--cwd`, OpenClaw inherits the **target agent's** workspace by default. Missing inherited paths (`ENOENT`/`ENOTDIR`) fall back to the backend default; other access errors (e.g. `EACCES`) surface as spawn errors.
+    - Without `--cwd`, OpenClaw inherits the configured ACP alias workspace when one owns the session; an unconfigured external harness inherits the requester workspace. Missing inherited paths (`ENOENT`/`ENOTDIR`) fall back to the backend default; other access errors (e.g. `EACCES`) surface as spawn errors.
     - Gateway management commands stay local in bound conversations - `/acp ...` commands are handled by OpenClaw even when normal follow-up text routes to the bound ACP session; `/status` and `/session` also stay local whenever command handling is enabled for that surface.
 
   </Accordion>
@@ -476,7 +476,7 @@ its current reasoning effort or conversation.
 - Configured ACP bindings own their session route. Channel broadcast fan-out does not replace the configured ACP session for a matched binding.
 - In bound conversations, `/new` and `/reset` reset the same ACP session key in place.
 - Runtime bindings created by thread-bound spawns still apply where present.
-- For cross-agent ACP spawns without an explicit `cwd`, OpenClaw inherits the target agent workspace from agent config.
+- Without an explicit `cwd`, configured ACP aliases inherit their owner workspace; unconfigured external harnesses inherit the requester workspace.
 - Missing inherited workspace paths fall back to the backend default cwd; non-missing access failures surface as spawn errors.
 
 ## Start ACP sessions
@@ -550,9 +550,9 @@ Two ways to start an ACP session:
 </ParamField>
 <ParamField path="cwd" type="string">
   Requested runtime working directory (validated by backend/runtime policy).
-  If omitted, ACP spawn inherits the target agent workspace when configured;
-  missing inherited paths fall back to backend defaults, while real access
-  errors are returned.
+  If omitted, ACP spawn inherits a configured alias owner workspace or the
+  requester workspace for an unconfigured external harness. Missing inherited
+  paths fall back to backend defaults, while real access errors are returned.
 </ParamField>
 <ParamField path="label" type="string">
   Operator-facing label used in session/banner text.
@@ -794,11 +794,21 @@ If no target resolves, OpenClaw returns a clear error
 
 ### Session owner and harness
 
-The OpenClaw agent that owns a session is separate from the external harness
-selected by ACP. For example, a session owned by `work` can run the `claude`
-harness. Owner-aware manager calls carry `agentId`; `agent` remains the harness
-name. Configured bindings use their OpenClaw agent owner and their configured
-ACP harness independently. Free ACP spawns keep their existing harness namespace.
+Three identities can participate in an ACP spawn:
+
+- **Requested alias**: the OpenClaw agent id passed to `/acp spawn` or
+  `sessions_spawn`, such as `reviewer`.
+- **External harness**: the ACP implementation selected by
+  `agents.entries.*.runtime.acp.agent`, such as `codex` or `claude`.
+- **Session owner**: the OpenClaw agent whose session key, store, workspace,
+  account binding, and lifecycle controls persist the session.
+
+A configured ACP alias is the session owner while its `runtime.acp.agent` value
+is only the external dispatch harness. For example, `reviewer` can own
+`agent:reviewer:acp:<uuid>` while running the `codex` harness. An unconfigured
+external harness has no OpenClaw alias to own it, so the requester owns the
+session. Owner-aware manager calls carry `agentId`; `agent` remains the harness
+name.
 
 Bare keys such as `global` require an explicit owner when ownership is explicit.
 ACP keeps arbitrary logical keys such as `shared-project` unchanged; ACPX scopes
@@ -812,7 +822,7 @@ sessions must be upgraded before those sessions can run.
 | Command              | What it does                                              | Example                                                       |
 | -------------------- | --------------------------------------------------------- | ------------------------------------------------------------- |
 | `/acp spawn`         | Create ACP session; optional current bind or thread bind. | `/acp spawn codex --bind here --cwd /repo`                    |
-| `/acp cancel`        | Cancel in-flight turn for target session.                 | `/acp cancel agent:codex:acp:<uuid>`                          |
+| `/acp cancel`        | Cancel in-flight turn for target session.                 | `/acp cancel agent:<owner>:acp:<uuid>`                        |
 | `/acp steer`         | Send steer instruction to running session.                | `/acp steer --session support inbox prioritize failing tests` |
 | `/acp close`         | Close session and unbind thread targets.                  | `/acp close`                                                  |
 | `/acp status`        | Show backend, mode, state, runtime options, capabilities. | `/acp status`                                                 |

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -817,6 +817,21 @@ An agent-qualified main alias retains its owner even when it resolves to `global
 Conflicting owner/key pairs fail visibly. A backend that cannot isolate bare
 sessions must be upgraded before those sessions can run.
 
+Legacy sessions created before owner/harness separation may still be stored
+under the external harness id. Runtime commands never read or promote those
+rows: resume, status, cancel, close, workspace, account, and binding lookup use
+the canonical configured owner only.
+
+Run `openclaw doctor` to inventory eligible legacy ACP sessions, then
+`openclaw doctor --fix` to migrate them explicitly. Doctor moves a legacy row
+only when one configured owner maps to its harness and the source identity is
+unambiguous. The migration consumes the legacy ACP metadata, rehomes the
+session-owned state under `agent:<owner>:...`, and is safe to retry. Doctor
+leaves the source unchanged and prints operator guidance when multiple aliases
+share a harness, a bare key is in a shared owner/harness store, or the canonical
+owner key already contains a different session. Resolve that ambiguity before
+rerunning Doctor; runtime does not provide a compatibility fallback.
+
 ## ACP controls
 
 | Command              | What it does                                              | Example                                                       |

--- a/extensions/acpx/src/runtime-alias-owner.process.test.ts
+++ b/extensions/acpx/src/runtime-alias-owner.process.test.ts
@@ -1,0 +1,246 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  getAcpSessionManager,
+  registerAcpRuntimeBackend,
+  testing as acpRuntimeTesting,
+  unregisterAcpRuntimeBackend,
+} from "openclaw/plugin-sdk/acp-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  registerSessionBindingAdapter,
+  testing as sessionBindingTesting,
+  type SessionBindingBindInput,
+  type SessionBindingRecord,
+} from "openclaw/plugin-sdk/conversation-runtime";
+import { createAdmittedHostCapabilityTestFixture } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { withOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { expect, it } from "vitest";
+import { validateAcpResumeSessionOwnership } from "../../../src/agents/subagents/spawn/acp-spawn-requester.js";
+import { handleAcpSpawnAction } from "../../../src/auto-reply/reply/commands-acp/lifecycle.js";
+import { buildCommandTestParams } from "../../../src/auto-reply/reply/commands-spawn.test-harness.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../../../src/plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../../src/test-utils/channel-plugins.js";
+import { AcpxRuntime, createAgentRegistry, createFileSessionStore } from "./runtime.js";
+
+const harness = "owner-fixture";
+const script = fileURLToPath(new URL("../test/fixtures/owner-agent.mjs", import.meta.url));
+
+function registerInMemoryDiscordBindings(): SessionBindingRecord[] {
+  const bindings: SessionBindingRecord[] = [];
+  registerSessionBindingAdapter({
+    channel: "discord",
+    accountId: "owner-account",
+    capabilities: {
+      placements: ["current"],
+      bindSupported: true,
+      unbindSupported: true,
+    },
+    bind: async (input: SessionBindingBindInput) => {
+      const record = {
+        bindingId: `discord:owner-account:${input.conversation.conversationId}`,
+        targetSessionKey: input.targetSessionKey,
+        targetKind: input.targetKind,
+        conversation: input.conversation,
+        status: "active",
+        boundAt: 1,
+        ...(input.metadata ? { metadata: input.metadata } : {}),
+      } satisfies SessionBindingRecord;
+      bindings.push(record);
+      return record;
+    },
+    listBySession: (targetSessionKey) =>
+      bindings.filter((entry) => entry.targetSessionKey === targetSessionKey),
+    resolveByConversation: (ref) =>
+      bindings.find(
+        (entry) =>
+          entry.conversation.channel === ref.channel &&
+          entry.conversation.accountId === ref.accountId &&
+          entry.conversation.conversationId === ref.conversationId,
+      ) ?? null,
+    unbind: async ({ bindingId, targetSessionKey }) =>
+      bindings.filter(
+        (entry) =>
+          (bindingId && entry.bindingId === bindingId) ||
+          (targetSessionKey && entry.targetSessionKey === targetSessionKey),
+      ),
+  });
+  return bindings;
+}
+
+it("runs a configured alias through real ACPX and rejects a foreign resume before process I/O", async () => {
+  await withOpenClawTestState({ label: "acpx-alias-owner-process" }, async (state) => {
+    const ownerWorkspace = path.join(state.root, "owner-workspace");
+    const peerDirectory = path.join(state.root, "peer");
+    await fs.mkdir(ownerWorkspace);
+    await fs.mkdir(peerDirectory);
+    const cfg = {
+      acp: {
+        enabled: true,
+        backend: "acpx",
+        defaultAgent: "reviewer",
+        allowedAgents: [harness],
+      },
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: {
+          main: {},
+          reviewer: {
+            workspace: ownerWorkspace,
+            runtime: { type: "acp" as const, acp: { agent: harness, backend: "acpx" } },
+          },
+        },
+      },
+      session: {
+        scope: "per-sender" as const,
+        store: path.join(state.root, "agents", "{agentId}", "sessions.json"),
+        threadBindings: { enabled: true },
+      },
+    } satisfies OpenClawConfig;
+    await state.writeConfig(cfg);
+
+    const runtime = new AcpxRuntime({
+      cwd: state.root,
+      sessionStore: createFileSessionStore({ stateDir: state.root }),
+      agentRegistry: createAgentRegistry({
+        overrides: { [harness]: [process.execPath, script, peerDirectory] },
+      }),
+      pluginToolsMcpBridgeEnabled: true,
+      openclawToolsMcpBridgeEnabled: true,
+      mcpServers: [],
+      permissionMode: "deny-all",
+      timeoutMs: 5_000,
+    });
+    registerAcpRuntimeBackend({ id: "acpx", runtime });
+    acpRuntimeTesting.resetAcpSessionManagerForTests();
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    const registrySnapshot = captureActivePluginRegistrySnapshot();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: createChannelTestPluginBase({ id: "discord", label: "Discord" }),
+        },
+      ]),
+    );
+    const bindings = registerInMemoryDiscordBindings();
+    const manager = getAcpSessionManager();
+    let sessionKey: string | undefined;
+    try {
+      const commandParams = buildCommandTestParams("/acp spawn reviewer --bind here", cfg, {
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:owner-room",
+        AccountId: "owner-account",
+        SenderId: "owner-user",
+        SessionKey: "agent:main:main",
+      });
+      commandParams.command.senderId = "owner-user";
+      const spawned = await handleAcpSpawnAction(commandParams, ["reviewer", "--bind", "here"]);
+      const match = spawned.reply?.text?.match(/Spawned ACP session (agent:[^ ]+)/);
+      sessionKey = match?.[1];
+      expect(sessionKey).toMatch(/^agent:reviewer:acp:/);
+      expect(spawned.reply?.text).toContain("Bound this conversation");
+      expect(bindings).toEqual([
+        expect.objectContaining({
+          targetSessionKey: sessionKey,
+          conversation: expect.objectContaining({
+            channel: "discord",
+            accountId: "owner-account",
+            conversationId: "owner-room",
+          }),
+          metadata: expect.objectContaining({
+            agentId: "reviewer",
+            introText: expect.stringContaining(`cwd: ${ownerWorkspace}`),
+          }),
+        }),
+      ]);
+
+      const target = { cfg, sessionKey: sessionKey!, agentId: "reviewer" };
+      const status = await manager.getSessionStatus(target);
+      expect(status).toMatchObject({
+        agentId: "reviewer",
+        sessionKey,
+      });
+
+      const admission = await createAdmittedHostCapabilityTestFixture({
+        config: cfg,
+        runId: "alias-owner-proof",
+        agentId: "reviewer",
+        sessionId: "reviewer-session",
+        sessionKey: sessionKey!,
+        workspaceDir: ownerWorkspace,
+        abortSignal: new AbortController().signal,
+      });
+      const chunks: string[] = [];
+      try {
+        await manager.runTurn({
+          ...target,
+          admittedRunContext: admission.admittedRunContext,
+          provenance: "human",
+          text: "owner-proof",
+          mode: "prompt",
+          requestId: "alias-owner-proof",
+          onEvent(event) {
+            if (event.type === "text_delta") {
+              chunks.push(event.text);
+            }
+          },
+        });
+      } finally {
+        admission.closeHost();
+        admission.closeAdmission();
+      }
+      expect(JSON.parse(chunks.join(""))).toMatchObject({ history: ["owner-proof"] });
+      const resumedStatus = await manager.getSessionStatus(target);
+      const resumeSessionId =
+        resumedStatus.identity?.agentSessionId ?? resumedStatus.identity?.acpxSessionId;
+      expect(resumeSessionId).toBeTruthy();
+      const peerFiles = await fs.readdir(peerDirectory);
+      expect(peerFiles).toHaveLength(1);
+      const peerFile = path.join(peerDirectory, peerFiles[0]!);
+      const peerStateBeforeForeignResume = await fs.readFile(peerFile, "utf8");
+      await expect(
+        validateAcpResumeSessionOwnership({
+          cfg,
+          sessionOwnerAgentId: "reviewer",
+          harnessAgentId: harness,
+          backendId: "acpx",
+          requesterSessionKey: "agent:foreign:main",
+          resumeSessionId,
+        }),
+      ).resolves.toMatchObject({ ok: false });
+      expect(await fs.readFile(peerFile, "utf8")).toBe(peerStateBeforeForeignResume);
+      await manager.setSessionRuntimeMode({ ...target, runtimeMode: "review" });
+      await manager.cancelSession(target);
+      await manager.closeSession({ ...target, reason: "test-complete" });
+    } finally {
+      if (sessionKey) {
+        await manager
+          .closeSession({
+            cfg,
+            sessionKey,
+            agentId: "reviewer",
+            reason: "test-cleanup",
+            requireAcpSession: false,
+          })
+          .catch(() => {});
+      }
+      restoreActivePluginRegistrySnapshot(registrySnapshot);
+      sessionBindingTesting.resetSessionBindingAdaptersForTests();
+      acpRuntimeTesting.resetAcpSessionManagerForTests();
+      unregisterAcpRuntimeBackend("acpx");
+    }
+  });
+});

--- a/src/acp/runtime/runtime-alias-owner.process.test.ts
+++ b/src/acp/runtime/runtime-alias-owner.process.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { AcpxRuntime, createAgentRegistry, createFileSessionStore } from "acpx/runtime";
 import {
   getAcpSessionManager,
   registerAcpRuntimeBackend,
@@ -17,22 +18,23 @@ import {
 import { createAdmittedHostCapabilityTestFixture } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { withOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { expect, it } from "vitest";
-import { validateAcpResumeSessionOwnership } from "../../../src/agents/subagents/spawn/acp-spawn-requester.js";
-import { handleAcpSpawnAction } from "../../../src/auto-reply/reply/commands-acp/lifecycle.js";
-import { buildCommandTestParams } from "../../../src/auto-reply/reply/commands-spawn.test-harness.js";
+import { validateAcpResumeSessionOwnership } from "../../agents/subagents/spawn/acp-spawn-requester.js";
+import { handleAcpSpawnAction } from "../../auto-reply/reply/commands-acp/lifecycle.js";
+import { buildCommandTestParams } from "../../auto-reply/reply/commands-spawn.test-harness.js";
 import {
   captureActivePluginRegistrySnapshot,
   restoreActivePluginRegistrySnapshot,
   setActivePluginRegistry,
-} from "../../../src/plugins/runtime.js";
+} from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
   createTestRegistry,
-} from "../../../src/test-utils/channel-plugins.js";
-import { AcpxRuntime, createAgentRegistry, createFileSessionStore } from "./runtime.js";
+} from "../../test-utils/channel-plugins.js";
 
 const harness = "owner-fixture";
-const script = fileURLToPath(new URL("../test/fixtures/owner-agent.mjs", import.meta.url));
+const script = fileURLToPath(
+  new URL("../../../extensions/acpx/test/fixtures/owner-agent.mjs", import.meta.url),
+);
 
 function registerInMemoryDiscordBindings(): SessionBindingRecord[] {
   const bindings: SessionBindingRecord[] = [];

--- a/src/acp/runtime/runtime-alias-owner.process.test.ts
+++ b/src/acp/runtime/runtime-alias-owner.process.test.ts
@@ -116,8 +116,6 @@ it("runs a configured alias through real ACPX and rejects a foreign resume befor
       agentRegistry: createAgentRegistry({
         overrides: { [harness]: [process.execPath, script, peerDirectory] },
       }),
-      pluginToolsMcpBridgeEnabled: true,
-      openclawToolsMcpBridgeEnabled: true,
       mcpServers: [],
       permissionMode: "deny-all",
       timeoutMs: 5_000,

--- a/src/acp/runtime/session-meta-owner-migration.ts
+++ b/src/acp/runtime/session-meta-owner-migration.ts
@@ -70,15 +70,27 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
   let result: AcpOwnerMigrationClaimResult = "missing";
   runOpenClawStateWriteTransaction(
     (database) => {
-      const targetMatch = targetDatabaseKeys
-        .map((key) => ({ key, row: selectAcpSessionRow(database.db, key) }))
-        .find((candidate) => candidate.row !== undefined);
+      const targetMatches = [...new Set(targetDatabaseKeys)].flatMap((key) => {
+        const row = selectAcpSessionRow(database.db, key);
+        return row ? [{ key, row }] : [];
+      });
+      const targetMatch = targetMatches[0];
       if (targetMatch?.row) {
         const targetRow = targetMatch.row;
         if (
           targetRow.agent !== params.expectedAgent ||
           !acpSessionRowMatchesEntry(targetRow, params.entry)
         ) {
+          result = "conflict";
+          return;
+        }
+        const divergentTarget = targetMatches.find(
+          ({ row }) =>
+            row.agent !== params.expectedAgent ||
+            !acpSessionRowMatchesEntry(row, params.entry) ||
+            !sameAcpSessionMetadata(row, targetRow),
+        );
+        if (divergentTarget) {
           result = "conflict";
           return;
         }

--- a/src/acp/runtime/session-meta-owner-migration.ts
+++ b/src/acp/runtime/session-meta-owner-migration.ts
@@ -68,16 +68,31 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
   let result: AcpOwnerMigrationClaimResult = "missing";
   runOpenClawStateWriteTransaction(
     (database) => {
-      const targetRow = targetDatabaseKeys
-        .map((key) => selectAcpSessionRow(database.db, key))
-        .find((row) => row !== undefined);
-      if (targetRow) {
+      const targetMatch = targetDatabaseKeys
+        .map((key) => ({ key, row: selectAcpSessionRow(database.db, key) }))
+        .find((candidate) => candidate.row !== undefined);
+      if (targetMatch?.row) {
+        const targetRow = targetMatch.row;
         if (
           targetRow.agent !== params.expectedAgent ||
           !acpSessionRowMatchesEntry(targetRow, params.entry)
         ) {
           result = "conflict";
           return;
+        }
+        if (targetMatch.key !== targetDatabaseKey) {
+          insertRow(database.db, {
+            ...targetRow,
+            session_key: targetDatabaseKey,
+            updated_at: params.now?.() ?? Date.now(),
+          });
+          deleteMatchingRows({
+            db: database.db,
+            entry: params.entry,
+            except: targetDatabaseKey,
+            expectedAgent: params.expectedAgent,
+            keys: targetDatabaseKeys,
+          });
         }
         deleteMatchingRows({
           db: database.db,
@@ -100,7 +115,7 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
       if (!sourceRow) {
         return;
       }
-      upsertRow(database.db, {
+      insertRow(database.db, {
         ...sourceRow,
         session_key: targetDatabaseKey,
         updated_at: params.now?.() ?? Date.now(),
@@ -145,15 +160,9 @@ function deleteMatchingRows(params: {
   }
 }
 
-function upsertRow(
+function insertRow(
   db: Parameters<typeof getAcpSessionKysely>[0],
   row: Insertable<AcpSessionsTable>,
 ): void {
-  executeSqliteQuerySync(
-    db,
-    getAcpSessionKysely(db)
-      .insertInto("acp_sessions")
-      .values(row)
-      .onConflict((conflict) => conflict.column("session_key").doNothing()),
-  );
+  executeSqliteQuerySync(db, getAcpSessionKysely(db).insertInto("acp_sessions").values(row));
 }

--- a/src/acp/runtime/session-meta-owner-migration.ts
+++ b/src/acp/runtime/session-meta-owner-migration.ts
@@ -70,6 +70,10 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
   let result: AcpOwnerMigrationClaimResult = "missing";
   runOpenClawStateWriteTransaction(
     (database) => {
+      const sourceRows = [...new Set(sourceDatabaseKeys)].flatMap((key) => {
+        const row = selectAcpSessionRow(database.db, key);
+        return row ? [row] : [];
+      });
       const targetMatches = [...new Set(targetDatabaseKeys)].flatMap((key) => {
         const row = selectAcpSessionRow(database.db, key);
         return row ? [{ key, row }] : [];
@@ -94,15 +98,12 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
           result = "conflict";
           return;
         }
-        const divergentSource = [...new Set(sourceDatabaseKeys)]
-          .map((key) => selectAcpSessionRow(database.db, key))
-          .find(
-            (row) =>
-              row !== undefined &&
-              row.agent === params.expectedAgent &&
-              acpSessionRowMatchesEntry(row, params.entry) &&
-              !sameAcpSessionMetadata(row, targetRow),
-          );
+        const divergentSource = sourceRows.find(
+          (row) =>
+            row.agent !== params.expectedAgent ||
+            !acpSessionRowMatchesEntry(row, params.entry) ||
+            !sameAcpSessionMetadata(row, targetRow),
+        );
         if (divergentSource) {
           result = "conflict";
           return;
@@ -131,10 +132,6 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
         result = "already-claimed";
         return;
       }
-      const sourceRows = [...new Set(sourceDatabaseKeys)].flatMap((key) => {
-        const row = selectAcpSessionRow(database.db, key);
-        return row ? [row] : [];
-      });
       const sourceRow = sourceRows.find(
         (row) => row.agent === params.expectedAgent && acpSessionRowMatchesEntry(row, params.entry),
       );

--- a/src/acp/runtime/session-meta-owner-migration.ts
+++ b/src/acp/runtime/session-meta-owner-migration.ts
@@ -131,15 +131,24 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
         result = "already-claimed";
         return;
       }
-      const sourceRow = sourceDatabaseKeys
-        .map((key) => selectAcpSessionRow(database.db, key))
-        .find(
-          (row) =>
-            row !== undefined &&
-            row.agent === params.expectedAgent &&
-            acpSessionRowMatchesEntry(row, params.entry),
-        );
+      const sourceRows = [...new Set(sourceDatabaseKeys)].flatMap((key) => {
+        const row = selectAcpSessionRow(database.db, key);
+        return row ? [row] : [];
+      });
+      const sourceRow = sourceRows.find(
+        (row) => row.agent === params.expectedAgent && acpSessionRowMatchesEntry(row, params.entry),
+      );
       if (!sourceRow) {
+        return;
+      }
+      const divergentSource = sourceRows.find(
+        (row) =>
+          row.agent !== params.expectedAgent ||
+          !acpSessionRowMatchesEntry(row, params.entry) ||
+          !sameAcpSessionMetadata(row, sourceRow),
+      );
+      if (divergentSource) {
+        result = "conflict";
         return;
       }
       insertRow(database.db, {

--- a/src/acp/runtime/session-meta-owner-migration.ts
+++ b/src/acp/runtime/session-meta-owner-migration.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import type { Insertable } from "kysely";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
@@ -6,6 +7,7 @@ import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.
 import {
   acpSessionRowMatchesEntry,
   type AcpSessionEntryBinding,
+  type AcpSessionRow,
   type AcpSessionsTable,
   buildAcpDatabaseSessionKey,
   getAcpSessionKysely,
@@ -80,6 +82,19 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
           result = "conflict";
           return;
         }
+        const divergentSource = [...new Set(sourceDatabaseKeys)]
+          .map((key) => selectAcpSessionRow(database.db, key))
+          .find(
+            (row) =>
+              row !== undefined &&
+              row.agent === params.expectedAgent &&
+              acpSessionRowMatchesEntry(row, params.entry) &&
+              !sameAcpSessionMetadata(row, targetRow),
+          );
+        if (divergentSource) {
+          result = "conflict";
+          return;
+        }
         if (targetMatch.key !== targetDatabaseKey) {
           insertRow(database.db, {
             ...targetRow,
@@ -132,6 +147,10 @@ export function claimAcpSessionMetaForOwnerMigration(params: {
     { env: params.env, path: params.databasePath },
   );
   return result;
+}
+
+function sameAcpSessionMetadata(left: AcpSessionRow, right: AcpSessionRow): boolean {
+  return isDeepStrictEqual(rowToAcpSessionMeta(left), rowToAcpSessionMeta(right));
 }
 
 function deleteMatchingRows(params: {

--- a/src/acp/runtime/session-meta-owner-migration.ts
+++ b/src/acp/runtime/session-meta-owner-migration.ts
@@ -33,7 +33,11 @@ export function readAcpSessionMetaForOwnerMigration(params: {
     ({ db }) =>
       keys
         .map((key) => selectAcpSessionRow(db, key))
-        .find((candidate) => candidate && acpSessionRowMatchesEntry(candidate, params.entry)),
+        .find(
+          (candidate) =>
+            candidate?.agent === params.agentId &&
+            acpSessionRowMatchesEntry(candidate, params.entry),
+        ),
     { env: params.env, path: params.databasePath },
   );
   return row ? rowToAcpSessionMeta(row) : undefined;

--- a/src/acp/runtime/session-meta-owner-migration.ts
+++ b/src/acp/runtime/session-meta-owner-migration.ts
@@ -1,0 +1,159 @@
+import type { Insertable } from "kysely";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
+import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
+import {
+  acpSessionRowMatchesEntry,
+  type AcpSessionEntryBinding,
+  type AcpSessionsTable,
+  buildAcpDatabaseSessionKey,
+  getAcpSessionKysely,
+  legacyAcpDatabaseSessionKeys,
+  selectAcpSessionRow,
+} from "./session-meta-keys.js";
+import { rowToAcpSessionMeta } from "./session-meta.js";
+
+export function readAcpSessionMetaForOwnerMigration(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+  entry: AcpSessionEntryBinding;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+}) {
+  const keys = [
+    buildAcpDatabaseSessionKey(params.sessionKey, params.agentId),
+    ...legacyAcpDatabaseSessionKeys(params.sessionKey, params.agentId, params.cfg),
+    params.sessionKey,
+  ];
+  const row = withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) =>
+      keys
+        .map((key) => selectAcpSessionRow(db, key))
+        .find((candidate) => candidate && acpSessionRowMatchesEntry(candidate, params.entry)),
+    { env: params.env, path: params.databasePath },
+  );
+  return row ? rowToAcpSessionMeta(row) : undefined;
+}
+
+export type AcpOwnerMigrationClaimResult = "claimed" | "already-claimed" | "conflict" | "missing";
+
+/** Doctor-only claim that consumes one legacy ACP identity before session state is rehomed. */
+export function claimAcpSessionMetaForOwnerMigration(params: {
+  cfg: OpenClawConfig;
+  sourceAgentId: string;
+  sourceSessionKey: string;
+  targetAgentId: string;
+  targetSessionKey: string;
+  expectedAgent: string;
+  entry: AcpSessionEntryBinding;
+  env?: NodeJS.ProcessEnv;
+  databasePath?: string;
+  now?: () => number;
+}): AcpOwnerMigrationClaimResult {
+  const sourceDatabaseKeys = [
+    buildAcpDatabaseSessionKey(params.sourceSessionKey, params.sourceAgentId),
+    ...legacyAcpDatabaseSessionKeys(params.sourceSessionKey, params.sourceAgentId, params.cfg),
+    params.sourceSessionKey,
+  ];
+  const targetDatabaseKey = buildAcpDatabaseSessionKey(
+    params.targetSessionKey,
+    params.targetAgentId,
+  );
+  const targetDatabaseKeys = [
+    targetDatabaseKey,
+    ...legacyAcpDatabaseSessionKeys(params.targetSessionKey, params.targetAgentId, params.cfg),
+  ];
+  let result: AcpOwnerMigrationClaimResult = "missing";
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      const targetRow = targetDatabaseKeys
+        .map((key) => selectAcpSessionRow(database.db, key))
+        .find((row) => row !== undefined);
+      if (targetRow) {
+        if (
+          targetRow.agent !== params.expectedAgent ||
+          !acpSessionRowMatchesEntry(targetRow, params.entry)
+        ) {
+          result = "conflict";
+          return;
+        }
+        deleteMatchingRows({
+          db: database.db,
+          entry: params.entry,
+          except: targetRow.session_key,
+          expectedAgent: params.expectedAgent,
+          keys: sourceDatabaseKeys,
+        });
+        result = "already-claimed";
+        return;
+      }
+      const sourceRow = sourceDatabaseKeys
+        .map((key) => selectAcpSessionRow(database.db, key))
+        .find(
+          (row) =>
+            row !== undefined &&
+            row.agent === params.expectedAgent &&
+            acpSessionRowMatchesEntry(row, params.entry),
+        );
+      if (!sourceRow) {
+        return;
+      }
+      upsertRow(database.db, {
+        ...sourceRow,
+        session_key: targetDatabaseKey,
+        updated_at: params.now?.() ?? Date.now(),
+      });
+      deleteMatchingRows({
+        db: database.db,
+        entry: params.entry,
+        except: targetDatabaseKey,
+        expectedAgent: params.expectedAgent,
+        keys: sourceDatabaseKeys,
+      });
+      result = "claimed";
+    },
+    { env: params.env, path: params.databasePath },
+  );
+  return result;
+}
+
+function deleteMatchingRows(params: {
+  db: Parameters<typeof getAcpSessionKysely>[0];
+  entry: AcpSessionEntryBinding;
+  except: string;
+  expectedAgent: string;
+  keys: string[];
+}) {
+  for (const key of new Set(params.keys)) {
+    if (key === params.except) {
+      continue;
+    }
+    const row = selectAcpSessionRow(params.db, key);
+    if (
+      !row ||
+      row.agent !== params.expectedAgent ||
+      !acpSessionRowMatchesEntry(row, params.entry)
+    ) {
+      continue;
+    }
+    executeSqliteQuerySync(
+      params.db,
+      getAcpSessionKysely(params.db).deleteFrom("acp_sessions").where("session_key", "=", key),
+    );
+  }
+}
+
+function upsertRow(
+  db: Parameters<typeof getAcpSessionKysely>[0],
+  row: Insertable<AcpSessionsTable>,
+): void {
+  executeSqliteQuerySync(
+    db,
+    getAcpSessionKysely(db)
+      .insertInto("acp_sessions")
+      .values(row)
+      .onConflict((conflict) => conflict.column("session_key").doNothing()),
+  );
+}

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -295,7 +295,6 @@ export function writeAcpSessionMetaForMigration(params: {
     { env: params.env, path: params.databasePath },
   );
 }
-
 export function repairAcpSessionMetaKeyForMigration(params: {
   sessionKey: string;
   candidateSessionKeys?: Iterable<string | null | undefined>;

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -298,28 +298,40 @@ export async function validateAcpResumeSessionOwnership(params: {
   }
 
   const configuredBackend = normalizeOptionalLowercaseString(params.backendId);
-  const storeAgentIds = [params.sessionOwnerAgentId];
-  if (
-    params.harnessAgentId !== params.sessionOwnerAgentId &&
-    Date.now() < LEGACY_ACP_HARNESS_STORE_MIGRATION_DEADLINE_MS
-  ) {
-    storeAgentIds.push(params.harnessAgentId);
-  }
-  const storeOwnersByPath = new Map<string, Set<string>>();
-  for (const storeAgentId of storeAgentIds) {
+  const storeSearchesByPath = new Map<
+    string,
+    { allowedOwners: Set<string>; possibleOwners: Set<string> }
+  >();
+  const registerStoreOwner = (storeAgentId: string, allowed: boolean) => {
     const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
       agentId: storeAgentId,
     });
-    const owners = storeOwnersByPath.get(storePath) ?? new Set<string>();
-    owners.add(storeAgentId);
-    storeOwnersByPath.set(storePath, owners);
+    const search = storeSearchesByPath.get(storePath) ?? {
+      allowedOwners: new Set<string>(),
+      possibleOwners: new Set<string>(),
+    };
+    search.possibleOwners.add(storeAgentId);
+    if (allowed) {
+      search.allowedOwners.add(storeAgentId);
+    }
+    storeSearchesByPath.set(storePath, search);
+  };
+  registerStoreOwner(params.sessionOwnerAgentId, true);
+  if (params.harnessAgentId !== params.sessionOwnerAgentId) {
+    registerStoreOwner(
+      params.harnessAgentId,
+      Date.now() < LEGACY_ACP_HARNESS_STORE_MIGRATION_DEADLINE_MS,
+    );
   }
-  for (const [storePath, allowedOwners] of storeOwnersByPath) {
+  for (const [storePath, { allowedOwners, possibleOwners }] of storeSearchesByPath) {
+    if (allowedOwners.size === 0) {
+      continue;
+    }
     const entries = listSessionEntriesReadOnly({ storePath, clone: false });
     const entryOwners = new Map(
       entries.map(({ sessionKey, entry }) => [
         entry,
-        resolveStoredSessionOwner(sessionKey, allowedOwners),
+        resolveStoredSessionOwner(sessionKey, possibleOwners),
       ]),
     );
     const metaByEntry = readAcpSessionMetaBatch({

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -9,12 +9,18 @@ import {
   loadSessionEntryReadOnly,
   resolveSessionTranscriptRuntimeTarget,
 } from "../../../config/sessions/session-accessor.js";
+import { isPerAgentSessionStoreConfig } from "../../../config/sessions/session-store-config.js";
+import { resolvePersistedSessionStoreOwnerForKey } from "../../../config/sessions/session-store-owner.js";
 import type { SessionAcpMeta, SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
-import { isSubagentSessionKey, parseAgentSessionKey } from "../../../routing/session-key.js";
+import {
+  isSubagentSessionKey,
+  isUnscopedSessionKeySentinel,
+  parseAgentSessionKey,
+} from "../../../routing/session-key.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import { resolveRequesterOriginForChild } from "../../spawn-requester-origin.js";
 import {
@@ -227,7 +233,15 @@ export async function validateAcpResumeSessionOwnership(params: {
     cfg: params.cfg,
   });
   for (const { sessionKey, entry } of entries) {
-    if (parseAgentSessionKey(sessionKey)?.agentId !== params.sessionOwnerAgentId) {
+    const parsedOwner = parseAgentSessionKey(sessionKey)?.agentId;
+    const persistedOwner = resolvePersistedSessionStoreOwnerForKey(params.cfg, sessionKey);
+    const hasCanonicalOwner = parsedOwner
+      ? parsedOwner === params.sessionOwnerAgentId
+      : isUnscopedSessionKeySentinel(sessionKey) &&
+        (isPerAgentSessionStoreConfig(params.cfg.session?.store) ||
+          (persistedOwner.kind === "configured" &&
+            persistedOwner.agentId === params.sessionOwnerAgentId));
+    if (!hasCanonicalOwner) {
       continue;
     }
     const acp = metaByEntry.get(entry);

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -21,7 +21,7 @@ import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
   isSubagentSessionKey,
   parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
+  toAgentStoreSessionKey,
 } from "../../../routing/session-key.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import { resolveRequesterOriginForChild } from "../../spawn-requester-origin.js";
@@ -206,6 +206,23 @@ function sessionEntryIsOwnedByRequester(params: {
   );
 }
 
+function resolveStoredSessionOwner(
+  sessionKey: string,
+  storeOwners: ReadonlySet<string>,
+): string | undefined {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (parsed?.agentId) {
+    return parsed.agentId;
+  }
+  if (sessionKey.trim().toLowerCase().startsWith("agent:")) {
+    return undefined;
+  }
+  if (storeOwners.size !== 1) {
+    return undefined;
+  }
+  return storeOwners.values().next().value;
+}
+
 async function promoteLegacyAcpResumeEntry(params: {
   cfg: OpenClawConfig;
   entry: SessionEntry;
@@ -214,10 +231,12 @@ async function promoteLegacyAcpResumeEntry(params: {
   sessionOwnerAgentId: string;
 }): Promise<boolean> {
   const parsed = parseAgentSessionKey(params.harnessSessionKey);
-  if (!parsed?.rest) {
-    return false;
-  }
-  const ownerSessionKey = `agent:${params.sessionOwnerAgentId}:${parsed.rest}`;
+  const ownerSessionKey = parsed?.rest
+    ? `agent:${params.sessionOwnerAgentId}:${parsed.rest}`
+    : toAgentStoreSessionKey({
+        agentId: params.sessionOwnerAgentId,
+        requestKey: params.harnessSessionKey,
+      });
   const ownerStorePath = resolveSessionStorePathCore(params.cfg.session?.store, {
     agentId: params.sessionOwnerAgentId,
   });
@@ -297,18 +316,22 @@ export async function validateAcpResumeSessionOwnership(params: {
   }
   for (const [storePath, allowedOwners] of storeOwnersByPath) {
     const entries = listSessionEntriesReadOnly({ storePath, clone: false });
-    const metaByEntry = readAcpSessionMetaBatch({
-      entries: entries.map(({ sessionKey, entry }) => ({
-        sessionKey,
-        agentId: resolveAgentIdFromSessionKey(sessionKey, params.sessionOwnerAgentId),
+    const entryOwners = new Map(
+      entries.map(({ sessionKey, entry }) => [
         entry,
-      })),
+        resolveStoredSessionOwner(sessionKey, allowedOwners),
+      ]),
+    );
+    const metaByEntry = readAcpSessionMetaBatch({
+      entries: entries.flatMap(({ sessionKey, entry }) => {
+        const agentId = entryOwners.get(entry);
+        return agentId ? [{ sessionKey, agentId, entry }] : [];
+      }),
       cfg: params.cfg,
     });
     for (const { sessionKey, entry } of entries) {
-      if (
-        !allowedOwners.has(resolveAgentIdFromSessionKey(sessionKey, params.sessionOwnerAgentId))
-      ) {
+      const entryOwnerAgentId = entryOwners.get(entry);
+      if (!entryOwnerAgentId || !allowedOwners.has(entryOwnerAgentId)) {
         continue;
       }
       const acp = metaByEntry.get(entry);
@@ -331,10 +354,6 @@ export async function validateAcpResumeSessionOwnership(params: {
           requesterSessionKey,
         })
       ) {
-        const entryOwnerAgentId = resolveAgentIdFromSessionKey(
-          sessionKey,
-          params.sessionOwnerAgentId,
-        );
         if (
           entryOwnerAgentId !== params.sessionOwnerAgentId &&
           !(await promoteLegacyAcpResumeEntry({

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -2,27 +2,19 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import {
-  readAcpSessionMetaBatch,
-  writeAcpSessionMetaForMigration,
-} from "../../../acp/runtime/session-meta.js";
+import { readAcpSessionMetaBatch } from "../../../acp/runtime/session-meta.js";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
 import {
   listSessionEntriesReadOnly,
   loadSessionEntryReadOnly,
   resolveSessionTranscriptRuntimeTarget,
-  upsertSessionEntryCore,
 } from "../../../config/sessions/session-accessor.js";
 import type { SessionAcpMeta, SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
-import {
-  isSubagentSessionKey,
-  parseAgentSessionKey,
-  toAgentStoreSessionKey,
-} from "../../../routing/session-key.js";
+import { isSubagentSessionKey, parseAgentSessionKey } from "../../../routing/session-key.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import { resolveRequesterOriginForChild } from "../../spawn-requester-origin.js";
 import {
@@ -35,11 +27,6 @@ import {
 } from "./acp-spawn-heartbeat.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
-
-// Owner/harness separation shipped after legacy ACP sessions had already been stored under the
-// harness. Keep the compatibility reader explicitly time-bounded; matched rows are promoted into
-// the canonical owner store so subsequent resumes no longer depend on the legacy namespace.
-const LEGACY_ACP_HARNESS_STORE_MIGRATION_DEADLINE_MS = Date.parse("2027-03-01T00:00:00Z");
 
 type AcpSpawnRequesterContext = {
   agentChannel?: string;
@@ -206,77 +193,6 @@ function sessionEntryIsOwnedByRequester(params: {
   );
 }
 
-function resolveStoredSessionOwner(
-  sessionKey: string,
-  storeOwners: ReadonlySet<string>,
-): string | undefined {
-  const parsed = parseAgentSessionKey(sessionKey);
-  if (parsed?.agentId) {
-    return parsed.agentId;
-  }
-  if (sessionKey.trim().toLowerCase().startsWith("agent:")) {
-    return undefined;
-  }
-  if (storeOwners.size !== 1) {
-    return undefined;
-  }
-  return storeOwners.values().next().value;
-}
-
-async function promoteLegacyAcpResumeEntry(params: {
-  cfg: OpenClawConfig;
-  entry: SessionEntry;
-  harnessSessionKey: string;
-  meta: SessionAcpMeta;
-  sessionOwnerAgentId: string;
-}): Promise<boolean> {
-  const parsed = parseAgentSessionKey(params.harnessSessionKey);
-  const ownerSessionKey = parsed?.rest
-    ? `agent:${params.sessionOwnerAgentId}:${parsed.rest}`
-    : toAgentStoreSessionKey({
-        agentId: params.sessionOwnerAgentId,
-        requestKey: params.harnessSessionKey,
-      });
-  const ownerStorePath = resolveSessionStorePathCore(params.cfg.session?.store, {
-    agentId: params.sessionOwnerAgentId,
-  });
-  if (
-    loadSessionEntryReadOnly({
-      agentId: params.sessionOwnerAgentId,
-      storePath: ownerStorePath,
-      sessionKey: ownerSessionKey,
-      clone: false,
-    })
-  ) {
-    return false;
-  }
-  try {
-    writeAcpSessionMetaForMigration({
-      sessionKey: ownerSessionKey,
-      sessionId: params.entry.sessionId,
-      lifecycleRevision: params.entry.lifecycleRevision,
-      meta: params.meta,
-    });
-  } catch (error) {
-    log.warn(
-      `ACP legacy owner promotion metadata write failed for ${ownerSessionKey}: ${formatErrorMessage(error)}`,
-    );
-    return false;
-  }
-  const promoted = await upsertSessionEntryCore(
-    {
-      agentId: params.sessionOwnerAgentId,
-      storePath: ownerStorePath,
-      sessionKey: ownerSessionKey,
-    },
-    params.entry,
-  );
-  if (!promoted) {
-    return false;
-  }
-  return true;
-}
-
 export async function validateAcpResumeSessionOwnership(params: {
   cfg: OpenClawConfig;
   sessionOwnerAgentId: string;
@@ -298,88 +214,40 @@ export async function validateAcpResumeSessionOwnership(params: {
   }
 
   const configuredBackend = normalizeOptionalLowercaseString(params.backendId);
-  const storeSearchesByPath = new Map<
-    string,
-    { allowedOwners: Set<string>; possibleOwners: Set<string> }
-  >();
-  const registerStoreOwner = (storeAgentId: string, allowed: boolean) => {
-    const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
-      agentId: storeAgentId,
-    });
-    const search = storeSearchesByPath.get(storePath) ?? {
-      allowedOwners: new Set<string>(),
-      possibleOwners: new Set<string>(),
-    };
-    search.possibleOwners.add(storeAgentId);
-    if (allowed) {
-      search.allowedOwners.add(storeAgentId);
-    }
-    storeSearchesByPath.set(storePath, search);
-  };
-  registerStoreOwner(params.sessionOwnerAgentId, true);
-  if (params.harnessAgentId !== params.sessionOwnerAgentId) {
-    registerStoreOwner(
-      params.harnessAgentId,
-      Date.now() < LEGACY_ACP_HARNESS_STORE_MIGRATION_DEADLINE_MS,
-    );
-  }
-  for (const [storePath, { allowedOwners, possibleOwners }] of storeSearchesByPath) {
-    if (allowedOwners.size === 0) {
+  const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+    agentId: params.sessionOwnerAgentId,
+  });
+  const entries = listSessionEntriesReadOnly({ storePath, clone: false });
+  const metaByEntry = readAcpSessionMetaBatch({
+    entries: entries.map(({ sessionKey, entry }) => ({
+      sessionKey,
+      agentId: params.sessionOwnerAgentId,
+      entry,
+    })),
+    cfg: params.cfg,
+  });
+  for (const { sessionKey, entry } of entries) {
+    if (parseAgentSessionKey(sessionKey)?.agentId !== params.sessionOwnerAgentId) {
       continue;
     }
-    const entries = listSessionEntriesReadOnly({ storePath, clone: false });
-    const entryOwners = new Map(
-      entries.map(({ sessionKey, entry }) => [
+    const acp = metaByEntry.get(entry);
+    // Resume identifiers are backend-local; requester ownership cannot authorize another backend.
+    if (
+      !acp ||
+      (configuredBackend && normalizeOptionalLowercaseString(acp.backend) !== configuredBackend) ||
+      normalizeOptionalString(acp.agent) !== params.harnessAgentId ||
+      !sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)
+    ) {
+      continue;
+    }
+    if (
+      sessionEntryIsOwnedByRequester({
+        sessionKey,
         entry,
-        resolveStoredSessionOwner(sessionKey, possibleOwners),
-      ]),
-    );
-    const metaByEntry = readAcpSessionMetaBatch({
-      entries: entries.flatMap(({ sessionKey, entry }) => {
-        const agentId = entryOwners.get(entry);
-        return agentId ? [{ sessionKey, agentId, entry }] : [];
-      }),
-      cfg: params.cfg,
-    });
-    for (const { sessionKey, entry } of entries) {
-      const entryOwnerAgentId = entryOwners.get(entry);
-      if (!entryOwnerAgentId || !allowedOwners.has(entryOwnerAgentId)) {
-        continue;
-      }
-      const acp = metaByEntry.get(entry);
-      // Resume identifiers are backend-local; requester ownership cannot authorize another backend.
-      if (
-        !acp ||
-        (configuredBackend &&
-          normalizeOptionalLowercaseString(acp?.backend) !== configuredBackend) ||
-        // An owner alias is mutable and cannot prove which harness created a legacy record.
-        // Fail closed unless persisted metadata names the currently requested harness.
-        normalizeOptionalString(acp?.agent) !== params.harnessAgentId ||
-        !sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)
-      ) {
-        continue;
-      }
-      if (
-        sessionEntryIsOwnedByRequester({
-          sessionKey,
-          entry,
-          requesterSessionKey,
-        })
-      ) {
-        if (
-          entryOwnerAgentId !== params.sessionOwnerAgentId &&
-          !(await promoteLegacyAcpResumeEntry({
-            cfg: params.cfg,
-            entry,
-            harnessSessionKey: sessionKey,
-            meta: acp,
-            sessionOwnerAgentId: params.sessionOwnerAgentId,
-          }))
-        ) {
-          continue;
-        }
-        return { ok: true };
-      }
+        requesterSessionKey,
+      })
+    ) {
+      return { ok: true };
     }
   }
 

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -2,19 +2,27 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { readAcpSessionMeta } from "../../../acp/runtime/session-meta.js";
+import {
+  readAcpSessionMetaBatch,
+  writeAcpSessionMetaForMigration,
+} from "../../../acp/runtime/session-meta.js";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
 import {
   listSessionEntriesReadOnly,
   loadSessionEntryReadOnly,
   resolveSessionTranscriptRuntimeTarget,
+  upsertSessionEntryCore,
 } from "../../../config/sessions/session-accessor.js";
 import type { SessionAcpMeta, SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
-import { isSubagentSessionKey, parseAgentSessionKey } from "../../../routing/session-key.js";
+import {
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../../../routing/session-key.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import { resolveRequesterOriginForChild } from "../../spawn-requester-origin.js";
 import {
@@ -27,6 +35,11 @@ import {
 } from "./acp-spawn-heartbeat.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
+
+// Owner/harness separation shipped after legacy ACP sessions had already been stored under the
+// harness. Keep the compatibility reader explicitly time-bounded; matched rows are promoted into
+// the canonical owner store so subsequent resumes no longer depend on the legacy namespace.
+const LEGACY_ACP_HARNESS_STORE_MIGRATION_DEADLINE_MS = Date.parse("2027-03-01T00:00:00Z");
 
 type AcpSpawnRequesterContext = {
   agentChannel?: string;
@@ -193,13 +206,59 @@ function sessionEntryIsOwnedByRequester(params: {
   );
 }
 
-export function validateAcpResumeSessionOwnership(params: {
+async function promoteLegacyAcpResumeEntry(params: {
   cfg: OpenClawConfig;
-  targetAgentId: string;
+  entry: SessionEntry;
+  harnessSessionKey: string;
+  meta: SessionAcpMeta;
+  sessionOwnerAgentId: string;
+}): Promise<boolean> {
+  const parsed = parseAgentSessionKey(params.harnessSessionKey);
+  if (!parsed?.rest) {
+    return false;
+  }
+  const ownerSessionKey = `agent:${params.sessionOwnerAgentId}:${parsed.rest}`;
+  const ownerStorePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+    agentId: params.sessionOwnerAgentId,
+  });
+  if (
+    loadSessionEntryReadOnly({
+      agentId: params.sessionOwnerAgentId,
+      storePath: ownerStorePath,
+      sessionKey: ownerSessionKey,
+      clone: false,
+    })
+  ) {
+    return false;
+  }
+  const promoted = await upsertSessionEntryCore(
+    {
+      agentId: params.sessionOwnerAgentId,
+      storePath: ownerStorePath,
+      sessionKey: ownerSessionKey,
+    },
+    params.entry,
+  );
+  if (!promoted) {
+    return false;
+  }
+  writeAcpSessionMetaForMigration({
+    sessionKey: ownerSessionKey,
+    sessionId: promoted.sessionId,
+    lifecycleRevision: promoted.lifecycleRevision,
+    meta: params.meta,
+  });
+  return true;
+}
+
+export async function validateAcpResumeSessionOwnership(params: {
+  cfg: OpenClawConfig;
+  sessionOwnerAgentId: string;
+  harnessAgentId: string;
   backendId?: string;
   requesterSessionKey?: string;
   resumeSessionId?: string;
-}): { ok: true } | { ok: false; error: string } {
+}): Promise<{ ok: true } | { ok: false; error: string }> {
   const resumeSessionId = normalizeOptionalString(params.resumeSessionId);
   if (!resumeSessionId) {
     return { ok: true };
@@ -213,28 +272,77 @@ export function validateAcpResumeSessionOwnership(params: {
   }
 
   const configuredBackend = normalizeOptionalLowercaseString(params.backendId);
-  const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
-    agentId: params.targetAgentId,
-  });
-  for (const { sessionKey, entry } of listSessionEntriesReadOnly({ storePath, clone: false })) {
-    const acp = readAcpSessionMeta({ sessionKey, cfg: params.cfg });
-    // Resume identifiers are backend-local; requester ownership cannot authorize another backend.
-    if (
-      (configuredBackend && normalizeOptionalLowercaseString(acp?.backend) !== configuredBackend) ||
-      !sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)
-    ) {
-      continue;
-    }
-    if (
-      sessionEntryIsOwnedByRequester({
+  const storeAgentIds = [params.sessionOwnerAgentId];
+  if (
+    params.harnessAgentId !== params.sessionOwnerAgentId &&
+    Date.now() < LEGACY_ACP_HARNESS_STORE_MIGRATION_DEADLINE_MS
+  ) {
+    storeAgentIds.push(params.harnessAgentId);
+  }
+  const storeOwnersByPath = new Map<string, Set<string>>();
+  for (const storeAgentId of storeAgentIds) {
+    const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+      agentId: storeAgentId,
+    });
+    const owners = storeOwnersByPath.get(storePath) ?? new Set<string>();
+    owners.add(storeAgentId);
+    storeOwnersByPath.set(storePath, owners);
+  }
+  for (const [storePath, allowedOwners] of storeOwnersByPath) {
+    const entries = listSessionEntriesReadOnly({ storePath, clone: false });
+    const metaByEntry = readAcpSessionMetaBatch({
+      entries: entries.map(({ sessionKey, entry }) => ({
         sessionKey,
+        agentId: resolveAgentIdFromSessionKey(sessionKey, params.sessionOwnerAgentId),
         entry,
-        requesterSessionKey,
-      })
-    ) {
-      return { ok: true };
+      })),
+      cfg: params.cfg,
+    });
+    for (const { sessionKey, entry } of entries) {
+      if (
+        !allowedOwners.has(resolveAgentIdFromSessionKey(sessionKey, params.sessionOwnerAgentId))
+      ) {
+        continue;
+      }
+      const acp = metaByEntry.get(entry);
+      // Resume identifiers are backend-local; requester ownership cannot authorize another backend.
+      if (
+        !acp ||
+        (configuredBackend &&
+          normalizeOptionalLowercaseString(acp?.backend) !== configuredBackend) ||
+        // An owner alias is mutable and cannot prove which harness created a legacy record.
+        // Fail closed unless persisted metadata names the currently requested harness.
+        normalizeOptionalString(acp?.agent) !== params.harnessAgentId ||
+        !sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)
+      ) {
+        continue;
+      }
+      if (
+        sessionEntryIsOwnedByRequester({
+          sessionKey,
+          entry,
+          requesterSessionKey,
+        })
+      ) {
+        const entryOwnerAgentId = resolveAgentIdFromSessionKey(
+          sessionKey,
+          params.sessionOwnerAgentId,
+        );
+        if (
+          entryOwnerAgentId !== params.sessionOwnerAgentId &&
+          !(await promoteLegacyAcpResumeEntry({
+            cfg: params.cfg,
+            entry,
+            harnessSessionKey: sessionKey,
+            meta: acp,
+            sessionOwnerAgentId: params.sessionOwnerAgentId,
+          }))
+        ) {
+          break;
+        }
+        return { ok: true };
+      }
     }
-    break;
   }
 
   return {

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -231,6 +231,19 @@ async function promoteLegacyAcpResumeEntry(params: {
   ) {
     return false;
   }
+  try {
+    writeAcpSessionMetaForMigration({
+      sessionKey: ownerSessionKey,
+      sessionId: params.entry.sessionId,
+      lifecycleRevision: params.entry.lifecycleRevision,
+      meta: params.meta,
+    });
+  } catch (error) {
+    log.warn(
+      `ACP legacy owner promotion metadata write failed for ${ownerSessionKey}: ${formatErrorMessage(error)}`,
+    );
+    return false;
+  }
   const promoted = await upsertSessionEntryCore(
     {
       agentId: params.sessionOwnerAgentId,
@@ -242,12 +255,6 @@ async function promoteLegacyAcpResumeEntry(params: {
   if (!promoted) {
     return false;
   }
-  writeAcpSessionMetaForMigration({
-    sessionKey: ownerSessionKey,
-    sessionId: promoted.sessionId,
-    lifecycleRevision: promoted.lifecycleRevision,
-    meta: params.meta,
-  });
   return true;
 }
 

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -376,7 +376,7 @@ export async function validateAcpResumeSessionOwnership(params: {
             sessionOwnerAgentId: params.sessionOwnerAgentId,
           }))
         ) {
-          break;
+          continue;
         }
         return { ok: true };
       }

--- a/src/agents/subagents/spawn/acp-spawn-runtime.ts
+++ b/src/agents/subagents/spawn/acp-spawn-runtime.ts
@@ -155,7 +155,8 @@ export function resolveAcpSpawnRuntimeOptions(params: {
 export async function initializeAcpSpawnRuntime(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
-  targetAgentId: string;
+  sessionOwnerAgentId: string;
+  harnessAgentId: string;
   runtimeMode: AcpRuntimeSessionMode;
   backendId?: string;
   resumeSessionId?: string;
@@ -164,12 +165,12 @@ export async function initializeAcpSpawnRuntime(params: {
   cwd?: string;
 }): Promise<AcpSpawnInitializedRuntime> {
   const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
-    agentId: params.targetAgentId,
+    agentId: params.sessionOwnerAgentId,
   });
   let sessionEntry = loadSessionEntry({
     storePath,
     sessionKey: params.sessionKey,
-    agentId: params.targetAgentId,
+    agentId: params.sessionOwnerAgentId,
     clone: false,
   });
   const sessionId = sessionEntry?.sessionId;
@@ -179,7 +180,7 @@ export async function initializeAcpSpawnRuntime(params: {
       sessionKey: params.sessionKey,
       storePath,
       sessionEntry,
-      agentId: params.targetAgentId,
+      agentId: params.sessionOwnerAgentId,
       stage: "spawn",
     });
   }
@@ -187,8 +188,8 @@ export async function initializeAcpSpawnRuntime(params: {
   const initialized = await getAcpSessionManager().initializeSession({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
-    agentId: params.targetAgentId,
-    agent: params.targetAgentId,
+    agentId: params.sessionOwnerAgentId,
+    agent: params.harnessAgentId,
     mode: params.runtimeMode,
     resumeSessionId: params.resumeSessionId,
     runtimeOptions: params.runtimeOptions,
@@ -212,7 +213,8 @@ export async function initializeAcpSpawnRuntime(params: {
 export async function bindPreparedAcpThread(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
-  targetAgentId: string;
+  sessionOwnerAgentId: string;
+  harnessAgentId: string;
   label?: string;
   preparedBinding: PreparedSpawnThreadBinding;
   initializedRuntime: AcpSpawnInitializedRuntime;
@@ -234,14 +236,14 @@ export async function bindPreparedAcpThread(params: {
     placement: params.preparedBinding.placement,
     metadata: {
       threadName: resolveThreadBindingThreadName({
-        agentId: params.targetAgentId,
-        label: params.label || params.targetAgentId,
+        agentId: params.harnessAgentId,
+        label: params.label || params.harnessAgentId,
       }),
-      agentId: params.targetAgentId,
+      agentId: params.sessionOwnerAgentId,
       label: params.label || undefined,
       boundBy: "system",
       introText: resolveThreadBindingIntroText({
-        agentId: params.targetAgentId,
+        agentId: params.harnessAgentId,
         label: params.label || undefined,
         idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
           cfg: params.cfg,
@@ -278,7 +280,7 @@ export async function bindPreparedAcpThread(params: {
         sessionKey: params.sessionKey,
         storePath: params.initializedRuntime.storePath,
         sessionEntry,
-        agentId: params.targetAgentId,
+        agentId: params.sessionOwnerAgentId,
         threadId: boundThreadId,
         stage: "thread-bind",
       });

--- a/src/agents/subagents/spawn/acp-spawn-target.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn-target.test.ts
@@ -21,4 +21,42 @@ describe("resolveTargetAcpAgentId", () => {
       }),
     ).toEqual({ ok: true, agentId: "codex" });
   });
+
+  it("maps a configured default ACP alias to its external harness", () => {
+    expect(
+      resolveTargetAcpAgentId({
+        cfg: {
+          acp: { defaultAgent: "codex-acp" },
+          agents: {
+            list: [
+              {
+                id: "codex-acp",
+                runtime: { type: "acp", acp: { agent: "codex", backend: "acpx" } },
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      ok: true,
+      agentId: "codex",
+      configAgentId: "codex-acp",
+      backendId: "acpx",
+    });
+  });
+
+  it("preserves ownership for a configured default allowed ACP agent", () => {
+    expect(
+      resolveTargetAcpAgentId({
+        cfg: {
+          acp: { defaultAgent: "claude-code", allowedAgents: ["claude-code"] },
+          agents: { list: [{ id: "claude-code" }] },
+        },
+      }),
+    ).toEqual({
+      ok: true,
+      agentId: "claude-code",
+      configAgentId: "claude-code",
+    });
+  });
 });

--- a/src/agents/subagents/spawn/acp-spawn-target.ts
+++ b/src/agents/subagents/spawn/acp-spawn-target.ts
@@ -69,11 +69,18 @@ export function resolveTargetAcpAgentId(params: {
   const configuredDefault = normalizeOptionalAgentId(params.cfg.acp?.defaultAgent);
   if (configuredDefault) {
     const configuredAgent = resolveAgentEntry(params.cfg, configuredDefault);
+    if (configuredAgent?.runtime?.type === "acp") {
+      return resolveAcpAgentTarget({
+        cfg: params.cfg,
+        agentId: normalizeOptionalAgentId(configuredAgent.runtime.acp?.agent) ?? configuredDefault,
+        configAgentId: configuredDefault,
+        agentBackend: configuredAgent.runtime.acp?.backend,
+      });
+    }
     return resolveAcpAgentTarget({
       cfg: params.cfg,
       agentId: configuredDefault,
-      agentBackend:
-        configuredAgent?.runtime?.type === "acp" ? configuredAgent.runtime.acp?.backend : undefined,
+      ...(configuredAgent ? { configAgentId: configuredDefault } : {}),
     });
   }
 

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -3042,6 +3042,49 @@ describe("spawnAcpDirect", () => {
     }
   });
 
+  it("keeps requester account routing for an unconfigured external ACP harness", async () => {
+    const boundRoom = "!external-harness-room:example.org";
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        allowedAgents: ["codex"],
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "codex",
+          match: {
+            channel: "matrix",
+            peer: { kind: "channel", id: boundRoom },
+            accountId: "harness-account",
+          },
+        },
+      ],
+    });
+
+    const result = await spawnAcpDirect(
+      { task: "Keep requester routing", agentId: "codex", mode: "run" },
+      {
+        agentSessionKey: "agent:main:matrix:room:requester",
+        agentChannel: "matrix",
+        agentAccountId: "requester-account",
+        agentTo: `room:${boundRoom}`,
+      },
+    );
+
+    expectAcceptedSpawn(result);
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterOrigin: expect.objectContaining({
+          channel: "matrix",
+          accountId: "requester-account",
+          to: `room:${boundRoom}`,
+        }),
+      }),
+    );
+  });
+
   it("falls back to the backend cwd when the configured owner workspace is missing", async () => {
     const fixture = await createCrossAgentWorkspaceFixture({
       targetDirName: "claude-code-missing",
@@ -3261,7 +3304,15 @@ describe("spawnAcpDirect", () => {
       ...hoisted.state.cfg,
       acp: {
         ...hoisted.state.cfg.acp,
-        allowedAgents: ["codex", "bot-alpha"],
+        allowedAgents: ["codex"],
+      },
+      agents: {
+        list: [
+          {
+            id: "bot-alpha",
+            runtime: { type: "acp", acp: { agent: "codex" } },
+          },
+        ],
       },
       channels: {
         ...hoisted.state.cfg.channels,

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1622,6 +1622,51 @@ describe("spawnAcpDirect", () => {
     );
   });
 
+  it("resumes the canonical row after a shared-store legacy row was already promoted", async () => {
+    const legacySessionKey = "agent:codex:acp:promoted";
+    const ownerSessionKey = "agent:main:acp:promoted";
+    hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      [legacySessionKey]: {
+        sessionId: "sess-promoted",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+      } satisfies SessionEntry,
+      [ownerSessionKey]: {
+        sessionId: "sess-promoted",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+      } satisfies SessionEntry,
+    });
+    hoisted.readAcpSessionMetaMock.mockReturnValue({
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "codex",
+      identity: {
+        state: "resolved",
+        source: "ensure",
+        agentSessionId: "promoted-resume",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Resume the promoted canonical ACP session",
+        agentId: "codex",
+        resumeSessionId: "promoted-resume",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectAcceptedSpawn(result);
+    expectInitializeSessionFields({ resumeSessionId: "promoted-resume" });
+    expect(hoisted.writeAcpSessionMetaForMigrationMock).not.toHaveBeenCalled();
+  });
+
   it("rejects requester-owned resume IDs from a third owner in a shared store", async () => {
     const foreignSessionKey = "agent:other:acp:foreign";
     hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1509,7 +1509,49 @@ describe("spawnAcpDirect", () => {
 
     expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
     expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "main" });
-    expect(hoisted.resolveStorePathMock).not.toHaveBeenCalledWith(undefined, { agentId: "codex" });
+    expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "codex" });
+    expect(hoisted.loadSessionStoreMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps bare keys in a shared owner and harness store ambiguous after migration expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-03-02T00:00:00Z"));
+    hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      global: {
+        sessionId: "sess-expired-ambiguous-bare",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+      } satisfies SessionEntry,
+    });
+    hoisted.readAcpSessionMetaMock.mockReturnValue({
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "codex",
+      identity: {
+        state: "resolved",
+        source: "ensure",
+        agentSessionId: "expired-ambiguous-bare-resume",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Reject expired ambiguous bare legacy ACP session",
+        agentId: "codex",
+        resumeSessionId: "expired-ambiguous-bare-resume",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.writeAcpSessionMetaForMigrationMock).not.toHaveBeenCalled();
+    expect(hoisted.upsertSessionEntryMock).not.toHaveBeenCalled();
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1755,8 +1755,8 @@ describe("spawnAcpDirect", () => {
     );
 
     expectAcceptedSpawn(result);
-    const initInput = expectInitializeSessionFields({ agent: "codex" });
-    expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+    const initInput = expectInitializeSessionFields({ agentId: "reviewer", agent: "codex" });
+    expect(initInput.sessionKey).toMatch(/^agent:reviewer:acp:/);
   });
 
   it("inherits subagent envelope fields onto ACP children", async () => {

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1418,6 +1418,73 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
+  it("leaves a failed legacy metadata promotion retryable", async () => {
+    const legacySessionKey = "agent:codex:acp:retryable";
+    hoisted.resolveStorePathMock.mockImplementation(
+      (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
+    );
+    hoisted.loadSessionStoreMock.mockImplementation((storePath: string) =>
+      storePath === "/tmp/codex-sessions.json"
+        ? {
+            [legacySessionKey]: {
+              sessionId: "sess-retryable",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:main",
+            } satisfies SessionEntry,
+          }
+        : {},
+    );
+    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      return params.sessionKey === legacySessionKey
+        ? {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "codex",
+            identity: {
+              state: "resolved",
+              source: "ensure",
+              agentSessionId: "retryable-resume",
+              lastUpdatedAt: Date.now(),
+            },
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: Date.now(),
+          }
+        : undefined;
+    });
+    hoisted.writeAcpSessionMetaForMigrationMock.mockImplementationOnce(() => {
+      throw new Error("synthetic metadata write failure");
+    });
+
+    const firstAttempt = await spawnAcpDirect(
+      {
+        task: "First migration attempt",
+        agentId: "codex",
+        resumeSessionId: "retryable-resume",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectRecordFields(firstAttempt, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.upsertSessionEntryMock).not.toHaveBeenCalled();
+
+    const retried = await spawnAcpDirect(
+      {
+        task: "Retry migration",
+        agentId: "codex",
+        resumeSessionId: "retryable-resume",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectAcceptedSpawn(retried);
+    expect(hoisted.upsertSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: "agent:main:acp:retryable" }),
+      expect.objectContaining({ sessionId: "sess-retryable" }),
+    );
+  });
+
   it("rejects requester-owned resume IDs from a third owner in a shared store", async () => {
     const foreignSessionKey = "agent:other:acp:foreign";
     hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1238,6 +1238,53 @@ describe("spawnAcpDirect", () => {
     },
   );
 
+  it("allows requester-owned global resume IDs from an owner-scoped store", async () => {
+    const resumeSessionId = "owner-global-resume";
+    hoisted.resolveStorePathMock.mockImplementation(
+      (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
+    );
+    hoisted.loadSessionStoreMock.mockImplementation((storePath: string) =>
+      storePath === "/tmp/main-sessions.json"
+        ? {
+            global: {
+              sessionId: "sess-owner-global",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:main",
+            } satisfies SessionEntry,
+          }
+        : {},
+    );
+    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      return params.sessionKey === "global"
+        ? {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "codex",
+            identity: {
+              state: "resolved",
+              source: "ensure",
+              agentSessionId: resumeSessionId,
+              lastUpdatedAt: Date.now(),
+            },
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: Date.now(),
+          }
+        : undefined;
+    });
+
+    const result = await spawnAcpDirect(
+      { task: "Resume owner global ACP session", agentId: "codex", resumeSessionId },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectAcceptedSpawn(result);
+    expectInitializeSessionFields({ resumeSessionId, backendId: "acpx" });
+    expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "main" });
+    expect(hoisted.resolveStorePathMock).not.toHaveBeenCalledWith(undefined, { agentId: "codex" });
+  });
+
   it("rejects ACP resume IDs not recorded for the requester session", async () => {
     const otherSessionKey = "agent:main:acp:other";
     hoisted.loadSessionStoreMock.mockReturnValue({
@@ -1430,6 +1477,10 @@ describe("spawnAcpDirect", () => {
   });
 
   it("fails closed for bare legacy keys in a shared owner and harness store", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      session: { ...hoisted.state.cfg.session, store: "/tmp/shared-sessions.json" },
+    });
     hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");
     hoisted.loadSessionStoreMock.mockReturnValue({
       global: {
@@ -1491,6 +1542,10 @@ describe("spawnAcpDirect", () => {
   });
 
   it("keeps bare keys in a shared owner and harness store unavailable at runtime", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      session: { ...hoisted.state.cfg.session, store: "/tmp/shared-sessions.json" },
+    });
     hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");
     hoisted.loadSessionStoreMock.mockReturnValue({
       global: {

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -1325,7 +1325,7 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
-  it("allows requester-owned legacy resume IDs stored under the harness agent", async () => {
+  it("rejects requester-owned legacy resume IDs stored under the harness agent", async () => {
     const legacySessionKey = "agent:codex:acp:legacy";
     hoisted.resolveStorePathMock.mockImplementation(
       (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
@@ -1371,31 +1371,15 @@ describe("spawnAcpDirect", () => {
       { agentSessionKey: "agent:main:main" },
     );
 
-    expectAcceptedSpawn(result);
-    expectInitializeSessionFields({
-      agentId: "main",
-      agent: "codex",
-      resumeSessionId: "codex-inner-legacy",
-    });
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
     expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "main" });
-    expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "codex" });
-    expect(hoisted.upsertSessionEntryMock).toHaveBeenCalledWith(
-      {
-        agentId: "main",
-        sessionKey: "agent:main:acp:legacy",
-        storePath: "/tmp/main-sessions.json",
-      },
-      expect.objectContaining({ sessionId: "sess-legacy" }),
-    );
-    expect(hoisted.writeAcpSessionMetaForMigrationMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey: "agent:main:acp:legacy",
-        sessionId: "sess-legacy",
-      }),
-    );
+    expect(hoisted.resolveStorePathMock).not.toHaveBeenCalledWith(undefined, { agentId: "codex" });
+    expect(hoisted.upsertSessionEntryMock).not.toHaveBeenCalled();
+    expect(hoisted.writeAcpSessionMetaForMigrationMock).not.toHaveBeenCalled();
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
-  it("promotes requester-owned bare legacy keys from a separate harness store", async () => {
+  it("rejects requester-owned bare legacy keys from a separate harness store", async () => {
     const legacySessionKey = "global";
     hoisted.resolveStorePathMock.mockImplementation(
       (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
@@ -1440,15 +1424,9 @@ describe("spawnAcpDirect", () => {
       { agentSessionKey: "agent:main:main" },
     );
 
-    expectAcceptedSpawn(result);
-    expect(hoisted.upsertSessionEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentId: "main",
-        sessionKey: "agent:main:global",
-        storePath: "/tmp/main-sessions.json",
-      }),
-      expect.objectContaining({ sessionId: "sess-bare-legacy" }),
-    );
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.upsertSessionEntryMock).not.toHaveBeenCalled();
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
   it("fails closed for bare legacy keys in a shared owner and harness store", async () => {
@@ -1490,9 +1468,7 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
-  it("stops consulting legacy harness stores after the bounded migration window", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2027-03-02T00:00:00Z"));
+  it("never consults legacy harness stores during runtime resume", async () => {
     hoisted.resolveStorePathMock.mockImplementation(
       (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
     );
@@ -1509,14 +1485,12 @@ describe("spawnAcpDirect", () => {
 
     expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
     expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "main" });
-    expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "codex" });
+    expect(hoisted.resolveStorePathMock).not.toHaveBeenCalledWith(undefined, { agentId: "codex" });
     expect(hoisted.loadSessionStoreMock).toHaveBeenCalledTimes(1);
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
-  it("keeps bare keys in a shared owner and harness store ambiguous after migration expires", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2027-03-02T00:00:00Z"));
+  it("keeps bare keys in a shared owner and harness store unavailable at runtime", async () => {
     hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");
     hoisted.loadSessionStoreMock.mockReturnValue({
       global: {
@@ -1555,7 +1529,7 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
-  it("leaves a failed legacy metadata promotion retryable", async () => {
+  it("does not promote legacy metadata during runtime resume", async () => {
     const legacySessionKey = "agent:codex:acp:retryable";
     hoisted.resolveStorePathMock.mockImplementation(
       (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
@@ -1615,11 +1589,8 @@ describe("spawnAcpDirect", () => {
       { agentSessionKey: "agent:main:main" },
     );
 
-    expectAcceptedSpawn(retried);
-    expect(hoisted.upsertSessionEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionKey: "agent:main:acp:retryable" }),
-      expect.objectContaining({ sessionId: "sess-retryable" }),
-    );
+    expectRecordFields(retried, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.upsertSessionEntryMock).not.toHaveBeenCalled();
   });
 
   it("resumes the canonical row after a shared-store legacy row was already promoted", async () => {
@@ -1706,7 +1677,7 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
-  it("continues to the legacy store after an owner-store resume collision", async () => {
+  it("does not consult a legacy store after an owner-store resume collision", async () => {
     const ownerSessionKey = "agent:main:acp:collision";
     const legacySessionKey = "agent:codex:acp:owned-legacy";
     hoisted.resolveStorePathMock.mockImplementation(
@@ -1764,8 +1735,8 @@ describe("spawnAcpDirect", () => {
       { agentSessionKey: "agent:main:main" },
     );
 
-    expectAcceptedSpawn(result);
-    expectInitializeSessionFields({ resumeSessionId: "shared-resume-id" });
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
   it("passes model and thinking overrides into ACP session initialization", async () => {

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -82,6 +82,7 @@ const hoisted = vi.hoisted(() => {
   const startAcpSpawnParentStreamRelayMock = vi.fn();
   const loadSessionStoreMock = vi.fn();
   const readAcpSessionMetaMock = vi.fn();
+  const writeAcpSessionMetaForMigrationMock = vi.fn();
   const resolveStorePathMock = vi.fn();
   const resolveSessionTranscriptFileMock = vi.fn();
   const areHeartbeatsEnabledMock = vi.fn();
@@ -177,6 +178,7 @@ const hoisted = vi.hoisted(() => {
     startAcpSpawnParentStreamRelayMock,
     loadSessionStoreMock,
     readAcpSessionMetaMock,
+    writeAcpSessionMetaForMigrationMock,
     resolveStorePathMock,
     resolveSessionTranscriptFileMock,
     areHeartbeatsEnabledMock,
@@ -202,6 +204,22 @@ vi.mock("../../../acp/control-plane/spawn.js", () => ({
 
 vi.mock("../../../acp/runtime/session-meta.js", () => ({
   readAcpSessionMeta: (params: unknown) => hoisted.readAcpSessionMetaMock(params),
+  readAcpSessionMetaBatch: (paramsUnknown: unknown) => {
+    const params = paramsUnknown as {
+      entries: Array<{ sessionKey: string; agentId?: string; entry: SessionEntry }>;
+    };
+    return new Map(
+      params.entries.map(({ sessionKey, agentId, entry }) => {
+        const sessionOwner = sessionKey.match(/^agent:([^:]+):/)?.[1] ?? "main";
+        return [
+          entry,
+          agentId === sessionOwner ? hoisted.readAcpSessionMetaMock({ sessionKey }) : undefined,
+        ];
+      }),
+    );
+  },
+  writeAcpSessionMetaForMigration: (params: unknown) =>
+    hoisted.writeAcpSessionMetaForMigrationMock(params),
 }));
 
 vi.mock("../../../channels/plugins/index.js", () => ({
@@ -800,7 +818,8 @@ describe("spawnAcpDirect", () => {
             metadata: {
               boundBy:
                 typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
-              agentId: "codex",
+              agentId:
+                typeof input.metadata?.agentId === "string" ? input.metadata.agentId : "main",
               webhookId: "wh-1",
             },
           }),
@@ -824,11 +843,12 @@ describe("spawnAcpDirect", () => {
       .mockImplementation(() => createRelayHandle());
     hoisted.resolveStorePathMock.mockReset().mockReturnValue("/tmp/codex-sessions.json");
     hoisted.readAcpSessionMetaMock.mockReset().mockReturnValue(undefined);
+    hoisted.writeAcpSessionMetaForMigrationMock.mockReset();
     hoisted.loadSessionStoreMock.mockReset().mockImplementation(() => {
       const store: Record<string, { sessionId: string; updatedAt: number }> = {};
       return new Proxy(store, {
         get(_target, prop) {
-          if (typeof prop === "string" && prop.startsWith("agent:codex:acp:")) {
+          if (typeof prop === "string" && /^agent:[^:]+:acp:/.test(prop)) {
             return { sessionId: "sess-123", updatedAt: Date.now() };
           }
           return undefined;
@@ -854,6 +874,7 @@ describe("spawnAcpDirect", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     setActivePluginRegistry(createTestRegistry());
     acpRuntimeRegistryTesting.resetAcpRuntimeBackendsForTests();
     sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
@@ -877,7 +898,7 @@ describe("spawnAcpDirect", () => {
     );
 
     const accepted = expectAcceptedSpawn(result);
-    expect(accepted.childSessionKey).toMatch(/^agent:codex:acp:/);
+    expect(accepted.childSessionKey).toMatch(/^agent:main:acp:/);
     expect(accepted.runId).toBe("run-1");
     expect(accepted.mode).toBe("session");
     expect(accepted.inlineDelivery).toBe(true);
@@ -918,7 +939,7 @@ describe("spawnAcpDirect", () => {
     expectResolvedIntroTextInBindMetadata();
 
     const agentCall = gatewayRequest("agent");
-    expect(agentCall?.params?.sessionKey).toMatch(/^agent:codex:acp:/);
+    expect(agentCall?.params?.sessionKey).toMatch(/^agent:main:acp:/);
     expect(agentCall?.params?.to).toBe("channel:child-thread");
     expect(agentCall?.params?.threadId).toBe("child-thread");
     expect(agentCall?.params?.deliver).toBe(true);
@@ -935,10 +956,14 @@ describe("spawnAcpDirect", () => {
     );
     expect(registeredAcpRun.taskRowOwnership).toBeUndefined();
     const initInput = expectInitializeSessionFields({
+      agentId: "main",
       agent: "codex",
       mode: "persistent",
     });
-    expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+    expect(initInput.sessionKey).toMatch(/^agent:main:acp:/);
+    expectRecordFields(firstMockCall(hoisted.upsertSessionEntryMock, "session create")[0], {
+      agentId: "main",
+    });
     const transcriptCalls = hoisted.resolveSessionTranscriptFileMock.mock.calls.map(
       (call: unknown[]) => call[0] as { threadId?: string },
     );
@@ -991,7 +1016,7 @@ describe("spawnAcpDirect", () => {
     expect(agentDispatchAttempts).toBe(2);
     const accepted = expectAcceptedSpawn(result);
     expect(accepted.runId).toBe("accepted-acp-run");
-    expect(accepted.childSessionKey).toMatch(/^agent:codex:acp:/);
+    expect(accepted.childSessionKey).toMatch(/^agent:main:acp:/);
   });
 
   it("does not register an ACP child when reconciliation finds a terminal run", async () => {
@@ -1154,7 +1179,8 @@ describe("spawnAcpDirect", () => {
       }
 
       const resumeSessionId = "codex-inner-resume";
-      const ownedSessionKey = "agent:codex:acp:owned";
+      const sessionOwnerAgentId = targetBackend ? "reviewer" : "main";
+      const ownedSessionKey = `agent:${sessionOwnerAgentId}:acp:owned`;
       hoisted.loadSessionStoreMock.mockReturnValue({
         [ownedSessionKey]: {
           sessionId: "sess-owned",
@@ -1193,6 +1219,9 @@ describe("spawnAcpDirect", () => {
           agentSessionKey: "agent:main:main",
         },
       );
+      expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, {
+        agentId: sessionOwnerAgentId,
+      });
 
       if (accepted) {
         expectAcceptedSpawn(result);
@@ -1210,7 +1239,7 @@ describe("spawnAcpDirect", () => {
   );
 
   it("rejects ACP resume IDs not recorded for the requester session", async () => {
-    const otherSessionKey = "agent:codex:acp:other";
+    const otherSessionKey = "agent:main:acp:other";
     hoisted.loadSessionStoreMock.mockReturnValue({
       [otherSessionKey]: {
         sessionId: "sess-other",
@@ -1258,6 +1287,238 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("rejects an owned resume ID recorded for a different ACP harness", async () => {
+    const ownedSessionKey = "agent:main:acp:other-harness";
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      [ownedSessionKey]: {
+        sessionId: "sess-other-harness",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+      } satisfies SessionEntry,
+    });
+    hoisted.readAcpSessionMetaMock.mockReturnValue({
+      backend: "acpx",
+      agent: "claude",
+      runtimeSessionName: "claude",
+      identity: {
+        state: "resolved",
+        source: "ensure",
+        agentSessionId: "shared-resume-id",
+        acpxSessionId: "shared-resume-id",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Do not cross harnesses",
+        agentId: "codex",
+        resumeSessionId: "shared-resume-id",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("allows requester-owned legacy resume IDs stored under the harness agent", async () => {
+    const legacySessionKey = "agent:codex:acp:legacy";
+    hoisted.resolveStorePathMock.mockImplementation(
+      (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
+    );
+    hoisted.loadSessionStoreMock.mockImplementation((storePath: string) =>
+      storePath === "/tmp/codex-sessions.json"
+        ? {
+            [legacySessionKey]: {
+              sessionId: "sess-legacy",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:main",
+            } satisfies SessionEntry,
+          }
+        : {},
+    );
+    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      return params.sessionKey === legacySessionKey
+        ? {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "codex",
+            identity: {
+              state: "resolved",
+              source: "ensure",
+              agentSessionId: "codex-inner-legacy",
+              acpxSessionId: "acpx-legacy",
+              lastUpdatedAt: Date.now(),
+            },
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: Date.now(),
+          }
+        : undefined;
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Resume legacy ACP session",
+        agentId: "codex",
+        resumeSessionId: "codex-inner-legacy",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectAcceptedSpawn(result);
+    expectInitializeSessionFields({
+      agentId: "main",
+      agent: "codex",
+      resumeSessionId: "codex-inner-legacy",
+    });
+    expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "main" });
+    expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "codex" });
+    expect(hoisted.upsertSessionEntryMock).toHaveBeenCalledWith(
+      {
+        agentId: "main",
+        sessionKey: "agent:main:acp:legacy",
+        storePath: "/tmp/main-sessions.json",
+      },
+      expect.objectContaining({ sessionId: "sess-legacy" }),
+    );
+    expect(hoisted.writeAcpSessionMetaForMigrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:acp:legacy",
+        sessionId: "sess-legacy",
+      }),
+    );
+  });
+
+  it("stops consulting legacy harness stores after the bounded migration window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-03-02T00:00:00Z"));
+    hoisted.resolveStorePathMock.mockImplementation(
+      (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
+    );
+    hoisted.loadSessionStoreMock.mockReturnValue({});
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Do not use an expired compatibility reader",
+        agentId: "codex",
+        resumeSessionId: "legacy-resume-id",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.resolveStorePathMock).toHaveBeenCalledWith(undefined, { agentId: "main" });
+    expect(hoisted.resolveStorePathMock).not.toHaveBeenCalledWith(undefined, { agentId: "codex" });
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects requester-owned resume IDs from a third owner in a shared store", async () => {
+    const foreignSessionKey = "agent:other:acp:foreign";
+    hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      [foreignSessionKey]: {
+        sessionId: "sess-foreign",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+      } satisfies SessionEntry,
+    });
+    hoisted.readAcpSessionMetaMock.mockReturnValue({
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "codex",
+      identity: {
+        state: "resolved",
+        source: "ensure",
+        agentSessionId: "foreign-resume-id",
+        acpxSessionId: "foreign-resume-id",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Do not cross owner namespaces",
+        agentId: "codex",
+        resumeSessionId: "foreign-resume-id",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("continues to the legacy store after an owner-store resume collision", async () => {
+    const ownerSessionKey = "agent:main:acp:collision";
+    const legacySessionKey = "agent:codex:acp:owned-legacy";
+    hoisted.resolveStorePathMock.mockImplementation(
+      (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
+    );
+    hoisted.loadSessionStoreMock.mockImplementation((storePath: string) => {
+      if (storePath === "/tmp/main-sessions.json") {
+        return {
+          [ownerSessionKey]: {
+            sessionId: "sess-collision",
+            updatedAt: Date.now(),
+            spawnedBy: "agent:other:main",
+          } satisfies SessionEntry,
+        };
+      }
+      if (storePath === "/tmp/codex-sessions.json") {
+        return {
+          [legacySessionKey]: {
+            sessionId: "sess-owned-legacy",
+            updatedAt: Date.now(),
+            spawnedBy: "agent:main:main",
+          } satisfies SessionEntry,
+        };
+      }
+      return {};
+    });
+    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      if (params.sessionKey !== ownerSessionKey && params.sessionKey !== legacySessionKey) {
+        return undefined;
+      }
+      return {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "codex",
+        identity: {
+          state: "resolved",
+          source: "ensure",
+          agentSessionId: "shared-resume-id",
+          acpxSessionId: "shared-resume-id",
+          lastUpdatedAt: Date.now(),
+        },
+        mode: "oneshot",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      };
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Resume the requester-owned legacy session",
+        agentId: "codex",
+        resumeSessionId: "shared-resume-id",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectAcceptedSpawn(result);
+    expectInitializeSessionFields({ resumeSessionId: "shared-resume-id" });
+  });
+
   it("passes model and thinking overrides into ACP session initialization", async () => {
     const result = await spawnAcpDirect(
       {
@@ -1279,7 +1540,7 @@ describe("spawnAcpDirect", () => {
         thinking: "high",
       },
     });
-    expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+    expect(initInput.sessionKey).toMatch(/^agent:main:acp:/);
   });
 
   it("strips an inherited OpenClaw auth profile before ACP initialization", async () => {
@@ -1401,8 +1662,9 @@ describe("spawnAcpDirect", () => {
       },
     );
 
-    expectAcceptedSpawn(result);
+    expect(expectAcceptedSpawn(result).childSessionKey).toMatch(/^agent:codex-acp:acp:/);
     expectInitializeSessionFields({
+      agentId: "codex-acp",
       agent: "codex",
       runtimeOptions: {
         model: "openai/gpt-5.5",
@@ -1542,7 +1804,7 @@ describe("spawnAcpDirect", () => {
         timeoutSeconds: 45,
       },
     });
-    expect(initInput.sessionKey).toMatch(/^agent:codex:acp:/);
+    expect(initInput.sessionKey).toMatch(/^agent:main:acp:/);
     const agentCall = findAgentGatewayCall();
     expect(agentCall?.params?.lane).toBe("subagent");
     expect(agentCall?.params?.timeout).toBe(45);
@@ -2271,6 +2533,41 @@ describe("spawnAcpDirect", () => {
     expect(failed.error).toContain("agentId is not allowed");
   });
 
+  it("admits configured ACP aliases by their configured owner id", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        allowedAgents: ["codex"],
+      },
+      agents: {
+        defaults: {
+          subagents: { allowAgents: ["reviewer"], maxSpawnDepth: 2 },
+        },
+        list: [
+          {
+            id: "main",
+            default: true,
+            subagents: { allowAgents: ["reviewer"] },
+          },
+          {
+            id: "reviewer",
+            runtime: { type: "acp", acp: { agent: "codex" } },
+          },
+        ],
+      },
+    });
+
+    const result = await spawnAcpDirect(createSpawnRequest({ agentId: "reviewer" }), {
+      ...createRequesterContext(),
+      agentSessionKey: "agent:main:subagent:parent",
+    });
+
+    expect(result.status, JSON.stringify(result)).toBe("accepted");
+    expectAcceptedSpawn(result);
+    expectInitializeSessionFields({ agentId: "reviewer", agent: "codex" });
+  });
+
   it("rejects explicit ACP self-targets when the subagent allowlist excludes the requester", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,
@@ -2479,7 +2776,7 @@ describe("spawnAcpDirect", () => {
     });
   });
 
-  it("uses the target agent workspace for cross-agent ACP spawns when cwd is omitted", async () => {
+  it("uses the configured session owner workspace for cross-agent ACP spawns", async () => {
     const fixture = await createCrossAgentWorkspaceFixture();
     try {
       configureCrossAgentWorkspaceSpawn(fixture);
@@ -2497,6 +2794,7 @@ describe("spawnAcpDirect", () => {
 
       expect(result.status).toBe("accepted");
       const initInput = expectInitializeSessionFields({
+        agentId: "claude-code",
         agent: "claude-code",
         cwd: fixture.targetWorkspace,
       });
@@ -2506,7 +2804,41 @@ describe("spawnAcpDirect", () => {
     }
   });
 
-  it("falls back to backend default cwd when the inherited target workspace does not exist", async () => {
+  it("uses the requester workspace for an unconfigured external ACP harness", async () => {
+    const fixture = await createCrossAgentWorkspaceFixture({
+      targetDirName: "unused-harness-workspace",
+      createTargetWorkspace: false,
+    });
+    try {
+      replaceSpawnConfig({
+        ...hoisted.state.cfg,
+        acp: {
+          ...hoisted.state.cfg.acp,
+          allowedAgents: ["codex"],
+        },
+        agents: {
+          list: [{ id: "main", default: true, workspace: fixture.mainWorkspace }],
+        },
+      });
+
+      const result = await spawnAcpDirect(
+        { task: "Inspect owner workspace", agentId: "codex", mode: "run" },
+        { agentSessionKey: "agent:main:main" },
+      );
+
+      expectAcceptedSpawn(result);
+      const initInput = expectInitializeSessionFields({
+        agentId: "main",
+        agent: "codex",
+        cwd: fixture.mainWorkspace,
+      });
+      expect(initInput.sessionKey).toMatch(/^agent:main:acp:/);
+    } finally {
+      await fs.rm(fixture.workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the backend cwd when the configured owner workspace is missing", async () => {
     const fixture = await createCrossAgentWorkspaceFixture({
       targetDirName: "claude-code-missing",
       createTargetWorkspace: false,
@@ -2527,6 +2859,7 @@ describe("spawnAcpDirect", () => {
 
       expect(result.status).toBe("accepted");
       const initInput = expectInitializeSessionFields({
+        agentId: "claude-code",
         agent: "claude-code",
         cwd: undefined,
       });
@@ -2835,6 +3168,131 @@ describe("spawnAcpDirect", () => {
     );
   });
 
+  it("uses a configured ACP alias's bound account instead of the external harness account", async () => {
+    const boundRoom = "!alias-room:example.org";
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      acp: {
+        ...hoisted.state.cfg.acp,
+        allowedAgents: ["codex"],
+      },
+      agents: {
+        list: [
+          {
+            id: "reviewer",
+            runtime: { type: "acp", acp: { agent: "codex" } },
+          },
+        ],
+      },
+      channels: {
+        ...hoisted.state.cfg.channels,
+        matrix: {
+          threadBindings: {
+            enabled: true,
+            spawnSessions: true,
+          },
+          accounts: {
+            reviewer: {
+              threadBindings: {
+                enabled: true,
+                spawnSessions: true,
+              },
+            },
+          },
+        },
+      },
+      bindings: [
+        {
+          type: "route",
+          agentId: "reviewer",
+          match: {
+            channel: "matrix",
+            peer: {
+              kind: "channel",
+              id: boundRoom,
+            },
+            accountId: "reviewer",
+          },
+        },
+      ],
+    });
+    registerSessionBindingAdapter({
+      channel: "matrix",
+      accountId: "reviewer",
+      capabilities: createSessionBindingCapabilities(),
+      bind: async (input) => await hoisted.sessionBindingBindMock(input),
+      listBySession: (targetSessionKey) =>
+        hoisted.sessionBindingListBySessionMock(targetSessionKey),
+      resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
+      unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
+    });
+    hoisted.sessionBindingBindMock.mockImplementationOnce(
+      async (input: {
+        targetSessionKey: string;
+        conversation: {
+          accountId: string;
+          conversationId: string;
+          parentConversationId?: string;
+        };
+        metadata?: Record<string, unknown>;
+      }) =>
+        createSessionBinding({
+          targetSessionKey: input.targetSessionKey,
+          conversation: {
+            channel: "matrix",
+            accountId: input.conversation.accountId,
+            conversationId: input.conversation.conversationId,
+            parentConversationId: input.conversation.parentConversationId,
+          },
+          metadata: {
+            boundBy:
+              typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+            agentId: "reviewer",
+          },
+        }),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Review flaky tests",
+        agentId: "reviewer",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:matrix:room:requester",
+        agentChannel: "matrix",
+        agentAccountId: "bot-beta",
+        agentTo: `room:${boundRoom}`,
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expectBindingCallFields({
+      placement: "child",
+      conversation: {
+        channel: "matrix",
+        accountId: "reviewer",
+        conversationId: boundRoom,
+      },
+    });
+    expectRecordFields(gatewayRequest("agent").params, {
+      deliver: true,
+      channel: "matrix",
+      accountId: "reviewer",
+      to: `room:${boundRoom}`,
+    });
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterOrigin: expect.objectContaining({
+          channel: "matrix",
+          accountId: "reviewer",
+          to: `room:${boundRoom}`,
+        }),
+      }),
+    );
+  });
+
   it.each([
     {
       name: "canonical line target",
@@ -2997,7 +3455,7 @@ describe("spawnAcpDirect", () => {
         {
           sessionId: "sess-123",
           storePath: "/tmp/codex-sessions.json",
-          agentId: "codex",
+          agentId: "main",
         },
       );
     }
@@ -3023,7 +3481,7 @@ describe("spawnAcpDirect", () => {
     );
 
     expect(result.status).toBe("accepted");
-    expect(result.childSessionKey).toMatch(/^agent:codex:acp:/);
+    expect(result.childSessionKey).toMatch(/^agent:main:acp:/);
     const agentCall = hoisted.callGatewayMock.mock.calls
       .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
       .find((request) => request.method === "agent");
@@ -3209,7 +3667,7 @@ describe("spawnAcpDirect", () => {
     expect(relayCallOrder < agentCallOrder).toBe(true);
     expectRelayCallFields({
       parentSessionKey: "agent:main:main",
-      agentId: "codex",
+      agentId: "main",
       childSessionId: "sess-123",
       emitStartNotice: false,
     });
@@ -3261,7 +3719,7 @@ describe("spawnAcpDirect", () => {
       };
       return new Proxy(store, {
         get(target, prop) {
-          if (typeof prop === "string" && prop.startsWith("agent:codex:acp:")) {
+          if (typeof prop === "string" && /^agent:[^:]+:acp:/.test(prop)) {
             return { sessionId: "sess-123", updatedAt: Date.now() };
           }
           return target[prop as keyof typeof target];
@@ -3293,7 +3751,7 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.threadId).toBeUndefined();
     expectRelayCallFields({
       parentSessionKey: "agent:main:subagent:parent",
-      agentId: "codex",
+      agentId: "main",
       childSessionId: "sess-123",
       deliveryContext: {
         channel: "discord",
@@ -3350,7 +3808,7 @@ describe("spawnAcpDirect", () => {
       };
       return new Proxy(store, {
         get(target, prop) {
-          if (typeof prop === "string" && prop.startsWith("agent:codex:acp:")) {
+          if (typeof prop === "string" && /^agent:[^:]+:acp:/.test(prop)) {
             return { sessionId: "sess-123", updatedAt: Date.now() };
           }
           return target[prop as keyof typeof target];
@@ -3481,8 +3939,8 @@ describe("spawnAcpDirect", () => {
       expect(hoisted.registerSubagentRunMock).toHaveBeenCalledWith(
         expect.objectContaining({
           requesterSessionKey: "global",
-          childSessionKey: expect.stringMatching(/^agent:codex:acp:/),
-          agentId: "codex",
+          childSessionKey: expect.stringMatching(/^agent:research:acp:/),
+          agentId: "research",
           requesterAgentId: "research",
         }),
       );

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -210,7 +210,7 @@ vi.mock("../../../acp/runtime/session-meta.js", () => ({
     };
     return new Map(
       params.entries.map(({ sessionKey, agentId, entry }) => {
-        const sessionOwner = sessionKey.match(/^agent:([^:]+):/)?.[1] ?? "main";
+        const sessionOwner = sessionKey.match(/^agent:([^:]+):/)?.[1] ?? agentId;
         return [
           entry,
           agentId === sessionOwner ? hoisted.readAcpSessionMetaMock({ sessionKey }) : undefined,
@@ -1393,6 +1393,101 @@ describe("spawnAcpDirect", () => {
         sessionId: "sess-legacy",
       }),
     );
+  });
+
+  it("promotes requester-owned bare legacy keys from a separate harness store", async () => {
+    const legacySessionKey = "global";
+    hoisted.resolveStorePathMock.mockImplementation(
+      (_template: unknown, params: { agentId?: string }) => `/tmp/${params.agentId}-sessions.json`,
+    );
+    hoisted.loadSessionStoreMock.mockImplementation((storePath: string) =>
+      storePath === "/tmp/codex-sessions.json"
+        ? {
+            [legacySessionKey]: {
+              sessionId: "sess-bare-legacy",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:main:main",
+            } satisfies SessionEntry,
+          }
+        : {},
+    );
+    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string };
+      return params.sessionKey === legacySessionKey
+        ? {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "codex",
+            identity: {
+              state: "resolved",
+              source: "ensure",
+              agentSessionId: "bare-legacy-resume",
+              lastUpdatedAt: Date.now(),
+            },
+            mode: "oneshot",
+            state: "idle",
+            lastActivityAt: Date.now(),
+          }
+        : undefined;
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Resume bare legacy ACP session",
+        agentId: "codex",
+        resumeSessionId: "bare-legacy-resume",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectAcceptedSpawn(result);
+    expect(hoisted.upsertSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:global",
+        storePath: "/tmp/main-sessions.json",
+      }),
+      expect.objectContaining({ sessionId: "sess-bare-legacy" }),
+    );
+  });
+
+  it("fails closed for bare legacy keys in a shared owner and harness store", async () => {
+    hoisted.resolveStorePathMock.mockReturnValue("/tmp/shared-sessions.json");
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      global: {
+        sessionId: "sess-ambiguous-bare",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+      } satisfies SessionEntry,
+    });
+    hoisted.readAcpSessionMetaMock.mockReturnValue({
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "codex",
+      identity: {
+        state: "resolved",
+        source: "ensure",
+        agentSessionId: "ambiguous-bare-resume",
+        lastUpdatedAt: Date.now(),
+      },
+      mode: "oneshot",
+      state: "idle",
+      lastActivityAt: Date.now(),
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Reject ambiguous bare legacy ACP session",
+        agentId: "codex",
+        resumeSessionId: "ambiguous-bare-resume",
+      },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expectRecordFields(result, { status: "forbidden", errorCode: "resume_forbidden" });
+    expect(hoisted.writeAcpSessionMetaForMigrationMock).not.toHaveBeenCalled();
+    expect(hoisted.upsertSessionEntryMock).not.toHaveBeenCalled();
+    expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
   });
 
   it("stops consulting legacy harness stores after the bounded migration window", async () => {

--- a/src/agents/subagents/spawn/acp-spawn.ts
+++ b/src/agents/subagents/spawn/acp-spawn.ts
@@ -271,7 +271,7 @@ export async function spawnAcpDirect(
   }
   const { agentId: harnessAgentId, backendId } = targetAgentResult;
   const sessionOwnerAgentId = targetAgentResult.configAgentId ?? requesterAgentId;
-  const requesterRoutingAgentId = targetAgentResult.configAgentId ?? harnessAgentId;
+  const admissionTargetAgentId = targetAgentResult.configAgentId ?? harnessAgentId;
   const agentPolicyError = resolveAcpAgentPolicyError(cfg, harnessAgentId);
   if (agentPolicyError) {
     return createAcpSpawnFailure({
@@ -287,7 +287,7 @@ export async function spawnAcpDirect(
     cfg,
     parentSessionKey,
     requesterAgentId,
-    targetAgentId: requesterRoutingAgentId,
+    targetAgentId: sessionOwnerAgentId,
     ctx,
   });
   const hasSubagentEnvelope = isSubagentEnvelopeSession(requesterInternalKey, {
@@ -300,7 +300,7 @@ export async function spawnAcpDirect(
       enabled: hasSubagentEnvelope,
       requesterSessionKey: requesterInternalKey,
       requesterAgentId,
-      targetAgentId: requesterRoutingAgentId,
+      targetAgentId: admissionTargetAgentId,
       requestedAgentId: params.agentId,
       configuredAgentIds: resolveConfiguredAcpSubagentTargetIds(cfg),
       additionalActiveChildren: hasSubagentEnvelope

--- a/src/agents/subagents/spawn/acp-spawn.ts
+++ b/src/agents/subagents/spawn/acp-spawn.ts
@@ -269,8 +269,10 @@ export async function spawnAcpDirect(
       error: targetAgentResult.error,
     });
   }
-  const { agentId: targetAgentId, backendId } = targetAgentResult;
-  const agentPolicyError = resolveAcpAgentPolicyError(cfg, targetAgentId);
+  const { agentId: harnessAgentId, backendId } = targetAgentResult;
+  const sessionOwnerAgentId = targetAgentResult.configAgentId ?? requesterAgentId;
+  const requesterRoutingAgentId = targetAgentResult.configAgentId ?? harnessAgentId;
+  const agentPolicyError = resolveAcpAgentPolicyError(cfg, harnessAgentId);
   if (agentPolicyError) {
     return createAcpSpawnFailure({
       status: "forbidden",
@@ -285,7 +287,7 @@ export async function spawnAcpDirect(
     cfg,
     parentSessionKey,
     requesterAgentId,
-    targetAgentId,
+    targetAgentId: requesterRoutingAgentId,
     ctx,
   });
   const hasSubagentEnvelope = isSubagentEnvelopeSession(requesterInternalKey, {
@@ -298,7 +300,7 @@ export async function spawnAcpDirect(
       enabled: hasSubagentEnvelope,
       requesterSessionKey: requesterInternalKey,
       requesterAgentId,
-      targetAgentId,
+      targetAgentId: requesterRoutingAgentId,
       requestedAgentId: params.agentId,
       configuredAgentIds: resolveConfiguredAcpSubagentTargetIds(cfg),
       additionalActiveChildren: hasSubagentEnvelope
@@ -312,9 +314,10 @@ export async function spawnAcpDirect(
   if (!admission.ok) {
     return rejectSubagentPolicy(admission.error);
   }
-  const resumeAuthorization = validateAcpResumeSessionOwnership({
+  const resumeAuthorization = await validateAcpResumeSessionOwnership({
     cfg,
-    targetAgentId,
+    sessionOwnerAgentId,
+    harnessAgentId,
     backendId,
     requesterSessionKey: requesterInternalKey,
     resumeSessionId: params.resumeSessionId,
@@ -328,7 +331,7 @@ export async function spawnAcpDirect(
   }
   const runtimeOptionsResult = resolveAcpSpawnRuntimeOptions({
     cfg,
-    targetAgentId,
+    targetAgentId: harnessAgentId,
     configAgentId: targetAgentResult.configAgentId,
     model: params.model,
     thinking: params.thinking,
@@ -348,11 +351,11 @@ export async function spawnAcpDirect(
     requester: requesterState,
   });
 
-  const sessionKey = mintSpawnSessionKey({ targetAgentId, backend: "acp" });
+  const sessionKey = mintSpawnSessionKey({ targetAgentId: sessionOwnerAgentId, backend: "acp" });
   const runtimeMode = resolveAcpSessionMode(spawnMode);
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
     config: cfg,
-    targetAgentId,
+    targetAgentId: sessionOwnerAgentId,
     requesterSessionKey: ctx.agentSessionKey,
     explicitWorkspaceDir: params.cwd,
   });
@@ -444,7 +447,9 @@ export async function spawnAcpDirect(
         via: "spawn",
         actor: { type: "agent", id: requesterAgentId },
       });
-      const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: targetAgentId });
+      const storePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: sessionOwnerAgentId,
+      });
       const childSessionPatch = admission.childSessionPatch
         ? {
             spawnDepth: admission.childSessionPatch.spawnDepth,
@@ -456,7 +461,7 @@ export async function spawnAcpDirect(
         : {};
       childCreationEntry =
         (await upsertSessionEntryCore(
-          { storePath, sessionKey, agentId: targetAgentId },
+          { storePath, sessionKey, agentId: sessionOwnerAgentId },
           {
             ...creationStamp,
             spawnedBy: requesterInternalKey,
@@ -475,7 +480,8 @@ export async function spawnAcpDirect(
       const initializedSession = await initializeAcpSpawnRuntime({
         cfg,
         sessionKey,
-        targetAgentId,
+        sessionOwnerAgentId,
+        harnessAgentId,
         runtimeMode,
         backendId,
         resumeSessionId: params.resumeSessionId,
@@ -489,7 +495,8 @@ export async function spawnAcpDirect(
             await bindPreparedAcpThread({
               cfg,
               sessionKey,
-              targetAgentId,
+              sessionOwnerAgentId,
+              harnessAgentId,
               label: params.label,
               preparedBinding,
               initializedRuntime: initializedSession,
@@ -510,7 +517,7 @@ export async function spawnAcpDirect(
       if (childCreationEntry) {
         recordSessionCreated({
           sessionKey,
-          agentId: targetAgentId,
+          agentId: sessionOwnerAgentId,
           entry: childCreationEntry,
         });
       }
@@ -518,7 +525,7 @@ export async function spawnAcpDirect(
         childSessionKey: sessionKey,
         childRunId: childIdem,
         requesterSessionKey: requesterInternalKey,
-        agentId: targetAgentId,
+        agentId: sessionOwnerAgentId,
       });
       const startParentRelay = (runId: string) =>
         effectiveStreamToParent && parentSessionKey
@@ -527,7 +534,7 @@ export async function spawnAcpDirect(
               parentSessionKey,
               childSessionKey: sessionKey,
               childSessionId: state.initializedSession.sessionId,
-              agentId: targetAgentId,
+              agentId: sessionOwnerAgentId,
               env: parentRelayStateEnv,
               mainKey: cfg.session?.mainKey,
               sessionScope: cfg.session?.scope,
@@ -554,14 +561,14 @@ export async function spawnAcpDirect(
           controllerRef: ownership.controllerSessionKey,
           depth: admission.childSessionPatch?.spawnDepth ?? 1,
           maxDepth: admission.maxSpawnDepth,
-          targetAgentId,
+          targetAgentId: harnessAgentId,
           sandbox: params.sandbox === "require" ? "require" : "inherit",
           inheritedToolAllowlist: ctx.inheritedToolAllowlist,
           inheritedToolDenylist: ctx.inheritedToolDenylist,
         },
         parentExecutionIdentityToken: readParentExecutionIdentity(ctx),
         participantStorePath: resolveSessionStorePathCore(cfg.session?.store, {
-          agentId: targetAgentId,
+          agentId: sessionOwnerAgentId,
         }),
       });
       const runId = readGatewayRunId(response) ?? childIdem;
@@ -577,7 +584,7 @@ export async function spawnAcpDirect(
       await cleanupFailedAcpSpawn({
         cfg,
         sessionKey,
-        agentId: targetAgentId,
+        agentId: sessionOwnerAgentId,
         shouldDeleteSession: sessionCreated,
         deleteTranscript: true,
         runtimeCloseHandle: initializedRuntime,
@@ -616,7 +623,7 @@ export async function spawnAcpDirect(
         requesterDisplayKey: ownership.completionRequesterDisplayKey,
         task: params.task,
         taskName: params.taskName,
-        agentId: targetAgentId,
+        agentId: sessionOwnerAgentId,
         requesterAgentId,
         cleanup: spawnMode === "session" ? "keep" : params.cleanup === "delete" ? "delete" : "keep",
         label: params.label,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -195,7 +195,7 @@ function createSessionsSpawnToolSchema(params: {
     cwd: Type.Optional(
       Type.String({
         description:
-          "Child working directory. Visible paths outside configured agent workspaces require operator.admin. Omitted with worktree=true: inherit the same-agent parent managed repository; otherwise use the target agent workspace.",
+          "Child working directory. Visible paths outside configured agent workspaces require operator.admin. Omitted with worktree=true: inherit the same-agent parent managed repository. Otherwise, native subagents use the target agent workspace; ACP uses a configured alias workspace or the requester workspace for an unconfigured harness.",
       }),
     ),
     ...(params.threadAvailable

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -923,6 +923,7 @@ describe("/acp command", () => {
     hoisted.resolveSessionStorePathForAcpMock.mockReset().mockReturnValue({
       cfg: baseCfg,
       storePath: "/tmp/sessions-acp.json",
+      agentId: "main",
     });
     hoisted.loadSessionStoreMock.mockReset().mockReturnValue({});
     hoisted.updateSessionEntryMock.mockReset().mockResolvedValue(null);
@@ -982,19 +983,24 @@ describe("/acp command", () => {
     acpManagerTesting.setAcpSessionManagerForTests({
       initializeSession: async (input: {
         sessionKey: string;
+        agentId: string;
         agent: string;
         mode: "persistent" | "oneshot";
         cwd?: string;
+        backendId?: string;
+        runtimeOptions?: { model?: string; thinking?: string; timeoutSeconds?: number };
       }) => {
-        const backend = hoisted.requireAcpRuntimeBackendMock("acpx") as {
+        const backend = hoisted.requireAcpRuntimeBackendMock(input.backendId ?? "acpx") as {
           id?: string;
           runtime: typeof runtimeBackend.runtime;
         };
         const ensured = await hoisted.ensureSessionMock({
           sessionKey: input.sessionKey,
+          agentId: input.agentId,
           agent: input.agent,
           mode: input.mode,
           cwd: input.cwd,
+          runtimeOptions: input.runtimeOptions,
         });
         const now = Date.now();
         const meta = {
@@ -1179,19 +1185,20 @@ describe("/acp command", () => {
 
   it("spawns an ACP session and binds a Discord thread", async () => {
     hoisted.ensureSessionMock.mockResolvedValueOnce({
-      sessionKey: "agent:codex:acp:s1",
+      sessionKey: "agent:main:acp:s1",
       backend: "acpx",
-      runtimeSessionName: "agent:codex:acp:s1:runtime",
+      runtimeSessionName: "agent:main:acp:s1:runtime",
       agentSessionId: "codex-inner-1",
       backendSessionId: "acpx-1",
     });
 
     const result = await runDiscordAcpCommand("/acp spawn codex --cwd /home/bob/clawd");
 
-    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
     expect(result?.reply?.text).toContain("Created thread thread-created and bound it");
     expect(hoisted.requireAcpRuntimeBackendMock).toHaveBeenCalledWith("acpx");
     expectMockCallFields(hoisted.ensureSessionMock, {
+      agentId: "main",
       agent: "codex",
       mode: "persistent",
       cwd: "/home/bob/clawd",
@@ -1202,6 +1209,10 @@ describe("/acp command", () => {
     });
     const introText = (bindInput.metadata as { introText?: unknown } | undefined)?.introText;
     expect(typeof introText).toBe("string");
+    expect(introText).toContain("codex session active");
+    expect(bindInput.metadata).toEqual(
+      expect.objectContaining({ agentId: "main", label: "codex" }),
+    );
     expect(introText).toContain("cwd: /home/bob/clawd");
     expectBoundIntroTextToExclude("session ids: pending (available after the first reply)");
     expectGatewayMethodNotCalled("sessions.patch");
@@ -1218,17 +1229,49 @@ describe("/acp command", () => {
           };
         }
       | undefined;
-    expect(upsertArgs?.sessionKey).toMatch(/^agent:codex:acp:/);
+    expect(upsertArgs?.sessionKey).toMatch(/^agent:main:acp:/);
     const seededWithoutEntry = upsertArgs?.mutate(undefined, undefined);
     expect(seededWithoutEntry?.backend).toBe("acpx");
     expect(seededWithoutEntry?.runtimeSessionName).toContain(":runtime");
   });
 
-  it("inherits the target agent workspace when /acp spawn omits --cwd", async () => {
+  it("maps a configured default ACP alias to its external harness", async () => {
+    const cfg = {
+      ...baseCfg,
+      acp: {
+        ...baseCfg.acp,
+        defaultAgent: "codex-acp",
+        allowedAgents: ["codex"],
+      },
+      agents: {
+        list: [
+          {
+            id: "codex-acp",
+            runtime: { type: "acp" as const, acp: { agent: "codex", backend: "alias-acpx" } },
+            model: "openai/gpt-5.4",
+            thinkingDefault: "high" as const,
+          },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await runDiscordAcpCommand("/acp spawn --thread off", cfg);
+
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex-acp:acp:");
+    expectMockCallFields(hoisted.ensureSessionMock, {
+      agentId: "codex-acp",
+      agent: "codex",
+      mode: "persistent",
+      runtimeOptions: { model: "openai/gpt-5.4", thinking: "high" },
+    });
+    expect(hoisted.requireAcpRuntimeBackendMock).toHaveBeenCalledWith("alias-acpx");
+  });
+
+  it("inherits the session owner workspace when /acp spawn omits --cwd", async () => {
     hoisted.ensureSessionMock.mockResolvedValueOnce({
-      sessionKey: "agent:codex:acp:s2",
+      sessionKey: "agent:main:acp:s2",
       backend: "acpx",
-      runtimeSessionName: "agent:codex:acp:s2:runtime",
+      runtimeSessionName: "agent:main:acp:s2:runtime",
       agentSessionId: "codex-inner-2",
       backendSessionId: "acpx-2",
     });
@@ -1240,7 +1283,7 @@ describe("/acp command", () => {
         agents: {
           list: [
             {
-              id: "codex",
+              id: "main",
               workspace,
             },
           ],
@@ -1249,8 +1292,9 @@ describe("/acp command", () => {
 
       const result = await runDiscordAcpCommand("/acp spawn codex", cfg);
 
-      expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+      expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
       expectMockCallFields(hoisted.ensureSessionMock, {
+        agentId: "main",
         agent: "codex",
         mode: "persistent",
         cwd: workspace,
@@ -1262,9 +1306,9 @@ describe("/acp command", () => {
 
   it("falls back to the backend default cwd when the inherited target workspace is missing", async () => {
     hoisted.ensureSessionMock.mockResolvedValueOnce({
-      sessionKey: "agent:codex:acp:s3",
+      sessionKey: "agent:main:acp:s3",
       backend: "acpx",
-      runtimeSessionName: "agent:codex:acp:s3:runtime",
+      runtimeSessionName: "agent:main:acp:s3:runtime",
       agentSessionId: "codex-inner-3",
       backendSessionId: "acpx-3",
     });
@@ -1274,7 +1318,7 @@ describe("/acp command", () => {
       agents: {
         list: [
           {
-            id: "codex",
+            id: "main",
             workspace: "/home/bob/codex-workspace-missing",
           },
         ],
@@ -1283,20 +1327,22 @@ describe("/acp command", () => {
 
     const result = await runDiscordAcpCommand("/acp spawn codex", cfg);
 
-    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
     expectMockCallFields(hoisted.ensureSessionMock, {
+      agentId: "main",
       agent: "codex",
       mode: "persistent",
       cwd: undefined,
     });
   });
 
-  it("persists ACP spawn labels to the target store without a gateway self-call", async () => {
+  it("persists ACP spawn labels to the owner store without a gateway self-call", async () => {
     const params = createDiscordParams("/acp spawn codex --bind here --label inbox");
     params.storePath = "/tmp/requester-sessions.json";
     hoisted.resolveSessionStorePathForAcpMock.mockReturnValue({
       cfg: baseCfg,
-      storePath: "/tmp/codex-sessions.json",
+      storePath: "/tmp/main-sessions.json",
+      agentId: "main",
     });
 
     const result = await handleAcpCommand(params, true);
@@ -1306,7 +1352,7 @@ describe("/acp command", () => {
     const spawnedSessionKey = (
       hoisted.ensureSessionMock.mock.calls[0]?.[0] as { sessionKey?: string } | undefined
     )?.sessionKey;
-    expect(spawnedSessionKey).toMatch(/^agent:codex:acp:/);
+    expect(spawnedSessionKey).toMatch(/^agent:main:acp:/);
     const updateCall = hoisted.updateSessionEntryMock.mock.calls[0] as
       | [
           { storePath: string; sessionKey: string },
@@ -1314,7 +1360,8 @@ describe("/acp command", () => {
         ]
       | undefined;
     expect(updateCall?.[0]).toEqual({
-      storePath: "/tmp/codex-sessions.json",
+      storePath: "/tmp/main-sessions.json",
+      agentId: "main",
       sessionKey: spawnedSessionKey,
     });
     expect(updateCall?.[1]({ sessionId: "target", updatedAt: 1 })).toEqual({
@@ -1328,7 +1375,7 @@ describe("/acp command", () => {
       "/acp spawn codex \u2014mode oneshot \u2014thread here \u2014cwd /home/bob/clawd \u2014label jeerreview",
     );
 
-    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
     expect(result?.reply?.text).toContain("Bound this thread to");
     expectMockCallFields(hoisted.ensureSessionMock, {
       agent: "codex",
@@ -1455,7 +1502,7 @@ describe("/acp command", () => {
   it("binds Telegram topic ACP spawns to full conversation ids", async () => {
     const result = await runTelegramAcpCommand("/acp spawn codex --thread here");
 
-    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
     expect(result?.reply?.text).toContain("Bound this conversation to");
     expect(result?.reply?.delivery).toEqual({ pin: { enabled: true } });
     expectBindingBindCall({
@@ -1471,7 +1518,7 @@ describe("/acp command", () => {
   it("binds Telegram DM ACP spawns to the DM conversation id", async () => {
     const result = await runTelegramDmAcpCommand("/acp spawn codex --thread here");
 
-    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
     expect(result?.reply?.text).toContain("Bound this conversation to");
     expect(result?.reply?.channelData).toBeUndefined();
     expectBindingBindCall({
@@ -1566,7 +1613,7 @@ describe("/acp command", () => {
   it("binds Feishu DM ACP spawns to the current DM conversation", async () => {
     const result = await runFeishuDmAcpCommand("/acp spawn codex --thread here");
 
-    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
     expect(result?.reply?.text).toContain("Bound this conversation to");
     expectBindingBindCall({
       placement: "current",
@@ -1581,7 +1628,7 @@ describe("/acp command", () => {
   it("binds LINE DM ACP spawns to the current conversation", async () => {
     const result = await runLineDmAcpCommand("/acp spawn codex --thread here");
 
-    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:main:acp:");
     expect(result?.reply?.text).toContain("Bound this conversation to");
     expectBindingBindCall({
       placement: "current",

--- a/src/auto-reply/reply/commands-acp/bindings.ts
+++ b/src/auto-reply/reply/commands-acp/bindings.ts
@@ -70,20 +70,21 @@ function buildSpawnedAcpBindingMetadata(params: {
   accountId: string;
   sessionKey: string;
   agentId: string;
+  displayAgentId: string;
   label: string;
   senderId: string;
   sessionMeta?: SessionAcpMeta;
 }): Record<string, unknown> {
   return {
     threadName: resolveThreadBindingThreadName({
-      agentId: params.agentId,
+      agentId: params.displayAgentId,
       label: params.label,
     }),
     agentId: params.agentId,
     label: params.label,
     boundBy: params.senderId || "unknown",
     introText: resolveThreadBindingIntroText({
-      agentId: params.agentId,
+      agentId: params.displayAgentId,
       label: params.label,
       idleTimeoutMs: resolveThreadBindingIdleTimeoutMsForChannel({
         cfg: params.cfg,
@@ -114,6 +115,7 @@ export async function bindSpawnedAcpSession(params: {
   commandParams: HandleCommandsParams;
   sessionKey: string;
   agentId: string;
+  displayAgentId: string;
   label?: string;
   mode: "conversation" | "thread-here" | "thread-auto";
   sessionMeta?: SessionAcpMeta;
@@ -217,7 +219,8 @@ export async function bindSpawnedAcpSession(params: {
         accountId: policy.accountId,
         sessionKey: params.sessionKey,
         agentId: params.agentId,
-        label: params.label || params.agentId,
+        displayAgentId: params.displayAgentId,
+        label: params.label || params.displayAgentId,
         senderId,
         sessionMeta: params.sessionMeta,
       }),

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -22,6 +22,8 @@ import {
   prepareAgentRunAdmission,
 } from "../../../agents/admitted-run-context.js";
 import { resolveSpawnedWorkspaceInheritance } from "../../../agents/spawned-context.js";
+import { resolveAcpSpawnRuntimeOptions } from "../../../agents/subagents/spawn/acp-spawn-runtime.js";
+import { resolveTargetAcpAgentId } from "../../../agents/subagents/spawn/acp-spawn-target.js";
 import {
   resolveAcpSpawnRuntimePolicyError,
   resolveRuntimeCwdForAcpSpawn,
@@ -127,6 +129,14 @@ export async function handleAcpSpawnAction(
   }
 
   const spawn = parsed.value;
+  const targetAgent = resolveTargetAcpAgentId({
+    requestedAgentId: spawn.agentId,
+    cfg: params.cfg,
+  });
+  if (!targetAgent.ok) {
+    return commandReply(`⚠️ ${targetAgent.error}`);
+  }
+  const harnessAgentId = targetAgent.agentId;
   const runtimePolicyError = resolveAcpSpawnRuntimePolicyError({
     cfg: params.cfg,
     requesterAgentId: params.agentId,
@@ -135,7 +145,7 @@ export async function handleAcpSpawnAction(
   if (runtimePolicyError) {
     return commandReply(`⚠️ ${runtimePolicyError}`);
   }
-  const agentPolicyError = resolveAcpAgentPolicyError(params.cfg, spawn.agentId);
+  const agentPolicyError = resolveAcpAgentPolicyError(params.cfg, harnessAgentId);
   if (agentPolicyError) {
     return commandReply(
       collectAcpErrorText({
@@ -147,10 +157,11 @@ export async function handleAcpSpawnAction(
   }
 
   const acpManager = getAcpSessionManager();
-  const sessionKey = `agent:${spawn.agentId}:acp:${randomUUID()}`;
+  const sessionOwnerAgentId = targetAgent.configAgentId ?? params.agentId;
+  const sessionKey = `agent:${sessionOwnerAgentId}:acp:${randomUUID()}`;
   const resolvedCwd = resolveSpawnedWorkspaceInheritance({
     config: params.cfg,
-    targetAgentId: spawn.agentId,
+    targetAgentId: sessionOwnerAgentId,
     requesterSessionKey: params.sessionKey,
     explicitWorkspaceDir: spawn.cwd,
   });
@@ -173,14 +184,24 @@ export async function handleAcpSpawnAction(
   let initializedBackend;
   let initializedMeta: SessionAcpMeta | undefined;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
+  const runtimeOptionsResult = resolveAcpSpawnRuntimeOptions({
+    cfg: params.cfg,
+    targetAgentId: harnessAgentId,
+    configAgentId: targetAgent.configAgentId,
+  });
+  if (!runtimeOptionsResult.ok) {
+    return commandReply(`⚠️ ${runtimeOptionsResult.error}`);
+  }
   try {
     const initialized = await acpManager.initializeSession({
       cfg: params.cfg,
       sessionKey,
-      agentId: spawn.agentId,
-      agent: spawn.agentId,
+      agentId: sessionOwnerAgentId,
+      agent: harnessAgentId,
+      backendId: targetAgent.backendId,
       mode: spawn.mode,
       cwd: runtimeCwd,
+      runtimeOptions: runtimeOptionsResult.runtimeOptions,
     });
     initializedRuntime = {
       runtime: initialized.runtime,
@@ -203,7 +224,8 @@ export async function handleAcpSpawnAction(
     const result = await bindSpawnedAcpSession({
       commandParams: params,
       sessionKey,
-      agentId: spawn.agentId,
+      agentId: sessionOwnerAgentId,
+      displayAgentId: harnessAgentId,
       label: spawn.label,
       mode:
         spawn.bind !== "off"
@@ -217,7 +239,7 @@ export async function handleAcpSpawnAction(
       await cleanupFailedSpawn({
         cfg: params.cfg,
         sessionKey,
-        agentId: spawn.agentId,
+        agentId: sessionOwnerAgentId,
         shouldDeleteSession: true,
         initializedRuntime,
       });
@@ -230,14 +252,14 @@ export async function handleAcpSpawnAction(
     await persistSpawnedSessionLabel({
       commandParams: params,
       sessionKey,
-      agentId: spawn.agentId,
+      agentId: sessionOwnerAgentId,
       label: spawn.label,
     });
   } catch (err) {
     await cleanupFailedSpawn({
       cfg: params.cfg,
       sessionKey,
-      agentId: spawn.agentId,
+      agentId: sessionOwnerAgentId,
       shouldDeleteSession: true,
       initializedRuntime,
     });

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -421,6 +421,43 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("rejects divergent canonical and legacy source metadata", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-source-meta-divergence-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      const canonicalSourceKey = buildAcpDatabaseSessionKey(sourceKey, "codex");
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "codex",
+          backend: "acpx",
+          lastActivityAt: 20,
+          mode: "persistent",
+          runtimeSessionName: "divergent-source-peer",
+          state: "idle",
+        },
+        sessionKey: canonicalSourceKey,
+      });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ conflicts: 1, eligible: 1, migrated: 0 });
+      const rows = withExistingOpenClawStateDatabaseReadOnly(
+        ({ db }) => ({
+          canonicalSource: selectAcpSessionRow(db, canonicalSourceKey),
+          legacySource: selectAcpSessionRow(db, sourceKey),
+          target: selectAcpSessionRow(db, buildAcpDatabaseSessionKey(targetKey, "reviewer")),
+        }),
+        { env },
+      );
+      expect(rows?.canonicalSource?.runtime_session_name).toBe("divergent-source-peer");
+      expect(rows?.legacySource?.runtime_session_name).toBe("legacy-peer");
+      expect(rows?.target).toBeUndefined();
+    });
+  });
+
   it("canonicalizes matching target metadata left under a legacy key", async () => {
     await withStateDirEnv("openclaw-doctor-acp-target-meta-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -234,6 +234,29 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("fails closed when a configured non-ACP owner is no longer allowed", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-configured-owner-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      cfg.acp = { allowedAgents: ["reviewer"] };
+      cfg.agents?.list?.push({ id: "codex" });
+      const sourceStorePath = seedLegacySession({ cfg, env });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ ambiguous: 1, eligible: 0, migrated: 0 });
+      expect(report.warnings.join("\n")).toContain("multiple owners (codex, reviewer)");
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        }),
+      ).toBeDefined();
+    });
+  });
+
   it("cannot replay a consumed legacy peer through a later alias", async () => {
     await withStateDirEnv("openclaw-doctor-acp-consumed-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
@@ -458,6 +481,51 @@ describe("Doctor ACP owner migration", () => {
           storePath: targetStorePath,
         })?.entry,
       ).toMatchObject(concurrentEntry);
+    });
+  });
+
+  it("preserves a canonical target completed by a concurrent migration", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-concurrent-finish-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+      const targetStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "reviewer",
+        env,
+      });
+      let removedConcurrently = false;
+      sessionAccessorTestHooks.applyLifecycleMutation.mockImplementation(async (params) => {
+        if (
+          !removedConcurrently &&
+          params.storePath === sourceStorePath &&
+          params.removals?.some((removal) => removal.sessionKey === sourceKey)
+        ) {
+          removedConcurrently = true;
+          await sessionAccessorTestHooks.applyLifecycleMutationDelegate!(params);
+        }
+        return await sessionAccessorTestHooks.applyLifecycleMutationDelegate!(params);
+      });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report.warnings).toEqual([]);
+      expect(report).toMatchObject({ conflicts: 0, eligible: 1, migrated: 1 });
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        }),
+      ).toBeUndefined();
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "reviewer",
+          env,
+          sessionKey: targetKey,
+          storePath: targetStorePath,
+        })?.entry,
+      ).toMatchObject(entry);
     });
   });
 

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -461,6 +461,59 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("keeps both rows when an interrupted staged target is stale on retry", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-interrupted-retry-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+      const targetStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "reviewer",
+        env,
+      });
+      expect(
+        claimAcpSessionMetaForOwnerMigration({
+          cfg,
+          entry,
+          env,
+          expectedAgent: "codex",
+          sourceAgentId: "codex",
+          sourceSessionKey: sourceKey,
+          targetAgentId: "reviewer",
+          targetSessionKey: targetKey,
+        }),
+      ).toBe("claimed");
+      replaceSessionEntrySync(
+        { agentId: "reviewer", env, sessionKey: targetKey, storePath: targetStorePath },
+        entry,
+      );
+      const concurrentEntry = { ...entry, model: "newer", updatedAt: 20 };
+      replaceSessionEntrySync(
+        { agentId: "codex", env, sessionKey: sourceKey, storePath: sourceStorePath },
+        concurrentEntry,
+      );
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ conflicts: 1, eligible: 0, migrated: 0 });
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        })?.entry,
+      ).toMatchObject(concurrentEntry);
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "reviewer",
+          env,
+          sessionKey: targetKey,
+          storePath: targetStorePath,
+        })?.entry,
+      ).toMatchObject(entry);
+    });
+  });
+
   it("leaves a bare key in a shared owner and harness store ambiguous", async () => {
     await withStateDirEnv("openclaw-doctor-acp-shared-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -320,6 +320,61 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("rejects divergent source metadata after an interrupted claim", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-meta-divergence-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      expect(
+        claimAcpSessionMetaForOwnerMigration({
+          cfg,
+          entry,
+          env,
+          expectedAgent: "codex",
+          sourceAgentId: "codex",
+          sourceSessionKey: sourceKey,
+          targetAgentId: "reviewer",
+          targetSessionKey: targetKey,
+        }),
+      ).toBe("claimed");
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "codex",
+          backend: "acpx",
+          lastActivityAt: 20,
+          mode: "persistent",
+          runtimeSessionName: "newer-legacy-peer",
+          state: "idle",
+        },
+        sessionKey: sourceKey,
+      });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ conflicts: 1, eligible: 1, migrated: 0 });
+      expect(
+        readAcpSessionMetaForEntry({
+          agentId: "codex",
+          cfg,
+          entry,
+          env,
+          sessionKey: sourceKey,
+        })?.runtimeSessionName,
+      ).toBe("newer-legacy-peer");
+      expect(
+        readAcpSessionMetaForEntry({
+          agentId: "reviewer",
+          cfg,
+          entry,
+          env,
+          sessionKey: targetKey,
+        })?.runtimeSessionName,
+      ).toBe("legacy-peer");
+    });
+  });
+
   it("canonicalizes matching target metadata left under a legacy key", async () => {
     await withStateDirEnv("openclaw-doctor-acp-target-meta-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -458,6 +458,66 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("rejects incompatible source metadata after an interrupted claim", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-source-meta-incompatible-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      expect(
+        claimAcpSessionMetaForOwnerMigration({
+          cfg,
+          entry,
+          env,
+          expectedAgent: "codex",
+          sourceAgentId: "codex",
+          sourceSessionKey: sourceKey,
+          targetAgentId: "reviewer",
+          targetSessionKey: targetKey,
+        }),
+      ).toBe("claimed");
+      const canonicalSourceKey = buildAcpDatabaseSessionKey(sourceKey, "codex");
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "codex",
+          backend: "acpx",
+          lastActivityAt: 10,
+          mode: "persistent",
+          runtimeSessionName: "legacy-peer",
+          state: "idle",
+        },
+        sessionKey: canonicalSourceKey,
+      });
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "other-harness",
+          backend: "acpx",
+          lastActivityAt: 10,
+          mode: "persistent",
+          runtimeSessionName: "other-peer",
+          state: "idle",
+        },
+        sessionKey: sourceKey,
+      });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ conflicts: 1, eligible: 1, migrated: 0 });
+      const rows = withExistingOpenClawStateDatabaseReadOnly(
+        ({ db }) => ({
+          canonicalSource: selectAcpSessionRow(db, canonicalSourceKey),
+          legacySource: selectAcpSessionRow(db, sourceKey),
+        }),
+        { env },
+      );
+      expect(rows?.canonicalSource?.agent).toBe("codex");
+      expect(rows?.legacySource?.agent).toBe("other-harness");
+    });
+  });
+
   it("canonicalizes matching target metadata left under a legacy key", async () => {
     await withStateDirEnv("openclaw-doctor-acp-target-meta-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -1,0 +1,377 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { claimAcpSessionMetaForOwnerMigration } from "../acp/runtime/session-meta-owner-migration.js";
+import {
+  readAcpSessionMetaForEntry,
+  writeAcpSessionMetaForMigration,
+} from "../acp/runtime/session-meta.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import {
+  loadExactSessionEntryReadOnly,
+  replaceSessionEntrySync,
+} from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { migrateLegacyAcpOwnerSessions } from "./doctor-acp-owner-sessions.js";
+import { insertLegacySession } from "./doctor-session-canonical-keys.test-support.js";
+
+const sourceKey = "agent:codex:acp:legacy";
+const targetKey = "agent:reviewer:acp:legacy";
+const entry = {
+  lifecycleRevision: "revision-legacy",
+  sessionId: "session-legacy",
+  spawnedBy: "agent:main:main",
+  updatedAt: 10,
+} satisfies SessionEntry;
+
+function createConfig(stateDir: string, owners = ["reviewer"]): OpenClawConfig {
+  return {
+    agents: {
+      list: owners.map((id) => ({
+        id,
+        runtime: { type: "acp" as const, acp: { agent: "codex", backend: "acpx" } },
+      })),
+    },
+    session: { store: path.join(stateDir, "agents", "{agentId}", "sessions.json") },
+  };
+}
+
+function seedLegacySession(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  sessionKey?: string;
+}): string {
+  const sessionKey = params.sessionKey ?? sourceKey;
+  const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+    agentId: "codex",
+    env: params.env,
+  });
+  replaceSessionEntrySync({ agentId: "codex", env: params.env, sessionKey, storePath }, entry);
+  writeAcpSessionMetaForMigration({
+    env: params.env,
+    lifecycleRevision: entry.lifecycleRevision,
+    meta: {
+      agent: "codex",
+      backend: "acpx",
+      lastActivityAt: 10,
+      mode: "persistent",
+      runtimeSessionName: "legacy-peer",
+      state: "idle",
+    },
+    sessionKey,
+  });
+  return storePath;
+}
+
+afterEach(() => closeOpenClawAgentDatabasesForTest());
+
+describe("Doctor ACP owner migration", () => {
+  it("moves one eligible harness-owned session exactly once", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-owner-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+      const targetStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "reviewer",
+        env,
+      });
+
+      await expect(
+        migrateLegacyAcpOwnerSessions({ apply: false, cfg, env }),
+      ).resolves.toMatchObject({
+        eligible: 1,
+        migrated: 0,
+      });
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        {
+          eligible: 1,
+          migrated: 1,
+        },
+      );
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        }),
+      ).toBeUndefined();
+      const migratedEntry = loadExactSessionEntryReadOnly({
+        agentId: "reviewer",
+        env,
+        sessionKey: targetKey,
+        storePath: targetStorePath,
+      })?.entry;
+      expect(migratedEntry).toMatchObject({ sessionId: entry.sessionId });
+      expect(
+        readAcpSessionMetaForEntry({
+          agentId: "reviewer",
+          cfg,
+          entry: migratedEntry,
+          env,
+          sessionKey: targetKey,
+        })?.runtimeSessionName,
+      ).toBe("legacy-peer");
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        {
+          eligible: 0,
+          migrated: 0,
+        },
+      );
+    });
+  });
+
+  it("fails closed when multiple configured owners share one harness", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-ambiguous-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir, ["reviewer", "writer"]);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+      expect(report).toMatchObject({ ambiguous: 1, eligible: 0, migrated: 0 });
+      expect(report.warnings.join("\n")).toContain("multiple owners (reviewer, writer)");
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        }),
+      ).toBeDefined();
+    });
+  });
+
+  it("fails closed when a harness is both a configured owner and another alias target", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-self-owner-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir, ["codex", "reviewer"]);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+      expect(report).toMatchObject({ ambiguous: 1, eligible: 0, migrated: 0 });
+      expect(report.warnings.join("\n")).toContain("multiple owners (codex, reviewer)");
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        }),
+      ).toBeDefined();
+    });
+  });
+
+  it("cannot replay a consumed legacy peer through a later alias", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-consumed-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        {
+          migrated: 1,
+        },
+      );
+
+      const reassigned = createConfig(stateDir, ["writer"]);
+      await expect(
+        migrateLegacyAcpOwnerSessions({ apply: true, cfg: reassigned, env }),
+      ).resolves.toMatchObject({ eligible: 0, migrated: 0 });
+      const writerStorePath = resolveSessionStorePathCore(reassigned.session?.store, {
+        agentId: "writer",
+        env,
+      });
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "writer",
+          env,
+          sessionKey: "agent:writer:acp:legacy",
+          storePath: writerStorePath,
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  it("finishes a retry after metadata was claimed before the session row moved", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-retry-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      expect(
+        claimAcpSessionMetaForOwnerMigration({
+          cfg,
+          entry,
+          env,
+          expectedAgent: "codex",
+          sourceAgentId: "codex",
+          sourceSessionKey: sourceKey,
+          targetAgentId: "reviewer",
+          targetSessionKey: targetKey,
+        }),
+      ).toBe("claimed");
+
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        {
+          eligible: 1,
+          migrated: 1,
+        },
+      );
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        {
+          eligible: 0,
+          migrated: 0,
+        },
+      );
+    });
+  });
+
+  it("fails closed when the canonical owner key contains another session", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-conflict-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+      const targetStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "reviewer",
+        env,
+      });
+      replaceSessionEntrySync(
+        { agentId: "reviewer", env, sessionKey: targetKey, storePath: targetStorePath },
+        { sessionId: "different-session", updatedAt: 20 },
+      );
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+      expect(report).toMatchObject({ conflicts: 1, eligible: 0, migrated: 0 });
+      expect(report.warnings.join("\n")).toContain("different identity");
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        }),
+      ).toBeDefined();
+    });
+  });
+
+  it("leaves a bare key in a shared owner and harness store ambiguous", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-shared-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const sharedStore = path.join(stateDir, "sessions.json");
+      const cfg = createConfig(stateDir);
+      cfg.session = { store: sharedStore };
+      insertLegacySession({
+        agentId: "codex",
+        entry,
+        env,
+        sessionKey: "shared-project",
+        storePath: sharedStore,
+      });
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "codex",
+          backend: "acpx",
+          lastActivityAt: 10,
+          mode: "persistent",
+          runtimeSessionName: "legacy-peer",
+          state: "idle",
+        },
+        sessionKey: "shared-project",
+      });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+      expect(report).toMatchObject({ ambiguous: 1, eligible: 0, migrated: 0 });
+      expect(report.warnings.join("\n")).toContain("owner is ambiguous");
+    });
+  });
+
+  it("moves a bare key from a separate harness store", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-bare-separate-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      const sourceStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "codex",
+        env,
+      });
+      insertLegacySession({
+        agentId: "codex",
+        entry,
+        env,
+        sessionKey: "shared-project",
+        storePath: sourceStorePath,
+      });
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "codex",
+          backend: "acpx",
+          lastActivityAt: 10,
+          mode: "persistent",
+          runtimeSessionName: "legacy-peer",
+          state: "idle",
+        },
+        sessionKey: "shared-project",
+      });
+      const targetStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "reviewer",
+        env,
+      });
+
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        { ambiguous: 0, eligible: 1, migrated: 1 },
+      );
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: "shared-project",
+          storePath: sourceStorePath,
+        }),
+      ).toBeUndefined();
+      const migratedEntry = loadExactSessionEntryReadOnly({
+        agentId: "reviewer",
+        env,
+        sessionKey: "agent:reviewer:shared-project",
+        storePath: targetStorePath,
+      })?.entry;
+      expect(migratedEntry).toMatchObject({ sessionId: entry.sessionId });
+      expect(
+        readAcpSessionMetaForEntry({
+          agentId: "reviewer",
+          cfg,
+          entry: migratedEntry,
+          env,
+          sessionKey: "agent:reviewer:shared-project",
+        })?.runtimeSessionName,
+      ).toBe("legacy-peer");
+    });
+  });
+
+  it("does not report unrelated bare sessions as ACP migration ambiguity", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-unrelated-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const sharedStore = path.join(stateDir, "sessions.json");
+      const cfg = createConfig(stateDir);
+      cfg.session = { store: sharedStore };
+      insertLegacySession({
+        agentId: "codex",
+        entry,
+        env,
+        sessionKey: "ordinary-chat",
+        storePath: sharedStore,
+      });
+
+      await expect(
+        migrateLegacyAcpOwnerSessions({ apply: false, cfg, env }),
+      ).resolves.toMatchObject({
+        ambiguous: 0,
+        eligible: 0,
+        migrated: 0,
+        warnings: [],
+      });
+    });
+  });
+});

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -375,6 +375,52 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("rejects divergent canonical and legacy target metadata", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-target-meta-divergence-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      expect(
+        claimAcpSessionMetaForOwnerMigration({
+          cfg,
+          entry,
+          env,
+          expectedAgent: "codex",
+          sourceAgentId: "codex",
+          sourceSessionKey: sourceKey,
+          targetAgentId: "reviewer",
+          targetSessionKey: targetKey,
+        }),
+      ).toBe("claimed");
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "codex",
+          backend: "acpx",
+          lastActivityAt: 20,
+          mode: "persistent",
+          runtimeSessionName: "divergent-target-peer",
+          state: "idle",
+        },
+        sessionKey: targetKey,
+      });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ conflicts: 1, eligible: 1, migrated: 0 });
+      const rows = withExistingOpenClawStateDatabaseReadOnly(
+        ({ db }) => ({
+          canonical: selectAcpSessionRow(db, buildAcpDatabaseSessionKey(targetKey, "reviewer")),
+          legacy: selectAcpSessionRow(db, targetKey),
+        }),
+        { env },
+      );
+      expect(rows?.canonical?.runtime_session_name).toBe("legacy-peer");
+      expect(rows?.legacy?.runtime_session_name).toBe("divergent-target-peer");
+    });
+  });
+
   it("canonicalizes matching target metadata left under a legacy key", async () => {
     await withStateDirEnv("openclaw-doctor-acp-target-meta-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildAcpDatabaseSessionKey,
   selectAcpSessionRow,
@@ -11,6 +11,7 @@ import {
 } from "../acp/runtime/session-meta.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import {
+  ensureTranscriptGenerationsForCanonicalRepair,
   loadExactSessionEntryReadOnly,
   replaceSessionEntrySync,
 } from "../config/sessions/session-accessor.js";
@@ -21,6 +22,27 @@ import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-sta
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { migrateLegacyAcpOwnerSessions } from "./doctor-acp-owner-sessions.js";
 import { insertLegacySession } from "./doctor-session-canonical-keys.test-support.js";
+
+const sessionAccessorTestHooks = vi.hoisted(() => ({
+  ensureTranscriptGenerations: vi.fn(),
+  ensureTranscriptGenerationsDelegate: undefined as
+    | typeof ensureTranscriptGenerationsForCanonicalRepair
+    | undefined,
+}));
+
+vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/session-accessor.js")>();
+  sessionAccessorTestHooks.ensureTranscriptGenerationsDelegate =
+    actual.ensureTranscriptGenerationsForCanonicalRepair;
+  sessionAccessorTestHooks.ensureTranscriptGenerations.mockImplementation((sources) =>
+    actual.ensureTranscriptGenerationsForCanonicalRepair(sources),
+  );
+  return {
+    ...actual,
+    ensureTranscriptGenerationsForCanonicalRepair:
+      sessionAccessorTestHooks.ensureTranscriptGenerations,
+  };
+});
 
 const sourceKey = "agent:codex:acp:legacy";
 const targetKey = "agent:reviewer:acp:legacy";
@@ -70,7 +92,13 @@ function seedLegacySession(params: {
   return storePath;
 }
 
-afterEach(() => closeOpenClawAgentDatabasesForTest());
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  sessionAccessorTestHooks.ensureTranscriptGenerations.mockReset();
+  sessionAccessorTestHooks.ensureTranscriptGenerations.mockImplementation((sources) =>
+    sessionAccessorTestHooks.ensureTranscriptGenerationsDelegate!(sources),
+  );
+});
 
 describe("Doctor ACP owner migration", () => {
   it("moves one eligible harness-owned session exactly once", async () => {
@@ -290,6 +318,49 @@ describe("Doctor ACP owner migration", () => {
           storePath: sourceStorePath,
         }),
       ).toBeDefined();
+    });
+  });
+
+  it("keeps the legacy row when the canonical target appears during migration preparation", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-race-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+      const targetStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "reviewer",
+        env,
+      });
+      const concurrentEntry = { sessionId: "concurrent-session", updatedAt: 20 };
+      sessionAccessorTestHooks.ensureTranscriptGenerations.mockImplementationOnce(
+        async (sources) => {
+          await sessionAccessorTestHooks.ensureTranscriptGenerationsDelegate!(sources);
+          replaceSessionEntrySync(
+            { agentId: "reviewer", env, sessionKey: targetKey, storePath: targetStorePath },
+            concurrentEntry,
+          );
+        },
+      );
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ conflicts: 1, eligible: 1, migrated: 0 });
+      expect(report.warnings.join("\n")).toContain("changed during migration");
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        })?.entry,
+      ).toMatchObject(entry);
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "reviewer",
+          env,
+          sessionKey: targetKey,
+          storePath: targetStorePath,
+        })?.entry,
+      ).toMatchObject(concurrentEntry);
     });
   });
 

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../acp/runtime/session-meta.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import {
+  applySessionEntryLifecycleMutation,
   ensureTranscriptGenerationsForCanonicalRepair,
   loadExactSessionEntryReadOnly,
   replaceSessionEntrySync,
@@ -24,6 +25,10 @@ import { migrateLegacyAcpOwnerSessions } from "./doctor-acp-owner-sessions.js";
 import { insertLegacySession } from "./doctor-session-canonical-keys.test-support.js";
 
 const sessionAccessorTestHooks = vi.hoisted(() => ({
+  applyLifecycleMutation: vi.fn(),
+  applyLifecycleMutationDelegate: undefined as
+    | typeof applySessionEntryLifecycleMutation
+    | undefined,
   ensureTranscriptGenerations: vi.fn(),
   ensureTranscriptGenerationsDelegate: undefined as
     | typeof ensureTranscriptGenerationsForCanonicalRepair
@@ -32,6 +37,11 @@ const sessionAccessorTestHooks = vi.hoisted(() => ({
 
 vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions/session-accessor.js")>();
+  sessionAccessorTestHooks.applyLifecycleMutationDelegate =
+    actual.applySessionEntryLifecycleMutation;
+  sessionAccessorTestHooks.applyLifecycleMutation.mockImplementation((params) =>
+    actual.applySessionEntryLifecycleMutation(params),
+  );
   sessionAccessorTestHooks.ensureTranscriptGenerationsDelegate =
     actual.ensureTranscriptGenerationsForCanonicalRepair;
   sessionAccessorTestHooks.ensureTranscriptGenerations.mockImplementation((sources) =>
@@ -39,6 +49,7 @@ vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
   );
   return {
     ...actual,
+    applySessionEntryLifecycleMutation: sessionAccessorTestHooks.applyLifecycleMutation,
     ensureTranscriptGenerationsForCanonicalRepair:
       sessionAccessorTestHooks.ensureTranscriptGenerations,
   };
@@ -94,6 +105,10 @@ function seedLegacySession(params: {
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
+  sessionAccessorTestHooks.applyLifecycleMutation.mockReset();
+  sessionAccessorTestHooks.applyLifecycleMutation.mockImplementation((params) =>
+    sessionAccessorTestHooks.applyLifecycleMutationDelegate!(params),
+  );
   sessionAccessorTestHooks.ensureTranscriptGenerations.mockReset();
   sessionAccessorTestHooks.ensureTranscriptGenerations.mockImplementation((sources) =>
     sessionAccessorTestHooks.ensureTranscriptGenerationsDelegate!(sources),
@@ -196,6 +211,29 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("fails closed when a configured default owner is also an alias harness", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-default-owner-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      cfg.acp = { defaultAgent: "codex" };
+      cfg.agents?.list?.push({ id: "codex" });
+      const sourceStorePath = seedLegacySession({ cfg, env });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ ambiguous: 1, eligible: 0, migrated: 0 });
+      expect(report.warnings.join("\n")).toContain("multiple owners (codex, reviewer)");
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        }),
+      ).toBeDefined();
+    });
+  });
+
   it("cannot replay a consumed legacy peer through a later alias", async () => {
     await withStateDirEnv("openclaw-doctor-acp-consumed-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
@@ -278,9 +316,9 @@ describe("Doctor ACP owner migration", () => {
         sessionKey: targetKey,
       });
 
-      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
-        { conflicts: 0, eligible: 1, migrated: 1 },
-      );
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+      expect(report.warnings).toEqual([]);
+      expect(report).toMatchObject({ conflicts: 0, eligible: 1, migrated: 1 });
       const rows = withExistingOpenClawStateDatabaseReadOnly(
         ({ db }) => ({
           canonical: selectAcpSessionRow(db, buildAcpDatabaseSessionKey(targetKey, "reviewer")),
@@ -364,6 +402,65 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("removes a staged canonical copy when the legacy source changes before removal", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-source-race-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      const sourceStorePath = seedLegacySession({ cfg, env });
+      const targetStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: "reviewer",
+        env,
+      });
+      const concurrentEntry = { ...entry, model: "newer", updatedAt: 20 };
+      let mutationCount = 0;
+      sessionAccessorTestHooks.applyLifecycleMutation.mockImplementation(async (params) => {
+        mutationCount += 1;
+        if (mutationCount === 2) {
+          replaceSessionEntrySync(
+            { agentId: "codex", env, sessionKey: sourceKey, storePath: sourceStorePath },
+            concurrentEntry,
+          );
+        }
+        return await sessionAccessorTestHooks.applyLifecycleMutationDelegate!(params);
+      });
+
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        { conflicts: 1, eligible: 1, migrated: 0 },
+      );
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sourceStorePath,
+        })?.entry,
+      ).toMatchObject(concurrentEntry);
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "reviewer",
+          env,
+          sessionKey: targetKey,
+          storePath: targetStorePath,
+        }),
+      ).toBeUndefined();
+
+      sessionAccessorTestHooks.applyLifecycleMutation.mockImplementation((params) =>
+        sessionAccessorTestHooks.applyLifecycleMutationDelegate!(params),
+      );
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+      expect(report.warnings).toEqual([]);
+      expect(report).toMatchObject({ conflicts: 0, eligible: 1, migrated: 1 });
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "reviewer",
+          env,
+          sessionKey: targetKey,
+          storePath: targetStorePath,
+        })?.entry,
+      ).toMatchObject(concurrentEntry);
+    });
+  });
+
   it("leaves a bare key in a shared owner and harness store ambiguous", async () => {
     await withStateDirEnv("openclaw-doctor-acp-shared-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
@@ -394,6 +491,36 @@ describe("Doctor ACP owner migration", () => {
       const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
       expect(report).toMatchObject({ ambiguous: 1, eligible: 0, migrated: 0 });
       expect(report.warnings.join("\n")).toContain("owner is ambiguous");
+    });
+  });
+
+  it("atomically moves scoped keys inside a shared owner and harness store", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-shared-scoped-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const sharedStore = path.join(stateDir, "sessions.json");
+      const cfg = createConfig(stateDir);
+      cfg.session = { store: sharedStore };
+      seedLegacySession({ cfg, env });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+      expect(report.warnings).toEqual([]);
+      expect(report).toMatchObject({ conflicts: 0, eligible: 1, migrated: 1 });
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "codex",
+          env,
+          sessionKey: sourceKey,
+          storePath: sharedStore,
+        }),
+      ).toBeUndefined();
+      expect(
+        loadExactSessionEntryReadOnly({
+          agentId: "reviewer",
+          env,
+          sessionKey: targetKey,
+          storePath: sharedStore,
+        })?.entry,
+      ).toMatchObject(entry);
     });
   });
 

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -518,6 +518,41 @@ describe("Doctor ACP owner migration", () => {
     });
   });
 
+  it("reports incompatible canonical source metadata before an eligible legacy row", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-source-meta-order-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      const canonicalSourceKey = buildAcpDatabaseSessionKey(sourceKey, "codex");
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "other-harness",
+          backend: "acpx",
+          lastActivityAt: 10,
+          mode: "persistent",
+          runtimeSessionName: "other-peer",
+          state: "idle",
+        },
+        sessionKey: canonicalSourceKey,
+      });
+
+      const report = await migrateLegacyAcpOwnerSessions({ apply: true, cfg, env });
+
+      expect(report).toMatchObject({ conflicts: 1, eligible: 1, migrated: 0 });
+      const rows = withExistingOpenClawStateDatabaseReadOnly(
+        ({ db }) => ({
+          canonicalSource: selectAcpSessionRow(db, canonicalSourceKey),
+          legacySource: selectAcpSessionRow(db, sourceKey),
+        }),
+        { env },
+      );
+      expect(rows?.canonicalSource?.agent).toBe("other-harness");
+      expect(rows?.legacySource?.agent).toBe("codex");
+    });
+  });
+
   it("canonicalizes matching target metadata left under a legacy key", async () => {
     await withStateDirEnv("openclaw-doctor-acp-target-meta-", async ({ stateDir }) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/commands/doctor-acp-owner-sessions.test.ts
+++ b/src/commands/doctor-acp-owner-sessions.test.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildAcpDatabaseSessionKey,
+  selectAcpSessionRow,
+} from "../acp/runtime/session-meta-keys.js";
 import { claimAcpSessionMetaForOwnerMigration } from "../acp/runtime/session-meta-owner-migration.js";
 import {
   readAcpSessionMetaForEntry,
@@ -13,6 +17,7 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { migrateLegacyAcpOwnerSessions } from "./doctor-acp-owner-sessions.js";
 import { insertLegacySession } from "./doctor-session-canonical-keys.test-support.js";
@@ -223,6 +228,40 @@ describe("Doctor ACP owner migration", () => {
           migrated: 0,
         },
       );
+    });
+  });
+
+  it("canonicalizes matching target metadata left under a legacy key", async () => {
+    await withStateDirEnv("openclaw-doctor-acp-target-meta-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const cfg = createConfig(stateDir);
+      seedLegacySession({ cfg, env });
+      writeAcpSessionMetaForMigration({
+        env,
+        lifecycleRevision: entry.lifecycleRevision,
+        meta: {
+          agent: "codex",
+          backend: "acpx",
+          lastActivityAt: 10,
+          mode: "persistent",
+          runtimeSessionName: "legacy-peer",
+          state: "idle",
+        },
+        sessionKey: targetKey,
+      });
+
+      await expect(migrateLegacyAcpOwnerSessions({ apply: true, cfg, env })).resolves.toMatchObject(
+        { conflicts: 0, eligible: 1, migrated: 1 },
+      );
+      const rows = withExistingOpenClawStateDatabaseReadOnly(
+        ({ db }) => ({
+          canonical: selectAcpSessionRow(db, buildAcpDatabaseSessionKey(targetKey, "reviewer")),
+          legacy: selectAcpSessionRow(db, targetKey),
+        }),
+        { env },
+      );
+      expect(rows?.canonical?.agent).toBe("codex");
+      expect(rows?.legacy).toBeUndefined();
     });
   });
 

--- a/src/commands/doctor-acp-owner-sessions.ts
+++ b/src/commands/doctor-acp-owner-sessions.ts
@@ -13,6 +13,7 @@ import {
   loadCanonicalSessionRepairEntries,
   loadExactSessionEntryReadOnly,
 } from "../config/sessions/session-accessor.js";
+import { SessionEntryLifecycleUpsertConflictError } from "../config/sessions/session-accessor.lifecycle-types.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -87,14 +88,17 @@ async function moveSessionEntry(params: {
   targetAgentId: string;
   targetKey: string;
   targetStorePath: string;
-}): Promise<void> {
-  const target = loadExactSessionEntryReadOnly({
+}): Promise<"conflict" | "moved"> {
+  const targetBeforePreparation = loadExactSessionEntryReadOnly({
     agentId: params.targetAgentId,
     env: params.env,
     sessionKey: params.targetKey,
     storePath: params.targetStorePath,
   })?.entry;
-  if (!target) {
+  if (targetBeforePreparation && !sameSessionIdentity(targetBeforePreparation, params.entry)) {
+    return "conflict";
+  }
+  if (!targetBeforePreparation) {
     await ensureTranscriptGenerationsForCanonicalRepair([
       {
         agentId: params.sourceAgentId,
@@ -103,10 +107,17 @@ async function moveSessionEntry(params: {
         storePath: params.sourceStorePath,
       },
     ]);
+  }
+  let copyOwnedState = false;
+  let targetConflict = false;
+  try {
     await applySessionEntryLifecycleMutation({
       agentId: params.targetAgentId,
       allowCanonicalRepair: true,
       afterUpsertsInTransaction: (database) => {
+        if (!copyOwnedState) {
+          return;
+        }
         copySessionOwnedStateForCanonicalRepair({
           canonicalKey: params.targetKey,
           destinationDatabase: database,
@@ -119,8 +130,31 @@ async function moveSessionEntry(params: {
       },
       skipMaintenance: true,
       storePath: params.targetStorePath,
-      upserts: [{ entry: params.entry, sessionKey: params.targetKey }],
+      upserts: [
+        {
+          buildEntry: ({ currentEntry }) => {
+            if (currentEntry && !sameSessionIdentity(currentEntry, params.entry)) {
+              targetConflict = true;
+              return null;
+            }
+            copyOwnedState = currentEntry === undefined;
+            return currentEntry ?? params.entry;
+          },
+          sessionKey: params.targetKey,
+        },
+      ],
     });
+  } catch (error) {
+    if (
+      error instanceof SessionEntryLifecycleUpsertConflictError &&
+      error.sessionKey === params.targetKey
+    ) {
+      return "conflict";
+    }
+    throw error;
+  }
+  if (targetConflict) {
+    return "conflict";
   }
   await applySessionEntryLifecycleMutation({
     agentId: params.sourceAgentId,
@@ -137,6 +171,7 @@ async function moveSessionEntry(params: {
     skipMaintenance: true,
     storePath: params.sourceStorePath,
   });
+  return "moved";
 }
 
 /** Doctor-only ACP owner migration. Runtime never reads or promotes legacy harness rows. */
@@ -234,7 +269,7 @@ export async function migrateLegacyAcpOwnerSessions(params: {
         );
         continue;
       }
-      await moveSessionEntry({
+      const move = await moveSessionEntry({
         env,
         entry,
         sourceAgentId: harnessAgentId,
@@ -244,6 +279,13 @@ export async function migrateLegacyAcpOwnerSessions(params: {
         targetKey,
         targetStorePath,
       });
+      if (move === "conflict") {
+        conflicts += 1;
+        warnings.push(
+          `Canonical ACP session "${targetKey}" changed during migration; legacy source "${sourceKey}" was left unchanged.`,
+        );
+        continue;
+      }
       migrated += 1;
     }
   }

--- a/src/commands/doctor-acp-owner-sessions.ts
+++ b/src/commands/doctor-acp-owner-sessions.ts
@@ -37,7 +37,8 @@ function collectAcpOwnerMappings(cfg: OpenClawConfig): {
   mappings: AcpOwnerMapping[];
 } {
   const ownersByHarness = new Map<string, Set<string>>();
-  for (const agent of listAgentEntries(cfg)) {
+  const configuredAgents = listAgentEntries(cfg);
+  for (const agent of configuredAgents) {
     if (agent.runtime?.type !== "acp") {
       continue;
     }
@@ -49,6 +50,27 @@ function collectAcpOwnerMappings(cfg: OpenClawConfig): {
     const owners = ownersByHarness.get(harnessAgentId) ?? new Set<string>();
     owners.add(ownerAgentId);
     ownersByHarness.set(harnessAgentId, owners);
+  }
+  const defaultAgentId = normalizeOptionalAgentId(cfg.acp?.defaultAgent);
+  const allowedAgentIds = new Set(
+    (cfg.acp?.allowedAgents ?? []).flatMap((entry) => {
+      const normalized = normalizeOptionalAgentId(entry);
+      return normalized ? [normalized] : [];
+    }),
+  );
+  const allowsConfiguredAgents = cfg.acp?.allowedAgents?.some((entry) => entry.trim() === "*");
+  for (const agent of configuredAgents) {
+    const ownerAgentId = normalizeOptionalAgentId(agent.id);
+    if (
+      !ownerAgentId ||
+      agent.runtime?.type === "acp" ||
+      (ownerAgentId !== defaultAgentId &&
+        !allowsConfiguredAgents &&
+        !allowedAgentIds.has(ownerAgentId))
+    ) {
+      continue;
+    }
+    ownersByHarness.get(ownerAgentId)?.add(ownerAgentId);
   }
   const ambiguousHarnesses = new Map<string, string[]>();
   const mappings: AcpOwnerMapping[] = [];
@@ -108,10 +130,17 @@ async function moveSessionEntry(params: {
       },
     ]);
   }
-  let copyOwnedState = false;
-  let targetConflict = false;
-  try {
-    await applySessionEntryLifecycleMutation({
+  const sourceRemoval = {
+    archiveRemovedTranscript: true,
+    deleteOwnedWindows: true,
+    exactStoredKey: true,
+    expectedEntry: params.entry,
+    sessionKey: params.sourceKey,
+  } as const;
+  const applyTarget = async () => {
+    let copyOwnedState = false;
+    let targetConflict = false;
+    const result = await applySessionEntryLifecycleMutation({
       agentId: params.targetAgentId,
       allowCanonicalRepair: true,
       afterUpsertsInTransaction: (database) => {
@@ -127,6 +156,11 @@ async function moveSessionEntry(params: {
           sourceEntries: [params.entry],
           sourceKeys: [params.sourceKey],
         });
+      },
+      beforeCommitInTransaction: () => {
+        if (targetConflict) {
+          throw new SessionEntryLifecycleUpsertConflictError(params.targetKey);
+        }
       },
       skipMaintenance: true,
       storePath: params.targetStorePath,
@@ -144,6 +178,36 @@ async function moveSessionEntry(params: {
         },
       ],
     });
+    return { createdTarget: copyOwnedState, result };
+  };
+  try {
+    const { createdTarget } = await applyTarget();
+    let sourceRemovalCommitted = false;
+    try {
+      const result = await applySessionEntryLifecycleMutation({
+        agentId: params.sourceAgentId,
+        allowCanonicalRepair: true,
+        onLifecycleCommitted: () => {
+          sourceRemovalCommitted = true;
+        },
+        removals: [sourceRemoval],
+        skipMaintenance: true,
+        storePath: params.sourceStorePath,
+      });
+      if (result.removedSessionKeys.includes(params.sourceKey)) {
+        return "moved";
+      }
+    } catch (error) {
+      if (sourceRemovalCommitted || !createdTarget) {
+        throw error;
+      }
+      await removeCreatedMigrationTarget(params);
+      throw error;
+    }
+    if (createdTarget) {
+      await removeCreatedMigrationTarget(params);
+    }
+    return "conflict";
   } catch (error) {
     if (
       error instanceof SessionEntryLifecycleUpsertConflictError &&
@@ -153,25 +217,29 @@ async function moveSessionEntry(params: {
     }
     throw error;
   }
-  if (targetConflict) {
-    return "conflict";
-  }
+}
+
+async function removeCreatedMigrationTarget(params: {
+  entry: SessionEntry;
+  env: NodeJS.ProcessEnv;
+  targetAgentId: string;
+  targetKey: string;
+  targetStorePath: string;
+}): Promise<void> {
   await applySessionEntryLifecycleMutation({
-    agentId: params.sourceAgentId,
+    agentId: params.targetAgentId,
     allowCanonicalRepair: true,
     removals: [
       {
-        archiveRemovedTranscript: true,
         deleteOwnedWindows: true,
         exactStoredKey: true,
         expectedEntry: params.entry,
-        sessionKey: params.sourceKey,
+        sessionKey: params.targetKey,
       },
     ],
     skipMaintenance: true,
-    storePath: params.sourceStorePath,
+    storePath: params.targetStorePath,
   });
-  return "moved";
 }
 
 /** Doctor-only ACP owner migration. Runtime never reads or promotes legacy harness rows. */

--- a/src/commands/doctor-acp-owner-sessions.ts
+++ b/src/commands/doctor-acp-owner-sessions.ts
@@ -1,0 +1,251 @@
+import {
+  claimAcpSessionMetaForOwnerMigration,
+  readAcpSessionMetaForOwnerMigration,
+} from "../acp/runtime/session-meta-owner-migration.js";
+import { readAcpSessionMetaForEntry } from "../acp/runtime/session-meta.js";
+import { listAgentEntries } from "../agents/agent-scope-config.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import {
+  applySessionEntryLifecycleMutation,
+  copySessionOwnedStateForCanonicalRepair,
+  ensureTranscriptGenerationsForCanonicalRepair,
+  listCanonicalSessionRepairFacts,
+  loadCanonicalSessionRepairEntries,
+  loadExactSessionEntryReadOnly,
+} from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  normalizeOptionalAgentId,
+  parseAgentSessionKey,
+  toAgentStoreSessionKey,
+} from "../routing/session-key.js";
+
+export type AcpOwnerSessionMigrationReport = {
+  ambiguous: number;
+  conflicts: number;
+  eligible: number;
+  migrated: number;
+  warnings: string[];
+};
+
+type AcpOwnerMapping = { harnessAgentId: string; ownerAgentId: string };
+
+function collectAcpOwnerMappings(cfg: OpenClawConfig): {
+  ambiguousHarnesses: Map<string, string[]>;
+  mappings: AcpOwnerMapping[];
+} {
+  const ownersByHarness = new Map<string, Set<string>>();
+  for (const agent of listAgentEntries(cfg)) {
+    if (agent.runtime?.type !== "acp") {
+      continue;
+    }
+    const ownerAgentId = normalizeOptionalAgentId(agent.id);
+    const harnessAgentId = normalizeOptionalAgentId(agent.runtime.acp?.agent) ?? ownerAgentId;
+    if (!ownerAgentId || !harnessAgentId) {
+      continue;
+    }
+    const owners = ownersByHarness.get(harnessAgentId) ?? new Set<string>();
+    owners.add(ownerAgentId);
+    ownersByHarness.set(harnessAgentId, owners);
+  }
+  const ambiguousHarnesses = new Map<string, string[]>();
+  const mappings: AcpOwnerMapping[] = [];
+  for (const [harnessAgentId, ownerSet] of ownersByHarness) {
+    const owners = [...ownerSet].toSorted();
+    if (owners.length !== 1) {
+      ambiguousHarnesses.set(harnessAgentId, owners);
+      continue;
+    }
+    if (owners[0] === harnessAgentId) {
+      continue;
+    }
+    mappings.push({ harnessAgentId, ownerAgentId: owners[0]! });
+  }
+  return { ambiguousHarnesses, mappings };
+}
+
+function resolveCanonicalOwnerKey(sourceSessionKey: string, ownerAgentId: string): string {
+  const parsed = parseAgentSessionKey(sourceSessionKey);
+  return parsed?.rest
+    ? `agent:${ownerAgentId}:${parsed.rest}`
+    : toAgentStoreSessionKey({ agentId: ownerAgentId, requestKey: sourceSessionKey });
+}
+
+function sameSessionIdentity(left: SessionEntry, right: SessionEntry): boolean {
+  return left.lifecycleRevision
+    ? left.lifecycleRevision === right.lifecycleRevision
+    : left.sessionId === right.sessionId;
+}
+
+async function moveSessionEntry(params: {
+  env: NodeJS.ProcessEnv;
+  entry: SessionEntry;
+  sourceAgentId: string;
+  sourceKey: string;
+  sourceStorePath: string;
+  targetAgentId: string;
+  targetKey: string;
+  targetStorePath: string;
+}): Promise<void> {
+  const target = loadExactSessionEntryReadOnly({
+    agentId: params.targetAgentId,
+    env: params.env,
+    sessionKey: params.targetKey,
+    storePath: params.targetStorePath,
+  })?.entry;
+  if (!target) {
+    await ensureTranscriptGenerationsForCanonicalRepair([
+      {
+        agentId: params.sourceAgentId,
+        entry: params.entry,
+        sessionKey: params.sourceKey,
+        storePath: params.sourceStorePath,
+      },
+    ]);
+    await applySessionEntryLifecycleMutation({
+      agentId: params.targetAgentId,
+      allowCanonicalRepair: true,
+      afterUpsertsInTransaction: (database) => {
+        copySessionOwnedStateForCanonicalRepair({
+          canonicalKey: params.targetKey,
+          destinationDatabase: database,
+          preferredEntry: params.entry,
+          preferredSessionKey: params.sourceKey,
+          source: { agentId: params.sourceAgentId, storePath: params.sourceStorePath },
+          sourceEntries: [params.entry],
+          sourceKeys: [params.sourceKey],
+        });
+      },
+      skipMaintenance: true,
+      storePath: params.targetStorePath,
+      upserts: [{ entry: params.entry, sessionKey: params.targetKey }],
+    });
+  }
+  await applySessionEntryLifecycleMutation({
+    agentId: params.sourceAgentId,
+    allowCanonicalRepair: true,
+    removals: [
+      {
+        archiveRemovedTranscript: true,
+        deleteOwnedWindows: true,
+        exactStoredKey: true,
+        expectedEntry: params.entry,
+        sessionKey: params.sourceKey,
+      },
+    ],
+    skipMaintenance: true,
+    storePath: params.sourceStorePath,
+  });
+}
+
+/** Doctor-only ACP owner migration. Runtime never reads or promotes legacy harness rows. */
+export async function migrateLegacyAcpOwnerSessions(params: {
+  apply: boolean;
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<AcpOwnerSessionMigrationReport> {
+  const env = params.env ?? process.env;
+  const { ambiguousHarnesses, mappings } = collectAcpOwnerMappings(params.cfg);
+  const warnings = [...ambiguousHarnesses].map(
+    ([harness, owners]) =>
+      `ACP harness "${harness}" is configured for multiple owners (${owners.join(", ")}); legacy sessions were not migrated. Configure exactly one owner or migrate the records manually.`,
+  );
+  let ambiguous = ambiguousHarnesses.size;
+  let conflicts = 0;
+  let eligible = 0;
+  let migrated = 0;
+  for (const { harnessAgentId, ownerAgentId } of mappings) {
+    const sourceStorePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+      agentId: harnessAgentId,
+      env,
+    });
+    const targetStorePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+      agentId: ownerAgentId,
+      env,
+    });
+    const sourceScope = { agentId: harnessAgentId, storePath: sourceStorePath };
+    const sourceFacts = listCanonicalSessionRepairFacts(sourceScope);
+    for (const { entry, sessionKey: sourceKey } of loadCanonicalSessionRepairEntries(
+      sourceScope,
+      sourceFacts,
+    )) {
+      const parsed = parseAgentSessionKey(sourceKey);
+      if (parsed?.agentId && parsed.agentId !== harnessAgentId) {
+        continue;
+      }
+      const targetKey = resolveCanonicalOwnerKey(sourceKey, ownerAgentId);
+      const sourceMeta = readAcpSessionMetaForOwnerMigration({
+        agentId: harnessAgentId,
+        cfg: params.cfg,
+        entry,
+        env,
+        sessionKey: sourceKey,
+      });
+      const targetMeta = readAcpSessionMetaForEntry({
+        agentId: ownerAgentId,
+        cfg: params.cfg,
+        entry,
+        env,
+        sessionKey: targetKey,
+      });
+      const meta = sourceMeta ?? targetMeta;
+      if (meta?.agent !== harnessAgentId) {
+        continue;
+      }
+      if (!parsed && sourceStorePath === targetStorePath) {
+        ambiguous += 1;
+        warnings.push(
+          `Legacy ACP session "${sourceKey}" shares the owner and harness store, so its owner is ambiguous; no change was made.`,
+        );
+        continue;
+      }
+      const targetEntry = loadExactSessionEntryReadOnly({
+        agentId: ownerAgentId,
+        env,
+        sessionKey: targetKey,
+        storePath: targetStorePath,
+      })?.entry;
+      if (targetEntry && !sameSessionIdentity(targetEntry, entry)) {
+        conflicts += 1;
+        warnings.push(
+          `Canonical ACP session "${targetKey}" already exists with a different identity; legacy source "${sourceKey}" was left unchanged.`,
+        );
+        continue;
+      }
+      eligible += 1;
+      if (!params.apply) {
+        continue;
+      }
+      const claim = claimAcpSessionMetaForOwnerMigration({
+        cfg: params.cfg,
+        entry,
+        env,
+        expectedAgent: harnessAgentId,
+        sourceAgentId: harnessAgentId,
+        sourceSessionKey: sourceKey,
+        targetAgentId: ownerAgentId,
+        targetSessionKey: targetKey,
+      });
+      if (claim === "conflict" || claim === "missing") {
+        conflicts += 1;
+        warnings.push(
+          `ACP metadata for legacy session "${sourceKey}" could not be claimed for owner "${ownerAgentId}"; no session row was moved.`,
+        );
+        continue;
+      }
+      await moveSessionEntry({
+        env,
+        entry,
+        sourceAgentId: harnessAgentId,
+        sourceKey,
+        sourceStorePath,
+        targetAgentId: ownerAgentId,
+        targetKey,
+        targetStorePath,
+      });
+      migrated += 1;
+    }
+  }
+  return { ambiguous, conflicts, eligible, migrated, warnings };
+}

--- a/src/commands/doctor-acp-owner-sessions.ts
+++ b/src/commands/doctor-acp-owner-sessions.ts
@@ -52,23 +52,9 @@ function collectAcpOwnerMappings(cfg: OpenClawConfig): {
     owners.add(ownerAgentId);
     ownersByHarness.set(harnessAgentId, owners);
   }
-  const defaultAgentId = normalizeOptionalAgentId(cfg.acp?.defaultAgent);
-  const allowedAgentIds = new Set(
-    (cfg.acp?.allowedAgents ?? []).flatMap((entry) => {
-      const normalized = normalizeOptionalAgentId(entry);
-      return normalized ? [normalized] : [];
-    }),
-  );
-  const allowsConfiguredAgents = cfg.acp?.allowedAgents?.some((entry) => entry.trim() === "*");
   for (const agent of configuredAgents) {
     const ownerAgentId = normalizeOptionalAgentId(agent.id);
-    if (
-      !ownerAgentId ||
-      agent.runtime?.type === "acp" ||
-      (ownerAgentId !== defaultAgentId &&
-        !allowsConfiguredAgents &&
-        !allowedAgentIds.has(ownerAgentId))
-    ) {
+    if (!ownerAgentId || agent.runtime?.type === "acp") {
       continue;
     }
     ownersByHarness.get(ownerAgentId)?.add(ownerAgentId);
@@ -200,6 +186,25 @@ async function moveSessionEntry(params: {
         storePath: params.sourceStorePath,
       });
       if (result.removedSessionKeys.includes(params.sourceKey)) {
+        return "moved";
+      }
+      const sourceAfterRemoval = loadExactSessionEntryReadOnly({
+        agentId: params.sourceAgentId,
+        env: params.env,
+        sessionKey: params.sourceKey,
+        storePath: params.sourceStorePath,
+      })?.entry;
+      const targetAfterRemoval = loadExactSessionEntryReadOnly({
+        agentId: params.targetAgentId,
+        env: params.env,
+        sessionKey: params.targetKey,
+        storePath: params.targetStorePath,
+      })?.entry;
+      if (
+        !sourceAfterRemoval &&
+        targetAfterRemoval &&
+        sameSessionEntry(targetAfterRemoval, params.entry)
+      ) {
         return "moved";
       }
     } catch (error) {

--- a/src/commands/doctor-acp-owner-sessions.ts
+++ b/src/commands/doctor-acp-owner-sessions.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import {
   claimAcpSessionMetaForOwnerMigration,
   readAcpSessionMetaForOwnerMigration,
@@ -101,6 +102,10 @@ function sameSessionIdentity(left: SessionEntry, right: SessionEntry): boolean {
     : left.sessionId === right.sessionId;
 }
 
+function sameSessionEntry(left: SessionEntry, right: SessionEntry): boolean {
+  return sameSessionIdentity(left, right) && isDeepStrictEqual(left, right);
+}
+
 async function moveSessionEntry(params: {
   env: NodeJS.ProcessEnv;
   entry: SessionEntry;
@@ -117,7 +122,7 @@ async function moveSessionEntry(params: {
     sessionKey: params.targetKey,
     storePath: params.targetStorePath,
   })?.entry;
-  if (targetBeforePreparation && !sameSessionIdentity(targetBeforePreparation, params.entry)) {
+  if (targetBeforePreparation && !sameSessionEntry(targetBeforePreparation, params.entry)) {
     return "conflict";
   }
   if (!targetBeforePreparation) {
@@ -167,7 +172,7 @@ async function moveSessionEntry(params: {
       upserts: [
         {
           buildEntry: ({ currentEntry }) => {
-            if (currentEntry && !sameSessionIdentity(currentEntry, params.entry)) {
+            if (currentEntry && !sameSessionEntry(currentEntry, params.entry)) {
               targetConflict = true;
               return null;
             }
@@ -309,7 +314,7 @@ export async function migrateLegacyAcpOwnerSessions(params: {
         sessionKey: targetKey,
         storePath: targetStorePath,
       })?.entry;
-      if (targetEntry && !sameSessionIdentity(targetEntry, entry)) {
+      if (targetEntry && !sameSessionEntry(targetEntry, entry)) {
         conflicts += 1;
         warnings.push(
           `Canonical ACP session "${targetKey}" already exists with a different identity; legacy source "${sourceKey}" was left unchanged.`,

--- a/src/commands/doctor-session-transcripts.ts
+++ b/src/commands/doctor-session-transcripts.ts
@@ -300,6 +300,11 @@ async function noteSessionSqliteMigrationHealth(params: {
     repairedGroups: 0,
     scannedStores: 0,
   };
+  let acpOwnerReport:
+    | Awaited<
+        ReturnType<typeof import("./doctor-acp-owner-sessions.js").migrateLegacyAcpOwnerSessions>
+      >
+    | undefined;
   let legacyMainSessionResult:
     | Awaited<
         ReturnType<
@@ -320,6 +325,12 @@ async function noteSessionSqliteMigrationHealth(params: {
       cfg: params.cfg ?? {},
       env: params.env,
       mode: params.shouldRepair ? "doctor-fix" : "detect",
+    });
+    const { migrateLegacyAcpOwnerSessions } = await import("./doctor-acp-owner-sessions.js");
+    acpOwnerReport = await migrateLegacyAcpOwnerSessions({
+      apply: params.shouldRepair,
+      cfg: params.cfg ?? {},
+      env: params.env,
     });
     const repairParams = {
       apply: params.shouldRepair,
@@ -377,6 +388,17 @@ async function noteSessionSqliteMigrationHealth(params: {
         ? `- Canonicalized ${canonicalKeyReport.repairedGroups} session-key group(s) in ${canonicalKeyReport.repairBatches} transaction batch(es), removed ${canonicalKeyReport.removedRows} duplicate or alias row(s), and preserved cross-store history in ${canonicalKeyReport.archivedTranscriptDirectories.length} archive director${canonicalKeyReport.archivedTranscriptDirectories.length === 1 ? "y" : "ies"}.`
         : `- Found ${canonicalKeyReport.foundGroups} non-canonical or duplicate session-key group(s). Run "openclaw doctor --fix" to preserve their history and canonicalize the rows.`,
       "Session SQLite",
+    );
+  }
+  if (acpOwnerReport && (acpOwnerReport.eligible > 0 || acpOwnerReport.warnings.length > 0)) {
+    note(
+      [
+        params.shouldRepair
+          ? `- Migrated ${acpOwnerReport.migrated} legacy ACP session(s) to their canonical configured owner.`
+          : `- Found ${acpOwnerReport.eligible} legacy ACP session(s) eligible for explicit owner migration. Run "openclaw doctor --fix" to migrate them.`,
+        ...acpOwnerReport.warnings.map((warning) => `- ${warning}`),
+      ].join("\n"),
+      "ACP session ownership",
     );
   }
   if (deliveryReport.found > 0) {


### PR DESCRIPTION
Related: #126539

## What Problem This Solves

Configured OpenClaw ACP aliases could dispatch through an external harness and then persist that harness as the session owner. Session lookup, workspace/account routing, bindings, resume authorization, cancellation, and cleanup could consequently disagree about who owned the session.

## Why This Change Was Made

Configured ACP aliases now remain the persistent OpenClaw owner. `agents.entries.*.runtime.acp.agent` is used only as the external dispatch harness. Owner identity is carried through session keys/stores, workspace and account selection, bindings, runtime initialization, lifecycle registration, resume, cancel, and cleanup.

Runtime compatibility fallback has been removed. Resume and lifecycle commands read only the canonical configured-owner store.

Legacy harness-owned rows are handled explicitly:

1. `openclaw doctor` inventories eligible legacy ACP sessions without changing them.
2. `openclaw doctor --fix` migrates a row only when its harness maps to exactly one configured owner.
3. Doctor atomically claims and consumes the legacy ACP metadata before re-homing session-owned state under `agent:<owner>:...`, so retries can finish a partial move and another alias cannot replay the source.
4. Multiple aliases for one harness, a harness that is itself an owner plus another alias, bare keys in shared owner/harness stores, and canonical target collisions fail closed with operator guidance.

This PR deliberately excludes Codex command detection, `CODEX_HOME` policy, and shell/interpreter/package-runner parsing.

## User Impact

- Configured aliases are stable across spawn, status, resume, cancel, close, and cleanup.
- Alias workspace and bound account remain authoritative while the external harness performs execution.
- Unconfigured external harnesses remain owned/routed by the requester.
- Legacy sessions do not resume implicitly. Operators inventory and migrate eligible records through Doctor; ambiguous records remain untouched until configuration or state is resolved.

## Evidence

Exact reviewed head: `79af7db588a4bd6f1e0dd9f775936fdd7b1bd0d0`  
Reviewed base: `9b95e87c4b2b506cc35c62e714f05cce4b71c61d`  
Diff: 17 files, `+2894/-116` (`+728/-58` production, `+2130/-47` tests, `+36/-11` docs).

### Exact-head proof

- Focused owner/target/Doctor/`/acp` lifecycle and process proof: **257/257 passed** across seven Vitest shards, including concurrent target-write rejection, source-removal race compensation, concurrent successful-migration preservation, divergent interrupted-stage retry rejection, expected-harness discovery, and strict source/canonical/legacy-target ACP metadata agreement.
- The configured-alias process test executes a real ACPX turn under owner `reviewer`, harness `owner-fixture`, owner workspace/account/binding, then rejects a foreign resume before any ACPX peer-state byte changes.
- Two real ACPX process tests preserve separate owner histories across restart and exercise resume/status/config/cancel/close for `global` and `shared-project` scopes.
- Doctor tests cover unique-owner migration, idempotency, partial-failure retry, consumed-source replay prevention, multiple aliases, ACP and every configured non-ACP self-owner ambiguity, legacy-target metadata canonicalization, expected-harness discovery plus strict agreement across all populated source/canonical/legacy-target metadata (including incompatible agent/binding rows), separate-store bare/scoped keys, shared-store ambiguity, unrelated bare rows, canonical collisions, source-removal race compensation followed by retry, preservation of a concurrent successful migration, and fail-closed recovery when an interrupted canonical stage diverges from the legacy source.
- Resume tests admit owner-scoped `global` sessions while continuing to reject ambiguous bare keys in fixed shared stores.
- Changed-file oxlint, formatting, diff, max-lines, assertion-safety, dependency-pin, plugin-boundary, and wrapper-shadowing gates pass.
- Scanner-backed P0-P2 autoreview and secret scan: scoped-clean at 0.91 confidence on the exact head.

### Environment-only baseline exceptions

- `check:changed` completes candidate-owned checks, then production core typecheck stops on four unrelated upstream `assertBeforeRename` errors in `src/infra/install-package-dir.ts`; the ACP diff does not touch that path.
- Docs formatting, markdown/template lint, MDX, glossary, and config-example checks pass; link audit cannot start because the shared install lacks unrelated `@sindresorhus/slugify`.
- The host's managed pnpm 12.1.0 shim is invalid (`ENOEXEC`); verification uses the installed pnpm 10.30.1 with automatic version switching disabled via an external temporary user config. No package files or dependencies are changed.

Standard CI will rerun missing-package lanes from a clean install.

### Deploy / rollback

No migration, deployment, or production configuration change is performed by this PR. Operators must invoke `openclaw doctor --fix` explicitly to migrate eligible legacy rows. Before that action, rollback is the previous draft head `28489b2985f4d6befc8b6ab8d2377276ba9d8738`. If an operator runs Doctor repair, normal state backups are the rollback boundary for migrated persisted data.

### Reviewer routing

Please review configured-alias ownership, canonical-only runtime reads, Doctor's single-owner claim/consumption protocol, ambiguity/collision handling, and owner-consistent account/binding lifecycle. Generalized command parsing is intentionally absent.

## Worked on by

Devmon (implementation, verification, and technical review) under Scott's authorization; coordinated by Asimov.
