### PR TITLE
fix(codex): let idle chats resume while other chats are running

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1051,10 +1051,11 @@ When `/codex resume` attaches a thread without an existing verified harness
 binding, its next turn checks the native thread's stored tool catalog and
 applies the current harness configuration before continuing. This first
 attachment requires the local stdio app-server and its per-agent Codex home.
-It also needs exclusive use of that app-server while applying configuration;
-if another turn or native child is active, wait for it to finish and retry.
-Use [Codex supervision](/plugins/codex-supervision) or native Codex to continue
-threads in a shared user home or on another app-server.
+The target native thread must be idle. OpenClaw coordinates attachment, resume,
+and release of that thread; unrelated chats and catalog reads can continue on
+the same app-server. If the target thread is active, wait for its turn to finish
+and retry. Use [Codex supervision](/plugins/codex-supervision) or native Codex to
+continue threads in a shared user home or on another app-server.
 
 Native child threads controlled by a parent cannot be attached with `/codex
 resume` or `/codex bind`. OpenClaw reports that restriction and keeps the current
@@ -1407,6 +1408,20 @@ attempt: progress does not reset it, and `0` means unlimited execution.
 OpenClaw still bounds its own requests, dynamic tools, cancellation, and local
 settlement. See [Timeouts](/plugins/codex-harness-reference#timeouts) for those
 budgets, Stop and replay behavior, and Doctor migration of retired idle settings.
+
+### Parallel chats and thread ownership
+
+Independent chats can share a Codex app-server and run concurrently. Resuming
+an idle chat does not require unrelated chats, model discovery, or tool-catalog
+reads to finish. OpenClaw coordinates its own lifecycle operations for each
+native thread and preserves that thread's identity across ordinary resumes.
+A closed, replaced, or retired client still cannot complete a stale handoff.
+
+This coordination does not make native configuration replacement atomic against
+Codex-internal controllers. Native subagent reloads or another native controller
+can operate outside OpenClaw's thread queue. Avoid concurrently reconfiguring the
+same native thread through multiple controllers; observing native teardown alone
+does not reserve it against a subsequent native reload.
 
 ### Local testing env overrides
 

--- a/extensions/codex/src/app-server/attempt-startup-retry.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup-retry.test.ts
@@ -571,7 +571,7 @@ describe("Codex app-server startup retry", () => {
     }
   });
 
