### PR TITLE
docs(channels): correct activation owners, pairing store location, and reef pairing support

### DIFF
--- a/docs/channels/group-messages.md
+++ b/docs/channels/group-messages.md
@@ -67,7 +67,7 @@ Use the group chat command:
 - `/activation mention`
 - `/activation always`
 
-Only owner numbers (from `channels.whatsapp.allowFrom`, or the bot's own E.164 when unset) can change this; `/activation` from anyone else is ignored and stored as context only. Send `/status` as a standalone message in the group to see the current activation mode.
+Only the command owner can change this: the sender must match `commands.ownerAllowFrom` (`openclaw pairing approve` bootstraps the first owner when that list is empty); channel `allowFrom` lists do not grant it. `/activation` from anyone else is ignored and stored as context only. See [Activation (owner-only)](/channels/groups#activation-owner-only). Send `/status` as a standalone message in the group to see the current activation mode.
 
 ## How to use
 

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -70,7 +70,7 @@ WhatsApp's login QR links a WhatsApp account to OpenClaw. DM access requests
 approve people who message that account. These are separate flows.
 </Note>
 
-Supported channels (any installed channel plugin that declares pairing; external plugins such as `openclaw-weixin` can add more): `discord`, `feishu`, `googlechat`, `imessage`, `irc`, `line`, `matrix`, `mattermost`, `msteams`, `nextcloud-talk`, `nostr`, `signal`, `slack`, `sms`, `synology-chat`, `telegram`, `twitch`, `whatsapp`, `zalo`, `zalouser`.
+Supported channels (any installed channel plugin that declares pairing; external plugins such as `openclaw-weixin` can add more): `discord`, `feishu`, `googlechat`, `imessage`, `irc`, `line`, `matrix`, `mattermost`, `msteams`, `nextcloud-talk`, `nostr`, `reef`, `signal`, `slack`, `sms`, `synology-chat`, `telegram`, `twitch`, `whatsapp`, `zalo`, `zalouser`.
 
 ### Reusable sender groups
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -188,7 +188,7 @@ Prefer pairing + allowlists for DMs. For groups, decide by membership, not by ch
 
 ### Allowlists (two layers)
 
-- **DM allowlist** (`allowFrom` / `channels.discord.allowFrom` / `channels.slack.allowFrom`; legacy: `channels.discord.dm.allowFrom`, `channels.slack.dm.allowFrom`): who can DM the bot. When `dmPolicy="pairing"`, approvals write to `~/.openclaw/credentials/<channel>-allowFrom.json` (default account) or `<channel>-<accountId>-allowFrom.json` (non-default accounts), merged with config allowlists.
+- **DM allowlist** (`allowFrom` / `channels.discord.allowFrom` / `channels.slack.allowFrom`; legacy: `channels.discord.dm.allowFrom`, `channels.slack.dm.allowFrom`): who can DM the bot. When `dmPolicy="pairing"`, approvals are stored in the shared SQLite state database (see [Where the state lives](/channels/pairing#where-the-state-lives)), merged with config allowlists.
 - **Group allowlist** (channel-specific): which groups/channels/guilds the bot accepts at all.
   - `channels.whatsapp.groups`, `channels.telegram.groups`, `channels.imessage.groups`: per-group defaults like `requireMention`; when set, also acts as a group allowlist (include `"*"` to keep allow-all behavior). Customize mention triggers with `agents.entries.*.groupChat.mentionPatterns` (for example `["@openclaw", "@mybot"]`) so `requireMention` gates on your own bot names.
   - `groupPolicy="allowlist"` + `groupAllowFrom`: restrict who can trigger the bot inside a group session (WhatsApp/Telegram/Signal/iMessage/Microsoft Teams).
@@ -799,7 +799,7 @@ Also useful for backup decisions:
 - Telegram bot token: config/env or `channels.telegram.tokenFile` (regular file only; symlinks rejected)
 - Discord bot token: config/env or SecretRef (env/file/exec/store providers)
 - Slack tokens: config/env (`channels.slack.*`)
-- Pairing allowlists: `~/.openclaw/credentials/<channel>-allowFrom.json` (default account) / `<channel>-<accountId>-allowFrom.json` (non-default accounts)
+- Pairing allowlists: `~/.openclaw/state/openclaw.sqlite` (`channel_pairing_allow_entries`; see [Where the state lives](/channels/pairing#where-the-state-lives))
 - Model auth profiles: `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite` (`auth_profile_store`)
 - MCP OAuth sessions: `~/.openclaw/state/openclaw.sqlite` (`mcp_oauth_stores`)
 - Legacy OAuth import: `~/.openclaw/credentials/oauth.json`


### PR DESCRIPTION
<!-- Source-first documentation bugs; no public issue. -->

## What Problem This Solves

Fixes an issue where users reading docs/channels/group-messages.md "Activation command (owner-only)" would expect `channels.whatsapp.allowFrom` entries (or the bot's own number) to be allowed to run `/activation`, while the runtime only honors `commands.ownerAllowFrom`.

Fixes an issue where users reading docs/gateway/security/index.md "Allowlists (two layers)" (and the backup list at the end of the same page) would look for pairing approvals in `~/.openclaw/credentials/<channel>-allowFrom.json`, a legacy location the runtime no longer reads or writes.

Fixes an issue where users reading docs/channels/pairing.md "Approve from the CLI" would conclude `reef` does not support `openclaw pairing approve`, although the plugin declares a pairing adapter.

## Why This Change Was Made

- docs/channels/group-messages.md: owner gating now matches docs/channels/groups.md "Activation (owner-only)": `/activation` goes through `rejectNonOwnerCommand` (src/auto-reply/reply/commands-session.ts:174, src/auto-reply/reply/command-gates.ts:82), and `senderIsOwner` is true only when the sender matches `commands.ownerAllowFrom` (src/auto-reply/command-auth.ts:299-321 builds `explicitOwners` from `cfg.commands.ownerAllowFrom`; lines 524-539 derive `senderIsOwner` from it). The first-owner bootstrap by `openclaw pairing approve` is documented in docs/cli/pairing.md "Owner bootstrap" and implemented in src/pairing/command-owner.ts:32 and src/cli/pairing-cli.ts:199-201.
- docs/gateway/security/index.md: both mentions of the legacy JSON path now point at the SQLite state database via docs/channels/pairing.md "Where the state lives" (src/pairing/pairing-store-sqlite.ts:91-101 reads `channel_pairing_allow_entries`; src/state/openclaw-state-db.paths.ts:12 names `openclaw.sqlite`).
- docs/channels/pairing.md: `reef` added to the supported-channel list (extensions/reef/src/channel.ts:214 declares `pairing`); the list now matches every bundled channel plugin that declares a pairing adapter.

No runtime change. An earlier revision of this PR also rewrote the Feishu group policy default on docs/channels/feishu.md; that turned out to be a runtime defect (the plugin schema declares `allowlist` but the runtime resolves an unset value to `open`), so it is being handled as a separate code fix instead of a docs rewording.

## User Impact

WhatsApp operators know `/activation` requires `commands.ownerAllowFrom`, not an `allowFrom` entry. Operators auditing or backing up pairing approvals look in the SQLite state database instead of a file that no longer exists. Reef users know CLI pairing approval works for them.

## Evidence

Corrections checked against source on origin/main `dae372c49c1`:

- `/activation` owner: src/auto-reply/reply/commands-session.ts:174 -> `rejectNonOwnerCommand` (src/auto-reply/reply/command-gates.ts:82-96) -> `senderIsOwner`, which src/auto-reply/command-auth.ts:524-539 sets only from `explicitOwners` (built from `cfg.commands.ownerAllowFrom` at lines 299-321). Owner bootstrap: src/cli/pairing-cli.ts:199-201, src/pairing/command-owner.ts:32.
- Pairing store: src/pairing/pairing-store-sqlite.ts:91-101; path src/state/openclaw-state-db.paths.ts:12. Nothing under src/pairing references the legacy `*-allowFrom.json` names; only the one-shot importer (src/infra/state-migrations.channel-pairing.ts) knows them.
- Reef pairing adapter: extensions/reef/src/channel.ts:214; the supported list was re-derived from every non-test `pairing: {` declaration under extensions/*/src and only `reef` was missing.
- Links: /channels/pairing#where-the-state-lives (heading at docs/channels/pairing.md:104), /channels/groups#activation-owner-only (docs/channels/groups.md:577).

Documentation checks run from the branch (all clean):

```
node scripts/check-docs-mdx.mjs docs README.md                        -> Docs MDX check passed (752 files)
node --import ./scripts/tsx.mjs scripts/format-docs.mts --check       -> Docs formatting clean (739 files)
node scripts/check-docs-config-examples.mjs                           -> 1215 fences validated, 0 failures
node --import ./scripts/tsx.mjs scripts/check-docs-i18n-glossary.mts  -> exit 0
./node_modules/.bin/oxfmt --check <3 changed files>                   -> All matched files use the correct format
git diff --check                                                      -> clean
```

Proof boundary: documentation-only change; the runtime is unchanged.
Exact head: db47fa3ec7057fd1bbc77e36c3bf8784c4e77f8d

Production LOC: 0. Tests: 0. Documentation: +4/-4.
