### PR TITLE
fix(feishu): expand quoted merged-forward messages

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -445,7 +445,7 @@ extensions/feishu/src/bot-content.ts	1
 extensions/feishu/src/bot-identity-cache.ts	1
 extensions/feishu/src/bot-name.ts	4
 extensions/feishu/src/bot-sender-name.ts	2
-extensions/feishu/src/bot.ts	9
+extensions/feishu/src/bot.ts	8
 extensions/feishu/src/card-action.ts	1
 extensions/feishu/src/card-interaction.ts	1
 extensions/feishu/src/channel.ts	7

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -1,12 +1,11 @@
 // Feishu plugin module implements bot content behavior.
-import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { buildFeishuConversationId } from "./conversation-id.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { parseInteractiveCardContent } from "./interactive-message-content.js";
 import { saveMessageResourceFeishu } from "./media.js";
 import { isFeishuBroadcastMention } from "./mention.js";
+import { formatFeishuMediaContent } from "./message-content.js";
 import { parsePostContent } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
 import type { FeishuChatType, FeishuMediaInfo } from "./types.js";
@@ -42,8 +41,6 @@ type FeishuMessageLike = {
 };
 
 type GroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
-
-type FeishuLogger = (...args: unknown[]) => void;
 
 type ResolvedFeishuGroupSession = {
   peerId: string;
@@ -177,100 +174,6 @@ export function parseMessageContent(content: string, messageType: string): strin
 }
 
 const FEISHU_MEDIA_MESSAGE_TYPES = new Set(["image", "file", "audio", "video", "media", "sticker"]);
