### PR TITLE
fix(qa): emit complete Responses stream lifecycle

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -4,7 +4,6 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
-import { MockResponseStream } from "./mock-openai-stream.js";
 
 export type ResponsesInputItem = Record<string, unknown>;
 
@@ -527,15 +526,6 @@ export function isRemoteCompactionV2Request(input: ResponsesInputItem[]) {
   // Codex sends compaction through /responses with a trigger item. Keep it
   // outside scenario dispatch so maintenance calls never become tool evidence.
   return input.some((item) => item.type === "compaction_trigger");
-}
-
-export function buildRemoteCompactionV2Events(): StreamEvent[] {
-  const stream = new MockResponseStream("resp_mock_compaction_1");
-  stream.item({
-    type: "compaction",
-    encrypted_content: "QA_MOCK_REMOTE_COMPACTION_SUMMARY",
-  });
-  return stream.complete(16);
 }
 
 export type AnthropicStreamEvent = Record<string, unknown> & {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
+import { MockResponseStream } from "./mock-openai-stream.js";
 
 export type ResponsesInputItem = Record<string, unknown>;
 
@@ -39,19 +40,38 @@ export type QaMockProviderDispatchResult = {
 };
 
 export type StreamEvent =
-  | { type: "response.created"; response: { id: string } }
+  | {
+      type: "response.created";
+      response: {
+        id: string;
+        object: "response";
+        status: "in_progress";
+        output: Array<Record<string, unknown>>;
+        created_at: number;
+        model?: string;
+      };
+    }
   | {
       type: "response.failed";
       response: {
         id: string;
+        object: "response";
         status: "failed";
+        output: Array<Record<string, unknown>>;
         error?: { code: string; message: string };
       };
     }
   | {
       type: "response.output_item.added";
-      output_index?: number;
+      output_index: number;
       item: Record<string, unknown>;
+    }
+  | {
+      type: "response.content_part.added" | "response.content_part.done";
+      item_id: string;
+      output_index: number;
+      content_index: number;
+      part: MockOutputText;
     }
   | {
       type: "response.output_text.delta";
@@ -69,19 +89,33 @@ export type StreamEvent =
     }
   | {
       type: "response.function_call_arguments.delta";
-      item_id?: string;
-      output_index?: number;
+      item_id: string;
+      output_index: number;
       delta: string;
+    }
+  | {
+      type: "response.function_call_arguments.done";
+      item_id: string;
+      output_index: number;
+      name: string;
+      arguments: string;
     }
   | {
       type: "response.custom_tool_call_input.delta";
       item_id: string;
       call_id: string;
+      output_index: number;
       delta: string;
     }
   | {
+      type: "response.custom_tool_call_input.done";
+      item_id: string;
+      output_index: number;
+      input: string;
+    }
+  | {
       type: "response.output_item.done";
-      output_index?: number;
+      output_index: number;
       item: Record<string, unknown>;
     }
   | {
@@ -99,23 +133,19 @@ export type StreamEvent =
       };
     };
 
