### PR TITLE
fix(ios): session list shows generated names instead of technical keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4648,6 +4648,7 @@ jobs:
             -only-testing:OpenClawTests/IOSGatewayChatTransportTests \
             -only-testing:OpenClawTests/NodeAppModelInvokeTests \
             -only-testing:OpenClawTests/NotificationServingPreferenceTests \
+            -only-testing:OpenClawTests/RootTabsPresentationTests \
             -only-testing:OpenClawTests/RootTabsSourceGuardTests \
             -only-testing:OpenClawTests/TraceHeadingVisualProofTests \
             test

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -303,7 +303,8 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             limit: limit,
             search: search,
             archived: archived,
-            agentID: self.globalAgentId)
+            agentID: self.globalAgentId,
+            includeDerivedTitles: true)
         let res = try await gateway.request(request)
         return try JSONDecoder().decode(OpenClawChatSessionsListResponse.self, from: res)
     }
@@ -322,6 +323,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
                 search: nil,
                 archived: false,
                 includeGlobal: false,
+                includeDerivedTitles: true,
                 spawnedBy: parentKey,
                 offset: offset,
                 configuredAgentsOnly: true)

--- a/apps/ios/Sources/Design/CommandCenterTab.swift
+++ b/apps/ios/Sources/Design/CommandCenterTab.swift
@@ -669,10 +669,6 @@ struct CommandCenterTab: View {
         if let label, !label.isEmpty {
             return label
         }
-        if let title = redactedSessionTitle(for: session.key) {
-            return title
-        }
-
         let displayName = session.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let displayName, !displayName.isEmpty {
             return Self.redactedSessionTitle(for: displayName) ?? displayName
@@ -680,6 +676,13 @@ struct CommandCenterTab: View {
         let subject = session.subject?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let subject, !subject.isEmpty {
             return Self.redactedSessionTitle(for: subject) ?? subject
+        }
+        let derivedTitle = session.derivedTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let derivedTitle, !derivedTitle.isEmpty, derivedTitle != session.key {
+            return derivedTitle
+        }
+        if let title = redactedSessionTitle(for: session.key) {
+            return title
         }
         return session.key
     }

--- a/apps/ios/Sources/RootSidebarModel.swift
+++ b/apps/ios/Sources/RootSidebarModel.swift
@@ -128,6 +128,7 @@ extension NodeAppModel {
                         search: nil,
                         archived: archived,
                         agentID: sourceAgentID,
+                        includeDerivedTitles: true,
                         offset: offset)
                     let data = try await self.operatorSession.request(request, ifCurrentRoute: route)
                     return try JSONDecoder().decode(OpenClawChatSessionsListResponse.self, from: data)

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -60,6 +60,23 @@ struct RootTabsPresentationTests {
         #expect(visible.map(\.key) == ["main"])
     }
 
+    @Test(arguments: [
+        ("Pinned label", "Generated name", "Derived title", "Pinned label"),
+        (nil, "Generated name", "Derived title", "Generated name"),
+        (nil, nil, "Derived title", "Derived title"),
+        (nil, nil, nil, "iOS chat"),
+    ] as [(String?, String?, String?, String)])
+    func `session titles prefer gateway names before key fallbacks`(
+        label: String?, displayName: String?, derivedTitle: String?, expected: String)
+    {
+        let session = Self.sessionEntry(
+            key: "agent:main:ios-session",
+            label: label,
+            displayName: displayName,
+            derivedTitle: derivedTitle)
+        #expect(CommandCenterTab.sessionTitle(session) == expected)
+    }
+
     @Test func `overview token usage sums known totals and marks stale or missing rows partial`() {
         let summary = RootSidebarModel.tokenUsageSummary(for: [
             Self.sessionEntry(key: "fresh", totalTokens: 1200, totalTokensFresh: true, contextTokens: 200_000),
@@ -1137,6 +1154,9 @@ struct RootTabsPresentationTests {
 
     private static func sessionEntry(
         key: String,
+        label: String? = nil,
+        displayName: String? = nil,
+        derivedTitle: String? = nil,
         archived: Bool? = nil,
         pinned: Bool? = nil,
         totalTokens: Int? = nil,
@@ -1149,7 +1169,7 @@ struct RootTabsPresentationTests {
         OpenClawChatSessionEntry(
             key: key,
             kind: nil,
-            displayName: nil,
+            displayName: displayName,
             surface: nil,
             subject: nil,
             room: nil,
@@ -1167,11 +1187,13 @@ struct RootTabsPresentationTests {
             modelProvider: nil,
             model: nil,
             contextTokens: contextTokens,
+            label: label,
             pinned: pinned,
             archived: archived,
             observerDigest: observerDigest,
             lastReadAt: lastReadAt,
-            worktree: worktree)
+            worktree: worktree,
+            derivedTitle: derivedTitle)
     }
 
     private static func cronJob(enabled: Bool, status: String) -> CronJob {

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -49,6 +49,14 @@ struct RootTabsSourceGuardTests {
         #expect(lifecycle.contains("self.stopScannerCapture()"))
     }
 
+    @Test func `iOS session rosters request gateway derived titles`() throws {
+        let transport = try Self.source("Sources/Chat/IOSGatewayChatTransport.swift")
+        let sidebar = try Self.source("Sources/RootSidebarModel.swift")
+
+        #expect(transport.components(separatedBy: "includeDerivedTitles: true").count - 1 == 2)
+        #expect(sidebar.contains("includeDerivedTitles: true"))
+    }
+
     @Test func `credential fields stay scoped to exact gateway owners`() throws {
         let onboarding = try Self.sources([
             "Sources/Onboarding/OnboardingWizardView.swift",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer+Controls.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer+Controls.swift
@@ -160,7 +160,7 @@ extension OpenClawChatComposer {
             set: { next in self.viewModel.switchSession(to: next) }))
         {
             ForEach(self.viewModel.sessionChoices, id: \.key) { session in
-                Text(session.displayName ?? session.key)
+                Text(ChatSessionSidebarModel.displayName(for: session))
                     .font(OpenClawChatTypography.mono(size: 12, relativeTo: .caption))
                     .tag(session.key)
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayRequest.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayRequest.swift
@@ -228,6 +228,7 @@ public enum OpenClawChatGatewayRequests {
         agentID: String? = nil,
         includeGlobal: Bool = true,
         includeUnknown: Bool = false,
+        includeDerivedTitles: Bool = false,
         activeMinutes: Int? = nil,
         spawnedBy: String? = nil,
         offset: Int? = nil,
@@ -238,6 +239,9 @@ public enum OpenClawChatGatewayRequests {
             "includeGlobal": AnyCodable(includeGlobal),
             "includeUnknown": AnyCodable(includeUnknown),
         ]
+        if includeDerivedTitles {
+            params["includeDerivedTitles"] = AnyCodable(true)
+        }
         if let agentID = normalized(agentID) {
             params["agentId"] = AnyCodable(agentID)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -180,9 +180,10 @@ public enum ChatSessionSidebarModel {
     }
 
     public static func displayName(for session: OpenClawChatSessionEntry) -> String {
-        for candidate in [session.displayName, session.label] {
+        for candidate in [session.label, session.displayName, session.derivedTitle] {
             if let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !trimmed.isEmpty
+               !trimmed.isEmpty,
+               trimmed != session.key
             {
                 return trimmed
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -380,7 +380,7 @@ public struct ChatSessionsSheet: View {
     private func sessionRowContent(_ session: OpenClawChatSessionEntry) -> some View {
         HStack(spacing: 8) {
             VStack(alignment: .leading, spacing: 4) {
-                Text(session.displayName ?? session.key)
+                Text(ChatSessionSidebarModel.displayName(for: session))
                     .font(OpenClawChatTypography.mono(size: 17, relativeTo: .body))
                     .lineLimit(1)
                 if let updatedAt = session.updatedAt, updatedAt > 0 {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
@@ -112,12 +112,14 @@ struct ChatGatewayRequestTests {
             limit: 12,
             search: "  incident  ",
             archived: true,
-            agentID: " Reviewer ")
+            agentID: " Reviewer ",
+            includeDerivedTitles: true)
 
         #expect(request.method == "sessions.list")
         #expect(request.timeoutMs == 15000)
         #expect(request.params["includeGlobal"]?.value as? Bool == true)
         #expect(request.params["includeUnknown"]?.value as? Bool == false)
+        #expect(request.params["includeDerivedTitles"]?.value as? Bool == true)
         #expect(request.params["limit"]?.value as? Int == 12)
         #expect(request.params["search"]?.value as? String == "incident")
         #expect(request.params["archived"]?.value as? Bool == true)
@@ -129,6 +131,7 @@ struct ChatGatewayRequestTests {
             archived: false,
             agentID: "   ")
         #expect(unscoped.params["agentId"] == nil)
+        #expect(unscoped.params["includeDerivedTitles"] == nil)
     }
 
     @Test func `child session request encodes focused pagination filters`() {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -8,6 +8,7 @@ struct ChatSessionSidebarModelTests {
     private func entry(
         key: String,
         displayName: String? = nil,
+        derivedTitle: String? = nil,
         label: String? = nil,
         subject: String? = nil,
         sessionId: String? = nil,
@@ -67,7 +68,8 @@ struct ChatSessionSidebarModelTests {
             hasActiveRun: hasActiveRun,
             activeRunIds: activeRunIds,
             hasActiveSubagentRun: hasActiveSubagentRun,
-            endedAt: endedAt)
+            endedAt: endedAt,
+            derivedTitle: derivedTitle)
     }
 
     @Test func `pinned sessions get their own section, rest sorted by recency`() {
@@ -360,9 +362,19 @@ struct ChatSessionSidebarModelTests {
         #expect(ChatSessionSidebarModel.displayName(forKey: "global") == "global")
     }
 
-    @Test func `display name prefers explicit names over key prettifying`() {
-        let named = self.entry(key: "agent:main:x", displayName: "  Weekly Sync  ")
+    @Test func `display name prefers explicit and derived names over key prettifying`() {
+        let labeled = self.entry(
+            key: "agent:main:x",
+            displayName: "Generated name",
+            derivedTitle: "Derived title",
+            label: "Pinned label")
+        #expect(ChatSessionSidebarModel.displayName(for: labeled) == "Pinned label")
+
+        let named = self.entry(key: "agent:main:x", displayName: "  Weekly Sync  ", derivedTitle: "Derived title")
         #expect(ChatSessionSidebarModel.displayName(for: named) == "Weekly Sync")
+
+        let derived = self.entry(key: "agent:main:x", derivedTitle: "  Derived title  ")
+        #expect(ChatSessionSidebarModel.displayName(for: derived) == "Derived title")
 
         let unnamed = self.entry(key: "agent:main:x")
         #expect(ChatSessionSidebarModel.displayName(for: unnamed) == "x")
@@ -845,7 +857,9 @@ struct ChatSessionSidebarModelTests {
 
         let omitted = try decoder.decode(
             OpenClawChatSessionsChangedEvent.self,
-            from: Data(#"{"reason":"run-progress","session":{"key":"agent:main:work","updatedAt":200,"hasActiveRun":true}}"#.utf8))
+            from: Data(
+                #"{"reason":"run-progress","session":{"key":"agent:main:work","updatedAt":200,"hasActiveRun":true}}"#
+                    .utf8))
         let retained = try #require(ChatSessionSidebarModel.applying(
             sessionChange: omitted,
             to: [existing]))
@@ -853,7 +867,9 @@ struct ChatSessionSidebarModelTests {
 
         let tombstoned = try decoder.decode(
             OpenClawChatSessionsChangedEvent.self,
-            from: Data(#"{"reason":"run-progress","session":{"key":"agent:main:work","updatedAt":300,"hasActiveRun":true,"activeRunIds":null}}"#.utf8))
+            from: Data(
+                #"{"reason":"run-progress","session":{"key":"agent:main:work","updatedAt":300,"hasActiveRun":true,"activeRunIds":null}}"#
+                    .utf8))
         let cleared = try #require(ChatSessionSidebarModel.applying(
             sessionChange: tombstoned,
             to: retained))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS users opening the session list would see opaque session keys or a generic `iOS chat` fallback even when the gateway had already generated a useful session title.

## Why This Change Was Made

iOS session roster requests now opt into gateway-derived titles, and Apple chat surfaces consistently resolve names in this order: pinned label, explicit display name, generated title, then a safe key fallback. The shared request keeps derived titles disabled by default so non-UI callers do not incur transcript reads.

The gateway currently derives titles for the first 100 rows of a response. iOS can request larger pages, so older rows beyond that bound retain the existing fallback behavior; changing gateway hydration is outside this focused fix.

## User Impact

iOS session lists and pickers now show the same meaningful generated session names available from the gateway instead of technical identifiers whenever that metadata is present.

## Evidence

- Regression proof: with the production fix temporarily removed, the new presentation test failed exactly for explicit `displayName` and `derivedTitle`, both rendering as `iOS chat`.
- Current fix: 72/72 `RootTabsPresentationTests` passed in a temporary compatibility checkout.
- Added request-encoding coverage, title-priority coverage, and a source guard that verifies all three iOS roster paths opt into derived titles.
- `swiftc -parse`, SwiftFormat, workflow YAML parsing, and `git diff --check` pass.
- The authoritative Xcode 26.6 / Swift 6.3 run is left to CI because the available host has Xcode 26.3 / Swift 6.2.4. No real iOS device was available, so before/after screenshot evidence could not be captured locally.
- Automated autoreview was attempted, but the local Codex CLI installation is missing its native executable; two independent read-only code/test reviews completed instead.
