### PR TITLE
docs(gateway): run Linux system services as the state owner

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -251,7 +251,7 @@ ExecStart=/usr/local/bin/openclaw gateway --port 18789
 Restart=always
 RestartSec=5
 RestartPreventExitStatus=78
-TimeoutStopSec=30
+TimeoutStopSec=330
 TimeoutStartSec=30
 SuccessExitStatus=0 143
 OOMPolicy=continue
@@ -260,6 +260,8 @@ KillMode=control-group
 [Install]
 WantedBy=default.target
 ```
+
+Keep `TimeoutStopSec` at `330` or higher: the Gateway drains active work for up to five minutes on stop and restart, and a shorter stop timeout makes systemd SIGKILL it mid-turn. `systemctl --user cat openclaw-gateway[-<profile>].service` shows the current managed unit body if you would rather copy that.
 
   </Tab>
 
@@ -289,8 +291,25 @@ sudo systemctl enable --now openclaw-gateway[-<profile>].service
 ```
 
 Use the same service body as the user unit, but install it under
-`/etc/systemd/system/openclaw-gateway[-<profile>].service` and adjust
-`ExecStart=` if your `openclaw` binary lives elsewhere.
+`/etc/systemd/system/openclaw-gateway[-<profile>].service`, adjust
+`ExecStart=` if your `openclaw` binary lives elsewhere, and add the account
+that owns the config and state directory to `[Service]`:
+
+```ini
+[Service]
+User=<user>
+Group=<user>
+Environment=HOME=/home/<user>
+```
+
+Do not run the Gateway as root. A system unit without `User=` runs as root, so
+every command the agent executes runs as root too, and with no `HOME` the
+Gateway looks for its config under `/root/.openclaw`, exits with code `78`
+(`Missing config`), and `RestartPreventExitStatus=78` keeps it stopped. Set
+`OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` in the unit instead when the
+state lives outside that home. On a single-user host, `loginctl enable-linger`
+plus the user unit above is the supported way to keep the Gateway running
+without a login session.
 
 Do not also let `openclaw doctor --fix` install a user-level gateway service for the same profile/port. Doctor refuses that automatic install when it finds a system-level OpenClaw gateway service; use `OPENCLAW_SERVICE_REPAIR_POLICY=external` when the system unit owns the lifecycle.
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -298,16 +298,16 @@ that owns the config and state directory to `[Service]`:
 ```ini
 [Service]
 User=<user>
-Group=<user>
-Environment=HOME=/home/<user>
 ```
 
 Do not run the Gateway as root. A system unit without `User=` runs as root, so
 every command the agent executes runs as root too, and with no `HOME` the
 Gateway looks for its config under `/root/.openclaw`, exits with code `78`
-(`Missing config`), and `RestartPreventExitStatus=78` keeps it stopped. Set
-`OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` in the unit instead when the
-state lives outside that home. On a single-user host, `loginctl enable-linger`
+(`Missing config`), and `RestartPreventExitStatus=78` keeps it stopped. With
+`User=` set, systemd supplies that account's primary group and home directory,
+so the Gateway finds `~/.openclaw` for that account; set `OPENCLAW_STATE_DIR`
+and `OPENCLAW_CONFIG_PATH` in the unit instead when the state lives outside
+that home. On a single-user host, `loginctl enable-linger`
 plus the user unit above is the supported way to keep the Gateway running
 without a login session.
 

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -295,7 +295,7 @@ ExecStart=/usr/local/bin/openclaw gateway --port 18789
 Restart=always
 RestartSec=5
 RestartPreventExitStatus=78
-TimeoutStopSec=30
+TimeoutStopSec=330
 TimeoutStartSec=30
 SuccessExitStatus=0 143
 OOMPolicy=continue
@@ -305,7 +305,7 @@ KillMode=control-group
 WantedBy=default.target
 ```
 
-Hand-written units do not inherit the adaptive heap sizing that `openclaw gateway install` writes for managed Gateway services. Prefer the managed installer, or set an explicit heap limit in the custom supervisor after accounting for native-memory headroom.
+Hand-written units do not inherit the adaptive heap sizing that `openclaw gateway install` writes for managed Gateway services. Prefer the managed installer, or set an explicit heap limit in the custom supervisor after accounting for native-memory headroom. Keep `TimeoutStopSec` at `330` or higher: the Gateway drains active work for up to five minutes on stop and restart, and a shorter stop timeout makes systemd SIGKILL it mid-turn.
 
 Enable it:
 


### PR DESCRIPTION
Related: #123872

## What Problem This Solves

Operators following the Linux system-service example could omit `User=` and run the Gateway under the root account instead of the account that owns its state and configuration.

## Why This Change Was Made

The system-service instructions now require the state-owning non-root account before enabling the unit. They explain systemd's primary-group and default home behavior, preserve the explicit state/configuration path controls, and warn against using root's home as a workaround.

Both unit examples retain the current managed fields, including `TimeoutStopSec=330`, `OOMPolicy=continue`, and `KillMode=mixed`. The added explanation connects the stop allowance to the five-minute cooperative drain and teardown reserve. Existing Doctor ownership, user-unit lingering, and profile naming guidance remain intact.

## User Impact

Operators can configure the service account and locate the intended state before starting the Gateway. The examples explain the existing shutdown allowance without changing service behavior.

## Evidence

- Compared both complete unit examples against the pinned current managed-unit generator and its existing tests.
- Checked account, group, home, restart-status, and lingering statements against the installed systemd 257.13 manuals and current configuration-path/start-guard source.
- Targeted formatting, MDX checks for both changed pages, and `git diff --check` passed.
- Fresh documentation review uses the complete source and manual evidence. Hosted documentation checks and the final exact-head review gate are required before landing.

Only two documentation pages change. No Gateway, service, configuration, shutdown, or runtime behavior is modified or operated by this repair. The original contributor commits are preserved.
