### PR TITLE
fix(imessage): stop reflected replies from starting new turns

### DIFF
--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -13,6 +13,18 @@ type SentMessageLookup = {
 type SentMessageLookupOptions = {
   skipIdShortCircuit?: boolean;
   includePendingText?: boolean;
+  requireTextMatchForId?: boolean;
+};
+
+type SentMessageFactCacheEntry = {
+  timestamp: number;
+  backedByMessageId: boolean;
+};
+
+type SentMessageIdCacheEntry = {
+  timestamp: number;
+  textKey?: string;
+  mediaKey?: string;
 };
 
 export type SentMessageCache = {
@@ -61,30 +73,33 @@ function normalizeEchoMessageIdKey(messageId: string | undefined): string | null
 }
 
 class DefaultSentMessageCache implements SentMessageCache {
-  private textCache = new Map<string, number>();
-  private textBackedByIdCache = new Map<string, number>();
-  private mediaCache = new Map<string, number>();
-  private mediaBackedByIdCache = new Map<string, number>();
-  private messageIdCache = new Map<string, number>();
+  private textCache = new Map<string, SentMessageFactCacheEntry>();
+  private mediaCache = new Map<string, SentMessageFactCacheEntry>();
+  private messageIdCache = new Map<string, SentMessageIdCacheEntry>();
 
   remember(scope: string, lookup: SentMessageLookup): void {
     const textKey = normalizeEchoTextKey(lookup.text);
-    if (textKey) {
-      this.textCache.set(`${scope}:${textKey}`, Date.now());
-    }
     const mediaKey = resolveIMessageEchoMediaKey(lookup.media);
-    if (mediaKey) {
-      this.mediaCache.set(`${scope}:${mediaKey}`, Date.now());
-    }
     const messageIdKey = normalizeEchoMessageIdKey(lookup.messageId);
+    const timestamp = Date.now();
+    if (textKey) {
+      this.textCache.set(`${scope}:${textKey}`, {
+        timestamp,
+        backedByMessageId: messageIdKey != null,
+      });
+    }
+    if (mediaKey) {
+      this.mediaCache.set(`${scope}:${mediaKey}`, {
+        timestamp,
+        backedByMessageId: messageIdKey != null,
+      });
+    }
     if (messageIdKey) {
-      this.messageIdCache.set(`${scope}:${messageIdKey}`, Date.now());
-      if (textKey) {
-        this.textBackedByIdCache.set(`${scope}:${textKey}`, Date.now());
-      }
-      if (mediaKey) {
-        this.mediaBackedByIdCache.set(`${scope}:${mediaKey}`, Date.now());
-      }
+      this.messageIdCache.set(`${scope}:${messageIdKey}`, {
+        timestamp,
+        ...(textKey ? { textKey } : {}),
+        ...(mediaKey ? { mediaKey } : {}),
+      });
     }
     this.cleanup();
   }
@@ -105,6 +120,7 @@ class DefaultSentMessageCache implements SentMessageCache {
         messageId: lookup.messageId,
         skipIdShortCircuit: resolvedOptions.skipIdShortCircuit,
         includePendingText: resolvedOptions.includePendingText,
+        requireTextMatchForId: resolvedOptions.requireTextMatchForId,
       })
     ) {
       return true;
@@ -112,70 +128,59 @@ class DefaultSentMessageCache implements SentMessageCache {
     const textKey = normalizeEchoTextKey(lookup.text);
     const mediaKey = resolveIMessageEchoMediaKey(lookup.media);
     const messageIdKey = normalizeEchoMessageIdKey(lookup.messageId);
+    const now = Date.now();
+    const textEntry = textKey ? this.textCache.get(`${scope}:${textKey}`) : undefined;
+    const mediaEntry = mediaKey ? this.mediaCache.get(`${scope}:${mediaKey}`) : undefined;
     let canUseMediaFallback = !messageIdKey;
     if (messageIdKey) {
-      const idTimestamp = this.messageIdCache.get(`${scope}:${messageIdKey}`);
-      if (idTimestamp && Date.now() - idTimestamp <= SENT_MESSAGE_ID_TTL_MS) {
-        return true;
+      const idEntry = this.messageIdCache.get(`${scope}:${messageIdKey}`);
+      if (idEntry && now - idEntry.timestamp <= SENT_MESSAGE_ID_TTL_MS) {
+        if (
+          !resolvedOptions.requireTextMatchForId ||
+          (textKey != null && idEntry.textKey === textKey)
+        ) {
+          return true;
+        }
       }
-      const textTimestamp = textKey ? this.textCache.get(`${scope}:${textKey}`) : undefined;
-      const textBackedByIdTimestamp = textKey
-        ? this.textBackedByIdCache.get(`${scope}:${textKey}`)
-        : undefined;
-      const hasTextOnlyMatch =
-        typeof textTimestamp === "number" &&
-        (!textBackedByIdTimestamp || textTimestamp > textBackedByIdTimestamp);
-      const mediaTimestamp = mediaKey ? this.mediaCache.get(`${scope}:${mediaKey}`) : undefined;
-      const mediaBackedByIdTimestamp = mediaKey
-        ? this.mediaBackedByIdCache.get(`${scope}:${mediaKey}`)
-        : undefined;
-      const hasMediaOnlyMatch =
-        typeof mediaTimestamp === "number" &&
-        (!mediaBackedByIdTimestamp || mediaTimestamp > mediaBackedByIdTimestamp);
+      // Reply-parent identities are only echoes when the same cached send also
+      // owns the inbound text; never fall through to a different text entry.
+      if (resolvedOptions.requireTextMatchForId) {
+        return false;
+      }
+      const hasTextOnlyMatch = textEntry?.backedByMessageId === false;
+      const hasMediaOnlyMatch = mediaEntry?.backedByMessageId === false;
       canUseMediaFallback = hasMediaOnlyMatch;
       if (!resolvedOptions.skipIdShortCircuit && !hasTextOnlyMatch && !hasMediaOnlyMatch) {
         return false;
       }
     }
-    if (textKey) {
-      const textTimestamp = this.textCache.get(`${scope}:${textKey}`);
-      if (textTimestamp && Date.now() - textTimestamp <= SENT_MESSAGE_TEXT_TTL_MS) {
-        return true;
-      }
+    if (textEntry && now - textEntry.timestamp <= SENT_MESSAGE_TEXT_TTL_MS) {
+      return true;
     }
-    if (mediaKey && canUseMediaFallback) {
-      const mediaTimestamp = this.mediaCache.get(`${scope}:${mediaKey}`);
-      if (mediaTimestamp && Date.now() - mediaTimestamp <= SENT_MESSAGE_TEXT_TTL_MS) {
-        return true;
-      }
+    if (
+      mediaEntry &&
+      canUseMediaFallback &&
+      now - mediaEntry.timestamp <= SENT_MESSAGE_TEXT_TTL_MS
+    ) {
+      return true;
     }
     return false;
   }
 
   private cleanup(): void {
     const now = Date.now();
-    for (const [key, timestamp] of this.textCache.entries()) {
-      if (now - timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
+    for (const [key, entry] of this.textCache.entries()) {
+      if (now - entry.timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
         this.textCache.delete(key);
       }
     }
-    for (const [key, timestamp] of this.textBackedByIdCache.entries()) {
-      if (now - timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
-        this.textBackedByIdCache.delete(key);
-      }
-    }
-    for (const [key, timestamp] of this.mediaCache.entries()) {
-      if (now - timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
+    for (const [key, entry] of this.mediaCache.entries()) {
+      if (now - entry.timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
         this.mediaCache.delete(key);
       }
     }
-    for (const [key, timestamp] of this.mediaBackedByIdCache.entries()) {
-      if (now - timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
-        this.mediaBackedByIdCache.delete(key);
-      }
-    }
-    for (const [key, timestamp] of this.messageIdCache.entries()) {
-      if (now - timestamp > SENT_MESSAGE_ID_TTL_MS) {
+    for (const [key, entry] of this.messageIdCache.entries()) {
+      if (now - entry.timestamp > SENT_MESSAGE_ID_TTL_MS) {
         this.messageIdCache.delete(key);
       }
     }

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -121,6 +121,9 @@ class DefaultSentMessageCache implements SentMessageCache {
         skipIdShortCircuit: resolvedOptions.skipIdShortCircuit,
         includePendingText: resolvedOptions.includePendingText,
         requireTextMatchForId: resolvedOptions.requireTextMatchForId,
+        messageIdMaxAgeMs: resolvedOptions.requireTextMatchForId
+          ? SENT_MESSAGE_TEXT_TTL_MS
+          : undefined,
       })
     ) {
       return true;
@@ -134,7 +137,10 @@ class DefaultSentMessageCache implements SentMessageCache {
     let canUseMediaFallback = !messageIdKey;
     if (messageIdKey) {
       const idEntry = this.messageIdCache.get(`${scope}:${messageIdKey}`);
-      if (idEntry && now - idEntry.timestamp <= SENT_MESSAGE_ID_TTL_MS) {
+      const messageIdTtlMs = resolvedOptions.requireTextMatchForId
+        ? SENT_MESSAGE_TEXT_TTL_MS
+        : SENT_MESSAGE_ID_TTL_MS;
+      if (idEntry && now - idEntry.timestamp <= messageIdTtlMs) {
         if (
           !resolvedOptions.requireTextMatchForId ||
           (textKey != null && idEntry.textKey === textKey)

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -733,7 +733,7 @@ export async function resolveIMessageInboundDecision(params: {
         text: bodyText || undefined,
         media: mediaFacts[0],
         messageIds: inboundMessageIds,
-        replyParentId: normalizeReplyField(params.message.reply_to_guid),
+        replyParentId: isSelfChat ? normalizeReplyField(params.message.reply_to_guid) : undefined,
         includePendingText: isSelfChat,
       })
     ) {

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -50,6 +50,7 @@ import {
   type IMessageService,
 } from "../targets.js";
 import type { IMessageDmHistoryContext } from "./dm-history.js";
+import type { SentMessageCache } from "./echo-cache.js";
 import {
   type IMessageReactionContext,
   resolveIMessageReactionContext,
@@ -254,17 +255,12 @@ export function rememberIMessageSkippedFromMeForSelfChatDedupe(params: {
 }
 
 function hasIMessageEchoMatch(params: {
-  echoCache: {
-    has: (
-      scope: string,
-      lookup: { text?: string; media?: MediaPlaceholderTextFact; messageId?: string },
-      options?: boolean | { skipIdShortCircuit?: boolean; includePendingText?: boolean },
-    ) => boolean;
-  };
+  echoCache: Pick<SentMessageCache, "has">;
   scope: string | readonly string[];
   text?: string;
   media?: MediaPlaceholderTextFact;
   messageIds: string[];
+  replyParentId?: string;
   skipIdShortCircuit?: boolean;
   includePendingText?: boolean;
 }): boolean {
@@ -285,6 +281,17 @@ function hasIMessageEchoMatch(params: {
       if (params.echoCache.has(scope, { messageId })) {
         return true;
       }
+    }
+    if (
+      params.replyParentId &&
+      params.text &&
+      params.echoCache.has(
+        scope,
+        { text: params.text, messageId: params.replyParentId },
+        { requireTextMatchForId: true },
+      )
+    ) {
+      return true;
     }
     const fallbackMessageId = params.messageIds[0];
     if (!params.text && !params.media && !fallbackMessageId) {
@@ -415,13 +422,7 @@ export async function resolveIMessageInboundDecision(params: {
   storeAllowFrom: string[];
   historyLimit: number;
   groupHistories: Map<string, HistoryEntry[]>;
-  echoCache?: {
-    has: (
-      scope: string,
-      lookup: { text?: string; media?: MediaPlaceholderTextFact; messageId?: string },
-      options?: boolean | { skipIdShortCircuit?: boolean; includePendingText?: boolean },
-    ) => boolean;
-  };
+  echoCache?: Pick<SentMessageCache, "has">;
   selfChatCache?: SelfChatCache;
   reactionNotifications?: IMessageReactionNotificationMode;
   isKnownFromMeMessageId?: typeof isKnownFromMeIMessageMessageId;
@@ -732,6 +733,7 @@ export async function resolveIMessageInboundDecision(params: {
         text: bodyText || undefined,
         media: mediaFacts[0],
         messageIds: inboundMessageIds,
+        replyParentId: normalizeReplyField(params.message.reply_to_guid),
         includePendingText: isSelfChat,
       })
     ) {

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
@@ -141,6 +141,23 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has("acct:imessage:+1555", { messageId: "guid-1" })).toBe(true);
   });
 
+  it("binds reply-parent message ids to the text from the same cached send", () => {
+    const scope = "acct:imessage:+1555";
+    rememberPersistedIMessageEcho({ scope, text: "persisted reply", messageId: "guid-persisted" });
+    rememberPersistedIMessageEcho({ scope, text: "different reply" });
+    const cache = createSentMessageCache();
+    cache.remember(scope, { text: "memory reply", messageId: "guid-memory" });
+
+    for (const [text, messageId, expected] of [
+      ["persisted reply", "guid-persisted", true],
+      ["memory reply", "guid-memory", true],
+      ["different reply", "guid-persisted", false],
+      ["different reply", "guid-memory", false],
+    ] as const) {
+      expect(cache.has(scope, { text, messageId }, { requireTextMatchForId: true })).toBe(expected);
+    }
+  });
+
   it("persists text-only and id-only echoes without undefined fields", () => {
     const scope = "acct:imessage:+1555";
     rememberPersistedIMessageEcho({ scope, text: "text-only" });

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -169,6 +169,7 @@ export function hasPersistedIMessageEcho(params: {
   skipIdShortCircuit?: boolean;
   includePendingText?: boolean;
   requireTextMatchForId?: boolean;
+  messageIdMaxAgeMs?: number;
 }): boolean {
   const text = normalizeText(params.text);
   const mediaKey = resolveIMessageEchoMediaKey(params.media);
@@ -180,9 +181,13 @@ export function hasPersistedIMessageEcho(params: {
     if (entry.scope !== params.scope) {
       continue;
     }
+    const messageIdWithinMaxAge =
+      params.messageIdMaxAgeMs == null ||
+      Math.max(0, Date.now() - entry.timestamp) <= params.messageIdMaxAgeMs;
     if (
       messageId &&
       entry.messageId === messageId &&
+      messageIdWithinMaxAge &&
       (!params.requireTextMatchForId || (text != null && entry.text === text))
     ) {
       return true;

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -168,6 +168,7 @@ export function hasPersistedIMessageEcho(params: {
   messageId?: string;
   skipIdShortCircuit?: boolean;
   includePendingText?: boolean;
+  requireTextMatchForId?: boolean;
 }): boolean {
   const text = normalizeText(params.text);
   const mediaKey = resolveIMessageEchoMediaKey(params.media);
@@ -179,8 +180,15 @@ export function hasPersistedIMessageEcho(params: {
     if (entry.scope !== params.scope) {
       continue;
     }
-    if (messageId && entry.messageId === messageId) {
+    if (
+      messageId &&
+      entry.messageId === messageId &&
+      (!params.requireTextMatchForId || (text != null && entry.text === text))
+    ) {
       return true;
+    }
+    if (params.requireTextMatchForId) {
+      continue;
     }
     const hasConflictingMessageIds = Boolean(
       messageId && entry.messageId && messageId !== entry.messageId,

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -163,6 +163,49 @@ describe("echo cache — backward compat for channels without messageId", () => 
   });
 });
 
+describe("reply-parent echo matching — #135704", () => {
+  it.each([
+    {
+      name: "drops matching text linked to the cached parent",
+      cachedScope: SELF_CHAT_SCOPE,
+      inboundText: "Agent reply",
+      expected: { kind: "drop", reason: "echo" },
+    },
+    {
+      name: "keeps different text linked to the cached parent",
+      cachedScope: SELF_CHAT_SCOPE,
+      inboundText: "Human follow-up",
+      expected: { kind: "dispatch" },
+    },
+    {
+      name: "keeps matching text in a different conversation scope",
+      cachedScope: "default:imessage:+15550000000",
+      inboundText: "Agent reply",
+      expected: { kind: "dispatch" },
+    },
+  ])("$name", async ({ cachedScope, inboundText, expected }) => {
+    const echoCache = createSentMessageCache();
+    echoCache.remember(cachedScope, {
+      text: "Agent reply",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    const decision = await resolveDecision({
+      message: {
+        id: 200,
+        guid: "p:0/GUID-inbound",
+        reply_to_guid: "p:0/GUID-outbound",
+        sender: SELF_CHAT_HANDLE,
+        text: inboundText,
+        is_from_me: false,
+      },
+      echoCache,
+    });
+
+    expect(decision).toMatchObject(expected);
+  });
+});
+
 describe("self-chat dedupe — #47830", () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -166,24 +166,73 @@ describe("echo cache — backward compat for channels without messageId", () => 
 describe("reply-parent echo matching — #135704", () => {
   it.each([
     {
-      name: "drops matching text linked to the cached parent",
+      name: "drops matching text linked to the cached parent in a verified self-chat",
       cachedScope: SELF_CHAT_SCOPE,
-      inboundText: "Agent reply",
+      message: selfChatMessage({
+        id: 200,
+        guid: "p:0/GUID-inbound",
+        reply_to_guid: "p:0/GUID-outbound",
+        text: "Agent reply",
+        is_from_me: false,
+      }),
       expected: { kind: "drop", reason: "echo" },
     },
     {
-      name: "keeps different text linked to the cached parent",
+      name: "keeps different text linked to the cached parent in a verified self-chat",
       cachedScope: SELF_CHAT_SCOPE,
-      inboundText: "Human follow-up",
+      message: selfChatMessage({
+        id: 200,
+        guid: "p:0/GUID-inbound",
+        reply_to_guid: "p:0/GUID-outbound",
+        text: "Human follow-up",
+        is_from_me: false,
+      }),
       expected: { kind: "dispatch" },
     },
     {
-      name: "keeps matching text in a different conversation scope",
-      cachedScope: "default:imessage:+15550000000",
-      inboundText: "Agent reply",
+      name: "keeps a matching inline reply in a normal direct message",
+      cachedScope: SELF_CHAT_SCOPE,
+      message: {
+        id: 200,
+        guid: "p:0/GUID-inbound",
+        reply_to_guid: "p:0/GUID-outbound",
+        sender: SELF_CHAT_HANDLE,
+        chat_identifier: SELF_CHAT_HANDLE,
+        destination_caller_id: "+15557654321",
+        text: "Agent reply",
+        is_from_me: false,
+        is_group: false,
+      },
       expected: { kind: "dispatch" },
     },
-  ])("$name", async ({ cachedScope, inboundText, expected }) => {
+    {
+      name: "keeps a matching inline reply in a group",
+      cachedScope: "default:chat_id:42",
+      message: {
+        id: 200,
+        guid: "p:0/GUID-inbound",
+        reply_to_guid: "p:0/GUID-outbound",
+        sender: SELF_CHAT_HANDLE,
+        chat_id: 42,
+        text: "Agent reply",
+        is_from_me: false,
+        is_group: true,
+      },
+      expected: { kind: "dispatch" },
+    },
+    {
+      name: "keeps matching text in a different self-chat scope",
+      cachedScope: "default:imessage:+15550000000",
+      message: selfChatMessage({
+        id: 200,
+        guid: "p:0/GUID-inbound",
+        reply_to_guid: "p:0/GUID-outbound",
+        text: "Agent reply",
+        is_from_me: false,
+      }),
+      expected: { kind: "dispatch" },
+    },
+  ])("$name", async ({ cachedScope, message, expected }) => {
     const echoCache = createSentMessageCache();
     echoCache.remember(cachedScope, {
       text: "Agent reply",
@@ -191,14 +240,7 @@ describe("reply-parent echo matching — #135704", () => {
     });
 
     const decision = await resolveDecision({
-      message: {
-        id: 200,
-        guid: "p:0/GUID-inbound",
-        reply_to_guid: "p:0/GUID-outbound",
-        sender: SELF_CHAT_HANDLE,
-        text: inboundText,
-        is_from_me: false,
-      },
+      message,
       echoCache,
     });
 

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -164,6 +164,10 @@ describe("echo cache — backward compat for channels without messageId", () => 
 });
 
 describe("reply-parent echo matching — #135704", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it.each([
     {
       name: "drops matching text linked to the cached parent in a verified self-chat",
@@ -245,6 +249,97 @@ describe("reply-parent echo matching — #135704", () => {
     });
 
     expect(decision).toMatchObject(expected);
+  });
+
+  it("keeps a matching self-chat inline reply after the in-memory reflection window expires", async () => {
+    useFakeTimersAt();
+    const echoCache = createSentMessageCache();
+    echoCache.remember(SELF_CHAT_SCOPE, {
+      text: "Agent reply",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    vi.advanceTimersByTime(5_000);
+
+    const decision = await resolveDecision({
+      message: selfChatMessage({
+        id: 201,
+        guid: "p:0/GUID-late-reply",
+        reply_to_guid: "p:0/GUID-outbound",
+        text: "Agent reply",
+        is_from_me: false,
+      }),
+      echoCache,
+    });
+
+    expect(decision).toMatchObject({ kind: "dispatch" });
+  });
+
+  it("drops a matching self-chat reflection from the persisted cache within the reflection window", async () => {
+    useFakeTimersAt();
+    rememberPersistedIMessageEcho({
+      scope: SELF_CHAT_SCOPE,
+      text: "Agent reply",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    vi.advanceTimersByTime(2_000);
+
+    const decision = await resolveDecision({
+      message: selfChatMessage({
+        id: 202,
+        guid: "p:0/GUID-persisted-reflection",
+        reply_to_guid: "p:0/GUID-outbound",
+        text: "Agent reply",
+        is_from_me: false,
+      }),
+      echoCache: createSentMessageCache(),
+    });
+
+    expect(decision).toMatchObject({ kind: "drop", reason: "echo" });
+  });
+
+  it("keeps a matching self-chat inline reply after the persisted reflection window expires", async () => {
+    useFakeTimersAt();
+    rememberPersistedIMessageEcho({
+      scope: SELF_CHAT_SCOPE,
+      text: "Agent reply",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    vi.advanceTimersByTime(5_000);
+
+    const decision = await resolveDecision({
+      message: selfChatMessage({
+        id: 203,
+        guid: "p:0/GUID-late-persisted-reply",
+        reply_to_guid: "p:0/GUID-outbound",
+        text: "Agent reply",
+        is_from_me: false,
+      }),
+      echoCache: createSentMessageCache(),
+    });
+
+    expect(decision).toMatchObject({ kind: "dispatch" });
+  });
+
+  it("keeps long-lived persisted direct-GUID echo matching after the reply-parent window expires", () => {
+    useFakeTimersAt();
+    rememberPersistedIMessageEcho({
+      scope: SELF_CHAT_SCOPE,
+      text: "Agent reply",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    vi.advanceTimersByTime(5 * 60_000);
+
+    const echoCache = createSentMessageCache();
+    expect(
+      echoCache.has(SELF_CHAT_SCOPE, {
+        text: "Different body",
+        messageId: "p:0/GUID-outbound",
+      }),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #135704

## What Problem This Solves

Fixes an issue where an outbound iMessage reflection could be treated as fresh user input when Messages assigned it a new row GUID but retained the original outbound GUID in `reply_to_guid`. In affected self-chats this could start a second agent turn and create a reply loop.

## Why This Change Was Made

Echo detection now accepts the reply-parent GUID only when it is bound to the same normalized text in the same conversation scope. The in-memory cache stores that ID/text association directly, matching the persisted-cache behavior while preserving the existing conflicting-ID guard. A different reply body or the same text in another conversation still dispatches normally.

## User Impact

Affected iMessage users no longer have reflected assistant text reprocessed as a user message. Legitimate inline replies remain deliverable.

## Evidence

- Regression-first: before production changes, the focused test returned `dispatch` for the reported tuple (1 failed, 36 passed).
- `pnpm test extensions/imessage/src/monitor/self-chat-dedupe.test.ts extensions/imessage/src/monitor/cache-lifecycle.test.ts` — 80/80 passed after the fix, including memory and persisted caches, a different-text reply, and cross-scope isolation.
- `pnpm check:changed` — all repository guards through formatting and plugin boundaries passed. The final repository-wide extension typecheck was blocked on this checkout by unrelated missing `yargs-parser` declarations in `extensions/browser/src/browser/chrome-mcp-options.ts`.
- `pnpm test:extension imessage` — all touched monitor tests passed; the Windows host then hit existing macOS-path and fake-`imsg` assumptions, and the runner was stopped after it stopped producing output.
- `git diff --check` passed.
- Live macOS Messages verification was not run because this Windows environment has no Messages `chat.db` or `imsg` bridge. The issue report includes a live no-recursion observation for the same strict guard shape.
- Production delta: 89 additions / 74 deletions (net +15). The added state is the ID/text association needed for exact matching; two parallel “backed by ID” maps and duplicated inline cache types were removed.