### PR TITLE
fix(media): preserve literal Markdown and balanced image URLs

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
@@ -700,7 +700,6 @@ def normalize_message(message, users=None):
         "replyToMessageId": reply_to_message_id,
         "threadId": message.get("message_thread_id"),
         **message_content(content),
-        "contentType": content.get("@type"),
         "raw": message,
     }
 
@@ -994,6 +993,7 @@ def serve_message(message, users):
         "senderUsername": normalized.get("senderUsername"),
         "replyToMessageId": normalized.get("replyToMessageId"),
         "timestamp": int(message.get("date") or 0) * 1000,
+        "contentType": normalized["contentType"],
         "text": normalized["text"],
         "entities": normalized["entities"],
     }
@@ -1023,8 +1023,8 @@ def message_content(content):
     key = "text" if content.get("@type") == "messageText" else "caption"
     formatted = content.get(key)
     if isinstance(formatted, dict) and isinstance(formatted.get("text"), str):
-        return {"text": formatted["text"], "entities": formatted["entities"]}
-    return {"text": "", "entities": []}
+        return {"contentType": content.get("@type"), "text": formatted["text"], "entities": formatted["entities"]}
+    return {"contentType": content.get("@type"), "text": "", "entities": []}
 
 
 def write_ndjson(payload):

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
@@ -124,6 +124,7 @@ class PhotoContentTest(unittest.TestCase):
         self.assertEqual(created["senderUsername"], "sut_bot")
         self.assertEqual(created["replyToMessageId"], 7)
         self.assertEqual(created["timestamp"], 123000)
+        self.assertEqual(created["contentType"], "messageText")
         self.assertEqual(created["text"], text)
         self.assertEqual(created["entities"], entities)
 
@@ -151,12 +152,13 @@ class PhotoContentTest(unittest.TestCase):
                     known,
                 )
                 self.assertEqual(edited["kind"], "edit")
+                self.assertEqual(edited["contentType"], "messageText")
                 self.assertEqual(edited["text"], edited_text)
                 self.assertEqual(edited["entities"], edited_entities)
                 self.assertEqual(edited["senderId"], 101)
                 self.assertEqual(known[message_id]["entities"], edited_entities)
 
-    def test_preserves_caption_entities_in_messages_and_edits(self):
+    def test_preserves_native_content_type_and_caption_entities_in_messages_and_edits(self):
         entities = [{"offset": 3, "length": 5, "type": {"@type": "textEntityTypeCode"}}]
         message = {
             "id": 43 << 20,
@@ -173,6 +175,7 @@ class PhotoContentTest(unittest.TestCase):
             {"@type": "updateNewMessage", "message": message}, {}, known
         )
         normalized = driver.normalize_message(message)
+        self.assertEqual(created["contentType"], "messagePhoto")
         self.assertEqual(created["text"], "😀 a   b")
         self.assertEqual(created["entities"], entities)
         self.assertEqual(normalized["entities"], entities)
@@ -182,13 +185,15 @@ class PhotoContentTest(unittest.TestCase):
                 "@type": "updateMessageContent",
                 "message_id": message["id"],
                 "new_content": {
-                    "@type": "messagePhoto",
+                    "@type": "messageVideo",
                     "caption": {"@type": "formattedText", "text": "😀 a   b", "entities": []},
                 },
             },
             {},
             known,
         )
+        self.assertEqual(edited["contentType"], "messageVideo")
+        self.assertEqual(known[message["id"]]["contentType"], "messageVideo")
         self.assertEqual(edited["text"], "😀 a   b")
         self.assertEqual(edited["entities"], [])
 

--- a/docs/nodes/images.md
+++ b/docs/nodes/images.md
@@ -60,6 +60,10 @@ The 16MB audio/video and 100MB document figures above are the shared per-kind me
 - When media is present, the web sender resolves local paths or URLs using the same pipeline as `openclaw message send`.
 - Multiple media entries are sent sequentially if provided.
 
+When a channel converts Markdown image links into attachments, image syntax inside
+code blocks or inline code, and escaped image syntax, stays in the text. Inline
+image destinations retain their URL punctuation.
+
 ## Inbound Media To Commands
 
 - When inbound web messages include media, OpenClaw downloads it to a temp file and exposes templating variables:

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
@@ -43,12 +43,12 @@ describe("Telegram userbot driver runtime", () => {
         "for line in sys.stdin:",
         "    request = json.loads(line)",
         "    message_id = 10 + int(request['id'])",
-        "    update = {'kind':'message','chatId':-1001,'messageId':message_id + 1,'senderId':200,'timestamp':1000,'text':request['text'],'entities':entities}",
+        "    update = {'kind':'message','chatId':-1001,'messageId':message_id + 1,'senderId':200,'timestamp':1000,'text':request['text'],'entities':entities,'contentType':'messagePhoto'}",
         "    print(json.dumps({'type':'update','update':update}), flush=True)",
         "    for replacement in [edited_entities, []]:",
-        "        update = {**update, 'kind':'edit', 'entities':replacement}",
+        "        update = {**update, 'kind':'edit', 'entities':replacement, 'contentType':'messageVideo'}",
         "        print(json.dumps({'type':'update','update':update}), flush=True)",
-        "    result = {'chatId':-1001,'messageId':message_id,'senderId':100,'timestamp':1000,'text':request['text'],'entities':entities}",
+        "    result = {'chatId':-1001,'messageId':message_id,'senderId':100,'timestamp':1000,'text':request['text'],'entities':entities,'contentType':'messageText'}",
         "    print(json.dumps({'type':'response','id':request['id'],'result':result}), flush=True)",
       ].join("\n"),
     );
