### PR TITLE
fix(daemon): keep doctor --fix reachable on non-English Windows locales

### DIFF
--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -31,6 +31,11 @@ import {
   terminateGatewayProcessTree,
 } from "./schtasks-process.js";
 import {
+  isScheduledTaskDefinitelyNotRunning,
+  probeScheduledTaskExists,
+  probeScheduledTaskState,
+} from "./schtasks-task-state.js";
+import {
   createServiceRuntimeInspectionFailure,
   type GatewayServiceRuntime,
 } from "./service-runtime.js";
@@ -42,12 +47,13 @@ import type {
 } from "./service-types.js";
 import { WINDOWS_TASK_SUPERVISOR_FLAG } from "./windows-task-supervisor-contract.js";
 
+export { isScheduledTaskDefinitelyNotRunning, probeScheduledTaskExists };
+
 type ScheduledTaskInfo = {
   status?: string;
   lastRunTime?: string;
   lastRunResult?: string;
 };
-
 function parseSchtasksQuery(output: string): ScheduledTaskInfo {
   const entries = parseKeyValueOutput(output, ":");
   const info: ScheduledTaskInfo = {};
@@ -373,60 +379,6 @@ export async function resolveFallbackRuntime(
   };
 }
 
-type ScheduledTaskStateProbe =
-  | { status: "found"; state: number | null }
-  | { status: "missing" }
-  | { status: "unknown" };
-
-function probeScheduledTaskState(taskName: string): ScheduledTaskStateProbe {
-  const encodedTaskName = Buffer.from(taskName, "utf8").toString("base64");
-  const script = [
-    "$ErrorActionPreference='Stop'",
-    `$taskName=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedTaskName}'))`,
-    "try { $service=New-Object -ComObject 'Schedule.Service'; $service.Connect(); $task=$service.GetFolder('\\').GetTask($taskName); [Console]::Out.Write([int]$task.State); exit 0 } catch { $exception=$_.Exception; while($null -ne $exception.InnerException){$exception=$exception.InnerException}; [Console]::Out.Write($exception.HResult); exit 1 }",
-  ].join("; ");
-  const probe = spawnSync(
-    getWindowsPowerShellExePath(),
-    [
-      "-NoProfile",
-      "-NonInteractive",
-      "-EncodedCommand",
-      Buffer.from(script, "utf16le").toString("base64"),
-    ],
-    { encoding: "utf8", timeout: 5_000, windowsHide: true },
-  );
-  if (probe.error) {
-    return { status: "unknown" };
-  }
-  if (probe.status === 0) {
-    const rawState = probe.stdout.trim();
-    const state = /^\d+$/.test(rawState) ? Number.parseInt(rawState, 10) : null;
-    return {
-      status: "found",
-      state,
-    };
-  }
-  const hresult = Number.parseInt(probe.stdout.trim(), 10);
-  // Only the locale-independent missing task/folder HRESULT values prove absence.
-  return hresult === -2147024894 || hresult === -2147024893
-    ? { status: "missing" }
-    : { status: "unknown" };
-}
-
-export function probeScheduledTaskExists(taskName: string): boolean | null {
-  const probe = probeScheduledTaskState(taskName);
-  return probe.status === "found" ? true : probe.status === "missing" ? false : null;
-}
-
-export function isScheduledTaskDefinitelyNotRunning(taskName: string): boolean {
-  const probe = probeScheduledTaskState(taskName);
-  if (probe.status !== "found") {
-    return false;
-  }
-  // TASK_STATE_DISABLED and TASK_STATE_READY both prove no instance is queued or running.
-  return probe.state === 1 || probe.state === 3;
-}
-
 export async function readWindowsStartupFallbackRuntimeForUpdate(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceRuntime | null> {
@@ -574,6 +526,22 @@ export async function readScheduledTaskRuntime(
       };
     }
   }
