### PR TITLE
perf(test): narrow direct reference searches to tests

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1656,10 +1656,12 @@ function readImportGraphEdges(
 function listImportGraphGrepMatches(
   cwd: string,
   terms: string[],
-  options: ImportGraphOptions = {},
+  options: ImportGraphOptions & { testFilesOnly?: boolean } = {},
 ) {
   const tooling = options.tooling === true;
-  const cacheKey = (term: string) => `${cwd}\0${tooling}\0${term}`;
+  const testFilesOnly = options.testFilesOnly === true;
+  // Narrow reference matches must not satisfy a later full import-frontier query.
+  const cacheKey = (term: string) => `${cwd}\0${tooling}\0${testFilesOnly}\0${term}`;
   const matches = new Map(
     terms.map((term) => [term, cachedImportGraphGrepMatches.get(cacheKey(term)) ?? null]),
   );
@@ -1671,6 +1673,13 @@ function listImportGraphGrepMatches(
   }
   const roots = tooling ? TOOLING_IMPORT_GRAPH_ROOTS : SOURCE_ROOTS_FOR_IMPORT_GRAPH;
   const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  // Literal-reference routing only consumes tests; keep import frontiers on the full scope.
+  const suffixes = testFilesOnly
+    ? extensions.flatMap((ext) => [`.test${ext}`, `.spec${ext}`])
+    : extensions;
+  const grepPaths = roots.flatMap((root) =>
+    suffixes.map((suffix) => `:(glob)${root}/**/*${suffix}`),
+  );
   const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
     cwd,
     encoding: "utf8",
@@ -1686,7 +1695,7 @@ function listImportGraphGrepMatches(
       "--fixed-strings",
       "--hidden",
       "--no-ignore",
-      ...extensions.flatMap((ext) => ["--glob", `*${ext}`]),
+      ...suffixes.flatMap((suffix) => ["--glob", `*${suffix}`]),
       "--glob",
       "!**/node_modules/**",
       "--glob",
@@ -1703,15 +1712,7 @@ function listImportGraphGrepMatches(
   if (result.error || (result.status !== 0 && result.status !== 1)) {
     result = spawnSync(
       "git",
-      [
-        "grep",
-        "-l",
-        "--fixed-strings",
-        "-f",
-        "-",
-        "--",
-        ...(tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS),
-      ],
+      ["grep", "-l", "--fixed-strings", "-f", "-", "--", ...grepPaths],
       spawnOptions,
     );
   }
@@ -3103,7 +3104,11 @@ function resolveGithubYamlGuardTargets(changedPath: string) {
 
 function resolveDirectToolingReferenceTests(changedPath: string, cwd: string) {
   const normalized = normalizePathPattern(changedPath);
-  return (listImportGraphGrepMatches(cwd, [normalized], { tooling: true }).get(normalized) ?? [])
+  return (
+    listImportGraphGrepMatches(cwd, [normalized], { tooling: true, testFilesOnly: true }).get(
+      normalized,
+    ) ?? []
+  )
     .filter(
       ({ file, references }) =>
         file !== "test/scripts/test-projects.test.ts" &&


### PR DESCRIPTION
## What Problem This Solves

Test selection repeatedly searches non-test source files when resolving literal references to changed tooling files, then discards every non-test result. Profiling the complete selector suite found that this search dominated its execution time.

## Why This Change Was Made

Narrow only the direct-reference search to supported `.test` and `.spec` suffixes, derived from the existing extension list. Import-frontier searches keep their complete scope. The search cache now distinguishes these scopes so a narrow result cannot hide a later import dependency. Ripgrep and the existing Git fallback use the same suffixes; tracked-file filtering and reference parsing stay intact.

## User Impact

Faster test planning with the same selected tests. No product runtime, configuration, dependency, or test-execution policy changes.

## Evidence

- Complete current selector suite: all 431 cases passed in identical order across the original, candidate and restored control. Complete runner time was 242.283s, 143.321s and 168.528s respectively. The candidate is about 15% faster than the restored control; the colder initial difference is not the claimed gain. An earlier 426-case snapshot also passed with 150.671s candidate versus 208.939s restored control.
- Paired direct-search measurements for three real references returned identical eligible candidates in both orders; each narrowed search was faster. The separate import-frontier search remains broad.
- Six temporary correctness scenarios pass against both versions, exercising all supported test/spec extensions and roots, sparse roots, tracked/staged/unstaged/deleted/untracked files, Git fallback, and both cache query orders.
- Deliberately removing cache-scope separation loses a required non-test import candidate and fails its oracle. Deliberately dropping `.spec` matching loses the expected spec owners and fails its oracle. All 14 temporary repositories were removed after their owning callbacks; both overlaid source files were restored exactly and all command groups exited.

Current measurements used a private indexed copy pinned to `3fe6d7192ae0c7b82c76639d6b51f1c567ecb9c5`, preserving all 36,606 tracked paths and repository dependencies. The earlier 426-case run and private fault proof used `9e6912ca0d2e0200bdcbcfc32bde2d27db262464`; the only later owner change is independent existing-directory routing, covered by the five additional current cases. All measured and fault overlays were restored after their command groups exited. Temporary observers and fault mutations are not part of the proposed change. One initial proof run omitted the console reporter, so the cleanup-receipt checker rejected it; the corrected run retained those receipts without changing its criteria.

Application production delta: 0. Internal test-tooling delta: +18/-13, including formatter compaction of the changed Git argument array. The existing full selector suite and direct temporary fault proof cover the changed boundary; no implementation-mirroring test is added.

Formatting, scoped typed lint, whitespace validation and fresh Codex review passed. The final file differs from the measured current candidate only in formatting of the Git argument array. Exact-head hosted CI is required before landing.
