### PR TITLE
fix(agents): clarify UI presentation surfaces

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -43,11 +43,12 @@ The prompt is compact, with fixed sections:
 - **Sandbox** (when enabled): sandboxed runtime, sandbox paths, elevated-exec availability.
 - **Temporal Context**: local date and time zone below the cache boundary; exact time comes from `session_status` when available.
 - **Assistant Output Directives**: compact attachment, voice-note, and reply-tag syntax.
+- **UI Presentation** (when presentation tools are available): compact widget, dashboard, and portal routing; verify the actual delivered surface.
 - **Collapsible Details** (when supported): teaches the model to keep optional depth in `<details>` disclosures while leaving the primary answer and required actions visible.
 - **Runtime**: host, OS, node, model, repo root (when detected), thinking level (one line).
 - **Reasoning**: current visibility level plus the `/reasoning` toggle hint.
 
-Large stable content (including **Project Context**) stays above the internal prompt cache boundary. Volatile per-turn sections (Control UI embed guidance, **Messaging**, **Collapsible Details**, **Voice**, **Group Chat Context**, **Reactions**, **Runtime**) are appended below that boundary so local backends with prefix caches can reuse the stable workspace prefix across channel turns. The boundary is internal transport metadata: every section remains system-prompt guidance for CLI backends. Tool descriptions should avoid embedding current channel names when the accepted schema already carries that runtime detail.
+Large stable content (including **Project Context**) stays above the internal prompt cache boundary. Volatile per-turn sections (**UI Presentation**, Control UI embed guidance, **Messaging**, **Collapsible Details**, **Voice**, **Group Chat Context**, **Reactions**, **Runtime**) are appended below that boundary so local backends with prefix caches can reuse the stable workspace prefix across channel turns. The boundary is internal transport metadata: every section remains system-prompt guidance for CLI backends. Tool descriptions should avoid embedding current channel names when the accepted schema already carries that runtime detail.
 
 Tooling also carries long-running-work guidance:
 
@@ -68,6 +69,19 @@ teaches metadata-first discovery, task-needed masked requests, and returned stor
 SecretRefs for supported config fields. Named-tool guidance disappears when the
 tool is filtered or disabled. Gateway egress additionally needs an enabled proxy
 and allowed hosts; there is no plaintext fallback. See [Secrets](/tools/secrets).
+
+UI presentation guidance is shared with native Codex developer instructions.
+It includes only current callable tools, including deferred and Code Mode tools;
+minimal prompts omit it. Tool eligibility follows client and channel-presenter
+capabilities, not a hardcoded channel list. A [widget](/tools/show-widget) may
+render inline or use a channel presenter; its returned presentation is authoritative.
+
+The compact guide distinguishes widgets from [dashboard](/web/dashboards) layout,
+[portals](/gateway/portals), and browser tabs. Missing authoring is a session
+limitation, not a platform limitation. Portals open through **Control UI → Portals**,
+not a bare `publicUrl`; token-bearing URLs stay private. The agent must verify the
+delivered interaction or say it is unverified. Tool descriptions and linked docs
+own the detailed sandbox, permission, and server-setup instructions.
 
 Safety guardrails in the system prompt are advisory, not enforcement. Use tool policy, exec approvals, sandboxing, and channel allowlists for hard enforcement; operators can disable prompt guardrails by design.
 

--- a/extensions/codex/src/app-server/thread-prompt.test.ts
+++ b/extensions/codex/src/app-server/thread-prompt.test.ts
@@ -158,3 +158,79 @@ describe("buildDeveloperInstructions credential guidance", () => {
     expect(instructions).toContain("safe external setup");
   });
 });