+  // `schtasks /FO LIST` labels are localized and encoding-fragile under UAC
+  // elevation, so an unclassified runtime falls back to the Task Scheduler's
+  // numeric state, which is locale- and encoding-independent (#136123).
+  const numericDerived =
+    derived.status === "unknown"
+      ? deriveScheduledTaskRuntimeStatusFromNumericState(probeScheduledTaskState(taskName))
+      : null;
+  if (numericDerived) {
+    return {
+      status: numericDerived.status,
+      state: parsed.status,
+      lastRunTime: parsed.lastRunTime,
+      lastRunResult: parsed.lastRunResult,
+      ...(numericDerived.detail ? { detail: numericDerived.detail } : {}),
+    };
+  }
   return {
     status: derived.status,
     state: parsed.status,
@@ -581,4 +549,29 @@ export async function readScheduledTaskRuntime(
     lastRunResult: parsed.lastRunResult,
     ...(derived.detail ? { detail: derived.detail } : {}),
   };
+}
+
+function deriveScheduledTaskRuntimeStatusFromNumericState(
+  probe: ReturnType<typeof probeScheduledTaskState>,
+): { status: GatewayServiceRuntime["status"]; detail?: string } | null {
+  if (probe.status !== "found" || probe.state === null) {
+    // Failed inspection must not be treated as stopped.
+    return null;
+  }
+  // TASK_STATE_RUNNING
+  if (probe.state === 4) {
+    return {
+      status: "running",
+      detail: "Task Scheduler numeric state=4 (running); locale-independent probe.",
+    };
+  }
+  // TASK_STATE_DISABLED and TASK_STATE_READY prove no instance is queued or running.
+  if (probe.state === 1 || probe.state === 3) {
+    return {
+      status: "stopped",
+      detail: `Task Scheduler numeric state=${probe.state}; locale-independent probe found no queued or running instance.`,
+    };
+  }
+  // TASK_STATE_UNKNOWN and TASK_STATE_QUEUED cannot establish a safe stop.
+  return null;
 }

--- a/src/daemon/schtasks-task-state.ts
+++ b/src/daemon/schtasks-task-state.ts
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import { getWindowsPowerShellExePath } from "../infra/windows-install-roots.js";
+
+export type ScheduledTaskStateProbe =
+  | { status: "found"; state: number | null }
+  | { status: "missing" }
+  | { status: "unknown" };
+
+/**
+ * Reads the task's numeric state from the Task Scheduler COM object.
+ *
+ * The COM `State` value is locale- and encoding-independent, unlike
+ * `schtasks /FO LIST` field labels which are localized (#136123).
+ */
+export function probeScheduledTaskState(taskName: string): ScheduledTaskStateProbe {
+  const encodedTaskName = Buffer.from(taskName, "utf8").toString("base64");
+  const script = [
+    "$ErrorActionPreference='Stop'",
+    `$taskName=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedTaskName}'))`,
+    "try { $service=New-Object -ComObject 'Schedule.Service'; $service.Connect(); $task=$service.GetFolder('\\').GetTask($taskName); [Console]::Out.Write([int]$task.State); exit 0 } catch { $exception=$_.Exception; while($null -ne $exception.InnerException){$exception=$exception.InnerException}; [Console]::Out.Write($exception.HResult); exit 1 }",
+  ].join("; ");
+  const probe = spawnSync(
+    getWindowsPowerShellExePath(),
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      Buffer.from(script, "utf16le").toString("base64"),
+    ],
+    { encoding: "utf8", timeout: 5_000, windowsHide: true },
+  );
+  if (probe.error) {
+    return { status: "unknown" };
+  }
+  if (probe.status === 0) {
+    const rawState = probe.stdout.trim();
+    const state = /^\d+$/.test(rawState) ? Number.parseInt(rawState, 10) : null;
+    return {
+      status: "found",
+      state,
+    };
+  }
+  const hresult = Number.parseInt(probe.stdout.trim(), 10);
+  // Only the locale-independent missing task/folder HRESULT values prove absence.
+  return hresult === -2147024894 || hresult === -2147024893
+    ? { status: "missing" }
+    : { status: "unknown" };
+}
+
+export function probeScheduledTaskExists(taskName: string): boolean | null {
+  const probe = probeScheduledTaskState(taskName);
+  return probe.status === "found" ? true : probe.status === "missing" ? false : null;
+}
+
+export function isScheduledTaskDefinitelyNotRunning(taskName: string): boolean {
+  const probe = probeScheduledTaskState(taskName);
+  if (probe.status !== "found") {
+    return false;
+  }
+  // TASK_STATE_DISABLED and TASK_STATE_READY both prove no instance is queued or running.
+  return probe.state === 1 || probe.state === 3;
+}

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -13,11 +13,25 @@ import {
 const schtasksResponses = vi.hoisted(
   (): Array<{ code: number; stdout: string; stderr: string }> => [],
 );
+const scheduledTaskStateProbes = vi.hoisted(
+  (): Array<{ status: string; state?: number | null }> => [],
+);
 const resolveWindowsOemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: async () => schtasksResponses.shift() ?? { code: 0, stdout: "", stderr: "" },
 }));
