### PR TITLE
test(agents): tighten rotation fixtures and simplify catalog mocks

### DIFF
--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -161,14 +161,10 @@ const installRunEmbeddedMocks = () => {
     }),
     resolveEmbeddedAuthCooldownProbePolicy: resolveEmbeddedAuthCooldownProbePolicyActual,
   }));
-  vi.doMock("./models-config.js", async () => {
-    const mod = await vi.importActual<typeof import("./models-config.js")>("./models-config.js");
-    return {
-      ...mod,
-      ensureOpenClawModelsJson: (...args: Parameters<typeof ensureOpenClawModelsJsonMock>) =>
-        ensureOpenClawModelsJsonMock(...args),
-    };
-  });
+  vi.doMock("./models-config.js", () => ({
+    ensureOpenClawModelsJson: (...args: Parameters<typeof ensureOpenClawModelsJsonMock>) =>
+      ensureOpenClawModelsJsonMock(...args),
+  }));
 };
 
 type ProductionRunEmbeddedAgent = typeof import("./embedded-agent-runner/run.js").runEmbeddedAgent;

--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -92,13 +92,9 @@ const installRunEmbeddedMocks = () => {
       throw new Error("compact should not run in auth profile rotation tests");
     }),
   }));
-  vi.doMock("./models-config.js", async () => {
-    const mod = await vi.importActual<typeof import("./models-config.js")>("./models-config.js");
-    return {
-      ...mod,
-      ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })),
-    };
-  });
+  vi.doMock("./models-config.js", () => ({
+    ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })),
+  }));
 };
 
 type ProductionRunEmbeddedAgent = typeof import("./embedded-agent-runner/run.js").runEmbeddedAgent;
@@ -379,24 +375,6 @@ const mockFailedThenSuccessfulAttempt = (errorMessage = "rate limit") => {
     );
 };
 
-const mockPromptErrorThenSuccessfulAttempt = (errorMessage: string) => {
-  runEmbeddedAttemptMock
-    .mockResolvedValueOnce(
-      makeAttempt({
-        terminal: { kind: "failed", source: "prompt", error: new Error(errorMessage) },
-      }),
-    )
-    .mockResolvedValueOnce(
-      makeAttempt({
-        assistantTexts: ["ok"],
-        lastAssistant: buildAssistant({
-          stopReason: "stop",
-          content: [{ type: "text", text: "ok" }],
-        }),
-      }),
-    );
-};
-
 const mockFailedThenSuccessfulAttemptForModel = (params: {
   errorMessage: string;
   provider: string;
@@ -459,18 +437,42 @@ async function expectProfileP2UsageUnchanged(agentDir: string) {
   expect(usageStats["openai:p2"]?.lastUsed).toBe(2);
 }
 
+function expectAuthProfileAttempts(profileIds: string[]) {
+  expect(
+    runEmbeddedAttemptMock.mock.calls.map(
+      ([attempt]) => requireRecord(attempt, "embedded attempt params").authProfileId,
+    ),
+  ).toEqual(profileIds);
+}
+
 async function runAutoPinnedRotationCase(params: {
   errorMessage: string;
   sessionKey: string;
   runId: string;
+  failureStage?: "assistant" | "prompt";
+  exhaustTransientRetries?: boolean;
   config?: OpenClawConfig;
 }) {
   runEmbeddedAttemptMock.mockReset();
   return withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
     await writeAuthStore(agentDir);
-    // First attempt fails on the auto-pinned profile; the second must use the
-    // next eligible profile without changing the caller-visible run contract.
-    mockFailedThenSuccessfulAttempt(params.errorMessage);
+    // Transient failures must exhaust three same-profile retries before rotating;
+    // credential/quota failures still rotate after the first failed attempt.
+    const failureCount = params.exhaustTransientRetries ? 4 : 1;
+    for (let attempt = 0; attempt < failureCount; attempt += 1) {
+      runEmbeddedAttemptMock.mockResolvedValueOnce(
+        params.failureStage === "prompt"
+          ? makeAttempt({
+              terminal: {
+                kind: "failed",
+                source: "prompt",
+                error: new Error(params.errorMessage),
+              },
+            })
+          : makeErrorAttempt({ errorMessage: params.errorMessage }),
+      );
+    }
+    mockSingleSuccessfulAttempt();
     await runAutoPinnedOpenAiTurn({
       agentDir,
       workspaceDir,
@@ -479,34 +481,14 @@ async function runAutoPinnedRotationCase(params: {
       config: params.config,
     });
 
-    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+    expectAuthProfileAttempts(
+      params.exhaustTransientRetries
+        ? ["openai:p1", "openai:p1", "openai:p1", "openai:p1", "openai:p2"]
+        : ["openai:p1", "openai:p2"],
+    );
+    expect(sleepWithAbortMock).toHaveBeenCalledTimes(params.exhaustTransientRetries ? 3 : 0);
     const usageStats = await readUsageStats(agentDir);
-    return { usageStats };
-  });
-}
-
-async function runAutoPinnedPromptErrorRotationCase(params: {
-  errorMessage: string;
-  sessionKey: string;
-  runId: string;
-  config?: OpenClawConfig;
-}) {
-  runEmbeddedAttemptMock.mockReset();
-  return withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
-    await writeAuthStore(agentDir);
-    // Prompt construction errors still rotate credentials because providers can
-    // surface auth failures before the transport attempt is created.
-    mockPromptErrorThenSuccessfulAttempt(params.errorMessage);
-    await runAutoPinnedOpenAiTurn({
-      agentDir,
-      workspaceDir,
-      sessionKey: params.sessionKey,
-      runId: params.runId,
-      config: params.config,
-    });
-
-    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
-    const usageStats = await readUsageStats(agentDir);
+    expect(usageStats["openai:p2"]?.lastUsed).toBeGreaterThan(2);
     return { usageStats };
   });
 }
