### PR TITLE
improve(agents): keep pending streamed replies current

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -72,7 +72,7 @@ const resolveAgentWorkspaceDirMock = vi.fn();
 const listAgentEntriesMock = vi.fn();
 const prepareProviderRuntimeAuthMock = vi.fn();
 const registerProviderStreamForModelMock = vi.fn();
-const resolveEmbeddedAgentStreamFnMock = vi.fn();
+const resolveEmbeddedAgentStreamMock = vi.fn();
 const prepareCliRunContextMock = vi.fn();
 const executePreparedCliRunMock = vi.fn();
 const diagDebugMock = vi.fn();
@@ -358,7 +358,7 @@ vi.mock("./provider-stream.js", () => ({
 }));
 
 vi.mock("./embedded-agent-runner/stream-resolution.js", () => ({
-  resolveEmbeddedAgentStreamFn: (...args: unknown[]) => resolveEmbeddedAgentStreamFnMock(...args),
+  resolveEmbeddedAgentStream: (...args: unknown[]) => resolveEmbeddedAgentStreamMock(...args),
 }));
 
 vi.mock("./auth-profiles/session-override.js", () => ({
@@ -734,7 +734,7 @@ describe("runBtwSideQuestion", () => {
     listAgentEntriesMock.mockReset();
     prepareProviderRuntimeAuthMock.mockReset();
     registerProviderStreamForModelMock.mockReset();
-    resolveEmbeddedAgentStreamFnMock.mockReset();
+    resolveEmbeddedAgentStreamMock.mockReset();
     prepareCliRunContextMock.mockReset();
     executePreparedCliRunMock.mockReset();
     diagDebugMock.mockReset();
@@ -814,9 +814,12 @@ describe("runBtwSideQuestion", () => {
     listAgentEntriesMock.mockReturnValue([]);
     prepareProviderRuntimeAuthMock.mockResolvedValue(undefined);
     registerProviderStreamForModelMock.mockReturnValue(undefined);
-    resolveEmbeddedAgentStreamFnMock.mockImplementation(
+    resolveEmbeddedAgentStreamMock.mockImplementation(
       (params: { currentStreamFn: unknown; providerStreamFn?: unknown }) => {
-        return params.providerStreamFn ?? params.currentStreamFn;
+        return {
+          streamFn: params.providerStreamFn ?? params.currentStreamFn,
+          strategy: "session-custom",
+        };
       },
     );
   });
@@ -2446,7 +2449,10 @@ describe("runBtwSideQuestion", () => {
     const resolvedStreamFn = vi
       .fn()
       .mockReturnValue(makeAsyncEvents([createDoneEvent("MiniMax answer.")]));
-    resolveEmbeddedAgentStreamFnMock.mockReturnValueOnce(resolvedStreamFn);
+    resolveEmbeddedAgentStreamMock.mockReturnValueOnce({
+      streamFn: resolvedStreamFn,
+      strategy: "boundary-aware:anthropic-messages",
+    });
 
     const result = await runSideQuestion({
       provider: "minimax-portal",
@@ -2454,7 +2460,7 @@ describe("runBtwSideQuestion", () => {
     });
 
     expect(result).toEqual({ text: "MiniMax answer." });
-    const resolverParams = expectRecordFields(mockArg(resolveEmbeddedAgentStreamFnMock, 0, 0), {
+    const resolverParams = expectRecordFields(mockArg(resolveEmbeddedAgentStreamMock, 0, 0), {
       sessionId: "session-1",
       resolvedApiKey: "secret",
       authProfileId: undefined,
@@ -2477,7 +2483,7 @@ describe("runBtwSideQuestion", () => {
     const result = await runSideQuestion();
 
     expect(result).toEqual({ text: "Fallback answer." });
-    expect(resolveEmbeddedAgentStreamFnMock).toHaveBeenCalledWith(
+    expect(resolveEmbeddedAgentStreamMock).toHaveBeenCalledWith(
       expect.objectContaining({
         currentStreamFn: expect.any(Function),
         providerStreamFn: undefined,

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -33,7 +33,7 @@ import { prepareCliRunContext } from "./cli-runner/prepare.runtime.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./embedded-agent-block-chunker.js";
 import { resolveModelAsync, resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
-import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
+import { resolveEmbeddedAgentStream } from "./embedded-agent-runner/stream-resolution.js";
 import { createAgentHarnessHostCapabilities } from "./harness/host-capability.js";
 import { resolveAgentHarnessOwnerPluginId } from "./harness/registry.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
@@ -1274,7 +1274,7 @@ export async function runBtwSideQuestion(
       env: process.env,
       apiRegistry: modelRegistryRuntime.apiRegistry,
     });
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       llmRuntime: modelRegistryRuntime.llmRuntime,
       currentStreamFn: modelRegistryRuntime.llmRuntime.streamSimple,
       providerStreamFn,

--- a/src/agents/embedded-agent-runner/compact.delegate.test.ts
+++ b/src/agents/embedded-agent-runner/compact.delegate.test.ts
@@ -128,7 +128,10 @@ async function createFixture(operation: "summary" | "endpoint", globalAlias = fa
   const modelRegistry = sessions.ModelRegistry.inMemory(authStorage);
   modelRegistry.registerProvider(model.provider, { api: model.api, streamSimple: stream });
   resolveModelMock.mockReturnValue({ model, error: null, authStorage, modelRegistry });
-  vi.mocked(streamResolution.resolveEmbeddedAgentStreamFn).mockReturnValue(stream);
+  vi.mocked(streamResolution.resolveEmbeddedAgentStream).mockReturnValue({
+    streamFn: stream,
+    strategy: "session-custom",
+  });
   applyExtraParamsToAgentMock.mockReturnValue({
     effectiveExtraParams: { responsesCompactEndpoint: operation === "endpoint" },
   });

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -259,9 +259,9 @@ export const listRegisteredPluginAgentPromptGuidanceMock = vi.fn((params?: { sur
 );
 export const buildEmbeddedSystemPromptMock = vi.fn<typeof buildEmbeddedSystemPrompt>(() => "");
 export const resolveSkillsPromptMock = vi.fn((): string | undefined => undefined);
-export const resolveEmbeddedAgentStreamFnMock: Mock<
-  (params?: unknown) => MockEmbeddedAgentStreamFn
-> = vi.fn((_params?: unknown) => vi.fn());
+export const resolveEmbeddedAgentStreamMock: Mock<
+  (params?: unknown) => { streamFn: MockEmbeddedAgentStreamFn; strategy: string }
+> = vi.fn((_params?: unknown) => ({ streamFn: vi.fn(), strategy: "session-custom" }));
 const getModelRegistryRuntimeMock = vi.fn(() => ({
   apiRegistry: {},
   llmRuntime: { streamSimple: vi.fn() },
@@ -511,8 +511,11 @@ export function resetCompactSessionStateMocks(): void {
   createAgentSessionMock.mockImplementation(async () => ({
     session: createMockCompactionSession(),
   }));
-  resolveEmbeddedAgentStreamFnMock.mockReset();
-  resolveEmbeddedAgentStreamFnMock.mockImplementation((_params?: unknown) => vi.fn());
+  resolveEmbeddedAgentStreamMock.mockReset();
+  resolveEmbeddedAgentStreamMock.mockImplementation((_params?: unknown) => ({
+    streamFn: vi.fn(),
+    strategy: "session-custom",
+  }));
   getModelRegistryRuntimeMock.mockReset();
   getModelRegistryRuntimeMock.mockReturnValue({
     apiRegistry: {},
@@ -942,7 +945,7 @@ export async function loadCompactHooksHarness(options: { durableSession?: boolea
   vi.doMock("./stream-resolution.js", () => ({
     resolveEmbeddedAgentApiKey: vi.fn(async () => "test-api-key"),
     resolveEmbeddedAgentBaseStreamFn: vi.fn(() => vi.fn()),
-    resolveEmbeddedAgentStreamFn: resolveEmbeddedAgentStreamFnMock,
+    resolveEmbeddedAgentStream: resolveEmbeddedAgentStreamMock,
   }));
 
   vi.doMock("./extra-params.js", () => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -61,7 +61,7 @@ import {
   resolveContextEngineMock,
   resolveDefaultAgentDirMock,
   resolveEffectiveCompactionModeMock,
-  resolveEmbeddedAgentStreamFnMock,
+  resolveEmbeddedAgentStreamMock,
   resolveMemorySearchConfigMock,
   resolveModelAsyncMock,
   resolveModelMock,
@@ -838,7 +838,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         return options?.authProfileId === "openai:missing";
       }),
     ).toBe(true);
-    expect(resolveEmbeddedAgentStreamFnMock).toHaveBeenCalledWith(
+    expect(resolveEmbeddedAgentStreamMock).toHaveBeenCalledWith(
       expect.objectContaining({ authProfileId: "openai:backup" }),
     );
     expect(buildAgentRuntimePlanMock).toHaveBeenCalledWith(
@@ -1297,7 +1297,10 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       mockResolvedModel(
         "providerTimeoutMs" in scenario ? { requestTimeoutMs: scenario.providerTimeoutMs } : {},
       );
-      resolveEmbeddedAgentStreamFnMock.mockReturnValue(vi.fn(() => providerRequest.promise));
+      resolveEmbeddedAgentStreamMock.mockReturnValue({
+        streamFn: vi.fn(() => providerRequest.promise),
+        strategy: "session-custom",
+      });
       attemptServerEndpointCompactionMock.mockImplementationOnce(async (input) => {
         const { context, model, streamFn } = input;
         const messages = context.messages.filter(
@@ -1360,7 +1363,10 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
 
   it("routes compaction through shared stream resolution and extra params", async () => {
     const resolvedStreamFn = vi.fn();
-    resolveEmbeddedAgentStreamFnMock.mockReturnValue(resolvedStreamFn);
+    resolveEmbeddedAgentStreamMock.mockReturnValue({
+      streamFn: resolvedStreamFn,
+      strategy: "session-custom",
+    });
     applyExtraParamsToAgentMock.mockReturnValue({
       effectiveExtraParams: { transport: "websocket" },
     });
@@ -1393,7 +1399,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       } as never,
     });
 
-    const streamArg = mockCallArg(resolveEmbeddedAgentStreamFnMock) as Record<string, unknown>;
+    const streamArg = mockCallArg(resolveEmbeddedAgentStreamMock) as Record<string, unknown>;
     expect(streamArg.currentStreamFn).toBeTypeOf("function");
     expect(streamArg.sessionId).toBe("session-1");
     expect(streamArg.authProfileId).toBe("openai:profile-1");
@@ -1888,7 +1894,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         const [
           { createAgentSessionForEmbeddedRunner },
           { guardSessionManager },
-          { resolveEmbeddedAgentStreamFn },
+          { resolveEmbeddedAgentStream },
           { buildEmbeddedExtensionFactories },
         ] = await Promise.all([
           import("../sessions/sdk.js"),
@@ -1956,7 +1962,10 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         vi.mocked(guardSessionManager).mockReturnValue(sessionManager);
         limitHistoryTurnsMock.mockImplementation((messages) => messages);
         resolveEffectiveCompactionModeMock.mockReturnValue("safeguard");
-        vi.mocked(resolveEmbeddedAgentStreamFn).mockReturnValue(stream);
+        vi.mocked(resolveEmbeddedAgentStream).mockReturnValue({
+          streamFn: stream,
+          strategy: "session-custom",
+        });
         vi.mocked(buildEmbeddedExtensionFactories).mockImplementation(({ model }) => {
           setSafeguardRuntime(sessionManager, {
             model,
@@ -2282,7 +2291,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       resolveModelMock,
       ([provider, modelId]) => provider === "openai" && modelId === "gpt-5.4-mini",
     );
-    expectRecordFields(mockCallArg(resolveEmbeddedAgentStreamFnMock, 1), {
+    expectRecordFields(mockCallArg(resolveEmbeddedAgentStreamMock, 1), {
       authProfileId: "openai:default",
     });
   });

--- a/src/agents/embedded-agent-runner/compaction-session-agent.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-agent.ts
@@ -9,7 +9,7 @@ import { applyExtraParamsToAgent } from "./extra-params.js";
 import {
   resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentBaseStreamFn,
-  resolveEmbeddedAgentStreamFn,
+  resolveEmbeddedAgentStream,
 } from "./stream-resolution.js";
 import { mapThinkingLevelForProvider } from "./utils.js";
 
@@ -59,7 +59,7 @@ export async function prepareCompactionSessionAgent(params: {
         authStorage,
       })
     : params.resolvedApiKey;
-  params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
+  params.session.agent.streamFn = resolveEmbeddedAgentStream({
     llmRuntime: params.llmRuntime,
     currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
     providerStreamFn: params.providerStreamFn as never,
@@ -70,7 +70,7 @@ export async function prepareCompactionSessionAgent(params: {
     transportAuthAvailable: Boolean(transportApiKey?.trim()),
     authProfileId: params.runtimePlan?.auth.forwardedAuthProfileId,
     authStorage: params.authStorage as never,
-  });
+  }).streamFn;
   const providerTextTransforms = resolveProviderTextTransforms({
     provider: params.provider,
     config: params.config,

--- a/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-phase.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../../sessions/agent-session-loop-correctness.test-support.js";
 import type { AgentSessionEvent } from "../../sessions/agent-session-types.js";
 import { SessionManager } from "../../sessions/session-manager.js";
-import { resolveEmbeddedAgentStreamFn } from "../stream-resolution.js";
+import { resolveEmbeddedAgentStream } from "../stream-resolution.js";
 
 const mocks = vi.hoisted(() => ({
   abortable: vi.fn(),
@@ -324,12 +324,12 @@ describe("runEmbeddedAttemptExecutionPhase", () => {
         settingsManager,
         contextOverflowRecoveryOwner: "caller",
       });
-      session.agent.streamFn = resolveEmbeddedAgentStreamFn({
+      session.agent.streamFn = resolveEmbeddedAgentStream({
         currentStreamFn: session.agent.streamFn,
         model,
         sessionId: session.sessionId,
         signal: fixture.input.runAbortController.signal,
-      });
+      }).streamFn;
       const summaryStarted = createDeferred();
       const releaseSummary = createDeferred();
       const events: EmbeddedContextAccountingEvent[] = [];

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -38,10 +38,9 @@ import {
   wrapStreamFnWithProviderPromptState,
 } from "../provider-prompt-state.js";
 import {
-  describeEmbeddedAgentStreamStrategy,
   resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentBaseStreamFn,
-  resolveEmbeddedAgentStreamFn,
+  resolveEmbeddedAgentStream,
 } from "../stream-resolution.js";
 import type { ProviderThinkLevel } from "../utils.js";
 import { joinWithRunLivenessDeadline, RUN_LIVENESS_JOIN_TIMEOUT_MS } from "./abortable.js";
@@ -526,13 +525,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
     resolvedApiKey: attempt.resolvedApiKey,
     authStorage: attempt.authStorage,
   });
-  const streamStrategy = describeEmbeddedAgentStreamStrategy({
-    currentStreamFn: defaultSessionStreamFn,
-    providerStreamFn: directProviderStreamFn,
-    model: attempt.model,
-    resolvedApiKey: transportApiKey,
-  });
-  session.agent.streamFn = resolveEmbeddedAgentStreamFn({
+  const { streamFn, strategy: streamStrategy } = resolveEmbeddedAgentStream({
     currentStreamFn: defaultSessionStreamFn,
     providerStreamFn: directProviderStreamFn,
     sessionId: attempt.sessionId,
@@ -544,6 +537,7 @@ export async function prepareEmbeddedAttemptTransport(input: {
     authProfileId: resolveAttemptStreamAuthProfileId(attempt),
     authStorage: attempt.authStorage,
   });
+  session.agent.streamFn = streamFn;
   // Install inside provider/config wrappers so their full onPayload chain runs
   // before admission hashes the request body that the built-in transport sends.
   session.agent.streamFn = wrapStreamFnWithProviderPromptState({

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -17,7 +17,7 @@ import { buildAgentSystemPrompt } from "../../system-prompt.js";
 import type { NormalizedUsage } from "../../usage.js";
 import {
   resolveEmbeddedAgentBaseStreamFn,
-  resolveEmbeddedAgentStreamFn as resolveEmbeddedAgentStreamFnImpl,
+  resolveEmbeddedAgentStream as resolveEmbeddedAgentStreamImpl,
 } from "../stream-resolution.js";
 import { buildContextEnginePromptCacheInfo } from "./attempt-context-engine-helpers.js";
 import {
@@ -40,10 +40,10 @@ const llmRuntime = {
   streamSimple,
 } as LlmRuntime;
 
-function resolveEmbeddedAgentStreamFn(
-  params: Omit<Parameters<typeof resolveEmbeddedAgentStreamFnImpl>[0], "llmRuntime">,
+function resolveEmbeddedAgentStream(
+  params: Omit<Parameters<typeof resolveEmbeddedAgentStreamImpl>[0], "llmRuntime">,
 ) {
-  return resolveEmbeddedAgentStreamFnImpl({ ...params, llmRuntime });
+  return resolveEmbeddedAgentStreamImpl({ ...params, llmRuntime });
 }
 
 type FakeWrappedStream = {
@@ -487,7 +487,7 @@ describe("mergeOrphanedTrailingUserPrompt", () => {
   });
 });
 
-describe("resolveEmbeddedAgentStreamFn", () => {
+describe("resolveEmbeddedAgentStream", () => {
   it("reuses the session's original base stream across later wrapper mutations", () => {
     const baseStreamFn = vi.fn();
     const wrapperStreamFn = vi.fn();
@@ -504,7 +504,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
 
   it("injects authStorage api keys into provider-owned stream functions", async () => {
     const providerStreamFn = vi.fn(async (_model, _context, options) => options);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       providerStreamFn,
       sessionId: "session-1",
@@ -533,7 +533,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
 
   it("strips the internal cache boundary before provider-owned stream calls", async () => {
     const providerStreamFn = vi.fn(async (_model, context) => context);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       providerStreamFn,
       sessionId: "session-1",
@@ -557,7 +557,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     expect(providerStreamFn).toHaveBeenCalledTimes(1);
   });
   it("routes supported default streamSimple fallbacks through boundary-aware transports", () => {
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       model: {
@@ -572,7 +572,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
 
   it("keeps explicit custom currentStreamFn values unchanged", () => {
     const currentStreamFn = vi.fn();
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: currentStreamFn as never,
       sessionId: "session-1",
       model: {
@@ -587,7 +587,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
 
   it("routes runtime-auth custom currentStreamFn values through boundary-aware transports", async () => {
     const currentStreamFn = vi.fn();
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: currentStreamFn as never,
       sessionId: "session-1",
       model: {

--- a/src/agents/embedded-agent-runner/stream-resolution.activity.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.activity.test.ts
@@ -11,7 +11,7 @@ import {
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { streamWithIdleTimeout } from "./run/llm-idle-timeout.js";
-import { resolveEmbeddedAgentStreamFn } from "./stream-resolution.js";
+import { resolveEmbeddedAgentStream } from "./stream-resolution.js";
 
 const model = {
   api: "openai-completions",
@@ -21,17 +21,17 @@ const model = {
 const requireRecord = createRequireRecord("record", "expected-label-object");
 
 function resolveProviderStream(
-  providerStreamFn: Parameters<typeof resolveEmbeddedAgentStreamFn>[0]["providerStreamFn"],
+  providerStreamFn: Parameters<typeof resolveEmbeddedAgentStream>[0]["providerStreamFn"],
   runSignal: AbortSignal,
 ) {
-  return resolveEmbeddedAgentStreamFn({
+  return resolveEmbeddedAgentStream({
     llmRuntime: defaultLlmRuntime,
     currentStreamFn: undefined,
     providerStreamFn,
     sessionId: "session-1",
     signal: runSignal,
     model,
-  });
+  }).streamFn;
 }
 
 afterEach(() => {

--- a/src/agents/embedded-agent-runner/stream-resolution.host.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.host.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 describe("embedded stream transport host", () => {
   it("installs runtime transport ports before resolving an embedded stream", async () => {
     const inertResolver = getAiTransportHost().plugin.resolveProviderStream;
-    const { describeEmbeddedAgentStreamStrategy } = await import("./stream-resolution.js");
+    const { resolveEmbeddedAgentStream } = await import("./stream-resolution.js");
     const model = {
       api: "test-embedded-runtime-host-api",
       provider: "test-embedded-runtime-host",
@@ -32,11 +32,12 @@ describe("embedded stream transport host", () => {
       }),
     ).toBeUndefined();
     expect(
-      describeEmbeddedAgentStreamStrategy({
+      resolveEmbeddedAgentStream({
+        sessionId: "session-1",
         llmRuntime: createLlmRuntime(),
         currentStreamFn: undefined,
         model,
-      }),
+      }).strategy,
     ).toBe("stream-simple");
   });
 });

--- a/src/agents/embedded-agent-runner/stream-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.test.ts
@@ -13,9 +13,8 @@ import type { Model } from "../../llm/types.js";
 import { mintSecretSentinel } from "../../secrets/sentinel.js";
 import { wrapStreamFnWithProviderPromptState } from "./provider-prompt-state.js";
 import {
-  describeEmbeddedAgentStreamStrategy as describeEmbeddedAgentStreamStrategyImpl,
   resolveEmbeddedAgentApiKey,
-  resolveEmbeddedAgentStreamFn as resolveEmbeddedAgentStreamFnImpl,
+  resolveEmbeddedAgentStream as resolveEmbeddedAgentStreamImpl,
 } from "./stream-resolution.js";
 
 const streamMocks = vi.hoisted(() => ({
@@ -53,16 +52,10 @@ const llmRuntime = {
   streamSimple: streamSimple as StreamFn,
 } as LlmRuntime;
 
-function describeEmbeddedAgentStreamStrategy(
-  params: Omit<Parameters<typeof describeEmbeddedAgentStreamStrategyImpl>[0], "llmRuntime">,
+function resolveEmbeddedAgentStream(
+  params: Omit<Parameters<typeof resolveEmbeddedAgentStreamImpl>[0], "llmRuntime">,
 ) {
-  return describeEmbeddedAgentStreamStrategyImpl({ ...params, llmRuntime });
-}
-
-function resolveEmbeddedAgentStreamFn(
-  params: Omit<Parameters<typeof resolveEmbeddedAgentStreamFnImpl>[0], "llmRuntime">,
-) {
-  return resolveEmbeddedAgentStreamFnImpl({ ...params, llmRuntime });
+  return resolveEmbeddedAgentStreamImpl({ ...params, llmRuntime });
 }
 
 const overrideBoundaryAwareStreamFnOnce = (streamFn: StreamFn): void => {
@@ -95,25 +88,27 @@ afterEach(() => {
   }
 });
 
-describe("describeEmbeddedAgentStreamStrategy", () => {
+describe("prepared embedded stream strategy", () => {
   it("recovers the lifecycle owner from a prepared session stream", () => {
     bindStreamLlmRuntime(streamSimple, llmRuntime);
 
     expect(
-      describeEmbeddedAgentStreamStrategyImpl({
+      resolveEmbeddedAgentStreamImpl({
+        sessionId: "session-1",
         currentStreamFn: streamSimple,
         model: {
           api: "openai-responses",
           provider: "openai",
           id: "gpt-5.4",
         } as never,
-      }),
+      }).strategy,
     ).toBe("boundary-aware:openai-responses");
   });
 
   it("describes provider-owned stream paths explicitly", () => {
     expect(
-      describeEmbeddedAgentStreamStrategy({
+      resolveEmbeddedAgentStream({
+        sessionId: "session-1",
         currentStreamFn: undefined,
         providerStreamFn: vi.fn() as never,
         model: {
@@ -121,65 +116,84 @@ describe("describeEmbeddedAgentStreamStrategy", () => {
           provider: "ollama",
           id: "qwen",
         } as never,
-      }),
+      }).strategy,
     ).toBe("provider");
   });
 
   it("describes default OpenAI fallback shaping", () => {
     expect(
-      describeEmbeddedAgentStreamStrategy({
+      resolveEmbeddedAgentStream({
+        sessionId: "session-1",
         currentStreamFn: undefined,
         model: {
           api: "openai-responses",
           provider: "openai",
           id: "gpt-5.4",
         } as never,
-      }),
+      }).strategy,
     ).toBe("boundary-aware:openai-responses");
   });
 
   it("describes default Codex fallback as OpenClaw native", () => {
     expect(
-      describeEmbeddedAgentStreamStrategy({
+      resolveEmbeddedAgentStream({
+        sessionId: "session-1",
         currentStreamFn: undefined,
         model: {
           api: "openai-chatgpt-responses",
           provider: "openai",
           id: "codex-mini-latest",
         } as never,
-      }),
+      }).strategy,
     ).toBe("openclaw-native-codex-responses");
   });
 
   it("keeps custom session streams labeled as custom", () => {
     expect(
-      describeEmbeddedAgentStreamStrategy({
+      resolveEmbeddedAgentStream({
+        sessionId: "session-1",
         currentStreamFn: vi.fn() as never,
         model: {
           api: "openai-responses",
           provider: "openai",
           id: "gpt-5.4",
         } as never,
-      }),
+      }).strategy,
     ).toBe("session-custom");
   });
 
-  it("describes runtime-auth custom session streams as boundary-aware", () => {
-    expect(
-      describeEmbeddedAgentStreamStrategy({
-        currentStreamFn: vi.fn() as never,
-        model: {
-          api: "anthropic-messages",
-          provider: "cloudflare-ai-gateway",
-          id: "claude-sonnet-4-6",
-        } as never,
-        resolvedApiKey: "runtime-key",
-      }),
-    ).toBe("boundary-aware:anthropic-messages");
+  it.each([
+    { reason: "runtime auth", provider: "cloudflare-ai-gateway", resolvedApiKey: "runtime-key" },
+    { reason: "transport auth", provider: "anthropic", transportAuthAvailable: true },
+    { reason: "proxied Anthropic", provider: "cloudflare-ai-gateway" },
+  ])("records the selected transport for $reason", async ({ reason: _reason, ...routing }) => {
+    const currentStreamFn = vi.fn<StreamFn>();
+    const boundaryStreamFn = vi.fn<StreamFn>();
+    overrideBoundaryAwareStreamFnOnce(boundaryStreamFn);
+    const boundaryFactory = vi.mocked(providerTransportStream.createBoundaryAwareStreamFnForModel);
+    const initialCalls = boundaryFactory.mock.calls.length;
+    const params = {
+      currentStreamFn,
+      sessionId: "session-1",
+      model: {
+        api: "anthropic-messages",
+        provider: routing.provider,
+        id: "claude-sonnet-4-6",
+      } as never,
+      resolvedApiKey: "resolvedApiKey" in routing ? routing.resolvedApiKey : undefined,
+      transportAuthAvailable: "transportAuthAvailable" in routing && routing.transportAuthAvailable,
+    };
+    const { streamFn, strategy } = resolveEmbeddedAgentStream(params);
+
+    expect(strategy).toBe("boundary-aware:anthropic-messages");
+    expect(boundaryFactory.mock.calls.slice(initialCalls)).toEqual([[params.model]]);
+    await streamFn(params.model, { messages: [] });
+    expect(boundaryStreamFn).toHaveBeenCalledTimes(1);
+    expect(currentStreamFn).not.toHaveBeenCalled();
   });
 });
 
-describe("resolveEmbeddedAgentStreamFn", () => {
+describe("resolveEmbeddedAgentStream", () => {
   it("preserves sentinels for registered provider streams", async () => {
     const secret = "plugin-stream-secret";
     const sentinel = mintSecretSentinel(secret, { label: "model-auth:plugin" });
@@ -190,7 +204,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       id: "plugin-model",
       headers: { Authorization: `Bearer ${sentinel}` },
     } as never;
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       providerStreamFn: providerStreamFn as never,
       sessionId: "session-1",
@@ -231,7 +245,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
   it("preserves run session identity in boundary-aware OpenAI transports", async () => {
     const innerStreamFn = vi.fn(async (_model, _context, options) => options);
     overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       model: {
@@ -255,7 +269,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     // markers stripped before the harness sees system prompt text.
     const nativeStreamFn = vi.fn(async (_model, context, options) => ({ context, options }));
     useNativeStreamFn(nativeStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       model: {
@@ -365,7 +379,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const initialBoundaryCalls = boundaryStreamFactory.mock.calls.length;
 
     try {
-      const embeddedStreamFn = resolveEmbeddedAgentStreamFnImpl({
+      const { streamFn: embeddedStreamFn } = resolveEmbeddedAgentStreamImpl({
         currentStreamFn: sessionBaseStream,
         model,
         sessionId: "session-websocket",
@@ -445,7 +459,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
         bindStreamLlmRuntime(customStream, { ...llmRuntime } as LlmRuntime);
       }
 
-      const streamFn = resolveEmbeddedAgentStreamFn({
+      const { streamFn } = resolveEmbeddedAgentStream({
         currentStreamFn: customStream as StreamFn,
         sessionId: "custom-session",
         model: {
@@ -460,7 +474,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
   );
 
   it("routes GitHub Copilot fallbacks through boundary-aware transports", () => {
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       model: {
@@ -487,7 +501,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const currentStreamFn = vi.fn(async (_model, _context, options) => options);
     const innerStreamFn = vi.fn(async (_model, _context, options) => options);
     overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: currentStreamFn as never,
       sessionId: "session-1",
       model: {
@@ -521,7 +535,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const innerStreamFn = vi.fn(async (_model, _context, options) => options);
     overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
 
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: nativeStreamFn,
       sessionId: "session-1",
       model: {
@@ -546,7 +560,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const innerStreamFn = vi.fn(async (_model, _context, options) => options);
     overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
 
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: currentStreamFn as never,
       sessionId: "session-1",
       model: {
@@ -576,7 +590,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const authStorage = {
       getApiKey: vi.fn(async () => "storage-key"),
     };
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       providerStreamFn,
       sessionId: "session-1",
@@ -602,7 +616,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     // Cron and shared runs can use a stable prompt cache key while keeping each
     // run's session id distinct for transcripts and aborts.
     const providerStreamFn = vi.fn(async (_model, _context, options) => options);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       providerStreamFn,
       sessionId: "run-session",
@@ -628,7 +642,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
 
   it("does not overwrite caller-supplied prompt cache identity", async () => {
     const providerStreamFn = vi.fn(async (_model, _context, options) => options);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       providerStreamFn,
       sessionId: "run-session",
@@ -653,7 +667,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
 
   it("propagates prompt cache identity into custom session streams", async () => {
     const currentStreamFn = vi.fn(async (_model, _context, options) => options);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: currentStreamFn as never,
       sessionId: "run-session",
       promptCacheKey: "cron-cache-key",
@@ -684,7 +698,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       if (provider === "anthropic-vertex") {
         streamMocks.anthropicVertex.mockReturnValueOnce(currentStreamFn);
       }
-      const streamFn = resolveEmbeddedAgentStreamFn({
+      const { streamFn } = resolveEmbeddedAgentStream({
         currentStreamFn: currentStreamFn as never,
         sessionId: "session-1",
         model: {
@@ -711,7 +725,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     }
     const runController = new AbortController();
     const callerController = new AbortController();
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: currentStreamFn as never,
       sessionId: "session-1",
       signal: runController.signal,
@@ -740,7 +754,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     async (signalOwner) => {
       const providerStreamFn = vi.fn(async (_model, _context, options) => options);
       const signal = new AbortController().signal;
-      const streamFn = resolveEmbeddedAgentStreamFn({
+      const { streamFn } = resolveEmbeddedAgentStream({
         currentStreamFn: undefined,
         providerStreamFn,
         sessionId: "session-1",
@@ -781,7 +795,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       if (abortBeforeResolve) {
         abortedController.abort(abortReason);
       }
-      const streamFn = resolveEmbeddedAgentStreamFn({
+      const { streamFn } = resolveEmbeddedAgentStream({
         currentStreamFn: undefined,
         providerStreamFn,
         sessionId: "session-1",
@@ -810,7 +824,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
   it("injects the resolved run api key into the OpenClaw native Codex Responses fallback", async () => {
     const nativeStreamFn = vi.fn(async (_model, _context, options) => options);
     useNativeStreamFn(nativeStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       model: {
@@ -835,7 +849,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       getApiKey: vi.fn(async () => "stored-bearer-token"),
     };
     useNativeStreamFn(nativeStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       model: {
@@ -858,7 +872,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const nativeStreamFn = vi.fn(async (_model, _context, options) => options);
     const runSignal = new AbortController().signal;
     useNativeStreamFn(nativeStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       signal: runSignal,
@@ -885,7 +899,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
       const runController = new AbortController();
       const callerController = new AbortController();
       useNativeStreamFn(nativeStreamFn as never);
-      const streamFn = resolveEmbeddedAgentStreamFn({
+      const { streamFn } = resolveEmbeddedAgentStream({
         currentStreamFn: undefined,
         sessionId: "session-1",
         signal: runController.signal,
@@ -913,7 +927,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     const nativeStreamFn = vi.fn(async (_model, _context, options) => options);
     const runSignal = new AbortController().signal;
     useNativeStreamFn(nativeStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       signal: runSignal,
@@ -934,7 +948,7 @@ describe("resolveEmbeddedAgentStreamFn", () => {
   it("strips cache boundary markers on the OpenClaw native fallback path", async () => {
     const nativeStreamFn = vi.fn(async (_model, context, _options) => context);
     useNativeStreamFn(nativeStreamFn as never);
-    const streamFn = resolveEmbeddedAgentStreamFn({
+    const { streamFn } = resolveEmbeddedAgentStream({
       currentStreamFn: undefined,
       sessionId: "session-1",
       model: {

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -94,43 +94,6 @@ function resolveOpenClawNativeCodexResponsesStreamFn(params: {
   return params.currentStreamFn ?? params.llmRuntime.streamSimple;
 }
 
-export function describeEmbeddedAgentStreamStrategy(
-  params: EmbeddedStreamRuntimeOwner & {
-    providerStreamFn?: StreamFn;
-    model: EmbeddedRunAttemptParams["model"];
-    resolvedApiKey?: string;
-  },
-): string {
-  const llmRuntime = resolveEmbeddedStreamRuntime(params);
-  if (params.providerStreamFn) {
-    return "provider";
-  }
-  if (params.model.provider === "anthropic-vertex") {
-    return "anthropic-vertex";
-  }
-  if (
-    resolveOpenClawNativeCodexResponsesStreamFn({
-      model: params.model,
-      currentStreamFn: params.currentStreamFn,
-      llmRuntime,
-    })
-  ) {
-    return "openclaw-native-codex-responses";
-  }
-  if (isDefaultOpenClawStreamFnForModel(params.model, params.currentStreamFn, llmRuntime)) {
-    return createBoundaryAwareStreamFnForModel(params.model)
-      ? `boundary-aware:${params.model.api}`
-      : "stream-simple";
-  }
-  if (
-    hasResolvedRuntimeApiKey(params.resolvedApiKey) &&
-    createBoundaryAwareStreamFnForModel(params.model)
-  ) {
-    return `boundary-aware:${params.model.api}`;
-  }
-  return "session-custom";
-}
-
 export async function resolveEmbeddedAgentApiKey(params: {
   provider: string;
   resolvedApiKey?: string;
@@ -143,7 +106,7 @@ export async function resolveEmbeddedAgentApiKey(params: {
   return params.authStorage ? await params.authStorage.getApiKey(params.provider) : undefined;
 }
 
-export function resolveEmbeddedAgentStreamFn(
+export function resolveEmbeddedAgentStream(
   params: EmbeddedStreamRuntimeOwner & {
     providerStreamFn?: StreamFn;
     sessionId: string;
@@ -155,107 +118,97 @@ export function resolveEmbeddedAgentStreamFn(
     authProfileId?: string;
     authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
   },
-): StreamFn {
+): { streamFn: StreamFn; strategy: string } {
   const llmRuntime = resolveEmbeddedStreamRuntime(params);
+  const wrapOptions = {
+    runSignal: params.signal,
+    resolvedApiKey: params.resolvedApiKey,
+    authProfileId: params.authProfileId,
+    authStorage: params.authStorage,
+    providerId: params.model.provider,
+    promptCacheKey: params.promptCacheKey,
+  };
+  const stripCacheBoundary = (context: Parameters<StreamFn>[1]) =>
+    context.systemPrompt
+      ? { ...context, systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt) }
+      : context;
   if (params.providerStreamFn) {
-    return wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
-      runSignal: params.signal,
-      resolvedApiKey: params.resolvedApiKey,
-      authProfileId: params.authProfileId,
-      authStorage: params.authStorage,
-      providerId: params.model.provider,
-      promptCacheKey: params.promptCacheKey,
-      transformContext: (context) =>
-        context.systemPrompt
-          ? {
-              ...context,
-              systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt),
-            }
-          : context,
-    });
+    return {
+      streamFn: wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
+        ...wrapOptions,
+        transformContext: stripCacheBoundary,
+      }),
+      strategy: "provider",
+    };
   }
 
   const currentStreamFn = params.currentStreamFn ?? llmRuntime.streamSimple;
   if (params.model.provider === "anthropic-vertex") {
     const vertexStreamFn = createAnthropicVertexStreamFnForModel(params.model);
-    return params.signal
-      ? wrapEmbeddedAgentStreamFn(vertexStreamFn, {
-          runSignal: params.signal,
-          providerId: params.model.provider,
-        })
-      : vertexStreamFn;
+    return {
+      streamFn: params.signal
+        ? wrapEmbeddedAgentStreamFn(vertexStreamFn, {
+            runSignal: params.signal,
+            providerId: params.model.provider,
+          })
+        : vertexStreamFn,
+      strategy: "anthropic-vertex",
+    };
   }
 
-  const openClawNativeCodexResponsesStreamFn = resolveOpenClawNativeCodexResponsesStreamFn({
+  const nativeStreamFn = resolveOpenClawNativeCodexResponsesStreamFn({
     model: params.model,
     currentStreamFn: params.currentStreamFn,
     llmRuntime,
   });
-  if (openClawNativeCodexResponsesStreamFn) {
-    return wrapEmbeddedAgentStreamFn(openClawNativeCodexResponsesStreamFn, {
-      runSignal: params.signal,
-      resolvedApiKey: params.resolvedApiKey,
-      authProfileId: params.authProfileId,
-      authStorage: params.authStorage,
-      providerId: params.model.provider,
-      sessionId: params.sessionId,
-      promptCacheKey: params.promptCacheKey,
-      transformContext: (context) =>
-        context.systemPrompt
-          ? {
-              ...context,
-              systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt),
-            }
-          : context,
-    });
+  if (nativeStreamFn) {
+    return {
+      streamFn: wrapEmbeddedAgentStreamFn(nativeStreamFn, {
+        ...wrapOptions,
+        sessionId: params.sessionId,
+        transformContext: stripCacheBoundary,
+      }),
+      strategy: "openclaw-native-codex-responses",
+    };
   }
 
+  const isDefault = isDefaultOpenClawStreamFnForModel(
+    params.model,
+    params.currentStreamFn,
+    llmRuntime,
+  );
   if (
-    isDefaultOpenClawStreamFnForModel(params.model, params.currentStreamFn, llmRuntime) ||
+    isDefault ||
     hasResolvedRuntimeApiKey(params.resolvedApiKey) ||
     params.transportAuthAvailable ||
-    // Proxied anthropic-messages providers (provider !== "anthropic", e.g. pioneer)
-    // must use the boundary-aware managed transport even without a resolved runtime
-    // key — it is the only place a tool-using turn's narration gets tagged
-    // phase:commentary; the base SDK stream never tags it, so proxied anthropic
-    // providers silently lost their narration lane. Scoped to non-"anthropic"
-    // providers so direct-anthropic edge cases (thinking-replay repair without a
-    // resolved key) are unchanged; the wrap below injects the resolved key
-    // (fallback options.apiKey), preserving x-api-key auth.
+    // Proxied Anthropic streams need the managed transport's commentary tagging
+    // even without a resolved key; direct Anthropic keeps its existing replay path.
     (params.model.api === "anthropic-messages" && params.model.provider !== "anthropic")
   ) {
     const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
     if (boundaryAwareStreamFn) {
-      // Some OpenClaw session factories return a provider-specific stream wrapper
-      // once runtime auth is resolved. Keep transport-supported APIs on
-      // OpenClaw's HTTP transport so provider-specific auth/header semantics
-      // are not lost behind that wrapper.
-      // Boundary-aware transports read credentials from options.apiKey just
-      // like provider-owned streams, but the embedded run layer never gets to
-      // inject the resolved runtime key for them. Without this wrap, OAuth
-      // providers (e.g. openai/gpt-5.5 over ChatGPT OAuth) hit the Responses API with an
-      // empty bearer and fail with 401 Missing bearer auth header.
-      return wrapEmbeddedAgentStreamFn(boundaryAwareStreamFn, {
-        runSignal: params.signal,
-        resolvedApiKey: params.resolvedApiKey,
-        authProfileId: params.authProfileId,
-        authStorage: params.authStorage,
-        providerId: params.model.provider,
-        sessionId: params.sessionId,
-        promptCacheKey: params.promptCacheKey,
-      });
+      return {
+        streamFn: wrapEmbeddedAgentStreamFn(boundaryAwareStreamFn, {
+          ...wrapOptions,
+          sessionId: params.sessionId,
+        }),
+        strategy: `boundary-aware:${params.model.api}`,
+      };
     }
   }
 
   const promptCacheKey = params.promptCacheKey?.trim();
-  if (!promptCacheKey && !params.signal) {
-    return currentStreamFn;
-  }
-  return wrapEmbeddedAgentStreamFn(currentStreamFn, {
-    runSignal: params.signal,
-    providerId: params.model.provider,
-    promptCacheKey,
-  });
+  return {
+    streamFn:
+      !promptCacheKey && !params.signal
+        ? currentStreamFn
+        : wrapEmbeddedAgentStreamFn(currentStreamFn, {
+            runSignal: params.signal,
+            providerId: params.model.provider,
+            promptCacheKey,
+          }),
+    strategy: isDefault ? "stream-simple" : "session-custom",
+  };
 }
 
 /** Preserve request activity across cancellation composition without retaining completed turns. */

--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -5,6 +5,7 @@ import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import type { AssistantMessage } from "../llm/types.js";
 import {
   emitAssistantTextDeltaAndEnd,
+  emitAssistantTextDelta,
   createSubscribedSessionHarness,
   emitMessageStartAndEndForAssistantText,
 } from "./embedded-agent-subscribe.e2e-harness.js";
@@ -199,9 +200,12 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       blockReplyBreak: "message_end",
     });
 
-    emitAssistantTextDeltaAndEnd({
-      emit,
-      text: "Visible stream.",
+    for (const delta of ["Visible", " stream", "."]) {
+      emitAssistantTextDelta({ emit, delta });
+    }
+    emit({
+      type: "message_end",
+      message: { role: "assistant", content: [{ type: "text", text: "Visible stream." }] },
     });
     expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
     expect(onPartialReply).not.toHaveBeenCalled();
@@ -219,8 +223,17 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     });
 
     await subscription.waitForPendingEvents();
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
-    expect(onPartialReply).toHaveBeenCalled();
+    const assistantEvents = onAgentEvent.mock.calls.filter(
+      ([event]) => event.stream === "assistant",
+    );
+    expect(assistantEvents).toHaveLength(1);
+    expect(assistantEvents[0]?.[0].data).toMatchObject({
+      text: "Visible stream.",
+      delta: "Visible stream.",
+    });
+    expect(onPartialReply).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ text: "Visible stream.", delta: "Visible stream." }),
+    );
     expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(true);
   });
 

--- a/src/agents/embedded-agent-subscribe.callback.ts
+++ b/src/agents/embedded-agent-subscribe.callback.ts
@@ -4,20 +4,31 @@ type CallbackLogger = {
   warn(message: string): void;
 };
 
-/** Contains failures from untracked subscriber presentation and telemetry callbacks. */
+/** Contains callback failures and tracks completion for delivery owners that join it. */
 export function runBestEffortCallback(params: {
   callback: () => unknown;
   label: string;
   log: CallbackLogger;
+  pending?: Set<Promise<void>>;
+  onSuccess?: () => void;
+  onError?: (error: unknown) => void;
 }): void {
+  const failed = (error: unknown) => {
+    params.onError?.(error);
+    params.log.warn(`${params.label} callback failed: ${String(error)}`);
+  };
   try {
     const result = params.callback();
     if (isPromiseLike(result)) {
-      void Promise.resolve(result).catch((error: unknown) => {
-        params.log.warn(`${params.label} callback failed: ${String(error)}`);
-      });
+      const task = Promise.resolve(result).then(() => params.onSuccess?.(), failed);
+      if (params.pending) {
+        params.pending.add(task);
+        void task.finally(() => params.pending?.delete(task));
+      }
+    } else {
+      params.onSuccess?.();
     }
   } catch (error) {
-    params.log.warn(`${params.label} callback failed: ${String(error)}`);
+    failed(error);
   }
 }

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -89,9 +89,9 @@ function createContext(
     flushBlockReplyBuffer: vi.fn(),
     emitBlockReply,
     emitAssistantStreamData: vi.fn(),
-    flushDeferredAssistantEvents: vi.fn(),
+    flushAssistantStream: vi.fn(),
     flushDeferredBlockReplies: vi.fn(),
-    clearDeferredAssistantEvents: vi.fn(),
+    clearAssistantStream: vi.fn(),
     clearDeferredBlockReplies: vi.fn(),
     resolveCompactionRetry: vi.fn(),
     maybeResolveCompactionWait: vi.fn(),
@@ -1096,9 +1096,9 @@ describe("handleAgentEnd", () => {
       expect(logger.error).toHaveBeenCalledWith(
         "[hooks] before_agent_finalize handler from test-plugin failed: timed out after 15000ms",
       );
-      expect(ctx.clearDeferredAssistantEvents).not.toHaveBeenCalled();
+      expect(ctx.clearAssistantStream).not.toHaveBeenCalled();
       expect(ctx.clearDeferredBlockReplies).not.toHaveBeenCalled();
-      expect(ctx.flushDeferredAssistantEvents).toHaveBeenCalledTimes(1);
+      expect(ctx.flushAssistantStream).toHaveBeenCalledTimes(1);
       expect(ctx.flushDeferredBlockReplies).toHaveBeenCalledTimes(1);
       expect(ctx.flushBlockReplyBuffer).toHaveBeenCalledWith({ final: true });
       expect(ctx.resolveCompactionRetry).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -330,7 +330,7 @@ export function handleAgentEnd(
 
   const deliverTerminal = () => {
     ctx.state.deferBlockReplyDelivery = false;
-    ctx.flushDeferredAssistantEvents();
+    ctx.flushAssistantStream();
     ctx.flushDeferredBlockReplies();
     const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer({ final: true });
     finalizeAgentEnd();
@@ -370,7 +370,7 @@ export function handleAgentEnd(
   };
 
   const suppressTerminalDelivery = () => {
-    ctx.clearDeferredAssistantEvents();
+    ctx.clearAssistantStream();
     ctx.clearDeferredBlockReplies();
     finalizeAgentEnd();
   };

--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -16,7 +16,6 @@ import {
   resolveManagedStreamMediaUrls,
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import {
-  buildAssistantStreamData,
   emitAssistantCommentaryStreamData,
   emitAssistantMessageStart,
   emitReasoningEnd,
@@ -144,7 +143,7 @@ export function handleMessageEnd(
   // Final media is emitted after the buffered text drains, never on its first chunk.
   recordPendingAssistantReplyDirectives(ctx.state, parsedText);
   const cleanedText = parsedText.text;
-  const { mediaUrls } = resolveSendableOutboundReplyParts(parsedText);
+  const { mediaUrls } = resolveSendableOutboundReplyParts(parsedText, { text: "" });
   const managedMediaUrls = resolveManagedStreamMediaUrls(ctx.state, mediaUrls);
 
   const sourceMessage = { ...assistantMessage, content: sourceContent };
@@ -248,13 +247,16 @@ export function handleMessageEnd(
     !suppressDeterministicApprovalOutput &&
     !suppressMessageToolOnlySourceReplyOutput
   ) {
-    const data = buildAssistantStreamData({
-      text: cleanedText,
-      mediaUrls,
-      managedMediaUrls,
-      phase: assistantPhase,
-    });
-    ctx.emitAssistantStreamData(data, { finalMessage: true });
+    ctx.emitAssistantStreamData(
+      {
+        text: cleanedText,
+        delta: "",
+        mediaUrls: mediaUrls.length ? mediaUrls : undefined,
+        managedMediaUrls: managedMediaUrls.length ? managedMediaUrls : undefined,
+        phase: assistantPhase,
+      },
+      { finalMessage: true },
+    );
   }
 
   const silentExpectedWithoutSentinel =

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream-replies.test.ts
@@ -5,7 +5,6 @@ import {
   recordPendingAssistantReplyDirectives,
   resolveManagedStreamMediaUrls,
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
-import { buildAssistantStreamData } from "./embedded-agent-subscribe.handlers.messages.stream.js";
 
 describe("hasAssistantVisibleReply", () => {
   it("treats audio-only payloads as visible", () => {
@@ -19,27 +18,7 @@ describe("hasAssistantVisibleReply", () => {
   });
 });
 
-describe("buildAssistantStreamData", () => {
-  it.each([true, false, undefined])("normalizes media and replacement flag %s", (replace) => {
-    expect(
-      buildAssistantStreamData({
-        text: "hello",
-        delta: "he",
-        replace,
-        mediaUrl: "https://example.com/a.png",
-        managedMediaUrls: ["https://example.com/a.png"],
-        phase: "final_answer",
-      }),
-    ).toEqual({
-      text: "hello",
-      delta: "he",
-      replace: replace || undefined,
-      mediaUrls: ["https://example.com/a.png"],
-      managedMediaUrls: ["https://example.com/a.png"],
-      phase: "final_answer",
-    });
-  });
-
+describe("assistant stream managed media", () => {
   it("keeps generic directive URLs separate from tool-owned managed media", () => {
     const state = {
       pendingToolMediaTrustByUrl: new Map([

--- a/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.stream.ts
@@ -3,7 +3,6 @@
  */
 import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import {
   parseReplyDirectives,
@@ -16,7 +15,6 @@ import { normalizeTextForComparison } from "./embedded-agent-helpers.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { hasReplyDirectiveMetadata } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import type {
-  AssistantStreamData,
   EmbeddedAgentSubscribeContext,
   EmbeddedAgentSubscribeState,
 } from "./embedded-agent-subscribe.handlers.types.js";
@@ -229,12 +227,7 @@ export function emitAssistantCommentaryStreamData(
       ? itemId
       : resolveAssistantStreamItemId({ message });
     ctx.emitAssistantStreamData(
-      buildAssistantStreamData({
-        text,
-        replace: true,
-        phase: "commentary",
-        itemId: commentaryItemId,
-      }),
+      { text, delta: "", replace: true, phase: "commentary", itemId: commentaryItemId },
       { finalMessage },
     );
   }
@@ -244,6 +237,7 @@ export function emitReasoningEnd(ctx: EmbeddedAgentSubscribeContext) {
   if (!ctx.state.reasoningStreamOpen) {
     return;
   }
+  ctx.flushAssistantStream();
   ctx.state.reasoningStreamOpen = false;
   runBestEffortCallback({
     label: "reasoning end",
@@ -253,6 +247,7 @@ export function emitReasoningEnd(ctx: EmbeddedAgentSubscribeContext) {
 }
 
 export function emitAssistantMessageStart(ctx: EmbeddedAgentSubscribeContext) {
+  ctx.flushAssistantStream();
   runBestEffortCallback({
     label: "assistant message start",
     log: ctx.log,
@@ -261,6 +256,9 @@ export function emitAssistantMessageStart(ctx: EmbeddedAgentSubscribeContext) {
 }
 
 export function openReasoningStream(ctx: EmbeddedAgentSubscribeContext) {
+  if (!ctx.state.reasoningStreamOpen) {
+    ctx.flushAssistantStream();
+  }
   ctx.state.reasoningStreamOpen = true;
 }
 
@@ -396,20 +394,5 @@ export function resolveStreamingReply(params: {
     delta: replace ? "" : (delta ?? text.slice(params.previousCleaned.length)),
     replace,
     hasText: Boolean(isAppend ? text : text.trim()),
-  };
-}
-
-export function buildAssistantStreamData(
-  params: Partial<Omit<AssistantStreamData, "replace">> & { replace?: boolean; mediaUrl?: string },
-): AssistantStreamData {
-  const mediaUrls = resolveSendableOutboundReplyParts(params, { text: "" }).mediaUrls;
-  return {
-    text: params.text ?? "",
-    delta: params.delta ?? "",
-    replace: params.replace ? true : undefined,
-    mediaUrls: mediaUrls.length ? mediaUrls : undefined,
-    managedMediaUrls: params.managedMediaUrls?.length ? params.managedMediaUrls : undefined,
-    phase: params.phase,
-    itemId: params.itemId,
   };
 }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test-helpers.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test-helpers.ts
@@ -67,6 +67,7 @@ export function createMessageUpdateContext(
       ),
     emitReasoningStream: params.emitReasoningStream ?? vi.fn(),
     flushBlockReplyBuffer: params.flushBlockReplyBuffer ?? vi.fn(),
+    flushAssistantStream: vi.fn(),
     blockChunker: new EmbeddedBlockChunker(),
     resetAssistantMessageState: params.resetAssistantMessageState ?? vi.fn(),
     captureModelEvent: vi.fn(),
@@ -137,6 +138,7 @@ export function createMessageEndContext(
   ctx.blockChunker.append(params.bufferedText ?? "");
   const delivery = createReplyDelivery(ctx);
   ctx.emitAssistantStreamData = delivery.emitAssistantStreamData;
+  ctx.flushAssistantStream = delivery.flushAssistantStream;
   ctx.emitBlockReply = vi.fn(delivery.emitBlockReply);
   ctx.finalizeAssistantTexts =
     params.finalizeAssistantTexts ?? vi.fn(delivery.finalizeAssistantTexts);

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -4,7 +4,6 @@
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import type { AssistantMessage } from "../llm/types.js";
-import { coerceChatContentText } from "../shared/chat-content.js";
 import { resolveAssistantMessagePhase } from "../shared/chat-message-content.js";
 import { createTextProjection, trimTextFilter } from "../shared/text/text-projection.js";
 import { updateLiveEditDiffProgress } from "./embedded-agent-live-edit-diff.js";
@@ -14,7 +13,6 @@ import {
   recordPendingAssistantReplyDirectives,
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import {
-  buildAssistantStreamData,
   emitAssistantCommentaryStreamData,
   emitAssistantMessageStart,
   emitReasoningEnd,
@@ -67,6 +65,9 @@ export function handleMessageUpdate(
       ? (assistantEvent as Record<string, unknown>)
       : undefined;
   const evtType = typeof assistantRecord?.type === "string" ? assistantRecord.type : "";
+  if (evtType !== "text_delta") {
+    ctx.flushAssistantStream();
+  }
   const liveEditDiff = updateLiveEditDiffProgress(ctx.state.liveEditDiffStateById, assistantRecord);
   if (liveEditDiff) {
     const data = { phase: "input_delta", ...liveEditDiff };
@@ -87,7 +88,9 @@ export function handleMessageUpdate(
   const assistantPhase = resolveAssistantMessagePhase(msg);
   const suppressVisibleAssistantOutput = assistantPhase === "commentary";
   if (suppressVisibleAssistantOutput && !isResponsesTextEvent) {
-    const commentaryText = coerceChatContentText(extractAssistantCommentaryText(msg));
+    // Even hidden commentary closes the preceding visible-text scope.
+    ctx.flushAssistantStream();
+    const commentaryText = extractAssistantCommentaryText(msg);
     if (commentaryText) {
       appendRawStream(() => ({
         ts: Date.now(),
@@ -221,6 +224,7 @@ export function handleMessageUpdate(
   }
   if (streamContentIndex !== undefined) {
     if (streamContentIndex !== ctx.state.lastAssistantStreamContentIndex) {
+      ctx.flushAssistantStream();
       ctx.state.streamBlockText = "";
       ctx.state.streamBlockOffset = ctx.blockChunker.sourceLength;
     }
@@ -248,18 +252,18 @@ export function handleMessageUpdate(
     }
     const commentaryText = isResponsesCommentary
       ? ctx.state.deltaBuffer
-      : coerceChatContentText(extractAssistantCommentaryText(streamAssistant));
-    const commentaryData =
-      commentaryText && (chunk || !hadResponsesCommentaryText || evtType === "text_end")
-        ? buildAssistantStreamData({
-            text: commentaryText,
-            replace: true,
-            phase: "commentary",
-            itemId: deliveryItemId,
-          })
-        : undefined;
-    if (commentaryData) {
-      ctx.emitAssistantStreamData(commentaryData, { finalMessage: evtType === "text_end" });
+      : extractAssistantCommentaryText(streamAssistant);
+    if (commentaryText && (chunk || !hadResponsesCommentaryText || evtType === "text_end")) {
+      ctx.emitAssistantStreamData(
+        {
+          text: commentaryText,
+          delta: "",
+          replace: true,
+          phase: "commentary",
+          itemId: deliveryItemId,
+        },
+        { finalMessage: evtType === "text_end" },
+      );
     }
     return undefined;
   }
@@ -564,13 +568,15 @@ export function handleMessageUpdate(
             })
           : { hold: false, text: cleanedText };
       const releaseHeldSnapshot = currentSourcePartial.text !== cleanedText;
-      const data = buildAssistantStreamData({
-        text: currentSourcePartial.text,
-        delta: releaseHeldSnapshot ? currentSourcePartial.text : deltaText,
-        replace: releaseHeldSnapshot || replace,
-        phase: deliveryPhase ?? assistantPhase,
-      });
-      ctx.emitAssistantStreamData(data, { emitPartialReply: !currentSourcePartial.hold });
+      ctx.emitAssistantStreamData(
+        {
+          text: currentSourcePartial.text,
+          delta: releaseHeldSnapshot ? currentSourcePartial.text : deltaText,
+          replace: releaseHeldSnapshot || replace || undefined,
+          phase: deliveryPhase ?? assistantPhase,
+        },
+        { emitPartialReply: !currentSourcePartial.hold },
+      );
     }
   }
 

--- a/src/agents/embedded-agent-subscribe.handlers.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.ts
@@ -28,6 +28,9 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
     // suppression flags would discard those events instead of preserving order.
     const run = () => {
       try {
+        if (evt.type !== "message_update") {
+          ctx.flushAssistantStream();
+        }
         return handler();
       } catch (err) {
         ctx.log.debug(`${evt.type} handler failed: ${String(err)}`);

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -68,14 +68,6 @@ export type AssistantStreamData = {
   itemId?: string;
 };
 
-/** Deferred assistant stream event plus whether it should emit partial replies. */
-type AssistantStreamDelivery = {
-  data: AssistantStreamData;
-  eventData?: AssistantStreamData;
-  emitPartialReply: boolean;
-  finalMessage?: boolean;
-};
-
 /** Incremental tag and Markdown parsing state, owned by one stream lane. */
 export type StreamBlockState = {
   thinking: boolean;
@@ -172,7 +164,6 @@ export type EmbeddedAgentSubscribeState = {
   lastDeliveredBlockReplyText?: string;
   deferBlockReplyDelivery: boolean;
   deferredBlockReplies: BlockReplyPayload[];
-  deferredAssistantEvents: AssistantStreamDelivery[];
   toolExecutionSinceLastBlockReply: boolean;
   reasoningStreamOpen: boolean;
   assistantMessageIndex: number;
@@ -308,9 +299,9 @@ export type EmbeddedAgentSubscribeContext = {
     payload: BlockReplyPayload,
     options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
   ) => void;
-  flushDeferredAssistantEvents: () => void;
+  flushAssistantStream: () => void;
   flushDeferredBlockReplies: () => void;
-  clearDeferredAssistantEvents: () => void;
+  clearAssistantStream: () => void;
   clearDeferredBlockReplies: () => void;
 };
 

--- a/src/agents/embedded-agent-subscribe.partial-reply-lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.partial-reply-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 
 const logger = vi.hoisted(() => ({
   debug: vi.fn(),
@@ -14,7 +15,24 @@ vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: () => logger,
 }));
 
-import { createSubscribedSessionHarness } from "./embedded-agent-subscribe.e2e-harness.js";
+import {
+  createStubSessionHarness,
+  createSubscribedSessionHarness,
+  emitAssistantTextDelta,
+} from "./embedded-agent-subscribe.e2e-harness.js";
+import { createReplyDelivery } from "./embedded-agent-subscribe.reply-delivery.js";
+import { createEmbeddedAgentSubscribeState } from "./embedded-agent-subscribe.run-state.js";
+import type { SubscribeEmbeddedAgentSessionParams } from "./embedded-agent-subscribe.types.js";
+
+function createDelivery(params: Omit<SubscribeEmbeddedAgentSessionParams, "session">) {
+  const { session } = createStubSessionHarness();
+  const options = { ...params, session };
+  return createReplyDelivery({
+    params: options,
+    state: createEmbeddedAgentSubscribeState(options),
+    log: logger,
+  });
+}
 
 function emitPartialThenProviderFailure(emit: (event: unknown) => void): void {
   emit({
@@ -89,60 +107,287 @@ describe("subscribeEmbeddedAgentSession partial reply lifecycle", () => {
     });
 
     await vi.waitFor(() => expect(onPartialReply).toHaveBeenCalledOnce());
+    emitAssistantTextDelta({ emit, delta: " queued" });
+    emitAssistantTextDelta({ emit, delta: " tail" });
+    await subscription.waitForPendingEvents({ includePartialReplies: false });
+    expect(onPartialReply).toHaveBeenCalledOnce();
     subscription.unsubscribe();
     rejectPartial?.(callbackError);
     await expect(subscription.waitForPendingEvents()).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
       `assistant partial reply callback failed: ${String(callbackError)}`,
     );
+    expect(onPartialReply).toHaveBeenCalledOnce();
   });
 
-  it("queue-only drain is not blocked by a stalled partial reply callback", async () => {
-    // Timeout salvage drains only the serialized event chain — the queue whose handlers mutate the assistant
-    // text buffer. A stalled onPartialReply transport callback is external
-    // fan-out and cannot change the buffered text, so it must not hold an
-    // already-aborted run in settlement. Pre-fix, the salvage path used
-    // waitForPendingEvents, which also awaits pendingPartialReplyTasks; a
-    // stalled callback would block the drain until the bounded liveness
-    // deadline (120s) elapsed.
-    let resolvePartialReply!: () => void;
-    const partialReply = new Promise<void>((resolve) => {
-      resolvePartialReply = resolve;
-    });
-    const onPartialReply = vi.fn(() => partialReply);
+  it("queue-only drain coalesces a stalled partial and joins its latest successor", async () => {
+    const first = createDeferred();
+    const latest = createDeferred();
+    const onPartialReply = vi.fn(() => latest.promise).mockImplementationOnce(() => first.promise);
+    const onAgentEvent = vi.fn();
     const { emit, subscription } = createSubscribedSessionHarness({
       runId: "run-stalled-partial-callback",
       onPartialReply,
+      onAgentEvent,
     });
+    try {
+      for (const delta of ["First", " second", " third"]) {
+        emitAssistantTextDelta({ emit, delta });
+      }
+      let broadDrained = false;
+      const broadDrain = subscription.waitForPendingEvents().then(() => {
+        broadDrained = true;
+      });
+      // Timeout salvage joins only handlers that mutate the raw text buffer.
+      await subscription.waitForPendingEvents({ includePartialReplies: false });
+      expect(broadDrained).toBe(false);
+      expect(onPartialReply).toHaveBeenCalledOnce();
+      expect(onPartialReply).toHaveBeenLastCalledWith(
+        expect.objectContaining({ text: "First", delta: "First" }),
+      );
+      const assistantEvents = onAgentEvent.mock.calls.filter(
+        ([event]) => event.stream === "assistant",
+      );
+      expect(assistantEvents).toHaveLength(3);
 
-    // First delta keeps the partial-reply callback pending through the queue-only drain.
-    emit({
-      type: "message_update",
-      message: { role: "assistant" },
-      assistantMessageEvent: { type: "text_delta", delta: "partial " },
-    });
-    await vi.waitFor(() => expect(onPartialReply).toHaveBeenCalledOnce());
-
-    // A second delta queues behind the first on the serialized event chain.
-    emit({
-      type: "message_update",
-      message: { role: "assistant" },
-      assistantMessageEvent: { type: "text_delta", delta: "answer" },
-    });
-
-    let broadDrained = false;
-    const broadDrain = subscription.waitForPendingEvents().then(() => {
-      broadDrained = true;
-    });
-
-    // The event chain drains while the broad join still waits for the callback.
-    await subscription.waitForPendingEvents({ includePartialReplies: false });
-    expect(broadDrained).toBe(false);
-
-    resolvePartialReply();
-    await broadDrain;
-    expect(broadDrained).toBe(true);
-
-    subscription.unsubscribe();
+      first.resolve();
+      await vi.waitFor(() => expect(onPartialReply).toHaveBeenCalledTimes(2));
+      expect(onPartialReply).toHaveBeenLastCalledWith(
+        expect.objectContaining({ text: "First second third", delta: " second third" }),
+      );
+      expect(broadDrained).toBe(false);
+      latest.resolve();
+      await broadDrain;
+      expect(broadDrained).toBe(true);
+    } finally {
+      first.resolve();
+      latest.resolve();
+      subscription.unsubscribe();
+      await subscription.waitForPendingEvents();
+    }
   });
+
+  it.each(["provider", "nested"] as const)(
+    "starts the latest partial before a %s tool without waiting for a stalled send",
+    async (source) => {
+      const pending = createDeferred();
+      const starts: string[] = [];
+      const { emit, subscription } = createSubscribedSessionHarness({
+        runId: `run-partial-${source}-tool`,
+        onPartialReply: (payload) => {
+          starts.push(`partial:${payload.text}`);
+          return pending.promise;
+        },
+        onAgentEvent: (event) => {
+          if (event.stream === "tool" && event.data.phase === "start") {
+            starts.push("tool");
+          }
+        },
+      });
+      try {
+        for (const delta of ["First", " second", " third"]) {
+          emitAssistantTextDelta({ emit, delta });
+        }
+        await subscription.waitForPendingEvents({ includePartialReplies: false });
+        expect(starts).toEqual(["partial:First"]);
+        const tool = {
+          toolName: "read",
+          toolCallId: "read-after-text",
+          args: { path: "/tmp/input" },
+        };
+        if (source === "provider") {
+          emit({ type: "tool_execution_start", ...tool });
+        } else {
+          await subscription.runToolLifecycle({
+            ...tool,
+            execute: async (onStart) => {
+              onStart();
+              return { content: [{ type: "text", text: "Read complete." }] };
+            },
+          });
+        }
+        await subscription.waitForPendingEvents({ includePartialReplies: false });
+        expect(starts).toEqual(["partial:First", "partial:First second third", "tool"]);
+        emitAssistantTextDelta({ emit, delta: " fourth" });
+        await subscription.waitForPendingEvents({ includePartialReplies: false });
+        expect(starts.at(-1)).toBe("partial:First second third fourth");
+      } finally {
+        pending.resolve();
+        subscription.unsubscribe();
+        await subscription.waitForPendingEvents();
+      }
+    },
+  );
+
+  it("preserves both delta domains when a retired callback reenters an unemitted scope", async () => {
+    const first = createDeferred();
+    const partials: Array<{ text?: string; delta?: string }> = [];
+    const bus: Array<{ text: unknown; delta: unknown }> = [];
+    let canReenter = false;
+    const delivery: ReturnType<typeof createReplyDelivery> = createDelivery({
+      runId: "run-partial-reentrant-phase",
+      onAgentEvent: (event) => {
+        if (event.stream === "assistant") {
+          bus.push({ text: event.data.text, delta: event.data.delta });
+        }
+      },
+      onPartialReply: (payload) => {
+        partials.push({ text: payload.text, delta: payload.delta });
+        if (payload.text === "A") {
+          return first.promise;
+        }
+        if (payload.text === "AB" && canReenter) {
+          delivery.emitAssistantStreamData(
+            { text: "ABCD", delta: "D", phase: "final_answer" },
+            { emitPartialReply: true },
+          );
+        }
+        return undefined;
+      },
+    });
+    try {
+      delivery.emitAssistantStreamData({ text: "A", delta: "A" }, { emitPartialReply: true });
+      delivery.emitAssistantStreamData({ text: "AB", delta: "B" }, { emitPartialReply: true });
+      expect(partials).toEqual([{ text: "A", delta: "A" }]);
+      canReenter = true;
+      delivery.emitAssistantStreamData(
+        { text: "ABC", delta: "C", phase: "final_answer" },
+        { emitPartialReply: true },
+      );
+      expect(partials).toEqual([
+        { text: "A", delta: "A" },
+        { text: "AB", delta: "B" },
+        { text: "ABCD", delta: "CD" },
+      ]);
+      expect(bus).toEqual(partials);
+    } finally {
+      first.resolve();
+      await delivery.waitForPendingEvents();
+    }
+  });
+
+  it("starts the first partial once before a reentrant block reply", async () => {
+    const starts: string[] = [];
+    const delivery: ReturnType<typeof createReplyDelivery> = createDelivery({
+      runId: "run-partial-reentrant-block",
+      onAgentEvent: (event) => {
+        if (event.stream === "assistant") {
+          delivery.emitBlockReply({ text: "Block." });
+        }
+      },
+      onPartialReply: (payload) => {
+        starts.push(`partial:${payload.text}`);
+      },
+      onBlockReply: (payload) => {
+        starts.push(`block:${payload.text}`);
+      },
+    });
+    delivery.emitAssistantStreamData({ text: "First", delta: "First" }, { emitPartialReply: true });
+    await delivery.waitForPendingEvents();
+    expect(starts).toEqual(["partial:First", "block:Block."]);
+  });
+
+  it.each([
+    { name: "append", text: "Hello world", delta: " world", replace: undefined },
+    { name: "correct", text: "Hi", delta: "", replace: true },
+    { name: "clear", text: "", delta: "", replace: true },
+  ])(
+    "publishes an authoritative $name with normalized final media",
+    async ({ text, delta, replace }) => {
+      const onAgentEvent = vi.fn();
+      const { emit, subscription } = createSubscribedSessionHarness({
+        runId: `run-final-media-${text.length}`,
+        onAgentEvent,
+      });
+      emitAssistantTextDelta({ emit, delta: "Hello" });
+      emit({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: `${text}\nMEDIA:https://example.com/a.png`,
+              textSignature: JSON.stringify({ v: 1, id: "answer", phase: "final_answer" }),
+            },
+          ],
+        },
+      });
+      await subscription.waitForPendingEvents();
+      const final = onAgentEvent.mock.calls.findLast(([event]) => event.stream === "assistant")?.[0]
+        .data;
+      expect(final?.text).toBe(text);
+      expect(final?.delta).toBe(delta);
+      expect(final?.replace).toBe(replace);
+      expect(final?.mediaUrls).toEqual(["https://example.com/a.png"]);
+      expect(final?.managedMediaUrls).toBeUndefined();
+      expect(final?.phase).toBe("final_answer");
+      subscription.unsubscribe();
+    },
+  );
+  it.each([
+    { name: "empty", text: "", preambles: 0 },
+    { name: "sanitized empty", text: "<think>hidden reasoning</think>", preambles: 0 },
+    { name: "duplicate", text: "Working.", preambles: 1 },
+  ])(
+    "retires pending partials at a $name generic commentary boundary",
+    async ({ text, preambles }) => {
+      const pending = createDeferred();
+      const partials: Array<{ text?: string; delta?: string }> = [];
+      const onAgentEvent = vi.fn();
+      const { emit, subscription } = createSubscribedSessionHarness({
+        runId: `run-commentary-boundary-${preambles}-${text.length}`,
+        onAgentEvent,
+        onPartialReply: (payload) => {
+          partials.push({ text: payload.text, delta: payload.delta });
+          return pending.promise;
+        },
+      });
+      const message = {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text,
+            textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+          },
+        ],
+      };
+      const commentary = {
+        type: "message_update",
+        message,
+        assistantMessageEvent: { type: "text_delta", delta: "", partial: message },
+      };
+      try {
+        emit(commentary);
+        for (const delta of ["First", " second", " third"]) {
+          emitAssistantTextDelta({ emit, delta });
+        }
+        await subscription.waitForPendingEvents({ includePartialReplies: false });
+        expect(partials).toEqual([{ text: "First", delta: "First" }]);
+
+        // Phase changes retire the old partial even if no new preamble is visible.
+        emit(commentary);
+        await subscription.waitForPendingEvents({ includePartialReplies: false });
+        expect(partials).toEqual([
+          { text: "First", delta: "First" },
+          { text: "First second third", delta: " second third" },
+        ]);
+        emitAssistantTextDelta({ emit, delta: " fourth" });
+        await subscription.waitForPendingEvents({ includePartialReplies: false });
+        expect(partials.at(-1)).toEqual({
+          text: "First second third fourth",
+          delta: " fourth",
+        });
+        const preambleEvents = onAgentEvent.mock.calls.filter(
+          ([event]) => event.stream === "item" && event.data.kind === "preamble",
+        );
+        expect(preambleEvents).toHaveLength(preambles);
+      } finally {
+        pending.resolve();
+        subscription.unsubscribe();
+        await subscription.waitForPendingEvents();
+      }
+    },
+  );
 });

--- a/src/agents/embedded-agent-subscribe.reply-delivery.ts
+++ b/src/agents/embedded-agent-subscribe.reply-delivery.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import {
   getReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
@@ -23,6 +22,28 @@ import type {
 } from "./embedded-agent-subscribe.handlers.types.js";
 import type { SubscribeEmbeddedAgentSessionParams } from "./embedded-agent-subscribe.types.js";
 
+type AssistantStreamDelivery = {
+  data: AssistantStreamData;
+  eventData?: AssistantStreamData;
+  emitPartialReply: boolean;
+  finalMessage: boolean;
+  blockIndex: number;
+};
+
+type AssistantStreamScope = {
+  delivery?: AssistantStreamDelivery;
+  active?: boolean;
+  pending?: boolean;
+  emitted?: boolean;
+};
+
+const isStreamAppend = ({ data, finalMessage }: AssistantStreamDelivery) =>
+  !finalMessage && !data.replace && !data.mediaUrls?.length && !data.managedMediaUrls?.length;
+const mergeStreamAppend = (previous: AssistantStreamData, next: AssistantStreamData) => ({
+  ...next,
+  delta: previous.delta + next.delta,
+});
+
 type ReplyDeliveryParams = {
   params: SubscribeEmbeddedAgentSessionParams;
   state: EmbeddedAgentSubscribeContext["state"];
@@ -31,9 +52,39 @@ type ReplyDeliveryParams = {
 
 export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams) {
   const assistantTexts = state.assistantTexts;
+  const deferredAssistantScopes: AssistantStreamScope[] = [];
   const lastEmittedCommentaryByItem = new Map<string, string>();
   const pendingBlockReplyTasks = new Set<Promise<void>>();
   const pendingPartialReplyTasks = new Set<Promise<void>>();
+  let streamScope: AssistantStreamScope = {};
+  const drainPartialReply = (scope: AssistantStreamScope) => {
+    if (
+      !scope.delivery ||
+      !scope.pending ||
+      state.unsubscribed ||
+      (scope === streamScope && scope.active)
+    ) {
+      return;
+    }
+    const data = scope.delivery.data;
+    scope.pending = false;
+    // Reserve before invocation: callbacks may synchronously enqueue text or open another scope.
+    scope.active = true;
+    const settled = () => {
+      if (scope === streamScope) {
+        scope.active = false;
+        drainPartialReply(scope);
+      }
+    };
+    runBestEffortCallback({
+      callback: () => params.onPartialReply?.(data),
+      label: "assistant partial reply",
+      log,
+      pending: pendingPartialReplyTasks,
+      onSuccess: settled,
+      onError: settled,
+    });
+  };
   // Retry subscriptions reuse run IDs and reset message counters. Their scopes
   // must stay distinct so a correction cannot overwrite an earlier attempt.
   const streamId = randomUUID();
@@ -43,12 +94,15 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
   let prefix = "";
   let streamedText = "";
   let finalized = false;
-  const shouldAllowSilentTurnText = (text: string | undefined) =>
-    Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
-  const emitAssistantStreamDataSafely = (
-    delivery: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number],
-  ) => {
-    const { data, eventData } = delivery;
+  const emitAssistantStreamDataSafely = (scope: AssistantStreamScope) => {
+    if (!scope.delivery || scope.emitted || state.unsubscribed) {
+      return;
+    }
+    const delivery = scope.delivery;
+    const { eventData } = delivery;
+    scope.emitted = true;
+    scope.pending ||=
+      delivery.emitPartialReply && Boolean(params.onPartialReply) && state.shouldEmitPartialReplies;
     const itemId = eventData?.itemId ?? "";
     const progressText =
       eventData?.phase === "commentary" ? eventData.text.replace(/\s+/g, " ").trim() : "";
@@ -86,29 +140,15 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
         });
       }
     }
-    if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
-      try {
-        const maybeTask = params.onPartialReply(data);
-        if (isPromiseLike(maybeTask)) {
-          const task = Promise.resolve(maybeTask)
-            .then(() => undefined)
-            .catch((error: unknown) => {
-              log.warn(`assistant partial reply callback failed: ${String(error)}`);
-            });
-          pendingPartialReplyTasks.add(task);
-          void task.finally(() => {
-            pendingPartialReplyTasks.delete(task);
-          });
-        }
-      } catch (error) {
-        log.warn(`assistant partial reply callback failed: ${String(error)}`);
-      }
-    }
+    drainPartialReply(scope);
   };
   const emitAssistantStreamData: EmbeddedAgentSubscribeContext["emitAssistantStreamData"] = (
     data,
     options,
   ) => {
+    if (state.unsubscribed) {
+      return;
+    }
     let eventData: AssistantStreamData | undefined;
     if (data.phase === "commentary") {
       eventData = data;
@@ -153,34 +193,69 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
         finalized = options?.finalMessage === true;
       }
     }
-    // Project before deferral while these message/block indices are current.
-    // Channel partials retain their block-scoped payload; the bus gets a whole message.
+    // Capture both coordinate domains before any callback can advance message state.
     const delivery = {
       data,
       eventData,
       emitPartialReply: options?.emitPartialReply === true,
       finalMessage: options?.finalMessage === true,
+      blockIndex: state.assistantMessageIndex,
     };
     if (!eventData && !delivery.emitPartialReply) {
       return;
     }
-    if (state.deferBlockReplyDelivery && data.phase !== "commentary") {
-      state.deferredAssistantEvents.push(delivery);
-      return;
+    const previous = streamScope.delivery;
+    const deferred = state.deferBlockReplyDelivery && data.phase !== "commentary";
+    const coalesce =
+      previous &&
+      isStreamAppend(previous) &&
+      isStreamAppend(delivery) &&
+      previous.blockIndex === delivery.blockIndex &&
+      previous.data.phase === data.phase &&
+      previous.data.itemId === data.itemId &&
+      previous.emitPartialReply === delivery.emitPartialReply &&
+      Boolean(previous.eventData) === Boolean(eventData);
+    const scope = coalesce ? streamScope : flushAssistantStream(delivery);
+    if (coalesce) {
+      // A reentrant boundary may append before this scope has emitted its first snapshot.
+      if (!scope.emitted || scope.pending) {
+        delivery.data = mergeStreamAppend(previous.data, data);
+      }
+      if (!scope.emitted && previous.eventData && eventData) {
+        delivery.eventData = mergeStreamAppend(previous.eventData, eventData);
+      }
+      scope.delivery = delivery;
+      scope.emitted = false;
     }
-    emitAssistantStreamDataSafely(delivery);
+    if (!deferred) {
+      emitAssistantStreamDataSafely(scope);
+    }
   };
-  const flushDeferredAssistantEvents = () => {
-    if (state.deferredAssistantEvents.length === 0) {
-      return;
+  const flushAssistantStream = (delivery?: AssistantStreamDelivery) => {
+    // Publish the next scope before callbacks: a reentrant boundary can flush it exactly once.
+    const previous = streamScope;
+    const scope: AssistantStreamScope = { delivery };
+    streamScope = scope;
+    if (delivery && state.deferBlockReplyDelivery && delivery.data.phase !== "commentary") {
+      deferredAssistantScopes.push(scope);
     }
-    const deferred = state.deferredAssistantEvents.splice(0);
-    for (const delivery of deferred) {
-      emitAssistantStreamDataSafely(delivery);
+    if (!state.deferBlockReplyDelivery) {
+      for (const deferred of deferredAssistantScopes.splice(0)) {
+        emitAssistantStreamDataSafely(deferred);
+        deferred.delivery = undefined;
+      }
     }
+    if (!state.deferBlockReplyDelivery || previous.delivery?.data.phase === "commentary") {
+      emitAssistantStreamDataSafely(previous);
+      drainPartialReply(previous);
+      previous.delivery = undefined;
+    }
+    return scope;
   };
-  const clearDeferredAssistantEvents = () => {
-    state.deferredAssistantEvents.length = 0;
+  const clearAssistantStream = () => {
+    streamScope.delivery = undefined;
+    streamScope = {};
+    deferredAssistantScopes.length = 0;
   };
   const deferredToolMediaReplies = new WeakMap<
     BlockReplyPayload,
@@ -189,7 +264,6 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedAgentSessionParams["onBlockReply"]>>[0],
     options?: {
-      assistantMessageIndex?: number;
       pendingToolMedia?: BlockReplyPayload | null;
       autoDeliveryMediaUrls?: string[];
     },
@@ -209,43 +283,29 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
         }
       }
     };
-    const recordDeliveryFailure = (error: unknown) => {
+    const recordDeliveryFailure = () => {
       if (options?.pendingToolMedia) {
         restorePendingToolMediaReply(state, options.pendingToolMedia);
       }
-      log.warn(`block reply callback failed: ${String(error)}`);
     };
-    try {
-      const taggedPayload =
-        options?.assistantMessageIndex !== undefined
-          ? setReplyPayloadMetadata(payload, {
-              assistantMessageIndex: options.assistantMessageIndex,
-            })
-          : payload;
-      const assistantMessageIndex =
-        options?.assistantMessageIndex ??
-        getReplyPayloadMetadata(taggedPayload)?.assistantMessageIndex;
-      const context = assistantMessageIndex === undefined ? undefined : { assistantMessageIndex };
-      const maybeTask = context
-        ? params.onBlockReply(taggedPayload, context)
-        : params.onBlockReply(taggedPayload);
-      if (!isPromiseLike<void>(maybeTask)) {
-        recordDeliveredReply();
-        return;
-      }
-      const task = Promise.resolve(maybeTask).then(recordDeliveredReply, recordDeliveryFailure);
-      pendingBlockReplyTasks.add(task);
-      void task.finally(() => {
-        pendingBlockReplyTasks.delete(task);
-      });
-    } catch (err) {
-      recordDeliveryFailure(err);
-    }
+    const assistantMessageIndex = getReplyPayloadMetadata(payload)?.assistantMessageIndex;
+    runBestEffortCallback({
+      callback: () =>
+        assistantMessageIndex === undefined
+          ? params.onBlockReply?.(payload)
+          : params.onBlockReply?.(payload, { assistantMessageIndex }),
+      label: "block reply",
+      log,
+      pending: pendingBlockReplyTasks,
+      onSuccess: recordDeliveredReply,
+      onError: recordDeliveryFailure,
+    });
   };
   const emitBlockReply = (
     payload: BlockReplyPayload,
     options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
   ) => {
+    flushAssistantStream();
     const withAssistantDirectives = consumePendingAssistantReplyDirectivesIntoReply(state, payload);
     const pendingToolMedia =
       payload.isReasoning || options?.consumePendingToolMedia === false
@@ -299,14 +359,10 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
       state.deferredBlockReplies.push(taggedPayload);
       return;
     }
-    emitBlockReplySafely(taggedPayload, { ...options, pendingToolMedia, autoDeliveryMediaUrls });
+    emitBlockReplySafely(taggedPayload, { pendingToolMedia, autoDeliveryMediaUrls });
   };
   const flushDeferredBlockReplies = () => {
-    if (state.deferredBlockReplies.length === 0) {
-      return;
-    }
-    const deferred = state.deferredBlockReplies.splice(0);
-    for (const payload of deferred) {
+    for (const payload of state.deferredBlockReplies.splice(0)) {
       const deferredToolMedia = deferredToolMediaReplies.get(payload);
       emitBlockReplySafely(payload, deferredToolMedia);
     }
@@ -337,17 +393,14 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
       return true;
     }
     const normalized = normalizedText ?? normalizeTextForComparison(text);
-    if (normalized.length > 0 && normalized === state.lastAssistantTextNormalized) {
-      return true;
-    }
-    return false;
+    return normalized.length > 0 && normalized === state.lastAssistantTextNormalized;
   };
 
   const pushAssistantText = (text: string, normalizedText?: string) => {
     if (!text) {
       return;
     }
-    if (params.silentExpected && !shouldAllowSilentTurnText(text)) {
+    if (params.silentExpected && !isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
       return;
     }
     if (shouldSkipAssistantText(text, normalizedText)) {
@@ -418,12 +471,12 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
 
   return {
     assistantTexts,
-    clearDeferredAssistantEvents,
+    clearAssistantStream,
     clearDeferredBlockReplies,
     emitAssistantStreamData,
     emitBlockReply,
     finalizeAssistantTexts,
-    flushDeferredAssistantEvents,
+    flushAssistantStream,
     flushDeferredBlockReplies,
     pendingBlockReplyTasks,
     pushAssistantText,

--- a/src/agents/embedded-agent-subscribe.run-state.ts
+++ b/src/agents/embedded-agent-subscribe.run-state.ts
@@ -48,7 +48,6 @@ export function createEmbeddedAgentSubscribeState(
     lastDeliveredBlockReplyText: undefined,
     deferBlockReplyDelivery: typeof params.onBeforeTerminalDelivery === "function",
     deferredBlockReplies: [],
-    deferredAssistantEvents: [],
     toolExecutionSinceLastBlockReply: false,
     reasoningStreamOpen: false,
     assistantMessageIndex: 0,

--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -98,6 +98,7 @@ type StreamRenderingParams = {
   log: EmbeddedAgentSubscribeContext["log"];
   blockChunker: EmbeddedAgentSubscribeContext["blockChunker"];
   emitBlockReply: EmbeddedAgentSubscribeContext["emitBlockReply"];
+  flushAssistantStream: EmbeddedAgentSubscribeContext["flushAssistantStream"];
   pendingBlockReplyTasks: Set<Promise<void>>;
   pushAssistantText: (text: string, normalizedText?: string) => void;
   shouldSkipAssistantText: (text: string, normalizedText?: string) => boolean;
@@ -109,6 +110,7 @@ export function createStreamRendering({
   log,
   blockChunker,
   emitBlockReply,
+  flushAssistantStream,
   pendingBlockReplyTasks,
   pushAssistantText,
   shouldSkipAssistantText,
@@ -527,6 +529,7 @@ export function createStreamRendering({
   const flushBlockReplyBuffer: EmbeddedAgentSubscribeContext["flushBlockReplyBuffer"] = (
     options,
   ) => {
+    flushAssistantStream();
     if (!params.onBlockReply) {
       return undefined;
     }
@@ -574,6 +577,7 @@ export function createStreamRendering({
     if (trimmed === state.lastStreamedReasoning) {
       return;
     }
+    flushAssistantStream();
     // Compute delta: new text since the last emitted reasoning.
     // Guard against non-prefix changes (e.g. trim altering earlier content).
     const prior = state.lastStreamedReasoning ?? "";
@@ -612,6 +616,7 @@ export function createStreamRendering({
   };
 
   const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
+    flushAssistantStream();
     state.deltaBuffer = "";
     state.streamBlockText = "";
     state.streamBlockOffset = 0;

--- a/src/agents/embedded-agent-subscribe.tool-lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.tool-lifecycle.ts
@@ -30,6 +30,7 @@ export function createEmbeddedToolLifecycleRunner(
   ctx: EmbeddedAgentSubscribeContext,
 ): EmbeddedToolLifecycleRunner {
   return async <T>(toolParams: EmbeddedToolLifecycleParams<T>): Promise<T> => {
+    ctx.flushAssistantStream();
     await handleToolExecutionStart(ctx, {
       type: "tool_execution_start",
       toolName: toolParams.toolName,
@@ -75,6 +76,7 @@ async function finishToolLifecycle(
   toolParams: EmbeddedToolLifecycleParams<unknown>,
   outcome: { executionStarted: boolean; isError: boolean; result: unknown },
 ): Promise<ToolTerminal> {
+  ctx.flushAssistantStream();
   const terminal = await handleToolExecutionEnd(ctx, {
     type: "tool_execution_end",
     toolName: toolParams.toolName,

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -70,12 +70,12 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const pendingMessagingTargets = state.pendingMessagingTargets;
   const replyDelivery = createReplyDelivery({ params, state, log });
   const {
-    clearDeferredAssistantEvents,
+    clearAssistantStream,
     clearDeferredBlockReplies,
     emitAssistantStreamData,
     emitBlockReply,
     finalizeAssistantTexts,
-    flushDeferredAssistantEvents,
+    flushAssistantStream,
     flushDeferredBlockReplies,
   } = replyDelivery;
 
@@ -266,6 +266,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     log,
     blockChunker,
     emitBlockReply: replyDelivery.emitBlockReply,
+    flushAssistantStream,
     pendingBlockReplyTasks: replyDelivery.pendingBlockReplyTasks,
     pushAssistantText: replyDelivery.pushAssistantText,
     shouldSkipAssistantText: replyDelivery.shouldSkipAssistantText,
@@ -327,7 +328,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.pendingToolMediaDeliveryFailed = false;
     state.visibleBlockReplyCount = 0;
     state.deferBlockReplyDelivery = typeof params.onBeforeTerminalDelivery === "function";
-    clearDeferredAssistantEvents();
+    clearAssistantStream();
     clearDeferredBlockReplies();
     state.deterministicApprovalPromptPending = false;
     state.deterministicApprovalPromptSent = false;
@@ -399,9 +400,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     flushBlockReplyBuffer,
     emitAssistantStreamData,
     emitBlockReply,
-    flushDeferredAssistantEvents,
+    flushAssistantStream,
     flushDeferredBlockReplies,
-    clearDeferredAssistantEvents,
+    clearAssistantStream,
     clearDeferredBlockReplies,
     emitReasoningStream,
     consumePartialReplyDirectives,
@@ -436,6 +437,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // Mark as unsubscribed FIRST to prevent waitForCompactionRetry from creating
     // new un-resolvable promises during teardown.
     state.unsubscribed = true;
+    clearAssistantStream();
     cleanupRunToolStartData(params.runId);
     state.liveEditDiffStateById.clear();
     // Reject pending compaction wait to unblock awaiting code.

--- a/src/agents/openai-thinking-contract.test.ts
+++ b/src/agents/openai-thinking-contract.test.ts
@@ -11,7 +11,7 @@ import {
   streamSimple,
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
-import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
+import { resolveEmbeddedAgentStream } from "./embedded-agent-runner/stream-resolution.js";
 
 type ResponsesModel = Model<"openai-responses"> | Model<"openai-chatgpt-responses">;
 
@@ -253,13 +253,13 @@ async function captureHttpProviderPayload(params: {
     const providerStream =
       params.transport === "direct"
         ? streamSimple
-        : resolveEmbeddedAgentStreamFn({
+        : resolveEmbeddedAgentStream({
             llmRuntime: createLlmRuntime(),
             currentStreamFn: undefined,
             model,
             sessionId: "thinking-contract",
             resolvedApiKey: "synthetic-test-key",
-          });
+          }).streamFn;
     const streamFn: StreamFn = (requestModel, context, options) =>
       providerStream(requestModel, context, {
         ...options,

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -187,25 +187,12 @@ export async function runCliFallbackCandidate(
             const textForTyping = classified.text;
             const sanitized = params.presentation.sanitizeStreamingText(textForTyping, false);
             const onPartialReply = turn.opts?.onPartialReply;
-            if (!params.preserveProgressCallbackStartOrder) {
-              await turn.typingSignals.signalTextDelta(textForTyping);
-              if (sanitized.skip || !sanitized.text || !onPartialReply) {
-                return false;
-              }
-              return await onPartialReply({ text: sanitized.text });
-            }
-            if (sanitized.skip || !sanitized.text) {
-              await turn.typingSignals.signalTextDelta(textForTyping);
-              return false;
-            }
-            if (!onPartialReply) {
-              await turn.typingSignals.signalTextDelta(textForTyping);
-              return false;
-            }
-            // Assistant and tool CLI bridges drain independently. Stage presentation first.
-            return await params.presentation.startPresentationWhileTyping(
+            return await params.presentation.presentWithTyping(
               turn.typingSignals.signalTextDelta(textForTyping),
-              () => onPartialReply({ text: sanitized.text }),
+              () =>
+                sanitized.skip || !sanitized.text || !onPartialReply
+                  ? false
+                  : onPartialReply({ text: sanitized.text }),
             );
           },
           onReasoningText: createCliReasoningStreamBridge(turn.opts?.onReasoningStream),
@@ -243,7 +230,7 @@ export async function runCliFallbackCandidate(
             // Tool and assistant bridges drain independently. Preserve source order.
             await Promise.all([
               summaryPromise,
-              params.presentation.startPresentationWhileTyping(
+              params.presentation.presentWithTyping(
                 turn.typingSignals.signalToolStart(),
                 async () => {
                   await turn.opts?.onToolStart?.({

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -280,33 +280,14 @@ export async function runEmbeddedFallbackCandidate(
             mediaUrls: payload.mediaUrls,
           };
           const onPartialReply = turn.opts?.onPartialReply;
-          if (!params.preserveProgressCallbackStartOrder) {
-            await turn.typingSignals.signalTextDelta(textForTyping);
-            if (!onPartialReply) {
-              return false;
-            }
-            return await onPartialReply(partialPayload);
-          }
-          if (!onPartialReply) {
-            await turn.typingSignals.signalTextDelta(textForTyping);
-            return false;
-          }
-          return await params.presentation.startPresentationWhileTyping(
+          return await params.presentation.presentWithTyping(
             turn.typingSignals.signalTextDelta(textForTyping),
-            () => onPartialReply(partialPayload),
+            () => (onPartialReply ? onPartialReply(partialPayload) : false),
           );
         },
         onAssistantMessageStart: async () => {
-          if (!params.preserveProgressCallbackStartOrder) {
-            await turn.typingSignals.signalMessageStart();
-            await turn.opts?.onAssistantMessageStart?.();
-            return;
-          }
-          await params.presentation.startPresentationWhileTyping(
-            turn.typingSignals.signalMessageStart(),
-            async () => {
-              await turn.opts?.onAssistantMessageStart?.();
-            },
+          await params.presentation.presentWithTyping(turn.typingSignals.signalMessageStart(), () =>
+            turn.opts?.onAssistantMessageStart?.(),
           );
         },
         onReasoningStream:
@@ -315,26 +296,15 @@ export async function runEmbeddedFallbackCandidate(
                 if (turn.followupRun.run.silentExpected) {
                   return;
                 }
-                if (!params.preserveProgressCallbackStartOrder) {
-                  await turn.typingSignals.signalReasoningDelta();
-                  await turn.opts?.onReasoningStream?.({
-                    text: payload.text,
-                    mediaUrls: payload.mediaUrls,
-                    isReasoningSnapshot: payload.isReasoningSnapshot,
-                    requiresReasoningProgressOptIn: payload.requiresReasoningProgressOptIn,
-                  });
-                  return;
-                }
-                await params.presentation.startPresentationWhileTyping(
+                await params.presentation.presentWithTyping(
                   turn.typingSignals.signalReasoningDelta(),
-                  async () => {
-                    await turn.opts?.onReasoningStream?.({
+                  () =>
+                    turn.opts?.onReasoningStream?.({
                       text: payload.text,
                       mediaUrls: payload.mediaUrls,
                       isReasoningSnapshot: payload.isReasoningSnapshot,
                       requiresReasoningProgressOptIn: payload.requiresReasoningProgressOptIn,
-                    });
-                  },
+                    }),
                 );
               }
             : undefined,

--- a/src/auto-reply/reply/agent-runner-presentation.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.ts
@@ -23,7 +23,7 @@ type AgentTurnPresentation = {
     errorContext: boolean,
   ) => { text?: string; skip: boolean };
   normalizeStreamingText: (payload: ReplyPayload) => { text?: string; skip: boolean };
-  startPresentationWhileTyping: (
+  presentWithTyping: (
     typingPromise: Promise<void>,
     startPresentation: () => boolean | void | Promise<boolean | void>,
   ) => Promise<boolean | void>;
@@ -40,7 +40,7 @@ export function createAgentTurnPresentation(params: {
 }): AgentTurnPresentation {
   const classifyStreamingPartial = (payload: ReplyPayload): { text?: string; skip: boolean } => {
     let text = payload.text;
-    const reply = resolveSendableOutboundReplyParts(payload);
+    const reply = resolveSendableOutboundReplyParts(payload, { text: "" });
     if (params.turn.followupRun.run.silentExpected) {
       return { skip: true };
     }
@@ -96,10 +96,16 @@ export function createAgentTurnPresentation(params: {
     return sanitizeStreamingText(classified.text, Boolean(payload.isError));
   };
 
-  const startPresentationWhileTyping = async (
+  const preserveProgressCallbackStartOrder =
+    params.turn.opts?.preserveProgressCallbackStartOrder === true;
+  const presentWithTyping = async (
     typingPromise: Promise<void>,
     startPresentation: () => boolean | void | Promise<boolean | void>,
   ) => {
+    if (!preserveProgressCallbackStartOrder) {
+      await typingPromise;
+      return await startPresentation();
+    }
     let presentationPromise: boolean | void | Promise<boolean | void>;
     try {
       presentationPromise = startPresentation();
@@ -137,7 +143,7 @@ export function createAgentTurnPresentation(params: {
     classifyStreamingPartial,
     sanitizeStreamingText,
     normalizeStreamingText,
-    startPresentationWhileTyping,
+    presentWithTyping,
     blockReplyHandler,
   };
 }

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -14,7 +14,6 @@ import {
 } from "../agents/command/attempt-callbacks.js";
 import { createAgentCommandLifecycle } from "../agents/command/lifecycle.js";
 import { createSubscribedSessionHarness } from "../agents/embedded-agent-subscribe.e2e-harness.js";
-import { buildAssistantStreamData } from "../agents/embedded-agent-subscribe.handlers.messages.stream.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
@@ -1313,7 +1312,7 @@ describe("agent event handler", () => {
         handler,
         "run-ordinary-relative-media",
         "assistant",
-        buildAssistantStreamData({ text, mediaUrls: [text.slice("MEDIA:".length)] }),
+        { text, delta: "", mediaUrls: [text.slice("MEDIA:".length)] },
         { seq: 1 },
       );
       emitLifecycleEnd(handler, "run-ordinary-relative-media", 2);

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -7,7 +7,7 @@ import {
 import type { resolveSessionAuthSelection } from "../../agents/auth-profiles/session-override.js";
 import type { applyExtraParamsToAgent } from "../../agents/embedded-agent-runner/extra-params.js";
 import type { resolveModelAsync } from "../../agents/embedded-agent-runner/model.js";
-import type { resolveEmbeddedAgentStreamFn } from "../../agents/embedded-agent-runner/stream-resolution.js";
+import type { resolveEmbeddedAgentStream } from "../../agents/embedded-agent-runner/stream-resolution.js";
 import type {
   acquireAgentRunPreparedModelRuntime,
   PreparedModelRuntimeSnapshot,
@@ -48,7 +48,7 @@ type Deps = {
   resolveSessionAuthSelection: typeof resolveSessionAuthSelection;
   resolveModel: typeof resolveModelAsync;
   resolveProviderStream: typeof registerProviderStreamForModel;
-  resolveStream: typeof resolveEmbeddedAgentStreamFn;
+  resolveStream: typeof resolveEmbeddedAgentStream;
 };
 type Execution = WorkerInferenceExecutionParams;
 
@@ -275,7 +275,10 @@ function setup(
   });
   const resolveStream = vi.fn<Deps["resolveStream"]>((streamParams) => {
     scope.authProfile = streamParams.authProfileId;
-    return streamParams.providerStreamFn ?? streamParams.currentStreamFn ?? fallbackStream;
+    return {
+      streamFn: streamParams.providerStreamFn ?? streamParams.currentStreamFn ?? fallbackStream,
+      strategy: "provider",
+    };
   });
   const applyStreamPolicy = vi.fn<Deps["applyStreamPolicy"]>(() => {
     options.observeStage?.("policy", observedRegistry());

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -204,7 +204,6 @@ function setup(
     agentDir?: string;
     agentRuntime?: string;
     authProfile?: string;
-    catalogWorkspace?: string;
     preparedModelRuntime?: boolean;
     prepareWorkspace?: string;
   } = {};
@@ -287,7 +286,6 @@ function setup(
   const releaseRuntime = vi.fn();
   const acquireRuntimeLease = vi.fn<Deps["acquireRuntimeLease"]>(async (runtimeParams) => {
     scope.agentDir = runtimeParams.agentDir;
-    scope.catalogWorkspace = WORKSPACE;
     const leased = { ...preparedModelRuntime, agentDir: runtimeParams.agentDir };
     leasedPreparedModelRuntime = leased;
     return {
@@ -519,7 +517,6 @@ describe("worker inference provider runtime", () => {
       agentDir: prepared?.agentDir,
       agentRuntime: "openclaw",
       authProfile: PROFILE,
-      catalogWorkspace: WORKSPACE,
       preparedModelRuntime: true,
       prepareWorkspace: WORKSPACE,
     });

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -17,7 +17,7 @@ import { resolveSessionAuthSelection } from "../../agents/auth-profiles/session-
 import { applyExtraParamsToAgent } from "../../agents/embedded-agent-runner/extra-params.js";
 import { resolveModelAsync } from "../../agents/embedded-agent-runner/model.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "../../agents/embedded-agent-runner/run/attempt.model-diagnostic-events.js";
-import { resolveEmbeddedAgentStreamFn } from "../../agents/embedded-agent-runner/stream-resolution.js";
+import { resolveEmbeddedAgentStream } from "../../agents/embedded-agent-runner/stream-resolution.js";
 import { mapThinkingLevel } from "../../agents/embedded-agent-runner/utils.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
@@ -106,7 +106,7 @@ type WorkerInferenceRuntimeDependencies = {
   resolveModel: typeof resolveModelAsync;
   prepareModel: typeof prepareSimpleCompletionModel;
   resolveProviderStream: typeof registerProviderStreamForModel;
-  resolveStream: typeof resolveEmbeddedAgentStreamFn;
+  resolveStream: typeof resolveEmbeddedAgentStream;
   applyStreamPolicy: typeof applyExtraParamsToAgent;
   wrapStream: typeof wrapStreamFnWithDiagnosticModelCallEvents;
   createTrace: typeof createDiagnosticTraceContextFromActiveScope;
@@ -333,7 +333,7 @@ const DEFAULT_DEPENDENCIES: WorkerInferenceRuntimeDependencies = {
   resolveModel: resolveModelAsync,
   prepareModel: prepareSimpleCompletionModel,
   resolveProviderStream: registerProviderStreamForModel,
-  resolveStream: resolveEmbeddedAgentStreamFn,
+  resolveStream: resolveEmbeddedAgentStream,
   applyStreamPolicy: applyExtraParamsToAgent,
   wrapStream: wrapStreamFnWithDiagnosticModelCallEvents,
   createTrace: createDiagnosticTraceContextFromActiveScope,
@@ -593,18 +593,16 @@ export function createWorkerInferenceExecutor(
           workspaceDir: approved.workspaceDir,
         });
         const authValue = approved.prepared.auth.apiKey;
-        const streamAgent = {
-          streamFn: dependencies.resolveStream({
-            llmRuntime,
-            currentStreamFn: llmRuntime.streamSimple,
-            ...(providerStream ? { providerStreamFn: providerStream } : {}),
-            sessionId: request.sessionId,
-            signal,
-            model: providerModel,
-            resolvedApiKey: authValue,
-            authProfileId: approved.prepared.auth.profileId,
-          }),
-        };
+        const streamAgent = dependencies.resolveStream({
+          llmRuntime,
+          currentStreamFn: llmRuntime.streamSimple,
+          ...(providerStream ? { providerStreamFn: providerStream } : {}),
+          sessionId: request.sessionId,
+          signal,
+          model: providerModel,
+          resolvedApiKey: authValue,
+          authProfileId: approved.prepared.auth.profileId,
+        });
         const streamPolicyOptions: WorkerInferenceStartParams["options"] = {
           ...(request.options.temperature !== undefined
             ? { temperature: request.options.temperature }


### PR DESCRIPTION
## What Problem This Solves

A slow reply consumer could keep thousands of obsolete partial snapshots alive while an agent continued streaming. Terminal acceptance also queued every intermediate snapshot, and transport selection repeated the same factory decisions to describe and execute each model call.

Related: #136180. This is the second PR in the concurrent-agent performance series.

## Why This Change Was Made

The delivery owner keeps the first partial immediate and coalesces compatible unstarted updates into the latest pending presentation. Whole-message bus deltas and block-local partial deltas retain separate coordinates. Phase, message, tool, media, replacement and completion boundaries start pending work before advancing; normal settlement joins all started callbacks, while unsubscribe and suppressed/retried terminal output discard unstarted work. Live bus updates remain immediate.

A single prepared stream selection now supplies both the callable transport and its strategy. Existing provider, Vertex, custom and native transport lifetimes remain with their original owners. Shared callback and typing/presentation handling removes repeated scaffolding. The patch changes no configuration, database schema, public API or Gateway protocol.

Production **+327/−362 (net −35)**; test/support **+455/−181 (net +274)**.

## User Impact

Slow reply consumers receive current text without retaining every superseded update. Tools and commentary still start promptly, final media and replacement facts retain their boundaries, and ordinary completion waits for presentation callbacks to finish. Mandatory boundaries may have more than one started callback awaiting an external consumer; this is not a global constant-memory guarantee.

## Evidence

Current head `fb1f833c2dfb1c548c26afa5eddf5673a466db02`, based on `b4a972ae7fb8fdc189fca29671adc812faa88e85`. The original paired evidence below compares candidate `a34698562858f7dbbd7a7d59e859951001e7280a` with baseline `060bad4a7d3c79394614d5a4e7fa628b2c51fc1d`. The required CI-fix rebase preserved all 37 changed files byte-for-byte. Rebased production was rebuilt and live-tested at `cc7a5156392f7d813c9f5c46858b02b6d7f435a0`; the final commit only removes three obsolete test-fixture lines, leaving production bytes unchanged.

- **1,680 tests / 49 files passed**, covering subscriber boundaries, reasoning/media, terminal suppression, callback failures, tools, CLI progress, compaction, Gateway events and actual native JavaScript WebSocket transport/auth/activity contracts. Seven delivery cases failed before the repair. Two descriptor/execution mismatch cases failed before canonical selection; the unkeyed proxied Anthropic case was an existing attempt-log mismatch, while attempt code already compensated the transport-auth case. Empty and sanitized-empty generic commentary boundary cases also failed before the producer flush.
- Changed checks passed core and test typechecking, boundaries, formatting, dead exports and production lint. Mechanical test-style findings were fixed; that exact file passed lint and focused tests afterward. Three Codex autoreview rounds were scoped-clean at the configured P0 threshold: original branch, required rebase, and final test-only cleanup. Its earlier oversized evidence-file preparation refusal did not run a review.
- A preliminary owner diagnostic preserved exactly 131,072 final bytes and both delta domains while reducing stalled partial callback starts from 4,096 to 2, and gated callback/bus starts from 4,096 to 1. Normal live bus updates remained 4,096. This diagnostic preceded final source adoption and is not exact-head live or Gateway RSS evidence; absolute RSS did not improve in that isolated diagnostic.

Both original paired isolated builds completed all ten build phases. The baseline and candidate each have verified inventories of 36,621 source files, 104,774 dependency entries and 8,773 build artifacts; the same pinned Node 24.19.0 and pnpm 12.1.0 were used. Every workload verifies its exact build/dependency inventory before and after execution.

The real OpenAI slow-consumer fixture passed on both heads through the public plugin runtime. Each side ran two overlapping long replies, actual file-read/exec tools, cancellation of a real exec child, and reuse of the same session. Three complete callback and live-bus replies per side matched their own closed SQLite transcript byte-for-byte; ordered usage events matched all actual model calls. The two 9,605-byte baseline replies retained 1,741 and 1,737 blocked callback payloads; the candidate retained 2 and 2. These are retained callback objects, not physical RSS measurements. The fixture versions differ by terminal-only permission/diagnostic changes and source paths; partial-mode behavior is equivalent, not hash-identical. Provider-generated outputs are checked against their own transcripts, never assumed identical between runs.

Sustained Gateway stress used 4,096 deltas and 92,160 final bytes per reply, timed chunk groups, a final-response barrier forcing all C8/C32 requests to overlap, real tools, serial/session-reuse and cancellation checks, control requests and 5/30-second idle observations. All four workloads and source/dependency guards passed. The original epoch verifier failed because two baseline C32 idle samples were taken just before their requested floor (4,999.444 and 29,998.862 ms); the original failed result is preserved. A separate qualified comparison accepts only those two exact observations and keeps all other assertions. It checked 100 successful replies, 96 complete stream projections and 304 model requests.

| Ordinary Gateway workload | Baseline CPU / wall | Candidate CPU / wall | Baseline / candidate terminal RSS |
| --- | --- | --- | --- |
| C8 | 3.83 s / 6.822 s | 6.00 s / 7.413 s | 1,228 / 1,224 MiB |
| C32 | 13.62 s / 11.882 s | 13.59 s / 12.176 s | 1,494 / 1,597 MiB |

The C8 CPU increase did not repeat consistently. Two additional unprofiled paired C8 runs, in balanced candidate/baseline order, passed 52 replies, 48 projections and 160 model requests. Median CPU was 3.930 / 4.045 s, wall time 6.928 / 6.877 s and terminal RSS 1,229 / 1,230 MiB. Separate C8 CPU-profile runs also passed complete output/tool/lifecycle checks; they are diagnostic, not a replacement comparison. These small samples do **not** establish a general CPU, latency or RSS win, and the original outlier remains in the evidence. The intended gain is bounded obsolete work at a slow consumer.

The original-head real terminal-gated mode also passed: three successful replies plus cancellation, eleven actual model calls/ordered usage events, actual read/exec, terminated exec child, same-session reuse, and clean Gateway exit. While both finalization hooks were held, callback count, assistant-bus count and terminal delivery remained zero. Releasing each hook produced one current callback and one assistant-bus presentation, and completion still waited for that callback to settle. All complete replies matched their own closed SQLite transcript. The two long replies were each 9,605 bytes; the reuse reply was 134 bytes.

Observed ordering for both long terminal-gated replies (event sequence numbers):

```text
24 finalize hook invoked (discovery registration 2, Gateway admission registration 1)
25 finalize hook entered
26 test releases finalization
27 finalize hook exited
28 complete assistant-bus presentation
29 complete partial callback starts (held)
30 lifecycle end
31 test releases partial callback
32 callback settled
33 run settled
```

The terminal verification report SHA256 is `bc4ebada32873c049b2f8ae58e4152b86f11a2b9be22c62f81b89dbfd3269079`, covering raw report `7c76074049f280c0725cd4a8d6307997420319c2d23a98998bbb9ce6dd318019`. Candidate partial verification is `fccfaeab1cf421cbc46cf07fb34711ca6c08a0d40da7414c042e8b4a3db5b277`; baseline partial verification is `5e00bf34723b47778ff1c13371f2b6676218ff90392b04f8967152fa2e7d7553`. Source/dependency/build inventories passed before and after all three runs. These are functional ownership checks, not live-provider timing comparisons.

After the required rebase, a fresh isolated build at `cc7a5156392f7d813c9f5c46858b02b6d7f435a0` completed all ten phases with 36,651 source files, 104,774 dependency entries and 8,777 build artifacts. Build provenance SHA256: `760860bfb3ce1cf922a48030297e21fb4dc1e229f66d485599082e47e9d51787`. The unchanged V7 collector/controller/oracle then passed the complete real OpenAI terminal-gated scenario again: three successful replies, one cancellation, ten model calls/usage events, real read/exec, child termination and same-session reuse. The two long replies remained 9,605 bytes each; each presentation had one callback and one bus event, no presentation preceded finalization release, and settlement waited for callback completion. All complete bytes matched the private closed SQLite copy, all inventories passed, and every owned process exited. Verification SHA256: `044cb87b9fb48d0f9ea499428f36a931cef2788ef8bfc4e70ace3764f4381602`; raw report: `2e20a0c09e93ce38040992aaee4dbbf1169bc9a48357b3f4e93f3ed9114328a7`. This is functional proof on the rebased production tree, not a new paired performance sample.

Earlier live fixture failures are preserved and excluded from successful proof: a returned RPC admission lease, abort-result expectations, an output-cap stop, missing existing hook permission, and collector state mistakenly scoped to each plugin registration. The final fixture uses one bounded module-owned collector across full/discovery registrations. The unchanged zero-provider reproduction fails before that fixture correction and passes afterward; live registration diagnostics confirm the same ownership boundary. No production code changed during these fixture repairs.

The latest ClawSweeper rank-up request is addressed by the redacted slow-callback and terminal-boundary traces plus paired Gateway stress results above, with each tested source commit identified. Its data-model heuristic on `inference-runtime.ts` is not a schema change: that diff only consumes the prepared transport selection. No persisted representation, migration or database access changes. Older source history was inspected locally; the remote review worker's promisor-fetch limitation is not being used as proof of introduction history. The final native review inspected main `b057266d78d0c6a829029484b0006acc121127f9`, including its outer execution-settled owner changes. The one overlapping Gateway test changes disjoint ranges; merge-tree is clean. No merged-tree test result is claimed.

CI initially failed fetching security-scan history after checkout had removed authentication. The required rebase includes the upstream repair from #136232. The next run passed that step but failed downloading the public ShellCheck pre-commit hook; that repository is still public and an independent fetch succeeded. CI also found this PR had pushed one test fixture to 1,001 counted lines. The final cleanup removes a fixture field that merely copied its own constant; the assertion observing the actual model-preparation workspace remains. The same lint command now passes, all 30 tests in that file pass, and the full changed-file gate passes. No lint limit or security check was relaxed.

Exact-head [CI run 33631366009, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33631366009) passed on `fb1f833c2dfb1c548c26afa5eddf5673a466db02`, including the required `openclaw/ci-gate`. Attempt 1 failed before tests in four jobs after repeated checkout deadlines, and before security scanning while fetching the public pre-commit-hooks repository. Once every product job had finished, only the queued aggregate remained; that attempt was cancelled and only failed jobs were retried on the unchanged commit. The original failed logs are preserved. No source change or gate relaxation was needed for this retry.

The latest ClawSweeper review, at 12:50 UTC on this exact head, reports no functional or security finding. Its maintainer decision is accepted under the explicit instruction to implement, measure and land this performance series. The existing callback boundaries remain part of the contract; the storage heuristic is addressed above. Live branch rules require the CI gate and do not impose an additional review approval. Native review validation passed; native prepare/merge are the remaining workflow steps.

Local evidence roots are `.artifacts/threading/stream-redesign-20260902/` and `.artifacts/threading/prepared-reply-delivery-20260902/`; these are local paths, not hosted artifacts. The first PR's CPU/RSS improvements are not attributed to this follow-up.
