### PR TITLE
docs(cli): fix config and hooks examples the CLI rejects

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -31,7 +31,7 @@ openclaw config schema
 openclaw config schema --json
 openclaw config get browser.executablePath
 openclaw config set browser.executablePath "/usr/bin/google-chrome"
-openclaw config set browser.profiles.work.executablePath "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+openclaw config set browser.profiles.work '{"cdpPort":18801,"executablePath":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"}' --strict-json
 openclaw config set agents.defaults.heartbeat.every "2h"
 openclaw config set logging.audit.executionIdentity true
 openclaw config set 'agents.entries.main.tools.exec.node' "node-id-or-name"
@@ -158,7 +158,7 @@ Values parse as JSON5 when possible; otherwise they are treated as raw strings. 
 ```bash
 openclaw config set agents.defaults.heartbeat.every "0m"
 openclaw config set gateway.port 19001 --strict-json
-openclaw config set channels.whatsapp.groups '["*"]' --strict-json
+openclaw config set channels.whatsapp.groups '{"*":{"requireMention":true}}' --strict-json
 ```
 
 For structured values that are awkward to quote in your shell, put a config-shaped JSON5 object in a file and use [`config patch --file <path> --dry-run`](/cli/config#config-patch). The file contains config keys and their values, not a bare array.
@@ -389,7 +389,7 @@ openclaw config patch --file ./discord.patch.json5 --replace-path 'channels.disc
 
 ## Dry run
 
-`--dry-run` validates changes without writing `openclaw.json`. Available on `config set`, `config patch`, and `config unset`.
+`--dry-run` simulates a change without writing `openclaw.json`. Available on `config set`, `config patch`, and `config unset`. Which checks run depends on the input mode: value mode (`config set <path> <value>` without `--strict-json`) runs no schema or SecretRef resolvability checks and reports `Dry run successful` even for a value the real write rejects. Use `--strict-json` (or `config patch --file --dry-run`) when you want the change validated.
 
 ```bash
 openclaw config set channels.discord.token \
@@ -409,6 +409,7 @@ openclaw config set channels.discord.token \
 
 <AccordionGroup>
   <Accordion title="Dry-run behavior">
+    - Value mode (a plain `<value>` without `--strict-json`): no schema or SecretRef resolvability checks; the CLI prints `Dry run note: value mode does not run schema/resolvability checks` and succeeds even when the real write would fail schema validation.
     - Builder mode: runs SecretRef resolvability checks for changed refs/providers.
     - JSON mode (`--strict-json`, `--json`, or batch mode): runs schema validation plus SecretRef resolvability checks.
     - Policy validation runs against the full post-change config, so parent-object writes (for example setting `hooks` as an object) cannot bypass unsupported-surface validation.
@@ -444,7 +445,7 @@ openclaw config set channels.discord.token \
   skippedExecRefs: number,
   errors?: [
     {
-      kind: "missing-path" | "schema" | "resolvability" | "model",
+      kind: "missing-path" | "schema" | "resolvability" | "model" | "conflict",
       message: string,
       ref?: string, // present for resolvability errors
     },
@@ -533,8 +534,8 @@ The active config path must be a regular file. Symlinked `openclaw.json` layouts
 Prefer CLI writes for small edits:
 
 ```bash
-openclaw config set gateway.reload.mode hybrid --dry-run
-openclaw config set gateway.reload.mode hybrid
+openclaw config set gateway.reload.mode '"hybrid"' --strict-json --dry-run
+openclaw config set gateway.reload.mode '"hybrid"' --strict-json
 openclaw config validate
 ```
 

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -31,7 +31,7 @@ openclaw config schema
 openclaw config schema --json
 openclaw config get browser.executablePath
 openclaw config set browser.executablePath "/usr/bin/google-chrome"
-openclaw config set browser.profiles.work '{"cdpPort":18801,"executablePath":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"}' --strict-json
+openclaw config set browser.profiles.work '{"cdpPort":18801,"executablePath":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"}' --strict-json --merge
 openclaw config set agents.defaults.heartbeat.every "2h"
 openclaw config set logging.audit.executionIdentity true
 openclaw config set 'agents.entries.main.tools.exec.node' "node-id-or-name"
@@ -389,7 +389,7 @@ openclaw config patch --file ./discord.patch.json5 --replace-path 'channels.disc
 
 ## Dry run
 
-`--dry-run` simulates a change without writing `openclaw.json`. Available on `config set`, `config patch`, and `config unset`. Which checks run depends on the input mode: value mode (`config set <path> <value>` without `--strict-json`) runs no schema or SecretRef resolvability checks and reports `Dry run successful` even for a value the real write rejects. Use `--strict-json` (or `config patch --file --dry-run`) when you want the change validated.
+`--dry-run` simulates a change without writing `openclaw.json`. Available on `config set`, `config patch`, and `config unset`. Which checks run depends on the input mode. Value mode (`config set <path> <value>` without `--strict-json`) skips the full schema pass and the ordinary SecretRef resolvability scan. Policy, provider, and model-reference checks can still run. When no checks apply, value mode reports `Dry run successful` even for a value the real write rejects. Use `--strict-json` (or `config patch --file --dry-run`) when you need schema validation.
 
 ```bash
 openclaw config set channels.discord.token \
@@ -409,7 +409,7 @@ openclaw config set channels.discord.token \
 
 <AccordionGroup>
   <Accordion title="Dry-run behavior">
-    - Value mode (a plain `<value>` without `--strict-json`): no schema or SecretRef resolvability checks; the CLI prints `Dry run note: value mode does not run schema/resolvability checks` and succeeds even when the real write would fail schema validation.
+    - Value mode (a plain `<value>` without `--strict-json`): skips the full schema pass and ordinary SecretRef resolvability scan. Policy, provider, and model-reference checks can still run. When no checks apply, the CLI prints `Dry run note: value mode does not run schema/resolvability checks` and can succeed even when the real write would fail schema validation.
     - Builder mode: runs SecretRef resolvability checks for changed refs/providers.
     - JSON mode (`--strict-json`, `--json`, or batch mode): runs schema validation plus SecretRef resolvability checks.
     - Policy validation runs against the full post-change config, so parent-object writes (for example setting `hooks` as an object) cannot bypass unsupported-surface validation.

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -238,7 +238,7 @@ archive records are not refreshed by the npm hook updater.
 when reached through the deprecated alias; it is not a hooks-only bulk command.
 
 When an applicable stored integrity hash differs from the downloaded artifact,
-the updater warns and asks for confirmation in the terminal. No flag answers
+the updater warns and asks for confirmation in the terminal. No CLI flag answers
 that prompt: neither `plugins update` nor the `hooks update` alias accepts
 `--yes`, and `--acknowledge-install-policy-warning` covers only install-policy
 warnings. `--dry-run` reports the drift without prompting.

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -208,9 +208,10 @@ including packs with only optional dependencies. Packages listed only in
 | `--acknowledge-install-policy-warning` | Acknowledge an operator `security.installPolicy` warning without its prompt. Blocks and policy failures still stop the install.             |
 
 Interactive non-ClawHub installs ask you to confirm trust. Noninteractive
-installs require `--force`; global `--yes` is not a substitute for that gate.
-`--force` is also not a substitute for acknowledging an install-policy warning.
-Review the source before supplying either acknowledgement.
+installs require `--force`; neither `plugins install` nor the `hooks install`
+alias accepts a `--yes` flag. `--force` is also not a substitute for
+acknowledging an install-policy warning. Review the source before supplying
+either acknowledgement.
 
 <Warning>
 A linked hook runs directly from the supplied path; linking does not copy it
@@ -237,9 +238,10 @@ archive records are not refreshed by the npm hook updater.
 when reached through the deprecated alias; it is not a hooks-only bulk command.
 
 When an applicable stored integrity hash differs from the downloaded artifact,
-the updater warns and asks for confirmation. Global `--yes` can accept that
-yes/no prompt, so use it only when you intend to accept the drift. It does not
-bypass operator policy blocks or replace the dedicated policy-warning flag.
+the updater warns and asks for confirmation in the terminal. No flag answers
+that prompt: neither `plugins update` nor the `hooks update` alias accepts
+`--yes`, and `--acknowledge-install-policy-warning` covers only install-policy
+warnings. `--dry-run` reports the drift without prompting.
 
 ### Deprecated aliases
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -420,7 +420,7 @@ for your OS home directory:
 
 ```bash
 openclaw config set browser.executablePath "/usr/bin/google-chrome"
-openclaw config set browser.profiles.work.executablePath "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+openclaw config set browser.profiles.work '{"cdpPort":18801,"executablePath":"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"}' --strict-json --merge
 ```
 
 Or set it in config, per platform:


### PR DESCRIPTION
## What Problem This Solves

Several copyable CLI examples and claims did not match the shipped parser, mutation rules, or config schema:

- `channels.whatsapp.groups` used an array, but the schema requires an object map.
- A new browser profile set only `executablePath`, but each declared managed profile also needs `cdpPort` or `cdpUrl`.
- The dry-run text implied that ordinary value mode validates the candidate, but it can skip the full schema pass and accept a value that the write rejects.
- The write-safety recipe used that non-validating value mode.
- The hooks page described a `--yes` option that hooks and plugin install/update commands do not expose.
- The documented dry-run JSON error union omitted `conflict`.

## Root cause

The documentation drifted as config validation, browser profile requirements, and the unified plugin updater changed. Static documentation checks do not execute shell examples, so the invalid commands remained green in CI.

## Fix

- Use the WhatsApp object-map shape accepted by the schema.
- Create or update the browser profile as one strict JSON object with `--merge`, so the command is valid and preserves existing profile fields.
- Use the same merge-preserving browser command in `docs/cli/config.md` and `docs/tools/browser.md`.
- Describe value-mode dry-run precisely: it skips the full schema pass and ordinary SecretRef scan, while policy, provider, and model-reference checks can still run.
- Make the write-safety recipe use strict JSON validation.
- State that no CLI flag answers the hook-package integrity prompt and that install/update reject `--yes`.
- Add `conflict` to the dry-run JSON error union.

No runtime behavior, config contract, or product policy changes.

## Evidence

### Compiled CLI proof

The command matrix built and ran exact head `564bb853bb3cdf1a47855290d3a65b33a8767cdc` on a fresh Blacksmith Testbox. The checkout guard verified the exact Git tree and commit before build. Hydration run: https://github.com/openclaw/openclaw/actions/runs/33640668832

| Case | Result |
| --- | --- |
| WhatsApp array | Exit 1: `channels.whatsapp.groups ... must be object` |
| WhatsApp object map | Exit 0 |
| Browser leaf-only profile | Exit 1: `Profile must set cdpPort or cdpUrl` |
| Whole profile replacement | Exit 0, but removed seeded `headless: true` |
| Whole profile with `--merge` | Exit 0 and retained seeded `headless: true` |
| `gateway.port notanumber --dry-run` | Exit 0 with the value-mode no-check note |
| Same invalid write | Exit 1: expected a number |
| `gateway.reload.mode bogus --dry-run` | Exit 0 in value mode |
| Same invalid value with strict JSON dry run | Exit 1 |
| Strict JSON `hybrid` dry run and write | Exit 0 |
| Hooks/plugin install/update with `--yes` | Exit 1: option not recognized |

The final harness result was `ALL CLI PROOF CASES PASSED`.

## Source and test evidence

- Parser and input modes: `src/cli/config-cli.ts`, `src/cli/config-set-parser.ts`, `src/cli/config-cli-input.ts`.
- Mutation and merge ownership: `src/cli/config-cli-runner.ts`, `src/cli/config-cli-path.ts`, `src/config/io.write.ts`.
- Schema: `src/config/zod-schema.providers-whatsapp.ts`, `src/config/zod-schema.root-shape.ts`.
- Hooks/plugin options and prompt behavior: `src/cli/hooks-cli.ts`, `src/cli/plugins-cli.ts`, `src/cli/plugins-update-command.ts`.
- Existing tests: `src/cli/config-cli.test.ts`, `src/cli/hooks-cli.test.ts`, `src/cli/plugins-cli.install.test.ts`, `src/cli/plugins-cli.update.test.ts`.

## Validation

- `node scripts/check-docs-mdx.mjs docs/cli/config.md docs/cli/hooks.md docs/tools/browser.md`
- `oxfmt --check docs/cli/config.md docs/cli/hooks.md docs/tools/browser.md`
- `pnpm docs:check-config-examples`
- `pnpm docs:list`
- `pnpm check:changed`
- `git diff --check`

Production LOC: 0. Tests: 0. Documentation: +16/-13.
