### PR TITLE
improve(github): publication options load without re-verifying GitHub credentials on every session switch

### DIFF
--- a/src/agents/github-managed-credential.test.ts
+++ b/src/agents/github-managed-credential.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { clearGitHubCredentialVerificationCache } from "./github-oauth-client.js";
 
 const commands = vi.hoisted(() => ({ run: vi.fn() }));
 vi.mock("../process/exec.js", () => ({ runCommandBuffered: commands.run }));
@@ -33,6 +34,8 @@ const result = (stdout = "") => ({
 
 describe("managed credential isolation", () => {
   beforeEach(() => {
+    // Cases reuse token literals with different verification responses.
+    clearGitHubCredentialVerificationCache();
     commands.run.mockReset().mockImplementation(async () => {
       throw new Error("Unexpected subprocess at the managed credential boundary");
     });

--- a/src/agents/github-oauth-client.test.ts
+++ b/src/agents/github-oauth-client.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { redactRegisteredSecretValues } from "../logging/secret-redaction-registry.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
+  clearGitHubCredentialVerificationCache,
   pollGitHubOAuthDeviceToken,
   refreshGitHubOAuthToken,
   requestGitHubOAuthDeviceCode,
@@ -10,6 +12,7 @@ import {
 const GITHUB_OAUTH_CLIENT_ID = "Ov23liUjOXHi28w2fDlH";
 const GITHUB_OAUTH_DEVICE_CODE_URL = "https://github.com/login/device/code";
 const GITHUB_OAUTH_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const GITHUB_CREDENTIAL_VERIFICATION_TTL_MS = 60_000;
 
 const DEVICE_CODE = "a".repeat(40);
 
@@ -58,7 +61,7 @@ describe("GitHub OAuth client", () => {
   it.each(["managed-user", "managed-user_org"])(
     "verifies the supplied %s credential at a fixed origin and registers redaction",
     async (login) => {
-      const token = "synthetic-bound-credential";
+      const token = `synthetic-bound-credential-${login}`;
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -89,6 +92,131 @@ describe("GitHub OAuth client", () => {
     },
   );
 
+  it("reuses a verified account within the TTL and re-probes after it", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const probe = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => jsonResponse({ id: 202, login: "ttl-user" }));
+    const first = await verifyGitHubCredential("synthetic-ttl-token");
+    expect(first.status).toBe("available");
+    const second = await verifyGitHubCredential("synthetic-ttl-token");
+    expect(probe).toHaveBeenCalledOnce();
+    expect(second).toBe(first);
+    expect(Object.isFrozen(first)).toBe(true);
+    if (first.status === "available") {
+      expect(Object.isFrozen(first.account)).toBe(true);
+      expect(Object.isFrozen(first.scopes)).toBe(true);
+    }
+
+    now.mockReturnValue(1_000 + GITHUB_CREDENTIAL_VERIFICATION_TTL_MS + 1);
+    expect(await verifyGitHubCredential("synthetic-ttl-token")).toEqual(first);
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-probes a remotely revoked token after expiry without caching its rejection", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(2_000);
+    const probe = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ id: 202, login: "revoked-user" }))
+      .mockImplementation(async () => jsonResponse({}, 401));
+    expect((await verifyGitHubCredential("synthetic-revoked-token")).status).toBe("available");
+    now.mockReturnValue(2_000 + GITHUB_CREDENTIAL_VERIFICATION_TTL_MS + 1);
+    expect(await verifyGitHubCredential("synthetic-revoked-token")).toEqual({
+      status: "unavailable",
+    });
+    expect(await verifyGitHubCredential("synthetic-revoked-token")).toEqual({
+      status: "unavailable",
+    });
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it("re-probes an unavailable credential immediately so reconnects recover", async () => {
+    const probe = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({}, 401))
+      .mockResolvedValueOnce(jsonResponse({ id: 202, login: "recovered-user" }));
+    expect(await verifyGitHubCredential("synthetic-recovered-token")).toEqual({
+      status: "unavailable",
+    });
+    expect(await verifyGitHubCredential("synthetic-recovered-token")).toMatchObject({
+      status: "available",
+      account: { login: "recovered-user" },
+    });
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps different tokens separate while sharing concurrent probes for one token", async () => {
+    const probe = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (_url, init) =>
+        jsonResponse({ id: 202, login: new Headers(init?.headers).get("Authorization") }),
+      );
+    const [first, concurrent, other] = await Promise.all([
+      verifyGitHubCredential("synthetic-concurrent-a"),
+      verifyGitHubCredential("synthetic-concurrent-a"),
+      verifyGitHubCredential("synthetic-concurrent-b"),
+    ]);
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(concurrent).toBe(first);
+    expect(other).not.toEqual(first);
+    expect(await verifyGitHubCredential("synthetic-concurrent-b")).toBe(other);
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("clearing verified credentials forces a re-probe", async () => {
+    const probe = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => jsonResponse({ id: 202, login: "cleared-user" }));
+    await verifyGitHubCredential("synthetic-cleared-token");
+    clearGitHubCredentialVerificationCache();
+    await verifyGitHubCredential("synthetic-cleared-token");
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["signal", "timeout"] as const)(
+    "keeps caller-specific %s probes independent but cacheable",
+    async (kind) => {
+      const token = `synthetic-independent-${kind}`;
+      const options =
+        kind === "signal" ? { signal: new AbortController().signal } : { timeoutMs: 1_000 };
+      const probe = vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async () => jsonResponse({ id: 202, login: "independent-user" }));
+      await Promise.all([verifyGitHubCredential(token, options), verifyGitHubCredential(token)]);
+      expect(probe).toHaveBeenCalledTimes(2);
+      expect((await verifyGitHubCredential(token, options)).status).toBe("available");
+      expect(probe).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("bounds verified entries and re-probes an evicted credential", async () => {
+    const probe = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => jsonResponse({ id: 202, login: "bounded-user" }));
+    for (let index = 0; index < 33; index++) {
+      await verifyGitHubCredential(`synthetic-bounded-${index}`);
+    }
+    await verifyGitHubCredential("synthetic-bounded-32");
+    expect(probe).toHaveBeenCalledTimes(33);
+    await verifyGitHubCredential("synthetic-bounded-0");
+    expect(probe).toHaveBeenCalledTimes(34);
+  });
+
+  it("does not let an in-flight probe repopulate cleared verification state", async () => {
+    const upstream = createDeferredCore<Response>();
+    const probe = vi
+      .spyOn(globalThis, "fetch")
+      .mockReturnValueOnce(upstream.promise)
+      .mockImplementation(async () => jsonResponse({ id: 202, login: "after-clear" }));
+    const first = verifyGitHubCredential("synthetic-inflight-clear");
+    clearGitHubCredentialVerificationCache();
+    const second = await verifyGitHubCredential("synthetic-inflight-clear");
+    upstream.resolve(jsonResponse({ id: 202, login: "before-clear" }));
+    await first;
+    expect(await verifyGitHubCredential("synthetic-inflight-clear")).toBe(second);
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
   it.each([
     { code: 401, headers: new Headers(), status: "unavailable" },
     { code: 403, headers: new Headers({ "x-ratelimit-remaining": "0" }), status: "rate_limited" },
@@ -102,24 +230,31 @@ describe("GitHub OAuth client", () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response("synthetic-secret-diagnostics", { status: code, headers }),
       );
-      expect(await verifyGitHubCredential("synthetic-token")).toEqual({ status });
+      const token = `synthetic-http-${code}-${status}-${headers.get("retry-after") ?? headers.get("x-ratelimit-remaining") ?? "none"}`;
+      expect(await verifyGitHubCredential(token)).toEqual({ status });
     },
   );
 
   it.each([
-    "not-json synthetic-token",
-    JSON.stringify({ id: 202, login: "x".repeat(101) }),
-    JSON.stringify({ id: "202", login: "managed-user" }),
-    JSON.stringify({ id: 202, login: "managed-user", padding: "x".repeat(17000) }),
-  ])("rejects malformed or unbounded account responses without diagnostics", async (body) => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body));
-    expect(await verifyGitHubCredential("synthetic-token")).toEqual({ status: "unverified" });
-  });
+    ["invalid-json", "not-json synthetic-token"],
+    ["long-login", JSON.stringify({ id: 202, login: "x".repeat(101) })],
+    ["invalid-id", JSON.stringify({ id: "202", login: "managed-user" })],
+    [
+      "oversized-body",
+      JSON.stringify({ id: 202, login: "managed-user", padding: "x".repeat(17000) }),
+    ],
+  ])(
+    "rejects malformed or unbounded %s account responses without diagnostics",
+    async (name, body) => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body));
+      expect(await verifyGitHubCredential(`synthetic-${name}`)).toEqual({ status: "unverified" });
+    },
+  );
 
   it("bounds the account body read and sanitizes network and cancellation errors", async () => {
     const cancel = vi.fn();
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new ReadableStream({ cancel })));
-    expect(await verifyGitHubCredential("synthetic-token", { timeoutMs: 10 })).toEqual({
+    expect(await verifyGitHubCredential("synthetic-body-timeout", { timeoutMs: 10 })).toEqual({
       status: "unverified",
     });
     expect(cancel).toHaveBeenCalled();
@@ -129,7 +264,9 @@ describe("GitHub OAuth client", () => {
       expect(init?.signal?.aborted).toBe(true);
       throw init?.signal?.reason;
     });
-    expect(await verifyGitHubCredential("synthetic-token", { signal: caller.signal })).toEqual({
+    expect(
+      await verifyGitHubCredential("synthetic-cancellation", { signal: caller.signal }),
+    ).toEqual({
       status: "unverified",
     });
   });

--- a/src/agents/github-oauth-client.ts
+++ b/src/agents/github-oauth-client.ts
@@ -1,7 +1,10 @@
+import { createHash } from "node:crypto";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { readResponseWithLimit } from "../infra/http-body.js";
+import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import type { GitHubToolAccount } from "./github-tool-account.js";
 
 const GITHUB_OAUTH_CLIENT_ID = "Ov23liUjOXHi28w2fDlH";
@@ -20,6 +23,28 @@ const GITHUB_OAUTH_SCOPE_MAX_LENGTH = 64;
 const GITHUB_OAUTH_ERROR_TEXT_MAX_CHARS = 2 * 1024;
 const GITHUB_OAUTH_MAX_DURATION_SECONDS = 366 * 24 * 60 * 60;
 const GITHUB_OAUTH_MAX_INTERVAL_SECONDS = 60 * 60;
+
+// TTL bounds only remote revocation staleness. Rotation changes the token key;
+// disconnected or retired profiles provide no token before any cache lookup.
+const GITHUB_CREDENTIAL_VERIFICATION_TTL_MS = 60_000;
+const GITHUB_CREDENTIAL_VERIFICATION_MAX_ENTRIES = 32;
+type GitHubCredentialVerificationResult =
+  | { status: "available"; account: GitHubToolAccount; scopes: string[] }
+  | { status: "unavailable" | "rate_limited" | "unverified" };
+let verifiedCredentials = new Map<
+  string,
+  {
+    result: Extract<GitHubCredentialVerificationResult, { status: "available" }>;
+    expiresAt: number;
+  }
+>();
+const pending = new Map<string, Promise<GitHubCredentialVerificationResult>>();
+
+export function clearGitHubCredentialVerificationCache(): void {
+  // Pending probes retain the old map, so clearing cannot be undone by their completion.
+  verifiedCredentials = new Map();
+  pending.clear();
+}
 
 type GitHubOAuthRequestOptions = {
   signal?: AbortSignal;
@@ -287,43 +312,66 @@ async function readGitHubResponse(response: Response, surface: string, timeoutMs
 export async function verifyGitHubCredential(
   token: string,
   options: GitHubOAuthRequestOptions = {},
-): Promise<
-  | { status: "available"; account: GitHubToolAccount; scopes: string[] }
-  | { status: "unavailable" | "rate_limited" | "unverified" }
-> {
+): Promise<GitHubCredentialVerificationResult> {
   registerSecretValueForRedaction(token);
   try {
     readBoundedString(token, "account");
     if (/\s/u.test(token)) {
       return { status: "unavailable" };
     }
-    const timeoutMs = resolveTimerTimeoutMs(options.timeoutMs, GITHUB_OAUTH_REQUEST_TIMEOUT_MS, 1);
-    const timeout = AbortSignal.timeout(timeoutMs);
-    const response = await fetch("https://api.github.com/user", {
-      method: "GET",
-      redirect: "error",
-      headers: { Accept: "application/vnd.github+json", Authorization: `Bearer ${token}` },
-      signal: options.signal ? AbortSignal.any([options.signal, timeout]) : timeout,
-    });
-    if (response.status !== 200) {
-      void response.body?.cancel().catch(() => undefined);
-      const rateLimited =
-        response.status === 429 ||
-        (response.status === 403 &&
-          (response.headers.get("x-ratelimit-remaining") === "0" ||
-            response.headers.has("retry-after")));
-      return {
-        status:
-          response.status === 401 ? "unavailable" : rateLimited ? "rate_limited" : "unverified",
-      };
+    const key = createHash("sha256").update(token).digest("hex");
+    const cache = verifiedCredentials;
+    const cached = cache.get(key);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.result;
     }
-    const body = await readGitHubResponse(response, "account", timeoutMs);
-    const accountId = readPositiveInteger(body.id, "account", Number.MAX_SAFE_INTEGER);
-    const login = readBoundedString(body.login, "account", 100);
-    const avatarUrl =
-      body.avatar_url == null ? null : readBoundedString(body.avatar_url, "account");
-    const scopes = normalizeGitHubScopes(response.headers.get("x-oauth-scopes") ?? "", "account");
-    return { status: "available", account: { accountId, login, avatarUrl }, scopes };
+    cache.delete(key);
+    const create = async (): Promise<GitHubCredentialVerificationResult> => {
+      const timeoutMs = resolveTimerTimeoutMs(
+        options.timeoutMs,
+        GITHUB_OAUTH_REQUEST_TIMEOUT_MS,
+        1,
+      );
+      const timeout = AbortSignal.timeout(timeoutMs);
+      const response = await fetch("https://api.github.com/user", {
+        method: "GET",
+        redirect: "error",
+        headers: { Accept: "application/vnd.github+json", Authorization: `Bearer ${token}` },
+        signal: options.signal ? AbortSignal.any([options.signal, timeout]) : timeout,
+      });
+      if (response.status !== 200) {
+        void response.body?.cancel().catch(() => undefined);
+        const rateLimited =
+          response.status === 429 ||
+          (response.status === 403 &&
+            (response.headers.get("x-ratelimit-remaining") === "0" ||
+              response.headers.has("retry-after")));
+        return {
+          status:
+            response.status === 401 ? "unavailable" : rateLimited ? "rate_limited" : "unverified",
+        };
+      }
+      const body = await readGitHubResponse(response, "account", timeoutMs);
+      const accountId = readPositiveInteger(body.id, "account", Number.MAX_SAFE_INTEGER);
+      const login = readBoundedString(body.login, "account", 100);
+      const avatarUrl =
+        body.avatar_url == null ? null : readBoundedString(body.avatar_url, "account");
+      const scopes = normalizeGitHubScopes(response.headers.get("x-oauth-scopes") ?? "", "account");
+      const result = {
+        status: "available" as const,
+        account: { accountId, login, avatarUrl },
+        scopes,
+      };
+      Object.freeze(result.account);
+      Object.freeze(result.scopes);
+      Object.freeze(result);
+      cache.set(key, { result, expiresAt: Date.now() + GITHUB_CREDENTIAL_VERIFICATION_TTL_MS });
+      pruneMapToMaxSize(cache, GITHUB_CREDENTIAL_VERIFICATION_MAX_ENTRIES);
+      return result;
+    };
+    return await (options.signal || options.timeoutMs !== undefined
+      ? create()
+      : getOrCreatePromise(pending, key, create, { evictOnSettled: true }));
   } catch {
     // Network errors, response bodies, and abort reasons can contain credentials.
     return { status: "unverified" };

--- a/src/agents/github-tool-identity.test.ts
+++ b/src/agents/github-tool-identity.test.ts
@@ -516,7 +516,7 @@ describe("GitHub tool identity", () => {
     await fs.mkdir(profileDir, { recursive: true, mode: 0o700 });
     await fs.writeFile(
       path.join(profileDir, "hosts.yml"),
-      "github.com:\n  oauth_token: managed-token\n",
+      "github.com:\n  oauth_token: managed-publication-token\n",
       { mode: 0o600 },
     );
     const identity = await prepareGitHubPublicationIdentity({
@@ -545,11 +545,11 @@ describe("GitHub tool identity", () => {
 
     expect(identity.env).toMatchObject({
       GH_CONFIG_DIR: profileDir,
-      GH_TOKEN: "managed-token",
+      GH_TOKEN: "managed-publication-token",
       GITHUB_TOKEN: undefined,
       PREVIEW_SERVICE_TOKEN: undefined,
     });
-    expect(childEnv.GH_TOKEN).toBe("managed-token");
+    expect(childEnv.GH_TOKEN).toBe("managed-publication-token");
     expect(childEnv.GITHUB_TOKEN).toBeUndefined();
     expect(childEnv.GH_CONFIG_DIR).toBe(profileDir);
     expect(childEnv.PREVIEW_SERVICE_TOKEN).toBeUndefined();
@@ -573,9 +573,79 @@ describe("GitHub tool identity", () => {
     expect(fetch).toHaveBeenCalledWith(
       "https://api.github.com/user",
       expect.objectContaining({
-        headers: expect.objectContaining({ Authorization: "Bearer managed-token" }),
+        headers: expect.objectContaining({ Authorization: "Bearer managed-publication-token" }),
       }),
     );
+  });
+
+  it("token rotation bypasses the verification cache", async () => {
+    const root = tempDirs.make("openclaw-github-token-rotation-");
+    const profileId = "ghp_dddddddddddddddddddddddddddddddd";
+    const env = { OPENCLAW_STATE_DIR: root };
+    const config = { tools: { github: { profileId } } };
+    const profileDir = resolveManagedGitHubProfileDir({
+      agentId: "main",
+      scope: "system",
+      profileId,
+      env,
+    });
+    await fs.mkdir(profileDir, { recursive: true, mode: 0o700 });
+    const hosts = path.join(profileDir, "hosts.yml");
+    await fs.writeFile(hosts, "github.com:\n  oauth_token: rotation-token-a\n", { mode: 0o600 });
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 202, login: "before-rotation" })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ id: 303, login: "after-rotation" })));
+
+    const before = await prepareGitHubPublicationIdentity({ config, agentId: "main", env });
+    expect(before.account.login).toBe("before-rotation");
+    await fs.writeFile(hosts, "github.com:\n  oauth_token: rotation-token-b\n", { mode: 0o600 });
+    const after = await prepareGitHubPublicationIdentity({ config, agentId: "main", env });
+    expect(after.account).toMatchObject({ accountId: 303, login: "after-rotation" });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer rotation-token-a" }),
+      }),
+    );
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer rotation-token-b" }),
+      }),
+    );
+  });
+
+  it("a disconnected profile is unavailable without a probe", async () => {
+    const root = tempDirs.make("openclaw-github-disconnected-");
+    const profileId = "ghp_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    const env = { OPENCLAW_STATE_DIR: root };
+    const config = { tools: { github: { profileId } } };
+    const profileDir = resolveManagedGitHubProfileDir({
+      agentId: "main",
+      scope: "system",
+      profileId,
+      env,
+    });
+    await fs.mkdir(profileDir, { recursive: true, mode: 0o700 });
+    await fs.writeFile(
+      path.join(profileDir, "hosts.yml"),
+      "github.com:\n  oauth_token: disconnected-token\n",
+      { mode: 0o600 },
+    );
+    expect(
+      (await prepareGitHubPublicationIdentity({ config, agentId: "main", env })).account.login,
+    ).toBe("managed-user");
+    await fs.rm(profileDir, { recursive: true });
+
+    await expect(
+      prepareGitHubPublicationIdentity({ config, agentId: "main", env }),
+    ).rejects.toThrow(
+      "The selected GitHub credential is unavailable; reconnect the agent's GitHub identity in Settings.",
+    );
+    expect(fetch).toHaveBeenCalledOnce();
   });
 
   it("removes a source-owned preview token from native publication commands", async () => {
@@ -688,7 +758,7 @@ describe("GitHub tool identity", () => {
     await fs.mkdir(profileDir, { recursive: true, mode: 0o700 });
     await fs.writeFile(
       path.join(profileDir, "hosts.yml"),
-      "github.com:\n  oauth_token: managed-token\n",
+      `github.com:\n  oauth_token: managed-status-${testCase.httpStatus}\n`,
       { mode: 0o600 },
     );
     vi.mocked(fetch).mockResolvedValue(

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -20,7 +20,7 @@ import {
 import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
 import {
   readSessionEntryCount,
-  readSessionEntryKeys,
+  iterateSessionEntryKeys,
 } from "./session-accessor.sqlite-entry-store.js";
 import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 
@@ -142,7 +142,7 @@ describe("SQLite session entry cache", () => {
     expect(snapshot.keys).toEqual([scope.sessionKey]);
     expect(snapshot.entries.size).toBe(readable ? 1 : 0);
     expect(readSessionEntryCount(database)).toBe(readable ? 1 : 0);
-    expect(readSessionEntryKeys(database)).toEqual(readable ? [scope.sessionKey] : []);
+    expect([...iterateSessionEntryKeys(database)]).toEqual(readable ? [scope.sessionKey] : []);
     expect(snapshot.entries.get(scope.sessionKey)?.skillsSnapshot).toBeUndefined();
   });
 

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -254,9 +254,10 @@ export function readSessionEntryCount(database: OpenClawAgentDatabase): number {
   return count;
 }
 
-export function readSessionEntryKeys(database: OpenClawAgentDatabaseReader): string[] {
+export function* iterateSessionEntryKeys(
+  database: OpenClawAgentDatabaseReader,
+): IterableIterator<string> {
   const db = getSessionKysely(database.db);
-  const keys: string[] = [];
   for (const row of iterateSqliteQuerySync(
     database.db,
     db
@@ -265,10 +266,9 @@ export function readSessionEntryKeys(database: OpenClawAgentDatabaseReader): str
       .orderBy("session_key", "asc"),
   )) {
     if (row.entry_json === null || parseSessionEntryRow({ entry_json: row.entry_json })) {
-      keys.push(row.session_key);
+      yield row.session_key;
     }
   }
-  return keys;
 }
 
 export function resolveLifecyclePrimaryEntry(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -83,7 +83,7 @@ import {
 } from "./session-accessor.js";
 import {
   readSessionEntryCount,
-  readSessionEntryKeys,
+  iterateSessionEntryKeys,
 } from "./session-accessor.sqlite-entry-store.js";
 import * as sessionEntryStore from "./session-accessor.sqlite-entry-store.js";
 import { loadExactSessionEntry, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
@@ -323,7 +323,7 @@ describe("session accessor seam", () => {
     const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
 
     expect(readSessionEntryCount(database)).toBe(1);
-    expect(readSessionEntryKeys(database)).toEqual(["agent:main:logical-entry"]);
+    expect([...iterateSessionEntryKeys(database)]).toEqual(["agent:main:logical-entry"]);
     expect(countSessionEntryRowsReadOnly({ agentId: "main", storePath })).toBe(2);
   });
 

--- a/src/config/sessions/targets-existing-store.test.ts
+++ b/src/config/sessions/targets-existing-store.test.ts
@@ -4,11 +4,44 @@ import { syncBuiltinESMExports } from "node:module";
 import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { OpenClawConfig } from "../config.js";
+import { replaceSessionEntry } from "./session-accessor.js";
+import * as sessionEntryStatus from "./session-accessor.sqlite-status.js";
 import { resolveExistingAgentSessionStoreTargetsSync } from "./targets.js";
 import { countMatching, createAgentSessionStores } from "./targets.test-support.js";
 
 describe("resolveExistingAgentSessionStoreTargetsSync", () => {
+  it("stops validating fixed-store entries after the first matching agent", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "shared.sqlite");
+      for (const agentId of ["main", "alpha", "zulu"]) {
+        await replaceSessionEntry(
+          { agentId, sessionKey: `agent:${agentId}:existing`, storePath },
+          { sessionId: `session-${agentId}`, updatedAt: Date.now() },
+        );
+      }
+      const database = openOpenClawAgentDatabase({ agentId: "main", path: storePath });
+      database.db.prepare("UPDATE session_nodes SET entry_valid = 0").run();
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+        session: { store: storePath },
+      };
+      const parseEntry = vi.spyOn(sessionEntryStatus, "parseSessionEntryJson");
+      try {
+        expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "main")).toEqual([
+          { agentId: "main", storePath },
+        ]);
+        expect(parseEntry.mock.results.map(({ value }) => value?.sessionId)).toEqual([
+          "session-alpha",
+          "session-main",
+        ]);
+      } finally {
+        parseEntry.mockRestore();
+      }
+    });
+  });
+
   it("validates a configured canonical SQLite target once", async () => {
     await withTempHome(async (home) => {
       const stateDir = path.join(home, ".openclaw");

--- a/src/config/sessions/targets-read-availability.ts
+++ b/src/config/sessions/targets-read-availability.ts
@@ -4,7 +4,7 @@ import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-ke
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionStorePathCore } from "./paths.js";
-import { readSessionEntryKeys } from "./session-accessor.sqlite-entry-store.js";
+import { iterateSessionEntryKeys } from "./session-accessor.sqlite-entry-store.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { resolvePersistedSessionStoreOwner } from "./session-store-owner.js";
 import {
@@ -61,7 +61,7 @@ function readSessionStoreTargetSnapshot(params: {
       (database) => {
         const scopedAgentIds = new Set<string>();
         let hasUnscopedRow = false;
-        for (const sessionKey of readSessionEntryKeys(database)) {
+        for (const sessionKey of iterateSessionEntryKeys(database)) {
           const parsed = parseAgentSessionKey(sessionKey);
           if (parsed) {
             scopedAgentIds.add(normalizeAgentId(parsed.agentId));

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -17,7 +17,7 @@ import {
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveAgentsDirFromSessionStorePath, resolveSessionStorePathCore } from "./paths.js";
-import { readSessionEntryKeys } from "./session-accessor.sqlite-entry-store.js";
+import { iterateSessionEntryKeys } from "./session-accessor.sqlite-entry-store.js";
 import {
   listDurableSqliteTargetOwnersForSessionStorePath,
   listDurableSqliteTargetPathsForSessionStorePath,
@@ -113,7 +113,7 @@ export function listKnownSessionStoreAgentIds(
       try {
         const logicalOwners = withOpenClawAgentDatabaseReadOnly(
           (database) =>
-            readSessionEntryKeys(database).flatMap((sessionKey) => {
+            Array.from(iterateSessionEntryKeys(database)).flatMap((sessionKey) => {
               const parsed = parseAgentSessionKey(sessionKey);
               return parsed ? [normalizeAgentId(parsed.agentId)] : [];
             }),
@@ -387,15 +387,18 @@ export function resolveExistingAgentSessionStoreTargetsSync(
           ? normalizeAgentId(resolvedTarget.agentId ?? defaultAgentId)
           : requested;
         const result = withOpenClawAgentDatabaseReadOnly(
-          (database) =>
-            readSessionEntryKeys(database).some((sessionKey) => {
+          (database) => {
+            for (const sessionKey of iterateSessionEntryKeys(database)) {
               const parsed = parseAgentSessionKey(sessionKey);
               // Unscoped keys belong to the validated database owner. Explicit agent keys must
               // match so a fixed store containing only another agent's rows proves nothing.
-              return parsed
-                ? normalizeAgentId(parsed.agentId) === requested
-                : databaseAgentId === requested;
-            }),
+              const ownerAgentId = parsed ? normalizeAgentId(parsed.agentId) : databaseAgentId;
+              if (ownerAgentId === requested) {
+                return true;
+              }
+            }
+            return false;
+          },
           { agentId: databaseAgentId, env, path: sqlitePath },
         );
         return result.found && result.value ? [fixedTarget] : [];

--- a/src/gateway/github-oauth-lifecycle.test.ts
+++ b/src/gateway/github-oauth-lifecycle.test.ts
@@ -25,6 +25,7 @@ import { recordAgentProvenance } from "../state/agent-provenance.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 
 const mocks = vi.hoisted(() => ({
+  clearVerificationCache: vi.fn(),
   verifyCredential: vi.fn(),
   requestDeviceCode: vi.fn(),
   pollDeviceToken: vi.fn(),
@@ -40,6 +41,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../agents/github-oauth-client.js", () => ({
+  clearGitHubCredentialVerificationCache: mocks.clearVerificationCache,
   verifyGitHubCredential: mocks.verifyCredential,
   requestGitHubOAuthDeviceCode: mocks.requestDeviceCode,
   pollGitHubOAuthDeviceToken: mocks.pollDeviceToken,
@@ -280,6 +282,13 @@ afterEach(async () => {
 });
 
 describe("GitHub OAuth authorization lifecycle", () => {
+  it("clears verified GitHub credentials when the lifecycle stops", async () => {
+    const lifecycle = createLifecycle();
+    expect(mocks.clearVerificationCache).not.toHaveBeenCalled();
+    await lifecycle.stop();
+    expect(mocks.clearVerificationCache).toHaveBeenCalledOnce();
+  });
+
   it.each(["system", "agent"] as const)(
     "records an exact %s-scope CAS snapshot and delays the initial poll",
     async (scope) => {

--- a/src/gateway/github-oauth-lifecycle.ts
+++ b/src/gateway/github-oauth-lifecycle.ts
@@ -10,6 +10,7 @@ import {
 } from "../agents/agent-lifecycle-registry.js";
 import { resolveAgentConfig } from "../agents/agent-scope.js";
 import {
+  clearGitHubCredentialVerificationCache,
   refreshGitHubOAuthToken,
   type GitHubOAuthTokenPair,
 } from "../agents/github-oauth-client.js";
@@ -621,6 +622,7 @@ export function createGitHubOAuthLifecycle(params: {
       interval.unref?.();
     },
     stop: async () => {
+      clearGitHubCredentialVerificationCache();
       stopping = true;
       if (interval) {
         clearInterval(interval);

--- a/src/gateway/github-personal-publication.test-support.ts
+++ b/src/gateway/github-personal-publication.test-support.ts
@@ -25,12 +25,12 @@ const mocks = githubPublicationTestMocks();
 export const personalPublicationAccount = { accountId: 101, login: "personal-alice" };
 const account = personalPublicationAccount;
 const profileId = "ghp_22222222222222222222222222222222";
-const personalToken = "synthetic-personal-credential";
 
 export async function createPersonalPublicationFixture() {
   const owner = ensureProfileForEmail("alice@example.test").id;
   const otherOwner = ensureProfileForEmail("bob@example.test").id;
   const generation = randomUUID();
+  const personalToken = `synthetic-personal-credential-${generation}`;
   updateUserGitHubConnection(
     owner,
     () => ({

--- a/src/gateway/server-methods/board.github-actions.test.ts
+++ b/src/gateway/server-methods/board.github-actions.test.ts
@@ -6,6 +6,7 @@ import type {
   BoardWidgetDeclared,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { clearGitHubCredentialVerificationCache } from "../../agents/github-oauth-client.js";
 import { resolveManagedGitHubProfileDir } from "../../agents/github-tool-identity.js";
 import { createTestBoardStore } from "../../boards/board-store.test-support.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -93,6 +94,7 @@ describe("board authenticated GitHub Actions", () => {
 
   beforeEach(async () => {
     resetPluginRuntimeStateForTest();
+    clearGitHubCredentialVerificationCache();
     state = await createOpenClawTestState({
       prefix: "board-github-",
       env: { GH_TOKEN: undefined, GITHUB_TOKEN: undefined },
@@ -265,6 +267,9 @@ describe("board authenticated GitHub Actions", () => {
       ]);
       const before = store.getSnapshot(target);
       broadcast.mockClear();
+      // Verified credentials are reused within their TTL; expire the entry so the
+      // next pin must prove the credential again.
+      clearGitHubCredentialVerificationCache();
       account.mockImplementationOnce(async () => new Response(token, { status: 401 }));
       const denied = await invoke("board.widget.put", input);
       expect(denied.mock.calls[0]?.[0]).toBe(false);
@@ -691,6 +696,7 @@ describe("board authenticated GitHub Actions", () => {
       const survivor = surviving === "leader" ? leader : follower;
       expect((await survivor.read()).mock.calls[0]).toEqual([true, result]);
       expect(actionCalls()).toHaveLength(1);
+      clearGitHubCredentialVerificationCache();
       account.mockImplementationOnce(async () => {
         await survivor.invoke("board.update", {
           sessionKey: "agent:main:runs",

--- a/src/gateway/server-methods/github-personal-authorization.test.ts
+++ b/src/gateway/server-methods/github-personal-authorization.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  prepareGitHubPublicationOptionsRead,
+  preparePersonalGitHubSessionAction,
+} from "./github-personal-authorization.js";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  loadSession: vi.fn<typeof import("../session-utils.js").loadGatewaySessionEntryReadOnly>(),
+}));
+
+vi.mock("../session-utils.js", () => ({
+  loadGatewaySessionEntryReadOnly: mocks.loadSession,
+}));
+vi.mock("../../agents/tools/gateway-caller-context.js", () => ({
+  getGatewayToolCallerIdentity: () => undefined,
+}));
+vi.mock("../../state/user-github-connections.js", () => ({
+  resolvePersonalGitHubOwner: (profile: string) => profile,
+}));
+vi.mock("../operator-role-policy.js", () => ({
+  resolveOperatorRolePolicy: () => null,
+  resolveOperatorRolePolicyForProfile: () => null,
+}));
+vi.mock("../session-sharing.js", () => ({
+  createSessionListEntryFilter: () => undefined,
+  resolveSessionMutationAuthorization: () => ({}),
+}));
+
+function createRequest() {
+  const client: GatewayClient = {
+    connId: "github-cache-client",
+    authenticatedUserProfile: {
+      profileId: "profile-cache-test",
+      displayName: null,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+    connect: {
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "test", mode: "test", platform: "test", version: "1" },
+    },
+  };
+  const context = {
+    getRuntimeConfig: () => ({}),
+    getClientConnIds: (filter?: (candidate: GatewayClient) => boolean) =>
+      new Set(!filter || filter(client) ? ["github-cache-client"] : []),
+  } as Partial<GatewayRequestContext> as GatewayRequestContext;
+  return { client, context };
+}
+
+describe("GitHub publication request discovery", () => {
+  beforeEach(() => {
+    mocks.loadSession.mockReset();
+    mocks.loadSession.mockReturnValue({
+      cfg: {},
+      canonicalKey: "agent:main:main",
+      agentId: "main",
+      storePath: "/test/sessions.json",
+      store: {},
+      storeKeys: ["agent:main:main"],
+      entry: { sessionId: "session-cache-test", updatedAt: 1 },
+      legacyKey: undefined,
+    });
+  });
+
+  it("shares store discovery while re-reading publication options live", () => {
+    const read = prepareGitHubPublicationOptionsRead(createRequest(), "main");
+
+    expect(read.currentSession()).toEqual(read.session);
+    expect(mocks.loadSession).toHaveBeenCalledTimes(2);
+    const targetDiscoveryCache = mocks.loadSession.mock.calls[0]?.[1]?.targetDiscoveryCache;
+    expect(targetDiscoveryCache).toBeInstanceOf(Map);
+    expect(mocks.loadSession.mock.calls[1]?.[1]?.targetDiscoveryCache).toBe(targetDiscoveryCache);
+    expect(mocks.loadSession).toHaveBeenNthCalledWith(2, "agent:main:main", {
+      agentId: "main",
+      targetDiscoveryCache,
+    });
+  });
+
+  it("shares store discovery across every personal session authority re-read", () => {
+    const action = preparePersonalGitHubSessionAction(createRequest(), "main");
+    action.assertCurrent();
+
+    expect(mocks.loadSession).toHaveBeenCalledTimes(3);
+    const targetDiscoveryCache = mocks.loadSession.mock.calls[0]?.[1]?.targetDiscoveryCache;
+    expect(targetDiscoveryCache).toBeInstanceOf(Map);
+    for (const call of [2, 3]) {
+      expect(mocks.loadSession.mock.calls[call - 1]?.[1]?.targetDiscoveryCache).toBe(
+        targetDiscoveryCache,
+      );
+      expect(mocks.loadSession).toHaveBeenNthCalledWith(call, "agent:main:main", {
+        agentId: "main",
+        targetDiscoveryCache,
+      });
+    }
+  });
+});

--- a/src/gateway/server-methods/github-personal-authorization.ts
+++ b/src/gateway/server-methods/github-personal-authorization.ts
@@ -10,7 +10,10 @@ import {
   createSessionListEntryFilter,
   resolveSessionMutationAuthorization,
 } from "../session-sharing.js";
-import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
+import {
+  type GatewaySessionStoreDiscoveryCache,
+  loadGatewaySessionEntryReadOnly,
+} from "../session-utils.js";
 import { isGatewayClientProfilePending } from "./gateway-client-identity.js";
 import type { GatewayClient, GatewayRequestHandlerOptions } from "./types.js";
 
@@ -87,6 +90,8 @@ type PersonalEligibility =
 
 /** Shared reads do not require a person; absence never substitutes for failed authentication. */
 export function prepareGitHubPublicationOptionsRead(options: Request, sessionKey: string) {
+  // Store discovery is stable within this request; session rows remain live reads.
+  const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
   const resolveEligibility = (): PersonalEligibility => {
     currentGitHubClient(options, "operator.read");
     const client = options.client;
@@ -116,7 +121,7 @@ export function prepareGitHubPublicationOptionsRead(options: Request, sessionKey
     );
   };
   const readSession = (key: string, agentId?: string) => {
-    const loaded = loadGatewaySessionEntryReadOnly(key, agentId ? { agentId } : undefined);
+    const loaded = loadGatewaySessionEntryReadOnly(key, { agentId, targetDiscoveryCache });
     const filter = createSessionListEntryFilter({
       cfg: options.context.getRuntimeConfig(),
       client: currentClient(),
@@ -187,7 +192,8 @@ export function preparePersonalGitHubSessionAction(
   sessionKey: string,
 ): PersonalGitHubAction & { sessionId: string; sessionKey: string; agentId: string } {
   const action = preparePersonalGitHubAction(options, "operator.write");
-  const initial = loadGatewaySessionEntryReadOnly(sessionKey);
+  const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+  const initial = loadGatewaySessionEntryReadOnly(sessionKey, { targetDiscoveryCache });
   if (!initial.entry?.sessionId) {
     throw new Error("GitHub publication session was not found.");
   }
@@ -196,6 +202,7 @@ export function preparePersonalGitHubSessionAction(
     action.assertCurrent();
     const current = loadGatewaySessionEntryReadOnly(initial.canonicalKey, {
       agentId: initial.agentId,
+      targetDiscoveryCache,
     });
     if (
       current.entry?.sessionId !== sessionId ||

--- a/src/gateway/server-methods/sessions-github.ts
+++ b/src/gateway/server-methods/sessions-github.ts
@@ -44,18 +44,6 @@ export const sessionsGitHubHandlers: GatewayRequestHandlers = {
         );
         return;
       }
-      const loaded = loadGatewaySessionEntryReadOnly(
-        sessionKey,
-        caller?.agentId ? { agentId: caller.agentId } : undefined,
-      );
-      if (!loaded.entry?.sessionId) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "GitHub publication session was not found"),
-        );
-        return;
-      }
       try {
         if (params.selection?.source === "personal") {
           if (!params.sessionKey) {
@@ -65,6 +53,18 @@ export const sessionsGitHubHandlers: GatewayRequestHandlers = {
           const result = await coordinator.requestPersonalForSession(params, action);
           action.assertCurrent();
           respond(true, result);
+          return;
+        }
+        const loaded = loadGatewaySessionEntryReadOnly(
+          sessionKey,
+          caller?.agentId ? { agentId: caller.agentId } : undefined,
+        );
+        if (!loaded.entry?.sessionId) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, "GitHub publication session was not found"),
+          );
           return;
         }
         sessionMutationAuthorization?.assertCurrent();

--- a/src/gateway/server-methods/users-github.test.ts
+++ b/src/gateway/server-methods/users-github.test.ts
@@ -50,6 +50,7 @@ const network = vi.hoisted(() => ({
   command: vi.fn(),
 }));
 vi.mock("../../agents/github-oauth-client.js", () => ({
+  clearGitHubCredentialVerificationCache: vi.fn(),
   requestGitHubOAuthDeviceCode: network.start,
   pollGitHubOAuthDeviceToken: network.poll,
   refreshGitHubOAuthToken: network.refresh,

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -43,6 +43,7 @@ import type { GatewayAgentOwnership } from "./agent-list.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
 import { resolveGatewayModelThinkingProfile } from "./session-utils-model.js";
 import {
+  type GatewaySessionStoreDiscoveryCache,
   resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
 } from "./session-utils-store-lookup.js";
@@ -142,6 +143,7 @@ function loadSessionEntryWithMode(
   opts:
     | (Pick<SessionEntryListScope, "agentId" | "clone" | "projection"> & {
         includeStoreChildEntries?: boolean;
+        targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
       })
     | undefined,
   readOnly: boolean,
@@ -154,6 +156,7 @@ function loadSessionEntryWithMode(
     exactRead: true,
     readOnly,
     projection: opts?.projection,
+    targetDiscoveryCache: opts?.targetDiscoveryCache,
     ...(opts?.clone === false ? { clone: false } : {}),
     ...(opts?.agentId ? { agentId: opts.agentId } : {}),
     ...(opts?.includeStoreChildEntries ? { includeStoreChildEntries: true } : {}),
@@ -194,7 +197,12 @@ export function loadGatewaySessionEntry(
 
 export function loadGatewaySessionEntryReadOnly(
   sessionKey: string,
-  opts?: { agentId?: string; clone?: boolean; includeStoreChildEntries?: boolean },
+  opts?: {
+    agentId?: string;
+    clone?: boolean;
+    includeStoreChildEntries?: boolean;
+    targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
+  },
 ) {
   return loadSessionEntryWithMode(sessionKey, opts, true);
 }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -46,6 +46,7 @@ import {
 import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import { buildGatewaySessionRow as buildGatewaySessionRowOwner } from "./session-utils-row.js";
 import {
+  type GatewaySessionStoreDiscoveryCache,
   resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
 } from "./session-utils-store-lookup.js";
@@ -3273,6 +3274,43 @@ describe("gateway session utils", () => {
 
         expect(loaded.entry).toBeUndefined();
         expect(fs.existsSync(path.join(stateDir, "agents", "missing"))).toBe(false);
+      });
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
+  test("loadGatewaySessionEntryReadOnly discovers stores once but reads changed rows live", async () => {
+    resetConfigRuntimeState();
+    try {
+      await withStateDirEnv("session-utils-request-discovery-", async ({ stateDir }) => {
+        const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+        const cfg = {
+          session: { mainKey: "main", store: storePath },
+          agents: { entries: { main: {} } },
+        } satisfies OpenClawConfig;
+        const sessionKey = "agent:main:main";
+        await seedSessionEntries(storePath, {
+          [sessionKey]: { sessionId: "session-before", updatedAt: 1 },
+        });
+        setRuntimeConfigSnapshot(cfg, cfg);
+        const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+        const discoveryWrites = vi.spyOn(targetDiscoveryCache, "set");
+        try {
+          const first = loadGatewaySessionEntryReadOnly(sessionKey, { targetDiscoveryCache });
+          await replaceSessionEntry(
+            { sessionKey, storePath },
+            { sessionId: "session-after", updatedAt: 2 },
+          );
+          const second = loadGatewaySessionEntryReadOnly(sessionKey, { targetDiscoveryCache });
+
+          expect(first.entry?.sessionId).toBe("session-before");
+          expect(second.entry?.sessionId).toBe("session-after");
+          expect(targetDiscoveryCache.size).toBe(1);
+          expect(discoveryWrites).toHaveBeenCalledTimes(1);
+        } finally {
+          discoveryWrites.mockRestore();
+        }
       });
     } finally {
       resetConfigRuntimeState();

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -22,6 +22,7 @@ export { resolveCanonicalGatewaySessionStoreKey } from "./session-utils-store.js
 export { listAgentsForGateway } from "./session-utils-store.js";
 export { resolveGatewaySessionStoreTargetWithStore } from "./session-utils-store-lookup.js";
 export { resolveGatewaySessionStoreTarget } from "./session-utils-store-lookup.js";
+export type { GatewaySessionStoreDiscoveryCache } from "./session-utils-store-lookup.js";
 export { getSessionDefaults } from "./session-utils-model.js";
 export { resolveGatewayModelSupportsImages } from "./session-utils-model.js";
 export { buildGatewaySessionRow } from "./session-utils-row.js";


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where opening a session, reconnecting, or changing sign-in state in the Control UI made the Publish PR row's `sessions.github.options` read take more than a second. Production logs show ~110 such slow reads per day. Every call re-verified the shared GitHub credential against `api.github.com`, re-verified the personal credential a second time, spawned `gh auth token` when `tools.github` is unconfigured, and ran session store discovery twice, validating every `session_nodes` row before a `.some()`.

## Why This Change Was Made

`verifyGitHubCredential` now owns a bounded, token-keyed verification cache (60s TTL, 32 entries, positive results only, concurrent probes for one token share a fetch). Invalidation is structural: rotation changes the key, disconnect or profile retirement yields no token before any lookup, and the GitHub OAuth lifecycle clears the cache on stop. Only a revocation performed on github.com waits for the TTL. Options, status, and personal publish reads share one request-scoped store discovery cache while session rows and every `assertCurrent` authority check are still re-read live. `readSessionEntryKeys` became the lazy `iterateSessionEntryKeys`, so fixed-store discovery stops at the first matching row. The personal publish branch no longer pays for the shared path's session load.

Non-goals: the native `gh auth token` read stays live per request because reading the token is what detects a host account change; no config, protocol, or schema surface was added.

## User Impact

The account chooser beside Publish PR loads immediately after the first verification instead of waiting on two GitHub round trips per session switch. Operators with a configured System or agent GitHub profile see warm `sessions.github.options` reads drop from hundreds of milliseconds to single-digit milliseconds. Operators on the unconfigured host `gh` identity still pay the `gh auth token` keyring spawn (370-800 ms on macOS), which is now the dominant remaining cost and is left as a named follow-up.

## Evidence

Live dev gateway (isolated `OPENCLAW_STATE_DIR`, port 18999, `--ws-log full`), real `api.github.com` calls with the host GitHub token, six sequential `sessions.github.options` requests. Server-side durations from the gateway log:

| Identity | Cold | Warm (5 subsequent calls) |
|---|---|---|
| `tools.github` managed profile (`system-configured`) | 578 ms | 4 ms each |
| unconfigured host `gh` (`system-detected`) | 755 ms | 342-605 ms (all `gh auth token` spawn; `gh auth token` alone measures 0.37-0.80 s) |

Scratch benchmark (mocked 250 ms fetch, 2000-row fixed SQLite store), same harness run against pre-fix production files and the fix:

| Measure | Before | After |
|---|---|---|
| warm `prepareGitHubPublicationIdentity` | ~275 ms | ~10 ms |
| `/user` fetches across 3 requests | 3 | 1 |
| two `loadGatewaySessionEntryReadOnly` reads (one options request) | 13.8 ms | 1.6 ms |
| `resolveExistingAgentSessionStoreTargetsSync`, fixed store | 2.6 ms | 0.8 ms |

Regression tests shown failing pre-fix (`expected "fetch" to be called once, but got 2 times`; `expected undefined to be an instance of Map`). Fault-injection coverage: revoked token after TTL, unavailable token recovering on the next call, rotation bypassing the cache, disconnected profile without a probe, in-flight probe not repopulating a cleared cache, bounded eviction. Live-authority closures untouched (`github-personal-authorization.test.ts` asserts the same discovery Map across live re-reads).

Local gates: focused Vitest (649 tests across 15 files + 25 in the data-version suite), `node scripts/check-changed.mjs` green, Codex autoreview scoped-clean.

Production LOC: +129/-60 (net +69; +48 is the cache itself, the rest is discovery plumbing). Tests: +318/-22 plus one new 100-line suite.