-export function buildCompletedResponseEvent(
-  id: string,
-  output: Array<Record<string, unknown>>,
-  outputTokens: number,
-): Extract<StreamEvent, { type: "response.completed" }> {
-  return {
-    type: "response.completed",
-    response: {
-      id,
-      // SDK clients use this discriminator to expose output_text.
-      object: "response",
-      status: "completed",
-      output,
-      usage: { input_tokens: 64, output_tokens: outputTokens, total_tokens: 64 + outputTokens },
-    },
-  };
-}
+export type MockOutputText = { type: "output_text"; text: string; annotations: [] };
+
+export type MockAssistantMessageSpec = {
+  id: string;
+  phase?: "commentary" | "final_answer";
+  streamDeltas?: string[];
+  text: string;
+};
+
+export type MockToolCallItem = { id: string; call_id: string; name: string; namespace?: string } & (
+  | { type: "function_call"; arguments: string }
+  | { type: "custom_tool_call"; input: string; status: "completed" }
+);
 
 /**
  * Provider variant tag for `body.model`. The mock previously ignored
@@ -451,6 +481,17 @@ export function transcriptionTextForAudioRequest(rawBody: string) {
   return QA_AUDIO_TRANSCRIPTION_TEXT;
 }
 
+export function isPreviewCompletion(
+  event: StreamEvent | AnthropicStreamEvent,
+  previous: StreamEvent | AnthropicStreamEvent | undefined,
+) {
+  // Message builders keep each preview's last delta next to text.done.
+  // Plain answers also finish text, but must not acquire a preview pause.
+  return (
+    event.type === "response.output_text.done" && previous?.type === "response.output_text.delta"
+  );
+}
+
 export async function writeSse(
   res: ServerResponse,
   events: Array<StreamEvent | AnthropicStreamEvent>,
@@ -464,7 +505,7 @@ export async function writeSse(
   const completionIndex =
     pauseMs === undefined
       ? -1
-      : events.findIndex((event) => event.type === "response.output_text.done");
+      : events.findIndex((event, index) => isPreviewCompletion(event, events[index - 1]));
   const body =
     frames.slice(Math.max(0, completionIndex)).join("") +
     (protocol === "responses" ? "data: [DONE]\n\n" : "");
@@ -488,18 +529,13 @@ export function isRemoteCompactionV2Request(input: ResponsesInputItem[]) {
   return input.some((item) => item.type === "compaction_trigger");
 }
 
-export function buildRemoteCompactionV2Events(): [
-  Extract<StreamEvent, { type: "response.output_item.done" }>,
-  Extract<StreamEvent, { type: "response.completed" }>,
-] {
-  const item = {
+export function buildRemoteCompactionV2Events(): StreamEvent[] {
+  const stream = new MockResponseStream("resp_mock_compaction_1");
+  stream.item({
     type: "compaction",
     encrypted_content: "QA_MOCK_REMOTE_COMPACTION_SUMMARY",
-  };
-  return [
-    { type: "response.output_item.done", item },
-    buildCompletedResponseEvent("resp_mock_compaction_1", [item], 16),
-  ];
+  });
+  return stream.complete(16);
 }
 
 export type AnthropicStreamEvent = Record<string, unknown> & {

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts
@@ -50,13 +50,14 @@ describe("mock OpenAI Responses output item slots", () => {
     expect(events.map((event) => event.type)).toEqual([
       "response.created",
       "response.output_item.added",
+      "response.content_part.added",
       "response.output_text.delta",
       "response.failed",
     ]);
     expect(events[1]).toMatchObject({
       item: { type: "message", role: "assistant", status: "in_progress" },
     });
-    expect(events[2]).toMatchObject({
+    expect(events[3]).toMatchObject({
       type: "response.output_text.delta",
       delta: marker,
     });

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
@@ -1,54 +1,25 @@
 // QA Lab mock provider output event builders.
 
-import { buildCompletedResponseEvent, type StreamEvent } from "./mock-openai-contracts.js";
+import type { MockAssistantMessageSpec, StreamEvent } from "./mock-openai-contracts.js";
+import { MockResponseStream } from "./mock-openai-stream.js";
 import { buildMockFunctionCall } from "./mock-openai-tooling.js";
 
 export function buildFailedResponseEvents(): StreamEvent[] {
-  const responseId = `resp_qa_failed_${Date.now()}`;
-  return [
-    { type: "response.created", response: { id: responseId } },
-    {
-      type: "response.failed",
-      response: {
-        id: responseId,
-        status: "failed",
-      },
-    },
-  ];
+  return new MockResponseStream(`resp_qa_failed_${Date.now()}`).fail();
 }
 
 export function buildPartialFailureEvents(partialText: string): StreamEvent[] {
-  const responseId = "resp_qa_partial_failed_1";
-  const itemId = "msg_qa_partial_failed_1";
-  return [
-    { type: "response.created", response: { id: responseId } },
+  const stream = new MockResponseStream("resp_qa_partial_failed_1");
+  stream.message(
     {
-      type: "response.output_item.added",
-      output_index: 0,
-      item: {
-        type: "message",
-        id: itemId,
-        role: "assistant",
-        phase: "final_answer",
-        content: [],
-        status: "in_progress",
-      },
+      id: "msg_qa_partial_failed_1",
+      phase: "final_answer",
+      streamDeltas: [partialText],
+      text: partialText,
     },
-    {
-      type: "response.output_text.delta",
-      item_id: itemId,
-      output_index: 0,
-      content_index: 0,
-      delta: partialText,
-    },
-    {
-      type: "response.failed",
-      response: {
-        id: responseId,
-        status: "failed",
-      },
-    },
-  ];
+    false,
+  );
+  return stream.fail();
 }
 
 export function buildReleaseAuditJson() {
@@ -192,13 +163,6 @@ export function extractPlannedToolArgs(events: StreamEvent[]) {
   return undefined;
 }
 
-type MockAssistantMessageSpec = {
-  id: string;
-  phase?: "commentary" | "final_answer";
-  streamDeltas?: string[];
-  text: string;
-};
-
 export function splitMockStreamingText(text: string, parts = 3) {
   if (text.length <= 1) {
     return [text];
@@ -229,93 +193,16 @@ export function buildQaLongFinalText({
   return `${startMarker}\n${body}\n${endMarker}`;
 }
 
-function buildAssistantOutputItem(spec: MockAssistantMessageSpec) {
-  return {
-    type: "message",
-    id: spec.id,
-    role: "assistant",
-    status: "completed",
-    ...(spec.phase ? { phase: spec.phase } : {}),
-    content: [{ type: "output_text", text: spec.text, annotations: [] }],
-  } as const;
-}
-
-function appendAssistantMessageEvents(
-  events: StreamEvent[],
-  spec: MockAssistantMessageSpec,
-  outputIndex: number,
-) {
-  events.push({
-    type: "response.output_item.added",
-    output_index: outputIndex,
-    item: {
-      type: "message",
-      id: spec.id,
-      role: "assistant",
-      ...(spec.phase ? { phase: spec.phase } : {}),
-      content: [],
-      status: "in_progress",
-    },
-  });
-  for (const delta of spec.streamDeltas ?? []) {
-    events.push({
-      type: "response.output_text.delta",
-      item_id: spec.id,
-      output_index: outputIndex,
-      content_index: 0,
-      delta,
-    });
-  }
-  if ((spec.streamDeltas ?? []).length > 0) {
-    events.push({
-      type: "response.output_text.done",
-      item_id: spec.id,
-      output_index: outputIndex,
-      content_index: 0,
-      text: spec.text,
-    });
-  }
-  const item = buildAssistantOutputItem(spec);
-  events.push({
-    type: "response.output_item.done",
-    output_index: outputIndex,
-    item,
-  });
-  return item;
-}
-
 export function buildAssistantThenToolCallEvents(
   spec: MockAssistantMessageSpec,
   name: string,
   args: Record<string, unknown>,
 ): StreamEvent[] {
   const call = buildMockFunctionCall(name, args);
-  const events: StreamEvent[] = [];
-  const message = appendAssistantMessageEvents(events, spec, 0);
-  events.push({
-    type: "response.output_item.added",
-    output_index: 1,
-    item: {
-      type: "function_call",
-      id: call.itemId,
-      call_id: call.callId,
-      name,
-      arguments: "",
-    },
-  });
-  events.push({
-    type: "response.function_call_arguments.delta",
-    item_id: call.itemId,
-    output_index: 1,
-    delta: call.serialized,
-  });
-  events.push({
-    type: "response.output_item.done",
-    output_index: 1,
-    item: call.item,
-  });
-  events.push(buildCompletedResponseEvent(call.responseId, [message, call.item], 32));
-  return events;
+  const stream = new MockResponseStream(call.responseId);
+  stream.message(spec);
+  stream.tool(call.item);
+  return stream.complete(32);
 }
 
 export function buildAssistantEvents(
@@ -330,12 +217,11 @@ export function buildAssistantEvents(
           },
         ]
       : specsOrText;
-  const events: StreamEvent[] = [];
-  const output = specs.map((spec, outputIndex) =>
-    appendAssistantMessageEvents(events, spec, outputIndex),
-  );
-  events.push(buildCompletedResponseEvent("resp_mock_msg_1", output, 24));
-  return events;
+  const stream = new MockResponseStream("resp_mock_msg_1");
+  for (const spec of specs) {
+    stream.message(spec);
+  }
+  return stream.complete(24);
 }
 
 export function buildStreamingFinalAnswerEvents(
@@ -359,23 +245,9 @@ export function buildReasoningOnlyEvents(summaryText: string, id: string): Strea
     id,
     summary: [{ text: summaryText }],
   } as const;
-  return [
-    {
-      type: "response.output_item.added",
-      output_index: 0,
-      item: {
-        type: "reasoning",
-        id,
-        summary: [],
-      },
-    },
-    {
-      type: "response.output_item.done",
-      output_index: 0,
-      item: reasoningItem,
-    },
-    buildCompletedResponseEvent(`resp_${id}`, [reasoningItem], 8),
-  ];
+  const stream = new MockResponseStream(`resp_${id}`);
+  stream.item(reasoningItem, { ...reasoningItem, summary: [] });
+  return stream.complete(8);
 }
 
 export function buildReasoningAndAssistantEvents(params: {
@@ -388,34 +260,13 @@ export function buildReasoningAndAssistantEvents(params: {
     id: params.reasoningId,
     summary: [],
   } as const;
-  const events: StreamEvent[] = [
-    {
-      type: "response.output_item.added",
-      output_index: 0,
-      item: {
-        type: "reasoning",
-        id: params.reasoningId,
-        summary: [],
-      },
-    },
-    {
-      type: "response.output_item.done",
-      output_index: 0,
-      item: reasoningItem,
-    },
-  ];
-  const answerItem = appendAssistantMessageEvents(
-    events,
-    {
-      id: params.answerId ?? "msg_mock_reasoned_answer",
-      phase: "final_answer",
-      streamDeltas: [params.answerText],
-      text: params.answerText,
-    },
-    1,
-  );
-  events.push(
-    buildCompletedResponseEvent(`resp_${params.reasoningId}`, [reasoningItem, answerItem], 16),
-  );
-  return events;
+  const stream = new MockResponseStream(`resp_${params.reasoningId}`);
+  stream.item(reasoningItem);
+  stream.message({
+    id: params.answerId ?? "msg_mock_reasoned_answer",
+    phase: "final_answer",
+    streamDeltas: [params.answerText],
+    text: params.answerText,
+  });
+  return stream.complete(16);
 }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-events.ts
@@ -4,6 +4,15 @@ import type { MockAssistantMessageSpec, StreamEvent } from "./mock-openai-contra
 import { MockResponseStream } from "./mock-openai-stream.js";
 import { buildMockFunctionCall } from "./mock-openai-tooling.js";
 
+export function buildRemoteCompactionV2Events(): StreamEvent[] {
+  const stream = new MockResponseStream("resp_mock_compaction_1");
+  stream.item({
+    type: "compaction",
+    encrypted_content: "QA_MOCK_REMOTE_COMPACTION_SUMMARY",
+  });
+  return stream.complete(16);
+}
+
 export function buildFailedResponseEvents(): StreamEvent[] {
   return new MockResponseStream(`resp_qa_failed_${Date.now()}`).fail();
 }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.ts
@@ -1,7 +1,11 @@
 import type { Server } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
-import type { QaMockProviderDispatchResult, ResponsesInputItem } from "./mock-openai-contracts.js";
+import {
+  isPreviewCompletion,
+  type QaMockProviderDispatchResult,
+  type ResponsesInputItem,
+} from "./mock-openai-contracts.js";
 
 type QaMockResponsesWebSocketDispatch = (params: {
   body: Record<string, unknown>;
@@ -201,27 +205,14 @@ export function attachQaMockResponsesWebSocketServer(params: {
           }
           const completion = events.find((event) => event.type === "response.completed");
           if (completion?.type === "response.completed") {
-            if (!events.some((event) => event.type === "response.created")) {
-              sendEvent({
-                type: "response.created",
-                response: {
-                  id: completion.response.id,
-                  object: "response",
-                  created_at: Math.floor(Date.now() / 1_000),
-                  model: typeof body.model === "string" ? body.model : "",
-                  status: "in_progress",
-                  output: [],
-                },
-              });
-            }
             cachedResponse = {
               id: completion.response.id,
               body,
               input: [...body.input, ...completion.response.output],
             };
           }
-          for (const event of events) {
-            if (dispatched.previewPauseMs && event.type === "response.output_text.done") {
+          for (const [index, event] of events.entries()) {
+            if (dispatched.previewPauseMs && isPreviewCompletion(event, events[index - 1])) {
               await sleep(dispatched.previewPauseMs);
             }
             sendEvent(event);

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-stream.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-stream.ts
@@ -1,0 +1,124 @@
+import type {
+  MockAssistantMessageSpec,
+  MockOutputText,
+  MockToolCallItem,
+  StreamEvent,
+} from "./mock-openai-contracts.js";
+
+export class MockResponseStream {
+  private readonly response: {
+    id: string;
+    object: "response";
+    output: Array<Record<string, unknown>>;
+  };
+  private readonly events: StreamEvent[];
+
+  constructor(id: string) {
+    this.response = { id, object: "response", output: [] };
+    this.events = [
+      {
+        type: "response.created",
+        // Creation must keep an empty snapshot while later items accumulate.
+        response: {
+          ...this.response,
+          status: "in_progress",
+          output: [],
+          created_at: Math.floor(Date.now() / 1_000),
+        },
+      },
+    ];
+  }
+
+  private start(item: Record<string, unknown>, initial = item) {
+    const outputIndex = this.response.output.push(item) - 1;
+    this.events.push({
+      type: "response.output_item.added",
+      output_index: outputIndex,
+      item: initial,
+    });
+    return outputIndex;
+  }
+
+  private done(item: Record<string, unknown>, outputIndex: number) {
+    this.events.push({ type: "response.output_item.done", output_index: outputIndex, item });
+  }
+
+  item(item: Record<string, unknown>, initial = item) {
+    this.done(item, this.start(item, initial));
+  }
+
+  message(spec: MockAssistantMessageSpec, complete = true) {
+    const part: MockOutputText = { type: "output_text", text: spec.text, annotations: [] };
+    const item = {
+      type: "message",
+      id: spec.id,
+      role: "assistant",
+      status: complete ? "completed" : "in_progress",
+      ...(spec.phase ? { phase: spec.phase } : {}),
+      content: [part],
+    };
+    const outputIndex = this.start(item, { ...item, content: [], status: "in_progress" });
+    const position = { item_id: spec.id, output_index: outputIndex, content_index: 0 };
+    this.events.push({
+      type: "response.content_part.added",
+      ...position,
+      part: { ...part, text: "" },
+    });
+    for (const delta of spec.streamDeltas ?? []) {
+      this.events.push({ type: "response.output_text.delta", ...position, delta });
+    }
+    if (!complete) {
+      return;
+    }
+    this.events.push({ type: "response.output_text.done", ...position, text: spec.text });
+    this.events.push({ type: "response.content_part.done", ...position, part });
+    this.done(item, outputIndex);
+  }
+
+  tool(item: MockToolCallItem) {
+    const initial =
+      item.type === "function_call"
+        ? { ...item, arguments: "" }
+        : { ...item, input: "", status: "in_progress" };
+    const position = { item_id: item.id, output_index: this.start(item, initial) };
+    if (item.type === "function_call") {
+      this.events.push(
+        { type: "response.function_call_arguments.delta", ...position, delta: item.arguments },
+        {
+          type: "response.function_call_arguments.done",
+          ...position,
+          name: item.name,
+          arguments: item.arguments,
+        },
+      );
+    } else {
+      this.events.push(
+        {
+          type: "response.custom_tool_call_input.delta",
+          ...position,
+          call_id: item.call_id,
+          delta: item.input,
+        },
+        { type: "response.custom_tool_call_input.done", ...position, input: item.input },
+      );
+    }
+    this.done(item, position.output_index);
+  }
+
+  complete(outputTokens: number): StreamEvent[] {
+    this.events.push({
+      type: "response.completed",
+      response: {
+        ...this.response,
+        status: "completed",
+        usage: { input_tokens: 64, output_tokens: outputTokens, total_tokens: 64 + outputTokens },
+      },
+    });
+    return this.events;
+  }
+
+  fail(): StreamEvent[] {
+    this.events.push({ type: "response.failed", response: { ...this.response, status: "failed" } });
+    return this.events;
+  }
+}

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -2,7 +2,8 @@
 import { createHash } from "node:crypto";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { QA_LAB_WEB_SEARCH_DENIED_INPUT_QUERY } from "../../qa-web-search-provider.js";
-import { buildCompletedResponseEvent, type StreamEvent } from "./mock-openai-contracts.js";
+import type { MockToolCallItem, StreamEvent } from "./mock-openai-contracts.js";
+import { MockResponseStream } from "./mock-openai-stream.js";
 
 let mockFunctionCallSequence = 0;
 
@@ -82,22 +83,17 @@ export function buildMockFunctionCall(
     .slice(0, 10);
   const sequence = ++mockFunctionCallSequence;
   const uniqueSuffix = `${callSuffix}_${sequence}`;
-  const callId = `call_mock_${name}_${uniqueSuffix}`;
-  const itemId = `fc_mock_${name}_${uniqueSuffix}`;
-  const item = {
+  const item: MockToolCallItem = {
     type: "function_call",
-    id: itemId,
-    call_id: callId,
+    id: `fc_mock_${name}_${uniqueSuffix}`,
+    call_id: `call_mock_${name}_${uniqueSuffix}`,
     name,
     ...(namespace ? { namespace } : {}),
     arguments: serialized,
   };
   return {
-    callId,
     item,
-    itemId,
     responseId: `resp_mock_${name}_${uniqueSuffix}`,
-    serialized,
   };
 }
 
@@ -107,25 +103,9 @@ export function buildToolCallEventsWithArgs(
   namespace?: string,
 ): StreamEvent[] {
   const call = buildMockFunctionCall(name, args, namespace);
-  return [
-    {
-      type: "response.output_item.added",
-      item: {
-        type: "function_call",
-        id: call.itemId,
-        call_id: call.callId,
-        name,
-        ...(namespace ? { namespace } : {}),
-        arguments: "",
-      },
-    },
-    { type: "response.function_call_arguments.delta", delta: call.serialized },
-    {
-      type: "response.output_item.done",
-      item: call.item,
-    },
-    buildCompletedResponseEvent(call.responseId, [call.item], 16),
-  ];
+  const stream = new MockResponseStream(call.responseId);
+  stream.tool(call.item);
+  return stream.complete(16);
 }
 
 export function buildCustomToolCallEventsWithInput(
@@ -134,34 +114,17 @@ export function buildCustomToolCallEventsWithInput(
   namespace?: string,
 ): StreamEvent[] {
   const call = buildMockFunctionCall(name, { input }, namespace);
-  const itemId = call.itemId.replace(/^fc_/, "ctc_");
-  const item = {
+  const stream = new MockResponseStream(call.responseId);
+  stream.tool({
     type: "custom_tool_call",
-    id: itemId,
-    call_id: call.callId,
+    id: call.item.id.replace(/^fc_/, "ctc_"),
+    call_id: call.item.call_id,
     name,
     ...(namespace ? { namespace } : {}),
     input,
     status: "completed",
-  };
-  return [
-    {
-      type: "response.created",
-      response: { id: call.responseId },
-    },
-    {
-      type: "response.output_item.added",
-      item: { ...item, input: "", status: "in_progress" },
-    },
-    {
-      type: "response.custom_tool_call_input.delta",
-      item_id: itemId,
-      call_id: call.callId,
-      delta: input,
-    },
-    { type: "response.output_item.done", item },
-    buildCompletedResponseEvent(call.responseId, [item], 16),
-  ];
+  });
+  return stream.complete(16);
 }
 
 export function extractRememberedFact(userTexts: string[]) {

--- a/extensions/qa-lab/src/providers/mock-openai/server.responses-stream.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.responses-stream.test.ts
@@ -1,0 +1,61 @@
+import OpenAI from "openai";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { startQaMockOpenAiServer } from "./server.js";
+
+beforeEach(() => vi.stubEnv("OPENAI_CUSTOM_HEADERS", undefined));
+afterEach(() => vi.unstubAllEnvs());
+
+it.each([
+  {
+    name: "plain answer",
+    prompt: "Reply exactly: QA-SDK-STREAM",
+    text: "QA-SDK-STREAM",
+    status: "completed",
+    preview: "",
+  },
+  {
+    name: "preview followed by different final text",
+    prompt: "Final-only marker streaming QA check. Reply exactly: QA-SDK-FINAL",
+    text: "QA-SDK-FINAL",
+    status: "completed",
+    preview: "QA streaming preview in progress",
+  },
+  {
+    name: "reasoning followed by an answer",
+    prompt: "QA thinking visibility check max: answer exactly THINKING-MAX-OK.",
+    text: "THINKING-MAX-OK",
+    status: "completed",
+    preview: "THINKING-MAX-OK",
+  },
+  {
+    name: "partial answer followed by failure",
+    prompt: "Telegram visible partial failure QA check",
+    text: "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE",
+    status: "failed",
+    preview: "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE",
+  },
+])("accumulates $name through the SDK stream", async ({ prompt, text, status, preview }) => {
+  const server = await startQaMockOpenAiServer({ finalOnlyMarkerPauseMs: 1 });
+  try {
+    const client = new OpenAI({
+      baseURL: `${server.baseUrl}/v1`,
+      apiKey: "qa-synthetic-key",
+      adminAPIKey: null,
+      organization: null,
+      project: null,
+      maxRetries: 0,
+    });
+    const stream = client.responses.stream({ model: "qa-model", input: prompt });
+    let streamedText = "";
+    const finishedTexts: string[] = [];
+    stream.on("response.output_text.delta", ({ delta }) => (streamedText += delta));
+    stream.on("response.output_text.done", (event) => finishedTexts.push(event.text));
+    const response = await stream.finalResponse();
+    expect(response.status).toBe(status);
+    expect(response.output_text).toBe(text);
+    expect(streamedText).toBe(preview);
+    expect(finishedTexts).toEqual(status === "completed" ? [text] : []);
+  } finally {
+    await server.stop();
+  }
+});

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1076,10 +1076,11 @@ describe("qa mock openai server", () => {
     expect(visibleEvents.map((event) => event.type)).toEqual([
       "response.created",
       "response.output_item.added",
+      "response.content_part.added",
       "response.output_text.delta",
       "response.failed",
     ]);
-    expect(visibleEvents[2]).toMatchObject({
+    expect(visibleEvents[3]).toMatchObject({
       type: "response.output_text.delta",
       delta: "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE",
     });
@@ -5871,10 +5872,11 @@ Update and merge these partial structured summaries.`,
       "response.created",
       "response.output_item.added",
       "response.custom_tool_call_input.delta",
+      "response.custom_tool_call_input.done",
       "response.output_item.done",
       "response.completed",
     ]);
-    const [created, added, delta, done, completed] = events;
+    const [created, added, delta, inputDone, done, completed] = events;
     expect(created?.response?.id).toBe(completed?.response?.id);
     expect(added?.item).toMatchObject({
       type: "custom_tool_call",
@@ -5891,6 +5893,7 @@ Update and merge these partial structured summaries.`,
     expect(delta?.item_id).toBe(done?.item?.id);
     expect(delta?.call_id).toBe(done?.item?.call_id);
     expect(delta?.delta).toBe(done?.item?.input);
+    expect(inputDone).toMatchObject({ item_id: done?.item?.id, input: done?.item?.input });
     expect(delta?.delta).toContain("runtime-tool-fixture-patch.txt");
     expect(completed?.response?.output).toEqual([done?.item]);
     for (const item of [added?.item, done?.item, completed?.response?.output?.[0]]) {
@@ -6552,18 +6555,22 @@ Update and merge these partial structured summaries.`,
     const events: StreamEvent[] = [
       {
         type: "response.output_item.added",
+        output_index: 0,
         item: { type: "function_call", name: "read", call_id: nativeId, arguments: "{}" },
       },
       {
         type: "response.output_item.done",
+        output_index: 0,
         item: { type: "function_call", name: "read", call_id: nativeId, arguments: "{}" },
       },
       {
         type: "response.output_item.added",
+        output_index: 1,
         item: { type: "function_call", name: "read", call_id: generatedId, arguments: "{}" },
       },
       {
         type: "response.output_item.done",
+        output_index: 1,
         item: { type: "function_call", name: "read", call_id: generatedId, arguments: "{}" },
       },
       {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -115,7 +115,6 @@ import {
   transcriptionTextForAudioRequest,
   writeSse,
   isRemoteCompactionV2Request,
-  buildRemoteCompactionV2Events,
   countApproxTokens,
   extractEmbeddingInputTexts,
   buildDeterministicEmbedding,
@@ -142,6 +141,7 @@ import {
   resolveHeartbeatPromptReply,
 } from "./mock-openai-directives.js";
 import {
+  buildRemoteCompactionV2Events,
   buildReleaseAuditJson,
   buildReleaseHandoffMarkdown,
   extractPlannedToolName,

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -2759,8 +2759,14 @@ export async function startQaMockOpenAiServer(params?: {
         : {}),
     };
   };
-  const dispatchResponses = (request: Omit<QaMockProviderDispatchRequest, "route">) =>
-    dispatchProvider({ ...request, route: "responses" });
+  const dispatchResponses = async (request: Omit<QaMockProviderDispatchRequest, "route">) => {
+    const dispatched = await dispatchProvider({ ...request, route: "responses" });
+    const created = dispatched.events[0];
+    if (created?.type === "response.created") {
+      created.response.model = typeof request.body.model === "string" ? request.body.model : "";
+    }
+    return dispatched;
+  };
   const server = createServer((req, res) => {
     dispatchQaHttpRequest(res, async () => {
       const url = new URL(req.url ?? "/", "http://127.0.0.1");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

QA Lab's mock Responses server returns valid text through JSON and raw SSE, but `client.responses.stream(...).finalResponse()` fails because the stream omits its initial response snapshot. Partial failures also lack the snapshot's output array. Several tool/content events omit indices or lifecycle boundaries, and plain answers omit the SDK's text-completion event.

Fixes #136163.

## Why This Change Was Made

One response builder now owns the initial envelope, output slots, message content, function/custom-tool arguments, and terminal state. Scenario helpers supply their existing identities, phases, preview/final text, and outcomes. The WebSocket transport's missing-creation workaround and duplicated tool/message framing are removed.

A shared preview predicate preserves the existing pause boundaries while every completed text part emits `output_text.done`. Failed partial messages remain unfinished and retain their emitted text.

## User Impact

SDK-driven QA scenarios can consume complete and partial responses through the normal streaming API, with their existing tool identities and timing preserved.

## Evidence

All four maintained SDK regressions fail on the starting head. The final patch passes **316 tests in seven suites**, including the SDK's `finalResponse()` and text-completion callbacks. A separate actual-SDK probe captured the plain-message callback omission before its repair.

**17 real-wire checks** cover default JSON, raw SSE, high-level SDK streaming, preview/final mismatch, empty and reasoning outputs, functions, namespaced custom tools, compaction, failures, WebSocket frames, and Anthropic success/error behavior. Installed native Codex also returns the requested text and executes its real freeform `apply_patch` tool against the local mock, producing the exact synthetic fixture file. All temporary state and servers are cleaned up.

Thirteen comparisons against the original Git-object owners preserve output identities, phase, usage, text/tool payloads, and every previous preview-pause boundary. The same missing lifecycle exists in stable v2026.8.2 source, which already pins OpenAI SDK 7.5.0; QA Lab is a source-checkout plugin.

Production TypeScript: **+259/-289, net -30**. Tests: **+72/-3**. No new dependency, configuration, schema, or protocol-version surface.

Full changed-file checks exited 0, including formatting, extension and test types, lint, plugin boundaries, declaration/assertion guards, dead-export scans, storage guards, and runtime import-cycle checks.
Fresh independent Codex P2 review is scoped-clean with zero findings (confidence 0.92).

The lead independently repeated all17 SDK/transport checks and inspected the actual installed SDK accumulator plus Codex event, tool, and compaction consumers. The branch includes the landed string-content input repair.

Hosted architecture CI caught a type-import cycle between the stream and contracts modules. Moving the byte-identical compaction factory into the existing event-builder owner removed it. The exact architecture gate, complete changed-file gate, 316 tests, 17 SDK checks, 13 original-owner comparisons and fresh full-PR P2 review all pass after that correction. Native text/tool evidence and the original proof artifacts remain unchanged.

### SDK contract inspection and review disposition

The acting maintainer directly inspected the installed OpenAI Node SDK **7.5.0**, resolving the source/type gap and applying the latest ClawSweeper rank-up request:

- `src/lib/responses/ResponseStream.ts:141-208,294-301` accumulates each event before callbacks and returns the final accumulated response.
- `src/internal/responses/response-accumulator.ts:795-805` requires `response.created` before the first snapshot. Its output/content handlers at `:145-193,229-307` require real, ordered array slots; the text-completion handler at `:365-385` replaces the preview with final text.
- `src/resources/responses/responses.ts:2007,2444,2558,6204,7492` defines the created/completed envelopes, output/content indices and text-completion payloads used by that accumulator. These are the installed dependency sources and types, not generated OpenClaw wrappers.

The maintained boundary tests are reproducible with:

```sh
node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.responses-stream.test.ts extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-lab/src/providers/mock-openai/server.responses-input.test.ts extensions/qa-lab/src/providers/mock-openai/server.memory-ranking-proof.test.ts extensions/qa-lab/src/providers/mock-openai/server.http.test.ts extensions/qa-lab/src/providers/mock-openai/mock-openai-events.test.ts extensions/qa-lab/src/providers/mock-openai/mock-openai-responses-websocket.test.ts
```

Result after the final correction: **316 passed in seven files**, exit 0. All **17 actual SDK/HTTP/WebSocket checks** and **13 original-owner event comparisons** also pass. The lead independently repeated the 17 checks. Hosted [CI at the submitted head](https://github.com/openclaw/openclaw/actions/runs/33611363106) is green.

Direct Codex inspection used commit `94cbbddafc1776d5e377bca1b05932c697e82238`: `codex-rs/codex-api/src/sse/responses.rs:353-525`, `protocol/src/models.rs:975-1120,1191-1201`, `core/src/session/turn.rs:2437-2514`, and `core/src/compact_remote_v2.rs:420-459`. The recorded real native text and freeform-tool runs additionally prove both initial and tool-continuation WebSocket requests.

The review's stored-data heuristic does not describe a persistent-store change: `mock-openai-tooling.ts:71-126` builds in-memory tool items and their transient wire events. This refactor removes redundant return-field copies and routes those events through the shared stream owner; it does not change a database, schema, persisted format, migration, configuration or authorization boundary. No migration is applicable.