-
-function formatFeishuMediaContent(parsed: Record<string, unknown>, messageType: string): string {
-  if (messageType === "sticker") {
-    const fileKey = normalizeFeishuExternalKey(parsed?.file_key);
-    return fileKey ? `<sticker key="${escapeHtml(fileKey)}"/>` : "[Sticker]";
-  }
-  const speechToText =
-    messageType === "audio" && typeof parsed.speech_to_text === "string"
-      ? parsed.speech_to_text.trim()
-      : "";
-  if (speechToText) {
-    return speechToText;
-  }
-  return "";
-}
-
-function formatSubMessageContent(content: string, contentType: string): string {
-  try {
-    const parsed = JSON.parse(content);
-    switch (contentType) {
-      case "text":
-        return parsed.text || content;
-      case "post":
-        return parsePostContent(content).textContent;
-      case "interactive":
-        return parseInteractiveCardContent(parsed);
-      case "image":
-        return "[Image]";
-      case "file":
-        return `[File: ${parsed.file_name || "unknown"}]`;
-      case "audio":
-        return "[Audio]";
-      case "video":
-        return "[Video]";
-      case "sticker":
-        return formatFeishuMediaContent(parsed, contentType);
-      case "merge_forward":
-        return "[Nested Merged Forward]";
-      default:
-        return `[${contentType}]`;
-    }
-  } catch {
-    return content;
-  }
-}
-
-export function parseMergeForwardContent(params: { content: string; log?: FeishuLogger }): string {
-  const { content, log } = params;
-  const maxMessages = 50;
-  log?.("feishu: parsing merge_forward sub-messages from API response");
-
-  let items: Array<{
-    message_id?: string;
-    msg_type?: string;
-    body?: { content?: string };
-    sender?: { id?: string };
-    upper_message_id?: string;
-    create_time?: string;
-  }>;
-  try {
-    items = JSON.parse(content);
-  } catch {
-    log?.("feishu: merge_forward items parse failed");
-    return "[Merged and Forwarded Message - parse error]";
-  }
-  if (!Array.isArray(items) || items.length === 0) {
-    return "[Merged and Forwarded Message - no sub-messages]";
-  }
-  const container = items.find(
-    (item) => item.msg_type === "merge_forward" && !item.upper_message_id,
-  );
-  const subMessages = container
-    ? items.filter((item) => item !== container)
-    : items.filter((item) => item.upper_message_id);
-  if (subMessages.length === 0) {
-    return "[Merged and Forwarded Message - no sub-messages found]";
-  }
-
-  log?.(`feishu: merge_forward contains ${subMessages.length} sub-messages`);
-  subMessages.sort(
-    (a, b) =>
-      (parseStrictNonNegativeInteger(a.create_time) ?? 0) -
-      (parseStrictNonNegativeInteger(b.create_time) ?? 0),
-  );
-
-  const lines = ["[Merged and Forwarded Messages]"];
-  for (const item of subMessages.slice(0, maxMessages)) {
-    lines.push(`- ${formatSubMessageContent(item.body?.content || "", item.msg_type || "text")}`);
-  }
-  if (subMessages.length > maxMessages) {
-    lines.push(`... and ${subMessages.length - maxMessages} more messages`);
-  }
-  return lines.join("\n");
-}
 
 export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string): boolean {
   if (!botOpenId) {

--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { buildFeishuAgentBody } from "./bot-agent-body.js";
 import { buildBroadcastSessionKey, resolveBroadcastAgents } from "./bot-broadcast.js";
-import { parseMergeForwardContent, parseMessageContent } from "./bot-content.js";
+import { parseMessageContent } from "./bot-content.js";
+import { parseMergeForwardContent } from "./message-content.js";
 
 describe("buildFeishuAgentBody", () => {
   it("builds message id, speaker, quoted content, mention context, and permission notice in order", () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2627,6 +2627,28 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("bounds merged-forward prompt content and marks truncation", () => {
+    const content = JSON.stringify([
+      {
+        message_id: "container",
+        msg_type: "merge_forward",
+        body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+      },
+      {
+        message_id: "oversized",
+        upper_message_id: "container",
+        msg_type: "text",
+        body: { content: JSON.stringify({ text: "😀".repeat(20_000) }) },
+      },
+    ]);
+
+    const parsed = parseMergeForwardContent({ content });
+
+    expect(parsed.length).toBeLessThanOrEqual(20_000);
+    expect(parsed.endsWith("\n... [Merged-forward content truncated]")).toBe(true);
+    expect(parsed).not.toMatch(/[\uD800-\uDFFF]/u);
+  });
+
   it("falls back when merge_forward API returns no sub-messages", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockCreateFeishuClient.mockReturnValue({

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -11,7 +11,6 @@ import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveGroupSessionKey } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
-import { parseMergeForwardContent } from "./bot-content.js";
 import type { FeishuMessageEvent } from "./bot.js";
 import { handleFeishuMessage, parseFeishuMessageEvent } from "./bot.js";
 import {
@@ -20,6 +19,7 @@ import {
   createFeishuTestRoute,
 } from "./bot.test-support.js";
 import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
+import { parseMergeForwardContent } from "./message-content.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { setFeishuRuntime } from "./runtime.js";
 import { setFeishuSyntheticDirectPreDispatchTarget } from "./synthetic-event-target.js";
@@ -2559,67 +2559,18 @@ describe("handleFeishuMessage command authorization", () => {
 
   it("expands merge_forward content from API sub-messages", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
-    const mockGetMerged = vi.fn().mockResolvedValue({
-      code: 0,
-      data: {
-        items: [
-          {
-            message_id: "container",
-            msg_type: "merge_forward",
-            body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
-          },
-          {
-            message_id: "sub-2",
-            upper_message_id: "container",
-            msg_type: "file",
-            body: { content: JSON.stringify({ file_name: "report.pdf" }) },
-            create_time: "2000",
-          },
-          {
-            message_id: "sub-card",
-            msg_type: "interactive",
-            body: {
-              content: JSON.stringify({
-                schema: "2.0",
-                header: { title: { tag: "plain_text", content: "Task summary" } },
-                body: {
-                  elements: [
-                    {
-                      tag: "table",
-                      columns: [
-                        { name: "task", display_name: "Task" },
-                        { name: "owner", display_name: "Owner" },
-                      ],
-                      rows: [{ task: "Investigate", owner: { name: "Alice" } }],
-                    },
-                  ],
-                },
-              }),
-            },
-            create_time: "1500",
-          },
-          {
-            message_id: "sub-1",
-            upper_message_id: "container",
-            msg_type: "text",
-            body: { content: JSON.stringify({ text: "alpha" }) },
-            create_time: "1000",
-          },
-        ],
-      },
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "msg-merge-forward",
+      chatId: "oc_group_1",
+      contentType: "merge_forward",
+      content:
+        "[Merged and Forwarded Messages]\n" +
+        "- alpha\n" +
+        "- Task summary\n" +
+        "Task | Owner\n" +
+        "Investigate | Alice\n" +
+        "- [File: report.pdf]",
     });
-    mockCreateFeishuClient.mockReturnValue({
-      contact: {
-        user: {
-          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
-        },
-      },
-      im: {
-        message: {
-          get: mockGetMerged,
-        },
-      },
-    } as unknown as PluginRuntime);
 
     const cfg = createFeishuTestConfig({ dmPolicy: "open" });
     const event = createFeishuTestEvent({
@@ -2631,9 +2582,10 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
-    expect(mockGetMerged).toHaveBeenCalledWith({
-      params: { card_msg_content_type: "user_card_content" },
-      path: { message_id: "msg-merge-forward" },
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "default",
+      messageId: "msg-merge-forward",
     });
     const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);
     expect(context.BodyForAgent).toContain(

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2649,20 +2649,9 @@ describe("handleFeishuMessage command authorization", () => {
     expect(parsed).not.toMatch(/[\uD800-\uDFFF]/u);
   });
 
-  it("falls back when merge_forward API returns no sub-messages", async () => {
+  it("falls back when shared merge_forward retrieval returns no message", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
-    mockCreateFeishuClient.mockReturnValue({
-      contact: {
-        user: {
-          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
-        },
-      },
-      im: {
-        message: {
-          get: vi.fn().mockResolvedValue({ code: 0, data: { items: [] } }),
-        },
-      },
-    });
+    mockGetMessageFeishu.mockResolvedValueOnce(null);
 
     const cfg = createFeishuTestConfig({ dmPolicy: "open" });
     const event = createFeishuTestEvent({
@@ -2674,6 +2663,11 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
+    expect(mockGetMessageFeishu).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      accountId: "default",
+      messageId: "msg-merge-empty",
+    });
     const context = mockCallArg<{ BodyForAgent?: string }>(mockFinalizeInboundContext, 0, 0);
     expect(context.BodyForAgent).toContain("[Merged and Forwarded Message - could not fetch]");
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -48,7 +48,6 @@ import {
   checkBotMentioned,
   normalizeFeishuCommandProbeBody,
   normalizeMentions,
-  parseMergeForwardContent,
   parseMessageContent,
   resolveFeishuGroupSession,
   resolveFeishuMediaList,
@@ -430,23 +429,13 @@ export async function handleFeishuMessage(params: {
       `feishu[${account.accountId}]: processing merge_forward message, fetching full content via API`,
     );
     try {
-      // Websocket event doesn't include sub-messages, need to fetch via API
-      // The API returns all sub-messages in the items array
-      const client = createFeishuClient(account);
-      const response = (await client.im.message.get({
-        params: { card_msg_content_type: "user_card_content" },
-        path: { message_id: event.message.message_id },
-      })) as { code?: number; data?: { items?: unknown[] } };
-
-      if (response.code === 0 && response.data?.items && response.data.items.length > 0) {
-        log(
-          `feishu[${account.accountId}]: merge_forward API returned ${response.data.items.length} items`,
-        );
-        const expandedContent = parseMergeForwardContent({
-          content: JSON.stringify(response.data.items),
-          log,
-        });
-        ctx = { ...ctx, content: expandedContent };
+      const messageInfo = await getMessageFeishu({
+        cfg,
+        messageId: event.message.message_id,
+        accountId: account.accountId,
+      });
+      if (messageInfo) {
+        ctx = { ...ctx, content: messageInfo.content };
       } else {
         log(`feishu[${account.accountId}]: merge_forward API returned no items`);
         ctx = { ...ctx, content: "[Merged and Forwarded Message - could not fetch]" };

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -437,7 +437,7 @@ export async function handleFeishuMessage(params: {
       if (messageInfo) {
         ctx = { ...ctx, content: messageInfo.content };
       } else {
-        log(`feishu[${account.accountId}]: merge_forward API returned no items`);
+        log(`feishu[${account.accountId}]: merge_forward message retrieval returned no result`);
         ctx = { ...ctx, content: "[Merged and Forwarded Message - could not fetch]" };
       }
     } catch (err) {

--- a/extensions/feishu/src/message-content-loopback.test.ts
+++ b/extensions/feishu/src/message-content-loopback.test.ts
@@ -273,7 +273,7 @@ describe("Feishu message content over the real Lark SDK", () => {
 
       await expect(
         getMessageFeishu({ cfg, messageId: "om_loopback_vendor_error" }),
-      ).resolves.toBeNull();
+      ).rejects.toThrow("Feishu message fetch failed: message not found");
 
       const loggedValues = mockLogVerbose.mock.calls.flat().map(String).join("\n");
       for (const { content } of sensitiveContentByMessageId.values()) {

--- a/extensions/feishu/src/message-content-loopback.test.ts
+++ b/extensions/feishu/src/message-content-loopback.test.ts
@@ -273,7 +273,7 @@ describe("Feishu message content over the real Lark SDK", () => {
 
       await expect(
         getMessageFeishu({ cfg, messageId: "om_loopback_vendor_error" }),
-      ).rejects.toThrow("Feishu message fetch failed: message not found");
+      ).resolves.toBeNull();
 
       const loggedValues = mockLogVerbose.mock.calls.flat().map(String).join("\n");
       for (const { content } of sensitiveContentByMessageId.values()) {

--- a/extensions/feishu/src/message-content-loopback.test.ts
+++ b/extensions/feishu/src/message-content-loopback.test.ts
@@ -125,6 +125,32 @@ describe("Feishu message content over the real Lark SDK", () => {
           return;
         }
 
+        if (messageId === "om_loopback_merge_forward") {
+          sendJson(200, {
+            code: 0,
+            msg: "ok",
+            data: {
+              items: [
+                {
+                  message_id: messageId,
+                  chat_id: "oc_feishu_content_107947",
+                  chat_type: "group",
+                  msg_type: "merge_forward",
+                  body: { content: JSON.stringify({ text: "Merged and Forwarded Message" }) },
+                },
+                {
+                  message_id: "om_loopback_merge_child",
+                  upper_message_id: messageId,
+                  msg_type: "text",
+                  body: { content: JSON.stringify({ text: "forwarded context" }) },
+                  create_time: "1710000000000",
+                },
+              ],
+            },
+          });
+          return;
+        }
+
         const malformed = sensitiveContentByMessageId.get(messageId);
         const message = malformed
           ? { msg_type: malformed.type, body: { content: malformed.content } }
@@ -238,6 +264,14 @@ describe("Feishu message content over the real Lark SDK", () => {
       });
 
       await expect(
+        getMessageFeishu({ cfg, messageId: "om_loopback_merge_forward" }),
+      ).resolves.toMatchObject({
+        messageId: "om_loopback_merge_forward",
+        contentType: "merge_forward",
+        content: "[Merged and Forwarded Messages]\n- forwarded context",
+      });
+
+      await expect(
         getMessageFeishu({ cfg, messageId: "om_loopback_vendor_error" }),
       ).resolves.toBeNull();
 
@@ -255,7 +289,7 @@ describe("Feishu message content over the real Lark SDK", () => {
           appId: "cli_feishu_content_107947",
         },
       ]);
-      expect(requests.filter((request) => request.method === "GET")).toHaveLength(6);
+      expect(requests.filter((request) => request.method === "GET")).toHaveLength(7);
       for (const request of requests.filter((entry) => entry.method === "GET")) {
         expect(request).toMatchObject({
           authorization: "Bearer tat-feishu-content-107947",

--- a/extensions/feishu/src/message-content.ts
+++ b/extensions/feishu/src/message-content.ts
@@ -1,5 +1,5 @@
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
+import { escapeHtml, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { parseInteractiveCardContent } from "./interactive-message-content.js";
 import { parsePostContent } from "./post.js";
@@ -92,5 +92,10 @@ export function parseMergeForwardContent(params: { content: string }): string {
   if (subMessages.length > maxMessages) {
     lines.push(`... and ${subMessages.length - maxMessages} more messages`);
   }
-  return lines.join("\n");
+  const rendered = lines.join("\n");
+  const maxContentChars = 20_000;
+  const marker = "\n... [Merged-forward content truncated]";
+  return rendered.length <= maxContentChars
+    ? rendered
+    : `${truncateUtf16Safe(rendered, maxContentChars - marker.length).trimEnd()}${marker}`;
 }

--- a/extensions/feishu/src/message-content.ts
+++ b/extensions/feishu/src/message-content.ts
@@ -1,0 +1,104 @@
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
+import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { parseInteractiveCardContent } from "./interactive-message-content.js";
+import { parsePostContent } from "./post.js";
+
+type FeishuLogger = (...args: unknown[]) => void;
+
+export function formatFeishuMediaContent(
+  parsed: Record<string, unknown>,
+  messageType: string,
+): string {
+  if (messageType === "sticker") {
+    const fileKey = normalizeFeishuExternalKey(parsed?.file_key);
+    return fileKey ? `<sticker key="${escapeHtml(fileKey)}"/>` : "[Sticker]";
+  }
+  const speechToText =
+    messageType === "audio" && typeof parsed.speech_to_text === "string"
+      ? parsed.speech_to_text.trim()
+      : "";
+  if (speechToText) {
+    return speechToText;
+  }
+  return "";
+}
+
+function formatSubMessageContent(content: string, contentType: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    switch (contentType) {
+      case "text":
+        return parsed.text || content;
+      case "post":
+        return parsePostContent(content).textContent;
+      case "interactive":
+        return parseInteractiveCardContent(parsed);
+      case "image":
+        return "[Image]";
+      case "file":
+        return `[File: ${parsed.file_name || "unknown"}]`;
+      case "audio":
+        return "[Audio]";
+      case "video":
+        return "[Video]";
+      case "sticker":
+        return formatFeishuMediaContent(parsed, contentType);
+      case "merge_forward":
+        return "[Nested Merged Forward]";
+      default:
+        return `[${contentType}]`;
+    }
+  } catch {
+    return content;
+  }
+}
+
+export function parseMergeForwardContent(params: { content: string; log?: FeishuLogger }): string {
+  const { content, log } = params;
+  const maxMessages = 50;
+  log?.("feishu: parsing merge_forward sub-messages from API response");
+
+  let items: Array<{
+    message_id?: string;
+    msg_type?: string;
+    body?: { content?: string };
+    sender?: { id?: string };
+    upper_message_id?: string;
+    create_time?: string;
+  }>;
+  try {
+    items = JSON.parse(content);
+  } catch {
+    log?.("feishu: merge_forward items parse failed");
+    return "[Merged and Forwarded Message - parse error]";
+  }
+  if (!Array.isArray(items) || items.length === 0) {
+    return "[Merged and Forwarded Message - no sub-messages]";
+  }
+  const container = items.find(
+    (item) => item.msg_type === "merge_forward" && !item.upper_message_id,
+  );
+  const subMessages = container
+    ? items.filter((item) => item !== container)
+    : items.filter((item) => item.upper_message_id);
+  if (subMessages.length === 0) {
+    return "[Merged and Forwarded Message - no sub-messages found]";
+  }
+
+  log?.(`feishu: merge_forward contains ${subMessages.length} sub-messages`);
+  subMessages.sort(
+    (a, b) =>
+      (parseStrictNonNegativeInteger(a.create_time) ?? 0) -
+      (parseStrictNonNegativeInteger(b.create_time) ?? 0),
+  );
+
+  const lines = ["[Merged and Forwarded Messages]"];
+  for (const item of subMessages.slice(0, maxMessages)) {
+    lines.push(`- ${formatSubMessageContent(item.body?.content || "", item.msg_type || "text")}`);
+  }
+  if (subMessages.length > maxMessages) {
+    lines.push(`... and ${subMessages.length - maxMessages} more messages`);
+  }
+  return lines.join("\n");
+}

--- a/extensions/feishu/src/message-content.ts
+++ b/extensions/feishu/src/message-content.ts
@@ -4,8 +4,6 @@ import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { parseInteractiveCardContent } from "./interactive-message-content.js";
 import { parsePostContent } from "./post.js";
 
-type FeishuLogger = (...args: unknown[]) => void;
-
 export function formatFeishuMediaContent(
   parsed: Record<string, unknown>,
   messageType: string,
@@ -54,23 +52,19 @@ function formatSubMessageContent(content: string, contentType: string): string {
   }
 }
 
-export function parseMergeForwardContent(params: { content: string; log?: FeishuLogger }): string {
-  const { content, log } = params;
+export function parseMergeForwardContent(params: { content: string }): string {
+  const { content } = params;
   const maxMessages = 50;
-  log?.("feishu: parsing merge_forward sub-messages from API response");
 
   let items: Array<{
-    message_id?: string;
     msg_type?: string;
     body?: { content?: string };
-    sender?: { id?: string };
     upper_message_id?: string;
     create_time?: string;
   }>;
   try {
     items = JSON.parse(content);
   } catch {
-    log?.("feishu: merge_forward items parse failed");
     return "[Merged and Forwarded Message - parse error]";
   }
   if (!Array.isArray(items) || items.length === 0) {
@@ -85,8 +79,6 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
   if (subMessages.length === 0) {
     return "[Merged and Forwarded Message - no sub-messages found]";
   }
-
-  log?.(`feishu: merge_forward contains ${subMessages.length} sub-messages`);
   subMessages.sort(
     (a, b) =>
       (parseStrictNonNegativeInteger(a.create_time) ?? 0) -

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -568,6 +568,20 @@ describe("getMessageFeishu", () => {
     });
   });
 
+  it("surfaces Feishu message API failures to callers", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 230001,
+      msg: "message not found",
+    });
+
+    await expect(
+      getMessageFeishu({
+        cfg: {} as ClawdbotConfig,
+        messageId: "om_missing",
+      }),
+    ).rejects.toThrow("Feishu message fetch failed: message not found");
+  });
+
   it("reuses the same content parsing for thread history messages", async () => {
     mockClientList.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -568,20 +568,6 @@ describe("getMessageFeishu", () => {
     });
   });
 
-  it("surfaces Feishu message API failures to callers", async () => {
-    mockClientGet.mockResolvedValueOnce({
-      code: 230001,
-      msg: "message not found",
-    });
-
-    await expect(
-      getMessageFeishu({
-        cfg: {} as ClawdbotConfig,
-        messageId: "om_missing",
-      }),
-    ).rejects.toThrow("Feishu message fetch failed: message not found");
-  });
-
   it("reuses the same content parsing for thread history messages", async () => {
     mockClientList.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -298,43 +298,36 @@ export async function getMessageFeishu(params: {
   }
 
   const client = createFeishuClient(account);
+  const response = (await client.im.message.get({
+    params: { card_msg_content_type: "user_card_content" },
+    path: { message_id: messageId },
+  })) as FeishuGetMessageResponse;
 
-  try {
-    const response = (await client.im.message.get({
-      params: { card_msg_content_type: "user_card_content" },
-      path: { message_id: messageId },
-    })) as FeishuGetMessageResponse;
+  assertFeishuApiSuccess(response, "Feishu message fetch failed");
 
-    if (response.code !== 0) {
-      return null;
-    }
-
-    // Support both list shape (including flattened merged forwards) and single-object shape.
-    const responseItems = response.data?.items;
-    const rawItem =
-      responseItems?.find((item) => item.msg_type === "merge_forward" && !item.upper_message_id) ??
-      responseItems?.[0] ??
-      response.data;
-    const item =
-      rawItem &&
-      (rawItem.body !== undefined || (rawItem as { message_id?: string }).message_id !== undefined)
-        ? rawItem
-        : null;
-    if (!item) {
-      return null;
-    }
-
-    const parsedItem = parseFeishuMessageItem(item, messageId);
-    if (parsedItem.contentType === "merge_forward" && responseItems) {
-      return {
-        ...parsedItem,
-        content: parseMergeForwardContent({ content: JSON.stringify(responseItems) }),
-      };
-    }
-    return parsedItem;
-  } catch {
+  // Support both list shape (including flattened merged forwards) and single-object shape.
+  const responseItems = response.data?.items;
+  const rawItem =
+    responseItems?.find((item) => item.msg_type === "merge_forward" && !item.upper_message_id) ??
+    responseItems?.[0] ??
+    response.data;
+  const item =
+    rawItem &&
+    (rawItem.body !== undefined || (rawItem as { message_id?: string }).message_id !== undefined)
+      ? rawItem
+      : null;
+  if (!item) {
     return null;
   }
+
+  const parsedItem = parseFeishuMessageItem(item, messageId);
+  if (parsedItem.contentType === "merge_forward" && responseItems) {
+    return {
+      ...parsedItem,
+      content: parseMergeForwardContent({ content: JSON.stringify(responseItems) }),
+    };
+  }
+  return parsedItem;
 }
 
 type FeishuThreadMessageInfo = {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -19,6 +19,7 @@ import {
 } from "./markdown.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
+import { parseMergeForwardContent } from "./message-content.js";
 import { resolveFeishuCardTemplate } from "./native-card.js";
 import { parsePostContent } from "./post.js";
 import { resolveFeishuReceiptKind, toFeishuSendResult } from "./send-result.js";
@@ -93,6 +94,7 @@ type FeishuMessageGetItem = {
   body?: { content?: string };
   sender?: FeishuMessageSender;
   create_time?: string;
+  upper_message_id?: string;
 };
 
 type FeishuGetMessageResponse = {
@@ -307,8 +309,12 @@ export async function getMessageFeishu(params: {
       return null;
     }
 
-    // Support both list shape (data.items[0]) and single-object shape (data as message)
-    const rawItem = response.data?.items?.[0] ?? response.data;
+    // Support both list shape (including flattened merged forwards) and single-object shape.
+    const responseItems = response.data?.items;
+    const rawItem =
+      responseItems?.find((item) => item.msg_type === "merge_forward" && !item.upper_message_id) ??
+      responseItems?.[0] ??
+      response.data;
     const item =
       rawItem &&
       (rawItem.body !== undefined || (rawItem as { message_id?: string }).message_id !== undefined)
@@ -318,7 +324,14 @@ export async function getMessageFeishu(params: {
       return null;
     }
 
-    return parseFeishuMessageItem(item, messageId);
+    const parsedItem = parseFeishuMessageItem(item, messageId);
+    if (parsedItem.contentType === "merge_forward" && responseItems) {
+      return {
+        ...parsedItem,
+        content: parseMergeForwardContent({ content: JSON.stringify(responseItems) }),
+      };
+    }
+    return parsedItem;
   } catch {
     return null;
   }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -298,36 +298,43 @@ export async function getMessageFeishu(params: {
   }
 
   const client = createFeishuClient(account);
-  const response = (await client.im.message.get({
-    params: { card_msg_content_type: "user_card_content" },
-    path: { message_id: messageId },
-  })) as FeishuGetMessageResponse;
 
-  assertFeishuApiSuccess(response, "Feishu message fetch failed");
+  try {
+    const response = (await client.im.message.get({
+      params: { card_msg_content_type: "user_card_content" },
+      path: { message_id: messageId },
+    })) as FeishuGetMessageResponse;
 
-  // Support both list shape (including flattened merged forwards) and single-object shape.
-  const responseItems = response.data?.items;
-  const rawItem =
-    responseItems?.find((item) => item.msg_type === "merge_forward" && !item.upper_message_id) ??
-    responseItems?.[0] ??
-    response.data;
-  const item =
-    rawItem &&
-    (rawItem.body !== undefined || (rawItem as { message_id?: string }).message_id !== undefined)
-      ? rawItem
-      : null;
-  if (!item) {
+    if (response.code !== 0) {
+      return null;
+    }
+
+    // Support both list shape (including flattened merged forwards) and single-object shape.
+    const responseItems = response.data?.items;
+    const rawItem =
+      responseItems?.find((item) => item.msg_type === "merge_forward" && !item.upper_message_id) ??
+      responseItems?.[0] ??
+      response.data;
+    const item =
+      rawItem &&
+      (rawItem.body !== undefined || (rawItem as { message_id?: string }).message_id !== undefined)
+        ? rawItem
+        : null;
+    if (!item) {
+      return null;
+    }
+
+    const parsedItem = parseFeishuMessageItem(item, messageId);
+    if (parsedItem.contentType === "merge_forward" && responseItems) {
+      return {
+        ...parsedItem,
+        content: parseMergeForwardContent({ content: JSON.stringify(responseItems) }),
+      };
+    }
+    return parsedItem;
+  } catch {
     return null;
   }
-
-  const parsedItem = parseFeishuMessageItem(item, messageId);
-  if (parsedItem.contentType === "merge_forward" && responseItems) {
-    return {
-      ...parsedItem,
-      content: parseMergeForwardContent({ content: JSON.stringify(responseItems) }),
-    };
-  }
-  return parsedItem;
 }
 
 type FeishuThreadMessageInfo = {


### PR DESCRIPTION
Closes #136200

## Summary

- Expand flattened merged-forward children in the shared Feishu `im.message.get` retrieval path.
- Reuse that retrieval owner for direct inbound and quoted-message reads.
- Bound rendered forwarded context to 20,000 UTF-16 code units with an explicit truncation marker.
- Align the direct-inbound fallback regression with the shared retrieval owner and use accurate no-result logging.

## What Problem This Solves

When a Feishu user replies to a merged-forward message, OpenClaw gives the agent only the container placeholder instead of the forwarded child content.

## Why This Change Was Made

Feishu returns merged-forward messages as one top-level container plus flattened child items. Message retrieval now selects the container and expands the complete item list before callers build agent context. The parser lives in an independent module so the generated Feishu runtime has an explicit dependency and direct inbound does not keep a second fetch-and-parse path.

The aggregate renderer is UTF-16-safe and bounded so a long forwarded message cannot exhaust the agent prompt. The existing message-fetch failure contract and the separate `listFeishuThreadMessages` path are unchanged.

## User Impact

Replies to merged-forward messages provide ordered child-message content to the agent instead of only `Merged and Forwarded Message`. Oversized forwarded content ends with an explicit truncation marker.

## Evidence

A controlled live Feishu run made the candidate Gateway the sole WebSocket receiver. A real reply to a newly created merged-forward card logged seven ordered child messages, entered agent dispatch, and produced a streaming Feishu response.

Current exact head `7f89cf6c586dd726d8bbc34ec58493e712b6d16f`:

- The corrected fallback assertion failed before the maintainer repair because the shared `getMessageFeishu` mock had zero calls.
- Sanitized AWS proof passed the four focused Feishu files: 160 tests.
- The complete Feishu extension suite passed: 102 files, 2,026 tests.
- `check:changed`, the full build, and `git diff --check` passed.
- A native current-main refresh found no relevant Feishu, package, or PR-tooling change since that proof, so no proof surface was invalidated.
- Final P3 autoreview was scoped-clean with no accepted or actionable findings.

Autoreview disposition: the earlier hypothetical rootless child-array concern was not confirmed. The pinned `@larksuiteoapi/node-sdk` 1.73.0 contract documents merged-forward retrieval as the parent item first without `upper_message_id`, followed by descendants with `upper_message_id`; the sanitized real payload contained one parent plus 22 children. A rootless child-only array is neither supported by that contract nor observed, so no `send.ts` expansion or hypothetical rootless regression was added.

The latest durable ClawSweeper review on the prior exact head rated overall readiness and patch quality 4/6, proof confidence 5/6, and listed `Before merge: None.` No rank-up moves were requested. A fresh exact-head re-review will be requested after hosted CI is green.

Final diff: 8 files, 208 additions, 199 deletions. Production is 126 additions and 120 deletions (net +6); tests are 81 additions and 78 deletions (net +3); the assertion-safety baseline is +1/-1. The maintainer repair itself is two files, production +1/-1 and tests +7/-13.

No dependency, configuration semantics, or persistent-data behavior changes.

## Test plan

- [x] Run focused getter, direct-inbound, helper, and SDK-loopback regressions
- [x] Reproduce and cover oversized aggregate truncation
- [x] Run the complete Feishu extension suite
- [x] Run changed checks and the full build
- [x] Run final P3 autoreview with the dependency-contract disposition
- [x] Verify a real Feishu reply expands merged-forward children
