### PR TITLE
fix(android): stop release signing from blocking Debug test filters

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -98,22 +98,6 @@ val resolvedAndroidStoreFile =
 val hasAndroidReleaseSigning =
   listOf(resolvedAndroidStoreFile, androidStorePassword, androidKeyAlias, androidKeyPassword).all { it != null }
 
-val wantsAndroidReleaseBuild =
-  gradle.startParameter.taskNames.any { taskName ->
-    taskName.contains("Release", ignoreCase = true) ||
-      Regex("""(^|:)(bundle|assemble)$""").containsMatchIn(taskName)
-  }
-val missingAndroidBuildMetadata =
-  explicitOpenClawBuildCommit == null || explicitOpenClawBuildTimestamp == null
-
-if (wantsAndroidReleaseBuild && !hasAndroidReleaseSigning) {
-  error(
-    "Missing Android release signing properties. Set OPENCLAW_ANDROID_STORE_FILE, " +
-      "OPENCLAW_ANDROID_STORE_PASSWORD, OPENCLAW_ANDROID_KEY_ALIAS, and " +
-      "OPENCLAW_ANDROID_KEY_PASSWORD in ~/.gradle/gradle.properties.",
-  )
-}
-
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.ktlint)
@@ -412,30 +396,44 @@ tasks.withType<Test>().configureEach {
   }
 }
 
