### PR TITLE
test(qa): resolve the preloaded exporter through its SDK owner

### DIFF
--- a/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { cp, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -455,11 +456,16 @@ describe("managed diagnostics-otel install runtime", () => {
       const preloadRoot = path.join(scratch, `otel-preload-${randomUUID()}`);
       const preloadModules = path.join(preloadRoot, "node_modules", "@opentelemetry");
       await mkdir(preloadModules, { recursive: true });
-      // The otherwise-empty preload root resolves the exact root-owned test SDK.
+      const requireFromSdk = createRequire(
+        createRequire(path.join(repoRoot, "package.json")).resolve(
+          "@opentelemetry/sdk-node/package.json",
+        ),
+      );
+      // Resolve through the root-owned SDK without relying on dependency hoisting.
       // The installed plugin remains independently packed without sdk-node.
       for (const packageName of ["sdk-node", "exporter-trace-otlp-proto"]) {
         await symlink(
-          path.join(repoRoot, "node_modules", "@opentelemetry", packageName),
+          path.dirname(requireFromSdk.resolve(`@opentelemetry/${packageName}/package.json`)),
           path.join(preloadModules, packageName),
           process.platform === "win32" ? "junction" : "dir",
         );


### PR DESCRIPTION
The managed OTel E2E fixture assumed its trace exporter was hoisted into the repository's root `node_modules`. A frozen isolated pnpm install has the exporter under sdk-node's declared dependency tree, so the real preloaded Gateway exited with `ERR_MODULE_NOT_FOUND` before listening. Resolve the preload package roots from the actual root-owned SDK package instead; the two independent real package/install flows and all existing assertions remain intact.

The original full run passed the sampling/flush case and failed the preloaded-SDK case. Two complete runs of this exact fix passed both cases (4/4), through real packaging, HTTP registry installation, Gateway startup and telemetry export. Cold and prepared whole-command times were 415.841s and 75.005s; this is a fixture correctness repair, with no speedup claim against a failing original. The [owned Testbox](https://github.com/openclaw/openclaw/actions/runs/33622682973) is stopped.

Proof ran at `9fda3b1855c798e632c8a390c1e0701565c39162`; all 94 guarded source/dependency/runner files remain identical at this branch's `dae372c49c12005cc1dff4a7eca9f4dec5a28e95` base. Formatting preserves the exact tested bytes. Test delta +8/-2; production delta 0. The 24 existing assertion sites and both independent package builds remain. Scoped typed lint, formatting, whitespace validation and Codex review passed; published-head CI is required before landing.