@@ -938,24 +920,22 @@ describe("runEmbeddedAgent auth profile rotation", () => {
   });
 
   it("rotates for auto-pinned profiles across retryable stream failures", async () => {
-    const { usageStats } = await runAutoPinnedRotationCase({
+    await runAutoPinnedRotationCase({
       errorMessage: "rate limit",
       sessionKey: "agent:test:auto",
       runId: "run:auto",
     });
-    expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
   });
 
   it("rotates for overloaded assistant failures across auto-pinned profiles", async () => {
     const { usageStats } = await runAutoPinnedRotationCase({
+      exhaustTransientRetries: true,
       errorMessage: '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
       sessionKey: "agent:test:overloaded-rotation",
       runId: "run:overloaded-rotation",
     });
-    expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
     expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
     expect(computeBackoffMock).not.toHaveBeenCalled();
-    expect(sleepWithAbortMock).not.toHaveBeenCalled();
   });
 
   it("logs structured failover decision metadata for overloaded assistant rotation", async () => {
@@ -968,6 +948,7 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     });
 
     await runAutoPinnedRotationCase({
+      exhaustTransientRetries: true,
       errorMessage:
         '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_overload"}',
       sessionKey: "agent:test:overloaded-logging",
@@ -1000,15 +981,15 @@ describe("runEmbeddedAgent auth profile rotation", () => {
   });
 
   it("rotates for overloaded prompt failures across auto-pinned profiles", async () => {
-    const { usageStats } = await runAutoPinnedPromptErrorRotationCase({
+    const { usageStats } = await runAutoPinnedRotationCase({
+      failureStage: "prompt",
+      exhaustTransientRetries: true,
       errorMessage: '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
       sessionKey: "agent:test:overloaded-prompt-rotation",
       runId: "run:overloaded-prompt-rotation",
     });
-    expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
     expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
     expect(computeBackoffMock).not.toHaveBeenCalled();
-    expect(sleepWithAbortMock).not.toHaveBeenCalled();
   });
 
   it("marks inline provider api key billing prompt failures without an auth profile", async () => {
@@ -1045,25 +1026,30 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     });
   });
 
-  it("rotates on timeout without cooling down the timed-out profile", async () => {
+  it("rotates after provider-started timeouts and records the failed profile cooldown", async () => {
     const { usageStats } = await runAutoPinnedRotationCase({
+      exhaustTransientRetries: true,
       errorMessage: "request ended without sending any chunks",
-      sessionKey: "agent:test:timeout-no-cooldown",
-      runId: "run:timeout-no-cooldown",
+      sessionKey: "agent:test:provider-timeout",
+      runId: "run:provider-timeout",
     });
-    expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
-    expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
+    const failedProfile = usageStats["openai:p1"];
+    expect(failedProfile?.errorCount).toBe(1);
+    expect(failedProfile?.failureCounts).toEqual({ timeout: 1 });
+    expect(failedProfile?.cooldownReason).toBe("timeout");
+    const lastFailureAt = failedProfile?.lastFailureAt;
+    expect(lastFailureAt).toBeTypeOf("number");
+    expect(failedProfile?.cooldownUntil).toBe(lastFailureAt! + 30_000);
     expect(computeBackoffMock).not.toHaveBeenCalled();
-    expect(sleepWithAbortMock).not.toHaveBeenCalled();
   });
 
   it("rotates on bare service unavailable without cooling down the profile", async () => {
     const { usageStats } = await runAutoPinnedRotationCase({
+      exhaustTransientRetries: true,
       errorMessage: "LLM error: service unavailable",
       sessionKey: "agent:test:service-unavailable-no-cooldown",
       runId: "run:service-unavailable-no-cooldown",
     });
-    expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
     expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
   });
 
@@ -1406,7 +1392,8 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     });
 
     expect(usageStats["openai:p1"]?.cooldownUntil).toBe(now + 60 * 60 * 1000);
-    expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
+    expectAuthProfileAttempts(["openai:p2"]);
+    expect(usageStats["openai:p2"]?.lastUsed).toBeGreaterThan(2);
   });
 
   it("fails over when all profiles are in cooldown and fallbacks are configured", async () => {
@@ -1747,10 +1734,10 @@ describe("runEmbeddedAgent auth profile rotation", () => {
         runId: "run:rotate-skip-cooldown",
       });
 
-      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+      expectAuthProfileAttempts(["openai:p1", "openai:p3"]);
       const usageStats = await readUsageStats(agentDir);
       expect(typeof usageStats["openai:p1"]?.lastUsed).toBe("number");
-      expect(typeof usageStats["openai:p3"]?.lastUsed).toBe("number");
+      expect(usageStats["openai:p3"]?.lastUsed).toBeGreaterThan(3);
       expect(usageStats["openai:p2"]?.cooldownUntil).toBe(p2CooldownUntil);
     });
   });

