### PR TITLE
docs: list QA and placeholder reference pages in navigation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1347,6 +1347,7 @@
                   "channels/group-messages",
                   "channels/groups",
                   "channels/ambient-room-events",
+                  "channels/bot-loop-protection",
                   "channels/broadcast-groups",
                   "channels/channel-routing",
                   "channels/location",
@@ -1455,6 +1456,7 @@
                   "plugins/codex-supervision",
                   "plugins/codex-native-plugins",
                   "plugins/codex-computer-use",
+                  "plugins/copilot",
                   "plugins/logbook",
                   "plugins/meeting-plugins",
                   "plugins/google-meet",
@@ -1655,6 +1657,7 @@
                   "providers/anthropic",
                   "providers/arcee",
                   "providers/azure-speech",
+                  "providers/baseten",
                   "providers/cerebras",
                   "providers/chutes",
                   "providers/clawrouter",
@@ -1887,7 +1890,8 @@
                   "security/network-proxy",
                   "security/formal-verification",
                   "security/THREAT-MODEL-ATLAS",
-                  "security/CONTRIBUTING-THREAT-MODEL"
+                  "security/CONTRIBUTING-THREAT-MODEL",
+                  "security/incident-response"
                 ]
               },
               {
@@ -1980,7 +1984,8 @@
                       "cli/promos",
                       "cli/sessions",
                       "cli/system",
-                      "cli/tasks"
+                      "cli/tasks",
+                      "cli/transcripts"
                     ]
                   },
                   {
@@ -2061,7 +2066,8 @@
                 "group": "Codex harness",
                 "pages": [
                   "plugins/codex-harness-reference",
-                  "plugins/codex-harness-runtime"
+                  "plugins/codex-harness-runtime",
+                  "specs/codex-supervision"
                 ]
               },
               {
@@ -2118,6 +2124,7 @@
                   "agent-runtime-architecture",
                   "reference/token-use",
                   "reference/secretref-credential-surface",
+                  "reference/secret-placeholder-conventions",
                   "reference/openclaw-ai",
                   "reference/prompt-caching",
                   "reference/api-usage-costs",
@@ -2215,7 +2222,10 @@
                 "pages": [
                   "help/testing",
                   "help/testing-updates-plugins",
-                  "help/testing-live"
+                  "help/testing-live",
+                  "concepts/mantis",
+                  "concepts/mantis-slack-desktop-runbook",
+                  "channels/qa-channel"
                 ]
               },
               {


### PR DESCRIPTION
## Review status: blocked on QA documentation policy

The current candidate must not be merged yet. The existing channel catalog check passes on the pinned baseline and fails on this candidate with `docs/docs.json exposes hidden channel routes: channels/qa-channel`.

QA metadata explicitly sets `exposure.docs: false`, and the catalog policy applies that exclusion to all navigation groups. PR #143845 deliberately preserved the same exclusion. The browser proof remains valid, but it cannot override that contract.

A placeholder-only alternative passes the catalog check and is prepared for a scope decision. It has not been applied to this branch. Keeping the QA entry would require an explicitly accepted, coherent exposure-contract change; no package metadata, validator, or test has been weakened.

## What Problem This Solves

The existing QA channel and secret placeholder reference pages are missing from the docs sidebar. Both already open through inbound links and site search; their unlisted navigation state also gives them the generic “Get started” search label.

## Why This Change Was Made

Add `channels/qa-channel` to Help → Testing and `reference/secret-placeholder-conventions` next to the SecretRef credential surface in Technical reference. Preserve the complete pages, frontmatter, inbound links, and all other navigation ordering.

This retains the remaining two-page public slice of the original contribution. Five other entries landed independently in #143845. The three internal QA/specification entries remain outside this change. The original contribution is preserved in branch history.

## User Impact

Readers can reach both pages from their appropriate sidebar groups. The QA channel page continues to describe a repo-local synthetic transport, a private package, and a tool excluded from packaged installs; it is not a production channel. Runtime, package, QA, and secret-scanner behavior do not change.

## Evidence

- Used the official full docs build and Pagefind search pipeline with preview filtering disabled.
- Baseline browser checks show missing sidebar entries, working inbound links, and existing search results for both pages.
- Candidate checks cover both new sidebar entries, real search results and navigation, complete page preservation, and existing inbound links.
- JSON, exact English placement, formatting, MDX, docs-list, internal links, the commit hook, review, and hosted CI provide the finishing gates.

Thanks to @yetval for the original contribution.
