### PR TITLE
docs(nodes): complete the two-stage approval flow

### DIFF
--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -70,12 +70,26 @@ openclaw devices reject <requestId>
 
 ### `openclaw devices join-code`
 
-Mint a single-use node onboarding URL.
+Mint a single-use node onboarding URL with administrator access to the
+Gateway. Paste the printed `npx openclaw connect <url>` command on the machine
+to enroll.
 
 ```bash
 openclaw devices join-code
 openclaw devices join-code --json
 ```
+
+Join-code creation and redemption are core Gateway operations; no pairing
+plugin needs to be enabled. The URL must be reachable from the joining machine.
+Remote join URLs require a TLS Gateway endpoint. Explicitly configured loopback
+endpoints can use HTTP, provided the joining machine can reach that loopback
+endpoint, for example through a local tunnel.
+
+With only the default loopback bind and no advertised endpoint, URL discovery
+refuses to mint a link. Configure a reachable secure endpoint first; see
+[Gateway deployments that cannot host nodes](/nodes/node-host#gateway-deployments-that-cannot-host-nodes).
+Plaintext LAN pairing can use a setup code directly instead of an HTTP join URL.
+See [Connect a machine](/cli/connect).
 
 ### `openclaw devices remove <deviceId>`
 

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -41,7 +41,7 @@ Paired device display names use this precedence: operator label (`operatorLabel`
 
 Mint a single-use node onboarding URL for the one-paste flow. Run it on the
 Gateway host with admin credentials, then paste the printed
-`openclaw connect <url>` command on the machine to enroll.
+`npx openclaw connect <url>` command on the machine to enroll.
 
 ```bash
 openclaw devices join-code

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -37,6 +37,22 @@ For a pending request on an already-paired device, the output shows requested ac
 
 Paired device display names use this precedence: operator label (`operatorLabel` from `devices rename`), then client `displayName`, then `clientId`, then `deviceId`.
 
+### `openclaw devices join-code`
+
+Mint a single-use node onboarding URL for the one-paste flow. Run it on the
+Gateway host with admin credentials, then paste the printed
+`openclaw connect <url>` command on the machine to enroll.
+
+```bash
+openclaw devices join-code
+openclaw devices join-code --json
+```
+
+Requires the bundled `device-pair` plugin and a Gateway URL that node hosts
+can reach; a loopback-only Gateway errors instead of minting a link. See
+[Gateway deployments that cannot host nodes](/nodes#gateway-deployments-that-cannot-host-nodes)
+and [Connect a machine](/cli/connect).
+
 ### `openclaw devices approve [requestId] [--latest]`
 
 Approve a pending pairing request by exact `requestId`. Omitting `requestId`, or passing `--latest`, only previews the newest pending request and exits (code 1); rerun with the exact request ID to approve.

--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -103,10 +103,15 @@ Options:
 ## Gateway auth for node host
 
 `--pair` uses a 10-minute single-use bootstrap token for the first connection.
-After pairing, reconnects use the durable device credential. The setup link
-does not pre-approve `system.run`; normal node approval and SSH verification
-remain in force. `node install --pair` is intentionally unavailable because a
-short-lived bearer setup link must not be persisted in service arguments.
+After pairing, reconnects use the durable device credential. Administrator-minted
+bootstrap enrollment approves the device and its first declared command surface,
+including `system.run` when declared. Later command, capability, or permission
+expansion still requires `openclaw nodes approve`. Gateway command policy and
+the node host's [exec approvals](/tools/exec-approvals) remain separate gates.
+Local exec approvals default to `full` with `ask: "off"`; configure them before
+using a setup link if that access is too broad. `node install --pair` is
+intentionally unavailable because a short-lived bearer setup link must not be
+persisted in service arguments.
 
 `openclaw node run` and `openclaw node install` resolve gateway auth from config/env (no `--token`/`--password` flags on node commands):
 
@@ -214,8 +219,26 @@ Otherwise approve manually via:
 
 ```bash
 openclaw devices list
-openclaw devices approve <requestId>
+openclaw devices approve <deviceRequestId>
 ```
+
+Device approval admits the connection, not its command surface. Restart an
+installed node with `openclaw node restart`, or stop and rerun the foreground
+`openclaw node run` command. A node paused on `PAIRING_REQUIRED` does not resume
+automatically after manual approval. This reconnect creates a separate
+command-surface request on the Gateway:
+
+```bash
+openclaw nodes pending
+openclaw nodes approve <nodeRequestId>
+openclaw nodes describe --node <idOrNameOrIp>
+```
+
+The device and node request IDs are distinct. An initial unapproved surface has
+no effective commands. SSH-verified and bootstrap enrollment can approve the
+first surface automatically; later expansions require approval. Previously
+approved commands that remain declared and allowed stay effective while an
+expansion waits.
 
 Inspect the local node identity the Gateway verifies against:
 
@@ -245,6 +268,9 @@ This is disabled by default (`autoApproveCidrs` is unset). It only applies to
 fresh `role: node` pairing with no requested scopes, from a client IP the
 Gateway trusts. Operator/browser clients, Control UI, WebChat, and role,
 scope, metadata, or public-key upgrades still require manual approval.
+
+Trusted-network device approval does not approve the node's command surface.
+Inspect `openclaw nodes pending` and approve the separate surface request.
 
 If the node retries pairing with changed auth details (role/scopes/public key),
 the previous pending request is superseded and a new `requestId` is created.

--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -103,10 +103,14 @@ Options:
 ## Gateway auth for node host
 
 `--pair` uses a 10-minute single-use bootstrap token for the first connection.
-After pairing, reconnects use the durable device credential. The setup link
-does not pre-approve `system.run`; normal node approval and SSH verification
-remain in force. `node install --pair` is intentionally unavailable because a
-short-lived bearer setup link must not be persisted in service arguments.
+After pairing, reconnects use the durable device credential. Because an admin
+minted the setup link, the Gateway approves the device pairing and the node's
+initial declared command surface (including `system.run`) at first connect;
+later surface upgrades still need `openclaw nodes approve`. Command execution
+then depends on the node host's [exec approvals](/tools/exec-approvals), which
+default to `full`, so configure them before sharing a link. `node install
+--pair` is intentionally unavailable because a short-lived bearer setup link
+must not be persisted in service arguments.
 
 `openclaw node run` and `openclaw node install` resolve gateway auth from config/env (no `--token`/`--password` flags on node commands):
 
@@ -216,6 +220,21 @@ Otherwise approve manually via:
 openclaw devices list
 openclaw devices approve <requestId>
 ```
+
+Manual approval admits the device only, and a node host paused on
+`PAIRING_REQUIRED` does not reconnect by itself. Restart it (`openclaw node
+restart`, or rerun `openclaw node run`); the reconnect creates a separate
+command-surface request. Approve it so `system.run` / `system.which` become
+effective:
+
+```bash
+openclaw nodes pending
+openclaw nodes approve <requestId>
+```
+
+Until then the node is connected and device-paired with no effective
+commands. SSH-verified pairing and setup-code enrollment (`--pair`,
+`openclaw connect`) approve the initial surface automatically.
 
 Inspect the local node identity the Gateway verifies against:
 

--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -60,7 +60,7 @@ Flags:
 - `--command <command>` (required): e.g. `device.info`.
 - `--params <json>`: JSON object string (default `{}`).
 - `--invoke-timeout <ms>`: node invoke timeout (default `15000`).
-- `--timeout <ms>`: Gateway transport timeout (default `30000`).
+- `--timeout <ms>`: Gateway transport timeout (default `10000`). The effective transport timeout is at least `--invoke-timeout` plus `10000`.
 - `--idempotency-key <key>`: optional idempotency key.
 
 `system.run` and `system.run.prepare` are blocked here; use the `exec` tool with `host=node` for shell execution instead. `system.which` is allowed through `invoke`.

--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -50,12 +50,18 @@ openclaw nodes remove --node <id|name|ip>
 openclaw nodes rename --node <id|name|ip> --name <displayName>
 ```
 
-These commands manage the node's approved command/capability surface on its paired-device record. Device pairing (`openclaw devices approve`) gates the node's WebSocket `connect` handshake. See [Nodes](/nodes) for how the two relate.
+These commands manage the node's approved command/capability surface on its paired-device record. Device pairing (`openclaw devices approve`) gates the node's WebSocket `connect` handshake.
+
+For manual enrollment, first approve the device request, then restart or rerun
+a node paused on `PAIRING_REQUIRED`. Its reconnect creates the separate request
+shown by `nodes pending`. Approve that node request, whose ID differs from the
+device request ID. See [Node pairing and status](/nodes/pairing-and-status#pairing-+-status)
+for the complete sequence.
 
 - `remove` revokes the device's `node` role and clears its approved and pending command/capability surfaces. It disconnects the device's node-role sessions. A mixed-role device keeps its record and other roles; a node-only device record is deleted.
 - Removal stays effective even if worker cleanup reports an error: revoked node connections still close.
 - `pending` only needs `operator.pairing` scope.
-- `gateway.nodes.pairing.autoApproveCidrs` can skip the pending step for explicitly trusted, first-time `role: node` device pairing. Off by default; does not approve role upgrades.
+- `gateway.nodes.pairing.autoApproveCidrs` can approve explicitly trusted, first-time `role: node` device pairing. It is off by default and does not approve role upgrades or the separate command surface; that request still appears in `nodes pending`.
 - `gateway.nodes.pairing.sshVerify` (on by default) auto-approves first-time `role: node` device pairing when the gateway can verify the device key over SSH to the node host; the first capability surface is approved in the same step. See [Node pairing](/gateway/pairing#ssh-verified-device-auto-approval-default).
 - `approve` scope requirements follow the pending request's declared commands:
   - commandless request: `operator.pairing`
@@ -75,7 +81,7 @@ Flags:
 - `--command <command>` (required): e.g. `device.info`.
 - `--params <json>`: JSON object string (default `{}`).
 - `--invoke-timeout <ms>`: node invoke timeout (default `15000`).
-- `--timeout <ms>`: Gateway transport timeout (default `30000`).
+- `--timeout <ms>`: Gateway transport timeout (default `30000`). The effective timeout is `max(timeout, invokeTimeout + 10000)`, allowing transport grace beyond the node's invoke deadline.
 - `--idempotency-key <key>`: optional idempotency key.
 
 `system.run` and `system.run.prepare` are blocked here; use the `exec` tool with `host=node` for shell execution instead. `system.which` is allowed through `invoke`.

--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -80,8 +80,8 @@ Flags:
 
 - `--command <command>` (required): e.g. `device.info`.
 - `--params <json>`: JSON object string (default `{}`).
-- `--invoke-timeout <ms>`: node invoke timeout (default `15000`).
-- `--timeout <ms>`: Gateway transport timeout (default `30000`). The effective timeout is `max(timeout, invokeTimeout + 10000)`, allowing transport grace beyond the node's invoke deadline.
+- `--invoke-timeout <ms>`: node invoke timeout as a positive integer (default `15000`).
+- `--timeout <ms>`: Gateway transport timeout (default `30000`). For a positive invoke timeout, the effective transport timeout is `max(timeout, invokeTimeout + 10000)`, allowing transport grace beyond the node's invoke deadline.
 - `--idempotency-key <key>`: optional idempotency key.
 
 `system.run` and `system.run.prepare` are blocked here; use the `exec` tool with `host=node` for shell execution instead. `system.which` is allowed through `invoke`.

--- a/docs/gateway/pairing.md
+++ b/docs/gateway/pairing.md
@@ -46,6 +46,10 @@ the Gateway checks its pairing identity and generation against the persisted
 approval and limits access to the capabilities and commands that connection
 declared.
 
+An initial unapproved surface has no effective commands. While a later expansion
+waits, previously approved commands remain effective only if the node still
+declares them and Gateway command policy allows them.
+
 The **5-minute expiry** still applies to **device-pairing** requests,
 not to capability approvals on an already-paired device.
 
@@ -85,17 +89,40 @@ leaf certificate. The bootstrap token expires after 10 minutes. Explicit
 The bootstrap token and resulting device credential are separate, like a
 short-lived Tailscale auth key and the durable device identity it admits.
 Revoking or expiring the setup link does not revoke the paired device; remove
-the device separately when needed. The link never pre-approves `system.run` or
-folder sync. Those operations still use pending approval or
+the device separately when needed. Administrator-minted bootstrap enrollment
+approves the device and its first declared command surface, including `system.run`
+when declared, like
 [SSH-verified device auto-approval](#ssh-verified-device-auto-approval-default).
+Later command, capability, or permission expansion still requires approval.
+Gateway command policy and [node-local exec approvals](/tools/exec-approvals)
+remain separate gates. Local exec approvals default to `full` with `ask: "off"`;
+configure them before using a link if that access is too broad.
 
 ## CLI workflow (headless friendly)
 
+For manual device admission, first run on the Gateway:
+
+```bash
+openclaw devices list
+openclaw devices approve <deviceRequestId>
+```
+
+Restart the installed node with `openclaw node restart`, or stop and rerun its
+foreground command. A node paused on `PAIRING_REQUIRED` does not resume after
+manual approval. Its reconnect creates the separate command-surface request:
+
 ```bash
 openclaw nodes pending
-openclaw nodes approve <requestId>
-openclaw nodes reject <requestId>
+openclaw nodes approve <nodeRequestId>
 openclaw nodes status
+openclaw nodes describe --node <idOrNameOrIp>
+```
+
+The device and node request IDs are distinct. To reject a surface request or
+manage an existing node instead:
+
+```bash
+openclaw nodes reject <nodeRequestId>
 openclaw nodes remove --node <id|name|ip>
 openclaw nodes rename --node <id|name|ip> --name "Living Room iPad"
 ```
@@ -150,13 +177,13 @@ top-level Gateway `fs.listDir` RPC needs `operator.write` for
 workspace-contained host browsing and `operator.admin` when `nodeId` is present.
 
 <Warning>
-Node pairing approval records the trusted capability surface. It does **not** pin the live node command surface per node.
+Node surface approval records the durable command/capability ceiling. It does
+not grant commands that the node adds later or no longer declares.
 
-- Live node commands come from what the node declares on connect, filtered by
-  the gateway's global node command policy (`gateway.nodes.commands.allow` and
-  `gateway.nodes.commands.deny`).
-- Per-node `system.run` allow and ask policy lives on the node in
-  `exec.approvals.node.*`, not in the pairing record.
+- Live commands must be both declared and approved, then pass the Gateway's
+  command policy (`gateway.nodes.commands.allow` and `gateway.nodes.commands.deny`).
+- Shell allowlist and ask policy for `system.run` live in the node's
+  [exec approvals](/tools/exec-approvals), not in the pairing record.
 
 </Warning>
 
@@ -340,6 +367,8 @@ Security boundary:
   network locality alone.
 - Only a fresh `role: node` device pairing request with no requested scopes is
   eligible.
+- This approves the device only. Its first command surface still needs
+  `openclaw nodes pending` and `openclaw nodes approve <nodeRequestId>`.
 - Operator, browser, Control UI, and WebChat clients stay manual.
 - Role, scope, metadata, and public-key upgrades stay manual.
 - Same-host loopback trusted-proxy header paths are not eligible, because that

--- a/docs/gateway/pairing.md
+++ b/docs/gateway/pairing.md
@@ -56,9 +56,14 @@ leaf certificate. The bootstrap token expires after 10 minutes. Explicit
 The bootstrap token and resulting device credential are separate, like a
 short-lived Tailscale auth key and the durable device identity it admits.
 Revoking or expiring the setup link does not revoke the paired device; remove
-the device separately when needed. The link never pre-approves `system.run` or
-folder sync. Those operations still use pending approval or
+the device separately when needed. Because an admin minted the link, the
+Gateway treats it as consent to the node's initial declared surface: device
+pairing and the first command surface (including `system.run` when the node
+declares it) are approved at first connect, like
 [SSH-verified device auto-approval](#ssh-verified-device-auto-approval-default).
+Only later surface upgrades create a pending request. Command execution is
+still gated by the node host's [exec approvals](/tools/exec-approvals), which
+default to `full`; configure them before sharing a link.
 
 ## CLI workflow (headless friendly)
 

--- a/docs/nodes/command-policy.md
+++ b/docs/nodes/command-policy.md
@@ -10,10 +10,19 @@ sidebarTitle: "Command policy"
 
 ## Command policy
 
-Node commands must pass two gates before they can be invoked:
+After device pairing, node commands must satisfy three requirements before they
+can be invoked:
 
 1. The node must declare the command in its authenticated connect metadata (`connect.commands`).
-2. The gateway's platform-and-approval-derived allowlist must include the declared command.
+2. The command must be in the node's approved command surface on its paired-device record.
+3. The Gateway's platform-and-approval-derived allowlist must include the declared command.
+
+Use `openclaw nodes pending` and `openclaw nodes approve <nodeRequestId>` to
+approve a pending surface. This request ID differs from the device request ID.
+An initial unapproved surface has no effective commands. During a pending
+expansion, only previously approved commands that remain declared and allowed
+stay effective. Local exec approvals and operating-system permissions still
+apply after these checks.
 
 Default allowlists by platform (before plugin defaults and `commands.allow`/`commands.deny` overrides):
 
@@ -47,7 +56,10 @@ Dangerous or privacy-heavy commands require a one-time persistent opt-in with `g
 
 Plugin-owned node commands can add a Gateway node-invoke policy. That policy runs after the allowlist check and before forwarding to the node, so raw `node.invoke`, CLI helpers, and dedicated agent tools share the same plugin permission boundary. Dangerous plugin node commands still require explicit `gateway.nodes.commands.allow` opt-in.
 
-After a node changes its declared command list, reconnect it, inspect `openclaw nodes pending`, and approve the widened surface with `openclaw nodes approve <requestId>` so the Gateway stores the updated command snapshot.
+After a node expands its declared commands, capabilities, or permissions,
+reconnect it, inspect `openclaw nodes pending`, and approve the widened surface
+with `openclaw nodes approve <nodeRequestId>`. Removing declarations does not
+grant new access or require approval for an expansion.
 
 ## Config (`openclaw.json`)
 
@@ -88,8 +100,8 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
     exec: {
       // Default exec host: "node" routes all exec calls to a paired node.
       host: "node",
-      // Security mode for node exec: allow only approved/allowlisted commands.
-      security: "allowlist",
+      // Exec policy mode for node exec: allow only approved/allowlisted commands.
+      mode: "allowlist",
       // Pin exec to a specific node (id or name). Omit to allow any node.
       node: "build-node",
     },

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -25,12 +25,14 @@ Troubleshooting runbook: [/nodes/troubleshooting](/nodes/troubleshooting)
 
 ## Pairing + status
 
-Nodes use **device pairing**. A node presents a signed device identity during connect; the Gateway creates a device pairing request for `role: node`. Approve via the devices CLI (or UI). The direct Apple Watch setup uses an admin-minted, short-lived node-only setup code to approve its fixed low-risk command surface; later capability expansion still requires normal approval.
+Nodes use **device pairing**. A node presents a signed device identity during connect; the Gateway creates a device pairing request for `role: node`. Approve via the devices CLI (or UI). Device approval admits the connection only: the node's declared command surface is a second approval (`openclaw nodes pending` / `openclaw nodes approve`) unless the device was SSH-verified or enrolled with a setup code. The direct Apple Watch setup uses an admin-minted, short-lived node-only setup code to approve its fixed low-risk command surface; later capability expansion still requires normal approval.
 
 ```bash
 openclaw devices list
 openclaw devices approve <requestId>
 openclaw devices reject <requestId>
+openclaw nodes pending
+openclaw nodes approve <requestId>
 openclaw nodes status
 openclaw nodes describe --node <idOrNameOrIp>
 ```
@@ -128,9 +130,13 @@ openclaw node run --pair "oc-pair://<setup-code>"
 
 The link is single-use and expires after 10 minutes. It supplies the endpoint,
 bootstrap token, TLS mode, and certificate pin when available. Explicit
-gateway flags override the corresponding `--pair` values. Pairing does not
-pre-approve command execution; the first `system.run` request still follows
-the normal pending-approval or SSH-verification path. See
+gateway flags override the corresponding `--pair` values. Because an admin
+minted the link, the Gateway approves the device pairing and the node's
+initial declared command surface (including `system.run` and `system.which`)
+at first connect; only later surface upgrades create a pending request.
+Command execution is then gated by the node host's exec approvals, which
+default to `full`, so set them before sharing a link (see
+[Allowlist the commands](#allowlist-the-commands)). See
 [Node pairing](/gateway/pairing#one-paste-node-pairing).
 
 `node run` also accepts `--pair`, `--context-path` (Gateway WS context path), `--tls`, `--tls-fingerprint <sha256>`, and `--node-id` (override the legacy client instance ID; this does not reset pairing). On macOS, pass `--share-installed-apps` to advertise `device.apps`; sharing is off by default. Use `--no-share-installed-apps` to disable a previously saved opt-in.
@@ -172,15 +178,31 @@ openclaw node restart
 
 ### Pair + name
 
-On the gateway host:
+On the gateway host, approve the device pairing request:
 
 ```bash
 openclaw devices list
 openclaw devices approve <requestId>
-openclaw nodes status
 ```
 
 If the node retries with changed auth details, re-run `openclaw devices list` and approve the current `requestId`.
+
+Device approval admits the connection only, and a node host paused on
+`PAIRING_REQUIRED` does not reconnect by itself. Restart it (`openclaw node
+restart`, or rerun `openclaw node run`). The reconnect creates a separate
+command-surface request; approve it, then check that `system.run` appears in
+the node's commands:
+
+```bash
+openclaw nodes pending
+openclaw nodes approve <requestId>
+openclaw nodes describe --node <id|name|ip>
+```
+
+The two request IDs are distinct. Until the surface is approved, the node is
+connected and device-paired with no effective commands. SSH-verified pairing
+and setup-code enrollment (`--pair`, `openclaw connect`) complete both steps
+automatically.
 
 Naming options:
 
@@ -786,8 +808,8 @@ Node-related settings live under `gateway.nodes` and `tools.exec`:
     exec: {
       // Default exec host: "node" routes all exec calls to a paired node.
       host: "node",
-      // Security mode for node exec: allow only approved/allowlisted commands.
-      security: "allowlist",
+      // Exec policy mode for node exec: allow only approved/allowlisted commands.
+      mode: "allowlist",
       // Pin exec to a specific node (id or name). Omit to allow any node.
       node: "build-node",
     },

--- a/docs/nodes/node-host.md
+++ b/docs/nodes/node-host.md
@@ -29,8 +29,8 @@ Approval note:
 A Gateway can remain healthy for browser users while node hosting is unavailable. Run `openclaw doctor` on the Gateway before onboarding nodes, and check these preconditions:
 
 - **Machine authentication:** Tailscale identity headers do not authenticate node-role connections. In `gateway.auth.mode: "trusted-proxy"`, a new node also cannot supply the proxy's user identity headers. To use a shared token, switch to token mode and configure `gateway.auth.token` with a SecretRef; trusted-proxy mode rejects mixed token configuration. A trusted-proxy Gateway can use `gateway.auth.password` only for clean loopback/direct callers. See [trusted-proxy mixed token configuration](/gateway/trusted-proxy-auth#mixed-token-configuration).
-- **Node onboarding URL:** With `gateway.bind: "loopback"`, configure Tailscale Serve, `gateway.remote.url`, or `plugins.entries.device-pair.config.publicUrl` before minting a join code. Otherwise `openclaw devices join-code` reports: `Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.`
-- **Node onboarding plugin:** Join codes and `openclaw connect` require the bundled `device-pair` plugin. If it is disabled or excluded by plugin policy, set `plugins.entries.device-pair.enabled: true`, make sure `device-pair` is allowed, and restart the Gateway.
+- **Node onboarding URL:** With only the default `gateway.bind: "loopback"` and no advertised endpoint, `openclaw devices join-code` reports: `Gateway is only bound to loopback. Set gateway.bind=lan, enable tailscale serve, or configure plugins.entries.device-pair.config.publicUrl.` Configure a reachable endpoint through Tailscale Serve, `gateway.remote.url`, or `plugins.entries.device-pair.config.publicUrl`. Remote join URLs require TLS; enabling LAN bind alone does not enable plaintext remote join URLs. Explicitly configured loopback endpoints can produce HTTP join URLs, but the joining machine must be able to reach that loopback endpoint, for example through a local tunnel. Plaintext LAN pairing can use a setup code directly.
+- **Node onboarding support:** Join-code creation and `/j` redemption are core Gateway operations. They do not require enabling the `device-pair` plugin, even though its retained `publicUrl` configuration field can supply an endpoint. See [Join codes](/cli/devices#openclaw-devices-join-code) for the printed `npx openclaw connect <url>` command.
 - **Device session runtime:** Paired-device runners support the embedded OpenClaw runtime and explicitly authorized Codex `remote-exec`; ACPX routes cannot dispatch to a paired device. Codex requires `codex.exec-server.stdio.v1` in `gateway.nodes.commands.allow` plus its normal pairing and invocation approvals. Runtime policy belongs on provider/model routes, not the ignored whole-agent runtime keys. Multi-agent rosters must also set `agents.ownership: "explicit"`. See [Codex paired-device placement](/plugins/codex-harness/placement#run-codex-on-a-paired-device) and [runtime policy](/gateway/config-agents/runtime-and-cli-backends#runtime-policy).
 - **Edge routing:** When a reverse proxy or access edge fronts the Gateway, the node must satisfy edge auth on the join request, its main Gateway WebSocket, and the worker WebSocket. Keep WebSocket upgrade enabled for `/__openclaw__/worker`. You can instead exempt `/j/*` and `/__openclaw__/worker` from edge identity auth because both routes enforce their own short-lived credentials. See [worker protocol](/gateway/protocol/handshake#worker-role-and-closed-protocol).
 
@@ -65,9 +65,13 @@ openclaw node run --pair "oc-pair://<setup-code>"
 
 The link is single-use and expires after 10 minutes. It supplies the endpoint,
 bootstrap token, TLS mode, and certificate pin when available. Explicit
-gateway flags override the corresponding `--pair` values. Pairing does not
-pre-approve command execution; the first `system.run` request still follows
-the normal pending-approval or SSH-verification path. See
+gateway flags override the corresponding `--pair` values. Administrator-minted
+bootstrap enrollment approves the device and its first declared command surface,
+including `system.run` and `system.which` when declared. Later command,
+capability, or permission expansion still creates an approval request.
+Gateway command policy and the node host's [exec approvals](/tools/exec-approvals)
+still apply. Local exec approvals default to `full` with `ask: "off"`; configure
+them before using the link if that access is too broad. See
 [Node pairing](/gateway/pairing#one-paste-node-pairing).
 
 `node run` also accepts `--pair`, `--context-path` (Gateway WS context path), `--tls`, `--tls-fingerprint <sha256>`, and `--node-id` (override the legacy client instance ID; this does not reset pairing). On macOS, pass `--share-installed-apps` to advertise `device.apps`; sharing is off by default. Use `--no-share-installed-apps` to disable a previously saved opt-in.
@@ -109,15 +113,32 @@ openclaw node restart
 
 ### Pair + name
 
-On the gateway host:
+On the Gateway host, approve the device request:
 
 ```bash
 openclaw devices list
-openclaw devices approve <requestId>
-openclaw nodes status
+openclaw devices approve <deviceRequestId>
 ```
 
 If the node retries with changed auth details, re-run `openclaw devices list` and approve the current `requestId`.
+
+Restart an installed node with `openclaw node restart`, or stop and rerun its
+foreground `openclaw node run` command. A node paused on `PAIRING_REQUIRED`
+does not resume automatically after manual approval. Its reconnect creates a
+separate command-surface request. On the Gateway:
+
+```bash
+openclaw nodes pending
+openclaw nodes approve <nodeRequestId>
+openclaw nodes describe --node <id|name|ip>
+```
+
+The device and node request IDs are distinct. An initial unapproved surface has
+no effective commands. SSH-verified and bootstrap enrollment can approve the
+first surface automatically; trusted-network device approval alone does not.
+Later expansions need approval, while previously approved commands that remain
+declared and allowed can still run. [Gateway command policy](/nodes/command-policy)
+and node-local exec approvals remain separate gates.
 
 Naming options:
 
@@ -182,7 +203,7 @@ openclaw node run --host <gateway-host> --port 18789
 
 Notes:
 
-- Pairing is still required (the Gateway will show a device pairing prompt).
+- Device pairing and command-surface approval are still required; follow [Pair + name](/nodes/node-host#pair-+-name) through both stages.
 - Client instance metadata, signed device identity, and pairing auth use separate state records; see [Headless identity state](#headless-identity-state).
 - Exec approvals are enforced locally via
   `~/.openclaw/state/openclaw.sqlite#exec_approvals_config` (see [Exec approvals](/tools/exec-approvals)).

--- a/docs/nodes/pairing-and-status.md
+++ b/docs/nodes/pairing-and-status.md
@@ -10,17 +10,43 @@ sidebarTitle: "Pairing and status"
 
 ## Pairing + status
 
-Nodes use **device pairing**. A node presents a signed device identity during connect; the Gateway creates a device pairing request for `role: node`. Approve via the devices CLI (or UI). The direct Apple Watch setup uses an admin-minted, short-lived node-only setup code to approve its fixed low-risk command surface; later capability expansion still requires normal approval.
+Nodes use **device pairing**. A node presents a signed device identity during connect; the Gateway creates a device pairing request for `role: node`. Device approval admits the connection; the declared command surface needs a separate approval. The direct Apple Watch setup uses an admin-minted, short-lived node-only setup code to approve its fixed low-risk command surface; later capability expansion still requires normal approval.
+
+For manual approval, run these commands on the Gateway:
 
 ```bash
 openclaw devices list
-openclaw devices approve <requestId>
-openclaw devices reject <requestId>
+openclaw devices approve <deviceRequestId>
+```
+
+Restart the installed node with `openclaw node restart`, or stop and rerun its
+foreground `openclaw node run` command. For an app node paused for manual pairing,
+restart node mode or the app. This reconnect creates a separate command-surface
+request. Back on the Gateway:
+
+```bash
+openclaw nodes pending
+openclaw nodes approve <nodeRequestId>
 openclaw nodes status
 openclaw nodes describe --node <idOrNameOrIp>
 ```
 
-Pending pairing requests expire 5 minutes after the device's last retry — a device that keeps reconnecting keeps its one pending request (and `requestId`) alive instead of minting a new prompt every few minutes; see [Node pairing](/gateway/pairing) for the full request/approve lifecycle. If a node retries with changed auth details (role/scopes/public key), the prior pending request is superseded and a new `requestId` is created — clients get a `device.pair.resolved` event for the superseded request, and you should re-run `openclaw devices list` before approving.
+The two request IDs are distinct. Use `openclaw devices reject <deviceRequestId>`
+to reject device admission instead of approving it. An initial unapproved surface
+has no effective commands. During an expansion, previously approved commands
+remain effective only while the node still declares them and Gateway policy
+allows them.
+
+SSH-verified and administrator-minted bootstrap enrollment can approve the first
+surface automatically. Trusted-network device approval alone does not; inspect
+`nodes pending` and approve the surface separately. Later command, capability,
+or permission expansion still needs approval. Surface approval does not bypass
+[Gateway command policy](/nodes/command-policy) or [local exec approvals](/tools/exec-approvals).
+
+Pending device-pairing requests expire 5 minutes after the device's last retry — a device that keeps reconnecting keeps its one pending request (and `requestId`) alive instead of minting a new prompt every few minutes; see [Node pairing](/gateway/pairing) for the full request/approve lifecycle. If a node retries with changed auth details (role/scopes/public key), the prior pending request is superseded and a new `requestId` is created — clients get a `device.pair.resolved` event for the superseded request, and you should re-run `openclaw devices list` before approving.
+
+Pending command-surface requests do not expire merely with time; they follow the
+[capability approval lifecycle](/gateway/pairing#how-capability-approval-works).
 
 - `nodes status` marks a node as **paired** when its device pairing role includes `node`.
 - A connected native Mac can opt in to coalesced physical-input activity from

--- a/docs/nodes/troubleshooting.md
+++ b/docs/nodes/troubleshooting.md
@@ -57,6 +57,7 @@ openclaw channels status --probe
 Then run node-specific checks:
 
 ```bash
+openclaw nodes pending
 openclaw nodes status
 openclaw nodes describe --node <idOrNameOrIp>
 openclaw approvals get --node <idOrNameOrIp>
@@ -100,26 +101,39 @@ If you see `NODE_BACKGROUND_UNAVAILABLE`, bring the node app to the foreground a
 
 ## Pairing versus approvals
 
-Three separate gates control whether a node command succeeds:
+Four separate approval and policy gates control whether a node command succeeds:
 
 1. **Device pairing**: can this node connect to the gateway?
-2. **Gateway node command policy**: is the RPC command ID allowed by `gateway.nodes.commands.allow` / `gateway.nodes.commands.deny` and platform defaults?
-3. **Exec approvals**: can this node run a specific shell command locally?
+2. **Node command surface approval**: has the declared command been approved through `openclaw nodes pending` and `openclaw nodes approve <nodeRequestId>`?
+3. **Gateway node command policy**: is the RPC command ID allowed by `gateway.nodes.commands.allow` / `gateway.nodes.commands.deny` and platform defaults?
+4. **Exec approvals**: can this node run a specific shell command locally?
 
-Node pairing is an identity/trust gate, not a per-command approval surface. For `system.run`, the per-node policy lives in that node's exec approvals file (`openclaw approvals get --node ...`), not in the gateway pairing record.
+Device pairing admits the identity; surface approval limits the commands on its
+paired-device record. The two request IDs are distinct. An initial unapproved
+surface exposes no effective commands. A pending expansion retains only commands
+that were already approved, remain declared, and pass Gateway policy. For
+`system.run`, shell allowlist and ask policy live in the node's exec approvals
+(`openclaw approvals get --node ...`), not the pairing record. Platform permissions
+and foreground requirements still apply.
 
 Quick checks:
 
 ```bash
 openclaw devices list
+openclaw nodes pending
 openclaw nodes status
 openclaw approvals get --node <idOrNameOrIp>
 openclaw approvals allowlist add --node <idOrNameOrIp> "/usr/bin/uname"
 ```
 
-- Pairing missing: approve the node device first.
+- Pairing missing: approve the current device request with `openclaw devices approve <deviceRequestId>`, then restart or rerun a node paused on `PAIRING_REQUIRED`. The reconnect creates the separate surface request.
+- Node paired and connected with an initial empty command list: inspect `openclaw nodes pending` and approve its distinct `<nodeRequestId>` with `openclaw nodes approve <nodeRequestId>`.
 - `nodes describe` missing a command: check the gateway node command policy and whether the node actually declared that command on connect.
-- Pairing fine but `system.run` fails: fix exec approvals/allowlist on that node.
+- Surface approved but `system.run` fails: check Gateway policy, then exec approvals/allowlist on that node.
+
+SSH-verified and bootstrap enrollment can approve the first surface automatically.
+Trusted-network device approval does not. Later command, capability, or permission
+expansion still needs surface approval.
 
 For approval-backed `host=node` runs, the gateway also binds execution to the prepared canonical `systemRunPlan`. If a later caller mutates the command, cwd, or session metadata before the approved run is forwarded, the gateway rejects the run as an approval mismatch instead of trusting the edited payload.
 
@@ -150,6 +164,7 @@ openclaw logs --follow
 If still stuck:
 
 - Re-approve device pairing.
+- Restart or rerun a node paused for manual pairing, then approve its pending surface request with `openclaw nodes pending` / `openclaw nodes approve <nodeRequestId>`.
 - Re-open the node app (foreground).
 - Re-grant OS permissions.
 - Recreate/adjust the exec approval policy.

--- a/docs/nodes/troubleshooting.md
+++ b/docs/nodes/troubleshooting.md
@@ -100,26 +100,29 @@ If you see `NODE_BACKGROUND_UNAVAILABLE`, bring the node app to the foreground a
 
 ## Pairing versus approvals
 
-Three separate gates control whether a node command succeeds:
+Four separate gates control whether a node command succeeds:
 
 1. **Device pairing**: can this node connect to the gateway?
-2. **Gateway node command policy**: is the RPC command ID allowed by `gateway.nodes.commands.allow` / `gateway.nodes.commands.deny` and platform defaults?
-3. **Exec approvals**: can this node run a specific shell command locally?
+2. **Node command surface approval**: has an operator approved the commands this node declared (`openclaw nodes pending` / `openclaw nodes approve <requestId>`)? A connected, device-paired node with this request pending has no effective commands.
+3. **Gateway node command policy**: is the RPC command ID allowed by `gateway.nodes.commands.allow` / `gateway.nodes.commands.deny` and platform defaults?
+4. **Exec approvals**: can this node run a specific shell command locally?
 
-Node pairing is an identity/trust gate, not a per-command approval surface. For `system.run`, the per-node policy lives in that node's exec approvals file (`openclaw approvals get --node ...`), not in the gateway pairing record.
+Device pairing is an identity/trust gate; the command surface approval, stored on the same paired-device record, is the per-command gate. For `system.run`, the shell allowlist and ask policy live in that node's exec approvals file (`openclaw approvals get --node ...`), not in the pairing record.
 
 Quick checks:
 
 ```bash
 openclaw devices list
+openclaw nodes pending
 openclaw nodes status
 openclaw approvals get --node <idOrNameOrIp>
 openclaw approvals allowlist add --node <idOrNameOrIp> "/usr/bin/uname"
 ```
 
-- Pairing missing: approve the node device first.
+- Pairing missing: approve the node device first. A headless node host paused on `PAIRING_REQUIRED` must be restarted after approval.
+- Node paired and connected but `nodes describe` lists no commands: approve the pending surface request shown by `openclaw nodes pending`.
 - `nodes describe` missing a command: check the gateway node command policy and whether the node actually declared that command on connect.
-- Pairing fine but `system.run` fails: fix exec approvals/allowlist on that node.
+- Surface approved but `system.run` fails: fix exec approvals/allowlist on that node.
 
 For approval-backed `host=node` runs, the gateway also binds execution to the prepared canonical `systemRunPlan`. If a later caller mutates the command, cwd, or session metadata before the approved run is forwarded, the gateway rejects the run as an approval mismatch instead of trusting the edited payload.
 
@@ -150,6 +153,7 @@ openclaw logs --follow
 If still stuck:
 
 - Re-approve device pairing.
+- Approve a pending command surface request (`openclaw nodes pending`).
 - Re-open the node app (foreground).
 - Re-grant OS permissions.
 - Recreate/adjust the exec approval policy.

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -71,7 +71,8 @@ the tray to confirm connection, pairing, node status, and channel health.
 
 Windows Hub can register as an OpenClaw node so the agent can use declared
 Windows-native capabilities through the Gateway. Node commands must be
-declared by the node and allowed by Gateway policy before they run; see
+declared by the node, included in its approved surface, and allowed by Gateway
+policy before they run; see
 [Nodes](/nodes/command-policy#command-policy) for the full allow/deny model.
 
 Common commands:
@@ -89,9 +90,25 @@ approve it from the Gateway host:
 
 ```powershell
 openclaw devices list
-openclaw devices approve <requestId>
-openclaw nodes status
+openclaw devices approve <deviceRequestId>
 ```
+
+Device approval admits the connection only. If node mode has paused for manual
+pairing, restart node mode or the app so it reconnects. This reconnect creates
+a separate command-surface request. On the Gateway:
+
+```powershell
+openclaw nodes pending
+openclaw nodes approve <nodeRequestId>
+openclaw nodes status
+openclaw nodes describe --node <idOrNameOrIp>
+```
+
+The two request IDs are distinct. An initial unapproved surface has no effective
+commands. During a pending expansion, approved commands that remain declared and
+allowed can still run. SSH-verified and bootstrap enrollment can approve the
+first surface automatically; trusted-network device approval alone does not.
+Later command, capability, or permission expansion still requires approval.
 
 The Gateway only forwards commands the node declares and server policy
 allows. Privacy-sensitive commands such as `screen.record`, `camera.snap`,
@@ -323,6 +340,11 @@ openclaw devices approve <requestId>
 
 If the device already had a token, reconnect from the Connections tab after
 approval.
+
+For a node request, complete the separate command-surface approval in
+[Windows node mode](#windows-node-mode): restart paused node mode, then run
+`openclaw nodes pending` and approve its distinct node request ID. Operator-device
+approval alone does not complete that node flow.
 
 ### Web chat cannot reach a remote Gateway
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -93,8 +93,10 @@ openclaw devices approve <requestId>
 openclaw nodes status
 ```
 
-Device approval admits the connection only. Approve the node's declared
-command surface as well, or the node stays connected with no usable commands:
+Device approval admits the connection only, and the paused node does not
+reconnect on its own after `PAIRING_REQUIRED`. Restart node mode in the app
+(or restart the app) so it reconnects, then approve the node's declared
+command surface, or the node stays connected with no usable commands:
 
 ```powershell
 openclaw nodes pending

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -93,6 +93,14 @@ openclaw devices approve <requestId>
 openclaw nodes status
 ```
 
+Device approval admits the connection only. Approve the node's declared
+command surface as well, or the node stays connected with no usable commands:
+
+```powershell
+openclaw nodes pending
+openclaw nodes approve <requestId>
+```
+
 The Gateway only forwards commands the node declares and server policy
 allows. Privacy-sensitive commands such as `screen.record`, `camera.snap`,
 and `camera.clip` need explicit `gateway.nodes.commands.allow` opt-in.


### PR DESCRIPTION
Related: #128446, #98045 (both remain closed)

## What Problem This Solves

Several manual node setup paths stopped after device approval. A node paused for pairing could remain disconnected; after reconnecting, its initial command surface could still be unapproved. Troubleshooting omitted that separate gate, while bootstrap instructions incorrectly said enrollment never approved the first declared surface.

## Why This Change Was Made

The current CLI, node-host, pairing/status, Windows, and troubleshooting pages now lead through device approval, restarting or rerunning a paused node, inspecting the separate surface request, and approving its distinct request ID. Initial empty surfaces are distinguished from pending expansions that retain approved, still-declared commands. SSH-verified and administrator bootstrap enrollment are distinguished from trusted-network device-only approval.

The join-code reference shows the exact `npx openclaw connect <url>` output and current core ownership. It distinguishes reachable TLS endpoints, explicitly configured loopback URLs, default-loopback URL-discovery refusal, and direct plaintext-LAN setup codes. The invoke reference retains the existing 30,000 ms transport default and explains its invoke-plus-10,000 grace. The current configuration example uses `tools.exec.mode`.

The old nodes index remains a routing page with its stable anchors. Already-landed identity, revocation and re-pair guidance is preserved in the current owning pages.

## User Impact

Operators can complete manual enrollment and identify the correct missing approval before changing shell policy. Bootstrap consent, later expansion approval, Gateway command policy, node-local exec approvals and platform permissions remain distinct. This changes documentation only; runtime, configuration schema, storage, protocol and security policy are unchanged.

## Evidence

- Complete source-to-document audit against pinned main `6d8281b385d0990d6245c2ca9e9cef083514c760`, including reconnect, surface reconciliation, bootstrap/trusted-network controls, core join routes, timeout registration/resolver and focused tests. Windows reconnect wording was checked against the separately maintained client source.
- Fresh source reviews resolved the three initial documentation findings; the final revision has no actionable source-to-document finding.
- Native docs inventory, changed-file checks, scoped MDX, Markdown lint, configuration examples, glossary, formatting and whitespace checks passed. The real publishing-parser anchor audit validates the changed documents. Its full run retains three unchanged maturity-page fragment errors also reproduced on pinned main with the same actual ClawHub documentation source.
- Full before/after Markdown and shared-parser HTML artifacts are retained. No node, Gateway, pairing, token, platform-permission or provider command was executed; tests were read as source evidence rather than reported as fresh runtime passes.

Thanks @yetval for the original cross-page correction and follow-up fixes. The contributor commits and previous review history are preserved; the older plugin prerequisite and 10-second invoke-command default are superseded by the current source facts above.

Independent artifact acceptance checked every affected manual entry path, including the standalone headless recipe and Windows troubleshooting. Its initial timeout-condition finding was corrected and freshly reviewed; final artifact results are 15 pass, 0 fail and 3 source/delivery limitations. Separate source evidence covers those source-only facts. The signed candidate passed the normal native commit hook with matching complete local/native indexed trees.
