### PR TITLE
fix(backup): stop failing backups on ACPX-generated codex-home symlinks

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -10,11 +10,6 @@
       "disposition": "regenerable",
       "scope": "state",
       "relativePath": "acpx/codex-home/.tmp/plugins"
-    },
-    {
-      "disposition": "regenerable",
-      "scope": "state",
-      "relativePath": "acpx/codex-home/.tmp/bundled-marketplaces"
     }
   ],
   "doctorContract": {

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -1,5 +1,22 @@
 {
   "id": "acpx",
+  "backupResources": [
+    {
+      "disposition": "regenerable",
+      "scope": "state",
+      "relativePath": "acpx/codex-home/tmp/arg0"
+    },
+    {
+      "disposition": "regenerable",
+      "scope": "state",
+      "relativePath": "acpx/codex-home/.tmp/plugins"
+    },
+    {
+      "disposition": "regenerable",
+      "scope": "state",
+      "relativePath": "acpx/codex-home/.tmp/bundled-marketplaces"
+    }
+  ],
   "doctorContract": {
     "configRepair": true,
     "stateMigrations": true

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -528,11 +528,14 @@ describe("prepareAcpxCodexAuthConfig", () => {
       resolveInstalledClaudeAcpBinPath: async () => installedBinPath,
     });
 
+    const env = { ...process.env };
+    delete env.CODEX_HOME;
     const { stdout } = await execFileAsync(
       process.execPath,
       [generated.wrapperPath, "--permission-mode", "bypass"],
       {
         cwd: root,
+        env,
       },
     );
     const launched = JSON.parse(stdout.trim()) as { argv?: unknown; codexHome?: unknown };

--- a/extensions/acpx/src/manifest.test.ts
+++ b/extensions/acpx/src/manifest.test.ts
@@ -12,9 +12,21 @@ type AcpxPackageManifest = {
   };
 };
 
+type AcpxPluginManifest = {
+  backupResources?: Array<{
+    disposition: string;
+    scope: string;
+    relativePath: string;
+  }>;
+};
+
 const packageJson = JSON.parse(
   fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 ) as AcpxPackageManifest;
+
+const pluginJson = JSON.parse(
+  fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+) as AcpxPluginManifest;
 
 describe("acpx package manifest", () => {
   it("keeps runtime dependencies in the package manifest", () => {
@@ -43,5 +55,31 @@ describe("acpx package manifest", () => {
       "@openai/codex-win32-x64",
       "@openai/codex-win32-arm64",
     ]);
+  });
+
+  it("declares ACPX-written codex-home scratch state as regenerable backup resources", () => {
+    expect(pluginJson.backupResources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          disposition: "regenerable",
+          scope: "state",
+          relativePath: "acpx/codex-home/tmp/arg0",
+        }),
+        expect.objectContaining({
+          disposition: "regenerable",
+          scope: "state",
+          relativePath: "acpx/codex-home/.tmp/plugins",
+        }),
+        expect.objectContaining({
+          disposition: "regenerable",
+          scope: "state",
+          relativePath: "acpx/codex-home/.tmp/bundled-marketplaces",
+        }),
+      ]),
+    );
+    for (const resource of pluginJson.backupResources ?? []) {
+      expect(resource.scope).toBe("state");
+      expect(resource.relativePath.startsWith("acpx/")).toBe(true);
+    }
   });
 });

--- a/extensions/acpx/src/manifest.test.ts
+++ b/extensions/acpx/src/manifest.test.ts
@@ -58,28 +58,17 @@ describe("acpx package manifest", () => {
   });
 
   it("declares ACPX-written codex-home scratch state as regenerable backup resources", () => {
-    expect(pluginJson.backupResources).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          disposition: "regenerable",
-          scope: "state",
-          relativePath: "acpx/codex-home/tmp/arg0",
-        }),
-        expect.objectContaining({
-          disposition: "regenerable",
-          scope: "state",
-          relativePath: "acpx/codex-home/.tmp/plugins",
-        }),
-        expect.objectContaining({
-          disposition: "regenerable",
-          scope: "state",
-          relativePath: "acpx/codex-home/.tmp/bundled-marketplaces",
-        }),
-      ]),
-    );
-    for (const resource of pluginJson.backupResources ?? []) {
-      expect(resource.scope).toBe("state");
-      expect(resource.relativePath.startsWith("acpx/")).toBe(true);
-    }
+    expect(pluginJson.backupResources).toStrictEqual([
+      {
+        disposition: "regenerable",
+        scope: "state",
+        relativePath: "acpx/codex-home/tmp/arg0",
+      },
+      {
+        disposition: "regenerable",
+        scope: "state",
+        relativePath: "acpx/codex-home/.tmp/plugins",
+      },
+    ]);
   });
 });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1259,6 +1259,82 @@ describe("createBackupArchive", () => {
     );
   });
 
