### PR TITLE
fix(agents): keep gateway alive when local providers OOM

### DIFF
--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -340,6 +340,13 @@ Use this opt-out only for controlled diagnosis: it removes child-first OOM
 protection and makes the Gateway more likely to be selected as the victim under
 real memory pressure.
 
+Managed local model and embedding services fall back to direct spawn when their
+effective environment defines `SHELLOPTS`, `BASHOPTS`, a `BASH_FUNC_*` key, or
+a reserved `OC_INTERNAL_OOM_EXEC_{BASH_ENV,ENV,CDPATH,PS4}` carrier. Exact
+environment fidelity and shell startup safety take precedence in these cases,
+so OpenClaw does not attempt to change `oom_score_adj`; use the verification
+below to check the child's effective value.
+
 Verify a child process:
 
 ```bash

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -330,6 +330,7 @@ Covered child process surfaces:
 - Supervisor-managed command children
 - PTY shell children
 - MCP stdio server children
+- Managed local model and embedding service children
 - OpenClaw-launched browser/Chrome processes (via the plugin SDK process runtime)
 
 The wrapper is Linux-only and skipped when `/bin/sh` is unavailable, or when

--- a/src/agents/provider-local-service.linux-oom.test.ts
+++ b/src/agents/provider-local-service.linux-oom.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 import { getFreePort } from "../test-utils/ports.js";
@@ -13,7 +15,7 @@ describe("provider local service Linux OOM scoring", () => {
   });
 
   it.runIf(process.platform === "linux")(
-    "raises managed local services' OOM score",
+    "raises OOM score without changing configured service environment",
     async ({ skip }) => {
       let hostOomScore: number;
       try {
@@ -40,38 +42,61 @@ describe("provider local service Linux OOM scoring", () => {
 
       const port = await getFreePort();
       const healthUrl = `http://127.0.0.1:${port}/v1/models`;
-      const lease = await ensureProviderLocalService({
-        providerId: "local-oom-score",
-        baseUrl: `http://127.0.0.1:${port}/v1`,
-        service: {
-          command: process.execPath,
-          args: [
-            "-e",
-            `const fs=require("node:fs");const http=require("node:http");const server=http.createServer((req,res)=>res.end(fs.readFileSync("/proc/self/oom_score_adj","utf8").trim())).listen(${port},"127.0.0.1");process.on("SIGTERM",()=>server.close(()=>process.exit(0)));`,
-          ],
-          healthUrl,
-          readyTimeoutMs: 5_000,
-          idleStopMs: 1,
-        },
-      });
-      if (!lease) {
-        throw new Error("Expected provider local service lease");
-      }
-      expect(await (await fetch(healthUrl)).text()).toBe("1000");
-      lease.release();
-      await expect
-        .poll(
-          async () => {
-            try {
-              await fetch(healthUrl);
-              return false;
-            } catch {
-              return true;
-            }
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-provider-oom-"));
+      const bashEnvPath = path.join(tempDir, "bash-env.sh");
+      const startupMarkerPath = path.join(tempDir, "wrapper-startup-marker");
+      await fs.writeFile(bashEnvPath, `printf touched > "${startupMarkerPath}"\n`);
+      try {
+        const lease = await ensureProviderLocalService({
+          providerId: "local-oom-score",
+          baseUrl: `http://127.0.0.1:${port}/v1`,
+          service: {
+            command: process.execPath,
+            args: [
+              "-e",
+              `const fs=require("node:fs");const http=require("node:http");const body=JSON.stringify({oomScore:fs.readFileSync("/proc/self/oom_score_adj","utf8").trim(),bashEnv:process.env.BASH_ENV,envPresent:Object.hasOwn(process.env,"ENV"),env:process.env.ENV,cdpath:process.env.CDPATH,ps4:process.env.PS4,carrierKeys:Object.keys(process.env).filter(key=>key.startsWith("OC_INTERNAL_OOM_EXEC_"))});const server=http.createServer((req,res)=>res.end(body)).listen(${port},"127.0.0.1");process.on("SIGTERM",()=>server.close(()=>process.exit(0)));`,
+            ],
+            env: {
+              BASH_ENV: bashEnvPath,
+              ENV: "",
+              CDPATH: "line1\nline2",
+              PS4: "final-trace-prefix",
+            },
+            healthUrl,
+            readyTimeoutMs: 5_000,
+            idleStopMs: 1,
           },
-          { timeout: 2_000, interval: 50 },
-        )
-        .toBe(true);
+        });
+        if (!lease) {
+          throw new Error("Expected provider local service lease");
+        }
+        expect(await (await fetch(healthUrl)).json()).toEqual({
+          oomScore: "1000",
+          bashEnv: bashEnvPath,
+          envPresent: true,
+          env: "",
+          cdpath: "line1\nline2",
+          ps4: "final-trace-prefix",
+          carrierKeys: [],
+        });
+        await expect(fs.stat(startupMarkerPath)).rejects.toMatchObject({ code: "ENOENT" });
+        lease.release();
+        await expect
+          .poll(
+            async () => {
+              try {
+                await fetch(healthUrl);
+                return false;
+              } catch {
+                return true;
+              }
+            },
+            { timeout: 2_000, interval: 50 },
+          )
+          .toBe(true);
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
     },
   );
 });

