### PR TITLE
refactor(ui): simplify shared message rendering

### DIFF
--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -43,10 +43,7 @@ async function expectDecodedThumbnail(image: Locator, expectedNaturalWidth?: num
   await image.scrollIntoViewIfNeeded();
   await expect
     .poll(() =>
-      image.evaluate(async (element, expectedWidth) => {
-        if (!(element instanceof HTMLImageElement)) {
-          return false;
-        }
+      image.evaluate(async (element: HTMLImageElement, expectedWidth) => {
         await element.decode();
         const bounds = element.getBoundingClientRect();
         return (

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -6,6 +6,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { icons, type IconName } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
+import type { MarkdownRenderOptions } from "../../../components/markdown-render-options.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { t } from "../../../i18n/index.ts";
 import type { BoardProvider } from "../../../lib/board/provider.ts";
@@ -50,7 +51,6 @@ import {
   renderMessageJson,
   renderMessageMarkdown,
   resolveMessageDisplayMarkdown,
-  resolveMessageMarkdownRenderOptions,
   type AssistantMessageDisclosure,
 } from "./chat-message-text.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
@@ -289,12 +289,16 @@ export function renderGroupedMessage(
   const markdown =
     (normalizedRole === "user" ? opts.messageActions?.markdown : undefined) ??
     (displayMarkdown || null);
-  const markdownRenderOptions = resolveMessageMarkdownRenderOptions({
-    role,
-    isStreaming: opts.isStreaming,
+  const markdownRenderOptions: MarkdownRenderOptions = {
+    assistantTranscriptRoleHeaders: role === "assistant",
+    codeBlockChrome: role === "user" ? "none" : "copy",
+    codeBlockInteraction: role === "assistant" ? "interactive" : "static",
+    fileLinks: true,
     interactiveImages: opts.onOpenImage !== undefined,
-    linkFavicons: Boolean(opts.fetchLinkFavicon),
-  });
+    sessionLinks: true,
+    tableInteractions: "enabled",
+    linkFavicons: Boolean(opts.fetchLinkFavicon) && !opts.isStreaming,
+  };
 
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;

--- a/ui/src/pages/chat/components/chat-message-text.ts
+++ b/ui/src/pages/chat/components/chat-message-text.ts
@@ -17,17 +17,12 @@ type DuplicateSuffix = {
   label: string;
 };
 
+// Bound synchronous parsing so large JSON messages cannot freeze the render loop.
 const MAX_JSON_AUTOPARSE_CHARS = 20_000;
 
-/**
- * Detect whether a trimmed string is a JSON object or array.
- * Must start with `{`/`[` and end with `}`/`]` and parse successfully.
- * Size-capped to prevent render-loop DoS from large JSON messages.
- */
 export function detectJson(text: string): { parsed: unknown; text: string } | null {
   const trimmed = text.trim();
 
-  // Enforce size cap to prevent UI freeze from multi-MB JSON payloads
   if (trimmed.length > MAX_JSON_AUTOPARSE_CHARS) {
     return null;
   }
@@ -47,7 +42,6 @@ export function detectJson(text: string): { parsed: unknown; text: string } | nu
   return null;
 }
 
-/** Build a short summary label for collapsed JSON (type + key count or array length). */
 function jsonSummaryLabel(parsed: unknown): string {
   if (Array.isArray(parsed)) {
     return t(
@@ -93,24 +87,6 @@ export function resolveMessageDisplayMarkdown(
   return normalizeRoleForGrouping(normalizedMessage.role) === "assistant"
     ? stripThinkingTags(markdown).trim()
     : markdown.trim();
-}
-
-export function resolveMessageMarkdownRenderOptions(options: {
-  role: string;
-  isStreaming?: boolean;
-  interactiveImages?: boolean;
-  linkFavicons?: boolean;
-}): MarkdownRenderOptions {
-  return {
-    assistantTranscriptRoleHeaders: options.role === "assistant",
-    codeBlockChrome: options.role === "user" ? "none" : "copy",
-    codeBlockInteraction: options.role === "assistant" ? "interactive" : "static",
-    fileLinks: true,
-    interactiveImages: Boolean(options.interactiveImages),
-    sessionLinks: true,
-    tableInteractions: "enabled",
-    linkFavicons: Boolean(options.linkFavicons) && !options.isStreaming,
-  };
 }
 
 // Character length owns normal disclosure; this high line cap only bounds newline-heavy prompts.


### PR DESCRIPTION
Related: #136069 (instant new-session text and image previews).

## What Problem This Solves

Maintainer-requested cleanup after the instant-send fix. Remove a Chat-only Markdown options builder with one caller, repeated parsing comments, and a redundant image-test type guard.

## Why This Change Was Made

Keep Chat's exact Markdown policy at its sole caller, while shared text presentation remains reusable by New Session. Raw-role behavior, streaming favicon suppression, bounded JSON parsing, and original JSON bytes are unchanged. The typed Playwright callback retains image decoding, visibility, exact-width, pixel-continuity, and node-identity assertions from #136072.

## User Impact

No intentional behavior or visual change. Immediate pending text/images, passive pending Markdown, accepted-session controls, failure recovery, and reconnect ownership remain intact. No Gateway, protocol, storage, dependency, or operator configuration changes.

## Evidence

Final head: `3ae47b8a257f86f4b35352d86ebf622320245534`, based on `13dd7d2e2dc15f80ec8ceb6f107da85bb56eb24c`. Three files: production **+11/-31 (net -20)**; tests **+1/-4 (net -3)**.

- **453 focused unit tests passed** on this head: rendering, Markdown options, JSON source bytes, attachments, image handoff, snapshot hydration, pending inputs, and history.
- **15 browser cases passed** on a fresh canonical bundle, covering delayed creation, decoded images, rejection/retry, reload/reconnect, accepted Chat controls, Inbox scope, and delayed canonical-media handoff. A separate fresh baseline passed the image rejection/retry case.
- UI and UI-test types, changed-file formatting, lint, and style checks passed. Direct inspection of Playwright 1.62.1 confirms the typed async element callback is supported.
- Fresh Codex autoreview was scoped-clean at the configured P0 threshold. Main's stronger image assertions are retained, addressing ClawSweeper's latest rank-up request. Exact-head CI is green.

The earlier CI failures are now repaired upstream: #135671 owns the Inbox route-readiness fix; #136232 fetches scan history during authenticated checkout. Both duplicate fixes were dropped from this PR. The upstream checkout/range checks also passed locally.

[Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33621750972) passed.

This follow-up uses a real Chromium browser with a mocked Gateway. The original fix's real-Gateway/image-provider evidence remains in #136069; no new live-provider claim is made.

## Before / After

All captures contain inspected synthetic data only. Fresh final-head and baseline captures confirm the views below: accepted views and pending-before match the published bytes; pending-after differs only in the animated Starting icon. Submitted text, image, and layout are unchanged.

| State | Before | After |
| --- | --- | --- |
| Pending prompt and decoded image | ![Pending before](https://github.com/user-attachments/assets/1d9bbcee-0a7b-4e5e-bd0d-c64e37b80cf3) | ![Pending after](https://github.com/user-attachments/assets/fe7f930e-6da8-4fd1-950b-751a6882702e) |
| Accepted Chat with Markdown controls | ![Accepted Chat before](https://github.com/user-attachments/assets/031c298f-9ca6-4145-acd1-2c6aaf5ce80c) | ![Accepted Chat after](https://github.com/user-attachments/assets/855083f6-9607-4287-8f3d-3032a2f4701a) |