+
+describe("buildDeveloperInstructions UI presentation guidance", () => {
+  const uiTools = ["show_widget", "dashboard", "portal"].map(
+    (name) =>
+      ({
+        type: "function",
+        name,
+        description: `Use ${name}`,
+        inputSchema: { type: "object" },
+      }) satisfies CodexDynamicToolSpec,
+  );
+
+  it.each([
+    { name: "direct", dynamicTools: uiTools, prefix: "" },
+    {
+      name: "deferred",
+      dynamicTools: uiTools.map((tool) => ({ ...tool, deferLoading: true })),
+      prefix: "",
+    },
+    {
+      name: "namespaced deferred",
+      dynamicTools: [
+        {
+          type: "namespace",
+          name: "openclaw",
+          description: "OpenClaw tools",
+          tools: uiTools.map((tool) => ({ ...tool, deferLoading: true })),
+        },
+      ],
+      prefix: "openclaw.",
+    },
+  ] satisfies { name: string; dynamicTools: CodexDynamicToolSpec[]; prefix: string }[])(
+    "explains the actual $name presentation routes",
+    ({ dynamicTools, prefix }) => {
+      const instructions = buildDeveloperInstructions(createParams(), { dynamicTools });
+
+      expect(instructions).toContain("## UI Presentation");
+      for (const tool of uiTools) {
+        expect(instructions).toContain(`\`${prefix}${tool.name}\``);
+      }
+      expect(instructions).toContain("pin=true");
+      expect(instructions).toContain("publicUrl");
+      expect(instructions).toContain("result.presentation");
+      expect(instructions).toContain("inline support varies by surface");
+    },
+  );
+
+  it("distinguishes unavailable custom authoring from dashboard and portal support", () => {
+    const instructions = buildDeveloperInstructions(createParams(), {
+      dynamicTools: uiTools.filter((tool) => tool.name !== "show_widget"),
+    });
+
+    expect(instructions).toContain("`dashboard`");
+    expect(instructions).toContain("`portal`");
+    expect(instructions).toContain(
+      "Custom authoring is unavailable this turn, not unsupported by dashboards.",
+    );
+    expect(instructions).not.toContain("`show_widget`");
+  });
+
+  it.each([
+    { name: "absent", dynamicTools: [], overrides: {} },
+    { name: "unsupplied", dynamicTools: undefined, overrides: {} },
+    { name: "disabled", dynamicTools: uiTools, overrides: { disableTools: true } },
+    { name: "minimal", dynamicTools: uiTools, overrides: { promptMode: "minimal" } },
+    { name: "none", dynamicTools: uiTools, overrides: { promptMode: "none" } },
+  ] satisfies {
+    name: string;
+    dynamicTools: CodexDynamicToolSpec[] | undefined;
+    overrides: Partial<EmbeddedRunAttemptParams>;
+  }[])("omits presentation guidance when $name", ({ dynamicTools, overrides }) => {
+    const instructions = buildDeveloperInstructions(createParams(overrides), { dynamicTools });
+
+    expect(instructions).not.toContain("## UI Presentation");
+  });
+});

