### PR TITLE
perf(test): reuse session branch fixture history

### DIFF
--- a/src/gateway/control-ui-session-prs-branch.test.ts
+++ b/src/gateway/control-ui-session-prs-branch.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { loadControlUiSessionPullRequests } from "./control-ui-session-prs.js";
 import {
   evictPullRequestCache,
@@ -15,12 +16,15 @@ import {
 
 describe("session branch diff stats", () => {
   const execFileAsync = promisify(execFile);
+  const templateDirs = useAutoCleanupTempDirTracker(afterAll);
+  let templateRepo: string;
   let root: string;
 
-  const git = (...args: string[]) =>
+  const gitIn = (cwd: string, ...args: string[]) =>
     execFileAsync("git", ["-c", "user.email=test@openclaw.ai", "-c", "user.name=Test", ...args], {
-      cwd: root,
+      cwd,
     });
+  const git = (...args: string[]) => gitIn(root, ...args);
 
   const writeFile = (file: string, contents: string | Uint8Array) =>
     fs.writeFile(path.join(root, file), contents);
@@ -47,9 +51,20 @@ describe("session branch diff stats", () => {
   const resolveRevision = async (revision: string) =>
     (await git("rev-parse", revision)).stdout.trim();
 
+  const initializeRepoAt = async (repo: string, initialContents = "one\n") => {
+    await gitIn(repo, "init", "--initial-branch=main", ".");
+    await fs.writeFile(path.join(repo, "a.txt"), initialContents);
+    await gitIn(repo, "add", "a.txt");
+    await gitIn(repo, "commit", "-m", "base");
+  };
+
   const initializeRepo = async (initialContents = "one\n") => {
-    await git("init", "--initial-branch=main", ".");
-    await writeCommit("a.txt", initialContents, "base");
+    if (initialContents !== "one\n") {
+      await initializeRepoAt(root, initialContents);
+      return;
+    }
+    // Each case owns its .git directory; only the unchanged base history is copied.
+    await fs.cp(templateRepo, root, { recursive: true });
   };
 
   const initializeFeatureBranch = async (initialContents = "one\n") => {
@@ -123,6 +138,11 @@ describe("session branch diff stats", () => {
 
   const loadMergedBranchState = (headSha: string, overrides: Record<string, unknown> = {}) =>
     loadBranchState({ pullRequests: [mergedPull(headSha, overrides)] });
+
+  beforeAll(async () => {
+    templateRepo = templateDirs.make("openclaw-session-prs-template-");
+    await initializeRepoAt(templateRepo);
+  });
 
   beforeEach(async () => {
     root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-prs-")));


### PR DESCRIPTION
## What Problem This Solves

The session branch tests reconstruct the same initial Git history nineteen times before exercising their distinct histories and diff behavior. Those repeated setup commands add process startup work without contributing separate coverage.

## Why This Change Was Made

Build that initial history once under the existing suite-owned temporary-directory tracker, then recursively copy it into each case's independent repository. Keep the special two-line base's real initialization and every scenario-specific Git operation. Each case owns its complete `.git` directory; there are no hardlinks, alternates or shared worktrees. The existing cache eviction remains unchanged.

## User Impact

Less test fixture setup. Product behavior, Git policy and selected coverage are unchanged.

## Evidence

All 20 original cases and 21 assertion sites are retained, with byte-identical case bodies. On one dedicated Linux worker, warm original/candidate/restored-control test execution was 3.07s/2.58s/3.10s, including suite hooks. Complete runner times were 15.972s/12.493s/12.684s: import warming affects those totals, so the measured claim is about 17% less test execution, not the larger first-run difference.

A temporary counter observed 225 original versus 171 candidate fixture Git commands: 54 fewer successful real commands. Initialization and base commits fall from 20 each to two each. All twenty case roots remain independent.

A private isolation probe verified distinct `.git` directories and file inodes, no alternates or inherited `core.worktree`, and independent working-tree, index, refs and objects. Actual mutations, including corruption of one disposable copy's object, left the template and second copy unchanged. A deliberate failure after template initialization preserved the expected setup error and the canonical tracker removed that template. All recorded command groups exited, fixture roots were removed, and source overlays were restored exactly.

Measurements and fault proof used the original source at `83ba15d2e1d93cd1eb34bfa27945ae997ec840e9`. All 17 recorded target, caller, owner, sibling and guide files still match current `main` at `c1744fda2aeedeb874edc13191a85dfe7cc6f305`. 

Application production delta: 0. Test delta: +25/-5 after formatting. A filtered run of only the special-base case may do extra template setup; the measured complete suite is the optimization target. No new implementation-mirroring test is added; the existing real Git behavior cases and private isolation/failure probes cover the changed fixture boundary.

Formatting, scoped typed lint, whitespace validation and fresh Codex review passed. The final file differs from the measured candidate only in one formatter adjustment. Exact-head hosted CI is required before landing.

## Reviewable terminal evidence

Addressing ClawSweeper’s proof request and rank-up move: these are excerpts from the retained Linux Testbox run, with temporary paths replaced by descriptive placeholders. They show the measured candidate at the source pin above; the final formatting-only difference is described above.

Complete focused suite:

```text
pnpm test src/gateway/control-ui-session-prs-branch.test.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  10.42s (transform 6.01s, setup 133ms, import 7.33s, tests 2.58s, environment 0ms)
```

Private copy-isolation probe, including actual independent Git-object mutation:

```text
GIT_FIXTURE_ISOLATION={"templateRepo":"<template>","first":"<first-copy>","second":"<second-copy>","files":27}
 ✓  gateway-core  ../../src/gateway/control-ui-session-prs-branch.test.ts > session branch diff stats > private proof: copied Git metadata and worktrees remain independent 145ms
 Test Files  1 passed (1)
      Tests  1 passed | 20 skipped (21)
   Duration  7.02s (transform 5.23s, setup 117ms, import 6.34s, tests 173ms, environment 0ms)
```

Extracted counter and cleanup receipts from the same proof:

```json
{
  "fixtureGitCommands": {
    "before": 225,
    "candidate": 171,
    "saved": 54
  },
  "candidateCaseAndTemplateRootsRemoved": 21,
  "isolationRootsRemoved": 3,
  "allRecordedGroupsExtinct": true,
  "sourceRestored": {
    "src/gateway/control-ui-session-prs-branch.test.ts": true
  }
}
```

The deliberate setup-failure probe exited 1 with its expected injected error and all 20 cases skipped; a separate read-only resource audit confirmed the reported template was absent afterward. That expected failure is separate from the complete passing suite.

CI follow-up: the first scheduled run failed while fetching Git history in security-fast with could not read Username for https://github.com, before the scan ran. The same commit is being retried through the normal failed-job rerun.