+
+vi.mock("./schtasks-task-state.js", async () => {
+  const actual = await vi.importActual<typeof import("./schtasks-task-state.js")>(
+    "./schtasks-task-state.js",
+  );
+  return {
+    ...actual,
+    probeScheduledTaskState: () =>
+      scheduledTaskStateProbes.shift() ?? { status: "unknown" as const },
+  };
+});
 
 vi.mock("../infra/windows-encoding.js", async () => {
   const actual = await vi.importActual<typeof import("../infra/windows-encoding.js")>(
@@ -32,6 +46,7 @@ vi.mock("../infra/windows-encoding.js", async () => {
 
 beforeEach(() => {
   schtasksResponses.length = 0;
+  scheduledTaskStateProbes.length = 0;
   resolveWindowsOemEncodingMock.mockReset();
   resolveWindowsOemEncodingMock.mockReturnValue(null);
 });
@@ -151,6 +166,62 @@ describe("scheduled task runtime derivation", () => {
     ).resolves.toMatchObject({
       status: "unknown",
       detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
+    });
+  });
+
+  // pt-BR LIST output: field labels are localized, so the English-only key
+  // lookup cannot extract Last Run Result (#136123).
+  function localizedTaskQueryOutput(): string {
+    return [
+      "Nome do Host: DESKTOP-TESTE",
+      "Nome da Tarefa: \\OpenClaw Gateway",
+      "Próxima Execução: 02/09/2026 09:00:00",
+      "Status: Pronto",
+      "Hora da Última Execução: 01/09/2026 22:00:00",
+      "Último Resultado: 0",
+      "",
+    ].join("\r\n");
+  }
+
+  it("classifies stopped via the numeric Task Scheduler state when LIST labels are localized (pt-BR, #136123)", async () => {
+    scheduledTaskStateProbes.push({ status: "found", state: 3 });
+    await expect(readRuntimeFromQueryOutput(localizedTaskQueryOutput())).resolves.toMatchObject({
+      status: "stopped",
+      state: "Pronto",
+      detail:
+        "Task Scheduler numeric state=3; locale-independent probe found no queued or running instance.",
+    });
+  });
+
+  it("classifies running via the numeric Task Scheduler state when LIST labels are localized (pt-BR, #136123)", async () => {
+    scheduledTaskStateProbes.push({ status: "found", state: 4 });
+    await expect(readRuntimeFromQueryOutput(localizedTaskQueryOutput())).resolves.toMatchObject({
+      status: "running",
+      detail: "Task Scheduler numeric state=4 (running); locale-independent probe.",
+    });
+  });
+
+  it("treats a disabled task (numeric state 1) as stopped (#136123)", async () => {
+    scheduledTaskStateProbes.push({ status: "found", state: 1 });
+    await expect(readRuntimeFromQueryOutput(localizedTaskQueryOutput())).resolves.toMatchObject({
+      status: "stopped",
+      detail:
+        "Task Scheduler numeric state=1; locale-independent probe found no queued or running instance.",
+    });
+  });
+
+  it("keeps unknown when the numeric Task Scheduler probe cannot establish state (fail-closed, #136123)", async () => {
+    scheduledTaskStateProbes.push({ status: "unknown" });
+    await expect(readRuntimeFromQueryOutput(localizedTaskQueryOutput())).resolves.toMatchObject({
+      status: "unknown",
+      detail: "Task status is locale-dependent and no numeric Last Run Result was available.",
+    });
+  });
+
+  it("keeps unknown when the numeric Task Scheduler state is queued (2) (#136123)", async () => {
+    scheduledTaskStateProbes.push({ status: "found", state: 2 });
+    await expect(readRuntimeFromQueryOutput(localizedTaskQueryOutput())).resolves.toMatchObject({
+      status: "unknown",
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

- **What problem does this PR solve?** On non-English Windows locales, `openclaw doctor --fix` is permanently blocked for gateway installs that run as a Scheduled Task. `schtasks /Query /V /FO LIST` localizes its field labels (`Last Run Result` → e.g. `Último Resultado` / `上次结果`), so the English-only key lookup in `parseSchtasksQuery` never extracts `lastRunResult`, and `readScheduledTaskRuntime` degrades to `status: "unknown"`. Under UAC elevation the situation is worse because `schtasks` also emits OEM-codepage bytes.
- **Why does this matter now?** The managed-service maintenance gate (`inspectManagedGatewayServiceBeforeUpdate`) only accepts `running` or `stopped` runtime statuses, so Doctor can never enter maintenance — a hard deadlock: the gateway cannot start until `doctor --fix` migrates the legacy workspace, and `doctor --fix` refuses to run until it can verify the already-stopped service is stopped (issue #136123).
- **What is the intended outcome?** A stopped Scheduled Task on any Windows locale is classified `stopped` via the locale-independent numeric Task Scheduler state, letting the maintenance gate proceed and `doctor --fix` complete.
- **What is intentionally out of scope?** No changes to English-locale classification, listener-backed running detection, startup-fallback paths, or the fail-closed safety behavior for inconclusive probes.
- **What does success look like?** `readScheduledTaskRuntime` returns `stopped` for a real Ready/Disabled task whose localized LIST output cannot be parsed, and keeps `unknown` only when the numeric probe itself cannot establish state.
- **What should reviewers focus on?** `src/daemon/schtasks-runtime.ts` (numeric fallback insertion after the listener-backed probe) and `src/daemon/schtasks-task-state.ts` (extracted COM probe; reuse of the state mapping already trusted by `isScheduledTaskDefinitelyNotRunning`).

## Linked context

- **Which issue does this close?** Closes #136123
- **Related issues or PRs:** None — freshness gate confirmed no competing open PR and no merged fix on origin/main at push time.
- **Was this requested by a maintainer or labeled with a fix signal?** Issue #136123 carries `clawsweeper:source-repro`, `clawsweeper:fix-shape-clear`, `clawsweeper:queueable-fix`, and `impact:ux-release-blocker`; the issue itself is a P0 user-facing release blocker.

## Evidence

- **Behavior or issue addressed:** Non-English Windows locales cannot run `openclaw doctor --fix` because a stopped Scheduled Task reads back as `unknown` (localized LIST labels defeat the English-only parser), which the maintenance gate rejects.

- **Real environment tested:** Yes — a real native Windows host: `WIN-MDN8MTKGLPT`, Windows NT 10.0.17763 (Windows Server 2019), **zh-CN UI locale** (non-English, same localization-failure class as pt-BR; raw `schtasks` LIST output confirmed localized Chinese/GBK on this host). Real Scheduled Task created via `schtasks /Create` under an interactive user session; real task execution verified (`/Run` → result 0). The repository's own `readScheduledTaskRuntime` was invoked against the real Task Scheduler COM object — no mocks, no stubs.

- **Exact steps or command run after this patch:**
  ```bash
  # 1) Create a real stopped (Ready) Scheduled Task on the zh-CN host
  schtasks /Create /TN "OpenClaw Gateway (locale-proof-136170)" \
    /TR "D:\\...\\gateway-launcher.cmd" /SC ONCE /ST 23:59 /RU <user> /F
  # -> 成功: 成功创建计划任务; 模式: 就绪; 上次结果: 267011 (never run)

  # 2) RED on origin/main (pre-fix) — real host, real task
  node --import ./scripts/tsx.mjs ../../openclaw-evidence/pr-136170/native-proof/step2.mts
  # -> {"status":"unknown"}          # bug reproduced: maintenance gate rejects

  # 3) GREEN on PR head 30d6044d — same host, same real task
  node --import ./scripts/tsx.mjs ../../openclaw-evidence/pr-136170/native-proof/step2.mts
  # -> {"status":"stopped","detail":"Task Scheduler numeric state=3; locale-independent
  #     probe found no queued or running instance."}
  ```

- **Evidence after fix:** On the real zh-CN Windows host with the real Ready Scheduled Task, `readScheduledTaskRuntime` at PR head returns:
  ```json
  {"status":"stopped","detail":"Task Scheduler numeric state=3; locale-independent probe found no queued or running instance."}
  ```
  The maintenance gate (`update-command-service-maintenance.ts`, rejects anything other than `running`/`stopped`) therefore accepts the state and Doctor can proceed. Unit-level RED→GREEN on the same logic: `src/daemon/schtasks.test.ts` — 3 new pt-BR-localized cases fail on main (`unknown`) and pass on PR head; 37/37 green including fail-closed cases (probe unknown/queued stay `unknown`). Related suites green: `update-command-service-maintenance.test.ts` + `doctor-health.update.test.ts` 13/13, `doctor-health.test.ts` 76/76.

- **Observed result after fix:** A stopped task that previously read as `unknown` (blocking the maintenance gate) now reads `stopped` from the numeric COM state on a real non-English Windows host; English-locale behavior is unchanged (LIST classification still matches first), and fail-closed `unknown` is preserved when the native probe cannot establish state.

- **What was not tested:** the exact pt-BR byte sequences (host locale is zh-CN — same localized-label failure class, verified by raw output), UAC-elevated OEM-codepage output (process was not elevated), and a full `openclaw doctor --fix` end-to-end run against a real gateway install. The repo's whole `test:windows:schtasks:integration` lifecycle lane could not complete on this host: its startup-fallback harness step timed out spawning a detached `tsx` process (environment limitation, unrelated to this change); the focused real-task runtime read above exercises the exact code path the maintenance gate consumes.

- **Before evidence (optional but encouraged):** Pre-fix on the same real host/task, `readScheduledTaskRuntime` (origin/main) returned `{"status":"unknown"}` — the maintenance gate's rejection branch, i.e. the #136123 deadlock, reproduced against a real Scheduled Task on a real non-English Windows host.

## Tests and validation

- **Which commands did you run?**
  - `node --import ./scripts/tsx.mjs .../step2.mts` against the real task at origin/main → `{"status":"unknown"}` (RED)
  - Same command at PR head `30d6044d` → `{"status":"stopped", ...numeric state=3...}` (GREEN)
  - `node scripts/run-vitest.mjs run src/daemon/schtasks.test.ts` → 37/37
  - `node scripts/run-vitest.mjs run src/cli/update-cli/update-command-service-maintenance.test.ts src/flows/doctor-health.update.test.ts` → 13/13
  - `node scripts/run-vitest.mjs run src/flows/doctor-health.test.ts` → 76/76
  - `skills/fix-pr/scripts/validate.sh` on the three changed files (oxfmt, oxlint, same-directory tests, `tsgo:core`) — green
- **What regression coverage was added or updated?** `schtasks.test.ts` — pt-BR localized LIST output with numeric COM state 3/4/1 expects `stopped`/`running`/`stopped`; fail-closed cases (probe unknown, queued state 2) keep `unknown`.
- **What failed before this fix, if known?** On main, localized (pt-BR) LIST output produced permanent `unknown` (`Task status is locale-dependent and no numeric Last Run Result was available.`); the 3 new unit cases failed and the real zh-CN host returned `{"status":"unknown"}`.
- **If no test was added, why not?** N/A — regression test added; native proof additionally supplied on a real non-English Windows host.

## Risk checklist

- **Did user-visible behavior change?** Yes for non-English Windows users whose Gateway runs as a Scheduled Task: `doctor --fix` maintenance is no longer permanently blocked when the stopped task's numeric state can establish it is stopped.
- **Did config, environment, or migration behavior change?** No.
- **Did security, auth, secrets, network, or tool execution behavior change?** No — the added path reuses the existing PowerShell COM probe seam (`probeScheduledTaskState`) already trusted on main; no new privileges or execution scopes.
- **What is the highest-risk area?** Misclassifying a genuinely ambiguous probe as `stopped` would let Doctor enter maintenance when it should not.
- **How is that risk mitigated?** Fail-closed mapping: only `TASK_STATE_DISABLED` (1) and `TASK_STATE_READY` (3) yield `stopped` — both prove no queued/running instance; `UNKNOWN` (0), `QUEUED` (2), probe failure, and missing task keep `unknown` (or the existing missing-unit path). This reuses the mapping already used by `isScheduledTaskDefinitelyNotRunning` on main.

## Current review state

- **What is the next action?** Maintainer / ClawSweeper re-review with the newly added real-Windows evidence.
- **What is still waiting on author, maintainer, CI, or external proof?** Native pt-BR/UAC-elevated end-to-end proof remains environment-limited; CI verdicts were green at last check.
- **Which bot or reviewer comments were addressed?** ClawSweeper P1 "needs real behavior proof" — addressed by the native zh-CN Windows RED→GREEN evidence above (same localization-failure class as the requested pt-BR proof).
