### PR TITLE
improve(agents): reduce overhead while streaming long replies

### DIFF
--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -1,26 +1,39 @@
 /** Strips internal scaffolding from text before user-facing delivery. */
-import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
 import { CURRENT_MESSAGE_MARKER, HISTORY_CONTEXT_MARKER } from "../../auto-reply/reply/history.js";
-import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
+import {
+  INBOUND_METADATA_MARKERS,
+  stripInboundMetadata,
+} from "../../auto-reply/reply/strip-inbound-meta.js";
 import { coerceChatContentText } from "../../shared/chat-content.js";
 import { escapeRegExp } from "../../shared/regexp.js";
 import {
-  stripAssistantInternalTraceLines,
+  assistantTraceTextFilter,
+  plainToolCallTextFilter,
   stripLegacyBracketToolCallBlocks,
   stripMinimaxToolCallXml,
   stripToolCallXmlTags,
 } from "../../shared/text/assistant-visible-text.js";
-import { findCodeRegions, isInsideCode } from "../../shared/text/code-regions.js";
+import {
+  findCodeRegions,
+  isInsideCode,
+  stripLinesOutsideCode,
+} from "../../shared/text/code-regions.js";
 import { stripFinalTags } from "../../shared/text/final-tags.js";
+import {
+  applyTextFilters,
+  duplicateParagraphTextFilter,
+  leadingEmptyLinesTextFilter,
+  type TextFilter,
+} from "../../shared/text/text-projection.js";
 import { EXEC_NO_OUTPUT_PLACEHOLDER } from "../bash-tools.exec-output.js";
-import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
+import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+  OPENCLAW_RUNTIME_CONTEXT_NOTICE,
+  stripInternalRuntimeContext,
+} from "../internal-runtime-context.js";
 
 const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
-
-function stripFinalTagsFromText(text: unknown): string {
-  const normalized = coerceChatContentText(text);
-  return normalized ? stripFinalTags(normalized) : normalized;
-}
 
 function stripInternalPlaceholderLines(text: string): string {
   if (
@@ -29,26 +42,12 @@ function stripInternalPlaceholderLines(text: string): string {
   ) {
     return text;
   }
-  let protectedRegions: ReturnType<typeof findCodeRegions> | undefined;
-  let result = "";
-  let start = 0;
-  while (start < text.length) {
-    const newlineIndex = text.indexOf("\n", start);
-    const end = newlineIndex === -1 ? text.length : newlineIndex + 1;
-    const chunk = text.slice(start, end);
-    const line = chunk.endsWith("\n") ? chunk.slice(0, -1).replace(/\r$/, "") : chunk;
-    const isInternalPlaceholder =
+  return stripLinesOutsideCode(
+    text,
+    (line) =>
       TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE.test(line) ||
-      line.trim() === EXEC_NO_OUTPUT_PLACEHOLDER;
-    if (
-      !isInternalPlaceholder ||
-      isInsideCode(start, (protectedRegions ??= findCodeRegions(text)))
-    ) {
-      result += chunk;
-    }
-    start = end;
-  }
-  return result;
+      line.trim() === EXEC_NO_OUTPUT_PLACEHOLDER,
+  );
 }
 
 const MARKDOWN_LINE_PREFIX =
@@ -223,26 +222,33 @@ export function createVerifiedConversationContextStreamFilter(
   };
 }
 
