### PR TITLE
fix(system-agent): stop setup writes after delegated run closure

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -218,6 +218,14 @@ setup workspace ~/Projects/work
 `setup` preserves the verified effective model. It does not configure or
 replace inference.
 
+Delegated setup remains tied to the requesting run through configuration,
+workspace, and session preparation. If that run ends or loses authority,
+OpenClaw stops before starting the next persistent effect. Earlier completed
+effects remain, including an agent whose creation already finished; setup may
+still be incomplete. Check `openclaw agents list` and `status`, then request
+setup again from an active run and approve the new request, or finish directly
+with `openclaw setup` on the Gateway host.
+
 If inference is missing or its live check fails, leave OpenClaw and run `openclaw onboard`. Guided onboarding tries the configured model first, then authenticated subscription CLIs, API keys, and remaining supported CLIs; it asks each candidate for a real reply and persists only a passing route. OpenClaw starts immediately after that boundary and can then configure the workspace, Gateway, channels, agents, plugins, and other optional features.
 
 The macOS app skips this ladder entirely when it reaches a configured Gateway

--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -224,7 +224,9 @@ OpenClaw stops before starting the next persistent effect. Earlier completed
 effects remain, including an agent whose creation already finished; setup may
 still be incomplete. Check `openclaw agents list` and `status`, then request
 setup again from an active run and approve the new request, or finish directly
-with `openclaw setup` on the Gateway host.
+with `openclaw setup` on the Gateway host. If cancellation deferred legacy
+history migration for a newly named agent, the next Gateway startup retries it;
+use `openclaw doctor --fix` on the same state/config to finish it sooner.
 
 If inference is missing or its live check fails, leave OpenClaw and run `openclaw onboard`. Guided onboarding tries the configured model first, then authenticated subscription CLIs, API keys, and remaining supported CLIs; it asks each candidate for a real reply and persists only a passing route. OpenClaw starts immediately after that boundary and can then configure the workspace, Gateway, channels, agents, plugins, and other optional features.
 

--- a/src/commands/onboard-agent.persistence.test.ts
+++ b/src/commands/onboard-agent.persistence.test.ts
@@ -3,14 +3,26 @@ import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  prepareSystemAgentRunAdmission,
+  resolveAdmittedRunActiveAssertion,
+} from "../agents/admitted-run-context.js";
+import {
   readConfigFileSnapshot,
   replaceConfigFile,
   resetConfigRuntimeState,
 } from "../config/config.js";
 import { readExactSessionEntryRowForCanonicalRepair } from "../config/sessions/session-accessor.sqlite-canonical-repair.js";
 import { writeSessionEntry } from "../config/sessions/session-accessor.sqlite-entry-store.js";
