### PR TITLE
fix(codex): align managed installs and release checks on 0.152.1

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -277,7 +277,7 @@ reconciliation so OpenClaw does not override that selection.
 ## Remote marketplaces
 
 Remote marketplace support was introduced in Codex 0.146.1 and remains
-available in OpenClaw's pinned Codex 0.151.0. OpenClaw passes the opaque remote
+available in OpenClaw's pinned Codex 0.152.1. OpenClaw passes the opaque remote
 plugin ID returned by Codex to `plugin/read` and `plugin/install`; a
 human-readable plugin name is not a valid substitute.
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -177,7 +177,7 @@ flags, and plugin allow/deny references into this block. Explicit canonical
 ## App-server transport
 
 For ordinary harness turns, OpenClaw starts the managed Codex binary shipped
-with the official plugin (currently `@openai/codex` `0.151.0`):
+with the official plugin (currently `@openai/codex` `0.152.1`):
 
 ```bash
 codex app-server --listen stdio://
@@ -319,7 +319,7 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 permission profile instead. Codex-managed network enforcement is sandboxed
 networking, so a full-access profile would not protect outbound traffic.
 
-The plugin manages stable Codex app-server `0.151.0`. Explicit custom
+The plugin manages stable Codex app-server `0.152.1`. Explicit custom
 executables, remote app-servers, and macOS desktop binaries must report a
 parseable semantic version of `0.149.0` or newer. Older, malformed, and
 unversioned handshakes are rejected. Newer versions log a compatibility warning
@@ -448,7 +448,7 @@ The stable default is fail-closed: active OpenClaw sandboxing disables native
 Codex execution surfaces that would otherwise run from the Codex app-server
 host. Use `appServer.experimental.sandboxExecServer: true` only when you want
 to try Codex's remote environment support with OpenClaw's sandbox backend.
-This preview path uses the pinned Codex `0.151.0` app-server.
+This preview path uses the pinned Codex `0.152.1` app-server.
 
 ```json5
 {
@@ -851,9 +851,10 @@ response remains authoritative even if it contains no visible models; HTTP
 `401` and `403` return an empty catalog rather than exposing fallback models.
 
 <Note>
-The current bundled harness is `@openai/codex` `0.151.0`. A live `model/list`
-probe against the official `0.151.0` app-server verified this public subset of
-picker rows:
+The current bundled harness is `@openai/codex` `0.152.1`. A live `model/list`
+probe against the official `0.152.1` app-server, using an isolated,
+unauthenticated Codex home and `includeHidden: true`, returned this public
+subset of catalog metadata:
 
 | Model id        | Input modalities | Reasoning efforts                    |
 | --------------- | ---------------- | ------------------------------------ |
@@ -864,9 +865,10 @@ picker rows:
 | `gpt-5.6-sol`   | text, image      | low, medium, high, xhigh, max, ultra |
 | `gpt-5.6-terra` | text, image      | low, medium, high, xhigh, max, ultra |
 
-Available model IDs, input modalities, and reasoning efforts remain
-account-scoped. Run `/codex models` after starting or upgrading the gateway to
-inspect the actual public picker for your account.
+The probe marked `gpt-5.4` and `gpt-5.4-mini` as hidden. This snapshot does not
+prove account entitlement. Available model IDs, input modalities, and reasoning
+efforts remain account-scoped. Run `/codex models` after starting or upgrading
+the gateway to inspect the actual public picker for your account.
 
 OpenClaw reasoning controls preserve supported native levels, including `ultra`.
 Codex owns Ultra's proactive delegation and model-specific inference effort;

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -103,8 +103,8 @@ channel is the communication surface.
 
 - The official `@openclaw/codex` plugin installed. Include `codex` in
   `plugins.allow` if your config uses an allowlist.
-- Managed Codex app-server `0.151.0`. The plugin ships and manages
-  `@openai/codex` `0.151.0` by default, so a `codex` command on `PATH` does not
+- Managed Codex app-server `0.152.1`. The plugin ships and manages
+  `@openai/codex` `0.152.1` by default, so a `codex` command on `PATH` does not
   affect normal startup. Explicit custom, remote, and macOS desktop-owned
   app-servers must report a parseable semantic version of `0.149.0` or newer.
   Newer versions continue with a compatibility warning and normal runtime

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -23,7 +23,7 @@ working.
 - `plugins.entries.codex.enabled` is `true`.
 - `plugins.entries.codex.config.codexPlugins.enabled` is `true`.
 - Codex app-server reports `0.149.0` or newer. The official plugin ships
-  `@openai/codex` `0.151.0`; newer custom, remote, and macOS desktop-owned
+  `@openai/codex` `0.152.1`; newer custom, remote, and macOS desktop-owned
   binaries continue with a compatibility warning and normal runtime validation.
 - The target Codex app-server can see the expected marketplace, plugin, and
   app inventory.

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@openai/codex": "0.151.0",
+    "@openai/codex": "0.152.1",
     "semver": "7.8.5",
     "smol-toml": "1.8.0",
     "typebox": "1.3.17",

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -1,5 +1,6 @@
 // Codex tests cover client plugin behavior.
 import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { SemVer } from "semver";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CodexAppServerClient,
@@ -14,6 +15,7 @@ const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 660_000;
 
 describe("CodexAppServerClient", () => {
   const clients: CodexAppServerClient[] = [];
+  const newerMinorVersion = new SemVer(CODEX_APP_SERVER_VERSION).inc("minor").version;
 
   function startInitialize() {
     const harness = createClientHarness();
@@ -500,9 +502,9 @@ describe("CodexAppServerClient", () => {
 
   it.each([
     ["0.149.0", 0],
-    ["0.152.0-alpha.4", 1],
-    ["0.152.0", 1],
-    ["1.0.0", 1],
+    [`${newerMinorVersion}-alpha.4`, 1],
+    [newerMinorVersion, 1],
+    [new SemVer(CODEX_APP_SERVER_VERSION).inc("major").version, 1],
   ])("accepts app-server version %s for normal startup validation", async (version, warnings) => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const { harness, initializing, outbound } = startInitialize();

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { SemVer } from "semver";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type RawData } from "ws";
 import type { CodexAppServerPreparedAuth } from "./auth-bridge.js";
@@ -846,11 +847,12 @@ describe("shared Codex app-server client", () => {
 
   it("keeps a supported desktop prerelease instead of falling back by version", async () => {
     const desktop = createClientHarness();
+    const desktopVersion = `${new SemVer(CODEX_APP_SERVER_VERSION).inc("minor").version}-alpha.4`;
     const startSpy = vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(desktop.client);
     const startOptions = configureManagedDesktopFallback();
 
     const acquire = getSharedCodexAppServerClient({ startOptions, timeoutMs: 1_000 });
-    await sendInitializeResult(desktop, "openclaw/0.152.0-alpha.4 (macOS; test)");
+    await sendInitializeResult(desktop, `openclaw/${desktopVersion} (macOS; test)`);
     const client = await acquire;
 
     expect(client).toBe(desktop.client);
@@ -864,7 +866,7 @@ describe("shared Codex app-server client", () => {
     expect(mocks.embeddedAgentLog.warn).toHaveBeenCalledWith(
       "codex app-server is newer than OpenClaw's managed runtime; continuing with normal startup validation",
       {
-        detectedVersion: "0.152.0-alpha.4",
+        detectedVersion: desktopVersion,
         validatedVersion: CODEX_APP_SERVER_VERSION,
       },
     );

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -2,7 +2,7 @@
  * Version and package pins for the managed Codex app-server runtime.
  */
 /** Exact Codex app-server version shipped by the OpenClaw Codex bridge. */
-export const CODEX_APP_SERVER_VERSION = "0.151.0";
+export const CODEX_APP_SERVER_VERSION = "0.152.1";
 /** Inclusive runtime compatibility floor for external app-server binaries. */
 export const MIN_SUPPORTED_CODEX_APP_SERVER_VERSION = "0.149.0";
 /** npm package name for the managed Codex app-server binary. */

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -92,7 +92,7 @@ function classifyOpenAiFailoverCode(code: string | undefined) {
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
 // Keep synchronized with extensions/codex's exact @openai/codex dependency;
 // the provider contract test fails when that managed-runtime pin changes.
-const OPENAI_CODEX_CLIENT_VERSION = "0.151.0";
+const OPENAI_CODEX_CLIENT_VERSION = "0.152.1";
 const OPENAI_CODEX_MODELS_ENDPOINT = `${OPENAI_CODEX_RESPONSES_BASE_URL}/models?client_version=${OPENAI_CODEX_CLIENT_VERSION}`;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 const OPENAI_CODEX_MODELS_CACHE_TTL_MS = 60_000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ settings:
 overrides:
   '@lancedb/lancedb>@huggingface/transformers': '-'
   baileys>sharp: '-'
-  '@agentclientprotocol/codex-acp@1.6.2>@openai/codex': 0.151.0
+  '@agentclientprotocol/codex-acp@1.6.2>@openai/codex': 0.152.1
   '@codemirror/commands@6.11.0>@codemirror/view': 6.43.9
   '@anthropic-ai/sdk': 0.120.0
   '@opentelemetry/core': 2.10.0
@@ -4107,47 +4107,6 @@ packages:
   '@npmcli/redact@5.0.0':
     resolution: {integrity: sha512-3zcN5Q3yEmeyxXBzqB6fXPQFzYa2ROsGFSr69W0ArXIAGJqxl/aFECOVPD2kbkYPm0U/EHxFKgclK3UA9WQg5A==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
-  '@openai/codex@0.151.0':
-    resolution: {integrity: sha512-mhtWmOZRdmWD1jPbLDnQb59BsaVP/V+lXe/OFNR9ZcLZU0UCiBwn98Fcav1ss7sDIlHkuqj6nWd44IPeXoOhJA==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  '@openai/codex@0.151.0-darwin-arm64':
-    resolution: {integrity: sha512-g7YzpaCZGCw19R/gly3vRPjnLqaW7JcBAu2WQQ6e8PIlvBPmS/gMplIUURMgNO6gi8LsPzdlQtLqkwoeOOlIdg==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@openai/codex@0.151.0-darwin-x64':
-    resolution: {integrity: sha512-0y+g8TVpP+Fn10mjoKYXER6qYjn29w7xBUsbPXJ6Accu/FoM4Qp4WbKXQPmE0G0yUACTQVZRjzTSsdWUezNgkg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@openai/codex@0.151.0-linux-arm64':
-    resolution: {integrity: sha512-CsLgFeX4TQ6I2Gdrxd2r5UbgIbDLCdtcLAlnMYjr06bCL057MTNGec7Ewb3+Z2DBiMuXCljdTBGqLOePkMV0sQ==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@openai/codex@0.151.0-linux-x64':
-    resolution: {integrity: sha512-xcVyY1FtwvVYhh2JBmz8fX8CQqFAxO/lxJ2IXsh8x5uwxZVHVl5fZHFHf8JdRaOGG0vpkYmu/DKKVoLd56/DDQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
-  '@openai/codex@0.151.0-win32-arm64':
-    resolution: {integrity: sha512-zDWzOoh9wHm+Om1Nhn7os47rAVeSGPh0SnM3YOttdq6iPJz2zn4vBnbGUZjeih1qW/3mvNF3Oyd4owlaHmphmg==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@openai/codex@0.151.0-win32-x64':
-    resolution: {integrity: sha512-sLT7xvID3jhU6tkzcwRPnMEclKRwUPbpo0mtfxIF9KpdZH3VJV7sM2/kXWXyvUM7Zt/YeyOaeATTEysbRz8Yog==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
 
   '@openai/codex@0.152.1':
     resolution: {integrity: sha512-dSwQzl6JgsFe8L9i8xUnwRz9Vy8gn4UvXFU9xq2IJ1eC7zsSttqQ2SGq49ZZIjEyZQ0LZjCs6Bvtxort2Iyebg==}
@@ -9735,7 +9694,7 @@ snapshots:
   '@agentclientprotocol/codex-acp@1.6.2':
     dependencies:
       '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
-      '@openai/codex': 0.151.0
+      '@openai/codex': 0.152.1
       diff: 9.0.0
       open: 11.0.1
       vscode-jsonrpc: 9.0.1
@@ -11457,33 +11416,6 @@ snapshots:
       semver: 7.8.5
 
   '@npmcli/redact@5.0.0': {}
-
-  '@openai/codex@0.151.0':
-    optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.151.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.151.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.151.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.151.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.151.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.151.0-win32-x64'
-
-  '@openai/codex@0.151.0-darwin-arm64':
-    optional: true
-
-  '@openai/codex@0.151.0-darwin-x64':
-    optional: true
-
-  '@openai/codex@0.151.0-linux-arm64':
-    optional: true
-
-  '@openai/codex@0.151.0-linux-x64':
-    optional: true
-
-  '@openai/codex@0.151.0-win32-arm64':
-    optional: true
-
-  '@openai/codex@0.151.0-win32-x64':
-    optional: true
 
   '@openai/codex@0.152.1':
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,8 +815,8 @@ importers:
   extensions/codex:
     dependencies:
       '@openai/codex':
-        specifier: 0.151.0
-        version: 0.151.0
+        specifier: 0.152.1
+        version: 0.152.1
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -4145,6 +4145,47 @@ packages:
 
   '@openai/codex@0.151.0-win32-x64':
     resolution: {integrity: sha512-sLT7xvID3jhU6tkzcwRPnMEclKRwUPbpo0mtfxIF9KpdZH3VJV7sM2/kXWXyvUM7Zt/YeyOaeATTEysbRz8Yog==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@openai/codex@0.152.1':
+    resolution: {integrity: sha512-dSwQzl6JgsFe8L9i8xUnwRz9Vy8gn4UvXFU9xq2IJ1eC7zsSttqQ2SGq49ZZIjEyZQ0LZjCs6Bvtxort2Iyebg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.152.1-darwin-arm64':
+    resolution: {integrity: sha512-H8i0uZHILM0Z2Ep+MryCF5rGXmXjmXTzXf5ZK6bobKtZc2yfomi42ZrQWuYQ5P02H0oLG7B5jLaSWZQ+VFgjbA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.152.1-darwin-x64':
+    resolution: {integrity: sha512-M2qW7YkRx+JeSFoZQsrjgA5yNglowuNAFOwRJoIjlgeP8bsyOqPtbSolu3w4Us7IyCH8f/yuKtlt/v/MdDqbfA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.152.1-linux-arm64':
+    resolution: {integrity: sha512-qZXqf7fxn/SCmaJW6tYrzWqwcDo0gMDJjj1Pm4OtrWXR7Oc0Y2e8ngAh/Mep9iFhVbsqntY1eGLaQaXssGvFgA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.152.1-linux-x64':
+    resolution: {integrity: sha512-ar59rr3CX5j4MLMnRcHqcE0eHZPsZlmXlz37ZS2yP3BsV5pNhO+wFXTOzXFdaYmg2cALX7a3Eqv+vB2jQlXnjQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.152.1-win32-arm64':
+    resolution: {integrity: sha512-YZjWCcArfSLlqG/4r2Ox5ZZhz1FAFQBZisz8U8r5JLxeLk0tXwZHleu8RjNjly++0S5zsgPtAuF0viSIj7NyRA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.152.1-win32-x64':
+    resolution: {integrity: sha512-B8h0/2Kt+rKQv2+vqBhlhWkMEdhf4dsn46FNKMEBTXj3YC5hwSioOcTX2hMgJxMEMtKIMH6Ire1eNrQPvaL9og==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -11442,6 +11483,33 @@ snapshots:
     optional: true
 
   '@openai/codex@0.151.0-win32-x64':
+    optional: true
+
+  '@openai/codex@0.152.1':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.152.1-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.152.1-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.152.1-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.152.1-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.152.1-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.152.1-win32-x64'
+
+  '@openai/codex@0.152.1-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.152.1-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.152.1-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.152.1-linux-x64':
+    optional: true
+
+  '@openai/codex@0.152.1-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.152.1-win32-x64':
     optional: true
 
   '@openclaw/crabline@0.1.17':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ overrides:
   # Memory LanceDB supplies vectors; WhatsApp prepares thumbnails with Rastermill.
   "@lancedb/lancedb>@huggingface/transformers": "-"
   "baileys>sharp": "-"
-  "@agentclientprotocol/codex-acp@1.6.2>@openai/codex": 0.151.0
+  "@agentclientprotocol/codex-acp@1.6.2>@openai/codex": 0.152.1
   "@codemirror/commands@6.11.0>@codemirror/view": 6.43.9
   "@anthropic-ai/sdk": 0.120.0
   "@opentelemetry/core": 2.10.0

--- a/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
+++ b/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
@@ -5,6 +5,7 @@ import {
   runFakeCodexAppServer,
 } from "../codex-app-server-fixture.mjs";
 
+const version = "0.152.1";
 const requestLog =
   process.env.OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG ??
   "/tmp/openclaw-codex-media-path-app-server.jsonl";
@@ -17,8 +18,8 @@ runFakeCodexAppServer({
       sendResult(
         createFakeInitializeResponse({
           name: "openclaw-codex-media-path-e2e",
-          version: "0.151.0",
-          userAgent: "openclaw-codex-media-path-e2e/0.151.0 (Docker; test)",
+          version,
+          userAgent: `openclaw-codex-media-path-e2e/${version} (Docker; test)`,
         }),
       ),
     "thread/start": ({ params, sendResult }) =>
@@ -27,7 +28,7 @@ runFakeCodexAppServer({
           params,
           threadId: "thread-codex-media-path-e2e",
           sessionId: "session-codex-media-path-e2e",
-          version: "0.151.0",
+          version,
         }),
       ),
     "turn/start": ({ sendResult }) => {

--- a/scripts/e2e/lib/codex-release-package-assertions.mjs
+++ b/scripts/e2e/lib/codex-release-package-assertions.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { assertPathInside, findPackageJson, readJson } from "./codex-install-utils.mjs";
 
-const EXPECTED_CODEX_VERSION = "0.151.0";
+const EXPECTED_CODEX_VERSION = "0.152.1";
 const CODEX_PLATFORM_TARGETS = new Map([
   ["linux:x64", { alias: "@openai/codex-linux-x64", os: "linux", cpu: "x64" }],
   ["linux:arm64", { alias: "@openai/codex-linux-arm64", os: "linux", cpu: "arm64" }],

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -18,7 +18,7 @@ const CODEX_ON_DEMAND_ASSERTIONS_SCRIPT = "scripts/e2e/lib/codex-on-demand/asser
 const CODEX_NPM_PLUGIN_LIVE_ASSERTIONS_SCRIPT =
   "scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs";
 const DISABLE_EXPERIMENTAL_WARNING = "--disable-warning=ExperimentalWarning";
-const CODEX_VERSION = "0.151.0";
+const CODEX_VERSION = "0.152.1";
 const tempDirs: string[] = [];
 const tmpFixtureFiles = [
   "/tmp/openclaw-codex-agent.err",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where release validation rejects an installed Codex 0.152.1 candidate in the on-demand and live npm-plugin checks. Updating the candidate alone is insufficient: these checks deliberately execute the separately trusted main-branch harness.

## Why This Change Was Made

Align the official plugin's managed dependency, runtime pin, release-package expectation, fixture, lockfile, and documented binary snapshot on 0.152.1. This keeps one exact managed-version contract rather than adding a configurable assertion or a fallback.

OpenClaw package version metadata and the external-runtime minimum of 0.149.0 stay unchanged. The ACP workspace override is also aligned to 0.152.1, preserving the existing intentionally shared managed-runtime contract without weakening its manifest test. The existing negotiated elicitation mode is unchanged; upstream's new form mode is opt-in and is not required by this upgrade. Maintained generated protocol mirrors are unchanged after canonical regeneration against [Codex rust-v0.152.1](https://github.com/openai/codex/tree/5adb68a49933ae446bf11935662c83dba55a0804).

## User Impact

Managed Codex installs use 0.152.1, and release checks accept that same exact version while continuing to validate the wrapper, native platform package, and executable. The model-catalog documentation now distinguishes an unauthenticated metadata snapshot from account entitlement. No new configuration, protocol, or persistence surface is introduced.

## Evidence

Local verification used Node 24.19.0 and pnpm 12.1.0:

- Reproduced the old trusted-harness failure against the actual installed candidate: `@openclaw/codex must depend on @openai/codex 0.151.0; found 0.152.1`. The same check passes after alignment, including the Darwin ARM64 native package and actual `codex-cli 0.152.1` executable.
- 355 tests passed across six focused files covering config, protocol validators, model catalog, install assertions, elicitation bridging, and native finalization.
- The existing restricted-MCP real-binary live test passed against managed 0.152.1. It exercised startup and thread creation, verified no tool exposure, and verified the disabled inherited MCP process was not launched. This is not an authenticated model-inference claim.
- `pnpm codex-app-server:protocol:check` passed using the exact upstream tag and its Rust 1.95.0 toolchain. Canonical source regeneration, maintained-type compatibility, and snippet checks passed without changing maintained generated outputs. Direct upstream inspection included `codex-rs/codex-mcp/src/client_capabilities.rs:16`, `codex-rs/rmcp-client/src/elicitation_client_service.rs:68`, and the protocol export owner `codex-rs/app-server-protocol/src/precomputed_exports.rs`.
- The canonical changed-file gate passed: 94 transient npm lock checks, all selected typechecks, typed lint, formatting, dependency/boundary guards, unused-code checks, and cycle checks. Frozen dependency installation also passed.
- The canonical package-local build and npm pack passed. The actual tarball contains the compiled 0.152.1 runtime pin, and both canonical install-entry validation and installed-global resolution accept `dist/index.js` without diagnostics. This local main-branch package retains version 2026.8.1; it is not a 2026.9.1 release artifact or a publication claim.
- Isolated Codex autoreview completed with no findings at its default P0 threshold. Source hashes were unchanged afterward. Exact-head PR CI and release validation remain separate gates.

## Gateway-backed authenticated live proof

The existing `gateway-codex-harness.live.test.ts` passed twice on clean `692b23ffc65b935bf5f8663b28b3b6526b40e000`, after the canonical `qaRuntime` build stamped that same head. Both runs used explicit `openai/gpt-5.6-luna`, low effort and API-key authentication through the real Gateway and plugin-owned managed Codex app-server. A fresh empty source home and the canonical test-owned temporary home kept personal Codex accounts and configuration out of the run.

The enabled lifecycle test passed all six mandatory model turns and the start/resume, `/new`, status, model listing, sibling-session survival, deletion and native-history reattachment assertions. Its only skipped counterpart was the intentionally disabled-harness opt-in test, not a skipped smoke. The command owner was:

```sh
node --import ./scripts/tsx.mjs scripts/test-live.mts --codex-harness -- src/gateway/gateway-codex-harness.live.test.ts --maxWorkers=1
```

The second run added a read-only process observer without changing the test. Both observed native app-server processes mapped the exact managed 0.152.1 executable, SHA-256 `8194ea3181f330e63023b234b0b231855e5874e0331c5ef7cbc490591497a7bf`, with stable process identity and ancestry to the isolated loopback Gateway. After exit 0, all 39 observed owned process identities were gone, the port refused connections, and the temporary state was removed. Source, build stamps and native bytes remained unchanged. This is authenticated PR-head Gateway proof, not final release/FRV proof.

## Initial CI findings and verified repair

The first CI run found six stale-version shards. Commit `692b23ffc65b935bf5f8663b28b3b6526b40e000` fixes their owners and retains the existing assertions:

- OpenAI discovery now sends the same `client_version=0.152.1` as the managed runtime. Three existing provider tests failed before the repair; all 75 now pass, as does the cross-plugin version-contract test.
- The ACP workspace override now selects 0.152.1. The unchanged manifest test passes, and the lock no longer retains a duplicate 0.151.0 wrapper or its native packages. History `a00438a867fe51bff88d6b03db0a105d23989210` establishes the deliberately shared runtime contract, so an exception in the manifest test would hide the missed update.
- Existing newer-version warning fixtures derive the next minor, prerelease and major with the existing SemVer dependency. The media-path fake server uses one explicit 0.152.1 fixture constant. One media and three warning cases were reproduced failing before the changes; all 168 targeted tests then passed, and the final future-major refinement passed all 49 client tests. Warning counts, minimum-floor checks and no-fallback assertions remain intact.

The exact published `@agentclientprotocol/codex-acp@1.6.2` adapter was checked against its npm integrity and source revision `9780d314d34616b476b1ae451ad31089b3dce49a`. Its actual default resolver launched the official Codex 0.152.1 executable and passed ACP initialization, expected unauthenticated rejection, an isolated loopback-provider selection, session creation, model listing, session close and clean exit. Five native model rows expanded into 25 ACP model/reasoning choices. The documented alternate-binary path passed the same probe. These are real-process protocol/lifecycle checks, not authenticated inference.

Standalone published `@openclaw/acpx` does not bundle runtime dependencies or inherit workspace overrides; its adapter still declares `@openai/codex: ^0.148.0`. This PR does not claim that separate installed dependency route uses 0.152.1. Final release ACP and install acceptance remain required.

The ClawSweeper discovery and ACP findings are addressed at their owning constants and dependency policy. The suggested ACP-test exception was not taken because direct history and actual adapter proof support preserving the existing shared-runtime invariant. Exact upstream source was available and personally inspected: [models query owner](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/codex-api/src/endpoint/models.rs#L35), [compiled version derivation](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/models-manager/src/lib.rs#L19), and [catalog request caller](https://github.com/openai/codex/blob/5adb68a49933ae446bf11935662c83dba55a0804/codex-rs/models-manager/src/manager.rs#L416).

After the complete repair, all 30 canonical changed-file checks passed, including 94 npm-lock validations, typechecks, three unused-export scans, formatting and typed lint. Independent Codex review of the entire 12-file PR, including these repairs, is scoped-clean at the default P0 threshold. Commit hooks preserved all reviewed source hashes. The first attempt of [CI 33615787672](https://github.com/openclaw/openclaw/actions/runs/33615787672) failed an unauthenticated Git-history fetch before scanning; the normal failed-jobs retry, [attempt 2](https://github.com/openclaw/openclaw/actions/runs/33615787672/attempts/2), passed on unchanged `692b23ffc65b935bf5f8663b28b3b6526b40e000`, including the actual required gate and every security step. The existing workflow selects GitHub-hosted Ubuntu for second attempts; no check was weakened or waived. #136232 separately repaired scan-history ownership on main. Blacksmith public-Git bootstrap failures remain a named infrastructure follow-up.

## Documentation follow-up

The latest ClawSweeper review correctly identified two additional current-runtime references in `docs/plugins/codex-native-plugins.md` and `docs/plugins/codex-computer-use.md`. Both now name the managed 0.152.1 pin in `48f1bb0c18458f39cacfa966b399d9d95bc87a5b`, published through the native preparation workflow with matching local/remote trees. The 0.149.0 external minimum, historical release notes, and the exact 2026.8.2 dependency exception remain unchanged. This is a two-line documentation-only follow-up; the preceding authenticated Gateway proof remains explicitly bound to `692b23ffc65b935bf5f8663b28b3b6526b40e000`. The follow-up passed independent scoped Codex autoreview at the default P0 threshold, and the full changed-file gate passed again over the complete fourteen-file PR. Resulting-head required CI passed before the native merge, as recorded below. This PR does not claim final release validation or publication.

Across the complete PR, production runtime and declarative version changes are net zero, lock changes are net zero, tests/support are +5 lines and docs are +2. No configuration, schema, fallback or test-only production seam was added.

## Final exact-head CI and landing

[CI 33622249860, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33622249860/attempts/2) passed on `48f1bb0c18458f39cacfa966b399d9d95bc87a5b`: 206 successful jobs and 15 intentionally skipped jobs, including the required `openclaw/ci-gate` and `security-fast`. Attempt one failed during the public pre-commit hook Git bootstrap before the private-key detector ran; the normal failed-jobs retry passed without changing source, credentials or checks. The original infrastructure failure remains recorded, not waived.

The fresh independent review covered all fourteen files and returned no findings at the default P0 threshold. The latest ClawSweeper review reported no actionable findings; its strict package/platform version-alignment merge gates were retained. The repository-native review, prepare and merge workflow landed the exact reviewed head as [cc4079ebe1d5b940a6208fd87c84784d5610c7bd](https://github.com/openclaw/openclaw/commit/cc4079ebe1d5b940a6208fd87c84784d5610c7bd). Final release-SHA validation, installed-package checks and publication verification remain separate gates.
