### PR TITLE
fix(sessions): keep incognito creation in its explicit environment

### DIFF
--- a/src/config/sessions/incognito-session-transcript.test.ts
+++ b/src/config/sessions/incognito-session-transcript.test.ts
@@ -1,19 +1,28 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  inspectOpenClawAgentDatabaseOwner,
+  listOpenClawRegisteredAgentDatabases,
   resolveIncognitoOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import { resolveSessionStorePathCore } from "./paths.js";
 import {
   createSessionEntryWithTranscript,
   listSessionEntriesCore,
   loadSessionEntry,
   loadTranscriptEvents,
+  loadTranscriptEventsSync,
   patchSessionEntryCore,
+  resolveSessionEntryCandidateTarget,
+  resolveSessionTranscriptRuntimeTarget,
 } from "./session-accessor.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 
@@ -21,6 +30,178 @@ const sessionKey = "agent:main:dashboard:incognito-round-trip";
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
+});
+
+describe("session creation scope", () => {
+  let ambient: OpenClawTestState;
+  let explicit: OpenClawTestState;
+  const agentId = "secondary";
+  const key = "agent:secondary:dashboard:incognito-fresh-session";
+
+  beforeEach(async () => {
+    ambient = await createOpenClawTestState({ prefix: "session-creation-env-ambient-" });
+    explicit = await createOpenClawTestState({
+      prefix: "session-creation-env-explicit-",
+      applyEnv: false,
+    });
+  });
+
+  afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    await explicit.cleanup();
+    await ambient.cleanup();
+  });
+
+  it.each(["ambient", "omitted", "sentinel", "durable"] as const)(
+    "creates and reloads a secondary transcript without disk state (%s store scope)",
+    async (variant) => {
+      const state = variant === "ambient" ? ambient : explicit;
+      const env = variant === "ambient" ? undefined : explicit.env;
+      const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId, env });
+      const scope = {
+        agentId,
+        env,
+        sessionKey: ` ${key} `,
+        ...(variant === "sentinel"
+          ? { storePath: sentinel }
+          : variant === "durable"
+            ? { storePath: state.statePath("ignored.sqlite") }
+            : {}),
+      };
+      const entry = { incognito: true as const, sessionId: "created-incognito", updatedAt: 1 };
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(ambient.stateDir);
+      expect(explicit.stateDir).not.toBe(ambient.stateDir);
+
+      const created = await createSessionEntryWithTranscript(
+        scope,
+        ({ existingEntry, sessionEntries }) => {
+          expect(existingEntry).toBeUndefined();
+          expect(sessionEntries).toEqual({});
+          return { ok: true, entry };
+        },
+        { cwd: state.workspaceDir },
+      );
+      expect(created).toEqual({ ok: true, entry, sessionFile: key });
+      // Inspect before reading: a bad creation can open the sentinel under the wrong agent.
+      expect
+        .soft(inspectOpenClawAgentDatabaseOwner(sentinel))
+        .toEqual({ status: "owned", agentId });
+      expect.soft(fs.readdirSync(explicit.stateDir, { recursive: true })).toEqual([]);
+      expect.soft(fs.readdirSync(ambient.stateDir, { recursive: true })).toEqual([]);
+
+      const transcriptScope = { ...scope, sessionKey: key, sessionId: entry.sessionId };
+      await expect(resolveSessionTranscriptRuntimeTarget(transcriptScope)).resolves.toEqual({
+        agentId,
+        sessionId: entry.sessionId,
+        sessionKey: key,
+        storePath: sentinel,
+      });
+      await expect(loadTranscriptEvents(transcriptScope)).resolves.toEqual([
+        expect.objectContaining({ type: "session", id: entry.sessionId, cwd: state.workspaceDir }),
+      ]);
+      expect(
+        resolveSessionEntryCandidateTarget({
+          agentId,
+          env,
+          cfg: {},
+          candidateKeys: [key],
+        }),
+      ).toMatchObject({ agentId, sessionKey: key, persisted: true, entry });
+
+      const updated = { ...entry, label: "recreated", updatedAt: 2 };
+      await expect(
+        createSessionEntryWithTranscript(scope, ({ existingEntry, sessionEntries }) => {
+          expect(existingEntry).toMatchObject(entry);
+          expect(Object.keys(sessionEntries)).toEqual([key]);
+          expect(sessionEntries[key]).toMatchObject(entry);
+          return { ok: true, entry: updated };
+        }),
+      ).resolves.toMatchObject({ ok: true, sessionFile: key });
+      expect(loadSessionEntry(scope)).toMatchObject(updated);
+
+      closeOpenClawAgentDatabasesForTest();
+      expect(loadSessionEntry(scope)).toBeUndefined();
+      await expect(loadTranscriptEvents(transcriptScope)).resolves.toEqual([]);
+      expect(fs.readdirSync(explicit.stateDir, { recursive: true })).toEqual([]);
+      expect(fs.readdirSync(ambient.stateDir, { recursive: true })).toEqual([]);
+    },
+  );
+
+  it.each(["default", "exact", "custom"] as const)(
+    "preserves durable storage and physical ownership (%s store)",
+    async (variant) => {
+      const storePath =
+        variant === "default"
+          ? undefined
+          : explicit.statePath(variant === "exact" ? "shared.sqlite" : "custom/sessions.json");
+      const databasePath =
+        variant === "default"
+          ? explicit.statePath("agents/secondary/agent/openclaw-agent.sqlite")
+          : variant === "exact"
+            ? explicit.statePath("shared.sqlite")
+            : explicit.statePath("custom/openclaw-agent.secondary.sqlite");
+      const physicalOwner = variant === "exact" ? "main" : agentId;
+      const scope = {
+        agentId,
+        env: explicit.env,
+        sessionKey: "agent:secondary:dashboard:durable-created",
+        storePath,
+      };
+      const entry = { sessionId: "durable-created", updatedAt: 1 };
+      await expect(
+        createSessionEntryWithTranscript(scope, () => ({ ok: true, entry })),
+      ).resolves.toMatchObject({ ok: true, sessionFile: scope.sessionKey });
+
+      expect(inspectOpenClawAgentDatabaseOwner(databasePath)).toEqual({
+        status: "owned",
+        agentId: physicalOwner,
+      });
+      expect(listOpenClawRegisteredAgentDatabases({ env: explicit.env })).toEqual([
+        expect.objectContaining({ agentId: physicalOwner, path: databasePath }),
+      ]);
+      expect(fs.existsSync(databasePath)).toBe(true);
+      closeOpenClawAgentDatabasesForTest();
+      expect(loadSessionEntry(scope)).toMatchObject(entry);
+      await expect(loadTranscriptEvents({ ...scope, sessionId: entry.sessionId })).resolves.toEqual(
+        [expect.objectContaining({ type: "session", id: entry.sessionId })],
+      );
+      expect(fs.readdirSync(ambient.stateDir, { recursive: true })).toEqual([]);
+    },
+  );
+
+  it.each(["header", "entry"] as const)(
+    "does not commit the protected %s mutation after authority is revoked",
+    async (rejectedPhase) => {
+      const scope = { agentId, env: explicit.env, sessionKey: key };
+      const original = { incognito: true as const, sessionId: "original", updatedAt: 1 };
+      await expect(
+        createSessionEntryWithTranscript(scope, () => ({ ok: true, entry: original })),
+      ).resolves.toMatchObject({ ok: true });
+      const next = { ...original, sessionId: "rejected", updatedAt: 2 };
+      const nextScope = { ...scope, sessionId: next.sessionId };
+      const revoked = new Error("creation authority revoked");
+
+      await expect(
+        createSessionEntryWithTranscript(scope, () => ({ ok: true, entry: next }), {
+          commitGuard: () => {
+            const headerCommitted = loadTranscriptEventsSync(nextScope).length > 0;
+            if (rejectedPhase === "header" || headerCommitted) {
+              throw revoked;
+            }
+          },
+        }),
+      ).rejects.toBe(revoked);
+      expect(loadSessionEntry(scope)).toMatchObject(original);
+      // Header and lifecycle commits are separate; a later refusal protects the entry mutation.
+      expect(loadTranscriptEventsSync(nextScope)).toEqual(
+        rejectedPhase === "header"
+          ? []
+          : [expect.objectContaining({ type: "session", id: next.sessionId })],
+      );
+      expect(fs.readdirSync(explicit.stateDir, { recursive: true })).toEqual([]);
+      expect(fs.readdirSync(ambient.stateDir, { recursive: true })).toEqual([]);
+    },
+  );
 });
 
 describe("incognito transcript access", () => {

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -69,11 +69,10 @@ export async function createSessionEntryWithTranscript<TError = string>(
 ): Promise<SessionEntryCreateWithTranscriptResult<TError>> {
   const storePath = resolveAccessStorePath(scope);
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  // The incognito sentinel is scoped to env; its path alone cannot identify the memory store.
+  const storeScope = { agentId, env: scope.env, storePath };
   const store = Object.fromEntries(
-    listSessionEntriesCore({ agentId, storePath }).map(({ sessionKey, entry }) => [
-      sessionKey,
-      entry,
-    ]),
+    listSessionEntriesCore(storeScope).map(({ sessionKey, entry }) => [sessionKey, entry]),
   );
   const resolved = resolveSessionEntryFromStore({ store, sessionKey: scope.sessionKey });
   const created = await createEntry({
@@ -87,10 +86,9 @@ export async function createSessionEntryWithTranscript<TError = string>(
   try {
     await appendTranscriptEvent(
       {
-        agentId,
+        ...storeScope,
         sessionId: created.entry.sessionId,
         sessionKey: resolved.normalizedKey,
-        storePath,
       },
       createSessionTranscriptHeader({ cwd: options.cwd, sessionId: created.entry.sessionId }),
       options.commitGuard ? { beforeCommitInTransaction: options.commitGuard } : undefined,
@@ -108,8 +106,7 @@ export async function createSessionEntryWithTranscript<TError = string>(
 
   const entry = created.entry;
   await applySessionEntryLifecycleMutation({
-    agentId,
-    storePath,
+    ...storeScope,
     removals: resolved.legacyKeys.map((sessionKey) => ({ sessionKey })),
     upserts: [{ sessionKey: resolved.normalizedKey, entry }],
     skipMaintenance: true,

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -244,6 +244,7 @@ function readProjectedRemovalEntry(
 /** Applies exact lifecycle removals/upserts using SQLite session rows. */
 export async function applySessionEntryLifecycleMutation(params: {
   agentId?: string;
+  env?: NodeJS.ProcessEnv;
   storePath: string;
   removals?: Iterable<SessionEntryLifecycleRemoval>;
   upserts?: Iterable<SessionEntryLifecycleUpsert>;
@@ -266,6 +267,7 @@ export async function applySessionEntryLifecycleMutation(params: {
 }): Promise<SessionEntryLifecycleMutationResult> {
   const resolved = resolveSqliteScope({
     ...(params.agentId ? { agentId: params.agentId } : {}),
+    env: params.env,
     sessionKey: "",
     storePath: params.storePath,
   });


### PR DESCRIPTION
Closes #136224

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in this repository; maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where developers creating an incognito session for a non-main agent could receive a successful creation result but then fail to read its transcript when passing an explicit environment different from the process environment. The reported failure is `incognito-openclaw-agent.sqlite is already open for agent main; requested agent secondary`.

This is a deterministic session-accessor boundary defect. The normal ambient-environment control passes; this PR does not claim a default Control UI failure or a released-version regression.

## Why This Change Was Made

Creation now retains one `{ agentId, env, storePath }` scope across entry listing, transcript header append, and lifecycle mutation. The lifecycle owner forwards optional `env` into its existing SQLite scope resolver instead of losing the environment after the initial path is resolved.

The fix is at the producer handoff, not a relaxed owner check or downstream fallback. Canonical key precedence, physical versus logical agent ownership, synchronous commit guards, and the existing separate header/lifecycle transactions are unchanged. No schema, database version, material persistence design, required API parameter, config option, dependency, or strict-append path changes.

Production LOC: **+7 / -8 (net -1)**. Tests: **+182 / -1**. The repeated reconstructed scopes are replaced by one shared scope; the lifecycle input adds only optional environment propagation.

## User Impact

Explicit-environment callers can create and reopen the intended non-main incognito session without switching `process.env`. Session entry and header share the same correctly owned in-memory database, and closing the database discards them. Durable default, custom, and exact shared SQLite stores retain their existing persistence and physical-owner contracts.

No disk-sentinel leak was observed in this reproduction: the pre-fix defect split state across incorrectly scoped in-memory databases. No migration or new operator action is needed.

## Evidence

Before/after proof uses real SQLite and the canonical synthetic key `agent:secondary:dashboard:incognito-fresh-session`. The explicit state root is distinct from the ambient root and is never applied to `process.env`.

| Observation | Before | After |
| --- | --- | --- |
| Creation result | Success | Success |
| Explicit-root incognito schema owner | `main` | `secondary` |
| Header location | Ambient-root secondary memory DB | Explicit-root secondary memory DB |
| Correctly scoped transcript read | Owner-mismatch error | Expected session header |
| Native open database count | Two memory databases | One memory database |
| Sentinel, WAL/SHM, registry or state-root artifacts | None observed | None observed |

The new creation regression failed on pre-fix production code: **5 failed / 3 passed**. After repair, the expanded file passes **11 tests**: omitted/explicit sentinel and supplied-durable-path incognito cases, ambient control, repeated creation/callback snapshots, three durable store controls, and separate header/lifecycle authority-rejection cases. The tests do not invent a combined atomicity guarantee: a later lifecycle refusal preserves the entry but may retain the already-committed header.

A standalone native source probe independently inspected `schema_meta`, `PRAGMA database_list`, the process-held handles and the filesystem. Parent assertions verified successful creation, one secondary-owned memory database, a readable header, and no filesystem artifacts.

Focused owner and sibling proof: **176 passed in 8 files**.

```bash
node scripts/run-vitest.mjs src/config/sessions/incognito-session-transcript.test.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.transcript-owner.test.ts src/config/sessions/session-accessor.transcript-turn-initialization.test.ts src/config/sessions/session-accessor.reset-boundary-race.test.ts src/config/sessions/session-sqlite-target.ownership.test.ts src/config/sessions/session-accessor.sqlite-handle-lifecycle.test.ts src/state/openclaw-agent-db.incognito.test.ts
```

Final parent regression and resolver controls: **28 passed in 2 files**.

```bash
node scripts/run-vitest.mjs src/config/sessions/incognito-session-transcript.test.ts src/config/sessions/session-sqlite-target.test.ts
```

Changed checks passed, including core/core-test typechecking, changed lint/format, dead-export checks, schema/legacy-store guards, and runtime import cycles.

```bash
node scripts/check-changed.mjs -- src/config/sessions/incognito-session-transcript.test.ts src/config/sessions/session-accessor.entry-mutation.ts src/config/sessions/session-accessor.sqlite-projection.ts
```

Formatting and `git diff --check` passed. Independent Codex autoreview is scoped-clean at the default P0 threshold. Current-main source comparison confirmed the relevant owners are unchanged from the reproduced base; stable-tag inspection confirmed optional-env and incognito contracts without attributing introduction or a shipped regression.

Proof boundary: this exercises the actual source creation/read flow with native SQLite, not mocked storage. No provider, browser, rebuilt package, or Gateway UI claim is made; those surfaces do not expose this explicit-env creation input. The separate strict transcript-append repair is not copied or required by these tests. Adjacent source-only scope-handoff follow-ups remain outside this change and require their own reproduction.
