### PR TITLE
perf(agents): reduce approval tracking across concurrent runs

### DIFF
--- a/src/agents/agent-run-approval-wait.ts
+++ b/src/agents/agent-run-approval-wait.ts
@@ -1,4 +1,4 @@
-import { onAgentEvent } from "../infra/agent-events.js";
+import { onAgentEventForRun } from "../infra/agent-events.js";
 
 export type AgentRunApprovalWait = {
   pending: boolean;
@@ -26,7 +26,7 @@ export function observeAgentRunApprovalWait(params: {
     return state;
   }
   // Lifecycle facts pause scheduling only; the original admitted run retains all authority.
-  unsubscribe = onAgentEvent((event) => {
+  unsubscribe = onAgentEventForRun(params.runId, (event) => {
     if (
       event.runId !== params.runId ||
       event.stream !== "lifecycle" ||


### PR DESCRIPTION
## What Problem This Solves

Approval tracking adds work to every concurrent run's streamed events, even when the event belongs to another run. This is the remaining approval-wait listener left on the global path after #129174.

## Why This Change Was Made

Subscribe through the existing run-indexed event API. The approval owner keeps its run/session guards, overlapping approval tracking, timeout-pause arithmetic and disposal. The dispatcher already preserves registration order, nested delivery and listener mutations; no new dispatcher, cache, configuration or authority path is added.

## User Impact

Concurrent agent runs spend less time dispatching events to unrelated approval observers. This is a dispatch improvement, not a measured reduction in provider or whole-turn latency. Production LOC: +2/-2 (net 0); tests unchanged. This completes a part of Tran Quang's original optimization proposal in #129174.

## Evidence

All 100 existing tests pass on both versions across the complete agent-events, run-listeners, Code Mode wait and embedded timeout preparation files. Changed-source checks pass. Independent native proof checked 16 control cases on each version, including overlapping approvals, cancellation, timeout/grace resumption, nested events, disposal, owner claims and lifecycle generation changes. No new authority semantics are claimed.

The fixed before/candidate/candidate/before benchmark retained all 912 calls (768 measured samples, plus every first/warm call), with real event emission and approval observers. All prospective median gates passed in both orders:

| Workload | Forward median | Reverse median |
| --- | ---: | ---: |
| 8 concurrent runs | 21.55% faster | 19.83% faster |
| 16 concurrent runs | 41.27% faster | 42.03% faster |
| Register + dispatch + dispose, 8 runs | 20.67% faster | 21.27% faster |
| Approval lifecycle traffic, 8 runs | 19.58% faster | 18.29% faster |

Registration/disposal alone was slower by 0.75–0.85 microseconds per eight observers (9.26–10.76%); the complete lifecycle saved 34.4–34.6 microseconds. That setup row was designated descriptive before data collection. Small-workload adverse medians remained below 3%; first-call and tail results were mixed, including a 173% forward p95 increase in the paired-observer row that did not repeat in reverse. No tail-latency improvement is claimed. No samples, failures or warmups were discarded and there were no timing retries.

The internal helper has no runtime retargeting contract: artificially replacing `params.runId` after subscription differs from the former global callback. Actual callers supply per-run inputs and never retarget them. Generation fencing remains with the existing emitter and lifecycle owner. Canonical tests, the exact native output comparison and independent source review cover those boundaries.

Local proof used `node scripts/run-vitest.mjs run` with the canonical infra, agents-core and agents-embedded-agent-run configurations, followed by `node scripts/check-changed.mjs`. The native benchmark exercised the actual owner without a live provider. The campaign separately ran real OpenAI dev-Gateway turns and web requests; those unpaired diagnostics are not attributed to this change. Raw benchmark and closure artifacts are retained locally. Fresh isolated Codex autoreview found no blocking findings; exact PR-head CI is required before landing.

## Maintainer disposition of review evidence risk

The ClawSweeper review correctly notes that its reviewer could not access the local raw benchmark artifacts. I reviewed the complete fixed cohort and an independent agent recomputed the measurements from all retained raw calls, checked source/build identities, and verified cleanup. The aggregate result is identified by SHA-256 `5a3f106e58ffaa7d96b8eb3673365004ba692322363a31651499495e19ad70b5`; the independent audit is identified by `70eefd9016eed75bdb4bbbdd8bb55f45ccdbde72c630d040f9e626e2395512b8`.

I accept the evidence-access limitation for this two-line internal consumer conversion: raw artifacts remain local, so these are maintainer-verified measurements, not publicly reproducible or ClawSweeper-verified results. The change's correctness is separately covered by the existing lifecycle suites and source review. No wider latency claim or benchmark retry is used to justify landing; normal exact-head CI still must pass. The unrelated scan-history authentication failure was repaired and merged in #136232. This branch was mechanically rebased onto that repair (main 9fda3b1855c798e632c8a390c1e0701565c39162); the approval owner, dispatcher, callers and canonical tests are unchanged from the measured sources. All 100 canonical tests were rerun successfully on refreshed head aae2c15f9f87879995d5e41d21726e2654d0fe57, and a fresh isolated Codex review found no blocking findings. The historical measurements above remain bound to their original experiment; the rebase is not a new benchmark.