@@ -67,14 +67,28 @@ describe("Telegram userbot driver runtime", () => {
       await expect(driver.send({ text })).resolves.toMatchObject({
         messageId: 11,
         senderId: 100,
+        contentType: "messageText",
         text,
         entities,
       });
       await vi.waitFor(() => expect(updates).toHaveLength(3));
       expect(updates).toMatchObject([
-        { kind: "message", messageId: 12, senderId: 200, text, entities },
-        { kind: "edit", messageId: 12, text, entities: editedEntities },
-        { kind: "edit", messageId: 12, text, entities: [] },
+        {
+          kind: "message",
+          messageId: 12,
+          senderId: 200,
+          contentType: "messagePhoto",
+          text,
+          entities,
+        },
+        {
+          kind: "edit",
+          messageId: 12,
+          contentType: "messageVideo",
+          text,
+          entities: editedEntities,
+        },
+        { kind: "edit", messageId: 12, contentType: "messageVideo", text, entities: [] },
       ]);
       expect(() => driver.assertHealthy()).not.toThrow();
     } finally {

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
@@ -13,6 +13,7 @@ export type TelegramUserbotUpdate = {
   entities: TelegramTextEntity[];
   botApiMessageId?: number;
   chatId: number;
+  contentType?: string;
   kind: "edit" | "message";
   messageId: number;
   replyToMessageId?: number;
@@ -86,6 +87,7 @@ function parseUserbotUpdate(value: unknown): TelegramUserbotUpdate {
     timestamp,
     text: value.text,
     entities: parseTextEntities(value.entities, value.text),
+    ...(typeof value.contentType === "string" ? { contentType: value.contentType } : {}),
     ...(typeof value.botApiMessageId === "number"
       ? { botApiMessageId: value.botApiMessageId }
       : {}),

--- a/packages/markdown-core/src/image-spans.ts
+++ b/packages/markdown-core/src/image-spans.ts
@@ -1,0 +1,91 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import MarkdownIt from "markdown-it";
+
+export type MarkdownImageSpan = {
+  start: number;
+  end: number;
+  destination: string;
+};
+
+/** Finds inline image destinations without treating code or escaped syntax as media. */
+export function findMarkdownImageSpans(markdown: string): MarkdownImageSpan[] {
+  const md = new MarkdownIt("commonmark");
+  md.inline.ruler.enableOnly(["image"]);
+  const parseImage = expectDefined(md.inline.ruler.getRules("")[0], "Markdown image rule");
+  md.configure("commonmark");
+  // Media normalization owns URL spelling and allowlist matching, not the renderer.
+  md.normalizeLink = (url) => url;
+  md.validateLink = () => true;
+  const environment = {};
+  const blocks = md.parse(markdown, environment);
+  const lineOffsets = [0];
+  // Block maps count CRLF and bare CR as line breaks before source normalization.
+  for (const newline of markdown.matchAll(/\r\n?|\n/g)) {
+    lineOffsets.push(newline.index + newline[0].length);
+  }
+  const sourceLines = markdown.replace(/\0/g, "\uFFFD").split(/\r\n?|\n/);
+
+  const images: MarkdownImageSpan[] = [];
+  let source = "";
+  let inlineLines: Array<{ start: number; offset: number }> = [];
+  let inlineLine = 0;
+  const sourceOffset = (position: number) => {
+    for (
+      let next = inlineLines[inlineLine + 1];
+      next && next.start <= position;
+      next = inlineLines[inlineLine + 1]
+    ) {
+      inlineLine += 1;
+    }
+    return position + expectDefined(inlineLines[inlineLine], "Markdown inline line").offset;
+  };
+  md.inline.ruler.at("image", (state, silent) => {
+    const start = state.pos;
+    const matched = parseImage(state, silent);
+    // Image labels recurse into the inline parser; only the outer source owns offsets.
+    if (matched && !silent && state.src === source) {
+      const token = expectDefined(state.tokens.at(-1), "Parsed Markdown image");
+      if (token.meta?.label) {
+        return matched;
+      }
+      images.push({
+        start: sourceOffset(start),
+        end: sourceOffset(state.pos),
+        destination: String(expectDefined(token.attrGet("src"), "Markdown image destination")),
+      });
+    }
+    return matched;
+  });
+  // Parse the same inline content as the renderer. Reintroducing container
+  // markers can change inline HTML/code semantics and hide valid images.
+  for (const block of blocks) {
+    if (
+      block.type !== "inline" ||
+      !block.map ||
+      !block.children?.some((token) => token.type === "image")
+    ) {
+      continue;
+    }
+    source = block.content;
+    const firstLine = block.map[0];
+    let start = 0;
+    inlineLines = source.split("\n").map((content, index) => {
+      const original = expectDefined(sourceLines[firstLine + index], "Markdown source line");
+      const text = content.trimStart();
+      // Block parsing removes container prefixes and can expand leading tabs;
+      // the non-whitespace inline bytes retain their position within that line.
+      const offset =
+        expectDefined(lineOffsets[firstLine + index], "Markdown source offset") +
+        original.indexOf(text) -
+        (content.length - text.length) -
+        start;
+      const line = { start, offset };
+      start += content.length + 1;
+      return line;
+    });
+    inlineLine = 0;
+    // Reference images remain text; only explicit inline destinations become attachments.
+    md.inline.parse(source, md, environment, []);
+  }
+  return images;
+}

--- a/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
+++ b/qa/scenarios/channels/telegram-semantic-formatting-boundaries.yaml
@@ -6,18 +6,21 @@ scenario:
   coverage:
     primary:
       - telegram.conversation-routing-and-delivery
-  objective: Preserve semantic whitespace and formatting ranges across real Telegram message boundaries.
+  objective: Preserve literal Markdown, image destinations, and semantic formatting across real Telegram message boundaries.
   successCriteria:
     - Actual Test Server messages match the literal text, chunk count, and UTF-16 entity ranges.
     - Code indentation and internal whitespace survive, and each visible checkbox stays with its bold label.
     - Plain-text fallback cannot satisfy the required native formatting entities.
+    - Inline-code and escaped image syntax remain native text messages; a genuine image retains its balanced URL and arrives as a photo.
   docsRefs:
     - docs/channels/telegram.md
     - docs/concepts/markdown-formatting.md
+    - docs/nodes/images.md
   codeRefs:
     - packages/markdown-core/src/render-aware-chunking.ts
     - extensions/telegram/src/format.ts
     - extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+    - src/media/parse.ts
   execution:
     kind: flow
     channel: telegram
@@ -25,7 +28,7 @@ scenario:
     timeoutMs: 180000
     suiteIsolation: isolated
     isolationReason: Native receive cursors and default formatting assertions belong to this proof.
-    summary: Send literal Markdown through the normal Gateway and inspect TDLib text and entities.
+    summary: Send literal Markdown through the normal Gateway and inspect TDLib content types, text, and entities.
     config:
       requiredProviderMode: live-frontier
       requiredChannelDriver: live
@@ -52,6 +55,14 @@ flow:
           saveAs: runId
         - set: proofs
           value: []
+        - set: candidateHead
+          value:
+            expr: "(await qaImport('node:child_process')).execFileSync('git', ['rev-parse', 'HEAD'], { cwd: env.repoRoot, encoding: 'utf8' }).trim()"
+        - set: imageUrl
+          value: https://artifacts.openclaw.ai/mantis/qa30-media-markdown/83b55b46f3b3575690f7bc2252ef66d78323cd517079da66aef9b9d475e934c9/markdown-image(chart.png)
+        - set: imageMarkdown
+          value:
+            expr: "`![chart](${imageUrl})`"
         - set: fixtures
           value:
             expr: |
@@ -60,6 +71,7 @@ flow:
                   id: "inline-code-utf16-and-link",
                   markdown: "😀 `a   b` [x](https://example.com/qa)",
                   expectedChunks: [{
+                    contentType: "messageText",
                     text: "😀 a   b x",
                     entities: [
                       { offset: 3, length: 5, type: { "@type": "textEntityTypeCode" } },
@@ -71,17 +83,40 @@ flow:
                   id: "fenced-code-rendered-boundary",
                   markdown: "```\n" + "A".repeat(3977) + "\n  x  \n \ny\n```",
                   expectedChunks: [
-                    { text: "A".repeat(3976), entities: [{ offset: 0, length: 3976, type: { "@type": "textEntityTypePre" } }] },
-                    { text: "A\n  x  \n \ny", entities: [{ offset: 0, length: 11, type: { "@type": "textEntityTypePre" } }] }
+                    { contentType: "messageText", text: "A".repeat(3976), entities: [{ offset: 0, length: 3976, type: { "@type": "textEntityTypePre" } }] },
+                    { contentType: "messageText", text: "A\n  x  \n \ny", entities: [{ offset: 0, length: 11, type: { "@type": "textEntityTypePre" } }] }
                   ]
                 },
                 {
                   id: "task-marker-boundary",
                   markdown: "- [ ] **" + "A".repeat(1988) + "**\n- [x] **" + "B".repeat(1988) + "**",
                   expectedChunks: [
-                    { text: "• [ ] " + "A".repeat(1988), entities: [{ offset: 6, length: 1988, type: { "@type": "textEntityTypeBold" } }] },
-                    { text: "• [x] " + "B".repeat(1988), entities: [{ offset: 6, length: 1988, type: { "@type": "textEntityTypeBold" } }] }
+                    { contentType: "messageText", text: "• [ ] " + "A".repeat(1988), entities: [{ offset: 6, length: 1988, type: { "@type": "textEntityTypeBold" } }] },
+                    { contentType: "messageText", text: "• [x] " + "B".repeat(1988), entities: [{ offset: 6, length: 1988, type: { "@type": "textEntityTypeBold" } }] }
                   ]
+                },
+                {
+                  id: "inline-code-image-is-text",
+                  markdown: "`" + imageMarkdown + "`",
+                  expectedChunks: [{
+                    contentType: "messageText",
+                    text: imageMarkdown,
+                    entities: [{ offset: 0, length: imageMarkdown.length, type: { "@type": "textEntityTypeCode" } }]
+                  }]
+                },
+                {
+                  id: "escaped-image-is-text",
+                  markdown: "\\" + imageMarkdown,
+                  expectedChunks: [{
+                    contentType: "messageText",
+                    text: "!chart",
+                    entities: [{ offset: 1, length: 5, type: { "@type": "textEntityTypeTextUrl", url: imageUrl } }]
+                  }]
+                },
+                {
+                  id: "balanced-image-url-is-photo",
+                  markdown: imageMarkdown,
+                  expectedChunks: [{ contentType: "messagePhoto", text: "", entities: [] }]
                 }
               ]
         - forEach:
@@ -116,12 +151,12 @@ flow:
                   expr: "readTelegramMessages().slice(startIndex)"
               - set: actual
                 value:
-                  expr: "received.map(({ text, entities }) => ({ text, entities: entities.map(({ offset, length, type }) => ({ offset, length, type: { '@type': type['@type'], ...(type['@type'] === 'textEntityTypeTextUrl' ? { url: type.url } : {}), ...(type['@type'] === 'textEntityTypePreCode' ? { language: type.language } : {}) } })) }))"
+                  expr: "received.map(({ contentType, text, entities }) => ({ contentType, text, entities: entities.map(({ offset, length, type }) => ({ offset, length, type: { '@type': type['@type'], ...(type['@type'] === 'textEntityTypeTextUrl' ? { url: type.url } : {}), ...(type['@type'] === 'textEntityTypePreCode' ? { language: type.language } : {}) } })) }))"
               - assert:
                   expr: "String(received.at(-1)?.botApiMessageId) === String(receipt.messageId) && JSON.stringify(actual) === JSON.stringify(fixture.expectedChunks)"
                   message:
-                    expr: "JSON.stringify({ case: fixture.id, expected: fixture.expectedChunks, observed: actual.map((message, index) => ({ text: message.text === fixture.expectedChunks[index]?.text ? message.text : message.text.replace(/\\S/gu, '?'), nonWhitespaceRedacted: message.text !== fixture.expectedChunks[index]?.text, entities: message.entities.map((entity) => ({ offset: entity.offset, length: entity.length, type: entity.type['@type'], expectedTypePayload: JSON.stringify(entity.type) === JSON.stringify(fixture.expectedChunks[index]?.entities.find((expected) => expected.offset === entity.offset && expected.length === entity.length)?.type) })) })) })"
+                    expr: "JSON.stringify({ case: fixture.id, expected: fixture.expectedChunks, observed: actual.map((message, index) => ({ contentType: message.contentType, text: message.text === fixture.expectedChunks[index]?.text ? message.text : message.text.replace(/\\S/gu, '?'), nonWhitespaceRedacted: message.text !== fixture.expectedChunks[index]?.text, entities: message.entities.map((entity) => ({ offset: entity.offset, length: entity.length, type: entity.type['@type'], expectedTypePayload: JSON.stringify(entity.type) === JSON.stringify(fixture.expectedChunks[index]?.entities.find((expected) => expected.offset === entity.offset && expected.length === entity.length)?.type) })) })) })"
               - set: proofs
                 value:
                   expr: "proofs.concat([{ case: fixture.id, chunks: actual }])"
-      detailsExpr: "JSON.stringify({ transport: 'Telegram Test Server', topology: 'leased group', operation: 'Gateway send', modelInvocation: false, cases: proofs })"
+      detailsExpr: "JSON.stringify({ transport: 'Telegram Test Server', topology: 'leased group', operation: 'Gateway send', candidateHead, modelInvocation: false, cases: proofs })"

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -418,6 +418,55 @@ describe("splitMediaFromOutput", () => {
     );
   });
 
+  it("selects an explicitly allowlisted file URL", () => {
+    const url = "file:///tmp/selected.png";
+    expectParsedMediaOutputCase(
+      `Before ![selected](${url}) after`,
+      { text: "Before after", mediaUrls: [url] },
+      { markdownImageAllowlist: [url] },
+    );
+  });
+
+  it("preserves blockquote inline semantics when locating an image", () => {
+    const url = "https://example.com/chart.png";
+    expectParsedMediaOutputCase(
+      `> <span title="![chart](${url})"\n> caption`,
+      { text: '> <span title=""\n> caption', mediaUrls: [url] },
+      extractMarkdownImages,
+    );
+  });
+
+  it("does not recursively parse nested image labels", () => {
+    const nested = "![".repeat(4_000) + "x" + "](x)".repeat(4_000);
+    const url = "https://example.com/chart.png";
+    const startedAt = performance.now();
+    expectParsedMediaOutputCase(
+      `${nested}\n![chart](${url})`,
+      { text: nested, mediaUrls: [url] },
+      extractMarkdownImages,
+    );
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("locates quoted images after an identical code example", () => {
+    const image = "![chart](https://example.com/chart.png)";
+    expectParsedMediaOutputCase(
+      `> \`${image}\` ${image}`,
+      { text: `> \`${image}\``, mediaUrls: ["https://example.com/chart.png"] },
+      extractMarkdownImages,
+    );
+  });
+
+  it("keeps nested labels within reference images literal", () => {
+    const input =
+      "![![nested](https://example.com/nested.png)][outer]\n\n[outer]: https://example.com/outer.png";
+    expectParsedMediaOutputCase(
+      input,
+      { text: input, mediaUrls: undefined },
+      extractMarkdownImages,
+    );
+  });
+
   it("extracts multiple markdown image urls in order", () => {
     expectParsedMediaOutputCase(
       "Before\n![one](https://example.com/one.png)\nMiddle\n![two](https://example.com/two.png)\nAfter",
@@ -447,6 +496,37 @@ describe("splitMediaFromOutput", () => {
         text: "Chart now",
         mediaUrls: ["https://example.com/a_(1).png"],
       },
+      extractMarkdownImages,
+    );
+  });
+
+  it.each([
+    ["inline code", "Use `![chart](https://example.com/chart.png)` as an example."],
+    ["escaped syntax", "\\![chart](https://example.com/chart.png)"],
+    ["indented code", "    ![chart](https://example.com/chart.png)"],
+    ["multiline inline code", "``example\n![chart](https://example.com/chart.png)\n``"],
+  ])("keeps Markdown image syntax literal in %s", (_name, input) => {
+    expectParsedMediaOutputCase(
+      input,
+      { text: input, mediaUrls: undefined },
+      extractMarkdownImages,
+    );
+  });
+
+  it("preserves balanced punctuation at the end of a Markdown image destination", () => {
+    const url = "https://example.com/render?label=(chart)";
+    expectParsedMediaOutputCase(
+      `![chart](${url})`,
+      { text: "", mediaUrls: [url] },
+      extractMarkdownImages,
+    );
+  });
+
+  it.each(["\n", "\r\n", "\r"])("keeps image offsets across %j line endings", (newline) => {
+    const url = "https://example.com/chart.png";
+    expectParsedMediaOutputCase(
+      `before${newline}${newline}![chart](${url})`,
+      { text: "before", mediaUrls: [url] },
       extractMarkdownImages,
     );
   });
@@ -493,6 +573,22 @@ describe("splitMediaFromOutput", () => {
       extractMarkdownImages,
     );
   });
+
+  it.each(["a* ", "] "])(
+    "extracts images after oversized delimiter-heavy prose (%s)",
+    (delimiter) => {
+      const prose = delimiter.repeat(40_000);
+      const url = "https://example.com/image.png";
+      const startedAt = performance.now();
+      expectParsedMediaOutputCase(
+        `${prose}\n![image](${url})`,
+        { text: prose.trimEnd(), mediaUrls: [url] },
+        extractMarkdownImages,
+      );
+      // Quadratic delimiter scans take seconds; normal parsing stays well below this margin.
+      expect(performance.now() - startedAt).toBeLessThan(2_000);
+    },
+  );
 
   it.each([
     "![Node.js](https://img.shields.io/badge/Node.js-339933?logo=node.js&logoColor=white)",

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -12,6 +12,10 @@ import {
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { expectDefined } from "@openclaw/normalization-core";
 import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
+import {
+  findMarkdownImageSpans,
+  type MarkdownImageSpan as MarkdownImageMatch,
+} from "../../packages/markdown-core/src/image-spans.js";
 import { parseAudioTag } from "./audio-tags.js";
 
 /** Captures legacy MEDIA: attachment directives from model/tool output. */
@@ -254,7 +258,7 @@ function unwrapQuoted(value: string): string | undefined {
 }
 
 function normalizeMarkdownImageDestination(destination: string): string {
-  return normalizeMediaSource(cleanCandidate(unwrapQuoted(destination) ?? destination));
+  return normalizeMediaSource(destination.trim());
 }
 
 function mayContainFenceMarkers(input: string): boolean {
@@ -265,205 +269,16 @@ function cleanLineText(text: string): string {
   return text.replace(/[ \t]{2,}/g, " ").trim();
 }
 
-type MarkdownImageMatch = {
-  start: number;
-  end: number;
-  destination: string;
-};
-
 const MAX_MARKDOWN_IMAGE_LINE_LENGTH = 20_000;
-const MAX_MARKDOWN_IMAGE_ATTEMPTS_PER_LINE = 80;
 const MAX_MARKDOWN_IMAGE_MATCHES_PER_LINE = 50;
-
-function findMatchingBracket(
-  input: string,
-  start: number,
-  open: string,
-  close: string,
-): number | undefined {
-  let depth = 1;
-  for (let i = start; i < input.length; i += 1) {
-    const ch = input[i];
-    if (ch === "\\") {
-      i += 1;
-      continue;
-    }
-    if (ch === open) {
-      depth += 1;
-      continue;
-    }
-    if (ch !== close) {
-      continue;
-    }
-    depth -= 1;
-    if (depth === 0) {
-      return i;
-    }
-  }
-  return undefined;
-}
 
 function isRemoteMarkdownImageMedia(candidate: string): boolean {
   return hasHttpUrlPrefix(candidate) && isValidMedia(candidate);
 }
 
-function parseMarkdownTitle(input: string, start: number): number | undefined {
-  let index = start;
-  while (index < input.length && /\s/.test(input[index] ?? "")) {
-    index += 1;
-  }
-  const opener = input[index];
-  if (!opener) {
-    return undefined;
-  }
-  const closer = opener === '"' || opener === "'" ? opener : opener === "(" ? ")" : null;
-  if (!closer) {
-    return undefined;
-  }
-  const closingIndex =
-    opener === "("
-      ? findMatchingBracket(input, index + 1, "(", ")")
-      : (() => {
-          for (let i = index + 1; i < input.length; i += 1) {
-            const ch = input[i];
-            if (ch === "\\") {
-              i += 1;
-              continue;
-            }
-            if (ch === closer) {
-              return i;
-            }
-          }
-          return undefined;
-        })();
-  if (closingIndex == null) {
-    return undefined;
-  }
-  let tailIndex = closingIndex + 1;
-  while (tailIndex < input.length && /\s/.test(input[tailIndex] ?? "")) {
-    tailIndex += 1;
-  }
-  return input[tailIndex] === ")" ? tailIndex + 1 : undefined;
-}
-
-function parseMarkdownImageDestination(
-  input: string,
-  start: number,
-): { destination: string; end: number } | undefined {
-  let index = start;
-  while (index < input.length && /\s/.test(input[index] ?? "")) {
-    index += 1;
-  }
-  if (index >= input.length) {
-    return undefined;
-  }
-
-  if (input[index] === "<") {
-    let closing = index + 1;
-    while (closing < input.length) {
-      const ch = input[closing];
-      if (ch === "\\") {
-        closing += 2;
-        continue;
-      }
-      if (ch === ">") {
-        const destination = input.slice(index + 1, closing).trim();
-        if (!destination) {
-          return undefined;
-        }
-        let tailIndex = closing + 1;
-        while (tailIndex < input.length && /\s/.test(input[tailIndex] ?? "")) {
-          tailIndex += 1;
-        }
-        if (input[tailIndex] === ")") {
-          return { destination, end: tailIndex + 1 };
-        }
-        const titledEnd = parseMarkdownTitle(input, tailIndex);
-        return titledEnd ? { destination, end: titledEnd } : undefined;
-      }
-      closing += 1;
-    }
-    return undefined;
-  }
-
-  const destinationStart = index;
-  let destinationEnd = index;
-  let parenDepth = 0;
-  while (index < input.length) {
-    const ch = input.charAt(index);
-    if (ch === "\\") {
-      index += 2;
-      destinationEnd = index;
-      continue;
-    }
-    if (ch === "(") {
-      parenDepth += 1;
-      index += 1;
-      destinationEnd = index;
-      continue;
-    }
-    if (ch === ")") {
-      if (parenDepth === 0) {
-        const destination = input.slice(destinationStart, destinationEnd).trim();
-        return destination ? { destination, end: index + 1 } : undefined;
-      }
-      parenDepth -= 1;
-      index += 1;
-      destinationEnd = index;
-      continue;
-    }
-    if (/\s/.test(ch) && parenDepth === 0) {
-      const destination = input.slice(destinationStart, destinationEnd).trim();
-      if (!destination) {
-        return undefined;
-      }
-      const titledEnd = parseMarkdownTitle(input, index);
-      return titledEnd ? { destination, end: titledEnd } : undefined;
-    }
-    index += 1;
-    destinationEnd = index;
-  }
-  return undefined;
-}
-
-function findMarkdownImageMatches(line: string): MarkdownImageMatch[] {
-  if (line.length > MAX_MARKDOWN_IMAGE_LINE_LENGTH) {
-    return [];
-  }
-  const matches: MarkdownImageMatch[] = [];
-  let searchIndex = 0;
-  let attempts = 0;
-  while (
-    matches.length < MAX_MARKDOWN_IMAGE_MATCHES_PER_LINE &&
-    attempts < MAX_MARKDOWN_IMAGE_ATTEMPTS_PER_LINE
-  ) {
-    const index = line.indexOf("![", searchIndex);
-    if (index < 0) {
-      break;
-    }
-    attempts += 1;
-    const altEnd = findMatchingBracket(line, index + 2, "[", "]");
-    if (altEnd == null || line[altEnd + 1] !== "(") {
-      searchIndex = index + 2;
-      continue;
-    }
-    const parsed = parseMarkdownImageDestination(line, altEnd + 2);
-    if (!parsed) {
-      searchIndex = index + 2;
-      continue;
-    }
-    matches.push({
-      start: index,
-      end: parsed.end,
-      destination: parsed.destination,
-    });
-    searchIndex = parsed.end;
-  }
-  return matches;
-}
-
 function collectMarkdownImageSegments(params: {
   line: string;
+  matches: MarkdownImageMatch[];
   media: string[];
   allowlist?: ReadonlyMap<string, string>;
 }): {
@@ -471,7 +286,7 @@ function collectMarkdownImageSegments(params: {
   lineSegments: ParsedMediaOutputSegment[];
   foundMedia: boolean;
 } {
-  const matches = findMarkdownImageMatches(params.line);
+  const { matches } = params;
   if (matches.length === 0) {
     return { lineSegments: [], foundMedia: false };
   }
@@ -553,7 +368,7 @@ export function splitMediaFromOutput(
     markdownImageAllowlist !== undefined || options.extractMarkdownImages === true;
   const extractMediaDirectives = options.extractMediaDirectives !== false;
   const mayContainMediaToken = extractMediaDirectives && /media:/i.test(trimmedRaw);
-  const mayContainMarkdownImage = extractMarkdownImages && /!\[[^\]]*]\(/.test(trimmedRaw);
+  const mayContainMarkdownImage = extractMarkdownImages && trimmedRaw.includes("![");
   const mayContainAudioTag = trimmedRaw.includes("[[");
   if (!mayContainMediaToken && !mayContainMarkdownImage && !mayContainAudioTag) {
     return { text: trimmedRaw };
@@ -585,11 +400,37 @@ export function splitMediaFromOutput(
   // Line-wise parsing preserves visible text while letting MEDIA-only lines disappear cleanly.
   const lines = trimmedRaw.split("\n");
   const keptLines: string[] = [];
+  const markdownImages =
+    mayContainMarkdownImage &&
+    lines.some((line) => line.length <= MAX_MARKDOWN_IMAGE_LINE_LENGTH && line.includes("!["))
+      ? findMarkdownImageSpans(trimmedRaw)
+      : [];
+  let markdownImageIndex = 0;
 
   let lineOffset = 0; // Track character offset for fence checking
   // Line offsets and scanner spans advance in source order.
   let fenceIndex = 0;
   for (const line of lines) {
+    const lineEnd = lineOffset + line.length;
+    const lineImages: MarkdownImageMatch[] = [];
+    for (; markdownImageIndex < markdownImages.length; markdownImageIndex += 1) {
+      const match = expectDefined(markdownImages[markdownImageIndex], "Markdown image span");
+      if (match.start >= lineEnd) {
+        break;
+      }
+      if (
+        line.length <= MAX_MARKDOWN_IMAGE_LINE_LENGTH &&
+        lineImages.length < MAX_MARKDOWN_IMAGE_MATCHES_PER_LINE &&
+        match.start >= lineOffset &&
+        match.end <= lineEnd
+      ) {
+        lineImages.push({
+          ...match,
+          start: match.start - lineOffset,
+          end: match.end - lineOffset,
+        });
+      }
+    }
     // Fenced examples must remain text; extracting their MEDIA tokens would mutate transcripts.
     let fence = fenceSpans[fenceIndex];
     while (fence && lineOffset >= fence.end) {
@@ -606,7 +447,12 @@ export function splitMediaFromOutput(
     const trimmedStart = line.trimStart();
     if (!extractMediaDirectives || !trimmedStart.toUpperCase().startsWith("MEDIA:")) {
       const markdownImageResult = extractMarkdownImages
-        ? collectMarkdownImageSegments({ line, media, allowlist: markdownImageAllowlist })
+        ? collectMarkdownImageSegments({
+            line,
+            matches: lineImages,
+            media,
+            allowlist: markdownImageAllowlist,
+          })
         : { lineSegments: [], foundMedia: false };
       if (!markdownImageResult.foundMedia) {
         keptLines.push(line);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Markdown image extraction has two separate user-visible failures. Code examples and escaped image syntax can become attachments and disappear from the message; genuine image destinations ending in a balanced parenthesis can lose that required character and fail to load. Fixes #136139 and #136140.

## Why This Change Was Made

Image spans now come from the existing Markdown parser's syntax owner instead of a second handwritten image grammar. Source offsets preserve surrounding text, container indentation and CRLF/bare-CR line endings. Code, escaped syntax and reference images remain text. Explicit inline image destinations retain their punctuation.

Media approval stays with the existing media owner: remote URL policy, local path policy, explicit allowlists, extraction limits and audio/MEDIA directives continue through their current checks. The syntax helper deliberately preserves the destination spelling for those checks.

The existing Telegram semantic-formatting scenario now covers code-image text, escaped-image text and a genuine image whose final URL parenthesis is required. Its existing native observer carries TDLib's own content type through create/edit events, so plain text cannot masquerade as a photo. The three previous formatting cases remain covered. This observer change does not infer content type or change message delivery.

Production **net -61 LOC**: parser/scanner -63, observer +2, Python projection move net zero. Tests add 115 lines, scenario fixtures add 35, and docs add 4. No new dependency, configuration, persisted data or protocol-version change.

## Evidence

Five original syntax regressions fail before the repair, with separate destination/normal-loader proof for the missing terminal parenthesis. The acting reviewer ran **515 owner/sibling tests** across four shards. The proof extension passes **112 TypeScript tests**, **nine Python tests** and **six complete scenario cases** covering catalog/flow initialization, outbound planning, formatting and photo selection.

The maintained scenario uses a synthetic 32×32 PNG on the existing OpenClaw artifact host. Real HTTPS fetch and the unmodified `loadWebMedia` return its exact 103 bytes and `image/png` type; removing only the final URL parenthesis returns 404. SHA-256: `83b55b46f3b3575690f7bc2252ef66d78323cd517079da66aef9b9d475e934c9`. The fixture is published for future scenario runs and adds no repository binary.

The complete changed-file gate passes all selected lanes, including types, lint, dead-export and import-cycle checks. Fresh independent Codex P2 review covers all nine changed text files and reports zero findings (confidence 0.87). Rebasing onto current main preserved all nine reviewed file hashes.

The exact-head Telegram Test Server run now passes all six semantic-formatting cases. Its native TDLib results and cleanup evidence are recorded below.

Post-rebase verification at `6f6c5203c058d70ebfe2eb1b7844e9c5d178e44b`: QA runtime build, the real public-image six-case probe, 112 TypeScript tests, nine Python tests and the full changed-file gate all pass. Dependency manifests and all nine reviewed source hashes are unchanged.

## Dependency contract checked by the acting reviewer

The review's dependency-environment gap is resolved by direct inspection of installed markdown-it 15.0.0, its owning package pin, and its shipped implementation/types. In dist/markdown-it.mjs, Ruler.at replaces the named rule and invalidates its cache (636–642); enableOnly/getRules select the original image rule (767–808); configure("commonmark") restores the preset's complete rule chains (3691–3715). The rule order preserves escaping and code parsing before image parsing (3303–3317).

The image rule advances state.pos only after a complete destination, parses labels recursively, and marks reference images with meta.label (3016–3096). Its normalization and validation hooks are explicit typed extension points; existing OpenClaw media approval remains the separate authority. CRLF/bare-CR and NUL normalization are confirmed at 1032–1039. The matching public types declare Ruler.at/enableOnly/getRules and link hooks at 407/490/509/821/826.

This checks the pinned dependency directly, rather than inferring its behavior from OpenClaw wrappers. The after-fix native Telegram result is recorded separately below; no local parser or mocked planner result substitutes for it.

## Native Telegram evidence

[Telegram Test Server job](https://github.com/openclaw/openclaw/actions/runs/33615962549/job/100203210086) passed on September 2 at 09:59UTC. The selected candidate recorded in the final result is `6f6c5203c058d70ebfe2eb1b7844e9c5d178e44b`; the workflow definition ran from main `c6dcb97176cfae5b918b5efd3b471f5bbbc689ed`. The maintained `telegram-semantic-formatting-boundaries` scenario calls the real Gateway send flow and observes native TDLib messages. It does not invoke a model.

All six cases passed, producing eight native chunks: seven `messageText` and one `messagePhoto`. The three existing cases preserved their UTF-16 code/link offsets, fenced-code split and task-marker split. These are the exact synthetic native outcomes for the three added cases:

```json
[
  {
    "case": "inline-code-image-is-text",
    "chunks": [
      {
        "contentType": "messageText",
        "text": "![chart](https://artifacts.openclaw.ai/mantis/qa30-media-markdown/83b55b46f3b3575690f7bc2252ef66d78323cd517079da66aef9b9d475e934c9/markdown-image(chart.png))",
        "entities": [
          {
            "offset": 0,
            "length": 157,
            "type": {
              "@type": "textEntityTypeCode"
            }
          }
        ]
      }
    ]
  },
  {
    "case": "escaped-image-is-text",
    "chunks": [
      {
        "contentType": "messageText",
        "text": "!chart",
        "entities": [
          {
            "offset": 1,
            "length": 5,
            "type": {
              "@type": "textEntityTypeTextUrl",
              "url": "https://artifacts.openclaw.ai/mantis/qa30-media-markdown/83b55b46f3b3575690f7bc2252ef66d78323cd517079da66aef9b9d475e934c9/markdown-image(chart.png)"
            }
          }
        ]
      }
    ]
  },
  {
    "case": "balanced-image-url-is-photo",
    "chunks": [
      {
        "contentType": "messagePhoto",
        "text": "",
        "entities": []
      }
    ]
  }
]
```

The artifact ZIP digest is `18beb03d3514c89a0882a399704c9691cc23ae5fa26d37829a574439345f367a`; the final summary and native evidence hashes are `a15b10479d70e6045be37a726c58ac510fcdce18834b32857cd9024ff4514a60` and `2716f169ac041d63d9553189fe1efd43c0279e7807bac8324db9d7805e73ad84`. The acting reviewer verified the downloaded digest and inspected the complete sanitized text/entity inventory. Bot, user and chat identities are omitted from this PR.

The cleanup owner returned successfully before publishing final results: Gateway stop, native observer/proxy cleanup and credential-lease release are awaited, and cleanup failures throw. Terminal job success plus final artifacts prove that owner completed; no separate broker receipt or process census is claimed.

The Telegram lane passed. Separate manual-workflow follow-ups remain: the Slack private QA bundle cannot resolve the plugin-local @slack/web-api package; the Discord voice-transcript fixture lacks its explicitly provisioned voiceChannelId. The Discord result is a fixture-provisioning gap, not a product defect, and the aggregate all-lanes workflow is not claimed green.

Normal PR CI33615555610 is green at this unchanged head on attempt2. Its first attempt failed before running the private-key hook because Git could not fetch the public pre-commit hook repository; the existing failed-job retry passed, including security-fast. The fresh PR rollup has238successes,47skips and1neutral with no failed or pending check.

## Maintainer disposition

The latest review at10:13UTC accepts the exact-head native Telegram proof and identifies no actionable code finding. This PR is being handled through the explicitly authorized maintainer QA-and-land workflow; the acting reviewer accepts the parser ownership repair and the inspected evidence. The protected maintainer label governs automated disposition and is retained. Landing proceeds through the normal native workflow and server-enforced branch checks.
