### PR TITLE
test(ui): seed typography history and settle cloud picker transitions

### DIFF
--- a/ui/src/e2e/new-session-page.places-live.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places-live.e2e.test.ts
@@ -35,7 +35,7 @@ suite.define(() => {
     }
   });
 
-  it("shows advertised cloud machines only to admins", async () => {
+  it("shows advertised cloud machines after selecting a profile", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -63,9 +63,13 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}new`);
       await gateway.waitForRequest("environments.list");
-      await page.locator("#new-session-where-trigger").click();
+      const where = page.locator("#new-session-where-trigger");
+      await where.click();
       const picker = page.locator("wa-popover.new-session-page__where-popover");
-      await picker.locator('[data-value="cloud:aws"]').click();
+      const profile = picker.locator('[data-value="cloud:aws"]');
+      await profile.click();
+      await profile.waitFor({ state: "hidden" });
+      await where.click();
       await picker.locator('[data-value="machine:fast"]').waitFor();
     } finally {
       await context.close();

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -10,10 +10,10 @@ import { finishElementAnimations } from "../test-helpers/animations.ts";
 import {
   controlUiBundledGatewayUrl,
   installMockGateway,
+  type ControlUiMockGatewayScenario,
   waitForControlUiRoute,
   waitForControlUiSettingsTakeover,
 } from "../test-helpers/control-ui-e2e.ts";
-import { requireRecord, requireString } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 /*
@@ -47,7 +47,11 @@ function themeConfigResponse(theme: string, mode: "dark" | "light") {
   };
 }
 
-async function openThemedChat(theme: string, mode: "dark" | "light", basePath = "") {
+async function openThemedChat(
+  theme: string,
+  mode: "dark" | "light",
+  scenario: Pick<ControlUiMockGatewayScenario, "basePath" | "historyMessages"> = {},
+) {
   const context = await suite.newBrowserContext({
     colorScheme: mode,
     locale: "en-US",
@@ -80,33 +84,10 @@ async function openThemedChat(theme: string, mode: "dark" | "light", basePath = 
     }
   });
   const gateway = await installMockGateway(page, {
-    ...(basePath ? { basePath } : {}),
+    ...scenario,
     methodResponses: { "config.get": themeConfigResponse(theme, mode) },
   });
   return { themeRequests, gateway, page };
-}
-
-async function renderAssistantProse(
-  gateway: Awaited<ReturnType<typeof installMockGateway>>,
-  page: Awaited<ReturnType<typeof openThemedChat>>["page"],
-) {
-  await page.locator(".agent-chat__composer-combobox textarea").fill("say something");
-  await page.getByRole("button", { name: "Send message" }).click();
-  const sendRequest = await gateway.waitForRequest("chat.send");
-  const runId = requireString(
-    requireRecord(sendRequest.params).idempotencyKey,
-    "chat send idempotency key",
-  );
-  const text =
-    "Typography carries the theme: chat prose renders in the reading face while chrome, chips, and code keep their own.";
-  await gateway.emitGatewayEvent("chat", {
-    message: { content: [{ text, type: "text" }], role: "assistant", timestamp: Date.now() },
-    runId,
-    sessionKey: "main",
-    state: "final",
-  });
-  // first() is the prompt this test just sent; the assistant reply is last.
-  await expect.poll(() => page.locator(".chat-text").last().textContent()).toContain("Typography");
 }
 
 async function captureTypography(
@@ -250,9 +231,27 @@ suite.define(() => {
   ] as const)(
     "paints %s chrome and chat prose in its own faces",
     async (theme, body, chat, faces, chatSmoothing) => {
-      const { themeRequests, gateway, page } = await openThemedChat(theme, "dark");
+      const timestamp = Date.now();
+      const text =
+        "Typography carries the theme: chat prose renders in the reading face while chrome, chips, and code keep their own.";
+      const { themeRequests, page } = await openThemedChat(theme, "dark", {
+        historyMessages: [
+          {
+            content: [{ text: "say something", type: "text" }],
+            role: "user",
+            timestamp: timestamp - 1,
+          },
+          {
+            content: [{ text, type: "text" }],
+            role: "assistant",
+            timestamp,
+          },
+        ],
+      });
       await page.goto(`${suite.server.baseUrl}chat`);
-      await renderAssistantProse(gateway, page);
+      await expect
+        .poll(() => page.locator(".chat-text").last().textContent())
+        .toContain("Typography");
 
       const report = await page.evaluate(async () => {
         await document.fonts.ready;
@@ -574,7 +573,7 @@ suite.define(() => {
     // root-absolute font URLs 404 there and the theme silently falls back to
     // system faces while its palette still applies.
     const basePath = "/openclaw";
-    const { page } = await openThemedChat("absolutely", "dark", basePath);
+    const { page } = await openThemedChat("absolutely", "dark", { basePath });
     const requested: string[] = [];
     // The preview server does not stamp Gateway HTML. Reproduce the actual
     // document contract, rather than letting runtime repair a wrong boot URL.


### PR DESCRIPTION
## Problem

Eleven typography cases send a chat turn and emit a final Gateway event solely to populate two text rows for font assertions. That repeats composer and message-delivery work for every theme; the messaging suite already covers those interactions directly.

The initial full CI run also exposed a separate cloud-picker fixture race: selecting a cloud profile closes its menu, but the test waits for a machine row without reopening it. On that run the row stayed hidden until the existing 30-second deadline.

## Solution

Seed the same user prompt and assistant prose through the existing mock Gateway history fixture. Keep their order, both rendered rows, the real browser and font assets, and every typography assertion. Remove the private send/event helper and its coercion imports; let the existing themed-page helper accept the narrow history/base-path scenario it needs.

All 26 cases, 36 source-declared fresh browser contexts, and 50 static assertion sites remain. The eleven font cases still check native font loading, successful font responses, computed families and smoothing. The other fifteen cases retain the CSS-only boot, palette takeover, mounted-path and missing-font coverage. The actual GUI send/final-event and hard-reload transcript cases remain in `chat-flow.messaging.e2e.test.ts`.

Repair the picker flow by waiting for the selected profile to become hidden, then clicking Where normally before checking the machine row. This follows the real popover animation and trigger fence. Rename the case to describe its actual profile-selection coverage; the existing admin/writer permission unit coverage remains intact.

Production delta: 0. Test delta: +35/-32 across two files. No runtime, configuration, dependency, or timing-budget change.

## Measurement and verification

The complete canonical UI file ran three times on one Linux Testbox with Node 24.19.0, pnpm 12.1.0, one worker and no file parallelism. Each stage included its real bundle build and passed all 26 cases in the same order.

| Measurement | Original | Candidate | Restored original |
| --- | --- | --- | --- |
| Whole command, including build | 28.407s | 23.289s | 32.653s |
| Eleven changed font cases | 11.833s | 7.871s | 14.298s |
| Other fifteen cases | 8.031s | 8.574s | 10.361s |

The observed original-to-candidate reductions were 18.0% for the whole command and 33.5% for the affected cases. Every affected case was faster than both originals. The restored control slowed generally, so these observations are not a fixed whole-suite guarantee or a claim that its full 28.7% difference comes from this patch.

Proof used `9fda3b1855c798e632c8a390c1e0701565c39162`. This branch starts at `dae372c49c12005cc1dff4a7eca9f4dec5a28e95`; the intervening renderer change inlines the same Markdown options at their caller and leaves the font/text contract intact. The final formatter only wraps the existing poll expression. Published-head CI must pass before landing.

All 86 proof source/asset guards and original test bytes were restored. The three command groups and all sampled process identities exited without rescue; the owned temporary root and newly created cache were removed. Sampling does not certify unseen detached descendants. The [exact Testbox lease](https://github.com/openclaw/openclaw/actions/runs/33622490108) was stopped. Formatting, scoped typed lint and whitespace validation passed; separate Codex reviews found no accepted P0 findings in the typography change or picker follow-up.

The picker's six cases passed in each fresh Linux before/candidate/restored run: 14.211s, 13.004s and 13.079s. Both private originals raced through successfully, so the reproducible evidence is the retained [initial CI failure](https://github.com/openclaw/openclaw/actions/runs/33623202367/job/100225047552); no private failure or picker speedup is claimed. All 21 assertion sites remain. The [picker proof run](https://github.com/openclaw/openclaw/actions/runs/33624758777) checked the actual Web Awesome 3.12.0 close implementation, restored all 38 source guards, joined its three command groups without rescue, removed its owned roots, and stopped its Testbox.
