### PR TITLE
fix(plugins): channels.<id>.enabled=false no longer loads the channel plugin when its plugin entry is enabled

### DIFF
--- a/src/agents/agent-project-settings-snapshot.ts
+++ b/src/agents/agent-project-settings-snapshot.ts
@@ -104,6 +104,7 @@ export function loadEnabledBundleAgentSettingsSnapshot(params: {
       const activationState = resolvePolicyPluginActivationState({
         id: record.id,
         origin: record.origin,
+        channelIds: record.channels,
         config: normalizedPlugins,
         rootConfig: config,
       });

--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -358,6 +358,7 @@ export function validateExplicitPluginConfig(params: {
     const activationState = resolveEffectivePluginActivationState({
       id: pluginId,
       origin: record.origin,
+      channelIds: record.channels,
       config: normalizedPlugins,
       rootConfig: config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(record),

--- a/src/hooks/plugin-hooks.ts
+++ b/src/hooks/plugin-hooks.ts
@@ -54,6 +54,7 @@ export function resolvePluginHookDirs(params: {
     const activationState = resolvePolicyPluginActivationState({
       id: record.id,
       origin: record.origin,
+      channelIds: record.channels,
       config: normalizedPlugins,
       rootConfig: params.config,
     });

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -291,6 +291,7 @@ export function evaluateBundledPluginPublicSurfaceAccess(params: {
   const activationState = resolveEffectivePluginActivationState({
     id: params.manifestRecord.id,
     origin: params.manifestRecord.origin,
+    channelIds: params.manifestRecord.channels,
     config: params.normalizedPluginsConfig,
     rootConfig: params.config,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(params.manifestRecord),

--- a/src/plugins/bundle-commands.ts
+++ b/src/plugins/bundle-commands.ts
@@ -170,6 +170,7 @@ export function loadEnabledClaudeBundleCommands(params: {
     const activationState = resolveEffectivePluginActivationState({
       id: record.id,
       origin: record.origin,
+      channelIds: record.channels,
       config: normalizedPlugins,
       rootConfig: params.cfg,
     });

--- a/src/plugins/bundle-config-shared.ts
+++ b/src/plugins/bundle-config-shared.ts
@@ -127,6 +127,7 @@ export function loadEnabledBundleConfig<TConfig, TDiagnostic>(params: {
     const activationState = resolveEffectivePluginActivationState({
       id: record.id,
       origin: record.origin,
+      channelIds: record.channels,
       config: normalizedPlugins,
       rootConfig: params.cfg,
       enabledByDefault: record.enabledByDefault,

--- a/src/plugins/bundled-manifest-contract-plugins.ts
+++ b/src/plugins/bundled-manifest-contract-plugins.ts
@@ -72,6 +72,7 @@ export function resolveEnabledBundledManifestContractPlugins(params: {
     return resolveEffectivePluginActivationState({
       id: plugin.id,
       origin: plugin.origin,
+      channelIds: plugin.channels,
       config: activation.normalized,
       rootConfig: activation.config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),

--- a/src/plugins/channel-presence-policy.ts
+++ b/src/plugins/channel-presence-policy.ts
@@ -325,6 +325,7 @@ function evaluateEffectiveChannelPlugin(params: {
   const activationState = resolveEffectivePluginActivationState({
     id: params.plugin.id,
     origin: params.plugin.origin,
+    channelIds: params.plugin.channels,
     config: params.normalizedConfig,
     rootConfig: params.config,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin),

--- a/src/plugins/channel-presence-policy.ts
+++ b/src/plugins/channel-presence-policy.ts
@@ -203,6 +203,7 @@ function normalizeActivationBlockedReason(reason?: string): ConfiguredChannelBlo
     case "blocked by denylist":
       return "blocked-by-denylist";
     case "disabled in config":
+    case "channel disabled in config":
       return "plugin-disabled";
     case "not in allowlist":
       return "not-in-allowlist";

--- a/src/plugins/config-activation-shared.ts
+++ b/src/plugins/config-activation-shared.ts
@@ -17,6 +17,7 @@ type PluginActivationCause =
   | "plugins-disabled"
   | "blocked-by-denylist"
   | "disabled-in-config"
+  | "channel-disabled-in-config"
   | "workspace-disabled-by-default"
   | "not-in-allowlist"
   | "enabled-by-effective-config"
@@ -61,6 +62,7 @@ const PLUGIN_ACTIVATION_REASON_BY_CAUSE: Record<PluginActivationCause, string> =
   "plugins-disabled": "plugins disabled",
   "blocked-by-denylist": "blocked by denylist",
   "disabled-in-config": "disabled in config",
+  "channel-disabled-in-config": "channel disabled in config",
   "workspace-disabled-by-default": "workspace plugin (disabled by default)",
   "not-in-allowlist": "not in allowlist",
   "enabled-by-effective-config": "enabled by effective config",
@@ -96,10 +98,10 @@ function resolveExplicitPluginSelectionShared<TRootConfig>(params: {
   origin: string;
   config: PluginActivationConfigLike;
   rootConfig?: TRootConfig;
-  isBundledChannelEnabledByChannelConfig: (
+  resolveChannelConfigEnablement: (
     rootConfig: TRootConfig | undefined,
     pluginId: string,
-  ) => boolean;
+  ) => boolean | undefined;
 }): { explicitlyEnabled: boolean; cause?: PluginExplicitSelectionCause } {
   const policyId = normalizePluginPolicyId(params.id);
   if (params.config.entries[policyId]?.enabled === true) {
@@ -107,7 +109,7 @@ function resolveExplicitPluginSelectionShared<TRootConfig>(params: {
   }
   if (
     params.origin === "bundled" &&
-    params.isBundledChannelEnabledByChannelConfig(params.rootConfig, params.id)
+    params.resolveChannelConfigEnablement(params.rootConfig, params.id) === true
   ) {
     return { explicitlyEnabled: true, cause: "bundled-channel-enabled-in-config" };
   }
@@ -132,10 +134,10 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   activationSource?: PluginActivationConfigSourceLike<TRootConfig>;
   autoEnabledReason?: string;
   allowBundledChannelExplicitBypassesAllowlist?: boolean;
-  isBundledChannelEnabledByChannelConfig: (
+  resolveChannelConfigEnablement: (
     rootConfig: TRootConfig | undefined,
     pluginId: string,
-  ) => boolean;
+  ) => boolean | undefined;
 }): PluginActivationDecision {
   const activationSource = params.activationSource ?? {
     plugins: params.config,
@@ -146,7 +148,7 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
     origin: params.origin,
     config: activationSource.plugins,
     rootConfig: activationSource.rootConfig,
-    isBundledChannelEnabledByChannelConfig: params.isBundledChannelEnabledByChannelConfig,
+    resolveChannelConfigEnablement: params.resolveChannelConfigEnablement,
   });
 
   // Keep result construction shared; policy precedence stays in the ordered branches below.
@@ -171,6 +173,17 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   const entry = params.config.entries[policyId];
   if (entry?.enabled === false) {
     return decision("disabled", { cause: "disabled-in-config" });
+  }
+  // `channels.<id>.enabled: false` is the operator's channel-level off switch. It must win over
+  // `plugins.entries.<id>.enabled: true` left behind by install/enable flows, or the channel
+  // plugin keeps importing (and can fail) for a channel the operator turned off.
+  if (
+    params.resolveChannelConfigEnablement(
+      activationSource.rootConfig ?? params.rootConfig,
+      params.id,
+    ) === false
+  ) {
+    return decision("disabled", { cause: "channel-disabled-in-config" });
   }
   const explicitlyAllowed = params.config.allow.includes(policyId);
   if (
@@ -207,7 +220,7 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   }
   if (
     params.origin === "bundled" &&
-    params.isBundledChannelEnabledByChannelConfig(params.rootConfig, params.id)
+    params.resolveChannelConfigEnablement(params.rootConfig, params.id) === true
   ) {
     return decision("auto", { explicitlyEnabled: false, cause: "bundled-channel-configured" });
   }

--- a/src/plugins/config-activation-shared.ts
+++ b/src/plugins/config-activation-shared.ts
@@ -98,9 +98,12 @@ function resolveExplicitPluginSelectionShared<TRootConfig>(params: {
   origin: string;
   config: PluginActivationConfigLike;
   rootConfig?: TRootConfig;
+  /** Manifest-owned channel ids; the plugin id alone cannot resolve `channels.<id>` for every owner. */
+  channelIds?: readonly string[];
   resolveChannelConfigEnablement: (
     rootConfig: TRootConfig | undefined,
     pluginId: string,
+    channelIds?: readonly string[],
   ) => boolean | undefined;
 }): { explicitlyEnabled: boolean; cause?: PluginExplicitSelectionCause } {
   const policyId = normalizePluginPolicyId(params.id);
@@ -109,7 +112,7 @@ function resolveExplicitPluginSelectionShared<TRootConfig>(params: {
   }
   if (
     params.origin === "bundled" &&
-    params.resolveChannelConfigEnablement(params.rootConfig, params.id) === true
+    params.resolveChannelConfigEnablement(params.rootConfig, params.id, params.channelIds) === true
   ) {
     return { explicitlyEnabled: true, cause: "bundled-channel-enabled-in-config" };
   }
@@ -134,9 +137,12 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   activationSource?: PluginActivationConfigSourceLike<TRootConfig>;
   autoEnabledReason?: string;
   allowBundledChannelExplicitBypassesAllowlist?: boolean;
+  /** Manifest-owned channel ids; the plugin id alone cannot resolve `channels.<id>` for every owner. */
+  channelIds?: readonly string[];
   resolveChannelConfigEnablement: (
     rootConfig: TRootConfig | undefined,
     pluginId: string,
+    channelIds?: readonly string[],
   ) => boolean | undefined;
 }): PluginActivationDecision {
   const activationSource = params.activationSource ?? {
@@ -148,6 +154,7 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
     origin: params.origin,
     config: activationSource.plugins,
     rootConfig: activationSource.rootConfig,
+    channelIds: params.channelIds,
     resolveChannelConfigEnablement: params.resolveChannelConfigEnablement,
   });
 
@@ -181,6 +188,7 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
     params.resolveChannelConfigEnablement(
       activationSource.rootConfig ?? params.rootConfig,
       params.id,
+      params.channelIds,
     ) === false
   ) {
     return decision("disabled", { cause: "channel-disabled-in-config" });
@@ -220,7 +228,7 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   }
   if (
     params.origin === "bundled" &&
-    params.resolveChannelConfigEnablement(params.rootConfig, params.id) === true
+    params.resolveChannelConfigEnablement(params.rootConfig, params.id, params.channelIds) === true
   ) {
     return decision("auto", { explicitlyEnabled: false, cause: "bundled-channel-configured" });
   }

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -255,21 +255,26 @@ export function normalizePluginsConfigWithResolverCore(
   };
 }
 
-export function isBundledChannelEnabledByChannelConfig(
+/**
+ * Reads the operator's `channels.<id>.enabled` decision for a channel plugin id.
+ * `true`/`false` are explicit channel-level decisions; `undefined` means no signal.
+ */
+export function resolveChannelConfigEnablement(
   cfg: OpenClawConfig | undefined,
   pluginId: string,
-): boolean {
+): boolean | undefined {
   const channels = cfg?.channels as Record<string, unknown> | undefined;
   if (!channels) {
-    return false;
+    return undefined;
   }
   const channelId = normalizeChatChannelId(pluginId);
   if (!channelId) {
-    return false;
+    return undefined;
   }
   const entry = channels[channelId];
   if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-    return false;
+    return undefined;
   }
-  return (entry as Record<string, unknown>).enabled === true;
+  const enabled = (entry as Record<string, unknown>).enabled;
+  return typeof enabled === "boolean" ? enabled : undefined;
 }

--- a/src/plugins/config-normalization-shared.ts
+++ b/src/plugins/config-normalization-shared.ts
@@ -262,19 +262,28 @@ export function normalizePluginsConfigWithResolverCore(
 export function resolveChannelConfigEnablement(
   cfg: OpenClawConfig | undefined,
   pluginId: string,
+  channelIds: readonly string[] = [],
 ): boolean | undefined {
   const channels = cfg?.channels as Record<string, unknown> | undefined;
   if (!channels) {
     return undefined;
   }
-  const channelId = normalizeChatChannelId(pluginId);
-  if (!channelId) {
-    return undefined;
+  // Manifest-owned channel ids come first: a plugin id can differ from its channel key
+  // (for example `openclaw-qqbot` owning `channels.qqbot`), and the built-in catalog only
+  // resolves ids that match.
+  const candidateIds = [
+    ...channelIds.map((channelId) => normalizeChatChannelId(channelId) ?? channelId),
+    normalizeChatChannelId(pluginId),
+  ];
+  for (const channelId of candidateIds) {
+    const entry = channelId ? channels[channelId] : undefined;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+    const enabled = (entry as Record<string, unknown>).enabled;
+    if (typeof enabled === "boolean") {
+      return enabled;
+    }
   }
-  const entry = channels[channelId];
-  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-    return undefined;
-  }
-  const enabled = (entry as Record<string, unknown>).enabled;
-  return typeof enabled === "boolean" ? enabled : undefined;
+  return undefined;
 }

--- a/src/plugins/config-policy.ts
+++ b/src/plugins/config-policy.ts
@@ -7,8 +7,8 @@ import {
 } from "./config-activation-shared.js";
 import {
   identityNormalizePluginId,
-  isBundledChannelEnabledByChannelConfig,
   normalizePluginsConfigWithResolverCore as normalizePluginsConfigWithResolverShared,
+  resolveChannelConfigEnablement,
   type NormalizePluginId,
   type NormalizedPluginsConfig as SharedNormalizedPluginsConfig,
 } from "./config-normalization-shared.js";
@@ -46,7 +46,7 @@ export function resolvePolicyPluginActivationState(
         plugins: params.sourceConfig ?? params.config,
         rootConfig: params.sourceRootConfig ?? params.rootConfig,
       },
-      isBundledChannelEnabledByChannelConfig,
+      resolveChannelConfigEnablement,
     }),
   );
 }

--- a/src/plugins/config-policy.ts
+++ b/src/plugins/config-policy.ts
@@ -34,6 +34,7 @@ type PolicyEffectiveActivationParams = {
   sourceConfig?: NormalizedPluginsConfig;
   sourceRootConfig?: OpenClawConfig;
   autoEnabledReason?: string;
+  channelIds?: readonly string[];
 };
 
 export function resolvePolicyPluginActivationState(

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -354,7 +354,10 @@ describe("resolveEffectivePluginActivationState", () => {
 
   it.each<{
     name: string;
-    params: Pick<ActivationParams, "id" | "origin" | "enabledByDefault" | "autoEnabledReason">;
+    params: Pick<
+      ActivationParams,
+      "id" | "origin" | "enabledByDefault" | "autoEnabledReason" | "channelIds"
+    >;
     rawConfig?: ActivationParams["rootConfig"];
     effectiveConfig?: ActivationParams["rootConfig"];
     expected: ReturnType<typeof resolveEffectivePluginActivationState>;
@@ -494,6 +497,23 @@ describe("resolveEffectivePluginActivationState", () => {
       rawConfig: {
         channels: { telegram: { enabled: false } },
         plugins: { entries: { telegram: { enabled: true } } },
+      },
+      expected: {
+        enabled: false,
+        activated: false,
+        explicitlyEnabled: true,
+        source: "disabled",
+        reason: "channel disabled in config",
+      },
+    },
+    {
+      name: "resolves an explicit channel disable through manifest-owned channel ids",
+      // QQ Bot style: plugin id `openclaw-demo` owns `channels.demo`, which the built-in
+      // catalog cannot map from the plugin id alone.
+      params: { id: "openclaw-demo", origin: "bundled", channelIds: ["demo"] },
+      rawConfig: {
+        channels: { demo: { enabled: false } },
+        plugins: { entries: { "openclaw-demo": { enabled: true } } },
       },
       expected: {
         enabled: false,

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -489,6 +489,21 @@ describe("resolveEffectivePluginActivationState", () => {
       },
     },
     {
+      name: "keeps an explicit channel disable authoritative over plugin entry enablement",
+      params: { id: "telegram", origin: "bundled" },
+      rawConfig: {
+        channels: { telegram: { enabled: false } },
+        plugins: { entries: { telegram: { enabled: true } } },
+      },
+      expected: {
+        enabled: false,
+        activated: false,
+        explicitlyEnabled: true,
+        source: "disabled",
+        reason: "channel disabled in config",
+      },
+    },
+    {
       name: "keeps a global plugin default-enabled without inventing explicit selection or a reason",
       params: { id: "global-helper", origin: "global" },
       expected: {

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -11,8 +11,8 @@ import {
   type PluginActivationStateLike,
 } from "./config-activation-shared.js";
 import {
-  isBundledChannelEnabledByChannelConfig as isBundledChannelEnabledByChannelConfigShared,
   normalizePluginsConfigWithResolverCore,
+  resolveChannelConfigEnablement,
   type NormalizedPluginsConfig as SharedNormalizedPluginsConfig,
 } from "./config-normalization-shared.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
@@ -216,7 +216,7 @@ function resolvePluginActivationState(params: {
           plugins: params.config,
         }),
       allowBundledChannelExplicitBypassesAllowlist: true,
-      isBundledChannelEnabledByChannelConfig: isBundledChannelEnabledByChannelConfigShared,
+      resolveChannelConfigEnablement,
     }),
   );
 }

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -205,6 +205,7 @@ function resolvePluginActivationState(params: {
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
   autoEnabledReason?: string;
+  channelIds?: readonly string[];
 }): PluginActivationState {
   return toPluginActivationState(
     resolvePluginActivationDecisionShared({
@@ -240,6 +241,7 @@ type EffectiveActivationParams = {
   rootConfig?: OpenClawConfig;
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
+  channelIds?: readonly string[];
 };
 
 export const resolveEffectiveEnableState = (
@@ -255,6 +257,7 @@ export function resolveEffectivePluginActivationState(params: {
   enabledByDefault?: EffectiveActivationParams["enabledByDefault"];
   activationSource?: EffectiveActivationParams["activationSource"];
   autoEnabledReason?: string;
+  channelIds?: EffectiveActivationParams["channelIds"];
 }): PluginActivationState {
   return resolvePluginActivationState(params);
 }

--- a/src/plugins/gateway-startup-plugin-activation.ts
+++ b/src/plugins/gateway-startup-plugin-activation.ts
@@ -111,6 +111,7 @@ function resolveStartupActivationState(
   return resolveEffectivePluginActivationState({
     id: params.plugin.pluginId,
     origin: params.plugin.origin,
+    channelIds: params.plugin.contributions?.channels,
     config: applyBundledProviderCompat
       ? normalizePluginsConfig(config.plugins)
       : params.pluginsConfig,

--- a/src/plugins/gateway-startup-plugin-config.ts
+++ b/src/plugins/gateway-startup-plugin-config.ts
@@ -185,6 +185,7 @@ export function resolveAuthorizedGatewayStartupDreamingPluginIds(params: {
   const activationState = resolveEffectivePluginActivationState({
     id: selectedPlugin.pluginId,
     origin: selectedPlugin.origin,
+    channelIds: selectedPlugin.contributions?.channels,
     config: params.pluginsConfig,
     rootConfig: params.config,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(selectedPlugin, params.platform),

--- a/src/plugins/gateway-startup-plugin-plan.ts
+++ b/src/plugins/gateway-startup-plugin-plan.ts
@@ -223,6 +223,7 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
     const activationState = resolveEffectivePluginActivationState({
       id: plugin.pluginId,
       origin: startupPolicyOrigin,
+      channelIds: plugin.contributions?.channels,
       config: pluginsConfig,
       rootConfig: params.config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin, params.platform),

--- a/src/plugins/installed-plugin-index-record-builder.ts
+++ b/src/plugins/installed-plugin-index-record-builder.ts
@@ -293,6 +293,7 @@ export function buildInstalledPluginIndexRecords(params: {
     const enabled = resolveEffectiveEnableState({
       id: record.id,
       origin: record.origin,
+      channelIds: record.channels,
       config: normalizedConfig,
       rootConfig: params.config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(record),

--- a/src/plugins/installed-plugin-index-store-write.ts
+++ b/src/plugins/installed-plugin-index-store-write.ts
@@ -330,6 +330,7 @@ function refreshPersistedPolicyState(
       enabled: resolveEffectiveEnableState({
         id: plugin.pluginId,
         origin: plugin.origin,
+        channelIds: plugin.contributions?.channels,
         config: normalizedConfig,
         rootConfig: activationConfig,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { recordPluginCandidateInstallOwner } from "./candidate-install-owner.js";
 import type { PluginCandidate } from "./discovery.js";
 import { resolveInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
@@ -625,6 +626,29 @@ describe("installed plugin index", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    { channelEnabled: false, expected: false },
+    { channelEnabled: true, expected: true },
+  ])(
+    "resolves channels.<id>.enabled=$channelEnabled through the record's channel ids when they differ from the plugin id",
+    ({ channelEnabled, expected }) => {
+      // The rich fixture's plugin id is `demo` while it owns `channels.demo-chat`.
+      const fixture = createRichPluginFixture({ id: "demo" });
+      const index = loadInstalledPluginIndex({
+        candidates: [fixture.candidate],
+        config: {},
+        env: hermeticEnv(),
+      });
+
+      expect(
+        isInstalledPluginEnabled(index, "demo", {
+          channels: { "demo-chat": { enabled: channelEnabled } },
+          plugins: { entries: { demo: { enabled: true } } },
+        } as OpenClawConfig),
+      ).toBe(expected);
+    },
+  );
 
   it("records explicit install records separately from package install intent", () => {
     const fixture = createRichPluginFixture({ installOwner: "demo" });

--- a/src/plugins/installed-plugin-index.ts
+++ b/src/plugins/installed-plugin-index.ts
@@ -195,6 +195,7 @@ export function isInstalledPluginEnabled(
   const state = resolveEffectivePluginActivationState({
     id: record.pluginId,
     origin: record.origin,
+    channelIds: record.contributions?.channels,
     config: normalizedConfig,
     rootConfig: activationConfig,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(record),

--- a/src/plugins/loader-cache.test.ts
+++ b/src/plugins/loader-cache.test.ts
@@ -1,0 +1,19 @@
+/** Tests plugin registry cache-key sensitivity to activation-relevant config. */
+import { describe, expect, it } from "vitest";
+import { resolvePluginRegistryLoadCacheKey } from "./loader-cache.js";
+
+describe("resolvePluginRegistryLoadCacheKey", () => {
+  it("separates absent, disabled, and enabled channel flags", () => {
+    // channels.<id>.enabled steers activation on both sides, so each state needs its own registry.
+    const keyFor = (channel: Record<string, unknown>) =>
+      resolvePluginRegistryLoadCacheKey({
+        config: { channels: { telegram: channel } },
+        env: {},
+      });
+    const absent = keyFor({});
+    const disabled = keyFor({ enabled: false });
+    const enabled = keyFor({ enabled: true });
+
+    expect(new Set([absent, disabled, enabled]).size).toBe(3);
+  });
+});

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -38,6 +38,7 @@ import {
   validatePluginConfig,
 } from "./loader-shared.js";
 import type { PluginLoadOptions } from "./loader-types.js";
+import { resolveExternalPluginRuntimeDependencyRepairHint } from "./official-external-plugin-repair-hints.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import { createPluginIdScopeSet } from "./plugin-scope.js";
@@ -246,6 +247,11 @@ export async function loadOpenClawPluginCliRegistry(
     }
     const safeSource = opened.path;
     fs.closeSync(opened.fd);
+    const missingDependencyHint = resolveExternalPluginRuntimeDependencyRepairHint({
+      pluginId,
+      packageName: candidate.packageName,
+      packageBuild: candidate.packageManifest?.build,
+    });
     let mod: OpenClawPluginModule | null;
     try {
       mod = withProfile(
@@ -265,6 +271,7 @@ export async function loadOpenClawPluginCliRegistry(
         error,
         logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
         diagnosticMessagePrefix: "failed to load plugin: ",
+        missingDependencyHint,
       });
       continue;
     }
@@ -359,6 +366,7 @@ export async function loadOpenClawPluginCliRegistry(
         error,
         logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
         diagnosticMessagePrefix: "plugin failed during register: ",
+        missingDependencyHint,
       });
     }
   }

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -133,6 +133,7 @@ export async function loadOpenClawPluginCliRegistry(
           config: context.normalized,
           rootConfig: context.cfg,
           enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+          channelIds: manifestRecord.channels,
           activationSource: context.activationSource,
           autoEnabledReason: formatAutoEnabledActivationReason(
             context.autoEnabledReasons[pluginId],
@@ -160,6 +161,7 @@ export async function loadOpenClawPluginCliRegistry(
           config: context.normalized,
           rootConfig: context.cfg,
           enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+          channelIds: manifestRecord.channels,
           activationSource: context.activationSource,
         });
     const entry = context.normalized.entries[policyId];

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -129,17 +129,19 @@ function buildActivationMetadataHash(params: {
   activationSource: PluginActivationConfigSource;
   autoEnabledReasons: Readonly<Record<string, string[]>>;
 }): string {
-  const enabledSourceChannels = Object.entries(
+  // Both sides of channels.<id>.enabled steer activation, so an added or flipped
+  // flag must miss the cache instead of reusing a registry built without it.
+  const sourceChannelEnablement = Object.entries(
     (params.activationSource.rootConfig?.channels as Record<string, unknown>) ?? {},
   )
-    .filter(([, value]) => {
+    .flatMap(([channelId, value]) => {
       if (!value || typeof value !== "object" || Array.isArray(value)) {
-        return false;
+        return [];
       }
-      return (value as { enabled?: unknown }).enabled === true;
+      const enabled = (value as { enabled?: unknown }).enabled;
+      return typeof enabled === "boolean" ? [[channelId, enabled] as const] : [];
     })
-    .map(([channelId]) => channelId)
-    .toSorted((left, right) => left.localeCompare(right));
+    .toSorted(([left], [right]) => left.localeCompare(right));
   // Source config selects validation and defaults even when resolved values match.
   // Object fields keep an absent config distinct from an explicit null source.
   const pluginEntryInputs = Object.entries(params.activationSource.plugins.entries)
@@ -157,7 +159,7 @@ function buildActivationMetadataHash(params: {
         deny: params.activationSource.plugins.deny,
         memorySlot: params.activationSource.plugins.slots.memory,
         entries: pluginEntryInputs,
-        enabledChannels: enabledSourceChannels,
+        channelEnablement: sourceChannelEnablement,
         autoEnabledReasons: autoEnableReasonEntries,
       }),
     )

--- a/src/plugins/loader-records.test.ts
+++ b/src/plugins/loader-records.test.ts
@@ -140,6 +140,17 @@ describe("plugin loader records", () => {
       expected: "Error: boom",
     },
     {
+      name: "survives a nested throwing code accessor without rethrowing",
+      error: new Error("wrapped", {
+        cause: Object.defineProperty(new Error("nested"), "code", {
+          get(): never {
+            throw new Error("code exploded");
+          },
+        }),
+      }),
+      expected: "Error: wrapped",
+    },
+    {
       name: "survives a throwing cause accessor without rethrowing",
       error: Object.defineProperty(new Error("hostile"), "cause", {
         get(): never {

--- a/src/plugins/loader-records.test.ts
+++ b/src/plugins/loader-records.test.ts
@@ -139,6 +139,15 @@ describe("plugin loader records", () => {
       error: new Error("boom"),
       expected: "Error: boom",
     },
+    {
+      name: "survives a throwing cause accessor without rethrowing",
+      error: Object.defineProperty(new Error("hostile"), "cause", {
+        get(): never {
+          throw new Error("cause exploded");
+        },
+      }),
+      expected: "Error: hostile",
+    },
   ])("$name", ({ error, expected }) => {
     const registry = createEmptyPluginRegistry();
     const record = createPluginRecord({

--- a/src/plugins/loader-records.test.ts
+++ b/src/plugins/loader-records.test.ts
@@ -123,4 +123,46 @@ describe("plugin loader records", () => {
 
     expect(record.error).toBe(expected);
   });
+
+  it.each([
+    {
+      name: "names the install path when a missing module sits on the error cause",
+      error: new Error("import failed", {
+        cause: Object.assign(new Error("Cannot find module 'discord-api-types/v10'"), {
+          code: "MODULE_NOT_FOUND",
+        }),
+      }),
+      expected: "install @openclaw/discord (Error: import failed)",
+    },
+    {
+      name: "keeps unrelated failures verbatim",
+      error: new Error("boom"),
+      expected: "Error: boom",
+    },
+  ])("$name", ({ error, expected }) => {
+    const registry = createEmptyPluginRegistry();
+    const record = createPluginRecord({
+      id: "discord",
+      source: "/tmp/discord/index.js",
+      origin: "bundled",
+      enabled: true,
+      configSchema: false,
+    });
+
+    recordPluginError({
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      registry,
+      record,
+      seenIds: new Map(),
+      pluginId: record.id,
+      origin: record.origin,
+      phase: "load",
+      error,
+      logPrefix: "",
+      diagnosticMessagePrefix: "",
+      missingDependencyHint: "install @openclaw/discord",
+    });
+
+    expect(record.error).toBe(expected);
+  });
 });

--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -146,6 +146,15 @@ export function formatAutoEnabledActivationReason(
   return reasons.join("; ");
 }
 
+// A plugin-thrown error may expose a throwing `cause` accessor; diagnostics must not rethrow it.
+function readCauseOrNothing(node: unknown): unknown[] {
+  try {
+    return [readErrorCause(node)];
+  } catch {
+    return [];
+  }
+}
+
 /** Records a loader failure in the registry, diagnostics list, and operator log consistently. */
 export function recordPluginError(params: {
   logger: PluginLogger;
@@ -175,7 +184,7 @@ export function recordPluginError(params: {
   // Native-require failures rewrap the Node error, so the missing-module code can sit on a cause.
   const missingDependencyHint =
     params.missingDependencyHint &&
-    collectErrorGraphCandidates(params.error, (node) => [readErrorCause(node)]).some((node) => {
+    collectErrorGraphCandidates(params.error, readCauseOrNothing).some((node) => {
       const code = extractErrorCode(node);
       return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
     })

--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -146,12 +146,22 @@ export function formatAutoEnabledActivationReason(
   return reasons.join("; ");
 }
 
-// A plugin-thrown error may expose a throwing `cause` accessor; diagnostics must not rethrow it.
+// A plugin-thrown error may expose throwing `cause`/`code` accessors; diagnostics inside the
+// loader's catch handler must classify without rethrowing.
 function readCauseOrNothing(node: unknown): unknown[] {
   try {
     return [readErrorCause(node)];
   } catch {
     return [];
+  }
+}
+
+function isMissingModuleNode(node: unknown): boolean {
+  try {
+    const code = extractErrorCode(node);
+    return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
+  } catch {
+    return false;
   }
 }
 
@@ -184,10 +194,7 @@ export function recordPluginError(params: {
   // Native-require failures rewrap the Node error, so the missing-module code can sit on a cause.
   const missingDependencyHint =
     params.missingDependencyHint &&
-    collectErrorGraphCandidates(params.error, readCauseOrNothing).some((node) => {
-      const code = extractErrorCode(node);
-      return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
-    })
+    collectErrorGraphCandidates(params.error, readCauseOrNothing).some(isMissingModuleNode)
       ? params.missingDependencyHint
       : null;
   // Rewrite the common removed-API failure into an actionable migration hint while preserving detail.

--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -1,4 +1,5 @@
 /** Converts loaded plugin registries into stable plugin records for status and diagnostics. */
+import { collectErrorGraphCandidates, extractErrorCode, readErrorCause } from "../infra/errors.js";
 import { parseBooleanValue } from "../utils/boolean.js";
 import type { PluginCompatCode } from "./compat/registry.js";
 import type { PluginActivationState } from "./config-state.js";
@@ -158,6 +159,8 @@ export function recordPluginError(params: {
   logPrefix: string;
   diagnosticMessagePrefix: string;
   diagnosticCode?: PluginDiagnosticCode;
+  /** Shown when the failure is a missing module so operators learn the install path. */
+  missingDependencyHint?: string;
 }) {
   const errorText =
     isPluginLifecycleTraceEnabled() &&
@@ -169,8 +172,18 @@ export function recordPluginError(params: {
     errorText.includes("api.registerHttpHandler") && errorText.includes("is not a function")
       ? "deprecated api.registerHttpHandler(...) was removed; use api.registerHttpRoute(...) for plugin-owned routes or registerPluginHttpRoute(...) for dynamic lifecycle routes"
       : null;
+  // Native-require failures rewrap the Node error, so the missing-module code can sit on a cause.
+  const missingDependencyHint =
+    params.missingDependencyHint &&
+    collectErrorGraphCandidates(params.error, (node) => [readErrorCause(node)]).some((node) => {
+      const code = extractErrorCode(node);
+      return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND";
+    })
+      ? params.missingDependencyHint
+      : null;
   // Rewrite the common removed-API failure into an actionable migration hint while preserving detail.
-  const displayError = deprecatedApiHint ? `${deprecatedApiHint} (${errorText})` : errorText;
+  const hint = deprecatedApiHint ?? missingDependencyHint;
+  const displayError = hint ? `${hint} (${errorText})` : errorText;
   params.logger.error(`${params.logPrefix}${displayError}`);
   params.record.status = "error";
   params.record.error = displayError;

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -48,6 +48,7 @@ import {
   resolveManifestOwnerBasePolicyBlock,
 } from "./manifest-owner-policy.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import { resolveExternalPluginRuntimeDependencyRepairHint } from "./official-external-plugin-repair-hints.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import {
@@ -204,6 +205,11 @@ export function loadRuntimePluginCandidate(params: {
       record,
       message,
     });
+  const missingDependencyHint = resolveExternalPluginRuntimeDependencyRepairHint({
+    pluginId,
+    packageName: candidate.packageName,
+    packageBuild: candidate.packageManifest?.build,
+  });
   if (blockUntrustedLocalScopedChannelSetupImport) {
     record.status = "disabled";
     record.error =
@@ -415,6 +421,7 @@ export function loadRuntimePluginCandidate(params: {
       error,
       logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
       diagnosticMessagePrefix: "failed to load plugin: ",
+      missingDependencyHint,
     });
     moduleLoadFailed = true;
     return;
@@ -565,6 +572,7 @@ export function loadRuntimePluginCandidate(params: {
       error,
       logPrefix: `[plugins] ${record.id} failed during register from ${record.source}: `,
       diagnosticMessagePrefix: "plugin failed during register: ",
+      missingDependencyHint,
       ...(error instanceof PluginDashboardDeclarationError
         ? { diagnosticCode: "dashboard-declaration-invalid" }
         : {}),

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -120,6 +120,7 @@ export function loadRuntimePluginCandidate(params: {
         config: context.normalized,
         rootConfig: context.cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+        channelIds: manifestRecord.channels,
         activationSource: context.activationSource,
         autoEnabledReason: formatAutoEnabledActivationReason(context.autoEnabledReasons[pluginId]),
       });
@@ -146,6 +147,7 @@ export function loadRuntimePluginCandidate(params: {
         config: context.normalized,
         rootConfig: context.cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
+        channelIds: manifestRecord.channels,
         activationSource: context.activationSource,
       });
   const entry = context.normalized.entries[policyId];

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -184,6 +184,7 @@ function loadOpenClawPluginsInternal(
       const activation = resolveEffectivePluginActivationState({
         id: record.id,
         origin: record.origin,
+        channelIds: record.channels,
         config: context.normalized,
         rootConfig: context.cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(record),

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -790,6 +790,27 @@ describe("loadOpenClawPlugins", () => {
         expect(telegram?.error).toBe("disabled in config");
       },
     },
+    {
+      name: "keeps channels.<id>.enabled=false authoritative over plugins.entries enablement",
+      config: {
+        channels: {
+          telegram: {
+            enabled: false,
+          },
+        },
+        plugins: {
+          entries: {
+            telegram: { enabled: true },
+          },
+        },
+      } satisfies PluginLoadConfig,
+      assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+        const telegram = registry.plugins.find((entry) => entry.id === "telegram");
+        expect(telegram?.status).toBe("disabled");
+        expect(telegram?.error).toBe("channel disabled in config");
+        expect(registry.channels.map((entry) => entry.plugin.id)).not.toContain("telegram");
+      },
+    },
   ] as const)(
     "handles bundled telegram plugin enablement and override rules: $name",
     ({ config, assert }) => {

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -32,9 +32,11 @@ import {
   type PluginLoadConfig,
   useNoBundledPlugins,
   writePlugin,
+  writePluginMetadata,
 } from "./loader.test-fixtures.js";
 import {
   cachedBundledTelegramDir,
+  channelPluginSource,
   listRegisteredAgentHarnessIdsForTest,
   countMatching,
   updatePluginManifest,
@@ -821,6 +823,41 @@ describe("loadOpenClawPlugins", () => {
         config,
       });
       assert(registry);
+    },
+  );
+
+  it.each([
+    { channelEnabled: false, status: "disabled", error: "channel disabled in config" },
+    { channelEnabled: true, status: "loaded", error: undefined },
+  ])(
+    "resolves channels.<id>.enabled=$channelEnabled through the manifest channel id when it differs from the plugin id",
+    ({ channelEnabled, status, error }) => {
+      const dir = makePluginLoaderTempDir();
+      writePlugin({
+        id: "openclaw-demo",
+        dir,
+        body: channelPluginSource({
+          pluginId: "openclaw-demo",
+          channelId: "demo",
+          label: "Demo",
+          docsPath: "/channels/demo",
+          blurb: "demo channel",
+        }),
+      });
+      writePluginMetadata({ dir, id: "openclaw-demo", channels: ["demo"] });
+      const registry = withEnv({ OPENCLAW_BUNDLED_PLUGINS_DIR: dir }, () =>
+        loadOpenClawPlugins({
+          cache: false,
+          workspaceDir: dir,
+          config: {
+            channels: { demo: { enabled: channelEnabled } },
+            plugins: { entries: { "openclaw-demo": { enabled: true } } },
+          },
+        }),
+      );
+      const plugin = registry.plugins.find((entry) => entry.id === "openclaw-demo");
+      expect(plugin?.status).toBe(status);
+      expect(plugin?.error).toBe(error);
     },
   );
 

--- a/src/plugins/management-service.test-helpers.ts
+++ b/src/plugins/management-service.test-helpers.ts
@@ -24,6 +24,8 @@ export function metadataSnapshot(params: {
   origin?: "bundled" | "global";
   installRecord?: Record<string, unknown>;
   icon?: string;
+  packageBuild?: { bundledDist?: boolean };
+  packageDependencies?: Record<string, string>;
 }) {
   const id = params.id ?? "workboard";
   const origin = params.origin ?? "bundled";
@@ -36,6 +38,7 @@ export function metadataSnapshot(params: {
     description: "Coordinate agent work in a shared board.",
     catalog: { featured: true, order: 10 },
     ...(params.icon ? { icon: params.icon } : {}),
+    ...(params.packageDependencies ? { packageDependencies: params.packageDependencies } : {}),
     channels: [],
     providers: [],
     cliBackends: [],
@@ -56,6 +59,7 @@ export function metadataSnapshot(params: {
           origin,
           enabled: params.enabled,
           rootDir: `/tmp/${id}`,
+          ...(params.packageBuild ? { packageBuild: params.packageBuild } : {}),
         },
       ],
       installRecords: installRecord ? { [id]: installRecord } : {},

--- a/src/plugins/management-service.test.ts
+++ b/src/plugins/management-service.test.ts
@@ -267,6 +267,40 @@ describe("plugin management service", () => {
     expect(catalog.mutationAllowed).toBe(true);
   });
 
+  it.each([
+    {
+      name: "reports missing dependencies for a bundled plugin distributed outside the root package",
+      packageBuild: { bundledDist: false },
+      expectsError: true,
+    },
+    {
+      name: "keeps plain bundled plugins free of package-local dependency health",
+      packageBuild: undefined,
+      expectsError: false,
+    },
+  ])("$name", async ({ packageBuild, expectsError }) => {
+    mocks.metadata.mockReturnValue(
+      metadataSnapshot({
+        enabled: true,
+        packageBuild,
+        packageDependencies: { "missing-runtime": "1.0.0" },
+      }),
+    );
+
+    const catalog = await listManagedPlugins({
+      config: { plugins: { entries: { workboard: { enabled: true } } } },
+      env: {},
+      officialCatalog: { entries: [] },
+    });
+
+    const entry = expectDefined(catalog.plugins[0], "catalog entry");
+    if (expectsError) {
+      expect(entry.error).toContain("required dependencies are missing: missing-runtime");
+    } else {
+      expect(entry.error).toBeUndefined();
+    }
+  });
+
   it("projects and resolves installed manifest icons by plugin identity", async () => {
     const icon = "https://cdn.example.test/workboard.svg";
     const config = {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -121,6 +121,7 @@ import {
   type HostedOfficialExternalPluginCatalogLoadResult,
   type OfficialExternalPluginCatalogEntry,
 } from "./official-external-plugin-catalog.js";
+import { tracksPluginDependencyStatus } from "./official-external-plugin-repair-hints.js";
 import {
   createPluginCache,
   getPluginCache,
@@ -341,7 +342,13 @@ function resolveManagedPluginDiagnostics(
     plugins: snapshot.index.plugins.map((record) => {
       const manifest = snapshot.byPluginId.get(record.pluginId);
       const enabled = isInstalledPluginEnabled(snapshot.index, record.pluginId, config);
-      if (manifest && record.origin !== "bundled" && !dependencies.has(manifest)) {
+      const tracksDependencies = tracksPluginDependencyStatus({
+        origin: record.origin,
+        pluginId: record.pluginId,
+        packageName: record.packageName,
+        packageBuild: record.packageBuild,
+      });
+      if (manifest && tracksDependencies && !dependencies.has(manifest)) {
         dependencies.set(
           manifest,
           buildPluginDependencyStatus({

--- a/src/plugins/manifest-owner-policy.ts
+++ b/src/plugins/manifest-owner-policy.ts
@@ -8,7 +8,8 @@ import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 type OwnerPlugin = Pick<
   PluginManifestRecord,
   "id" | "origin" | "enabledByDefault" | "enabledByDefaultOnPlatforms"
->;
+> &
+  Partial<Pick<PluginManifestRecord, "channels">>;
 
 type NormalizedPluginsConfig = ReturnType<typeof normalizePluginsConfig>;
 
@@ -85,6 +86,7 @@ export function isActivatedManifestOwner(params: {
   return resolveEffectivePluginActivationState({
     id: params.plugin.id,
     origin: params.plugin.origin,
+    channelIds: params.plugin.channels,
     config: params.normalizedConfig,
     rootConfig: params.rootConfig,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin),

--- a/src/plugins/official-external-plugin-repair-hints.test.ts
+++ b/src/plugins/official-external-plugin-repair-hints.test.ts
@@ -84,7 +84,7 @@ describe("resolveMissingOfficialExternalChannelPluginRepairHint", () => {
     expect(mocks.resolveConfiguredChannelPresencePolicy).not.toHaveBeenCalled();
   });
 
-  it("prefers the ClawHub install hint for externalized WhatsApp", () => {
+  it("prefers the npm install hint for externalized WhatsApp", () => {
     mocks.resolveConfiguredChannelPresencePolicy.mockReturnValue([
       {
         channelId: "whatsapp",
@@ -104,8 +104,8 @@ describe("resolveMissingOfficialExternalChannelPluginRepairHint", () => {
       pluginId: "whatsapp",
       channelId: "whatsapp",
       label: "WhatsApp",
-      installSpec: "clawhub:@openclaw/whatsapp",
-      installCommand: "openclaw plugins install clawhub:@openclaw/whatsapp",
+      installSpec: "@openclaw/whatsapp",
+      installCommand: "openclaw plugins install @openclaw/whatsapp",
     });
   });
 

--- a/src/plugins/official-external-plugin-repair-hints.test.ts
+++ b/src/plugins/official-external-plugin-repair-hints.test.ts
@@ -1,6 +1,7 @@
 // Covers repair hints for official external plugin installs.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  resolveExternalPluginRuntimeDependencyRepairHint,
   resolveMissingOfficialExternalChannelPluginRepairHint,
   resolveMissingOfficialExternalChannelPluginRepairHints,
 } from "./official-external-plugin-repair-hints.js";
@@ -145,5 +146,37 @@ describe("resolveMissingOfficialExternalChannelPluginRepairHint", () => {
         channelId: "whatsapp",
       }),
     ).toBeNull();
+  });
+});
+
+describe("resolveExternalPluginRuntimeDependencyRepairHint", () => {
+  it.each([
+    {
+      name: "names the official install command for the package that owns the id",
+      candidate: { pluginId: "discord", packageName: "@openclaw/discord" },
+      expected: "openclaw plugins install @openclaw/discord",
+    },
+    {
+      name: "withholds the official install command from a foreign package reusing the id",
+      candidate: {
+        pluginId: "discord",
+        packageName: "@example/discord-fork",
+        packageBuild: { bundledDist: false },
+      },
+      expected: "reinstall or update the plugin package",
+    },
+  ])("$name", ({ candidate, expected }) => {
+    const hint = resolveExternalPluginRuntimeDependencyRepairHint(candidate);
+    expect(hint).toContain("runtime dependencies are missing");
+    expect(hint).toContain(expected);
+  });
+
+  it("stays silent for plugins shipped inside the root package", () => {
+    expect(
+      resolveExternalPluginRuntimeDependencyRepairHint({
+        pluginId: "telegram",
+        packageName: "@openclaw/telegram",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/plugins/official-external-plugin-repair-hints.ts
+++ b/src/plugins/official-external-plugin-repair-hints.ts
@@ -5,6 +5,7 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import {
   getOfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogManifest,
+  isExternallyDistributedPlugin,
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstallSources,
   resolveOfficialExternalPluginLabel,
@@ -24,6 +25,25 @@ export type OfficialExternalPluginRepairHint = {
 type MissingOfficialExternalChannelPluginRepairHint = OfficialExternalPluginRepairHint & {
   channelId: string;
 };
+
+/**
+ * Names the install path when an externally distributed plugin fails to import its runtime
+ * dependencies. Source builds compile these plugins into `dist/extensions/<id>` but their
+ * dependencies stay plugin-local, so a moved or pruned checkout leaves the dist link dangling.
+ */
+export function resolveExternalPluginRuntimeDependencyRepairHint(candidate: {
+  pluginId: string;
+  packageName?: string;
+  packageBuild?: { bundledDist?: boolean };
+}): string | undefined {
+  if (!isExternallyDistributedPlugin(candidate)) {
+    return undefined;
+  }
+  const hint = resolveOfficialExternalPluginRepairHint(candidate.pluginId);
+  return hint
+    ? `runtime dependencies are missing for externally distributed plugin ${hint.label}; ${hint.repairHint}`
+    : undefined;
+}
 
 /** Resolves install/doctor commands for an official external plugin or channel id. */
 export function resolveOfficialExternalPluginRepairHint(

--- a/src/plugins/official-external-plugin-repair-hints.ts
+++ b/src/plugins/official-external-plugin-repair-hints.ts
@@ -27,6 +27,20 @@ type MissingOfficialExternalChannelPluginRepairHint = OfficialExternalPluginRepa
 };
 
 /**
+ * Bundled plugins ship their dependencies inside the root package, so dependency status is
+ * only meaningful for external installs and for externally distributed plugins whose runtime
+ * was compiled into the bundled tree without its plugin-local dependencies.
+ */
+export function tracksPluginDependencyStatus(candidate: {
+  origin: string;
+  pluginId: string;
+  packageName?: string;
+  packageBuild?: { bundledDist?: boolean };
+}): boolean {
+  return candidate.origin !== "bundled" || isExternallyDistributedPlugin(candidate);
+}
+
+/**
  * Names the install path when an externally distributed plugin fails to import its runtime
  * dependencies. Source builds compile these plugins into `dist/extensions/<id>` but their
  * dependencies stay plugin-local, so a moved or pruned checkout leaves the dist link dangling.

--- a/src/plugins/official-external-plugin-repair-hints.ts
+++ b/src/plugins/official-external-plugin-repair-hints.ts
@@ -4,11 +4,13 @@ import { resolveConfiguredChannelPresencePolicy } from "./channel-plugin-ids.js"
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import {
   getOfficialExternalPluginCatalogEntry,
+  getOfficialExternalPluginCatalogEntryForPackage,
   getOfficialExternalPluginCatalogManifest,
   isExternallyDistributedPlugin,
   resolveOfficialExternalPluginId,
   resolveOfficialExternalPluginInstallSources,
   resolveOfficialExternalPluginLabel,
+  type OfficialExternalPluginCatalogEntry,
 } from "./official-external-plugin-catalog.js";
 
 /** Repair hint for installing an official external plugin that owns a missing surface. */
@@ -53,10 +55,16 @@ export function resolveExternalPluginRuntimeDependencyRepairHint(candidate: {
   if (!isExternallyDistributedPlugin(candidate)) {
     return undefined;
   }
-  const hint = resolveOfficialExternalPluginRepairHint(candidate.pluginId);
+  // Only the official package that owns this canonical id earns its install command; a foreign
+  // package reusing the id must not be told to install the official one over itself.
+  const entry = getOfficialExternalPluginCatalogEntryForPackage(candidate.packageName);
+  const hint =
+    entry && resolveOfficialExternalPluginId(entry) === candidate.pluginId
+      ? buildOfficialExternalPluginRepairHint(entry, candidate.pluginId)
+      : null;
   return hint
     ? `runtime dependencies are missing for externally distributed plugin ${hint.label}; ${hint.repairHint}`
-    : undefined;
+    : `runtime dependencies are missing for externally distributed plugin ${candidate.pluginId}; reinstall or update the plugin package, then restart the Gateway.`;
 }
 
 /** Resolves install/doctor commands for an official external plugin or channel id. */
@@ -64,9 +72,13 @@ export function resolveOfficialExternalPluginRepairHint(
   pluginIdOrChannelId: string,
 ): OfficialExternalPluginRepairHint | null {
   const entry = getOfficialExternalPluginCatalogEntry(pluginIdOrChannelId);
-  if (!entry) {
-    return null;
-  }
+  return entry ? buildOfficialExternalPluginRepairHint(entry, pluginIdOrChannelId) : null;
+}
+
+function buildOfficialExternalPluginRepairHint(
+  entry: OfficialExternalPluginCatalogEntry,
+  pluginIdOrChannelId: string,
+): OfficialExternalPluginRepairHint | null {
   const installSpec = resolveOfficialExternalPluginInstallSources(entry)[0]?.spec;
   if (!installSpec) {
     return null;

--- a/src/plugins/plugin-policy-id.test.ts
+++ b/src/plugins/plugin-policy-id.test.ts
@@ -40,7 +40,7 @@ describe("mixed-case plugin policy ids", () => {
         origin: "bundled",
         config: normalizePluginsConfig({ deny: ["malicious-scraper"] }),
         enabledByDefault: true,
-        isBundledChannelEnabledByChannelConfig: () => false,
+        resolveChannelConfigEnablement: () => undefined,
       }),
     ).toMatchObject({ enabled: false, activated: false, cause: "blocked-by-denylist" });
   });

--- a/src/plugins/plugin-runtime-inventory.ts
+++ b/src/plugins/plugin-runtime-inventory.ts
@@ -29,6 +29,7 @@ export function listEnabledPluginRecords(config: OpenClawConfig): EnabledPluginR
         resolveEffectivePluginActivationState({
           id: plugin.id,
           origin: plugin.origin,
+          channelIds: plugin.channels,
           config: normalizedConfig,
           rootConfig: config,
           enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -165,6 +165,7 @@ function resolveEffectiveRegistryPluginActivation(params: {
   return resolveEffectivePluginActivationState({
     id: params.plugin.pluginId,
     origin: params.plugin.origin,
+    channelIds: params.plugin.contributions?.channels,
     config: params.normalizedConfig,
     rootConfig: params.rootConfig,
     enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin),

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -16,6 +16,7 @@ import { resolveInstalledPluginIndexInstallOwner } from "./installed-plugin-inde
 import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
+import { tracksPluginDependencyStatus } from "./official-external-plugin-repair-hints.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type {
@@ -161,14 +162,18 @@ function buildPluginRecordFromInstalledIndex(
     hookCount: 0,
     configSchema: Boolean(manifest?.configSchema),
     contracts: manifest?.contracts,
-    dependencyStatus:
-      plugin.origin === "bundled"
-        ? undefined
-        : buildPluginDependencyStatus({
-            rootDir: plugin.rootDir,
-            dependencies: manifest?.packageDependencies,
-            optionalDependencies: manifest?.packageOptionalDependencies,
-          }),
+    dependencyStatus: tracksPluginDependencyStatus({
+      origin: plugin.origin,
+      pluginId: plugin.pluginId,
+      packageName: plugin.packageName,
+      packageBuild: plugin.packageBuild,
+    })
+      ? buildPluginDependencyStatus({
+          rootDir: plugin.rootDir,
+          dependencies: manifest?.packageDependencies,
+          optionalDependencies: manifest?.packageOptionalDependencies,
+        })
+      : undefined,
   };
 }
 

--- a/src/plugins/status.dependency-health.test.ts
+++ b/src/plugins/status.dependency-health.test.ts
@@ -55,7 +55,9 @@ function createDependencyHealthRegistry(
   });
 }
 
-function createDependencyHealthFixture(identity: { pluginId?: string; packageName?: string } = {}) {
+function createDependencyHealthFixture(
+  identity: { pluginId?: string; packageName?: string; bundledDist?: false } = {},
+) {
   const rootDir = makeTrackedTempDir("openclaw-plugin-dependency-health", tempDirs);
   const pluginRoot = path.join(rootDir, "plugin");
   const bundledRoot = path.join(rootDir, "bundled");
@@ -70,6 +72,14 @@ function createDependencyHealthFixture(identity: { pluginId?: string; packageNam
       optionalDependencies: { "optional-runtime": "2.0.0" },
     },
   });
+  if (identity.bundledDist === false) {
+    const packageJsonPath = path.join(pluginRoot, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+      openclaw: Record<string, unknown>;
+    };
+    packageJson.openclaw.build = { bundledDist: false };
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), "utf8");
+  }
   return {
     fixture,
     reportParams: {
@@ -135,6 +145,21 @@ describe("plugin dependency health projection", () => {
     expect(report.plugins[0]?.dependencyStatus).toBeUndefined();
     expect(report.plugins[0]?.status).toBe("loaded");
     expect(report.diagnostics).toEqual([]);
+  });
+
+  it("projects runtime dependency health onto generic source-external bundled plugins", () => {
+    const { fixture, reportParams } = createDependencyHealthFixture({ bundledDist: false });
+    loaderState.registry = createDependencyHealthRegistry(fixture.pluginId, {
+      dependencyStatus: undefined,
+      origin: "bundled",
+    });
+
+    const report = buildPluginDiagnosticsReport(reportParams);
+
+    expect(report.plugins[0]?.dependencyStatus).toEqual(
+      expect.objectContaining({ requiredInstalled: false, missing: ["missing-runtime"] }),
+    );
+    expect(report.plugins[0]?.status).toBe("error");
   });
 
   it("projects dependency health onto bundled official plugins distributed externally", () => {

--- a/src/plugins/status.dependency-health.test.ts
+++ b/src/plugins/status.dependency-health.test.ts
@@ -55,7 +55,7 @@ function createDependencyHealthRegistry(
   });
 }
 
-function createDependencyHealthFixture() {
+function createDependencyHealthFixture(identity: { pluginId?: string; packageName?: string } = {}) {
   const rootDir = makeTrackedTempDir("openclaw-plugin-dependency-health", tempDirs);
   const pluginRoot = path.join(rootDir, "plugin");
   const bundledRoot = path.join(rootDir, "bundled");
@@ -63,7 +63,8 @@ function createDependencyHealthFixture() {
   fs.mkdirSync(bundledRoot);
   const fixture = createColdPluginFixture({
     rootDir: pluginRoot,
-    pluginId: "missing-dependency-plugin",
+    pluginId: identity.pluginId ?? "missing-dependency-plugin",
+    packageName: identity.packageName,
     packageJson: {
       dependencies: { "missing-runtime": "1.0.0", "optional-runtime": "1.0.0" },
       optionalDependencies: { "optional-runtime": "2.0.0" },
@@ -134,6 +135,25 @@ describe("plugin dependency health projection", () => {
     expect(report.plugins[0]?.dependencyStatus).toBeUndefined();
     expect(report.plugins[0]?.status).toBe("loaded");
     expect(report.diagnostics).toEqual([]);
+  });
+
+  it("projects dependency health onto bundled official plugins distributed externally", () => {
+    const { fixture, reportParams } = createDependencyHealthFixture({
+      pluginId: "discord",
+      packageName: "@openclaw/discord",
+    });
+    loaderState.registry = createDependencyHealthRegistry(fixture.pluginId, {
+      dependencyStatus: undefined,
+      origin: "bundled",
+      packageName: "@openclaw/discord",
+    });
+
+    const report = buildPluginDiagnosticsReport(reportParams);
+
+    expect(report.plugins[0]?.dependencyStatus).toEqual(
+      expect.objectContaining({ requiredInstalled: false, missing: ["missing-runtime"] }),
+    );
+    expect(report.plugins[0]?.status).toBe("error");
   });
 
   it("preserves an existing error diagnostic when dependency health also fails", () => {

--- a/src/plugins/status.registry-snapshot.dependency-health.test.ts
+++ b/src/plugins/status.registry-snapshot.dependency-health.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+// Covers dependency-health projection for bundled-origin plugins in registry snapshots.
+import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { buildPluginRegistrySnapshotReport } from "./status.js";
+import {
+  createColdPluginFixture,
+  createColdPluginHermeticEnv,
+} from "./test-helpers/cold-plugin-fixtures.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+const requireRecord = createRequireRecord("record", "expected-non-array-record");
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function snapshotBundledPluginWithMissingDependency(params: {
+  pluginId: string;
+  bundledDist?: false;
+}) {
+  const tempRoot = makeTrackedTempDir("openclaw-plugin-status-deps", tempDirs);
+  const bundledRoot = path.join(tempRoot, "bundled");
+  const pluginRoot = path.join(bundledRoot, params.pluginId);
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  createColdPluginFixture({
+    rootDir: pluginRoot,
+    pluginId: params.pluginId,
+    packageJson: { dependencies: { "missing-plugin-local-dependency": "1.0.0" } },
+  });
+  if (params.bundledDist === false) {
+    // Source builds compile these plugins into the bundled tree but leave their
+    // dependencies plugin-local, so the bundled origin alone must not hide them.
+    const packageJsonPath = path.join(pluginRoot, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+      openclaw: Record<string, unknown>;
+    };
+    packageJson.openclaw.build = { bundledDist: false };
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), "utf8");
+  }
+  const report = buildPluginRegistrySnapshotReport({
+    config: { plugins: { entries: { [params.pluginId]: { enabled: true } } } },
+    env: createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: bundledRoot }),
+  });
+  const plugin = report.plugins.find((entry) => entry.id === params.pluginId);
+  if (!plugin) {
+    throw new Error(`Expected plugin ${params.pluginId}`);
+  }
+  return { report, plugin: requireRecord(plugin) };
+}
+
+describe("buildPluginRegistrySnapshotReport dependency health", () => {
+  it("does not project package-local dependency health onto bundled plugins", () => {
+    const { report, plugin } = snapshotBundledPluginWithMissingDependency({
+      pluginId: "bundled-demo",
+    });
+
+    expect(plugin).toMatchObject({ origin: "bundled", status: "loaded" });
+    expect(plugin.dependencyStatus).toBeUndefined();
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  it("projects dependency health onto bundled plugins distributed outside the root package", () => {
+    const { report, plugin } = snapshotBundledPluginWithMissingDependency({
+      pluginId: "source-external-demo",
+      bundledDist: false,
+    });
+
+    expect(plugin).toMatchObject({ origin: "bundled", status: "error" });
+    expect(requireRecord(plugin.dependencyStatus)).toMatchObject({
+      requiredInstalled: false,
+      missing: ["missing-plugin-local-dependency"],
+    });
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "source-external-demo",
+        message: expect.stringContaining("required dependencies are missing"),
+      }),
+    );
+  });
+});

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -312,67 +312,6 @@ describe("buildPluginRegistrySnapshotReport", () => {
     );
   });
 
-  it("does not project package-local dependency health onto bundled plugins", () => {
-    const tempRoot = makeTempDir();
-    const bundledRoot = path.join(tempRoot, "bundled");
-    const pluginRoot = path.join(bundledRoot, "bundled-demo");
-    fs.mkdirSync(pluginRoot, { recursive: true });
-    createColdPluginFixture({
-      rootDir: pluginRoot,
-      pluginId: "bundled-demo",
-      packageJson: { dependencies: { "missing-build-time-dependency": "1.0.0" } },
-    });
-
-    const report = buildPluginRegistrySnapshotReport({
-      config: { plugins: { entries: { "bundled-demo": { enabled: true } } } },
-      env: createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: bundledRoot }),
-    });
-    const plugin = requirePlugin(report.plugins, "bundled-demo");
-
-    expectFields(plugin, { origin: "bundled", status: "loaded" });
-    expect(plugin.dependencyStatus).toBeUndefined();
-    expect(report.diagnostics).toEqual([]);
-  });
-
-  it("projects dependency health onto bundled plugins distributed outside the root package", () => {
-    const tempRoot = makeTempDir();
-    const bundledRoot = path.join(tempRoot, "bundled");
-    const pluginRoot = path.join(bundledRoot, "source-external-demo");
-    fs.mkdirSync(pluginRoot, { recursive: true });
-    createColdPluginFixture({
-      rootDir: pluginRoot,
-      pluginId: "source-external-demo",
-      packageJson: { dependencies: { "missing-plugin-local-dependency": "1.0.0" } },
-    });
-    // Source builds compile these plugins into the bundled tree but leave their
-    // dependencies plugin-local, so the bundled origin alone must not hide them.
-    const packageJsonPath = path.join(pluginRoot, "package.json");
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
-      openclaw: Record<string, unknown>;
-    };
-    packageJson.openclaw.build = { bundledDist: false };
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), "utf8");
-
-    const report = buildPluginRegistrySnapshotReport({
-      config: { plugins: { entries: { "source-external-demo": { enabled: true } } } },
-      env: createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: bundledRoot }),
-    });
-    const plugin = requirePlugin(report.plugins, "source-external-demo");
-
-    expectFields(plugin, { origin: "bundled", status: "error" });
-    expect(requireRecord(plugin.dependencyStatus)).toMatchObject({
-      requiredInstalled: false,
-      missing: ["missing-plugin-local-dependency"],
-    });
-    expect(report.diagnostics).toContainEqual(
-      expect.objectContaining({
-        level: "error",
-        pluginId: "source-external-demo",
-        message: expect.stringContaining("required dependencies are missing"),
-      }),
-    );
-  });
-
   it.each([
     { consent: "missing", enabled: true, tracked: true, warns: true },
     { consent: "stale", enabled: true, tracked: true, warns: true },

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -334,6 +334,45 @@ describe("buildPluginRegistrySnapshotReport", () => {
     expect(report.diagnostics).toEqual([]);
   });
 
+  it("projects dependency health onto bundled plugins distributed outside the root package", () => {
+    const tempRoot = makeTempDir();
+    const bundledRoot = path.join(tempRoot, "bundled");
+    const pluginRoot = path.join(bundledRoot, "source-external-demo");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    createColdPluginFixture({
+      rootDir: pluginRoot,
+      pluginId: "source-external-demo",
+      packageJson: { dependencies: { "missing-plugin-local-dependency": "1.0.0" } },
+    });
+    // Source builds compile these plugins into the bundled tree but leave their
+    // dependencies plugin-local, so the bundled origin alone must not hide them.
+    const packageJsonPath = path.join(pluginRoot, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+      openclaw: Record<string, unknown>;
+    };
+    packageJson.openclaw.build = { bundledDist: false };
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), "utf8");
+
+    const report = buildPluginRegistrySnapshotReport({
+      config: { plugins: { entries: { "source-external-demo": { enabled: true } } } },
+      env: createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: bundledRoot }),
+    });
+    const plugin = requirePlugin(report.plugins, "source-external-demo");
+
+    expectFields(plugin, { origin: "bundled", status: "error" });
+    expect(requireRecord(plugin.dependencyStatus)).toMatchObject({
+      requiredInstalled: false,
+      missing: ["missing-plugin-local-dependency"],
+    });
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "source-external-demo",
+        message: expect.stringContaining("required dependencies are missing"),
+      }),
+    );
+  });
+
   it.each([
     { consent: "missing", enabled: true, tracked: true, warns: true },
     { consent: "stale", enabled: true, tracked: true, warns: true },

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -234,6 +234,10 @@ function buildPluginReport(
           workspaceDir,
         };
   const manifestByPluginId = metadataSnapshot.byPluginId;
+  // Runtime records drop package build metadata; the installed index still owns it.
+  const packageBuildByPluginId = new Map(
+    metadataSnapshot.index.plugins.map((plugin) => [plugin.pluginId, plugin.packageBuild]),
+  );
   const config = context.config;
 
   // Apply bundled-provider allowlist compat so that `plugins list` and `doctor`
@@ -330,6 +334,7 @@ function buildPluginReport(
             origin: plugin.origin,
             pluginId: plugin.id,
             packageName: plugin.packageName ?? manifestByPluginId.get(plugin.id)?.packageName,
+            packageBuild: packageBuildByPluginId.get(plugin.id),
           })
             ? buildPluginDependencyStatus({
                 rootDir: plugin.rootDir,

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -23,6 +23,7 @@ import {
 } from "./inspect-shape.js";
 import { loadPluginRegistryHandle, resolveCompatibleRuntimePluginRegistry } from "./loader.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
+import { tracksPluginDependencyStatus } from "./official-external-plugin-repair-hints.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
 import {
   loadPluginMetadataSnapshot,
@@ -325,14 +326,18 @@ function buildPluginReport(
         version: resolveReportedPluginVersion(plugin, params?.env),
         dependencyStatus:
           plugin.dependencyStatus ??
-          (plugin.origin === "bundled"
-            ? undefined
-            : buildPluginDependencyStatus({
+          (tracksPluginDependencyStatus({
+            origin: plugin.origin,
+            pluginId: plugin.id,
+            packageName: plugin.packageName ?? manifestByPluginId.get(plugin.id)?.packageName,
+          })
+            ? buildPluginDependencyStatus({
                 rootDir: plugin.rootDir,
                 dependencies: manifestByPluginId.get(plugin.id)?.packageDependencies,
                 optionalDependencies: manifestByPluginId.get(plugin.id)
                   ?.packageOptionalDependencies,
-              })),
+              })
+            : undefined),
       }),
     ),
   });

--- a/src/skills/loading/plugin-skills.test.ts
+++ b/src/skills/loading/plugin-skills.test.ts
@@ -300,6 +300,50 @@ describe("resolvePluginSkillRoots", () => {
   );
 
   it.each([
+    { channelEnabled: false, expectsSkills: false },
+    { channelEnabled: true, expectsSkills: true },
+  ])(
+    "honors channels.<id>.enabled=$channelEnabled through the manifest channel id when it differs from the plugin id",
+    async ({ channelEnabled, expectsSkills }) => {
+      const workspaceDir = await tempDirs.make("openclaw-");
+      const pluginRoot = await tempDirs.make("openclaw-demo-plugin-");
+      await fs.mkdir(path.join(pluginRoot, "skills"), { recursive: true });
+      // QQ Bot style: plugin `openclaw-demo` owns `channels.demo`; the plugin id alone
+      // cannot resolve that channel key.
+      hoisted.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
+        diagnostics: [],
+        plugins: [
+          {
+            id: "openclaw-demo",
+            name: "Demo",
+            channels: ["demo"],
+            providers: [],
+            cliBackends: [],
+            skills: ["./skills"],
+            hooks: [],
+            origin: "bundled",
+            rootDir: pluginRoot,
+            source: pluginRoot,
+            manifestPath: path.join(pluginRoot, "openclaw.plugin.json"),
+          },
+        ],
+      });
+
+      const roots = resolvePluginSkillRoots({
+        workspaceDir,
+        config: {
+          channels: { demo: { enabled: channelEnabled } },
+          plugins: { entries: { "openclaw-demo": { enabled: true } } },
+        } as OpenClawConfig,
+      });
+
+      expect(roots.map((root) => root.dir)).toEqual(
+        expectsSkills ? [path.resolve(pluginRoot, "skills")] : [],
+      );
+    },
+  );
+
+  it.each([
     {
       name: "keeps acpx plugin skills when ACP runtime is available",
       acpEnabled: true,

--- a/src/skills/loading/plugin-skills.ts
+++ b/src/skills/loading/plugin-skills.ts
@@ -108,6 +108,7 @@ function resolvePluginSkillRootsInOwner(
     const activationState = resolvePolicyPluginActivationState({
       id: record.id,
       origin: record.origin,
+      channelIds: record.channels,
       config: normalizedPlugins,
       rootConfig: config,
       enabledByDefault: record.enabledByDefault,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who turned a channel off with `channels.<id>.enabled: false` still had that channel's plugin loaded by the Gateway and CLI whenever `plugins.entries.<id>.enabled: true` was also present in `openclaw.json`. That is exactly the state `openclaw plugins install @openclaw/<id>` and `openclaw plugins enable <id>` leave behind, so "install the official plugin, later switch the channel off" ends with the plugin still being imported.

On git-built installs of source-external plugins (Discord, Slack) that import surfaced as startup `ERROR` lines every boot: the plugin runtime tree is compiled into `dist/extensions/<id>` but its dependencies are linked back to `extensions/<id>/node_modules`, which an immutable release tree does not carry, so the import failed with `Cannot find module 'discord-api-types/v10'` / `'@slack/web-api'` for a channel the operator had disabled. The error text gave no path to resolve it.

## Why This Change Was Made

Every other activation owner already treated `channels.<id>.enabled: false` as an explicit disable (auto-enable, the Gateway startup plan, channel presence policy, official-external repair targets). The shared plugin activation decision was the one owner that only read the `true` side of that flag. The fix teaches it a closed `channel-disabled-in-config` cause, ordered right after the plugin-entry disable, with the channel-config reader made tri-state so both sides of the flag live in one place.

Separately, plugin status skipped dependency health for every bundled-origin plugin, so a source-external plugin compiled into `dist/extensions/<id>` without its plugin-local `node_modules` never showed the typed "required dependencies are missing" state in `plugins list`, `status`, or `doctor`. That gate is narrowed: bundled plugins distributed outside the root package now get dependency status like external installs. And when such a plugin still fails to import because a module is missing, the loader error names the enablement path (`openclaw plugins install <spec>` or `openclaw doctor --fix`) at both loader failure sites, so `status`/`doctor` tell operators what to do next instead of dead-ending on a raw Node error.

Also aligns one stale repair-hint test with the npm-first install ordering from #134490; it was failing on `main` before this change.

Non-goal: the git-built dependency link itself (`dist/extensions/<id>/node_modules -> ../../../extensions/<id>/node_modules` assumes plugin-local deps exist at runtime) is a packaging decision and is called out as a follow-up, not changed here.

## User Impact

- `channels.<id>.enabled: false` now reliably keeps that channel's plugin from loading, regardless of `plugins.entries.<id>.enabled`. `openclaw plugins list` reports it as `disabled` with reason `channel disabled in config`.
- Operators whose externally distributed plugin cannot import a dependency get an actionable error naming the install command instead of a bare `Cannot find module`.

## Evidence

Regression tests fail on pre-fix code and pass after:

- `src/plugins/config-state.test.ts` — decision-level: bundled channel plugin with `channels.<id>.enabled: false` + `plugins.entries.<id>.enabled: true` resolves `disabled` / `channel disabled in config` (pre-fix: enabled).
- `src/plugins/loader.test.ts` — loader-level with the bundled telegram fixture: pre-fix `status: "loaded"`, post-fix `status: "disabled"`, no module import.
- `src/plugins/loader-records.test.ts` — missing-module failure on a source-external plugin carries the install/doctor hint; unrelated failures and non-external plugins do not.

Focused suites green: config-state (55), loader (184), config-policy, plugin-policy-id, activation-planner, channel-plugin-ids, loader-records, official-external-plugin-repair-hints.

Live, rebuilt CLI on an isolated `OPENCLAW_STATE_DIR` with `plugins.entries.{discord,slack}.enabled: true` and `channels.{discord,slack}.enabled: false`:

```
before: {'id': 'discord', 'status': 'loaded', 'enabled': True}
        {'id': 'slack',   'status': 'loaded', 'enabled': True}
after:  {'id': 'discord', 'status': 'disabled', 'enabled': False}
        {'id': 'slack',   'status': 'disabled', 'enabled': False}
```

`node scripts/check-changed.mjs` exit 0 (format, lint, typecheck lanes, import cycles). Codex autoreview on the diff: scoped-clean, no findings.

Production LOC: +240/-61 (net +179) across the fix commits | Tests: +372/-7 plus two new test files (one is a split of the oversized status snapshot suite). Growth is the closed activation cause with manifest-owned channel ids, the tri-state cache fingerprint, the narrowed dependency-status gate (snapshot and runtime), guarded error classification, and the typed enablement-path hint; no guards-on-symptoms or fallbacks. The growth is one closed activation cause, the tri-state cache fingerprint, the narrowed dependency-status gate, and the typed enablement-path hint; no guards or fallbacks.

Follow-up commit (review findings from ClawSweeper):

- Registry cache key now fingerprints both sides of `channels.<id>.enabled`; `src/plugins/loader-cache.test.ts` fails pre-fix (absent and `enabled: false` produced the same key).
- `recordPluginError` survives a throwing `cause` accessor; `loader-records.test.ts` fails pre-fix with `cause exploded` escaping the loader.
- Dependency health for externally distributed bundled plugins; `status.registry-snapshot.test.ts` and `status.dependency-health.test.ts` fail pre-fix (`dependencyStatus` undefined, status `loaded`).
- The installed-index enablement check (`isInstalledPluginEnabled`) and Gateway `plugins.list` diagnostics use the same channel ids and dependency-status gate; `installed-plugin-index.test.ts` and `management-service.test.ts` regressions fail pre-fix.
- Every activation consumer with a manifest or installed-index record in scope (skills, hooks, embedded settings, startup planning, presence policy, index writes, provider inventory, public-surface access, validation) now passes its channel ids, so a renamed-channel plugin honors the disable everywhere, not only in the loaders; `plugin-skills.test.ts` (bundled `openclaw-demo` owning `channels.demo`) fails pre-fix. Id-only callers keep the built-in catalog mapping.
- Manifest-owned channel ids reach the activation decision from both loaders, so a plugin whose id differs from its channel key (QQ Bot: `openclaw-qqbot` owning `channels.qqbot`) honors the disable; `config-state.test.ts` and `loader.test.ts` fail pre-fix.
- Runtime status carries the installed index's `packageBuild`, so a generic source-external bundled plugin (no official catalog entry) reports missing dependencies in `status`/`doctor`; `status.dependency-health.test.ts` fails pre-fix.
- Nested error-code reads in the missing-module classifier are guarded; a throwing `code` getter on a nested cause no longer escapes the loader; `loader-records.test.ts` fails pre-fix.
- The install hint resolves the official catalog entry by package name and requires canonical-id equality, so a foreign `bundledDist: false` package reusing an official id gets a generic reinstall hint instead of `openclaw plugins install @openclaw/<id>`; `official-external-plugin-repair-hints.test.ts` fails pre-fix.

Real after-fix missing-module run (isolated gateway, `OPENCLAW_STATE_DIR` under the scratchpad, a copy of the built Discord plugin placed outside the checkout with no `node_modules`, loaded through `plugins.load.paths`; paths redacted):

```
[plugins] discord failed to load from <fixture>/ext-discord/index.js: runtime dependencies are missing for externally distributed plugin Discord; Install the official external plugin with: openclaw plugins install @openclaw/discord, or run: openclaw doctor --fix. (Error: Cannot find module 'discord-api-types/v10' ...
[plugins] 1 plugin(s) failed to initialize (load: discord). Run 'openclaw plugins inspect <id> --runtime --json' ...
[gateway] http server listening (1 plugin: memory-core; 20.7s)
```

`openclaw plugins list --json` on the same fixture reports the plugin as `status: "error"` with `Plugin "discord" cannot load because required dependencies are missing: @discord/embedded-app-sdk, @discordjs/voice, discord-api-types, ...` before any import.