--- a/src/agents/provider-local-service.linux-oom.test.ts
+++ b/src/agents/provider-local-service.linux-oom.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { getFreePort } from "../test-utils/ports.js";
+import {
+  ensureProviderLocalService,
+  stopManagedProviderLocalServices,
+} from "./provider-local-service.js";
+
+describe("provider local service Linux OOM scoring", () => {
+  afterEach(async () => {
+    await stopManagedProviderLocalServices();
+  });
+
+  it.runIf(process.platform === "linux")(
+    "raises managed local services' OOM score",
+    async ({ skip }) => {
+      let hostOomScore: number;
+      try {
+        hostOomScore = Number.parseInt(
+          (await fs.readFile("/proc/self/oom_score_adj", "utf8")).trim(),
+          10,
+        );
+      } catch {
+        skip();
+        return;
+      }
+      if (!Number.isFinite(hostOomScore) || hostOomScore >= 1000) {
+        skip();
+        return;
+      }
+
+      const port = await getFreePort();
+      const healthUrl = `http://127.0.0.1:${port}/v1/models`;
+      const lease = await ensureProviderLocalService({
+        providerId: "local-oom-score",
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        service: {
+          command: process.execPath,
+          args: [
+            "-e",
+            `const fs=require("node:fs");const http=require("node:http");const server=http.createServer((req,res)=>res.end(fs.readFileSync("/proc/self/oom_score_adj","utf8").trim())).listen(${port},"127.0.0.1");process.on("SIGTERM",()=>server.close(()=>process.exit(0)));`,
+          ],
+          healthUrl,
+          readyTimeoutMs: 5_000,
+          idleStopMs: 1,
+        },
+      });
+      if (!lease) {
+        throw new Error("Expected provider local service lease");
+      }
+      expect(await (await fetch(healthUrl)).text()).toBe("1000");
+      lease.release();
+      await expect
+        .poll(
+          async () => {
+            try {
+              await fetch(healthUrl);
+              return false;
+            } catch {
+              return true;
+            }
+          },
+          { timeout: 2_000, interval: 50 },
+        )
+        .toBe(true);
+    },
+  );
+});

