### PR TITLE
fix(heartbeat): bind scheduled replies to published runtime

### DIFF
--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -900,6 +900,7 @@ export function buildGatewayCronService(params: {
       requestHeartbeatAndWait(resolveCronHeartbeatWake(opts).wake, lifecycle),
     runHeartbeatOnce: async (opts) => {
       const { runtimeConfig, wake } = resolveCronHeartbeatWake(opts, true);
+      const { getReplyFromConfig: _getReplyFromConfig, ...heartbeatDeps } = params.deps;
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         ...wake,
@@ -907,7 +908,8 @@ export function buildGatewayCronService(params: {
         // the cron run that is awaiting it.
         owningCronJobMarker: opts?.owningCronJobMarker,
         owningCronLaneTaskMarker: opts?.owningCronLaneTaskMarker,
-        deps: { ...params.deps, runtime: defaultRuntime },
+        // Gateway heartbeats acquire reply preparation from their published runtime boundary.
+        deps: { ...heartbeatDeps, runtime: defaultRuntime },
       });
     },
     runSkillCollectionReview: ({ agentId, abortSignal }) =>

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -102,7 +102,7 @@ const CRON_COMMAND_LANE: string = CommandLane.Cron;
 
 export type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {
-    getReplyFromConfig?: typeof import("./heartbeat-runner.runtime.js").getReplyFromConfig;
+    getReplyFromConfig?: typeof import("./heartbeat-runner.runtime.js").getHeartbeatReplyFromConfig;
     runtime?: RuntimeEnv;
     getQueueSize?: (lane?: string) => number;
     isReplyRunActive?: (sessionKey: string) => boolean;
@@ -605,7 +605,8 @@ export async function invokeHeartbeatAgentRun(
   const replyOperationRunState: ReplyOperationRunState = {};
   const heartbeatModelOverride = normalizeOptionalString(heartbeat?.model);
   const getReplyFromConfig =
-    opts.deps?.getReplyFromConfig ?? (await loadHeartbeatRunnerRuntime()).getReplyFromConfig;
+    opts.deps?.getReplyFromConfig ??
+    (await loadHeartbeatRunnerRuntime()).getHeartbeatReplyFromConfig;
   const heartbeatWakeAbortSignal = getHeartbeatWakeAbortSignal();
   const replyOpts = {
     isHeartbeat: true,

--- a/src/infra/heartbeat-runner.runtime.ts
+++ b/src/infra/heartbeat-runner.runtime.ts
@@ -1,3 +1,21 @@
 // Lazy heartbeat runtime facade keeps tests from importing the full auto-reply
 // runtime unless the runner path needs it.
-export { getReplyFromConfig } from "../auto-reply/reply.js";
+import { loadPublishedGatewayReplyDispatchRuntime } from "../agents/prepared-model-runtime.js";
+import { getReplyFromConfig as resolveReplyFromConfig } from "../auto-reply/reply.js";
+import { bindPreparedReplyDispatchRuntime } from "../auto-reply/reply/prepared-reply-dispatch-context.js";
+
+export async function getReplyFromConfig(
+  ...args: Parameters<typeof resolveReplyFromConfig>
+): ReturnType<typeof resolveReplyFromConfig> {
+  const [ctx, opts, configOverride] = args;
+  const agentId = ctx.AgentId?.trim();
+  const runtime = agentId
+    ? await loadPublishedGatewayReplyDispatchRuntime({
+        agentId,
+        abortSignal: opts?.abortSignal,
+      })
+    : undefined;
+  return runtime
+    ? bindPreparedReplyDispatchRuntime(runtime, resolveReplyFromConfig)(ctx, opts)
+    : resolveReplyFromConfig(ctx, opts, configOverride);
+}

--- a/src/infra/heartbeat-runner.runtime.ts
+++ b/src/infra/heartbeat-runner.runtime.ts
@@ -4,7 +4,7 @@ import { loadPublishedGatewayReplyDispatchRuntime } from "../agents/prepared-mod
 import { getReplyFromConfig as resolveReplyFromConfig } from "../auto-reply/reply.js";
 import { bindPreparedReplyDispatchRuntime } from "../auto-reply/reply/prepared-reply-dispatch-context.js";
 
-export async function getReplyFromConfig(
+export async function getHeartbeatReplyFromConfig(
   ...args: Parameters<typeof resolveReplyFromConfig>
 ): ReturnType<typeof resolveReplyFromConfig> {
   const [ctx, opts, configOverride] = args;

--- a/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import { createServer, type ServerResponse } from "node:http";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { markCompleteReplyConfig } from "../../../../src/auto-reply/reply/get-reply-fast-path.test-support.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
@@ -328,6 +327,7 @@ describe("Gateway heartbeat session routing", () => {
                 [provider.modelRef]: {
                   params: { transport: "sse", openaiWsWarmup: false },
                 },
+                "catalog-proof/*": {},
               },
             },
             entries: { main: { default: true } },
@@ -343,6 +343,8 @@ describe("Gateway heartbeat session routing", () => {
               },
             },
           },
+          // Full configs may contain nested nulls; heartbeat admission must not reinterpret them as patches.
+          tts: { providers: { fixture: { disabledVoice: null } } },
           gateway: { auth: { mode: "token", token } },
           plugins: {
             enabled: true,
@@ -359,11 +361,20 @@ describe("Gateway heartbeat session routing", () => {
           token,
           clientDisplayName: "vitest-gateway-heartbeat-session-routing",
         });
+        await gateway.server.startupSettled;
+        await disconnectGatewayClient(gateway.client);
+        await gateway.server.close({ reason: "heartbeat catalog-owner restart proof" });
+        gateway = await startGatewayWithClient({
+          cfg: config,
+          configPath,
+          token,
+          clientDisplayName: "vitest-gateway-heartbeat-session-routing-restarted",
+        });
+        await gateway.server.startupSettled;
         const runtimeConfig = getRuntimeConfigSnapshot();
         if (!runtimeConfig) {
           throw new Error("gateway runtime config snapshot was not initialized");
         }
-        markCompleteReplyConfig(runtimeConfig, { runtimeMode: "full" });
         const client = gateway.client;
 
         const seedSession = async (params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes #136225.

After a clean Gateway restart, a system-owned heartbeat could fail before provider dispatch because it passed the complete Gateway config as an explicit reply override. That bypassed the prepared reply-dispatch runtime and reinterpreted the complete config as a merge patch. A valid nested `null` could then change the config identity, so model catalog admission rejected the turn.

Reported by @Famyoff.

## Why This Change Was Made

Gateway-owned heartbeat replies now load the published `PreparedReplyDispatchRuntime` for their agent and bind that immutable config, catalog, workspace, and plugin generation to reply preparation. The Gateway cron adapter no longer injects the unbound generic resolver into the heartbeat runner.

Standalone heartbeat callers keep the exact explicit-config path when no Gateway lifecycle is active. The change adds no retry, fallback, configuration option, or model-policy change.

Alternatives rejected:

- Catching and retrying catalog replacement errors would mask stale ownership.
- Weakening exact catalog matching would break explicit config isolation.
- Marking the heartbeat config as complete would fix only merge-patch drift, not a real publication race.

## User Impact

System-owned heartbeats survive clean Gateway restarts and reach their configured provider. Session isolation still affects only heartbeat session context.

## Evidence

- Baseline `e936020d5b0cd93da7e157c9fdda5e301e07ba53`: a real Gateway close/restart followed by forced `heartbeat:main` execution recorded `status=error`, `completionStatus=failed`, `deliveryStatus=not-requested`, and zero provider requests.
- Exact repair behavior: the same restart and forced system heartbeat recorded `status=ok`, `completionStatus=succeeded`, and one loopback `POST /v1/responses` provider request.
- [Blacksmith Testbox run 33622164751](https://github.com/openclaw/openclaw/actions/runs/33622164751): a packaged Gateway process restarted from PID 7894 to PID 8172, then the system heartbeat completed and the provider recorded one request.
- [Exact-head CI run 33622647235](https://github.com/openclaw/openclaw/actions/runs/33622647235): green after rerunning the runner-only pre-commit tag-fetch failure.
- The changed Gateway E2E regression fails on the baseline because cron records `status=error`, then passes on the exact head.
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.model-override.test.ts src/auto-reply/reply/get-reply.config-override.test.ts src/agents/prepared-model-catalog.test.ts --reporter=verbose` — 47 passed.
- `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts --reporter=verbose` — 1 passed.
- Targeted format, Oxlint, runtime-sidecar, import-cycle, conflict-marker, and test-temp checks passed.
- Host policy forbids local OpenClaw typechecks and builds; pull-request CI owns those gates.

Production LOC: +25/-4 (net +21) for the Gateway publication boundary. Tests: +13/-2 (net +11).
