### PR TITLE
refactor(agents): simplify context window cache loading

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -6,7 +6,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { computeBackoff, type BackoffPolicy } from "../infra/backoff.js";
 import {
   applyConfiguredContextWindows,
-  type ContextWindowCatalog,
   prepareContextWindowCaches,
   prepareDiscoveredContextTokenCache,
 } from "./context-cache-projection.js";
@@ -41,10 +40,6 @@ export {
   applyConfiguredContextWindows,
   applyDiscoveredContextWindows,
 } from "./context-cache-projection.js";
-type ContextWindowCatalogOwner = {
-  config: OpenClawConfig;
-  modelCatalog: ContextWindowCatalog;
-};
 const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
   initialMs: 1_000,
   maxMs: 60_000,
@@ -87,10 +82,7 @@ function primeConfiguredContextWindows(): OpenClawConfig | undefined {
   }
 }
 
-function ensureContextWindowCacheLoadedFromOwner(params: {
-  cfgOverride?: OpenClawConfig;
-  catalogOwner?: ContextWindowCatalogOwner;
-}): Promise<void> {
+export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Promise<void> {
   const generation = CONTEXT_WINDOW_RUNTIME_STATE.generation;
   if (
     CONTEXT_WINDOW_RUNTIME_STATE.loadPromise &&
@@ -99,11 +91,9 @@ function ensureContextWindowCacheLoadedFromOwner(params: {
     return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
   }
 
-  const cfg = params.catalogOwner
-    ? primeConfiguredContextWindowsFromConfig(params.catalogOwner.config)
-    : params.cfgOverride
-      ? primeConfiguredContextWindowsFromConfig(params.cfgOverride)
-      : primeConfiguredContextWindows();
+  const cfg = cfgOverride
+    ? primeConfiguredContextWindowsFromConfig(cfgOverride)
+    : primeConfiguredContextWindows();
   if (!cfg) {
     return Promise.resolve();
   }
@@ -114,19 +104,16 @@ function ensureContextWindowCacheLoadedFromOwner(params: {
       }
       let stagedTokenCache = new Map<string, number>();
       try {
-        const catalogResult = params.catalogOwner
-          ? ({ status: "fulfilled" as const, value: params.catalogOwner } as const)
-          : await (async () => {
-              const { loadPreparedModelCatalogOwnerSnapshot } =
-                await loadPreparedModelCatalogRuntime();
-              return await loadPreparedModelCatalogOwnerSnapshot({
-                config: cfg,
-                readOnly: true,
-              }).then(
-                (value) => ({ status: "fulfilled" as const, value }),
-                (reason: unknown) => ({ status: "rejected" as const, reason }),
-              );
-            })();
+        const catalogResult = await (async () => {
+          const { loadPreparedModelCatalogOwnerSnapshot } = await loadPreparedModelCatalogRuntime();
+          return await loadPreparedModelCatalogOwnerSnapshot({
+            config: cfg,
+            readOnly: true,
+          }).then(
+            (value) => ({ status: "fulfilled" as const, value }),
+            (reason: unknown) => ({ status: "rejected" as const, reason }),
+          );
+        })();
         if (CONTEXT_WINDOW_RUNTIME_STATE.generation !== generation) {
           return;
         }
@@ -153,10 +140,6 @@ function ensureContextWindowCacheLoadedFromOwner(params: {
     });
   CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration = generation;
   return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
-}
-
-export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Promise<void> {
-  return ensureContextWindowCacheLoadedFromOwner({ cfgOverride });
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Context-window cache loading retains an unused internal route for a supplied model catalog. This makes the loading lifecycle harder to follow despite all current callers using the normal asynchronous catalog loader.

## Why This Change Was Made

Remove the unused private route and inline the remaining loading work into the existing cache-loading owner. Keep its exported signature, cached Promise, synchronous configuration priming, deferred loading, retry/backoff, generation checks, and cache publication behavior unchanged. No public API, configuration, dependency, or persistent-state changes are intended.

## User Impact

No user-visible behavior change is intended. This is an internal ownership cleanup: production +14/-31 lines (net -17), with no test changes. The cleanup removes 16 semantic lines; normal formatting joins one existing statement, accounting for the additional physical line.

## Evidence

The existing context lookup and cache-projection suites passed all 36 cases before and after the semantic cleanup. The normal 16-stage full build also passed on those pre-format candidate bytes. Final formatting changed only one exactly verified statement line join; normal format and format checks passed on the final source. These earlier functional results are not relabeled as tests of the final byte hash.

The final local Codex review is scoped-clean at P0. Its first report-writing attempt failed because the external output directory was missing; the unchanged retry completed and saved the canonical result.

The corrected full 28-check configured gate passed on the final source. Its full source, dependency/generated inventory, index/config, and owned sync/lease/process after-checks also passed. The first attempt stopped during remote base reconstruction before project checks; the unchanged retry reached the formatting check, which exposed the line join corrected here. The separate signed-commit Codex review completed once and is scoped-clean at P0, with no findings. Exact-head CI remains pending. No live provider/Gateway/TUI flow or explicit Promise-identity test is claimed.
