### PR TITLE
fix(agents): preserve post-compaction continuation prompts

### DIFF
--- a/src/acp/translator.abort-cause.e2e.test.ts
+++ b/src/acp/translator.abort-cause.e2e.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it } from "vitest";
+import { writeOpenAiResponsesSse } from "../../test/helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -49,14 +50,7 @@ function writeToolCall(response: ServerResponse): void {
       },
     },
   ];
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(response, events);
 }
 
 async function listen(server: Server): Promise<number> {

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -657,6 +657,7 @@ export async function runPreparedEmbeddedLoop(
         replayState: accumulatedReplayState,
         activePromptPersisted: sessionPromptState.activePrompt.persisted,
         activateInternalPrompt: sessionPromptState.activateInternalPrompt,
+        activateCompactionContinuation: sessionPromptState.activateCompactionContinuation,
         setSuppressNextUserMessagePersistence: (value) => {
           sessionPromptState.suppressNextUserMessagePersistence = value;
         },

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -658,6 +658,7 @@ export async function runPreparedEmbeddedLoop(
         activePromptPersisted: sessionPromptState.activePrompt.persisted,
         activateInternalPrompt: sessionPromptState.activateInternalPrompt,
         activateCompactionContinuation: sessionPromptState.activateCompactionContinuation,
+        clearCompactionContinuation: sessionPromptState.clearCompactionContinuation,
         setSuppressNextUserMessagePersistence: (value) => {
           sessionPromptState.suppressNextUserMessagePersistence = value;
         },

--- a/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
+import { makeEmbeddedRunnerAttempt } from "../test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import type { PreparedEmbeddedRunInput } from "./run/execution-context.js";
 import { createEmbeddedRunSessionPromptState } from "./run/session-prompt-state.js";
+import { resolveEmbeddedRunTerminal } from "./run/terminal-resolution.js";
+import { makeTerminalInput } from "./run/terminal-resolution.test-support.js";
 
 const assertActive = () => {};
 
@@ -83,6 +86,63 @@ function createState(overrides: Partial<PreparedEmbeddedRunInput["runParams"]> =
 }
 
 describe("embedded run session prompt state", () => {
+  it("owns compaction continuation as an internal persisted prompt", () => {
+    const state = createState();
+
+    state.activateCompactionContinuation("continue after compaction");
+
+    expect(state.activePrompt).toEqual({
+      override: "continue after compaction",
+      persisted: true,
+      internal: true,
+    });
+    expect(state.suppressNextUserMessagePersistence).toBe(true);
+  });
+
+  it("preserves exact internal prompt bytes when composing compaction continuation", () => {
+    const state = createState();
+
+    state.activateInternalPrompt("  finish the reasoning exactly  ");
+    state.activateCompactionContinuation("continue after compaction");
+
+    expect(state.activePrompt).toEqual({
+      override: "  finish the reasoning exactly  \n\ncontinue after compaction",
+      persisted: true,
+      internal: true,
+    });
+    expect(state.suppressNextUserMessagePersistence).toBe(true);
+  });
+
+  it("keeps a compound internal prompt across a missing-assistant retry", async () => {
+    const state = createState();
+    state.activateInternalPrompt("finish the reasoning");
+    state.activateCompactionContinuation("continue after compaction");
+    const activePrompt = { ...state.activePrompt };
+    const attempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [],
+      lastAssistant: undefined,
+      currentAttemptAssistant: undefined,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+
+    const resolved = await resolveEmbeddedRunTerminal(
+      makeTerminalInput({
+        attempt,
+        attemptAssistant: undefined,
+        activePromptPersisted: state.activePrompt.persisted,
+        activateInternalPrompt: state.activateInternalPrompt,
+        activateCompactionContinuation: state.activateCompactionContinuation,
+        setSuppressNextUserMessagePersistence: (value) => {
+          state.suppressNextUserMessagePersistence = value;
+        },
+      }),
+    );
+
+    expect(resolved).toEqual({ action: "retry" });
+    expect(state.activePrompt).toEqual(activePrompt);
+    expect(state.suppressNextUserMessagePersistence).toBe(true);
+  });
+
   it("adds failed-tool guidance to current-transcript continuation", () => {
     const state = createState();
 

--- a/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/run.session-prompt-state.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
-import { makeEmbeddedRunnerAttempt } from "../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import {
+  buildEmbeddedRunnerAssistant,
+  makeEmbeddedRunnerAttempt,
+} from "../test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import type { PreparedEmbeddedRunInput } from "./run/execution-context.js";
 import { createEmbeddedRunSessionPromptState } from "./run/session-prompt-state.js";
 import { resolveEmbeddedRunTerminal } from "./run/terminal-resolution.js";
 import { makeTerminalInput } from "./run/terminal-resolution.test-support.js";
+import { createEmbeddedRunTerminalRetryState } from "./run/terminal-retry-state.js";
 
 const assertActive = () => {};
 
@@ -141,6 +145,133 @@ describe("embedded run session prompt state", () => {
     expect(resolved).toEqual({ action: "retry" });
     expect(state.activePrompt).toEqual(activePrompt);
     expect(state.suppressNextUserMessagePersistence).toBe(true);
+  });
+
+  it("retains compaction continuation across reasoning and empty retries", async () => {
+    const state = createState();
+    const retryState = createEmbeddedRunTerminalRetryState();
+    const compactionAssistant = buildEmbeddedRunnerAssistant({
+      stopReason: "length",
+      providerReplay: {
+        v: 1,
+        type: "openai-responses-compaction",
+        id: "cmp-shared-state",
+        data: "opaque-compaction",
+        provider: "openai",
+        api: "openai-responses",
+        model: "gpt-5.6-luna",
+        baseUrlHash: "base-url-hash",
+      },
+    });
+    const compactionAttempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [],
+      lastAssistant: compactionAssistant,
+      currentAttemptAssistant: compactionAssistant,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+    const terminalInput = {
+      retryState,
+      activePromptPersisted: state.activePrompt.persisted,
+      activateInternalPrompt: state.activateInternalPrompt,
+      activateCompactionContinuation: state.activateCompactionContinuation,
+      clearCompactionContinuation: state.clearCompactionContinuation,
+      setSuppressNextUserMessagePersistence: (value: boolean) => {
+        state.suppressNextUserMessagePersistence = value;
+      },
+    };
+
+    await expect(
+      resolveEmbeddedRunTerminal(
+        makeTerminalInput({
+          ...terminalInput,
+          attempt: compactionAttempt,
+          attemptAssistant: compactionAssistant,
+        }),
+      ),
+    ).resolves.toEqual({ action: "retry" });
+
+    const reasoningAssistant = buildEmbeddedRunnerAssistant({
+      content: [
+        {
+          type: "thinking",
+          thinking: "internal reasoning",
+          thinkingSignature: JSON.stringify({ id: "rs-shared-state", type: "reasoning" }),
+        },
+      ],
+    });
+    const reasoningAttempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [],
+      lastAssistant: reasoningAssistant,
+      currentAttemptAssistant: reasoningAssistant,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+    await expect(
+      resolveEmbeddedRunTerminal(
+        makeTerminalInput({
+          ...terminalInput,
+          attempt: reasoningAttempt,
+          attemptAssistant: reasoningAssistant,
+        }),
+      ),
+    ).resolves.toEqual({ action: "retry" });
+
+    const emptyResponseAssistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: "" }],
+    });
+    await expect(
+      resolveEmbeddedRunTerminal(
+        makeTerminalInput({
+          ...terminalInput,
+          attempt: makeEmbeddedRunnerAttempt({
+            assistantTexts: [],
+            lastAssistant: emptyResponseAssistant,
+            currentAttemptAssistant: emptyResponseAssistant,
+            currentAttemptReplayMetadata: {
+              hadPotentialSideEffects: false,
+              replaySafe: true,
+            },
+          }),
+        }),
+      ),
+    ).resolves.toEqual({ action: "retry" });
+
+    const prompt = state.activePrompt.override ?? "";
+    expect(prompt).toContain("The previous attempt did not produce a user-visible answer.");
+    expect(prompt).not.toContain("recorded reasoning");
+    expect(prompt.match(/Continue from the compacted transcript/gu)).toHaveLength(1);
+  });
+
+  it("releases compaction continuation before a visible draft revision", async () => {
+    const state = createState();
+    state.activateCompactionContinuation("continue after compaction");
+    const assistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: "Visible draft." }],
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: ["Visible draft."],
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      beforeAgentFinalizeRevisionReason: "Tighten the final wording.",
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+
+    await expect(
+      resolveEmbeddedRunTerminal(
+        makeTerminalInput({
+          attempt,
+          attemptAssistant: assistant,
+          payloadsWithToolMedia: [{ text: "Visible draft." }],
+          finalAssistantVisibleText: "Visible draft.",
+          activePromptPersisted: state.activePrompt.persisted,
+          activateInternalPrompt: state.activateInternalPrompt,
+          activateCompactionContinuation: state.activateCompactionContinuation,
+          clearCompactionContinuation: state.clearCompactionContinuation,
+        }),
+      ),
+    ).resolves.toEqual({ action: "retry" });
+
+    expect(state.activePrompt.override).toContain("Tighten the final wording.");
+    expect(state.activePrompt.override).not.toContain("continue after compaction");
   });
 
   it("adds failed-tool guidance to current-transcript continuation", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -101,12 +101,9 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
   if (!input.startupStagesEmitted) {
     startupStages.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.workspace);
   }
