### PR TITLE
fix(ios): preserve focus for protected chat inputs

### DIFF
--- a/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
+++ b/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
@@ -322,6 +322,34 @@ struct LocalFixtureChatTransport: OpenClawChatTransport {
             })
     }
 
+    func listQuestions() async throws -> [QuestionRecord] {
+        guard ProcessInfo.processInfo.arguments.contains("--openclaw-protected-question-fixture") else { return [] }
+        let now = Int(Date().timeIntervalSince1970 * 1000)
+        return [
+            QuestionRecord(
+                id: "screenshot-protected-question",
+                questions: [
+                    Question(
+                        questionid: "credential",
+                        header: "Authentication",
+                        question: "Enter a synthetic credential",
+                        options: [],
+                        isother: true,
+                        issecret: true,
+                        secretstore: QuestionSecretStoreBinding(
+                            name: "SYNTHETIC_CREDENTIAL",
+                            kind: AnyCodable("secret"),
+                            reason: "Verifies protected entry focus.")),
+                ],
+                agentid: self.fixture.defaultAgentID,
+                sessionkey: self.fixture.sessionKey,
+                runid: "screenshot-protected-question-run",
+                createdatms: now,
+                expiresatms: now + 600_000,
+                status: .pending),
+        ]
+    }
+
     func listChildSessions(parentKey: String) async throws -> [OpenClawChatSessionEntry] {
         guard ProcessInfo.processInfo.arguments.contains("--openclaw-swarm-chat-fixture") else { return [] }
         let groupID = "swarm:\(parentKey):research"

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -44,6 +44,9 @@ final class OpenClawSnapshotUITests: XCTestCase {
     }
 
     func testReleaseChatScreenshot() {
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            self.assertProtectedQuestionKeepsFocus()
+        }
         self.captureReleaseScreenshot(Self.chatScreenshotTarget) { app in
             let input = self.chatMessageInput(in: app)
             XCTAssertTrue(input.waitForExistence(timeout: 8))
@@ -62,6 +65,42 @@ final class OpenClawSnapshotUITests: XCTestCase {
                 XCTAssertTrue(keyboard.waitForNonExistence(timeout: 3))
             }
         }
+    }
+
+    private func assertProtectedQuestionKeepsFocus() {
+        self.launchApp(
+            for: Self.chatScreenshotTarget,
+            additionalArguments: [
+                "--openclaw-empty-chat-fixture",
+                "--openclaw-protected-question-fixture",
+            ])
+        guard let app = self.app else {
+            XCTFail("Protected-question fixture app is unavailable")
+            return
+        }
+
+        let protectedInput = app.secureTextFields["Secret value"]
+        XCTAssertTrue(protectedInput.waitForExistence(timeout: 8))
+        self.waitForHittable(true, of: protectedInput)
+        let submit = app.buttons["Submit"]
+        XCTAssertTrue(submit.waitForExistence(timeout: 3))
+        XCTAssertFalse(submit.isEnabled)
+
+        protectedInput.tap()
+        let keyboard = app.keyboards.firstMatch
+        XCTAssertTrue(keyboard.waitForExistence(timeout: 3))
+
+        // Repositioning within an already-focused protected field must not let the
+        // message-list background gesture resign its first responder.
+        protectedInput.tap()
+        Thread.sleep(forTimeInterval: 1.2)
+        self.attachScreenshot(named: "protected-question-focused")
+        XCTAssertTrue(keyboard.exists)
+
+        protectedInput.typeText("synthetic-focus-probe")
+        XCTAssertTrue(keyboard.exists)
+        self.waitForEnabled(submit)
+        self.attachScreenshot(named: "protected-question-typed")
     }
 
     func testReleaseAgentScreenshot() {
@@ -1264,7 +1303,7 @@ extension OpenClawSnapshotUITests {
         XCTAssertTrue(send.waitForExistence(timeout: 3))
         XCTAssertFalse(send.isEnabled)
         XCTAssertTrue(app.staticTexts[
-            "Authentication failed. Review the provider credential or sign-in, then retry."
+            "Authentication failed. Review the provider credential or sign-in, then retry.",
         ].waitForExistence(timeout: 3))
         self.attachScreenshot(named: "chat-composer-model-auth-failed")
     }


### PR DESCRIPTION
## What Problem This Solves

Protected credential prompts inside the iOS chat transcript immediately lose focus because the transcript's ancestor tap gesture runs alongside the field tap and globally resigns the active responder. This blocks secure setup and also risks the card's free-text and allowed-host inputs.

This change keeps interactive question inputs focused while preserving tap-to-dismiss on passive transcript areas. It also adds an opt-in synthetic protected-question fixture to the existing release chat UI test.

Fixes #135216.

## Root cause

The message-list container used `simultaneousGesture` for tap-to-dismiss. SwiftUI therefore ran that ancestor tap alongside descendant controls, and the handler broadcast `resignFirstResponder`, racing the `SecureField` that had just been tapped. The same boundary also affected the card's free-text and allowed-host inputs.

## Evidence

- Apple documents that `simultaneousGesture` processes the ancestor gesture alongside descendant gestures, while `gesture` has lower precedence than gestures defined by the view hierarchy.
- The regression test opens a synthetic protected question, taps `secureTextFields["Secret value"]`, waits across a countdown re-render, types a synthetic value, and requires the keyboard to remain present and Submit to become enabled.
- The same release-chat test then relaunches its normal fixture and retains the existing assertion that a passive transcript tap dismisses the composer keyboard.
- Pinned SwiftFormat 0.63.0 reports the changed Swift files formatted.

## Test plan

- [x] pinned SwiftFormat 0.63.0 on the changed Swift files
- [ ] pre-fix iPhone UI regression (draft RED run in progress)
- [ ] post-fix iPhone UI regression
- [ ] GitHub `ios-build` / screenshot CI

Local simulator proof is unavailable on this host because only Command Line Tools are installed: there is no Xcode app, iOS simulator runtime, or `simctl`. The UI test captures sanitized screenshots before and after synthetic input so the Xcode CI result bundle contains visual evidence.

Additional local limitations: `pnpm install` failed while fetching an unrelated optional macOS binary package, which left `tsx` and the generated Mermaid resource unavailable; consequently `pnpm ios:gen` and the shared Swift package test could not complete locally.