--- a/extensions/codex/src/app-server/thread-prompt.ts
+++ b/extensions/codex/src/app-server/thread-prompt.ts
@@ -39,6 +39,9 @@ export function buildDeveloperInstructions(
 ): string {
   const deferredToolNames = new Set<string>();
   let secretsToolName: string | undefined;
+  let showWidgetToolName: string | undefined;
+  let dashboardToolName: string | undefined;
+  let portalToolName: string | undefined;
   let hasSkillWorkshop = false;
   let hasSessionsSpawn = false;
   let hasSessionsYield = false;
@@ -56,11 +59,21 @@ export function buildDeveloperInstructions(
     }
     for (const tool of spec.type === "namespace" ? spec.tools : [spec]) {
       const name = tool.name.trim();
+      const qualifiedName = spec.type === "namespace" ? `${spec.name}.${name}` : name;
       if (tool.deferLoading === true && name) {
         deferredToolNames.add(name);
       }
       if (name === "secrets" && params.disableTools !== true) {
-        secretsToolName ??= spec.type === "namespace" ? `${spec.name}.${name}` : name;
+        secretsToolName ??= qualifiedName;
+      }
+      if (name === "show_widget") {
+        showWidgetToolName ??= qualifiedName;
+      }
+      if (name === "dashboard") {
+        dashboardToolName ??= qualifiedName;
+      }
+      if (name === "portal") {
+        portalToolName ??= qualifiedName;
       }
       hasSkillWorkshop ||= name === SKILL_WORKSHOP_TOOL_NAME;
       hasSessionsSpawn ||= name === "sessions_spawn";
@@ -127,6 +140,12 @@ export function buildDeveloperInstructions(
     buildHarnessVisibleReplyGuidance({
       sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
       messageToolAvailable,
+      uiPresentation:
+        params.disableTools !== true &&
+        params.promptMode !== "minimal" &&
+        params.promptMode !== "none"
+          ? { showWidgetToolName, dashboardToolName, portalToolName }
+          : undefined,
     }),
     buildCredentialSafetyPrompt(secretsToolName),
     nativeCommandGuidance,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -637,6 +637,67 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain('[embed content_type="html" title="Status"]...[/embed]');
   });
 
+  it.each([
+    { name: "direct", toolNames: ["show_widget", "dashboard", "portal"] },
+    {
+      name: "Code Mode",
+      toolNames: ["exec", "wait"],
+      capabilityToolNames: ["show_widget", "dashboard", "portal"],
+      codeModeActive: true,
+    },
+  ])("teaches UI presentation boundaries for $name tools", (surface) => {
+    const prompt = buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw", ...surface });
+    const presentation = prompt.split("## UI Presentation\n")[1]?.split("\n## ")[0] ?? "";
+
+    expect(Buffer.byteLength(presentation, "utf8")).toBeLessThan(800);
+    expect(presentation).toContain("`show_widget`");
+    expect(presentation).toContain("pin=true");
+    expect(presentation).toContain("result.presentation");
+    expect(presentation).toContain("inline support varies by surface");
+    expect(presentation).toContain("`dashboard`");
+    expect(presentation).toContain("`portal`");
+    expect(presentation).toContain("publicUrl");
+    expect(presentation).toContain("token URLs stay private");
+    expect(presentation).toContain("Control UI");
+    expect(presentation).toContain("delivered interaction");
+    expect(presentation).toContain("unverified");
+    expect(prompt.indexOf("## UI Presentation")).toBeGreaterThan(
+      prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY),
+    );
+  });
+
+  it("explains missing custom authoring without inventing a product-wide limitation", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["dashboard", "portal"],
+      runtimeInfo: { channel: "webchat" },
+    });
+
+    expect(prompt).toContain(
+      "Custom authoring is unavailable this turn, not unsupported by dashboards",
+    );
+    expect(prompt).not.toContain("show_widget");
+    expect(prompt).toContain("publicUrl");
+  });
+
+  it.each([
+    { name: "absent", toolNames: [] },
+    {
+      name: "filtered Code Mode",
+      toolNames: ["exec"],
+      capabilityToolNames: [],
+      codeModeActive: true,
+    },
+    { name: "minimal", toolNames: ["show_widget", "dashboard", "portal"], promptMode: "minimal" },
+    { name: "none", toolNames: ["show_widget", "dashboard", "portal"], promptMode: "none" },
+  ] satisfies Array<{ name: string } & Partial<Parameters<typeof buildAgentSystemPrompt>[0]>>)(
+    "omits UI presentation guidance when $name",
+    (surface) => {
+      const prompt = buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw", ...surface });
+      expect(prompt).not.toContain("## UI Presentation");
+    },
+  );
+
   it("offers routine promotion only when the automations tool is available", () => {
     const withAutomations = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -69,6 +69,7 @@ import type {
 import type { PromptMode, SilentReplyPromptMode } from "./system-prompt.types.js";
 import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 import { buildCredentialSafetyPrompt } from "./transcript-credential-safety.js";
+import { buildUiPresentationPrompt } from "./ui-presentation-prompt.js";
 import {
   buildWatchedSessionsPromptLines,
   type PreparedWatchedSessionsPrompt,
@@ -1477,6 +1478,19 @@ export function buildAgentSystemPrompt(params: {
           }),
         ]),
     ...buildUserIdentitySection(ownerLine, isMinimal),
+    ...(!isMinimal
+      ? [
+          buildUiPresentationPrompt({
+            showWidgetToolName: availableTools.has("show_widget")
+              ? resolveToolName("show_widget")
+              : undefined,
+            dashboardToolName: availableTools.has("dashboard")
+              ? resolveToolName("dashboard")
+              : undefined,
+            portalToolName: availableTools.has("portal") ? resolveToolName("portal") : undefined,
+          }),
+        ]
+      : []),
     ...buildWebchatCanvasSection({
       isMinimal,
       runtimeChannel,

--- a/src/agents/ui-presentation-prompt.ts
+++ b/src/agents/ui-presentation-prompt.ts
@@ -1,0 +1,30 @@
+/** Tool eligibility and results own surface support; do not infer it from channel names. */
+export function buildUiPresentationPrompt(params: {
+  showWidgetToolName?: string;
+  dashboardToolName?: string;
+  portalToolName?: string;
+}): string {
+  const { showWidgetToolName, dashboardToolName, portalToolName } = params;
+  if (!showWidgetToolName && !dashboardToolName && !portalToolName) {
+    return "";
+  }
+  return [
+    "## UI Presentation",
+    ...(showWidgetToolName
+      ? [
+          `\`${showWidgetToolName}\`: self-contained sandboxed HTML/JS; pin=true adds a Control UI dashboard widget. Follow result.presentation; inline support varies by surface.`,
+        ]
+      : []),
+    ...(dashboardToolName
+      ? [
+          `\`${dashboardToolName}\`: layout/plugin widgets, not HTML authoring.${showWidgetToolName ? "" : " Custom authoring is unavailable this turn, not unsupported by dashboards."}`,
+        ]
+      : []),
+    ...(portalToolName
+      ? [
+          `\`${portalToolName}\`: separate app in Control UI → Portals. publicUrl is not a launch link; token URLs stay private.`,
+        ]
+      : []),
+    "Browser tabs, links, and launch cards are not embeds. Verify the delivered interaction or say unverified.",
+  ].join("\n");
+}

--- a/src/auto-reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/source-reply-delivery-mode.ts
@@ -1,4 +1,5 @@
-/** Canonical predicate for message-tool-owned visible replies. */
+/** Visible-reply ownership and presentation guidance shared with agent harnesses. */
+import { buildUiPresentationPrompt } from "../agents/ui-presentation-prompt.js";
 
 /**
  * True when the visible source reply must flow through the message tool, either
@@ -17,11 +18,18 @@ export function messageToolOwnsVisibleReply(params: {
 export function buildHarnessVisibleReplyGuidance(params: {
   sourceReplyDeliveryMode?: string;
   messageToolAvailable: boolean;
+  uiPresentation?: Parameters<typeof buildUiPresentationPrompt>[0];
 }): string {
-  if (messageToolOwnsVisibleReply(params) && params.messageToolAvailable) {
-    return "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. For progress, set `final=false`. Set `final=true`, or omit it, for the completed reply to the current source conversation; OpenClaw stops after confirming delivery. Do not repeat visible message content in your final answer.";
-  }
-  return params.messageToolAvailable
-    ? "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation. Use `message` for supported non-text actions in the current conversation, such as reacting to its current message. Reserve other `message` actions for explicit out-of-band sends or media/file delivery. Reactions are not delivered automatically."
-    : "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation.";
+  const deliveryGuidance =
+    messageToolOwnsVisibleReply(params) && params.messageToolAvailable
+      ? "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. For progress, set `final=false`. Set `final=true`, or omit it, for the completed reply to the current source conversation; OpenClaw stops after confirming delivery. Do not repeat visible message content in your final answer."
+      : params.messageToolAvailable
+        ? "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation. Use `message` for supported non-text actions in the current conversation, such as reacting to its current message. Reserve other `message` actions for explicit out-of-band sends or media/file delivery. Reactions are not delivered automatically."
+        : "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation.";
+  return [
+    deliveryGuidance,
+    params.uiPresentation ? buildUiPresentationPrompt(params.uiPresentation) : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users asking for an embedded dashboard app could receive a browser tab or launch card presented as equivalent, or be told dashboards cannot run custom HTML because the current turn lacks the authoring tool. Agents also need to distinguish an app's portal base URL from an authenticated launch path.

## Why This Change Was Made

Adds one compact, tool-aware UI Presentation section shared by core prompts and native Codex developer instructions through the existing delivery-guidance API. It follows the tool's returned presentation instead of guessing renderer support from channel names; tool eligibility, rendering, storage, portal authentication, and public SDK exports remain unchanged.

## User Impact

Agents receive explicit guidance for widget authoring, dashboard layout, and separate previews in Control UI → Portals. Missing custom authoring is described as a limitation of this turn, token-bearing URLs stay private, and agents must verify the delivered interaction or call it unverified.

The full guide is 61 words / 443 UTF-8 bytes; widget-only guidance is 37 words. With no relevant tools, it adds nothing. Minimal prompts omit it. This is an instruction improvement, not a capability enablement or a portal-authentication fix.

## Evidence

- **193 focused tests passed:** 171 core prompt tests and 22 Codex prompt tests. Coverage includes direct, deferred, Code Mode, and namespaced tools; unavailable authoring; disabled/minimal/none cases; and the core prompt-cache boundary.
- The new assembly regressions failed before the guidance was added; the size guard also rejected the longer draft (2,145 bytes against an 800-byte bound).
- Changed core/Codex lint, existing prompt snapshots, and the SDK surface check passed.
- Isolated Codex review found no accepted P0 issues or suspected credentials.
- Upstream Codex contracts were inspected directly: [namespace/deferred tool exposure](https://github.com/openai/codex/blob/eb10d91e48ccbd0930427461fb392337addb1ac0/codex-rs/core/src/tools/handlers/dynamic.rs#L50) and [developer-role instructions](https://github.com/openai/codex/blob/eb10d91e48ccbd0930427461fb392337addb1ac0/codex-rs/core/src/context/developer_instructions.rs#L17).

The broader `check:changed` run stopped at extension typechecking because the linked worktree could not resolve `@types/yargs-parser` for unchanged browser-plugin code. That gate is not reported as passing. No live model replay or deployment was performed; validation here covers prompt construction and contracts, not the generated app's behavior.

Production: +79/−8 (net +71); tests: +137; docs: +15/−1. Production growth is the shared guide and availability wiring for both prompt owners, avoiding duplicated prompt text or a new public SDK export.
