### PR TITLE
refactor(scripts): reuse startup trace duration predicate

### DIFF
--- a/scripts/openclaw-performance-source-summary.mts
+++ b/scripts/openclaw-performance-source-summary.mts
@@ -7,6 +7,7 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { requireOptionArgument } from "./lib/arg-utils.mts";
+import { isStartupTraceDuration } from "./lib/gateway-startup-trace-ranking.js";
 import { collectSqliteQueryPlanEvidence } from "./lib/sqlite-query-plan-evidence.js";
 
 type JsonObject = { [key: string]: JsonValue };
@@ -560,14 +561,6 @@ function buildTraceRows(startup: JsonValue) {
     }
   }
   return rows;
-}
-
-function isStartupTraceDuration(name: string) {
-  if (name.endsWith(".total") || name.startsWith("memory.")) {
-    return false;
-  }
-  const metricName = name.slice(name.lastIndexOf(".") + 1);
-  return !metricName.endsWith("Count") && !metricName.endsWith("Mb");
 }
 
 function buildMockHelloRows(summaries: MockHelloEntry[]) {


### PR DESCRIPTION
## What Problem This Solves

The performance source summary carried a byte-identical copy of startup-trace duration classification that was already owned by the gateway startup ranking helper. In the explicit maintainer-directed function-duplication cleanup campaign, this was identified as duplicate policy that could drift between benchmark collection and report generation.

## Why This Change Was Made

Reuse `isStartupTraceDuration` from `scripts/lib/gateway-startup-trace-ranking.ts` and delete the local copy. The helper checkout already includes the complete immutable `scripts/` tree, so workflow execution and loader behavior are unchanged.

No tests, workflow files, docs, SDK seams, or changelog entries change.

## User Impact

No user-visible behavior changes. Startup hotspot reports keep excluding `.total`, `memory.*`, `*Count`, and `*Mb` metrics through one canonical predicate.

## Evidence

- Exact head: 50/50 focused tests passed locally; CLI `--help`, changed-file selection, formatting, and `git diff --check` passed.
- Fresh trusted Testbox proof did not complete. Lease `tbx_01m1hwz9wv0x9547efsp9xbnf6` failed before test execution during the frozen install path with exit 2: `fatal: could not read Username for 'https://github.com'`. The lease was stopped and is not counted as passing evidence. Run: https://github.com/openclaw/openclaw/actions/runs/33679551115
- Fresh branch `gpt-5.6-sol` autoreview: no accepted/actionable P0/P1 findings, correctness 0.97.
- Independent frozen-commit `gpt-5.6-sol` review: no accepted/actionable P0/P1 findings, correctness 0.90.
- Open-PR overlap: exhaustive UPDATED_AT and CREATED_AT scans covered the dynamic 2,423-2,425 open-PR set, fetched complete tails for every PR above 100 files, and found no touched-file overlap. A final recent-PR delta also found none.
- Current main `5cbfebd4a86526ec4bb851415ba10d5c004c0a3b` retained byte-identical affected blobs relative to the PR parent and produced a clean synthetic merge.
- Commit: `153d3db6bd65ad1ab7b6cfa5d153424aaa90d999`, signed.
- LOC: tooling `+1/-8` (net `-7`); production `0`; tests `0`.
