### PR TITLE
fix(ci): fetch security scan history during authenticated checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1653,11 +1653,27 @@ jobs:
     env:
       PRE_COMMIT_HOME: .cache/pre-commit-security-fast
     steps:
+      - name: Resolve security checkout depth
+        if: github.event_name == 'pull_request'
+        id: checkout_depth
+        env:
+          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_COMMIT_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid pull request commit count: $PR_COMMIT_COUNT"
+            exit 2
+          fi
+          # Fetch the merge, every PR commit, and one ancestor while checkout
+          # still owns authentication; scanners run after credential cleanup.
+          fetch_depth=$((PR_COMMIT_COUNT + 2))
+          echo "depth=$fetch_depth" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         if: github.event_name != 'workflow_dispatch' || inputs.target_ref == ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 2
+          fetch-depth: ${{ steps.checkout_depth.outputs.depth || 2 }}
           persist-credentials: false
 
       # Manual target validation has a distinct fallback contract: a missing branch/tag
@@ -1720,24 +1736,6 @@ jobs:
         with:
           base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
-
-      - name: Fetch pull request scan history
-        if: github.event_name == 'pull_request'
-        env:
-          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
-          PR_MERGE_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if ! [[ "$PR_COMMIT_COUNT" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid pull request commit count: $PR_COMMIT_COUNT"
-            exit 2
-          fi
-          # Include the synthetic merge, every pull request commit, and one
-          # ancestor so TruffleHog can clone and resolve the bounded range.
-          fetch_depth=$((PR_COMMIT_COUNT + 2))
-          python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 \
-            -c protocol.version=2 \
-            fetch --no-tags --no-recurse-submodules --depth="$fetch_depth" origin "$PR_MERGE_SHA"
 
       - name: Scan pull request for leaked credentials
         if: github.event_name == 'pull_request'

--- a/test/scripts/ci-git-owner.test-support.ts
+++ b/test/scripts/ci-git-owner.test-support.ts
@@ -55,8 +55,6 @@ const defaults: Record<string, string> = {
   EVENT_BASE_SHA: base,
   GH_TOKEN: "",
   PULL_REQUEST_NUMBER: "17",
-  PR_COMMIT_COUNT: "5",
-  PR_MERGE_SHA: merge,
   TARGET_SHA: candidate,
   RELEASE_GATE: "false",
   FROZEN_TARGET: "false",
@@ -215,8 +213,9 @@ export async function runCiGitStep(options: {
     `linux:${options.scenario ?? "configured"}`,
     (root) => {
       const actions = path.join(root, "trusted-actions");
-      if (options.performance)
+      if (options.performance) {
         performanceFixture = preparePerformanceFixture(root, options.performance);
+      }
       env = stepEnvironment(step, {
         PUBLISH_ACTION_PATH: path.resolve(".github/actions/publish-generated-pr"),
         CONTENTS_TOKEN: "fixture-contents",

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -275,14 +275,6 @@ const historyProfiles: {
     consumer: "",
   },
   {
-    job: "security-fast",
-    step: "Fetch pull request scan history",
-    env: {},
-    target: merge,
-    depth: 7,
-    consumer: "",
-  },
-  {
     job: "checks-fast-core",
     step: "Prepare release-gate ratchet merge tree",
     env: {},
@@ -424,23 +416,6 @@ linuxIt.each([23, "hang"] satisfies FetchResult[])(
     expect(report.commands.filter(({ tool }) => tool === "pnpm").map(({ args }) => args)).toEqual([
       ["deps:npm-lock:check"],
     ]);
-  },
-  55_000,
-);
-
-linuxIt(
-  "security rejects malformed scan depth before starting Git",
-  async () => {
-    const report = await runCiGitStep({
-      job: "security-fast",
-      step: "Fetch pull request scan history",
-      env: { PR_COMMIT_COUNT: "invalid" },
-      fetchResults: [],
-      prepare: true,
-    });
-    expect(report.code).toBe(2);
-    expect(report.fetches).toEqual([]);
-    expect(report.readyAttempts).toEqual([]);
   },
   55_000,
 );
@@ -605,11 +580,11 @@ posixIt.each(qaGitCases)(
     expect(
       report.commands
         .filter(({ args }) => args[0] === "rev-parse")
-        .map(({ args, cwd }) => ({ args, cwd })),
+        .map(({ args, cwd: commandCwd }) => ({ args, cwd: commandCwd })),
     ).toEqual(profile.readbacks.map((ref) => ({ args: ["rev-parse", ref], cwd })));
-    expect(report.checkouts.map(({ args, cwd }) => ({ args, cwd }))).toEqual(
-      profile.checkout ? [{ args: ["checkout", "--detach", profile.checkout], cwd }] : [],
-    );
+    expect(
+      report.checkouts.map(({ args, cwd: commandCwd }) => ({ args, cwd: commandCwd })),
+    ).toEqual(profile.checkout ? [{ args: ["checkout", "--detach", profile.checkout], cwd }] : []);
     if (profile.step === "Checkout selected ref") {
       expect(report.commands.map(({ args }) => args[0])).toEqual([
         "init",
@@ -686,7 +661,7 @@ const mantisCases = [
 }[];
 
 posixIt.each([
-  ...mantisCases.map((entry) => ({ ...entry, failure: 0 as FetchResult })),
+  ...mantisCases.map((entry) => Object.assign({}, entry, { failure: 0 as FetchResult })),
   ...[true, false].flatMap((shared) =>
     (["cleanup-failure", 23] satisfies FetchResult[]).map((failure) => ({
       label: `${shared ? "shared action" : "Discord"} terminal ${failure}`,
@@ -799,7 +774,7 @@ posixIt.each([
   ...mantisInstallers.map((profile) => ({ ...profile, failure: false })),
   ...mantisInstallers
     .filter(({ workflow }) => workflow !== "discord-thread-attachment")
-    .map((profile) => ({ ...profile, failure: true })),
+    .map((profile) => Object.assign({}, profile, { failure: true })),
 ])(
   "Mantis installer Git owner drains before checkout/build/probes: $workflow (cleanup failure=$failure)",
   async ({ workflow, job, fetch, failure }) => {
@@ -1179,7 +1154,9 @@ posixIt.each(["Clone publish repo", "Commit publish repo sync"])(
     expect(backoffs(report)).toEqual([2, 4, 6, 8, 10]);
     expect(report.clones).toHaveLength(cloning ? 5 : 0);
     expect(report.fetches).toHaveLength(cloning ? 0 : 6);
-    expect(report.rebases.map(({ args }) => args)).toEqual(cloning ? [] : Array(5).fill(abort));
+    expect(report.rebases.map(({ args }) => args)).toEqual(
+      cloning ? [] : Array.from({ length: 5 }, () => [...abort]),
+    );
     expect(report.pushes).toEqual([]);
     expect(
       report.output

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -16,9 +16,9 @@ import {
 } from "node:fs";
 import { isBuiltin } from "node:module";
 import { connect } from "node:net";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { runInNewContext } from "node:vm";
 import { expectDefined } from "@openclaw/normalization-core";
 import ts from "typescript";
@@ -4257,29 +4257,122 @@ NODE
     }
   });
 
+  it("fetches the complete pull request scan range before checkout removes credentials", () => {
+    const securitySteps = readCiWorkflow().jobs["security-fast"].steps as WorkflowStep[];
+    const checkoutIndex = securitySteps.findIndex((step) => step.name === "Checkout");
+    const checkout = expectDefined(securitySteps[checkoutIndex], "security checkout");
+    const prepare = securitySteps
+      .slice(0, checkoutIndex)
+      .find((step) => step.env?.PR_COMMIT_COUNT !== undefined);
+    const root = tempDirs.make("openclaw-security-checkout-");
+    let depth = checkout.with?.["fetch-depth"];
+    if (prepare?.run) {
+      const output = path.join(root, "depth-output");
+      const result = spawnSync("bash", ["-e", "-c", prepare.run], {
+        encoding: "utf8",
+        timeout: 5_000,
+        env: { ...process.env, PR_COMMIT_COUNT: "3", GITHUB_OUTPUT: output },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const outputs = Object.fromEntries(
+        readFileSync(output, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => line.split("=")),
+      );
+      depth = evaluateWorkflowExpression(depth, {
+        eventName: "pull_request",
+        repository: "openclaw/openclaw",
+        runAttempt: 1,
+        steps: { [expectDefined(prepare.id, "depth output step")]: { outputs } },
+      });
+    }
+    expect(Number.isInteger(Number(depth)) && Number(depth) > 0).toBe(true);
+    expect(checkout.with?.["persist-credentials"]).toBe(false);
+
+    const source = path.join(root, "source");
+    const selected = path.join(root, "selected");
+    mkdirSync(source);
+    mkdirSync(selected);
+    const git = (cwd: string, ...args: string[]) =>
+      execFileSync(
+        "git",
+        [
+          "-C",
+          cwd,
+          "-c",
+          "user.name=CI Fixture",
+          "-c",
+          "user.email=ci@example.invalid",
+          "-c",
+          "commit.gpgsign=false",
+          ...args,
+        ],
+        {
+          encoding: "utf8",
+          timeout: 5_000,
+          env: {
+            ...process.env,
+            GIT_ALLOW_PROTOCOL: "file",
+            GIT_CONFIG_GLOBAL: devNull,
+            GIT_CONFIG_NOSYSTEM: "1",
+            GIT_TERMINAL_PROMPT: "0",
+          },
+        },
+      ).trim();
+    git(source, "init", "--initial-branch=main");
+    writeFileSync(path.join(source, "base.txt"), "base\n");
+    git(source, "add", ".");
+    git(source, "commit", "-m", "base");
+    git(source, "checkout", "-b", "pull-request");
+    const commits = [];
+    for (let index = 0; index < 3; index++) {
+      writeFileSync(path.join(source, "change.txt"), `change ${index}\n`);
+      git(source, "add", ".");
+      git(source, "commit", "-m", `change ${index}`);
+      commits.push(git(source, "rev-parse", "HEAD"));
+    }
+    git(source, "checkout", "main");
+    writeFileSync(path.join(source, "base.txt"), "advanced base\n");
+    git(source, "commit", "-am", "advance main");
+    const base = git(source, "rev-parse", "HEAD");
+    git(source, "merge", "--no-ff", "pull-request", "-m", "synthetic merge");
+    const merge = git(source, "rev-parse", "HEAD");
+    git(selected, "init");
+    git(
+      selected,
+      "fetch",
+      "--no-tags",
+      `--depth=${String(depth)}`,
+      pathToFileURL(source).href,
+      merge,
+    );
+    git(selected, "checkout", "--detach", "FETCH_HEAD");
+
+    // The scanner clones locally after auth cleanup: no later fetch may supply missing commits.
+    expect(git(selected, "rev-list", `${base}..HEAD`).split("\n").toSorted()).toEqual(
+      [merge, ...commits].toSorted(),
+    );
+  });
+
   it("scans only the pull request commit range for leaked credentials", () => {
     const securitySteps = readCiWorkflow().jobs["security-fast"].steps as WorkflowStep[];
-    const fetchScanHistoryIndex = securitySteps.findIndex(
-      (step) => step.name === "Fetch pull request scan history",
-    );
+    const checkoutIndex = securitySteps.findIndex((step) => step.name === "Checkout");
+    const depthIndex = securitySteps.findIndex((step) => step.id === "checkout_depth");
     const scanIndex = securitySteps.findIndex(
       (step) => step.name === "Scan pull request for leaked credentials",
     );
-    const fetchScanHistoryStep = expectDefined(
-      securitySteps[fetchScanHistoryIndex],
-      "TruffleHog history fetch step",
-    );
+    const depthStep = expectDefined(securitySteps[depthIndex], "security checkout depth");
     const scanStep = expectDefined(securitySteps[scanIndex], "TruffleHog pull request scan step");
 
-    expect(scanIndex).toBeGreaterThan(fetchScanHistoryIndex);
-    expect(fetchScanHistoryStep.if).toBe("github.event_name == 'pull_request'");
-    expect(fetchScanHistoryStep.env).toEqual({
+    expect(checkoutIndex).toBeGreaterThan(depthIndex);
+    expect(scanIndex).toBeGreaterThan(checkoutIndex);
+    expect(depthStep.if).toBe("github.event_name == 'pull_request'");
+    expect(depthStep.env).toEqual({
       PR_COMMIT_COUNT: "${{ github.event.pull_request.commits }}",
-      PR_MERGE_SHA: "${{ github.sha }}",
     });
-    expect(fetchScanHistoryStep.run).toContain("fetch_depth=$((PR_COMMIT_COUNT + 2))");
-    expect(fetchScanHistoryStep.run).toContain(
-      'fetch --no-tags --no-recurse-submodules --depth="$fetch_depth" origin "$PR_MERGE_SHA"',
+    expect(securitySteps.some((step) => step.name === "Fetch pull request scan history")).toBe(
+      false,
     );
     expect(scanStep.if).toBe("github.event_name == 'pull_request'");
     expect(scanStep.uses).toBe(TRUFFLEHOG_V3_95_9);
@@ -4289,6 +4382,24 @@ NODE
       version: "3.97.0@sha256:ff4c95e9df7d645daf2140e3ca1039031c63106268d5fbb25feb43ceca1bcc33",
       extra_args: "--results=verified,unknown --fail-on-scan-errors",
     });
+  });
+
+  it.each(["", "-1", "1.5"])("rejects invalid security checkout depth input %j", (count) => {
+    const step = expectDefined(
+      readCiWorkflow().jobs["security-fast"].steps.find(
+        (entry: WorkflowStep) => entry.id === "checkout_depth",
+      ),
+      "security checkout depth",
+    );
+    const output = path.join(tempDirs.make("openclaw-security-depth-"), "output");
+    const result = spawnSync("bash", ["-e", "-c", step.run], {
+      encoding: "utf8",
+      timeout: 5_000,
+      env: { ...process.env, PR_COMMIT_COUNT: count, GITHUB_OUTPUT: output },
+    });
+    expect(result.status).toBe(2);
+    expect(result.stdout).toContain("Invalid pull request commit count");
+    expect(existsSync(output)).toBe(false);
   });
 
   it("keeps setup cache access explicit and isolates every cache write", () => {
@@ -7206,7 +7317,17 @@ server.listen(0, "127.0.0.1", () => {
     expect(checkoutStep.if).toBe(
       "github.event_name != 'workflow_dispatch' || inputs.target_ref == ''",
     );
-    expect(checkoutStep.with).toEqual({ "fetch-depth": 2, "persist-credentials": false });
+    expect(checkoutStep.with["persist-credentials"]).toBe(false);
+    for (const eventName of ["push", "workflow_dispatch"] as const) {
+      expect(
+        evaluateWorkflowExpression(checkoutStep.with["fetch-depth"], {
+          eventName,
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+          steps: { checkout_depth: { outputs: {} } },
+        }),
+      ).toBe(2);
+    }
     expect(manualCheckoutStep.if).toBe(
       "github.event_name == 'workflow_dispatch' && inputs.target_ref != ''",
     );

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -924,7 +924,12 @@ async function supervise() {
   for (const tool of extraTools) {
     writeConsumer(path.join(bin, tool), tool);
   }
-  if (options.performance || options.pluginRelease || options.releaseAdmission) {
+  if (
+    options.performance ||
+    options.pluginRelease ||
+    options.releaseAdmission ||
+    options.publisher
+  ) {
     fs.writeFileSync(
       path.join(bin, "timeout"),
       '#!/bin/bash\nwhile [[ "$1" == --* ]]; do shift; done\nshift\nexec "$@"\n',


### PR DESCRIPTION
## Why

The security-fast job can fail before running its scanners: checkout removes temporary credentials as requested, then a separate PR-history fetch reaches GitHub without authentication. This happened on #136205 in run 33613960320, job 100195389239, where Git exited 128 with an authentication challenge. The log does not establish why that public request was challenged.

## Change

Calculate the existing validated PR commit count plus two before checkout and pass it to the pinned checkout action. That action now acquires the complete bounded scan range while it owns authentication, then removes credentials as before. Delete the redundant later fetch and its unused merge-SHA environment value.

Non-PR depth remains two. Event ref/SHA selection, manual target checkout, scan base/head, scanner pins, permissions, and `persist-credentials: false` are unchanged. The removed supplemental fetch's 120-second deadline does not transfer to checkout; the existing checkout lifecycle and 20-minute job deadline apply. There is no new credential scope or authentication fallback.

## Verification

A real local Git fixture creates a three-commit PR and synthetic merge. The regression fails before the change because the initial depth-two checkout contains only two of the four required range commits; it passes with the complete range afterward. Six targeted security cases pass, including invalid commit counts and unchanged non-PR defaults.

The original two complete canonical owner suites passed 244 tests, with two existing Linux-only tests skipped on macOS. Expanded verification across all three Git-owner suites passed 448 tests with 88 unchanged native platform skips. A subsequent mechanical lint cleanup passed 22 affected cases; these selected cases do not replace the full-suite result. Changed-code checks and the full workflow checker pass, including actionlint and zizmor. The first workflow-check attempt used system Python 3.9 and could not install the unchanged pre-commit pin; rerunning the same checker with the existing Python 3.14 passed without changing pins.

Direct inspection of pinned `actions/checkout` confirms authentication wraps its fetch and is removed in `finally` when persistence is disabled. The local fixture does not reproduce GitHub's remote authentication challenge or claim to execute the Actions runner; exact-head CI remains required.

Workflow delta: +17/-19 (net -2). Tests and support: +155/-53 (net +102). This is a CI correctness repair, not a performance result.


## Follow-up from hosted CI

The first candidate security-fast job passed on GitHub Actions (run 33615893519, job 100201497622). The Linux Git test shard then found three stale tests still selecting the deleted supplemental-fetch step. Remove those obsolete cases and unused fixture inputs; the new first-checkout range and invalid-depth guards cover the replacement owner.

The expanded macOS suites exposed a fixture portability gap: publisher scenarios expected `timeout` without using the stub already supplied to related fixture families. Extend that existing provision to publishers. Production deadlines, assertions and platform skips stay unchanged. Nearby changed-file lint fixes preserve expected values and ordering.

ClawSweeper's final-head September 2 review found no code defect and requested hosted workflow confirmation because its environment could not retrieve the pinned checkout source. The maintainer and independent review inspected that source directly. Final head `04c51bf8fb7062da1e12fd2b1f545a641f76c004` now passes CI run 33618909815, attempt 2: 184 passing checks and 23 appropriate skips. Attempt 1 passed checkout and TruffleHog but failed while pre-commit fetched its separate public hook repository; the ordinary failed-job retry passed without source, credentials or scanner changes. This completes the review's requested rank-up proof. Final isolated Codex review also found no actionable P0 defect.