+  it("keeps ACPX codex-home scratch symlinks out of the archive via the real acpx manifest", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-acpx-regenerable-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const acpxRoot = state.statePath("acpx");
+        const codexHome = path.join(acpxRoot, "codex-home");
+        const arg0Root = path.join(codexHome, "tmp", "arg0");
+        const arg0Session = path.join(arg0Root, "codex-arg0gJpCMD");
+        await fs.mkdir(arg0Session, { recursive: true });
+        await fs.mkdir(path.join(codexHome, ".tmp", "plugins"), { recursive: true });
+        await fs.writeFile(
+          path.join(codexHome, "config.toml"),
+          "# regenerated isolated codex home config\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(acpxRoot, "codex-acp-wrapper.mjs"),
+          "// regenerated wrapper script\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(arg0Session, "apply_patch"),
+          "placeholder when symlinks are unsupported\n",
+          "utf8",
+        );
+        if (process.platform !== "win32") {
+          // The codex-acp adapter recreates these argv0 symlinks pointing at
+          // the absolute installed binary path on every launch.
+          await fs.rm(path.join(arg0Session, "apply_patch"));
+          await fs.symlink(
+            "/opt/homebrew/lib/node_modules/@openclaw/acpx/node_modules/@zed-industries/codex-acp-linux-x64/bin/codex-acp",
+            path.join(arg0Session, "apply_patch"),
+          );
+        }
+        await state.writeConfig({
+          plugins: {
+            load: { paths: [path.resolve("extensions/acpx")] },
+            entries: { acpx: { enabled: true } },
+          },
+        });
+
+        const result = await createBackupArchive({
+          output: state.path("acpx-backup.tar.gz"),
+          includeWorkspace: false,
+        });
+        const entries = await listArchiveEntries(result.archivePath);
+
+        // Durable ACPX state stays in the archive.
+        expect(entries.some((entry) => entry.endsWith("/state/acpx/codex-home/config.toml"))).toBe(
+          true,
+        );
+        expect(entries.some((entry) => entry.endsWith("/state/acpx/codex-acp-wrapper.mjs"))).toBe(
+          true,
+        );
+        // Regenerable codex-home scratch (arg0 symlinks, plugin caches) is
+        // excluded before traversal, so the portable-archive symlink guard
+        // never sees the absolute adapter links.
+        expect(entries.some((entry) => entry.includes("/codex-home/tmp/arg0/"))).toBe(false);
+        expect(entries.some((entry) => entry.includes("/codex-home/.tmp/plugins/"))).toBe(false);
+        expect(result.skipped).toContainEqual(
+          expect.objectContaining({ sourcePath: arg0Root, reason: "regenerable" }),
+        );
+        expect(result.skipped).toContainEqual(
+          expect.objectContaining({
+            sourcePath: path.join(codexHome, ".tmp", "plugins"),
+            reason: "regenerable",
+          }),
+        );
+      },
+    );
+  });
+
   it("falls back when injected nowMs is outside Date range", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1270,17 +1270,19 @@ describe("createBackupArchive", () => {
         const acpxRoot = state.statePath("acpx");
         const codexHome = path.join(acpxRoot, "codex-home");
         const arg0Root = path.join(codexHome, "tmp", "arg0");
-        const arg0Session = path.join(arg0Root, "codex-arg0gJpCMD");
+        const arg0Session = path.join(arg0Root, "codex-arg0-session");
         await fs.mkdir(arg0Session, { recursive: true });
         await fs.mkdir(path.join(codexHome, ".tmp", "plugins"), { recursive: true });
+        await fs.writeFile(path.join(codexHome, ".tmp", "plugins", "README.md"), "cache\n");
         await fs.writeFile(
           path.join(codexHome, "config.toml"),
-          "# regenerated isolated codex home config\n",
+          "# isolated codex home config\n",
           "utf8",
         );
+        await fs.writeFile(path.join(codexHome, "user-state.txt"), "keep\n", "utf8");
         await fs.writeFile(
           path.join(acpxRoot, "codex-acp-wrapper.mjs"),
-          "// regenerated wrapper script\n",
+          "// wrapper script\n",
           "utf8",
         );
         await fs.writeFile(
@@ -1289,13 +1291,9 @@ describe("createBackupArchive", () => {
           "utf8",
         );
         if (process.platform !== "win32") {
-          // The codex-acp adapter recreates these argv0 symlinks pointing at
-          // the absolute installed binary path on every launch.
+          // Codex creates argv0 aliases as absolute links to its installed binary.
           await fs.rm(path.join(arg0Session, "apply_patch"));
-          await fs.symlink(
-            "/opt/homebrew/lib/node_modules/@openclaw/acpx/node_modules/@zed-industries/codex-acp-linux-x64/bin/codex-acp",
-            path.join(arg0Session, "apply_patch"),
-          );
+          await fs.symlink("/opt/codex/bin/codex", path.join(arg0Session, "apply_patch"));
         }
         await state.writeConfig({
           plugins: {
@@ -1310,10 +1308,13 @@ describe("createBackupArchive", () => {
         });
         const entries = await listArchiveEntries(result.archivePath);
 
-        // Durable ACPX state stays in the archive.
+        // Adjacent ACPX state stays in the archive.
         expect(entries.some((entry) => entry.endsWith("/state/acpx/codex-home/config.toml"))).toBe(
           true,
         );
+        expect(
+          entries.some((entry) => entry.endsWith("/state/acpx/codex-home/user-state.txt")),
+        ).toBe(true);
         expect(entries.some((entry) => entry.endsWith("/state/acpx/codex-acp-wrapper.mjs"))).toBe(
           true,
         );
@@ -1331,6 +1332,7 @@ describe("createBackupArchive", () => {
             reason: "regenerable",
           }),
         );
+        await expect(verifyBackupArchive(result.archivePath)).resolves.toMatchObject({ ok: true });
       },
     );
   });

--- a/src/plugins/manifest-backup-resources.test.ts
+++ b/src/plugins/manifest-backup-resources.test.ts
@@ -143,6 +143,7 @@ describe("plugin manifest backup resources", () => {
     });
     const config: OpenClawConfig = {
       plugins: {
+        allow: [enabled.id, disabled.id],
         load: { paths: [enabled.pluginRoot, disabled.pluginRoot] },
         entries: {
           [enabled.id]: { enabled: true },
@@ -197,9 +198,12 @@ describe("plugin manifest backup resources", () => {
         workspace: true,
         backupResources: [{ disposition: "include", scope: "state", relativePath: "../outside" }],
       });
-      const config: OpenClawConfig = activated
-        ? { plugins: { entries: { [fixture.id]: { enabled: true } } } }
-        : {};
+      const config: OpenClawConfig = {
+        plugins: {
+          allow: [fixture.id],
+          entries: { [fixture.id]: { enabled: activated } },
+        },
+      };
       const resolveInventory = () =>
         resolveActivatedPluginBackupInventory({
           config,


### PR DESCRIPTION
## What Problem This Solves

`openclaw backup create --verify` fails after writing its temporary archive when ACPX has left Codex argv0 helper links under `state/acpx/codex-home/tmp/arg0`. Codex creates those links as absolute paths to its installed binary, while OpenClaw correctly rejects arbitrary absolute links from portable backups.

## Why This Change Was Made

ACPX owns the isolated Codex home under the OpenClaw state directory. Its plugin manifest now declares the two scratch roots that the pinned ACPX/Codex runtime demonstrably recreates:

- `acpx/codex-home/tmp/arg0`
- `acpx/codex-home/.tmp/plugins`

Backup planning skips these roots before tar traversal. The shared archive validator remains strict for user data and every other absolute or escaping link. Adjacent ACPX and Codex state stays in the archive.

The native Codex plugin also owns a Computer Use marketplace cache. ACPX does not materialize that cache, so this change does not declare it for ACPX.

## User Impact

Operators who used the bundled ACPX runtime can create and verify portable backups without removing Codex-generated links by hand. Other absolute links still fail closed with the existing actionable error.

## Evidence

- RED on current `main` `69cc88a9583efa264e6320a4311c1813c41ed41d`: a real `acpx@0.13.1` -> `@agentclientprotocol/codex-acp@1.6.2` -> `@openai/codex@0.151.0` process created four absolute links under `tmp/arg0`; `openclaw backup create --verify --no-include-workspace` exited 1 with `Archive symbolic link target must be relative` and did not publish the requested archive.
- Causality probe: after stopping the task-owned adapter and removing only its stale argv0 session directory, the same current-main command returned `verified: true`.
- GREEN on `b58f258b3251581bab1f4a089cb04b46d30bd261`: the same real ACPX state, with a live Codex adapter and the absolute links present, returned `verified: true`. The result reported both owner roots as `regenerable` and retained `codex-home/config.toml` plus the ACPX wrapper.
- Codex contract: [`rust-v0.151.0` creates `CODEX_HOME/tmp/arg0/codex-arg0*` and Unix aliases to `current_exe`](https://github.com/openai/codex/blob/d8673cb68e349c208659b986697773d3145dbb14/codex-rs/arg0/src/lib.rs#L325-L401).
- `node scripts/run-vitest.mjs extensions/acpx/src/manifest.test.ts src/infra/backup-create.test.ts` — 97 passed.
- `node scripts/run-vitest.mjs src/plugins/manifest-backup-resources.test.ts` — 23 passed.
- `node scripts/run-vitest.mjs src/commands/backup-verify.test.ts` — 47 passed, 1 platform skip.
- `node scripts/run-vitest.mjs extensions/acpx/src/codex-auth-bridge.test.ts` — 22 passed.
- Format, targeted lint, conflict-marker, max-lines, assertion-safety, plugin-boundary, manifest-metadata, wrapper-shadowing, and coercion gates passed.
- Local type-check and build were intentionally left to CI under the maintainer host policy.

Fixes #136159