+import { readTranscriptEventRows } from "../config/sessions/session-accessor.sqlite-read.js";
 import { appendTranscriptEventInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
 import { runSessionStartupMigration } from "../config/sessions/startup-migration.js";
+import { resetAgentRunRegistryForTest } from "../infra/agent-run-registry.js";
+import {
+  beginAgentDeletionJournal,
+  completeAgentDeletionJournal,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
+import { readAgentProvenance } from "../state/agent-provenance.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -21,6 +33,25 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { ensureOnboardingAgent } from "./onboard-agent.js";
 
+const migrationWindow = vi.hoisted(() => ({
+  afterPublication: undefined as (() => void) | undefined,
+}));
+vi.mock("../config/config.js", async (original) => {
+  const actual = await original<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    readConfigFileSnapshot: async () => {
+      const snapshot = await actual.readConfigFileSnapshot();
+      if (snapshot.config.agents?.entries?.robby) {
+        const afterPublication = migrationWindow.afterPublication;
+        migrationWindow.afterPublication = undefined;
+        afterPublication?.();
+      }
+      return snapshot;
+    },
+  };
+});
+
 describe("onboarding authored config persistence", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
 
@@ -29,6 +60,8 @@ describe("onboarding authored config persistence", () => {
   });
 
   afterEach(() => {
+    migrationWindow.afterPublication = undefined;
+    resetAgentRunRegistryForTest();
     envSnapshot.restore();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
@@ -194,102 +227,153 @@ describe("onboarding authored config persistence", () => {
     });
   });
 
-  it("surfaces a locked migration and converges it on the next startup", async () => {
-    await withTempHome(async (rawHome) => {
-      const home = await fs.realpath(rawHome);
-      const stateDir = path.join(home, ".openclaw");
-      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-      deleteTestEnvValue("OPENCLAW_AGENT_DIR");
-      resetConfigRuntimeState();
-      await replaceConfigFile({ nextConfig: {}, afterWrite: { mode: "auto" } });
+  it.each(["locked", "closed after publication"] as const)(
+    "defers migration when %s and converges on the next startup",
+    async (boundary) => {
+      await withTempHome(async (rawHome) => {
+        const home = await fs.realpath(rawHome);
+        const stateDir = path.join(home, ".openclaw");
+        setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+        deleteTestEnvValue("OPENCLAW_AGENT_DIR");
+        resetConfigRuntimeState();
+        await replaceConfigFile({ nextConfig: {}, afterWrite: { mode: "auto" } });
 
-      const legacyKey = "agent:main:main";
-      const canonicalKey = "agent:robby:main";
-      const legacyDatabasePath = path.join(
-        stateDir,
-        "agents",
-        "main",
-        "agent",
-        "openclaw-agent.sqlite",
-      );
-      const entry = { sessionId: "locked-legacy-session", updatedAt: 100 };
-      runOpenClawAgentWriteTransaction(
-        (database) => {
-          writeSessionEntry(database, legacyKey, entry, {
-            allowStoredAliases: true,
-            previousEntry: null,
-          });
-          appendTranscriptEventInTransaction(
-            database,
-            {
-              agentId: "main",
-              path: legacyDatabasePath,
-              sessionId: entry.sessionId,
-              sessionKey: legacyKey,
-            },
-            { type: "message", text: "locked history" },
-            { allowStoredAlias: true },
-          );
-        },
-        { agentId: "main", path: legacyDatabasePath },
-      );
-      const sourceDatabase = openOpenClawAgentDatabase({
-        agentId: "main",
-        path: legacyDatabasePath,
-      });
-      sourceDatabase.db.exec("BEGIN IMMEDIATE");
-      let result: Awaited<ReturnType<typeof ensureOnboardingAgent>>;
-      try {
-        result = await ensureOnboardingAgent({
-          config: {},
-          workspace: path.join(stateDir, "workspace"),
-          firstAgent: { name: "robby" },
-        });
-      } finally {
-        sourceDatabase.db.exec("ROLLBACK");
-      }
-
-      expect(result.sessionMigrationWarnings).toEqual([
-        expect.stringMatching(/incomplete.*openclaw doctor --fix/),
-      ]);
-      const readLedgerStatus = () =>
-        withExistingOpenClawStateDatabaseReadOnly(
-          ({ db }) =>
-            db
-              .prepare(
-                "SELECT status FROM migration_sources WHERE source_key = 'legacy-main-session-keys'",
-              )
-              .get() as { status: string } | undefined,
+        const legacyKey = "agent:main:main";
+        const canonicalKey = "agent:robby:main";
+        const legacyDatabasePath = path.join(
+          stateDir,
+          "agents",
+          "main",
+          "agent",
+          "openclaw-agent.sqlite",
         );
-      expect(readLedgerStatus()).toBeUndefined();
-      const log = { info: vi.fn(), warn: vi.fn() };
-      await runSessionStartupMigration({
-        cfg: result.config,
-        env: process.env,
-        log,
-        deps: {
-          resolveAllAgentSessionStoreTargetsSync: () => [],
-        },
-      });
-      const ownerDatabasePath = path.join(
-        stateDir,
-        "agents",
-        "robby",
-        "agent",
-        "openclaw-agent.sqlite",
-      );
-      const readEntry = (databasePath: string, agentId: string, key: string) =>
+        const entry = { sessionId: "locked-legacy-session", updatedAt: 100 };
         runOpenClawAgentWriteTransaction(
-          (database) => readExactSessionEntryRowForCanonicalRepair(database, key)?.entry,
-          { agentId, path: databasePath },
+          (database) => {
+            writeSessionEntry(database, legacyKey, entry, {
+              allowStoredAliases: true,
+              previousEntry: null,
+            });
+            appendTranscriptEventInTransaction(
+              database,
+              {
+                agentId: "main",
+                path: legacyDatabasePath,
+                sessionId: entry.sessionId,
+                sessionKey: legacyKey,
+              },
+              { type: "message", text: "locked history" },
+              { allowStoredAlias: true },
+            );
+          },
+          { agentId: "main", path: legacyDatabasePath },
         );
+        const sourceDatabase = openOpenClawAgentDatabase({
+          agentId: "main",
+          path: legacyDatabasePath,
+        });
+        const admission = prepareSystemAgentRunAdmission({}, "onboard-migration", "main", "setup");
+        const beforePersistentApply = resolveAdmittedRunActiveAssertion(
+          await admission.admit("embedded"),
+        )!;
+        const beforeRows = readTranscriptEventRows(sourceDatabase, entry.sessionId);
+        if (boundary === "locked") {
+          sourceDatabase.db.exec("BEGIN IMMEDIATE");
+        } else {
+          beginAgentDeletionJournal({
+            agentId: "robby",
+            operationId: "previous-robby",
+            deleteFiles: false,
+            agentDir: path.join(stateDir, "agents", "robby", "agent"),
+            sessionsDir: path.join(stateDir, "agents", "robby", "sessions"),
+            workspaceDir: path.join(stateDir, "workspace"),
+          });
+          completeAgentDeletionJournal("robby", "previous-robby");
+          migrationWindow.afterPublication = () => {
+            beforePersistentApply();
+            admission.close();
+          };
+        }
+        let result: Awaited<ReturnType<typeof ensureOnboardingAgent>> | undefined;
+        let failure: unknown;
+        try {
+          result = await ensureOnboardingAgent({
+            config: {},
+            workspace: path.join(stateDir, "workspace"),
+            firstAgent: { name: "robby" },
+            beforePersistentApply,
+          });
+        } catch (error) {
+          failure = error;
+        } finally {
+          if (boundary === "locked") {
+            sourceDatabase.db.exec("ROLLBACK");
+          }
+          admission.close();
+        }
 
-      expect(readEntry(ownerDatabasePath, "robby", canonicalKey)).toMatchObject(entry);
-      expect(readEntry(legacyDatabasePath, "main", legacyKey)).toBeUndefined();
-      expect(log.info).toHaveBeenCalledWith(
-        expect.stringContaining("migrated retired main-agent session keys"),
-      );
-      expect(readLedgerStatus()).toEqual({ status: "completed" });
-    });
-  });
+        if (boundary === "locked") {
+          expect(failure).toBeUndefined();
+          expect(result?.sessionMigrationWarnings).toEqual([
+            expect.stringMatching(/incomplete.*openclaw doctor --fix/),
+          ]);
+        } else {
+          expect.soft(failure).toEqual(new Error("admitted run authority is no longer active"));
+          expect.soft(readAgentDeletionJournal("robby")).toBeUndefined();
+          expect.soft(readAgentProvenance("robby")).toMatchObject({ createdVia: "operator" });
+          expect
+            .soft(readExactSessionEntryRowForCanonicalRepair(sourceDatabase, legacyKey)?.entry)
+            .toMatchObject(entry);
+          expect.soft(readTranscriptEventRows(sourceDatabase, entry.sessionId)).toEqual(beforeRows);
+          expect
+            .soft(
+              await fs
+                .stat(path.join(stateDir, "agents", "robby", "agent", "openclaw-agent.sqlite"))
+                .catch(() => null),
+            )
+            .toBeNull();
+        }
+        const readLedgerStatus = () =>
+          withExistingOpenClawStateDatabaseReadOnly(
+            ({ db }) =>
+              db
+                .prepare(
+                  "SELECT status FROM migration_sources WHERE source_key = 'legacy-main-session-keys'",
+                )
+                .get() as { status: string } | undefined,
+          );
+        expect.soft(readLedgerStatus()).toBeUndefined();
+        const published = await readConfigFileSnapshot();
+        expect(Object.keys(published.config.agents?.entries ?? {})).toEqual(["robby"]);
+        const log = { info: vi.fn(), warn: vi.fn() };
+        await runSessionStartupMigration({
+          cfg: published.config,
+          env: process.env,
+          log,
+          deps: {
+            resolveAllAgentSessionStoreTargetsSync: () => [],
+          },
+        });
+        const ownerDatabasePath = path.join(
+          stateDir,
+          "agents",
+          "robby",
+          "agent",
+          "openclaw-agent.sqlite",
+        );
+        const readEntry = (databasePath: string, agentId: string, key: string) =>
+          runOpenClawAgentWriteTransaction(
+            (database) => readExactSessionEntryRowForCanonicalRepair(database, key)?.entry,
+            { agentId, path: databasePath },
+          );
+
+        expect(readEntry(ownerDatabasePath, "robby", canonicalKey)).toMatchObject(entry);
+        expect(readEntry(legacyDatabasePath, "main", legacyKey)).toBeUndefined();
+        expect(log.info).toHaveBeenCalledWith(
+          expect.stringContaining("migrated retired main-agent session keys"),
+        );
+        expect(readLedgerStatus()).toEqual({ status: "completed" });
+      });
+    },
+  );
 });

--- a/src/commands/onboard-agent.ts
+++ b/src/commands/onboard-agent.ts
@@ -153,6 +153,8 @@ export async function ensureOnboardingAgent(params: {
   const sessionMigration = await migrateLegacyMainSessionKeys({
     cfg: after.config,
     mode: "automatic",
+    // Unlike creation bookkeeping, convergence can wait for the next startup.
+    beforePersistentApply: params.beforePersistentApply,
   });
   const sessionMigrationWarnings =
     sessionMigration.armed && !sessionMigration.complete

--- a/src/commands/onboard-agent.ts
+++ b/src/commands/onboard-agent.ts
@@ -59,6 +59,7 @@ export async function ensureOnboardingAgent(params: {
   preserveCandidateRoster?: boolean;
   baseConfig?: OpenClawConfig;
   expectedConfigHash?: string | null;
+  beforePersistentApply?: () => void;
 }): Promise<{
   config: OpenClawConfig;
   agentId: string;
@@ -132,6 +133,7 @@ export async function ensureOnboardingAgent(params: {
     ...(hasExpectedConfigHash ? { expectedConfigHash: params.expectedConfigHash } : {}),
     skipBootstrap: params.config.agents?.defaults?.skipBootstrap,
     skipOptionalBootstrapFiles: params.config.agents?.defaults?.skipOptionalBootstrapFiles,
+    beforePersistentApply: params.beforePersistentApply,
   });
   if (created.status === "error") {
     throw new Error(created.message);

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -215,15 +215,18 @@ export async function ensureWorkspaceAndSessions(
     skipBootstrap?: boolean;
     skipOptionalBootstrapFiles?: OptionalBootstrapFileName[];
     agentId: string;
+    beforePersistentApply?: () => void;
   },
 ): Promise<{ bootstrapPending: boolean }> {
   const ws = await ensureAgentWorkspace({
     dir: workspaceDir,
     ensureBootstrapFiles: !options?.skipBootstrap,
     skipOptionalBootstrapFiles: options?.skipOptionalBootstrapFiles,
+    beforePersistentApply: options.beforePersistentApply,
   });
   runtime.log(`Workspace OK: ${shortenHomePath(ws.dir)}`);
   const sessionsDir = resolveSessionTranscriptsDirForAgent(options.agentId);
+  options.beforePersistentApply?.();
   await fs.mkdir(sessionsDir, { recursive: true });
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
   return { bootstrapPending: ws.bootstrapPending === true };

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -31,6 +31,7 @@ import {
   setRuntimeConfigSnapshotRefreshHandler,
   writeConfigFile,
 } from "./io.js";
+import { replaceConfigFile, transformConfigFile, transformConfigFileWithRetry } from "./mutate.js";
 import { ConfigMutationConflictError } from "./mutation-conflict.js";
 import { createProviderConfigFixture } from "./runtime-snapshot.test-fixtures.js";
 import type { AgentModelEntryConfig, AgentModelPolicyConfig } from "./types.agent-defaults.js";
@@ -1205,6 +1206,43 @@ describe("config io write", () => {
       "config path changed since last load",
     );
   });
+
+  it.each(["replace", "transform", "retry"] as const)(
+    "composes caller authority with captured destination ownership for %s",
+    async (mutation) => {
+      await withSuiteHome(async (home) => {
+        const firstConfigPath = path.join(home, ".openclaw", "first.json");
+        const secondConfigPath = path.join(home, ".openclaw", "second.json");
+        await fs.mkdir(path.dirname(firstConfigPath), { recursive: true });
+        await fs.writeFile(firstConfigPath, "{}\n");
+        await fs.writeFile(secondConfigPath, "{}\n");
+        const env = { OPENCLAW_CONFIG_PATH: firstConfigPath, OPENCLAW_TEST_FAST: "1" };
+        const io = createHomeConfigIO(home, { env });
+        const callerGuard = vi.fn();
+        const writeOptions = {
+          assertConfigPathForWrite: callerGuard,
+          preCommitRuntimePreflight: async () => {
+            env.OPENCLAW_CONFIG_PATH = secondConfigPath;
+          },
+        };
+        const nextConfig: OpenClawConfig = { gateway: { port: 19001 } };
+        const transform = () => ({ nextConfig });
+        const pending =
+          mutation === "replace"
+            ? replaceConfigFile({ io, writeOptions, nextConfig })
+            : (mutation === "transform" ? transformConfigFile : transformConfigFileWithRetry)({
+                io,
+                writeOptions,
+                transform,
+              });
+
+        await expect(pending).rejects.toThrow("config path changed since last load");
+        expect(callerGuard).toHaveBeenCalled();
+        expect(await fs.readFile(firstConfigPath, "utf8")).toBe("{}\n");
+        expect(await fs.readFile(secondConfigPath, "utf8")).toBe("{}\n");
+      });
+    },
+  );
 
   itWithHome(
     "rejects write snapshots when the IO instance no longer owns its config path",

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -306,14 +306,31 @@ async function readConfigSnapshotForMutation(params: {
   return await readConfigFileSnapshotForWrite(options);
 }
 
+function mergeConfigMutationWriteOptions(
+  prepared: ConfigWriteOptions,
+  caller?: ConfigWriteOptions,
+): ConfigWriteOptions {
+  const merged = copyRuntimeConfigWriteApplication(caller, { ...prepared, ...caller });
+  const capturedGuard = prepared.assertConfigPathForWrite;
+  const callerGuard = caller?.assertConfigPathForWrite;
+  // Caller authority narrows the captured destination; it must never replace
+  // that ownership check through retries and post-write validation.
+  if (capturedGuard && callerGuard && capturedGuard !== callerGuard) {
+    merged.assertConfigPathForWrite = () => {
+      capturedGuard();
+      callerGuard();
+    };
+  } else if (capturedGuard) {
+    merged.assertConfigPathForWrite = capturedGuard;
+  }
+  return merged;
+}
+
 function createConfigMutationOwnership(
   prepared: Awaited<ReturnType<typeof readConfigSnapshotForMutation>>,
   writeOptions?: ConfigWriteOptions,
 ): ConfigMutationOwnership {
-  const mergedWriteOptions = {
-    ...prepared.writeOptions,
-    ...writeOptions,
-  };
+  const mergedWriteOptions = mergeConfigMutationWriteOptions(prepared.writeOptions, writeOptions);
   return {
     initialized: true,
     expectedConfigPath: mergedWriteOptions.expectedConfigPath ?? prepared.snapshot.path,
@@ -1012,10 +1029,7 @@ export async function replaceConfigFile(params: {
         await replaceConfigFileUnlocked({
           ...params,
           snapshot: prepared.snapshot,
-          writeOptions: copyRuntimeConfigWriteApplication(params.writeOptions, {
-            ...prepared.writeOptions,
-            ...params.writeOptions,
-          }),
+          writeOptions: mergeConfigMutationWriteOptions(prepared.writeOptions, params.writeOptions),
         }),
     );
   }
@@ -1040,10 +1054,7 @@ async function replaceConfigFileUnlocked(params: {
         writeOptions: params.writeOptions,
       });
   const { snapshot, writeOptions } = prepared;
-  const mergedWriteOptions = copyRuntimeConfigWriteApplication(params.writeOptions, {
-    ...writeOptions,
-    ...params.writeOptions,
-  });
+  const mergedWriteOptions = mergeConfigMutationWriteOptions(writeOptions, params.writeOptions);
   mergedWriteOptions.assertConfigPathForWrite?.();
   assertExpectedConfigPathMatches(snapshot, mergedWriteOptions.expectedConfigPath);
   assertConfigWriteAllowedInCurrentMode({ configPath: snapshot.path });
@@ -1141,13 +1152,7 @@ async function transformConfigFileAttempt<T>(
       io: params.io,
       writeOptions: params.writeOptions,
     }));
-  let mergedWriteOptions: ConfigWriteOptions = copyRuntimeConfigWriteApplication(
-    params.writeOptions,
-    {
-      ...writeOptions,
-      ...params.writeOptions,
-    },
-  );
+  let mergedWriteOptions = mergeConfigMutationWriteOptions(writeOptions, params.writeOptions);
   if (ownership) {
     if (!ownership.initialized) {
       ownership.initialized = true;

--- a/src/config/sessions/legacy-main-session-migration-operations.ts
+++ b/src/config/sessions/legacy-main-session-migration-operations.ts
@@ -130,6 +130,7 @@ function mutateLegacySessionClaims<T>(
     env: NodeJS.ProcessEnv;
     claims: readonly SessionClaim[];
     operationLabel: string;
+    beforePersistentApply?: () => void;
   },
   commit: (database: OpenClawAgentDatabase) => T,
 ): Promise<T> {
@@ -142,16 +143,19 @@ function mutateLegacySessionClaims<T>(
   return withSqliteSessionDeletions(
     scope,
     params.claims.map(({ key: sessionKey, entry }) => ({ sessionKey, entry })),
-    async () =>
-      runExclusiveSqliteSessionWrite(scope, async () =>
-        runSqliteSessionDeletionTransaction(commit, scope, {
+    async (assertCurrent) =>
+      runExclusiveSqliteSessionWrite(scope, async () => {
+        assertCurrent();
+        params.beforePersistentApply?.();
+        return runSqliteSessionDeletionTransaction(commit, scope, {
           operationLabel: params.operationLabel,
-        }),
-      ),
+        });
+      }),
   );
 }
 
 function migrateClaimsInPlace(params: {
+  beforePersistentApply?: () => void;
   aliases: readonly SessionClaim[];
   canonical?: SessionClaim;
   canonicalKey: string;
@@ -204,12 +208,14 @@ function migrateClaimsInPlace(params: {
 }
 
 async function copyClaimCrossStore(params: {
+  beforePersistentApply?: () => void;
   canonicalKey: string;
   destination: PhysicalStore;
   env: NodeJS.ProcessEnv;
   source: SessionClaim;
 }): Promise<SessionClaim | undefined> {
   await importSqliteSessionRows({
+    beforePersistentApply: params.beforePersistentApply,
     agentId: params.destination.databaseAgentId,
     defaultAgentId: params.destination.databaseAgentId,
     env: params.env,
@@ -234,8 +240,12 @@ async function copyClaimCrossStore(params: {
   return destination.found ? destination.value : undefined;
 }
 
-async function deleteExpectedClaim(claim: SessionClaim): Promise<boolean> {
+async function deleteExpectedClaim(
+  claim: SessionClaim,
+  commitGuard?: () => void,
+): Promise<boolean> {
   const result = await deleteSessionEntryLifecycle({
+    commitGuard,
     agentId: claim.store.databaseAgentId,
     archiveTranscript: false,
     deleteTranscriptWithoutArchive: true,
@@ -252,12 +262,14 @@ async function deleteExpectedClaim(claim: SessionClaim): Promise<boolean> {
 }
 
 function quarantineClaim(params: {
+  beforePersistentApply?: () => void;
   claim: SessionClaim;
   env: NodeJS.ProcessEnv;
   ownerAgentId: string;
 }): Promise<string | undefined> {
   return mutateLegacySessionClaims(
     {
+      beforePersistentApply: params.beforePersistentApply,
       store: params.claim.store,
       env: params.env,
       claims: [params.claim],
@@ -292,6 +304,7 @@ function quarantineClaim(params: {
 }
 
 export async function processIdenticalClaims(params: {
+  beforePersistentApply?: () => void;
   aliases: SessionClaim[];
   canonical?: SessionClaim;
   canonicalKey: string;
@@ -324,6 +337,7 @@ export async function processIdenticalClaims(params: {
     const inPlaceWinner = freshestClaim(destinationAliases);
     if (
       !(await migrateClaimsInPlace({
+        beforePersistentApply: params.beforePersistentApply,
         aliases: destinationAliases,
         canonicalKey: params.canonicalKey,
         env: params.env,
@@ -351,6 +365,7 @@ export async function processIdenticalClaims(params: {
   if (!canonical) {
     const sourceBefore = winner;
     const copied = await copyClaimCrossStore({
+      beforePersistentApply: params.beforePersistentApply,
       canonicalKey: params.canonicalKey,
       destination: params.destination,
       env: params.env,
@@ -393,7 +408,7 @@ export async function processIdenticalClaims(params: {
     if (samePhysicalStore(claim.store, params.destination)) {
       continue;
     }
-    if (!(await deleteExpectedClaim(claim))) {
+    if (!(await deleteExpectedClaim(claim, params.beforePersistentApply))) {
       return {
         kind: "divergent-canonical",
         canonicalKey: params.canonicalKey,
@@ -404,6 +419,7 @@ export async function processIdenticalClaims(params: {
   if (params.canonical && destinationAliases.length > 0) {
     if (
       !(await migrateClaimsInPlace({
+        beforePersistentApply: params.beforePersistentApply,
         aliases: destinationAliases,
         canonical: params.canonical,
         canonicalKey: params.canonicalKey,
@@ -432,6 +448,7 @@ export async function processIdenticalClaims(params: {
 }
 
 export async function repairDivergentClaims(params: {
+  beforePersistentApply?: () => void;
   canonicalKey: string;
   claims: SessionClaim[];
   destination: PhysicalStore;
@@ -442,6 +459,7 @@ export async function repairDivergentClaims(params: {
   const winner = params.destinationCanonical ?? freshestClaim(params.claims);
   if (!params.destinationCanonical) {
     const migrated = await processIdenticalClaims({
+      beforePersistentApply: params.beforePersistentApply,
       aliases: [winner],
       canonicalKey: params.canonicalKey,
       destination: params.destination,
@@ -473,6 +491,7 @@ export async function repairDivergentClaims(params: {
     if (claimsMatch(claim, canonical)) {
       const cleaned = samePhysicalStore(claim.store, params.destination)
         ? await migrateClaimsInPlace({
+            beforePersistentApply: params.beforePersistentApply,
             aliases: [claim],
             canonical,
             canonicalKey: params.canonicalKey,
@@ -480,13 +499,14 @@ export async function repairDivergentClaims(params: {
             store: params.destination,
             winner: canonical,
           })
-        : await deleteExpectedClaim(claim);
+        : await deleteExpectedClaim(claim, params.beforePersistentApply);
       if (!cleaned) {
         return { quarantinedKeys, resolved: false };
       }
       continue;
     }
     const quarantineKey = await quarantineClaim({
+      beforePersistentApply: params.beforePersistentApply,
       claim,
       env: params.env,
       ownerAgentId: params.ownerAgentId,

--- a/src/config/sessions/legacy-main-session-migration.race.test.ts
+++ b/src/config/sessions/legacy-main-session-migration.race.test.ts
@@ -1,19 +1,48 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  prepareSystemAgentRunAdmission,
+  resolveAdmittedRunActiveAssertion,
+} from "../../agents/admitted-run-context.js";
+import { resetAgentRunRegistryForTest } from "../../infra/agent-run-registry.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { migrateLegacyMainSessionKeys } from "./legacy-main-session-migration.js";
 import { readExactSessionEntryRowForCanonicalRepair } from "./session-accessor.sqlite-canonical-repair.js";
 import { writeSessionEntry } from "./session-accessor.sqlite-entry-store.js";
+import { replaceSessionOwnerInTransaction } from "./session-accessor.sqlite-owner.js";
 import { readTranscriptEventRows } from "./session-accessor.sqlite-read.js";
+import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
 import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 
-const race = vi.hoisted(() => ({ beforeDelete: undefined as (() => void) | undefined }));
+const race = vi.hoisted(() => ({
+  beforeDelete: undefined as (() => void) | undefined,
+  afterDelete: undefined as (() => void) | undefined,
+  queued: undefined as ((pathname: string | undefined) => void) | undefined,
+}));
+
+vi.mock("./session-accessor.sqlite-scope.js", async (original) => {
+  const actual = await original<typeof import("./session-accessor.sqlite-scope.js")>();
+  return {
+    ...actual,
+    runExclusiveSqliteSessionWrite: (
+      ...args: Parameters<typeof actual.runExclusiveSqliteSessionWrite>
+    ) => {
+      const pending = actual.runExclusiveSqliteSessionWrite(...args);
+      race.queued?.(args[0].path);
+      return pending;
+    },
+  };
+});
 
 vi.mock("./session-accessor.sqlite-lifecycle.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-lifecycle.js")>();
@@ -25,7 +54,11 @@ vi.mock("./session-accessor.sqlite-lifecycle.js", async (importOriginal) => {
       const beforeDelete = race.beforeDelete;
       race.beforeDelete = undefined;
       beforeDelete?.();
-      return await actual.deleteSessionEntryLifecycle(params);
+      const result = await actual.deleteSessionEntryLifecycle(params);
+      const afterDelete = race.afterDelete;
+      race.afterDelete = undefined;
+      afterDelete?.();
+      return result;
     },
   };
 });
@@ -39,11 +72,16 @@ function databasePath(stateDir: string, agentId: string): string {
 function seedClaim(databaseAgentId: string, databasePathname: string, key: string): void {
   runOpenClawAgentWriteTransaction(
     (database) => {
-      const entry = { sessionId: "race-session", updatedAt: 100 };
+      const entry = {
+        sessionId: "race-session",
+        updatedAt: 100,
+        owner: { actor: { type: "human" as const, id: "migration-owner" }, assignedAt: 40 },
+      };
       writeSessionEntry(database, key, entry, {
         allowStoredAliases: true,
         previousEntry: null,
       });
+      replaceSessionOwnerInTransaction(database, key, entry.owner);
       appendTranscriptEventInTransaction(
         database,
         {
@@ -61,7 +99,7 @@ function seedClaim(databaseAgentId: string, databasePathname: string, key: strin
 }
 
 function readClaim(databaseAgentId: string, databasePathname: string, key: string) {
-  return runOpenClawAgentWriteTransaction(
+  const result = withOpenClawAgentDatabaseReadOnly(
     (database) => {
       const entry = readExactSessionEntryRowForCanonicalRepair(database, key)?.entry;
       return entry
@@ -73,13 +111,139 @@ function readClaim(databaseAgentId: string, databasePathname: string, key: strin
     },
     { agentId: databaseAgentId, path: databasePathname },
   );
+  return result.found ? result.value : undefined;
 }
 
 afterEach(() => {
   race.beforeDelete = undefined;
+  race.afterDelete = undefined;
+  race.queued = undefined;
+  resetAgentRunRegistryForTest();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
+
+it.each(["import queue", "in-place queue", "cleanup queue", "ledger"] as const)(
+  "preserves committed work but defers new migration writes after closure at %s",
+  async (boundary) => {
+    await withOpenClawTestState({ label: "migration-lifetime" }, async (state) => {
+      const mainPath = databasePath(state.stateDir, "main");
+      const opsPath = databasePath(state.stateDir, "ops");
+      const inPlace = boundary === "in-place queue";
+      const sourceAgentId = inPlace ? "ops" : "main";
+      const sourcePath = inPlace ? opsPath : mainPath;
+      const cfg = {
+        agents: { entries: { ops: {} } },
+        ...(inPlace ? { session: { store: opsPath } } : {}),
+      };
+      await state.writeConfig(cfg);
+      seedClaim(sourceAgentId, sourcePath, "agent:main:chat");
+      const original = readClaim(sourceAgentId, sourcePath, "agent:main:chat")!;
+      const admission = prepareSystemAgentRunAdmission(cfg, "migration-race", "ops", "setup");
+      const beforePersistentApply = resolveAdmittedRunActiveAssertion(
+        await admission.admit("embedded"),
+      )!;
+      const entered = createDeferred();
+      const resume = createDeferred();
+      const queued = createDeferred();
+      let blocker: Promise<void> | undefined;
+      let migration: Promise<unknown> | undefined;
+      const readLedger = () =>
+        withExistingOpenClawStateDatabaseReadOnly(
+          ({ db }) =>
+            db
+              .prepare(
+                "SELECT * FROM migration_sources WHERE source_key = 'legacy-main-session-keys'",
+              )
+              .all(),
+          { env: state.env },
+        );
+      const ledgerBefore = readLedger();
+      try {
+        if (boundary === "ledger") {
+          race.afterDelete = () => admission.close();
+        } else {
+          const blockedPath = boundary === "cleanup queue" ? mainPath : opsPath;
+          blocker = runExclusiveSqliteSessionWrite(
+            {
+              agentId: boundary === "cleanup queue" ? "main" : "ops",
+              path: blockedPath,
+              env: state.env,
+            },
+            async () => {
+              entered.resolve();
+              await resume.promise;
+            },
+          );
+          await entered.promise;
+          race.queued = (pathname) => {
+            if (pathname === blockedPath) {
+              race.queued = undefined;
+              queued.resolve();
+            }
+          };
+        }
+        migration = migrateLegacyMainSessionKeys({
+          cfg,
+          env: state.env,
+          mode: "automatic",
+          beforePersistentApply,
+        }).then(
+          (result) => ({ result }),
+          (error: unknown) => ({ error }),
+        );
+        if (boundary !== "ledger") {
+          await withTestTimeout(
+            Promise.race([
+              queued.promise,
+              migration.then(() => {
+                throw new Error("migration ended before writer queue");
+              }),
+            ]),
+            10_000,
+            "migration never queued",
+          );
+          beforePersistentApply();
+          admission.close();
+          resume.resolve();
+        }
+        expect
+          .soft(await migration)
+          .toMatchObject({ error: new Error("admitted run authority is no longer active") });
+        expect.soft(readLedger()).toEqual(ledgerBefore);
+        const copied = boundary === "cleanup queue" || boundary === "ledger";
+        const source = readClaim(sourceAgentId, sourcePath, "agent:main:chat");
+        expect.soft(source).toEqual(boundary === "ledger" ? undefined : original);
+        const destination = readClaim("ops", opsPath, "agent:ops:chat");
+        if (copied) {
+          expect.soft(destination?.events).toEqual(original.events);
+          expect.soft(destination?.entry.owner).toEqual(original.entry.owner);
+        } else {
+          expect.soft(destination).toBeUndefined();
+          if (!inPlace) {
+            expect.soft(fs.existsSync(opsPath)).toBe(false);
+          }
+        }
+        const recovered = await migrateLegacyMainSessionKeys({
+          cfg,
+          env: state.env,
+          mode: "automatic",
+        });
+        expect(recovered.complete).toBe(true);
+        expect(readClaim(sourceAgentId, sourcePath, "agent:main:chat")).toBeUndefined();
+        expect(readClaim("ops", opsPath, "agent:ops:chat")?.events).toEqual(original.events);
+        expect(readLedger()).toEqual([expect.objectContaining({ status: "completed" })]);
+      } finally {
+        race.queued = undefined;
+        race.afterDelete = undefined;
+        resume.resolve();
+        await blocker;
+        await migration;
+        admission.close();
+      }
+    });
+  },
+);
 
 async function runCleanupRace(mutateSource: (mainPath: string) => void) {
   const root = fs.realpathSync.native(tempDirs.make("openclaw-legacy-main-race-"));

--- a/src/config/sessions/legacy-main-session-migration.ts
+++ b/src/config/sessions/legacy-main-session-migration.ts
@@ -278,6 +278,7 @@ function ledgerMatches(
 }
 
 function writeLedger(params: {
+  beforePersistentApply?: () => void;
   env: NodeJS.ProcessEnv;
   identity: Omit<LedgerReport, "outcomes" | "status" | "version">;
   now: number;
@@ -293,6 +294,7 @@ function writeLedger(params: {
   const reportJson = JSON.stringify(report);
   const identityHash = createHash("sha256").update(JSON.stringify(params.identity)).digest("hex");
   const runId = `${SOURCE_KEY}:${identityHash.slice(0, 24)}`;
+  params.beforePersistentApply?.();
   runOpenClawStateWriteTransaction(
     ({ db }) => {
       const kysely = getNodeSqliteKysely<LedgerDatabase>(db);
@@ -353,14 +355,9 @@ function writeLedger(params: {
 }
 
 /** Migrates retired agent-owned session keys without adding runtime read aliases. */
-async function migrateLegacyMainSessionKeysInternal(params: {
-  cfg: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  forceScan?: boolean;
-  legacyAgentId?: string;
-  mode: LegacyMainSessionMigrationMode;
-  now?: () => number;
-}): Promise<LegacyMainSessionMigrationResult> {
+async function migrateLegacyMainSessionKeysInternal(
+  params: Parameters<typeof migrateLegacyMainSessionKeys>[0],
+): Promise<LegacyMainSessionMigrationResult> {
   const env = params.env ?? process.env;
   const legacyAgentId = normalizeAgentId(params.legacyAgentId ?? "main");
   const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
@@ -548,6 +545,7 @@ async function migrateLegacyMainSessionKeysInternal(params: {
       };
       if (params.mode === "doctor-fix") {
         const repaired = await repairDivergentClaims({
+          beforePersistentApply: params.beforePersistentApply,
           canonicalKey,
           claims: divergentClaims,
           destination,
@@ -577,6 +575,7 @@ async function migrateLegacyMainSessionKeysInternal(params: {
       };
       if (params.mode === "doctor-fix") {
         const repaired = await repairDivergentClaims({
+          beforePersistentApply: params.beforePersistentApply,
           canonicalKey,
           claims: aliases,
           destination,
@@ -597,6 +596,7 @@ async function migrateLegacyMainSessionKeysInternal(params: {
     }
 
     const outcome = await processIdenticalClaims({
+      beforePersistentApply: params.beforePersistentApply,
       aliases,
       ...(destinationCanonical ? { canonical: destinationCanonical } : {}),
       canonicalKey,
@@ -637,6 +637,7 @@ async function migrateLegacyMainSessionKeysInternal(params: {
         );
   if (complete && params.mode !== "detect") {
     writeLedger({
+      beforePersistentApply: params.beforePersistentApply,
       env,
       identity: { ...identityBase, sourceLayout: resolveSourceLayout(resolved) },
       now: params.now?.() ?? Date.now(),
@@ -659,6 +660,7 @@ async function migrateLegacyMainSessionKeysInternal(params: {
 }
 
 export async function migrateLegacyMainSessionKeys(params: {
+  beforePersistentApply?: () => void;
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   /** Bypass the startup ledger shortcut and verify the physical legacy stores. */
@@ -670,6 +672,8 @@ export async function migrateLegacyMainSessionKeys(params: {
   try {
     return await migrateLegacyMainSessionKeysInternal(params);
   } catch (error) {
+    // Lost caller authority must abort setup, not become a retryable store warning.
+    params.beforePersistentApply?.();
     if (params.mode === "doctor-fix") {
       throw error;
     }

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -41,6 +41,7 @@ type SqliteSessionImportRowsParams = Pick<
   SessionAccessScope,
   "agentId" | "defaultAgentId" | "env" | "sessionKey" | "storePath"
 > & {
+  beforePersistentApply?: () => void;
   allowMalformedRowRepair?: boolean;
   repairLegacyTranscript?: boolean;
   preserveExactStoredKey?: boolean;
@@ -243,6 +244,9 @@ export async function importSqliteSessionRowsBatch(
       // No filesystem readers or callbacks cross the synchronous SQLite commit boundary.
       for (const validate of validators) {
         validate();
+      }
+      for (const { params: importParams } of prepared) {
+        importParams.beforePersistentApply?.();
       }
       return runOpenClawAgentWriteTransaction(
         (database) =>

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -234,6 +234,8 @@ export function deleteMaterializedSessionStatePlans(
   plans: readonly MaterializedSessionStateDeletePlan[],
   protectedSessionIds?: ReadonlySet<string>,
   excludedSessionKeys?: ReadonlySet<string>,
+  /** Synchronous mutation notification; durable completion still belongs to COMMIT. */
+  onDeleted?: () => void,
 ): SessionLifecycleArchivedTranscript[] {
   if (plans.length === 0) {
     return [];
@@ -254,7 +256,9 @@ export function deleteMaterializedSessionStatePlans(
     if (plan.archive) {
       persistSessionTranscriptArchive(database, plan);
     }
-    deleteSqliteSessionStateRows(database, plan.sessionId);
+    if (deleteSqliteSessionStateRows(database, plan.sessionId)) {
+      onDeleted?.();
+    }
     if (plan.snapshot.lastSeq !== null && plan.archivedTranscript) {
       archivedTranscripts.push(plan.archivedTranscript);
     }
@@ -493,15 +497,16 @@ export function collectProjectedReferencedSessionIds(params: {
 
 export { collectSessionStateIdsForEntry };
 
-function deleteSqliteSessionStateRows(database: OpenClawAgentDatabase, sessionId: string): void {
+function deleteSqliteSessionStateRows(database: OpenClawAgentDatabase, sessionId: string): boolean {
   const db = getSessionKysely(database.db);
   // The window row cascades canonical transcript tables, but FTS is virtual;
   // clear its projection before dropping the owner row.
   deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
-  executeSqliteQuerySync(
+  const deleted = executeSqliteQuerySync(
     database.db,
     db.deleteFrom("session_windows").where("session_id", "=", sessionId),
   );
+  return Number(deleted.numAffectedRows ?? 0n) > 0;
 }
 
 // Plans orphan cleanup without file writes or row deletion; finalization

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -324,6 +324,8 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   expectedPluginOwnerId?: string,
 ): Promise<DeleteSessionEntryLifecycleResult> {
   const prepared = await runExclusiveSqliteSessionWrite(resolved, async () => {
+    // Opening a store can register durable ownership, even before the deletion transaction.
+    params.commitGuard?.();
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
     const current = targetSnapshot[0];
@@ -416,6 +418,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
       for (const sessionId of prepared.historicalGenerationIds) {
         const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
+          params.commitGuard?.();
           const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
           const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
           if (
@@ -456,8 +459,9 @@ async function deleteSqliteSessionEntryLifecycleLocked(
           continue;
         }
         const materializedGeneration = await materializeSessionStateDeletePlans([plan]);
-        const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () =>
-          runOpenClawAgentWriteTransaction((transactionDb) => {
+        const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () => {
+          params.commitGuard?.();
+          return runOpenClawAgentWriteTransaction((transactionDb) => {
             assertCurrent();
             const targetSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
             if (
@@ -480,8 +484,8 @@ async function deleteSqliteSessionEntryLifecycleLocked(
               );
             }
             return deleteMaterializedSessionStatePlans(transactionDb, materializedGeneration);
-          }, toDatabaseOptions(resolved)),
-        );
+          }, toDatabaseOptions(resolved));
+        });
         if (archivedGeneration === DELETE_EXPECTED_ENTRY_MISMATCH) {
           return expectedEntryMismatchResult(historicalArchivedTranscripts);
         }
@@ -496,49 +500,53 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       // Archive materialization is the expensive phase. It must run between short
       // writer-lane sections so unrelated writes to this store can keep progressing.
       const materializedPlans = await materializeSessionStateDeletePlans(prepared.entryPlans);
-      const result = await runExclusiveSqliteSessionWrite(resolved, async () =>
-        runOpenClawAgentWriteTransaction<DeleteSessionEntryLifecycleResult>((transactionDb) => {
-          assertCurrent();
-          const transactionSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
-          const transactionEntry = transactionSnapshot[0]?.entry;
-          if (
-            !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, transactionSnapshot) ||
-            !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, transactionEntry, params)
-          ) {
-            return expectedEntryMismatchResult([]);
-          }
-          const archivedTranscripts = deleteMaterializedSessionStatePlans(
-            transactionDb,
-            materializedPlans,
-            undefined,
-            new Set([
+      const result = await runExclusiveSqliteSessionWrite(resolved, async () => {
+        params.commitGuard?.();
+        return runOpenClawAgentWriteTransaction<DeleteSessionEntryLifecycleResult>(
+          (transactionDb) => {
+            assertCurrent();
+            const transactionSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
+            const transactionEntry = transactionSnapshot[0]?.entry;
+            if (
+              !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, transactionSnapshot) ||
+              !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, transactionEntry, params)
+            ) {
+              return expectedEntryMismatchResult([]);
+            }
+            const archivedTranscripts = deleteMaterializedSessionStatePlans(
+              transactionDb,
+              materializedPlans,
+              undefined,
+              new Set([
+                params.target.canonicalKey,
+                ...params.target.storeKeys,
+                ...transactionSnapshot.map((row) => row.sessionKey),
+              ]),
+            );
+            deleteLifecycleTargetRows(transactionDb, params.target);
+            if (params.deleteDeliveryArtifacts === true) {
+              deleteSessionDeliveryArtifacts(transactionDb, params.target.canonicalKey, [
+                ...params.target.storeKeys,
+                ...transactionSnapshot.map((row) => row.sessionKey),
+              ]);
+            }
+            deleteSessionBoardRows(transactionDb, [
               params.target.canonicalKey,
               ...params.target.storeKeys,
               ...transactionSnapshot.map((row) => row.sessionKey),
-            ]),
-          );
-          deleteLifecycleTargetRows(transactionDb, params.target);
-          if (params.deleteDeliveryArtifacts === true) {
-            deleteSessionDeliveryArtifacts(transactionDb, params.target.canonicalKey, [
-              ...params.target.storeKeys,
-              ...transactionSnapshot.map((row) => row.sessionKey),
             ]);
-          }
-          deleteSessionBoardRows(transactionDb, [
-            params.target.canonicalKey,
-            ...params.target.storeKeys,
-            ...transactionSnapshot.map((row) => row.sessionKey),
-          ]);
-          return {
-            archivedTranscripts,
-            deleted: true,
-            deletedEntry: cloneSessionEntry(prepared.current.entry),
-            ...(prepared.current.entry.sessionId
-              ? { deletedSessionId: prepared.current.entry.sessionId }
-              : {}),
-          };
-        }, toDatabaseOptions(resolved)),
-      );
+            return {
+              archivedTranscripts,
+              deleted: true,
+              deletedEntry: cloneSessionEntry(prepared.current.entry),
+              ...(prepared.current.entry.sessionId
+                ? { deletedSessionId: prepared.current.entry.sessionId }
+                : {}),
+            };
+          },
+          toDatabaseOptions(resolved),
+        );
+      });
       if (result.deleted) {
         deletePersonalGitHubSessionReceipts({
           agentId: resolved.agentId,

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -12,6 +12,7 @@ import { deletePersonalGitHubSessionReceipts } from "../../state/github-personal
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
+  deferOpenClawAgentPostCommitPublication,
   openOpenClawAgentDatabase,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
@@ -75,6 +76,26 @@ import { buildSessionResetBoundaryEvent } from "./session-reset-boundary-event.j
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 // Single-target lifecycle owner: cleanup, reset, guarded delete, and trusted rollback.
+
+async function withCommittedHistoryMaintenance<T>(
+  { agentId, storePath }: { agentId?: string; storePath: string },
+  run: (recordCommit: (database: OpenClawAgentDatabase) => void) => Promise<T>,
+): Promise<T> {
+  let committed = false;
+  try {
+    return await run((database) => {
+      deferOpenClawAgentPostCommitPublication(database, () => {
+        committed = true;
+      });
+    });
+  } finally {
+    // A partial commit still needs maintenance, but only after archive publication and
+    // lifecycle-owner cleanup finish. Rejected preparation or rollback creates no pressure.
+    if (committed) {
+      kickSessionHistoryDiskBudgetMaintenance({ agentId, storePath, force: true });
+    }
+  }
+}
 
 type SessionBoardCleanupDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -201,92 +222,84 @@ export async function resetSessionEntryLifecycle(
 ): Promise<ResetSessionEntryLifecycleResult> {
   const agentId = params.agentId ?? parseAgentSessionKey(params.target.canonicalKey)?.agentId;
   const resolved = resolveSqliteStoreScope(params.storePath, { agentId });
-  // Retained reset history is the store's growth event; give the throttled
-  // budget pass a chance to extract-and-evict once we finish.
-  try {
-    return await runExclusiveSqliteSessionWrite(resolved, async () => {
-      const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-      const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-      const current = targetSnapshot[0];
-      const nextEntry = await params.buildNextEntry({
-        currentEntry: current ? cloneSessionEntry(current.entry) : undefined,
-        primaryKey: params.target.canonicalKey,
-      });
-      const shouldAppendResetBoundary =
-        params.resetBoundary &&
-        current?.entry.sessionId &&
-        !sqliteSessionEntriesEqual(current.entry, nextEntry);
-      const mutation: ResetSessionEntryLifecycleMutation = {
-        nextEntry: cloneSessionEntry(nextEntry),
-        ...(current ? { previousEntry: cloneSessionEntry(current.entry) } : {}),
-        ...(current?.entry.sessionId ? { previousSessionId: current.entry.sessionId } : {}),
-      };
-      runOpenClawAgentWriteTransaction((transactionDb) => {
-        assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
-        if (shouldAppendResetBoundary && current?.entry.sessionId && params.resetBoundary) {
-          const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId, {
-              projection: "reset-boundary",
-            }),
-            ...params.resetBoundary,
-          });
-          const appended = appendTranscriptEventsInTransaction(
-            transactionDb,
-            {
-              ...resolved,
-              sessionId: current.entry.sessionId,
-              sessionKey: current.sessionKey,
-            },
-            [event],
-          );
-          if (appended !== 1) {
-            throw new Error(`Failed to append reset boundary for ${current.sessionKey}`);
+  return await withCommittedHistoryMaintenance(
+    { agentId: resolved.agentId, storePath: params.storePath },
+    async (recordCommit) =>
+      runExclusiveSqliteSessionWrite(resolved, async () => {
+        const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+        const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+        const current = targetSnapshot[0];
+        const nextEntry = await params.buildNextEntry({
+          currentEntry: current ? cloneSessionEntry(current.entry) : undefined,
+          primaryKey: params.target.canonicalKey,
+        });
+        const shouldAppendResetBoundary =
+          params.resetBoundary &&
+          current?.entry.sessionId &&
+          !sqliteSessionEntriesEqual(current.entry, nextEntry);
+        const mutation: ResetSessionEntryLifecycleMutation = {
+          nextEntry: cloneSessionEntry(nextEntry),
+          ...(current ? { previousEntry: cloneSessionEntry(current.entry) } : {}),
+          ...(current?.entry.sessionId ? { previousSessionId: current.entry.sessionId } : {}),
+        };
+        runOpenClawAgentWriteTransaction((transactionDb) => {
+          assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
+          if (shouldAppendResetBoundary && current?.entry.sessionId && params.resetBoundary) {
+            const event = buildSessionResetBoundaryEvent({
+              events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId, {
+                projection: "reset-boundary",
+              }),
+              ...params.resetBoundary,
+            });
+            const appended = appendTranscriptEventsInTransaction(
+              transactionDb,
+              {
+                ...resolved,
+                sessionId: current.entry.sessionId,
+                sessionKey: current.sessionKey,
+              },
+              [event],
+            );
+            if (appended !== 1) {
+              throw new Error(`Failed to append reset boundary for ${current.sessionKey}`);
+            }
           }
+          writeSessionEntry(transactionDb, params.target.canonicalKey, nextEntry, {
+            previousEntry: current?.entry ?? null,
+          });
+          recordCommit(transactionDb);
+          // Reset only advances the live entry and route. Historical rows stay searchable;
+          // disk-budget cleanup owns durable extraction before reclaiming them.
+        }, toDatabaseOptions(resolved));
+        if (current) {
+          emitSessionIdentityMutation({
+            kind: "reset",
+            previous: {
+              ...(current.entry.sessionId ? { sessionId: current.entry.sessionId } : {}),
+              sessionKeys: targetSnapshot.map((row) => row.sessionKey),
+            },
+            current: {
+              ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
+              sessionKeys: [params.target.canonicalKey],
+            },
+          });
+        } else {
+          emitSessionIdentityMutation({
+            kind: "create",
+            previous: { sessionKeys: [] },
+            current: {
+              ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
+              sessionKeys: [params.target.canonicalKey],
+            },
+          });
         }
-        writeSessionEntry(transactionDb, params.target.canonicalKey, nextEntry, {
-          previousEntry: current?.entry ?? null,
-        });
-        // Reset only advances the live entry and route. Historical rows stay searchable;
-        // disk-budget cleanup owns durable extraction before reclaiming them.
-      }, toDatabaseOptions(resolved));
-      if (current) {
-        emitSessionIdentityMutation({
-          kind: "reset",
-          previous: {
-            ...(current.entry.sessionId ? { sessionId: current.entry.sessionId } : {}),
-            sessionKeys: targetSnapshot.map((row) => row.sessionKey),
-          },
-          current: {
-            ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
-            sessionKeys: [params.target.canonicalKey],
-          },
-        });
-      } else {
-        emitSessionIdentityMutation({
-          kind: "create",
-          previous: { sessionKeys: [] },
-          current: {
-            ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
-            sessionKeys: [params.target.canonicalKey],
-          },
-        });
-      }
-      await params.afterEntryMutation?.(mutation);
-      return {
-        ...mutation,
-        archivedTranscripts: [],
-      };
-    });
-  } finally {
-    // Reset is what turns the old generation into an eviction candidate; a
-    // throttled kick could be suppressed by a recent pre-reset pass and never
-    // retried if the agent idles, leaving an over-budget store unreclaimed.
-    kickSessionHistoryDiskBudgetMaintenance({
-      ...(resolved.agentId ? { agentId: resolved.agentId } : {}),
-      storePath: params.storePath,
-      force: true,
-    });
-  }
+        await params.afterEntryMutation?.(mutation);
+        return {
+          ...mutation,
+          archivedTranscripts: [],
+        };
+      }),
+  );
 }
 
 async function deleteSqliteSessionEntryLifecycleInternal(
@@ -296,23 +309,15 @@ async function deleteSqliteSessionEntryLifecycleInternal(
 ): Promise<DeleteSessionEntryLifecycleResult> {
   const agentId = params.agentId ?? parseAgentSessionKey(params.target.canonicalKey)?.agentId;
   const resolved = resolveSqliteStoreScope(params.storePath, { agentId });
-  try {
-    return await deleteSqliteSessionEntryLifecycleLocked(
+  return await withCommittedHistoryMaintenance(params, async (recordCommit) =>
+    deleteSqliteSessionEntryLifecycleLocked(
       resolved,
       params,
       allowLockedEntryRemoval,
       expectedPluginOwnerId,
-    );
-  } finally {
-    // Deletion writes an archive per retained generation before reclaiming
-    // rows, so usage can spike well past the budget; force a pass instead of
-    // waiting up to the throttle interval (or forever, if the agent idles).
-    kickSessionHistoryDiskBudgetMaintenance({
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      storePath: params.storePath,
-      force: true,
-    });
-  }
+      recordCommit,
+    ),
+  );
 }
 
 const DELETE_EXPECTED_ENTRY_MISMATCH = Symbol("delete-expected-entry-mismatch");
@@ -321,7 +326,8 @@ async function deleteSqliteSessionEntryLifecycleLocked(
   resolved: ReturnType<typeof resolveSqliteStoreScope>,
   params: DeleteSessionEntryLifecycleParams,
   allowLockedEntryRemoval: boolean,
-  expectedPluginOwnerId?: string,
+  expectedPluginOwnerId: string | undefined,
+  recordCommit: (database: OpenClawAgentDatabase) => void,
 ): Promise<DeleteSessionEntryLifecycleResult> {
   const prepared = await runExclusiveSqliteSessionWrite(resolved, async () => {
     // Opening a store can register durable ownership, even before the deletion transaction.
@@ -483,7 +489,13 @@ async function deleteSqliteSessionEntryLifecycleLocked(
                 `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
               );
             }
-            return deleteMaterializedSessionStatePlans(transactionDb, materializedGeneration);
+            return deleteMaterializedSessionStatePlans(
+              transactionDb,
+              materializedGeneration,
+              undefined,
+              undefined,
+              () => recordCommit(transactionDb),
+            );
           }, toDatabaseOptions(resolved));
         });
         if (archivedGeneration === DELETE_EXPECTED_ENTRY_MISMATCH) {
@@ -524,6 +536,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
               ]),
             );
             deleteLifecycleTargetRows(transactionDb, params.target);
+            recordCommit(transactionDb);
             if (params.deleteDeliveryArtifacts === true) {
               deleteSessionDeliveryArtifacts(transactionDb, params.target.canonicalKey, [
                 ...params.target.storeKeys,

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -243,7 +243,7 @@ export function readTranscriptSnapshot(
 
 /** Reads transcript rows without decoding payloads for snapshot comparison. */
 export function readTranscriptEventRows(
-  database: OpenClawAgentDatabase,
+  database: Pick<OpenClawAgentDatabase, "db">,
   sessionId: string,
 ): SqliteTranscriptSnapshotRow[] {
   const db = getSessionKysely(database.db);

--- a/src/config/sessions/session-history-eviction.test.ts
+++ b/src/config/sessions/session-history-eviction.test.ts
@@ -2,6 +2,11 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  prepareSystemAgentRunAdmission,
+  resolveAdmittedRunActiveAssertion,
+} from "../../agents/admitted-run-context.js";
+import { replaceConfigFile } from "../config.js";
 
 const evictionWarnSpy = vi.hoisted(() => vi.fn());
 vi.mock("../../logging/subsystem.js", async () => {
@@ -18,6 +23,7 @@ vi.mock("../../logging/subsystem.js", async () => {
     },
   };
 });
+import { resetAgentRunRegistryForTest } from "../../infra/agent-run-registry.js";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import {
@@ -62,6 +68,7 @@ describe("SQLite historical session disk budget", () => {
   });
 
   afterEach(async () => {
+    resetAgentRunRegistryForTest();
     vi.restoreAllMocks();
     await enforceSqliteSessionHistoryDiskBudget({
       storePath,
@@ -71,6 +78,120 @@ describe("SQLite historical session disk budget", () => {
     closeOpenClawAgentDatabasesForTest();
     await testState.cleanup();
   });
+
+  it.each([
+    { operation: "delete", phase: "closed", committed: false },
+    { operation: "delete", phase: "rollback", committed: false },
+    { operation: "delete", phase: "complete", committed: true },
+    { operation: "delete", phase: "partial", committed: true },
+    { operation: "reset", phase: "closed", committed: false },
+    { operation: "reset", phase: "post-commit failure", committed: true },
+  ] as const)(
+    "forces maintenance only after a commit: $operation / $phase",
+    async ({ operation, phase, committed }) => {
+      const sessionKey = "agent:main:target";
+      for (const name of ["target", "unrelated"]) {
+        await createHistoricalTranscript({
+          sessionKey: `agent:main:${name}`,
+          sessionId: `${name}-old`,
+          nextSessionId: `${name}-live`,
+          content: "retained history".repeat(4096),
+          updatedAt: Date.now(),
+        });
+      }
+      // Drain fixture writes before enabling pressure; only this lifecycle attempt may force it.
+      await enforceSqliteSessionHistoryDiskBudget({
+        storePath,
+        mode: "warn",
+        maintenance: { maxDiskBytes: 1, highWaterBytes: 1 },
+      });
+      const archive = path.join(tempDir, "retained.jsonl.deleted.2026-01-01T00-00-00.000Z");
+      fs.writeFileSync(archive, Buffer.alloc(64 * 1024));
+      await replaceConfigFile({
+        nextConfig: {
+          session: { maintenance: { mode: "enforce", maxDiskBytes: 1, highWaterBytes: 1 } },
+        },
+        afterWrite: { mode: "auto" },
+      });
+      const owner = database();
+      const checkpoint = vi.spyOn(owner.walMaintenance, "checkpoint");
+      const admission = prepareSystemAgentRunAdmission({}, "maintenance-lifetime", "main", "setup");
+      const assertActive = resolveAdmittedRunActiveAssertion(await admission.admit("embedded"))!;
+      const target = { canonicalKey: sessionKey, storeKeys: [sessionKey] };
+      const exec = owner.db.exec.bind(owner.db);
+      if (phase === "rollback") {
+        let failed = false;
+        vi.spyOn(owner.db, "exec").mockImplementation((sql) => {
+          if (sql === "COMMIT" && !failed) {
+            failed = true;
+            throw new Error("injected commit failure");
+          }
+          return exec(sql);
+        });
+      }
+      try {
+        if (phase === "closed") {
+          admission.close();
+        }
+        const attempt =
+          operation === "delete"
+            ? deleteSessionEntryLifecycle({
+                storePath,
+                target,
+                archiveTranscript: true,
+                commitGuard: () => {
+                  if (phase === "partial" && !sessionExists("target-old")) {
+                    expect(readArchiveNames("target-old")).toHaveLength(1);
+                    expect(checkpoint).not.toHaveBeenCalled();
+                    admission.close();
+                  }
+                  assertActive();
+                },
+              })
+            : resetSessionEntryLifecycle({
+                storePath,
+                target,
+                buildNextEntry: () => {
+                  assertActive();
+                  return { sessionId: "target-next", updatedAt: 3 };
+                },
+                afterEntryMutation: () => {
+                  expect(checkpoint).not.toHaveBeenCalled();
+                  admission.close();
+                  assertActive();
+                },
+              });
+        if (phase === "complete") {
+          await expect(attempt).resolves.toMatchObject({ deleted: true });
+        } else {
+          await expect(attempt).rejects.toThrow(
+            phase === "rollback" ? "injected commit failure" : "authority is no longer active",
+          );
+        }
+        // Warn mode shares the real retention queue but performs no reclamation itself.
+        await enforceSqliteSessionHistoryDiskBudget({
+          storePath,
+          mode: "warn",
+          maintenance: { maxDiskBytes: 1, highWaterBytes: 1 },
+        });
+        expect.soft(checkpoint.mock.calls.length > 0).toBe(committed);
+        expect.soft(fs.existsSync(archive)).toBe(!committed);
+        expect.soft(sessionExists("unrelated-old")).toBe(!committed);
+        expect.soft(sessionExists("unrelated-live")).toBe(true);
+        expect
+          .soft(sessionExists("target-live"))
+          .toBe(phase !== "complete" && !(operation === "reset" && committed));
+        if (phase === "partial") {
+          expect.soft(sessionExists("target-old")).toBe(false);
+        }
+        if (operation === "reset" && committed) {
+          expect.soft(sessionExists("target-next")).toBe(true);
+        }
+      } finally {
+        admission.close();
+      }
+    },
+  );
 
   it("evicts the oldest historical session and stops after reaching high water", async () => {
     const sessionKey = "agent:main:history-order";

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -499,10 +499,8 @@ export async function executeSetup(
           : undefined;
       const workspace =
         recovery?.workspace ?? resolveUserPath(operation.workspace ?? process.cwd());
-      // The guarded setup transaction publishes the load-time injected main
-      // roster before any workspace provisioning or other follow-up effect.
-      // The outer boundary covers injected implementations. The production
-      // setup helper also uses this same seam for each of its internal writes.
+      // Cover injected implementations at entry and carry the same synchronous
+      // authority into production setup's workspace and config owners.
       const applied = await ctx.commit(() =>
         applySetup(
           {
@@ -513,7 +511,7 @@ export async function executeSetup(
             surface,
             runtime: ctx.runtime,
           },
-          { commit: (effect) => ctx.commit(effect) },
+          { beforePersistentApply: ctx.assertPersistentApply },
         ),
       );
       if (!applied.workspaceReady) {

--- a/src/system-agent/operations.setup-transaction.test.ts
+++ b/src/system-agent/operations.setup-transaction.test.ts
@@ -267,7 +267,7 @@ describe("system-agent setup transaction", () => {
     expect(result.applied).toBe(true);
     expect(applySetup).toHaveBeenCalledWith(
       expect.objectContaining({ workspace: pending.workspace, resume: true, surface: "cli" }),
-      { commit: expect.any(Function) },
+      { beforePersistentApply },
     );
     expect(localOnboarding.complete).toHaveBeenCalledWith({
       configPath: pending.configPath,
@@ -295,7 +295,7 @@ describe("system-agent setup transaction", () => {
 
     expect(result.applied).toBe(true);
     expect(applySetup).toHaveBeenCalledWith(expect.not.objectContaining({ resume: true }), {
-      commit: expect.any(Function),
+      beforePersistentApply: undefined,
     });
     expect(localOnboarding.complete).not.toHaveBeenCalled();
     expect(localOnboarding.states.get(pending.configPath)).toEqual(pending);
@@ -593,7 +593,7 @@ describe("system-agent setup transaction", () => {
 
     expect(result.applied).toBe(true);
     expect(applySetup).toHaveBeenCalledWith(expect.not.objectContaining({ resume: true }), {
-      commit: expect.any(Function),
+      beforePersistentApply: undefined,
     });
     expect(localOnboarding.readForConfig).not.toHaveBeenCalled();
     expect(localOnboarding.complete).not.toHaveBeenCalled();

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -253,7 +253,7 @@ describe("parseSystemAgentOperation", () => {
         surface: "cli",
         runtime,
       },
-      { commit: expect.any(Function) },
+      { beforePersistentApply: undefined },
     );
     expect(lines.join("\n")).toContain("Default model: openai/gpt-5.5 (verified and kept)");
     const audit = readLastAuditEntry();
@@ -410,7 +410,7 @@ describe("parseSystemAgentOperation", () => {
     expect(mockConfig.currentConfig()).toMatchObject({ gateway: { port: 19000 } });
     expect(applySetup).toHaveBeenCalledWith(
       expect.objectContaining({ expectedInferenceRoute: expect.any(Object) }),
-      { commit: expect.any(Function) },
+      { beforePersistentApply: undefined },
     );
   });
 
@@ -482,7 +482,7 @@ describe("parseSystemAgentOperation", () => {
         surface: "cli",
         runtime,
       },
-      { commit: expect.any(Function) },
+      { beforePersistentApply: undefined },
     );
   });
 

--- a/src/system-agent/setup-apply.concurrency.test.ts
+++ b/src/system-agent/setup-apply.concurrency.test.ts
@@ -1,109 +1,76 @@
 import fs from "node:fs/promises";
-import path from "node:path";
-import { withTempHome } from "openclaw/plugin-sdk/test-env";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentDir } from "../agents/agent-scope.js";
+import * as onboarding from "../commands/onboard-agent.js";
 import { readConfigFileSnapshot, resetConfigRuntimeState } from "../config/config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { applySystemAgentSetup } from "./setup-apply.js";
 
 const runtime: RuntimeEnv = {
   log: () => {},
   error: () => {},
-  exit: ((code: number) => {
+  exit: (code) => {
     throw new Error(`exit:${code}`);
-  }) as RuntimeEnv["exit"],
+  },
 };
-
-const sourceConfig = {
-  agents: { defaults: { model: "openai/gpt-5.5" } },
-} satisfies OpenClawConfig;
-
-async function writeConcurrentRoster(pathname: string, agentId: string): Promise<void> {
-  await fs.writeFile(
-    pathname,
-    JSON.stringify({
-      agents: {
-        defaults: { model: "openai/gpt-5.5" },
-        entries: { [agentId]: {} },
-      },
-    }),
-  );
-  resetConfigRuntimeState();
-}
-
-async function writeInitialConfig() {
-  const absent = await readConfigFileSnapshot();
-  await fs.mkdir(path.dirname(absent.path), { recursive: true });
-  await fs.writeFile(absent.path, JSON.stringify(sourceConfig));
-  resetConfigRuntimeState();
-  return await readConfigFileSnapshot();
-}
+const model = "openai/gpt-5.6-luna";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   resetConfigRuntimeState();
 });
 
 describe("applySystemAgentSetup first-agent concurrency", () => {
-  it("rejects a same-route agent switch after the controlled first-agent handoff", async () => {
-    await withTempHome(async () => {
-      const initial = await writeInitialConfig();
-      const initialRuntime = initial.runtimeConfig ?? initial.config;
-      let commitCount = 0;
+  it.each([
+    { phase: "before", agentId: "concurrent", error: /config changed before first-agent creation/ },
+    { phase: "after", agentId: "other", error: /config changed|default agent changed/ },
+  ] as const)(
+    "rejects a roster changed $phase first-agent creation",
+    async ({ phase, agentId, error }) => {
+      const state = await createOpenClawTestState({ label: "setup-first-agent-race" });
+      try {
+        await state.writeConfig({ agents: { defaults: { model } } });
+        const initial = await readConfigFileSnapshot();
+        const initialRuntime = initial.runtimeConfig ?? initial.config;
+        const ensureOnboardingAgent = onboarding.ensureOnboardingAgent;
+        const replaceRoster = async () => {
+          await state.writeConfig({ agents: { defaults: { model }, entries: { [agentId]: {} } } });
+          resetConfigRuntimeState();
+        };
+        vi.spyOn(onboarding, "ensureOnboardingAgent").mockImplementationOnce(async (params) => {
+          if (phase === "before") {
+            await replaceRoster();
+          }
+          const created = await ensureOnboardingAgent(params);
+          if (phase === "after") {
+            await replaceRoster();
+          }
+          return created;
+        });
 
-      await expect(
-        applySystemAgentSetup(
-          {
-            workspace: "/tmp/openclaw-first-agent-race",
+        await expect(
+          applySystemAgentSetup({
+            workspace: state.workspaceDir,
             firstAgent: { name: "robby" },
             expectedAgentId: "main",
             expectedAgentDir: resolveAgentDir(initialRuntime, "main"),
-            expectedModelRef: "openai/gpt-5.5",
-            surface: "gateway",
-            runtime,
-          },
-          {
-            commit: async (effect) => {
-              commitCount += 1;
-              if (commitCount === 2) {
-                await writeConcurrentRoster(initial.path, "other");
-              }
-              return await effect();
-            },
-          },
-        ),
-      ).rejects.toThrow(/config changed|default agent changed/);
-
-      const after = await readConfigFileSnapshot();
-      expect(after.sourceConfig?.agents?.entries).toEqual({ other: {} });
-    });
-  });
-
-  it("rejects a roster written before the conditional first-agent create", async () => {
-    await withTempHome(async () => {
-      const initial = await writeInitialConfig();
-
-      await expect(
-        applySystemAgentSetup(
-          {
-            workspace: "/tmp/openclaw-first-agent-race",
-            firstAgent: { name: "robby" },
+            expectedModelRef: model,
             expectedConfigHash: initial.hash ?? null,
             surface: "gateway",
             runtime,
-          },
-          {
-            commit: async (effect) => {
-              await writeConcurrentRoster(initial.path, "concurrent");
-              return await effect();
-            },
-          },
-        ),
-      ).rejects.toThrow("config changed before first-agent creation");
+          }),
+        ).rejects.toThrow(error);
 
-      const after = await readConfigFileSnapshot();
-      expect(after.sourceConfig?.agents?.entries).toEqual({ concurrent: {} });
-    });
-  });
+        const after: unknown = JSON.parse(await fs.readFile(state.configPath, "utf8"));
+        expect(after).toHaveProperty("agents.entries", { [agentId]: {} });
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+        await state.cleanup();
+      }
+    },
+  );
 });

--- a/src/system-agent/setup-apply.test.ts
+++ b/src/system-agent/setup-apply.test.ts
@@ -858,21 +858,17 @@ describe("applySystemAgentSetup transaction boundaries", () => {
       };
       authorityValid = false;
     });
-    let guardCalls = 0;
     let authorityValid = true;
-    const authorityCommit = async <T>(effect: () => Promise<T> | T): Promise<T> => {
-      guardCalls += 1;
+    const beforePersistentApply = () => {
       if (!authorityValid) {
         throw new Error("verified inference binding changed");
       }
-      return await effect();
     };
 
     await expect(
-      applySystemAgentSetup(baseParams({ expectedInferenceRoute }), { commit: authorityCommit }),
+      applySystemAgentSetup(baseParams({ expectedInferenceRoute }), { beforePersistentApply }),
     ).rejects.toThrow("verified inference binding changed");
 
-    expect(guardCalls).toBe(3);
     expect(mocks.ensureWorkspace).toHaveBeenCalledOnce();
     expect(mocks.updateExecApprovals).not.toHaveBeenCalled();
   });

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -89,8 +89,8 @@ export type SystemAgentSetupApplyResult = {
 };
 
 type SystemAgentSetupApplyHooks = {
-  /** Host-owned authority seam; called at every persistent setup boundary. */
-  commit<T>(effect: () => Promise<T> | T): Promise<T>;
+  /** Revalidate the original host authority at each owner's persistent boundary. */
+  beforePersistentApply?: () => void;
 };
 
 /** Prompter for quickstart-only flows: notes go to the log, prompts fail loud. */
@@ -163,9 +163,7 @@ export async function applySystemAgentSetup(
     runtime,
   } = params;
   const hasExpectedConfigHash = Object.hasOwn(params, "expectedConfigHash");
-  const commit: SystemAgentSetupApplyHooks["commit"] = hooks
-    ? async (effect) => await hooks.commit(effect)
-    : async (effect) => await effect();
+  const beforePersistentApply = hooks?.beforePersistentApply;
   const [
     { readSetupConfigFileSnapshot, resolveQuickstartGatewayDefaults },
     onboardHelpers,
@@ -270,16 +268,15 @@ export async function applySystemAgentSetup(
   let expectedWriteHash = expectedConfigHash;
   if (startedWithoutAuthoredRoster) {
     const { ensureOnboardingAgent } = await import("../commands/onboard-agent.js");
-    const created = await commit(
-      async () =>
-        await ensureOnboardingAgent({
-          config: onboardingSourceConfig,
-          workspace: setupWorkspace,
-          baseConfig: onboardingSourceConfig,
-          firstAgent: params.firstAgent ?? { name: "main" },
-          expectedConfigHash: configHashBefore ?? null,
-        }),
-    );
+    beforePersistentApply?.();
+    const created = await ensureOnboardingAgent({
+      config: onboardingSourceConfig,
+      workspace: setupWorkspace,
+      baseConfig: onboardingSourceConfig,
+      firstAgent: params.firstAgent ?? { name: "main" },
+      expectedConfigHash: configHashBefore ?? null,
+      beforePersistentApply,
+    });
     if (!created.createdAgent || !created.configHash) {
       throw new Error(
         "OpenClaw did not create the approved first agent because the roster changed. Retry setup.",
@@ -390,71 +387,71 @@ export async function applySystemAgentSetup(
       settings: gateway.settings,
     };
   };
-  const committed = await commit(
-    async () =>
-      await transformConfigWithPendingPluginInstalls({
-        afterWrite: { mode: "auto" },
-        writeOptions: { auditOrigin: "system-agent", allowConfigSizeDrop: false },
-        transform: async (currentConfig, context) => {
-          const currentSnapshot = requireValidSystemAgentSetupSnapshot(context.snapshot);
-          if (
-            (hasExpectedConfigHash || startedWithoutAuthoredRoster) &&
-            context.previousHash !== expectedWriteHash
-          ) {
-            throw new Error(
-              "OpenClaw config changed while AI access was being tested. Try setup again.",
-            );
-          }
-          await assertVerifiedRoute(context.snapshot);
-          assertExpectedTarget(currentSnapshot.runtimeConfig);
+  beforePersistentApply?.();
+  const committed = await transformConfigWithPendingPluginInstalls({
+    afterWrite: { mode: "auto" },
+    writeOptions: {
+      auditOrigin: "system-agent",
+      allowConfigSizeDrop: false,
+      assertConfigPathForWrite: beforePersistentApply,
+    },
+    transform: async (currentConfig, context) => {
+      const currentSnapshot = requireValidSystemAgentSetupSnapshot(context.snapshot);
+      if (
+        (hasExpectedConfigHash || startedWithoutAuthoredRoster) &&
+        context.previousHash !== expectedWriteHash
+      ) {
+        throw new Error(
+          "OpenClaw config changed while AI access was being tested. Try setup again.",
+        );
+      }
+      await assertVerifiedRoute(context.snapshot);
+      assertExpectedTarget(currentSnapshot.runtimeConfig);
 
-          // Rebuild config and Gateway settings from the same locked snapshot.
-          // A retry can preserve unrelated concurrent edits without carrying
-          // stale settings from the losing attempt into service setup or probes.
-          const setupCandidate = await buildSetupCandidate(
-            currentConfig,
-            startedWithoutAuthoredRoster
-              ? false
-              : hasResolvedRosterBeforeMigrations(context.snapshot),
+      // Rebuild config and Gateway settings from the same locked snapshot.
+      // A retry can preserve unrelated concurrent edits without carrying
+      // stale settings from the losing attempt into service setup or probes.
+      const setupCandidate = await buildSetupCandidate(
+        currentConfig,
+        startedWithoutAuthoredRoster ? false : hasResolvedRosterBeforeMigrations(context.snapshot),
+      );
+      const finalizedConfig = finalizeConfig
+        ? finalizeConfig(setupCandidate.nextConfig, currentSnapshot.sourceConfig)
+        : setupCandidate.nextConfig;
+      const expectedSourceRoute = verifiedRoute
+        ? await projectDefaultInferenceRoute(finalizedConfig)
+        : undefined;
+      if (
+        verifiedRoute &&
+        (!verifiedRoute.route ||
+          !expectedSourceRoute?.route ||
+          !sameSetupConfiguredRoute(expectedSourceRoute.route, verifiedRoute.route, false))
+      ) {
+        throw new Error(
+          "The setup candidate no longer preserves the exact verified inference route, so it was not saved. Retry setup from the current OpenClaw session.",
+        );
+      }
+      // This is the auth/config operation's linearization point. Never hold
+      // the synchronous cross-store guard across async config I/O.
+      if (assertCommitPreconditions) {
+        assertCommitPreconditions(currentSnapshot.sourceConfig);
+        if (
+          resolveUserPath(resolveSystemTarget(finalizedConfig).workspaceDir) !==
+          resolveUserPath(setupWorkspace)
+        ) {
+          throw new Error(
+            "Another onboarding run owns a different workspace. Retry onboarding with its approved workspace.",
           );
-          const finalizedConfig = finalizeConfig
-            ? finalizeConfig(setupCandidate.nextConfig, currentSnapshot.sourceConfig)
-            : setupCandidate.nextConfig;
-          const expectedSourceRoute = verifiedRoute
-            ? await projectDefaultInferenceRoute(finalizedConfig)
-            : undefined;
-          if (
-            verifiedRoute &&
-            (!verifiedRoute.route ||
-              !expectedSourceRoute?.route ||
-              !sameSetupConfiguredRoute(expectedSourceRoute.route, verifiedRoute.route, false))
-          ) {
-            throw new Error(
-              "The setup candidate no longer preserves the exact verified inference route, so it was not saved. Retry setup from the current OpenClaw session.",
-            );
-          }
-          // This is the auth/config operation's linearization point. Never hold
-          // the synchronous cross-store guard across async config I/O.
-          if (assertCommitPreconditions) {
-            assertCommitPreconditions(currentSnapshot.sourceConfig);
-            if (
-              resolveUserPath(resolveSystemTarget(finalizedConfig).workspaceDir) !==
-              resolveUserPath(setupWorkspace)
-            ) {
-              throw new Error(
-                "Another onboarding run owns a different workspace. Retry onboarding with its approved workspace.",
-              );
-            }
-          }
-          return {
-            nextConfig: finalizedConfig,
-            result: {
-              settings: setupCandidate.settings,
-            },
-          };
+        }
+      }
+      return {
+        nextConfig: finalizedConfig,
+        result: {
+          settings: setupCandidate.settings,
         },
-      }),
-  );
+      };
+    },
+  });
   const nextConfig = committed.nextConfig;
   const setupResult = committed.result;
   const settings = setupResult?.settings;
@@ -499,19 +496,13 @@ export async function applySystemAgentSetup(
     effect: () => Promise<T>,
     onFailure: (error: unknown) => void,
   ): Promise<T | undefined> => {
-    let effectStarted = false;
+    beforePersistentApply?.();
     try {
-      return await commit(async () => {
-        effectStarted = true;
-        return await effect();
-      });
+      return await effect();
     } catch (error) {
-      // The config commit is the success boundary, so effect failures are
-      // visible but recoverable. A stale authority failure happens before the
-      // effect starts and must stop every remaining continuation.
-      if (!effectStarted) {
-        throw error;
-      }
+      // Owners can reject after async preparation. Never turn lost authority
+      // into a recoverable post-config warning or continue subsequent effects.
+      beforePersistentApply?.();
       onFailure(error);
       return undefined;
     }
@@ -524,6 +515,7 @@ export async function applySystemAgentSetup(
         agentId: effectiveAgentId,
         skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
         skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
+        beforePersistentApply,
       }),
     (error) => lines.push(`Workspace files: ${formatErrorMessage(error)}`),
   );
@@ -533,6 +525,7 @@ export async function applySystemAgentSetup(
   await runCommittedFollowUp(
     async () => {
       const { updateExecApprovals } = await import("../infra/exec-approvals.js");
+      beforePersistentApply?.();
       await updateExecApprovals({
         update: (approvals) =>
           approvals.agents?.openclaw
@@ -557,6 +550,7 @@ export async function applySystemAgentSetup(
       async () => {
         const { refreshPluginRegistryAfterConfigMutation } =
           await import("../plugins/registry-refresh.js");
+        beforePersistentApply?.();
         await refreshPluginRegistryAfterConfigMutation({
           config: nextConfig,
           reason: "source-changed",
@@ -578,6 +572,7 @@ export async function applySystemAgentSetup(
     await runCommittedFollowUp(
       async () => {
         const { ensureGatewayServiceForOnboarding } = await import("../wizard/setup.finalize.js");
+        beforePersistentApply?.();
         const serviceSetup = await ensureGatewayServiceForOnboarding({
           flow: "quickstart",
           opts: { installDaemon: params.installDaemon },

--- a/src/system-agent/setup-lifetime.test.ts
+++ b/src/system-agent/setup-lifetime.test.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import {
+  prepareSystemAgentRunAdmission,
+  resolveAdmittedRunActiveAssertion,
+} from "../agents/admitted-run-context.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
+import { resetAgentRunRegistryForTest } from "../infra/agent-run-registry.js";
+import { loadExecApprovalsReadOnly } from "../infra/exec-approvals.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { executeSystemAgentOperation } from "./operations-execute.js";
+import type { SystemAgentOverview } from "./overview.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
+import { installSystemAgentPluginMetadataTestSnapshot } from "./system-agent.test-helpers.js";
+
+const preparation = vi.hoisted(() => ({
+  gateway: undefined as (() => Promise<void>) | undefined,
+  execImport: undefined as (() => void) | undefined,
+}));
+vi.mock("../infra/exec-approvals.js", async (original) => {
+  const actual = await original<typeof import("../infra/exec-approvals.js")>();
+  return {
+    ...actual,
+    get updateExecApprovals() {
+      preparation.execImport?.();
+      return actual.updateExecApprovals;
+    },
+  };
+});
+vi.mock("../wizard/setup.gateway-config.js", async (original) => {
+  const actual = await original<typeof import("../wizard/setup.gateway-config.js")>();
+  return {
+    ...actual,
+    configureGatewayForSetup: async (
+      ...args: Parameters<typeof actual.configureGatewayForSetup>
+    ) => {
+      await preparation.gateway?.();
+      return await actual.configureGatewayForSetup(...args);
+    },
+  };
+});
+
+afterEach(() => {
+  preparation.gateway = undefined;
+  preparation.execImport = undefined;
+  vi.restoreAllMocks();
+  resetAgentRunRegistryForTest();
+});
+
+// The approval queue has its own tests; exercise its synchronous admission contract through
+// the real setup dispatcher and disk owners, substituting only inference and paused reads.
+it.each([
+  { phase: "config", loss: "close" },
+  { phase: "config", loss: "replace" },
+  { phase: "config", loss: "lifecycle" },
+  { phase: "config", loss: "abort" },
+  { phase: "first-agent", loss: "close" },
+  { phase: "workspace", loss: "close" },
+  { phase: "sessions", loss: "close" },
+  { phase: "exec-approval", loss: "close" },
+  { phase: "config", loss: "live" },
+  { phase: "first-agent", loss: "live" },
+  { phase: "first-agent", loss: "direct" },
+] as const)("setup $phase preparation with $loss authority", async ({ phase, loss }) => {
+  const state = await createOpenClawTestState({ label: "setup-lifetime" });
+  const admission = prepareSystemAgentRunAdmission({}, "setup-run", "main", "setup-test");
+  let replacement: ReturnType<typeof prepareSystemAgentRunAdmission> | undefined;
+  const admitted = await admission.admit("embedded");
+  const abort = new AbortController();
+  const beforePersistentApply = resolveAdmittedRunActiveAssertion(admitted, abort.signal)!;
+  const entered = createDeferred();
+  const resume = createDeferred();
+  let paused = false;
+  let metadata: ReturnType<typeof installSystemAgentPluginMetadataTestSnapshot> | undefined;
+  let completion: Promise<unknown> | undefined;
+  const { runtime, lines } = createSystemAgentTestRuntime();
+  const workspace = state.workspaceDir;
+  const model = "anthropic/claude-sonnet-4-6";
+  const config: OpenClawConfig = {
+    agents: {
+      defaults: {
+        workspace,
+        model,
+        models: { [model]: { agentRuntime: { id: "openclaw" } } },
+        ...(phase === "sessions" ? { skipBootstrap: true } : {}),
+      },
+      ...(phase === "first-agent" ? {} : { entries: { main: { workspace } } }),
+    },
+    gateway: {
+      mode: "local",
+      bind: "loopback",
+      tailscale: { mode: "off" },
+      auth: { mode: "token", token: "synthetic-setup-token" },
+    },
+  };
+  const pause = async () => {
+    if (paused) {
+      return;
+    }
+    paused = true;
+    beforePersistentApply();
+    entered.resolve();
+    await resume.promise;
+  };
+  try {
+    await state.writeConfig(config);
+    metadata = installSystemAgentPluginMetadataTestSnapshot(
+      (await readConfigFileSnapshot()).config,
+    );
+    const beforeRaw = await fs.readFile(state.configPath, "utf8");
+    if (phase === "config") {
+      preparation.gateway = pause;
+    }
+    const realAccess = fs.access.bind(fs);
+    vi.spyOn(fs, "access").mockImplementation(async (file, mode) => {
+      if (
+        (phase === "first-agent" || phase === "workspace") &&
+        file === path.join(workspace, "AGENTS.md")
+      ) {
+        await pause();
+      }
+      return await realAccess(file, mode);
+    });
+    if (phase === "sessions") {
+      const realReaddir = fs.readdir.bind(fs);
+      vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+        if (args[0] === workspace) {
+          await pause();
+        }
+        return await realReaddir(...args);
+      });
+    }
+    if (phase === "exec-approval") {
+      // Resolve the real mutation export after the awaited import, revoking its caller
+      // before invocation. The real synchronous SQLite updater must never be entered.
+      preparation.execImport = () => {
+        beforePersistentApply();
+        admission.close();
+        paused = true;
+        entered.resolve();
+      };
+    }
+    completion = executeSystemAgentOperation({ kind: "setup", workspace }, runtime, {
+      approved: true,
+      ...(loss === "direct" ? {} : { beforePersistentApply }),
+      deps: {
+        setupSurface: "gateway",
+        loadOverview: async () => ({ defaultModel: model }) as SystemAgentOverview,
+        verifyInferenceConfig: async () => ({ ok: true, modelRef: model, latencyMs: 1 }),
+      },
+    }).then(
+      (result) => ({ result }),
+      (error: unknown) => ({ error }),
+    );
+    await withTestTimeout(
+      Promise.race([
+        entered.promise,
+        completion.then((result) => {
+          if (!paused) {
+            throw new Error(`setup ended before pause: ${JSON.stringify(result)}`);
+          }
+        }),
+      ]),
+      10_000,
+      "setup did not reach preparation pause",
+    );
+    const pauseRaw = await fs.readFile(state.configPath, "utf8");
+    const pauseFiles = (await fs.readdir(workspace)).toSorted();
+    if (loss === "close") {
+      admission.close();
+    }
+    if (loss === "replace") {
+      replacement = prepareSystemAgentRunAdmission(
+        {},
+        admitted.operationalRunInstance.runId,
+        "main",
+        "successor",
+      );
+      const successor = await replacement.admit("embedded");
+      expect(successor.operationalRunInstance.instanceId).not.toBe(
+        admitted.operationalRunInstance.instanceId,
+      );
+      expect(resolveAdmittedRunActiveAssertion(successor)).not.toThrow();
+    }
+    if (loss === "lifecycle") {
+      rotateAgentEventLifecycleGeneration();
+    }
+    if (loss === "abort") {
+      abort.abort();
+    }
+    const closed = loss !== "live" && loss !== "direct";
+    if (closed) {
+      expect(beforePersistentApply).toThrow("authority is no longer active");
+    }
+    resume.resolve();
+    const outcome = await completion;
+    const afterRaw = await fs.readFile(state.configPath, "utf8");
+    if (closed) {
+      expect
+        .soft(outcome)
+        .toMatchObject({ error: new Error("admitted run authority is no longer active") });
+      expect.soft(afterRaw).toBe(pauseRaw);
+      expect.soft((await fs.readdir(workspace)).toSorted()).toEqual(pauseFiles);
+      if (phase !== "exec-approval") {
+        expect.soft(await fs.stat(state.sessionsDir()).catch(() => null)).toBeNull();
+      }
+      expect.soft(loadExecApprovalsReadOnly().agents?.openclaw).toBeUndefined();
+      expect.soft(lines).not.toContain("[openclaw] done: openclaw.setup");
+    } else {
+      expect(outcome).toMatchObject({ result: { applied: true, bootstrapPending: true } });
+      expect(afterRaw).not.toBe(beforeRaw);
+      expect(JSON.parse(afterRaw)).toHaveProperty("agents.entries.main");
+      expect(await fs.readFile(path.join(workspace, "AGENTS.md"), "utf8")).not.toBe("");
+      expect((await fs.stat(state.sessionsDir())).isDirectory()).toBe(true);
+      expect(loadExecApprovalsReadOnly().agents?.openclaw).toEqual({
+        security: "full",
+        ask: "off",
+      });
+    }
+  } finally {
+    resume.resolve();
+    await completion;
+    admission.close();
+    replacement?.close();
+    metadata?.restore();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await state.cleanup();
+  }
+});


### PR DESCRIPTION
## What Problem This Solves

Closes #136219 (delegated setup could persist changes after the requesting run closed).

A regular agent can delegate typed `setup` and obtain a real operator `allow-once` approval. Setup checked the original run before entering asynchronous work, but did not carry that check to its creation/configuration owners. Closing or replacing the exact run during preparation could therefore leave new configuration, bootstrap files, or session directories behind, followed by a misleading `not-applied` result.

Named first-agent setup had a second window: after agent publication, automatic legacy-session migration could still start or continue new durable writes after closure. The migration is deferrable; unlike creation's tombstone/provenance completion, it can safely finish through the existing startup/Doctor recovery path.

This is separate from #136090, the merged direct agent-creation repair. Existing-roster setup never calls `createAgent`, and first-agent setup was not forwarding its guard to that repaired owner.

## Why This Change Was Made

Carry the original synchronous `beforePersistentApply` assertion from the approved operation into onboarding, config mutation, workspace/session preparation, followups, and legacy-session migration's actual write owners. Delete setup's private async-only `commit` forwarding and effect-start bookkeeping. Keep entry validation for injected setup implementations.

The config mutation owner composes captured destination ownership with caller authority instead of letting a supplied write option replace the destination check, including retries. Migration revalidates after writer queues/source staging and before canonical database creation, in-place changes, source cleanup, and ledger writes. It reuses the existing deletion `commitGuard`; no parallel deletion/import path or new lifetime framework.

Existing conditional root/include compensation, plugin-before-config lock order, exact-run/lifecycle/worker-claim validation, and post-commit publication remain. Already-published agents keep their completed tombstone/provenance bookkeeping. Already-committed session copies remain and recovery completes the remainder. A read-only transcript helper now requires only the database handle it actually reads, rather than a writable-maintenance object or a fixture cast.

Forced disk-budget maintenance now belongs to actual committed lifecycle mutations. The shared completion barrier replaces unconditional delete/reset triggers, records actual historical row deletion and SQL COMMIT, and waits until archive/native/lifecycle cleanup finishes before scheduling maintenance. Rejected preparation and rollback do not start a sweep; partial commits retain completion-owned maintenance under the existing retention policy.

**Production LOC: +332/-273, net +59. Tests: +796/-190, net +606. Docs: +10/-0.** Production growth is explicit guard plumbing into existing import/deletion/ledger owners and actual-commit outcome recording, including pre-open checks after waits. Removing async forwarding/effect-start tracking, duplicated migration parameter declarations, and duplicate unconditional maintenance blocks absorbs part of that cost. No new configuration option, environment variable, schema, retention policy, protocol, dependency, compatibility path, or fallback.

## User Impact

Delegated setup stops before the next persistent effect when its requesting run loses authority. Ordinary live-authority setup and direct onboarding still work. Earlier completed effects remain; this is not a cross-operation transaction. If cancellation defers legacy history for a newly named agent, the next Gateway startup or `openclaw doctor --fix` against the same state/config completes migration. The CLI docs explain partial completion and recovery.

Gateway regular-agent delegation is the exposed path verified here. This does not claim isolated worker turns expose setup or establish an affected stable-release range.

## Evidence

Current head: `0100ce820b9f1d3eeb3091543ceda9ad4ac12d20`.

The final maintenance regression produced **3 failed / 14 passed before → 17 passed after**. **224 sibling tests across 13 files** passed, overlapping earlier suites. Five additional standalone Node processes exercised the real production owners outside Vitest: queued closure blocked all observed checkpoints and preserved retained archives/unrelated history; authorized and partially committed controls still enforced the configured budget after lifecycle settlement. Production source hashes match this head; all synthetic state was removed. These owner/I/O traces do not claim a separate live Gateway migration/retention race.

- Original isolated delegation/approval reproduction: **3 failed / 5 passed before → 8 passed after**. Transport/inference were substituted; approval, exact authority, filesystem/configuration, and SQLite owners were real.
- Setup-owner regressions: **8 failed / 3 passed pre-fix**; three destination-composition cases also failed before the fix. Coverage includes closure, same-run-ID replacement, lifecycle rotation, abort, first-agent preparation, workspace/session continuation, and exec-approval import.
- **400 initial focused tests across 16 files passed.** The migration follow-up ran **189 tests across 13 files, with overlap**, and the rebased focused rerun passed **158 tests across 4 files**.
- All **five new migration closure cases failed before production edits and pass afterward**: post-create snapshot, destination import queue, shared-store in-place queue, source cleanup queue, and ledger after a completed delete. Tests also prove preserved published-agent bookkeeping, committed copies/human ownership, exact source-race handling, and callback-free recovery.
- Final `node scripts/check-changed.mjs` and `pnpm build` passed. Fresh isolated Codex autoreviews returned scoped-clean at the configured P0 threshold. The type-only read-handle correction was separately reviewed and checked.
- [Migration review response and red-to-green evidence](https://github.com/openclaw/openclaw/pull/136247#issuecomment-5508755347).

### Real live before/after proof

[Inspected before/after videos, normal-flow recording, and exact validation commands](https://github.com/openclaw/openclaw/pull/136247#issuecomment-5508188616).

Initial Blacksmith Testbox **tbx_01m1grt7qb3wy9n9w3xfnvz1fb** ([environment run](https://github.com/openclaw/openclaw/actions/runs/33616903135)): Linux Node **24.19.0**, pnpm **12.1.0**, real **anthropic/claude-sonnet-4-6**. Built Gateway/Control UI, fresh synthetic HOME/state/workspace per case, task loopback ports, normal dashboard pairing, real regular-agent delegation and operator UI approval. No mocked model, Gateway, approval registry, or authority; default execution policy unchanged.

A separate process held the canonical config mutation lock. The driver observed actual Gateway `O_EXCL`/`EEXIST` contention with `strace`, clicked the real Stop control, required exact-run `chat.abort` acknowledgement plus its terminal event, and only then released the lock.

| Build/scenario | Application status | Config bytes changed | Config renames after approval |
| --- | --- | --- | --- |
| Pre-fix `d413210bc7420923d101ce64211511cdac7b9464`, abort while waiting | `not-applied` | **yes — reproduced bug** | **1** |
| Initial repaired candidate, same race | `not-applied` | **no — hashes identical** | **0** |
| Repaired, contended lock released while run remains live | `applied` | yes, expected setup result | 1 |
| Repaired, ordinary approved setup | `applied` | yes, expected setup result | 1 |

An independent reread verified all four actual final config hashes. All owned Gateway launchers exited and that lease is stopped. Recordings were inspected over their full duration using extracted frames and full-size terminal screenshots; only synthetic task data is visible. Videos show the operator flow; disk outcomes are measured, not inferred from model prose.

**The `25085b6a` live refresh passed all three scenarios** on Blacksmith Testbox `tbx_01m1gy6a4a93c2862aq3g3qd8v` ([environment run 33625022669](https://github.com/openclaw/openclaw/actions/runs/33625022669)). All changed production owners and dependency pins matched the final candidate. The exact-run cancellation again produced `not-applied`, byte-identical configuration and zero renames; both live-authority controls applied. Independent disk rereads, process-exit and closed-port checks passed, and the lease is stopped. [Inspected final-head recordings and measured results](https://github.com/openclaw/openclaw/pull/136247#issuecomment-5509082548).

**Final commit `0100ce820b9` also passed all three real Gateway/operator scenarios** on fresh Blacksmith Testbox `tbx_01m1h2g4h764287cadqm46ekkp` ([environment run33631819725](https://github.com/openclaw/openclaw/actions/runs/33631819725)). Candidate owner/dependency hashes matched. Normal and contended-live setup applied with one config rename each; exact-run abort produced `not-applied`, identical config bytes and zero renames. Independent disk/process/port verification passed; the lease is stopped. [Inspected final-commit recordings, current-head maintenance I/O trace and full validation](https://github.com/openclaw/openclaw/pull/136247#issuecomment-5509676343).

The migration-specific queue/cleanup/ledger windows are deterministic real-admission/SQLite regressions, and the maintenance windows also have standalone production-owner traces; neither is claimed as a separate live HTTP race.

### CI and review follow-through

The initial PR CI failed before scanning because its post-checkout history fetch lacked GitHub authentication. The existing canonical fix, #136232 (fetch scan history during authenticated checkout), landed and is included in this branch; no duplicate CI workaround or gate bypass. The `25085b6a` head then passed all CI after bounded retries for GitHub Git HTTP429 and trusted-base fetch timeouts before check bodies. Final head `0100ce820b9` passed [CI33631168090 attempt2](https://github.com/openclaw/openclaw/actions/runs/33631168090). Only security-fast's public pre-commit-hook fetch failed on attempt1, before the scanner ran, and its exact-job retry passed. No code, check, or policy was weakened.

Both ClawSweeper findings and their Rank-up moves were applied: deferrable post-create migration and the post-rejection forced-maintenance trigger were independently reproduced before repair. Committed creation bookkeeping and completion-owned maintenance remain. Initial test-style findings and the rebased read-only database type mismatch were corrected without weakening assertions or casting away ownership.

The final pending-plugin-install scope question was checked, not silently skipped. Delegated `executeSetup` verifies an existing route and supplies no install-producing patch. Actual legacy `plugins.installs` is invalid in both normal/setup readers; an actual canonical installed index with one record yields valid snapshots with empty source/runtime pending maps. The nonempty pending-record writer is therefore not reached by this delegated operation. Separate operator activation/install staging and its compensation remain unchanged; no narrower-authority waiver or fabricated valid legacy snapshot was used.

No operator Gateway/state or the separate agent-creation worktree was modified. Release-note context is recorded here; no changelog edits.
