### PR TITLE
fix(release): run SDK tooling from its checkout

### DIFF
--- a/.github/workflows/openclaw-npm-preflight.yml
+++ b/.github/workflows/openclaw-npm-preflight.yml
@@ -448,7 +448,6 @@ jobs:
           while IFS= read -r previous_tag; do
             git -C "$tooling_dir" rev-parse --verify "${previous_tag}^{commit}" >/dev/null
           done < <(jq -r '.[]' <<< "$bases_json")
-          pnpm --dir "$tooling_dir" install --frozen-lockfile --ignore-scripts --filter openclaw
           diff_args=(
             --head "$target_sha"
             --evidence "${GITHUB_WORKSPACE}/.artifacts/npm-sdk-proof/plugin-sdk-api-release-evidence.json"
@@ -460,7 +459,11 @@ jobs:
           else
             diff_args+=(--base "$(jq -r '.[]' <<< "$bases_json")")
           fi
-          pnpm --dir "$tooling_dir" run plugin-sdk:api:diff -- "${diff_args[@]}"
+          (
+            cd "$tooling_dir"
+            pnpm install --frozen-lockfile --ignore-scripts --filter openclaw
+            pnpm run plugin-sdk:api:diff -- "${diff_args[@]}"
+          )
 
       - name: Upload npm sdk proof
         id: artifact

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -224,7 +224,14 @@ describe("minimal npm extended-stable workflow", () => {
     expect(trustedToolingCheckout.with?.ref).toBe("${{ github.workflow_sha }}");
     expect(preflightDiff.run).toContain('git -C "$tooling_dir" status --porcelain');
     expect(preflightDiff.run).not.toContain('pkg.scripts?.["plugin-sdk:api:diff"]');
-    expect(preflightDiff.run).toContain('pnpm --dir "$tooling_dir" run plugin-sdk:api:diff');
+    // Corepack resolves packageManager from its working directory before pnpm
+    // receives command flags. The trusted tooling checkout must own both calls.
+    expect(preflightDiff.run).toContain('cd "$tooling_dir"');
+    expect(preflightDiff.run).toContain(
+      "pnpm install --frozen-lockfile --ignore-scripts --filter openclaw",
+    );
+    expect(preflightDiff.run).toContain('pnpm run plugin-sdk:api:diff -- "${diff_args[@]}"');
+    expect(preflightDiff.run).not.toContain('pnpm --dir "$tooling_dir"');
     expect(publishProvenanceRun).toContain("plugin-sdk-api-release-evidence.mjs");
     expect(publishProvenanceRun).toContain('--acknowledge "$PLUGIN_SDK_API_ACKNOWLEDGEMENT"');
     expect(publishProvenanceRun).toContain('--npm-dist-tag "$RELEASE_NPM_DIST_TAG"');


### PR DESCRIPTION
## Summary

Fixes frozen-target full validation before any candidate child lane runs. The Plugin SDK API qualification checks out trusted workflow tooling, but invoked its pnpm 12.1 commands from a 2026.6.35 target pinned to pnpm 11.2. Corepack resolves the package manager from the current directory before `--dir`, so qualification failed before SDK analysis.

The two pnpm commands now run in the already-verified trusted tooling checkout. Target SHA, diff inputs, and artifact paths remain unchanged.

## Evidence

- Reproduction: [Full validation 33610645422 / failed qualification job](https://github.com/openclaw/openclaw/actions/runs/33610645422/job/100186701273): candidate `pnpm build` succeeds; trusted tooling then rejects pnpm 11.2 for its required 12.1.
- Exact rebased head `995d37f824a8798ed2bbed0f4f96048836dfb7ae`: focused workflow contract test passes 16/16.
- `actionlint .github/workflows/openclaw-npm-preflight.yml` passed.
- `oxfmt --check` passed for both changed files.
- `git diff origin/main...HEAD --check` passed.
- `pnpm check:workflows` is blocked solely because the configured package index does not provide `pre-commit==4.6.2` (its newest available version is 4.3.0).
- Focused frozen-pnpm proof on exact head `995d37f824a8798ed2bbed0f4f96048836dfb7ae` passed in Blacksmith Testbox `tbx_01m1h5am68rdbc40bj63h8p9t1` ([run 33636697471](https://github.com/openclaw/openclaw/actions/runs/33636697471)). In the same fixture, candidate cwd plus `corepack pnpm --dir tooling --version` selected pnpm `11.2.0` and failed as expected; entering the tooling cwd before `corepack pnpm --version` selected `12.1.0` and the command exited 0. Crabbox then stopped the successful one-shot lease, so the backing Actions Testbox step records the documented lifecycle cancellation.
- Exact-head CI [run 33636006895](https://github.com/openclaw/openclaw/actions/runs/33636006895), attempt 2, passed. The initial `checks-node-compact-small-21` failure exhausted checkout retries before setup or tests ran; targeted replacement job `100277006799` passed checkout and the shard, then aggregate `openclaw/ci-gate` job `100278692825` passed.
- No full FRV, release, publish, tag, or registry mutation was dispatched.

## Scope

Main harness only; no candidate/package/tag/npm state changed.

Production LOC: +5/-2 (net +3) | Tests: +8/-1 (net +7)