--- a/src/agents/provider-local-service.linux-oom.test.ts
+++ b/src/agents/provider-local-service.linux-oom.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 import { getFreePort } from "../test-utils/ports.js";
 import {
   ensureProviderLocalService,
@@ -25,6 +26,14 @@ describe("provider local service Linux OOM scoring", () => {
         return;
       }
       if (!Number.isFinite(hostOomScore) || hostOomScore >= 1000) {
+        skip();
+        return;
+      }
+
+      const preparedSpawn = prepareOomScoreAdjustedSpawn(process.execPath, [], {
+        env: process.env,
+      });
+      if (!preparedSpawn.wrapped) {
         skip();
         return;
       }

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -24,7 +24,7 @@ import {
   signalChildProcessTree,
   shouldDetachChildForProcessTree,
 } from "../process/child-process-tree.js";
-import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
+import { prepareOomScoreAdjustedSpawnPreservingExecEnv as prepareLocalServiceSpawn } from "../process/linux-oom-score.js";
 import { setManagedProviderLocalServicesActive } from "./provider-runtime-lifecycle.js";
 import { unwrapHeadersInitSentinelsForProviderEgress } from "./provider-secret-egress.js";
 
@@ -426,7 +426,7 @@ async function startAndWaitForLocalService(params: {
   throwIfAborted(signal);
   log.info(`starting ${provider} local service: ${service.command}`);
   const serviceEnv = service.env ? mergeProcessEnv([process.env, service.env]) : process.env;
-  const preparedSpawn = prepareOomScoreAdjustedSpawn(service.command, service.args ?? [], {
+  const preparedSpawn = prepareLocalServiceSpawn(service.command, service.args ?? [], {
     env: serviceEnv,
   });
   managed.process = spawn(preparedSpawn.command, preparedSpawn.args, {

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -24,6 +24,7 @@ import {
   signalChildProcessTree,
   shouldDetachChildForProcessTree,
 } from "../process/child-process-tree.js";
+import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 import { setManagedProviderLocalServicesActive } from "./provider-runtime-lifecycle.js";
 import { unwrapHeadersInitSentinelsForProviderEgress } from "./provider-secret-egress.js";
 
@@ -424,9 +425,13 @@ async function startAndWaitForLocalService(params: {
   // Recheck at the spawn boundary so cleanup cannot orphan a newly created child.
   throwIfAborted(signal);
   log.info(`starting ${provider} local service: ${service.command}`);
-  managed.process = spawn(service.command, service.args ?? [], {
+  const serviceEnv = service.env ? mergeProcessEnv([process.env, service.env]) : process.env;
+  const preparedSpawn = prepareOomScoreAdjustedSpawn(service.command, service.args ?? [], {
+    env: serviceEnv,
+  });
+  managed.process = spawn(preparedSpawn.command, preparedSpawn.args, {
     cwd: service.cwd,
-    env: service.env ? mergeProcessEnv([process.env, service.env]) : process.env,
+    env: preparedSpawn.env,
     stdio: ["ignore", "pipe", "pipe"],
     detached: shouldDetachChildForProcessTree(),
   });

--- a/src/process/linux-oom-score.test.ts
+++ b/src/process/linux-oom-score.test.ts
@@ -281,48 +281,51 @@ describe("prepareOomScoreAdjustedSpawnPreservingExecEnv", () => {
     });
   });
 
-  it("restores exact values only for the final executable", () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oom-env-"));
-    const bashEnvPath = path.join(tempDir, "bash-env.sh");
-    const startupMarkerPath = path.join(tempDir, "wrapper-startup-marker");
-    fs.writeFileSync(bashEnvPath, `printf touched > "${startupMarkerPath}"\n`);
-    try {
-      const prepared = prepareOomScoreAdjustedSpawnPreservingExecEnv(
-        process.execPath,
-        [
-          "-e",
-          `process.stdout.write(JSON.stringify({bashEnv:process.env.BASH_ENV,envPresent:Object.hasOwn(process.env,"ENV"),env:process.env.ENV,cdpath:process.env.CDPATH,ps4:process.env.PS4,carrierKeys:Object.keys(process.env).filter(key=>key.startsWith("OC_INTERNAL_OOM_EXEC_"))}))`,
-        ],
-        {
-          ...linux,
-          env: {
-            PATH: process.env.PATH,
-            BASH_ENV: bashEnvPath,
-            ENV: "",
-            CDPATH: "line1\nline2",
-            PS4: "final-trace-prefix",
+  it.runIf(process.platform !== "win32")(
+    "restores exact values only for the final executable",
+    () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oom-env-"));
+      const bashEnvPath = path.join(tempDir, "bash-env.sh");
+      const startupMarkerPath = path.join(tempDir, "wrapper-startup-marker");
+      fs.writeFileSync(bashEnvPath, `printf touched > "${startupMarkerPath}"\n`);
+      try {
+        const prepared = prepareOomScoreAdjustedSpawnPreservingExecEnv(
+          process.execPath,
+          [
+            "-e",
+            `process.stdout.write(JSON.stringify({bashEnv:process.env.BASH_ENV,envPresent:Object.hasOwn(process.env,"ENV"),env:process.env.ENV,cdpath:process.env.CDPATH,ps4:process.env.PS4,carrierKeys:Object.keys(process.env).filter(key=>key.startsWith("OC_INTERNAL_OOM_EXEC_"))}))`,
+          ],
+          {
+            ...linux,
+            env: {
+              PATH: process.env.PATH,
+              BASH_ENV: bashEnvPath,
+              ENV: "",
+              CDPATH: "line1\nline2",
+              PS4: "final-trace-prefix",
+            },
           },
-        },
-      );
-      const child = spawnSync(prepared.command, prepared.args, {
-        env: prepared.env,
-        encoding: "utf8",
-      });
+        );
+        const child = spawnSync(prepared.command, prepared.args, {
+          env: prepared.env,
+          encoding: "utf8",
+        });
 
-      expect(child.status).toBe(0);
-      expect(JSON.parse(child.stdout)).toEqual({
-        bashEnv: bashEnvPath,
-        envPresent: true,
-        env: "",
-        cdpath: "line1\nline2",
-        ps4: "final-trace-prefix",
-        carrierKeys: [],
-      });
-      expect(fs.existsSync(startupMarkerPath)).toBe(false);
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
+        expect(child.status).toBe(0);
+        expect(JSON.parse(child.stdout)).toEqual({
+          bashEnv: bashEnvPath,
+          envPresent: true,
+          env: "",
+          cdpath: "line1\nline2",
+          ps4: "final-trace-prefix",
+          carrierKeys: [],
+        });
+        expect(fs.existsSync(startupMarkerPath)).toBe(false);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.runIf(bashAvailable)(
     "does not expose preserving carriers to Bash-as-sh xtrace startup",

--- a/src/process/linux-oom-score.test.ts
+++ b/src/process/linux-oom-score.test.ts
@@ -1,15 +1,59 @@
 // Linux OOM score tests cover best-effort process OOM score adjustment.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { prepareOomScoreAdjustedSpawn } from "./linux-oom-score.js";
+import {
+  prepareOomScoreAdjustedSpawn,
+  prepareOomScoreAdjustedSpawnPreservingExecEnv,
+  type OomScoreAdjustedSpawn,
+} from "./linux-oom-score.js";
 
 const wrapScript = 'echo 1000 > /proc/self/oom_score_adj 2>/dev/null; exec "$0" "$@"';
+const carriers = {
+  BASH_ENV: "OC_INTERNAL_OOM_EXEC_BASH_ENV",
+  ENV: "OC_INTERNAL_OOM_EXEC_ENV",
+  CDPATH: "OC_INTERNAL_OOM_EXEC_CDPATH",
+  PS4: "OC_INTERNAL_OOM_EXEC_PS4",
+} as const;
+const restoreScript = [
+  "echo 1000 > /proc/self/oom_score_adj 2>/dev/null",
+  `if [ "\${${carriers.BASH_ENV}+x}" = x ]; then BASH_ENV="$${carriers.BASH_ENV}"; export BASH_ENV; fi; unset ${carriers.BASH_ENV}`,
+  `if [ "\${${carriers.ENV}+x}" = x ]; then ENV="$${carriers.ENV}"; export ENV; fi; unset ${carriers.ENV}`,
+  `if [ "\${${carriers.CDPATH}+x}" = x ]; then CDPATH="$${carriers.CDPATH}"; export CDPATH; fi; unset ${carriers.CDPATH}`,
+  `if [ "\${${carriers.PS4}+x}" = x ]; then PS4="$${carriers.PS4}"; export PS4; fi; unset ${carriers.PS4}`,
+  'exec "$0" "$@"',
+].join("; ");
 const linux = { platform: "linux", env: {}, shellAvailable: () => true } as const;
+const bashAvailable = fs.existsSync("/bin/bash");
+
+function spawnPreparedWithBashAsSh(prepared: OomScoreAdjustedSpawn) {
+  return spawnSync(prepared.wrapped ? "/bin/bash" : prepared.command, prepared.args, {
+    ...(prepared.wrapped
+      ? { argv0: "sh" }
+      : prepared.argv0 === undefined
+        ? {}
+        : { argv0: prepared.argv0 }),
+    env: prepared.env,
+    encoding: "utf8",
+  });
+}
 
 describe("prepareOomScoreAdjustedSpawn", () => {
   it("returns command, args, and hardened env when wrap applies", () => {
     const result = prepareOomScoreAdjustedSpawn("/usr/bin/node", ["run.js"], {
       ...linux,
-      env: { PATH: "/usr/bin", BASH_ENV: "/tmp/bashenv", ENV: "/tmp/env", CDPATH: "/tmp" },
+      env: {
+        PATH: "/usr/bin",
+        BASH_ENV: "/tmp/bashenv",
+        ENV: "/tmp/env",
+        CDPATH: "/tmp",
+        SHELLOPTS: "xtrace",
+        BASHOPTS: "extdebug",
+        PS4: "trace",
+        "BASH_FUNC_echo%%": "() { :; }",
+      },
     });
     expect(result).toEqual({
       command: "/bin/sh",
@@ -73,7 +117,14 @@ describe("prepareOomScoreAdjustedSpawn", () => {
     expect(
       prepareOomScoreAdjustedSpawn("/bin/sh", ["-c", wrapScript, "/usr/bin/node", "run.js"], {
         ...linux,
-        env: { PATH: "/usr/bin", BASH_ENV: "/tmp/bashenv" },
+        env: {
+          PATH: "/usr/bin",
+          BASH_ENV: "/tmp/bashenv",
+          SHELLOPTS: "xtrace",
+          BASHOPTS: "extdebug",
+          PS4: "trace",
+          "BASH_FUNC_echo%%": "() { :; }",
+        },
       }),
     ).toEqual({
       command: "/bin/sh",
@@ -90,4 +141,269 @@ describe("prepareOomScoreAdjustedSpawn", () => {
       wrapped: false,
     });
   });
+});
+
+describe("prepareOomScoreAdjustedSpawnPreservingExecEnv", () => {
+  it("carries configured shell-init values without exposing them to the wrapper", () => {
+    const result = prepareOomScoreAdjustedSpawnPreservingExecEnv("/usr/bin/node", ["run.js"], {
+      ...linux,
+      env: {
+        PATH: "/usr/bin",
+        BASH_ENV: "/tmp/bashenv",
+        ENV: "",
+        CDPATH: "line1\nline2",
+        PS4: "final-trace-prefix",
+      },
+    });
+
+    expect(result).toEqual({
+      command: "/bin/sh",
+      args: ["-c", restoreScript, "/usr/bin/node", "run.js"],
+      env: {
+        PATH: "/usr/bin",
+        [carriers.BASH_ENV]: "/tmp/bashenv",
+        [carriers.ENV]: "",
+        [carriers.CDPATH]: "line1\nline2",
+        [carriers.PS4]: "final-trace-prefix",
+      },
+      wrapped: true,
+    });
+  });
+
+  it("does not create carriers for absent or undefined values", () => {
+    expect(
+      prepareOomScoreAdjustedSpawnPreservingExecEnv("/usr/bin/node", [], {
+        ...linux,
+        env: { PATH: "/usr/bin", BASH_ENV: undefined },
+      }),
+    ).toMatchObject({
+      env: { PATH: "/usr/bin" },
+      wrapped: true,
+    });
+  });
+
+  it.each([
+    ["SHELLOPTS", { SHELLOPTS: "xtrace" }],
+    ["BASHOPTS", { BASHOPTS: "extdebug" }],
+    ["imported function", { "BASH_FUNC_echo%%": "() { :; }" }],
+  ])("falls back to direct spawn for defined %s controls", (_name, startupEnv) => {
+    const env = { PATH: "/usr/bin", ...startupEnv };
+    const result = prepareOomScoreAdjustedSpawnPreservingExecEnv("/usr/bin/node", ["run.js"], {
+      ...linux,
+      env,
+    });
+
+    expect(result).toEqual({
+      command: "/usr/bin/node",
+      args: ["run.js"],
+      env,
+      wrapped: false,
+    });
+    expect(result.env).toBe(env);
+  });
+
+  it("falls back to direct spawn on a defined carrier collision", () => {
+    const env = {
+      PATH: "/usr/bin",
+      BASH_ENV: "/tmp/bashenv",
+      [carriers.ENV]: "reserved",
+    };
+    const result = prepareOomScoreAdjustedSpawnPreservingExecEnv("/usr/bin/node", ["run.js"], {
+      ...linux,
+      env,
+    });
+
+    expect(result).toEqual({
+      command: "/usr/bin/node",
+      args: ["run.js"],
+      env,
+      wrapped: false,
+    });
+    expect(result.env).toBe(env);
+  });
+
+  it("ignores undefined carrier properties", () => {
+    const result = prepareOomScoreAdjustedSpawnPreservingExecEnv("/usr/bin/node", [], {
+      ...linux,
+      env: {
+        PATH: "/usr/bin",
+        ENV: "",
+        [carriers.ENV]: undefined,
+        SHELLOPTS: undefined,
+        BASHOPTS: undefined,
+        "BASH_FUNC_echo%%": undefined,
+      },
+    });
+
+    expect(result).toMatchObject({
+      env: {
+        PATH: "/usr/bin",
+        [carriers.ENV]: "",
+      },
+      wrapped: true,
+    });
+  });
+
+  it.each([
+    {
+      name: "non-Linux platform",
+      command: "/usr/bin/node",
+      options: { ...linux, platform: "darwin" as const },
+    },
+    {
+      name: "OOM opt-out",
+      command: "/usr/bin/node",
+      options: { ...linux, env: { OPENCLAW_CHILD_OOM_SCORE_ADJ: "0", ENV: "" } },
+    },
+    {
+      name: "missing shell",
+      command: "/usr/bin/node",
+      options: { ...linux, shellAvailable: () => false },
+    },
+    {
+      name: "leading-dash command",
+      command: "-p",
+      options: linux,
+    },
+    {
+      name: "custom argv0",
+      command: "/usr/bin/node",
+      options: { ...linux, argv0: "/opt/shims/node" },
+    },
+  ])("preserves the original environment for $name", ({ command, options }) => {
+    const result = prepareOomScoreAdjustedSpawnPreservingExecEnv(command, ["run.js"], options);
+
+    expect(result).toMatchObject({
+      command,
+      args: ["run.js"],
+      env: options.env,
+      wrapped: false,
+    });
+  });
+
+  it("restores exact values only for the final executable", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oom-env-"));
+    const bashEnvPath = path.join(tempDir, "bash-env.sh");
+    const startupMarkerPath = path.join(tempDir, "wrapper-startup-marker");
+    fs.writeFileSync(bashEnvPath, `printf touched > "${startupMarkerPath}"\n`);
+    try {
+      const prepared = prepareOomScoreAdjustedSpawnPreservingExecEnv(
+        process.execPath,
+        [
+          "-e",
+          `process.stdout.write(JSON.stringify({bashEnv:process.env.BASH_ENV,envPresent:Object.hasOwn(process.env,"ENV"),env:process.env.ENV,cdpath:process.env.CDPATH,ps4:process.env.PS4,carrierKeys:Object.keys(process.env).filter(key=>key.startsWith("OC_INTERNAL_OOM_EXEC_"))}))`,
+        ],
+        {
+          ...linux,
+          env: {
+            PATH: process.env.PATH,
+            BASH_ENV: bashEnvPath,
+            ENV: "",
+            CDPATH: "line1\nline2",
+            PS4: "final-trace-prefix",
+          },
+        },
+      );
+      const child = spawnSync(prepared.command, prepared.args, {
+        env: prepared.env,
+        encoding: "utf8",
+      });
+
+      expect(child.status).toBe(0);
+      expect(JSON.parse(child.stdout)).toEqual({
+        bashEnv: bashEnvPath,
+        envPresent: true,
+        env: "",
+        cdpath: "line1\nline2",
+        ps4: "final-trace-prefix",
+        carrierKeys: [],
+      });
+      expect(fs.existsSync(startupMarkerPath)).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(bashAvailable)(
+    "does not expose preserving carriers to Bash-as-sh xtrace startup",
+    () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oom-xtrace-"));
+      const markerPath = path.join(tempDir, "ps4-marker");
+      const secret = "review-secret-carried-value";
+      try {
+        const env = {
+          PATH: process.env.PATH,
+          BASH_ENV: secret,
+          SHELLOPTS: "braceexpand:hashall:interactive-comments:xtrace",
+          PS4: `$(printf touched > "${markerPath}")trace `,
+        };
+        const prepared = prepareOomScoreAdjustedSpawnPreservingExecEnv(
+          process.execPath,
+          ["-e", ""],
+          { ...linux, env },
+        );
+        const child = spawnPreparedWithBashAsSh(prepared);
+
+        expect(child.status).toBe(0);
+        expect(fs.existsSync(markerPath)).toBe(false);
+        expect(child.stderr).not.toContain(secret);
+        expect(child.stderr).not.toContain(carriers.BASH_ENV);
+        expect(prepared.wrapped).toBe(false);
+        expect(prepared.env).toBe(env);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(bashAvailable)("strips xtrace startup controls from Bash-as-sh", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oom-strip-xtrace-"));
+    const markerPath = path.join(tempDir, "ps4-marker");
+    try {
+      const prepared = prepareOomScoreAdjustedSpawn(process.execPath, ["-e", ""], {
+        ...linux,
+        env: {
+          PATH: process.env.PATH,
+          SHELLOPTS: "braceexpand:hashall:interactive-comments:xtrace",
+          PS4: `$(printf touched > "${markerPath}")trace `,
+        },
+      });
+      const child = spawnPreparedWithBashAsSh(prepared);
+
+      expect(child.status).toBe(0);
+      expect(fs.existsSync(markerPath)).toBe(false);
+      expect(prepared.wrapped).toBe(true);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform === "linux" && bashAvailable)(
+    "blocks imported Bash functions from overriding wrapper commands",
+    () => {
+      for (const [prepare, expectedWrapped] of [
+        [prepareOomScoreAdjustedSpawnPreservingExecEnv, false],
+        [prepareOomScoreAdjustedSpawn, true],
+      ] as const) {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-oom-function-"));
+        const markerPath = path.join(tempDir, "echo-marker");
+        try {
+          const prepared = prepare(process.execPath, ["-e", ""], {
+            ...linux,
+            env: {
+              PATH: process.env.PATH,
+              "BASH_FUNC_echo%%": `() { printf touched > "${markerPath}"; builtin echo "$@"; }`,
+            },
+          });
+          const child = spawnPreparedWithBashAsSh(prepared);
+
+          expect(child.status).toBe(0);
+          expect(fs.existsSync(markerPath)).toBe(false);
+          expect(prepared.wrapped).toBe(expectedWrapped);
+        } finally {
+          fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
+    },
+  );
 });

--- a/src/process/linux-oom-score.ts
+++ b/src/process/linux-oom-score.ts
@@ -22,10 +22,22 @@ const CHILD_OOM_SCORE_ADJ_ENV_KEY = "OPENCLAW_CHILD_OOM_SCORE_ADJ";
 const OOM_SCORE_WRAP_SHELL = "/bin/sh";
 const OOM_SCORE_WRAP_SCRIPT = 'echo 1000 > /proc/self/oom_score_adj 2>/dev/null; exec "$0" "$@"';
 
-// Env keys that can cause /bin/sh (especially bash invoked as sh) to source
-// caller-influenced startup files before the final `exec`. Stripped when we
-// wrap so the shim can't become an env-controlled code-exec primitive.
-const SHELL_INIT_ENV_KEYS = ["BASH_ENV", "ENV", "CDPATH"] as const;
+// Env keys that can make /bin/sh (especially Bash invoked as sh) execute or
+// expose caller-influenced startup behavior before the final `exec`. Stripped
+// when we wrap so the shim can't become an env-controlled code-exec primitive.
+const SHELL_INIT_ENV_CARRIERS = [
+  ["BASH_ENV", "OC_INTERNAL_OOM_EXEC_BASH_ENV"],
+  ["ENV", "OC_INTERNAL_OOM_EXEC_ENV"],
+  ["CDPATH", "OC_INTERNAL_OOM_EXEC_CDPATH"],
+  ["PS4", "OC_INTERNAL_OOM_EXEC_PS4"],
+] as const;
+const NON_RESTORABLE_BASH_ENV_KEY = /^(?:SHELLOPTS|BASHOPTS|BASH_FUNC_.*)$/u;
+const OOM_SCORE_RESTORE_EXEC_ENV_SCRIPT = [
+  'echo 1000 > /proc/self/oom_score_adj 2>/dev/null; if [ "${OC_INTERNAL_OOM_EXEC_BASH_ENV+x}" = x ]; then BASH_ENV="$OC_INTERNAL_OOM_EXEC_BASH_ENV"; export BASH_ENV; fi; unset OC_INTERNAL_OOM_EXEC_BASH_ENV',
+  'if [ "${OC_INTERNAL_OOM_EXEC_ENV+x}" = x ]; then ENV="$OC_INTERNAL_OOM_EXEC_ENV"; export ENV; fi; unset OC_INTERNAL_OOM_EXEC_ENV',
+  'if [ "${OC_INTERNAL_OOM_EXEC_CDPATH+x}" = x ]; then CDPATH="$OC_INTERNAL_OOM_EXEC_CDPATH"; export CDPATH; fi; unset OC_INTERNAL_OOM_EXEC_CDPATH',
+  'if [ "${OC_INTERNAL_OOM_EXEC_PS4+x}" = x ]; then PS4="$OC_INTERNAL_OOM_EXEC_PS4"; export PS4; fi; unset OC_INTERNAL_OOM_EXEC_PS4; exec "$0" "$@"',
+].join("; ");
 
 function isDisabled(value: string | undefined): boolean {
   switch (value?.trim().toLowerCase()) {
@@ -92,16 +104,22 @@ function canUseShellExecCommand(command: string): boolean {
 
 function hardenShellEnv(baseEnv: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
   const next: NodeJS.ProcessEnv = { ...(baseEnv ?? process.env) };
-  for (const key of SHELL_INIT_ENV_KEYS) {
+  for (const [key] of SHELL_INIT_ENV_CARRIERS) {
     delete next[key];
+  }
+  for (const key of Object.keys(next)) {
+    if (NON_RESTORABLE_BASH_ENV_KEY.test(key)) {
+      delete next[key];
+    }
   }
   return next;
 }
 
-export function prepareOomScoreAdjustedSpawn(
+function prepareOomScoreAdjustedSpawnWithExecEnvPolicy(
   command: string,
   args: readonly string[] = [],
   options?: OomWrapOptions,
+  preserveExecEnv = false,
 ): OomScoreAdjustedSpawn {
   const copy = [...args];
   const directSpawn: OomScoreAdjustedSpawn = {
@@ -120,13 +138,53 @@ export function prepareOomScoreAdjustedSpawn(
     // POSIX sh cannot preserve an argv0 that differs from the exec pathname.
     return directSpawn;
   }
-  if (isWrapped(command, copy)) {
+  if (!preserveExecEnv && isWrapped(command, copy)) {
     return { command, args: copy, env: hardenShellEnv(options?.env), wrapped: true };
   }
+  const effectiveEnv = options?.env ?? process.env;
+  if (
+    preserveExecEnv &&
+    Object.entries(effectiveEnv).some(
+      ([key, value]) => value !== undefined && NON_RESTORABLE_BASH_ENV_KEY.test(key),
+    )
+  ) {
+    // Bash consumes these readonly/imported controls before the shim can
+    // neutralize and restore them, so only direct spawn preserves exact env.
+    return directSpawn;
+  }
+  const wrappedEnv = hardenShellEnv(effectiveEnv);
+  if (preserveExecEnv) {
+    for (const [key, carrier] of SHELL_INIT_ENV_CARRIERS) {
+      if (effectiveEnv[carrier] !== undefined) {
+        return directSpawn;
+      }
+      delete wrappedEnv[carrier];
+      if (effectiveEnv[key] !== undefined) {
+        wrappedEnv[carrier] = effectiveEnv[key];
+      }
+    }
+  }
+  const wrapScript = preserveExecEnv ? OOM_SCORE_RESTORE_EXEC_ENV_SCRIPT : OOM_SCORE_WRAP_SCRIPT;
   return {
     command: OOM_SCORE_WRAP_SHELL,
-    args: ["-c", OOM_SCORE_WRAP_SCRIPT, command, ...copy],
-    env: hardenShellEnv(options?.env),
+    args: ["-c", wrapScript, command, ...copy],
+    env: wrappedEnv,
     wrapped: true,
   };
+}
+
+export function prepareOomScoreAdjustedSpawn(
+  command: string,
+  args: readonly string[] = [],
+  options?: OomWrapOptions,
+): OomScoreAdjustedSpawn {
+  return prepareOomScoreAdjustedSpawnWithExecEnvPolicy(command, args, options);
+}
+
+export function prepareOomScoreAdjustedSpawnPreservingExecEnv(
+  command: string,
+  args: readonly string[] = [],
+  options?: OomWrapOptions,
+): OomScoreAdjustedSpawn {
+  return prepareOomScoreAdjustedSpawnWithExecEnvPolicy(command, args, options, true);
 }


### PR DESCRIPTION
Closes #136275
Related: #70404

## What Problem This Solves

Fixes an issue where Linux operators using managed local model or embedding services could lose the entire Gateway when the service and Gateway hit a shared cgroup memory limit.

The managed provider child inherited the Gateway's default `oom_score_adj`. Because the Gateway usually has the larger RSS, the kernel could kill it instead of the replaceable provider service, disconnecting channels and sessions.

## Why This Change Was Made

Managed provider local services now use the shared Linux child OOM-score preparation at their process-owner spawn boundary. The normal path gives the replaceable child `oom_score_adj=1000` before `exec`.

The wrapper also preserves the documented final service environment without exposing it to the transient `/bin/sh`: restorable shell values cross through private environment carriers, while readonly or imported Bash startup controls fall back to the original direct spawn. Existing browser, MCP, supervisor-child, and PTY callers retain hardened strip behavior. No configuration, storage, protocol, dependency, or Plugin SDK surface was added.

Production LOC: +74/-11 (net +63) | Tests: +424/-3 (net +421) | Docs: +8/-0

The production growth implements two conflicting process-boundary requirements: protect the implementation-detail shell from startup code execution or disclosure, while preserving the configured final-process environment exactly.

## User Impact

Under Linux cgroup-local OOM pressure, a managed local model or embedding service is now preferred as the OOM victim, allowing the Gateway to remain available for channel connections, diagnostics, and recovery.

Configured `localService.env` values remain exact for the final service. `BASH_ENV`, empty `ENV`, newline-containing `CDPATH`, and `PS4` are preserved without carrier leakage. `SHELLOPTS`, `BASHOPTS`, imported `BASH_FUNC_*` controls, and reserved internal carrier collisions preserve exact behavior through direct spawn rather than controlling the wrapper. These direct-spawn cases do not receive the OOM-score adjustment and are documented with the `/proc/<child-pid>/oom_score_adj` verification command.

This does not reduce the memory required by a local model. It contains the failure to the replaceable provider process.

## Evidence

- Controlled cgroup-v2 A/B with `memory.swap.max=0` and `memory.oom.group=0`:
  - control: Gateway host killed 3/3
  - candidate: managed provider child killed 3/3, Gateway host survived 3/3
  - candidate failures were visible to the surviving host
- Environment compatibility red proof on Linux:
  - wrapper still reached `oom_score_adj=1000`
  - final child lost `BASH_ENV`, `ENV`, and `CDPATH`
- Bash startup-control red proof: 18 passed, 9 failed, 0 skipped.
  - default mode forwarded `SHELLOPTS`, `BASHOPTS`, `PS4`, and imported functions
  - command-substituting `PS4` and imported `echo` could execute in Bash-as-`sh`
  - run: https://github.com/openclaw/openclaw/actions/runs/33636188920
- Final Linux zero-skip proof: 134 passed, 0 skipped.
  - process/helper/child/PTY: 86 passed
  - provider/MCP: 12 passed
  - browser sibling: 36 passed
  - managed service observed `oom_score_adj=1000`, exact configured environment, no startup marker, and no carrier keys
  - Bash-as-`sh` created no `PS4` marker, emitted no carrier values, and could not import an overriding wrapper function
  - run: https://github.com/openclaw/openclaw/actions/runs/33636945634
- POSIX shell portability follow-up: 26 passed, 2 expected platform skips.
  - the real `/bin/sh` environment-restoration test now skips only on native Windows
  - pure helper coverage remains cross-platform; macOS retains the POSIX integration check
- Focused formatting, oxlint, docs list/format/MDX/link checks, `git diff --check`, environment-budget, Plugin SDK export/surface, and exact-diff checks passed.
- Independent code review: no blocking findings.
- Structured autoreview at P1 depth: scoped clean, no accepted/actionable findings.

The cgroup A/B proves process-level failure containment. It does not claim that a local model will fit within a 1-4 GiB device or prove full channel/session recovery after provider loss.