-function collapseConsecutiveDuplicateBlocks(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return text;
-  }
-  const blocks = trimmed.split(/\n{2,}/);
-  if (blocks.length < 2) {
-    return text;
-  }
-  const result: string[] = [];
-  let lastNormalized: string | null = null;
-  for (const block of blocks) {
-    const normalized = block.trim().replace(/\s+/g, " ");
-    if (lastNormalized && normalized === lastNormalized) {
-      continue;
-    }
-    result.push(block.trim());
-    lastNormalized = normalized;
-  }
-  return result.length === blocks.length ? text : result.join("\n\n");
+export function userFacingTextFilters(errorContext = false): TextFilter[] {
+  return [
+    { transform: stripFinalTags, activationTokens: ["<"] },
+    {
+      transform: stripInternalRuntimeContext,
+      activationTokens: [
+        INTERNAL_RUNTIME_CONTEXT_BEGIN,
+        INTERNAL_RUNTIME_CONTEXT_END,
+        OPENCLAW_RUNTIME_CONTEXT_NOTICE,
+      ],
+    },
+    { transform: stripInboundMetadata, activationTokens: INBOUND_METADATA_MARKERS },
+    { transform: stripMinimaxToolCallXml, activationTokens: ["<"] },
+    {
+      transform: (text) => stripToolCallXmlTags(text, { stripFunctionCallsXmlPayloads: true }),
+      activationTokens: ["<"],
+    },
+    {
+      transform: stripInternalPlaceholderLines,
+      activationTokens: [EXEC_NO_OUTPUT_PLACEHOLDER, "[tool calls omitted]"],
+    },
+    ...(errorContext ? [assistantTraceTextFilter] : []),
+    { transform: stripLegacyBracketToolCallBlocks, activationTokens: ["["] },
+    plainToolCallTextFilter,
+    leadingEmptyLinesTextFilter,
+    duplicateParagraphTextFilter,
+  ];
 }
 
 export function sanitizeUserFacingText(
@@ -262,24 +268,5 @@ export function sanitizeUserFacingText(
           opts?.streaming,
         )
       : raw;
-  const stripped = stripInboundMetadata(
-    stripInternalRuntimeContext(stripFinalTagsFromText(withoutConversationContext)),
-  );
-  const withoutToolCallXml = stripToolCallXmlTags(stripMinimaxToolCallXml(stripped), {
-    stripFunctionCallsXmlPayloads: true,
-  });
-  // Replay repair and empty exec output produce placeholders that never belong in visible replies.
-  const withoutPlaceholder = stripInternalPlaceholderLines(withoutToolCallXml);
-  const withoutInternalTraceLines = opts?.errorContext
-    ? stripAssistantInternalTraceLines(withoutPlaceholder)
-    : withoutPlaceholder;
-  const withoutToolCallBlocks = stripPlainTextToolCallBlocks(
-    stripLegacyBracketToolCallBlocks(withoutInternalTraceLines),
-    { resolveProtectedRanges: findCodeRegions },
-  );
-  if (!withoutToolCallBlocks.trim()) {
-    return "";
-  }
-  const withoutLeadingEmptyLines = withoutToolCallBlocks.replace(/^(?:[ \t]*\r?\n)+/, "");
-  return collapseConsecutiveDuplicateBlocks(withoutLeadingEmptyLines);
+  return applyTextFilters(withoutConversationContext, userFacingTextFilters(opts?.errorContext));
 }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -142,7 +142,7 @@ export function handleMessageEnd(
   ctx.resetPartialReplyDirectives();
   const parsedText = parseReplyDirectives(trimmedText);
   // Final media is emitted after the buffered text drains, never on its first chunk.
-  recordPendingAssistantReplyDirectives(ctx.state, { ...parsedText, mediaUrls: undefined });
+  recordPendingAssistantReplyDirectives(ctx.state, parsedText);
   const cleanedText = parsedText.text;
   const { mediaUrls } = resolveSendableOutboundReplyParts(parsedText);
   const managedMediaUrls = resolveManagedStreamMediaUrls(ctx.state, mediaUrls);

--- a/src/agents/embedded-agent-subscribe.handlers.messages.replies.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.replies.ts
@@ -12,18 +12,8 @@ export function hasReplyDirectiveMetadata(
 ): boolean {
   return Boolean(
     parsed &&
-    ((parsed.mediaUrls?.length ?? 0) > 0 ||
-      parsed.audioAsVoice ||
-      parsed.replyToId ||
-      parsed.replyToTag ||
-      parsed.replyToCurrent),
+    (parsed.audioAsVoice || parsed.replyToId || parsed.replyToTag || parsed.replyToCurrent),
   );
-}
-
-function hasReplyDirectiveMetadataResult(
-  parsed: ReplyDirectiveParseResult | null | undefined,
-): parsed is ReplyDirectiveParseResult {
-  return hasReplyDirectiveMetadata(parsed);
 }
 
 export function mergeReplyDirectiveResults(
@@ -36,10 +26,8 @@ export function mergeReplyDirectiveResults(
   if (!second) {
     return first;
   }
-  const mediaUrls = uniqueStrings([...(first.mediaUrls ?? []), ...(second.mediaUrls ?? [])]);
   return {
     text: `${first.text ?? ""}${second.text ?? ""}`,
-    mediaUrls: mediaUrls.length ? mediaUrls : undefined,
     replyToId: second.replyToId ?? first.replyToId,
     replyToCurrent: first.replyToCurrent || second.replyToCurrent,
     replyToTag: first.replyToTag || second.replyToTag,
@@ -224,17 +212,13 @@ export function recordPendingAssistantReplyDirectives(
   state: Pick<EmbeddedAgentSubscribeState, "pendingAssistantReplyDirectives">,
   parsed: ReplyDirectiveParseResult | null | undefined,
 ) {
-  if (!hasReplyDirectiveMetadataResult(parsed)) {
+  if (!parsed || !hasReplyDirectiveMetadata(parsed)) {
     return;
   }
   const current = state.pendingAssistantReplyDirectives;
-  const mediaUrls = Array.from(
-    new Set([...(current?.mediaUrls ?? []), ...(parsed.mediaUrls ?? [])]),
-  );
   state.pendingAssistantReplyDirectives = {
-    mediaUrls: mediaUrls.length ? mediaUrls : undefined,
-    audioAsVoice: current?.audioAsVoice || parsed?.audioAsVoice || undefined,
-    replyToId: parsed?.replyToId ?? current?.replyToId,
+    audioAsVoice: current?.audioAsVoice || parsed.audioAsVoice || undefined,
+    replyToId: parsed.replyToId ?? current?.replyToId,
     replyToTag: current?.replyToTag || parsed.replyToTag || undefined,
     replyToCurrent: current?.replyToCurrent || parsed.replyToCurrent || undefined,
   };
@@ -249,13 +233,9 @@ export function consumePendingAssistantReplyDirectivesIntoReply(
     return payload;
   }
   const pending = state.pendingAssistantReplyDirectives;
-  const mediaUrls = Array.from(
-    new Set([...(payload.mediaUrls ?? []), ...(pending.mediaUrls ?? [])]),
-  );
   state.pendingAssistantReplyDirectives = undefined;
   return {
     ...payload,
-    mediaUrls: mediaUrls.length ? mediaUrls : undefined,
     audioAsVoice: payload.audioAsVoice || pending.audioAsVoice || undefined,
     replyToId: payload.replyToId ?? pending.replyToId,
     replyToTag: Boolean(payload.replyToTag || pending.replyToTag) || undefined,
@@ -282,5 +262,3 @@ export function resolveManagedStreamMediaUrls(
     mediaUrls.filter((url) => state.pendingToolMediaTrustByUrl.get(url.trim()) === true),
   );
 }
-
-/** Builds normalized stream payload data for assistant visible output. */

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts
@@ -60,7 +60,6 @@ describe("pending assistant reply directives", () => {
 
     recordPendingAssistantReplyDirectives(state, {
       text: "",
-      mediaUrls: ["/tmp/reply.ogg"],
       replyToCurrent: true,
       replyToTag: true,
       audioAsVoice: true,
@@ -73,7 +72,6 @@ describe("pending assistant reply directives", () => {
       }),
     ).toEqual({
       text: "Done.",
-      mediaUrls: ["/tmp/reply.ogg"],
       audioAsVoice: true,
       replyToId: undefined,
       replyToTag: true,
@@ -85,7 +83,7 @@ describe("pending assistant reply directives", () => {
   it("does not consume pending directive metadata on reasoning replies", () => {
     const state = {
       pendingAssistantReplyDirectives: {
-        mediaUrls: ["/tmp/reply.png"],
+        replyToId: "parent-message",
       },
     };
 
@@ -98,6 +96,6 @@ describe("pending assistant reply directives", () => {
       text: "Thinking...",
       isReasoning: true,
     });
-    expect(state.pendingAssistantReplyDirectives?.mediaUrls).toEqual(["/tmp/reply.png"]);
+    expect(state.pendingAssistantReplyDirectives?.replyToId).toBe("parent-message");
   });
 });

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
@@ -356,7 +356,7 @@ export function resolveStreamingReply(params: {
   previousText: string;
   previousCleaned: string;
   visibleDelta: string;
-  textIsAppend: boolean;
+  appendDelta: string | null;
   parsedStreamDirectives: ReplyDirectiveParseResult | null;
 }): { text: string; delta: string; replace: boolean; hasText: boolean } {
   if (!params.parsedStreamDirectives && params.evtType === "text_delta") {
@@ -373,34 +373,18 @@ export function resolveStreamingReply(params: {
     !params.parsedStreamDirectives.isSilent &&
     !hasReplyDirectiveMetadata(params.parsedStreamDirectives) &&
     !/(?:^|\n)\s*MEDIA:\s*\S[^\n]*(?:\n|$)/i.test(params.visibleDelta) &&
-    params.parsedStreamDirectives.text === params.visibleDelta
+    params.parsedStreamDirectives.text === params.visibleDelta &&
+    params.appendDelta !== null &&
+    params.previousText === params.previousCleaned
   ) {
-    if (params.textIsAppend && params.previousText === params.previousCleaned) {
-      // Reuse the normalized prefix and small delta. Trimming the cumulative
-      // snapshot can flatten it; slicing can retain it in queued updates.
-      delta = params.previousCleaned ? params.visibleDelta.trimEnd() : params.visibleDelta.trim();
-      text = delta === params.visibleDelta ? params.next : `${params.previousCleaned}${delta}`;
-      isAppend = true;
-    } else if (params.textIsAppend && params.previousCleaned === params.previousText.trim()) {
-      text = params.next.trim();
-      isAppend = true;
-    } else {
-      const candidate = `${params.previousCleaned}${params.parsedStreamDirectives.text}`.trim();
-      const normalizedNext = params.next.trim();
-      if (candidate === normalizedNext) {
-        text = normalizedNext;
-        // Appending cannot alter the prior prefix unless trimming removed its whitespace.
-        isAppend =
-          candidate.length >= params.previousCleaned.length &&
-          params.previousCleaned.trimStart().length === params.previousCleaned.length;
-      }
-    }
+    // Visibility and trim owners already prepared this exact append.
+    text = params.next;
+    delta = params.appendDelta;
+    isAppend = true;
   }
 
   text ??= parseReplyDirectives(
-    params.evtType === "text_end"
-      ? params.next.trim()
-      : splitTrailingDirective(params.next.trim()).text,
+    params.evtType === "text_end" ? params.next : splitTrailingDirective(params.next).text,
   ).text;
   const replace = Boolean(
     !isAppend && params.previousCleaned && !text.startsWith(params.previousCleaned),

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -1,18 +1,17 @@
 /**
  * Handles assistant message deltas, reasoning, directives, and block replies.
  */
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import type { AssistantMessage } from "../llm/types.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
 import { resolveAssistantMessagePhase } from "../shared/chat-message-content.js";
+import { createTextProjection, trimTextFilter } from "../shared/text/text-projection.js";
 import { updateLiveEditDiffProgress } from "./embedded-agent-live-edit-diff.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import {
   mergeReplyDirectiveResults,
   recordPendingAssistantReplyDirectives,
-  resolveManagedStreamMediaUrls,
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import {
   buildAssistantStreamData,
@@ -41,12 +40,12 @@ import type {
 } from "./embedded-agent-subscribe.handlers.types.js";
 import { appendRawStream } from "./embedded-agent-subscribe.raw-stream.js";
 import {
+  createAssistantVisibleStreamText,
   createThinkingTagStreamState,
   extractAssistantCommentaryText,
   extractAssistantThinking,
   extractAssistantVisibleText,
   extractThinkingFromTaggedStream,
-  sanitizeAssistantVisibleStreamText,
 } from "./embedded-agent-utils.js";
 import type { AgentEvent, AgentMessage } from "./runtime/index.js";
 
@@ -308,6 +307,7 @@ export function handleMessageUpdate(
   const wasThinking = ctx.state.partialBlockState.thinking;
   let visibleDelta = "";
   let textIsAppend = false;
+  let appendDelta: string | null = null;
   let previousText = ctx.state.assistantStream?.raw ?? "";
   // A text_start partial may already contain text that the following text_delta replays.
   // Use starts only for lifecycle boundaries; consume their text from delta/end events.
@@ -348,31 +348,18 @@ export function handleMessageUpdate(
   if (!next && evtType !== "text_end") {
     next = undefined;
   }
+  const hasSnapshotText = next !== undefined;
   let nextRawStreamText = next ?? "";
-  let sanitized: NonNullable<EmbeddedAgentSubscribeState["assistantStream"]>["sanitized"];
+  let projection: NonNullable<EmbeddedAgentSubscribeState["assistantStream"]>["projection"];
   if (next === undefined && deliveryPhase === "final_answer" && (reprojectBlockReply || chunk)) {
     // A late phase can reveal inline examples; retain already scoped snapshots above.
-    const previousStream = reprojectBlockReply ? undefined : ctx.state.assistantStream;
-    const previousRawText = previousStream?.raw ?? "";
     visibleDelta = reprojectBlockReply
       ? ctx.state.deltaBuffer
       : ctx.params.enforceFinalTag
         ? ctx.stripBlockTags(chunk, ctx.state.partialBlockState, { final: finalText })
         : chunk;
-    nextRawStreamText = `${previousRawText}${visibleDelta}`;
-    const sanitizerPhase = ctx.params.enforceFinalTag ? undefined : deliveryPhase;
-    next = sanitizeAssistantVisibleStreamText(nextRawStreamText, sanitizerPhase).trim();
-    sanitized = { phase: sanitizerPhase, text: next };
-    previousText =
-      previousStream?.sanitized && previousStream.sanitized.phase === sanitizerPhase
-        ? previousStream.sanitized.text
-        : sanitizeAssistantVisibleStreamText(previousRawText, sanitizerPhase).trim();
-    textIsAppend = next.startsWith(previousText);
-    visibleDelta = textIsAppend
-      ? next.slice(previousText.length)
-      : previousText.startsWith(next)
-        ? ""
-        : next;
+    next = visibleDelta;
+    textIsAppend = true;
     if (reprojectBlockReply) {
       ctx.resetPartialReplyDirectives();
     }
@@ -390,7 +377,7 @@ export function handleMessageUpdate(
       });
       const isFullStreamReplacement = !recomputedRawText.startsWith(previousText);
       textIsAppend = !isFullStreamReplacement;
-      next = recomputedRawText.trim();
+      next = recomputedRawText;
       visibleDelta = isFullStreamReplacement
         ? recomputedRawText
         : recomputedRawText.slice(previousText.length);
@@ -408,8 +395,7 @@ export function handleMessageUpdate(
         next = ctx.state.assistantStream?.text ?? "";
         nextRawStreamText = ctx.state.assistantStream?.raw ?? "";
       } else {
-        nextRawStreamText = `${ctx.state.assistantStream?.raw ?? ""}${visibleDelta}`;
-        next = nextRawStreamText;
+        next = visibleDelta;
         textIsAppend = true;
       }
     }
@@ -419,6 +405,38 @@ export function handleMessageUpdate(
     });
   }
   if (next !== undefined) {
+    if (!hasSnapshotText) {
+      const kind =
+        deliveryPhase !== "final_answer"
+          ? "raw"
+          : ctx.params.enforceFinalTag
+            ? "delivery"
+            : "final";
+      const previousStream = reprojectBlockReply ? undefined : ctx.state.assistantStream;
+      projection = previousStream?.projection;
+      if (!projection || projection.kind !== kind) {
+        projection = {
+          kind,
+          projector:
+            kind === "raw"
+              ? createTextProjection([trimTextFilter("both")])
+              : createAssistantVisibleStreamText(kind === "final" ? "final_answer" : undefined),
+        };
+        projection.projector.replace(previousStream?.raw ?? "");
+      }
+      previousText = projection.projector.text;
+      const projected = textIsAppend
+        ? projection.projector.append(visibleDelta)
+        : projection.projector.replace(nextRawStreamText);
+      nextRawStreamText = projection.projector.source;
+      next = projected.text;
+      appendDelta = projected.delta;
+      // Generic directives retain their raw chunk coordinates: restored trim whitespace
+      // could otherwise make an inline tag look like an indented code block.
+      if (kind !== "raw") {
+        visibleDelta = projected.delta ?? (previousText.startsWith(next) ? "" : next);
+      }
+    }
     if (
       !suppressMessageToolOnlySourceReplyOutput &&
       !wasThinking &&
@@ -457,20 +475,16 @@ export function handleMessageUpdate(
       previousText,
       previousCleaned,
       visibleDelta,
-      textIsAppend,
+      appendDelta,
       parsedStreamDirectives,
     });
-    const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
-    const managedMediaUrls = resolveManagedStreamMediaUrls(ctx.state, mediaUrls);
     const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
 
-    const hasVisibleReply = hasText || hasMedia || hasAudio;
+    const hasVisibleReply = hasText || hasAudio;
     const deltaText = hasVisibleReply ? replyDelta : "";
     let shouldEmit =
       (hasVisibleReply || replace) &&
-      (replace
-        ? cleanedText !== previousCleaned || hasMedia || hasAudio
-        : Boolean(deltaText || hasMedia || hasAudio));
+      (replace ? cleanedText !== previousCleaned || hasAudio : Boolean(deltaText || hasAudio));
 
     if (snapshot) {
       const undrained = ctx.state.lastBlockReplyText == null;
@@ -529,8 +543,8 @@ export function handleMessageUpdate(
       ctx.state.streamBlockText = content;
     }
 
-    // Snapshot recovery must not seed the next streaming sanitizer result.
-    ctx.state.assistantStream = { raw: nextRawStreamText, text: cleanedText, sanitized };
+    // Snapshot recovery discards incremental state; its scoped source seeds the next append.
+    ctx.state.assistantStream = { raw: nextRawStreamText, text: cleanedText, projection };
 
     if (
       ctx.params.silentExpected ||
@@ -554,8 +568,6 @@ export function handleMessageUpdate(
         text: currentSourcePartial.text,
         delta: releaseHeldSnapshot ? currentSourcePartial.text : deltaText,
         replace: releaseHeldSnapshot || replace,
-        mediaUrls,
-        managedMediaUrls,
         phase: deliveryPhase ?? assistantPhase,
       });
       ctx.emitAssistantStreamData(data, { emitPartialReply: !currentSourcePartial.hold });

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -24,7 +24,10 @@ import type {
   BlockReplyChunking,
   SubscribeEmbeddedAgentSessionParams,
 } from "./embedded-agent-subscribe.types.js";
-import type { ThinkingTagStreamState } from "./embedded-agent-utils.js";
+import type {
+  createAssistantVisibleStreamText,
+  ThinkingTagStreamState,
+} from "./embedded-agent-utils.js";
 import type { McpConnectAction } from "./mcp-connect-action.js";
 import type { McpAppChannelView } from "./mcp-ui-resource.js";
 import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
@@ -158,7 +161,10 @@ export type EmbeddedAgentSubscribeState = {
   assistantStream?: {
     raw: string;
     text: string;
-    sanitized?: { phase: AssistantPhase | undefined; text: string };
+    projection?: {
+      kind: "raw" | "delivery" | "final";
+      projector: ReturnType<typeof createAssistantVisibleStreamText>;
+    };
   };
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
@@ -222,9 +228,10 @@ export type EmbeddedAgentSubscribeState = {
   pendingToolMediaDeliveryFailed: boolean;
   hasToolMediaBlockReply: boolean;
   visibleBlockReplyCount: number;
+  /** Media selection belongs to message_end; only voice/reply intent waits for a block. */
   pendingAssistantReplyDirectives?: Pick<
     BlockReplyPayload,
-    "mediaUrls" | "audioAsVoice" | "replyToId" | "replyToTag" | "replyToCurrent"
+    "audioAsVoice" | "replyToId" | "replyToTag" | "replyToCurrent"
   >;
   deterministicApprovalPromptPending: boolean;
   deterministicApprovalPromptSent: boolean;

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -124,7 +124,17 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     }
   });
 
-  it("streams partial replies past reply_to tags split across chunks", () => {
+  it.each([
+    { name: "a split reply tag", chunks: ["[[reply_to:1897", "]] Hello", " world"] },
+    {
+      name: "held whitespace before hidden reasoning",
+      chunks: [" \nHello \t", "<think>private</think> [[reply_to_current]] world  "],
+    },
+    {
+      name: "held whitespace before a split reasoning tag",
+      chunks: [" \nHello \t<think", ">private</think> [[reply_to_current]] world  "],
+    },
+  ])("streams partial replies past $name", ({ chunks }) => {
     // Split tags are buffered until complete so partial replies never expose raw
     // directive syntax.
     const { session, emit } = createStubSessionHarness();
@@ -138,11 +148,12 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     });
 
     emit({ type: "message_start", message: { role: "assistant" } });
-    emitAssistantTextDelta({ emit, delta: "[[reply_to:1897" });
-    emitAssistantTextDelta({ emit, delta: "]] Hello" });
-    emitAssistantTextDelta({ emit, delta: " world" });
-    emitAssistantTextEnd({ emit });
+    for (const delta of chunks) {
+      emitAssistantTextDelta({ emit, delta });
+    }
 
+    expect(replyTexts(onPartialReply)).toEqual(["Hello", "Hello world"]);
+    emitAssistantTextEnd({ emit });
     expect(lastReplyPayload(onPartialReply).text).toBe("Hello world");
     for (const call of onPartialReply.mock.calls) {
       expect(call[0]?.text?.includes("[[reply_to")).toBe(false);

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -11,8 +11,15 @@ import {
   parseAssistantTextSignature,
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
-import { sanitizeAssistantVisibleTextWithProfile } from "../shared/text/assistant-visible-text.js";
-import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-facing-text.js";
+import {
+  assistantVisibleTextFilters,
+  sanitizeAssistantVisibleTextWithProfile,
+} from "../shared/text/assistant-visible-text.js";
+import { createTextProjection, trimTextFilter } from "../shared/text/text-projection.js";
+import {
+  sanitizeUserFacingText,
+  userFacingTextFilters,
+} from "./embedded-agent-helpers/sanitize-user-facing-text.js";
 import { renderUserFacingText } from "./embedded-agent-helpers/user-facing-text.js";
 import type { AgentMessage } from "./runtime/index.js";
 
@@ -37,6 +44,17 @@ function isAssistantTextContentBlockType(value: unknown): boolean {
 
 export function sanitizeAssistantVisibleStreamText(text: string, phase?: AssistantPhase): string {
   return sanitizeUserFacingText(sanitizeAssistantText(text, phase, true), { errorContext: false });
+}
+
+export function createAssistantVisibleStreamText(phase?: AssistantPhase) {
+  return createTextProjection([
+    ...assistantVisibleTextFilters(
+      phase === "final_answer" ? "final-answer-delivery" : "delivery",
+      phase === "final_answer",
+    ),
+    ...userFacingTextFilters(),
+    trimTextFilter("both"),
+  ]);
 }
 
 function finalizeAssistantExtraction(msg: AssistantMessage, extracted: string): string {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1533,6 +1533,14 @@ describe("createStreamingDirectiveAccumulator", () => {
     const second = accumulator.consume("test 2");
     expect(second?.replyToId).toBe("abc-123");
     expect(second?.replyToTag).toBe(true);
+
+    expect(accumulator.consume("[[reply_to_current]][[reply_to: later]]")).toBeNull();
+    expect(accumulator.consume("third")).toMatchObject({
+      text: "third",
+      replyToId: "later",
+      replyToCurrent: true,
+      replyToTag: true,
+    });
   });
 
   it("clears sticky reply context on reset", () => {

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -13,12 +13,6 @@ import {
 } from "../tokens.js";
 import type { ReplyDirectiveParseResult } from "./reply-directives.js";
 
-type PendingReplyState = {
-  explicitId?: string;
-  sawCurrent: boolean;
-  hasTag: boolean;
-};
-
 type ConsumeOptions = {
   final?: boolean;
   silentToken?: string;
@@ -77,15 +71,17 @@ export const splitTrailingDirective = (text: string): { text: string; tail: stri
 export function createStreamingDirectiveAccumulator() {
   let pendingTail = "";
   let pendingSeparator = "";
-  let pendingReply: PendingReplyState = { sawCurrent: false, hasTag: false };
-  let activeReply: PendingReplyState = { sawCurrent: false, hasTag: false };
+  let replyToId: string | undefined;
+  let replyToCurrent = false;
+  let replyToTag = false;
   let hasReturnedText = false;
 
   const reset = () => {
     pendingTail = "";
     pendingSeparator = "";
-    pendingReply = { sawCurrent: false, hasTag: false };
-    activeReply = { sawCurrent: false, hasTag: false };
+    replyToId = undefined;
+    replyToCurrent = false;
+    replyToTag = false;
     hasReturnedText = false;
   };
 
@@ -132,41 +128,25 @@ export function createStreamingDirectiveAccumulator() {
     if (options?.final && !hasReturnedText) {
       text = stripInlineDirectiveTagsForDelivery(text).text;
     }
-    const hasTag = activeReply.hasTag || pendingReply.hasTag || parsed?.hasReplyTag === true;
-    const sawCurrent =
-      activeReply.sawCurrent || pendingReply.sawCurrent || parsed?.replyToCurrent === true;
-    const explicitId =
-      parsed?.replyToExplicitId ?? pendingReply.explicitId ?? activeReply.explicitId;
+    // Reply context survives directive-only and visible chunks until the assistant message resets.
+    replyToId = parsed?.replyToExplicitId ?? replyToId;
+    replyToCurrent ||= parsed?.replyToCurrent === true;
+    replyToTag ||= parsed?.hasReplyTag === true;
 
     const combinedResult = {
       text,
-      replyToId: explicitId,
+      replyToId,
       replyToExplicitId: parsed?.replyToExplicitId,
-      replyToCurrent: sawCurrent,
-      replyToTag: hasTag,
+      replyToCurrent,
+      replyToTag,
       audioAsVoice: parsed?.audioAsVoice ?? false,
       isSilent,
     };
 
     if (!hasOutboundReplyContent(combinedResult) && !combinedResult.audioAsVoice) {
-      if (hasTag) {
-        pendingReply = {
-          explicitId,
-          sawCurrent,
-          hasTag,
-        };
-      }
       return null;
     }
 
-    // Keep reply context sticky for the full assistant message so split/newline chunks
-    // stay on the same native reply target until reset() is called for the next message.
-    activeReply = {
-      explicitId,
-      sawCurrent,
-      hasTag,
-    };
-    pendingReply = { sawCurrent: false, hasTag: false };
     hasReturnedText ||= Boolean(combinedResult.text);
     return combinedResult;
   };

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -9,6 +9,12 @@ const CHANNEL_CONTEXT_HEADER = `Context: ${INBOUND_CONTEXT_MARKER}`;
 const ACTIVE_MEMORY_CONTEXT_HEADER = "Context:";
 const ACTIVE_MEMORY_OPEN_TAG = "<active_memory_plugin>";
 const ACTIVE_MEMORY_CLOSE_TAG = "</active_memory_plugin>";
+export const INBOUND_METADATA_MARKERS = [
+  "[",
+  INBOUND_CONTEXT_MARKER,
+  ...MESSAGE_TOOL_DELIVERY_HINTS,
+  ACTIVE_MEMORY_CONTEXT_HEADER,
+];
 const METADATA_TOKENS_RE = new RegExp(
   [INBOUND_CONTEXT_MARKER, ...MESSAGE_TOOL_DELIVERY_HINTS].map(escapeRegExp).join("|"),
   "g",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -1,15 +1,16 @@
 import { expectDefined } from "@openclaw/normalization-core";
 // Assistant visible text helpers strip hidden reasoning and control marker text.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
-import { findCodeRegions, isInsideCode } from "./code-regions.js";
-import { stripModelSpecialTokens } from "./model-special-tokens.js";
 import {
-  stripReasoningTagsFromText,
-  type ReasoningTagMode,
-  type ReasoningTagScope,
-  type ReasoningTagTrim,
-} from "./reasoning-tags.js";
+  consumeLineBreak,
+  skipHorizontalWhitespace,
+  skipWhitespace,
+} from "../../../packages/tool-call-repair/src/grammar.js";
+import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
+import { findCodeRegions, isInsideCode, stripLinesOutsideCode } from "./code-regions.js";
+import { stripModelSpecialTokens } from "./model-special-tokens.js";
+import { stripReasoningTagsFromText } from "./reasoning-tags.js";
+import { applyTextFilters, trimTextFilter, type TextFilter } from "./text-projection.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
@@ -93,63 +94,27 @@ interface ParsedToolCallTag {
   isTruncated: boolean;
 }
 
+// Match only the tag head; quote-aware scanning owns the close boundary.
+const XML_TAG_HEAD_RE = /<\s*(?:(\/)\s*)?([A-Za-z_:][A-Za-z0-9_.:-]*)(?=$|[\s/>])/y;
+
 function parseXmlTagAt(text: string, start: number): ParsedToolCallTag | null {
-  if (text[start] !== "<") {
+  XML_TAG_HEAD_RE.lastIndex = start;
+  const match = XML_TAG_HEAD_RE.exec(text);
+  if (!match) {
     return null;
   }
-
-  let cursor = start + 1;
-  while (cursor < text.length && /\s/.test(text.charAt(cursor))) {
-    cursor += 1;
-  }
-
-  let isClose = false;
-  if (text[cursor] === "/") {
-    isClose = true;
-    cursor += 1;
-    while (cursor < text.length && /\s/.test(text.charAt(cursor))) {
-      cursor += 1;
-    }
-  }
-
-  const nameStart = cursor;
-  if (!/[A-Za-z_:]/.test(text[cursor] ?? "")) {
-    return null;
-  }
-  cursor += 1;
-  while (cursor < text.length && /[A-Za-z0-9_.:-]/.test(text.charAt(cursor))) {
-    cursor += 1;
-  }
-
-  const tagName = normalizeLowercaseStringOrEmpty(text.slice(nameStart, cursor));
-  if (!isToolCallBoundary(text[cursor])) {
-    return null;
-  }
-  const contentStart = cursor;
-  const closeIndex = findTagCloseIndex(text, cursor);
-  if (closeIndex === -1) {
-    return {
-      contentStart,
-      end: text.length,
-      isClose,
-      isSelfClosing: false,
-      tagName,
-      isTruncated: true,
-    };
-  }
-
+  const contentStart = XML_TAG_HEAD_RE.lastIndex;
+  const isClose = match[1] === "/";
+  const closeIndex = findTagCloseIndex(text, contentStart);
+  const isTruncated = closeIndex === -1;
   return {
     contentStart,
-    end: closeIndex + 1,
+    end: isTruncated ? text.length : closeIndex + 1,
     isClose,
-    isSelfClosing: !isClose && /\/\s*$/.test(text.slice(cursor, closeIndex)),
-    tagName,
-    isTruncated: false,
+    isSelfClosing: !isTruncated && !isClose && /\/\s*$/.test(text.slice(contentStart, closeIndex)),
+    tagName: normalizeLowercaseStringOrEmpty(match[2]),
+    isTruncated,
   };
-}
-
-function isToolCallBoundary(char: string | undefined): boolean {
-  return !char || /\s/.test(char) || char === "/" || char === ">";
 }
 
 function findTagCloseIndex(text: string, start: number): number {
@@ -203,11 +168,7 @@ function startsWithNestedJsonToolCallPayload(text: string, start: number): boole
   if (!NESTED_JSON_TOOL_CALL_PAYLOAD_START_RE.test(text.slice(start))) {
     return false;
   }
-  let cursor = start;
-  while (cursor < text.length && /\s/.test(text.charAt(cursor))) {
-    cursor += 1;
-  }
-  const nestedTag = parseToolCallTagAt(text, cursor);
+  const nestedTag = parseToolCallTagAt(text, skipWhitespace(text, start));
   if (
     !nestedTag ||
     nestedTag.isClose ||
@@ -239,49 +200,6 @@ function isLikelyStandaloneFunctionToolCall(
   }
 
   return idx < 0 || text[idx] === "\n" || text[idx] === "\r" || /[.!?:]/.test(text.charAt(idx));
-}
-
-function isStandaloneOpeningTagLine(
-  text: string,
-  tagStart: number,
-  tag: ParsedToolCallTag,
-): boolean {
-  let idx = tagStart - 1;
-  while (idx >= 0 && (text[idx] === " " || text[idx] === "\t")) {
-    idx -= 1;
-  }
-  if (!(idx < 0 || text[idx] === "\n" || text[idx] === "\r")) {
-    return false;
-  }
-  let after = tag.end;
-  while (after < text.length && (text[after] === " " || text[after] === "\t")) {
-    after += 1;
-  }
-  return after >= text.length || text[after] === "\n" || text[after] === "\r";
-}
-
-function isOpeningTagFollowedByLineBreak(text: string, tag: ParsedToolCallTag): boolean {
-  let after = tag.end;
-  while (after < text.length && (text[after] === " " || text[after] === "\t")) {
-    after += 1;
-  }
-  return after >= text.length || text[after] === "\n" || text[after] === "\r";
-}
-
-function hasSameLineContentAfterOpeningTag(text: string, tag: ParsedToolCallTag): boolean {
-  let after = tag.end;
-  while (after < text.length && (text[after] === " " || text[after] === "\t")) {
-    after += 1;
-  }
-  return after < text.length && text[after] !== "\n" && text[after] !== "\r";
-}
-
-function isVisibleLineStart(text: string): boolean {
-  let idx = text.length - 1;
-  while (idx >= 0 && (text[idx] === " " || text[idx] === "\t")) {
-    idx -= 1;
-  }
-  return idx < 0 || text[idx] === "\n" || text[idx] === "\r";
 }
 
 function isAdjacentToStrippedToolCallBlock(
@@ -322,14 +240,7 @@ function findAdjacentOpeningToolCallTag(
   start: number,
   tagName: string,
 ): ParsedToolCallTag | null {
-  let idx = start;
-  while (idx < text.length && /\s/.test(text.charAt(idx))) {
-    idx += 1;
-  }
-  if (text[idx] !== "<") {
-    return null;
-  }
-  const tag = parseToolCallTagAt(text, idx);
+  const tag = parseToolCallTagAt(text, skipWhitespace(text, start));
   if (!tag || tag.isClose || tag.tagName !== tagName) {
     return null;
   }
@@ -368,19 +279,8 @@ function isDanglingFunctionParameterParent(text: string, tag: ParsedToolCallTag)
   if (tag.tagName !== "function" || !/\bname\s*=/.test(text.slice(tag.contentStart, tag.end))) {
     return false;
   }
-  let cursor = tag.end;
-  while (cursor < text.length && /\s/.test(text.charAt(cursor))) {
-    cursor += 1;
-  }
-  const nextTag = parseXmlTagAt(text, cursor);
+  const nextTag = parseXmlTagAt(text, skipWhitespace(text, tag.end));
   return nextTag?.tagName === "parameter" && !nextTag.isClose;
-}
-
-function consumeImmediateLineBreak(text: string, start: number): number | null {
-  if (text[start] === "\r" && text[start + 1] === "\n") {
-    return start + 2;
-  }
-  return text[start] === "\n" || text[start] === "\r" ? start + 1 : null;
 }
 
 function trimImmediateLineBreakBefore(text: string, start: number, end: number): number {
@@ -399,10 +299,7 @@ function isLineStartAt(text: string, start: number): boolean {
 }
 
 function isLineEndAfter(text: string, end: number): boolean {
-  let cursor = end;
-  while (cursor < text.length && (text[cursor] === " " || text[cursor] === "\t")) {
-    cursor += 1;
-  }
+  const cursor = skipHorizontalWhitespace(text, end);
   return cursor >= text.length || text[cursor] === "\n" || text[cursor] === "\r";
 }
 
@@ -455,9 +352,7 @@ function unwrapStandaloneParameterTags(text: string): string {
       if (unwrap) {
         result += text.slice(lastIndex, idx);
         lastIndex = tag.end;
-        const contentStart = isLineStartAt(text, idx)
-          ? consumeImmediateLineBreak(text, lastIndex)
-          : null;
+        const contentStart = isLineStartAt(text, idx) ? consumeLineBreak(text, lastIndex) : null;
         if (contentStart !== null) {
           lastIndex = contentStart;
           trimBoundaryLineBreaks = true;
@@ -563,22 +458,14 @@ export function stripToolCallXmlTags(
         tag.tagName === "function_response"
           ? findMatchingToolCallCloseIndex(text, tag.end, tag.tagName)
           : -1;
-      const shouldStripAdjacentResult =
-        isAdjacentToStrippedToolCallBlock(text, idx, lastStrippedToolCallBlockEnd) &&
-        (isOpeningTagFollowedByLineBreak(text, tag) ||
-          functionResponseCloseStart !== -1 ||
-          hasSameLineContentAfterOpeningTag(text, tag));
       const shouldStripStandaloneResult =
         tag.tagName === "function_response" &&
-        (isStandaloneOpeningTagLine(text, idx, tag) ||
-          shouldStripAdjacentResult ||
+        ((isLineStartAt(text, idx) && isLineEndAfter(text, tag.end)) ||
+          isAdjacentToStrippedToolCallBlock(text, idx, lastStrippedToolCallBlockEnd) ||
           (functionResponseCloseStart !== -1 &&
-            isVisibleLineStart(result) &&
-            isOpeningTagFollowedByLineBreak(text, tag)));
-      if (
-        !tag.isClose &&
-        ((payloadKind && shouldStripStandaloneFunction) || shouldStripStandaloneResult)
-      ) {
+            isLineStartAt(result, result.length) &&
+            isLineEndAfter(text, tag.end)));
+      if ((payloadKind && shouldStripStandaloneFunction) || shouldStripStandaloneResult) {
         inToolCallBlock = true;
         toolCallBlockContentStart = tag.end;
         toolCallBlockNeedsQuoteBalance =
@@ -678,45 +565,107 @@ export function stripLegacyBracketToolCallBlocks(text: string): string {
   const codeRegions = findCodeRegions(text);
   let result = "";
   let cursor = 0;
-  while (cursor < text.length) {
-    const openMatch = /\[\s*TOOL_(CALL|RESULT)\s*\]/gi.exec(text.slice(cursor));
-    if (!openMatch?.[0]) {
-      result += text.slice(cursor);
-      break;
+  for (const openMatch of text.matchAll(/\[\s*TOOL_(CALL|RESULT)\s*\]/gi)) {
+    const openStart = openMatch.index;
+    if (openStart < cursor || isInsideCode(openStart, codeRegions)) {
+      continue;
     }
-    const blockKind = openMatch[1]?.toUpperCase();
-    const openStart = cursor + (openMatch.index ?? 0);
     const payloadStart = openStart + openMatch[0].length;
-    if (isInsideCode(openStart, codeRegions)) {
-      result += text.slice(cursor, payloadStart);
-      cursor = payloadStart;
-      continue;
-    }
-
-    const closeRe =
-      blockKind === "RESULT" ? /\[\s*\/\s*TOOL_RESULT\s*\]/gi : /\[\s*\/\s*TOOL_CALL\s*\]/gi;
-    const closeMatch = closeRe.exec(text.slice(payloadStart));
+    const isResult = openMatch[1]?.toUpperCase() === "RESULT";
+    const closeRe = isResult ? /\[\s*\/\s*TOOL_RESULT\s*\]/gi : /\[\s*\/\s*TOOL_CALL\s*\]/gi;
+    closeRe.lastIndex = payloadStart;
+    const closeMatch = closeRe.exec(text);
     const closeStart =
-      closeMatch?.[0] && !isInsideCode(payloadStart + (closeMatch.index ?? 0), codeRegions)
-        ? payloadStart + (closeMatch.index ?? 0)
-        : -1;
-    const payloadEnd = closeStart >= 0 ? closeStart : text.length;
-    const payload = text.slice(payloadStart, payloadEnd);
-    const shouldStrip =
-      blockKind === "RESULT"
+      closeMatch && !isInsideCode(closeMatch.index, codeRegions) ? closeMatch.index : -1;
+    const payload = text.slice(payloadStart, closeStart >= 0 ? closeStart : text.length);
+    if (
+      !(isResult
         ? isLegacyBracketToolResultPayload(payload)
-        : isLegacyBracketToolCallPayload(payload);
-    if (!shouldStrip) {
-      result += text.slice(cursor, payloadStart);
-      cursor = payloadStart;
+        : isLegacyBracketToolCallPayload(payload))
+    ) {
       continue;
     }
-
     result += text.slice(cursor, openStart);
     cursor = closeStart >= 0 ? closeStart + (closeMatch?.[0].length ?? 0) : text.length;
+    if (cursor === text.length) {
+      break;
+    }
+  }
+  return result + text.slice(cursor);
+}
+
+function consumeJsonish(input: string, start: number): number | null {
+  let index = start;
+  while (index < input.length && /[ \t\r\n]/.test(input[index] ?? "")) {
+    index += 1;
+  }
+  const opening = input[index];
+  if (opening === undefined) {
+    return null;
+  }
+  if (opening !== "{" && opening !== "[" && opening !== '"') {
+    while (index < input.length && input[index] !== "\n" && input[index] !== "\r") {
+      index += 1;
+    }
+    return index;
   }
 
-  return result;
+  // Downgraded history accepts quoted scalars and mixed container balance without JSON validation.
+  let depth = opening === '"' ? 0 : 1;
+  let inString = opening === '"';
+  let escaped = false;
+  for (index += 1; index < input.length; index += 1) {
+    const char = input[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+    } else if (char === '"') {
+      inString = true;
+    } else if (char === "{" || char === "[") {
+      depth += 1;
+    } else if (char === "}" || char === "]") {
+      depth -= 1;
+    }
+    if (!inString && depth === 0) {
+      return index + 1;
+    }
+  }
+  return null;
+}
+
+function stripDowngradedToolCalls(input: string): string {
+  let codeRegions: ReturnType<typeof findCodeRegions> | undefined;
+  let result = "";
+  let cursor = 0;
+  for (const match of input.matchAll(/\[Tool Call:[^\]]*\]/gi)) {
+    const start = match.index;
+    if (start < cursor || isInsideCode(start, (codeRegions ??= findCodeRegions(input)))) {
+      continue;
+    }
+    result += input.slice(cursor, start);
+    let index = skipHorizontalWhitespace(input, start + match[0].length);
+    index = skipHorizontalWhitespace(input, consumeLineBreak(input, index) ?? index);
+    if (normalizeLowercaseStringOrEmpty(input.slice(index, index + 9)) === "arguments") {
+      index += 9;
+      if (input[index] === ":") {
+        index += 1;
+      }
+      if (input[index] === " ") {
+        index += 1;
+      }
+      index = consumeJsonish(input, index) ?? index;
+    }
+    if (!result || result.endsWith("\n") || result.endsWith("\r")) {
+      index = consumeLineBreak(input, index) ?? index;
+    }
+    cursor = index;
+  }
+  return result + input.slice(cursor);
 }
 
 /**
@@ -724,171 +673,21 @@ export function stripLegacyBracketToolCallBlocks(text: string): string {
  * text content when replaying history across providers.
  */
 export function stripDowngradedToolCallText(text: string): string {
-  if (!text) {
+  if (!text || (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text))) {
     return text;
   }
-  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
-    return text;
-  }
-
-  const consumeJsonish = (
-    input: string,
-    start: number,
-    options?: { allowLeadingNewlines?: boolean },
-  ): number | null => {
-    const { allowLeadingNewlines = false } = options ?? {};
-    let index = start;
-    while (index < input.length) {
-      const ch = input[index];
-      if (ch === " " || ch === "\t") {
-        index += 1;
-        continue;
-      }
-      if (allowLeadingNewlines && (ch === "\n" || ch === "\r")) {
-        index += 1;
-        continue;
-      }
-      break;
-    }
-    if (index >= input.length) {
-      return null;
-    }
-
-    const startChar = input[index];
-    if (startChar === "{" || startChar === "[") {
-      let depth = 0;
-      let inString = false;
-      let escape = false;
-      for (let idx = index; idx < input.length; idx += 1) {
-        const ch = input[idx];
-        if (inString) {
-          if (escape) {
-            escape = false;
-          } else if (ch === "\\") {
-            escape = true;
-          } else if (ch === '"') {
-            inString = false;
-          }
-          continue;
-        }
-        if (ch === '"') {
-          inString = true;
-          continue;
-        }
-        if (ch === "{" || ch === "[") {
-          depth += 1;
-        } else if (ch === "}" || ch === "]") {
-          depth -= 1;
-          if (depth === 0) {
-            return idx + 1;
-          }
-        }
-      }
-      return null;
-    }
-
-    if (startChar === '"') {
-      let escape = false;
-      for (let idx = index + 1; idx < input.length; idx += 1) {
-        const ch = input[idx];
-        if (escape) {
-          escape = false;
-          continue;
-        }
-        if (ch === "\\") {
-          escape = true;
-          continue;
-        }
-        if (ch === '"') {
-          return idx + 1;
-        }
-      }
-      return null;
-    }
-
-    let end = index;
-    while (end < input.length && input[end] !== "\n" && input[end] !== "\r") {
-      end += 1;
-    }
-    return end;
-  };
-
-  const stripToolCalls = (input: string): string => {
-    const toolCallRe = /\[Tool Call:[^\]]*\]/gi;
-    const codeRegions = findCodeRegions(input);
-    let result = "";
-    let cursor = 0;
-    for (const match of input.matchAll(toolCallRe)) {
-      const start = match.index ?? 0;
-      if (start < cursor) {
-        continue;
-      }
-      if (isInsideCode(start, codeRegions)) {
-        continue;
-      }
-      result += input.slice(cursor, start);
-      let index = start + match[0].length;
-      while (index < input.length && (input[index] === " " || input[index] === "\t")) {
-        index += 1;
-      }
-      if (input[index] === "\r") {
-        index += 1;
-        if (input[index] === "\n") {
-          index += 1;
-        }
-      } else if (input[index] === "\n") {
-        index += 1;
-      }
-      while (index < input.length && (input[index] === " " || input[index] === "\t")) {
-        index += 1;
-      }
-      if (normalizeLowercaseStringOrEmpty(input.slice(index, index + 9)) === "arguments") {
-        index += 9;
-        if (input[index] === ":") {
-          index += 1;
-        }
-        if (input[index] === " ") {
-          index += 1;
-        }
-        const end = consumeJsonish(input, index, { allowLeadingNewlines: true });
-        if (end !== null) {
-          index = end;
-        }
-      }
-      if (
-        (input[index] === "\n" || input[index] === "\r") &&
-        (result.endsWith("\n") || result.endsWith("\r") || result.length === 0)
-      ) {
-        if (input[index] === "\r") {
-          index += 1;
-        }
-        if (input[index] === "\n") {
-          index += 1;
-        }
-      }
-      cursor = index;
-    }
-    result += input.slice(cursor);
-    return result;
-  };
-
-  // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
-  let cleaned = stripToolCalls(text);
-
-  // Remove [Tool Result for ID ...] blocks and their content, unless the
-  // marker is quoted inside a fenced code block where it is reference material.
-  let codeRegions = findCodeRegions(cleaned);
-  cleaned = cleaned.replace(
+  let cleaned = stripDowngradedToolCalls(text);
+  for (const pattern of [
     /\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi,
-    (match, offset: number) => (isInsideCode(offset, codeRegions) ? match : ""),
-  );
-
-  // Remove [Historical context: ...] markers (self-contained within brackets).
-  codeRegions = findCodeRegions(cleaned);
-  cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, (match, offset: number) =>
-    isInsideCode(offset, codeRegions) ? match : "",
-  );
-
+    /\[Historical context:[^\]]*\]\n?/gi,
+  ]) {
+    const input = cleaned;
+    // An earlier removal can change Markdown ownership for the next marker family.
+    let codeRegions: ReturnType<typeof findCodeRegions> | undefined;
+    cleaned = input.replace(pattern, (match, offset: number) =>
+      isInsideCode(offset, (codeRegions ??= findCodeRegions(input))) ? match : "",
+    );
+  }
   return cleaned.trim();
 }
 
@@ -929,32 +728,20 @@ function stripRelevantMemoriesTags(text: string): string {
   return result;
 }
 
-export function stripAssistantInternalTraceLines(text: string): string {
+function stripAssistantInternalTraceLines(text: string): string {
   if (!text || !INTERNAL_TRACE_LINE_QUICK_RE.test(text)) {
     return text;
   }
 
-  const codeRegions = findCodeRegions(text);
-  let result = "";
-  let lineStart = 0;
-  while (lineStart < text.length) {
-    const newlineIndex = text.indexOf("\n", lineStart);
-    const lineEnd = newlineIndex === -1 ? text.length : newlineIndex + 1;
-    const rawLine = text.slice(lineStart, lineEnd);
-    const line = rawLine.endsWith("\n") ? rawLine.slice(0, -1).replace(/\r$/, "") : rawLine;
+  return stripLinesOutsideCode(text, (line) => {
     const trimmed = line.trim();
-    const shouldStrip =
-      !isInsideCode(lineStart, codeRegions) &&
-      (INTERNAL_TRACE_LINE_RE.test(trimmed) ||
-        INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE.test(trimmed) ||
-        INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE.test(trimmed) ||
-        INTERNAL_CHANNEL_TRACE_LINE_RE.test(trimmed));
-    if (!shouldStrip) {
-      result += rawLine;
-    }
-    lineStart = lineEnd;
-  }
-  return result;
+    return (
+      INTERNAL_TRACE_LINE_RE.test(trimmed) ||
+      INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE.test(trimmed) ||
+      INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE.test(trimmed) ||
+      INTERNAL_CHANNEL_TRACE_LINE_RE.test(trimmed)
+    );
+  });
 }
 
 export type AssistantVisibleTextSanitizerProfile =
@@ -964,127 +751,77 @@ export type AssistantVisibleTextSanitizerProfile =
   | "internal-scaffolding"
   | "tool-progress";
 
-type AssistantVisibleTextPipelineOptions = {
-  finalTrim: ReasoningTagTrim;
-  preserveDowngradedToolText?: boolean;
-  preserveMinimaxToolXml?: boolean;
-  stripFunctionCallsXmlPayloads?: boolean;
-  stripFunctionResponseAfterPluralToolCalls?: boolean;
-  stripInternalTraceLines?: boolean;
-  reasoningMode: ReasoningTagMode;
-  reasoningScope?: ReasoningTagScope;
-  reasoningTrim: ReasoningTagTrim;
-  stageOrder: "reasoning-first" | "reasoning-last";
-};
+const profileFilters = new Map<string, readonly TextFilter[]>();
 
-const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
-  AssistantVisibleTextSanitizerProfile,
-  AssistantVisibleTextPipelineOptions
-> = {
-  delivery: {
-    finalTrim: "both",
-    stripFunctionResponseAfterPluralToolCalls: true,
-    reasoningMode: "strict",
-    reasoningTrim: "both",
-    stageOrder: "reasoning-last",
-  },
-  "final-answer-delivery": {
-    finalTrim: "both",
-    stripFunctionResponseAfterPluralToolCalls: true,
-    reasoningMode: "strict",
-    reasoningScope: "leading",
-    reasoningTrim: "both",
-    stageOrder: "reasoning-last",
-  },
-  history: {
-    finalTrim: "none",
-    reasoningMode: "strict",
-    reasoningTrim: "none",
-    stageOrder: "reasoning-last",
-  },
-  "internal-scaffolding": {
-    finalTrim: "start",
-    preserveDowngradedToolText: true,
-    preserveMinimaxToolXml: true,
-    reasoningMode: "preserve",
-    reasoningTrim: "start",
-    stageOrder: "reasoning-first",
-  },
-  "tool-progress": {
-    finalTrim: "both",
-    stripFunctionCallsXmlPayloads: true,
-    stripInternalTraceLines: false,
-    reasoningMode: "strict",
-    reasoningTrim: "both",
-    stageOrder: "reasoning-last",
-  },
-};
-
-function applyAssistantVisibleTextStagePipeline(
-  text: string,
-  options: AssistantVisibleTextPipelineOptions,
+export function assistantVisibleTextFilters(
+  profile: AssistantVisibleTextSanitizerProfile,
   streaming = false,
-): string {
-  if (!text) {
-    return text;
+): readonly TextFilter[] {
+  const key = `${profile}:${streaming}`;
+  const cached = profileFilters.get(key);
+  if (cached) {
+    return cached;
   }
-
-  const stripReasoning = (value: string) =>
-    stripReasoningTagsFromText(value, {
-      mode: options.reasoningMode,
-      scope: options.reasoningScope,
-      trim: options.reasoningTrim,
-      // An unfinished stream cannot use terminal malformed-output recovery.
-      recoverUnclosed: !streaming,
-    });
-  const applyFinalTrim = (value: string) => {
-    if (options.finalTrim === "none") {
-      return value;
-    }
-    if (options.finalTrim === "start") {
-      return value.trimStart();
-    }
-    return value.trim();
+  const preserve = profile === "internal-scaffolding";
+  const trim = preserve ? "start" : profile === "history" ? "none" : "both";
+  const reasoning: TextFilter = {
+    activationTokens: ["<"],
+    transform: (text) =>
+      stripReasoningTagsFromText(text, {
+        mode: preserve ? "preserve" : "strict",
+        scope: profile === "final-answer-delivery" ? "leading" : "all",
+        trim,
+        // An unfinished stream cannot use terminal malformed-output recovery.
+        recoverUnclosed: !streaming,
+      }),
   };
-  const stripNonReasoningStages = (value: string) => {
-    let cleaned = value;
-    if (!options.preserveMinimaxToolXml) {
-      cleaned = stripMinimaxToolCallXml(cleaned);
-    }
-    cleaned = stripModelSpecialTokens(cleaned);
-    cleaned = stripRelevantMemoriesTags(cleaned);
-    cleaned = stripToolCallXmlTags(cleaned, {
-      stripFunctionCallsXmlPayloads: options.stripFunctionCallsXmlPayloads,
-      stripFunctionResponseAfterPluralToolCalls: options.stripFunctionResponseAfterPluralToolCalls,
-    });
-    if (options.stripInternalTraceLines !== false) {
-      cleaned = stripAssistantInternalTraceLines(cleaned);
-    }
-    cleaned = stripLegacyBracketToolCallBlocks(cleaned);
-    cleaned = stripPlainTextToolCallBlocks(cleaned, { resolveProtectedRanges: findCodeRegions });
-    if (!options.preserveDowngradedToolText) {
-      cleaned = stripDowngradedToolCallText(cleaned);
-    }
-    return cleaned;
-  };
-
-  if (options.stageOrder === "reasoning-first") {
-    return applyFinalTrim(stripNonReasoningStages(stripReasoning(text)));
+  const filters: TextFilter[] = [
+    ...(!preserve ? [{ transform: stripMinimaxToolCallXml, activationTokens: ["<"] }] : []),
+    { transform: stripModelSpecialTokens, activationTokens: ["<"] },
+    { transform: stripRelevantMemoriesTags, activationTokens: ["<"] },
+    {
+      activationTokens: ["<"],
+      transform: (text) =>
+        stripToolCallXmlTags(text, {
+          stripFunctionCallsXmlPayloads: profile === "tool-progress",
+          stripFunctionResponseAfterPluralToolCalls:
+            profile === "delivery" || profile === "final-answer-delivery",
+        }),
+    },
+    ...(profile === "tool-progress" ? [] : [assistantTraceTextFilter]),
+    { transform: stripLegacyBracketToolCallBlocks, activationTokens: ["["] },
+    plainToolCallTextFilter,
+    ...(!preserve ? [{ transform: stripDowngradedToolCallText, activationTokens: ["["] }] : []),
+  ];
+  if (preserve) {
+    filters.unshift(reasoning);
+  } else {
+    filters.push(reasoning);
   }
-
-  return applyFinalTrim(stripReasoning(stripNonReasoningStages(text)));
+  filters.push(trimTextFilter(trim));
+  profileFilters.set(key, filters);
+  return filters;
 }
+
+// Activation is a necessary condition only; the canonical parsers still own
+// syntax, code protection, and later corrections once a marker has appeared.
+export const assistantTraceTextFilter: TextFilter = {
+  transform: stripAssistantInternalTraceLines,
+  activationTokens: ["tool", "function", "📊", "🛠", "📖", "📝", "🔍", "🔎", "⚙"],
+};
+
+export const plainToolCallTextFilter: TextFilter = {
+  transform: (text) =>
+    stripPlainTextToolCallBlocks(text, { resolveProtectedRanges: findCodeRegions }),
+  activationTokens: ["[", "<", "to="],
+};
 
 export function sanitizeAssistantVisibleTextWithProfile(
   text: string,
   profile: AssistantVisibleTextSanitizerProfile = "delivery",
   streaming = false,
 ): string {
-  return applyAssistantVisibleTextStagePipeline(
-    text,
-    ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS[profile],
-    streaming,
-  );
+  return applyTextFilters(text, assistantVisibleTextFilters(profile, streaming));
 }
 
 export function stripAssistantInternalScaffolding(text: string): string {

--- a/src/shared/text/code-regions.ts
+++ b/src/shared/text/code-regions.ts
@@ -15,3 +15,17 @@ export function findCodeRegions(text: string): CodeRegion[] {
 export function isInsideCode(pos: number, regions: CodeRegion[]): boolean {
   return regions.some((region) => pos >= region.start && pos < region.end);
 }
+
+/** Removes control lines while retaining literal code and original line endings. */
+export function stripLinesOutsideCode(
+  text: string,
+  shouldStrip: (line: string) => boolean,
+): string {
+  let regions: CodeRegion[] | undefined;
+  return text.replace(/[^\n]*(?:\n|$)/g, (raw: string, offset: number) => {
+    const line = raw.endsWith("\n") ? raw.slice(0, -1).replace(/\r$/, "") : raw;
+    return shouldStrip(line) && !isInsideCode(offset, (regions ??= findCodeRegions(text)))
+      ? ""
+      : raw;
+  });
+}

--- a/src/shared/text/text-projection.test.ts
+++ b/src/shared/text/text-projection.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTextFilters,
+  createTextProjection,
+  duplicateParagraphTextFilter,
+  leadingEmptyLinesTextFilter,
+  trimTextFilter,
+  type TextFilter,
+} from "./text-projection.js";
+
+describe("createTextProjection", () => {
+  it("activates split markers, reprojects completed syntax, and replaces the source", () => {
+    const projection = createTextProjection([
+      {
+        activationTokens: ["<private>"],
+        transform: (text) => text.replace(/<private>[\s\S]*?<\/private>/gi, ""),
+      },
+    ]);
+    expect(projection.append("Before <PRI")).toEqual({ text: "Before <PRI", delta: "Before <PRI" });
+    expect(projection.append("VATE>secret")).toEqual({
+      text: "Before <PRIVATE>secret",
+      delta: "VATE>secret",
+    });
+    expect(projection.append("</PRIVATE>after")).toEqual({ text: "Before after", delta: null });
+    expect(projection.append(".")).toEqual({ text: "Before after.", delta: "." });
+    expect(projection.replace("Fresh ")).toEqual({ text: "Fresh ", delta: null });
+    expect(projection.append("reply")).toEqual({ text: "Fresh reply", delta: "reply" });
+    expect(projection.source).toBe("Fresh reply");
+    expect(projection.text).toBe("Fresh reply");
+  });
+
+  it("rechecks downstream activation when a preceding filter joins a marker", () => {
+    const filters: TextFilter[] = [
+      { activationTokens: ["<cut>"], transform: (text) => text.replace(/<cut>.*?<\/cut>/g, "") },
+      { activationTokens: ["BEGIN"], transform: (text) => text.replace(/BEGIN.*?END/g, "") },
+    ];
+    const projection = createTextProjection(filters);
+    projection.append("Before BE<cut>hidden");
+    expect(projection.append("</cut>GIN private ENDafter")).toEqual({
+      text: "Before after",
+      delta: null,
+    });
+    expect(applyTextFilters(projection.source, filters)).toBe("Before after");
+  });
+
+  it("preserves an append when downstream filtering cancels an intermediate correction", () => {
+    const projection = createTextProjection([
+      { activationTokens: ["<cut>"], transform: (text) => text.replace(/<cut>.*?<\/cut>/g, "") },
+      { activationTokens: ["<cut>"], transform: (text) => text.replace(/<cut>.*/g, "") },
+    ]);
+    expect(projection.append("Ready <cut>hidden")).toEqual({ text: "Ready ", delta: "Ready " });
+    expect(projection.append("</cut>reply")).toEqual({ text: "Ready reply", delta: "reply" });
+    expect(projection.replace("Ready reply")).toEqual({ text: "Ready reply", delta: null });
+  });
+
+  it.each(["none", "start", "both"] as const)("trims %s across whitespace boundaries", (mode) => {
+    const filter = trimTextFilter(mode);
+    const projection = createTextProjection([filter]);
+    let source = "";
+    let delivered = "";
+    for (const delta of [" \r", "\n\u00a0", " A ", "\t", "B\r", "\n", " C", "  "]) {
+      source += delta;
+      const result = projection.append(delta);
+      const expected =
+        mode === "both" ? source.trim() : mode === "start" ? source.trimStart() : source;
+      expect(result).toEqual({ text: expected, delta: expected.slice(delivered.length) });
+      delivered = expected;
+    }
+    expect(projection.replace(" \tReset \n")).toEqual({
+      text: filter.transform(" \tReset \n"),
+      delta: null,
+    });
+    expect(projection.append("end").text).toBe(filter.transform(" \tReset \nend"));
+  });
+
+  it.each([
+    { chunks: [" \r", "\n\t\n", "  Code", "\n next"], expected: "  Code\n next" },
+    { chunks: ["\v", "\n", " Text"], expected: "\v\n Text" },
+    { chunks: [" \n\r\n", "\t"], expected: "" },
+  ])("removes only leading empty lines %#", ({ chunks, expected }) => {
+    const projection = createTextProjection([leadingEmptyLinesTextFilter]);
+    let delivered = "";
+    for (const chunk of chunks) {
+      const result = projection.append(chunk);
+      expect(result.delta).not.toBeNull();
+      delivered += result.delta;
+      expect(delivered).toBe(result.text);
+    }
+    expect(projection.text).toBe(expected);
+    expect(projection.replace("\n  Reset")).toEqual({ text: "  Reset", delta: null });
+  });
+});
+
+describe("duplicate paragraphs", () => {
+  it.each([
+    { text: " \r\n\t ", expected: " \r\n\t " },
+    { text: "  A \n\n \tA  ", expected: "A" },
+    { text: "A\n\nB\n\nA", expected: "A\n\nB\n\nA" },
+    { text: "A  B\n\nA\tB", expected: "A  B" },
+    { text: "A\r\n\r\nA", expected: "A\r\n\r\nA" },
+    { text: "A\n\nA\n\nB\n\nB", expected: "A\n\nB" },
+    { text: "first\n\nfirst diverges\n\nfirst diverges", expected: "first\n\nfirst diverges" },
+    { text: "A\n\nA\n\nB C\n\nB\u00a0C", expected: "A\n\nB C" },
+    { text: "A\n\n \n\nA", expected: "A\n\n \n\nA" },
+    { text: "A\n\nA\n\n \n\nB", expected: "A\n\n\n\nB" },
+    { text: "\n\n \n\nA\n\nA\n\n \n\n", expected: "A" },
+  ])("preserves canonical separators and whitespace %#", ({ text, expected }) => {
+    expect(duplicateParagraphTextFilter.transform(text)).toBe(expected);
+    const partitions = [
+      text.split(""),
+      ...Array.from({ length: text.length + 1 }, (_, split) => [
+        text.slice(0, split),
+        text.slice(split),
+      ]),
+    ];
+    for (const chunks of partitions) {
+      const projection = createTextProjection([duplicateParagraphTextFilter]);
+      let delivered = "";
+      for (const chunk of chunks) {
+        const result = projection.append(chunk);
+        delivered = result.delta === null ? result.text : delivered + result.delta;
+        expect(delivered).toBe(result.text);
+      }
+      expect(projection.text).toBe(expected);
+    }
+  });
+
+  it.each([
+    {
+      initial: "A\n\n\nB\n\nB",
+      initialText: "A\n\nB",
+      appended: " changes",
+      expected: { text: "A\n\n\nB\n\nB changes", delta: null },
+    },
+    {
+      initial: "first\n\nfirst",
+      initialText: "first",
+      appended: " diverges\n\nfirst diverges",
+      expected: { text: "first\n\nfirst diverges", delta: "\n\nfirst diverges" },
+    },
+  ])(
+    "reconciles a provisional duplicate as later paragraphs diverge %#",
+    ({ initial, initialText, appended, expected }) => {
+      const projection = createTextProjection([duplicateParagraphTextFilter]);
+      expect(projection.append(initial)).toEqual({ text: initialText, delta: initialText });
+      expect(projection.append(appended)).toEqual(expected);
+      expect(projection.replace("  New\n\nNew")).toEqual({ text: "New", delta: null });
+      expect(projection.append("\n\nLast ")).toEqual({ text: "New\n\nLast", delta: "\n\nLast" });
+      expect(projection.append("word")).toEqual({ text: "New\n\nLast word", delta: " word" });
+    },
+  );
+});

--- a/src/shared/text/text-projection.ts
+++ b/src/shared/text/text-projection.ts
@@ -42,7 +42,8 @@ function createActivatedProjector(
   };
 }
 
-export function applyTextFilters(text: string, filters: readonly TextFilter[]): string {
+export function applyTextFilters(input: string, filters: readonly TextFilter[]): string {
+  let text = input;
   for (const filter of filters) {
     text = filter.transform(text);
   }
@@ -55,7 +56,8 @@ export function createTextProjection(filters: readonly TextFilter[]) {
   }));
   let source = "";
   let text = "";
-  const project = (input: TextProjection) => {
+  const project = (value: TextProjection) => {
+    let input = value;
     for (const stage of stages) {
       // Replacements can expose earlier syntax, so every downstream probe starts fresh.
       if (!stage.projector || input.delta === null) {

--- a/src/shared/text/text-projection.ts
+++ b/src/shared/text/text-projection.ts
@@ -1,0 +1,264 @@
+import { escapeRegExp } from "../regexp.js";
+
+type TextProjection = { text: string; delta: string | null };
+type TextProjector = (input: TextProjection) => TextProjection;
+// Token absence must prove identity; activated syntax stays with the canonical transform.
+export type TextFilter = { transform: (text: string) => string } & (
+  | { activationTokens: readonly string[] }
+  | { create: () => TextProjector }
+);
+
+function createActivatedProjector(
+  filter: Extract<TextFilter, { activationTokens: readonly string[] }>,
+): TextProjector {
+  const activation = new RegExp(filter.activationTokens.map(escapeRegExp).join("|"), "i");
+  const overlap = Math.max(0, ...filter.activationTokens.map((token) => token.length - 1));
+  let tail = "";
+  let active = false;
+  let previous = "";
+  let identity = true;
+  return (input) => {
+    if (input.delta === "") {
+      return identity ? input : { text: previous, delta: "" };
+    }
+    if (!active) {
+      const appended = tail + (input.delta ?? input.text);
+      active = activation.test(appended);
+      tail = !active && overlap ? appended.slice(-overlap) : "";
+    }
+    const text = active ? filter.transform(input.text) : input.text;
+    const nextIdentity = text === input.text;
+    const delta =
+      input.delta === null
+        ? null
+        : identity && nextIdentity
+          ? input.delta
+          : text.startsWith(previous)
+            ? text.slice(previous.length)
+            : null;
+    previous = text;
+    identity = nextIdentity;
+    return nextIdentity && delta === input.delta ? input : { text, delta };
+  };
+}
+
+export function applyTextFilters(text: string, filters: readonly TextFilter[]): string {
+  for (const filter of filters) {
+    text = filter.transform(text);
+  }
+  return text;
+}
+
+export function createTextProjection(filters: readonly TextFilter[]) {
+  const stages = filters.map((filter): { filter: TextFilter; projector?: TextProjector } => ({
+    filter,
+  }));
+  let source = "";
+  let text = "";
+  const project = (input: TextProjection) => {
+    for (const stage of stages) {
+      // Replacements can expose earlier syntax, so every downstream probe starts fresh.
+      if (!stage.projector || input.delta === null) {
+        stage.projector =
+          "create" in stage.filter ? stage.filter.create() : createActivatedProjector(stage.filter);
+      }
+      input = stage.projector(input);
+    }
+    return input;
+  };
+  return {
+    get source() {
+      return source;
+    },
+    get text() {
+      return text;
+    },
+    append(delta: string): TextProjection {
+      source += delta;
+      const next = project({ text: source, delta });
+      // A downstream filter can cancel an intermediate replacement without changing the final prefix.
+      if (next.delta === null && next.text.startsWith(text)) {
+        next.delta = next.text.slice(text.length);
+      }
+      text = next.text;
+      return next;
+    },
+    replace(value: string): TextProjection {
+      source = value;
+      const next = project({ text: source, delta: null });
+      next.delta = null;
+      text = next.text;
+      return next;
+    },
+  };
+}
+
+export function trimTextFilter(mode: "none" | "start" | "both"): TextFilter {
+  return {
+    transform: (text) =>
+      mode === "both" ? text.trim() : mode === "start" ? text.trimStart() : text,
+    create: () => {
+      let text = "";
+      let leading = true;
+      let removedLeading = false;
+      let pending = "";
+      return (input) => {
+        if (mode === "none") {
+          return input;
+        }
+        const appended = input.delta ?? input.text;
+        let delta = leading ? appended.trimStart() : appended;
+        removedLeading ||= delta.length !== appended.length;
+        leading &&= !delta;
+        if (mode === "both") {
+          const content = delta.trimEnd();
+          if (content) {
+            const trailing = delta.slice(content.length);
+            delta = pending + content;
+            pending = trailing;
+          } else {
+            pending += delta;
+            delta = "";
+          }
+        }
+        text = !removedLeading && !pending ? input.text : text + delta;
+        return { text, delta: input.delta === null ? null : delta };
+      };
+    },
+  };
+}
+
+function stripLeadingEmptyLines(text: string): string {
+  return text.trim() ? text.replace(/^(?:[ \t]*\r?\n)+/, "") : "";
+}
+
+export const leadingEmptyLinesTextFilter: TextFilter = {
+  transform: stripLeadingEmptyLines,
+  create: () => {
+    let started = false;
+    let identity = false;
+    let text = "";
+    return (input) => {
+      let delta = input.delta ?? input.text;
+      if (!started) {
+        started = /\S/.test(delta);
+        text = started ? stripLeadingEmptyLines(input.text) : "";
+        identity = text === input.text;
+        delta = text;
+      } else {
+        text = identity ? input.text : text + delta;
+      }
+      return { text, delta: input.delta === null ? null : delta };
+    };
+  },
+};
+
+function createDuplicateParagraphProjector(): TextProjector {
+  let active = false;
+  let trailingNewline = false;
+  let text = "";
+  let completed = "";
+  let lastNormalized: string | null = null;
+  let pendingEmpty = 0;
+  let paragraph = "";
+  let pending = "";
+  let normalizedLength = 0;
+  let equal = false;
+  let newlines = 0;
+  let hasDuplicate = false;
+  let wasCollapsed = false;
+  let wasDuplicate = false;
+  return (input) => {
+    let appended = input.delta ?? input.text;
+    if (!active) {
+      active = (trailingNewline && appended.startsWith("\n")) || appended.includes("\n\n");
+      trailingNewline = appended ? appended.endsWith("\n") : trailingNewline;
+      if (!active) {
+        text = input.text;
+        return input;
+      }
+      appended = input.text;
+    }
+    let completedParagraph = false;
+    let added = "";
+    for (const part of appended.matchAll(/\n+|[^\n]+/g)) {
+      if (part[0].startsWith("\n")) {
+        if (newlines < 2 && newlines + part[0].length >= 2) {
+          // One append can leave and re-enter duplicate state across this boundary.
+          completedParagraph = true;
+          if (!paragraph) {
+            if (lastNormalized !== null) {
+              pendingEmpty++;
+            }
+          } else if (equal && normalizedLength === lastNormalized?.length) {
+            hasDuplicate = true;
+          } else {
+            completed += (completed ? "\n\n" : "") + paragraph;
+            lastNormalized = paragraph.replace(/\s+/g, " ");
+          }
+          paragraph = "";
+          pending = "";
+          normalizedLength = 0;
+          equal = Boolean(lastNormalized);
+        } else if (newlines + part[0].length < 2 && paragraph) {
+          pending += part[0];
+        }
+        newlines += part[0].length;
+        continue;
+      }
+      newlines = 0;
+      const raw = paragraph ? part[0] : part[0].trimStart();
+      const content = raw.trimEnd();
+      if (!content) {
+        pending += raw;
+        continue;
+      }
+      const piece = pending + content;
+      pending = raw.slice(content.length);
+      if (!paragraph) {
+        const empty = "\n\n".repeat(pendingEmpty);
+        if (pendingEmpty) {
+          completed += empty;
+          pendingEmpty = 0;
+          lastNormalized = "";
+          equal = false;
+        }
+        added += completed ? empty + "\n\n" : "";
+      }
+      paragraph += piece;
+      added += piece;
+      if (equal) {
+        const normalized = piece.replace(/\s+/g, " ");
+        equal = lastNormalized?.startsWith(normalized, normalizedLength) === true;
+        normalizedLength += normalized.length;
+      }
+    }
+    const duplicate = Boolean(paragraph) && equal && normalizedLength === lastNormalized?.length;
+    const collapsed = hasDuplicate || duplicate;
+    let delta = input.delta;
+    if (collapsed) {
+      delta =
+        input.delta === null || !wasCollapsed || duplicate !== wasDuplicate || completedParagraph
+          ? null
+          : added;
+      text =
+        delta === null
+          ? completed + (paragraph && !duplicate ? (completed ? "\n\n" : "") + paragraph : "")
+          : text + delta;
+    } else {
+      text = input.text;
+      // A provisional duplicate can diverge, restoring every original separator, not just its own.
+      if (wasCollapsed) {
+        delta = null;
+      }
+    }
+    wasCollapsed = collapsed;
+    wasDuplicate = duplicate;
+    return { text, delta };
+  };
+}
+
+export const duplicateParagraphTextFilter: TextFilter = {
+  transform: (text) => createDuplicateParagraphProjector()({ text, delta: null }).text,
+  create: createDuplicateParagraphProjector,
+};


### PR DESCRIPTION
## What Problem This Solves

Long streamed replies repeatedly rescanned growing text and allocated temporary strings on the Gateway event loop. At 32 concurrent long replies, the baseline stress run exhausted the default JavaScript heap. This change reuses an incremental reply projection and consolidates overlapping sanitizer passes.

## Why This Change Was Made

The subscriber owns one projection using the canonical sanitizer grammar. Marker-free appends reuse the existing prefix; marker activation and corrections retain the full grammar. Raw reply directives keep their raw parser coordinates. Dead pending partial-media state is removed; message completion remains the media producer and delivery boundary.

Production **+645/−656 (net −11)**; tests **+178/−9 (net +169)**. No configuration, database, provider API, or Gateway protocol changes. This is the first PR in the concurrent-agent performance series; prepared delivery and warm loop workers follow separately.

## User Impact

Concurrent long replies consume substantially less CPU and peak memory in the measured workloads. Text, directive, reasoning, Markdown and final-media behavior retain the existing contracts. Control latency is mixed across whole-run samples; the measurements below include that tradeoff.

## Evidence

Fresh baseline `9e6912ca0d2e0200bdcbcfc32bde2d27db262464` and exact-head `3e0330d9e85ac096e37317411af1a234847a2345` builds, pinned Node 24.19.0 and pnpm 12.1.0. Deterministic Gateway runs use real read/exec tools, same-session serialization, cancellation/reuse and exact 92,160-byte replies. Every accepted final matches both the sealed expected output and its full persisted transcript.

| Workload | Wall time, before → after | CPU time, before → after | Peak Gateway RSS, before → after |
|---|---:|---:|---:|
| 8 admitted turns, 256 updates, short burst | 2.552 → 1.917 s | 3.000 → 2.320 s | 1,210 → 1,197 MiB |
| 8 admitted turns, 4,096 updates, short burst | 19.660 → 5.802 s | 17.380 → 4.390 s | 2,674 → 1,235 MiB |
| 8 overlapping streams, 4,096 paced updates | 15.447 → 6.946 s | 15.970 → 4.100 s | 2,523 → 1,231 MiB |

The sustained eight-stream pair reduced wall time by **55.0%**, CPU by **74.3%**, and peak RSS by **51.2%**. All eight provider streams overlapped for about 5.4 seconds. Independent control probes covered over 98% of that overlap: readiness p95 **12.24 → 2.25 ms**, sessions-list p95 **21.82 → 6.14 ms**. Across the entire concurrent phase, readiness p95 was **29.16 → 23.20 ms**, while sessions-list p95 increased **32.71 → 38.07 ms** (123 versus 60 samples). This is an accepted measured tradeoff, not an across-the-board latency claim. After all lifecycle cases, RSS at 5 seconds idle was **2,756 → 1,260 MiB**, and at 30 seconds **614 → 587 MiB**, without forced GC.

**32-stream capacity result:** the candidate completed 37 exact replies including lifecycle cases, 112 provider requests, tools, serialization and cancellation/reuse. Its concurrent phase took **12.039 s / 14.000 s CPU**, peaked at **1,504 MiB**, and returned to **594 MiB** after 30 seconds idle. All 32 provider streams overlapped for 5.414 seconds; whole-phase readiness/sessions p95 was **53.12 / 108.47 ms**. The subsequent baseline admitted all 32 streams but aborted with `Reached heap limit / JavaScript heap out of memory`. The eight-run batch stopped there: four repeat runs were never started. The original batch remains failed/incomplete; an independent offline verifier accepted only the three completed runs and recorded the baseline failure. There is **one completed sustained eight-stream pair and one unpaired candidate 32-stream result**, not repeated-pair or maximum-throughput evidence.

CPU uses alive process-tree snapshots and can omit exited tool processes. RSS includes Gateway workers and excludes the provider/harness/tools. Host load was uncontrolled. Short bursts overlapped only two to three provider requests; their small control samples regressed at 4,096 updates (readiness p95 66 → 114 ms; sessions 75 → 284 ms). The paced fixture supplies the stronger overlap evidence. These results do not prove statistical significance, retained-heap leaks, or parallel JavaScript execution. Source, dependencies, helper and built-output inventories remained unchanged; generated pnpm shims were compared with narrowly checked own-root normalization.

**Real OpenAI:** exact-head `openai/gpt-5.6-luna` completed nine successful turns plus cancellation, 27 model calls/usage events and eight reconciled session projections. Cold/warm execution, four concurrent long replies, same-session serialization, real read/exec, cancellation/reuse and clean shutdown passed. Every streamed final matched the full final message in a private copy of the closed SQLite transcript. Concurrent replies were **13,668 / 14,156 / 24,307 / 27,663 bytes**, over **311 / 326 / 677 / 758 frames**. Each call had an 8,192-output-token cap. Live timing is diagnostic, not a paired performance result. Credentials were neither printed nor persisted.

**Correctness:** 1,311 tests in 41 files passed, including subscriber lifecycle, shared sanitization and WhatsApp delivery. An independent original/current oracle compared **90,016 byte-identical observations** across static prefixes, incremental partitions and real subscriber events. It caught duplicate-paragraph and raw/display-coordinate prototype regressions, which have failing-before/passing-after evidence. Final mechanical type/export/local-variable cleanup received focused tests, types, lint and review. Changed checks passed types, boundaries, formatting and dead exports; two final lint findings were corrected and the lint rerun passed. Three Codex autoreview rounds were clean at the configured P0 threshold.

[Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33612191512). The initial ready event hit GitHub's PR merge-ref startup race; one close/reopen produced the green run without product changes.

**ClawSweeper follow-through:** CPU/RSS and real-provider proof are supplied above. I accept the focused deterministic split-directive/final-media coverage alongside the live long-stream proof for this behavior-preserving refactor. A combined live directive/media trace is not claimed. The removed pending-media state had no production producer; partial parsing never produced media URLs, so this does not delay previously emitted media. The stored-data heuristic is a false positive: there is no schema, SQLite, migration or persistence change. Current-main commentary completion and delivery-gate bypass were inspected.

Local evidence index: `.artifacts/threading/stream-redesign-20260902/`. Key receipts: `paired-c8-d256-v4-1/summary.json`, `paired-c8-d4096-v4-1/summary.json`, `sustained-partial-evidence-v1/summary.json` (SHA-256 `9622fa03198fbf26215cada2ef4a1f282e82175904293aa4dd05ebc79dffeb9c`), and `candidate-long-live-c4-1-oracle/verification.json`. These are local evidence paths, not hosted artifact links. All failed attempts remain preserved.

<details>
<summary>Local verification commands (Node 24.19.0)</summary>

```sh
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-helpers.sanitizeuserfacingtext.scaffolding.test.ts \
  src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts \
  src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts \
  src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts \
  src/agents/embedded-agent-subscribe.callback-fatal.test.ts \
  src/agents/embedded-agent-subscribe.code-span-awareness.test.ts \
  src/agents/embedded-agent-subscribe.handlers.compaction.test.ts \
  src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.replies.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.update-commentary.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.update-source.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.update-stream-phases.test.ts \
  src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts \
  src/agents/embedded-agent-subscribe.handlers.tools.test.ts \
  src/agents/embedded-agent-subscribe.lifecycle-billing-error.test.ts \
  src/agents/embedded-agent-subscribe.partial-reply-lifecycle.test.ts \
  src/agents/embedded-agent-subscribe.raw-stream.test.ts \
  src/agents/embedded-agent-subscribe.reply-tags.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.block-reply-flushing.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.chunking-fences.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.compaction-and-tool-summaries.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-tag-streaming.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.text-end-reconciliation.test.ts \
  src/agents/embedded-agent-subscribe.tool-result-ordering.test.ts \
  src/agents/embedded-agent-subscribe.tools.extract.test.ts \
  src/agents/embedded-agent-subscribe.tools.media.test.ts \
  src/agents/embedded-agent-subscribe.tools.reconcile-thread.test.ts \
  src/agents/embedded-agent-subscribe.tools.test.ts \
  src/agents/embedded-agent-subscribe.unsubscribe-tool-start.test.ts \
  src/agents/embedded-agent-utils.test.ts \
  src/auto-reply/reply/reply-utils.test.ts \
  src/shared/text/assistant-visible-text.test.ts \
  src/shared/text/text-projection.test.ts \
  extensions/whatsapp/src/channel-outbound.test.ts

node scripts/check-changed.mjs \
  -- \
  src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.replies.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.stream.ts \
  src/agents/embedded-agent-subscribe.handlers.messages.update.ts \
  src/agents/embedded-agent-subscribe.handlers.types.ts \
  src/agents/embedded-agent-subscribe.reply-tags.test.ts \
  src/agents/embedded-agent-utils.ts \
  src/auto-reply/reply/reply-utils.test.ts \
  src/auto-reply/reply/streaming-directives.ts \
  src/auto-reply/reply/strip-inbound-meta.ts \
  src/shared/text/assistant-visible-text.ts \
  src/shared/text/code-regions.ts \
  src/shared/text/text-projection.test.ts \
  src/shared/text/text-projection.ts

```
The changed gate reached the final lint step with all earlier checks passing; its two parameter-reassignment findings were fixed and the exact file-scoped lint rerun passed. Exact-head hosted CI independently passed.
</details>