+val validateOpenClawReleaseSigning =
+  tasks.register("validateOpenClawReleaseSigning") {
+    val signingConfigured = hasAndroidReleaseSigning
+    doLast {
+      check(signingConfigured) {
+        "Missing Android release signing properties. Set OPENCLAW_ANDROID_STORE_FILE, " +
+          "OPENCLAW_ANDROID_STORE_PASSWORD, OPENCLAW_ANDROID_KEY_ALIAS, and " +
+          "OPENCLAW_ANDROID_KEY_PASSWORD in ~/.gradle/gradle.properties."
+      }
+    }
+  }
+
 val validateOpenClawReleaseBuildMetadata =
   tasks.register("validateOpenClawReleaseBuildMetadata") {
+    val metadataProvided =
+      explicitOpenClawBuildCommit != null && explicitOpenClawBuildTimestamp != null
     doLast {
-      if (missingAndroidBuildMetadata) {
-        error(
-          "Android release builds require -PopenclawBuildCommit and -PopenclawBuildTimestamp. " +
-            "Use the repository Android release helper.",
-        )
+      check(metadataProvided) {
+        "Android release builds require -PopenclawBuildCommit and -PopenclawBuildTimestamp. " +
+          "Use the repository Android release helper."
       }
     }
   }
 
 val validateThirdPartyLicenseAssets =
   tasks.register("validateThirdPartyLicenseAssets") {
-    inputs.dir(thirdPartyLicensesDir)
+    val licensesDir = thirdPartyLicensesDir
+    val licensesPath = licensesDir.relativeTo(rootProject.projectDir).path
+    inputs.dir(licensesDir)
     doLast {
-      if (!thirdPartyLicensesDir.isDirectory) {
-        error("Missing Android third-party license directory: ${thirdPartyLicensesDir.relativeTo(rootProject.projectDir)}")
+      if (!licensesDir.isDirectory) {
+        error("Missing Android third-party license directory: $licensesPath")
       }
       val invalidFiles =
-        thirdPartyLicensesDir
+        licensesDir
           .walkTopDown()
           .filter { file -> file.isFile && file.extension.lowercase() != "txt" }
-          .map { file -> file.relativeTo(thirdPartyLicensesDir).path }
+          .map { file -> file.relativeTo(licensesDir).path }
           .toList()
 
       if (invalidFiles.isNotEmpty()) {
@@ -476,9 +474,10 @@ tasks.matching { task -> task.name.startsWith("merge") && task.name.endsWith("As
 
 androidComponents {
   onVariants(selector().withBuildType("release")) { variant ->
+    // Validate the selected variant graph, not task arguments that can also contain "Release".
+    variant.lifecycleTasks.registerPreBuild(validateOpenClawReleaseSigning, validateOpenClawReleaseBuildMetadata)
     val variantName = variant.name
     val variantNameCapitalized = variantName.replaceFirstChar(Char::titlecase)
-    val preBuildTaskName = "pre${variantNameCapitalized}Build"
     val stripTaskName = "strip${variantNameCapitalized}DnsjavaServiceDescriptor"
     val mergeTaskName = "merge${variantNameCapitalized}JavaResource"
     val minifyTaskName = "minify${variantNameCapitalized}WithR8"
@@ -486,10 +485,6 @@ androidComponents {
       layout.buildDirectory.file(
         "intermediates/merged_java_res/$variantName/$mergeTaskName/base.jar",
       )
-
-    tasks.matching { task -> task.name == preBuildTaskName }.configureEach {
-      dependsOn(validateOpenClawReleaseBuildMetadata)
-    }
 
     val stripTask =
       tasks.register(stripTaskName) {

--- a/apps/android/wear/build.gradle.kts
+++ b/apps/android/wear/build.gradle.kts
@@ -86,6 +86,12 @@ android {
   }
 }
 
+androidComponents {
+  onVariants(selector().withBuildType("release")) { variant ->
+    variant.lifecycleTasks.registerPreBuild(":app:validateOpenClawReleaseSigning")
+  }
+}
+
 kotlin {
   compilerOptions {
     jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running a Debug test whose filter contains “Release” were asked for release-signing credentials before any test could run. It also ensures indirectly selected release builds cannot miss the signing guard.

## Why This Change Was Made

Gradle's requested task names also include task arguments. The old substring/aggregate-name heuristic therefore confused test filters with release tasks. Validation now belongs to the selected AGP release variant's pre-build lifecycle, including task dependencies and abbreviations. Both phone flavors retain explicit build-metadata validation; standalone Wear retains its existing signing-only policy and shared phone signing configuration.

Strict configuration-cache validation exposed a nearby existing failure: the license validation action captured the build-script object. It now captures only the directory and diagnostic path during configuration; its inputs, checks, messages, and dependency remain unchanged. The new signing/metadata actions likewise capture task-local values.

## User Impact

Debug tests no longer need unrelated release credentials. Real Play, ThirdParty, and Wear release graphs still reject missing signing properties; phone release graphs still reject missing build metadata. No new settings, credentials, dependencies, or release artifacts are introduced.

## Current-head Verification

Current commit: `d01147edb246cb0db3b89b6c9ff7495d8ccc69fa`, mechanically rebased onto `e29d55a6c058f48310abeb2509f903ed0b090401` after the separate CI-budget fix #136307 landed. The upstream Compose dependency removal is preserved. Gradle remains 9.7.1 and AGP remains 9.4.0; there is no dependency upgrade in this PR.

The exact clean commit repeated the original ordered **20-case native Gradle matrix**: nine successful exits and eleven intentional release-guard rejections, with **five fresh JUnit executions and no failures/errors/skips**. Summed Gradle runtime was 307.045 seconds, including fresh flavor compilation. All 759 captured source facts, HEAD, original driver and alias fixtures remained unchanged. Strict cache storage/reuse and signing/metadata invalidation passed; release APK/AAB outputs did not change.

The initially absent dependency graph was provisioned once through the documented native-PR workflow using frozen repository-pinned pnpm 12.1; all 766 captured source/manifest facts and the lockfile remained unchanged. The fresh matrix used separate cache roots. The task-local Debug key was removed after verifying its exact recorded identity, without reading its contents or touching operator/release keys.

Direct inspection covered both complete build scripts and the pinned AGP lifecycle implementation/callers. The published [AGP 9.4.0 API sources](https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/9.4.0/gradle-api-9.4.0-sources.jar) define `LifecycleTasks.registerPreBuild`; the matching [implementation sources](https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/9.4.0/gradle-9.4.0-sources.jar) store those dependencies and attach them to the actual variant pre-build task. Publisher checksums matched both downloaded archives. This directly addresses the dependency-contract gap in the latest ClawSweeper review. Fresh managed Codex P0–P2 review found no actionable findings.

[Exact-head CI, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33642886063/attempts/2) succeeded: nine successful jobs and 26 intentionally skipped jobs, including [the required gate](https://github.com/openclaw/openclaw/actions/runs/33642886063/job/100305019432), both phone test flavors, Wear tests, phone/Wear builds, lint, and security-fast. Six successful jobs executed on the retry; three successes were retained from attempt 1. The hosted Play build completed in 18m46s. The previous candidate's hosted build timeout remains historical evidence, not a passing result; the separately landed budget fix is now in this branch.

The retained first-attempt security-fast failure occurred while pre-commit bootstrapped its public hook repository: `git fetch` exited 128 before the private-key hook executed. It was not a detected committed key. After confirming there was no useful work executing, only failed/cancelled unfinished lanes were recovered. The current security job and all selected Android checks passed, satisfying the latest review's CI rank-up request. No validation, test, or scanner was disabled.

## Retained Before/After Evidence

Source: `eb4b3b201e18cb9146da68c6e1389afdcf892b7f`. The native runs used the byte-identical candidate before commit; all 759 captured inputs remained unchanged during every run. Managed Codex P0 review found no actionable findings, with direct owner/caller/sibling and pinned dependency-source inspection.

The original Debug selection `:app:testPlayDebugUnitTest --tests ai.openclaw.app.chat.ChatControllerOutboxTest.healthFlushRequestDuringActiveFlushIsDrainedAfterRelease` failed at configuration with missing signing properties and **zero executed tests**. The fixed Play and ThirdParty selections each executed the existing JUnit test successfully.

The final native Gradle matrix matched **20/20 expected outcomes**: nine successful runs and eleven intentional signing/metadata rejections. This is twenty real Gradle executions, not twenty unit tests. Five fresh JUnit executions passed without failures or skips. Coverage includes all three direct release graphs, aggregate app assembly, three root aliases (including the abbreviated `:phonePlP`), both phone metadata guards, unchanged standalone-Wear metadata policy, strict Debug cache storage/reuse, guard cache storage/reuse, and invalidation when signing or metadata inputs change.

The license-task cache failure was first observed on the initial candidate and then reproduced on unchanged baseline code using the existing `deleteRemovesQueuedRow` test. That JUnit test passed, but Gradle rejected configuration-cache storage. The final candidate stores and reuses the strict cache without suppressions. No release APK/AAB output changed. Aggregate assembly may build Debug outputs; any generated Debug signing material was confined to task-local Android preferences. No release keystore was read, release signing/upload/install performed, task action replaced, or validation skipped. Aggregate Debug prerequisites use only task-local generated Debug signing material, not release credentials.

The contract checks used the pinned AGP 9.4 lifecycle implementation and [Gradle's task-name API](https://docs.gradle.org/current/javadoc/org/gradle/StartParameter.html#getTaskNames()). The task-local capture fix follows [Gradle's configuration-cache requirements](https://docs.gradle.org/current/userguide/configuration_cache_requirements.html#config_cache:requirements:disallowed_types).

Production +32/-31 (net +1); no test-source growth. Existing JUnit coverage plus real task-graph/cache runs provide the regression proof without adding source-text assertions. The two local license captures are required to detach the action from the nonserializable script owner; the obsolete task-name policy is deleted.

Follow-up boundary: this does not establish full release-artifact configuration-cache compatibility. The existing release-only DNS stripping action still uses Project-backed file operations and needs its own full release-cache audit. No claim is made that a complete signed release was built.

Release note: Android Debug test filters no longer trigger release signing checks; signing and metadata validation follow the actual selected release variants.
