### PR TITLE
fix: keep compaction in one persistent transcript marker

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3997,7 +3997,6 @@ ui/src/pages/chat/chat-session-companion.ts	5
 ui/src/pages/chat/chat-state-events.ts	6
 ui/src/pages/chat/chat-state-page.ts	5
 ui/src/pages/chat/chat-state-route.ts	1
-ui/src/pages/chat/chat-thread-build.ts	1
 ui/src/pages/chat/chat-thread-grouping.ts	2
 ui/src/pages/chat/chat-thread-items.ts	3
 ui/src/pages/chat/components/chat-audio-player.ts	1

--- a/extensions/codex/src/app-server/context-compaction-activity.test.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.test.ts
@@ -55,7 +55,7 @@ describe("persistCodexContextCompactionActivity", () => {
         display: true,
         excludeFromContext: true,
         idempotencyKey: "codex-context-compaction:thread-1:turn-1:compact-1",
-        __openclaw: { runId: "run-1" },
+        __openclaw: { runId: "run-1", itemId: "compact-1" },
       },
     });
     expect(publishUpdate).toHaveBeenCalledOnce();

--- a/extensions/codex/src/app-server/context-compaction-activity.ts
+++ b/extensions/codex/src/app-server/context-compaction-activity.ts
@@ -39,7 +39,7 @@ export async function persistCodexContextCompactionActivity(params: {
       itemId: params.itemId,
       ...(params.runId ? { runId: params.runId } : {}),
     },
-    ...(params.runId ? { __openclaw: { runId: params.runId } } : {}),
+    __openclaw: { itemId: params.itemId, ...(params.runId ? { runId: params.runId } : {}) },
     timestamp: params.timestamp,
     idempotencyKey: activityId,
   };

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1665,6 +1665,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
   it("uses the caller context token budget during runtime compaction", async () => {
     await compactEmbeddedAgentSessionDirect({
       sessionId: "session-1",
+      runId: "manual-compaction-operation",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
       workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
@@ -1676,6 +1677,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
     expectRecordFields(mockCallArg(guardSessionManagerMock, 0, 1), {
       contextWindowTokens: 64_000,
+      runId: "manual-compaction-operation",
     });
     expectRecordFields(mockCallArg(createPreparedEmbeddedAgentSettingsManagerMock), {
       contextTokenBudget: 64_000,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -147,6 +147,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
         memoryTranscript?.sessionManager ?? SessionManager.open(sessionTarget),
         {
           agentId: sessionAgentId,
+          runId: params.runId,
           sessionKey: params.sessionKey,
           config: params.config,
           contextWindowTokens: contextTokenBudget,

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -207,52 +207,62 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
     expect(sessionManager.getBranch().map((entry) => entry.type)).toContain("label");
   });
 
-  it("remaps compaction keep markers when rewritten entries change ids", () => {
-    // Re-appending entries changes ids; compaction records must follow the new
-    // first-kept entry or future branch reconstruction points at stale ids.
-    const {
-      sessionManager,
-      toolResultEntryId,
-      tailAssistantEntryId: keptAssistantEntryId,
-    } = createReadRewriteSession({ tailAssistantText: "keep me" });
-    sessionManager.appendCompaction(
-      "summary",
-      expectDefined(keptAssistantEntryId, "keptAssistantEntryId test invariant"),
-      123,
-    );
-
-    const result = expectDefined(
-      rewriteTranscriptEntriesInSessionManager({
+  it.each([undefined, { runId: "run-original", itemId: "compaction-original" }])(
+    "preserves compaction identity %j when rewriting keep markers",
+    (identity) => {
+      // Re-appending entries changes ids; compaction records must follow the new
+      // first-kept entry or future branch reconstruction points at stale ids.
+      const {
         sessionManager,
-        replacements: [
-          {
-            entryId: expectDefined(toolResultEntryId, "toolResultEntryId test invariant"),
-            message: createToolResultReplacement("read", "[externalized file_123]", 3),
-          },
-        ],
-      }),
-      "rewriteTranscriptEntriesInSessionManager({ sessionManager, replacemen... test invariant",
-    );
+        toolResultEntryId,
+        tailAssistantEntryId: keptAssistantEntryId,
+      } = createReadRewriteSession({ tailAssistantText: "keep me" });
+      const originalCompactionId = sessionManager.appendCompaction(
+        "summary",
+        expectDefined(keptAssistantEntryId, "keptAssistantEntryId test invariant"),
+        123,
+        undefined,
+        undefined,
+        identity,
+      );
+      installSessionToolResultGuard(sessionManager, { runId: "run-rewrite" });
 
-    expect(result.changed).toBe(true);
-    const branch = sessionManager.getBranch();
-    const keptAssistantEntry = branch.find(
-      (entry) =>
-        entry.type === "message" &&
-        entry.message.role === "assistant" &&
-        Array.isArray(entry.message.content) &&
-        entry.message.content.some((part) => part.type === "text" && part.text === "keep me"),
-    );
-    const compactionEntry = branch.find((entry) => entry.type === "compaction");
+      const result = expectDefined(
+        rewriteTranscriptEntriesInSessionManager({
+          sessionManager,
+          replacements: [
+            {
+              entryId: expectDefined(toolResultEntryId, "toolResultEntryId test invariant"),
+              message: createToolResultReplacement("read", "[externalized file_123]", 3),
+            },
+          ],
+        }),
+        "rewriteTranscriptEntriesInSessionManager({ sessionManager, replacemen... test invariant",
+      );
 
-    const keptAssistant = requireValue(keptAssistantEntry, "kept assistant entry");
-    const compaction = requireValue(compactionEntry, "compaction entry");
-    if (compaction.type !== "compaction") {
-      throw new Error("expected compaction entry");
-    }
-    expect(compaction.firstKeptEntryId).toBe(keptAssistant.id);
-    expect(compaction.firstKeptEntryId).not.toBe(keptAssistantEntryId);
-  });
+      expect(result.changed).toBe(true);
+      const branch = sessionManager.getBranch();
+      const keptAssistantEntry = branch.find(
+        (entry) =>
+          entry.type === "message" &&
+          entry.message.role === "assistant" &&
+          Array.isArray(entry.message.content) &&
+          entry.message.content.some((part) => part.type === "text" && part.text === "keep me"),
+      );
+      const compactionEntry = branch.find((entry) => entry.type === "compaction");
+
+      const keptAssistant = requireValue(keptAssistantEntry, "kept assistant entry");
+      const compaction = requireValue(compactionEntry, "compaction entry");
+      if (compaction.type !== "compaction") {
+        throw new Error("expected compaction entry");
+      }
+      expect(compaction.firstKeptEntryId).toBe(keptAssistant.id);
+      expect(compaction.firstKeptEntryId).not.toBe(keptAssistantEntryId);
+      expect(compaction.id).not.toBe(originalCompactionId);
+      const { __openclaw: rewrittenIdentity } = compaction;
+      expect(rewrittenIdentity).toEqual(identity);
+    },
+  );
 
   it("bypasses persistence hooks when replaying rewritten messages", () => {
     const { sessionManager, toolResultEntryId } = createExecRewriteSession();

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -66,12 +66,15 @@ function appendBranchEntry(params: {
     );
   }
   if (entry.type === "compaction") {
+    const { __openclaw: identity } = entry;
     return sessionManager.appendCompaction(
       entry.summary,
       remapEntryId(entry.firstKeptEntryId, rewrittenEntryIds) ?? entry.firstKeptEntryId,
       entry.tokensBefore,
       entry.details,
       entry.fromHook,
+      // An unknown historical run must not inherit the rewriting run's identity.
+      { runId: identity?.runId, ...identity },
     );
   }
   if (entry.type === "reset") {

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -24,6 +24,7 @@ type CompactionStartEvent =
   | {
       type: "compaction_start";
       reason?: unknown;
+      itemId?: string;
     };
 
 // Unknown reasons come from external runtimes or older sessions. Treat them as
@@ -37,9 +38,10 @@ function normalizeCompactionReason(reason: unknown): CompactionReason {
 function emitCompactionAgentEvent(
   ctx: EmbeddedAgentSubscribeContext,
   data:
-    | { phase: "start" }
+    | { phase: "start"; itemId?: string }
     | {
         phase: "end";
+        itemId?: string;
         completed: boolean;
         willRetry: boolean;
         outcome: SessionCompactionEndEvent["outcome"]["status"];
@@ -104,7 +106,7 @@ export function handleCompactionStart(
     reason,
     consoleMessage: `embedded run ${kind} start: runId=${ctx.params.runId} reason=${reason}`,
   });
-  emitCompactionAgentEvent(ctx, { phase: "start" });
+  emitCompactionAgentEvent(ctx, { phase: "start", ...(evt.itemId ? { itemId: evt.itemId } : {}) });
 
   // Hooks are fire-and-forget so compaction state updates and liveness pauses
   // cannot be delayed by plugin work.
@@ -218,6 +220,7 @@ export function handleCompactionEnd(
   }
   emitCompactionAgentEvent(ctx, {
     phase: "end",
+    ...(evt.itemId ? { itemId: evt.itemId } : {}),
     completed,
     willRetry,
     outcome: outcome.status,

--- a/src/agents/session-tool-result-guard.transcript-events.test.ts
+++ b/src/agents/session-tool-result-guard.transcript-events.test.ts
@@ -60,6 +60,32 @@ afterEach(() => {
 });
 
 describe("guardSessionManager transcript updates", () => {
+  it("persists compaction item identity under each current run across reload", async () => {
+    const { sessionManager, root, target } = await openPersistedSessionManager();
+    for (const runId of ["run-first", "run-second"]) {
+      const guarded = guardSessionManager(sessionManager, { runId });
+      const keptId = guarded.appendMessage({ role: "user", content: runId, timestamp: 1 });
+      guarded.appendCompaction("summary", keptId, 100, { source: "hook" }, true, {
+        itemId: `compaction-${runId}`,
+      });
+    }
+    const compactions = SessionManager.open(target, root)
+      .getBranch()
+      .filter((entry) => entry.type === "compaction");
+    expect(compactions).toMatchObject([
+      {
+        __openclaw: { runId: "run-first", itemId: "compaction-run-first" },
+        details: { source: "hook" },
+        fromHook: true,
+      },
+      {
+        __openclaw: { runId: "run-second", itemId: "compaction-run-second" },
+        details: { source: "hook" },
+        fromHook: true,
+      },
+    ]);
+  });
+
   it("consumes a steered source under its own custody and does not repeat its approval hook", async () => {
     const { root, target, sessionEntry } = await openPersistedSessionManager();
     const recorderTarget = { ...target, sessionEntry };

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -760,6 +760,8 @@ export function installSessionToolResultGuard(
   const guardedAppendCompaction = ((
     ...args: Parameters<SessionManager["appendCompaction"]>
   ): string => {
+    // Replayed boundaries supply their recorded identity; new ones inherit the owning run.
+    args[5] = { runId: transcriptRunId, ...args[5] };
     const append = () => originalAppendCompaction(...args);
     return opts?.withCompactionPersistence
       ? opts.withCompactionPersistence(append, isExpectedCompactionAppend)

--- a/src/agents/sessions/agent-session-compaction-correlation.test.ts
+++ b/src/agents/sessions/agent-session-compaction-correlation.test.ts
@@ -1,0 +1,89 @@
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it, vi } from "vitest";
+import { subscribeEmbeddedAgentSession } from "../embedded-agent-subscribe.js";
+import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  createAutoCompactionSettings,
+  createOverflowAssistant,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  streamMocks,
+  testModel,
+} from "./agent-session-loop-correctness.test-support.js";
+import {
+  createCompactionHandlers,
+  createResourceLoader,
+} from "./agent-session-loop-resource-loader.test-support.js";
+import { SessionManager } from "./session-manager.js";
+
+registerAgentSessionLoopTestLifecycle();
+
+describe("AgentSession compaction correlation", () => {
+  it.each(["manual", "automatic"])(
+    "correlates repeated %s compactions and tokens through the subscriber",
+    async (mode) => {
+      const runId = "run-tokens-after";
+      const sessionManager = guardSessionManager(SessionManager.inMemory(), { runId });
+      sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+      sessionManager.appendMessage({
+        ...createAssistant(testModel, [{ type: "text", text: "retained answer" }]),
+        timestamp: 2,
+      });
+      let requests = 0;
+      streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+        createAssistantResultStream(
+          ++requests % 2 === 1
+            ? createOverflowAssistant(activeModel)
+            : createAssistant(activeModel, [{ type: "text", text: "complete retry" }]),
+        ),
+      );
+      const { session } = await createTestSession({
+        sessionManager,
+        settingsManager: createAutoCompactionSettings(),
+        resourceLoader: createResourceLoader(createCompactionHandlers()),
+      });
+      const onAgentEvent = vi.fn();
+      const subscription = subscribeEmbeddedAgentSession({ session, runId, onAgentEvent });
+      try {
+        for (const prompt of ["first long request", "second long request"]) {
+          if (mode === "manual") {
+            sessionManager.appendMessage({ role: "user", content: prompt, timestamp: 3 });
+            sessionManager.appendMessage(
+              createAssistant(testModel, [{ type: "text", text: "answer" }]),
+            );
+            await session.compact();
+          } else {
+            await session.prompt(prompt);
+          }
+        }
+        const compactions = sessionManager
+          .getBranch()
+          .filter((entry) => entry.type === "compaction");
+        expect(compactions).toHaveLength(2);
+        const itemIds = compactions.map(({ __openclaw: metadata }) => metadata?.itemId);
+        expect(itemIds).toEqual([expect.any(String), expect.any(String)]);
+        expect(new Set(itemIds).size).toBe(2);
+        expect(compactions.map(({ __openclaw: metadata }) => metadata?.runId)).toEqual([
+          runId,
+          runId,
+        ]);
+        const events = onAgentEvent.mock.calls
+          .map(([event]) => event)
+          .filter((event) => event.stream === "compaction");
+        expect(events.map(({ data }) => ({ phase: data.phase, itemId: data.itemId }))).toEqual(
+          itemIds.flatMap((itemId) => [
+            { phase: "start", itemId },
+            { phase: "end", itemId },
+          ]),
+        );
+        expect(subscription.getCompactionCount()).toBe(2);
+        expect(subscription.getLastCompactionTokensAfter()).toEqual(expect.any(Number));
+        expect(subscription.getLastCompactionTokensAfter()).toBeGreaterThan(0);
+      } finally {
+        subscription.unsubscribe();
+      }
+    },
+  );
+});

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -388,38 +388,6 @@ describe("AgentSession compaction", () => {
     });
   });
 
-  it("records post-compaction live-message tokens through the subscriber", async () => {
-    const sessionManager = SessionManager.inMemory();
-    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
-    const firstKeptEntryId = sessionManager.appendMessage({
-      ...createAssistant(testModel, [{ type: "text", text: "retained answer" }]),
-      timestamp: 2,
-    });
-    let requests = 0;
-    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
-      createAssistantResultStream(
-        ++requests === 1
-          ? createOverflowAssistant(activeModel)
-          : createAssistant(activeModel, [{ type: "text", text: "complete retry" }]),
-      ),
-    );
-    const { session } = await createTestSession({
-      sessionManager,
-      settingsManager: createAutoCompactionSettings(),
-      resourceLoader: createResourceLoader(
-        createResultHandlers("condensed history", firstKeptEntryId),
-      ),
-    });
-    const subscription = subscribeEmbeddedAgentSession({ session, runId: "run-tokens-after" });
-
-    await session.prompt("long request");
-
-    expect(subscription.getCompactionCount()).toBe(1);
-    expect(subscription.getLastCompactionTokensAfter()).toEqual(expect.any(Number));
-    expect(subscription.getLastCompactionTokensAfter()).toBeGreaterThan(0);
-    subscription.unsubscribe();
-  });
-
   it("sends a pre-persisted keyed user once after pre-prompt compaction", async () => {
     const dir = tempDirs.make("openclaw-agent-session-compaction-keyed-user-");
     const scope = {
@@ -587,10 +555,15 @@ describe("AgentSession compaction", () => {
       .map(([event]) => event)
       .filter((event) => event.stream === "compaction");
     expect(compactionEvents).toHaveLength(2);
+    expect(compactionEvents[0]).toEqual({
+      stream: "compaction",
+      data: { phase: "start", itemId: expect.any(String) },
+    });
     expect(compactionEvents.at(-1)).toEqual({
       stream: "compaction",
       data: {
         phase: "end",
+        itemId: compactionEvents[0].data.itemId,
         outcome: "aborted",
         completed: false,
         willRetry: false,
@@ -646,10 +619,15 @@ describe("AgentSession compaction", () => {
       .map(([event]) => event)
       .filter((event) => event.stream === "compaction");
     expect(compactionEvents).toHaveLength(2);
+    expect(compactionEvents[0]).toEqual({
+      stream: "compaction",
+      data: { phase: "start", itemId: expect.any(String) },
+    });
     expect(compactionEvents.at(-1)).toEqual({
       stream: "compaction",
       data: {
         phase: "end",
+        itemId: compactionEvents[0].data.itemId,
         outcome: "aborted",
         completed: false,
         willRetry: false,

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -21,6 +21,7 @@ import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
 import { createCompactionRuntime } from "./compaction/runtime.js";
 import { preflightManualSessionCompaction } from "./manual-compaction-preflight.js";
+import { generateSessionEntryId } from "./session-manager-id.js";
 import { getLatestCompactionEntry } from "./session-manager.js";
 import { recordSessionModelUsage } from "./session-model-usage.js";
 import type { SettingsManager } from "./settings-manager.js";
@@ -105,13 +106,15 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     await this.abort();
     const abortController = new AbortController();
     this.compactionAbortController = abortController;
-    this.emit({ type: "compaction_start", reason: "manual" });
+    const itemId = generateSessionEntryId();
+    this.emit({ type: "compaction_start", reason: "manual", itemId });
 
     try {
       const settings = this.settingsManager.getCompactionSettings();
       let outcome: CompactionWorkOutcome;
       try {
         outcome = await this.runCompactionWork({
+          itemId,
           customInstructions,
           mode: "manual",
           summaryOutputPolicy,
@@ -126,6 +129,7 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
         this.emit({
           type: "compaction_end",
           reason: "manual",
+          itemId,
           outcome: aborted
             ? { status: "aborted" }
             : { status: "failed", reason: `Compaction failed: ${message}` },
@@ -133,17 +137,18 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
         throw error;
       }
       if (outcome.status === "skipped") {
-        this.emit({ type: "compaction_end", reason: "manual", outcome });
+        this.emit({ type: "compaction_end", reason: "manual", itemId, outcome });
         throw new Error(outcome.reason);
       }
       if (outcome.status === "aborted") {
-        this.emit({ type: "compaction_end", reason: "manual", outcome });
+        this.emit({ type: "compaction_end", reason: "manual", itemId, outcome });
         throw new Error("Compaction cancelled");
       }
 
       this.emit({
         type: "compaction_end",
         reason: "manual",
+        itemId,
         outcome: {
           status: "completed",
           tokensBefore: outcome.result.tokensBefore,
@@ -176,6 +181,7 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
   }
 
   private async runCompactionWork(options: {
+    itemId: string;
     settings: ReturnType<SettingsManager["getCompactionSettings"]>;
     signal: AbortSignal;
     customInstructions?: string;
@@ -316,6 +322,7 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       compactionResult.tokensBefore,
       compactionResult.details,
       fromExtension,
+      { itemId: options.itemId },
     );
     const sessionContext = this.sessionManager.buildSessionContext();
     // Compaction replaces the request prefix, invalidating retained usage and thinking signatures.
@@ -451,12 +458,14 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
   ): Promise<boolean> {
     const settings = this.settingsManager.getCompactionSettings();
 
-    this.emit({ type: "compaction_start", reason });
+    const itemId = generateSessionEntryId();
+    this.emit({ type: "compaction_start", reason, itemId });
     const abortController = new AbortController();
     this.autoCompactionAbortController = abortController;
 
     try {
       const outcome = await this.runCompactionWork({
+        itemId,
         mode: "auto",
         ...(willRetry ? { requestState: "unresolved" as const } : {}),
         summaryOutputPolicy: "retry-invalid-once",
@@ -464,16 +473,17 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
         signal: abortController.signal,
       });
       if (outcome.status === "skipped") {
-        this.emit({ type: "compaction_end", reason, outcome });
+        this.emit({ type: "compaction_end", reason, itemId, outcome });
         return false;
       }
       if (outcome.status === "aborted") {
-        this.emit({ type: "compaction_end", reason, outcome });
+        this.emit({ type: "compaction_end", reason, itemId, outcome });
         return false;
       }
       this.emit({
         type: "compaction_end",
         reason,
+        itemId,
         outcome: {
           status: "completed",
           tokensBefore: outcome.result.tokensBefore,
@@ -499,13 +509,14 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
       return this.agent.hasQueuedMessages();
     } catch (error) {
       if (abortController.signal.aborted) {
-        this.emit({ type: "compaction_end", reason, outcome: { status: "aborted" } });
+        this.emit({ type: "compaction_end", reason, itemId, outcome: { status: "aborted" } });
         return false;
       }
       const errorMessage = compactionErrorMessage(error, "compaction failed");
       this.emit({
         type: "compaction_end",
         reason,
+        itemId,
         outcome: {
           status: "failed",
           reason:

--- a/src/agents/sessions/agent-session-types.ts
+++ b/src/agents/sessions/agent-session-types.ts
@@ -30,6 +30,7 @@ type AgentSessionCompactionOutcome =
 
 type AgentSessionCompactionEndEvent = {
   type: "compaction_end";
+  itemId?: string;
   reason: "manual" | "threshold" | "overflow";
   outcome: AgentSessionCompactionOutcome;
 };
@@ -45,7 +46,7 @@ export type AgentSessionEvent =
   | { type: "queue_update"; steering: readonly string[]; followUp: readonly string[] }
   | { type: "agent_settled" }
   | { type: "agent_handoff" }
-  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow"; itemId?: string }
   | { type: "session_info_changed"; name: string | undefined }
   | { type: "thinking_level_changed"; level: ThinkingLevel }
   | AgentSessionCompactionEndEvent

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -203,6 +203,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     tokensBefore: number,
     details?: unknown,
     fromHook?: boolean,
+    metadata?: CompactionEntry["__openclaw"],
   ): string {
     const entry: CompactionEntry = {
       type: "compaction",
@@ -214,6 +215,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
       tokensBefore,
       details,
       fromHook,
+      ...(metadata?.runId || metadata?.itemId ? { __openclaw: metadata } : {}),
     };
     this.appendEntry(entry, {
       invalidateSerializedPrefixCache: fromHook === true || details !== undefined,

--- a/src/agents/sessions/session-manager-types.ts
+++ b/src/agents/sessions/session-manager-types.ts
@@ -43,6 +43,7 @@ export interface ModelChangeEntry extends SessionEntryBase {
 
 export interface CompactionEntry<T = unknown> extends SessionEntryBase {
   type: "compaction";
+  __openclaw?: { runId?: string; itemId?: string };
   summary: string;
   firstKeptEntryId: string;
   tokensBefore: number;

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -394,6 +394,7 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
               {
                 cfg,
                 entry: latestEntry,
+                runId: operationId,
                 agentId: target.agentId,
                 sessionId,
                 sessionKey: target.canonicalKey,

--- a/src/gateway/server-methods/sessions-compaction-runner.ts
+++ b/src/gateway/server-methods/sessions-compaction-runner.ts
@@ -25,6 +25,7 @@ type GatewaySessionCompactionParams = {
   agentId: string;
   cfg: OpenClawConfig;
   entry: SessionEntry;
+  runId?: string;
   sessionId: string;
   sessionKey: string;
   sessionStoreKey: string;
@@ -105,6 +106,7 @@ export async function runGatewaySessionCompaction(
   return await compactEmbeddedAgentSession(
     {
       contextEngineAgentId: params.agentId,
+      runId: params.runId,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       agentId: params.agentId,

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -824,6 +824,7 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
         model?: string;
         provider?: string;
         reasoningLevel?: string;
+        runId?: string;
         sessionFile?: string;
         sessionId?: string;
         sessionKey?: string;
@@ -846,6 +847,7 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
     agents?: { defaults?: { model?: { primary?: unknown }; workspace?: unknown } };
   };
   expect(compactionCall.sessionId).toBe("sess-main");
+  expect(compactionCall.runId).toBe(startPayload.operationId);
   expect(compactionCall.sessionKey).toBe("agent:main:main");
   if (!compactionCall.sessionFile) {
     throw new Error("expected embedded compaction session file");

--- a/src/gateway/session-transcript-message.test.ts
+++ b/src/gateway/session-transcript-message.test.ts
@@ -40,9 +40,17 @@ describe("trusted transcript display metadata", () => {
   it.each(["compaction", "reset"])(
     "keeps %s markers in the same physical coordinate space",
     (type) => {
-      expect(projectTranscriptEntryMessage({ type, id: "boundary" }, 3, position)).toMatchObject({
-        role: "system",
-        __openclaw: { kind: type, id: "boundary", seq: 3, transcriptPosition: position },
+      const identity = { runId: "run-compaction", itemId: "item-compaction" };
+      const projected = asOptionalRecord(
+        projectTranscriptEntryMessage({ type, id: "boundary", __openclaw: identity }, 3, position),
+      );
+      expect(projected?.role).toBe("system");
+      expect(projected?.["__openclaw"]).toEqual({
+        kind: type,
+        id: "boundary",
+        seq: 3,
+        transcriptPosition: position,
+        ...(type === "compaction" ? identity : {}),
       });
     },
   );

--- a/src/gateway/session-transcript-message.ts
+++ b/src/gateway/session-transcript-message.ts
@@ -138,6 +138,8 @@ export function projectTranscriptEntryMessage(
     return null;
   }
   const kind = record.type;
+  const compactionIdentity =
+    kind === "compaction" ? asOptionalRecord(record["__openclaw"]) : undefined;
   const parsedTimestamp =
     typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN;
   return {
@@ -147,6 +149,10 @@ export function projectTranscriptEntryMessage(
     __openclaw: {
       kind,
       id: typeof record.id === "string" ? record.id : undefined,
+      ...(typeof compactionIdentity?.runId === "string" ? { runId: compactionIdentity.runId } : {}),
+      ...(typeof compactionIdentity?.itemId === "string"
+        ? { itemId: compactionIdentity.itemId }
+        : {}),
       transcriptPosition,
       seq,
     },

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -146,6 +146,8 @@ export type ChatItem =
   | {
       kind: "divider";
       key: string;
+      compaction?: "active" | "complete";
+      compactionId?: string;
       label: string;
       icon?: keyof typeof toolIcons;
       metric?: string;

--- a/ui/src/pages/chat/chat-agent-run-grouping.ts
+++ b/ui/src/pages/chat/chat-agent-run-grouping.ts
@@ -122,7 +122,6 @@ function messageCanOwnCompletedFrame(message: unknown, explicitOnly: boolean): b
     phase === "commentary" ||
     stopReason === "toolUse" ||
     stopReason === "error" ||
-    metadata?.runtimeActivityKind === "context_compaction" ||
     (metadata?.mirrorOrigin === "codex-app-server" && metadata.runTerminal !== true)
   ) {
     return false;

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -587,17 +587,24 @@ describe("executeSlashCommand directives", () => {
     });
   });
 
-  it("passes selected-agent scope for global compaction", async () => {
+  it("refreshes successful compaction without a duplicate command message", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.compact") {
-        return { ok: true, compacted: false };
+        return { ok: true, compacted: true };
       }
       throw new Error(`unexpected method: ${method}`);
     });
 
-    await executeSlashCommand(createTestGatewayClient(request), "global", "compact", "", {
-      agentId: "work",
-    });
+    const result = await executeSlashCommand(
+      createTestGatewayClient(request),
+      "global",
+      "compact",
+      "",
+      {
+        agentId: "work",
+      },
+    );
+    expect(result).toEqual({ action: "refresh" });
 
     expect(request).toHaveBeenCalledWith("sessions.compact", {
       key: "global",

--- a/ui/src/pages/chat/chat-command-executor.ts
+++ b/ui/src/pages/chat/chat-command-executor.ts
@@ -44,7 +44,7 @@ import { patchChatCommandSessionSettings, selectedGlobalScope } from "./chat-set
 
 type SlashCommandResult = {
   /** Markdown-formatted result to display in chat. */
-  content: string;
+  content?: string;
   /** Side-effect action the caller should perform after displaying the result. */
   action?: "refresh" | "export" | "new-session" | "reset" | "stop" | "clear" | "navigate-usage";
   /** Model-dependent tools need refreshing after a confirmed selection. */
@@ -221,17 +221,7 @@ async function executeCompact(
       };
     }
     if (result?.compacted) {
-      const before = result.result?.tokensBefore;
-      const after = result.result?.tokensAfter;
-      const tokenSummary =
-        typeof before === "number" && typeof after === "number"
-          ? t("chat.commandResults.compaction.tokenSummary", {
-              before: before.toLocaleString(),
-              after: after.toLocaleString(),
-            })
-          : "";
       return {
-        content: `${t("chat.commandResults.compaction.succeeded")}${tokenSummary}.`,
         action: "refresh",
       };
     }

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -1043,15 +1043,9 @@ describe("renderChatComposer status", () => {
     expect(view.container.querySelector(".agent-chat__run-status--interrupted")).toBeNull();
   });
 
-  it("renders fresh compaction and fallback status", () => {
+  it("keeps fallback status in the composer without a compaction overlay", () => {
     vi.spyOn(Date, "now").mockReturnValue(1_000);
     const { container } = renderComposer({
-      compactionStatus: {
-        phase: "active",
-        runId: "run-1",
-        startedAt: 1_000,
-        completedAt: null,
-      },
       fallbackStatus: {
         selected: "fireworks/minimax-m2p5",
         active: "deepinfra/moonshotai/Kimi-K2.5",
@@ -1059,9 +1053,8 @@ describe("renderChatComposer status", () => {
         occurredAt: 900,
       },
     });
-    expect(container.querySelector(".compaction-indicator--active")?.textContent?.trim()).toBe(
-      "Compacting context...",
-    );
+    expect(container.querySelector(".compaction-indicator--active")).toBeNull();
+    expect(container.querySelector(".chat-compaction")).toBeNull();
     expect(container.querySelector(".compaction-indicator--fallback")?.textContent?.trim()).toBe(
       "Fallback active: deepinfra/moonshotai/Kimi-K2.5",
     );

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -4,7 +4,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatGuardianNotice, ChatItem, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
-import type { RunOutputUsage } from "./tool-stream-contract.ts";
+import type { CompactionStatus, RunOutputUsage } from "./tool-stream-contract.ts";
 
 type WorkingProgress = {
   key: string;
@@ -16,32 +16,20 @@ type WorkingProgressCache = WorkingProgress;
 
 const CONTEXT_COMPACTION_CUSTOM_TYPE = "openclaw.context-compaction";
 
-export function isContextCompactionActivity(message: unknown): boolean {
-  return asRecord(asRecord(message)?.["__openclaw"])?.runtimeActivityKind === "context_compaction";
+export function isContextCompactionMessage(message: unknown): boolean {
+  const record = asRecord(message);
+  return record?.role === "custom" && record.customType === CONTEXT_COMPACTION_CUSTOM_TYPE;
 }
 
-export function projectContextCompactionActivity(message: unknown): unknown {
+export function matchesCompactionOperation(message: unknown, status: CompactionStatus): boolean {
   const record = asRecord(message);
-  if (record?.role !== "custom" || record.customType !== CONTEXT_COMPACTION_CUSTOM_TYPE) {
-    return message;
-  }
-  const metadata = asRecord(record["__openclaw"]);
-  const details = asRecord(record.details);
-  const { idempotencyKey: _activityId, ...activity } = record;
-  return {
-    ...activity,
-    role: "assistant",
-    content: [{ type: "text", text: t("chat.composer.contextCompacted") }],
-    ...(typeof metadata?.runId === "string"
-      ? { runId: metadata.runId }
-      : typeof details?.runId === "string"
-        ? { runId: details.runId }
-        : {}),
-    __openclaw: {
-      ...metadata,
-      runtimeActivityKind: "context_compaction",
-    },
-  };
+  const marker = asRecord(record?.["__openclaw"]);
+  return Boolean(
+    (marker?.kind === "compaction" || isContextCompactionMessage(message)) &&
+    status.runId &&
+    marker?.runId === status.runId &&
+    (!status.itemId || marker.itemId === status.itemId),
+  );
 }
 
 const workingProgressBySession = new Map<string, WorkingProgressCache>();
@@ -112,6 +100,7 @@ export function buildCompactionDividerItem(
   marker: Record<string, unknown>,
   timestamp: number,
   index: number,
+  phase: "active" | "complete" = "complete",
 ): Extract<ChatItem, { kind: "divider" }> {
   const tokensBefore = marker.tokensBefore;
   const tokensAfter = marker.tokensAfter;
@@ -129,8 +118,10 @@ export function buildCompactionDividerItem(
       typeof marker.id === "string"
         ? `divider:compaction:${marker.id}`
         : `divider:compaction:${timestamp}:${index}`,
-    label: t("chat.compaction.label"),
-    icon: "foldVertical",
+    label: t(
+      phase === "active" ? "chat.composer.compactingContext" : "chat.composer.contextCompacted",
+    ),
+    compaction: phase,
     ...(tokensSaved === null
       ? {}
       : {
@@ -138,8 +129,15 @@ export function buildCompactionDividerItem(
             count: formatCompactTokenCount(tokensSaved),
           }),
         }),
-    description: t("chat.compaction.description"),
-    action: { kind: "session-checkpoints", label: t("chat.compaction.openCheckpoints") },
+    ...(phase === "complete" && marker.kind === "compaction"
+      ? {
+          description: t("chat.compaction.description"),
+          action: {
+            kind: "session-checkpoints" as const,
+            label: t("chat.compaction.openCheckpoints"),
+          },
+        }
+      : {}),
     timestamp,
   };
 }

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -400,7 +400,7 @@ function handleSessionsChangedEvent(
     state.selectedChatSessionArchived = event.archived;
   }
   const result = reconcileSessionEvent(state, payload);
-  if (resetsSelectedSession) {
+  if (resetsSelectedSession || (matchesChat && source?.reason === "compact")) {
     void loadChatHistory(state, { deferBranches: !presented }).finally(() =>
       state.requestUpdate?.(),
     );

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -30,7 +30,8 @@ import {
   buildGuardianNoticeItem,
   buildResetDividerItem,
   clearWorkingProgress,
-  projectContextCompactionActivity,
+  isContextCompactionMessage,
+  matchesCompactionOperation,
   resolveWorkingProgress,
   shouldRenderQueuedSendInThread,
 } from "./chat-progress.ts";
@@ -72,12 +73,14 @@ import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
 import { selectChatInputDisplay } from "./history-merge.ts";
 import { resolveSystemNoticeKind } from "./system-notice-kinds.ts";
 import { isLiveTerminalForRun } from "./terminal-message-identity.ts";
+import type { CompactionStatus } from "./tool-stream-contract.ts";
 
 export type BuildChatItemsProps = {
   paneId: string;
   sessionKey: string;
   archiveNotice?: Extract<ChatItem, { kind: "notice" }>;
   runId?: string | null;
+  compactionStatus?: CompactionStatus | null;
   /** Invalidates cached display copy when the active UI language changes. */
   locale?: string;
   messages: unknown[];
@@ -124,18 +127,33 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   );
   const searchFiltering = props.searchOpen === true && Boolean(props.searchQuery?.trim());
   const persistedCanvasIdentities = new Set<string>();
+  const compaction = props.compactionStatus;
+  const compactionKey = compaction
+    ? `divider:compaction:live:${compaction.runId}:${compaction.itemId ?? "manual"}`
+    : undefined;
+  let hasPersistedCompaction = false;
   for (const [i, item] of buildMessageItems(history).entries()) {
-    const msg = projectContextCompactionActivity(item.message);
-    item.message = msg;
+    const msg = item.message;
     const itemKey = item.key;
-    const normalized = safeNormalizeMessage(msg);
-    if (!normalized) {
+    const raw = asRecord(msg) ?? {};
+    const marker = asRecord(raw["__openclaw"]);
+    if (marker?.kind === "compaction" || isContextCompactionMessage(msg)) {
+      const matchesLive = compaction != null && matchesCompactionOperation(msg, compaction);
+      const divider = buildCompactionDividerItem(
+        marker ?? {},
+        rawMessageTimestamp(msg) ?? Date.now(),
+        i,
+      );
+      items.push({
+        ...divider,
+        compactionId: divider.key,
+        ...(matchesLive && compactionKey ? { key: compactionKey } : {}),
+      });
+      hasPersistedCompaction ||= matchesLive;
       continue;
     }
-    const raw = asRecord(msg) ?? {};
-    const marker = raw["__openclaw"] as Record<string, unknown> | undefined;
-    if (marker && marker.kind === "compaction") {
-      items.push(buildCompactionDividerItem(marker, normalized.timestamp ?? Date.now(), i));
+    const normalized = safeNormalizeMessage(msg);
+    if (!normalized) {
       continue;
     }
     if (marker && marker.kind === "reset") {
@@ -243,6 +261,20 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     pendingInputs,
     props.searchOpen ? props.searchQuery : undefined,
   ).map((item) => ({ item }));
+  if (compaction && compactionKey && !hasPersistedCompaction) {
+    const timestamp = compaction.startedAt ?? compaction.completedAt ?? Date.now();
+    projections.push({
+      item: {
+        ...buildCompactionDividerItem(
+          {},
+          timestamp,
+          0,
+          compaction.phase === "complete" ? "complete" : "active",
+        ),
+        key: compactionKey,
+      },
+    });
+  }
   const appendQueuedSend = (queued: ChatQueueItem) => {
     if (!shouldRenderQueuedSendInThread(queued)) {
       return;
@@ -522,11 +554,12 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   // catches up.
   const hasEmptyLiveStream = props.stream !== null && props.stream.trim().length === 0;
   const showWorkingIndicator =
-    (props.runWorking === true && !initialHistoryLoad) ||
-    hasEmptyLiveStream ||
-    queuedSends.some(
-      (item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item),
-    );
+    (!compaction || compaction.phase === "complete") &&
+    ((props.runWorking === true && !initialHistoryLoad) ||
+      hasEmptyLiveStream ||
+      queuedSends.some(
+        (item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item),
+      ));
   if (props.runWorking !== true && props.stream === null && !showWorkingIndicator) {
     clearWorkingProgress(props.sessionKey);
   }

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -8,7 +8,6 @@ import type { ChatItem, MessageGroup } from "../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
-import { isContextCompactionActivity } from "./chat-progress.ts";
 import { prepareMessagesForGrouping } from "./chat-thread-duplicates.ts";
 import { userTurnRunId } from "./chat-thread-items.ts";
 import {
@@ -24,9 +23,6 @@ import {
 import { indexTurnContinuations, persistedSteerTargetRunId } from "./stream-causal-boundary.ts";
 
 function assistantMessageKind(message: unknown) {
-  if (isContextCompactionActivity(message)) {
-    return "compaction";
-  }
   if (isKeyedAssistantStreamFallbackMessage(message)) {
     return "commentary";
   }
@@ -244,7 +240,6 @@ export function assistantGroupCanOwnActiveRunStatus(group: MessageGroup): boolea
   return (
     group.role.toLowerCase() === "assistant" &&
     !assistantGroupIsForwardedBoundary(group) &&
-    !group.messages.every(({ message }) => isContextCompactionActivity(message)) &&
     groupHasVisibleReplyContent(group)
   );
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -945,7 +945,7 @@ describe("collapseCompletedTurnWork", () => {
     },
   );
 
-  it("keeps durable context compaction inside completed work instead of treating it as the reply", () => {
+  it("renders durable context compaction as a marker, not an assistant reply", () => {
     const items = collapsedItems({
       messages: [
         userMessage("do it", 1_000),
@@ -963,16 +963,8 @@ describe("collapseCompletedTurnWork", () => {
       ],
     });
 
-    expect(items.map((item) => item.kind)).toEqual(["group", "work-group", "group"]);
-    const work = requireWorkGroup(items[1]);
-    expect(work.groups).toHaveLength(1);
-    expect(work.groups[0]?.messages[0]?.message).toMatchObject({
-      role: "assistant",
-      content: [{ type: "text", text: "Context compacted" }],
-      runId: "run-1",
-      __openclaw: { runtimeActivityKind: "context_compaction" },
-    });
-    expect(work.groups[0]?.messages[0]?.message).not.toHaveProperty("idempotencyKey");
+    expect(items.map((item) => item.kind)).toEqual(["group", "divider", "group"]);
+    expect(items[1]).toMatchObject({ compaction: "complete", label: "Context compacted" });
     expect(requireGroup(items[2]).messages[0]?.message).toMatchObject({
       content: "All done.",
     });
@@ -4619,8 +4611,8 @@ describe("buildCachedChatItems", () => {
     expect(items).toHaveLength(1);
     const divider = requireRecord(items[0]);
     expect(divider.kind).toBe("divider");
-    expect(divider.label).toBe("Compacted history");
-    expect(divider.icon).toBe("foldVertical");
+    expect(divider.label).toBe("Context compacted");
+    expect(divider.compaction).toBe("complete");
     expect(divider.description).toBe("The compacted transcript is preserved as a checkpoint.");
     const action = requireRecord(divider.action);
     expect(action.kind).toBe("session-checkpoints");
@@ -4641,7 +4633,7 @@ describe("buildCachedChatItems", () => {
 
     expect(items[0]).toMatchObject({
       kind: "divider",
-      label: "Compacted history",
+      label: "Context compacted",
       metric: "saved 875.3k tokens",
     });
   });

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -118,6 +118,8 @@ function sameChatItem(previous: RenderChatItem, next: RenderChatItem): boolean {
     case "divider":
       return (
         previous.kind === "divider" &&
+        previous.compaction === next.compaction &&
+        previous.compactionId === next.compactionId &&
         previous.label === next.label &&
         previous.metric === next.metric &&
         previous.description === next.description &&
@@ -177,7 +179,16 @@ function stabilizeChatItems(
     next.filter((item) => item.kind === "group").map((item) => item.key),
   );
   const claimedGroupKeys = new Set<string>();
+  const previousCompactions = new Map(
+    previous.flatMap((item) =>
+      item.kind === "divider" && item.compactionId ? [[item.compactionId, item.key] as const] : [],
+    ),
+  );
   const reconciled = next.map((item) => {
+    if (item.kind === "divider" && item.compactionId) {
+      const key = previousCompactions.get(item.compactionId);
+      return key ? { ...item, key } : item;
+    }
     if (item.kind !== "group") {
       return item;
     }
@@ -245,6 +256,7 @@ function sameChatItemsStructuralInput(
     previous.archiveNotice?.key === next.archiveNotice?.key &&
     previous.archiveNotice?.label === next.archiveNotice?.label &&
     previous.runId === next.runId &&
+    previous.compactionStatus === next.compactionStatus &&
     previous.locale === next.locale &&
     previous.messages === next.messages &&
     previous.toolMessages === next.toolMessages &&

--- a/ui/src/pages/chat/components/chat-composer-status.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.browser.test.ts
@@ -3,13 +3,16 @@ import { nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cdp } from "vitest/browser";
 import "../../../components/tooltip.ts";
-import { renderCompactionIndicator, renderFallbackIndicator } from "./chat-composer-status.ts";
+import { buildCompactionDividerItem } from "../chat-progress.ts";
+import { renderFallbackIndicator } from "./chat-composer-status.ts";
+import { renderChatDivider } from "./chat-divider.ts";
 import baseStyles from "../../../styles/base.css?inline";
 import composerStatusStyles from "../../../styles/chat/composer-status.css?inline";
+import groupedStyles from "../../../styles/chat/grouped.css?inline";
 import chatLayoutStyles from "../../../styles/chat/layout.css?inline";
 import componentStyles from "../../../styles/components.css?inline";
 
-describe("chat composer compaction motion", () => {
+describe("inline compaction motion", () => {
   let container: HTMLDivElement;
   let styles: HTMLStyleElement;
   let session: CDPSession;
@@ -20,9 +23,13 @@ describe("chat composer compaction motion", () => {
       features: [{ name: "prefers-reduced-motion", value: "no-preference" }],
     });
     styles = document.createElement("style");
-    styles.textContent = [baseStyles, componentStyles, chatLayoutStyles, composerStatusStyles].join(
-      "\n",
-    );
+    styles.textContent = [
+      baseStyles,
+      componentStyles,
+      groupedStyles,
+      chatLayoutStyles,
+      composerStatusStyles,
+    ].join("\n");
     document.head.append(styles);
     container = document.createElement("div");
     document.body.append(container);
@@ -35,22 +42,14 @@ describe("chat composer compaction motion", () => {
     await session.send("Emulation.setEmulatedMedia", { features: [] });
   });
 
-  it("folds lines on a readable borderless scrim, then reveals the completion check", async () => {
-    render(
-      renderCompactionIndicator({
-        phase: "active",
-        runId: "run-motion",
-        startedAt: Date.now(),
-        completedAt: null,
-      }),
-      container,
-    );
-    const indicator = container.querySelector<HTMLElement>(".compaction-indicator")!;
-    const lines = Array.from(container.querySelectorAll(".compaction-indicator__line"));
-    const check = container.querySelector<SVGElement>(".compaction-indicator__glyph svg")!;
+  it("folds lines inline without a floating scrim, then reveals the completion check", async () => {
+    render(renderChatDivider(buildCompactionDividerItem({}, 1_000, 0, "active")), container);
+    const indicator = container.querySelector<HTMLElement>(".chat-compaction")!;
+    const lines = Array.from(container.querySelectorAll(".chat-compaction__line"));
+    const check = container.querySelector<SVGElement>(".chat-compaction__glyph svg")!;
     expect(lines.length).toBeGreaterThan(0);
-    expect(getComputedStyle(indicator).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
-    expect(getComputedStyle(indicator).boxShadow).not.toBe("none");
+    expect(getComputedStyle(indicator).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(indicator).boxShadow).toBe("none");
     expect(getComputedStyle(indicator).borderTopWidth).toBe("0px");
     expect(getComputedStyle(indicator).animationName).toBe("none");
     expect(getComputedStyle(check).opacity).toBe("0");
@@ -62,15 +61,7 @@ describe("chat composer compaction motion", () => {
       expect(getComputedStyle(element).animationName).not.toContain("spin");
     }
 
-    render(
-      renderCompactionIndicator({
-        phase: "complete",
-        runId: "run-motion",
-        startedAt: Date.now(),
-        completedAt: Date.now(),
-      }),
-      container,
-    );
+    render(renderChatDivider(buildCompactionDividerItem({}, 1_000, 0, "complete")), container);
     for (const line of lines) {
       expect(getComputedStyle(line).visibility).toBe("hidden");
       expect(getComputedStyle(line).animationName).toBe("none");
@@ -85,24 +76,16 @@ describe("chat composer compaction motion", () => {
       .toBe(false);
   });
 
-  it("keeps active, retrying, and complete states readable without reduced-motion animations", async () => {
+  it("keeps active and complete states readable without reduced-motion animations", async () => {
     await session.send("Emulation.setEmulatedMedia", {
       features: [{ name: "prefers-reduced-motion", value: "reduce" }],
     });
     expect(matchMedia("(prefers-reduced-motion: reduce)").matches).toBe(true);
-    for (const phase of ["active", "retrying", "complete"] as const) {
-      render(
-        renderCompactionIndicator({
-          phase,
-          runId: "run-static",
-          startedAt: Date.now(),
-          completedAt: phase === "complete" ? Date.now() : null,
-        }),
-        container,
-      );
-      const indicator = container.querySelector<HTMLElement>(".compaction-indicator")!;
-      const label = container.querySelector<HTMLElement>(".compaction-indicator__label")!;
-      const check = container.querySelector<SVGElement>(".compaction-indicator__glyph svg")!;
+    for (const phase of ["active", "complete"] as const) {
+      render(renderChatDivider(buildCompactionDividerItem({}, 1_000, 0, phase)), container);
+      const indicator = container.querySelector<HTMLElement>(".chat-compaction")!;
+      const label = container.querySelector<HTMLElement>(".chat-divider__title")!;
+      const check = container.querySelector<SVGElement>(".chat-compaction__glyph svg")!;
       expect(label.textContent?.trim()).not.toBe("");
       expect(getComputedStyle(label).webkitTextFillColor).not.toBe("rgba(0, 0, 0, 0)");
       expect(getComputedStyle(label).backgroundImage).toBe("none");

--- a/ui/src/pages/chat/components/chat-composer-status.test.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.test.ts
@@ -2,8 +2,7 @@ import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../../i18n/index.ts";
 import { captureI18nStateForTesting } from "../../../i18n/lib/translate.test-support.ts";
-import type { CompactionStatus } from "../tool-stream-contract.ts";
-import { renderCompactionIndicator, renderFallbackIndicator } from "./chat-composer-status.ts";
+import { renderFallbackIndicator } from "./chat-composer-status.ts";
 
 describe("chat composer status localization", () => {
   let container: HTMLDivElement;
@@ -21,101 +20,6 @@ describe("chat composer status localization", () => {
     await restoreI18nState();
     vi.restoreAllMocks();
     container.remove();
-  });
-
-  it.each(["active", "retrying"] as const)(
-    "announces localized %s compaction without exposing the decorative glyph",
-    (phase) => {
-      render(
-        renderCompactionIndicator({
-          phase,
-          runId: "run-1",
-          startedAt: 1_000,
-          completedAt: null,
-        }),
-        container,
-      );
-      const status = container.querySelector(".compaction-indicator--active");
-      expect(status?.getAttribute("role")).toBe("status");
-      expect(status?.getAttribute("aria-live")).toBe("polite");
-      expect(status?.textContent?.trim()).toBe("Kontext wird komprimiert...");
-      const glyph = status?.querySelector(".compaction-indicator__glyph");
-      expect(glyph?.getAttribute("aria-hidden")).toBe("true");
-      expect(glyph?.textContent?.trim()).toBe("");
-    },
-  );
-
-  it("retains the glyph and its children through retry and completion for the transition", () => {
-    const status: CompactionStatus = {
-      phase: "active",
-      runId: "run-1",
-      startedAt: 1_000,
-      completedAt: null,
-    };
-    render(renderCompactionIndicator(status), container);
-    const indicator = container.querySelector(".compaction-indicator");
-    const glyph = container.querySelector(".compaction-indicator__glyph");
-    expect(glyph).not.toBeNull();
-    const children = Array.from(glyph!.children);
-    expect(children.length).toBeGreaterThan(0);
-
-    for (const phase of ["retrying", "complete"] as const) {
-      render(
-        renderCompactionIndicator({
-          ...status,
-          phase,
-          completedAt: phase === "complete" ? 1_000 : null,
-        }),
-        container,
-      );
-      expect(container.querySelector(".compaction-indicator")).toBe(indicator);
-      expect(container.querySelector(".compaction-indicator__glyph")).toBe(glyph);
-      expect(glyph!.children).toHaveLength(children.length);
-      children.forEach((child, index) => expect(glyph!.children[index]).toBe(child));
-    }
-    expect(indicator?.classList.contains("compaction-indicator--complete")).toBe(true);
-    expect(indicator?.getAttribute("role")).toBe("status");
-    expect(indicator?.getAttribute("aria-live")).toBe("polite");
-    expect(indicator?.textContent?.trim()).toBe("Kontext komprimiert");
-  });
-
-  it("removes completed feedback at the five-second boundary on rerender", () => {
-    const status: CompactionStatus = {
-      phase: "complete",
-      runId: "run-1",
-      startedAt: 900,
-      completedAt: 1_000,
-    };
-    vi.mocked(Date.now).mockReturnValue(5_999);
-    render(renderCompactionIndicator(status), container);
-    expect(container.querySelector("[role='status']")?.textContent?.trim()).toBe(
-      "Kontext komprimiert",
-    );
-    vi.mocked(Date.now).mockReturnValue(6_000);
-    render(renderCompactionIndicator(status), container);
-    expect(container.childElementCount).toBe(0);
-  });
-
-  it.each<{ name: string; status: CompactionStatus | null | undefined }>([
-    { name: "null status", status: null },
-    { name: "undefined status", status: undefined },
-    {
-      name: "completion without a timestamp",
-      status: { phase: "complete", runId: "run-1", startedAt: 900, completedAt: null },
-    },
-  ])("clears a rendered indicator for $name", ({ status }) => {
-    render(
-      renderCompactionIndicator({
-        phase: "active",
-        runId: "run-1",
-        startedAt: 1_000,
-        completedAt: null,
-      }),
-      container,
-    );
-    expect(container.querySelector("[role='status']")).not.toBeNull();
-    render(renderCompactionIndicator(status), container);
-    expect(container.childElementCount).toBe(0);
   });
 
   it("renders translated fallback status", () => {

--- a/ui/src/pages/chat/components/chat-composer-status.ts
+++ b/ui/src/pages/chat/components/chat-composer-status.ts
@@ -2,9 +2,8 @@ import { html, nothing } from "lit";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { CHAT_RUN_STATUS_TOAST_DURATION_MS, type ChatRunUiStatus } from "../run-lifecycle.ts";
-import type { CompactionStatus, FallbackStatus } from "../tool-stream-contract.ts";
+import type { FallbackStatus } from "../tool-stream-contract.ts";
 
-const COMPACTION_TOAST_DURATION_MS = 5000;
 const FALLBACK_TOAST_DURATION_MS = 8000;
 
 export type ComposerRunStatus =
@@ -29,38 +28,6 @@ export function renderChatRunStatusIndicator(status: ComposerRunStatus | null | 
     >
       ${icons.square}<span class="agent-chat__run-status-label">${interrupted}</span>
     </span>
-  `;
-}
-
-export function renderCompactionIndicator(status: CompactionStatus | null | undefined) {
-  if (!status) {
-    return nothing;
-  }
-  const active = status.phase === "active" || status.phase === "retrying";
-  if (
-    !active &&
-    (!status.completedAt || Date.now() - status.completedAt >= COMPACTION_TOAST_DURATION_MS)
-  ) {
-    return nothing;
-  }
-  return html`
-    <div
-      class="compaction-indicator compaction-indicator--${active ? "active" : "complete"}"
-      role="status"
-      aria-live="polite"
-    >
-      <span class="compaction-indicator__glyph" aria-hidden="true">
-        <span class="compaction-indicator__line"></span>
-        <span class="compaction-indicator__line"></span>
-        <span class="compaction-indicator__line"></span>
-        <span class="compaction-indicator__line"></span>
-        <span class="compaction-indicator__line"></span>
-        ${icons.check}
-      </span>
-      <span class="compaction-indicator__label">
-        ${t(active ? "chat.composer.compactingContext" : "chat.composer.contextCompacted")}
-      </span>
-    </div>
   `;
 }
 

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -25,7 +25,7 @@ import type { RealtimeTalkCameraDevice } from "../realtime-talk-input.ts";
 import type { RealtimeTalkLevelSignal } from "../realtime-talk-level.ts";
 import type { RealtimeTalkStatus } from "../realtime-talk.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
-import type { CompactionStatus, FallbackStatus } from "../tool-stream-contract.ts";
+import type { FallbackStatus } from "../tool-stream-contract.ts";
 import type { ChatAttachmentControlsProps } from "./chat-attachments.ts";
 import type {
   ChatComposerCapabilityMenuProps,
@@ -82,7 +82,6 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   canAbort?: boolean;
   runStatus?: ChatRunUiStatus | null;
   waitingApproval?: boolean;
-  compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;
   progressCard?: ProgressCard | null;
   progressCardHasActiveRun?: boolean;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -38,7 +38,6 @@ import {
 } from "./chat-composer-slash-menu.ts";
 import {
   renderChatRunStatusIndicator,
-  renderCompactionIndicator,
   renderFallbackIndicator,
   type ComposerRunStatus,
 } from "./chat-composer-status.ts";
@@ -244,7 +243,6 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     ? nothing
     : renderChatRunStatusIndicator(composerRunStatus);
   const fallbackStatus = renderFallbackIndicator(props.fallbackStatus);
-  const compactionStatus = renderCompactionIndicator(props.compactionStatus);
   const progressCard = props.progressCard
     ? html`<div class="agent-chat__progress-float">
         ${renderSessionProgressCard(
@@ -295,7 +293,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
         : ""}"
     >
       <div class="agent-chat__composer-overlay">
-        ${props.anchoredNotices ?? nothing} ${composerAlerts} ${fallbackStatus} ${compactionStatus}
+        ${props.anchoredNotices ?? nothing} ${composerAlerts} ${fallbackStatus}
         ${interruptedStatus === nothing
           ? nothing
           : html`<div class="agent-chat__composer-run-status">${interruptedStatus}</div>`}

--- a/ui/src/pages/chat/components/chat-divider.ts
+++ b/ui/src/pages/chat/components/chat-divider.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { toolIcons } from "../../../components/icons-tools.ts";
+import { icons } from "../../../components/icons.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
@@ -10,20 +11,31 @@ function renderSystemLine(params: {
   icon?: keyof typeof toolIcons;
   label: string;
   metric?: string;
+  compaction?: "active" | "complete";
 }) {
   return html`
     <div
       class="chat-divider__rule"
-      role="separator"
+      role=${params.compaction ? "status" : "separator"}
+      aria-live=${params.compaction ? "polite" : nothing}
       aria-label=${params.metric ? `${params.label}, ${params.metric}` : params.label}
     >
       <span class="chat-divider__line"></span>
       <span class="chat-divider__label">
-        ${params.icon
-          ? html`<span class="chat-divider__icon" aria-hidden="true"
-              >${toolIcons[params.icon]}</span
-            >`
-          : nothing}
+        ${params.compaction
+          ? html`<span class="chat-compaction__glyph" aria-hidden="true">
+              <span class="chat-compaction__line"></span>
+              <span class="chat-compaction__line"></span>
+              <span class="chat-compaction__line"></span>
+              <span class="chat-compaction__line"></span>
+              <span class="chat-compaction__line"></span>
+              ${icons.check}
+            </span>`
+          : params.icon
+            ? html`<span class="chat-divider__icon" aria-hidden="true"
+                >${toolIcons[params.icon]}</span
+              >`
+            : nothing}
         <span class="chat-divider__title">${params.label}</span>
         ${params.metric
           ? html`
@@ -46,7 +58,13 @@ export function renderChatDivider(
       ? item.action
       : undefined;
   return html`
-    <div class="chat-divider" data-chat-row-key=${item.key} data-ts=${String(item.timestamp)}>
+    <div
+      class="chat-divider ${item.compaction
+        ? `chat-compaction chat-compaction--${item.compaction}`
+        : ""}"
+      data-chat-row-key=${item.key}
+      data-ts=${String(item.timestamp)}
+    >
       ${renderSystemLine(item)}
       ${item.description || action
         ? html`

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -30,7 +30,7 @@ import { resetChatThreadState } from "../chat-thread.ts";
 import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
 import type { ChatRunUiStatus } from "../run-lifecycle.ts";
-import type { RunOutputUsage } from "../tool-stream-contract.ts";
+import type { CompactionStatus, RunOutputUsage } from "../tool-stream-contract.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
 import type { ChatHistoryBoundaryProps } from "./chat-history-boundary.ts";
 import type { MessageActionDetails } from "./chat-message-markdown.ts";
@@ -67,6 +67,7 @@ type ReplyMessageAccess = {
 };
 
 export type ChatThreadProps = ChatSendStatusActions & {
+  compactionStatus?: CompactionStatus | null;
   paneId: string;
   /** Routing for peer sender names in a shared session. */
   personActivity?: PersonActivityRouting;

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -116,6 +116,7 @@ export function projectChatTranscript(
     sessionKey: props.sessionKey,
     archiveNotice,
     runId: props.runId ?? null,
+    compactionStatus: props.compactionStatus,
     locale,
     messages: props.messages,
     toolMessages: props.toolMessages,

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../../api/types.ts";
 import { createTestGatewayClient } from "../../../test-helpers/gateway-client.ts";
 import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { getChatSessionProjection, reduceChatSessionProjection } from "../history-merge.ts";
 import { agentEvent, createHost } from "../tool-stream.test-helpers.ts";
 import { handleAgentEvent } from "../tool-stream.ts";
 import { renderTranscriptSearch, toggleTranscriptSearch } from "./chat-thread-interactions.ts";
@@ -41,6 +42,131 @@ function touchPointerUp(element: Element): void {
 describe("chat transcript rendering", () => {
   beforeEach(installTranscriptDomMocks);
   afterEach(resetTranscriptTestDom);
+
+  it("keeps one inline compaction row through completion and history refresh", async () => {
+    const props: ReturnType<typeof threadProps> = {
+      ...threadProps("pane-compaction"),
+      runWorking: true,
+      compactionStatus: {
+        phase: "active",
+        runId: "compact-run",
+        startedAt: 5_000,
+        completedAt: null,
+      },
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const transcript = createTestTranscript();
+    const rerender = () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    try {
+      rerender();
+      transcript.hostConnected();
+      await flushDeferredRowPrune();
+      const marker = requireElement(container, ".chat-compaction");
+      const glyph = requireElement(marker, ".chat-compaction__glyph");
+      expect(marker.textContent).toContain("Compacting context");
+      expect(container.querySelector(".chat-working-indicator")).toBeNull();
+      props.compactionStatus = {
+        phase: "complete",
+        runId: "compact-run",
+        startedAt: 5_000,
+        completedAt: 6_000,
+      };
+      rerender();
+      expect(container.querySelector(".chat-compaction")).toBe(marker);
+      expect(marker.textContent).toContain("Context compacted");
+      const owner = {
+        sessionKey: props.sessionKey,
+        chatMessages: props.messages,
+        compactionStatus: props.compactionStatus,
+      };
+      getChatSessionProjection(owner, {
+        sessionKey: props.sessionKey,
+        activeLeafEntryId: "previous",
+      });
+      const messages = [
+        ...props.messages,
+        {
+          role: "custom",
+          customType: "openclaw.context-compaction",
+          content: "Context compacted",
+          __openclaw: { id: "compacted-item", runId: "compact-run" },
+          timestamp: 6_000,
+        },
+      ];
+      reduceChatSessionProjection(
+        owner,
+        { type: "snapshotLoaded", messages },
+        {
+          scope: { sessionKey: props.sessionKey, activeLeafEntryId: "compacted-item" },
+        },
+      );
+      props.messages = owner.chatMessages;
+      props.compactionStatus = owner.compactionStatus;
+      rerender();
+      expect(container.querySelectorAll(".chat-compaction")).toHaveLength(1);
+      expect(container.querySelector(".chat-compaction")).toBe(marker);
+      expect(marker.querySelector(".chat-compaction__glyph")).toBe(glyph);
+      expect(container.textContent?.match(/Context compacted/g)).toHaveLength(1);
+      props.compactionStatus = null;
+      rerender();
+      expect(container.querySelector(".chat-compaction")).toBe(marker);
+      props.messages = [
+        ...props.messages,
+        { role: "assistant", content: "Next reply", timestamp: 9_000 },
+      ];
+      rerender();
+      expect(container.querySelector(".chat-compaction")).toBe(marker);
+    } finally {
+      transcript.hostDisconnected();
+      container.remove();
+    }
+  });
+
+  it("keeps repeated compactions in one run distinct during history adoption", async () => {
+    const persisted = (itemId: string, timestamp: number) => ({
+      role: "custom",
+      customType: "openclaw.context-compaction",
+      content: "Context compacted",
+      __openclaw: { id: itemId, runId: "same-run", itemId },
+      timestamp,
+    });
+    const props = threadProps("pane-repeated-compaction", "agent:main:main", [
+      persisted("first", 1_000),
+    ]);
+    props.compactionStatus = {
+      phase: "active",
+      runId: "same-run",
+      itemId: "second",
+      startedAt: 2_000,
+      completedAt: null,
+    };
+    const container = document.body.appendChild(document.createElement("div"));
+    const transcript = createTestTranscript();
+    const rerender = () => {
+      render(renderChatThread(props, transcript), container);
+      transcript.hostUpdated();
+    };
+    try {
+      rerender();
+      transcript.hostConnected();
+      await flushDeferredRowPrune();
+      const active = requireElement(container, ".chat-compaction--active");
+      expect(container.querySelectorAll(".chat-compaction")).toHaveLength(2);
+      props.messages = [...props.messages, persisted("second", 3_000)];
+      rerender();
+      expect(container.querySelectorAll(".chat-compaction")).toHaveLength(2);
+      expect(active.isConnected).toBe(true);
+      expect(active.classList.contains("chat-compaction--complete")).toBe(true);
+      expect(container.querySelector(".chat-compaction--active")).toBeNull();
+    } finally {
+      transcript.hostDisconnected();
+      container.remove();
+    }
+  });
 
   it("keeps exact-run usage visible through final event batching and later corrections", async () => {
     const runId = "watched-run";

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -17,6 +17,7 @@ import {
   publishChatSessionProjection,
   publishChatSessionProjectionMessages,
 } from "./history-merge.ts";
+import type { CompactionStatus } from "./tool-stream-contract.ts";
 import { buildInitialChatSubmission } from "./user-message-content.ts";
 
 const imageDataUrl = "data:image/png;base64,iVBORw0KGgo=";
@@ -104,6 +105,37 @@ function createAuthoritativeInitialMessage(sequence = 1) {
 }
 
 describe("pane-owned canonical session projection", () => {
+  it.each(["reset", "session", "branch"] as const)(
+    "retires the compaction marker's live state on %s changes",
+    (change) => {
+      const owner = {
+        sessionKey: "agent:main:one",
+        chatMessages: [] as unknown[],
+        compactionStatus: null as CompactionStatus | null,
+      };
+      const scope = { sessionKey: owner.sessionKey, activeLeafEntryId: "first" };
+      getChatSessionProjection(owner, scope);
+      owner.compactionStatus = {
+        phase: "complete",
+        runId: "compact-one",
+        startedAt: 1_000,
+        completedAt: 2_000,
+      };
+      reduceChatSessionProjection(
+        owner,
+        change === "reset" ? { type: "sessionReset" } : { type: "snapshotLoaded", messages: [] },
+        {
+          scope: {
+            ...scope,
+            ...(change === "session" ? { sessionKey: "agent:main:two" } : {}),
+            ...(change === "branch" ? { activeLeafEntryId: "other" } : {}),
+          },
+        },
+      );
+      expect(owner.compactionStatus).toBeNull();
+    },
+  );
+
   it("publishes run-only events without traversing the unchanged transcript", () => {
     const owner = { sessionKey: "agent:main:shared", chatMessages: [] as unknown[] };
     const initial = reduceChatSessionProjection(owner, {

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -25,6 +25,8 @@ import {
   resolveUiSelectedSessionAgentId,
   resolveUiConversationIdentity,
 } from "../../lib/sessions/session-key.ts";
+import { matchesCompactionOperation } from "./chat-progress.ts";
+import type { CompactionStatus } from "./tool-stream-contract.ts";
 
 const chatSessionProjections = new WeakMap<
   object,
@@ -49,7 +51,17 @@ type ChatSessionProjectionOwner = ChatComposerScope & {
   chatSubmissions?: ApplicationChatSubmissions;
   currentSessionId?: string | null;
   chatDisplayedLeafEntryId?: string | null;
+  compactionStatus?: CompactionStatus | null;
+  compactionClearTimer?: number | null;
 };
+
+function resetCompactionProjection(owner: ChatSessionProjectionOwner): void {
+  if (owner.compactionClearTimer != null) {
+    clearTimeout(owner.compactionClearTimer);
+    owner.compactionClearTimer = null;
+  }
+  owner.compactionStatus = null;
+}
 
 type ChatSessionProjectionScopeOptions = Omit<SessionProjectionScope, "sessionId"> & {
   sessionId?: string | null;
@@ -208,6 +220,29 @@ export function publishChatSessionProjection(
 ): void {
   const current = chatSessionProjections.get(owner);
   const runId = current?.runId;
+  if (
+    current?.projection &&
+    chatProjectionScopeChanged(current.projection.scope, projection.scope)
+  ) {
+    const status = owner.compactionStatus;
+    const sessionKeys = ["sessionKey", "sessionId", "agentId"] as const;
+    const previousScope = current.projection.scope;
+    const sessionChanged = sessionKeys.some(
+      (key) =>
+        Object.hasOwn(projection.scope, key) &&
+        previousScope[key] !== undefined &&
+        previousScope[key] !== projection.scope[key],
+    );
+    // Appending the completed marker advances the active leaf. Retain its live
+    // identity through that refresh, but never carry it into another session or branch.
+    if (
+      sessionChanged ||
+      !status ||
+      !projection.messages.some((message) => matchesCompactionOperation(message, status))
+    ) {
+      resetCompactionProjection(owner);
+    }
+  }
   chatSessionProjections.set(owner, {
     projection,
     runId:
@@ -462,6 +497,9 @@ export function reduceChatSessionProjection(
     });
   }
   projection = reduceSessionProjection(projection, { ...preparedEvent, scope });
+  if (event.type === "sessionReset" && projection !== current) {
+    resetCompactionProjection(owner);
+  }
   // Without a transcript anchor this is best-effort display chronology, assuming
   // comparable browser/Gateway clocks. Never assign a sequence or reorder canonical
   // rows; older or untimestamped history stays ahead until authoritative adoption.

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -428,7 +428,10 @@ function clearRunIndicators(host: RunLifecycleHost, runId?: string | null) {
   if (!runId || host.chatRunStartup?.runId === runId) {
     host.chatRunStartup = null;
   }
-  if (!runId || host.compactionStatus?.runId === runId) {
+  if (
+    (!runId || host.compactionStatus?.runId === runId) &&
+    host.compactionStatus?.phase !== "complete"
+  ) {
     clearTimer(host.compactionClearTimer);
     host.compactionClearTimer = null;
     host.compactionStatus = null;

--- a/ui/src/pages/chat/tool-stream-contract.ts
+++ b/ui/src/pages/chat/tool-stream-contract.ts
@@ -42,6 +42,7 @@ export type RunOutputUsage = { outputTokens: number; seq: number };
 export type CompactionStatus = {
   phase: "active" | "retrying" | "complete";
   runId: string | null;
+  itemId?: string;
   startedAt: number | null;
   completedAt: number | null;
 };

--- a/ui/src/pages/chat/tool-stream-fallback.node.test.ts
+++ b/ui/src/pages/chat/tool-stream-fallback.node.test.ts
@@ -649,6 +649,55 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.fallbackStatus).toBeNull();
   });
 
+  it.each([
+    { phase: "start" },
+    { phase: "end", completed: true },
+    { phase: "end", completed: false },
+    { phase: "end", completed: true, willRetry: true },
+  ])("keeps newer compaction active after stale $phase event %j", (staleData) => {
+    useToolStreamFakeTimers();
+    const host = createHost();
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "compaction", { phase: "start", itemId: "compact-1" }),
+    );
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 3, "compaction", { phase: "start", itemId: "compact-2" }),
+    );
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 2, "compaction", { ...staleData, itemId: "compact-1" }),
+    );
+    expect(host.compactionStatus).toMatchObject({ phase: "active", itemId: "compact-2" });
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 4, "compaction", {
+        phase: "end",
+        completed: true,
+        itemId: "compact-2",
+      }),
+    );
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 3, "compaction", { phase: "start", itemId: "compact-2" }),
+    );
+    expectCompactionCompleteAndRetained(host, "compact-2");
+
+    handleAgentEvent(
+      host,
+      agentEvent("run-2", 1, "compaction", { phase: "start", itemId: "compact-3" }),
+    );
+    expect(host.compactionStatus).toMatchObject({
+      phase: "active",
+      runId: "run-2",
+      itemId: "compact-3",
+    });
+    vi.advanceTimersByTime(5 * 60_000);
+    expect(host.compactionStatus).toBeNull();
+  });
+
   it("keeps compaction in retry-pending state until the matching lifecycle end", () => {
     useToolStreamFakeTimers();
     const host = createHost();
@@ -685,6 +734,7 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     expect(host.compactionClearTimer).not.toBeNull();
 
     handleAgentEvent(host, agentEvent("run-2", 3, "lifecycle", { phase: "end" }));
+    handleAgentEvent(host, agentEvent("run-1", 1, "lifecycle", { phase: "end" }));
 
     expect(host.compactionStatus).toEqual({
       itemId: "compact-1",

--- a/ui/src/pages/chat/tool-stream-fallback.node.test.ts
+++ b/ui/src/pages/chat/tool-stream-fallback.node.test.ts
@@ -16,24 +16,17 @@ import {
 } from "./tool-stream.test-helpers.ts";
 import { handleAgentEvent } from "./tool-stream.ts";
 
-function expectCompactionCompleteAndAutoClears(host: ReturnType<typeof createHost>) {
+function expectCompactionCompleteAndRetained(host: ReturnType<typeof createHost>, itemId?: string) {
   expect(host.compactionStatus).toEqual({
+    ...(itemId ? { itemId } : {}),
     phase: "complete",
     runId: "run-1",
     startedAt: TOOL_STREAM_TEST_NOW,
     completedAt: TOOL_STREAM_TEST_NOW,
   });
-  const clearTimer = host.compactionClearTimer as unknown as {
-    hasRef?: unknown;
-    ref?: unknown;
-    unref?: unknown;
-  };
-  expect(typeof clearTimer.hasRef).toBe("function");
-  expect(typeof clearTimer.ref).toBe("function");
-  expect(typeof clearTimer.unref).toBe("function");
-
+  const status = host.compactionStatus;
   vi.advanceTimersByTime(5_000);
-  expect(host.compactionStatus).toBeNull();
+  expect(host.compactionStatus).toBe(status);
   expect(host.compactionClearTimer).toBeNull();
 }
 
@@ -660,9 +653,13 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     useToolStreamFakeTimers();
     const host = createHost();
 
-    handleAgentEvent(host, agentEvent("run-1", 1, "compaction", { phase: "start" }));
+    handleAgentEvent(
+      host,
+      agentEvent("run-1", 1, "compaction", { phase: "start", itemId: "compact-1" }),
+    );
 
     expect(host.compactionStatus).toEqual({
+      itemId: "compact-1",
       phase: "active",
       runId: "run-1",
       startedAt: TOOL_STREAM_TEST_NOW,
@@ -679,6 +676,7 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     );
 
     expect(host.compactionStatus).toEqual({
+      itemId: "compact-1",
       phase: "retrying",
       runId: "run-1",
       startedAt: TOOL_STREAM_TEST_NOW,
@@ -689,6 +687,7 @@ describe("app-tool-stream fallback lifecycle handling", () => {
     handleAgentEvent(host, agentEvent("run-2", 3, "lifecycle", { phase: "end" }));
 
     expect(host.compactionStatus).toEqual({
+      itemId: "compact-1",
       phase: "retrying",
       runId: "run-1",
       startedAt: TOOL_STREAM_TEST_NOW,
@@ -697,7 +696,7 @@ describe("app-tool-stream fallback lifecycle handling", () => {
 
     handleAgentEvent(host, agentEvent("run-1", 4, "lifecycle", { phase: "end" }));
 
-    expectCompactionCompleteAndAutoClears(host);
+    expectCompactionCompleteAndRetained(host, "compact-1");
 
     vi.useRealTimers();
   });
@@ -927,7 +926,7 @@ describe("app-tool-stream fallback lifecycle handling", () => {
 
     handleAgentEvent(host, agentEvent("run-1", 3, "lifecycle", { phase: "error", error: "boom" }));
 
-    expectCompactionCompleteAndAutoClears(host);
+    expectCompactionCompleteAndRetained(host);
 
     vi.useRealTimers();
   });

--- a/ui/src/pages/chat/tool-stream-status.ts
+++ b/ui/src/pages/chat/tool-stream-status.ts
@@ -163,7 +163,6 @@ export function reconcileWaitingApprovalsFromSnapshot(
   return changed;
 }
 
-const COMPACTION_TOAST_DURATION_MS = 5000;
 const COMPACTION_ACTIVE_STALE_TIMEOUT_MS = 5 * 60_000;
 const FALLBACK_TOAST_DURATION_MS = 8000;
 
@@ -176,7 +175,7 @@ function clearCompactionTimer(host: ToolStreamHost) {
 
 function scheduleCompactionClear(
   host: ToolStreamHost,
-  delayMs = COMPACTION_TOAST_DURATION_MS,
+  delayMs: number,
   expected?: { phase?: CompactionStatus["phase"]; runId?: string | null },
 ) {
   host.compactionClearTimer = window.setTimeout(() => {
@@ -197,22 +196,24 @@ function setCompactionStatus(
   host: ToolStreamHost,
   runId: string,
   phase: CompactionStatus["phase"],
+  itemId?: string,
 ) {
   const completed = phase === "complete";
+  const previous = host.compactionStatus;
+  const sameOperation =
+    previous?.runId === runId && (!itemId || !previous.itemId || previous.itemId === itemId);
+  const currentItemId = itemId ?? (sameOperation ? previous?.itemId : undefined);
+  clearCompactionTimer(host);
   host.compactionStatus = {
     phase,
     runId,
-    startedAt:
-      phase === "active"
-        ? Date.now()
-        : (host.compactionStatus?.startedAt ?? (completed ? null : Date.now())),
+    ...(currentItemId ? { itemId: currentItemId } : {}),
+    startedAt: sameOperation ? previous.startedAt : Date.now(),
     completedAt: completed ? Date.now() : null,
   };
-  scheduleCompactionClear(
-    host,
-    completed ? COMPACTION_TOAST_DURATION_MS : COMPACTION_ACTIVE_STALE_TIMEOUT_MS,
-    { phase, runId },
-  );
+  if (!completed) {
+    scheduleCompactionClear(host, COMPACTION_ACTIVE_STALE_TIMEOUT_MS, { phase, runId });
+  }
 }
 
 export function handleSessionOperationEvent(
@@ -254,22 +255,23 @@ function handleCompactionEvent(host: ToolStreamHost, payload: AgentEventPayload)
   const data = payload.data ?? {};
   const phase = typeof data.phase === "string" ? data.phase : "";
   const completed = data.completed === true;
+  const itemId = toTrimmedString(data.itemId) ?? undefined;
 
   clearCompactionTimer(host);
 
   if (phase === "start") {
-    setCompactionStatus(host, payload.runId, "active");
+    setCompactionStatus(host, payload.runId, "active", itemId);
     return;
   }
   if (phase === "end") {
     if (data.willRetry === true && completed) {
       // Compaction already succeeded, but the run is still retrying.
       // Keep that distinct state until the matching lifecycle end arrives.
-      setCompactionStatus(host, payload.runId, "retrying");
+      setCompactionStatus(host, payload.runId, "retrying", itemId);
       return;
     }
     if (completed) {
-      setCompactionStatus(host, payload.runId, "complete");
+      setCompactionStatus(host, payload.runId, "complete", itemId);
       return;
     }
     host.compactionStatus = null;

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -273,12 +273,21 @@ function acceptActivityEvent(host: ToolStreamHost, payload: AgentEventPayload): 
     }
     return true;
   }
-  if (payload.stream !== "item" || payload.data?.kind !== "preamble") {
+  let identity: string;
+  const terminalLifecycle =
+    payload.stream === "lifecycle" &&
+    (payload.data?.phase === "end" || payload.data?.phase === "error");
+  if (payload.stream === "compaction" || terminalLifecycle) {
+    // One visible compaction per run: older items and retry completions must
+    // not replace a newer operation restored or received on the live stream.
+    identity = `compaction:${payload.runId}`;
+  } else if (payload.stream === "item" && payload.data?.kind === "preamble") {
+    const itemId =
+      toTrimmedString(payload.data.itemId) ?? toTrimmedString(payload.data.id) ?? "latest";
+    identity = `preamble:${payload.runId}:${itemId}`;
+  } else {
     return true;
   }
-  const itemId =
-    toTrimmedString(payload.data.itemId) ?? toTrimmedString(payload.data.id) ?? "latest";
-  const identity = `preamble:${payload.runId}:${itemId}`;
   const previous = host.activityEventSeqById?.get(identity);
   if (previous !== undefined && seq <= previous) {
     return false;
@@ -455,7 +464,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return false;
   }
   // History can replay an older active-run snapshot after newer live activity.
-  // Fence each tool/preamble identity by Gateway sequence so restore fills gaps
+  // Fence activity by Gateway sequence so restore fills gaps
   // without regressing a result or newer progress already rendered by this pane.
   if (!acceptActivityEvent(host, payload)) {
     return false;

--- a/ui/src/styles/chat/composer-status.css
+++ b/ui/src/styles/chat/composer-status.css
@@ -28,21 +28,19 @@
   flex-shrink: 0;
 }
 
-.compaction-indicator:is(.compaction-indicator--active, .compaction-indicator--complete) {
-  gap: 10px;
-  max-width: 100%;
-  min-width: 0;
-  padding: 6px 12px;
-  border: 0;
-  border-radius: var(--radius-md);
-  background: var(--bg);
-  box-shadow: 0 0 12px 8px var(--bg);
-  color: var(--muted);
-  white-space: normal;
-  animation: none;
+.chat-compaction {
+  margin: var(--space-5) 8px;
 }
 
-.compaction-indicator__glyph {
+.chat-compaction .chat-divider__label {
+  gap: 10px;
+  font-weight: 400;
+  font-size: 13px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.chat-compaction__glyph {
   position: relative;
   flex: 0 0 28px;
   width: 28px;
@@ -50,7 +48,7 @@
   color: var(--accent);
 }
 
-.compaction-indicator__line {
+.chat-compaction__line {
   position: absolute;
   left: 1px;
   height: 2px;
@@ -60,7 +58,7 @@
   transform: translate(3px, var(--fold-y)) scaleX(var(--fold-scale));
 }
 
-.compaction-indicator__line:nth-child(1) {
+.chat-compaction__line:nth-child(1) {
   top: 3px;
   width: 26px;
   --fold-y: 6px;
@@ -68,7 +66,7 @@
   --fold-opacity: 0.85;
 }
 
-.compaction-indicator__line:nth-child(2) {
+.chat-compaction__line:nth-child(2) {
   top: 8px;
   width: 20px;
   --fold-y: 1px;
@@ -76,7 +74,7 @@
   --fold-opacity: 0;
 }
 
-.compaction-indicator__line:nth-child(3) {
+.chat-compaction__line:nth-child(3) {
   top: 13px;
   width: 24px;
   --fold-y: 0px;
@@ -84,7 +82,7 @@
   --fold-opacity: 1;
 }
 
-.compaction-indicator__line:nth-child(4) {
+.chat-compaction__line:nth-child(4) {
   top: 18px;
   width: 16px;
   --fold-y: -1px;
@@ -92,7 +90,7 @@
   --fold-opacity: 0;
 }
 
-.compaction-indicator__line:nth-child(5) {
+.chat-compaction__line:nth-child(5) {
   top: 23px;
   width: 22px;
   --fold-y: -6px;
@@ -100,31 +98,34 @@
   --fold-opacity: 0.85;
 }
 
-.compaction-indicator__glyph svg {
+.chat-compaction__glyph svg {
   position: absolute;
   inset: 4px;
   width: 20px;
   height: 20px;
-  color: var(--ok);
+  color: var(--muted);
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
   opacity: 0;
   transform: scale(0.75);
 }
 
-.compaction-indicator--complete .compaction-indicator__line {
+.chat-compaction--complete .chat-compaction__line {
   visibility: hidden;
 }
 
-.compaction-indicator--complete .compaction-indicator__glyph svg {
+.chat-compaction--complete .chat-compaction__glyph svg {
   opacity: 1;
   transform: scale(1);
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .compaction-indicator--active .compaction-indicator__line {
+  .chat-compaction--active .chat-compaction__line {
     animation: compaction-fold 3.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
   }
 
-  .compaction-indicator__glyph svg {
+  .chat-compaction__glyph svg {
     transition:
       opacity 0.25s,
       transform 0.25s;
@@ -132,7 +133,7 @@
 }
 
 @media (prefers-reduced-motion: no-preference) and (forced-colors: none) {
-  .compaction-indicator--active .compaction-indicator__label {
+  .chat-compaction--active .chat-divider__title {
     background: linear-gradient(105deg, var(--muted) 35%, var(--text) 48%, var(--muted) 61%);
     background-size: 260% 100%;
     background-clip: text;

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -158,6 +158,20 @@ export function createUiBrowserVitestConfig(env = process.env): ViteUserConfig {
   return defineProject({
     root: here,
     plugins: [controlUiLocaleModulesPlugin()],
+    optimizeDeps: {
+      include: [
+        "@openclaw/uirouter",
+        "dompurify",
+        "highlight.js/lib/core",
+        "highlight.js/lib/languages/{bash,cpp,css,diff,java,javascript,json,markdown,python,rust,typescript,xml,yaml}",
+        "lit/async-directive.js",
+        "lit/directive.js",
+        "lit/directives/unsafe-html.js",
+        "markdown-it",
+        "markdown-it-task-lists",
+        "remend",
+      ],
+    },
     resolve: {
       alias: workspaceSourceAliases,
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users compacting a conversation see both a transient composer status and a separate “Context compacted” transcript message. The approved follow-up is one inline transcript element: animate while compacting, settle into a compacted marker, and retain that marker after history refresh or reload.

Related: #135988 — the original folding-line compaction animation. This is the maintainer-requested presentation and lifecycle follow-up, not a change to compaction policy.

## Why This Change Was Made

The composer toast, slash-command success response, and persisted runtime activity had independent presentation paths. The transient row also lacked a stable identity connecting it to the stored boundary. Compaction producers now carry the same operation/item identity through lifecycle events and persistence; the shared transcript projection adopts the persisted boundary without replacing the live row. Rewriting old transcript boundaries preserves their recorded identity, including an unknown historical run.

Removed paths: compaction toast rendering and five-second completion clearing, successful `/compact` assistant text, and native compaction activity conversion into an assistant message. Cancellation, no-op and failure outcomes remain explicit. No settings, database schema version, model/provider routing, or compaction-policy changes.

## User Impact

- Chat and Home show the folding lines and soft shimmer inline, then retain the same row as a compacted marker.
- History refresh and reload do not add another completion message; later compactions retain their own distinct markers.
- Reduced-motion and forced-color treatments remain supported. Embedded compaction markers keep their checkpoint action.

## Evidence

### Behavior and regression coverage

https://github.com/user-attachments/assets/48e24470-273d-4dfc-8ff7-da3d63a80bd2

Before is **left**, after is **right**. Real isolated gateway/browser proof exercises `/compact`, observes the same DOM row transition from active to complete, asserts exactly one visible marker and no compaction toast, and reloads to confirm the persisted marker. Both source captures and the comparison's active/completed/reloaded frames were personally inspected. The video trims setup, crops surrounding chrome, preserves playback speed, and holds the final frame to align the two recordings. Baseline UI is `0b9cf4bf187`; both use the same isolated gateway and synthetic observatory notes. The existing generic command queue row is not a compaction toast and disappears when `/compact` finishes.

Focused regression coverage includes manual and automatic compaction identity, cancellation, transcript replay, native activity projection, matching persisted-row adoption, active-leaf refresh, repeated compactions, session/reset boundaries, and browser accessibility/motion. The history-handoff and historical-identity regressions failed before their fixes.

The late ClawSweeper sequence-order finding and both Rank-up moves are addressed: compaction and terminal lifecycle events reuse the existing per-run Gateway sequence fence. Delayed start/success/cancel/retry events cannot replace a newer active item, and stale lifecycle completion cannot finish a newer retry. Five regression cases failed before this correction; the corrected lifecycle/transcript suites pass 207 tests across six files. Different runs still accept their own sequence numbering. No extra state or cleanup path was added. The attached nominal-flow recording predates this ordering-only correction; the correction is proven at the real event-handler boundary in the reported order and does not change the visual treatment.

Dependency contract inspected directly: sibling Codex `codex-rs/core/src/compact.rs:252` creates one compaction item for start; `compact.rs:379` persists compacted history before completing that same item at `compact.rs:392`. OpenClaw preserves this identity rather than inferring completion from timing.

### Validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/transcript-rewrite.test.ts src/agents/sessions/agent-session-compaction-correlation.test.ts src/agents/sessions/agent-session-compaction.test.ts ui/src/pages/chat/history-merge.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts` — 87 tests passed across five files.
- Browser compaction/motion suite — 4 tests passed; broader UI and producer/projection suites were also run during development.
- After rebasing, `node scripts/run-vitest.mjs ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/pages/chat/history-merge.test.ts` — 297 tests passed across three files, including the upstream reasoning-grouping changes.
- `pnpm ui:build` and `node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime` passed, including UI budgets and runtime bundle/import guards.
- Fresh post-rebase independent autoreview completed scoped-clean. Changed-file guards, core/UI/plugin and test typechecks, and dead-export scans passed. The combined check caught one metadata-access lint error; it was corrected, then the full core lint shard and all remaining selected style/plugin/schema/import/security gates passed. Exact-head CI is recorded in the pre-merge verification comment.
- After the sequence-order correction: focused lifecycle/transcript tests (207), fresh UI build and independent autoreview passed; final changed-file checks and exact-head CI are tracked in the verification comment.

### Scope and known proof limitation

Production delta: +263 / -163, net +100 lines. This adds the missing operation-to-persisted-marker identity boundary and persistent inline presentation while removing competing toast/message paths. The late sequence fix contributes net +9 by extending the existing fence instead of adding state. Tests/support: +477 / -262, net +215. Assertion baseline: -1, recording a removed assertion. No proof assets are committed.

The existing native active-writer conflict reproduced in both baseline and candidate immediately after creating a fresh session. It is separately tracked by #135441 — native compaction writer coordination. Successful capture uses the existing synthetic session after restarting only the isolated test gateway; the operator gateway and live state are untouched.
