### PR TITLE
test(ui): close all Board fixture resources

### DIFF
--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -1,5 +1,4 @@
 import { spawn, type ChildProcessByStdio } from "node:child_process";
-import { once } from "node:events";
 import { writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import { type AddressInfo, createServer } from "node:net";
@@ -7,8 +6,10 @@ import path from "node:path";
 import type { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
+import { stopChildProcess } from "../../../test/helpers/stop-child-process.ts";
 import type { ApplicationRuntime } from "../app/bootstrap.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
@@ -97,15 +98,8 @@ async function startFixtureServer(fixture?: "attachments"): Promise<FixtureServe
 }
 
 async function stopFixtureServer(server: FixtureServer | undefined): Promise<void> {
-  if (!server || server.child.exitCode !== null || server.child.signalCode !== null) {
-    return;
-  }
-  const exited = once(server.child, "exit");
-  server.child.kill("SIGTERM");
-  await Promise.race([exited, delay(5_000)]);
-  if (server.child.exitCode === null && server.child.signalCode === null) {
-    server.child.kill("SIGKILL");
-    await exited;
+  if (server) {
+    await stopChildProcess(server.child, 5_000);
   }
 }
 
@@ -184,8 +178,12 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
   });
 
   afterAll(async () => {
-    await browser?.close();
-    await stopFixtureServer(fixtureServer);
+    await runQaGatewayFixture(
+      async () => {
+        await browser?.close();
+      },
+      () => stopFixtureServer(fixtureServer),
+    );
   });
 
   it("correlates concurrent caretaker replies with their original requests", async () => {
@@ -365,50 +363,53 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
 
   it("keeps profile and presence HTTP inside the standalone mock", async () => {
     const artifacts = createControlUiE2eArtifactDir("standalone-network-isolation");
+    const origin = new URL(fixtureServer.url).origin;
+    const escaped: string[] = [];
+    const requests: string[] = [];
     const context = await browser.newContext({
       serviceWorkers: "block",
       viewport: { width: 1440, height: 1000 },
       recordVideo: { dir: artifacts },
     });
-    const origin = new URL(fixtureServer.url).origin;
-    const escaped: string[] = [];
-    const requests: string[] = [];
-    // A pre-fix tripwire protects the operator, but every rejected escape still fails the test.
-    await context.route("**/*", (route) => {
-      const url = route.request().url();
-      requests.push(url);
-      if (new URL(url).origin !== origin) {
-        escaped.push(url);
-        return route.abort("blockedbyclient");
-      }
-      return route.continue();
-    });
-    const page = await context.newPage();
-    try {
-      await page.goto(`${origin}/chat`, { waitUntil: "networkidle" });
-      await page.getByText("OpenClaw work checkout", { exact: true }).click();
-      await page.getByRole("button", { name: "Write a message to send." }).waitFor();
-      await page.screenshot({ path: path.join(artifacts, "chat.png") });
-      await page.goto(`${origin}/profile`, { waitUntil: "networkidle" });
-      await expect
-        .poll(() => page.getByRole("textbox", { name: "Display name", exact: true }).inputValue())
-        .toBe("Riley");
-      await page.screenshot({ path: path.join(artifacts, "profile.png") });
-      await page.goto(`${origin}/focus/terminal`, { waitUntil: "networkidle" });
-      const terminal = page.locator("openclaw-terminal-panel");
-      await terminal.locator(".tabstrip-tab.is-live").waitFor();
-      await terminal.locator(".tp-host canvas").waitFor({ state: "visible" });
-      await page.screenshot({ path: path.join(artifacts, "terminal.png") });
-      expect(escaped, "standalone mock must not attempt Gateway HTTP or external requests").toEqual(
-        [],
-      );
-    } finally {
-      await writeFile(
-        path.join(artifacts, "network.json"),
-        JSON.stringify({ origin, escaped, requests }, null, 2),
-      );
-      await context.close();
-    }
+    await runQaGatewayFixture(
+      async () => {
+        // A pre-fix tripwire protects the operator, but every rejected escape still fails the test.
+        await context.route("**/*", (route) => {
+          const url = route.request().url();
+          requests.push(url);
+          if (new URL(url).origin !== origin) {
+            escaped.push(url);
+            return route.abort("blockedbyclient");
+          }
+          return route.continue();
+        });
+        const page = await context.newPage();
+        await page.goto(`${origin}/chat`, { waitUntil: "networkidle" });
+        await page.getByText("OpenClaw work checkout", { exact: true }).click();
+        await page.getByRole("button", { name: "Write a message to send." }).waitFor();
+        await page.screenshot({ path: path.join(artifacts, "chat.png") });
+        await page.goto(`${origin}/profile`, { waitUntil: "networkidle" });
+        await expect
+          .poll(() => page.getByRole("textbox", { name: "Display name", exact: true }).inputValue())
+          .toBe("Riley");
+        await page.screenshot({ path: path.join(artifacts, "profile.png") });
+        await page.goto(`${origin}/focus/terminal`, { waitUntil: "networkidle" });
+        const terminal = page.locator("openclaw-terminal-panel");
+        await terminal.locator(".tabstrip-tab.is-live").waitFor();
+        await terminal.locator(".tp-host canvas").waitFor({ state: "visible" });
+        await page.screenshot({ path: path.join(artifacts, "terminal.png") });
+        expect(
+          escaped,
+          "standalone mock must not attempt Gateway HTTP or external requests",
+        ).toEqual([]);
+      },
+      () =>
+        writeFile(
+          path.join(artifacts, "network.json"),
+          JSON.stringify({ origin, escaped, requests }, null, 2),
+        ),
+      () => context.close(),
+    );
   });
 
   it("blocks native egress before connecting while preserving local HMR and frame resources", async () => {
@@ -428,260 +429,276 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     });
     const sinkUrl = `http://127.0.0.1:${(sink.address() as AddressInfo).port}`;
     const origin = new URL(fixtureServer.url).origin;
-    const context = await browser.newContext({ serviceWorkers: "block" });
+    let context: BrowserContext | undefined;
     const escaped: string[] = [];
-    // Allow the synthetic sink through: the browser/server boundary, not the
-    // test router, must prevent TCP connections. Still protect other origins.
-    await context.route("**/*", (route) => {
-      const target = new URL(route.request().url()).origin;
-      if (target === origin || target === sinkUrl) {
-        return route.continue();
-      }
-      escaped.push(route.request().url());
-      return route.abort("blockedbyclient");
-    });
-    const page = await context.newPage();
-    const hmr: string[] = [];
-    page.on("websocket", (socket) => {
-      socket.on("framereceived", ({ payload }) => {
-        if (String(payload).includes('"type":"connected"')) {
-          hmr.push(new URL(socket.url()).origin);
-        }
-      });
-    });
     const outcomes: Record<string, unknown> = {};
-    try {
-      const response = await page.goto(fixtureServer.url, { waitUntil: "networkidle" });
-      expect(response?.headers()["content-security-policy"]).toContain("worker-src 'none'");
-      await expect.poll(() => hmr.length).toBeGreaterThan(0);
-      expect(hmr.every((url) => new URL(url).host === new URL(origin).host)).toBe(true);
-      outcomes.hmr = hmr;
-
-      outcomes.top = await page.evaluate(async (sinkOrigin) => {
-        const results: Record<string, string> = {};
-        const rejected = async (name: string, run: () => unknown) => {
-          try {
-            await run();
-            results[name] = "allowed";
-          } catch {
-            results[name] = "blocked";
+    await runQaGatewayFixture(
+      async () => {
+        context = await browser.newContext({ serviceWorkers: "block" });
+        // Allow the synthetic sink through: the browser/server boundary, not the
+        // test router, must prevent TCP connections. Still protect other origins.
+        await context.route("**/*", (route) => {
+          const target = new URL(route.request().url()).origin;
+          if (target === origin || target === sinkUrl) {
+            return route.continue();
           }
-        };
-        await rejected("fetch", () => fetch(`${sinkOrigin}/fetch`));
-        await rejected("rtc", () => new RTCPeerConnection());
-        const workerUrl = URL.createObjectURL(
-          new Blob(["postMessage('escaped')"], { type: "text/javascript" }),
-        );
-        const worker = new Worker(workerUrl);
-        await rejected(
-          "worker",
-          () =>
-            new Promise((resolve, reject) => {
-              worker.addEventListener("message", resolve, { once: true });
-              worker.addEventListener("error", reject, { once: true });
-            }),
-        );
-        worker.terminate();
-        URL.revokeObjectURL(workerUrl);
-        results.popup = window.open(`${sinkOrigin}/popup`) === null ? "blocked" : "allowed";
-
-        // Each native attempt completes at the browser's policy event; no sleep
-        // or request interception can make a missing boundary pass this proof.
-        const policy = async (name: string, directive: string, run: () => void) => {
-          await new Promise<void>((resolve) => {
-            const listener = (event: SecurityPolicyViolationEvent) => {
-              if (
-                event.effectiveDirective !== directive ||
-                !event.blockedURI.startsWith(sinkOrigin)
-              ) {
-                return;
-              }
-              document.removeEventListener("securitypolicyviolation", listener);
-              resolve();
-            };
-            document.addEventListener("securitypolicyviolation", listener);
-            run();
-          });
-          results[name] = "blocked";
-        };
-        await policy("xhr", "connect-src", () => {
-          const xhr = new XMLHttpRequest();
-          xhr.open("GET", `${sinkOrigin}/xhr`);
-          xhr.send();
+          escaped.push(route.request().url());
+          return route.abort("blockedbyclient");
         });
-        let events: EventSource;
-        await policy("eventSource", "connect-src", () => {
-          events = new EventSource(`${sinkOrigin}/events`);
-        });
-        events!.close();
-        await policy("beacon", "connect-src", () => {
-          navigator.sendBeacon(`${sinkOrigin}/beacon`, "probe");
-        });
-        await policy("image", "img-src", () => {
-          const image = new Image();
-          image.src = `${sinkOrigin}/image`;
-          document.body.append(image);
-        });
-        await policy("media", "media-src", () => {
-          const audio = document.createElement("audio");
-          audio.preload = "auto";
-          audio.src = `${sinkOrigin}/media`;
-          document.body.append(audio);
-          audio.load();
-        });
-        for (const setter of ["property", "attribute", "namespaced", "empty-namespace"] as const) {
-          await rejected(`iframe:${setter}`, () => {
-            const frame = document.createElement("iframe");
-            const url = `${sinkOrigin}/frame`;
-            if (setter === "property") {
-              frame.src = url;
-            } else if (setter === "attribute") {
-              frame.setAttribute("src", url);
-            } else {
-              const namespace = setter === "namespaced" ? null : "";
-              frame.setAttributeNS(namespace, "src", url);
+        const page = await context.newPage();
+        const hmr: string[] = [];
+        page.on("websocket", (socket) => {
+          socket.on("framereceived", ({ payload }) => {
+            if (String(payload).includes('"type":"connected"')) {
+              hmr.push(new URL(socket.url()).origin);
             }
-            document.body.append(frame);
           });
-        }
-        await policy("script", "script-src-elem", () => {
-          const script = document.createElement("script");
-          script.src = `${sinkOrigin}/script`;
-          document.head.append(script);
         });
-        await policy("style", "style-src-elem", () => {
-          const link = document.createElement("link");
-          link.rel = "stylesheet";
-          link.href = `${sinkOrigin}/style`;
-          document.head.append(link);
-        });
-        await rejected("font", () => new FontFace("sink-probe", `url(${sinkOrigin}/font)`).load());
-        const forgedHmr = new WebSocket(
-          `${sinkOrigin.replace("http:", "ws:")}/forged-hmr`,
-          "vite-hmr",
-        );
-        await new Promise<void>((resolve) => {
-          forgedHmr.addEventListener("error", () => resolve(), { once: true });
-        });
-        forgedHmr.close();
-        results.forgedHmr = "blocked";
-        const beforeNavigation = location.href;
-        location.assign(`${sinkOrigin}/navigation`);
-        results.navigation = location.href === beforeNavigation ? "blocked" : "allowed";
-        // Same-origin completion sentinel proves the document is still live.
-        const sentinel = await fetch("/control-ui-config.json");
-        results.sentinel = sentinel.ok ? "local" : "failed";
-        return results;
-      }, sinkUrl);
-      expect(outcomes.top).toEqual({
-        fetch: "blocked",
-        rtc: "blocked",
-        worker: "blocked",
-        popup: "blocked",
-        xhr: "blocked",
-        eventSource: "blocked",
-        beacon: "blocked",
-        image: "blocked",
-        media: "blocked",
-        "iframe:property": "blocked",
-        "iframe:attribute": "blocked",
-        "iframe:namespaced": "blocked",
-        "iframe:empty-namespace": "blocked",
-        script: "blocked",
-        style: "blocked",
-        font: "blocked",
-        forgedHmr: "blocked",
-        navigation: "blocked",
-        sentinel: "local",
-      });
-      expect(new URL(page.url()).origin).toBe(origin);
+        const response = await page.goto(fixtureServer.url, { waitUntil: "networkidle" });
+        expect(response?.headers()["content-security-policy"]).toContain("worker-src 'none'");
+        await expect.poll(() => hmr.length).toBeGreaterThan(0);
+        expect(hmr.every((url) => new URL(url).host === new URL(origin).host)).toBe(true);
+        outcomes.hmr = hmr;
 
-      await expect
-        .poll(() => page.frames().some((frame) => frame.url().startsWith("data:text/html")))
-        .toBe(true);
-      const widgetFrame = page.frames().find((frame) => frame.url().startsWith("data:text/html"))!;
-      outcomes.frame = await widgetFrame.evaluate(async (sinkOrigin) => {
-        try {
-          await fetch(`${sinkOrigin}/frame-native-fetch`);
-          return "allowed";
-        } catch {
-          return "blocked";
-        }
-      }, sinkUrl);
-      expect(outcomes.frame).toBe("blocked");
-      const missing = await page.evaluate(async () => {
-        const apiResponse = await fetch("/api/unimplemented-mock-probe");
-        return { status: apiResponse.status, body: await apiResponse.json() };
-      });
-      expect(missing).toEqual({
-        status: 404,
-        body: { error: "Standalone mock has no HTTP fixture for this route." },
-      });
-      outcomes.missing = missing;
-      await page.screenshot({ path: path.join(artifacts, "board.png") });
-      expect(escaped).toEqual([]);
-      expect(received).toEqual([]);
-      expect(connections).toBe(0);
-    } finally {
-      await context.close();
-      sink.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        sink.close((error) => (error ? reject(error) : resolve()));
-      });
-      await writeFile(
-        path.join(artifacts, "probes.json"),
-        JSON.stringify(
-          { origin, sinkOrigin: sinkUrl, connections, received, escaped, outcomes },
-          null,
-          2,
+        outcomes.top = await page.evaluate(async (sinkOrigin) => {
+          const results: Record<string, string> = {};
+          const rejected = async (name: string, run: () => unknown) => {
+            try {
+              await run();
+              results[name] = "allowed";
+            } catch {
+              results[name] = "blocked";
+            }
+          };
+          await rejected("fetch", () => fetch(`${sinkOrigin}/fetch`));
+          await rejected("rtc", () => new RTCPeerConnection());
+          const workerUrl = URL.createObjectURL(
+            new Blob(["postMessage('escaped')"], { type: "text/javascript" }),
+          );
+          const worker = new Worker(workerUrl);
+          await rejected(
+            "worker",
+            () =>
+              new Promise((resolve, reject) => {
+                worker.addEventListener("message", resolve, { once: true });
+                worker.addEventListener("error", reject, { once: true });
+              }),
+          );
+          worker.terminate();
+          URL.revokeObjectURL(workerUrl);
+          results.popup = window.open(`${sinkOrigin}/popup`) === null ? "blocked" : "allowed";
+
+          // Each native attempt completes at the browser's policy event; no sleep
+          // or request interception can make a missing boundary pass this proof.
+          const policy = async (name: string, directive: string, run: () => void) => {
+            await new Promise<void>((resolve) => {
+              const listener = (event: SecurityPolicyViolationEvent) => {
+                if (
+                  event.effectiveDirective !== directive ||
+                  !event.blockedURI.startsWith(sinkOrigin)
+                ) {
+                  return;
+                }
+                document.removeEventListener("securitypolicyviolation", listener);
+                resolve();
+              };
+              document.addEventListener("securitypolicyviolation", listener);
+              run();
+            });
+            results[name] = "blocked";
+          };
+          await policy("xhr", "connect-src", () => {
+            const xhr = new XMLHttpRequest();
+            xhr.open("GET", `${sinkOrigin}/xhr`);
+            xhr.send();
+          });
+          let events: EventSource;
+          await policy("eventSource", "connect-src", () => {
+            events = new EventSource(`${sinkOrigin}/events`);
+          });
+          events!.close();
+          await policy("beacon", "connect-src", () => {
+            navigator.sendBeacon(`${sinkOrigin}/beacon`, "probe");
+          });
+          await policy("image", "img-src", () => {
+            const image = new Image();
+            image.src = `${sinkOrigin}/image`;
+            document.body.append(image);
+          });
+          await policy("media", "media-src", () => {
+            const audio = document.createElement("audio");
+            audio.preload = "auto";
+            audio.src = `${sinkOrigin}/media`;
+            document.body.append(audio);
+            audio.load();
+          });
+          for (const setter of [
+            "property",
+            "attribute",
+            "namespaced",
+            "empty-namespace",
+          ] as const) {
+            await rejected(`iframe:${setter}`, () => {
+              const frame = document.createElement("iframe");
+              const url = `${sinkOrigin}/frame`;
+              if (setter === "property") {
+                frame.src = url;
+              } else if (setter === "attribute") {
+                frame.setAttribute("src", url);
+              } else {
+                const namespace = setter === "namespaced" ? null : "";
+                frame.setAttributeNS(namespace, "src", url);
+              }
+              document.body.append(frame);
+            });
+          }
+          await policy("script", "script-src-elem", () => {
+            const script = document.createElement("script");
+            script.src = `${sinkOrigin}/script`;
+            document.head.append(script);
+          });
+          await policy("style", "style-src-elem", () => {
+            const link = document.createElement("link");
+            link.rel = "stylesheet";
+            link.href = `${sinkOrigin}/style`;
+            document.head.append(link);
+          });
+          await rejected("font", () =>
+            new FontFace("sink-probe", `url(${sinkOrigin}/font)`).load(),
+          );
+          const forgedHmr = new WebSocket(
+            `${sinkOrigin.replace("http:", "ws:")}/forged-hmr`,
+            "vite-hmr",
+          );
+          await new Promise<void>((resolve) => {
+            forgedHmr.addEventListener("error", () => resolve(), { once: true });
+          });
+          forgedHmr.close();
+          results.forgedHmr = "blocked";
+          const beforeNavigation = location.href;
+          location.assign(`${sinkOrigin}/navigation`);
+          results.navigation = location.href === beforeNavigation ? "blocked" : "allowed";
+          // Same-origin completion sentinel proves the document is still live.
+          const sentinel = await fetch("/control-ui-config.json");
+          results.sentinel = sentinel.ok ? "local" : "failed";
+          return results;
+        }, sinkUrl);
+        expect(outcomes.top).toEqual({
+          fetch: "blocked",
+          rtc: "blocked",
+          worker: "blocked",
+          popup: "blocked",
+          xhr: "blocked",
+          eventSource: "blocked",
+          beacon: "blocked",
+          image: "blocked",
+          media: "blocked",
+          "iframe:property": "blocked",
+          "iframe:attribute": "blocked",
+          "iframe:namespaced": "blocked",
+          "iframe:empty-namespace": "blocked",
+          script: "blocked",
+          style: "blocked",
+          font: "blocked",
+          forgedHmr: "blocked",
+          navigation: "blocked",
+          sentinel: "local",
+        });
+        expect(new URL(page.url()).origin).toBe(origin);
+
+        await expect
+          .poll(() => page.frames().some((frame) => frame.url().startsWith("data:text/html")))
+          .toBe(true);
+        const widgetFrame = page
+          .frames()
+          .find((frame) => frame.url().startsWith("data:text/html"))!;
+        outcomes.frame = await widgetFrame.evaluate(async (sinkOrigin) => {
+          try {
+            await fetch(`${sinkOrigin}/frame-native-fetch`);
+            return "allowed";
+          } catch {
+            return "blocked";
+          }
+        }, sinkUrl);
+        expect(outcomes.frame).toBe("blocked");
+        const missing = await page.evaluate(async () => {
+          const apiResponse = await fetch("/api/unimplemented-mock-probe");
+          return { status: apiResponse.status, body: await apiResponse.json() };
+        });
+        expect(missing).toEqual({
+          status: 404,
+          body: { error: "Standalone mock has no HTTP fixture for this route." },
+        });
+        outcomes.missing = missing;
+        await page.screenshot({ path: path.join(artifacts, "board.png") });
+        expect(escaped).toEqual([]);
+        expect(received).toEqual([]);
+        expect(connections).toBe(0);
+      },
+      () => context?.close(),
+      async () => {
+        sink.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          sink.close((error) => (error ? reject(error) : resolve()));
+        });
+      },
+      () =>
+        writeFile(
+          path.join(artifacts, "probes.json"),
+          JSON.stringify(
+            { origin, sinkOrigin: sinkUrl, connections, received, escaped, outcomes },
+            null,
+            2,
+          ),
         ),
-      );
-    }
+    );
   });
 
   it("serves attachment fixtures and blob previews under the same isolation policy", async () => {
     const attachments = await startFixtureServer("attachments");
-    const artifacts = createControlUiE2eArtifactDir("standalone-isolated-attachments");
-    const context = await browser.newContext({ serviceWorkers: "block" });
-    const origin = new URL(attachments.url).origin;
-    const escaped: string[] = [];
-    await context.route("**/*", (route) => {
-      if (new URL(route.request().url()).origin === origin) {
-        return route.continue();
-      }
-      escaped.push(route.request().url());
-      return route.abort("blockedbyclient");
-    });
-    try {
-      const page = await context.newPage();
-      await page.goto(`${origin}/chat`, { waitUntil: "networkidle" });
-      const result = await page.evaluate(async () => {
-        const response = await fetch("/__fixtures/chat-attachments/sample-image.svg");
-        const blob = await response.blob();
-        const image = new Image();
-        image.src = URL.createObjectURL(blob);
-        document.body.append(image);
-        await image.decode();
-        URL.revokeObjectURL(image.src);
-        return {
-          type: blob.type,
-          width: image.naturalWidth,
-          policy: response.headers.get("content-security-policy"),
-        };
-      });
-      expect(result.type).toBe("image/svg+xml");
-      expect(result.width).toBe(640);
-      expect(result.policy).toContain("worker-src 'none'");
-      await page.screenshot({ path: path.join(artifacts, "attachments.png") });
-      expect(escaped).toEqual([]);
-      await writeFile(
-        path.join(artifacts, "network.json"),
-        JSON.stringify({ origin, escaped, result }, null, 2),
-      );
-    } finally {
-      await context.close();
-      await stopFixtureServer(attachments);
-    }
+    let context: BrowserContext | undefined;
+    await runQaGatewayFixture(
+      async () => {
+        const artifacts = createControlUiE2eArtifactDir("standalone-isolated-attachments");
+        context = await browser.newContext({ serviceWorkers: "block" });
+        const origin = new URL(attachments.url).origin;
+        const escaped: string[] = [];
+        await context.route("**/*", (route) => {
+          if (new URL(route.request().url()).origin === origin) {
+            return route.continue();
+          }
+          escaped.push(route.request().url());
+          return route.abort("blockedbyclient");
+        });
+        const page = await context.newPage();
+        await page.goto(`${origin}/chat`, { waitUntil: "networkidle" });
+        const result = await page.evaluate(async () => {
+          const response = await fetch("/__fixtures/chat-attachments/sample-image.svg");
+          const blob = await response.blob();
+          const image = new Image();
+          image.src = URL.createObjectURL(blob);
+          document.body.append(image);
+          await image.decode();
+          URL.revokeObjectURL(image.src);
+          return {
+            type: blob.type,
+            width: image.naturalWidth,
+            policy: response.headers.get("content-security-policy"),
+          };
+        });
+        expect(result.type).toBe("image/svg+xml");
+        expect(result.width).toBe(640);
+        expect(result.policy).toContain("worker-src 'none'");
+        await page.screenshot({ path: path.join(artifacts, "attachments.png") });
+        expect(escaped).toEqual([]);
+        await writeFile(
+          path.join(artifacts, "network.json"),
+          JSON.stringify({ origin, escaped, result }, null, 2),
+        );
+      },
+      () => context?.close(),
+      () => stopFixtureServer(attachments),
+    );
   });
 
   for (const mode of ["dark", "light"] as const) {


### PR DESCRIPTION
## What Problem This Solves

Board browser tests leave a five-second shutdown timer alive after a fixture process exits promptly. Their cleanup paths also skip later resources when a browser/context close or evidence write rejects.

## Why This Change Was Made

Use the existing `stopChildProcess(child, 5_000)` and `runQaGatewayFixture` owners. Browser, context, standalone process, and egress sink cleanup all remain ordered and awaited; each acquired resource is released even when an earlier phase fails. The original readiness loop and graceful-shutdown interval remain intact. The shared helper also bounds the final SIGKILL wait, which was previously unbounded.

## User Impact

Test infrastructure only. All 16 Board cases and their 37 assertion sites remain, including standalone-process isolation, CSP/network boundaries, attachments, theme/HMR, and recorded browser evidence. No production, configuration, persistence, or UI behavior changes.

## Evidence

- Same Linux worker, complete file: original 16/16 in 47.488s; candidate 16/16 in 44.696s, with identical case names/order. This small whole-run difference is not treated as a fixed speedup.
- A real promptly exiting child exposes the timer cost directly: original driver naturally exits after 5,006.213ms with one losing timeout retained; candidate naturally exits after 4.813ms with none. Neither driver forces process exit or unreferences the timer.
- Six failure scenarios exercised against both versions: attachment context acquisition, context close, simultaneous body/close failure, profile-report failure, native-egress context close, and suite browser close. All twelve checks preserve the intended failure; the candidate closes the resources that the original skips and preserves both errors when appropriate.
- Final audit: all 20 recorded fixture child PIDs dead, no standalone Vite cache directories left, all owned command groups gone, exact overlaid sources restored.
- Ordinary proof is pinned to `905f810622b0b9b3c56146b52e66141c78a05957`; fault proof to `83ba15d2e1d93cd1eb34bfa27945ae997ec840e9`, with unchanged owning source verified. The first original browser run lacked FFmpeg; after installing Playwright’s FFmpeg dependency, the full before/after runs passed.

Production delta: 0. Test-only diff is +308/-291, mostly indentation and formatting around existing bodies. No new committed tests or local cleanup abstraction. Generic cleanup composition is already covered by `test/helpers/qa-gateway-cleanup.test.ts`; these real fixture failures verify its integration.

Remaining limits: forced SIGKILL cannot run the fixture’s JavaScript cache-removal hook; cancellation of an in-flight startup/context acquisition remains separate work. Standalone retained-assets and service-worker cleanup sequencing are named follow-ups. This change does not claim to repair those lifetimes.

All 56 source/runtime guards remain identical on base `3fe6d7192ae0c7b82c76639d6b51f1c567ecb9c5`. The final file differs from the tested candidate only by four formatter line wraps, inspected directly. Scoped typed lint, formatting, whitespace validation, and Codex review passed.

CI refresh: the original scheduled run failed in the unrelated disclosure-scroll return case. This branch now includes its fix from #136150; the Board fixture itself is byte-identical across the rebase. The earlier manual fallback passed QA after a dependency-download retry, but its Android build reached the 20-minute job limit. New scheduled CI must pass on the refreshed head before landing.

Published-head CI is now green: [scheduled run, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33618894094). Attempt 1 failed because a Git fetch could not authenticate during security-job setup; rerunning only failed jobs passed. All selected test lanes passed without assertion or timeout changes. This also resolves the security-gate follow-up in review.
