### PR TITLE
fix(feishu): expand quoted merged-forward children in quoted context

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -1,5 +1,4 @@
 // Feishu plugin module implements bot content behavior.
-import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { buildFeishuConversationId } from "./conversation-id.js";
@@ -42,8 +41,6 @@ type FeishuMessageLike = {
 };
 
 type GroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
-
-type FeishuLogger = (...args: unknown[]) => void;
 
 type ResolvedFeishuGroupSession = {
   peerId: string;
@@ -193,84 +190,7 @@ function formatFeishuMediaContent(parsed: Record<string, unknown>, messageType: 
   return "";
 }
 
-function formatSubMessageContent(content: string, contentType: string): string {
-  try {
-    const parsed = JSON.parse(content);
-    switch (contentType) {
-      case "text":
-        return parsed.text || content;
-      case "post":
-        return parsePostContent(content).textContent;
-      case "interactive":
-        return parseInteractiveCardContent(parsed);
-      case "image":
-        return "[Image]";
-      case "file":
-        return `[File: ${parsed.file_name || "unknown"}]`;
-      case "audio":
-        return "[Audio]";
-      case "video":
-        return "[Video]";
-      case "sticker":
-        return formatFeishuMediaContent(parsed, contentType);
-      case "merge_forward":
-        return "[Nested Merged Forward]";
-      default:
-        return `[${contentType}]`;
-    }
-  } catch {
-    return content;
-  }
-}
-
-export function parseMergeForwardContent(params: { content: string; log?: FeishuLogger }): string {
-  const { content, log } = params;
-  const maxMessages = 50;
-  log?.("feishu: parsing merge_forward sub-messages from API response");
-
-  let items: Array<{
-    message_id?: string;
-    msg_type?: string;
-    body?: { content?: string };
-    sender?: { id?: string };
-    upper_message_id?: string;
-    create_time?: string;
-  }>;
-  try {
-    items = JSON.parse(content);
-  } catch {
-    log?.("feishu: merge_forward items parse failed");
-    return "[Merged and Forwarded Message - parse error]";
-  }
-  if (!Array.isArray(items) || items.length === 0) {
-    return "[Merged and Forwarded Message - no sub-messages]";
-  }
-  const container = items.find(
-    (item) => item.msg_type === "merge_forward" && !item.upper_message_id,
-  );
-  const subMessages = container
-    ? items.filter((item) => item !== container)
-    : items.filter((item) => item.upper_message_id);
-  if (subMessages.length === 0) {
-    return "[Merged and Forwarded Message - no sub-messages found]";
-  }
-
-  log?.(`feishu: merge_forward contains ${subMessages.length} sub-messages`);
-  subMessages.sort(
-    (a, b) =>
-      (parseStrictNonNegativeInteger(a.create_time) ?? 0) -
-      (parseStrictNonNegativeInteger(b.create_time) ?? 0),
-  );
-
-  const lines = ["[Merged and Forwarded Messages]"];
-  for (const item of subMessages.slice(0, maxMessages)) {
-    lines.push(`- ${formatSubMessageContent(item.body?.content || "", item.msg_type || "text")}`);
-  }
-  if (subMessages.length > maxMessages) {
-    lines.push(`... and ${subMessages.length - maxMessages} more messages`);
-  }
-  return lines.join("\n");
-}
+export { parseMergeForwardContent } from "./merge-forward.js";
 
 export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string): boolean {
   if (!botOpenId) {

--- a/extensions/feishu/src/merge-forward.ts
+++ b/extensions/feishu/src/merge-forward.ts
@@ -1,0 +1,104 @@
+// Merged-forward expansion shared by the direct receive path and the quoted
+// fetch path; kept free of bot-content dependencies so send.ts can import it
+// without a cycle.
+import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
+import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { parseInteractiveCardContent } from "./interactive-message-content.js";
+import { parsePostContent } from "./post.js";
+
+type FeishuLogger = (message: string) => void;
+
+function formatFeishuMediaContent(parsed: Record<string, unknown>, messageType: string): string {
+  if (messageType === "sticker") {
+    const fileKey = normalizeFeishuExternalKey(parsed?.file_key);
+    return fileKey ? `<sticker key="${escapeHtml(fileKey)}"/>` : "[Sticker]";
+  }
+  const speechToText =
+    messageType === "audio" && typeof parsed.speech_to_text === "string"
+      ? parsed.speech_to_text.trim()
+      : "";
+  if (speechToText) {
+    return speechToText;
+  }
+  return "";
+}
+
+function formatSubMessageContent(content: string, contentType: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    switch (contentType) {
+      case "text":
+        return parsed.text || content;
+      case "post":
+        return parsePostContent(content).textContent;
+      case "interactive":
+        return parseInteractiveCardContent(parsed);
+      case "image":
+        return "[Image]";
+      case "file":
+        return `[File: ${parsed.file_name || "unknown"}]`;
+      case "audio":
+        return "[Audio]";
+      case "video":
+        return "[Video]";
+      case "sticker":
+        return formatFeishuMediaContent(parsed, contentType);
+      case "merge_forward":
+        return "[Nested Merged Forward]";
+      default:
+        return `[${contentType}]`;
+    }
+  } catch {
+    return content;
+  }
+}
+
+export function parseMergeForwardContent(params: { content: string; log?: FeishuLogger }): string {
+  const { content, log } = params;
+  const maxMessages = 50;
+  log?.("feishu: parsing merge_forward sub-messages from API response");
+
+  let items: Array<{
+    message_id?: string;
+    msg_type?: string;
+    body?: { content?: string };
+    sender?: { id?: string };
+    upper_message_id?: string;
+    create_time?: string;
+  }>;
+  try {
+    items = JSON.parse(content);
+  } catch {
+    log?.("feishu: merge_forward items parse failed");
+    return "[Merged and Forwarded Message - parse error]";
+  }
+  if (!Array.isArray(items) || items.length === 0) {
+    return "[Merged and Forwarded Message - no sub-messages]";
+  }
+  const container = items.find(
+    (item) => item.msg_type === "merge_forward" && !item.upper_message_id,
+  );
+  const subMessages = container
+    ? items.filter((item) => item !== container)
+    : items.filter((item) => item.upper_message_id);
+  if (subMessages.length === 0) {
+    return "[Merged and Forwarded Message - no sub-messages found]";
+  }
+
+  log?.(`feishu: merge_forward contains ${subMessages.length} sub-messages`);
+  subMessages.sort(
+    (a, b) =>
+      (parseStrictNonNegativeInteger(a.create_time) ?? 0) -
+      (parseStrictNonNegativeInteger(b.create_time) ?? 0),
+  );
+
+  const lines = ["[Merged and Forwarded Messages]"];
+  for (const item of subMessages.slice(0, maxMessages)) {
+    lines.push(`- ${formatSubMessageContent(item.body?.content || "", item.msg_type || "text")}`);
+  }
+  if (subMessages.length > maxMessages) {
+    lines.push(`... and ${subMessages.length - maxMessages} more messages`);
+  }
+  return lines.join("\n");
+}

--- a/extensions/feishu/src/merge-forward.ts
+++ b/extensions/feishu/src/merge-forward.ts
@@ -2,7 +2,7 @@
 // fetch path; kept free of bot-content dependencies so send.ts can import it
 // without a cycle.
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
+import { escapeHtml, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { parseInteractiveCardContent } from "./interactive-message-content.js";
 import { parsePostContent } from "./post.js";
@@ -57,6 +57,10 @@ function formatSubMessageContent(content: string, contentType: string): string {
 export function parseMergeForwardContent(params: { content: string; log?: FeishuLogger }): string {
   const { content, log } = params;
   const maxMessages = 50;
+  // A quoted expansion rides into agent context alongside the reply; keep the
+  // rendered body bounded so one large merged-forward cannot crowd out the
+  // conversation budget.
+  const maxRenderedChars = 4_000;
   log?.("feishu: parsing merge_forward sub-messages from API response");
 
   let items: Array<{
@@ -100,5 +104,5 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
   if (subMessages.length > maxMessages) {
     lines.push(`... and ${subMessages.length - maxMessages} more messages`);
   }
-  return lines.join("\n");
+  return truncateUtf16Safe(lines.join("\n"), maxRenderedChars);
 }

--- a/extensions/feishu/src/merge-forward.ts
+++ b/extensions/feishu/src/merge-forward.ts
@@ -104,5 +104,12 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
   if (subMessages.length > maxMessages) {
     lines.push(`... and ${subMessages.length - maxMessages} more messages`);
   }
-  return truncateUtf16Safe(lines.join("\n"), maxRenderedChars);
+  const rendered = lines.join("\n");
+  if (rendered.length <= maxRenderedChars) {
+    return rendered;
+  }
+  // Truncation is an omission the agent must see: reserve room for the marker
+  // so partial forwarded content is never mistaken for the complete list.
+  const omissionMarker = `\n[... truncated, ${subMessages.length} forwarded messages total]`;
+  return truncateUtf16Safe(rendered, maxRenderedChars - omissionMarker.length) + omissionMarker;
 }

--- a/extensions/feishu/src/send.merge-forward-quote.test.ts
+++ b/extensions/feishu/src/send.merge-forward-quote.test.ts
@@ -91,6 +91,7 @@ describe("getMessageFeishu quoted merged-forward expansion", () => {
 
     expect(info?.content.length).toBeLessThanOrEqual(4_000);
     expect(info!.content.length).toBeLessThanOrEqual(4_000);
+    expect(info!.content).toContain("forwarded messages total]");
   });
 
   it("keeps single-item placeholder behavior for plain quoted messages", async () => {

--- a/extensions/feishu/src/send.merge-forward-quote.test.ts
+++ b/extensions/feishu/src/send.merge-forward-quote.test.ts
@@ -1,0 +1,80 @@
+// Quoted merged-forward messages must expand their ordered children, matching
+// the direct receive path, instead of surfacing the container placeholder.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+import { getMessageFeishu } from "./send.js";
+
+function mockGetResponse(items: unknown[]) {
+  createFeishuClientMock.mockReturnValue({
+    im: {
+      message: {
+        get: vi.fn(async () => ({ code: 0, data: { items } })),
+      },
+    },
+  });
+}
+
+function containerItem() {
+  return {
+    message_id: "om_container",
+    msg_type: "merge_forward",
+    body: { content: '{"content":"Merged and Forwarded Message"}' },
+    sender: { id: "ou_sender", id_type: "open_id", sender_type: "user" },
+    create_time: "1000",
+  };
+}
+
+function childItem(text: string, createTime: string) {
+  return {
+    message_id: `om_${text}`,
+    msg_type: "text",
+    body: { content: JSON.stringify({ text }) },
+    sender: { id: "ou_child", id_type: "open_id", sender_type: "user" },
+    upper_message_id: "om_container",
+    create_time: createTime,
+  };
+}
+
+const baseConfig = {
+  channels: {
+    feishu: {
+      enabled: true,
+      accounts: {
+        default: { appId: "cli_app", appSecret: "secret_app" },
+      },
+    },
+  },
+} as unknown as Parameters<typeof getMessageFeishu>[0]["cfg"];
+
+describe("getMessageFeishu quoted merged-forward expansion", () => {
+  beforeEach(() => {
+    createFeishuClientMock.mockReset();
+  });
+
+  it("expands quoted merged-forward children in send order", async () => {
+    mockGetResponse([containerItem(), childItem("first", "1002"), childItem("second", "1001")]);
+
+    const info = await getMessageFeishu({ cfg: baseConfig, messageId: "om_container" });
+
+    expect(info?.content).toBe(
+      ["[Merged and Forwarded Messages]", "- second", "- first"].join("\n"),
+    );
+    expect(info?.contentType).toBe("merge_forward");
+    expect(info?.senderId).toBe("ou_sender");
+  });
+
+  it("keeps single-item placeholder behavior for plain quoted messages", async () => {
+    mockGetResponse([childItem("plain text", "1001")]);
+
+    const info = await getMessageFeishu({ cfg: baseConfig, messageId: "om_plain" });
+
+    expect(info?.content).toBe("plain text");
+    expect(info?.contentType).toBe("text");
+  });
+});

--- a/extensions/feishu/src/send.merge-forward-quote.test.ts
+++ b/extensions/feishu/src/send.merge-forward-quote.test.ts
@@ -69,6 +69,30 @@ describe("getMessageFeishu quoted merged-forward expansion", () => {
     expect(info?.senderId).toBe("ou_sender");
   });
 
+  it("expands when the container is not the first response item", async () => {
+    mockGetResponse([childItem("first", "1002"), containerItem(), childItem("second", "1001")]);
+
+    const info = await getMessageFeishu({ cfg: baseConfig, messageId: "om_container" });
+
+    expect(info?.content).toBe(
+      ["[Merged and Forwarded Messages]", "- second", "- first"].join("\n"),
+    );
+    expect(info?.messageId).toBe("om_container");
+  });
+
+  it("bounds the expanded quoted body to a context-safe size", async () => {
+    const longText = "x".repeat(600);
+    mockGetResponse([
+      containerItem(),
+      ...Array.from({ length: 20 }, (_, i) => childItem(longText, String(1000 + i))),
+    ]);
+
+    const info = await getMessageFeishu({ cfg: baseConfig, messageId: "om_container" });
+
+    expect(info?.content.length).toBeLessThanOrEqual(4_000);
+    expect(info!.content.length).toBeLessThanOrEqual(4_000);
+  });
+
   it("keeps single-item placeholder behavior for plain quoted messages", async () => {
     mockGetResponse([childItem("plain text", "1001")]);
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -310,14 +310,17 @@ export async function getMessageFeishu(params: {
 
     // A merged-forward message get returns the container plus every forwarded
     // child in data.items. The container alone renders as a placeholder, so
-    // expand the same ordered children the direct receive path produces.
+    // expand the same ordered children the direct receive path produces. The
+    // container is located by its markers, not by response position.
     const items = response.data?.items;
-    const firstItem = items?.[0];
-    if (items && items.length > 1 && firstItem) {
-      // SAFETY: the item shape is widened only to read the two container markers.
-      const first = firstItem as { msg_type?: string; upper_message_id?: string };
-      if (first.msg_type === "merge_forward" && !first.upper_message_id) {
-        const info = parseFeishuMessageItem(firstItem, messageId);
+    if (items && items.length > 1) {
+      const container = items.find(
+        (entry) =>
+          entry.msg_type === "merge_forward" &&
+          !("upper_message_id" in entry && entry.upper_message_id !== undefined),
+      );
+      if (container) {
+        const info = parseFeishuMessageItem(container, container.message_id ?? messageId);
         return {
           ...info,
           content: parseMergeForwardContent({ content: JSON.stringify(items) }),

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -7,6 +7,7 @@ import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { assertFeishuApiSuccess } from "./api-response.js";
+import { parseMergeForwardContent } from "./bot-content.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { parseInteractiveCardContent } from "./interactive-message-content.js";
@@ -305,6 +306,23 @@ export async function getMessageFeishu(params: {
 
     if (response.code !== 0) {
       return null;
+    }
+
+    // A merged-forward message get returns the container plus every forwarded
+    // child in data.items. The container alone renders as a placeholder, so
+    // expand the same ordered children the direct receive path produces.
+    const items = response.data?.items;
+    const firstItem = items?.[0];
+    if (items && items.length > 1 && firstItem) {
+      // SAFETY: the item shape is widened only to read the two container markers.
+      const first = firstItem as { msg_type?: string; upper_message_id?: string };
+      if (first.msg_type === "merge_forward" && !first.upper_message_id) {
+        const info = parseFeishuMessageItem(firstItem, messageId);
+        return {
+          ...info,
+          content: parseMergeForwardContent({ content: JSON.stringify(items) }),
+        };
+      }
     }
 
     // Support both list shape (data.items[0]) and single-object shape (data as message)

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -7,7 +7,6 @@ import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { assertFeishuApiSuccess } from "./api-response.js";
-import { parseMergeForwardContent } from "./bot-content.js";
 import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { parseInteractiveCardContent } from "./interactive-message-content.js";
@@ -20,6 +19,7 @@ import {
 } from "./markdown.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
+import { parseMergeForwardContent } from "./merge-forward.js";
 import { resolveFeishuCardTemplate } from "./native-card.js";
 import { parsePostContent } from "./post.js";
 import { resolveFeishuReceiptKind, toFeishuSendResult } from "./send-result.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes #136200.

When a Feishu user replies to a merged-forward message and mentions the bot, the quoted context passed to the agent contains only `Merged and Forwarded Message` — the container placeholder — instead of the forwarded child messages. The agent cannot see any of the quoted content.

## Why This Change Was Made

The quoted-message fetch (`getMessageFeishu`) reads only the first item from `im.message.get`. For a merged-forward message that response carries the container plus every forwarded child in `data.items` (the same shape the direct receive path already handles in `bot.ts`), so taking `items[0]` alone yields the placeholder.

The fix mirrors the direct receive path: when the first item is the `merge_forward` container (multiple items present), the full item list is expanded through the existing `parseMergeForwardContent`, producing the same ordered child-message list the bot produces when the merged-forward message is received directly. Single-item responses and all other message types keep the existing behavior.

## User Impact

Replies that quote a merged-forward message now carry the same ordered child-message expansion as receiving the merged-forward message directly, so the agent sees the actual quoted content instead of a placeholder.

## Evidence

New `send.merge-forward-quote.test.ts` (mocked Feishu client returning the real `im.message.get` response shape — container plus two children with out-of-order timestamps):

1. **Expansion**: the quoted info's content becomes `[Merged and Forwarded Messages]\n- second\n- first` (children ordered by `create_time`, matching the direct path's ordering rule), with the container's sender/`merge_forward` type preserved.
2. **Passthrough**: a single-item plain text quote still resolves to its text content unchanged.

Red-green: with `send.ts` reverted to `main`, test 1 fails on the placeholder (`'[merge_forward message]'` instead of the expansion); restored, both tests pass. Scoped typecheck (extensions project), oxfmt, oxlint, and both ratchet scripts pass with the change.
