### PR TITLE
fix(test): prevent residual cleanup fixture readiness race

### DIFF
--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -2,8 +2,8 @@
 import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
-import os from "node:os";
 import nodePath from "node:path";
+import { createInterface } from "node:readline";
 import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -955,14 +955,10 @@ describe("scripts/run-vitest", () => {
   });
 
   posixIt("stops residual process-group descendants before completing", async () => {
-    const descendantPidPath = nodePath.join(
-      os.tmpdir(),
-      `openclaw-run-vitest-residual-${process.pid}-${Date.now()}.pid`,
-    );
     const watchedEnv = {
-      OPENCLAW_RESIDUAL_PID_PATH: descendantPidPath,
       OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "5000",
     };
+    let noOutputTimedOut = false;
     const watched = spawnWatchedVitestProcess({
       pnpmArgs: [
         "exec",
@@ -970,16 +966,15 @@ describe("scripts/run-vitest", () => {
         "-e",
         [
           'const { spawn } = require("node:child_process");',
-          'const fs = require("node:fs");',
-          'const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {',
-          '  stdio: "ignore",',
+          'process.once("SIGTERM", () => process.exit(0));',
+          'const descendant = spawn(process.execPath, ["-e",',
+          '  "setInterval(() => {}, 1000); process.send(process.pid);",',
+          '], { stdio: ["ignore", "ignore", "ignore", "ipc"] });',
+          'descendant.once("message", (pid) => {',
+          "  descendant.disconnect();",
+          "  process.stdout.write(`${pid}\\n`);",
           "});",
           "descendant.unref();",
-          'process.once("SIGTERM", () => process.exit(0));',
-          "const pidPath = process.env.OPENCLAW_RESIDUAL_PID_PATH;",
-          "const pendingPath = `${pidPath}.${process.pid}.tmp`;",
-          "fs.writeFileSync(pendingPath, String(descendant.pid));",
-          "fs.renameSync(pendingPath, pidPath);",
           "setInterval(() => {}, 1000);",
         ].join("\n"),
       ],
@@ -989,18 +984,32 @@ describe("scripts/run-vitest", () => {
         stdio: ["ignore", "pipe", "pipe"],
       },
       env: watchedEnv,
+      onNoOutputTimeout: () => {
+        noOutputTimedOut = true;
+      },
     });
     let descendantPid = 0;
+    const lines = createInterface({ input: watched.child.stdout! });
+    const ready = new Promise<void>((resolve, reject) => {
+      lines.once("line", (line) => {
+        try {
+          // The descendant acknowledges its running loop on the watched pipe. Check
+          // and signal in this notification, before a delayed poll can outlive it.
+          descendantPid = Number(line);
+          expect(Number.isInteger(descendantPid) && descendantPid > 0).toBe(true);
+          expect(isProcessAlive(descendantPid)).toBe(true);
+          process.kill(watched.child.pid!, "SIGTERM");
+          resolve();
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      });
+      lines.once("close", () => reject(new Error("fixture closed before reporting readiness")));
+    });
 
     try {
-      await waitFor(() => fs.existsSync(descendantPidPath), LOAD_SENSITIVE_PROCESS_TIMEOUT_MS);
-      descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
-      expect(Number.isInteger(descendantPid)).toBe(true);
-      expect(isProcessAlive(descendantPid)).toBe(true);
-
-      process.kill(watched.child.pid!, "SIGTERM");
       const snapshot = await Promise.race([
-        watched.completion.then((result) => {
+        Promise.all([ready, watched.completion]).then(([, result]) => {
           const psArgs =
             process.platform === "linux" ? ["-eL", "-o", "pgid=,state="] : ["-axo", "pgid=,state="];
           const stateResult = spawnSync("ps", psArgs, {
@@ -1019,7 +1028,7 @@ describe("scripts/run-vitest", () => {
             rows
               .filter((row) => Number(row?.[1]) === watched.child.pid)
               .every((row) => /^[ZX]/.test(row?.[2] ?? ""));
-          return { groupStopped, result };
+          return { groupStopped, noOutputTimedOut, result };
         }),
         delay(LOAD_SENSITIVE_PROCESS_TIMEOUT_MS, undefined, { ref: false }).then(() => {
           throw new Error("timed out waiting for watched Vitest completion");
@@ -1028,15 +1037,17 @@ describe("scripts/run-vitest", () => {
 
       expect(snapshot).toEqual({
         groupStopped: true,
+        noOutputTimedOut: false,
         result: { code: 0, signal: null },
       });
     } finally {
+      lines.close();
       watched.teardown();
       forceKillVitestProcessGroup(watched.child);
       if (descendantPid && isProcessAlive(descendantPid)) {
         process.kill(descendantPid, "SIGKILL");
       }
-      fs.rmSync(descendantPidPath, { force: true });
+      await watched.completion;
     }
   });
 
@@ -1319,16 +1330,6 @@ describe("scripts/run-vitest", () => {
     ).toBeNull();
   });
 });
-
-async function waitFor(condition: () => boolean, timeoutMs = 3_000) {
-  const startedAt = Date.now();
-  while (!condition()) {
-    if (Date.now() - startedAt > timeoutMs) {
-      throw new Error("timed out waiting for condition");
-    }
-    await delay(5);
-  }
-}
 
 async function waitForClose(child: ReturnType<typeof spawn>, timeoutMs = 5_000) {
   return await Promise.race([


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running the Vitest runner tests could hit a residual-descendant fixture failure when readiness polling resumed after the real no-output watchdog had already terminated the process group. This is a maintainer-requested fixture repair, kept separate from other lifecycle work.

## Why This Change Was Made

The fixture now waits for an acknowledgment from the descendant after it installs its running loop. The leader disconnects private IPC and forwards the PID over watched stdout; the test validates a positive, live PID and signals only the leader synchronously in the line callback. This replaces the stale PID-file handoff and independent polling continuation with one readiness path.

The real 5000 ms watchdog still starts at spawn. No timeout increase, fake clock, keepalive, suppression, or production seam is added. The test now rejects watchdog termination explicitly, retains the complete stopped/zombie-only group snapshot at completion, and awaits the owned completion promise in final cleanup. Descendant stdout/stderr remain ignored, so pipe closure cannot substitute for process-group cleanup.

## User Impact

No product behavior changes. Developers get a fixture that proves residual-descendant cleanup without confusing delayed readiness polling or watchdog group termination with the intended leader-only exit. A truly silent startup exceeding five seconds still fails intentionally.

Production/tooling LOC: **+0/-0**. Tests: **+34/-33** (one existing test file; no new test-only production hooks). No changelog, dependency, configuration, schema, or release changes.

## Evidence

- A fault-injected real-process scheduling probe extracted the original test body with equivalent Node assertions and delayed its first 5 ms readiness poll to 6500 ms. Before the fix, the descendant was live at 468 ms, the real watchdog fired at 5385 ms, completion settled at 5573 ms, and the liveness assertion failed at 7012 ms. This is not a claim that the unchanged Vitest command failed naturally; that original-order command passed once.
- The same probe against the repaired fixture passes, observing a live descendant at leader exit and no running group members at completion. An independent landing replay reproduced the expected before/after exit codes 1/0 and the same causal ordering.
- Negative controls fail when group joining is omitted (`groupStopped: false`) and when leader-only termination is withheld (`noOutputTimedOut: true`). They exercise real production processes, watchdogs, signals, and joining; repository production code is unchanged.
- `OPENCLAW_VITEST_MAX_WORKERS=16 node scripts/run-vitest.mjs test/scripts/test-projects.test.ts test/scripts/test-projects-routing.test.ts test/scripts/run-vitest.test.ts` — **644 passed in 3 files**, exit 0, 593.7 s. This isolated baseline contains 644 tests, not the initial report's 649; no unrelated routing changes were imported.
- `OPENCLAW_VITEST_MAX_WORKERS=16 node scripts/run-vitest.mjs test/scripts/run-vitest.test.ts test/scripts/vitest-process-group.test.ts` — **172 passed**, independently rerun during landing with exit 0.
- `node scripts/check-changed.mjs -- test/scripts/run-vitest.test.ts` — exit 0: selected guards, formatting, root-test typecheck, script lint, and targeted test lint. `git diff --check` also passes.
- Fresh isolated Codex autoreview: scoped-clean at the required P0 priority, no accepted/actionable findings. Current-main comparison at `f0d792a772188c1efbcf21ff4db63a1115cc8747` confirms the old fixture remains and relevant runner/process-group sources are unchanged.

Known local extra-proof limitation: a separate command selecting only `test/scripts/vitest-process-group.test.ts` and unchanged `test/scripts/run-vitest-progress.test.ts` passed 38 group tests but failed two progress cases: `stall=false` timed out waiting for case-1 readiness, and `stall=true` timed out waiting for owned group cleanup. It did not load the changed file. Its exact fixture namespace/process commands were verified gone. These failures, plus the unchanged silent-child case's late diagnostic output, remain in the separately tracked follow-up **Investigate Vitest progress fixture timeouts**; this PR does not claim that wider sibling sweep passed.

Local proof used macOS and Node 24.20.0; no full-suite or browser proof is claimed. Regression introduction is not attributed here because raw-parent provenance was not independently reverified for landing.
