### PR TITLE
perf(test): use prepared entry in Gateway QA fixtures

### DIFF
--- a/test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-session-dedup-reconnect.e2e.test.ts
@@ -219,7 +219,7 @@ describe("agent session deduplication across reconnect", () => {
         repoRoot: process.cwd(),
         command: {
           executablePath: process.execPath,
-          argsPrefix: ["--import", "tsx", "src/entry.ts"],
+          argsPrefix: ["dist/entry.js"],
           cwd: process.cwd(),
           usePackagedPlugins: true,
         },

--- a/test/e2e/qa-lab/runtime/agent-session-scope-continuity.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-session-scope-continuity.e2e.test.ts
@@ -307,7 +307,7 @@ describe("agent session scope continuity", () => {
         repoRoot: process.cwd(),
         command: {
           executablePath: process.execPath,
-          argsPrefix: ["--import", "tsx", "src/entry.ts"],
+          argsPrefix: ["dist/entry.js"],
           cwd: process.cwd(),
           usePackagedPlugins: true,
         },

--- a/test/e2e/qa-lab/runtime/agent-session-streaming.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/agent-session-streaming.e2e.test.ts
@@ -292,7 +292,7 @@ describe("agent session streaming", () => {
         repoRoot: process.cwd(),
         command: {
           executablePath: process.execPath,
-          argsPrefix: ["--import", "tsx", "src/entry.ts"],
+          argsPrefix: ["dist/entry.js"],
           cwd: process.cwd(),
           usePackagedPlugins: true,
         },

--- a/test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
@@ -105,7 +105,7 @@ describe("Gateway node control plane", () => {
         repoRoot: process.cwd(),
         command: {
           executablePath: process.execPath,
-          argsPrefix: ["--import", "tsx", "src/entry.ts"],
+          argsPrefix: ["dist/entry.js"],
           cwd: process.cwd(),
           usePackagedPlugins: true,
         },
@@ -521,7 +521,7 @@ describe("Gateway node control plane", () => {
           repoRoot: process.cwd(),
           command: {
             executablePath: process.execPath,
-            argsPrefix: ["--import", "tsx", "src/entry.ts"],
+            argsPrefix: ["dist/entry.js"],
             cwd: process.cwd(),
             usePackagedPlugins: true,
           },

--- a/test/e2e/qa-lab/runtime/gateway-node-pending-work.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-pending-work.e2e.test.ts
@@ -65,7 +65,7 @@ describe("Gateway node pending work", () => {
         repoRoot: process.cwd(),
         command: {
           executablePath: process.execPath,
-          argsPrefix: ["--import", "tsx", "src/entry.ts"],
+          argsPrefix: ["dist/entry.js"],
           cwd: process.cwd(),
           usePackagedPlugins: true,
         },


### PR DESCRIPTION
## What Problem This Solves

Five slow Gateway QA suites repeatedly start the TypeScript CLI through tsx even though their canonical E2E setup has already built the executable entry. That source loading is repeated during authentication setup, repair, and Gateway startup.

## Why This Change Was Made

Change six fixture command prefixes to dist/entry.js, the compiled output of the same src/entry.ts entrypoint. Keep the explicit command descriptor, Node executable, working directory, packaged-plugin setting, authentication setup, repair steps, and full E2E prerequisites. The descriptor is important because removing it would also change fixture plugin/auth staging.

The tsdown entry map and run-node prerequisite owner both identify dist/entry.js as this executable. These tests exercise real pairing, node protocol/upgrade/reconnect, work delivery, session continuity, streaming, and deduplication; TypeScript loader startup is incidental to those contracts.

## User Impact

Test-only: nine cases and 120 static assertion sites remain unchanged. All provider request counts, transcript assertions, actual protocol exchanges, negative observation windows, timeouts, and cleanup paths remain. Production delta: 0. Test diff: +6/-6 across five files.

## Evidence

Dedicated Linux workers used Node 24.19.0 and the unchanged canonical command:

    node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts <complete target files> --reporter=default --reporter=json --outputFile=<owned-report.json>

| Complete selection | Candidate full runner | Restored-original control | Candidate test bodies | Control test bodies |
| --- | --- | --- | --- | --- |
| Node control plane, 5 cases | 49.083s | 124.776s | 36.84s | 111.49s |
| Pending work + dedup + continuity + streaming, 4 cases | 80.522s | 212.126s | 66.629s | 198.857s |

Every original, candidate, and restored-control case passed. These warm comparisons reduce full-run time by approximately 61% and 62%, respectively. Initial cold runs (386.009s and 453.284s) include build preparation and are not the speedup baseline. In the four-file comparison, candidate transform/import time was slightly higher than the control; the saving was in the actual fixture cases. Default Vitest timing-cache ordering changed the cross-file order between runs, which is recorded; each full case and its internal order remained intact.

Node proof used base 89198d6661647441ee1d078f3e27b5751de25c2a; the four-file proof used fc8a452938a063a8009db5b8f99e6b69e229d2c5. Their source contracts were unchanged at final base 986c9e48a42b9eae2d4ff15788c1a84767d3b23c.

A fresh final-base worker ran all five files together because the normal E2E worker is non-isolated: all nine passed, including node cleanup-failure and protocol/upgrade siblings. The final run took 321.350s including the normal cold build; it is integration evidence, not another timing comparison. Raw run: https://github.com/openclaw/openclaw/actions/runs/33618706547. Four-file timing run: https://github.com/openclaw/openclaw/actions/runs/33617411373.

    combined: 9 passed, 0 failed
    five source files restored; 47 source/runner guards matched
    tracked delta empty; owned temporary root removed
    no observed live descendants or rescue signals; Testbox stopped

Formatting, whitespace validation, and Codex review passed. CI must pass on the published head before landing.

Named follow-up: the existing dedup/reconnect fixture does not register its first client for cleanup before early assertions. This performance change preserves that fixture; a failure-injection proof is needed before repairing its broader lifetime.

Published-head CI is green: [scheduled run, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33619654853). The first attempt failed during security scan-history fetching because Git could not authenticate. Rerunning only failed jobs passed; all selected test lanes passed without assertion or timeout changes.
