### PR TITLE
fix(qa): keep Crabline crypto available in bundled builds

### DIFF
--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@copilotkit/aimock": "1.39.0",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "@openclaw/crabline": "0.1.17",
+    "@openclaw/crabline": "0.1.20",
     "playwright-core": "1.62.1",
     "semver": "7.8.5",
     "ws": "8.21.3",

--- a/package.json
+++ b/package.json
@@ -2143,7 +2143,7 @@
     "@lit/context": "1.1.6",
     "@lit/task": "1.0.3",
     "@mdx-js/mdx": "3.1.1",
-    "@openclaw/crabline": "0.1.17",
+    "@openclaw/crabline": "0.1.20",
     "@openclaw/session-url-contract": "workspace:*",
     "@opentelemetry/sdk-node": "0.221.0",
     "@shikijs/core": "4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(supports-color@10.2.2)
       '@openclaw/crabline':
-        specifier: 0.1.17
-        version: 0.1.17
+        specifier: 0.1.20
+        version: 0.1.20
       '@openclaw/session-url-contract':
         specifier: workspace:*
         version: link:packages/session-url-contract
@@ -1808,8 +1808,8 @@ importers:
         specifier: 1.30.0
         version: 1.30.0(supports-color@10.2.2)(zod@4.4.3)
       '@openclaw/crabline':
-        specifier: 0.1.17
-        version: 0.1.17
+        specifier: 0.1.20
+        version: 0.1.20
       playwright-core:
         specifier: 1.62.1
         version: 1.62.1