-  const basePrompt =
+  const prompt =
     sessionPromptState.activePrompt.override ??
     resolveEmbeddedAttemptBasePrompt({ provider, prompt: params.prompt });
-  const prompt = terminalRetryState.compactionContinuationInstruction
-    ? `${basePrompt}\n\n${terminalRetryState.compactionContinuationInstruction}`
-    : basePrompt;
   const resolvedAttemptApiKey = resolveAttemptDispatchApiKey({
     apiKeyInfo: runtime.apiKeyInfo,
     runtimeAuthState: runtime.runtimeAuthState,

--- a/src/agents/embedded-agent-runner/run/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/run/session-prompt-state.ts
@@ -103,6 +103,10 @@ export function createEmbeddedRunSessionPromptState(input: {
     activePrompt = { override: prompt, persisted: true, internal: true };
     suppressNextUserMessagePersistence = true;
   };
+  const activateCompactionContinuation = (instruction: string) => {
+    const priorPrompt = activePrompt.internal ? activePrompt.override : undefined;
+    activateInternalPrompt(priorPrompt?.trim() ? `${priorPrompt}\n\n${instruction}` : instruction);
+  };
   const onUserMessagePersisted: NonNullable<
     PreparedEmbeddedRunInput["runParams"]["onUserMessagePersisted"]
   > = (message) => {
@@ -196,6 +200,7 @@ export function createEmbeddedRunSessionPromptState(input: {
     recordCommittedCompactionSuccessor,
     notifyCompactionSessionAdopted,
     activateInternalPrompt,
+    activateCompactionContinuation,
     markOwnedTranscriptRetry: () => {
       settleOwnedTranscriptProjection = true;
     },

--- a/src/agents/embedded-agent-runner/run/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/run/session-prompt-state.ts
@@ -61,7 +61,15 @@ export function createEmbeddedRunSessionPromptState(input: {
   // Fresh attempts retain the projection owner's bounded, retryable failure contract.
   let settleOwnedTranscriptProjection = false;
   let suppressNextUserMessagePersistence = params.suppressNextUserMessagePersistence ?? false;
-  let activePrompt: ActivePrompt = {
+  let basePromptOverride: string | undefined;
+  let compactionContinuationInstruction: string | undefined;
+  const activePrompt: ActivePrompt = {
+    get override() {
+      const instruction = compactionContinuationInstruction;
+      return instruction && basePromptOverride?.trim()
+        ? `${basePromptOverride}\n\n${instruction}`
+        : (instruction ?? basePromptOverride);
+    },
     persisted: suppressNextUserMessagePersistence,
     internal: false,
   };
@@ -100,13 +108,15 @@ export function createEmbeddedRunSessionPromptState(input: {
   };
   // Internal control prompts are model-only context, never operator-authored transcript turns.
   const activateInternalPrompt = (prompt: string) => {
-    activePrompt = { override: prompt, persisted: true, internal: true };
+    basePromptOverride = prompt;
+    Object.assign(activePrompt, { persisted: true, internal: true });
     suppressNextUserMessagePersistence = true;
   };
   const activateCompactionContinuation = (instruction: string) => {
-    const priorPrompt = activePrompt.internal ? activePrompt.override : undefined;
-    activateInternalPrompt(priorPrompt?.trim() ? `${priorPrompt}\n\n${instruction}` : instruction);
+    compactionContinuationInstruction = instruction;
+    activateInternalPrompt(basePromptOverride ?? "");
   };
+  const clearCompactionContinuation = () => (compactionContinuationInstruction = undefined);
   const onUserMessagePersisted: NonNullable<
     PreparedEmbeddedRunInput["runParams"]["onUserMessagePersisted"]
   > = (message) => {
@@ -201,6 +211,7 @@ export function createEmbeddedRunSessionPromptState(input: {
     notifyCompactionSessionAdopted,
     activateInternalPrompt,
     activateCompactionContinuation,
+    clearCompactionContinuation,
     markOwnedTranscriptRetry: () => {
       settleOwnedTranscriptProjection = true;
     },

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test-support.ts
@@ -71,6 +71,7 @@ export function makeTerminalInput(overrides: TerminalInputOverrides = {}): Termi
     replayState: { ...attempt.replayMetadata, replayInvalid: false },
     activePromptPersisted: true,
     activateInternalPrompt: vi.fn(),
+    activateCompactionContinuation: vi.fn(),
     setSuppressNextUserMessagePersistence: vi.fn(),
     armPostCompactionGuard: vi.fn(),
     readTerminalToolPresentation: () => undefined,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test-support.ts
@@ -72,6 +72,7 @@ export function makeTerminalInput(overrides: TerminalInputOverrides = {}): Termi
     activePromptPersisted: true,
     activateInternalPrompt: vi.fn(),
     activateCompactionContinuation: vi.fn(),
+    clearCompactionContinuation: vi.fn(),
     setSuppressNextUserMessagePersistence: vi.fn(),
     armPostCompactionGuard: vi.fn(),
     readTerminalToolPresentation: () => undefined,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -756,6 +756,40 @@ describe("terminal resolution", () => {
     },
   );
 
+  it("activates the prompt owner for an OpenAI Responses compaction checkpoint", async () => {
+    const assistant = buildEmbeddedRunnerAssistant({
+      stopReason: "length",
+      providerReplay: {
+        v: 1,
+        type: "openai-responses-compaction",
+        id: "cmp-terminal-retry",
+        data: "opaque-compaction",
+        provider: "openai",
+        api: "openai-responses",
+        model: "gpt-5.6-luna",
+        baseUrlHash: "base-url-hash",
+      },
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [],
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+    const activateCompactionContinuation = vi.fn();
+    const input = makeTerminalInput({
+      attempt,
+      attemptAssistant: assistant,
+      activateCompactionContinuation,
+    });
+
+    await expect(resolveEmbeddedRunTerminal(input)).resolves.toEqual({ action: "retry" });
+    expect(activateCompactionContinuation).toHaveBeenCalledWith(
+      expect.stringContaining("Continue from the compacted transcript"),
+    );
+    expect(input.armPostCompactionGuard).toHaveBeenCalledOnce();
+  });
+
   it.each([
     { expectation: "required" as const, expectedError: true },
     { expectation: "optional" as const, expectedError: false },

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -205,6 +205,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   replayState: EmbeddedRunReplayState;
   activePromptPersisted: boolean;
   activateInternalPrompt: (prompt: string) => void;
+  activateCompactionContinuation: (instruction: string) => void;
   setSuppressNextUserMessagePersistence: (value: boolean) => void;
   armPostCompactionGuard: () => void;
   readTerminalToolPresentation: () => string | undefined;
@@ -396,7 +397,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     retryState.compactionContinuationAttempts < 1
   ) {
     retryState.compactionContinuationAttempts += 1;
-    retryState.compactionContinuationInstruction = COMPACTION_CONTINUATION_RETRY_INSTRUCTION;
+    input.activateCompactionContinuation(COMPACTION_CONTINUATION_RETRY_INSTRUCTION);
     log.warn(
       `compaction interrupted visible final answer: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
         `compactions=${input.attemptCompactionCount} — retrying ${retryState.compactionContinuationAttempts}/1 with compacted-transcript continuation`,
@@ -404,7 +405,6 @@ export async function resolveEmbeddedRunTerminal(input: {
     input.armPostCompactionGuard();
     return { action: "retry" };
   }
-  retryState.compactionContinuationInstruction = null;
 
   if (reasoningOnlyRetriesExhausted && !input.finalAssistantVisibleText) {
     const incompletePayloadText = "⚠️ Agent couldn't generate a response. Please try again.";
@@ -468,7 +468,6 @@ export async function resolveEmbeddedRunTerminal(input: {
     input.activateInternalPrompt(
       `${BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX}\n\n${beforeFinalizeRevisionReason}`,
     );
-    retryState.compactionContinuationInstruction = null;
     log.warn(
       `before_agent_finalize requested one more pass: ` +
         `runId=${runParams.runId} sessionId=${runParams.sessionId} ` +

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -206,6 +206,7 @@ export async function resolveEmbeddedRunTerminal(input: {
   activePromptPersisted: boolean;
   activateInternalPrompt: (prompt: string) => void;
   activateCompactionContinuation: (instruction: string) => void;
+  clearCompactionContinuation: () => void;
   setSuppressNextUserMessagePersistence: (value: boolean) => void;
   armPostCompactionGuard: () => void;
   readTerminalToolPresentation: () => string | undefined;
@@ -405,6 +406,8 @@ export async function resolveEmbeddedRunTerminal(input: {
     input.armPostCompactionGuard();
     return { action: "retry" };
   }
+  // Invisible retries return above; visible and terminal paths release this retained constraint.
+  input.clearCompactionContinuation();
 
   if (reasoningOnlyRetriesExhausted && !input.finalAssistantVisibleText) {
     const incompletePayloadText = "⚠️ Agent couldn't generate a response. Please try again.";

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
@@ -5,7 +5,6 @@ export type EmbeddedRunTerminalRetryState = {
   emptyResponseAttempts: number;
   missingAssistantAttempts: number;
   compactionContinuationAttempts: number;
-  compactionContinuationInstruction: string | null;
   beforeFinalizeRevisionAttempts: number;
 };
 
@@ -15,7 +14,6 @@ export function createEmbeddedRunTerminalRetryState(): EmbeddedRunTerminalRetryS
     emptyResponseAttempts: 0,
     missingAssistantAttempts: 0,
     compactionContinuationAttempts: 0,
-    compactionContinuationInstruction: null,
     beforeFinalizeRevisionAttempts: 0,
   };
 }

--- a/src/commands/onboard-guided.inference.e2e.test.ts
+++ b/src/commands/onboard-guided.inference.e2e.test.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeOpenAiResponsesSse } from "../../test/helpers/openai-responses-sse.js";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { listKnownProviderEnvApiKeyNames } from "../agents/model-auth-env-vars.js";
 import { captureFullEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
@@ -287,12 +288,5 @@ function writeMockOpenAiResponse(response: ServerResponse): void {
       },
     },
   ];
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(response, events);
 }

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it, type TestFunction } from "vitest";
+import { writeOpenAiResponsesSse } from "../../test/helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -317,14 +318,7 @@ function writeInvalidEditCallSse(res: ServerResponse, requestIndex: number) {
       },
     },
   ];
-  res.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  res.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(res, events);
 }
 
 async function readJsonRequest(req: IncomingMessage): Promise<Record<string, unknown>> {

--- a/test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../../../packages/gateway-protocol/src/client-info.js";
+import { writeOpenAiResponsesSse } from "../../../helpers/openai-responses-sse.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 
 const TEST_TIMEOUT_MS = 120_000;
@@ -45,17 +46,6 @@ afterEach(async () => {
   }
 });
 
-function writeResponsesEvents(response: ServerResponse, events: unknown[]): void {
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
-}
-
 function writeAssistantResponse(response: ServerResponse): void {
   const message = {
     type: "message",
@@ -64,7 +54,7 @@ function writeAssistantResponse(response: ServerResponse): void {
     status: "completed",
     content: [{ type: "output_text", text: TERMINAL_TEXT, annotations: [] }],
   };
-  writeResponsesEvents(response, [
+  writeOpenAiResponsesSse(response, [
     {
       type: "response.output_item.added",
       output_index: 0,

--- a/test/e2e/qa-lab/runtime/agent-session-scope-continuity.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-session-scope-continuity.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../../../packages/gateway-protocol/src/client-info.js";
+import { writeOpenAiResponsesSse } from "../../../helpers/openai-responses-sse.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 
 const TEST_TIMEOUT_MS = 120_000;
@@ -68,17 +69,6 @@ afterEach(async () => {
   }
 });
 
-function writeResponsesEvents(response: ServerResponse, events: unknown[]): void {
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
-}
-
 function writeAssistantResponse(response: ServerResponse, text: string, index: number): void {
   const message = {
     type: "message",
@@ -87,7 +77,7 @@ function writeAssistantResponse(response: ServerResponse, text: string, index: n
     status: "completed",
     content: [{ type: "output_text", text, annotations: [] }],
   };
-  writeResponsesEvents(response, [
+  writeOpenAiResponsesSse(response, [
     {
       type: "response.output_item.added",
       output_index: 0,

--- a/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
@@ -25,6 +25,7 @@ import { peekSystemEvents, resetSystemEventsForTest } from "../../../../src/infr
 import { resetTaskRegistryForTests } from "../../../../src/tasks/task-runtime.test-helpers.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../../../src/test-utils/env.js";
 import { normalizeSessionDeliveryState } from "../../../../src/utils/delivery-context.shared.js";
+import { writeOpenAiResponsesSse } from "../../../helpers/openai-responses-sse.js";
 import { waitForFile } from "../../../helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
@@ -71,17 +72,6 @@ function resetGatewayState(): void {
   resetTaskRegistryForTests({ persist: false });
 }
 
-function writeResponsesEvents(response: ServerResponse, events: unknown[]): void {
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
-}
-
 function writeAssistantResponse(response: ServerResponse, text: string): void {
   const message = {
     type: "message",
@@ -90,7 +80,7 @@ function writeAssistantResponse(response: ServerResponse, text: string): void {
     status: "completed",
     content: [{ type: "output_text", text, annotations: [] }],
   };
-  writeResponsesEvents(response, [
+  writeOpenAiResponsesSse(response, [
     {
       type: "response.output_item.added",
       output_index: 0,

--- a/test/e2e/qa-lab/runtime/gateway-provider-timeout-recovery.product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-provider-timeout-recovery.product-proof.e2e.test.ts
@@ -3,6 +3,7 @@ import { createServer, type ServerResponse } from "node:http";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { createQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
+import { writeOpenAiResponsesSse } from "../../../helpers/openai-responses-sse.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 
 const MODEL_REF = "mock-openai/gpt-5.6-luna";
@@ -63,17 +64,6 @@ afterEach(async () => {
   }
 });
 
-function writeResponsesEvents(response: ServerResponse, events: unknown[]): void {
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
-}
-
 function writeAssistantResponse(response: ServerResponse): void {
   const message = {
     type: "message",
@@ -82,7 +72,7 @@ function writeAssistantResponse(response: ServerResponse): void {
     status: "completed",
     content: [{ type: "output_text", text: RESPONSE_MARKER, annotations: [] }],
   };
-  writeResponsesEvents(response, [
+  writeOpenAiResponsesSse(response, [
     {
       type: "response.output_item.added",
       output_index: 0,

--- a/test/e2e/qa-lab/runtime/gateway-rpc-automation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-automation.e2e.test.ts
@@ -25,6 +25,7 @@ import { resetAgentEventsForTest } from "../../../../src/infra/agent-events.js";
 import { resetSystemEventsForTest } from "../../../../src/infra/system-events.js";
 import { resetTaskRegistryForTests } from "../../../../src/tasks/task-runtime.test-helpers.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../../../src/test-utils/env.js";
+import { writeOpenAiResponsesSse } from "../../../helpers/openai-responses-sse.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
 const ISOLATED_GATEWAY_ENV_KEYS = [
@@ -62,17 +63,6 @@ function resetGatewayState(): void {
   resetTaskRegistryForTests({ persist: false });
 }
 
-function writeResponsesEvents(response: ServerResponse, events: unknown[]): void {
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
-}
-
 function writeAssistantResponse(response: ServerResponse, text: string): void {
   const message = {
     type: "message",
@@ -81,7 +71,7 @@ function writeAssistantResponse(response: ServerResponse, text: string): void {
     status: "completed",
     content: [{ type: "output_text", text, annotations: [] }],
   };
-  writeResponsesEvents(response, [
+  writeOpenAiResponsesSse(response, [
     {
       type: "response.output_item.added",
       output_index: 0,

--- a/test/gateway-hook-concurrency.e2e.test.ts
+++ b/test/gateway-hook-concurrency.e2e.test.ts
@@ -2,6 +2,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -478,12 +479,5 @@ function writeModelResponse(response: ServerResponse, sequence: number): void {
       },
     },
   ];
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(response, events);
 }

--- a/test/gateway-openai-compaction-replay.e2e.test.ts
+++ b/test/gateway-openai-compaction-replay.e2e.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { SessionManager } from "../src/agents/sessions/session-manager.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -97,10 +98,11 @@ describe("Gateway OpenAI Responses compaction replay", () => {
           sessionHash: expect.any(String),
         });
         expect(persistedReplay).not.toHaveProperty("authProfileHash");
-        expectCompactionReplay(modelServer.requests[1]?.body.input ?? []);
-        expect(JSON.stringify(modelServer.requests[1]?.body.input)).toContain(
-          "Continue from the compacted transcript",
-        );
+        const continuationInput = modelServer.requests[1]?.body.input ?? [];
+        expectCompactionReplay(continuationInput);
+        const encodedContinuationInput = JSON.stringify(continuationInput);
+        expect(encodedContinuationInput).toContain("Continue from the compacted transcript");
+        expect(encodedContinuationInput).not.toContain("capture compaction state");
 
         await runAgentTurn(client, "replay compaction state");
         expect(modelServer.requests).toHaveLength(3);
@@ -261,7 +263,7 @@ function writeModelResponse(response: ServerResponse, sequence: number): void {
       id: COMPACTION_ID,
       encrypted_content: COMPACTION_DATA,
     };
-    writeSseEvents(response, [
+    writeOpenAiResponsesSse(response, [
       { type: "response.output_item.added", output_index: 0, item: compaction },
       { type: "response.output_item.done", output_index: 0, item: compaction },
       {
@@ -303,16 +305,5 @@ function writeModelResponse(response: ServerResponse, sequence: number): void {
       usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
     },
   });
-  writeSseEvents(response, events);
-}
-
-function writeSseEvents(response: ServerResponse, events: MockSseEvent[]): void {
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(response, events);
 }

--- a/test/gateway-openai-compaction-replay.e2e.test.ts
+++ b/test/gateway-openai-compaction-replay.e2e.test.ts
@@ -66,8 +66,8 @@ describe("Gateway OpenAI Responses compaction replay", () => {
       try {
         await runAgentTurn(client, "capture compaction state");
         // The provider can terminate after emitting only a compaction item. The
-        // runner must continue from that checkpoint before completing the turn.
-        expect(modelServer.requests).toHaveLength(2);
+        // runner must retain that checkpoint through another invisible retry.
+        expect(modelServer.requests).toHaveLength(3);
 
         const session = await client.request<{
           sessions?: Array<{ key?: string; sessionId?: string }>;
@@ -104,9 +104,18 @@ describe("Gateway OpenAI Responses compaction replay", () => {
         expect(encodedContinuationInput).toContain("Continue from the compacted transcript");
         expect(encodedContinuationInput).not.toContain("capture compaction state");
 
+        const reasoningContinuationInput = modelServer.requests[2]?.body.input ?? [];
+        expectCompactionReplay(reasoningContinuationInput);
+        const encodedReasoningContinuationInput = JSON.stringify(reasoningContinuationInput);
+        expectTextOnce(encodedReasoningContinuationInput, "Continue from the compacted transcript");
+        expectTextOnce(
+          encodedReasoningContinuationInput,
+          "recorded reasoning but did not produce a user-visible answer",
+        );
+
         await runAgentTurn(client, "replay compaction state");
-        expect(modelServer.requests).toHaveLength(3);
-        const replayInput = modelServer.requests[2]?.body.input ?? [];
+        expect(modelServer.requests).toHaveLength(4);
+        const replayInput = modelServer.requests[3]?.body.input ?? [];
         expectCompactionReplay(replayInput);
         const compactionIndex = replayInput.findIndex(
           (item) =>
@@ -128,7 +137,7 @@ describe("Gateway OpenAI Responses compaction replay", () => {
         ).toBe(true);
         const encodedReplayInput = JSON.stringify(replayInput);
         expect(encodedReplayInput).not.toContain("capture compaction state");
-        expect(encodedReplayInput).toContain("gateway replay response 2");
+        expect(encodedReplayInput).toContain("gateway replay response 3");
         expect(encodedReplayInput).toContain("replay compaction state");
       } finally {
         await disconnectGatewayClient(client);
@@ -204,6 +213,10 @@ function expectCompactionReplay(input: unknown[]): void {
   });
 }
 
+function expectTextOnce(encodedInput: string, text: string): void {
+  expect(encodedInput.split(text)).toHaveLength(2);
+}
+
 async function startMockModelServer(): Promise<MockModelServer> {
   const requests: CapturedRequest[] = [];
   const server = createServer((request, response) => {
@@ -274,6 +287,32 @@ function writeModelResponse(response: ServerResponse, sequence: number): void {
           incomplete_details: { reason: "max_output_tokens" },
           output: [compaction],
           usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+        },
+      },
+    ]);
+    return;
+  }
+  if (sequence === 2) {
+    const reasoning = {
+      type: "reasoning",
+      id: "rs_gateway_replay_2",
+      encrypted_content: "opaque-gateway-reasoning",
+      summary: [{ type: "summary_text", text: "Working from the compacted transcript." }],
+    };
+    writeOpenAiResponsesSse(response, [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { type: "reasoning", id: reasoning.id },
+      },
+      { type: "response.output_item.done", output_index: 0, item: reasoning },
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_gateway_replay_2",
+          status: "completed",
+          output: [reasoning],
+          usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
         },
       },
     ]);

--- a/test/gateway-queued-session-rotation.e2e.test.ts
+++ b/test/gateway-queued-session-rotation.e2e.test.ts
@@ -6,6 +6,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { GatewayChatClient } from "../src/tui/gateway-chat.js";
+import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -85,14 +86,7 @@ function writeResponse(res: ServerResponse, text: string): void {
       },
     },
   ];
-  res.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  res.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(res, events);
 }
 
 async function startMockModelServer(): Promise<MockModelServer> {

--- a/test/gateway-restored-requester-settle.e2e.test.ts
+++ b/test/gateway-restored-requester-settle.e2e.test.ts
@@ -8,6 +8,7 @@ import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagen
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import type { Deferred } from "../src/shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../src/state/openclaw-state-db.js";
+import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -301,12 +302,5 @@ function writeModelResponse(response: ServerResponse, sequence: number): void {
       },
     },
   ];
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(response, events);
 }

--- a/test/gateway-steer-fifo.e2e.test.ts
+++ b/test/gateway-steer-fifo.e2e.test.ts
@@ -9,6 +9,7 @@ import { GatewayClient, type GatewayClientOptions } from "../src/gateway/client.
 import { buildMockOpenAiResponsesProvider } from "../src/gateway/test-openai-responses-model.js";
 import { GatewayChatClient } from "../src/tui/gateway-chat.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../src/utils/message-channel.js";
+import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -104,17 +105,6 @@ async function readJsonRequest(req: IncomingMessage): Promise<Record<string, unk
   return body ? (JSON.parse(body) as Record<string, unknown>) : {};
 }
 
-function writeSse(res: ServerResponse, events: Record<string, unknown>[]): void {
-  res.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  res.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
-}
-
 function writeTextResponse(res: ServerResponse, requestIndex: number): void {
   const id = `msg_steer_fifo_${requestIndex}`;
   const text = `TURN_${requestIndex}_COMPLETE`;
@@ -125,7 +115,7 @@ function writeTextResponse(res: ServerResponse, requestIndex: number): void {
     status: "completed",
     content: [{ type: "output_text", text, annotations: [] }],
   };
-  writeSse(res, [
+  writeOpenAiResponsesSse(res, [
     {
       type: "response.output_item.added",
       output_index: 0,
@@ -167,7 +157,7 @@ function writeToolResponse(res: ServerResponse): void {
     arguments: "{}",
     status: "completed",
   };
-  writeSse(res, [
+  writeOpenAiResponsesSse(res, [
     {
       type: "response.output_item.added",
       output_index: 0,
@@ -211,7 +201,7 @@ function writeSequentialToolsResponse(res: ServerResponse): void {
       status: "completed",
     },
   ];
-  writeSse(res, [
+  writeOpenAiResponsesSse(res, [
     ...items.flatMap((item, outputIndex) => [
       {
         type: "response.output_item.added",

--- a/test/plugin-cron-registry-owner.e2e.test.ts
+++ b/test/plugin-cron-registry-owner.e2e.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/gateway/test-helpers.e2e.js";
 import { upsertSessionEntry } from "../src/plugin-sdk/session-store-runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../src/plugin-sdk/sqlite-runtime-testing.js";
+import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -131,14 +132,7 @@ function writeModelResponse(res: ServerResponse, sequence: number): void {
       },
     },
   ];
-  res.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  res.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
+  writeOpenAiResponsesSse(res, events);
 }
 
 async function startMockModelServer(rejectModel?: string): Promise<MockModelServer> {
@@ -467,7 +461,9 @@ describe("plugin cron registry ownership e2e", () => {
         expect(requestText(server.requests[0]!)).toContain(`PROVIDER_HOOK_${provider}`);
         expect(requestText(server.requests.at(-1)!)).toContain(`PROVIDER_HOOK_${fallbackProvider}`);
       } finally {
-        if (jobId) await client.request("cron.remove", { id: jobId });
+        if (jobId) {
+          await client.request("cron.remove", { id: jobId });
+        }
         await disconnectGatewayClient(client);
       }
     },


### PR DESCRIPTION
## What Problem This Solves

OpenAI Responses can finish an attempt with only a compaction checkpoint and no visible assistant answer. The runner requested a continuation, but split that instruction from the session prompt owner. A later reasoning-only or empty-response retry could then replace the active prompt and silently drop the compaction constraint before the model produced a visible answer.

This PR also consolidates duplicate one-shot OpenAI Responses SSE test writers onto the existing shared fixture.

## Root Cause And Fix

Prompt identity, persistence, and prepared-user handling belong to `sessionPromptState`, while compaction continuation was previously appended from separate retry state during dispatch. The first repair moved it into the active prompt, but represented it as the same replaceable value used by later retry instructions.

The canonical fix keeps one session-owned prompt model with two components:

- the latest replaceable per-attempt retry instruction
- an independently retained compaction continuation overlay

Reasoning-only, missing-assistant, and empty-response retries replace only the base instruction. Visible or terminal resolution clears the retained overlay before any final-revision prompt is installed. The original operator prompt is never replayed because the compaction checkpoint already owns it.

## User Impact

Compaction-only OpenAI Responses attempts now retain their continuation constraint through chained invisible retries and continue to a visible final answer.

## Evidence

Exact head: `e3305f44a7eb4f5124d5ef3b9d04deefb2df5fdd`

- pre-fix reproduction: compaction followed by reasoning-only retry dropped the continuation instruction
- focused unit coverage: 63 tests passed (session prompt state 15, terminal resolution 48)
- real Gateway/model-transport E2E: 1 test passed
- request 3 retains the compaction checkpoint and continuation instruction exactly once
- request 3 includes the reasoning-only retry instruction exactly once
- changed-surface gate passed: core/root test typechecks, dead exports, database-first, import cycles, formatting, and lint
- exact-head hosted CI: 131 passed, 45 skipped, 0 failed
- unrelated Slack loopback timeout reproduced as healthy locally (19 ms) and passed on the isolated failed-job rerun
- independent high-reasoning review: no P0-P2 findings; owner-level fix judged best
- direct Codex contract check: reasoning and compaction are distinct response items; reasoning-only output is not a visible assistant answer
- fresh main: `6a97159ececbf6c0f5a2180b97d761ba1c5fe4df`
- no fresh-main commits touch the repaired paths; synthetic merge tree `5f13ce26fc1f6ded7f02c525dd6dc5ab36b76813`

## ClawSweeper Follow-Up

Applied the required rank-up move and P1 finding:

- compaction continuation survives reasoning-only and empty-response retry prompts
- shared-state coverage exercises compaction -> reasoning -> empty retry
- Gateway request-shape coverage exercises compaction -> reasoning-only -> visible answer

The reported data-model compatibility item is not applicable: this changes ephemeral in-memory prompt composition only. No serialized state, schema, migration, config, protocol, or persistence contract changes.

## Test Audit

The regression coverage is split by owner:

- session prompt state proves overlay composition, replacement, exact-once retention, and visible-path release
- terminal resolution proves the real retry ordering and lifecycle boundary
- the Gateway E2E proves the provider-visible request sequence

The shared SSE helper remains framing-only. Scenario events and behavioral assertions stay local.

## Scope

- production: `+26/-11` (net `+15`)
- tests/test support: `+309/-152` (net `+157`)
- docs/changelog: `+0/-0`

The production growth is the session-owned overlay and explicit lifecycle release seam; moving it into dispatch or individual retry callers would recreate split ownership.
