### PR TITLE
test(security): share trust audit fixture lifetime

### DIFF
--- a/src/security/audit-plugins-trust.test.ts
+++ b/src/security/audit-plugins-trust.test.ts
@@ -9,6 +9,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   captureEnv,
   createPathResolutionEnv,
@@ -16,17 +17,7 @@ import {
   setTestEnvValue,
   withEnvAsync,
 } from "../test-utils/env.js";
-
-type CollectPluginsTrustFindings =
-  typeof import("./audit-plugins-trust.js").collectPluginsTrustFindings;
-
-async function collectPluginsTrustFindingsForTest(
-  ...args: Parameters<CollectPluginsTrustFindings>
-): Promise<Awaited<ReturnType<CollectPluginsTrustFindings>>> {
-  vi.resetModules();
-  const { collectPluginsTrustFindings } = await import("./audit-plugins-trust.js");
-  return await collectPluginsTrustFindings(...args);
-}
+import { collectPluginsTrustFindings } from "./audit-plugins-trust.js";
 
 const mockChannelPlugins = vi.hoisted(() => [
   {
@@ -172,7 +163,7 @@ describe("security audit install metadata findings", () => {
   };
 
   const runInstallMetadataAudit = async (cfg: OpenClawConfig, stateDir: string) => {
-    return await collectPluginsTrustFindingsForTest({ cfg, stateDir });
+    return await collectPluginsTrustFindings({ cfg, stateDir });
   };
 
   const writeHookInstalls = (
@@ -231,8 +222,10 @@ describe("security audit install metadata findings", () => {
   });
 
   afterAll(async () => {
+    // Fixture writers and audit readers share one SQLite owner; close it before removing files.
+    closeOpenClawStateDatabaseForTest();
     if (fixtureRoot) {
-      await fs.rm(fixtureRoot, { recursive: true, force: true }).catch(() => undefined);
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
     }
   });
 
@@ -473,7 +466,7 @@ describe("security audit extension tool reachability findings", () => {
   let pathResolutionEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
 
   const runSharedExtensionsAudit = async (config: OpenClawConfig) => {
-    return await collectPluginsTrustFindingsForTest({
+    return await collectPluginsTrustFindings({
       cfg: config,
       stateDir: sharedExtensionsStateDir,
     });
@@ -509,7 +502,7 @@ describe("security audit extension tool reachability findings", () => {
     homedirSpy?.mockRestore();
     pathResolutionEnvSnapshot?.restore();
     if (fixtureRoot) {
-      await fs.rm(fixtureRoot, { recursive: true, force: true }).catch(() => undefined);
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

The plugin trust audit fixture resets and reloads its collector before each of fourteen audits, even though its mocks are unchanged. Its statically imported metadata writers retain SQLite handles outside those new module graphs, and teardown removes the fixture directory without closing them.

## Why This Change Was Made

Import the real collector once, share the existing database owner with the fixture writers, and close that owner before removing its files. Remove the reset wrapper and stop suppressing directory-removal errors. The isolated test project already gives this file its own module graph. Audit findings and policies are invocation-local; the existing plugin inventory cache already survives module resets and remains keyed by each scenario's distinct state directory.

## User Impact

Test infrastructure only: five cases, fourteen real audits, sixteen assertion sites, all eleven existing mocks, database writes/reads, finding severities, and environment restoration remain. No production, schema, configuration, dependency, timeout, or coverage changes. Test diff: +8/-15; production delta: 0.

## Evidence

Canonical complete-file command on a dedicated Linux Testbox, Node 24.19.0, base 986c9e48a42b9eae2d4ff15788c1a84767d3b23c:

    node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast-isolated.config.ts src/security/audit-plugins-trust.test.ts --reporter=default --reporter=json --outputFile=<owned-report.json>

| Run | Cases | Full runner | Vitest | Import | Test bodies |
| --- | --- | --- | --- | --- | --- |
| Original | 5 passed | 11.137s | 5.85s | 4.97s | 602ms |
| Candidate | 5 passed | 9.124s | 4.01s | 3.66s | 228ms |
| Restored original | 5 passed | 11.287s | 5.92s | 5.07s | 670ms |

The candidate reduces full runner time by about 19% against the restored control; body-only timing is not used as the performance claim. All five names and their order match.

A separate private probe throws the same Error after the first real plugin-index and hook writes. It observes the canonical database lifecycle without mocking SQL or native open/close. Before actually removing each root, it records live handles and rescues only any remaining exact owner:

    original: 4 passed, 1 intentional failure; bodyFailureSame=true
    metadata root: owners=1, openBeforeRemoval=1, rescued=1, removed=true
    candidate: 4 passed, 1 intentional failure; bodyFailureSame=true
    metadata root: owners=1, openBeforeRemoval=0, rescued=0, removed=true
    both: openAfterRescue=0, envRestored=true, homedirRestored=true

Both roots were absent afterward. All 45 source/runner guards were restored, every observed command descendant exited without rescue, and the Testbox was stopped. The initial probe's report-path translation retained a macOS /private prefix on Linux; that observer error was corrected and only the failure pair rerun. Its failed report attempt is excluded from the cleanup verdict.

The canonical closer intentionally retains the fixture root if closing fails. This does not claim to change its existing close-all failure semantics. Existing database read-only and installed-index tests continue to own cache invalidation, transaction isolation, and real metadata round trips. Formatting, whitespace checks, and Codex review passed; CI must pass on the published head before landing.

Published-head CI is now green: [scheduled run, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33619269530). Attempt 1 failed because a Git fetch could not authenticate during security-job setup; rerunning only failed jobs passed. All selected test lanes passed without assertion or timeout changes. This also resolves the security-gate follow-up in review.