@@ -4149,8 +4149,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/crabline@0.1.17':
-    resolution: {integrity: sha512-tMjpIhzJvCulDA6mYL8nOA6XExWXZoBOrD4XgL3gsNdEDAWY4FCaHYyNCXwKPU2QSs78FU0xZ3NIQRr9ErHRpQ==}
+  '@openclaw/crabline@0.1.20':
+    resolution: {integrity: sha512-2m2Vfmp6qvXKrpbaPKoTYx3s2VVeyVkWBcXnCe4Vpj1PhPXrLfE0rW7KZ9M+/+23tqAYGGzp8wKsqe0CHko+OQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -9659,6 +9659,9 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -11444,7 +11447,7 @@ snapshots:
   '@openai/codex@0.151.0-win32-x64':
     optional: true
 
-  '@openclaw/crabline@0.1.17':
+  '@openclaw/crabline@0.1.20':
     dependencies:
       '@types/node': 22.20.1
       commander: 15.0.0
@@ -11455,7 +11458,7 @@ snapshots:
       re2js: 2.8.6
       ws: 8.21.3
       yaml: 2.9.0
-      zod: 4.4.3
+      zod: 4.5.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17285,5 +17288,7 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zod@4.5.2: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,9 @@ minimumReleaseAgeStrict: true
 
 # Trusted Codex runtimes are outside the dependency cooldown.
 minimumReleaseAgeExclude:
+  # Reviewed Crabline bundle fix and its required Zod version; remove after 2026-09-10.
+  - "@openclaw/crabline@0.1.20"
+  - "zod@4.5.2"
   - "@openai/codex"
   - "@openai/codex-*"
   # fs-safe 0.7.0 validates original ZIP names; remove after 2026-09-07.

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -326,7 +326,9 @@ describe("tsdown config", () => {
       const { nativePackages } = worker
         ? { nativePackages: [] }
         : copyFsSafePackageFixture(sourceRoot);
-      if (!worker) expect(nativePackages.length).toBeGreaterThan(0);
+      if (!worker) {
+        expect(nativePackages.length).toBeGreaterThan(0);
+      }
       const sdkSource = path.resolve("src/plugin-sdk/memory-core-host-engine-fs.ts");
       const observerSource = path.join(sourceRoot, "observer.ts");
       fs.writeFileSync(
@@ -411,7 +413,9 @@ describe("tsdown config", () => {
           const errors = results.flatMap((result) =>
             result.status === "rejected" ? [result.reason] : [],
           );
-          if (errors.length) throw new AggregateError(errors, "fs-safe package probes failed");
+          if (errors.length) {
+            throw new AggregateError(errors, "fs-safe package probes failed");
+          }
         };
         if (worker) {
           await join([
@@ -428,10 +432,11 @@ describe("tsdown config", () => {
             probe("shared-config", "configured", "native"),
             probe("default", "off", "fallback"),
           ]);
-          for (const nativePackage of nativePackages)
+          for (const nativePackage of nativePackages) {
             fs.rmSync(path.join(relocatedRoot, path.relative(sourceRoot, nativePackage.root)), {
               recursive: true,
             });
+          }
           await join([
             probe("missing", "require", "missing", { FS_SAFE_NATIVE_MODE: "require" }),
             ...["off", "auto"].map((mode) =>
@@ -440,7 +445,9 @@ describe("tsdown config", () => {
           ]);
         }
       } finally {
-        for (const bundle of bundles) await bundle[Symbol.asyncDispose]();
+        for (const bundle of bundles) {
+          await bundle[Symbol.asyncDispose]();
+        }
       }
     },
   );
@@ -525,6 +532,7 @@ describe("tsdown config", () => {
             !bundleAll &&
             packageName === name &&
             name !== "@lancedb/lancedb" &&
+            name !== "@openclaw/crabline" &&
             (name !== "zod" || declarations)
           ) {
             expectedImports.push(...imports);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -296,8 +296,6 @@ const rootDependencyOptions = withExternalPackageSubpaths({
     "@larksuiteoapi/node-sdk",
     "@matrix-org/matrix-sdk-crypto-nodejs",
     "@openclaw/ai",
-    // Its crypto loader uses createRequire(import.meta.url) for package-owned dependencies.
-    "@openclaw/crabline",
     // Its native loader resolves optional platform packages from the package scope.
     "@openclaw/fs-safe",
     "@slack/bolt",


### PR DESCRIPTION
Related: #135728

## What Problem This Solves

Resolves the Crabline bundling limitation exposed by the isolated-pnpm migration. The prior PR preserved Crabline as an external package because its package-relative crypto loader could not survive bundling. The owner repair is now in Crabline 0.1.20.

## Why This Change Was Made

Update the root tooling and QA Lab's exact Crabline dependency to 0.1.20, then remove the now-obsolete Crabline-specific `neverBundle` rule. Keep the existing dependency-boundary fixture and assert that Crabline is bundled in runtime, declaration, and worker outputs. No new root crypto dependency, loader fallback, public API, runtime configuration, or protocol change is needed.

Best-fix verdict: repair dependency loading in the package that owns it, then return the consumer to the normal bundling path. Keeping the externalization exception would retain a workaround after its cause is fixed; adding curve25519-js to OpenClaw's root would hide dependency ownership again.

## User Impact

Private QA builds use the released bundle-safe Crabline package without requiring its installation directory at runtime. The source linker stays isolated. The dependency update also includes Crabline's previously released recorder-shutdown improvements.

## Evidence

- Crabline owner fix: https://github.com/openclaw/crabline/pull/290.
- Its packed isolated-pnpm regression disables hoisting, bundles the public entry and crypto module, removes the installed dependency tree, and executes the relocated bundles. The original code failed with `Cannot find module 'curve25519-js'`; the fix passes, including native and JavaScript X25519 paths.
- The adjusted OpenClaw configuration regression failed in four runtime/declaration cases before removing the exception; all eight selected runtime/declaration/worker/receiver cases pass afterward.
- Directly inspected Crabline's loader, dependency exports/types, public entry, and OpenClaw's private QA callers/build ownership. Independent read-only inspection agreed that no remaining package-relative loader/native-asset contract requires the exception.
- [Crabline 0.1.20 is published](https://github.com/openclaw/crabline/releases/tag/v0.1.20). Registry `latest`, version, publication time, tarball bytes/SHA-512, static-import payload, and GitHub release notes were verified. Release run 33606567051 completed successfully after an unchanged stress-test retry and npm processing/read-back delay.
- `pnpm install --frozen-lockfile` passes under pnpm 12.1.0. The lockfile changes only Crabline plus its required Zod 4.5.2 snapshot; all existing patch/peer identities remain unchanged.
- Focused local proof: **75 tests passed across 4 files**: `test/scripts/tsdown-config.test.ts`, `extensions/qa-lab/src/crabline-transport.test.ts`, `extensions/qa-lab/src/crabline-transport-readiness.test.ts`, and `extensions/qa-lab/src/suite.test.ts`.
- Fresh Codex autoreview: no accepted/actionable P0 findings. This is P0-scoped, not an all-priority audit.
- The compiled private QA runtime build passes locally (3m43s) and on a clean Linux Blacksmith Testbox (44.6s), including all 53 built control-plane module checks.
- Linux end-to-end `matrix-restart-resume` passes: **1 passed, 0 failed, 0 skipped**, including the gateway restart. Blacksmith Testbox `tbx_01m1gk34mxhahv3ggfy38sedba`, [run 33607908381](https://github.com/openclaw/openclaw/actions/runs/33607908381), completed with wrapper exit 0 and was stopped. Production files matched the candidate; the later sync also included the test-only brace cleanup.
- Stock WhatsApp whoami QA stops before scenario execution: the harness supplies channel configuration but no linked credential fixture, and the unchanged gateway correctly skips unlinked accounts. The timeout omits linkage fields. Source inspection and 19 passing auth-store/runtime-loader tests support this diagnosis; A synthetic, test-owned linked account reaches the normal encrypted connection and `Listening for WhatsApp inbound messages` state on the compiled candidate. The stock whoami/restart fixtures then fail their native-JID input contracts before delivery; they are not counted as end-to-end passes. No production linkage check is weakened.
- [Exact-head CI 33609061263](https://github.com/openclaw/openclaw/actions/runs/33609061263): the initial run reached 241 passing checks with one browser popover-visibility timeout in unchanged `new-session-page.places-live.e2e.test.ts`; the failed-job retry passed and the full run completed **SUCCESS** on exact head `a9b37f3a49188984752637548358cdd9b14d3c30`. No timeout or test is weakened.

### Scope and upgrade considerations

The seven-day cooldown remains enabled. Two exact-version exceptions admit this explicitly requested new release and its required `zod@4.5.2`; the comment specifies removal after September 10. No broad package/scope exemption or dependency override is added.

Crabline's public exports and adapter shapes are unchanged from 0.1.17. Its prior recorder fixes now drain admitted persistence during server close and initialize process/machine identity before readiness. The independent owner-boundary review found those contracts compatible with OpenClaw's synchronous observer and awaited adapter cleanup; Matrix restart proof passes; the stock WhatsApp harness setup gap is documented above.

Production build configuration removes two lines. Test coverage adds one expectation condition in the existing executable fixture; four existing single-line control statements in that fixture receive the braces required by its current lint gate. All 21 tooling tests and targeted type-aware lint pass after that formatting-only cleanup. The remaining changes are exact dependency pins, scoped cooldown entries, and lockfile metadata, not new production logic. The global changed-check classifier selects all lanes for root package/lock inputs; focused local proof and the exact-head hosted CI gates provide the proportional validation without running duplicate whole-repository local gates.

### Published dependency verification

Both downloaded registry tarballs match their exact SHA-512 lockfile integrity. Zod 4.5.2 has no runtime dependencies or install lifecycle hooks. Both npm registry signatures verify against the registry signing key; its provenance subject matches the downloaded bytes and records the official `colinhacks/zod` release workflow at `9a193aa24b4efa3b315b91d4c56c8bc385b8513f`, matching upstream `v4.5.2`. The package lists Colin McDonnell as maintainer and GitHub Actions as publisher. This is artifact/ownership verification, not a claim of an exhaustive dependency security audit.

The ordinary WhatsApp QA harness needs a separate synthetic-auth/native-JID fixture repair. That is recorded as a follow-up, not silently fixed by changing production authentication or relabeled as a passing scenario. The standalone package crypto/bundle regression, normal encrypted WhatsApp connection, and full Matrix gateway restart exercise the changed dependency-loading boundary.
