### PR TITLE
fix(codex): honor user timezone in temporal context

### DIFF
--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -160,6 +160,20 @@ all of them before dispatch. Implicit selection uses OpenClaw if no plugin can
 own the full set; an explicit or persisted plugin selection fails closed unless
 the plugin declares the lossless OpenClaw fallback.
 
+### Per-turn temporal context
+
+Native harnesses that own their model prompt can use `buildTemporalContextText`
+from `openclaw/plugin-sdk/agent-harness-runtime`. It renders the same current
+local date and time zone as the built-in OpenClaw runtime. It uses
+`agents.defaults.userTimezone` when configured and the host zone otherwise.
+
+Call it for each turn, after the final tool surface is known. Pass
+`sessionStatusAvailable: true` only when that exact surface includes
+`session_status`; this keeps the exact-time hint out of prompts where the tool
+is unavailable. Carry the result through the native runtime's existing
+per-turn application or developer context instead of appending it to stable
+thread instructions.
+
 ## Register a harness
 
 **Import:** `openclaw/plugin-sdk/agent-harness`

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -32,7 +32,7 @@ export async function prepareCodexAttemptTurnRequest(
   const { runtime, attemptTools, hookContextWindowFields, workspaceBootstrapContext } = context;
   const { connection, runtimeParams, effectiveRuntimeProviderId, effectiveRuntimeModelId } =
     runtime;
-  const { tools } = attemptTools;
+  const { tools, toolBridge } = attemptTools;
   const {
     params,
     usesSupervisionConnection,
@@ -123,6 +123,9 @@ export async function prepareCodexAttemptTurnRequest(
       skillsCollaborationInstructions: context.skillsCollaborationInstructions,
       memoryCollaborationInstructions: workspaceBootstrapContext.memoryCollaborationInstructions,
       preserveNativeTurnSettings: usesSupervisionConnection,
+      sessionStatusAvailable: toolBridge.availableTools.some(
+        (tool) => tool.name === "session_status",
+      ),
     });
     codexModelCallDiagnostics.setRequestPayloadBytes(utf8JsonByteLength(turnStartParams));
     state.latestStartupErrorNotification = undefined;

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -620,11 +620,35 @@ describe("runCodexAppServerSideQuestion", () => {
   });
 
   it("forks an ephemeral side thread and returns the completed assistant text", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-02T00:30:00.000Z"));
     const client = createFakeClient();
     getSharedCodexAppServerClientMock.mockResolvedValue(client);
+    createOpenClawCodingToolsMock.mockReturnValue([
+      {
+        name: "wiki_status",
+        description: "Check wiki status",
+        parameters: { type: "object", properties: {}, additionalProperties: true },
+        execute: toolExecuteMock,
+      },
+      {
+        name: "web_search",
+        description: "Search the web",
+        parameters: { type: "object", properties: {}, additionalProperties: true },
+        execute: toolExecuteMock,
+      },
+      {
+        name: "session_status",
+        description: "Show session status",
+        parameters: { type: "object", properties: {}, additionalProperties: false },
+        execute: toolExecuteMock,
+      },
+    ]);
 
     const result = await runCodexAppServerSideQuestion(
       sideParams({
+        cfg: {
+          agents: { defaults: { userTimezone: "America/Los_Angeles" } },
+        } as never,
         messageChannel: "discord",
         messageProvider: "discord-voice",
         chatId: "discord-native-room",
@@ -737,6 +761,13 @@ describe("runCodexAppServerSideQuestion", () => {
       {
         threadId: "side-thread",
         input: [{ type: "text", text: "What changed?", text_elements: [] }],
+        additionalContext: {
+          openclaw_temporal_context: {
+            kind: "application",
+            value:
+              "## Temporal Context\nCurrent date: 2026-09-01\nTime zone: America/Los_Angeles\nFor the exact current time, use `session_status`.",
+          },
+        },
         cwd: "/tmp/workspace",
         model: "codex-side-execution-model",
         personality: "none",

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -151,6 +151,7 @@ import {
   CodexThreadPolicyHandoffError,
   refreshCodexThreadPolicy,
 } from "./thread-policy.js";
+import { buildCodexTemporalAdditionalContext } from "./turn-params.js";
 import { filterCodexVisionTools } from "./vision-tools.js";
 import {
   resolveCodexWebSearchPlan,
@@ -856,6 +857,11 @@ export async function runCodexAppServerSideQuestion(
           {
             threadId: sideThreadId,
             input: [{ type: "text", text: params.question.trim(), text_elements: [] }],
+            additionalContext: buildCodexTemporalAdditionalContext(sideRunParams, {
+              sessionStatusAvailable: toolBridge.availableTools.some(
+                (tool) => tool.name === "session_status",
+              ),
+            }),
             ...(sandboxEnvironment
               ? {
                   cwd: sandboxEnvironment.cwd,

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1780,13 +1780,17 @@ describe("Codex app-server native code mode config", () => {
       expect(request).not.toHaveProperty("effort");
       expect(request).not.toHaveProperty("collaborationMode");
       expect(request).not.toHaveProperty("personality");
-      expect(request.additionalContext).toEqual(
-        notice
+      expect(request.additionalContext).toEqual({
+        openclaw_temporal_context: {
+          kind: "application",
+          value: expect.stringContaining("## Temporal Context"),
+        },
+        ...(notice
           ? {
               openclaw_permission_change: { kind: "application", value: notice },
             }
-          : undefined,
-      );
+          : {}),
+      });
     },
   );
 

--- a/extensions/codex/src/app-server/turn-params.test.ts
+++ b/extensions/codex/src/app-server/turn-params.test.ts
@@ -1,26 +1,34 @@
-import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { describe, expect, it } from "vitest";
-import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createAppServerOptions,
+  createParams,
+  resetThreadLifecycleTestFixtures,
+} from "./thread-lifecycle.test-fixtures.js";
 import { buildTurnStartParams } from "./turn-params.js";
 
-const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
+afterEach(() => {
+  resetThreadLifecycleTestFixtures();
+  vi.restoreAllMocks();
+});
 
 describe("buildTurnStartParams temporal context", () => {
   it("uses the configured user timezone on every turn without changing cron input", () => {
-    const params = {
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "run exactly",
-      trigger: "cron",
-      bootstrapContextMode: "lightweight",
-      bootstrapContextRunKind: "cron",
-      startedAtMs: Date.parse("2026-09-02T00:30:00.000Z"),
-      config: { agents: { defaults: { userTimezone: "America/Los_Angeles" } } },
-    } as EmbeddedRunAttemptParams;
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-02T00:30:00.000Z"));
+    const params = createParams("/tmp/session.jsonl", "/repo", {
+      agents: { defaults: { userTimezone: "America/Los_Angeles" } },
+    });
+    params.provider = "openai";
+    params.modelId = "gpt-5.4";
+    params.prompt = "run exactly";
+    params.trigger = "cron";
+    params.bootstrapContextMode = "lightweight";
+    params.bootstrapContextRunKind = "cron";
+    params.startedAtMs = Date.parse("2026-09-01T00:30:00.000Z");
     const options = {
       threadId: "thread-1",
       cwd: "/repo",
-      appServer,
+      appServer: createAppServerOptions(),
+      sessionStatusAvailable: true,
     };
 
     const firstTurn = buildTurnStartParams(params, options);
@@ -28,17 +36,13 @@ describe("buildTurnStartParams temporal context", () => {
     expect(firstTurn.additionalContext).toEqual({
       openclaw_temporal_context: {
         kind: "application",
-        value: "## Temporal Context\nCurrent date: 2026-09-01\nTime zone: America/Los_Angeles",
+        value:
+          "## Temporal Context\nCurrent date: 2026-09-01\nTime zone: America/Los_Angeles\nFor the exact current time, use `session_status`.",
       },
     });
 
-    const nextTurn = buildTurnStartParams(
-      {
-        ...params,
-        startedAtMs: Date.parse("2026-09-03T00:30:00.000Z"),
-      } as EmbeddedRunAttemptParams,
-      options,
-    );
+    clock.mockReturnValue(Date.parse("2026-09-03T00:30:00.000Z"));
+    const nextTurn = buildTurnStartParams(params, options);
     expect(nextTurn.input).toEqual(firstTurn.input);
     expect(nextTurn.additionalContext?.openclaw_temporal_context?.value).toContain(
       "Current date: 2026-09-02",
@@ -46,37 +50,30 @@ describe("buildTurnStartParams temporal context", () => {
   });
 
   it("emits the host fallback after a timezone override is removed", () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-09-02T00:30:00.000Z"));
     const hostTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone?.trim() || "UTC";
     const options = {
       threadId: "thread-1",
       cwd: "/repo",
-      appServer,
+      appServer: createAppServerOptions(),
+      sessionStatusAvailable: false,
     };
     const configured = buildTurnStartParams(
-      {
-        provider: "openai",
-        modelId: "gpt-5.4",
-        prompt: "test prompt",
-        startedAtMs: Date.parse("2026-09-02T00:30:00.000Z"),
-        config: { agents: { defaults: { userTimezone: "America/Los_Angeles" } } },
-      } as EmbeddedRunAttemptParams,
+      createParams("/tmp/session.jsonl", "/repo", {
+        agents: { defaults: { userTimezone: "America/Los_Angeles" } },
+      }),
       options,
     );
-    const fallback = buildTurnStartParams(
-      {
-        provider: "openai",
-        modelId: "gpt-5.4",
-        prompt: "test prompt",
-        startedAtMs: Date.parse("2026-09-02T00:30:00.000Z"),
-      } as EmbeddedRunAttemptParams,
-      options,
-    );
+    const fallback = buildTurnStartParams(createParams("/tmp/session.jsonl", "/repo"), options);
 
     expect(configured.additionalContext?.openclaw_temporal_context?.value).toContain(
       "Current date: 2026-09-01",
     );
     expect(fallback.additionalContext?.openclaw_temporal_context?.value).toContain(
       `Time zone: ${hostTimezone}`,
+    );
+    expect(fallback.additionalContext?.openclaw_temporal_context?.value).not.toContain(
+      "America/Los_Angeles",
     );
   });
 });

--- a/extensions/codex/src/app-server/turn-params.test.ts
+++ b/extensions/codex/src/app-server/turn-params.test.ts
@@ -1,0 +1,82 @@
+import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { describe, expect, it } from "vitest";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { buildTurnStartParams } from "./turn-params.js";
+
+const appServer = resolveCodexAppServerRuntimeOptions({ env: {}, requirementsToml: null });
+
+describe("buildTurnStartParams temporal context", () => {
+  it("uses the configured user timezone on every turn without changing cron input", () => {
+    const params = {
+      provider: "openai",
+      modelId: "gpt-5.4",
+      prompt: "run exactly",
+      trigger: "cron",
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
+      startedAtMs: Date.parse("2026-09-02T00:30:00.000Z"),
+      config: { agents: { defaults: { userTimezone: "America/Los_Angeles" } } },
+    } as EmbeddedRunAttemptParams;
+    const options = {
+      threadId: "thread-1",
+      cwd: "/repo",
+      appServer,
+    };
+
+    const firstTurn = buildTurnStartParams(params, options);
+    expect(firstTurn.input).toEqual([{ type: "text", text: "run exactly", text_elements: [] }]);
+    expect(firstTurn.additionalContext).toEqual({
+      openclaw_temporal_context: {
+        kind: "application",
+        value: "## Temporal Context\nCurrent date: 2026-09-01\nTime zone: America/Los_Angeles",
+      },
+    });
+
+    const nextTurn = buildTurnStartParams(
+      {
+        ...params,
+        startedAtMs: Date.parse("2026-09-03T00:30:00.000Z"),
+      } as EmbeddedRunAttemptParams,
+      options,
+    );
+    expect(nextTurn.input).toEqual(firstTurn.input);
+    expect(nextTurn.additionalContext?.openclaw_temporal_context?.value).toContain(
+      "Current date: 2026-09-02",
+    );
+  });
+
+  it("emits the host fallback after a timezone override is removed", () => {
+    const hostTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone?.trim() || "UTC";
+    const options = {
+      threadId: "thread-1",
+      cwd: "/repo",
+      appServer,
+    };
+    const configured = buildTurnStartParams(
+      {
+        provider: "openai",
+        modelId: "gpt-5.4",
+        prompt: "test prompt",
+        startedAtMs: Date.parse("2026-09-02T00:30:00.000Z"),
+        config: { agents: { defaults: { userTimezone: "America/Los_Angeles" } } },
+      } as EmbeddedRunAttemptParams,
+      options,
+    );
+    const fallback = buildTurnStartParams(
+      {
+        provider: "openai",
+        modelId: "gpt-5.4",
+        prompt: "test prompt",
+        startedAtMs: Date.parse("2026-09-02T00:30:00.000Z"),
+      } as EmbeddedRunAttemptParams,
+      options,
+    );
+
+    expect(configured.additionalContext?.openclaw_temporal_context?.value).toContain(
+      "Current date: 2026-09-01",
+    );
+    expect(fallback.additionalContext?.openclaw_temporal_context?.value).toContain(
+      `Time zone: ${hostTimezone}`,
+    );
+  });
+});

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -1,4 +1,7 @@
-import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  buildTemporalContextText,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   asOptionalRecord,
   normalizeOptionalString,
@@ -92,10 +95,22 @@ export function buildTurnStartParams(
   const useThreadPermissionProfile = options.appServer.networkProxy && !options.sandboxPolicy;
   const currentSenderContext =
     params.trigger === "user" ? buildCodexCurrentSenderContextValue(params) : undefined;
+  const temporalContext = buildTemporalContextText(
+    params.config?.agents?.defaults?.userTimezone,
+    params.startedAtMs,
+  );
+  // Codex emits only changed values and cannot retract omitted fragments from model history.
+  // Always send configured-or-host context so warm threads see rollover and removed overrides.
+  let additionalContext: CodexTurnStartParams["additionalContext"] = {
+    openclaw_temporal_context: { kind: "application", value: temporalContext },
+  };
   // Untrusted context exposes authenticated attribution without promoting human-controlled labels.
-  let additionalContext: CodexTurnStartParams["additionalContext"] = currentSenderContext
-    ? { openclaw_current_sender: { kind: "untrusted", value: currentSenderContext } }
-    : undefined;
+  if (currentSenderContext) {
+    additionalContext = {
+      ...additionalContext,
+      openclaw_current_sender: { kind: "untrusted", value: currentSenderContext },
+    };
+  }
   if (params.permissionChange?.notice) {
     // Application context is a developer message in Codex 0.151.0 and also
     // reaches native-preserved threads without overriding their turn settings.

--- a/extensions/codex/src/app-server/turn-params.ts
+++ b/extensions/codex/src/app-server/turn-params.ts
@@ -72,6 +72,7 @@ export function buildTurnStartParams(
     memoryCollaborationInstructions?: string;
     preserveNativeTurnSettings?: boolean;
     clearInheritedServiceTier?: boolean;
+    sessionStatusAvailable?: boolean;
   },
 ): CodexTurnStartParams {
   const modelSelection = options.preserveNativeTurnSettings
@@ -95,15 +96,11 @@ export function buildTurnStartParams(
   const useThreadPermissionProfile = options.appServer.networkProxy && !options.sandboxPolicy;
   const currentSenderContext =
     params.trigger === "user" ? buildCodexCurrentSenderContextValue(params) : undefined;
-  const temporalContext = buildTemporalContextText(
-    params.config?.agents?.defaults?.userTimezone,
-    params.startedAtMs,
-  );
   // Codex emits only changed values and cannot retract omitted fragments from model history.
   // Always send configured-or-host context so warm threads see rollover and removed overrides.
-  let additionalContext: CodexTurnStartParams["additionalContext"] = {
-    openclaw_temporal_context: { kind: "application", value: temporalContext },
-  };
+  let additionalContext = buildCodexTemporalAdditionalContext(params, {
+    sessionStatusAvailable: options.sessionStatusAvailable === true,
+  });
   // Untrusted context exposes authenticated attribution without promoting human-controlled labels.
   if (currentSenderContext) {
     additionalContext = {
@@ -163,6 +160,21 @@ export function buildTurnStartParams(
         }
       : {}),
     ...(options.environmentSelection ? { environments: options.environmentSelection } : {}),
+  };
+}
+
+export function buildCodexTemporalAdditionalContext(
+  params: Pick<EmbeddedRunAttemptParams, "config">,
+  options: { sessionStatusAvailable: boolean },
+): NonNullable<CodexTurnStartParams["additionalContext"]> {
+  return {
+    openclaw_temporal_context: {
+      kind: "application",
+      value: buildTemporalContextText({
+        configuredTimezone: params.config?.agents?.defaults?.userTimezone,
+        sessionStatusAvailable: options.sessionStatusAvailable,
+      }),
+    },
   };
 }
 

--- a/extensions/codex/test-api.ts
+++ b/extensions/codex/test-api.ts
@@ -14,7 +14,11 @@ import {
 } from "./src/app-server/config.js";
 import { filterCodexDynamicTools } from "./src/app-server/dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge } from "./src/app-server/dynamic-tools.js";
-import type { CodexDynamicToolSpec, JsonObject } from "./src/app-server/protocol.js";
+import {
+  flattenCodexDynamicToolFunctions,
+  type CodexDynamicToolSpec,
+  type JsonObject,
+} from "./src/app-server/protocol.js";
 import {
   buildDeveloperInstructions,
   buildThreadResumeParams,
@@ -92,6 +96,9 @@ export function buildCodexHarnessPromptSnapshot(params: {
       appServer: params.appServer,
       promptText: params.promptText,
       turnScopedDeveloperInstructions: params.turnScopedDeveloperInstructions,
+      sessionStatusAvailable: flattenCodexDynamicToolFunctions(params.dynamicTools).some(
+        (tool) => tool.name === "session_status",
+      ),
     }),
   };
 }

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -338,7 +338,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: shipped conversation-binding inspection function and result type.
       // +4: canonical node CLI option, envelope, presentation, and error owners.
       // +1: Gateway caller ownership for standalone browser routing.
-      4369,
+      // +1: canonical temporal context renderer for plugin-owned agent harnesses.
+      4370,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -451,7 +452,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: shipped read-only conversation-binding inspection function.
       // +4: canonical node CLI option, envelope, presentation, and error owners.
       // +1: Gateway caller ownership for standalone browser routing.
-      2603,
+      // +1: canonical temporal context renderer for plugin-owned agent harnesses.
+      2604,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -64,6 +64,37 @@ export function formatDateStamp(nowMs: number, timeZone: string): string {
   return date.toISOString().slice(0, 10);
 }
 
+export function buildTemporalContextSection(params: {
+  userDate?: string;
+  userTimezone?: string;
+  sessionStatusAvailable: boolean;
+}): string[] {
+  const userDate = params.userDate?.trim();
+  const userTimezone = params.userTimezone?.trim();
+  if (!userDate || !userTimezone) {
+    return [];
+  }
+  return [
+    "## Temporal Context",
+    `Current date: ${userDate}`,
+    `Time zone: ${userTimezone}`,
+    ...(params.sessionStatusAvailable ? ["For the exact current time, use `session_status`."] : []),
+    "",
+  ];
+}
+
+/** Build current prompt text using the configured timezone or the canonical host fallback. */
+export function buildTemporalContextText(configuredTimezone?: string, nowMs = Date.now()): string {
+  const userTimezone = resolveUserTimezone(configuredTimezone);
+  return buildTemporalContextSection({
+    userDate: formatDateStamp(nowMs, userTimezone),
+    userTimezone,
+    sessionStatusAvailable: false,
+  })
+    .join("\n")
+    .trimEnd();
+}
+
 /** Normalize Date, second, millisecond, or parseable string timestamps. */
 function normalizeTimestamp(
   raw: unknown,

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -84,12 +84,15 @@ export function buildTemporalContextSection(params: {
 }
 
 /** Build current prompt text using the configured timezone or the canonical host fallback. */
-export function buildTemporalContextText(configuredTimezone?: string, nowMs = Date.now()): string {
-  const userTimezone = resolveUserTimezone(configuredTimezone);
+export function buildTemporalContextText(params: {
+  configuredTimezone?: string;
+  sessionStatusAvailable: boolean;
+}): string {
+  const userTimezone = resolveUserTimezone(params.configuredTimezone);
   return buildTemporalContextSection({
-    userDate: formatDateStamp(nowMs, userTimezone),
+    userDate: formatDateStamp(Date.now(), userTimezone),
     userTimezone,
-    sessionStatusAvailable: false,
+    sessionStatusAvailable: params.sessionStatusAvailable,
   })
     .join("\n")
     .trimEnd();

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -44,6 +44,7 @@ import {
   buildFullBootstrapPromptLines,
   buildLimitedBootstrapPromptLines,
 } from "./bootstrap-prompt.js";
+import { buildTemporalContextSection } from "./date-time.js";
 import { buildDelegationGuidanceSection } from "./delegation-guidance.js";
 import type { EmbeddedContextFile } from "./embedded-agent-helpers.js";
 import type {
@@ -416,25 +417,6 @@ function buildOwnerIdentityLine(
     return undefined;
   }
   return `${OWNER_PROMPT_PREFIX}${displayOwnerNumbers.join(", ")}${OWNER_PROMPT_SUFFIX}`;
-}
-
-function buildTemporalContextSection(params: {
-  userDate?: string;
-  userTimezone?: string;
-  sessionStatusAvailable: boolean;
-}) {
-  const userDate = params.userDate?.trim();
-  const userTimezone = params.userTimezone?.trim();
-  if (!userDate || !userTimezone) {
-    return [];
-  }
-  return [
-    "## Temporal Context",
-    `Current date: ${userDate}`,
-    `Time zone: ${userTimezone}`,
-    ...(params.sessionStatusAvailable ? ["For the exact current time, use `session_status`."] : []),
-    "",
-  ];
 }
 
 function buildAssistantOutputDirectivesSection(params: {

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -70,6 +70,7 @@ export function buildWatchedSessionsHarnessContext(params: {
 }
 
 export { FAST_MODE_AUTO_PROGRESS_KIND } from "../auto-reply/reply-payload.js";
+export { buildTemporalContextText } from "../agents/date-time.js";
 export {
   isDeliveredMessageToolOnlySourceReplyResult,
   isDeliveredMessagingToolResult,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=2985e61cfd81e5cdca8ba61cb4e07b56509d0ed714d7e3a75b62b55c44805f1f
-+++ discord-group-codex-message-tool.md	sha256=28d9374bc387b9a5eb456d0dc1ec4ab443fe6be61e4310603eaf4e1efed8b818
+--- telegram-direct-codex-message-tool.md	sha256=d34d752dc536112b64be490513a501650982c65b48000ce5146780e49e9a05ad
++++ discord-group-codex-message-tool.md	sha256=b5fdd042400d28e793090195c5f14c11446eb8f723bfbb14ebac9ee25835f9e7
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=b12f733bdbba6657a559b2c2550ab9b139444224de38675123ee45148e74d5ca
-+++ discord-group-codex-message-tool.md	sha256=0f16c3e037677c58a52e123893fbef715be92d764de7eb79131b58fd7fba8781
+--- telegram-direct-codex-message-tool.md	sha256=2985e61cfd81e5cdca8ba61cb4e07b56509d0ed714d7e3a75b62b55c44805f1f
++++ discord-group-codex-message-tool.md	sha256=28d9374bc387b9a5eb456d0dc1ec4ab443fe6be61e4310603eaf4e1efed8b818
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -16,44 +16,44 @@
 @@ -30,1 +30,1 @@
 -  "toolSnapshot": "codex-dynamic-tools.telegram-direct.json",
 +  "toolSnapshot": "codex-dynamic-tools.discord-group.json",
-@@ -134,1 +134,1 @@
+@@ -135,1 +135,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -145,1 +145,1 @@
+@@ -146,1 +146,1 @@
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
 +      "value": "{\"sender\":{\"id\":\"424242\",\"name\":\"Pash\",\"username\":\"pash\"}}"
-@@ -172,1 +172,1 @@
+@@ -177,1 +177,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-discord-group-codex-message-tool"
-@@ -209,1 +209,1 @@
+@@ -214,1 +214,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
-@@ -237,2 +237,2 @@
+@@ -242,2 +242,2 @@
 -    "chars": 56379,
 -    "roughTokens": 14095
 +    "chars": 56959,
 +    "roughTokens": 14240
-@@ -241,2 +241,2 @@
+@@ -246,2 +246,2 @@
 -    "chars": 3224,
 -    "roughTokens": 806
 +    "chars": 4333,
 +    "roughTokens": 1084
-@@ -245,2 +245,2 @@
+@@ -250,2 +250,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 28650,
 +    "roughTokens": 7163
-@@ -249,2 +249,2 @@
+@@ -254,2 +254,2 @@
 -    "chars": 83551,
 -    "roughTokens": 20888
 +    "chars": 85611,
 +    "roughTokens": 21403
-@@ -253,2 +253,2 @@
+@@ -258,2 +258,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1234,
 +    "roughTokens": 309
-@@ -462,4 +462,4 @@
+@@ -467,4 +467,4 @@
 -  "channel": "telegram",
 -  "provider": "telegram",
 -  "surface": "telegram",
@@ -62,21 +62,21 @@
 +  "provider": "discord",
 +  "surface": "discord",
 +  "chat_type": "group"
-@@ -470,1 +470,3 @@
+@@ -475,1 +475,3 @@
 -You are in a Telegram direct conversation. Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation. If no visible direct response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to the conversation.
 +You are in a Discord group chat. Normal final replies are private and are not automatically sent to this group chat. To post visible output here, use the message tool with action=send; the target defaults to this group chat. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \n sequences; use real line breaks sparingly. If addressed to someone else, stay silent unless invited or correcting key facts. Discord: wrap bare URLs like <https://example.com> to suppress embeds. When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value. If no visible group response is needed, do not call message(action=send). Your normal final answer stays private and will not be posted to this group chat. Be extremely selective: reply only when directly addressed or clearly helpful.
 +
 +Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included). Address the specific sender noted in the message context.
-@@ -526,1 +528,1 @@
+@@ -531,1 +533,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"channel:987654321","message_id":"discord-msg-0001","conversation_label":"OpenClaw/#agent-sandbox","sender":{"id":"424242","name":"Pash","username":"pash"},"group_subject":"OpenClaw maintainers","group_channel":"#agent-sandbox","group_space":"OpenClaw","is_group_chat":true,"was_mentioned":true,"history_count":2}
-@@ -529,1 +531,5 @@
+@@ -534,1 +536,5 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Chat history since last reply: ⟦openclaw:ctx⟧
 +Peter: I pushed the Discord-side message-tool bridge.
 +Pash: @OpenClaw please verify the Codex happy path too.
 +
 +can you audit whether this prompt path has conflicting silence instructions?
-@@ -534,1 +540,1 @@
+@@ -539,1 +545,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.discord-group.json` (base: `codex-dynamic-tools.telegram-direct.json`)

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -147,7 +147,7 @@
     },
     "openclaw_temporal_context": {
       "kind": "application",
-      "value": "## Temporal Context\nCurrent date: 2026-01-01\nTime zone: UTC"
+      "value": "## Temporal Context\nCurrent date: 2026-01-01\nTime zone: UTC\nFor the exact current time, use `session_status`."
     }
   },
   "approvalPolicy": "never",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -40,7 +40,8 @@
     "defaults": {
       "heartbeat": {
         "every": "30m"
-      }
+      },
+      "userTimezone": "UTC"
     },
     "entries": {
       "main": {
@@ -143,6 +144,10 @@
     "openclaw_current_sender": {
       "kind": "untrusted",
       "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
+    },
+    "openclaw_temporal_context": {
+      "kind": "application",
+      "value": "## Temporal Context\nCurrent date: 2026-01-01\nTime zone: UTC"
     }
   },
   "approvalPolicy": "never",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=2985e61cfd81e5cdca8ba61cb4e07b56509d0ed714d7e3a75b62b55c44805f1f
-+++ telegram-heartbeat-codex-tool.md	sha256=22a69174045a3e61e50d60724261d3aa9844783a104a499104a76b2efb970104
+--- telegram-direct-codex-message-tool.md	sha256=d34d752dc536112b64be490513a501650982c65b48000ce5146780e49e9a05ad
++++ telegram-heartbeat-codex-tool.md	sha256=34e5effb10b918859678a8f46e06602c59f14854a05c80732731f8f3d1093c60
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=b12f733bdbba6657a559b2c2550ab9b139444224de38675123ee45148e74d5ca
-+++ telegram-heartbeat-codex-tool.md	sha256=8d3ba39656fd63f3163240b4de824d305b32958b2e3047ab1cc749b05f40ba18
+--- telegram-direct-codex-message-tool.md	sha256=2985e61cfd81e5cdca8ba61cb4e07b56509d0ed714d7e3a75b62b55c44805f1f
++++ telegram-heartbeat-codex-tool.md	sha256=22a69174045a3e61e50d60724261d3aa9844783a104a499104a76b2efb970104
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -13,56 +13,54 @@
 -  "trigger": "user"
 +  "toolSnapshot": "codex-dynamic-tools.heartbeat-turn.json",
 +  "trigger": "heartbeat"
-@@ -96,0 +97,1 @@
+@@ -97,0 +98,1 @@
 +    "heartbeat_respond",
-@@ -134,1 +135,1 @@
+@@ -135,1 +136,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -142,6 +142,0 @@
--  "additionalContext": {
+@@ -144,4 +144,0 @@
 -    "openclaw_current_sender": {
 -      "kind": "untrusted",
 -      "value": "{\"sender\":{\"id\":\"1000001\",\"name\":\"Pash\",\"username\":\"pash\"}}"
--    }
--  },
-@@ -172,1 +167,1 @@
+-    },
+@@ -177,1 +174,1 @@
 -  "threadId": "thread-telegram-direct-codex-message-tool"
 +  "threadId": "thread-telegram-heartbeat-codex-tool"
-@@ -209,1 +204,1 @@
+@@ -214,1 +211,1 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
-@@ -237,2 +232,2 @@
+@@ -242,2 +239,2 @@
 -    "chars": 56379,
 -    "roughTokens": 14095
 +    "chars": 57872,
 +    "roughTokens": 14468
-@@ -245,2 +240,2 @@
+@@ -250,2 +247,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 27512,
 +    "roughTokens": 6878
-@@ -249,2 +244,2 @@
+@@ -254,2 +251,2 @@
 -    "chars": 83551,
 -    "roughTokens": 20888
 +    "chars": 85386,
 +    "roughTokens": 21347
-@@ -253,2 +248,2 @@
+@@ -258,2 +255,2 @@
 -    "chars": 863,
 -    "roughTokens": 216
 +    "chars": 1205,
 +    "roughTokens": 302
-@@ -526,1 +521,1 @@
+@@ -531,1 +528,1 @@
 -{"chat_id":"user:1000001","message_id":"tg-msg-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
 +{"chat_id":"user:1000001","message_id":"heartbeat-0001","sender":{"id":"1000001","name":"Pash","username":"pash"}}
-@@ -529,1 +524,1 @@
+@@ -534,1 +531,1 @@
 -Can you check whether the nightly build finished and tell me what happened?
 +Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. Use heartbeat_respond to report the wake outcome. Set notify=false when nothing needs the user's attention. Set notify=true with notificationText only when the user should be interrupted.
-@@ -534,1 +529,1 @@
+@@ -539,1 +536,1 @@
 -Full JSON: `codex-dynamic-tools.telegram-direct.json`
 +Full tool overrides: `codex-dynamic-tools.heartbeat-turn.json` (base: `codex-dynamic-tools.telegram-direct.json`)
-@@ -554,0 +550,1 @@
+@@ -559,0 +557,1 @@
 +  "heartbeat_respond",
-@@ -701,0 +698,39 @@
+@@ -706,0 +705,39 @@
 +  },
 +  {
 +    "description": "Accept heartbeat result for post-turn handling. `notify=false` no visible send. `notify=true` needs concise notificationText. Scratch is monitor prose only.",

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -863,16 +863,21 @@ function renderScenarioSnapshot(
   });
   const appServer = codexApi.resolveCodexPromptSnapshotAppServerOptions();
   const codexTurnPromptText = prependCodexOpenClawRuntimeContext(scenario.prompt);
-  const codexSnapshot = codexApi.buildCodexHarnessPromptSnapshot({
-    attempt,
-    cwd: WORKSPACE_DIR,
-    threadId: `thread-${scenario.id}`,
-    dynamicTools: scenario.dynamicTools,
-    appServer,
-    config: CODEX_PROMPT_SNAPSHOT_THREAD_CONFIG,
-    promptText: codexTurnPromptText,
-    turnScopedDeveloperInstructions: CODEX_WORKSPACE_TURN_SCOPED_DEVELOPER_INSTRUCTIONS,
-  });
+  if (attempt.startedAtMs === undefined) {
+    throw new Error("Codex prompt snapshot attempt requires a fixed start time");
+  }
+  const codexSnapshot = withFixedDateNow(attempt.startedAtMs, () =>
+    codexApi.buildCodexHarnessPromptSnapshot({
+      attempt,
+      cwd: WORKSPACE_DIR,
+      threadId: `thread-${scenario.id}`,
+      dynamicTools: scenario.dynamicTools,
+      appServer,
+      config: CODEX_PROMPT_SNAPSHOT_THREAD_CONFIG,
+      promptText: codexTurnPromptText,
+      turnScopedDeveloperInstructions: CODEX_WORKSPACE_TURN_SCOPED_DEVELOPER_INSTRUCTIONS,
+    }),
+  );
   const dynamicToolFunctions = flattenCodexDynamicToolSpecs(scenario.dynamicTools);
   const criticalToolSpecs = dynamicToolFunctions.filter((tool) =>
     ["message", "heartbeat_respond"].includes(tool.name),
@@ -938,6 +943,18 @@ function renderScenarioSnapshot(
     markdownFence("json", stableJson(criticalToolSpecs)),
     "",
   ].join("\n");
+}
+
+function withFixedDateNow<T>(nowMs: number, build: () => T): T {
+  // Snapshot generation is synchronous here. Restore the process clock so this fixture cannot
+  // leak its pinned calendar date into later scenarios or checks.
+  const readNow = Date.now;
+  Date.now = () => nowMs;
+  try {
+    return build();
+  } finally {
+    Date.now = readNow;
+  }
 }
 
 function renderReadme(scenarios: PromptScenario[]): string {

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -298,6 +298,7 @@ const baseConfig: OpenClawConfig = {
   },
   agents: {
     defaults: {
+      userTimezone: "UTC",
       heartbeat: {
         every: "30m",
       },
@@ -410,6 +411,7 @@ function createAttempt(params: {
     sessionKey: params.sessionKey,
     sessionId: `session-${params.scenario.id}`,
     runId: `run-${params.scenario.id}`,
+    startedAtMs: Date.parse("2026-01-01T00:00:00.000Z"),
     provider: "codex",
     modelId: MODEL_ID,
     model: happyPathModel,


### PR DESCRIPTION
Closes #136015

## What Problem This Solves

Codex-runtime agents ignored `agents.defaults.userTimezone`. Their model context used the host date and time zone while native OpenClaw agents used the configured zone.

This could produce the next calendar date for users west of the host time zone.

## Why This Change Was Made

The native runtime already owns the canonical `Temporal Context` renderer. Codex already supports keyed per-turn application context that becomes developer input.

This change connects those existing owners:

- normal Codex turns send the canonical temporal context on every `turn/start`;
- warm threads get a new value after date rollover;
- removing the override sends the host fallback under the same key;
- `/btw` side-question turns use the same carrier;
- the exact-time hint appears only when the final tool surface includes `session_status`;
- lightweight cron user input remains byte-for-byte unchanged.

The Agent Harness SDK now documents the shared temporal renderer. This adds no configuration, database, or Gateway protocol surface.

Production LOC: +77/-24 (net +53). The growth creates one core-to-plugin renderer seam, one plugin-private keyed carrier, final-tool gating, and coverage for both Codex turn paths. It removes the native-only renderer copy from `system-prompt.ts`.

## User Impact

Codex-runtime agents now receive the same current local date and time-zone grounding as native agents, including warm sessions, `/btw`, lightweight cron turns, date rollover, and timezone override removal.

## Evidence

Current-main red at `69cc88a9583efa264e6320a4311c1813c41ed41d`:

- A real Codex turn with `America/Los_Angeles` configured returned `2026-09-02 | Europe/Berlin` instead of `2026-09-01|America/Los_Angeles`.
- The neutral request contained no expected date or zone.
- The request had no `openclaw_temporal_context` application entry.

Exact-head green at `13059fa4b1f833d4d8af7f3904a765e1eb163ea7`:

- One real warm Codex thread handled three turns.
- Turn 1: `2026-09-01 | America/Los_Angeles`.
- Turn 2 after date rollover: `2026-09-02 | America/Los_Angeles`.
- Turn 3 after override removal: `2026-09-03 | Europe/Berlin`.
- Each rollout contained the exact keyed developer context and the tool-gated `session_status` hint.

Focused validation:

- 154 native temporal-context tests passed.
- 456 Codex turn, `/btw`, lifecycle, warm-thread, and cron tests passed.
- 16 prompt-snapshot tests passed; 7 generated snapshots are current.
- Plugin SDK surface and export checks passed.
- Core and touched-path lint passed.
- Docs MDX passed for 752 files; 7,249 internal links passed.
- Import-cycle, plugin-boundary, script-erasability, coercion-helper, and deprecated-API guards passed.
- Type-check and build run in CI per maintainer host policy.

Upstream contract checked against `@openai/codex` 0.151.0 at `78c290807ce710180111df227df3b7a4fe845452`: Codex derives its environment date and zone from the host, forwards `additionalContext` per turn, renders application context as developer input, and emits a keyed value again only when it changes.