-  it("preserves the shared client and binding across contended and overloaded resumes", async () => {
+  it("preserves the shared client and binding on an overloaded resume with a sibling lease", async () => {
     const fixture = await createStartupFailureFixture("overload");
     const sibling = await startFixtureAttempt(fixture);
     sibling.turnRoute.release();
@@ -586,14 +586,7 @@ describe("Codex app-server startup retry", () => {
       expect(binding?.threadId).toBe("thread-recovered");
       const requestsBeforeResume = await fs.readFile(fixture.requestLogPath, "utf8");
 
-      await expect(startFixtureAttempt(fixture)).rejects.toMatchObject({
-        name: "CodexAdoptedThreadActiveError",
-        scope: undefined,
-      });
-      expect(await fs.readFile(fixture.requestLogPath, "utf8")).toBe(requestsBeforeResume);
-      await expect(testCodexAppServerBindingStore.read(identity)).resolves.toEqual(binding);
-      // Only the sole lease can reach native resume; contention must not write first.
-      sibling.releaseSharedClientLease();
+      // An unrelated lease must not hide a native refusal or lose its healthy client.
       await expect(startFixtureAttempt(fixture)).rejects.toMatchObject({
         name: "CodexAppServerRpcError",
         code: -32_001,

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -485,12 +485,10 @@ describe("startCodexAttemptThread", () => {
       '[plugins."computer-use@openai-bundled"]\nenabled = true\n',
     );
 
-    const restart = result.restartContextEngineCodexThread();
-    const read = JSON.parse(await harness.waitForWrite(writesBeforeRestart));
-    expect(read.method).toBe("thread/read");
-    harness.send({ id: read.id, result: { thread: threadStartResult("thread-original").thread } });
-    await expect(restart).rejects.toThrow("codex app-server client is closed");
-    expect(harness.writes).toHaveLength(writesBeforeRestart + 1);
+    await expect(result.restartContextEngineCodexThread()).rejects.toThrow(
+      "codex app-server client is closed",
+    );
+    expect(harness.writes).toHaveLength(writesBeforeRestart);
 
     result.turnRoute.release();
     result.releaseSharedClientLease();
@@ -578,15 +576,17 @@ describe("startCodexAttemptThread", () => {
     const sibling = retainSharedCodexAppServerClientIfCurrent(harness.client);
     expect(sibling).toBeTypeOf("function");
     const before = harness.writes.length;
-    await expect(startThreadWithHarness(5_000, undefined, common).run).rejects.toMatchObject({
-      name: "CodexAdoptedThreadActiveError",
-    });
-    expect(harness.writes).toHaveLength(before);
-    const reacquired = retainSharedCodexAppServerClientIfCurrent(harness.client);
-    expect(reacquired).toBeTypeOf("function");
-    reacquired?.();
+    const refused = new AgentHarnessPreflightError("session owner revoked");
+    const attemptParams = createAttemptParams(paths);
+    const assertActive = () => {
+      throw refused;
+    };
+    const hostCapabilities = { ...attemptParams.hostCapabilities, assertActive };
+    const buildAttemptParams = () => ({ ...attemptParams, hostCapabilities });
+    await expect(
+      startThreadWithHarness(5_000, undefined, { ...common, buildAttemptParams }).run,
+    ).rejects.toBe(refused);
     sibling?.();
-    expect(harness.client.getCloseError()).toBeUndefined();
     const continued = await startThreadWithHarness(5_000, undefined, incognito).run;
     expect(continued.client).toBe(harness.client);
     expect(continued.thread.threadId).toBe(previous.thread.threadId);

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -10,7 +10,6 @@ import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
@@ -49,14 +48,16 @@ import {
   releaseLeasedSharedCodexAppServerClient,
   type CodexAppServerClientFactory,
 } from "./shared-client.js";
-import { isSameCodexAppServerThreadOwner } from "./thread-ownership.js";
+import {
+  isSameCodexAppServerThreadOwner,
+  withCodexAppServerThreadMutation,
+} from "./thread-ownership.js";
 import { assertCodexSupervisionThreadLineage } from "./thread-policy.js";
 import { resumeCodexAppServerThread } from "./thread-resume.js";
 
 // ttlMs: 0 retains keys until the 4,096-entry LRU cap evicts them, after which a
 // previously suppressed warning can intentionally emit again.
 const warnedIgnoredCompactionOverrides = createDedupeCache({ ttlMs: 0, maxSize: 4096 });
-const codexNativeCompactionQueue = new KeyedAsyncQueue();
 const CODEX_NATIVE_COMPACTION_INTERRUPT_GRACE_MS = 30_000;
 type CodexAppServerCompactOptions = {
   bindingStore: CodexAppServerBindingStore;
@@ -313,7 +314,7 @@ async function runExclusiveCodexNativeCompaction<T>(
 ): Promise<T> {
   signal?.throwIfAborted();
   let started = false;
-  const queued = codexNativeCompactionQueue.enqueue(threadId, async () => {
+  const queued = withCodexAppServerThreadMutation(threadId, async () => {
     started = true;
     signal?.throwIfAborted();
     return run();

--- a/extensions/codex/src/app-server/session-binding.test-helpers.ts
+++ b/extensions/codex/src/app-server/session-binding.test-helpers.ts
@@ -99,9 +99,11 @@ export function registerCodexTestSessionIdentity(
 }
 
 export function seedCodexTestBinding(locator: string, binding: CodexAppServerThreadBinding): void {
-  sharedStateStore.register(bindingStoreKey(testIdentity(locator)), {
+  const identity = testIdentity(locator);
+  sharedStateStore.register(bindingStoreKey(identity), {
     version: 1,
     state: "active",
+    sessionId: identity.sessionId,
     binding,
   });
 }

--- a/extensions/codex/src/app-server/session-binding.test-helpers.ts
+++ b/extensions/codex/src/app-server/session-binding.test-helpers.ts
@@ -99,11 +99,9 @@ export function registerCodexTestSessionIdentity(
 }
 
 export function seedCodexTestBinding(locator: string, binding: CodexAppServerThreadBinding): void {
-  const identity = testIdentity(locator);
-  sharedStateStore.register(bindingStoreKey(identity), {
+  sharedStateStore.register(bindingStoreKey(testIdentity(locator)), {
     version: 1,
     state: "active",
-    sessionId: identity.sessionId,
     binding,
   });
 }

--- a/extensions/codex/src/app-server/session-retirement.ts
+++ b/extensions/codex/src/app-server/session-retirement.ts
@@ -23,7 +23,10 @@ import type {
 } from "./session-binding.js";
 import { getCodexSessionInitializationRollback } from "./session-initialization.js";
 import { retainSharedCodexAppServerClientByInstanceId } from "./shared-client.js";
-import { withCodexAppServerThreadMutation } from "./thread-ownership.js";
+import {
+  isSameCodexAppServerThreadOwner,
+  withCodexAppServerThreadMutation,
+} from "./thread-ownership.js";
 
 async function releaseSessionSubscription(
   client: NonNullable<ReturnType<typeof retainSharedCodexAppServerClientByInstanceId>>["client"],
@@ -163,27 +166,29 @@ export async function retireCodexAppServerSessionGeneration(params: {
     // callers need the original absent/conflict result for reset reclamation.
     return await retireGeneration();
   }
-  return await params.bindingStore.withLease(params.identity, async () => {
-    const binding = await params.bindingStore.read(params.identity);
-    if (binding?.threadId !== expectedBinding.threadId) {
-      return "conflict";
-    }
-    const result = await retireGeneration();
-    if (result !== "applied" || !binding?.clientId) {
-      return result;
-    }
+  return await withCodexAppServerThreadMutation(expectedBinding.threadId, () =>
+    params.bindingStore.withLease(params.identity, async () => {
+      const binding = await params.bindingStore.read(params.identity);
+      if (!binding || !isSameCodexAppServerThreadOwner(binding, expectedBinding)) {
+        return "conflict";
+      }
+      const result = await retireGeneration();
+      if (result !== "applied" || !binding?.clientId) {
+        return result;
+      }
 
-    // Locate the original physical client only after its exact binding was
-    // retired; delayed reset events must never unsubscribe a newer generation.
-    const clientLease = retainSharedCodexAppServerClientByInstanceId(binding.clientId);
-    if (!clientLease) {
+      // Locate the original physical client only after its exact binding was
+      // retired; delayed reset events must never unsubscribe a newer generation.
+      const clientLease = retainSharedCodexAppServerClientByInstanceId(binding.clientId);
+      if (!clientLease) {
+        return result;
+      }
+      try {
+        await releaseSessionSubscription(clientLease.client, binding, params.identity.sessionKey);
+      } finally {
+        clientLease.release();
+      }
       return result;
-    }
-    try {
-      await releaseSessionSubscription(clientLease.client, binding, params.identity.sessionKey);
-    } finally {
-      clientLease.release();
-    }
-    return result;
-  });
+    }),
+  );
 }

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -113,7 +113,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
 
 import {
   assertCodexAppServerClientStartSelectionCurrent,
-  captureExclusiveSharedCodexAppServerClient,
+  captureCodexAppServerClientLifetime,
   captureSharedCodexAppServerCatalogLifetime,
   getSharedCodexAppServerClient,
   readCodexAppServerClientDesktopGeneration,
@@ -552,13 +552,13 @@ describe("shared Codex app-server client", () => {
       const client = await acquire;
       if (!scenario.allowed) {
         const writes = harness.writes.length;
-        expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
+        expect(() => captureCodexAppServerClientLifetime(client, "native-process")).toThrow(
           "reconnect through managed local stdio",
         );
         expect(harness.writes).toHaveLength(writes);
         expect(client.getCloseError()).toBeUndefined();
       } else {
-        const assertCurrent = captureExclusiveSharedCodexAppServerClient(client, "native-process");
+        const assertCurrent = captureCodexAppServerClientLifetime(client, "native-process");
         expect(assertCurrent).not.toThrow();
         client.close();
         expect(assertCurrent).toThrow(CodexAdoptedThreadActiveError);
@@ -570,30 +570,34 @@ describe("shared Codex app-server client", () => {
     },
   );
 
-  it("captures configuration ownership only for a sole registered lease", async () => {
+  it("captures registered client lifetime independently of lease counts", async () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
-    expect(() => captureExclusiveSharedCodexAppServerClient(harness.client, "connection")).toThrow(
+    expect(() => captureCodexAppServerClientLifetime(harness.client, "connection")).toThrow(
       CodexAdoptedThreadActiveError,
     );
     const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
-    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+    await sendInitializeResult(harness, "openclaw/0.151.0 (Linux; test)");
     const client = await acquire;
-    expect(captureExclusiveSharedCodexAppServerClient(client, "native-process")).not.toThrow();
-
+    const assertCurrent = captureCodexAppServerClientLifetime(client, "native-process");
     const retained = retainSharedCodexAppServerClientByInstanceId(client.getInstanceId());
-    expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
-      CodexAdoptedThreadActiveError,
-    );
+    expect(assertCurrent).not.toThrow();
     retained?.release();
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
-    expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
-      CodexAdoptedThreadActiveError,
-    );
+    expect(assertCurrent).not.toThrow();
+    const catalogCurrent = captureSharedCodexAppServerCatalogLifetime(client);
+    const configWrite = client.request("config/batchWrite", { edits: [], reloadUserConfig: false });
+    const written = JSON.parse(harness.writes.at(-1)!);
+    harness.send({ id: written.id, result: {} });
+    await configWrite;
+    expect(catalogCurrent()).toBe(false);
+    expect(assertCurrent).not.toThrow();
+    client.close();
+    expect(assertCurrent).toThrow(CodexAdoptedThreadActiveError);
   });
 
   it.each(["websocket", "unix", "proxy"] as const)(
-    "preserves supervised connection-lease ownership over %s without claiming its native process",
+    "preserves supervised connection lifetime over %s without claiming its native process",
     async (transport) => {
       const harness = createClientHarness();
       vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
@@ -611,13 +615,13 @@ describe("shared Codex app-server client", () => {
       await sendInitializeResult(harness, "openclaw/0.151.0 (Linux; test)");
       const client = await acquire;
       try {
-        const assertCurrent = captureExclusiveSharedCodexAppServerClient(client, "connection");
+        const assertCurrent = captureCodexAppServerClientLifetime(client, "connection");
         expect(assertCurrent).not.toThrow();
         const release = retainSharedCodexAppServerClientIfCurrent(client);
-        expect(assertCurrent).toThrow(CodexAdoptedThreadActiveError);
+        expect(assertCurrent).not.toThrow();
         release?.();
-        expect(assertCurrent).toThrow(CodexAdoptedThreadActiveError);
-        expect(captureExclusiveSharedCodexAppServerClient(client, "connection")).not.toThrow();
+        expect(assertCurrent).not.toThrow();
+        expect(captureCodexAppServerClientLifetime(client, "connection")).not.toThrow();
       } finally {
         releaseLeasedSharedCodexAppServerClient(client);
         client.close();
@@ -626,7 +630,7 @@ describe("shared Codex app-server client", () => {
   );
 
   it.each(["acquire", "retain"] as const)(
-    "revokes captured configuration ownership after a completed sibling %s",
+    "preserves captured client lifetime after a completed sibling %s",
     async (operation) => {
       const harness = createClientHarness();
       vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
@@ -644,7 +648,7 @@ describe("shared Codex app-server client", () => {
       const acquire = getLeasedSharedCodexAppServerClient(options);
       await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
       const client = await acquire;
-      const assertExclusive = captureExclusiveSharedCodexAppServerClient(client, "native-process");
+      const assertCurrent = captureCodexAppServerClientLifetime(client, "native-process");
       if (operation === "acquire") {
         expect(await getLeasedSharedCodexAppServerClient(options)).toBe(client);
         expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
@@ -652,34 +656,32 @@ describe("shared Codex app-server client", () => {
         retainSharedCodexAppServerClientIfCurrent(client)?.();
       }
 
-      expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
-      expect(captureExclusiveSharedCodexAppServerClient(client, "native-process")).not.toThrow();
+      expect(assertCurrent).not.toThrow();
+      expect(captureCodexAppServerClientLifetime(client, "native-process")).not.toThrow();
       expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
     },
   );
 
-  it("revokes configuration ownership when an unleased acquire is pending", async () => {
+  it("preserves client lifetime while an unleased acquire is pending", async () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockResolvedValue(harness.client);
     const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
     await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
     const client = await acquire;
-    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client, "native-process");
+    const assertCurrent = captureCodexAppServerClientLifetime(client, "native-process");
     let observedPendingAcquire = false;
     await getSharedCodexAppServerClient({
       timeoutMs: 1_000,
       onStartedClient: () => {
         observedPendingAcquire = true;
-        expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
-          CodexAdoptedThreadActiveError,
-        );
-        expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
+        expect(captureCodexAppServerClientLifetime(client, "native-process")).not.toThrow();
+        expect(assertCurrent).not.toThrow();
       },
     });
 
     expect(observedPendingAcquire).toBe(true);
-    expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
-    expect(captureExclusiveSharedCodexAppServerClient(client, "native-process")).not.toThrow();
+    expect(assertCurrent).not.toThrow();
+    expect(captureCodexAppServerClientLifetime(client, "native-process")).not.toThrow();
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
   });
 
@@ -689,11 +691,11 @@ describe("shared Codex app-server client", () => {
     const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
     await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
     const client = await acquire;
-    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client, "native-process");
+    const assertExclusive = captureCodexAppServerClientLifetime(client, "native-process");
     retireSharedCodexAppServerClientIfCurrent(client);
 
     expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
-    expect(() => captureExclusiveSharedCodexAppServerClient(client, "native-process")).toThrow(
+    expect(() => captureCodexAppServerClientLifetime(client, "native-process")).toThrow(
       CodexAdoptedThreadActiveError,
     );
     expect(harness.stdinDestroyed).toBe(false);

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -59,7 +59,6 @@ type SharedCodexAppServerClientEntry = {
   startup?: SharedCodexAppServerClientStartup;
   activeLeases: number;
   pendingAcquires: number;
-  leaseGeneration: number;
   closeWhenIdle: boolean;
   closeError?: Error;
   startupAbort?: AbortController;
@@ -1324,12 +1323,17 @@ export function clearSharedCodexAppServerClientIfCurrent(
 export function captureSharedCodexAppServerCatalogLifetime(
   client: CodexAppServerClient,
 ): () => boolean {
+  const isCurrent = captureSharedClientRegistration(client);
+  const revision = client.getModelCatalogRevision();
+  return () => isCurrent() && client.getModelCatalogRevision() === revision;
+}
+
+/** Registration ends on retirement even when sibling leases keep the process alive. */
+function captureSharedClientRegistration(client: CodexAppServerClient): () => boolean {
   const state = getSharedCodexAppServerClientState();
   const entry = state.entriesByClient.get(client);
   const key = [...state.clients].find(([, candidate]) => candidate === entry)?.[0];
   const generation = readCodexAppServerClientDesktopGeneration(client);
-  const revision = client.getModelCatalogRevision();
-  // Detachment retires an owner even while outstanding leases keep its process alive.
   return () =>
     key !== undefined &&
     state.clients.get(key) === entry &&
@@ -1337,7 +1341,6 @@ export function captureSharedCodexAppServerCatalogLifetime(
     !entry.closeWhenIdle &&
     !entry.closeError &&
     !client.getCloseError() &&
-    client.getModelCatalogRevision() === revision &&
     (!generation || isCodexDesktopGenerationCurrent(generation));
 }
 
@@ -1375,14 +1378,14 @@ export function retainSharedCodexAppServerClientByInstanceId(
   return undefined;
 }
 
-/** Captures the required connection or native-process ownership across awaited work. */
-export function captureExclusiveSharedCodexAppServerClient(
+/** Captures physical ownership, independently of unrelated thread and reader leases. */
+export function captureCodexAppServerClientLifetime(
   client: CodexAppServerClient,
   requiredOwnership: "connection" | "native-process",
 ): () => void {
   const state = getSharedCodexAppServerClientState();
   // Ordinary refresh needs a process, not a connection to an external server.
-  // Supervision/release retain their existing shared connection-lease contract.
+  // Supervision/release require only their original registered connection.
   const start = getCodexAppServerClientStartMetadata().get(client)?.startOptions;
   if (
     requiredOwnership === "native-process" &&
@@ -1392,41 +1395,20 @@ export function captureExclusiveSharedCodexAppServerClient(
       "Codex ordinary configuration refresh requires an OpenClaw-managed local stdio process, not an external socket or app-server proxy. No turn was sent; reconnect through managed local stdio before continuing.",
     );
   }
-  if (requiredOwnership === "native-process" && state.isolatedClients.has(client)) {
-    // Worker clients already have a sole per-attempt owner, not a shared-pool lease.
-    // Host/placement authority is checked by the caller across every awaited handoff.
-    const assertIsolated = () => {
-      if (!state.isolatedClients.has(client) || client.getCloseError()) {
-        throw new CodexAdoptedThreadActiveError();
-      }
-    };
-    assertIsolated();
-    return assertIsolated;
-  }
-  for (const [key, entry] of state.clients) {
-    if (entry.client !== client) {
-      continue;
+  const isolated = requiredOwnership === "native-process" && state.isolatedClients.has(client);
+  const isCurrent = isolated
+    ? () => state.isolatedClients.has(client) && !client.getCloseError()
+    : captureSharedClientRegistration(client);
+  const assertCurrent = () => {
+    if (!isCurrent()) {
+      throw new CodexAdoptedThreadActiveError(
+        "Codex app-server connection changed during thread preparation; reconnect before continuing",
+      );
     }
-    const generation = entry.leaseGeneration;
-    const assertExclusive = () => {
-      // A sibling can resume native children without OpenClaw's thread queue.
-      // Even a completed intervening lease invalidates this configuration proof.
-      if (
-        state.clients.get(key) !== entry ||
-        entry.client !== client ||
-        entry.closeWhenIdle ||
-        entry.closeError ||
-        entry.activeLeases !== 1 ||
-        entry.pendingAcquires !== 0 ||
-        entry.leaseGeneration !== generation
-      ) {
-        throw new CodexAdoptedThreadActiveError();
-      }
-    };
-    assertExclusive();
-    return assertExclusive;
-  }
-  throw new CodexAdoptedThreadActiveError();
+    assertCodexAppServerClientStartSelectionCurrent({ client });
+  };
+  assertCurrent();
+  return assertCurrent;
 }
 
 /**
@@ -1622,7 +1604,6 @@ function getOrCreateSharedClientEntry(
     entry = {
       activeLeases: 0,
       pendingAcquires: 0,
-      leaseGeneration: 0,
       closeWhenIdle: false,
       onStartedClientCallbacks: new Set(),
     };
@@ -1662,7 +1643,6 @@ export function clearSharedCodexAppServerClientIfCurrentAndUnclaimed(
 
 function retainPendingSharedClientAcquire(entry: SharedCodexAppServerClientEntry): () => void {
   let released = false;
-  entry.leaseGeneration += 1;
   entry.pendingAcquires += 1;
   return () => {
     if (released) {
@@ -1677,7 +1657,6 @@ function retainPendingSharedClientAcquire(entry: SharedCodexAppServerClientEntry
 
 function retainSharedClientEntry(entry: SharedCodexAppServerClientEntry): () => void {
   let released = false;
-  entry.leaseGeneration += 1;
   entry.activeLeases += 1;
   return () => {
     if (released) {

--- a/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
@@ -14,7 +14,7 @@ import {
   type CodexAppServerBindingIdentity,
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
-import { captureExclusiveSharedCodexAppServerClient } from "./shared-client.js";
+import { captureCodexAppServerClientLifetime } from "./shared-client.js";
 import { shouldRotateCodexGpt56MultiAgentBinding } from "./thread-binding-policy.js";
 import { isContextEngineBindingCompatible } from "./thread-context-engine.js";
 import { codexDynamicToolsFingerprint } from "./thread-fingerprints.js";
@@ -57,7 +57,7 @@ async function assertAdoptedCodexThreadResumeAllowed(
   return thread;
 }
 
-/** Preserve attach's native-queue-before-binding-lease order when consuming pending intent. */
+/** All bound preparation follows attach's native-queue-before-binding-lease order. */
 export async function withCodexThreadLifecycleBinding(
   params: CodexStartOrResumeThreadParams,
   run: (
@@ -72,32 +72,25 @@ export async function withCodexThreadLifecycleBinding(
     config: params.params.config,
   });
   const snapshot = await params.bindingStore.read(identity);
-  const pendingThreadId = snapshot?.pendingResumeConfiguration ? snapshot.threadId : undefined;
   const runWithLease = () =>
     params.bindingStore.withLease(identity, async () => {
       const binding = await params.bindingStore.read(identity);
-      if (
-        pendingThreadId &&
-        (binding?.threadId !== pendingThreadId || !binding.pendingResumeConfiguration)
-      ) {
+      // Never prepare a replacement under the queue selected for an obsolete snapshot.
+      if (binding?.threadId !== snapshot?.threadId || binding?.clientId !== snapshot?.clientId) {
         throw new CodexThreadBindingConflictError(
-          pendingThreadId,
-          "acquiring a pending resume configuration",
+          binding?.threadId ?? snapshot?.threadId ?? params.params.sessionId,
+          "acquiring thread lifecycle ownership",
         );
       }
-      if (!pendingThreadId && binding?.pendingResumeConfiguration) {
-        throw new CodexThreadBindingConflictError(
-          binding.threadId,
-          "acquiring a pending resume configuration",
-        );
-      }
+      params.params.hostCapabilities.assertActive();
+      params.signal?.throwIfAborted();
       return await run(identity, binding);
     });
-  return pendingThreadId
+  return snapshot
     ? await withExclusiveCodexAppServerThread({
         bindingStore: params.bindingStore,
         identity,
-        threadId: pendingThreadId,
+        threadId: snapshot.threadId,
         run: runWithLease,
       })
     : await runWithLease();
@@ -197,9 +190,16 @@ async function preparePendingCodexThreadResume(
   if (isCodexAppServerLiveThreadClaimed(params.client, binding.threadId)) {
     throw fail("the thread is claimed by active work; stop that run before resuming");
   }
-  // Codex can reuse a concurrently resumed child while ignoring overrides.
-  // Only an uninterrupted sole client lease makes the unload receipt conclusive.
-  const assertCurrent = captureExclusiveSharedCodexAppServerClient(params.client, "native-process");
+  const assertClient = captureCodexAppServerClientLifetime(params.client, "native-process");
+  const assertCurrent = () => {
+    params.params.hostCapabilities.assertActive();
+    params.signal?.throwIfAborted();
+    assertClient();
+    if (isCodexAppServerLiveThreadClaimed(params.client, binding.threadId)) {
+      throw new CodexAdoptedThreadActiveError();
+    }
+  };
+  assertCurrent();
   const { thread } = await params.client.request(
     "thread/read",
     { threadId: binding.threadId, includeTurns: false },
@@ -250,17 +250,17 @@ export async function prepareCodexThreadResume(
   binding: CodexAppServerThreadBinding,
   context: Pick<CodexThreadRequestContext, "lifecycleTiming" | "throwIfAborted">,
 ) {
-  if (isCodexAppServerLiveThreadClaimed(params.client, binding.threadId)) {
-    throw new CodexAdoptedThreadActiveError();
-  }
-  const assertExclusive = captureExclusiveSharedCodexAppServerClient(
+  const assertClient = captureCodexAppServerClientLifetime(
     params.client,
     binding.connectionScope === "supervision" ? "connection" : "native-process",
   );
   const assertCurrent = () => {
     params.params.hostCapabilities.assertActive();
     params.signal?.throwIfAborted();
-    assertExclusive();
+    assertClient();
+    if (isCodexAppServerLiveThreadClaimed(params.client, binding.threadId)) {
+      throw new CodexAdoptedThreadActiveError();
+    }
   };
   assertCurrent();
   const thread = await assertAdoptedCodexThreadResumeAllowed(params, binding.threadId, context);
@@ -296,7 +296,8 @@ function observeCodexThreadConfiguration(
     assertConfigured: () => {
       assertCurrent();
       // Native resume can acknowledge ignored overrides when another subscriber
-      // or failed shutdown retains the session. Only notLoaded proves teardown.
+      // or failed shutdown retains the session. notLoaded proves teardown, not a
+      // reservation against native-internal reloads outside OpenClaw's thread queue.
       if (!unloaded) {
         throw new Error(
           "Codex did not confirm unloading its previous configuration. The thread is preserved; stop competing native work and reconnect before retrying.",

--- a/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
@@ -30,7 +30,10 @@ import type {
   CodexThreadRequestContext,
 } from "./thread-lifecycle-types.js";
 import { releaseCodexConsumedLiveThread } from "./thread-lifecycle-warm.js";
-import { withExclusiveCodexAppServerThread } from "./thread-ownership.js";
+import {
+  withCodexAppServerThreadMutation,
+  withExclusiveCodexAppServerThread,
+} from "./thread-ownership.js";
 import { assertCodexSupervisionThreadLineage } from "./thread-policy.js";
 
 /** Passive refusal must precede releasing or acquiring any native subscription. */
@@ -86,14 +89,18 @@ export async function withCodexThreadLifecycleBinding(
       params.signal?.throwIfAborted();
       return await run(identity, binding);
     });
-  return snapshot
+  // Ordinary resumes own their binding key even when a legacy row omits sessionId.
+  // Foreign-owner rejection belongs to adoption, not an upgrade of that same binding.
+  return snapshot?.pendingResumeConfiguration
     ? await withExclusiveCodexAppServerThread({
         bindingStore: params.bindingStore,
         identity,
         threadId: snapshot.threadId,
         run: runWithLease,
       })
-    : await runWithLease();
+    : snapshot
+      ? await withCodexAppServerThreadMutation(snapshot.threadId, runWithLease)
+      : await runWithLease();
 }
 
 type PendingResumeContext = CodexThreadRequestContext & {

--- a/extensions/codex/src/app-server/thread-lifecycle-errors.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-errors.ts
@@ -18,8 +18,10 @@ export class CodexThreadBindingConflictError extends Error {
 }
 
 export class CodexAdoptedThreadActiveError extends AgentHarnessPreflightError {
-  constructor() {
-    super("Codex session became active in another runner; wait for it to finish before continuing");
+  constructor(
+    message = "Codex session became active in another runner; wait for it to finish before continuing",
+  ) {
+    super(message);
     this.name = "CodexAdoptedThreadActiveError";
   }
 }

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -34,7 +34,6 @@ import {
   readActiveCodexTurnIdsFromResume,
 } from "./thread-fingerprints.js";
 import {
-  CodexAdoptedThreadActiveError,
   CodexThreadBindingConflictError,
   CodexThreadStartRequestError,
 } from "./thread-lifecycle-errors.js";
@@ -170,7 +169,6 @@ export async function resumeExistingCodexThread(
         request: resumeParams,
         signal: params.signal,
         assertCurrent: context.assertResumeOwnership,
-        isPrewriteOwnershipError: (error) => error instanceof CodexAdoptedThreadActiveError,
       }),
     );
     resumeResponseAccepted = true;

--- a/extensions/codex/src/app-server/thread-lifecycle-warm.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-warm.ts
@@ -23,7 +23,7 @@ import {
 } from "./plugin-thread-config.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 import {
-  captureExclusiveSharedCodexAppServerClient,
+  captureCodexAppServerClientLifetime,
   retainSharedCodexAppServerClientByInstanceId,
 } from "./shared-client.js";
 import { fingerprintCodexThreadConfig } from "./thread-fingerprints.js";
@@ -141,7 +141,7 @@ export async function releaseCodexBoundLiveThread(
     const client = previous?.client ?? options.client;
     const assertPrevious =
       previous && options.assertCurrent
-        ? captureExclusiveSharedCodexAppServerClient(client, "connection")
+        ? captureCodexAppServerClientLifetime(client, "connection")
         : undefined;
     if (isCodexAppServerLiveThreadClaimed(client, options.threadId)) {
       throw new Error(`Codex thread ${options.threadId} is claimed by active work; stop it first.`);

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -16,11 +16,12 @@ import { CodexAppServerClient, CodexAppServerRpcError } from "./client.js";
 import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import type { PluginAppPolicyContext } from "./plugin-thread-config.js";
-import type {
-  CodexDynamicToolFunctionSpec,
-  JsonObject,
-  JsonValue,
-  RpcRequest,
+import {
+  isJsonObject,
+  type CodexDynamicToolFunctionSpec,
+  type JsonObject,
+  type JsonValue,
+  type RpcRequest,
 } from "./protocol.js";
 import {
   bindProductionHarnessHostCapabilitiesForTest,
@@ -35,11 +36,14 @@ import {
   testCodexAppServerBindingStore,
   writeCodexAppServerBinding as writeRawCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
+import { retireCodexAppServerSessionGeneration } from "./session-retirement.js";
 import {
+  clearSharedCodexAppServerClientIfCurrentAndUnclaimed,
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
   resolveCodexNativeConfigFenceKey,
   retainSharedCodexAppServerClientIfCurrent,
+  retireSharedCodexAppServerClientIfCurrent,
 } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
 import { fingerprintEnvironmentSelection } from "./thread-fingerprints.js";
@@ -48,7 +52,10 @@ import {
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
 import { createLeasedCodexLifecycleHarness } from "./thread-lifecycle.test-fixtures.js";
-import { withCodexAppServerThreadMutation } from "./thread-ownership.js";
+import {
+  releaseCodexAppServerBindingSubscription,
+  withCodexAppServerThreadMutation,
+} from "./thread-ownership.js";
 import { CodexIncognitoPolicyChangeError } from "./thread-policy.js";
 
 function startOrResumeThread(
@@ -347,8 +354,7 @@ async function createManualResumeFixture(
   const thread = { ...response.thread, path: rolloutPath };
   let resumes = 0;
   const compete = () => {
-    // A sibling can start and finish between reads; sole ownership at the
-    // final snapshot must not erase that intervening native runtime activity.
+    // Completed catalog/prewarm leases do not replace this physical thread owner.
     const release = retainSharedCodexAppServerClientIfCurrent(client);
     expect(release).toBeTypeOf("function");
     release?.();
@@ -452,47 +458,49 @@ async function createManualResumeFixture(
   }
   const params = { ...createParams(sessionFile, workspaceDir), agentDir };
   registerCodexTestSessionIdentity(sessionFile, params.sessionId, params.sessionKey);
-  await resumeThread(
-    resolveCodexCommandDeps({
-      bindingStore: testCodexAppServerBindingStore,
-      codexControlRequest: async (_pluginConfig, method, requestParams, requestOptions) => {
-        await requestOptions?.beforeRequest?.(
-          <T>({
-            method: preflightMethod,
-            requestParams: preflightParams,
-          }: {
-            method: string;
-            requestParams?: unknown;
-          }) => client.request<T>(preflightMethod, preflightParams, { timeoutMs: 60_000 }),
-          client,
-          { assertCurrent: () => undefined },
-        );
-        const result = await client.request<JsonValue>(method, requestParams, {
-          timeoutMs: 60_000,
-        });
-        await requestOptions?.onResponse?.(result, client, {
-          authProfileId: undefined,
-          assertCurrent: () => undefined,
-        });
-        return result;
+  const attach = () =>
+    resumeThread(
+      resolveCodexCommandDeps({
+        bindingStore: testCodexAppServerBindingStore,
+        codexControlRequest: async (_pluginConfig, method, requestParams, requestOptions) => {
+          await requestOptions?.beforeRequest?.(
+            <T>({
+              method: preflightMethod,
+              requestParams: preflightParams,
+            }: {
+              method: string;
+              requestParams?: unknown;
+            }) => client.request<T>(preflightMethod, preflightParams, { timeoutMs: 60_000 }),
+            client,
+            { assertCurrent: () => undefined },
+          );
+          const result = await client.request<JsonValue>(method, requestParams, {
+            timeoutMs: 60_000,
+          });
+          await requestOptions?.onResponse?.(result, client, {
+            authProfileId: undefined,
+            assertCurrent: () => undefined,
+          });
+          return result;
+        },
+      }),
+      {
+        channel: "test",
+        isAuthorizedSender: true,
+        senderIsOwner: true,
+        commandBody: `/codex resume ${threadId}`,
+        config: {},
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile,
+        requestConversationBinding: async () => ({ status: "error", message: "unused" }),
+        detachConversationBinding: async () => ({ removed: false }),
+        getCurrentConversationBinding: async () => null,
       },
-    }),
-    {
-      channel: "test",
-      isAuthorizedSender: true,
-      senderIsOwner: true,
-      commandBody: `/codex resume ${threadId}`,
-      config: {},
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      sessionFile,
-      requestConversationBinding: async () => ({ status: "error", message: "unused" }),
-      detachConversationBinding: async () => ({ removed: false }),
-      getCurrentConversationBinding: async () => null,
-    },
-    undefined,
-    [threadId],
-  );
+      undefined,
+      [threadId],
+    );
+  await attach();
   const common = {
     client,
     params,
@@ -503,6 +511,7 @@ async function createManualResumeFixture(
   };
   return {
     ...harness,
+    attach,
     client,
     wire,
     close: () => {
@@ -583,6 +592,174 @@ async function createLeasedLifecycleWireClient(
 }
 
 describe("Codex app-server thread lifecycle bindings", () => {
+  it("resumes idle A with current policy while B stays active and catalog leases come and go", async () => {
+    const sessionFile = path.join(tempDir, "parallel-policy.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const threadId = "parallel-policy-a";
+    const siblingId = "parallel-policy-b";
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "agent"),
+      respond: async (method) => {
+        if (method === "thread/resume") {
+          const reader = await getLeasedSharedCodexAppServerClient(fixture.acquireOptions);
+          try {
+            await reader.request("thread/read", { threadId: siblingId, includeTurns: false });
+          } finally {
+            releaseLeasedSharedCodexAppServerClient(reader);
+          }
+          return threadStartResult(threadId);
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    });
+    fixture.seed(threadStartResult(threadId), { loaded: true, subscribed: false });
+    const siblingResponse = threadStartResult(siblingId);
+    fixture.seed(
+      {
+        ...siblingResponse,
+        thread: { ...siblingResponse.thread, status: { type: "active", activeFlags: [] } },
+      },
+      { loaded: true, subscribed: true },
+    );
+    await writeCodexAppServerBinding(sessionFile, { threadId, cwd: workspaceDir });
+    const sibling = await getLeasedSharedCodexAppServerClient(fixture.acquireOptions);
+    const siblingClaim = await claimCodexAppServerLiveThread(sibling, siblingId);
+    try {
+      const resumed = await startOrResumeThread({
+        client: fixture.client,
+        params: createParams(sessionFile, workspaceDir),
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        userMcpServersEnabled: false,
+        developerInstructions: "current A policy",
+      });
+      expect(resumed).toMatchObject({ threadId, lifecycle: { action: "resumed" } });
+      expect((await readCodexAppServerBinding(sessionFile))?.threadId).toBe(threadId);
+      const injection = fixture.request.mock.calls.find(
+        ([method]) => method === "thread/inject_items",
+      );
+      expect(JSON.stringify(injection?.[1])).toContain("current A policy");
+      expect(siblingClaim).toBeDefined();
+      expect(() => siblingClaim!.assertCurrent()).not.toThrow();
+      await expect(
+        sibling.request("thread/read", { threadId: siblingId, includeTurns: false }),
+      ).resolves.toMatchObject({ thread: { status: { type: "active" } } });
+      expect(fixture.request.mock.calls.some(([method]) => method === "thread/start")).toBe(false);
+      expect(fixture.client.getCloseError()).toBeUndefined();
+    } finally {
+      await siblingClaim?.release(siblingId);
+      releaseLeasedSharedCodexAppServerClient(sibling);
+    }
+  });
+
+  it("accounts for 100 seeded rounds across eight native thread owners without leaked or stale claims", async () => {
+    const fixture = await createLeasedCodexLifecycleHarness({
+      agentDir: path.join(tempDir, "stress-agent"),
+      respond: async (method, requestParams) => {
+        if (
+          method === "thread/resume" &&
+          isJsonObject(requestParams) &&
+          typeof requestParams.threadId === "string"
+        ) {
+          return threadStartResult(requestParams.threadId);
+        }
+        throw new Error(`unexpected method: ${method}`);
+      },
+    });
+    const runs = Array.from({ length: 8 }, (_, index) => {
+      const sessionId = `stress-session-${index}`;
+      const sessionFile = path.join(tempDir, `${sessionId}.jsonl`);
+      const params = {
+        ...createParams(sessionFile, tempDir),
+        sessionId,
+        sessionKey: `agent:main:${sessionId}`,
+      };
+      registerCodexTestSessionIdentity(sessionFile, sessionId, params.sessionKey);
+      return { params, threadId: `stress-thread-${index}`, completed: 0 };
+    });
+    for (const run of runs) {
+      fixture.seed(threadStartResult(run.threadId));
+      await writeRawCodexAppServerBinding(run.params.sessionFile, {
+        threadId: run.threadId,
+        cwd: tempDir,
+        webSearchThreadConfigFingerprint: DEFAULT_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT,
+      });
+    }
+    let seed = 0x136143;
+    const next = () => (seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0);
+    for (let round = 0; round < 100; round++) {
+      const ordered = runs
+        .map((run) => ({ run, order: next() }))
+        .toSorted((a, b) => a.order - b.order);
+      const outcomes = await Promise.allSettled(
+        ordered.map(async ({ run, order }) => {
+          const client = await getLeasedSharedCodexAppServerClient(fixture.acquireOptions);
+          try {
+            if (order % 2 === 0) {
+              const prewarm = await getLeasedSharedCodexAppServerClient(fixture.acquireOptions);
+              releaseLeasedSharedCodexAppServerClient(prewarm);
+            }
+            const entered = createDeferred<void>();
+            const proceed = createDeferred<void>();
+            const predecessor = withCodexAppServerThreadMutation(run.threadId, async () => {
+              entered.resolve();
+              await proceed.promise;
+            });
+            await entered.promise;
+            const preparing = startOrResumeThread({
+              client,
+              params: run.params,
+              cwd: tempDir,
+              dynamicTools: [],
+              appServer: createThreadLifecycleAppServerOptions(),
+              userMcpServersEnabled: false,
+              developerInstructions: `policy round ${round}`,
+            });
+            await withCodexAppServerThreadMutation(`stress-independent-${round}`, async () => {});
+            proceed.resolve();
+            const binding = await preparing;
+            await predecessor;
+            expect(binding.threadId).toBe(run.threadId);
+            const first = await claimCodexAppServerLiveThread(client, run.threadId);
+            expect(first).toBeDefined();
+            expect(await retainCodexAppServerLiveThread(client, run.threadId, first!.release)).toBe(
+              true,
+            );
+            const successor = await claimCodexAppServerLiveThread(client, run.threadId);
+            expect(successor).toBeDefined();
+            await first!.release(run.threadId);
+            successor!.assertCurrent();
+            await successor!.release(run.threadId);
+            expect(isCodexAppServerLiveThreadClaimed(client, run.threadId)).toBe(false);
+            run.completed++;
+          } finally {
+            releaseLeasedSharedCodexAppServerClient(client);
+          }
+        }),
+      );
+      expect(
+        outcomes.every((outcome) => outcome.status === "fulfilled"),
+        JSON.stringify(outcomes),
+      ).toBe(true);
+    }
+    expect(runs.map((run) => run.completed)).toEqual(Array(8).fill(100));
+    for (const method of ["thread/resume", "thread/inject_items", "thread/unsubscribe"]) {
+      expect(
+        fixture.request.mock.calls.filter(([called]) => called === method),
+        method,
+      ).toHaveLength(800);
+    }
+    expect(fixture.request.mock.calls.some(([method]) => method === "thread/start")).toBe(false);
+    releaseLeasedSharedCodexAppServerClient(fixture.client);
+    expect(clearSharedCodexAppServerClientIfCurrentAndUnclaimed(fixture.client)).toEqual({
+      found: true,
+      closed: true,
+      activeLeases: 0,
+      pendingAcquires: 0,
+    });
+  });
+
   it("exposes incognito policy refusal as an unscoped preflight", () => {
     const error = new CodexIncognitoPolicyChangeError();
     expect(error).toBeInstanceOf(AgentHarnessPreflightError);
@@ -592,7 +769,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     { developerInstructions: "replacement policy", fault: "none" },
     { developerInstructions: "", fault: "none" },
     { developerInstructions: "replacement policy", fault: "unload" },
-    { developerInstructions: "replacement policy", fault: "competing resume" },
+    { developerInstructions: "replacement policy", fault: "client retired" },
     { developerInstructions: "replacement policy", fault: "unknown write" },
     { developerInstructions: "replacement policy", fault: "retirement failure" },
     { developerInstructions: "replacement policy", fault: "binding commit" },
@@ -615,8 +792,8 @@ describe("Codex app-server thread lifecycle bindings", () => {
           };
         }
         if (request.method === "thread/resume") {
-          if (fault === "competing resume") {
-            retainSharedCodexAppServerClientIfCurrent(wire.client)?.();
+          if (fault === "client retired") {
+            retireSharedCodexAppServerClientIfCurrent(wire.client);
           }
           return response;
         }
@@ -1444,117 +1621,220 @@ describe("Codex app-server thread lifecycle bindings", () => {
   );
 
   it.each(["read", "release", "resume"] as const)(
-    "does not certify resume configuration after a competing client lease during %s",
+    "keeps manual resume configuration across unrelated client leases during %s",
     async (competingLease) => {
       const fixture = await createManualResumeFixture({ cold: true, competingLease });
-      const before = await readCodexAppServerBinding(fixture.sessionFile);
       try {
-        const run = fixture.start();
-        await expect(run).rejects.toBeInstanceOf(AgentHarnessPreflightError);
-        await expect(run).rejects.toMatchObject({ scope: undefined });
-        await expect(run).rejects.toMatchObject(
-          competingLease === "resume"
-            ? {
-                name: "CodexThreadPolicyHandoffError",
-                outcome: "not-written",
-                cause: { name: "CodexAdoptedThreadActiveError" },
-              }
-            : { name: "CodexAdoptedThreadActiveError" },
-        );
-        expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
+        await expect(fixture.start()).resolves.toMatchObject({ threadId: fixture.threadId });
+        expect(
+          (await readCodexAppServerBinding(fixture.sessionFile))?.pendingResumeConfiguration,
+        ).toBeUndefined();
         expect(fixture.request.mock.calls.some(([method]) => method === "thread/start")).toBe(
           false,
         );
         expect(
-          fixture.request.mock.calls.filter(([method]) => method === "thread/unsubscribe"),
-        ).toHaveLength(competingLease === "read" ? 0 : 1);
+          fixture.request.mock.calls.filter(([method]) => method === "thread/inject_items"),
+        ).toHaveLength(1);
       } finally {
         fixture.close();
       }
     },
   );
 
-  it("does not write a pending resume after its sole client lease changes behind the native config fence", async () => {
-    const fixture = await createManualResumeFixture({ wireClient: true });
-    const before = await readCodexAppServerBinding(fixture.sessionFile);
-    const fenceKey = resolveCodexNativeConfigFenceKey({ client: fixture.client });
-    expect(fenceKey).toBeTypeOf("string");
-    const releaseFence = await acquireCodexNativeConfigFence(fenceKey!);
-    const guardEntered = createDeferred<void>();
-    const abort = new AbortController();
-    fixture.client.setThreadSessionRequestGuard(async (options) => {
-      guardEntered.resolve();
-      return await acquireCodexNativeConfigFence(fenceKey!, options);
-    });
-    const starting = fixture.start({ signal: abort.signal });
-    const settled = starting.then(
-      () => undefined,
-      (error: unknown) => error,
-    );
-    try {
-      await Promise.race([
-        guardEntered.promise,
-        settled.then(() => {
-          throw new Error("manual resume settled before reaching its native config fence");
-        }),
-      ]);
-      const releaseSibling = retainSharedCodexAppServerClientIfCurrent(fixture.client);
-      expect(releaseSibling).toBeTypeOf("function");
-      releaseSibling?.();
-      releaseFence();
-
-      await expect(starting).rejects.toThrow("another runner");
-      expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
-      expect(fixture.client.getCloseError()).toBeUndefined();
-      expect(
-        fixture
-          .wire!.writes.map((message) => (JSON.parse(message) as RpcRequest).method)
-          .filter((method) => method === "thread/resume"),
-      ).toEqual(["thread/resume"]);
-    } finally {
-      abort.abort();
-      releaseFence();
-      await settled;
-      fixture.close();
-    }
-  });
-
-  it("rejects a pending binding deleted while waiting for the native owner queue", async () => {
-    const fixture = await createManualResumeFixture();
-    const entered = createDeferred<void>();
-    const release = createDeferred<void>();
-    const blocker = withCodexAppServerThreadMutation(fixture.threadId, async () => {
-      entered.resolve();
-      await release.promise;
-    });
-    await entered.promise;
-    const read = vi.spyOn(testCodexAppServerBindingStore, "read");
-    const pendingRead = createDeferred<void>();
-    read.mockImplementationOnce(async () => {
-      const binding = await readCodexAppServerBinding(fixture.sessionFile);
-      pendingRead.resolve();
-      return binding;
-    });
-    const starting = fixture.start();
-    try {
-      await pendingRead.promise;
-      await testCodexAppServerBindingStore.mutate(fixture.identity, {
-        kind: "clear",
-        threadId: fixture.threadId,
+  it.each(["reader", "retired"] as const)(
+    "checks physical ownership after a %s interleaves behind the native config fence",
+    async (interleaving) => {
+      const fixture = await createManualResumeFixture({ wireClient: true });
+      const before = await readCodexAppServerBinding(fixture.sessionFile);
+      const fenceKey = resolveCodexNativeConfigFenceKey({ client: fixture.client });
+      expect(fenceKey).toBeTypeOf("string");
+      const releaseFence = await acquireCodexNativeConfigFence(fenceKey!);
+      const guardEntered = createDeferred<void>();
+      const abort = new AbortController();
+      fixture.client.setThreadSessionRequestGuard(async (options) => {
+        guardEntered.resolve();
+        return await acquireCodexNativeConfigFence(fenceKey!, options);
       });
-      release.resolve();
-      await expect(starting).rejects.toThrow("acquiring a pending resume configuration");
-      expect(fixture.request.mock.calls.map(([method]) => method)).toEqual([
-        "thread/read",
-        "thread/resume",
-      ]);
-    } finally {
-      release.resolve();
-      await blocker;
-      read.mockRestore();
-      fixture.close();
-    }
-  });
+      const starting = fixture.start({ signal: abort.signal });
+      const settled = starting.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      try {
+        await Promise.race([
+          guardEntered.promise,
+          settled.then(() => {
+            throw new Error("manual resume settled before reaching its native config fence");
+          }),
+        ]);
+        const releaseSibling = retainSharedCodexAppServerClientIfCurrent(fixture.client);
+        expect(releaseSibling).toBeTypeOf("function");
+        releaseSibling?.();
+        if (interleaving === "retired") {
+          retireSharedCodexAppServerClientIfCurrent(fixture.client);
+        }
+        releaseFence();
+
+        if (interleaving === "retired") {
+          await expect(starting).rejects.toThrow("connection changed");
+          expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
+        } else {
+          await expect(starting).resolves.toMatchObject({ threadId: fixture.threadId });
+          expect(
+            (await readCodexAppServerBinding(fixture.sessionFile))?.pendingResumeConfiguration,
+          ).toBeUndefined();
+        }
+        expect(fixture.client.getCloseError()).toBeUndefined();
+        expect(
+          fixture
+            .wire!.writes.map((message) => (JSON.parse(message) as RpcRequest).method)
+            .filter((method) => method === "thread/resume"),
+        ).toEqual(
+          interleaving === "retired" ? ["thread/resume"] : ["thread/resume", "thread/resume"],
+        );
+      } finally {
+        abort.abort();
+        releaseFence();
+        await settled;
+        fixture.close();
+      }
+    },
+  );
+
+  it.each(["attach", "release", "reset"] as const)(
+    "queues same-thread %s behind ordinary preparation without blocking siblings",
+    async (operation) => {
+      const fixture = await createManualResumeFixture({ wireClient: true });
+      await fixture.start();
+      fixture.wire!.writes.length = 0;
+      const entered = createDeferred<void>();
+      const proceed = createDeferred<void>();
+      fixture.client.setThreadSessionRequestGuard(async () => {
+        entered.resolve();
+        await proceed.promise;
+        return () => {};
+      });
+      const starting = fixture.start();
+      const settledStart = Promise.allSettled([starting]);
+      let mutation: Promise<unknown> | undefined;
+      try {
+        await Promise.race([
+          entered.promise,
+          settledStart.then(() => {
+            throw new Error("resume failed before its write fence");
+          }),
+        ]);
+        mutation =
+          operation === "attach"
+            ? fixture.attach()
+            : operation === "reset"
+              ? retireCodexAppServerSessionGeneration({
+                  bindingStore: testCodexAppServerBindingStore,
+                  identity: fixture.identity,
+                  mode: "reset",
+                })
+              : withCodexAppServerThreadMutation(fixture.threadId, () =>
+                  testCodexAppServerBindingStore.withLease(fixture.identity, async () => {
+                    const binding = await testCodexAppServerBindingStore.read(fixture.identity);
+                    if (binding) {
+                      await releaseCodexAppServerBindingSubscription(binding, {
+                        allowUntracked: true,
+                      });
+                    }
+                  }),
+                );
+        let mutationSettled = false;
+        const settledMutation = mutation.finally(() => {
+          mutationSettled = true;
+        });
+        const results = Promise.allSettled([starting, settledMutation]);
+        await withCodexAppServerThreadMutation("unrelated-thread", async () => {});
+        expect(mutationSettled).toBe(false);
+        proceed.resolve();
+        for (const result of await results) {
+          expect(
+            result.status,
+            result.status === "rejected" ? String(result.reason) : operation,
+          ).toBe("fulfilled");
+        }
+        const methods = fixture.wire!.writes.map((line) => (JSON.parse(line) as RpcRequest).method);
+        expect(methods.indexOf("thread/inject_items")).toBeGreaterThan(
+          methods.lastIndexOf("thread/read", methods.indexOf("thread/inject_items")),
+        );
+        expect((await readCodexAppServerBinding(fixture.sessionFile))?.threadId).toBe(
+          operation === "reset" ? undefined : fixture.threadId,
+        );
+      } finally {
+        proceed.resolve();
+        await Promise.allSettled([starting, mutation]);
+        fixture.close();
+      }
+    },
+  );
+
+  it.each([
+    { pending: true, change: "delete" },
+    { pending: false, change: "delete" },
+    { pending: false, change: "replace-client" },
+    { pending: false, change: "replace-thread" },
+  ])(
+    "rejects a changed binding queued for preparation ($change, manual intent: $pending)",
+    async ({ pending, change }) => {
+      const fixture = await createManualResumeFixture();
+      if (!pending) {
+        await testCodexAppServerBindingStore.mutate(fixture.identity, {
+          kind: "patch",
+          threadId: fixture.threadId,
+          patch: { pendingResumeConfiguration: undefined },
+        });
+      }
+      const entered = createDeferred<void>();
+      const release = createDeferred<void>();
+      const blocker = withCodexAppServerThreadMutation(fixture.threadId, async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      await entered.promise;
+      const read = vi.spyOn(testCodexAppServerBindingStore, "read");
+      const pendingRead = createDeferred<void>();
+      read.mockImplementationOnce(async () => {
+        const binding = await readCodexAppServerBinding(fixture.sessionFile);
+        pendingRead.resolve();
+        return binding;
+      });
+      const starting = fixture.start();
+      try {
+        await pendingRead.promise;
+        const current = await readCodexAppServerBinding(fixture.sessionFile);
+        expect(current).toBeDefined();
+        await testCodexAppServerBindingStore.mutate(
+          fixture.identity,
+          change === "delete"
+            ? { kind: "clear", threadId: fixture.threadId }
+            : {
+                kind: "set",
+                binding: {
+                  ...current!,
+                  ...(change === "replace-client"
+                    ? { clientId: "replacement-client" }
+                    : { threadId: "replacement-thread" }),
+                },
+              },
+        );
+        release.resolve();
+        await expect(starting).rejects.toThrow("acquiring thread lifecycle ownership");
+        expect(fixture.request.mock.calls.map(([method]) => method)).toEqual([
+          "thread/read",
+          "thread/resume",
+        ]);
+      } finally {
+        release.resolve();
+        await blocker;
+        read.mockRestore();
+        fixture.close();
+      }
+    },
+  );
 
   it("reuses an isolated retained thread without dropping native skill isolation", async () => {
     vi.stubEnv("HOME", tempDir);
@@ -3411,9 +3691,9 @@ describe("Codex app-server thread lifecycle bindings", () => {
         return { status: "unsubscribed" };
       }
       if (request.method === "thread/resume") {
-        // The response is valid, but another lease revokes the adoption proof
-        // after the physical resume write and before configuration is committed.
+        // Retirement revokes this preparation, while an unrelated live lease drains.
         releaseSibling = retainSharedCodexAppServerClientIfCurrent(wire.client);
+        retireSharedCodexAppServerClientIfCurrent(wire.client);
         return response;
       }
       throw new Error(`unexpected method: ${request.method}`);

--- a/extensions/codex/src/app-server/thread-ownership.test.ts
+++ b/extensions/codex/src/app-server/thread-ownership.test.ts
@@ -1,0 +1,87 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { describe, expect, it, vi } from "vitest";
+import { createCodexTestBindingStore } from "./session-binding.test-helpers.js";
+
+describe("Codex thread ownership across module copies", () => {
+  it("orders ordinary mutation and adoption while another thread proceeds", async () => {
+    const first = await import("./thread-ownership.js");
+    vi.resetModules();
+    const second = await import("./thread-ownership.js");
+    expect(first.withCodexAppServerThreadMutation).not.toBe(
+      second.withCodexAppServerThreadMutation,
+    );
+    const bindingStore = createCodexTestBindingStore();
+    const identity = { kind: "session" as const, agentId: "main", sessionId: "shared-session" };
+    const threadId = "shared-thread";
+    await bindingStore.mutate(identity, {
+      kind: "set",
+      binding: { threadId, cwd: "/before" },
+    });
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const events: string[] = [];
+    const mutation = first.withCodexAppServerThreadMutation(threadId, async () => {
+      events.push("mutation");
+      entered.resolve();
+      await release.promise;
+      await bindingStore.mutate(identity, {
+        kind: "set",
+        binding: { threadId, cwd: "/after" },
+      });
+    });
+    await entered.promise;
+    const adoption = second.withExclusiveCodexAppServerThread({
+      bindingStore,
+      identity,
+      threadId,
+      run: async () => {
+        events.push("adoption");
+        return await bindingStore.read(identity);
+      },
+    });
+    const completed = Promise.all([mutation, adoption]);
+    try {
+      await second.withCodexAppServerThreadMutation("other-thread", async () => {
+        events.push("other");
+      });
+      expect(events).toEqual(["mutation", "other"]);
+    } finally {
+      release.resolve();
+      await completed;
+    }
+    expect(events).toEqual(["mutation", "other", "adoption"]);
+    await expect(adoption).resolves.toMatchObject({ threadId, cwd: "/after" });
+  });
+
+  it("shares conversation activity ordering across module copies", async () => {
+    const first = await import("./thread-ownership.js");
+    vi.resetModules();
+    const second = await import("./thread-ownership.js");
+    expect(first.withCodexConversationThreadActivity).not.toBe(
+      second.withCodexConversationThreadActivity,
+    );
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const events: string[] = [];
+    const active = first.withCodexConversationThreadActivity("conversation", async () => {
+      events.push("active");
+      entered.resolve();
+      await release.promise;
+    });
+    await entered.promise;
+    const waiting = second.withCodexConversationThreadActivity("conversation", async () => {
+      events.push("waiting");
+    });
+    const completed = Promise.all([active, waiting]);
+    try {
+      await second.withCodexConversationThreadActivity("other-conversation", async () => {
+        events.push("other");
+      });
+      expect(events).toEqual(["active", "other"]);
+    } finally {
+      release.resolve();
+      await completed;
+    }
+    expect(events).toEqual(["active", "other", "waiting"]);
+  });
+});

--- a/extensions/codex/src/app-server/thread-ownership.ts
+++ b/extensions/codex/src/app-server/thread-ownership.ts
@@ -21,7 +21,7 @@ import { retainSharedCodexAppServerClientByInstanceId } from "./shared-client.js
 
 const nativeThreadOwners = new KeyedAsyncQueue();
 
-/** Serialize connection-scoped unsubscribe with attach/resume of the same native thread. */
+/** Serialize OpenClaw-owned lifecycle changes, not native-internal thread controllers. */
 export async function withCodexAppServerThreadMutation<T>(
   threadId: string,
   run: () => Promise<T>,
@@ -183,52 +183,55 @@ export async function retireCodexConversationThreadBinding(params: {
   if (!expected || (params.expectedThreadId && expected.threadId !== params.expectedThreadId)) {
     return false;
   }
-  return await params.bindingStore.withLease(params.identity, async () => {
-    const current = await params.bindingStore.read(params.identity);
-    if (
-      current?.threadId !== expected.threadId ||
-      (params.expectedStartId && current.conversationStartId !== params.expectedStartId)
-    ) {
-      return false;
-    }
-    // Keep the old row authoritative through unsubscribe; Codex has one
-    // subscription per physical client, so clearing first races a new owner.
-    await releaseCodexAppServerBindingSubscription(current, {
-      allowUntracked: params.allowUntracked,
-    });
-    const cleared = await params.bindingStore.mutate(params.identity, {
-      kind: "clear",
-      threadId: current.threadId,
-    });
-    if (!cleared || !params.afterClear) {
-      return cleared;
-    }
-    try {
-      await params.afterClear();
-      return true;
-    } catch (error) {
-      try {
-        // Public binding storage commits separately. Restore its exact native
-        // owner on failure without ever overwriting a replacement generation.
-        const restored = await params.bindingStore.mutate(params.identity, {
-          kind: "set",
-          binding: current,
-          if: { kind: "absent" },
-        });
-        if (!restored) {
-          throw new Error("the previous Codex binding generation could not be restored", {
-            cause: error,
-          });
-        }
-      } catch (restorationError) {
-        const recoveryError = new AggregateError(
-          [error, restorationError],
-          `Codex conversation detachment failed and native thread ${current.threadId} could not be restored; run /codex resume ${current.threadId} to recover it`,
-          { cause: restorationError },
-        );
-        throw recoveryError;
+  return await withCodexAppServerThreadMutation(expected.threadId, () =>
+    params.bindingStore.withLease(params.identity, async () => {
+      const current = await params.bindingStore.read(params.identity);
+      if (
+        !current ||
+        !isSameCodexAppServerThreadOwner(current, expected) ||
+        (params.expectedStartId && current?.conversationStartId !== params.expectedStartId)
+      ) {
+        return false;
       }
-      throw error;
-    }
-  });
+      // Keep the old row authoritative through unsubscribe; Codex has one
+      // subscription per physical client, so clearing first races a new owner.
+      await releaseCodexAppServerBindingSubscription(current, {
+        allowUntracked: params.allowUntracked,
+      });
+      const cleared = await params.bindingStore.mutate(params.identity, {
+        kind: "clear",
+        threadId: current.threadId,
+      });
+      if (!cleared || !params.afterClear) {
+        return cleared;
+      }
+      try {
+        await params.afterClear();
+        return true;
+      } catch (error) {
+        try {
+          // Public binding storage commits separately. Restore its exact native
+          // owner on failure without ever overwriting a replacement generation.
+          const restored = await params.bindingStore.mutate(params.identity, {
+            kind: "set",
+            binding: current,
+            if: { kind: "absent" },
+          });
+          if (!restored) {
+            throw new Error("the previous Codex binding generation could not be restored", {
+              cause: error,
+            });
+          }
+        } catch (restorationError) {
+          const recoveryError = new AggregateError(
+            [error, restorationError],
+            `Codex conversation detachment failed and native thread ${current.threadId} could not be restored; run /codex resume ${current.threadId} to recover it`,
+            { cause: restorationError },
+          );
+          throw recoveryError;
+        }
+        throw error;
+      }
+    }),
+  );
 }

--- a/extensions/codex/src/app-server/thread-ownership.ts
+++ b/extensions/codex/src/app-server/thread-ownership.ts
@@ -1,3 +1,4 @@
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
@@ -19,7 +20,12 @@ import type {
 } from "./session-binding.js";
 import { retainSharedCodexAppServerClientByInstanceId } from "./shared-client.js";
 
-const nativeThreadOwners = new KeyedAsyncQueue();
+// Dist and source copies share physical clients, so their lifecycle queues must
+// share ownership too. Settled entries drain naturally; never clear active tails.
+const nativeThreadOwners = resolveGlobalSingleton(
+  Symbol.for("openclaw.codexNativeThreadOwners"),
+  () => new KeyedAsyncQueue(),
+);
 
 /** Serialize OpenClaw-owned lifecycle changes, not native-internal thread controllers. */
 export async function withCodexAppServerThreadMutation<T>(

--- a/extensions/codex/src/app-server/thread-resume.test.ts
+++ b/extensions/codex/src/app-server/thread-resume.test.ts
@@ -127,29 +127,30 @@ describe("resumeCodexAppServerThread", () => {
     expect(abandonClient).not.toHaveBeenCalled();
   });
 
-  it("preserves a physical pre-write ownership rejection without cleanup or retirement", async () => {
-    const harness = createClientHarness();
-    const rejection = new CodexAdoptedThreadActiveError();
-    const abandonClient = vi.fn(async () => undefined);
-    try {
-      await expect(
-        resumeCodexAppServerThread({
-          client: harness.client,
-          abandonClient,
-          request: { threadId: "thread-1" },
-          assertCurrent: () => {
-            throw rejection;
-          },
-          isPrewriteOwnershipError: (error) => error instanceof CodexAdoptedThreadActiveError,
-        }),
-      ).rejects.toBe(rejection);
-      expect(harness.writes).toEqual([]);
-      expect(harness.client.getCloseError()).toBeUndefined();
-      expect(abandonClient).not.toHaveBeenCalled();
-    } finally {
-      harness.client.close();
-    }
-  });
+  it.each([new CodexAdoptedThreadActiveError(), new Error("host authority ended")])(
+    "preserves a physical pre-write ownership rejection without cleanup or retirement: %s",
+    async (rejection) => {
+      const harness = createClientHarness();
+      const abandonClient = vi.fn(async () => undefined);
+      try {
+        await expect(
+          resumeCodexAppServerThread({
+            client: harness.client,
+            abandonClient,
+            request: { threadId: "thread-1" },
+            assertCurrent: () => {
+              throw rejection;
+            },
+          }),
+        ).rejects.toBe(rejection);
+        expect(harness.writes).toEqual([]);
+        expect(harness.client.getCloseError()).toBeUndefined();
+        expect(abandonClient).not.toHaveBeenCalled();
+      } finally {
+        harness.client.close();
+      }
+    },
+  );
 
   it("retires the exact client after a written structured failure loses cleanup ownership", async () => {
     const harness = createClientHarness();
@@ -165,7 +166,6 @@ describe("resumeCodexAppServerThread", () => {
             throw new CodexAdoptedThreadActiveError();
           }
         },
-        isPrewriteOwnershipError: (error) => error instanceof CodexAdoptedThreadActiveError,
       });
       const failure = expect(resume).rejects.toMatchObject({
         name: "CodexAppServerUnsafeSubscriptionError",

--- a/extensions/codex/src/app-server/thread-resume.ts
+++ b/extensions/codex/src/app-server/thread-resume.ts
@@ -25,13 +25,23 @@ export async function resumeCodexAppServerThread(params: {
   timeoutMs?: number;
   signal?: AbortSignal;
   assertCurrent?: () => void;
-  /** Identifies ownership rejection by the request's physical pre-write fence only. */
-  isPrewriteOwnershipError?: (error: unknown) => boolean;
   onSubscriptionReleased?: () => void;
   requestResume?: (request: CodexThreadResumeParams) => Promise<unknown>;
 }): Promise<CodexThreadResumeResponse> {
   const threadId = params.request.threadId;
   let response: CodexThreadResumeResponse;
+  let ownershipRejected = false;
+  const assertCurrent =
+    params.assertCurrent &&
+    (() => {
+      try {
+        params.assertCurrent?.();
+      } catch (error) {
+        // Only this physical pre-write callback proves no subscription was acquired.
+        ownershipRejected = true;
+        throw error;
+      }
+    });
   try {
     response = assertCodexThreadResumeResponse(
       await (params.requestResume
@@ -39,13 +49,13 @@ export async function resumeCodexAppServerThread(params: {
         : params.client.request("thread/resume", params.request, {
             ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
             ...(params.signal ? { signal: params.signal } : {}),
-            assertCurrent: params.assertCurrent,
+            assertCurrent,
           })),
     );
     assertCodexThreadResumeSubscription(threadId, response.thread.id);
   } catch (error) {
     if (
-      params.isPrewriteOwnershipError?.(error) ||
+      ownershipRejected ||
       isCodexAppServerStartSelectionChangedError(error) ||
       isCodexAppServerStartupError(error) ||
       error instanceof CodexAppServerScopedRequestRejectedError ||

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -333,10 +333,18 @@ async function startCodexConversationThread(
     agentId: params.agentId,
   };
   const threadId = params.threadId?.trim();
-  if (threadId) {
-    await attachExistingThread({ ...bindingParams, threadId });
+  const bind = () =>
+    params.bindingStore.withLease(identity, () => bindThread(bindingParams, threadId));
+  const ownedThreadId = threadId ?? existingBinding?.threadId;
+  if (ownedThreadId) {
+    await withExclusiveCodexAppServerThread({
+      bindingStore: params.bindingStore,
+      identity,
+      threadId: ownedThreadId,
+      run: bind,
+    });
   } else {
-    await bindThread(bindingParams);
+    await bind();
   }
   const storedBinding = await params.bindingStore.read(identity);
   if (!storedBinding) {
@@ -692,19 +700,6 @@ async function writeThreadBindingFromResponse(
   }
 }
 
-async function attachExistingThread(
-  params: CodexThreadBindingParams & {
-    threadId: string;
-  },
-): Promise<void> {
-  await withExclusiveCodexAppServerThread({
-    bindingStore: params.bindingStore,
-    identity: params.identity,
-    threadId: params.threadId,
-    run: () => bindThread(params, params.threadId),
-  });
-}
-
 async function bindThread(params: CodexThreadBindingParams, threadId?: string): Promise<void> {
   const current = await params.bindingStore.read(params.identity);
   assertCodexBindingMayBeReplaced(current, "binding a conversation-bound Codex thread");
@@ -789,394 +784,408 @@ async function runBoundTurn(params: {
   if (!binding?.threadId) {
     throw new Error("bound Codex conversation has no thread binding");
   }
-  assertCodexBindingMayBeReplaced(binding, "running a conversation-bound Codex thread");
-  let threadId = binding.threadId;
-  const requestedWorkspaceDir = binding.cwd || params.data.workspaceDir;
-  const reviewerModelProvider = resolveModelBackedReviewerPolicyProvider({
-    authProfileId: binding.authProfileId,
-    modelProvider: binding.modelProvider,
-    ...agentLookup,
-  });
-  const { runtime, workspaceDir } = await resolveConversationAppServerRuntime({
-    pluginConfig: params.pluginConfig,
-    config: params.config,
-    agentId: params.data.source?.agentId ?? params.data.agentId,
-    sessionKey: params.data.legacyBinding ? params.sessionKey : params.data.source?.sessionKey,
-    source: params.data.source,
-    workspaceDir: requestedWorkspaceDir,
-    modelProvider: reviewerModelProvider,
-    model: binding.model,
-    agentDir: params.data.agentDir,
-  });
-  const modelScopedRuntime = resolveCodexAppServerForModelProvider({
-    appServer: runtime,
-    provider: reviewerModelProvider,
-    model: binding.model,
-    config: params.config,
-    env: process.env,
-    agentDir: params.data.agentDir,
-  });
-  const sessionRoot = modelScopedRuntime.sessionRoot;
-  const approvalPolicy = modelScopedRuntime.approvalPolicy;
-  const sandbox = modelScopedRuntime.sandbox;
-  const permissionProfile = modelScopedRuntime.networkProxy?.profileName;
-  const networkProxyConfigFingerprint = modelScopedRuntime.networkProxy?.configFingerprint;
-  const networkProxyBindingChanged =
-    binding.networkProxyProfileName !== permissionProfile ||
-    binding.networkProxyConfigFingerprint !== networkProxyConfigFingerprint;
-  const serviceTier = binding.serviceTier ?? runtime.serviceTier;
-  let useStickyNetworkProfile =
-    permissionProfile !== undefined &&
-    binding.networkProxyProfileName === permissionProfile &&
-    binding.networkProxyConfigFingerprint === networkProxyConfigFingerprint;
-  assertNativeConversationApprovalPolicySupported(modelScopedRuntime);
-  const modelSelection = binding.model
-    ? resolveCodexAppServerRequestModelSelection({
-        model: binding.model,
+  return await withExclusiveCodexAppServerThread({
+    bindingStore: params.bindingStore,
+    identity,
+    threadId: binding.threadId,
+    run: async () => {
+      const current = await params.bindingStore.read(identity);
+      if (!isSameCodexAppServerThreadOwner(current, binding)) {
+        throw new Error("Codex conversation binding changed before its turn.");
+      }
+      assertCodexBindingMayBeReplaced(binding, "running a conversation-bound Codex thread");
+      let threadId = binding.threadId;
+      const requestedWorkspaceDir = binding.cwd || params.data.workspaceDir;
+      const reviewerModelProvider = resolveModelBackedReviewerPolicyProvider({
+        authProfileId: binding.authProfileId,
         modelProvider: binding.modelProvider,
+        ...agentLookup,
+      });
+      const { runtime, workspaceDir } = await resolveConversationAppServerRuntime({
+        pluginConfig: params.pluginConfig,
+        config: params.config,
+        agentId: params.data.source?.agentId ?? params.data.agentId,
+        sessionKey: params.data.legacyBinding ? params.sessionKey : params.data.source?.sessionKey,
+        source: params.data.source,
+        workspaceDir: requestedWorkspaceDir,
+        modelProvider: reviewerModelProvider,
+        model: binding.model,
+        agentDir: params.data.agentDir,
+      });
+      const modelScopedRuntime = resolveCodexAppServerForModelProvider({
+        appServer: runtime,
+        provider: reviewerModelProvider,
+        model: binding.model,
+        config: params.config,
+        env: process.env,
+        agentDir: params.data.agentDir,
+      });
+      const sessionRoot = modelScopedRuntime.sessionRoot;
+      const approvalPolicy = modelScopedRuntime.approvalPolicy;
+      const sandbox = modelScopedRuntime.sandbox;
+      const permissionProfile = modelScopedRuntime.networkProxy?.profileName;
+      const networkProxyConfigFingerprint = modelScopedRuntime.networkProxy?.configFingerprint;
+      const networkProxyBindingChanged =
+        binding.networkProxyProfileName !== permissionProfile ||
+        binding.networkProxyConfigFingerprint !== networkProxyConfigFingerprint;
+      const serviceTier = binding.serviceTier ?? runtime.serviceTier;
+      let useStickyNetworkProfile =
+        permissionProfile !== undefined &&
+        binding.networkProxyProfileName === permissionProfile &&
+        binding.networkProxyConfigFingerprint === networkProxyConfigFingerprint;
+      assertNativeConversationApprovalPolicySupported(modelScopedRuntime);
+      const modelSelection = binding.model
+        ? resolveCodexAppServerRequestModelSelection({
+            model: binding.model,
+            modelProvider: binding.modelProvider,
+            authProfileId: binding.authProfileId,
+            ...agentLookup,
+          })
+        : undefined;
+      const threadRequestRuntime = { runtime: modelScopedRuntime, workspaceDir, ...modelSelection };
+
+      const clientOptions = {
+        startOptions: runtime.start,
+        timeoutMs: runtime.requestTimeoutMs,
         authProfileId: binding.authProfileId,
         ...agentLookup,
-      })
-    : undefined;
-  const threadRequestRuntime = { runtime: modelScopedRuntime, workspaceDir, ...modelSelection };
-
-  const clientOptions = {
-    startOptions: runtime.start,
-    timeoutMs: runtime.requestTimeoutMs,
-    authProfileId: binding.authProfileId,
-    ...agentLookup,
-  } satisfies CodexAppServerClientOptions;
-  let client = await getLeasedSharedCodexAppServerClient(clientOptions);
-  const clientLease: CodexAppServerClientLease = { client };
-  let activeTurnId: string | undefined;
-  let activeTurnCleanup: () => void = () => undefined;
-  // Released or retired subscriptions need no further cleanup on that physical client.
-  let isolatedSubscriptionClient: CodexAppServerClient | undefined;
-  let turnRoute: CodexThreadRouteReservation | undefined;
-  let liveThreadOwnership:
-    | {
-        client: CodexAppServerClient;
-        threadId: string;
-        ownership: CodexAppServerLiveThreadOwnership;
-      }
-    | undefined;
-  let ownsNativeSubscription = false;
-  let turnSucceeded = false;
-  const assertResumeInputAllowed = async () => {
-    const { thread } = await client.request(
-      "thread/read",
-      { threadId, includeTurns: false },
-      { timeoutMs: runtime.requestTimeoutMs },
-    );
-    assertCodexThreadAcceptsDirectInput(thread);
-  };
-  try {
-    if (!networkProxyBindingChanged && binding.clientId !== client.getInstanceId()) {
-      // A new client may already retain this parent's child; check before claiming it.
-      await assertResumeInputAllowed();
-    }
-    if (!params.incognito && isCodexAppServerClientRuntimeLive(client)) {
-      const ownership = await consumeCodexAppServerLiveThread(client, threadId);
-      if (ownership) {
-        liveThreadOwnership = { client, threadId, ownership };
-        ownsNativeSubscription = true;
-      }
-    }
-    if (networkProxyBindingChanged) {
-      const response = assertCodexThreadStartResponse(
-        await withLeasedCodexAppServerClientStartSelectionRetry({
-          lease: clientLease,
-          options: clientOptions,
-          run: async (requestClient, requestOptions) =>
-            await requestClient.request(
-              "thread/start",
-              {
-                ...buildConversationThreadRequest(threadRequestRuntime, serviceTier),
-                developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
-                experimentalRawEvents: true,
-                ...(params.incognito ? { ephemeral: true } : {}),
-              },
-              requestOptions(),
-            ),
-          onClientChange: (nextClient) => {
-            client = nextClient;
-          },
-        }),
-      );
-      threadId = response.thread.id;
-      ownsNativeSubscription = true;
-      assertCodexThreadAcceptsDirectInput(response.thread);
-      if (
-        liveThreadOwnership &&
-        (liveThreadOwnership.threadId !== threadId || liveThreadOwnership.client !== client)
-      ) {
-        const previousOwnership = liveThreadOwnership;
-        try {
-          await previousOwnership.ownership.release(previousOwnership.threadId);
-        } catch (error) {
-          // A failed unsubscribe leaves the old subscription alive. Restore
-          // its exact branded owner before rolling back the new native thread.
-          const restored =
-            isCodexAppServerClientRuntimeLive(previousOwnership.client) &&
-            (await retainCodexAppServerBindingSubscription(
-              previousOwnership.client,
-              previousOwnership.threadId,
-              previousOwnership.ownership,
-            ).catch(() => false));
-          if (!restored) {
-            await closeCodexStartupClientBestEffort(previousOwnership.client);
+      } satisfies CodexAppServerClientOptions;
+      let client = await getLeasedSharedCodexAppServerClient(clientOptions);
+      const clientLease: CodexAppServerClientLease = { client };
+      let activeTurnId: string | undefined;
+      let activeTurnCleanup: () => void = () => undefined;
+      // Released or retired subscriptions need no further cleanup on that physical client.
+      let isolatedSubscriptionClient: CodexAppServerClient | undefined;
+      let turnRoute: CodexThreadRouteReservation | undefined;
+      let liveThreadOwnership:
+        | {
+            client: CodexAppServerClient;
+            threadId: string;
+            ownership: CodexAppServerLiveThreadOwnership;
           }
-          liveThreadOwnership = undefined;
+        | undefined;
+      let ownsNativeSubscription = false;
+      let turnSucceeded = false;
+      const assertResumeInputAllowed = async () => {
+        const { thread } = await client.request(
+          "thread/read",
+          { threadId, includeTurns: false },
+          { timeoutMs: runtime.requestTimeoutMs },
+        );
+        assertCodexThreadAcceptsDirectInput(thread);
+      };
+      try {
+        if (!networkProxyBindingChanged && binding.clientId !== client.getInstanceId()) {
+          // A new client may already retain this parent's child; check before claiming it.
+          await assertResumeInputAllowed();
+        }
+        if (!params.incognito && isCodexAppServerClientRuntimeLive(client)) {
+          const ownership = await consumeCodexAppServerLiveThread(client, threadId);
+          if (ownership) {
+            liveThreadOwnership = { client, threadId, ownership };
+            ownsNativeSubscription = true;
+          }
+        }
+        if (networkProxyBindingChanged) {
+          const response = assertCodexThreadStartResponse(
+            await withLeasedCodexAppServerClientStartSelectionRetry({
+              lease: clientLease,
+              options: clientOptions,
+              run: async (requestClient, requestOptions) =>
+                await requestClient.request(
+                  "thread/start",
+                  {
+                    ...buildConversationThreadRequest(threadRequestRuntime, serviceTier),
+                    developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
+                    experimentalRawEvents: true,
+                    ...(params.incognito ? { ephemeral: true } : {}),
+                  },
+                  requestOptions(),
+                ),
+              onClientChange: (nextClient) => {
+                client = nextClient;
+              },
+            }),
+          );
+          threadId = response.thread.id;
+          ownsNativeSubscription = true;
+          assertCodexThreadAcceptsDirectInput(response.thread);
+          if (
+            liveThreadOwnership &&
+            (liveThreadOwnership.threadId !== threadId || liveThreadOwnership.client !== client)
+          ) {
+            const previousOwnership = liveThreadOwnership;
+            try {
+              await previousOwnership.ownership.release(previousOwnership.threadId);
+            } catch (error) {
+              // A failed unsubscribe leaves the old subscription alive. Restore
+              // its exact branded owner before rolling back the new native thread.
+              const restored =
+                isCodexAppServerClientRuntimeLive(previousOwnership.client) &&
+                (await retainCodexAppServerBindingSubscription(
+                  previousOwnership.client,
+                  previousOwnership.threadId,
+                  previousOwnership.ownership,
+                ).catch(() => false));
+              if (!restored) {
+                await closeCodexStartupClientBestEffort(previousOwnership.client);
+              }
+              liveThreadOwnership = undefined;
+              throw error;
+            }
+            liveThreadOwnership = undefined;
+          } else if (binding.threadId !== threadId) {
+            await releaseCodexAppServerBindingSubscription(binding);
+          }
+          const committed = await params.bindingStore.mutate(identity, {
+            kind: "set",
+            binding: {
+              threadId,
+              clientId: client.getInstanceId(),
+              cwd: response.thread.cwd ?? workspaceDir,
+              authProfileId: binding.authProfileId,
+              model: response.model ?? modelSelection?.model ?? binding.model,
+              modelProvider: normalizeCodexAppServerBindingModelProvider({
+                authProfileId: binding.authProfileId,
+                modelProvider:
+                  response.modelProvider ?? modelSelection?.modelProvider ?? binding.modelProvider,
+                ...agentLookup,
+              }),
+              serviceTier: serviceTier ?? undefined,
+              networkProxyProfileName: modelScopedRuntime.networkProxy?.profileName,
+              networkProxyConfigFingerprint: modelScopedRuntime.networkProxy?.configFingerprint,
+              conversationStartId: binding.conversationStartId,
+              conversationSourceTransferComplete: binding.conversationSourceTransferComplete,
+              historyCoveredThrough: binding.historyCoveredThrough,
+            },
+          });
+          if (!committed) {
+            throw new Error("Codex conversation binding changed while rotating its thread.");
+          }
+          useStickyNetworkProfile = modelScopedRuntime.networkProxy !== undefined;
+        } else if (
+          binding.clientId !== client.getInstanceId() ||
+          (isCodexAppServerClientRuntimeLive(client) && !params.incognito && !liveThreadOwnership)
+        ) {
+          if (binding.clientId === client.getInstanceId()) {
+            await assertResumeInputAllowed();
+          }
+          const response = await withLeasedCodexAppServerClientStartSelectionRetry({
+            lease: clientLease,
+            options: clientOptions,
+            run: async (requestClient, requestOptions) =>
+              await resumeCodexAppServerThread({
+                client: requestClient,
+                onSubscriptionReleased: () => {
+                  isolatedSubscriptionClient = requestClient;
+                },
+                abandonClient: async () => {
+                  await closeCodexStartupClientBestEffort(requestClient);
+                  isolatedSubscriptionClient = requestClient;
+                },
+                request: {
+                  threadId,
+                  ...buildConversationThreadRequest(threadRequestRuntime, serviceTier),
+                },
+                requestResume: (request) =>
+                  requestClient.request("thread/resume", request, requestOptions()),
+              }),
+            onClientChange: (nextClient) => {
+              client = nextClient;
+            },
+          });
+          threadId = response.thread.id;
+          ownsNativeSubscription = true;
+          assertCodexThreadAcceptsDirectInput(response.thread);
+          if (
+            !isSameCodexAppServerThreadOwner(binding, {
+              threadId,
+              clientId: client.getInstanceId(),
+            })
+          ) {
+            // Keep the old physical owner authoritative until unsubscribe succeeds;
+            // failed migration then rolls back only the newly resumed connection.
+            await releaseCodexAppServerBindingSubscription(binding);
+          }
+          const committed = await params.bindingStore.mutate(identity, {
+            kind: "patch",
+            threadId: binding.threadId,
+            patch: {
+              clientId: client.getInstanceId(),
+              cwd: response.thread.cwd ?? binding.cwd,
+              model: response.model ?? modelSelection?.model ?? binding.model,
+              modelProvider: normalizeCodexAppServerBindingModelProvider({
+                authProfileId: binding.authProfileId,
+                modelProvider:
+                  response.modelProvider ?? modelSelection?.modelProvider ?? binding.modelProvider,
+                ...agentLookup,
+              }),
+            },
+          });
+          if (!committed) {
+            throw new Error("Codex conversation binding changed while resuming on a new client.");
+          }
+        }
+        const turnCollector = createCodexConversationTurnCollector(threadId);
+        turnRoute = getCodexAppServerTurnRouter(client).reserveThread({
+          threadId,
+          onNotification: turnCollector.handleNotification,
+        });
+        // The client denies unclaimed approvals and dynamic tools. Its keyed router owns
+        // pre-bind buffering so this conversation cannot claim sibling turn requests.
+        turnRoute.armTurn();
+        const response: CodexTurnStartResponse = await client.request(
+          "turn/start",
+          {
+            threadId,
+            input: buildCodexConversationTurnInput({
+              prompt: params.prompt,
+              event: params.event,
+            }),
+            cwd: workspaceDir,
+            ...(sessionRoot ? { runtimeWorkspaceRoots: [sessionRoot] } : {}),
+            approvalPolicy,
+            approvalsReviewer: modelScopedRuntime.approvalsReviewer,
+            ...(useStickyNetworkProfile
+              ? {}
+              : {
+                  sandboxPolicy: codexSandboxPolicyForTurn(sandbox, sessionRoot ?? workspaceDir),
+                }),
+            ...(modelSelection?.model ? { model: modelSelection.model } : {}),
+            personality: CODEX_NATIVE_PERSONALITY_NONE,
+            ...(serviceTier ? { serviceTier } : {}),
+          },
+          { timeoutMs: runtime.requestTimeoutMs },
+        );
+        activeTurnId = response.turn.id;
+        activeTurnCleanup = trackCodexConversationActiveTurn({
+          identity,
+          client,
+          threadId,
+          turnId: activeTurnId,
+        });
+        turnCollector.setTurnId(activeTurnId);
+        await turnRoute.bindTurn(activeTurnId);
+        const completion = await turnCollector.wait({
+          timeoutMs: params.timeoutMs ?? DEFAULT_BOUND_TURN_TIMEOUT_MS,
+        });
+        const replyText = completion.replyText.trim();
+        turnSucceeded = true;
+        return {
+          reply: {
+            text: replyText || "Codex completed without a text reply.",
+          },
+        };
+      } catch (error) {
+        if (isCodexAppServerOverloadError(error) && error.method === "thread/resume") {
           throw error;
         }
-        liveThreadOwnership = undefined;
-      } else if (binding.threadId !== threadId) {
-        await releaseCodexAppServerBindingSubscription(binding);
-      }
-      const committed = await params.bindingStore.mutate(identity, {
-        kind: "set",
-        binding: {
-          threadId,
-          clientId: client.getInstanceId(),
-          cwd: response.thread.cwd ?? workspaceDir,
-          authProfileId: binding.authProfileId,
-          model: response.model ?? modelSelection?.model ?? binding.model,
-          modelProvider: normalizeCodexAppServerBindingModelProvider({
-            authProfileId: binding.authProfileId,
-            modelProvider:
-              response.modelProvider ?? modelSelection?.modelProvider ?? binding.modelProvider,
-            ...agentLookup,
-          }),
-          serviceTier: serviceTier ?? undefined,
-          networkProxyProfileName: modelScopedRuntime.networkProxy?.profileName,
-          networkProxyConfigFingerprint: modelScopedRuntime.networkProxy?.configFingerprint,
-          conversationStartId: binding.conversationStartId,
-          conversationSourceTransferComplete: binding.conversationSourceTransferComplete,
-          historyCoveredThrough: binding.historyCoveredThrough,
-        },
-      });
-      if (!committed) {
-        throw new Error("Codex conversation binding changed while rotating its thread.");
-      }
-      useStickyNetworkProfile = modelScopedRuntime.networkProxy !== undefined;
-    } else if (
-      binding.clientId !== client.getInstanceId() ||
-      (isCodexAppServerClientRuntimeLive(client) && !params.incognito && !liveThreadOwnership)
-    ) {
-      if (binding.clientId === client.getInstanceId()) {
-        await assertResumeInputAllowed();
-      }
-      const response = await withLeasedCodexAppServerClientStartSelectionRetry({
-        lease: clientLease,
-        options: clientOptions,
-        run: async (requestClient, requestOptions) =>
-          await resumeCodexAppServerThread({
-            client: requestClient,
-            onSubscriptionReleased: () => {
-              isolatedSubscriptionClient = requestClient;
-            },
-            abandonClient: async () => {
-              await closeCodexStartupClientBestEffort(requestClient);
-              isolatedSubscriptionClient = requestClient;
-            },
-            request: {
+        if (error instanceof CodexThreadDirectInputError) {
+          if (params.incognito && ownsNativeSubscription) {
+            // Resume can reveal a cold child's capability only after subscribing.
+            // Release that subscription without clearing the preserved binding.
+            const released = await unsubscribeCodexThreadBestEffort(client, {
               threadId,
-              ...buildConversationThreadRequest(threadRequestRuntime, serviceTier),
-            },
-            requestResume: (request) =>
-              requestClient.request("thread/resume", request, requestOptions()),
-          }),
-        onClientChange: (nextClient) => {
-          client = nextClient;
-        },
-      });
-      threadId = response.thread.id;
-      ownsNativeSubscription = true;
-      assertCodexThreadAcceptsDirectInput(response.thread);
-      if (
-        !isSameCodexAppServerThreadOwner(binding, {
-          threadId,
-          clientId: client.getInstanceId(),
-        })
-      ) {
-        // Keep the old physical owner authoritative until unsubscribe succeeds;
-        // failed migration then rolls back only the newly resumed connection.
-        await releaseCodexAppServerBindingSubscription(binding);
-      }
-      const committed = await params.bindingStore.mutate(identity, {
-        kind: "patch",
-        threadId: binding.threadId,
-        patch: {
-          clientId: client.getInstanceId(),
-          cwd: response.thread.cwd ?? binding.cwd,
-          model: response.model ?? modelSelection?.model ?? binding.model,
-          modelProvider: normalizeCodexAppServerBindingModelProvider({
-            authProfileId: binding.authProfileId,
-            modelProvider:
-              response.modelProvider ?? modelSelection?.modelProvider ?? binding.modelProvider,
-            ...agentLookup,
-          }),
-        },
-      });
-      if (!committed) {
-        throw new Error("Codex conversation binding changed while resuming on a new client.");
-      }
-    }
-    const turnCollector = createCodexConversationTurnCollector(threadId);
-    turnRoute = getCodexAppServerTurnRouter(client).reserveThread({
-      threadId,
-      onNotification: turnCollector.handleNotification,
-    });
-    // The client denies unclaimed approvals and dynamic tools. Its keyed router owns
-    // pre-bind buffering so this conversation cannot claim sibling turn requests.
-    turnRoute.armTurn();
-    const response: CodexTurnStartResponse = await client.request(
-      "turn/start",
-      {
-        threadId,
-        input: buildCodexConversationTurnInput({
-          prompt: params.prompt,
-          event: params.event,
-        }),
-        cwd: workspaceDir,
-        ...(sessionRoot ? { runtimeWorkspaceRoots: [sessionRoot] } : {}),
-        approvalPolicy,
-        approvalsReviewer: modelScopedRuntime.approvalsReviewer,
-        ...(useStickyNetworkProfile
-          ? {}
-          : {
-              sandboxPolicy: codexSandboxPolicyForTurn(sandbox, sessionRoot ?? workspaceDir),
-            }),
-        ...(modelSelection?.model ? { model: modelSelection.model } : {}),
-        personality: CODEX_NATIVE_PERSONALITY_NONE,
-        ...(serviceTier ? { serviceTier } : {}),
-      },
-      { timeoutMs: runtime.requestTimeoutMs },
-    );
-    activeTurnId = response.turn.id;
-    activeTurnCleanup = trackCodexConversationActiveTurn({
-      identity,
-      client,
-      threadId,
-      turnId: activeTurnId,
-    });
-    turnCollector.setTurnId(activeTurnId);
-    await turnRoute.bindTurn(activeTurnId);
-    const completion = await turnCollector.wait({
-      timeoutMs: params.timeoutMs ?? DEFAULT_BOUND_TURN_TIMEOUT_MS,
-    });
-    const replyText = completion.replyText.trim();
-    turnSucceeded = true;
-    return {
-      reply: {
-        text: replyText || "Codex completed without a text reply.",
-      },
-    };
-  } catch (error) {
-    if (isCodexAppServerOverloadError(error) && error.method === "thread/resume") {
-      throw error;
-    }
-    if (error instanceof CodexThreadDirectInputError) {
-      if (params.incognito && ownsNativeSubscription) {
-        // Resume can reveal a cold child's capability only after subscribing.
-        // Release that subscription without clearing the preserved binding.
-        const released = await unsubscribeCodexThreadBestEffort(client, {
-          threadId,
-          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-        });
-        if (!released) {
-          await retireUnsafeCodexTurnClientBestEffort(client, "parent-owned thread unsubscribe");
-        }
-      }
-      throw error;
-    }
-    if (
-      (error instanceof CodexConversationTurnTimeoutError && activeTurnId) ||
-      (turnRoute && isCodexAppServerIndeterminateRequestCancellationError(error))
-    ) {
-      // Per-thread serialization makes an empty startup interrupt follow an
-      // accepted turn whose id was lost to local request cancellation.
-      const completed = await interruptCodexTurnAndWaitBestEffort(client, {
-        threadId,
-        turnId: activeTurnId ?? "",
-      });
-      if (!completed) {
-        // Retirement detaches the physical client while sibling leases finish;
-        // never send another cleanup request or retire that detached client twice.
-        await retireUnsafeCodexTurnClientBestEffort(client, "turn interrupt");
-        isolatedSubscriptionClient = client;
-      }
-    }
-    if (params.incognito) {
-      const bindingReleased = await params.bindingStore.mutate(identity, {
-        kind: "clear",
-        threadId,
-      });
-      if (bindingReleased && isolatedSubscriptionClient !== client) {
-        const unsubscribed = await unsubscribeCodexThreadBestEffort(client, {
-          threadId,
-          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-        });
-        if (!unsubscribed) {
-          await retireUnsafeCodexTurnClientBestEffort(client, "thread unsubscribe");
-        }
-      }
-    }
-    throw error;
-  } finally {
-    activeTurnCleanup();
-    turnRoute?.release();
-    try {
-      if (
-        ownsNativeSubscription &&
-        isolatedSubscriptionClient !== client &&
-        !params.incognito &&
-        isCodexAppServerClientRuntimeLive(client)
-      ) {
-        // Ownership callbacks are branded to one physical client and native
-        // thread; an old generation must never clean up its replacement.
-        const currentLiveThreadOwnership =
-          liveThreadOwnership?.client === client && liveThreadOwnership.threadId === threadId
-            ? liveThreadOwnership.ownership
-            : undefined;
-        let retained = false;
-        if (turnSucceeded) {
-          retained = await params.bindingStore.withLease(identity, async () => {
-            const current = await params.bindingStore.read(identity);
-            if (current?.threadId !== threadId || current.clientId !== client.getInstanceId()) {
-              return false;
+              timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+            });
+            if (!released) {
+              await retireUnsafeCodexTurnClientBestEffort(
+                client,
+                "parent-owned thread unsubscribe",
+              );
             }
-            // Claim before turn/start and republish only its unchanged owner;
-            // TTL/LRU eviction must never detach an active conversation turn.
-            return await retainCodexAppServerBindingSubscription(
-              client,
-              threadId,
-              currentLiveThreadOwnership,
-            );
-          });
+          }
+          throw error;
         }
-        if (!retained) {
-          const released = currentLiveThreadOwnership
-            ? await currentLiveThreadOwnership.release(threadId).then(() => true)
-            : await unsubscribeCodexThreadBestEffort(client, {
-                threadId,
-                timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-              });
-          if (!released) {
-            await closeCodexStartupClientBestEffort(client);
+        if (
+          (error instanceof CodexConversationTurnTimeoutError && activeTurnId) ||
+          (turnRoute && isCodexAppServerIndeterminateRequestCancellationError(error))
+        ) {
+          // Per-thread serialization makes an empty startup interrupt follow an
+          // accepted turn whose id was lost to local request cancellation.
+          const completed = await interruptCodexTurnAndWaitBestEffort(client, {
+            threadId,
+            turnId: activeTurnId ?? "",
+          });
+          if (!completed) {
+            // Retirement detaches the physical client while sibling leases finish;
+            // never send another cleanup request or retire that detached client twice.
+            await retireUnsafeCodexTurnClientBestEffort(client, "turn interrupt");
+            isolatedSubscriptionClient = client;
           }
         }
+        if (params.incognito) {
+          const bindingReleased = await params.bindingStore.mutate(identity, {
+            kind: "clear",
+            threadId,
+          });
+          if (bindingReleased && isolatedSubscriptionClient !== client) {
+            const unsubscribed = await unsubscribeCodexThreadBestEffort(client, {
+              threadId,
+              timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+            });
+            if (!unsubscribed) {
+              await retireUnsafeCodexTurnClientBestEffort(client, "thread unsubscribe");
+            }
+          }
+        }
+        throw error;
+      } finally {
+        activeTurnCleanup();
+        turnRoute?.release();
+        try {
+          if (
+            ownsNativeSubscription &&
+            isolatedSubscriptionClient !== client &&
+            !params.incognito &&
+            isCodexAppServerClientRuntimeLive(client)
+          ) {
+            // Ownership callbacks are branded to one physical client and native
+            // thread; an old generation must never clean up its replacement.
+            const currentLiveThreadOwnership =
+              liveThreadOwnership?.client === client && liveThreadOwnership.threadId === threadId
+                ? liveThreadOwnership.ownership
+                : undefined;
+            let retained = false;
+            if (turnSucceeded) {
+              retained = await params.bindingStore.withLease(identity, async () => {
+                const latest = await params.bindingStore.read(identity);
+                if (latest?.threadId !== threadId || latest.clientId !== client.getInstanceId()) {
+                  return false;
+                }
+                // Claim before turn/start and republish only its unchanged owner;
+                // TTL/LRU eviction must never detach an active conversation turn.
+                return await retainCodexAppServerBindingSubscription(
+                  client,
+                  threadId,
+                  currentLiveThreadOwnership,
+                );
+              });
+            }
+            if (!retained) {
+              const released = currentLiveThreadOwnership
+                ? await currentLiveThreadOwnership.release(threadId).then(() => true)
+                : await unsubscribeCodexThreadBestEffort(client, {
+                    threadId,
+                    timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+                  });
+              if (!released) {
+                await closeCodexStartupClientBestEffort(client);
+              }
+            }
+          }
+        } catch (error) {
+          embeddedAgentLog.warn("codex conversation subscription cleanup failed", {
+            threadId,
+            reason: formatErrorMessage(error),
+          });
+          await closeCodexStartupClientBestEffort(client);
+        } finally {
+          releaseCodexAppServerClientLease(clientLease);
+        }
       }
-    } catch (error) {
-      embeddedAgentLog.warn("codex conversation subscription cleanup failed", {
-        threadId,
-        reason: formatErrorMessage(error),
-      });
-      await closeCodexStartupClientBestEffort(client);
-    } finally {
-      releaseCodexAppServerClientLease(clientLease);
-    }
-  }
+    },
+  });
 }
 
 function assertNativeConversationApprovalPolicySupported(
@@ -1225,107 +1234,123 @@ async function prepareConversationBinding(
   options: { forceNew?: boolean } = {},
 ): Promise<void> {
   const identity = conversationBindingIdentity(params.data);
-  await params.bindingStore.withLease(identity, async () => {
-    const current = await params.bindingStore.read(identity);
-    const requested =
-      params.data.start && current?.conversationStartId !== params.data.start.id
-        ? params.data.start
+  const snapshot = await params.bindingStore.read(identity);
+  const run = () =>
+    params.bindingStore.withLease(identity, async () => {
+      const current = await params.bindingStore.read(identity);
+      if (current?.threadId !== snapshot?.threadId || current?.clientId !== snapshot?.clientId) {
+        throw new Error("Codex conversation binding changed before preparation.");
+      }
+      const requested =
+        params.data.start && current?.conversationStartId !== params.data.start.id
+          ? params.data.start
+          : undefined;
+      if (current && !requested && !options.forceNew) {
+        return;
+      }
+      const sourceIdentity = params.data.source
+        ? sessionBindingIdentity({
+            agentId: params.data.source.agentId,
+            sessionId: params.data.source.sessionId,
+            sessionKey: params.data.source.sessionKey,
+            config: params.config,
+          })
         : undefined;
-    if (current && !requested && !options.forceNew) {
-      return;
-    }
-    const sourceIdentity = params.data.source
-      ? sessionBindingIdentity({
-          agentId: params.data.source.agentId,
-          sessionId: params.data.source.sessionId,
-          sessionKey: params.data.source.sessionKey,
-          config: params.config,
-        })
-      : undefined;
-    const sourceBinding = sourceIdentity
-      ? await params.bindingStore.read(sourceIdentity)
-      : undefined;
-    assertCodexBindingMayBeReplaced(current, "initializing a conversation-bound Codex thread");
-    assertCodexBindingMayBeReplaced(
-      sourceBinding,
-      "transferring a session into a conversation-bound Codex thread",
-    );
-    const inherited = current ?? sourceBinding;
-    const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir, config: params.config });
-    const bindingParams: CodexThreadBindingParams = {
+      const sourceBinding = sourceIdentity
+        ? await params.bindingStore.read(sourceIdentity)
+        : undefined;
+      assertCodexBindingMayBeReplaced(current, "initializing a conversation-bound Codex thread");
+      assertCodexBindingMayBeReplaced(
+        sourceBinding,
+        "transferring a session into a conversation-bound Codex thread",
+      );
+      const inherited = current ?? sourceBinding;
+      const agentLookup = buildAgentLookup({
+        agentDir: params.data.agentDir,
+        config: params.config,
+      });
+      const bindingParams: CodexThreadBindingParams = {
+        bindingStore: params.bindingStore,
+        identity,
+        pluginConfig: params.pluginConfig,
+        workspaceDir: requested
+          ? params.data.workspaceDir
+          : (inherited?.cwd ?? params.data.workspaceDir),
+        ...agentLookup,
+        model: requested?.model ?? inherited?.model,
+        modelProvider: requested?.modelProvider ?? inherited?.modelProvider,
+        authProfileId: requested?.authProfileId ?? inherited?.authProfileId,
+        serviceTier: inherited?.serviceTier,
+        config: params.config,
+        sessionKey: params.data.legacyBinding ? params.sessionKey : params.data.source?.sessionKey,
+        source: params.data.source,
+        incognito: params.incognito,
+        agentId: params.data.source?.agentId ?? params.data.agentId,
+      };
+      // Harness threads retain immutable tools, developer instructions, and app
+      // policy. Transfer bounded visible history into a fresh bound-only thread.
+      const threadId = requested?.threadId;
+      await bindThread(bindingParams, options.forceNew ? undefined : threadId);
+      const stored = await params.bindingStore.read(identity);
+      if (!stored) {
+        throw new Error("Codex conversation binding disappeared while initializing its thread.");
+      }
+      if (sourceIdentity && params.data.source && !current?.conversationSourceTransferComplete) {
+        await params.bindingStore.withLease(sourceIdentity, async () => {
+          const source = await params.bindingStore.read(sourceIdentity);
+          if (source && source.threadId === params.data.source?.threadId) {
+            const sourceSessionKey =
+              sourceIdentity.sessionKey ??
+              resolveTranscriptSessionKeyBySessionId({
+                agentId: sourceIdentity.agentId,
+                sessionId: sourceIdentity.sessionId,
+                storePath: resolveStorePath(params.config?.session?.store, {
+                  agentId: sourceIdentity.agentId,
+                }),
+              });
+            if (
+              sourceSessionKey &&
+              resolveActiveEmbeddedRunSessionId(sourceSessionKey) === sourceIdentity.sessionId
+            ) {
+              throw new Error(
+                "Codex source session has an active run; stop it before binding this conversation.",
+              );
+            }
+            if (source.threadId !== stored.threadId) {
+              await releaseCodexAppServerBindingSubscription(source);
+              await projectConversationSourceHistory(params.data.source, stored, params.config);
+            }
+            await params.bindingStore.mutate(sourceIdentity, {
+              kind: "clear",
+              threadId: source.threadId,
+            });
+          }
+        });
+      }
+      const patched = await params.bindingStore.mutate(identity, {
+        kind: "patch",
+        threadId: stored.threadId,
+        patch: {
+          ...(params.data.start ? { conversationStartId: params.data.start.id } : {}),
+          ...(sourceIdentity ? { conversationSourceTransferComplete: true } : {}),
+        },
+      });
+      if (!patched) {
+        throw new Error("Codex conversation binding changed while initializing its thread.");
+      }
+    });
+  // Attach and ordinary resume acquire the native queue before a durable binding lease.
+  const threadId = params.data.start?.threadId ?? snapshot?.threadId;
+  if (threadId) {
+    await withExclusiveCodexAppServerThread({
       bindingStore: params.bindingStore,
       identity,
-      pluginConfig: params.pluginConfig,
-      workspaceDir: requested
-        ? params.data.workspaceDir
-        : (inherited?.cwd ?? params.data.workspaceDir),
-      ...agentLookup,
-      model: requested?.model ?? inherited?.model,
-      modelProvider: requested?.modelProvider ?? inherited?.modelProvider,
-      authProfileId: requested?.authProfileId ?? inherited?.authProfileId,
-      serviceTier: inherited?.serviceTier,
-      config: params.config,
-      sessionKey: params.data.legacyBinding ? params.sessionKey : params.data.source?.sessionKey,
-      source: params.data.source,
-      incognito: params.incognito,
-      agentId: params.data.source?.agentId ?? params.data.agentId,
-    };
-    // Harness threads retain immutable tools, developer instructions, and app
-    // policy. Transfer bounded visible history into a fresh bound-only thread.
-    const threadId = requested?.threadId;
-    if (threadId && !options.forceNew) {
-      await attachExistingThread({ ...bindingParams, threadId });
-    } else {
-      await bindThread(bindingParams);
-    }
-    const stored = await params.bindingStore.read(identity);
-    if (!stored) {
-      throw new Error("Codex conversation binding disappeared while initializing its thread.");
-    }
-    if (sourceIdentity && params.data.source && !current?.conversationSourceTransferComplete) {
-      await params.bindingStore.withLease(sourceIdentity, async () => {
-        const source = await params.bindingStore.read(sourceIdentity);
-        if (source && source.threadId === params.data.source?.threadId) {
-          const sourceSessionKey =
-            sourceIdentity.sessionKey ??
-            resolveTranscriptSessionKeyBySessionId({
-              agentId: sourceIdentity.agentId,
-              sessionId: sourceIdentity.sessionId,
-              storePath: resolveStorePath(params.config?.session?.store, {
-                agentId: sourceIdentity.agentId,
-              }),
-            });
-          if (
-            sourceSessionKey &&
-            resolveActiveEmbeddedRunSessionId(sourceSessionKey) === sourceIdentity.sessionId
-          ) {
-            throw new Error(
-              "Codex source session has an active run; stop it before binding this conversation.",
-            );
-          }
-          if (source.threadId !== stored.threadId) {
-            await releaseCodexAppServerBindingSubscription(source);
-            await projectConversationSourceHistory(params.data.source, stored, params.config);
-          }
-          await params.bindingStore.mutate(sourceIdentity, {
-            kind: "clear",
-            threadId: source.threadId,
-          });
-        }
-      });
-    }
-    const patched = await params.bindingStore.mutate(identity, {
-      kind: "patch",
-      threadId: stored.threadId,
-      patch: {
-        ...(params.data.start ? { conversationStartId: params.data.start.id } : {}),
-        ...(sourceIdentity ? { conversationSourceTransferComplete: true } : {}),
-      },
+      threadId,
+      run,
     });
-    if (!patched) {
-      throw new Error("Codex conversation binding changed while initializing its thread.");
-    }
-  });
+  } else {
+    await run();
+  }
 }
 
 async function projectConversationSourceHistory(


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/136143 — idle Codex chats falsely report another runner when unrelated work shares their app-server.

## What Problem This Solves

Fixes an issue where users continuing an idle Codex chat would receive **“Codex session became active in another runner”** while an unrelated chat, catalog reader, or prewarm acquisition used the same app-server. Ordinary cold resume incorrectly required exclusive use of the entire shared client. Even a completed acquire/release pair could invalidate preparation.

## Why This Change Was Made

Coordinate OpenClaw lifecycle mutations around the **target native thread**, then acquire/revalidate its binding lease. Capture the actual physical client's lifetime rather than treating unrelated pool activity as lost ownership. The same ownership order now covers resume/attachment, conversation-bound turns, compaction, and retirement; old lease-generation exclusivity, the separate compaction queue, the attachment wrapper, and caller-supplied pre-write error classification are removed.

Native status/claim checks, cancellation, stale-client rejection, configuration/policy handoff, catalog attestation, binding CAS, and exact-owner cleanup remain. A rejection by the physical pre-write callback is recorded at that callback, so cleanup distinguishes a request never sent from an indeterminate native write.

**Scope:** OpenClaw only; unchanged Codex 0.151.0. No process-per-chat isolation, automatic history forks, configuration knobs, persistence/schema changes, dependency changes, or native protocol additions. OpenClaw's queue does **not** reserve a thread against Codex-internal AgentControl reloads; the separate native-internal same-thread race remains outside this fix. The docs make that limitation explicit.

## User Impact

Independent chats and catalog reads continue in parallel on a shared Codex app-server. Resuming a chat preserves its native thread identity and history rather than forking it to escape contention. Genuine target-thread activity and stale physical owners are still rejected.

## Evidence

### Real Gateway and Control UI

Unchanged native Codex 0.151.0, authenticated `openai/gpt-5.6-sol`, fresh synthetic workspace, isolated state and port; no operator Gateway touched.

- **Before:** seed A with a marker, restart the baseline Gateway, hold B inside a real native command, then resume A. The exact reported error appears; B completes after its gate is released.
- **After:** switch the same state to the candidate, hold another B command, and resume A. A replies `ALPHA_CEDAR_731 RESUMED` before B's gate is released; B then replies `B_FINISHED`.
- Read-only identity checks confirm A kept its original native thread ID across restart, used a new physical client, and shared that client with B's different native thread. Both sessions finish `done`.
- Screenshots and the unmocked recording were inspected for the asserted states and sensitive data. All chat/workspace content is synthetic. The two recall requests in the after screenshot are the failed baseline attempt and successful candidate attempt in the same conversation.

### Native dependency contract

Personally inspected pinned Codex 0.151.0 source, including [thread-keyed request serialization and independently drained queues](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server/src/request_serialization.rs#L59-L213) and its [different-key concurrency regression](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server/src/request_serialization.rs#L366-L398). An actual-binary protocol probe also completed A's policy handoff and turn while B remained active. Native configuration reload alone does not rewrite existing developer history, so OpenClaw's explicit policy injection is retained.

### Regression and deterministic stress

The new owner-boundary regression failed on the original code with the exact `CodexAdoptedThreadActiveError` before production edits. The final production code passed **684 tests in nine focused files**, including shared-client lifetime, lifecycle/bindings, resume cleanup, compaction, retirement, conversation binding, and client cleanup. Seven selected boundary cases were rerun after test-only refinements.

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/thread-resume.test.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/app-server/session-retirement.test.ts extensions/codex/src/conversation-binding.test.ts extensions/codex/src/app-server/client-runtime.test.ts extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts
```

Seeded host-owned stress ran **100 rounds × eight thread owners in four passing local runs: 3,200 lifecycle operations**. It checks same-thread predecessor ordering, unrelated lease interleavings, unchanged IDs/no starts, policy injection, exact unsubscribe accounting, replacement-claim protection, and zero leaked active/pending leases. This is deterministic OpenClaw/wire-boundary stress, not live model inference.

### Validation

- `pnpm build` passed, including full runtime, declarations, plugin SDK, and Control UI; zero ineffective-dynamic-import warnings. The subsequent production change was only a lint-only local-variable rename.
- After the three lint-only repairs, **263 lifecycle/conversation tests passed** in two files, including another 800-operation seeded stress run.
- Fresh isolated Codex autoreview on the final patch: `scoped-clean`, no actionable findings at its default **P0-only** threshold; reviewer did not run tests.
- Changed-check components: formatting, extension and test typechecks, doctor contracts, boundary/dependency/coercion/deprecation guards, and dead-export scans passed. The initial wrapper run exposed three lint violations; corrected lint and all remaining database-first/media/sidecar/import-cycle guards passed when run separately, without repeating already-green gates.
- Review fixes passed **389 tests in six files**: supported legacy binding rows remain resumable, and two distinct plugin module copies serialize same-thread/conversation work while unrelated keys proceed. All four review regressions failed before the owner-boundary repairs and passed afterward. A preceding test-only CI correction passed 162 tests in five files.
- The independent expanded live suite **failed** during the second compaction wave's durable large-output assertion. It passed 16 child runs, native child bridging, the first compaction wave, and all three same-native-ID/history-preserving restarts. A successful 100,000-byte-output command had only a 63-character durable mirror result; raw output was not retained, so attribution is unresolved. No retries or weakened assertions. This lane is non-blocking by explicit maintainer direction, and a separate output-mirroring investigation is queued. Existing primary live before/after proof passed. No native-internal atomicity guarantee is claimed.

### Review and CI follow-through

Ordinary resume serializes its own binding without applying foreign-adoption checks to legacy rows whose top-level session generation is absent. Explicit adoption remains strict. The raw legacy fixture was preserved rather than hiding the upgrade regression. The queue is now process-global through the existing SDK singleton helper, covering duplicate dist/source module copies. Startup tests now induce real authority refusal and native overload rather than expecting the removed false lease guard.

The previous CI run's remaining failure was the unauthenticated scan-history fetch before scanners. The existing infrastructure repair is https://github.com/openclaw/openclaw/pull/136232; it is not duplicated here.

Production **+668/−631 = +37 lines**; tests **+590/−228 = +362**; docs **+19/−4 = +15**. Most raw production churn is indentation from moving the existing conversation flow under its owner scope. Net growth supplies missing owner coverage, pre-write rejection provenance, cross-copy serialization, and preserved legacy-resume behavior; the shared-client fix itself deletes more code than it adds.

![Before: idle chat A falsely fails while chat B is running](https://github.com/user-attachments/assets/baf859a2-062a-421c-8d64-d38845de8382)

![After: chat A recalls its history while chat B remains active](https://github.com/user-attachments/assets/10a368db-6605-4e65-87ba-5640bec38526)

https://github.com/user-attachments/assets/5e65a186-72b4-4453-a9ff-d12b4c34fe3d
