### PR TITLE
fix(cli): preserve literal completion cache paths

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -42,6 +42,8 @@ The install writes a small `# OpenClaw Completion` block into your shell profile
 
 Profile changes are staged beside the destination and atomically replace it only after a complete durable write. A failed install leaves an existing profile unchanged.
 
+Installed source lines preserve literal cache paths, including spaces, quotes, dollar signs, and backslashes. Reinstalling replaces OpenClaw's previous source line after the state directory changes.
+
 ## Notes
 
 - Without `--install` or `--write-state`, the command prints the script to stdout.

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -288,36 +288,38 @@ describe("completion-runtime", () => {
     });
   });
 
-  it("recognizes cached Bash completion installed into the login profile", async () => {
-    await withBashCompletionHome(async ({ homeDir }) => {
-      const cachePath = resolveCompletionCachePath("bash", "openclaw");
-      await fs.mkdir(path.dirname(cachePath), { recursive: true });
-      await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
+  it.each(["ordinary", "literal$dollar", "Ada's !42"])(
+    "loads cached Bash completion from a %s path through the login profile",
+    async (stateName) => {
+      await withBashCompletionHome(async ({ homeDir }) => {
+        const cachePath = resolveCompletionCachePath("bash", "openclaw");
+        await fs.mkdir(path.dirname(cachePath), { recursive: true });
+        await fs.writeFile(cachePath, "complete -W 'status' openclaw\n", "utf-8");
 
-      await installCompletion("bash", true, "openclaw");
+        await installCompletion("bash", true, "openclaw");
 
-      const profilePath = path.join(homeDir, ".bash_profile");
-      await expect(fs.readFile(profilePath, "utf-8")).resolves.toContain(cachePath);
-      await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
-      await expect(usesSlowDynamicCompletion("bash", "openclaw")).resolves.toBe(false);
+        const profilePath = path.join(homeDir, ".bash_profile");
+        await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
+        await expect(usesSlowDynamicCompletion("bash", "openclaw")).resolves.toBe(false);
 
-      const shell = spawnSync(
-        "bash",
-        [
-          "--noprofile",
-          "--norc",
-          "-c",
-          'source "$1"; complete -p openclaw',
-          "openclaw",
-          profilePath,
-        ],
-        { encoding: "utf8" },
-      );
-      expect(shell.stderr).toBe("");
-      expect(shell.status).toBe(0);
-      expect(shell.stdout).toContain("complete -W 'status' openclaw");
-    });
-  });
+        const shell = spawnSync(
+          "bash",
+          [
+            "--noprofile",
+            "--norc",
+            "-c",
+            'source "$1"; complete -p openclaw',
+            "openclaw",
+            profilePath,
+          ],
+          { encoding: "utf8" },
+        );
+        expect(shell.stderr).toBe("");
+        expect(shell.status).toBe(0);
+        expect(shell.stdout).toContain("complete -W 'status' openclaw");
+      }, `openclaw-completion-${stateName}-`);
+    },
+  );
 
   it("prints the same canonical reload hint used by Doctor and onboarding", async () => {
     await withBashCompletionHome(async ({ homeDir }) => {
@@ -461,30 +463,51 @@ describe("completion-runtime", () => {
     });
   });
 
-  it.each(COMPLETION_SHELLS)(
-    "replaces the old generated %s source after the state directory changes",
-    async (shell) => {
-      await withBashCompletionHome(async ({ stateDir }) => {
-        const previousStateDir = tempDirs.make("openclaw-completion-previous-state-");
-        let previousCachePath = "";
+  it.each(
+    COMPLETION_SHELLS.flatMap((shell) => [
+      { shell, generation: "legacy" },
+      { shell, generation: "current" },
+    ]),
+  )(
+    "replaces the $generation $shell source after the literal state directory changes",
+    async ({ shell, generation }) => {
+      await withBashCompletionHome(async () => {
+        const previousStateDir = tempDirs.make(
+          `openclaw-completion-previous-${process.platform === "win32" ? "" : '"'}$state's-`,
+        );
+        const profilePath = resolveCompletionProfilePath(shell);
         await withEnvAsync({ OPENCLAW_STATE_DIR: previousStateDir }, async () => {
-          previousCachePath = resolveCompletionCachePath(shell, "openclaw");
+          const previousCachePath = resolveCompletionCachePath(shell, "openclaw");
           await fs.mkdir(path.dirname(previousCachePath), { recursive: true });
           await fs.writeFile(previousCachePath, "# previous completion\n", "utf-8");
-          await installCompletion(shell, true, "openclaw");
+          if (generation === "current") {
+            await installCompletion(shell, true, "openclaw");
+          } else {
+            // Stable v2026.8.2 wrote POSIX/Fish paths in raw double quotes.
+            const source =
+              shell === "powershell"
+                ? `. '${previousCachePath.replaceAll("'", "''")}'`
+                : shell === "fish"
+                  ? `test -f "${previousCachePath}"; and source "${previousCachePath}"`
+                  : `[ -f "${previousCachePath}" ] && source "${previousCachePath}"`;
+            await fs.mkdir(path.dirname(profilePath), { recursive: true });
+            await fs.writeFile(profilePath, `# OpenClaw Completion\n${source}\n`, "utf8");
+          }
         });
+        const previousSource = (await fs.readFile(profilePath, "utf8")).trim().split("\n").at(-1)!;
 
         const currentCachePath = resolveCompletionCachePath(shell, "openclaw");
-        expect(currentCachePath).toContain(stateDir);
         await fs.mkdir(path.dirname(currentCachePath), { recursive: true });
         await fs.writeFile(currentCachePath, "# current completion\n", "utf-8");
         await installCompletion(shell, true, "openclaw");
 
-        const profile = await fs.readFile(resolveCompletionProfilePath(shell), "utf-8");
-        expect(profile).toContain(currentCachePath);
-        expect(profile).not.toContain(previousCachePath);
+        const profile = await fs.readFile(profilePath, "utf-8");
+        expect(profile).not.toContain(previousSource);
         expect(profile.match(/^# OpenClaw Completion$/gm)).toHaveLength(1);
-      });
+        await expect(isCompletionInstalled(shell, "openclaw")).resolves.toBe(true);
+        await installCompletion(shell, true, "openclaw");
+        await expect(fs.readFile(profilePath, "utf8")).resolves.toBe(profile);
+      }, "openclaw-completion-current-$state's-");
     },
   );
 
@@ -494,15 +517,35 @@ describe("completion-runtime", () => {
       const profilePath = path.join(homeDir, ".bash_profile");
       const unrelatedSource = 'source "/opt/tools/completions/openclaw.zsh"';
       const unmarkedPriorSource = 'source "/opt/tools/completions/openclaw.bash"';
+      const markedUserSources = [
+        "source '/opt/tools/not-completions/openclaw.bash'",
+        "source '/opt/tools/completions/openclaw.zsh'",
+        "[ -f '/other/completions/openclaw.bash' ] && source '/opt/tools/completions/openclaw.bash'",
+        '[ -f "/opt/tools/completions/openclaw.bash" ] && source "/opt/tools/completions/openclaw.bash"; export IMPORTANT=keep',
+        "source '/opt/tools/completions/openclaw.bash'; export IMPORTANT=keep",
+        'source "/old/completions/openclaw.bash"; printf "%s" "/other/completions/openclaw.bash"',
+        "source '/opt/tools/completions/openclaw.bash",
+        '. "/opt/tools/completions/openclaw.bash"',
+      ];
       await fs.mkdir(path.dirname(cachePath), { recursive: true });
       await fs.writeFile(cachePath, "# current completion\n", "utf-8");
-      await fs.writeFile(profilePath, `${unrelatedSource}\n${unmarkedPriorSource}\n`, "utf-8");
+      await fs.writeFile(
+        profilePath,
+        [
+          unrelatedSource,
+          unmarkedPriorSource,
+          ...markedUserSources.flatMap((source) => ["# OpenClaw Completion", source]),
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
 
       await installCompletion("bash", true, "openclaw");
 
       const profile = await fs.readFile(profilePath, "utf-8");
-      expect(profile).toContain(`${unrelatedSource}\n`);
-      expect(profile).toContain(`${unmarkedPriorSource}\n`);
+      for (const source of [unrelatedSource, unmarkedPriorSource, ...markedUserSources]) {
+        expect(profile).toContain(`${source}\n`);
+      }
       expect(profile).toContain(cachePath);
     });
   });
@@ -593,7 +636,7 @@ describe("completion-runtime", () => {
 
       const profile = await fs.readFile(profilePath, "utf-8");
       expect(profile).toContain(`${compoundLine}\n`);
-      expect(profile).toContain(`[ -f "${cachePath}" ] && source "${cachePath}"`);
+      await expect(isCompletionInstalled("bash", "openclaw")).resolves.toBe(true);
     });
   });
 

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -69,16 +69,10 @@ export function resolveShellFromEnv(
 ): CompletionShell {
   const shellPath = normalizeOptionalString(env.SHELL) ?? "";
   const shellName = shellPath ? resolveShellBasename(shellPath, platform) : "";
-  if (shellName === "zsh") {
-    return "zsh";
+  if (isCompletionShell(shellName)) {
+    return shellName;
   }
-  if (shellName === "bash") {
-    return "bash";
-  }
-  if (shellName === "fish") {
-    return "fish";
-  }
-  if (shellName === "pwsh" || shellName === "powershell") {
+  if (shellName === "pwsh") {
     return "powershell";
   }
   return platform === "win32" ? "powershell" : "zsh";
@@ -97,14 +91,13 @@ function resolveCompletionCacheDir(env: NodeJS.ProcessEnv = process.env): string
   return path.join(stateDir, "completions");
 }
 
-function completionShellExtension(shell: CompletionShell): string {
-  return shell === "powershell" ? "ps1" : shell;
-}
-
 /** Returns the per-shell cached completion script path for a sanitized CLI binary name. */
 export function resolveCompletionCachePath(shell: CompletionShell, binName: string): string {
   const basename = sanitizeCompletionBasename(binName);
-  return path.join(resolveCompletionCacheDir(), `${basename}.${completionShellExtension(shell)}`);
+  return path.join(
+    resolveCompletionCacheDir(),
+    `${basename}.${shell === "powershell" ? "ps1" : shell}`,
+  );
 }
 
 /** Check if the completion cache file exists for the given shell. */
@@ -116,18 +109,25 @@ export async function completionCacheExists(
   return pathExists(cachePath);
 }
 
-function escapePowerShellSingleQuotedString(value: string): string {
-  return value.replace(/'/g, "''");
+function quoteCompletionPath(shell: CompletionShell, value: string): string {
+  if (shell === "powershell") {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  // Single quotes also keep pasted reload hints literal when interactive history expansion is on.
+  const escaped =
+    shell === "fish" ? value.replace(/[\\']/gu, "\\$&") : value.replaceAll("'", "'\\''");
+  return `'${escaped}'`;
 }
 
 function formatCompletionSourceLine(shell: CompletionShell, cachePath: string): string {
+  const quotedPath = quoteCompletionPath(shell, cachePath);
   if (shell === "powershell") {
-    return `. '${escapePowerShellSingleQuotedString(cachePath)}'`;
+    return `. ${quotedPath}`;
   }
   if (shell === "fish") {
-    return `test -f "${cachePath}"; and source "${cachePath}"`;
+    return `test -f ${quotedPath}; and source ${quotedPath}`;
   }
-  return `[ -f "${cachePath}" ] && source "${cachePath}"`;
+  return `[ -f ${quotedPath} ] && source ${quotedPath}`;
 }
 
 function appendCompletionProfilePath(
@@ -144,61 +144,70 @@ function appendCompletionProfilePath(
 /** Formats the command users can run to reload the shell profile after installation. */
 export function formatCompletionReloadCommand(shell: CompletionShell, profilePath: string): string {
   if (shell === "powershell") {
-    return `. '${escapePowerShellSingleQuotedString(profilePath)}'`;
+    return `. ${quoteCompletionPath(shell, profilePath)}`;
   }
   if (/^[a-zA-Z0-9_./~+-]+$/u.test(profilePath)) {
     return `source ${profilePath}`;
   }
   const homePrefix = profilePath.startsWith("~/") ? "~/" : "";
   const value = profilePath.slice(homePrefix.length);
-  const escapedPath =
-    shell === "fish" ? value.replace(/[\\']/gu, "\\$&") : value.replaceAll("'", "'\\''");
-  return `source ${homePrefix}'${escapedPath}'`;
+  return `source ${homePrefix}${quoteCompletionPath(shell, value)}`;
 }
 
 function isCompletionProfileHeader(line: string): boolean {
   return line.trim() === "# OpenClaw Completion";
 }
 
-function isCompletionProfileLine(line: string, binName: string, cachePath: string | null): boolean {
+function isCompletionProfileLine(line: string, binName: string, cachePath: string): boolean {
   if (isSlowDynamicCompletionLine(line, binName)) {
     return true;
   }
-  if (!cachePath) {
-    return false;
-  }
   const trimmed = line.trim();
   return (
+    // Stable releases wrote these paths without escaping shell expansion characters.
     trimmed === `source "${cachePath}"` ||
+    trimmed === `[ -f "${cachePath}" ] && source "${cachePath}"` ||
+    trimmed === `test -f "${cachePath}"; and source "${cachePath}"` ||
     COMPLETION_SHELLS.some((shell) => trimmed === formatCompletionSourceLine(shell, cachePath))
   );
 }
 
-function isPreviousCompletionSourceLine(line: string, currentCachePath: string | null): boolean {
-  if (!currentCachePath) {
+function isPreviousCompletionSourceLine(
+  line: string,
+  currentCachePath: string,
+  shell: CompletionShell,
+): boolean {
+  const trimmed = line.trim();
+  const guarded = /^(?:\[\s+-f|test\s+-f)\s+(.+?)\s*(?:\]\s*&&|;\s*and)\s+source\s+\1$/u.exec(
+    trimmed,
+  );
+  const direct = /^(source|\.)\s+(.+)$/u.exec(trimmed);
+  const quotedPath = guarded?.[1] ?? direct?.[2];
+  if (!quotedPath) {
     return false;
   }
-  const trimmed = line.trim();
-  const guarded =
-    /^(?:\[\s+-f|test\s+-f)\s+"([^"]+)"\s*(?:\]\s*&&|;\s*and)\s+source\s+"([^"]+)"$/u.exec(trimmed);
-  const direct = /^source\s+"([^"]+)"$/u.exec(trimmed);
-  const powershell = /^\.\s+'((?:[^']|'')+)'$/u.exec(trimmed);
-  let sourcePath: string | undefined;
-  if (guarded && guarded[1] === guarded[2]) {
-    sourcePath = guarded[1];
-  } else if (direct) {
-    sourcePath = direct[1];
-  } else if (powershell) {
-    sourcePath = powershell[1]?.replace(/''/g, "'");
-  }
-  if (!sourcePath) {
+  const quoteShell = direct?.[1] === "." ? "powershell" : shell;
+  // Old guarded emitters repeated raw paths even when they contained quotes.
+  const legacyPath = guarded
+    ? /^"(.+)"$/u.exec(quotedPath)?.[1]
+    : /^source\s+"([^"]+)"$/u.exec(trimmed)?.[1];
+  const escapedPath = quotedPath.slice(1, -1);
+  const sourcePath =
+    legacyPath ??
+    (quoteShell === "powershell"
+      ? escapedPath.replaceAll("''", "'")
+      : quoteShell === "fish"
+        ? escapedPath.replace(/\\([\\'])/gu, "$1")
+        : escapedPath.replaceAll("'\\''", "'"));
+  // Only our complete literal operand is owned; never consume compound profile commands.
+  if (!legacyPath && quoteCompletionPath(quoteShell, sourcePath) !== quotedPath) {
     return false;
   }
   const sourcePaths = sourcePath.includes("\\") ? path.win32 : path;
-  if (sourcePaths.basename(sourcePaths.dirname(sourcePath)) !== "completions") {
-    return false;
-  }
-  return sourcePaths.basename(sourcePath) === path.basename(currentCachePath);
+  return (
+    sourcePaths.basename(sourcePaths.dirname(sourcePath)) === "completions" &&
+    sourcePaths.basename(sourcePath) === path.basename(currentCachePath)
+  );
 }
 
 function isOwnedCompletionInvocation(invocation: string, binName: string): boolean {
@@ -206,22 +215,12 @@ function isOwnedCompletionInvocation(invocation: string, binName: string): boole
   if (command !== binName || action !== "completion") {
     return false;
   }
-  if (args.length === 0) {
-    return true;
-  }
-  if (args.length === 1) {
-    const argument = args[0] ?? "";
-    const shell = argument.startsWith("--shell=")
-      ? argument.slice("--shell=".length)
-      : argument.startsWith("-s") && argument.length > 2
-        ? argument.slice(2).replace(/^=/u, "")
-        : argument;
-    return isCompletionShell(shell);
+  if (args.length === 2 && (args[0] === "--shell" || args[0] === "-s")) {
+    return isCompletionShell(args[1] ?? "");
   }
   return (
-    args.length === 2 &&
-    (args[0] === "--shell" || args[0] === "-s") &&
-    isCompletionShell(args[1] ?? "")
+    args.length === 0 ||
+    (args.length === 1 && isCompletionShell((args[0] ?? "").replace(/^(?:--shell=|-s=?)/u, "")))
   );
 }
 
@@ -271,8 +270,8 @@ function isSlowDynamicCompletionLine(line: string, binName: string): boolean {
 function updateCompletionProfile(
   content: string,
   binName: string,
-  cachePath: string | null,
-  sourceLine: string,
+  cachePath: string,
+  shell: CompletionShell,
 ): { next: string; changed: boolean; hadExisting: boolean } {
   // Remove both cached and old dynamic blocks so installs converge to one fast source line.
   const lines = content.split("\n");
@@ -287,7 +286,7 @@ function updateCompletionProfile(
       const following = lines[i + 1] ?? "";
       if (
         isCompletionProfileLine(following, binName, cachePath) ||
-        isPreviousCompletionSourceLine(following, cachePath)
+        isPreviousCompletionSourceLine(following, cachePath, shell)
       ) {
         i += 1;
       }
@@ -301,7 +300,7 @@ function updateCompletionProfile(
   }
 
   const trimmed = filtered.join("\n").trimEnd();
-  const block = `# OpenClaw Completion\n${sourceLine}`;
+  const block = `# OpenClaw Completion\n${formatCompletionSourceLine(shell, cachePath)}`;
   const next = trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
   return { next, changed: next !== content, hadExisting };
 }
@@ -443,14 +442,9 @@ export async function usesSlowDynamicCompletion(
 
   const cachePath = resolveCompletionCachePath(shell, binName);
   const { content } = await readCompletionProfile(profilePath, shell);
-  const lines = content.split("\n");
-
-  for (const line of lines) {
-    if (isSlowDynamicCompletionLine(line, binName) && !line.includes(cachePath)) {
-      return true;
-    }
-  }
-  return false;
+  return content
+    .split("\n")
+    .some((line) => isSlowDynamicCompletionLine(line, binName) && !line.includes(cachePath));
 }
 
 const PROFILE_WRITE_ERROR_CODES = new Set(["EACCES", "EPERM", "EROFS"]);
@@ -463,8 +457,7 @@ export function findCompletionProfileWriteError(err: unknown): NodeJS.ErrnoExcep
 }
 
 export async function installCompletion(shell: string, yes: boolean, binName = "openclaw") {
-  const isShellSupported = isCompletionShell(shell);
-  if (!isShellSupported) {
+  if (!isCompletionShell(shell)) {
     throw new Error(`Automated installation not supported for ${shell} yet.`);
   }
 
@@ -477,7 +470,6 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 
   const profilePath = resolveCompletionProfilePath(shell);
-  const sourceLine = formatCompletionSourceLine(shell, cachePath);
 
   try {
     let content: string;
@@ -494,7 +486,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       content = "";
     }
 
-    const update = updateCompletionProfile(content, binName, cachePath, sourceLine);
+    const update = updateCompletionProfile(content, binName, cachePath, shell);
     if (!update.changed) {
       if (!yes) {
         console.log(`Completion already installed in ${profilePath}`);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Installing shell completion can report success while a fresh shell cannot load a valid generated cache. Raw double quotes let dollar signs, quotes, doubled backslashes and command substitutions change the resolved source path. Fixes #136237.

## Why This Change Was Made

Installed cache hooks now share the existing reload formatter's shell-specific literal quoting policy. Bash/zsh, Fish and PowerShell retain their distinct rules; PowerShell output is unchanged. Reinstall recognizes current literal hooks and exact stable-release hooks, including malformed guarded hooks generated when an old directory name contained a quote.

Previous-directory cleanup still requires the OpenClaw marker, complete matching guard/source operands, the completions directory and the current cache filename. Unmarked sources, compound user commands, mismatched guards and other shell files are preserved. Profile selection, symlink handling, atomic writes, missing-cache status, Doctor behavior and cache generation retain their contracts.

The owner cleanup removes repeated supported-shell branches, obsolete private nullable states, redundant invocation branches, the manual dynamic-line scan and a one-use extension wrapper. Production changes are **+69/-77, net -8 LOC**; tests +90/-47, net +43; docs +2. Pure moves receive no deletion credit. No dependency, configuration, protocol or storage change.

## Evidence

The original runtime is byte-identical in stable v2026.8.2 and pre-fix main. Actual Commander registration generates real completion scripts and installs them into synthetic temporary profiles. In the unchanged before/after harness, nine variants through both routes improve from 16/36 to 36/36 successful Bash/zsh loads. Independent Fish 4.8.1 checks pass all nine installed/reload cases after repair; four failed before.

Observed literal-dollar results from the real-shell receipts:

```json
[
  {
    "shell": "bash",
    "pathVariant": "literal$qa24unset",
    "before": {
      "reportedInstalled": true,
      "routes": [
        {
          "route": "installed",
          "exit": 1,
          "loaded": false
        },
        {
          "route": "reload",
          "exit": 1,
          "loaded": false
        }
      ]
    },
    "after": {
      "reportedInstalled": true,
      "routes": [
        {
          "route": "installed",
          "exit": 0,
          "loaded": true
        },
        {
          "route": "reload",
          "exit": 0,
          "loaded": true
        }
      ]
    }
  },
  {
    "shell": "zsh",
    "pathVariant": "literal$qa24unset",
    "before": {
      "reportedInstalled": true,
      "routes": [
        {
          "route": "installed",
          "exit": 1,
          "loaded": false
        },
        {
          "route": "reload",
          "exit": 1,
          "loaded": false
        }
      ]
    },
    "after": {
      "reportedInstalled": true,
      "routes": [
        {
          "route": "installed",
          "exit": 0,
          "loaded": true
        },
        {
          "route": "reload",
          "exit": 0,
          "loaded": true
        }
      ]
    }
  },
  {
    "shell": "fish",
    "pathVariant": "literal$qa24unset",
    "before": {
      "reportedInstalled": true,
      "sourceExit": 0,
      "generatedCompletionLoaded": false,
      "reloadExit": 0,
      "reloadGeneratedCompletionLoaded": false
    },
    "after": {
      "reportedInstalled": true,
      "sourceExit": 0,
      "generatedCompletionLoaded": true,
      "reloadExit": 0,
      "reloadGeneratedCompletionLoaded": true
    }
  }
]
```

The migration proof runs in the original order: the stable owner writes a quote-containing old path, the candidate installs at a new path, then each real shell sources the profile. Before repair, the stale hook remains and all three shells print startup diagnostics. After repair:

```json
[
  {
    "shell": "bash",
    "oldSourceRetained": false,
    "currentLoaded": true,
    "exit": 0,
    "stderr": ""
  },
  {
    "shell": "zsh",
    "oldSourceRetained": false,
    "currentLoaded": true,
    "exit": 0,
    "stderr": ""
  },
  {
    "shell": "fish",
    "oldSourceRetained": false,
    "currentLoaded": true,
    "exit": 0,
    "stderr": ""
  }
]
```

The owner/sibling suites pass **259 unique tests**. The remaining 49 local skips require PowerShell/Windows, unavailable on this host; native PowerShell execution is not claimed. Its emitter is unchanged and the grammar contract was checked against primary documentation. Bash, zsh and Fish also preserve user commands and produce byte-identical profiles on a second install. Synthetic fixtures were removed.

The full changed-file gate passes, including types, lint, dead exports and required guards. Fresh isolated Codex P2 review examined the complete diff plus owner/caller/sibling/dependency evidence in two validated passes and returned zero findings, confidence 0.90. Rebase onto main `986c9e48a42b9eae2d4ff15788c1a84767d3b23c` preserved all three reviewed file hashes; candidate head is `a702c5b41f4a5ffc069640684372c45c24d931b9`. Production source SHA-256: `5c916efb2f0a895837190182aa300b0e55acc4a7e3c2ddee45ba141b580c80de`.

Related follow-ups remain separate: #127450 concerns cache validity/generation mode; #112625 and PR #119722 concern uninstall cleanup. This PR repairs the source-line producer and its reinstall ownership path.

Post-integration verification at that exact head passes 63 runtime-owner tests, 54 real Bash/zsh/Fish installed/reload routes and the original-order legacy migration in all three shells. All three reviewed hashes and dependency manifests remain unchanged; no dependency refresh was needed.

## Final CI and review disposition

Full [CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33618753457/attempts/2) passed at unchanged head `a702c5b41f4a5ffc069640684372c45c24d931b9`. The final PR rollup has 231 successful checks, 57 skips and one neutral check, with no failed or pending checks.

The first attempt retained three failures: Git authentication while fetching scan history before security scans, a Windows checkout `PermissionError` before dependencies/tests, and an unchanged state-lease heartbeat test missing worker readiness before its operation callback. An independent replay passed all 10 existing heartbeat cases in declaration order; the failed return case passed in 214 ms. The same complete Linux shard, security scans and Windows1 tests then passed on the unchanged retry. The original readiness delay remains unattributed. No source, assertion, fixture deadline or workflow policy changed for the retry. Windows2 additionally passed all four existing completion-profile encoding cases; this is CI coverage, not a new native PowerShell execution claim.

The latest completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/136241#issuecomment-5508079748) accepts the real-shell evidence and has no patch/security findings or rank-up moves. Its remaining CI condition is satisfied. Maintainer disposition: accept the canonical literal-path formatter and marker-bounded migration behavior under the authorized QA/landing workflow. Fresh main `18508eff3a41c297a0843d0827b68c6352a6fa6b` preserves all three reviewed preimages unchanged.