--- a/src/agents/model-fallback.reply-entry.e2e.test.ts
+++ b/src/agents/model-fallback.reply-entry.e2e.test.ts
@@ -40,10 +40,9 @@ const { computeBackoffMock, sleepWithAbortMock } = vi.hoisted(() => ({
   sleepWithAbortMock: vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined),
 }));
 
-vi.mock("./models-config.js", async () => {
-  const mod = await vi.importActual<typeof import("./models-config.js")>("./models-config.js");
-  return { ...mod, ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })) };
-});
+vi.mock("./models-config.js", () => ({
+  ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })),
+}));
 
 function installReplyEntryMocks() {
   vi.doMock("../plugins/runtime.js", () => ({

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -43,13 +43,9 @@ const { computeBackoffMock, sleepWithAbortMock } = vi.hoisted(() => ({
   sleepWithAbortMock: vi.fn(async (_ms: number, _abortSignal?: AbortSignal) => undefined),
 }));
 
-vi.mock("./models-config.js", async () => {
-  const mod = await vi.importActual<typeof import("./models-config.js")>("./models-config.js");
-  return {
-    ...mod,
-    ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })),
-  };
-});
+vi.mock("./models-config.js", () => ({
+  ensureOpenClawModelsJson: vi.fn(async () => ({ wrote: false })),
+}));
 
 const installRunEmbeddedMocks = () => {
   // Install the runner mocks before importing runEmbeddedAgent so the e2e path


### PR DESCRIPTION
## Problem

The embedded-runner rotation fixture expected an immediate profile change for transient failures, while the real controller permits three same-profile retries first. Its bare-service check also accepted a seeded usage timestamp without proving the next profile ran. Separately, four fast-run suites loaded the real catalog and planner modules merely to replace a catalog writer they already mocked.

## Solution

Queue failures through the real retry budget, assert the complete profile sequence and updated persisted usage, and check the existing health bookkeeping for provider-started timeouts. Merge the duplicate prompt/assistant fixture setup. Keep the four existing writer mocks directly and remove their unused real-module imports. The real retry controller, auth state, admission, session persistence, and fallback orchestration remain exercised.

This changes four test files (+68/-90), with no production, configuration, schema, or dependency changes. It retains all 75 cases; the timeout case is renamed to describe the existing provider-started contract. The separate eight-case failure-policy unit remains the lower-level policy oracle.

## Evidence

- The original 31-case auth file reproduced four stale-expectation failures. A private complete-file diagnostic additionally exposed the bare-service false positive: the final profile was still p1 and p2's timestamp was still the seeded value 2. The revised fixture proves the exact transient sequence `[p1,p1,p1,p1,p2]`, three retry sleeps, and p2 usage greater than 2; credential/quota cases retain immediate rotation.
- With that fixture correction held constant, all 75 cases passed using the original catalog factories, the simplified factories, and restored original factories on the same Linux worker. All eight failure-policy cases passed separately.
- Both instrumented 75-case runs passed with zero calls to the real planner export. Actual module-body receipts showed each selected test file stopped evaluating both catalog modules. Each module's total fell from five evaluations to one, with one evaluation outside a test-file context remaining. Catalog test-API publications also fell from five to one.
- Suppressing only the writer spy's forwarding call caused exactly its four existing assertions to fail in the complete 21-case main suite, confirming the writer contract remains covered.

| Prepared full runner | Original factories | Simplified factories | Restored factories |
| --- | --- | --- | --- |
| 75 cases | 34.086s | 24.394s | 29.230s |

Native Vitest file order and cache warming differed, so these are qualified observations, not a causal percentage or whole-suite speedup claim. The first private fixed-order checker failed after all three complete runs passed; the separate contract proof passed. Instrumented runtime rebuilds are excluded from timing. The earlier console-marker diagnostic checker also failed independently; its structured assertion failures were retained, and its candidate observer was not run.

The combined proof ran at `986c9e48a42b9eae2d4ff15788c1a84767d3b23c`; all 81 source/runner guards remain identical at this branch's newer base `9fda3b1855c798e632c8a390c1e0701565c39162`. All nine owned process groups exited, source overlays were restored, private roots were removed, and the [Testbox lease](https://github.com/openclaw/openclaw/actions/runs/33618243941) was stopped. Formatting, scoped typed lint, whitespace validation, and Codex review passed. Published-head CI is required before landing.

Validation update: scheduled CI run [33621638065](https://github.com/openclaw/openclaw/actions/runs/33621638065) passed on attempt 2 at the unchanged PR head. The first security-fast job reported zero verified or unverified secret findings, then failed during pre-commit Git fetch authentication; only failed jobs were retried. All selected test jobs passed.
