### PR TITLE
fix(tui): use matchesKey for Ctrl+C in pickers to support modern keyboard protocols

### DIFF
--- a/src/tui/components/filterable-select-list.ts
+++ b/src/tui/components/filterable-select-list.ts
@@ -4,6 +4,7 @@ import {
   type Focusable,
   fuzzyFilter,
   Input,
+  Key,
   matchesKey,
   type SelectItem,
   SelectList,
@@ -127,7 +128,7 @@ export class FilterableSelectList implements Component, Focusable {
     }
 
     // Escape: clear filter or cancel
-    if (matchesKey(keyData, "escape") || keyData === "\u0003") {
+    if (matchesKey(keyData, "escape") || matchesKey(keyData, Key.ctrl("c"))) {
       if (this.filterText) {
         this.filterText = "";
         this.input.setValue("");

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -5,6 +5,7 @@ import {
   fuzzyFilter,
   Input,
   isKeyRelease,
+  Key,
   matchesKey,
   type SelectItem,
   type SelectListTheme,
@@ -375,7 +376,7 @@ export class SearchableSelectList implements Component, Focusable {
       return;
     }
 
-    if (matchesKey(keyData, "escape") || keyData === "\u0003") {
+    if (matchesKey(keyData, "escape") || matchesKey(keyData, Key.ctrl("c"))) {
       if (this.onCancel) {
         this.onCancel();
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Ctrl+C does not cancel TUI model, agent, and session pickers when the terminal sends Kitty CSI-u or xterm modifyOtherKeys input instead of the legacy ETX byte.

## Why This Change Was Made

The existing code used raw ETX byte comparison (\\u0003\) for Ctrl+C detection. Modern terminals that use Kitty keyboard protocol (CSI-u) or xterm modifyOtherKeys mode send different encodings for Ctrl+C, causing the raw comparison to silently fail.

The fix replaces the raw byte comparison with \matchesKey(keyData, Key.ctrl('c'))\, which is the pi-tui decoder that handles all keyboard encoding protocols transparently. This is the same pattern already used in \custom-editor.ts\ for Ctrl+C handling.

## User Impact

Operators using terminals with Kitty CSI-u or xterm modifyOtherKeys input can now cancel TUI pickers with Ctrl+C. The fix is backward-compatible with legacy ETX byte input.

## Evidence

- Existing test \ilterable-select-list.test.ts:146\ uses \\\u0003\ (legacy ETX byte) and will continue to pass
- The \matchesKey\ decoder from pi-tui recognizes all three encodings: legacy ETX, Kitty CSI-u, and xterm modifyOtherKeys
- The pattern is already used in \custom-editor.ts:103\ for the same purpose

Closes #133128