### PR TITLE
fix(autoreview): keep reviews scoped to one checkout

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -5,150 +5,47 @@ description: "Structured Codex, Claude, Amp, Pi, or Kimi code review when explic
 
 # Auto Review
 
-Run the bundled structured review helper only when the user explicitly asks for autoreview, a second-model review, or one of its named review engines. This is code review, not Guardian `auto_review` approval routing.
+Run an independent review when the user or an owning workflow asks for one.
+This is code review, not Guardian approval routing. Let the reviewer choose how
+to analyze the change; provide the target, relevant context, and desired severity.
+Findings are advice to verify, not instructions to apply blindly.
 
-Codex review is the default when no engine is set. It uses `gpt-5.6-sol` with `high` reasoning by default, then retries once with `gpt-5.6-terra` only when the account cannot access Sol. Claude review is optional and uses `claude-fable-5` by default. Amp review is optional and uses `openai/gpt-5.6-sol` with `high` reasoning by default. Pi and Kimi use the model configured by their respective CLIs unless `--model` overrides it.
+## Run
 
-Do not invoke Autoreview automatically before a commit, push, PR, merge, deploy, or final reply. Repository or workflow rules may call it only when they explicitly name it.
-
-## Contract
-
-- Default accepted findings are P0 only: report issues worth blocking the current change
-  because they materially break the normal flow, outcome, or safety boundary.
-  Use `--max-priority P1`, `P2`, or `P3` only when the caller explicitly asks
-  for a wider review.
-- Treat review output as advisory. Never blindly apply it.
-- Verify every finding by reading the real code path and adjacent files.
-- Read dependency docs/source/types when the finding depends on external behavior.
-- Reject unrealistic edge cases, speculative risks, unrelated rewrites, and fixes that over-complicate the codebase.
-- Prefer root-cause fixes at the right ownership boundary. A coherent refactor is appropriate when it removes the bug class, duplicate policy, stale paths, or ownership confusion; do not default to a symptom patch.
-- When an accepted finding exposes a bug class or repeated pattern, inspect its owner and relevant sibling implementations before fixing.
-- Fix the same bug class across its owner-boundary neighborhood when practical; stop at unrelated invariants, different owners, and unapproved contract changes.
-- Run one bounded review pass. If an accepted finding changes code, run the smallest relevant test; rerun Autoreview only when the user explicitly requests another pass.
-- For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
-- Never switch or override the requested review engine/model except for the documented Codex Sol-to-Terra account-access fallback. Capacity, rate-limit, and unrelated failures keep the same engine/model.
-- Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
-- Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex and Claude filter tool/file chatter, other runnable engines pass raw output through.
-- Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
-- Tools are useful in review mode. Codex receives the validated bundle in an empty workspace so ignored files and linked-worktree metadata remain unreadable; web search stays available for dependency contracts and upstream docs.
-- Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
-- Reviewer subprocesses preserve engine authentication and non-credentialed proxy variables needed by headless or restricted-network environments while stripping process-injection, Git override, and credentialed proxy values.
-- Credential checking belongs to the reviewer: the hard rules require inspection of the entire change bundle for accidentally committed credentials and require every suspected real credential to be reported as a P0 security finding without reproducing its value. The helper does not invoke an external credential scanner. Security-sensitive paths remain omitted. Safe large diffs are sent as one pass while they fit the aggregate prompt limit, then partitioned into complete bounded passes without truncation.
-- Regression provenance needs patch proof, not blame alone. `git log -S/-G`, `git blame`, commit subjects, and PR metadata locate candidates. Before saying `introduced by`, inspect raw parents with `git --no-replace-objects cat-file -p <sha>` and verify the implicated behavior changed in `git --no-replace-objects diff --no-ext-diff --no-textconv <raw-parent> <sha> -- <path>`; a genuine root needs raw-header proof that it has no parents.
-- Blame `^sha`, porcelain `boundary`, and shallow/grafted history alone are not introduction proof. `--root` can hide boundary markers; `git show` or `rev-list --parents` can make a shallow boundary look like a root. An available raw parent permits explicit comparison even at a shallow boundary; missing parents or an unverifiable patch require `unknown` with the gap. Use `carried forward` only for verified preexisting behavior and `made visible` only for a verified trigger. Apply the same bar to finding prose, summaries, and owner hints.
-- Keep code author, introducing PR author, merger, committer, automation trigger, and current PR author separate; none of those roles alone proves causation. Cite the verified commit/PR/date. If no PR is traceable, use the verified commit and known author identity; unknown identities stay unknown, and missing PR metadata is not a separate finding.
-- For automation merges, identify the human trigger only from explicit timeline/comment/event evidence, such as a maintainer automerge command or arming label. Report `automerge triggered by @login` only when verified; otherwise say trigger unknown. Triggering or merging is not proof of authorship or introduction.
-- Do not invoke built-in `codex review`, nested reviewers, or review panels from inside the review. The helper builds one validated bundle, calls the selected engine once for normal inputs or once per complete bounded chunk for oversized inputs, validates the structured results, and stops.
-- Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
-- Treat `scoped-clean` with exit 0 as clean only for the selected Git target and requested priority. `filtered` is not a correctness certificate; `incomplete` requires resolving the scope mismatch or missing required finding before claiming clean.
-- If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
-- If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
-- If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
-- Do not push just to review. Push only when the user requested push/ship/PR update.
-
-## Scope
-
-Autoreview does not expand the task. Fix only verified blockers in the requested path. Mention unrelated findings without opening a new workstream, and stop when the requested review pass is complete.
-
-## Skill Path (set once)
-
-Set the skill script paths once, then use `"$AUTOREVIEW"` and `"$AUTOREVIEW_HARNESS"` in the examples below.
-
-Choose one:
+Use `scripts/autoreview` beside this skill. Keep its custom `codex exec` path:
+native `codex review` cannot combine explicit Git target flags with custom instructions.
+The helper combines those with evidence, severity filtering, and validated JSON;
+it leaves review judgment to Codex. For an OpenClaw checkout:
 
 ```bash
-# Project-local skill in the current repo for Codex and other agents:
-export AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS=".agents/skills/autoreview/scripts/test-review-harness"
-```
-
-```bash
-# Claude Code project-local skill in the current repo:
-export AUTOREVIEW=".claude/skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS=".claude/skills/autoreview/scripts/test-review-harness"
-```
-
-```bash
-# Source checkout of openclaw/agent-skills:
-export AUTOREVIEW="skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS="skills/autoreview/scripts/test-review-harness"
-```
-
-```bash
-# Global skill:
-export AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
-export AUTOREVIEW="$AGENTS_HOME/skills/autoreview/scripts/autoreview"
-export AUTOREVIEW_HARNESS="$AGENTS_HOME/skills/autoreview/scripts/test-review-harness"
-```
-
-When using Claude Code, set `AGENTS_HOME="$HOME/.claude"` for global skills.
-
-On native Windows, choose the matching pair:
-
-```powershell
-# Project-local skill in the current repo for Codex and other agents:
-$AUTOREVIEW = ".agents\skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = ".agents\skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-```powershell
-# Claude Code project-local skill in the current repo:
-$AUTOREVIEW = ".claude\skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = ".claude\skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-```powershell
-# Source checkout of openclaw/agent-skills:
-$AUTOREVIEW = "skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = "skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-```powershell
-# Global skill:
-$AgentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $HOME ".agents" }
-$AUTOREVIEW = Join-Path $AgentsHome "skills\autoreview\scripts\autoreview"
-$AUTOREVIEW_HARNESS = Join-Path $AgentsHome "skills\autoreview\scripts\test-review-harness.ps1"
-```
-
-## Pick Target
-
-Dirty local work relative to HEAD:
-
-```bash
+AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
 "$AUTOREVIEW" --mode local
 ```
 
-Without `--base`, this reviews HEAD-to-index, index-to-working-tree, and validated
-untracked files only. `--mode auto` selects the same HEAD-based scope when dirty;
-it does not include the committed PR merely because the checkout is on a PR
-branch. `--mode uncommitted` is an alias for `--mode local`. A clean local checkout
-without an explicit base has no local patch to review.
+In the canonical agent-skills repo, the path is
+`skills/autoreview/scripts/autoreview`. On Windows, invoke the helper with Python.
+Use `--help` for the complete flags and environment overrides.
 
-To review a dirty candidate against an explicit base, including a resolved merge
-that has not been committed:
+Choose the Git target explicitly when the default is ambiguous:
 
-```bash
-"$AUTOREVIEW" --mode local --base origin/main
-```
+| Target                         | Arguments                      | Scope                                                       |
+| ------------------------------ | ------------------------------ | ----------------------------------------------------------- |
+| Local work                     | `--mode local`                 | HEAD → index → working tree, plus untracked files           |
+| Local candidate against a base | `--mode local --base <ref>`    | Pinned base → index → working tree, plus untracked files    |
+| Committed branch/PR            | `--mode branch --base <ref>`   | Merge-base → HEAD; excludes dirty work                      |
+| One commit                     | `--mode commit --commit <ref>` | Raw parent → commit; a root compares against the empty tree |
 
-The helper pins that base to a commit at target selection. It reviews base-to-index
-changes and index-to-working-tree changes separately, plus validated untracked
-files. Only files identical across the base, index, and working tree are outside
-the change bundle; staged changes later undone remain included. Actual binary
-or submodule changes still refuse review. The bundle labels its pinned
-staged base. Git status remains relative to HEAD and does not define review scope.
-Without `--base`, local mode retains its usual HEAD-to-index behavior; it never
-infers a base from an in-progress merge.
+`--mode auto` selects local work when dirty, otherwise a branch review using the
+PR base or `origin/main`. Clean main has no implicit review target.
+`--mode uncommitted` is an alias for local. The helper does not fetch refs.
 
-Committed-only branch/PR work:
+Registered nested linked checkouts from the same repository are outside the
+current review scope. Their presence or edits do not make the parent dirty;
+ordinary adjacent files remain included and scanned. Worktree boundaries are
+revalidated without changing Git ignore rules.
 
-```bash
-"$AUTOREVIEW" --mode branch --base origin/main
-```
-
-Branch mode reviews `BASE...HEAD` (merge-base-to-HEAD); staged, unstaged, and
-untracked changes are excluded even in a dirty checkout. To review the **complete
-PR candidate including dirty rewrites**, pin the PR merge base and use local mode:
+For a complete PR candidate **including dirty rewrites**, use local mode with
+its pinned merge base—not branch mode:
 
 ```bash
 pr_base=$(gh pr view --json baseRefName --jq .baseRefName)
@@ -156,269 +53,83 @@ merge_base=$(git merge-base HEAD "origin/$pr_base")
 "$AUTOREVIEW" --mode local --base "$merge_base"
 ```
 
-The remote base must already be available and current locally; the helper does
-not fetch. The pinned merge base avoids including unrelated upstream changes.
-Add `--max-priority P2` when the caller requests P2 findings. An explicit `--base`
-also applies when auto selects local, but explicit local mode avoids changing
-targets when the checkout becomes clean.
+When a file has both staged and unstaged changes, both states are reviewed.
+A defect in the index remains actionable even if the working tree fixes it;
+the report labels it `INDEX-only`.
+Git display settings cannot suppress context markers or add patch colors;
+repository configuration is not changed. Source paths and text retain literal
+whitespace. An empty present
+source uses line 1, column 1, and an empty excerpt; empty physical lines also
+use an empty excerpt at column 1. Source identity remains mandatory.
 
-Optional review context is first-class. Prompt files and datasets must be repo-relative so review bundles cannot pull arbitrary host files. Context never expands the selected Git target, even if it contains a complete candidate diff or asks to review the whole PR. Finding membership is checked by changed file, not individual hunk:
+## Context and severity
 
-```bash
-"$AUTOREVIEW" --mode branch --base origin/main --prompt-file review-notes.md --dataset evidence.json
-```
+Use `--prompt` for task-specific guidance, or `--prompt-file` and `--dataset` for
+repository-relative context files. Context does not expand the selected Git
+target. The reviewer cannot read unchanged repository files from its empty
+sandbox; supply relevant source or dependency evidence when the diff is insufficient.
 
-If an open PR exists, use its actual base:
-
-```bash
-base=$(gh pr view --json baseRefName --jq .baseRefName)
-"$AUTOREVIEW" --mode branch --base "origin/$base"
-```
-
-Committed single change:
-
-```bash
-"$AUTOREVIEW" --mode commit --commit HEAD
-```
-
-Use commit review for already-landed or already-pushed work on `main`. Reviewing
-clean `main` against `origin/main` is usually an empty diff after push. For a
-small stack, review each commit explicitly or review the branch before merging
-with `--base`. Commit review compares the raw recorded parent with the selected
-commit, ignoring replacement refs and legacy grafts. A genuine root compares
-against the empty tree. Missing parent objects stop review: explicitly deepen/fetch the needed
-history and rerun. The helper does not fetch it automatically.
-
-## Oversized Bundles
-
-The helper validates the complete patch before partitioning it. A bundle that fits
-the aggregate prompt limit remains one integrated review pass. Larger bundles
-are split at bundle sections and file boundaries where possible; an oversized
-single-file block is split at line boundaries with repeated file/hunk context
-and an absolute new- or old-file line offset. Untracked snapshots use
-injection-safe source-line records so continuation passes retain reportable
-locations. A single physical diff line split across passes also retains its
-original addition, deletion, or context marker.
-Prompt instructions remain whole in every pass. Large datasets are grouped from
-their validated file records, never by reparsing headings inside evidence.
-Individual oversized datasets split at lines or UTF-8 boundaries with their
-original path and byte offset. Each evidence batch is paired with the complete
-change bundle: every original change byte appears exactly once per evidence
-batch, and every evidence byte is retained. All validated reports are merged
-before required-finding and exit-status checks.
-There is no fixed pass-count ceiling: the complete frozen input determines the
-finite pass sequence. The helper prints its size and pass count before running
-passes serially. Each pass retains the same prompt-size limit and
-reviewer isolation; a failed pass aborts without publishing a partial verdict.
-
-Preparation prints immediate phase updates and periodic elapsed time to stderr,
-with file/byte counts during hashing and no filenames or contents. These updates
-are separate from provider heartbeats and do not count against engine deadlines.
-Bundle construction captures finding membership alongside validated text; normal
-and dry runs reuse that record without reopening untracked files for membership.
-
-Dry runs reuse captured inputs and prompt construction without whole-tree integrity sweeps. Real
-reviews retain full fresh tree hashing before bundle construction, before review,
-and before publication, including unrelated tracked files, nonignored untracked files, index
-state, and initialized submodules. Explicit prompt files and datasets also retain
-their own frozen bytes and raw path identities, regardless of Git ignore status
-or finding scope. They are revalidated before sending each pass and before
-publication; content changes, replacements, and leaf or ancestor symlink swaps
-refuse stale results. These endpoint checks are not atomic filesystem snapshots
-and cannot guarantee detection of transient changes restored between checks.
-
-Evidence batches can multiply the pass count. Chunking cannot give one model
-call every cross-file implementation detail. For architecture-heavy changes, still prefer
-a coherent branch or PR shape whose semantic decision surface fits one pass.
-Removing verified non-authoritative generated noise remains useful, but never
-drop lockfiles, generated clients, policies, manifests, schemas, or other
-independently semantic artifacts merely to shrink the review.
-
-## Models and thinking
-
-The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
-
-Recommended model defaults:
-
-| Engine              | Default model                                      | Source note                                           |
-| ------------------- | -------------------------------------------------- | ----------------------------------------------------- |
-| **codex** (default) | `gpt-5.6-sol` -> `gpt-5.6-terra` on access failure | OpenClaw org review default                           |
-| **claude**          | `claude-fable-5`                                   | Anthropic's most capable widely released Claude model |
-| **amp**             | `openai/gpt-5.6-sol`                               | Amp structured-generation review default              |
-
-CLI flags and environment variables override these defaults. Amp model IDs must use `provider/model` form. Pi and Kimi do not get built-in model defaults because their configured model catalogs may vary by installation.
-
-| Engine              | Model flag                 | Example model IDs                                                            | Thinking flag                             | Accepted levels                                            |
-| ------------------- | -------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------- |
-| **codex** (default) | `codex --model X exec ...` | `gpt-5.6-sol`, then `gpt-5.6-terra` on Sol access failure                    | `-c model_reasoning_effort=Y`             | `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` |
-| **claude**          | `claude --model X`         | `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `--effort Y`                              | `low`, `medium`, `high`, `xhigh`, `max`                    |
-| **amp**             | Amp `amp.ai.generate`      | `openai/gpt-5.6-sol`                                                         | `reasoningEffort`                         | `none`, `low`, `medium`, `high`, `xhigh`, `max`            |
-| **pi**              | `pi --model X`             | `anthropic/claude-sonnet-4`, `openai/gpt-4o`                                 | `--thinking Y`                            | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`         |
-| **kimi**            | `kimi --model X`           | A model alias from the user's Kimi config                                    | `[thinking] enabled` in the staged config | `on`, `off`                                                |
-
-Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
-
-[OpenAI's model guidance](https://developers.openai.com/api/docs/guides/latest-model) identifies Sol as the GPT-5.6 frontier-capability route and documents `max` support. Autoreview keeps `high` as its default; use `max` only for the hardest quality-first reviews after comparing its latency and cost with `xhigh` on representative changes.
-
-Examples matching current `main` behavior:
+The default threshold is **P0 only**: material blockers to normal operation or
+safety. Use `--max-priority P1`, `P2`, or `P3` when the caller requests a wider
+review. Do not add unrelated redesign goals or prescribe file counts, reading
+sequences, or ritual extra passes. Historical blame requires a verified
+parent-relative patch; otherwise leave the attribution unknown.
 
 ```bash
-# Codex with explicit model and reasoning
-"$AUTOREVIEW" --engine codex --model gpt-5.6-sol --thinking high
-
-# Codex fast mode (priority service tier); needs a model whose catalog lists the tier, silently standard otherwise
-"$AUTOREVIEW" --engine codex --codex-speed fast
-
-# Safe Codex model/response tuning overrides (--codex-speed wins over a service_tier here)
-"$AUTOREVIEW" --engine codex --codex-config 'service_tier="fast"'
-
-# Claude Code aliases or full model names, with optional availability fallback
-"$AUTOREVIEW" --engine claude --model claude-fable-5 --thinking max
-"$AUTOREVIEW" --engine claude --model claude-fable-5 --fallback-model claude-opus-4-8,claude-sonnet-4-6
-
-# Amp direct structured generation (requires AMP_API_KEY)
-"$AUTOREVIEW" --engine amp --model openai/gpt-5.6-sol --thinking high --amp-bin amp
-
-# Pi with explicit model and thinking level
-"$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high --pi-bin pi
-
-# Kimi with its configured default model, or a configured model alias
-"$AUTOREVIEW" --engine kimi --thinking on --kimi-bin kimi
-"$AUTOREVIEW" --engine kimi --model kimi-model-alias
-
+"$AUTOREVIEW" --mode local --prompt-file review-notes.md --dataset evidence.json
 ```
 
-### Environment defaults
+## Engines
 
-CLI flags take precedence over environment variables.
+Codex is the default: `gpt-5.6-sol`, high reasoning, with a `gpt-5.6-terra` retry
+only for an account-access failure. Honor explicit engine/model choices; do not
+switch because a review is slow or rate-limited.
 
-Store persistent personal defaults in your shell startup file or launcher
-environment. For repository-local defaults, use an existing local environment
-loader such as an untracked `.envrc`; the helper does not write a config file.
+Use `--engine`, `--model`, and `--thinking` to override the defaults.
+`--codex-speed fast` selects priority service when supported. Only Claude accepts
+`--fallback-model`. Per-engine environment overrides use `AUTOREVIEW_<ENGINE>_*`.
 
-| Variable                            | Purpose                                                                                                                          |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTOREVIEW_MODEL`                  | Override the built-in default `--model` for all engines                                                                          |
-| `AUTOREVIEW_THINKING`               | Default `--thinking` for all engines                                                                                             |
-| `AUTOREVIEW_FALLBACK_MODEL`         | Default Claude `--fallback-model` chain                                                                                          |
-| `AUTOREVIEW_ENGINE_TIMEOUT_SECONDS` | Optional positive wall-clock limit for each reviewer process; disabled by default                                                |
-| `AUTOREVIEW_<ENGINE>_MODEL`         | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.6-sol`                                                      |
-| `AUTOREVIEW_<ENGINE>_THINKING`      | Per-engine thinking override                                                                                                     |
-| `AUTOREVIEW_CODEX_CONFIG`           | Safe Codex model/response tuning overrides, semicolon-separated, e.g. `service_tier="fast"`; capability-bearing keys fail closed |
-| `AUTOREVIEW_CODEX_SPEED`            | Codex service tier override: `fast` (priority), `flex`, or `default`; silently standard when the model does not list the tier    |
-| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL`  | Claude-only fallback chain                                                                                                       |
-| `AUTOREVIEW_PROVIDER_ENV_ALLOW`     | Comma-separated custom Pi credential variable names; names must end in a recognized credential suffix                            |
-| `AMP_API_KEY`                       | Required Amp API credential; file/keychain auth is intentionally excluded from the isolated runtime                              |
+| Optional engine | Prerequisites                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| Claude          | CLI 2.1.169+; safe mode with web-only tools                                                           |
+| Amp             | `AMP_API_KEY` for a plugin-free account; local POSIX execution, no custom endpoint or cloud/orb agent |
+| Pi              | CLI 0.79.0+; configured model; no tools or project resources                                          |
+| Kimi            | CLI 0.30.0+; configured model; Python 3.11+ or `tomli` for TOML config                                |
 
-Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Amp maps thinking to `amp.ai.generate.reasoningEffort`. Pi maps thinking to `--thinking`. Kimi maps `on` and `off` to `[thinking] enabled` in the staged review config. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+## Runtime boundaries
 
-Amp receives only `AMP_API_KEY` from the caller. Autoreview intentionally ignores `AMP_URL`, user settings, stored authentication, inherited MCP configuration, and other runtime variables. The API key's authenticated account and workspace must have no personal or workspace plugins: current normal Amp execution loads every authenticated plugin, so the preflight requests the complete inventory and fails before creating the review prompt unless the generated adapter is the only plugin. A dedicated Amp API key/account without plugins is the safest setup. Amp can still discover personal and workspace skill metadata, but the isolated settings deny every local and remote MCP server before use, and the outer adapter has no skill tool. Custom Amp endpoints are not supported because forwarding an arbitrary endpoint could disclose the API key and review bundle. Native Windows is refused because its `chmod` behavior cannot establish or attest the POSIX private-file permissions used here; use Linux, macOS, or WSL.
+The helper owns reviewer isolation, sanitized authentication, process cleanup,
+Git scope, and structured result validation. Keep those controls enabled.
+TruffleHog must scan the complete frozen input for partitioned reviews and each
+exact outgoing pack before it is sent; missing or failed scanning stops the run.
+Source-controlled ignore tags cannot suppress this gate. Scanner refusals never
+echo input headings or finding payloads; remove credentials locally and rerun.
+Never reproduce credentials in findings or work around an isolation failure.
 
-## Review engine isolation
+Review files have no size/count cap and are never truncated. Large diffs and
+datasets are partitioned automatically. Intact instructions and required mixed
+source context must still fit the per-pass prompt budget. A failed pass does not
+produce a partial clean verdict.
 
-When autoreview runs inside the repository under review, external reviewer CLIs must not load project-local trust or configuration that the branch controls.
+Do not edit inputs during a review: the helper verifies captured sources before
+sending and publishing results. Long reviews are normal; advancing heartbeats
+mean progress. Use `--stream-engine-output` for visibility, not extra reviewer
+runs. `--dry-run` checks preparation and startup without contacting a reviewer.
 
-| Engine     | Isolation flags                                                                                                                                                                                                                                                                                               | Reference                                                                      |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| **codex**  | Auth-only config overrides, isolated workspace, `exec --ignore-user-config --ignore-rules --skip-git-repo-check`, plus read-only sandbox                                                                                                                                                                      | Codex CLI `exec --help`                                                        |
-| **claude** | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*`; auto-memory and filesystem/shell tools disabled; empty external workspace; WebSearch by default (`v2.1.169+`)                                                                                                              | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference)     |
-| **amp**    | Empty external workspace and isolated HOME/XDG roots; complete authenticated plugin inventory must contain only the generated adapter; catch-all MCP denial with a process-spawn probe; fixed outer trigger and one input-free adapter tool; private prompt only reaches schema-constrained `amp.ai.generate` | Amp [plugin API](https://ampcode.com/manual/plugin-api) and local CLI `--help` |
-| **pi**     | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes --no-tools`                                                                                                                                                                                       | Pi CLI `--help`; requires Pi `v0.79.0+`                                        |
-| **kimi**   | Empty external workspace; staged `KIMI_CODE_HOME` with sanitized config; Markdown custom agent with no tools/subagents; explicit empty `--skills-dir`; isolated runtime state                                                                                                                                 | Kimi Code CLI `--help`; requires Kimi `v0.30.0+`                               |
+## Results
 
-Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication usable without forwarding unrelated user configuration. Codex runs in an empty temporary workspace: the validated bundle is its sole repository input, ignored files and linked-worktree metadata remain unreadable, and the zero project-doc budget keeps workspace instructions out of the prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md; autoreview supplies WebSearch by default, permits only explicitly domain-constrained WebFetch rules, and exposes no filesystem or shell tools. Amp runs its local CLI with isolated HOME/XDG roots and one generated adapter plugin whose name includes a fresh 128-bit random suffix. Current normal Amp execution loads all authenticated plugins, so the preflight deliberately requests that same complete inventory and fails before writing the private prompt unless the generated adapter is the only active plugin, with exactly its expected tool, agent, and mode. Users with personal or workspace plugins must use a dedicated plugin-free Amp API key/account. Isolated `amp.mcpPermissions` reject every local command and remote URL. Before writing the private prompt, autoreview creates a temporary skill whose MCP command would write a marker, runs `amp tools list`, and requires Amp to report the policy rejection without creating the marker; it removes that skill before continuing. A custom outer mode then receives only a fixed harmless trigger and exposes exactly one trusted, input-free `autoreview_generate` tool. That tool reads the private prompt file and calls `amp.ai.generate` directly with an explicit system prompt and report schema, so the untrusted patch never enters the outer agent context. Autoreview requires the stream's leading init event to attest the empty working directory, the exact singleton adapter-tool inventory, and `mcp_servers: []`; it then requires exactly one correctly ordered empty-input tool call/result and one terminal result before consuming the permission-checked private structured-result file. Native Windows is refused; Linux, macOS, and WSL use permission-checked private files. Pi runs from a neutral temporary directory with project resources disabled and `--no-tools`. Kimi (`-p`, `stream-json`) runs from an empty external workspace with a staged `KIMI_CODE_HOME`: sanitized model/provider config only (no services, hooks, or extra skill/agent dirs), its OAuth credential directory linked in and device identity copied so native token refreshes remain durable without exposing the rest of the user's Kimi state. A Markdown `--agent-file` with `tools: []` and `subagents: []` plus an empty `--skills-dir` keep project instructions, tools, and MCP servers out of the review; the prompt travels as the `--prompt` argument, so per-pass prompts are capped at a platform-safe argv budget (120 KiB POSIX, 30 KiB Windows) and larger bundles partition into bounded passes.
+`--output` and `--json-output` paths must be outside the reviewed repository.
 
-Amp cloud/orb agent execution is deliberately unsupported. In current Amp CLI behavior, `--orb-execute` does not preserve the local tool isolation and can expose shell, patch, thread, and reviewer tools. Autoreview therefore never passes `--orb-execute`: the local isolated adapter may call Amp's cloud inference service through `amp.ai.generate`, but it does not launch a cloud Amp agent over an untrusted diff.
+| Exit | Meaning                                                                         |
+| ---- | ------------------------------------------------------------------------------- |
+| `0`  | `scoped-clean`, or a correct verdict with only filtered lower-priority findings |
+| `1`  | Accepted findings or an incorrect provider verdict                              |
+| `2`  | Incomplete scope/attribution, or a missing required finding                     |
 
-Codex uses a named permission profile that grants read access only to an empty temporary workspace. This is narrower than repository-root access, which would expose ignored credentials, and narrower than the legacy `read-only` sandbox, which permits reads across the host filesystem.
+Treat `scoped-clean` as clean only for the selected target and requested priority.
+`filtered` is not clean; resolve `incomplete` before claiming completion.
+Verify findings against the actual code and task before changing anything.
+No extra review rounds for a nicer verdict; follow the owning workflow after fixes.
 
-## Context Efficiency
-
-Run the helper directly so target selection, engine choice, structured validation, and exit status all stay in one path. If output is noisy, summarize the completed helper output after it returns; do not ask another agent or reviewer to rerun the review.
-
-## Helper
-
-After setting `AUTOREVIEW` and `AUTOREVIEW_HARNESS` above:
-
-```bash
-"$AUTOREVIEW" --help
-```
-
-The smoke harness has thin shell wrappers over a shared Python implementation:
-
-```bash
-"$AUTOREVIEW_HARNESS" --fixture benign --engine codex
-```
-
-On native Windows, invoke the extensionless Python helper through Python:
-
-```powershell
-python $AUTOREVIEW --help
-```
-
-and the smoke harness:
-
-```powershell
-& $AUTOREVIEW_HARNESS -Fixture benign -Engine codex
-```
-
-The helper:
-
-- chooses dirty local changes first
-- accepts `--mode uncommitted` as an alias for `--mode local`
-- otherwise uses current PR base if `gh pr view` works
-- otherwise uses `origin/main` for non-main branches
-- does not fetch automatically during branch review; the selected base ref must already resolve locally
-- supports `codex`, `claude`, `amp`, `pi`, and `kimi`; default is `AUTOREVIEW_ENGINE` or `codex`
-- resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit `--*-bin` paths are interpreted from the reviewed repository root when relative and accepted only when both the supplied path and resolved target stay outside the reviewed repository
-- use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
-- validates complete Git patches, reviews them in one pass up to the aggregate prompt limit, and automatically uses complete bounded passes above it
-- uses branch mode for committed-only PR work, or explicit local mode with a pinned merge base for a complete PR plus dirty candidate
-- writes reports to stdout and optionally to `--output` or `--json-output` files; preparation progress and provider heartbeats use stderr
-- supports `--dry-run` (validates bundle construction, reviewer CLI resolution, and local isolation startup with version/help probes without contacting a provider; exits nonzero if any check fails), an opt-in per-reviewer wall-clock bound via `--engine-timeout-seconds`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, repeatable Codex-only safe model/response tuning with `--codex-config key=value`, Codex-only `--codex-speed fast|flex|default`, and commit refs
-- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
-- supports per-engine `--model`, `--thinking`, and Claude `--fallback-model`
-- uses built-in defaults `codex=gpt-5.6-sol` with `high` reasoning and an access-only `gpt-5.6-terra` retry, `claude=claude-fable-5`, and `amp=openai/gpt-5.6-sol` with `high` reasoning; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
-- gives Codex the bundle in an empty workspace with web search available; Claude receives the bundle plus WebSearch by default and optional domain-constrained WebFetch; Amp sends the bundle only through direct schema-constrained generation; Pi and Kimi receive the bundle with no tools
-- runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP and auto-memory disabled, no filesystem/shell tools, an empty external workspace, and `--fallback-model` when set
-- runs Amp locally from an empty temporary workspace with isolated runtime roots, complete plugin inventory attestation that fails if any authenticated personal/workspace plugin exists, catch-all MCP denial verified by a no-spawn marker probe, a fixed outer trigger, one input-free adapter tool, and direct `amp.ai.generate`; requires `AMP_API_KEY`, refuses native Windows, and refuses cloud/orb agent execution
-- runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and `--no-tools` because its built-in read tools are not repository-confined
-- runs Kimi Code CLI `v0.30.0+` from an empty temporary workspace with a staged `KIMI_CODE_HOME`, sanitized config, an empty `--skills-dir`, and a no-tools/no-subagents Markdown `--agent-file`
-- prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
-- prints `autoreview scoped-clean` only when no findings were rejected or filtered and the provider returned a correct verdict
-- exits nonzero for accepted findings, a provider's incorrect verdict, or an incomplete result
-
-## Result handling
-
-Filtering never rewrites provider correctness, explanation, or confidence.
-`findings` contains accepted findings at the requested priority; local JSON and
-text results retain `scope_rejected_findings` and `priority_filtered_findings`
-separately. Any scope rejection makes `review_status` `incomplete` and exits 2,
-including when other findings remain or `--expect-findings` is set. Resolve the
-target mismatch explicitly; do not infer a broader target from prompt prose.
-
-With no scope rejection, status is `findings` for accepted findings, `filtered`
-when only lower-priority findings remain, `incorrect` for an incorrect verdict
-without findings, or `scoped-clean` otherwise. Exit 1 means accepted findings or
-an incorrect provider verdict; even a priority-filtered incorrect verdict stays
-nonzero. Exit 0 for a filtered correct verdict does not certify correctness.
-`--expect-findings` accepts retained findings for harness checks, never scope
-rejections. `--require-finding` checks only accepted findings after both filters
-across every pass; missing text is retained in `missing_required_findings` and
-exits 2 after writing results.
-
-Chunked results retain each provider report under `pass_reports`, print each
-provider explanation, and use the minimum pass confidence rather than promoting
-confidence from another pass. Provider JSON remains strictly validated before
-the helper adds local audit metadata. All engines use this same result path.
-
-The exact source filename `CredentialFile.swift` is allowed for untracked and
-evidence inputs only outside sensitive parent paths, matching its existing
-tracked-source treatment. This is not a general source-extension exemption:
-credential stores, credential directories, `.env`, PEM, and key files retain
-their exclusions. Reviewers inspect the source content, deleted lines, prompts,
-and datasets present in each outgoing pack for accidentally committed credentials.
-
-## Final Report
-
-Report material findings and the resulting status in chat. If there are none, say so plainly. Do not add command logs, test ledgers, proof blocks, or review receipts unless the user asks for them.
+Report material findings and status plainly. Do not add transcripts, proof
+ledgers, commits, pushes, or a new workstream unless requested.

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -29,30 +29,11 @@ import time
 import unicodedata
 import urllib.parse
 from pathlib import Path, PurePosixPath
-from typing import Any, Callable, NamedTuple
+from typing import Any, BinaryIO, Callable, NamedTuple
 
 
 ENGINES = ("codex", "claude", "amp", "pi", "kimi")
 ENGINE_CHOICES = ENGINES
-SAFE_GIT_CONFIG_ARGS = (
-    "-c",
-    "core.fsmonitor=false",
-    "-c",
-    "core.pager=cat",
-    "-c",
-    "diff.external=",
-    "-c",
-    "diff.renames=false",
-    "-c",
-    "pager.diff=cat",
-    "-c",
-    "pager.log=cat",
-    "-c",
-    "pager.show=cat",
-)
-SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames")
-COMMIT_DIFF_FLAGS = (*SAFE_DIFF_FLAGS, "--root", "--no-commit-id", "-r")
-DIFF_HUNK_CONTENT_BOUNDARY = "\0autoreview-diff-hunk-boundary\0"
 ENGINE_GIT_CONFIG_OVERRIDES = (
     ("core.fsmonitor", "false"),
     ("core.pager", "cat"),
@@ -62,6 +43,13 @@ ENGINE_GIT_CONFIG_OVERRIDES = (
     ("pager.log", "cat"),
     ("pager.show", "cat"),
 )
+# Machine-parsed diffs require space-prefixed empty context lines.
+SAFE_GIT_CONFIG_ARGS = tuple(
+    arg for key, value in ENGINE_GIT_CONFIG_OVERRIDES for arg in ("-c", f"{key}={value}")
+) + ("-c", "diff.suppressBlankEmpty=false")
+SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames", "--no-color")
+COMMIT_DIFF_FLAGS = (*SAFE_DIFF_FLAGS, "--root", "--no-commit-id", "-r")
+DIFF_HUNK_CONTENT_BOUNDARY = "\0autoreview-diff-hunk-boundary\0"
 SENSITIVE_PATH_PARTS = {
     ".aws",
     ".azure",
@@ -153,7 +141,6 @@ TRACKED_TOKEN_CREDENTIAL_EXTENSIONS = {
     ".yaml",
     ".yml",
 }
-MAX_BUNDLE_TEXT_BYTES = 180_000
 MAX_REVIEW_PROMPT_BYTES = 512_000
 # Kimi takes the prompt as a single `--prompt` argv element (no stdin mode),
 # so its per-pass ceiling must respect platform argv limits: Linux caps one
@@ -166,6 +153,9 @@ MAX_REVIEW_CHUNK_CONTEXT_BYTES = 64_000
 class ReviewChunk(NamedTuple):
     content: str
     context: str = ""
+    byte_offset: int = 0
+    sources: tuple[MixedPath, ...] = ()
+    transitions: tuple[tuple[str, str], ...] = ()
 
 
 class ReviewDataset(NamedTuple):
@@ -176,8 +166,51 @@ class ReviewDataset(NamedTuple):
 
 class CapturedBundle(NamedTuple):
     text: str
-    truncated: bool
     paths: set[str]
+    mixed: tuple[MixedPath, ...] = ()
+    spans: tuple[SourceSpan, ...] = ()
+
+
+class UntrackedSources(NamedTuple):
+    files: list[str]
+    worktrees: tuple[tuple[str, object], ...] = ()
+
+
+class SourceVersion(NamedTuple):
+    identity: str
+    mode: str | None
+    content: str | None
+
+
+class MixedPath(NamedTuple):
+    path: str
+    identity: str
+    base: SourceVersion
+    index: SourceVersion
+    working_tree: SourceVersion
+    staged: str
+    unstaged: str
+    index_removed: tuple[tuple[int, str], ...]
+    working_tree_removed: tuple[tuple[int, str], ...]
+    topology: tuple[tuple[int, int, int], ...]
+
+
+class SourceSpan(NamedTuple):
+    start: int
+    end: int
+    path: str
+    target: str
+
+
+class ReviewPass(NamedTuple):
+    prompt: str
+    chunk: ReviewChunk
+    datasets: tuple[ReviewDataset, ...] = ()
+    evidence_batch: int = 1
+
+
+class MixedContextCapacityError(SystemExit):
+    """A pack may fit after rebatching evidence, never by detaching source."""
 
 
 class EvidenceFile(NamedTuple):
@@ -185,14 +218,12 @@ class EvidenceFile(NamedTuple):
     label: str
     path: Path
     content: str
-    truncated: bool
     topology: tuple[tuple[int, int, int], ...]
 
 
 class EvidenceInputs(NamedTuple):
     prompt: str
     datasets: list[ReviewDataset]
-    truncated: bool
     files: list[EvidenceFile]
 
 
@@ -396,6 +427,7 @@ SCHEMA: dict[str, Any] = {
                     "confidence",
                     "category",
                     "code_location",
+                    "source_attribution",
                 ],
                 "properties": {
                     "title": {"type": "string", "minLength": 1, "maxLength": 140},
@@ -415,6 +447,24 @@ SCHEMA: dict[str, Any] = {
                             "line": {"type": "integer", "minimum": 1},
                         },
                     },
+                    "source_attribution": {
+                        "anyOf": [
+                            {"type": "null"},
+                            {
+                                "type": "object",
+                                "additionalProperties": False,
+                                "required": ["target", "record_id", "source_id", "side", "column", "excerpt"],
+                                "properties": {
+                                    "target": {"type": "string", "enum": ["index", "working_tree"]},
+                                    "record_id": {"type": "string"},
+                                    "source_id": {"type": "string"},
+                                    "side": {"type": "string", "enum": ["present", "removed"]},
+                                    "column": {"type": "integer", "minimum": 1},
+                                    "excerpt": {"type": "string"},
+                                },
+                            },
+                        ],
+                    },
                 },
             },
         },
@@ -433,6 +483,7 @@ def run(
     cwd: Path,
     *,
     input_text: str | None = None,
+    stdin: BinaryIO | None = None,
     check: bool = True,
     env: dict[str, str] | None = None,
     text_errors: str = SUBPROCESS_TEXT_ERRORS,
@@ -441,6 +492,7 @@ def run(
         args,
         cwd=cwd,
         input=input_text,
+        stdin=stdin,
         text=True,
         encoding=SUBPROCESS_TEXT_ENCODING,
         errors=text_errors,
@@ -484,24 +536,15 @@ def global_excludes_file(repo: Path) -> Path | None:
     home = Path(env["HOME"]).expanduser()
     if not external_env_path(repo, str(home)):
         return None
-    result = run(
-        [
-            resolve_command("git", repo),
-            "--no-optional-locks",
-            *SAFE_GIT_CONFIG_ARGS,
-            "config",
-            "--global",
-            "--path",
-            "--get",
-            "core.excludesFile",
-        ],
+    result = git_result(
         repo,
+        "config", "--global", "--path", "--get", "core.excludesFile",
         check=False,
         env=env,
     )
     if result.returncode != 0:
         return None
-    raw_path = result.stdout.strip()
+    raw_path = result.stdout.removesuffix("\n")
     if not raw_path:
         return None
     candidate = Path(raw_path).expanduser()
@@ -1386,14 +1429,16 @@ def git_result(
     repo: Path,
     *args: str,
     check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     try:
-        return run(
-            [resolve_command("git", repo), "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, *args],
-            repo,
-            check=check,
-            env=safe_git_env(repo),
-            text_errors="strict",
+        # Text-mode pipes alias CR/CRLF pathnames to LF and alter patch bytes.
+        # Decode the shared binary capture without newline translation.
+        result = git_bytes(repo, *args, check=check, env=env)
+        return subprocess.CompletedProcess(
+            result.args, result.returncode,
+            result.stdout.decode(SUBPROCESS_TEXT_ENCODING),
+            result.stderr.decode(SUBPROCESS_TEXT_ENCODING),
         )
     except UnicodeDecodeError as exc:
         raise SystemExit(
@@ -1413,24 +1458,12 @@ def git_path_list(repo: Path, *args: str, check: bool = True) -> list[str]:
 def repo_root() -> Path:
     start = Path.cwd().resolve()
     unsafe_root = discover_repo_root(start) or start
-    git_bin = find_command("git", unsafe_root)
-    if not git_bin:
+    if not find_command("git", unsafe_root):
         raise SystemExit("git executable not found. Install Git or add it to PATH.")
-    try:
-        result = subprocess.run(
-            [git_bin, "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, "rev-parse", "--show-toplevel"],
-            text=True,
-            encoding=SUBPROCESS_TEXT_ENCODING,
-            errors="strict",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=safe_git_env(unsafe_root),
-        )
-    except UnicodeDecodeError as exc:
-        raise SystemExit("repository root is not valid UTF-8") from exc
+    result = git_result(unsafe_root, "rev-parse", "--show-toplevel", check=False)
     if result.returncode != 0:
         raise SystemExit("autoreview must run inside a git repository")
-    return Path(result.stdout.strip()).resolve()
+    return Path(result.stdout.removesuffix("\n")).resolve()
 
 
 def discover_repo_root(start: Path) -> Path | None:
@@ -1449,12 +1482,8 @@ def current_branch(repo: Path) -> str:
 
 def is_dirty(repo: Path) -> bool:
     return bool(
-        git(
-            repo,
-            *global_excludes_git_args(repo),
-            "status",
-            "--porcelain",
-        ).strip()
+        git(repo, "status", "--porcelain", "--untracked-files=no").strip()
+        or untracked_sources(repo).files
     )
 
 
@@ -1566,10 +1595,15 @@ def validate_git_ref(repo: Path, ref: str, label: str, *, pin: bool = False) -> 
     return result.strip() if pin else ref
 
 
+TRUFFLEHOG_INSTALL_URL = "https://github.com/trufflesecurity/trufflehog#installation"
+TRUFFLEHOG_FINDINGS_EXIT_CODE = 183
+
+
 def git_bytes(
     repo: Path,
     *args: str,
     check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     result = subprocess.run(
         [
@@ -1581,7 +1615,7 @@ def git_bytes(
         cwd=repo,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=safe_git_env(repo),
+        env=env if env is not None else safe_git_env(repo),
     )
     if check and result.returncode != 0:
         detail = (result.stderr or result.stdout).decode(
@@ -1595,18 +1629,71 @@ def git_bytes(
     return result
 
 
-def bounded(text: str, limit: int = 180_000) -> str:
-    if len(text) <= limit:
-        return text
-    return text[:limit] + f"\n\n[truncated at {limit} characters]\n"
+def safe_trufflehog_env(repo: Path) -> dict[str, str]:
+    env = safe_git_env(repo)
+    for key in (
+        "ALL_PROXY",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "all_proxy",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    ):
+        value = os.environ.get(key)
+        if not value:
+            continue
+        if key.casefold() != "no_proxy" and not safe_proxy_url(value):
+            raise SystemExit(
+                f"unsafe credentialed or malformed proxy URL in {key}; "
+                "configure a credential-free proxy URL before running autoreview"
+            )
+        env[key] = value
+    return env
 
 
-def ensure_reviewer_input_complete(reviewer: argparse.Namespace, input_truncated: bool) -> None:
-    if input_truncated:
+def scan_outgoing_review_pack(repo: Path, prompt: str) -> None:
+    trufflehog_bin = find_command("trufflehog", repo)
+    if not trufflehog_bin:
         raise SystemExit(
-            f"{reviewer.engine} engine refused truncated review input because it cannot recover omitted diff hunks; "
-            "reduce the change/input size"
+            "refusing to send review pack: TruffleHog is required but was not found. "
+            f"Install it using the official instructions, then rerun autoreview: {TRUFFLEHOG_INSTALL_URL}"
         )
+    with tempfile.TemporaryDirectory(
+        prefix="autoreview-pack-scan.",
+        dir=safe_temp_root(repo),
+    ) as tempdir:
+        pack_path = Path(tempdir) / "review-pack.txt"
+        pack_path.write_bytes(prompt.encode("utf-8"))
+        pack_path.chmod(0o600)
+        scanner_env = safe_trufflehog_env(repo)
+        # Filesystem preserves read/extraction failures; stdin does not honor
+        # inline ignore tags, including decoded ones. Both must pass. A binary
+        # file descriptor preserves exact bytes and avoids stdin pipe buffering.
+        with pack_path.open("rb") as pack_input:
+            for source_args, scan_input in ((["filesystem", str(pack_path)], None), (["stdin"], pack_input)):
+                result = run(
+                    [
+                        trufflehog_bin, *source_args,
+                        "--json", "--no-color", "--results=verified,unknown",
+                        "--fail", "--fail-on-scan-errors", "--no-update",
+                    ],
+                    Path(tempdir),
+                    stdin=scan_input,
+                    check=False,
+                    env=scanner_env,
+                )
+                if result.returncode == TRUFFLEHOG_FINDINGS_EXIT_CODE:
+                    # Input headings, filenames, and scanner metadata can themselves contain credentials.
+                    raise SystemExit(
+                        "refusing to send review pack: TruffleHog found credentials; "
+                        "remove credential material from selected changes, prompt files, and datasets, then rerun"
+                    )
+                if result.returncode != 0:
+                    raise SystemExit(
+                        "refusing to send review pack: TruffleHog could not complete the scan"
+                    )
 
 
 def bounded_field(text: str, limit: int) -> str:
@@ -1647,7 +1734,9 @@ def stream_display_escape(text: str) -> str:
     )
 
 
-def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
+def read_file_bytes(path: Path, limit: int | None = None) -> bytes:
+    # Review files are captured whole; only local auth validation supplies a
+    # limit. Prompt partitioning, not file reads, owns review capacity.
     descriptor: int | None = None
     try:
         # os.stat, not Path.stat: the follow_symlinks kwarg on pathlib needs
@@ -1669,13 +1758,12 @@ def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
         ):
             raise OSError("file changed while opening")
         chunks: list[bytes] = []
-        remaining = limit + 1
-        while remaining:
-            chunk = os.read(descriptor, remaining)
-            if not chunk:
-                break
+        size = 0
+        while chunk := os.read(descriptor, 64 * 1024):
             chunks.append(chunk)
-            remaining -= len(chunk)
+            size += len(chunk)
+            if limit is not None and size > limit:
+                raise OSError(f"file exceeds {limit} bytes")
         after = os.fstat(descriptor)
         if (
             (opened.st_dev, opened.st_ino, opened.st_size, opened.st_mtime_ns)
@@ -1691,30 +1779,7 @@ def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
     finally:
         if descriptor is not None:
             os.close(descriptor)
-    return data[:limit], len(data) > limit
-
-
-def read_text_with_status(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> tuple[str, bool]:
-    try:
-        data, truncated = read_prefix(path, limit)
-    except SystemExit as exc:
-        return f"[unreadable: {exc}]", True
-    if b"\0" in data:
-        return "[binary file omitted]", True
-    try:
-        text = data.decode("utf-8")
-    except UnicodeDecodeError:
-        return "[non-UTF-8 file omitted]", True
-    if len(text) > limit:
-        text = text[:limit]
-        truncated = True
-    if truncated:
-        return text + f"\n\n[truncated at {limit} characters]\n", True
-    return text, False
-
-
-def read_text(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> str:
-    return read_text_with_status(path, limit)[0]
+    return data
 
 
 def path_has_sensitive_part(rel: str | Path) -> bool:
@@ -1974,17 +2039,9 @@ def omit_tracked_sensitive_diff_units(
 
 
 def validate_review_patch(
-    label: str,
     paths: list[str],
     patch: str,
-    limit: int | None = None,
 ) -> str:
-    patch_bytes = len(patch.encode("utf-8"))
-    if limit is not None and patch_bytes > limit:
-        raise SystemExit(
-            f"{label} is too large to review safely "
-            f"({patch_bytes} bytes; limit {limit}); split the change into smaller review targets"
-        )
     blocked_paths = tracked_sensitive_paths(paths)
     return omit_tracked_sensitive_diff_units(patch, paths, blocked_paths)
 
@@ -2044,62 +2101,85 @@ def require_no_gitlink_diff(label: str, raw_diff: str) -> None:
         )
 
 
-def file_bundle_risk(
-    repo: Path,
-    path: Path,
-    rel: str,
-    *,
-    allow_binary_omission: bool = False,
-) -> str | None:
-    return file_bundle_snapshot(
-        repo,
-        path,
-        rel,
-        allow_binary_omission=allow_binary_omission,
-    )[2]
-
-
 def file_bundle_snapshot(
     repo: Path,
     path: Path,
     rel: str,
-    *,
-    allow_binary_omission: bool = False,
-) -> tuple[str, bool, str | None]:
+) -> tuple[str, str | None]:
     normalized = rel.replace(os.sep, "/")
     path_risk = sensitive_repo_path_risk(normalized)
     if path_risk:
-        return "", True, path_risk
+        return "", path_risk
     if path.is_symlink():
-        return "", True, "symlink"
+        return "", "symlink"
     try:
         resolved = path.resolve(strict=True)
     except OSError as exc:
-        return "", True, f"unreadable file: {exc}"
+        return "", f"unreadable file: {exc}"
     if not is_within(resolved, repo.resolve()):
-        return "", True, "path outside repository"
+        return "", "path outside repository"
     if not path.is_file():
-        return "", True, "not a regular file"
+        return "", "not a regular file"
     try:
-        data, truncated = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
+        data = read_file_bytes(path)
     except SystemExit as exc:
-        return "", True, str(exc)
+        return "", str(exc)
     if b"\0" in data:
-        if allow_binary_omission:
-            return "[binary file omitted]", True, None
-        return "", True, "binary file"
-    if truncated:
-        return "", True, "file too large to scan safely"
+        return "", "binary file"
     try:
         text = data.decode("utf-8")
     except UnicodeDecodeError:
-        return "", True, "non-UTF-8 file"
-    return text, False, None
+        return "", "non-UTF-8 file"
+    return text, None
 
 
-def collect_untracked_file_snapshots(
-    repo: Path,
-) -> tuple[list[tuple[str, str, bool]], int]:
+def linked_worktree_boundary(
+    repo: Path, path: Path, common_dir: Path, worktrees_dir: Path,
+) -> tuple[object, ...] | None:
+    git_file = path / ".git"
+    if git_file.is_symlink() or not git_file.is_file():
+        return None
+    relative_git_file = str(git_file.relative_to(repo.resolve()))
+    topology = mixed_source_topology(repo, relative_git_file)
+    before = source_file_fingerprint(git_file)
+    # Keep the original root as the executable/env trust anchor: using the
+    # child here could admit a parent-controlled bin/git from PATH.
+    results = [
+        git_result(repo, "-C", str(path), "rev-parse", flag, check=False)
+        for flag in ("--show-toplevel", "--absolute-git-dir", "--git-common-dir")
+    ]
+    if any(result.returncode != 0 for result in results):
+        return None
+    top, git_dir, child_common = (
+        (path / result.stdout.removesuffix("\n")).resolve() for result in results
+    )
+    # A listed path may be stale; its .git pointer must name a private owner
+    # from this repository's actual worktree registry, not a copied admin dir.
+    if top != path or child_common != common_dir or git_dir.parent != worktrees_dir:
+        return None
+    backlink = git_dir / "gitdir"
+    try:
+        if backlink.is_symlink():
+            return None
+        backlink_bytes = read_file_bytes(backlink)
+        target = backlink_bytes.decode("utf-8").rstrip("\r\n")
+        if (git_dir / target).resolve() != git_file:
+            return None
+        owner = git_dir.stat()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if (source_file_fingerprint(git_file) != before
+            or mixed_source_topology(repo, relative_git_file) != topology):
+        raise SystemExit("worktree boundary changed while being captured")
+    # Only the boundary belongs to this snapshot. Child HEAD/index/content
+    # belong to its independent review; replacing its owner must still fence us.
+    return ("linked-worktree", str(git_dir), owner.st_dev, owner.st_ino,
+            topology, before, hashlib.sha256(backlink_bytes).hexdigest())
+
+
+def untracked_sources(
+    repo: Path, claimed_paths: list[str] | tuple[str, ...] = (),
+) -> UntrackedSources:
     files = git_path_list(
         repo,
         *global_excludes_git_args(repo),
@@ -2108,21 +2188,54 @@ def collect_untracked_file_snapshots(
         "--exclude-standard",
         "-z",
     )
+    directories = [
+        rel for rel in files
+        if rel.endswith("/") and not any(
+            claim == rel[:-1] or claim.startswith(rel) or rel.startswith(claim + "/")
+            for claim in claimed_paths
+        )
+    ]
+    if not directories:
+        return UntrackedSources(files)
+    registered = {
+        Path(record.removeprefix("worktree ")).resolve()
+        for record in git_path_list(repo, "worktree", "list", "--porcelain", "-z")
+        if record.startswith("worktree ")
+    }
+    root = repo.resolve()
+    common_dir = (root / git(repo, "rev-parse", "--git-common-dir").removesuffix("\n")).resolve()
+    worktrees_dir = (root / git(repo, "rev-parse", "--git-path", "worktrees").removesuffix("\n")).resolve()
+    worktrees = []
+    for rel in directories:
+        candidate = root / rel
+        path = candidate.resolve()
+        if (candidate.is_symlink() or path == root
+                or not is_within(path, root) or path not in registered):
+            continue
+        if boundary := linked_worktree_boundary(repo, path, common_dir, worktrees_dir):
+            worktrees.append((rel, boundary))
+    excluded = {rel for rel, _boundary in worktrees}
+    return UntrackedSources([rel for rel in files if rel not in excluded], tuple(sorted(worktrees)))
+
+
+def collect_untracked_file_snapshots(
+    repo: Path,
+    claimed_paths: list[str] | tuple[str, ...] = (),
+) -> tuple[list[tuple[str, str]], int]:
+    files = untracked_sources(repo, claimed_paths).files
     omitted = 0
-    included: list[tuple[str, str, bool]] = []
+    included: list[tuple[str, str]] = []
     for rel in files:
-        content, truncated, risk = file_bundle_snapshot(
+        content, risk = file_bundle_snapshot(
             repo,
             repo / rel,
             rel,
-            allow_binary_omission=True,
         )
         if risk:
             if (
                 sensitive_repo_path_risk(rel) is not None
                 or risk
                 in {
-                    "secret-like content",
                     "symlink",
                     "path outside repository",
                 }
@@ -2134,7 +2247,7 @@ def collect_untracked_file_snapshots(
                     f"{display_escape(rel, 500)}: {risk}"
                 )
         else:
-            included.append((rel, content, truncated))
+            included.append((rel, content))
     return included, omitted
 
 
@@ -2145,6 +2258,157 @@ def local_status(repo: Path, untracked: list[str], *, redact: bool = False) -> s
     lines = [status] if status else []
     lines.extend(f"?? {rel}" for rel in untracked)
     return "\n".join(lines)
+
+
+def mixed_source_text(path: str, version: str, data: bytes) -> str:
+    label = f"mixed source {display_escape(path, 500)} ({version})"
+    if b"\0" in data:
+        raise SystemExit(f"{label}: binary file")
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        raise SystemExit(f"{label}: non-UTF-8 file") from None
+
+
+def git_source_version(repo: Path, path: str, ref: str | None) -> SourceVersion:
+    command = ("ls-files", "--stage", "-z") if ref is None else ("ls-tree", "-z", ref)
+    entries = git_path_list(repo, "--literal-pathspecs", *command, "--", path)
+    # Directory queries return a tree or its descendants, not a blob here.
+    # Keep only exact entries, preserving their conflict stages and unsafe modes.
+    entries = [
+        metadata for metadata, actual in (entry.split("\t", 1) for entry in entries)
+        if actual == path and not (ref is not None and metadata.startswith("040000 tree "))
+    ]
+    if not entries:
+        return SourceVersion("absent", None, None)
+    if len(entries) != 1:
+        raise SystemExit(f"unmerged mixed source: {display_escape(path, 500)}")
+    mode, middle, last = entries[0].split()
+    oid = middle if ref is None else last
+    if (ref is None and last != "0") or mode not in {"100644", "100755"}:
+        raise SystemExit(f"unsafe mixed source mode: {display_escape(path, 500)} ({mode})")
+    return SourceVersion(f"git:{oid}:{mode}", mode, None)
+
+
+def read_git_source(repo: Path, path: str, version: str, source: SourceVersion) -> SourceVersion:
+    if source.mode is None:
+        return source
+    oid = source.identity.split(":")[1]
+    content = mixed_source_text(path, version, git_bytes(repo, "cat-file", "blob", oid).stdout)
+    return source._replace(content=content)
+
+
+def mixed_source_topology(repo: Path, path: str) -> tuple[tuple[int, int, int], ...]:
+    current = repo.resolve()
+    identities = []
+    for part in Path(path).parts:
+        current /= part
+        try:
+            info = os.stat(current, follow_symlinks=False)
+        except (FileNotFoundError, NotADirectoryError):
+            identities.append((0, 0, 0))
+            break
+        if stat.S_ISLNK(info.st_mode):
+            raise SystemExit(f"symlinked mixed source: {display_escape(path, 500)}")
+        identities.append((info.st_dev, info.st_ino, info.st_mode))
+    return tuple(identities)
+
+
+def working_blob_stat(source: Path) -> os.stat_result | None:
+    try:
+        info = source.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return None
+    # Directories are not Git blobs. Keep symlinks/nonregular files visible
+    # to the caller's unsafe-file checks instead of following their targets.
+    return None if stat.S_ISDIR(info.st_mode) else info
+
+
+def working_source_version(
+    repo: Path, path: str, untracked: dict[str, str] | None = None,
+) -> SourceVersion:
+    source = repo / path
+    info = working_blob_stat(source)
+    if info is None:
+        return SourceVersion("absent", None, None)
+    if not stat.S_ISREG(info.st_mode):
+        raise SystemExit(f"nonregular mixed source: {display_escape(path, 500)}")
+    if untracked is not None and path in untracked:
+        data = untracked[path].encode("utf-8")
+    else:
+        data = read_file_bytes(source)
+    content = mixed_source_text(path, "working_tree", data)
+    mode = "100755" if info.st_mode & stat.S_IXUSR else "100644"
+    return SourceVersion(f"sha256:{hashlib.sha256(data).hexdigest()}:{mode}", mode, content)
+
+
+def removed_source_lines(patch: str) -> tuple[tuple[int, str], ...]:
+    removed = []
+    old_line = None
+    for line in literal_lf_lines(patch):
+        match = re.match(r"^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@", line)
+        if match:
+            old_line = int(match[1])
+        elif old_line is not None and line.startswith(("-", " ")):
+            if line.startswith("-"):
+                removed.append((old_line, line[1:].removesuffix("\n")))
+            old_line += 1
+    return tuple(removed)
+
+
+def local_patch_ownership(patch: str, paths: list[str]) -> list[tuple[str, str]]:
+    # Git supplies the path order. Never infer identity from source-controlled
+    # path headings; require a one-to-one mapping before attaching ownership.
+    units = review_bundle_units(patch)
+    if len(units) != len(paths) or any(not unit.startswith("diff --git ") for unit in units):
+        raise SystemExit("cannot establish mixed local patch ownership")
+    return list(zip(paths, units))
+
+
+def capture_mixed_paths(
+    repo: Path, base_ref: str | None, paths: set[str],
+    staged: dict[str, str], unstaged: dict[str, str],
+    untracked: dict[str, str],
+) -> tuple[MixedPath, ...]:
+    records = []
+    if base_ref is None:
+        head = git_result(repo, "rev-parse", "--verify", "HEAD", check=False)
+        base_ref = head.stdout.strip() if head.returncode == 0 else None
+    for path in sorted(paths):
+        # Tracked role policy is authoritative here; datasets keep their own
+        # stricter policy and can never stand in for these source records.
+        if tracked_sensitive_repo_path_risk(path):
+            raise SystemExit("sensitive mixed source was not omitted")
+        topology = mixed_source_topology(repo, path)
+        base = git_source_version(repo, path, base_ref) if base_ref else SourceVersion("absent", None, None)
+        index = read_git_source(repo, path, "index", git_source_version(repo, path, None))
+        working = working_source_version(repo, path, untracked)
+        index_removed = removed_source_lines(staged[path])
+        working_removed = removed_source_lines(unstaged[path])
+        if index_removed:
+            base = read_git_source(repo, path, "base", base)
+        for source, removed in ((base, index_removed), (index, working_removed)):
+            lines = literal_lf_lines(source.content or "")
+            if any(line < 1 or line > len(lines) or lines[line - 1].removesuffix("\n") != text
+                   for line, text in removed):
+                raise SystemExit(f"mixed deletion source does not match patch: {display_escape(path, 500)}")
+        if mixed_source_topology(repo, path) != topology:
+            raise SystemExit("mixed source changed while being captured")
+        identity = hashlib.sha256(json.dumps(
+            [path, base_ref, base.identity, index.identity, working.identity, staged[path], unstaged[path]],
+            ensure_ascii=True,
+        ).encode()).hexdigest()
+        records.append(MixedPath(path, identity, base, index, working, staged[path], unstaged[path],
+                                 index_removed, working_removed, topology))
+    return tuple(records)
+
+
+def verify_mixed_sources(repo: Path, records: tuple[MixedPath, ...]) -> None:
+    for record in records:
+        if (mixed_source_topology(repo, record.path) != record.topology
+                or git_source_version(repo, record.path, None).identity != record.index.identity
+                or working_source_version(repo, record.path) != record.working_tree):
+            raise SystemExit("mixed source changed; rerun autoreview against the updated inputs")
 
 
 def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
@@ -2161,10 +2425,8 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         "local unstaged diff",
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--numstat", "-z"),
     )
-    require_no_gitlink_diff(
-        "local staged diff",
-        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--raw", "-z", *staged_base),
-    )
+    staged_raw = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--raw", "-z", *staged_base)
+    require_no_gitlink_diff("local staged diff", staged_raw)
     require_no_gitlink_diff(
         "local unstaged diff",
         git(repo, "diff", *SAFE_DIFF_FLAGS, "--raw", "-z"),
@@ -2185,8 +2447,10 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         "--name-only",
         "-z",
     )
-    untracked_snapshots, omitted_untracked = collect_untracked_file_snapshots(repo)
-    untracked = [rel for rel, _content, _truncated in untracked_snapshots]
+    untracked_snapshots, omitted_untracked = collect_untracked_file_snapshots(
+        repo, staged_paths + unstaged_paths,
+    )
+    untracked = [rel for rel, _content in untracked_snapshots]
     omitted_tracked = len(
         tracked_sensitive_paths(staged_paths) | tracked_sensitive_paths(unstaged_paths)
     )
@@ -2199,8 +2463,24 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         raise SystemExit("no local changes to review")
     staged_blocked_paths = tracked_sensitive_paths(staged_paths)
     unstaged_blocked_paths = tracked_sensitive_paths(unstaged_paths)
-    staged_patch = validate_review_patch("local staged diff", staged_paths, staged_patch)
-    unstaged_patch = validate_review_patch("local unstaged diff", unstaged_paths, unstaged_patch)
+    raw_records = staged_raw.split("\0")
+    for index in range(0, len(raw_records) - 1, 2):
+        metadata = raw_records[index]
+        if metadata.startswith(":") and metadata.split()[-1] == "D":
+            path = raw_records[index + 1]
+            if (path not in staged_blocked_paths and working_blob_stat(repo / path) is not None
+                    and path not in untracked):
+                # An ignored or unsafe re-addition must not silently become an
+                # index-only review through the old untracked omission path.
+                raise SystemExit(
+                    f"mixed source {display_escape(path, 500)} (working_tree): "
+                    "re-addition is not in validated untracked membership"
+                )
+    mixed_paths = (set(staged_paths) & (set(unstaged_paths) | set(untracked))) - staged_blocked_paths - unstaged_blocked_paths
+    staged_units = local_patch_ownership(staged_patch, staged_paths) if mixed_paths else []
+    unstaged_units = local_patch_ownership(unstaged_patch, unstaged_paths) if mixed_paths else []
+    staged_patch = validate_review_patch(staged_paths, staged_patch)
+    unstaged_patch = validate_review_patch(unstaged_paths, unstaged_patch)
     parts = [
         "# Git Status",
         local_status(
@@ -2223,6 +2503,7 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
         ),
         unstaged_patch,
     ]
+    owned_parts = {4: (staged_units, "index"), 7: (unstaged_units, "working_tree")}
     if omitted_tracked or omitted_untracked:
         parts[0:0] = [
             "# Review Input Omissions",
@@ -2232,11 +2513,10 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
                 f"omitted untracked files: {omitted_untracked}."
             ),
         ]
-    input_truncated = False
+        owned_parts = {index + 3: value for index, value in owned_parts.items()}
     if untracked:
         parts.append("# Untracked Files")
-        for rel, content, truncated in untracked_snapshots:
-            input_truncated = input_truncated or truncated
+        for rel, content in untracked_snapshots:
             records = literal_lf_lines(content) or [""]
             parts.append(
                 "# Untracked File\n"
@@ -2246,8 +2526,32 @@ def local_bundle(repo: Path, base_ref: str | None = None) -> CapturedBundle:
                     for line_number, record in enumerate(records, start=1)
                 )
             )
+            if rel in mixed_paths:
+                owned_parts[len(parts) - 1] = ([(rel, parts[-1])], "working_tree")
+    spans = []
+    offset = 0
+    transitions = {"index": {}, "working_tree": {}}
+    for part_index, part in enumerate(parts):
+        if part_index in owned_parts and mixed_paths:
+            units, target = owned_parts[part_index]
+            retained = [(path, unit) for path, unit in units if not tracked_sensitive_repo_path_risk(path)]
+            prefix = REVIEW_SECURITY_OMISSION + "\n" if len(retained) != len(units) else ""
+            if prefix + "".join(unit for _, unit in retained) != part:
+                raise SystemExit("cannot establish mixed local bundle coverage")
+            unit_offset = offset + utf8_size(prefix)
+            for path, unit in retained:
+                end = unit_offset + utf8_size(unit)
+                if path in mixed_paths:
+                    spans.append(SourceSpan(unit_offset, end, path, target))
+                    transitions[target][path] = unit
+                unit_offset = end
+        offset += utf8_size(part) + 2
+    mixed = capture_mixed_paths(
+        repo, base_ref, mixed_paths, transitions["index"], transitions["working_tree"],
+        dict(untracked_snapshots),
+    ) if mixed_paths else ()
     paths = (set(staged_paths) - staged_blocked_paths) | (set(unstaged_paths) - unstaged_blocked_paths)
-    return CapturedBundle("\n\n".join(parts), input_truncated, paths | set(untracked))
+    return CapturedBundle("\n\n".join(parts), paths | set(untracked), mixed, tuple(spans))
 
 
 def source_file_fingerprint(
@@ -2255,7 +2559,7 @@ def source_file_fingerprint(
 ) -> tuple[str, int, int, str]:
     try:
         before = os.stat(path, follow_symlinks=False)
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         return "missing", 0, 0, ""
     file_mode = stat.S_IMODE(before.st_mode)
     if stat.S_ISLNK(before.st_mode):
@@ -2385,16 +2689,9 @@ def source_tree_snapshot(
         if record and "\t" in record
         for metadata, rel in (record.split("\t", 1),)
     }
-    untracked = git_path_list(
-        repo,
-        *global_excludes_git_args(repo),
-        "ls-files",
-        "--others",
-        "--exclude-standard",
-        "-z",
-    )
-    fingerprints = []
-    for rel in sorted(set(tracked + untracked)):
+    untracked = untracked_sources(repo, tracked)
+    fingerprints = list(untracked.worktrees)
+    for rel in sorted(set(tracked + untracked.files)):
         fingerprints.append((
             rel,
             source_tree_snapshot(repo / rel, progress)
@@ -2404,7 +2701,7 @@ def source_tree_snapshot(
         ))
         if progress is not None:
             progress.advance(files=1)
-    return head, index_entries, tuple(fingerprints)
+    return head, index_entries, tuple(sorted(fingerprints))
 
 
 def branch_bundle(repo: Path, base_ref: str) -> CapturedBundle:
@@ -2455,7 +2752,6 @@ def branch_bundle(repo: Path, base_ref: str) -> CapturedBundle:
     )
     omitted_tracked = bool(tracked_sensitive_paths(branch_paths))
     branch_patch = validate_review_patch(
-        "branch diff",
         branch_paths,
         branch_patch,
     )
@@ -2477,7 +2773,7 @@ def branch_bundle(repo: Path, base_ref: str) -> CapturedBundle:
             ),
             branch_patch,
         ]
-    ), False, set(branch_paths) - tracked_sensitive_paths(branch_paths))
+    ), set(branch_paths) - tracked_sensitive_paths(branch_paths))
 
 
 def commit_diff_refs(repo: Path, commit_ref: str) -> tuple[str, ...]:
@@ -2521,7 +2817,7 @@ def commit_bundle(repo: Path, commit_ref: str) -> CapturedBundle:
         git(repo, "diff-tree", *COMMIT_DIFF_FLAGS, "--raw", "-z", *refs),
     )
     blocked_paths = tracked_sensitive_paths(commit_paths)
-    commit_patch = validate_review_patch("commit diff", commit_paths, commit_patch)
+    commit_patch = validate_review_patch(commit_paths, commit_patch)
     commit_summary = REVIEW_SECURITY_OMISSION
     if not blocked_paths:
         commit_summary = git(repo, "show", "--no-patch", "--format=fuller", refs[-1])
@@ -2537,7 +2833,7 @@ def commit_bundle(repo: Path, commit_ref: str) -> CapturedBundle:
         ]
     )
     paths = set(commit_paths) - blocked_paths
-    return CapturedBundle(text, False, paths)
+    return CapturedBundle(text, paths)
 
 
 def build_bundle(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> CapturedBundle:
@@ -2549,7 +2845,7 @@ def build_bundle(repo: Path, target: str, target_ref: str | None, commit_ref: st
     return commit_bundle(repo, commit_ref)
 
 
-def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str, bool]:
+def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str]:
     original = Path(raw_path)
     if original.is_absolute() or ".." in original.parts or not original.parts:
         raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
@@ -2562,10 +2858,10 @@ def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path,
     if not is_within(path, repo.resolve()):
         raise SystemExit(f"{label} must be inside the reviewed repository: {raw_path}")
     rel = str(path.relative_to(repo.resolve()))
-    content, truncated, risk = file_bundle_snapshot(repo, path, rel)
+    content, risk = file_bundle_snapshot(repo, path, rel)
     if risk:
         raise SystemExit(f"refusing to include unsafe {label}: {rel} ({risk})")
-    return path, content, truncated
+    return path, content
 
 
 def evidence_topology(repo: Path, raw_path: str) -> tuple[tuple[int, int, int], ...]:
@@ -2591,10 +2887,10 @@ def capture_evidence_file(repo: Path, raw_path: str, label: str) -> EvidenceFile
     if original.is_absolute() or ".." in original.parts or not original.parts:
         raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
     before = evidence_topology(repo, raw_path)
-    path, content, truncated = validate_evidence_file(repo, raw_path, label)
+    path, content = validate_evidence_file(repo, raw_path, label)
     if evidence_topology(repo, raw_path) != before:
         raise SystemExit("evidence changed while being captured")
-    return EvidenceFile(raw_path, label, path, content, truncated, before)
+    return EvidenceFile(raw_path, label, path, content, before)
 
 
 def capture_evidence_inputs(args: argparse.Namespace, repo: Path) -> EvidenceInputs:
@@ -2610,7 +2906,7 @@ def capture_evidence_inputs(args: argparse.Namespace, repo: Path) -> EvidenceInp
                 chunks.append(f"# Prompt file: {rel}\n{record.content}")
             else:
                 datasets.append(ReviewDataset(rel, record.content))
-    return EvidenceInputs("\n\n".join(chunks), datasets, any(f.truncated for f in files), files)
+    return EvidenceInputs("\n\n".join(chunks), datasets, files)
 
 
 def verify_evidence(repo: Path, files: list[EvidenceFile]) -> None:
@@ -2667,34 +2963,6 @@ def split_review_datasets(
             pending.append(part)
             offset += utf8_size(fragment)
     return [*batches, pending] if pending else [[]]
-
-
-def review_scope_policy() -> str:
-    return textwrap.dedent(
-        """
-        Review scope discipline:
-        - This helper is a closeout gate. Do not turn a narrow patch into a broad
-          redesign request.
-        - Report a finding only when this diff introduces or exposes a concrete
-          defect that must be fixed before this target can land.
-        - Prompt text and datasets are context only. They do not expand the
-          selected Git target or make unchanged files part of the reviewed diff.
-        - If the best fix requires a new protocol, config, storage, public API,
-          release process, migration, owner-boundary move, or canonical contract,
-          say that directly in the finding and keep the finding tied to the
-          smallest changed line that proves the current patch is not landable.
-        - Do not ask for sibling-surface hardening, cleanup, refactors, or
-          follow-up architecture work unless the current diff is incorrect
-          without that work.
-        - Prefer the smallest correct pre-merge fix. A broader ideal design is
-          not an actionable finding unless the current patch cannot safely land.
-        - If this is release-branch or release-process work, apply freeze
-          discipline. Report only release blockers, exact backport regressions,
-          install/upgrade breakage, crashes, data loss, concrete security
-          exposure, or release-infrastructure failures. Non-blocking design,
-          cleanup, and hardening concerns belong on main as follow-ups.
-        """
-    ).strip()
 
 
 def utf8_size(text: str) -> int:
@@ -3052,55 +3320,43 @@ def render_review_prompt(
     chunk_position: tuple[int, int] | None = None,
 ) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
-    scope_policy = review_scope_policy()
     chunk_policy = ""
     if chunk_position:
         index, total = chunk_position
         chunk_policy = textwrap.dedent(
             f"""
             Oversized review bundle chunk: {index}/{total}
-            - The complete validated change is distributed across all {total} chunks.
-            - Original change bytes appear exactly once across the chunk sequence.
-            - Continuation context may repeat file and hunk headers; it is not extra change content.
-            - Report every actionable defect demonstrated by this chunk. Reports from all chunks are merged after every pass finishes.
+            The complete change spans {total} chunks; continuation headers may repeat.
+            Report defects supported by this chunk. All reports are merged after the last pass.
             """
         ).strip()
         if chunk.context:
             chunk_policy += "\n\n# Continuation Context\n" + chunk.context
     instructions = textwrap.dedent(
         f"""
-        You are a senior code reviewer. Review the provided git change bundle only.
+        Review the selected Git change for actionable defects, ordered by severity.
+        Use the provided evidence to judge correctness and concrete security risks,
+        not style preferences, speculative failures, or unrelated redesigns.
 
-        Hard rules:
-        - Return exactly one JSON object and nothing else. Do not wrap it in Markdown.
-        - The JSON object must match this schema exactly:
-        {json.dumps(SCHEMA, indent=2)}
-        - Do not modify files.
-        - Do not invoke nested reviewers or review tools.
-        - Forbidden nested review commands include: codex review, autoreview, claude review, oracle review.
-        - The review sandbox is intentionally empty. The change bundle and explicit prompt or datasets are the only reviewed-repository source. Read-only tools cannot access unchanged repository files.
-        - You may use read-only tools and web search to inspect external dependency contracts, upstream docs, current public behavior, and security implications.
-        - Do not report a missing import, symbol, definition, call site, config entry, or other unchanged context solely because it is absent from the change bundle. Such a finding requires direct proof in the bundle or explicit datasets.
-        - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
-        - Report only actionable defects introduced or exposed by this change.
-        - Historical attribution requires raw commit parents and a verified parent-relative patch that changed the implicated behavior before saying "introduced by". Blame, commit subjects, PR metadata, and ownership hints locate candidates; they are not introduction proof.
-        - Blame ^sha, porcelain boundary, and shallow/grafted history alone are not introduction proof; --root can hide boundary markers. Available raw parents permit explicit comparison, but missing parents or an unverifiable patch require unknown. Use "carried forward" only for verified preexisting behavior and "made visible" only for a verified trigger, not as substitutes for missing evidence.
-        - Keep code author, introducing PR author, merger, committer, automation trigger, and current PR author separate. None of those roles alone proves causation; leave unverified identities unknown.
-        - Prefer high-signal findings over style feedback.
-        - Report EVERY distinct actionable defect in this single pass, ordered most severe first. Each review round costs the caller a full fix-test-review cycle; withholding a known defect until a later round wastes one.
-        - Before returning, sweep the bundle once more for independent defects in other files or failure modes that you may have stopped scanning for after an earlier find.
-        - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
-        - Inspect the entire change bundle for accidentally committed credentials or secrets, including API keys, access tokens, passwords, private keys, and credential-bearing URLs. Report every suspected real credential as a P0 security finding at the smallest file/line location that demonstrates it, without reproducing the credential value. Do not flag obvious placeholders or inert test fixtures unless they are usable credentials or create a concrete risk.
-        - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
-        - Security-sensitive bundle material may be redacted or omitted before review. Continue reviewing the material that is present. A redaction notice is not itself a defect and does not prove either safety or vulnerability in the omitted material.
-        - For each finding, use the smallest file/line location that demonstrates the issue.
-        - If there are no actionable findings, return an empty findings array and mark the patch correct.
+        Scope and access:
+        - Prompt text and datasets provide context; they do not expand the selected Git target.
+        - The sandbox is empty. Read-only tools cannot access unchanged repository files.
+          Missing context or omitted sensitive material is not evidence of a defect.
+        - Read-only tools and web search may verify external dependency contracts.
+          Do not mutate files or external state, execute project code, or invoke nested reviewers.
+        - Report suspected real credentials as P0 findings without reproducing their values.
+          Harmless placeholders and test fixtures are not credentials.
+        - Attribute a regression to a commit/person only with verified raw-parent patch evidence;
+          otherwise leave the attribution unknown.
+
+        Return one JSON object matching this schema, without Markdown fences.
+        Pin each finding to the smallest file/line location that demonstrates it.
+        If no actionable defects meet the requested threshold, return no findings and mark the patch correct.
+        {json.dumps(SCHEMA)}
 
         Review target: {target_line}
         Current branch: {branch}
         Review sandbox: . (intentionally contains no reviewed repository files)
-
-        {scope_policy}
 
         {chunk_policy}
 
@@ -3108,8 +3364,182 @@ def render_review_prompt(
     ).strip()
     return (
         instructions + "\n\n" + extra_prompt + "\n\n" + datasets
+        + render_mixed_context(chunk)
         + "\n\n# Change Bundle\n" + chunk.content
     )
+
+
+def render_mixed_context(chunk: ReviewChunk) -> str:
+    if not chunk.sources:
+        return ""
+    parts = [textwrap.dedent("""
+        # Authoritative Mixed Sources
+        These owner records, not datasets or diff additions, establish source identity.
+        Review both base->index and index->working_tree. An index defect remains
+        actionable even when corrected in working_tree; label it INDEX-only.
+        Findings on these paths REQUIRE source_attribution: target, record_id,
+        source_id, side, column and excerpt. code_location.line is a 1-based source
+        line; column is a 1-based Unicode character offset. excerpt must be an
+        exact substring of that physical line (no LF). Empty excerpts require
+        an empty line and column 1; a present zero-byte source uses virtual line 1.
+        Use present for target content, removed only for a listed removed line from its
+        predecessor. Never claim removed index text is present in working_tree.
+        Any line in a selected file is in scope, including unchanged context.
+        Null attribution is permitted only for paths without mixed records.
+        Repeated source records are context, never additional change bytes.
+    """).strip()]
+    parts.append("Original fragment ownership: " + json.dumps(chunk.transitions))
+    parts.append(f"Original bundle byte offset: {chunk.byte_offset}")
+    for record in chunk.sources:
+        manifest = {
+            "path": record.path, "record_id": record.identity,
+            "versions": {name: {"source_id": source.identity, "mode": source.mode,
+                                "state": "absent" if source.mode is None else "present"}
+                         for name, source in (("base", record.base), ("index", record.index),
+                                              ("working_tree", record.working_tree))},
+        }
+        parts.append("Mixed record: " + json.dumps(manifest))
+        for target, source, previous, removed in (
+            ("index", record.index, record.base, record.index_removed),
+            ("working_tree", record.working_tree, record.index, record.working_tree_removed),
+        ):
+            content = source.content or ""
+            parts.append("Source snapshot: " + json.dumps({
+                "path": record.path, "target": target, "side": "present",
+                "source_id": source.identity, "content_bytes": utf8_size(content),
+                "line_count": len(literal_lf_lines(content)),
+            }) + "\n" + content + "\nEnd source snapshot: " + source.identity)
+            parts.append("Removed source: " + json.dumps({
+                "path": record.path, "target": target, "side": "removed",
+                "source_id": previous.identity, "lines": removed,
+            }, ensure_ascii=False))
+    return "\n\n" + "\n".join(parts)
+
+
+def mixed_bundle_chunk(captured: CapturedBundle) -> ReviewChunk:
+    return ReviewChunk(captured.text, "", 0, captured.mixed,
+                       tuple(dict.fromkeys((span.path, span.target) for span in captured.spans)))
+
+
+def mixed_capacity_error(record: MixedPath, required: int, limit: int) -> MixedContextCapacityError:
+    sizes = ", ".join(f"{name}={utf8_size(source.content or '')} bytes"
+                      for name, source in (("index", record.index), ("working_tree", record.working_tree)))
+    return MixedContextCapacityError(
+        f"mixed source {display_escape(record.path, 500)} ({sizes}; "
+        f"base removed={utf8_size(json.dumps(record.index_removed, ensure_ascii=False))} bytes): "
+        f"mandatory context/instructions/continuation and fragment require {required} bytes; "
+        f"prompt limit {limit}; cannot split authoritative context"
+    )
+
+
+def build_mixed_change_passes(
+    branch: str, target: str, target_ref: str | None, captured: CapturedBundle,
+    extra_prompt: str, datasets: list[ReviewDataset], max_prompt_bytes: int,
+) -> list[ReviewPass]:
+    rendered = render_datasets(datasets)
+    full = mixed_bundle_chunk(captured)
+    prompt = render_review_prompt(branch, target, target_ref, full, extra_prompt, rendered)
+    if utf8_size(prompt) <= max_prompt_bytes:
+        return [ReviewPass(prompt, full, tuple(datasets))]
+    records = {record.path: record for record in captured.mixed}
+    data = captured.text.encode("utf-8")
+    ranges = []
+    offset = 0
+    for span in captured.spans:
+        if offset < span.start:
+            ranges.append((offset, span.start, (), ()))
+        ranges.append((span.start, span.end, (records[span.path],), ((span.path, span.target),)))
+        offset = span.end
+    if offset < len(data):
+        ranges.append((offset, len(data), (), ()))
+    chunks = []
+    for start, end, sources, transitions in ranges:
+        template = ReviewChunk("", "", start, sources, transitions)
+        overhead = utf8_size(render_review_prompt(
+            branch, target, target_ref, template, extra_prompt, rendered, (999_999, 999_999),
+        ))
+        limit = max_prompt_bytes - overhead
+        while limit >= 4:
+            pieces = split_review_bundle(data[start:end].decode("utf-8"), limit)
+            owned = []
+            position = start
+            for piece in pieces:
+                owned.append(piece._replace(byte_offset=position, sources=sources, transitions=transitions))
+                position += utf8_size(piece.content)
+            largest = max(utf8_size(render_review_prompt(
+                branch, target, target_ref, piece, extra_prompt, rendered, (999_999, 999_999),
+            )) for piece in owned)
+            if largest <= max_prompt_bytes:
+                chunks.extend(owned)
+                break
+            limit -= largest - max_prompt_bytes
+        else:
+            required = max_prompt_bytes - limit + 4
+            if sources:
+                raise mixed_capacity_error(sources[0], required, max_prompt_bytes)
+            raise MixedContextCapacityError(
+                f"review instructions/evidence/continuation and fragment require {required} bytes; "
+                f"prompt limit {max_prompt_bytes}"
+            )
+    if "".join(chunk.content for chunk in chunks) != captured.text:
+        raise SystemExit("internal error: mixed bundle coverage changed")
+    return [ReviewPass(render_review_prompt(
+        branch, target, target_ref, chunk, extra_prompt, rendered, (index, len(chunks)),
+    ), chunk, tuple(datasets)) for index, chunk in enumerate(chunks, 1)]
+
+
+def build_mixed_review_passes(
+    repo: Path, target: str, target_ref: str | None, captured: CapturedBundle,
+    extra_prompt: str, datasets: list[ReviewDataset], max_prompt_bytes: int,
+) -> list[ReviewPass]:
+    branch = current_branch(repo)
+    full = mixed_bundle_chunk(captured)
+    prompt = render_review_prompt(branch, target, target_ref, full, extra_prompt, render_datasets(datasets))
+    if utf8_size(prompt) <= max_prompt_bytes:
+        return [ReviewPass(prompt, full, tuple(datasets))]
+    # Establish that every mandatory record fits even with no evidence before
+    # spending time rebatching. Source context is never scheduled independently.
+    for record in captured.mixed:
+        chunk = ReviewChunk("xxxx", "", 0, (record,), ((record.path, "working_tree"),))
+        required = utf8_size(render_review_prompt(
+            branch, target, target_ref, chunk, extra_prompt, "", (999_999, 999_999),
+        ))
+        if required > max_prompt_bytes:
+            raise mixed_capacity_error(record, required, max_prompt_bytes)
+    try:
+        return build_mixed_change_passes(
+            branch, target, target_ref, captured, extra_prompt, datasets, max_prompt_bytes,
+        )
+    except MixedContextCapacityError:
+        if not datasets:
+            raise
+    minimum_evidence = max(
+        utf8_size(render_datasets([ReviewDataset(item.path, "", utf8_size(item.content))])) + 4
+        for item in datasets
+    )
+    evidence_limit = max_prompt_bytes // 2
+    while True:
+        evidence_limit = max(evidence_limit, minimum_evidence)
+        batches = split_review_datasets(datasets, evidence_limit)
+        passes = []
+        for index, batch in enumerate(batches, 1):
+            instructions = extra_prompt + (
+                f"\n\nEvidence batch: {index}/{len(batches)}\n"
+                "Every original change byte appears once in this batch. Dataset fragments "
+                "are context only; missing evidence is not proof of missing behavior."
+            )
+            try:
+                batch_passes = build_mixed_change_passes(
+                    branch, target, target_ref, captured, instructions, batch, max_prompt_bytes,
+                )
+            except MixedContextCapacityError:
+                if evidence_limit == minimum_evidence:
+                    raise
+                break
+            passes.extend(item._replace(evidence_batch=index) for item in batch_passes)
+        else:
+            return passes
+        evidence_limit //= 2
 
 
 def build_change_review_prompts(
@@ -3173,11 +3603,15 @@ def build_review_prompts(
     repo: Path,
     target: str,
     target_ref: str | None,
-    bundle: str,
+    bundle: str | CapturedBundle,
     extra_prompt: str,
     datasets: list[ReviewDataset],
     max_prompt_bytes: int = MAX_REVIEW_PROMPT_BYTES,
-) -> list[str]:
+) -> list[str] | list[ReviewPass]:
+    if isinstance(bundle, CapturedBundle):
+        if bundle.mixed:
+            return build_mixed_review_passes(repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes)
+        bundle = bundle.text
     branch = current_branch(repo)
     rendered_datasets = render_datasets(datasets)
     full_prompt = render_review_prompt(
@@ -3236,14 +3670,23 @@ def prepare_review_prompts(
     repo: Path,
     target: str,
     target_ref: str | None,
-    bundle: str,
+    bundle: str | CapturedBundle,
     extra_prompt: str,
     datasets: list[ReviewDataset],
     max_prompt_bytes: int,
-) -> list[str]:
-    return build_review_prompts(
+) -> list[str] | list[ReviewPass]:
+    prompts = build_review_prompts(
         repo, target, target_ref, bundle, extra_prompt, datasets, max_prompt_bytes,
     )
+    if len(prompts) > 1:
+        # A credential can span a partition boundary. Scan the complete frozen
+        # input before any send, in addition to each exact outgoing pack.
+        chunk = mixed_bundle_chunk(bundle) if isinstance(bundle, CapturedBundle) else ReviewChunk(bundle)
+        scan_outgoing_review_pack(repo, render_review_prompt(
+            current_branch(repo), target, target_ref, chunk,
+            extra_prompt, render_datasets(datasets),
+        ))
+    return prompts
 
 
 def write_json_temp(data: dict[str, Any], temp_root: Path) -> Path:
@@ -3430,11 +3873,11 @@ def codex_file_auth_source(repo: Path) -> Path | None:
     if not stat.S_ISREG(source_stat.st_mode):
         return None
     try:
-        data, truncated = read_prefix(source_auth, 1_000_000)
+        data = read_file_bytes(source_auth, 1_000_000)
         parsed = json.loads(data)
     except (OSError, SystemExit, json.JSONDecodeError):
         return None
-    if truncated or not isinstance(parsed, dict):
+    if not isinstance(parsed, dict):
         return None
     return source_auth
 
@@ -4164,6 +4607,10 @@ def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
                     model,
                     force_file_auth=file_auth_linked,
                 )
+                if index:
+                    # The initial send was scanned by run_reviewer; a retry is
+                    # a new provider invocation even with the same frozen pack.
+                    scan_outgoing_review_pack(repo, prompt)
                 result = run_with_heartbeat(
                     cmd,
                     review_root,
@@ -5242,11 +5689,64 @@ def parse_json_candidate(text: str) -> Any | None:
     return parsed
 
 
+def validate_attribution_shape(value: Any, index: int) -> None:
+    if value is None:
+        return
+    keys = {"target", "record_id", "source_id", "side", "column", "excerpt"}
+    if not isinstance(value, dict) or set(value) != keys:
+        raise SystemExit(f"finding {index} has invalid source_attribution keys")
+    if (value["target"] not in {"index", "working_tree"}
+            or value["side"] not in {"present", "removed"}
+            or not all(isinstance(value[key], str) for key in ("record_id", "source_id", "excerpt"))
+            or not isinstance(value["column"], int) or isinstance(value["column"], bool)
+            or value["column"] < 1):
+        raise SystemExit(f"finding {index} has invalid source_attribution")
+
+
+def mixed_attribution_error(
+    finding: dict[str, Any], record: MixedPath, available: set[str],
+) -> str | None:
+    attribution = finding.get("source_attribution")
+    if attribution is None:
+        return "mixed path requires explicit source attribution"
+    if attribution["record_id"] != record.identity:
+        return "mixed source record identity does not match"
+    if record.identity not in available:
+        return "mixed source record was not available in this pass"
+    target = attribution["target"]
+    removed = attribution["side"] == "removed"
+    source = (record.base if target == "index" else record.index) if removed else getattr(record, target)
+    if attribution["source_id"] != source.identity:
+        return "target/side source identity does not match"
+    if source.mode is None:
+        return "anchor refers to an absent source"
+    line = finding["code_location"]["line"]
+    if removed:
+        lines = dict(record.index_removed if target == "index" else record.working_tree_removed)
+        if line not in lines:
+            return "anchor is not a genuinely removed line of this transition"
+        text = lines[line]
+    else:
+        # Present empty blobs still need a file-level anchor; absent sources were rejected above.
+        lines = literal_lf_lines(source.content or "") or [""]
+        if line > len(lines):
+            return "source anchor line is out of range"
+        text = lines[line - 1].removesuffix("\n")
+    column = attribution["column"] - 1
+    excerpt = attribution["excerpt"]
+    if ((not excerpt and (text != "" or column != 0))
+            or "\n" in excerpt or text[column:column + len(excerpt)] != excerpt):
+        return "source anchor excerpt does not match exactly at line/column"
+    return None
+
+
 def _validate_report(
     report: dict[str, Any],
     repo: Path,
     changed_paths: set[str],
     required: list[str],
+    mixed: tuple[MixedPath, ...] = (),
+    available: set[str] | None = None,
 ) -> None:
     allowed_top = {"findings", "overall_correctness", "overall_explanation", "overall_confidence"}
     extra_top = set(report) - allowed_top
@@ -5267,16 +5767,19 @@ def _validate_report(
         raise SystemExit("review JSON overall_confidence must be numeric")
     kept_findings: list[dict[str, Any]] = []
     ignored_findings: list[tuple[int, dict[str, Any], str, int]] = []
+    attribution_rejected = []
+    records = {record.path: record for record in mixed}
     for index, finding in enumerate(report["findings"]):
         if not isinstance(finding, dict):
             raise SystemExit(f"finding {index} must be an object")
         allowed_finding = {"title", "body", "priority", "confidence", "category", "code_location"}
-        extra_finding = set(finding) - allowed_finding
+        extra_finding = set(finding) - allowed_finding - {"source_attribution"}
         if extra_finding:
             raise SystemExit(f"finding {index} has unexpected keys: {sorted(extra_finding)}")
         for key in allowed_finding:
             if key not in finding:
                 raise SystemExit(f"finding {index} missing required key: {key}")
+        validate_attribution_shape(finding.get("source_attribution"), index)
         title = finding.get("title")
         if not isinstance(title, str) or not title or len(title) > 140:
             raise SystemExit(f"finding {index} has invalid title")
@@ -5301,9 +5804,9 @@ def _validate_report(
                 f"{sorted(location)}"
             )
         raw_file_path = location.get("file_path")
-        if not isinstance(raw_file_path, str) or not raw_file_path.strip():
+        if not isinstance(raw_file_path, str) or not raw_file_path:
             raise SystemExit(f"finding {index} has invalid location: {location}")
-        raw_rel = raw_file_path.strip()
+        raw_rel = raw_file_path
         normalized_rel = raw_rel if raw_rel in changed_paths else raw_rel.replace("\\", "/")
         while normalized_rel.startswith("./"):
             normalized_rel = normalized_rel[2:]
@@ -5317,6 +5820,16 @@ def _validate_report(
         location["file_path"] = rel
         if rel not in changed_paths:
             ignored_findings.append((index, finding, rel, line))
+            continue
+        reason = None
+        if rel in records:
+            reason = mixed_attribution_error(finding, records[rel], available or set())
+        elif finding.get("source_attribution") is not None:
+            reason = "source attribution has no owner-built mixed record for this path"
+        if reason:
+            rejected = copy.deepcopy(finding)
+            rejected["attribution_rejection_reason"] = reason
+            attribution_rejected.append(rejected)
             continue
         kept_findings.append(finding)
     if ignored_findings:
@@ -5336,8 +5849,10 @@ def _validate_report(
                 ),
                 file=sys.stderr,
             )
-        report["findings"] = kept_findings
         report["scope_rejected_findings"] = [finding for _, finding, _, _ in ignored_findings]
+    report["findings"] = kept_findings
+    if attribution_rejected:
+        report["attribution_rejected_findings"] = attribution_rejected
     require_findings(report, required)
 
 
@@ -5362,9 +5877,11 @@ def validate_report(
     repo: Path,
     changed_paths: set[str],
     required: list[str],
+    mixed: tuple[MixedPath, ...] = (),
+    available: set[str] | None = None,
 ) -> None:
     try:
-        _validate_report(report, repo, changed_paths, required)
+        _validate_report(report, repo, changed_paths, required, mixed, available)
     except SystemExit as exc:
         if isinstance(exc.code, str):
             raise SystemExit(
@@ -5397,7 +5914,8 @@ def number_in_range(value: Any) -> bool:
 
 
 def review_status(report: dict[str, Any]) -> str:
-    if report.get("scope_rejected_findings") or report.get("missing_required_findings"):
+    if (report.get("scope_rejected_findings") or report.get("missing_required_findings")
+            or report.get("attribution_rejected_findings")):
         return "incomplete"
     if report["findings"]:
         return "findings"
@@ -5413,7 +5931,21 @@ def print_findings(findings: list[dict[str, Any]]) -> None:
         loc = finding["code_location"]
         print(f"[{finding['priority']}] {display_escape(finding['title'], 140)}")
         print(f"{display_escape(loc['file_path'], 500)}:{loc['line']}")
+        if attribution := finding.get("source_attribution"):
+            target = "INDEX-only" if attribution["target"] == "index" else "WORKING_TREE"
+            print(f"target: {target}; side: {attribution['side']}; "
+                  f"source: {display_escape(attribution['source_id'], 200)}")
         print(display_escape(finding["body"], 2000, multiline=True))
+        if reason := finding.get("attribution_rejection_reason"):
+            print(f"Rejected attribution: {reason}")
+        for index, variant in enumerate(finding.get("claim_variants", []), 1):
+            print(f"Claim variant {index}:")
+            print(display_escape(variant["body"], 2000, multiline=True))
+            for observation in variant["observations"]:
+                print(display_escape(
+                    f"{observation['pass']}: [{observation['priority']}] {observation['title']} "
+                    f"(confidence {observation['confidence']})", 500,
+                ))
         print()
 
 
@@ -5440,6 +5972,7 @@ def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
     print_findings(findings)
     for key, description in (
         ("scope_rejected_findings", "Rejected out-of-scope findings (retained for audit)"),
+        ("attribution_rejected_findings", "Rejected source attributions (retained for audit)"),
         ("priority_filtered_findings", "Findings below the requested priority (retained for audit)"),
     ):
         if report.get(key):
@@ -5810,22 +6343,13 @@ def dry_run_preflight(
     target: str,
     target_ref: str | None,
 ) -> int:
-    """Validate what upstream can check before a real run without
-    contacting any review engine: that the review bundle can be built for
-    the chosen target, that --prompt-file and --dataset inputs resolve
-    and pass the same repo-relative/existence checks the real run applies
-    via capture_evidence_inputs, that the assembled prompt(s) pass
-    the same aggregate-size/partition and truncation-refusal checks the
-    real run applies via build_review_prompts/ensure_reviewer_input_complete,
-    and that each configured reviewer's CLI binary resolves and
-    its configuration (including, for Kimi, load_kimi_review_config and
-    validate_kimi_runtime_auth_sources, and for Claude, the tool
-    inventory) is one a real run would actually accept. Returns the
-    process exit status: 0 when every check passes, 1 otherwise.
+    """Build, scan and verify real review inputs, then probe reviewer startup.
+
+    Never contact a review provider. Return 0 only when every check passes.
     """
     ok = True
     inputs_ok = True
-    evidence = EvidenceInputs("", [], False, [])
+    evidence = EvidenceInputs("", [], [])
     try:
         with PreparationProgress("evidence selection"):
             evidence = capture_evidence_inputs(args, repo)
@@ -5834,7 +6358,7 @@ def dry_run_preflight(
         ok = inputs_ok = False
         print(f"inputs: FAILED ({exc})", flush=True)
 
-    captured = CapturedBundle("", False, set())
+    captured = CapturedBundle("", set())
     bundle_ok = True
     try:
         with PreparationProgress("bundle preparation"):
@@ -5846,25 +6370,21 @@ def dry_run_preflight(
         ok = bundle_ok = False
         print(f"bundle: FAILED ({exc})", flush=True)
 
-    # The normal path (see main() below) does not stop at per-file
-    # validation: it also assembles the final prompt(s) and enforces the
-    # aggregate-size/partition limits and truncated-input refusal that
-    # build_review_prompts()/ensure_reviewer_input_complete() apply before
-    # any engine call. A dry run that skipped those would report OK for
-    # inputs a real run rejects once combined.
+    # Use the real prompt builder: individually valid inputs may exceed a
+    # pass's capacity once combined with intact instructions/source context.
     if bundle_ok and inputs_ok:
         try:
-            with PreparationProgress("bundle/evidence preparation"):
-                input_truncated = captured.truncated or evidence.truncated
-                if reviewers:
-                    ensure_reviewer_input_complete(reviewers[0], input_truncated)
+            with PreparationProgress("bundle/evidence preparation and scan"):
                 threshold_extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
                 prompts = prepare_review_prompts(
-                    repo, target, target_ref, captured.text, threshold_extra_prompt,
+                    repo, target, target_ref, captured, threshold_extra_prompt,
                     evidence.datasets, max_prompt_bytes_for_reviewers(reviewers),
                 )
+                for prompt in prompts:
+                    scan_outgoing_review_pack(repo, prompt.prompt if isinstance(prompt, ReviewPass) else prompt)
             with PreparationProgress("evidence verification"):
                 verify_evidence(repo, evidence.files)
+                verify_mixed_sources(repo, captured.mixed)
             print("prompt: OK", flush=True)
         except SystemExit as exc:
             ok = False
@@ -5891,19 +6411,29 @@ def dry_run_preflight(
 def run_reviewer(
     args: argparse.Namespace,
     repo: Path,
-    prompt: str,
-    changed_paths: set[str],
+    prompt: str | ReviewPass,
+    changed_paths: set[str] | CapturedBundle,
     required: list[str],
-    input_truncated: bool = False,
     evidence: list[EvidenceFile] | None = None,
 ) -> dict[str, Any]:
-    ensure_reviewer_input_complete(args, input_truncated)
-    with PreparationProgress("evidence verification"):
+    mixed = changed_paths.mixed if isinstance(changed_paths, CapturedBundle) else ()
+    paths = changed_paths.paths if isinstance(changed_paths, CapturedBundle) else changed_paths
+    available = {record.identity for record in prompt.chunk.sources} if isinstance(prompt, ReviewPass) else set()
+    if mixed and not isinstance(prompt, ReviewPass):
+        raise SystemExit("mixed review requires owner-built pass metadata")
+    outgoing = prompt.prompt if isinstance(prompt, ReviewPass) else prompt
+    with PreparationProgress("outgoing pack scan and evidence verification"):
+        scan_outgoing_review_pack(repo, outgoing)
         verify_evidence(repo, evidence or [])
-    raw = run_engine(args, repo, prompt)
+        verify_mixed_sources(repo, mixed)
+    raw = run_engine(args, repo, outgoing)
     report = extract_json(raw)
-    validate_report(report, repo, changed_paths, [])
+    provider_report = copy.deepcopy(report)
+    validate_report(report, repo, paths, [], mixed, available)
     filter_findings_by_priority(report, args.max_priority)
+    report["provider_report"] = provider_report
+    if mixed:
+        report["available_source_records"] = sorted(available)
     require_findings(report, required)
     return report
 
@@ -5911,9 +6441,30 @@ def run_reviewer(
 def merge_chunk_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
     findings: list[dict[str, Any]] = []
     seen: set[tuple[str, int, str, str]] = set()
+    mixed_groups = {}
     for label, chunk_report in reports:
         for finding in chunk_report["findings"]:
             location = finding["code_location"]
+            attribution = finding.get("source_attribution")
+            if attribution:
+                key = (location["file_path"], location["line"], finding["category"],
+                       attribution["target"], attribution["record_id"], attribution["source_id"],
+                       attribution["side"], attribution["column"], attribution["excerpt"])
+                if key not in mixed_groups:
+                    merged = copy.deepcopy(finding)
+                    merged["claim_variants"] = []
+                    mixed_groups[key] = merged
+                    findings.append(merged)
+                merged = mixed_groups[key]
+                variant = next((item for item in merged["claim_variants"] if item["body"] == finding["body"]), None)
+                if variant is None:
+                    variant = {"body": finding["body"], "observations": []}
+                    merged["claim_variants"].append(variant)
+                variant["observations"].append({"pass": label, "title": finding["title"],
+                                                "priority": finding["priority"], "confidence": finding["confidence"]})
+                merged["priority"] = min(merged["priority"], finding["priority"])
+                merged["confidence"] = min(merged["confidence"], finding["confidence"])
+                continue
             key = (
                 location["file_path"],
                 location["line"],
@@ -5944,7 +6495,12 @@ def merge_chunk_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, 
         ),
         "pass_reports": [{"label": label, "report": copy.deepcopy(chunk_report)} for label, chunk_report in reports],
     }
-    for field in ("scope_rejected_findings", "priority_filtered_findings"):
+    if len(reports) == 1:
+        # One pass uses the same audit/grouping path without rewriting the
+        # provider's conclusion, explanation or confidence.
+        report.update(copy.deepcopy(reports[0][1]))
+        report["findings"] = findings
+    for field in ("scope_rejected_findings", "priority_filtered_findings", "attribution_rejected_findings"):
         retained = [copy.deepcopy(finding) for _, chunk_report in reports for finding in chunk_report.get(field, [])]
         if retained:
             report[field] = retained
@@ -5955,9 +6511,8 @@ def run_review_passes(
     args: argparse.Namespace,
     reviewers: list[argparse.Namespace],
     repo: Path,
-    prompts: list[str],
-    changed_paths: set[str],
-    input_truncated: bool,
+    prompts: list[str] | list[ReviewPass],
+    changed_paths: set[str] | CapturedBundle,
     evidence: list[EvidenceFile] | None = None,
 ) -> list[tuple[str, dict[str, Any]]]:
     chunk_reports: list[tuple[str, dict[str, Any]]] = []
@@ -5965,7 +6520,7 @@ def run_review_passes(
         if len(prompts) > 1:
             print(
                 f"review pass: {index}/{len(prompts)} "
-                f"({utf8_size(prompt)} prompt bytes)"
+                f"({utf8_size(prompt.prompt if isinstance(prompt, ReviewPass) else prompt)} prompt bytes)"
             )
         chunk_report = run_reviewer(
             reviewers[0],
@@ -5973,7 +6528,6 @@ def run_review_passes(
             prompt,
             changed_paths,
             [],
-            input_truncated,
             evidence,
         )
         chunk_reports.append((f"chunk {index}/{len(prompts)}", chunk_report))
@@ -6072,21 +6626,20 @@ def main_impl() -> int:
         evidence = capture_evidence_inputs(args, repo)
     with PreparationProgress("initial source snapshot") as progress:
         review_source_snapshot = source_tree_snapshot(repo, progress)
-    with PreparationProgress("bundle/evidence preparation"):
+    with PreparationProgress("bundle/evidence preparation and scan"):
         captured = build_bundle(repo, target, target_ref, args.commit)
         if target == "commit":
             target_ref = args.commit
         extra_prompt = apply_finding_threshold_prompt(args, evidence.prompt)
-        input_truncated = captured.truncated or evidence.truncated
-        ensure_reviewer_input_complete(reviewer, input_truncated)
         prompts = prepare_review_prompts(
-            repo, target, target_ref, captured.text, extra_prompt, evidence.datasets,
+            repo, target, target_ref, captured, extra_prompt, evidence.datasets,
             max_prompt_bytes_for_reviewers(reviewers),
         )
     print(f"bundle: {utf8_size(captured.text)} bytes; review passes: {len(prompts)}", flush=True)
     with PreparationProgress("pre-review verification") as progress:
         current_snapshot = source_tree_snapshot(repo, progress)
         verify_evidence(repo, evidence.files)
+        verify_mixed_sources(repo, captured.mixed)
         if current_snapshot != review_source_snapshot:
             raise SystemExit(
                 "source changed while the review bundle was being created; "
@@ -6097,11 +6650,10 @@ def main_impl() -> int:
         reviewers,
         repo,
         prompts,
-        captured.paths,
-        input_truncated,
+        captured,
         evidence.files,
     )
-    if len(chunk_reports) == 1:
+    if len(chunk_reports) == 1 and not captured.mixed:
         report = chunk_reports[0][1]
     else:
         report = merge_chunk_reports(chunk_reports)
@@ -6116,6 +6668,7 @@ def main_impl() -> int:
     with PreparationProgress("final source verification") as progress:
         current_snapshot = source_tree_snapshot(repo, progress)
         verify_evidence(repo, evidence.files)
+        verify_mixed_sources(repo, captured.mixed)
         if current_snapshot != review_source_snapshot:
             print(
                 "source changed after the review bundle was created; "

--- a/.agents/skills/autoreview/scripts/autoreview_test.py
+++ b/.agents/skills/autoreview/scripts/autoreview_test.py
@@ -9,6 +9,7 @@ import io
 import json
 import os
 import runpy
+import stat
 import subprocess
 import sys
 import tempfile
@@ -158,10 +159,10 @@ class AutoreviewResultScopeTests(unittest.TestCase):
         args = argparse.Namespace(engine="codex", max_priority="P0", require_finding=["Draft finding"])
         for count in (1, 2):
             with self.subTest(count=count), mock.patch.object(
-                AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)
-            ):
+                AUTOREVIEW, "scan_outgoing_review_pack"
+            ), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(DRAFT_REPORT)):
                 reports = AUTOREVIEW.run_review_passes(
-                    args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}, False
+                    args, [args], Path.cwd(), ["pack"] * count, {"draft.js"}
                 )
             report = reports[0][1] if count == 1 else AUTOREVIEW.merge_chunk_reports(reports)
             self.assertEqual(
@@ -185,6 +186,195 @@ class AutoreviewResultScopeTests(unittest.TestCase):
         self.assertEqual(len(merged["findings"]), 1)
         self.assertEqual(AUTOREVIEW.missing_required_findings(merged, ["required tail"]), [])
 
+
+class AutoreviewTargetResultTests(unittest.TestCase):
+    def setUp(self):
+        source = AUTOREVIEW.SourceVersion
+        self.record = AUTOREVIEW.MixedPath(
+            "src/migrate.py", "synthetic-record",
+            source("base-source", "100644", "original()\nkeep()\n"),
+            source("index-source", "100644", "obsolete()\nkeep()\n"),
+            source("working-source", "100644", "corrected()\nkeep()\nbroken()\n"),
+            "synthetic staged delta", "synthetic unstaged delta",
+            ((1, "original()"),), ((1, "obsolete()"),), (),
+        )
+
+    def finding(self, target="index", side="present", line=1, excerpt=None, **changes):
+        source = ((self.record.base if target == "index" else self.record.index)
+                  if side == "removed" else getattr(self.record, target))
+        if excerpt is None:
+            excerpt = source.content.splitlines()[line - 1]
+        finding = {
+            "title": "Synthetic defect", "body": "A concrete synthetic claim.",
+            "priority": "P0", "confidence": 0.8, "category": "bug",
+            "code_location": {"file_path": self.record.path, "line": line},
+            "source_attribution": {"target": target, "record_id": self.record.identity,
+                                   "source_id": source.identity, "side": side,
+                                   "column": 1, "excerpt": excerpt},
+        }
+        finding.update(changes)
+        return finding
+
+    def validate(self, findings, available=True):
+        report = copy.deepcopy(FINAL_REPORT)
+        report["findings"] = copy.deepcopy(findings)
+        AUTOREVIEW.validate_report(report, Path.cwd(), {self.record.path}, [], (self.record,),
+                                   {self.record.identity} if available else set())
+        return report
+
+    def test_explicit_targets_anchors_and_pass_availability(self):
+        accepted = [self.finding(), self.finding("working_tree", line=3),
+                    self.finding("working_tree", line=2), self.finding(side="removed"),
+                    self.finding("working_tree", side="removed")]
+        self.assertEqual(self.validate(accepted)["findings"], accepted)
+        cases = []
+        missing = self.finding()
+        missing.pop("source_attribution")
+        cases.append((missing, "requires explicit"))
+        null = self.finding(source_attribution=None)
+        cases.append((null, "requires explicit"))
+        for field, value, reason in (
+            ("record_id", "wrong", "record identity"),
+            ("source_id", "wrong", "source identity"),
+            ("column", 1000, "excerpt"),
+            ("excerpt", "invented()", "excerpt"),
+        ):
+            finding = self.finding()
+            finding["source_attribution"][field] = value
+            cases.append((finding, reason))
+        cases.extend([
+            (self.finding("working_tree", excerpt="obsolete()"), "excerpt"),
+            (self.finding("working_tree", line=900, excerpt="broken()"), "out of range"),
+            (self.finding("working_tree", side="removed", line=2), "genuinely removed"),
+        ])
+        for finding, reason in cases:
+            with self.subTest(reason=reason, finding=finding):
+                report = self.validate([finding])
+                self.assertEqual(report["findings"], [])
+                self.assertIn(reason, report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+                self.assertEqual(AUTOREVIEW.review_status(report), "incomplete")
+                self.assertEqual(report["overall_correctness"], "patch is correct")
+        report = self.validate([self.finding()], available=False)
+        self.assertIn("not available", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+        original = self.record
+        for path in (" src/migrate.py", "src/migrate.py ", " "):
+            with self.subTest(path=path):
+                self.record = original._replace(path=path)
+                finding = self.finding()
+                self.assertEqual(self.validate([finding])["findings"], [finding])
+            self.record = original
+
+    def test_absence_readd_and_removed_side_are_distinct(self):
+        absent = AUTOREVIEW.SourceVersion("absent", None, None)
+        for target in ("index", "working_tree"):
+            with self.subTest(target=target):
+                original = self.record
+                if target == "index":
+                    self.record = original._replace(index=absent, working_tree_removed=())
+                else:
+                    self.record = original._replace(working_tree=absent)
+                present = self.finding(target, excerpt="obsolete()")
+                removed = self.finding(target, side="removed")
+                report = self.validate([present, removed])
+                self.assertEqual(report["findings"], [removed])
+                self.assertIn("absent", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+                self.record = original
+
+        original = self.record
+        for target, side, content, line in (
+            ("index", "present", "", 1), ("working_tree", "present", "", 1),
+            ("index", "present", "before()\n\n", 2), ("working_tree", "present", "before()\n\n", 2),
+            ("index", "removed", "\n", 1), ("working_tree", "removed", "\n", 1),
+        ):
+            with self.subTest(target=target, side=side, content=content):
+                owner = ("base" if target == "index" else "index") if side == "removed" else target
+                self.record = original._replace(**{owner: getattr(original, owner)._replace(content=content)})
+                if side == "removed":
+                    self.record = self.record._replace(**{target + "_removed": ((line, ""),)})
+                valid = self.finding(target, side=side, line=line, excerpt="")
+                self.assertEqual(self.validate([valid])["findings"], [valid])
+                invalid = []
+                for key, value in (("record_id", "wrong"), ("source_id", "wrong"),
+                                   ("column", 2), ("excerpt", "invented")):
+                    bad = copy.deepcopy(valid)
+                    bad["source_attribution"][key] = value
+                    invalid.append(bad)
+                bad = copy.deepcopy(valid)
+                bad["code_location"]["line"] = 2 if not content else 900
+                invalid.append(bad)
+                if side == "present" and content:
+                    bad = copy.deepcopy(valid)
+                    bad["code_location"]["line"] = 1
+                    invalid.append(bad)
+                for bad in invalid:
+                    report = self.validate([bad])
+                    self.assertEqual(report["findings"], [])
+                    self.assertEqual(AUTOREVIEW.review_status(report), "incomplete")
+                self.record = original
+        for target in ("index", "working_tree"):
+            for side in ("present", "removed"):
+                report = self.validate([self.finding(target, side=side, excerpt="")])
+                self.assertEqual(report["findings"], [])
+            self.record = original._replace(**{target: absent})
+            report = self.validate([self.finding(target, excerpt="")])
+            self.assertIn("absent", report["attribution_rejected_findings"][0]["attribution_rejection_reason"])
+            self.record = original
+
+    def test_title_independent_groups_keep_variants_targets_and_observations(self):
+        reports = []
+        for index in range(8):
+            finding = self.finding(title=f"Index title {index}")
+            findings = [finding]
+            if index == 7:
+                findings += [self.finding(body="Distinct consequence requiring a different fix."),
+                             self.finding("working_tree")]
+            reports.append((f"pass {index}", self.validate(findings)))
+        for selected in (reports, [("single", self.validate([
+            finding for _, report in reports for finding in report["findings"]
+        ]))]):
+            with self.subTest(passes=len(selected)):
+                result = AUTOREVIEW.merge_chunk_reports(selected)
+                self.assertEqual(len(result["findings"]), 2)
+                grouped = result["findings"][0]
+                self.assertEqual(len(grouped["claim_variants"]), 2)
+                self.assertEqual(len(grouped["claim_variants"][0]["observations"]), 8)
+                self.assertEqual(AUTOREVIEW.missing_required_findings(result, ["Index title 7", "different fix"]), [])
+                self.assertEqual(len(result["pass_reports"]), len(selected))
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    AUTOREVIEW.print_report(result)
+                for text in ("INDEX-only", "WORKING_TREE", "Index title 7", "different fix"):
+                    self.assertIn(text, output.getvalue())
+
+    def test_all_engines_keep_raw_reports_before_normalization_and_filters(self):
+        captured = AUTOREVIEW.CapturedBundle("delta", {self.record.path}, (self.record,), ())
+        prompt = AUTOREVIEW.ReviewPass("synthetic pack", AUTOREVIEW.ReviewChunk("delta", sources=(self.record,)))
+        valid = self.finding()
+        valid["code_location"]["file_path"] = r".\src\migrate.py"
+        stale = self.finding("working_tree", excerpt="obsolete()")
+        outside = self.finding(code_location={"file_path": "outside.py", "line": 1})
+        provider = {**FINAL_REPORT, "findings": [valid, stale, outside],
+                    "overall_correctness": "patch is incorrect", "overall_confidence": 0.43}
+        for engine in AUTOREVIEW.ENGINES:
+            with self.subTest(engine=engine), mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(provider)), \
+                    mock.patch.object(AUTOREVIEW, "scan_outgoing_review_pack"), \
+                    mock.patch.object(AUTOREVIEW, "verify_mixed_sources"), contextlib.redirect_stderr(io.StringIO()):
+                report = AUTOREVIEW.run_reviewer(argparse.Namespace(engine=engine, max_priority="P0"),
+                                                 Path.cwd(), prompt, captured, [])
+            self.assertEqual(report["provider_report"], provider)
+            self.assertEqual(report["overall_confidence"], 0.43)
+            self.assertEqual(len(report["findings"]), 1)
+            self.assertEqual(len(report["scope_rejected_findings"]), 1)
+            self.assertEqual(len(report["attribution_rejected_findings"]), 1)
+            self.assertEqual(AUTOREVIEW.review_status(report), "incomplete")
+            self.assertEqual(report["available_source_records"], [self.record.identity])
+        low = self.validate([self.finding(priority="P2")])
+        AUTOREVIEW.filter_findings_by_priority(low, "P0")
+        self.assertEqual(AUTOREVIEW.missing_required_findings(low, ["Synthetic defect"]), ["Synthetic defect"])
+        self.assertEqual(AUTOREVIEW.review_status(low), "filtered")
+        for bad in ({}, {**self.finding()["source_attribution"], "column": True}):
+            with self.assertRaisesRegex(SystemExit, "source_attribution"):
+                self.validate([self.finding(source_attribution=bad)])
 
 def amp_test_stream(
     cwd: Path,
@@ -744,6 +934,163 @@ class AutoreviewAmpTests(unittest.TestCase):
                     AUTOREVIEW.run_amp(args, repo, "review")
 
 
+class AutoreviewTruffleHogTests(unittest.TestCase):
+    def test_refusal_does_not_echo_input_headings_or_scanner_fields(self) -> None:
+        marker = "SYNTHETIC_SCAN_SENTINEL_NOT_A_CREDENTIAL"
+        headings = [
+            f"# Dataset: {marker}",
+            f"# Prompt file: {marker}",
+            'Source snapshot: ' + json.dumps({"path": marker, "line_count": 0}),
+            'Removed source: ' + json.dumps({"path": marker}),
+            '# Untracked File\npath: ' + json.dumps(marker),
+            f"+++ b/{marker}",
+            f"diff --git a/old.txt b/{marker}\n--- a/old.txt\n+++ b/{marker}\n@@ -1 +1 @@\n+example",
+        ]
+        for heading in headings:
+            with self.subTest(heading=heading), tempfile.TemporaryDirectory() as tempdir:
+                prompt = "# Dataset: safe-evidence.txt\n" + heading
+                lines = [number for number, line in enumerate(prompt.splitlines(), 1) if marker in line]
+                output = json.dumps({"SourceMetadata": {"Data": {"Filesystem": {"line": lines[-1]}}},
+                                     "Raw": marker, "RawV2": marker})
+                with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
+                        mock.patch.object(AUTOREVIEW, "run", return_value=subprocess.CompletedProcess(
+                            [], AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, output, marker,
+                        )), mock.patch.object(AUTOREVIEW, "run_engine") as provider:
+                    with self.assertRaises(SystemExit) as error:
+                        AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
+                                                 Path(tempdir), prompt, {"change.txt"}, [])
+                self.assertNotIn(marker, str(error.exception))
+                self.assertIn("remove credential material", str(error.exception))
+                provider.assert_not_called()
+
+    def test_scanner_checks_stdin_without_literal_ignore_markers(self) -> None:
+        prompt = "unicode \u03c0\r\nsource without suppression instructions\n"
+        commands = []
+        with tempfile.TemporaryDirectory() as tempdir:
+            def scanner(command, cwd, **kwargs):
+                commands.append(command[1])
+                if command[1] == "filesystem":
+                    self.assertEqual(Path(command[2]).read_bytes(), prompt.encode("utf-8"))
+                    return subprocess.CompletedProcess(command, 0, "", "")
+                self.assertEqual(command[1], "stdin")
+                self.assertEqual(kwargs["stdin"].read(), prompt.encode("utf-8"))
+                return subprocess.CompletedProcess(command, AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "", "")
+
+            with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog"), \
+                    mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
+                    mock.patch.object(AUTOREVIEW, "run_engine", return_value=json.dumps(FINAL_REPORT)) as provider:
+                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                    AUTOREVIEW.run_reviewer(argparse.Namespace(engine="codex", max_priority="P0"),
+                                             Path(tempdir), prompt, {"change.txt"}, [])
+            self.assertEqual(commands, ["filesystem", "stdin"])
+            provider.assert_not_called()
+
+    def test_binary_stdin_preserves_utf8_and_crlf_bytes(self) -> None:
+        payload = "unicode \u03c0\r\nnext\n".encode("utf-8")
+        with tempfile.TemporaryDirectory() as tempdir, tempfile.TemporaryFile() as source:
+            source.write(payload)
+            source.seek(0)
+            result = AUTOREVIEW.run(
+                [sys.executable, "-c", "import sys; print(sys.stdin.buffer.read().hex())"],
+                Path(tempdir), stdin=source,
+            )
+        self.assertEqual(result.stdout.strip(), payload.hex())
+
+    def test_every_provider_scans_each_pack_and_refuses_scanner_failures(self) -> None:
+        for engine in ("codex", "claude", "amp", "pi", "kimi"):
+            for failed_source, failure in ((None, None), (None, "missing"),
+                                           ("filesystem", "finding"), ("filesystem", "error"),
+                                           ("stdin", "finding"), ("stdin", "error")):
+                with self.subTest(engine=engine, source=failed_source, failure=failure), tempfile.TemporaryDirectory() as tempdir:
+                    repo = Path(tempdir)
+                    args = argparse.Namespace(engine=engine, max_priority="P0")
+                    prompts = [f"complete pack {index}: unicode \u03c0\r\n-context\n+change\n" for index in range(2)]
+                    events: list[tuple[str, str]] = []
+                    packs: list[Path] = []
+
+                    def scanner(command, cwd, **kwargs):
+                        source = command[1]
+                        pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
+                        data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
+                        packs.append(pack)
+                        prompt = data.decode("utf-8")
+                        self.assertIn(prompt, prompts)
+                        self.assertEqual(cwd, pack.parent)
+                        if os.name != "nt":
+                            self.assertEqual(stat.S_IMODE(pack.stat().st_mode), 0o600)
+                            self.assertEqual(stat.S_IMODE(pack.parent.stat().st_mode), 0o700)
+                        events.append((source, prompt))
+                        code = 0
+                        if prompt == prompts[1] and source == failed_source:
+                            code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
+                        return subprocess.CompletedProcess(command, code, "", "")
+
+                    def provider(_args, _repo, prompt):
+                        events.append(("send", prompt))
+                        return json.dumps(FINAL_REPORT)
+
+                    with mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
+                            mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), contextlib.ExitStack() as stack:
+                        providers = {
+                            name: stack.enter_context(mock.patch.object(AUTOREVIEW, f"run_{name}", side_effect=provider))
+                            for name in ("codex", "claude", "amp", "pi", "kimi")
+                        }
+                        AUTOREVIEW.run_reviewer(args, repo, prompts[0], set(), [])
+                        if failure == "missing":
+                            find.return_value = None
+                        if failure:
+                            with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                                AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
+                        else:
+                            AUTOREVIEW.run_reviewer(args, repo, prompts[1], set(), [])
+                        for name, call in providers.items():
+                            self.assertEqual(call.call_count, (1 if failure else 2) if name == engine else 0)
+                    expected = [("filesystem", prompts[0]), ("stdin", prompts[0]), ("send", prompts[0])]
+                    if failure != "missing":
+                        expected.append(("filesystem", prompts[1]))
+                        if failed_source != "filesystem":
+                            expected.append(("stdin", prompts[1]))
+                    if not failure:
+                        expected.append(("send", prompts[1]))
+                    self.assertEqual(events, expected)
+                    self.assertTrue(all(not pack.parent.exists() for pack in packs))
+
+    def test_scanner_command_requests_verified_and_unknown_results(self) -> None:
+        prompt = "review pack with redacted examples only"
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = Path(tempdir)
+
+            def run_scanner(
+                command: list[str],
+                cwd: Path,
+                **kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                pack = Path(command[2]) if command[1] == "filesystem" else Path(kwargs["stdin"].name)
+                self.assertEqual(cwd, pack.parent)
+                data = pack.read_bytes() if command[1] == "filesystem" else kwargs["stdin"].read()
+                self.assertEqual(data, prompt.encode("utf-8"))
+                self.assertEqual(
+                    command[3:] if command[1] == "filesystem" else command[2:],
+                    [
+                        "--json",
+                        "--no-color",
+                        "--results=verified,unknown",
+                        "--fail",
+                        "--fail-on-scan-errors",
+                        "--no-update",
+                    ],
+                )
+                self.assertEqual(kwargs["check"], False)
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with mock.patch.object(
+                AUTOREVIEW,
+                "find_command",
+                return_value="/trusted/trufflehog",
+            ), mock.patch.object(AUTOREVIEW, "run", side_effect=run_scanner):
+                AUTOREVIEW.scan_outgoing_review_pack(repo, prompt)
+
+
 class AutoreviewCompatibilityTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -928,30 +1275,62 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
             web_search=False,
         )
         prompt = "complete retry pack: unicode \u03c0\r\n-deleted line\n unchanged context\n"
-        with tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
-            events: list[str] = []
+        for failed_source, failure in ((None, None), (None, "missing"),
+                                       ("filesystem", "finding"), ("filesystem", "error"),
+                                       ("stdin", "finding"), ("stdin", "error")):
+            with self.subTest(source=failed_source, failure=failure), tempfile.TemporaryDirectory(prefix="autoreview-codex-fallback.") as tmpdir:
+                events: list[str] = []
+                packs: list[Path] = []
 
-            def fake_run(command, _cwd, **kwargs):
-                self.assertEqual(kwargs["input_text"], prompt)
-                model = command[command.index("--model") + 1]
-                events.append(model)
-                if model == "gpt-5.6-sol":
-                    return subprocess.CompletedProcess(
-                        command, 1, "",
-                        "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
-                    )
-                output_path = Path(command[command.index("--output-last-message") + 1])
-                output_path.write_text(json.dumps(FINAL_REPORT))
-                return subprocess.CompletedProcess(command, 0, "", "")
+                def scanner(command, _cwd, **kwargs):
+                    source = command[1]
+                    pack = Path(command[2]) if source == "filesystem" else Path(kwargs["stdin"].name)
+                    data = pack.read_bytes() if source == "filesystem" else kwargs["stdin"].read()
+                    packs.append(pack)
+                    self.assertEqual(data, prompt.encode("utf-8"))
+                    events.append(source)
+                    code = 0
+                    if "gpt-5.6-sol" in events and source == failed_source:
+                        code = {"finding": AUTOREVIEW.TRUFFLEHOG_FINDINGS_EXIT_CODE, "error": 1}.get(failure, 0)
+                    return subprocess.CompletedProcess(command, code, "", "")
 
-            with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
-                    mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
-                    mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
-                    mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
-                    mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
-                report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
-                self.assertEqual(report["findings"], [])
-            self.assertEqual(events, ["gpt-5.6-sol", "gpt-5.6-terra"])
+                def fake_run(command, _cwd, **kwargs):
+                    self.assertEqual(kwargs["input_text"], prompt)
+                    model = command[command.index("--model") + 1]
+                    events.append(model)
+                    if model == "gpt-5.6-sol":
+                        if failure == "missing":
+                            find.return_value = None
+                        return subprocess.CompletedProcess(
+                            command, 1, "",
+                            "The model `gpt-5.6-sol` does not exist or you do not have access to it.",
+                        )
+                    output_path = Path(command[command.index("--output-last-message") + 1])
+                    output_path.write_text(json.dumps(FINAL_REPORT))
+                    return subprocess.CompletedProcess(command, 0, "", "")
+
+                with mock.patch.object(AUTOREVIEW, "resolve_command", return_value="/usr/bin/codex"), \
+                        mock.patch.object(AUTOREVIEW, "ensure_codex_isolation_supported", return_value="/usr/bin/codex"), \
+                        mock.patch.object(AUTOREVIEW, "codex_auth_config_flags", return_value=[]), \
+                        mock.patch.object(AUTOREVIEW, "prepare_codex_runtime_auth", return_value=None), \
+                        mock.patch.object(AUTOREVIEW, "find_command", return_value="/trusted/trufflehog") as find, \
+                        mock.patch.object(AUTOREVIEW, "run", side_effect=scanner), \
+                        mock.patch.object(AUTOREVIEW, "run_with_heartbeat", side_effect=fake_run):
+                    if failure:
+                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                            AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
+                    else:
+                        report = AUTOREVIEW.run_reviewer(args, Path(tmpdir), prompt, set(), [])
+                        self.assertEqual(report["findings"], [])
+                expected = ["filesystem", "stdin", "gpt-5.6-sol"]
+                if failure != "missing":
+                    expected.append("filesystem")
+                    if failed_source != "filesystem":
+                        expected.append("stdin")
+                if not failure:
+                    expected.append("gpt-5.6-terra")
+                self.assertEqual(events, expected)
+                self.assertTrue(all(not pack.parent.exists() for pack in packs))
 
     def test_codex_runs_outside_repo_with_bundle_only_workspace(self) -> None:
         args = argparse.Namespace(

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import runpy
 import shutil
 import stat
 import subprocess
@@ -146,23 +145,8 @@ def create_fixture_repo(repo: Path, fixture: str) -> None:
     write_fixture_file(repo, MALICIOUS_CHANGED if fixture == "malicious" else BENIGN_CHANGED)
 
 
-def validate_prompt_policy(repo: Path, autoreview: Path) -> None:
-    namespace = runpy.run_path(str(autoreview))
-    prompt, = namespace["build_review_prompts"](repo, "local", None, "fixture diff", "", [])
-    required = (
-        "This helper is a closeout gate.",
-        "Do not turn a narrow patch into a broad",
-        "If this is release-branch or release-process work",
-        "Non-blocking design,",
-    )
-    missing = [needle for needle in required if needle not in prompt]
-    if missing:
-        raise RuntimeError(f"autoreview prompt missing scope policy: {missing}")
-
-
 def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) -> None:
     autoreview = script_dir / "autoreview"
-    validate_prompt_policy(repo, autoreview)
     for engine in engines:
         print(f"== {engine} ==", flush=True)
         command = [

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -11,6 +11,7 @@ import re
 import runpy
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -230,6 +231,21 @@ def init_repo(tempdir: Path) -> Path:
     return repo
 
 
+def posix_process_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    result = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    state = result.stdout.strip()
+    return result.returncode == 0 and bool(state) and not state.startswith("Z")
+
+
 def installed_java() -> str | None:
     java = shutil.which("java")
     if java is None:
@@ -246,6 +262,702 @@ def installed_java() -> str | None:
     return java if probe.returncode == 0 else None
 
 
+def add_fake_trufflehog(
+    helper: dict[str, object],
+    root: Path,
+    env: dict[str, str],
+) -> None:
+    write_executable(
+        root / "trufflehog",
+        "#!/usr/bin/env python3\nraise SystemExit(0)\n",
+    )
+    env["PATH"] = f"{root}{os.pathsep}{env.get('PATH', '')}"
+
+
+def path_excluding_command(name: str) -> str:
+    """Build a PATH value with every directory that resolves ``name``
+    removed, so a subprocess launched with it cannot find that command
+    even when it is genuinely installed on the host running the tests.
+    """
+    kept = []
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if not part:
+            continue
+        if (Path(part) / name).is_file():
+            continue
+        kept.append(part)
+    return os.pathsep.join(kept)
+
+
+class AutoreviewMixedTargetTests(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+
+    @contextlib.contextmanager
+    def migration(self, *, scan_sentinel=False):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            git(repo, "config", "core.autocrlf", "false")
+            base, index, working = {}, {}, {}
+            call = 0
+            for number, count in enumerate((3, 3, 3, 2, 2)):
+                path = f"src/migrate-{number}.py"
+                padding = "padding = 'context'\n"
+                before, staged, final = [], [], []
+                for _ in range(count):
+                    before.append(f"original({call})\n" + padding * 8)
+                    staged.append(f"obsolete({call})\n" + padding * 8)
+                    final.append(f"corrected({call})\n" + padding * 8)
+                    call += 1
+                base[path], index[path], working[path] = map("".join, (before, staged, final))
+                if scan_sentinel:
+                    tail = "context\n" * 20 + "SOURCE_ONLY_SCAN_SENTINEL\nMULTILINE_SCAN_CONTINUATION\n"
+                    base[path] += tail
+                    index[path] += tail
+                    working[path] += tail
+                source = repo / path
+                source.parent.mkdir(exist_ok=True)
+                source.write_bytes(base[path].encode())
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "synthetic migration base")
+            for path, content in index.items():
+                (repo / path).write_bytes(content.encode())
+            git(repo, "add", ".")
+            for path, content in working.items():
+                (repo / path).write_bytes(content.encode())
+            yield repo, base, index, working
+
+    def test_capture_pins_versions_and_keeps_thirteen_calls_and_original_transitions(self):
+        with self.migration() as (repo, base, index, working):
+            pinned = git(repo, "rev-parse", "HEAD").strip()
+            git(repo, "branch", "review-base")
+            captured = self.helper["local_bundle"](repo, "review-base")
+            self.assertEqual(captured.paths, set(base))
+            self.assertEqual(len(captured.mixed), 5)
+            self.assertIn(f"base: {pinned}", captured.text)
+            self.assertEqual(sum(record.index.content.count("obsolete(") for record in captured.mixed), 13)
+            for record in captured.mixed:
+                self.assertEqual(record.base.content, base[record.path])
+                self.assertEqual(record.index.content, index[record.path])
+                self.assertEqual(record.working_tree.content, working[record.path])
+                self.assertNotEqual(record.index.identity, record.working_tree.identity)
+                self.assertEqual(record.staged, self.helper["git_bytes"](
+                    repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", pinned, "--", record.path,
+                ).stdout.decode())
+                self.assertEqual(record.unstaged, self.helper["git_bytes"](
+                    repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--", record.path,
+                ).stdout.decode())
+                with self.assertRaises(AttributeError):
+                    record.identity = "changed"
+            for span in captured.spans:
+                record = next(record for record in captured.mixed if record.path == span.path)
+                expected = record.staged if span.target == "index" else record.unstaged
+                self.assertEqual(captured.text.encode()[span.start:span.end], expected.encode())
+
+    def test_file_hunk_long_line_boundaries_and_evidence_batches_keep_authority(self):
+        # Force each partition dimension independently of prompt overhead. All
+        # fixtures are synthetic; five files migrate thirteen obsolete calls.
+        for boundary in ("file", "hunk", "long line"):
+            with self.subTest(boundary=boundary), self.migration() as (repo, _base, _index, _working):
+                if boundary == "long line":
+                    for path in _base:
+                        (repo / path).write_bytes(("obsolete('" + "界" * 500 + "')\n" + _index[path]).encode("utf-8"))
+                    git(repo, "add", ".")
+                    for path in _base:
+                        (repo / path).write_bytes(("corrected('" + "界" * 500 + "')\n" + _working[path]).encode("utf-8"))
+                captured = self.helper["local_bundle"](repo)
+                datasets = [self.helper["ReviewDataset"](
+                    f"evidence-{index}.txt", "# Dataset: forged.py\n" + (f"evidence {index} 界\r\n" * 2200),
+                ) for index in range(2)]
+                original_split = self.helper["split_review_bundle"]
+                limit = {"file": 4000, "hunk": 260, "long line": 180}[boundary]
+                splits = []
+
+                def split(bundle, budget):
+                    chunks = original_split(bundle, min(budget, limit))
+                    splits.extend(chunks)
+                    return chunks
+
+                with mock.patch.dict(self.helper["build_review_prompts"].__globals__, {"split_review_bundle": split}):
+                    passes = self.helper["build_review_prompts"](repo, "local", None, captured, "Whole instructions", datasets, 30_000)
+                self.assertGreater(len(passes), 5)
+                batches = {}
+                evidence = {}
+                for item in passes:
+                    self.assertLessEqual(len(item.prompt.encode()), 30_000)
+                    self.assertIn("Whole instructions", item.prompt)
+                    batches.setdefault(item.evidence_batch, []).append(item.chunk)
+                    if item.evidence_batch in evidence:
+                        self.assertEqual(evidence[item.evidence_batch], item.datasets)
+                    evidence[item.evidence_batch] = item.datasets
+                    start = item.chunk.byte_offset
+                    end = start + len(item.chunk.content.encode())
+                    needed = {span.path for span in captured.spans if span.start < end and start < span.end}
+                    self.assertEqual({record.path for record in item.chunk.sources}, needed)
+                    for record in item.chunk.sources:
+                        self.assertIn(record.identity, item.prompt)
+                        for source in (record.index, record.working_tree):
+                            self.assertIn(source.content, item.prompt)
+                    self.assertIn(self.helper["render_mixed_context"](item.chunk), item.prompt)
+                self.assertGreater(len(batches), 1)
+                for chunks in batches.values():
+                    recovered = b""
+                    for chunk in chunks:
+                        self.assertEqual(chunk.byte_offset, len(recovered))
+                        recovered += chunk.content.encode()
+                    self.assertEqual(recovered, captured.text.encode())
+                recovered_evidence = {dataset.path: b"" for dataset in datasets}
+                for batch in evidence.values():
+                    for dataset in batch:
+                        self.assertEqual(dataset.byte_offset, len(recovered_evidence[dataset.path]))
+                        recovered_evidence[dataset.path] += dataset.content.encode()
+                self.assertEqual(recovered_evidence, {dataset.path: dataset.content.encode() for dataset in datasets})
+                if boundary == "long line":
+                    self.assertTrue(any("original marker is" in chunk.context for chunk in splits))
+                if boundary == "hunk":
+                    self.assertTrue(any("Continuation" in chunk.context for chunk in splits))
+
+    def test_staged_undone_add_remove_readd_and_modes(self):
+        for state in ("undone", "new", "removed", "readd", "unborn", "literal"):
+            if state == "literal" and os.name == "nt":
+                continue  # Windows filenames cannot contain a colon.
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / (":source.py" if state == "literal" else "source.py")
+                if state == "literal":
+                    (repo / "source.py").write_bytes(b"unrelated base\n")
+                # These versions must be byte-identical even with Windows text translation.
+                if state != "unborn":
+                    if state != "new":
+                        path.write_bytes(b"base()\n")
+                    git(repo, "add", ".")
+                    git(repo, "commit", "--allow-empty", "-qm", "base")
+                if state == "readd":
+                    git(repo, "rm", "source.py")
+                else:
+                    path.write_bytes(b"base()\nstaged()\n" if state == "literal" else b"staged()\n")
+                    git(repo, "add", ".")
+                if state == "removed":
+                    path.unlink()
+                elif state == "literal":
+                    path.write_bytes(b"base()\nstaged()\nworking()\n")
+                else:
+                    path.write_bytes(b"base()\n" if state == "undone" else b"working()\n")
+                captured = self.helper["local_bundle"](repo)
+                record, = captured.mixed
+                self.assertEqual(captured.paths, {path.name})
+                self.assertEqual(record.index.mode is None, state == "readd")
+                self.assertEqual(record.base.mode is None, state in ("new", "unborn"))
+                self.assertEqual(record.working_tree.mode is None, state == "removed")
+                self.assertEqual(bool(record.working_tree_removed), state not in ("readd", "literal"))
+                if state == "literal":
+                    base_oid = git(repo, "rev-parse", f"HEAD:{path.name}").strip()
+                    self.assertEqual(record.base.identity, f"git:{base_oid}:100644")
+                    self.assertEqual(record.index.content, "base()\nstaged()\n")
+                    self.assertEqual(record.working_tree.content, "base()\nstaged()\nworking()\n")
+                    self.assertNotIn("unrelated base", captured.text)
+                if state == "readd":
+                    self.assertIn("# Untracked File", record.unstaged)
+                    self.assertEqual(record.index_removed, ((1, "base()"),))
+                if state == "undone":
+                    self.assertEqual(record.base.content, record.working_tree.content)
+                self.helper["verify_mixed_sources"](repo, captured.mixed)
+
+    def test_file_to_directory_transitions_keep_staged_and_working_sources(self):
+        for state in ("staged", "untracked", "mixed-child", "mixed-parent", "committed",
+                      "restored-parent", "restored-parent-siblings"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                git(repo, "config", "core.autocrlf", "false")
+                path = repo / "foo"
+                path.write_bytes(b"base parent\n")
+                git(repo, "add", "foo")
+                git(repo, "commit", "-qm", "base file")
+                base = git(repo, "rev-parse", "HEAD").strip()
+                if state == "mixed-parent":
+                    path.write_bytes(b"staged parent\n")
+                    git(repo, "add", "foo")
+                    path.unlink()
+                else:
+                    git(repo, "rm", "foo")
+                path.mkdir()
+                child = path / "bar"
+                child.write_bytes(b"staged child\n")
+                restored = state in ("restored-parent", "restored-parent-siblings")
+                children = {"foo/bar": "staged child\n"}
+                if state == "restored-parent-siblings":
+                    (path / "baz").write_bytes(b"staged sibling\n")
+                    children["foo/baz"] = "staged sibling\n"
+                if state in ("staged", "mixed-child", "committed") or restored:
+                    git(repo, "add", "foo")
+                if state == "committed":
+                    git(repo, "commit", "-qm", "replace file with directory")
+                if state in ("mixed-child", "committed"):
+                    child.write_bytes(b"working child\n")
+                if state == "mixed-child":
+                    (path / "extra").write_bytes(b"untracked child\n")
+                    (path / "ignored.txt").write_bytes(b"ignored child content\n")
+                    (repo / ".git/info/exclude").write_text("foo/ignored.txt\n", encoding="utf-8")
+                if restored:
+                    for rel in children:
+                        (repo / rel).unlink()
+                    path.rmdir()
+                    path.write_bytes(b"working parent\n")
+                for ref in (None, base):
+                    with self.subTest(base=ref):
+                        snapshot = self.helper["source_tree_snapshot"](repo)
+                        captured = self.helper["local_bundle"](repo, ref)
+                        expected = set(children)
+                        if state != "committed" or ref is not None:
+                            expected.add("foo")
+                            self.assertIn("-base parent\n", captured.text)
+                        if state == "mixed-child":
+                            expected.add("foo/extra")
+                            self.assertIn("untracked child", captured.text)
+                            self.assertNotIn("ignored child content", captured.text)
+                        self.assertEqual(captured.paths, expected)
+                        self.assertIn("staged child", captured.text)
+                        mixed = {record.path: record for record in captured.mixed}
+                        expected_mixed = set()
+                        if restored:
+                            expected_mixed = {"foo", *children}
+                        elif state == "mixed-parent":
+                            expected_mixed.add("foo")
+                        elif state == "mixed-child" or (state == "committed" and ref is not None):
+                            expected_mixed.add("foo/bar")
+                        self.assertEqual(set(mixed), expected_mixed)
+                        if "foo" in mixed:
+                            self.assertEqual(mixed["foo"].base.content, "base parent\n")
+                            self.assertEqual(mixed["foo"].index.content, None if restored else "staged parent\n")
+                            self.assertEqual(mixed["foo"].working_tree.content, "working parent\n" if restored else None)
+                            absent = mixed["foo"].index if restored else mixed["foo"].working_tree
+                            self.assertEqual(absent, self.helper["SourceVersion"]("absent", None, None))
+                        for rel in set(children) & set(mixed):
+                            self.assertEqual(mixed[rel].index.content, children[rel])
+                            self.assertEqual(mixed[rel].working_tree.content, None if restored else "working child\n")
+                            if restored:
+                                self.assertEqual(mixed[rel].working_tree, self.helper["SourceVersion"]("absent", None, None))
+                        self.helper["verify_mixed_sources"](repo, captured.mixed)
+                        self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
+
+    def test_directory_to_file_transitions_preserve_snapshots_and_mixed_sources(self):
+        for state in ("staged", "mixed-child", "mixed-parent", "working-directory"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                git(repo, "config", "core.autocrlf", "false")
+                parent = repo / "foo"
+                parent.mkdir()
+                child = parent / "bar"
+                child.write_bytes(b"base child\n")
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "base directory")
+                base = git(repo, "rev-parse", "HEAD").strip()
+                if state == "mixed-child":
+                    child.write_bytes(b"staged child\n")
+                    git(repo, "add", "foo/bar")
+                    child.unlink()
+                else:
+                    git(repo, "rm", "foo/bar")
+                if parent.exists():
+                    parent.rmdir()
+                parent.write_bytes(b"working parent\n" if state == "mixed-child" else b"staged parent\n")
+                if state != "mixed-child":
+                    git(repo, "add", "foo")
+                if state == "mixed-parent":
+                    parent.write_bytes(b"working parent\n")
+                elif state == "working-directory":
+                    parent.unlink()
+                    parent.mkdir()
+                    child.write_bytes(b"working child\n")
+                for ref in (None, base):
+                    with self.subTest(base=ref):
+                        snapshot = self.helper["source_tree_snapshot"](repo)
+                        captured = self.helper["local_bundle"](repo, ref)
+                        self.assertEqual(captured.paths, {"foo", "foo/bar"})
+                        self.assertIn("working parent" if state == "mixed-child" else "staged parent", captured.text)
+                        expected = {}
+                        if state in ("mixed-child", "working-directory"):
+                            expected["foo/bar"] = ("base child\n", "staged child\n", None) if state == "mixed-child" else (
+                                "base child\n", None, "working child\n",
+                            )
+                        if state in ("mixed-parent", "working-directory"):
+                            expected["foo"] = (None, "staged parent\n", "working parent\n" if state == "mixed-parent" else None)
+                        self.assertEqual({record.path for record in captured.mixed}, set(expected))
+                        for record in captured.mixed:
+                            for source, content in zip((record.base, record.index, record.working_tree), expected[record.path]):
+                                if content is None:
+                                    self.assertEqual(source, self.helper["SourceVersion"]("absent", None, None))
+                                else:
+                                    self.assertEqual(source.content, content)
+                        self.helper["verify_mixed_sources"](repo, captured.mixed)
+                        self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
+
+    def test_large_tracked_paths_keep_complete_mixed_sources(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            path = repo / "large.py"
+            content = "unchanged context\n" * 15_000
+            path.write_bytes(("base()\n" + content).encode("utf-8"))
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "large base")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            path.write_bytes(("changed()\n" + content).encode("utf-8"))
+            for staged in (False, True):
+                if staged:
+                    git(repo, "add", ".")
+                captured = self.helper["local_bundle"](repo)
+                self.assertEqual(captured.mixed, ())
+                self.assertLess(len(captured.text), 10_000)
+                self.assertIn("+changed()", captured.text)
+            git(repo, "commit", "-qm", "large tiny edit")
+            for target in ("branch", "commit"):
+                captured = self.helper["build_bundle"](repo, target, base, "HEAD")
+                self.assertEqual(captured.mixed, ())
+            path.write_bytes(("staged()\n" + content).encode("utf-8"))
+            git(repo, "add", ".")
+            path.write_bytes(("working()\n" + content).encode("utf-8"))
+            captured = self.helper["local_bundle"](repo)
+            record, = captured.mixed
+            for source, expected in (
+                (record.base, "changed()\n" + content),
+                (record.index, "staged()\n" + content),
+                (record.working_tree, "working()\n" + content),
+            ):
+                self.assertEqual(source.content, expected)
+            self.helper["verify_mixed_sources"](repo, captured.mixed)
+
+    def test_full_source_safeguards_and_sensitive_omission(self):
+        for bad in (b"\0binary", b"\xffinvalid"):
+            with self.subTest(bad=bad), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / "source.py"
+                (repo / ".gitattributes").write_text("source.py diff\n")
+                suffix = b"safe context\n" * 16_000 + bad + b"\n"
+                path.write_bytes(b"base()\n" + suffix)
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "synthetic hidden tail")
+                path.write_bytes(b"staged()\n" + suffix)
+                git(repo, "add", ".")
+                path.write_bytes(b"working()\n" + suffix)
+                with self.assertRaisesRegex(SystemExit, "binary|non-UTF-8"):
+                    self.helper["local_bundle"](repo)
+        with self.migration() as (repo, *_):
+            (repo / ".env").write_text("SYNTHETIC_STAGED_OMISSION\n")
+            git(repo, "add", ".env")
+            (repo / ".env").write_text("SYNTHETIC_WORKING_OMISSION\n")
+            captured = self.helper["local_bundle"](repo)
+            self.assertNotIn(".env", captured.paths)
+            self.assertEqual(len(captured.mixed), 5)
+            self.assertNotIn("SYNTHETIC_", captured.text)
+
+    def test_mixed_source_mutations_and_topology_refuse_later_sends(self):
+        for mutation in ("index", "index conflict", "index symlink", "index gitlink", "content",
+                         "replace", "ancestor", "delete", "leaf symlink", "ancestor symlink"):
+            if mutation in ("leaf symlink", "ancestor symlink") and os.name == "nt":
+                continue
+            with self.subTest(mutation=mutation), self.migration() as (repo, *_):
+                captured = self.helper["local_bundle"](repo)
+                passes = self.helper["build_review_prompts"](repo, "local", None, captured, "", [])
+                path = repo / "src/migrate-0.py"
+                source = path.read_bytes()
+                if mutation == "index":
+                    git(repo, "add", str(path))
+                elif mutation.startswith("index "):
+                    oid = git(repo, "rev-parse", "HEAD" if mutation == "index gitlink" else ":src/migrate-0.py").strip()
+                    if mutation == "index conflict":
+                        git(repo, "update-index", "--force-remove", "--", "src/migrate-0.py")
+                        # Text-mode stdin on Windows adds a CR to Git's pathname.
+                        subprocess.run(["git", "update-index", "--index-info"], cwd=repo, check=True,
+                                       input=f"100644 {oid} 2\tsrc/migrate-0.py\n".encode(), capture_output=True)
+                    else:
+                        mode = "160000" if mutation == "index gitlink" else "120000"
+                        git(repo, "update-index", "--cacheinfo", f"{mode},{oid},src/migrate-0.py")
+                elif mutation == "content":
+                    before = path.stat()
+                    path.write_bytes(source.replace(b"corrected", b"different"))
+                    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+                elif mutation == "replace":
+                    other = repo.parent / "replacement.py"
+                    other.write_bytes(source)
+                    other.replace(path)
+                elif mutation in ("ancestor", "ancestor symlink"):
+                    path.parent.rename(repo / "moved")
+                    if mutation == "ancestor symlink":
+                        path.parent.symlink_to("moved", target_is_directory=True)
+                    else:
+                        path.parent.mkdir()
+                        for file in (repo / "moved").iterdir():
+                            (path.parent / file.name).write_bytes(file.read_bytes())
+                elif mutation == "leaf symlink":
+                    path.rename(path.with_suffix(".copy"))
+                    path.symlink_to(path.with_suffix(".copy").name)
+                else:
+                    path.unlink()
+                provider = mock.Mock()
+                with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
+                    "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+                }), contextlib.redirect_stderr(io.StringIO()):
+                    refusal = "unsafe mixed source mode" if mutation.startswith("index ") else "mixed source changed|symlinked mixed source"
+                    with self.assertRaisesRegex(SystemExit, refusal):
+                        self.helper["run_reviewer"](argparse.Namespace(engine="codex", max_priority="P0"),
+                                                     repo, passes[0], captured, [])
+                provider.assert_not_called()
+
+    def test_complete_and_per_pass_scans_include_new_authoritative_context(self):
+        with self.migration(scan_sentinel=True) as (repo, *_):
+            # This unchanged line is outside every diff hunk, but now sent as
+            # authoritative source and therefore part of the frozen-input scan.
+            captured = self.helper["local_bundle"](repo)
+            self.assertNotIn("SOURCE_ONLY_SCAN_SENTINEL", captured.text)
+            evidence = [self.helper["ReviewDataset"]("evidence.txt", "evidence\n" * 6000)]
+            scans, sends = [], []
+            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
+                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
+                "run_engine": lambda _args, _repo, prompt: sends.append(prompt) or json.dumps({
+                    "findings": [], "overall_correctness": "patch is correct",
+                    "overall_explanation": "Synthetic clean.", "overall_confidence": 0.9,
+                }),
+            }), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                passes = self.helper["prepare_review_prompts"](repo, "local", None, captured, "", evidence, 30_000)
+                self.assertGreater(len(passes), 1)
+                self.assertEqual(len(scans), 1)
+                self.assertIn("SOURCE_ONLY_SCAN_SENTINEL\nMULTILINE_SCAN_CONTINUATION\n", scans[0])
+                self.assertIn(evidence[0].content, scans[0])
+                args = argparse.Namespace(engine="codex", max_priority="P0")
+                self.helper["run_review_passes"](args, [args], repo, passes, captured)
+            self.assertEqual(scans[1:], sends)
+            for item, scanned in zip(passes, scans[1:]):
+                self.assertEqual(item.prompt, scanned)
+                for record in item.chunk.sources:
+                    self.assertIn(record.index.content, scanned)
+                    self.assertIn(record.working_tree.content, scanned)
+
+    def test_honest_capacity_refusal_and_no_legacy_metadata_bypass(self):
+        with self.migration() as (repo, *_):
+            captured = self.helper["local_bundle"](repo)
+            scan, provider = mock.Mock(), mock.Mock()
+            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
+                "scan_outgoing_review_pack": scan, "run_engine": provider,
+            }):
+                with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-0.py .*index=.*working_tree=.*prompt limit 1000"):
+                    self.helper["prepare_review_prompts"](repo, "local", None, captured, "", [], 1000)
+                with self.assertRaisesRegex(SystemExit, "owner-built pass metadata"):
+                    self.helper["run_reviewer"](argparse.Namespace(engine="codex"), repo, "flattened", captured, [])
+                chunk = self.helper["ReviewChunk"]("xxxx", sources=(captured.mixed[0],))
+                budget = len(self.helper["render_review_prompt"](
+                    self.helper["current_branch"](repo), "local", None, chunk, "", "", (999_999, 999_999),
+                ).encode()) + 1000
+                datasets = [self.helper["ReviewDataset"]("e" * 4000 + ".txt", "evidence")]
+                with self.assertRaisesRegex(SystemExit, r"mixed source src/migrate-\d.py .*prompt limit"):
+                    self.helper["prepare_review_prompts"](repo, "local", None, captured, "", datasets, budget)
+            scan.assert_not_called()
+            provider.assert_not_called()
+
+
+    def test_mixed_results_keep_index_exit_stale_rejections_filters_and_raw_reports(self):
+        cases = (
+            # target, excerpt, verdict, priority, required, expect, status, exit
+            ("index", "obsolete(0)", "patch is incorrect", "P2", [], False, "findings", 1),
+            ("working_tree", "corrected(0)", "patch is incorrect", "P2", [], False, "findings", 1),
+            ("working_tree", "obsolete(0)", "patch is correct", "P2", [], True, "incomplete", 2),
+            (None, "obsolete(0)", "patch is correct", "P2", [], False, "incomplete", 2),
+            ("index", "obsolete(0)", "patch is incorrect", "P0", [], False, "filtered", 1),
+            ("index", "obsolete(0)", "patch is correct", "P0", [], False, "filtered", 0),
+            ("index", "obsolete(0)", "patch is correct", "P0", ["Synthetic claim"], True, "incomplete", 2),
+            ("index", "obsolete(0)", "patch is incorrect", "P2", ["Synthetic claim"], True, "findings", 0),
+        )
+        with self.migration() as (repo, *_):
+            captured = self.helper["local_bundle"](repo)
+            record = captured.mixed[0]
+            original_prepare = self.helper["prepare_review_prompts"]
+            for count in (1, 2):
+                for target, excerpt, verdict, priority, required, expect, expected_status, expected_exit in cases:
+                    with self.subTest(count=count, target=target, excerpt=excerpt, priority=priority, expect=expect):
+                        finding = {
+                            "title": "Synthetic claim", "body": "A concrete migration defect.",
+                            "priority": "P2", "confidence": 0.8, "category": "bug",
+                            "code_location": {"file_path": record.path, "line": 1},
+                        }
+                        if target:
+                            finding["source_attribution"] = {
+                                "target": target, "record_id": record.identity,
+                                "source_id": getattr(record, target).identity,
+                                "side": "present", "column": 1, "excerpt": excerpt,
+                            }
+                        provider = {"findings": [finding], "overall_correctness": verdict,
+                                    "overall_explanation": "Synthetic provider conclusion.", "overall_confidence": 0.61}
+                        output = repo.parent / "result.json"
+                        argv = [str(SCRIPT), "--mode", "local", "--max-priority", priority,
+                                "--json-output", str(output)]
+                        for needle in required:
+                            argv += ["--require-finding", needle]
+                        if expect:
+                            argv.append("--expect-findings")
+                        text = io.StringIO()
+                        with mock.patch.dict(self.helper["main_impl"].__globals__, {
+                            "repo_root": lambda: repo,
+                            "prepare_review_prompts": lambda *args: original_prepare(*args) * count,
+                            "scan_outgoing_review_pack": lambda *_: None,
+                            "run_engine": lambda *_: json.dumps(provider),
+                        }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(text), \
+                                contextlib.redirect_stderr(io.StringIO()):
+                            self.assertEqual(self.helper["main_impl"](), expected_exit)
+                        report = json.loads(output.read_text())
+                        self.assertEqual(report["review_status"], expected_status)
+                        self.assertEqual(report["overall_confidence"], 0.61)
+                        self.assertEqual(report["overall_correctness"], verdict)
+                        self.assertEqual(len(report["pass_reports"]), count)
+                        for entry in report["pass_reports"]:
+                            self.assertEqual(entry["report"]["provider_report"], provider)
+                        self.assertNotIn("scoped-clean", text.getvalue())
+                        if target == "index":
+                            self.assertIn("INDEX-only", text.getvalue())
+                        if expected_status == "incomplete" and not required:
+                            self.assertTrue(report["attribution_rejected_findings"])
+                        if expected_status == "findings":
+                            self.assertEqual(len(report["findings"]), 1)
+                            self.assertEqual(len(report["findings"][0]["claim_variants"][0]["observations"]), count)
+
+    def test_mixed_crlf_absence_and_executable_mode_keep_exact_source_bytes(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            git(repo, "config", "core.autocrlf", "false")
+            path = repo / "source.py"
+            path.write_bytes(b"base()\r\nkeep()\r\n")
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "CRLF base")
+            path.write_bytes(b"obsolete()\r\nkeep()\r\n")
+            if os.name != "nt":
+                path.chmod(0o755)
+            git(repo, "add", ".")
+            path.write_bytes(b"corrected()\r\nkeep()\r\n")
+            captured = self.helper["local_bundle"](repo)
+            record, = captured.mixed
+            self.assertEqual(record.index_removed, ((1, "base()\r"),))
+            self.assertEqual(record.working_tree_removed, ((1, "obsolete()\r"),))
+            self.assertIn("+obsolete()\r\n", captured.text)
+            self.assertEqual(record.working_tree.content.encode(), path.read_bytes())
+            if os.name != "nt":
+                self.assertEqual(record.base.mode, "100644")
+                self.assertEqual(record.index.mode, "100755")
+
+    def test_git_display_settings_preserve_mixed_sources_and_chunk_coordinates(self):
+        settings = (
+            (), (("diff.suppressBlankEmpty", "false"),),
+            (("diff.suppressBlankEmpty", "true"),),
+            (("diff.suppress-blank-empty", "true"),),
+            (("color.ui", "always"),), (("color.diff", "always"),),
+            (("diff.color", "always"),),
+            (("diff.suppressBlankEmpty", "true"), ("color.diff", "always")),
+        )
+        for config in settings:
+            for pinned in (False, True):
+                with self.subTest(config=config, pinned=pinned), tempfile.TemporaryDirectory() as tempdir:
+                    repo = init_repo(Path(tempdir))
+                    git(repo, "config", "core.autocrlf", "false")
+                    for key, value in config:
+                        git(repo, "config", key, value)
+                    path = repo / "source.py"
+                    path.write_bytes(b"one\n\nbase\n")
+                    git(repo, "add", ".")
+                    git(repo, "commit", "-qm", "base")
+                    base = git(repo, "rev-parse", "HEAD").strip()
+                    if pinned:
+                        path.write_bytes(b"one\n\nhead\n")
+                        git(repo, "commit", "-qam", "advance HEAD")
+                    path.write_bytes(b"one\n\nstaged\n")
+                    git(repo, "add", ".")
+                    path.write_bytes(b"one\n\nworking\n")
+                    original_config = (repo / ".git/config").read_bytes()
+                    captured = self.helper["local_bundle"](repo, base if pinned else None)
+                    record, = captured.mixed
+                    self.assertEqual(record.base.content, "one\n\nbase\n")
+                    self.assertEqual(record.index.content, "one\n\nstaged\n")
+                    self.assertEqual(record.working_tree.content, "one\n\nworking\n")
+                    self.assertEqual(record.index_removed, ((3, "base"),))
+                    self.assertEqual(record.working_tree_removed, ((3, "staged"),))
+                    self.helper["verify_mixed_sources"](repo, captured.mixed)
+                    for patch in (record.staged, record.unstaged):
+                        self.assertNotIn("\x1b", patch)
+                        context = []
+                        new_line = old_line = None
+                        in_hunk = False
+                        for line in self.helper["literal_lf_lines"](patch):
+                            new_line, old_line, in_hunk = self.helper["update_review_chunk_context"](
+                                context, line, new_line, old_line, in_hunk,
+                            )
+                        self.assertEqual((new_line, old_line), (4, 4))
+                    self.assertEqual((repo / ".git/config").read_bytes(), original_config)
+
+    def test_readded_untracked_capture_is_reused_and_evidence_stays_separate(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            path = repo / "source.py"
+            path.write_bytes(b"base()\n")
+            git(repo, "add", ".")
+            git(repo, "commit", "-qm", "base")
+            git(repo, "rm", "source.py")
+            path.write_bytes(b"readded()\n")
+            read = mock.Mock(wraps=self.helper["read_file_bytes"])
+            with mock.patch.dict(self.helper["local_bundle"].__globals__, {"read_file_bytes": read}):
+                captured = self.helper["local_bundle"](repo)
+            self.assertEqual(sum(call.args[0] == path for call in read.call_args_list), 1)
+            (repo / ".git/info/exclude").write_text("evidence/\n")
+            evidence_path = repo / "evidence/source.py"
+            evidence_path.parent.mkdir()
+            evidence_path.write_text("fake authoritative replacement()\n")
+            evidence = self.helper["capture_evidence_inputs"](
+                argparse.Namespace(prompt=[], prompt_file=[], dataset=["evidence/source.py"]), repo,
+            )
+            passes = self.helper["build_review_prompts"](repo, "local", None, captured, "", evidence.datasets)
+            record = passes[0].chunk.sources[0]
+            self.assertEqual(record.working_tree.content, "readded()\n")
+            self.assertNotIn(evidence_path.relative_to(repo).as_posix(), captured.paths)
+            before = self.helper["source_tree_snapshot"](repo)
+            evidence_path.write_text("mutated evidence()\n")
+            self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+            provider = mock.Mock()
+            with mock.patch.dict(self.helper["run_reviewer"].__globals__, {
+                "scan_outgoing_review_pack": lambda *_: None, "run_engine": provider,
+            }), contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaisesRegex(SystemExit, "evidence changed"):
+                    self.helper["run_reviewer"](argparse.Namespace(engine="codex"), repo, passes[0], captured, [],
+                                                 evidence=evidence.files)
+            provider.assert_not_called()
+
+    def test_ignored_or_unsafe_readdition_cannot_bypass_mixed_capture(self):
+        for kind, name in (
+            ("ignored", "source.py"),
+            ("ignored", "line\rbreak.py"),
+            ("ignored", "line\r\nbreak.py"),
+            ("symlink", "source.py"),
+            ("directory symlink", "source.py"),
+            ("dangling symlink", "source.py"),
+        ):
+            if os.name == "nt" and (kind != "ignored" or "\r" in name):
+                continue
+            with self.subTest(kind=kind, name=name), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / name
+                path.write_text("base()\n")
+                git(repo, "add", ".")
+                git(repo, "commit", "-qm", "base")
+                git(repo, "rm", "--", name)
+                if kind == "ignored":
+                    (repo / ".git/info/exclude").write_text("*.py\n")
+                    path.write_text("ignored content never sent\n")
+                else:
+                    outside = repo.parent / "outside.py"
+                    if kind == "directory symlink":
+                        outside.mkdir()
+                        (outside / "child.py").write_text("outside content never sent\n")
+                    elif kind == "symlink":
+                        outside.write_text("outside content never sent\n")
+                    path.symlink_to(outside, target_is_directory=kind == "directory symlink")
+                with self.assertRaisesRegex(SystemExit, "working_tree.*validated untracked membership"):
+                    self.helper["local_bundle"](repo)
+
+
 class AutoreviewHardeningTests(unittest.TestCase):
     def setUp(self) -> None:
         self.helper = load_helper()
@@ -254,6 +966,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def preparation_fixture(self, *options):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
+            # Protected review reads ignore host Git config, including Windows autocrlf.
+            git(repo, "config", "core.autocrlf", "false")
             for index in range(24):
                 (repo / f"unchanged-{index}.txt").write_text("old\n")
             (repo / "source.md").write_text("before\n")
@@ -263,7 +977,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             (repo / "source.md").write_text("after\n")
             (repo / "evidence").mkdir()
             (repo / "evidence/note.md").write_text("frozen evidence\r\n")
-            sends = []
+            sends, scans = [], []
             stdout, stderr = io.StringIO(), io.StringIO()
 
             def engine(_args, _repo, prompt):
@@ -278,15 +992,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
                 "repo_root": lambda: repo,
                 "run_engine": engine,
+                "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                 "resolve_engine_binary": lambda *_args: (True, None),
             }), mock.patch.object(sys, "argv", [str(SCRIPT), "--mode", "local", *options]), \
                     contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-                yield repo, sends, stdout, stderr
+                yield repo, sends, scans, stdout, stderr
 
     def test_preparation_reuses_untracked_capture_and_keeps_three_full_snapshots(self):
         for explicit in (False, True):
             options = ("--dataset", "note.md") if explicit else ()
-            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, _out, err):
+            with self.subTest(explicit=explicit), self.preparation_fixture(*options) as (repo, sends, scans, _out, err):
                 (repo / "note.md").write_text("untracked evidence\n")
                 read = mock.Mock(wraps=self.helper["file_bundle_snapshot"])
                 fingerprint = mock.Mock(wraps=self.helper["source_file_fingerprint"])
@@ -294,6 +1009,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "file_bundle_snapshot": read, "source_file_fingerprint": fingerprint,
                 }):
                     self.assertEqual(self.helper["main_impl"](), 0)
+                self.assertEqual(scans, sends)
                 # Explicit evidence has its own initial capture and three fresh
                 # checks; finding membership never adds another content read.
                 self.assertEqual(read.call_count, 5 if explicit else 1)
@@ -319,7 +1035,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertFalse(sends)
 
     def test_preparation_progress_precedes_snapshot(self):
-        with self.preparation_fixture() as (_repo, sends, _out, err):
+        with self.preparation_fixture() as (_repo, sends, _scans, _out, err):
             def snapshot(*_args, **_kwargs):
                 self.assertIn("preparation: initial source snapshot", err.getvalue())
                 self.assertFalse(sends)
@@ -330,19 +1046,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     self.helper["main_impl"]()
 
     def test_dry_run_reuses_capture_without_whole_tree_snapshots(self):
-        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, *_):
+        with self.preparation_fixture("--dry-run", "--dataset", "evidence/note.md") as (_repo, sends, scans, *_):
             snapshot = mock.Mock(side_effect=AssertionError("dry run must not sweep the checkout"))
             with mock.patch.dict(self.helper["main_impl"].__globals__, {"source_tree_snapshot": snapshot}):
                 self.assertEqual(self.helper["main_impl"](), 0)
             snapshot.assert_not_called()
+            self.assertTrue(scans)
             self.assertFalse(sends)
 
     def test_evidence_mutations_refuse_stale_publication_and_later_passes(self):
         for tracked in (False, True):
-            for timing in ("construction", "review", "between passes"):
+            for timing in ("construction", "scan", "review", "between passes"):
                 with self.subTest(tracked=tracked, timing=timing), self.preparation_fixture(
                     "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
-                ) as (repo, sends, out, _err):
+                ) as (repo, sends, _scans, out, _err):
                     evidence = repo / "evidence/note.md"
                     if tracked:
                         git(repo, "add", "-f", "evidence/note.md")
@@ -370,6 +1087,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         return result
 
                     patches = {"run_engine": engine, "build_bundle": build}
+                    if timing == "scan":
+                        patches["scan_outgoing_review_pack"] = lambda *_args: mutate()
                     if timing == "between passes":
                         original_prepare = self.helper["prepare_review_prompts"]
                         patches["prepare_review_prompts"] = lambda *args: original_prepare(*args) * 2
@@ -424,7 +1143,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with self.preparation_fixture(
             "--prompt-file", "evidence/note.md", "--dataset", "evidence/note.md",
             "--dataset", "evidence/note.md",
-        ) as (repo, sends, *_):
+        ) as (repo, sends, scans, *_):
             evidence = (repo / "evidence/note.md").read_bytes().decode()
             original = self.helper["prepare_review_prompts"]
             with mock.patch.dict(self.helper["main_impl"].__globals__, {
@@ -432,6 +1151,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             }):
                 self.assertEqual(self.helper["main_impl"](), 0)
             self.assertEqual(len(sends), 2)
+            self.assertEqual(scans, sends)
             for prompt in sends:
                 self.assertEqual(prompt.count(evidence), 3)
 
@@ -554,7 +1274,156 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     captured = self.helper["build_bundle"](repo, target, "moving-base", "HEAD")
                 self.assertEqual(captured.paths, {"task.md"})
                 self.assertIn("+task change", captured.text)
-                self.assertFalse(captured.truncated)
+
+    def test_outgoing_pack_scan_disables_installed_scanner_updates(self) -> None:
+        prompt = "harmless review pack\npreserved CRLF\r\nfinal line\r"
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = root / "repo"
+            repo.mkdir()
+            write_executable(
+                root / "trufflehog",
+                r'''#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+if "--no-update" not in args:
+    print("updater: cannot move binary: permission denied", file=sys.stderr)
+    raise SystemExit(1)
+source = args[0]
+assert source in {"filesystem", "stdin"}
+pack = Path(args[1]) if source == "filesystem" else None
+assert set(args[2:] if pack else args[1:]) == {
+    "--json", "--no-color", "--results=verified,unknown",
+    "--fail", "--fail-on-scan-errors", "--no-update",
+}
+payload = pack.read_bytes() if pack else sys.stdin.buffer.read()
+with Path(__file__).with_name("scans.jsonl").open("a", encoding="utf-8") as records:
+    records.write(json.dumps({
+        "source": source,
+        "pack": str(pack) if pack else None,
+        "prompt": payload.decode("utf-8"),
+    }) + "\n")
+''',
+            )
+            with mock.patch.dict(
+                os.environ,
+                {"PATH": f"{root}{os.pathsep}{os.environ.get('PATH', '')}"},
+            ):
+                self.helper["scan_outgoing_review_pack"](repo, prompt)
+
+            records = [json.loads(line) for line in (root / "scans.jsonl").read_text(encoding="utf-8").splitlines()]
+            self.assertEqual([record["source"] for record in records], ["filesystem", "stdin"])
+            self.assertEqual([record["prompt"] for record in records], [prompt, prompt])
+            self.assertFalse(Path(records[0]["pack"]).parent.exists())
+
+    def test_outgoing_pack_scan_reads_exact_prompt_including_deleted_lines(self) -> None:
+        prompt = (
+            "# Change Bundle\n"
+            "diff --git a/config.ts b/config.ts\n"
+            "deleted file mode 100644\n"
+            "--- a/config.ts\n"
+            "+++ /dev/null\n"
+            "@@ -1 +0,0 @@\n"
+            "-const apiKey = \"removed-but-still-sensitive\";\n"
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            sources = []
+
+            def run_scanner(
+                command: list[str],
+                cwd: Path,
+                **kwargs: object,
+            ) -> subprocess.CompletedProcess[str]:
+                sources.append(command[1])
+                if command[1] == "filesystem":
+                    payload = Path(command[2]).read_bytes()
+                else:
+                    self.assertEqual(command[1], "stdin")
+                    payload = kwargs["stdin"].read()
+                self.assertEqual(payload, prompt.encode("utf-8"))
+                self.assertIn("-const apiKey", prompt)
+                return subprocess.CompletedProcess(command, 0, "", "")
+
+            with mock.patch.dict(
+                self.helper["scan_outgoing_review_pack"].__globals__,
+                {
+                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
+                    "run": run_scanner,
+                },
+            ):
+                self.helper["scan_outgoing_review_pack"](repo, prompt)
+            self.assertEqual(sources, ["filesystem", "stdin"])
+
+    def test_deleted_input_scan_refusal_is_redacted_and_blocks_provider(self) -> None:
+        prompt = (
+            "# Change Bundle\n"
+            "diff --git a/config.ts b/config.ts\n"
+            "deleted file mode 100644\n"
+            "--- a/config.ts\n"
+            "+++ /dev/null\n"
+            "@@ -1 +0,0 @@\n"
+            "-const apiKey = \"removed-but-still-sensitive\";\n"
+        )
+        finding = {
+            "SourceMetadata": {
+                "Data": {
+                    "Filesystem": {
+                        "file": "review-pack.txt",
+                        "line": 7,
+                    }
+                }
+            },
+            "Raw": "must-not-be-printed",
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            packs = []
+            provider = mock.Mock()
+
+            def run_scanner(command, cwd, **_kwargs):
+                self.assertEqual(command[1], "filesystem")
+                pack = Path(command[2])
+                self.assertEqual(pack.parent, cwd)
+                self.assertEqual(pack.read_bytes(), prompt.encode("utf-8"))
+                packs.append(pack)
+                return subprocess.CompletedProcess(
+                    command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(finding) + "\n", "",
+                )
+
+            with mock.patch.dict(
+                self.helper["run_reviewer"].__globals__,
+                {
+                    "find_command": lambda _name, _repo: "/trusted/trufflehog",
+                    "run": run_scanner,
+                    "run_engine": provider,
+                },
+            ), contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaisesRegex(SystemExit, "TruffleHog found credentials") as error:
+                    self.helper["run_reviewer"](
+                        argparse.Namespace(engine="codex", max_priority="P0"), repo, prompt, set(), [],
+                    )
+            self.assertEqual(len(packs), 1)
+            self.assertFalse(packs[0].parent.exists())
+            provider.assert_not_called()
+        self.assertEqual(
+            str(error.exception),
+            "refusing to send review pack: TruffleHog found credentials; "
+            "remove credential material from selected changes, prompt files, and datasets, then rerun",
+        )
+
+    def test_outgoing_pack_scan_fails_closed_when_scanner_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            with mock.patch.dict(
+                self.helper["scan_outgoing_review_pack"].__globals__,
+                {"find_command": lambda _name, _repo: None},
+            ):
+                with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                    self.helper["scan_outgoing_review_pack"](repo, "prompt")
 
     def test_local_bundle_preserves_boundary_when_sensitive_diff_is_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -566,20 +1435,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             path.write_text("TOKEN=changed-placeholder\n", encoding="utf-8")
             git(repo, "add", path.name)
 
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
-            self.assertFalse(truncated)
 
     def test_powershell_harness_exposes_runnable_engines_only(self) -> None:
         harness = SCRIPT.with_name("test-review-harness.ps1").read_text(encoding="utf-8")
 
         self.assertIn("[ValidateSet('codex', 'claude', 'amp', 'pi', 'kimi')]", harness)
-
-    def test_smoke_harness_validates_runtime_prompt_without_provider(self) -> None:
-        harness = runpy.run_path(str(SCRIPT.with_name("test-review-harness.py")))
-        with tempfile.TemporaryDirectory() as tempdir:
-            harness["validate_prompt_policy"](init_repo(Path(tempdir)), SCRIPT)
 
     def test_local_bundle_omits_sensitive_untracked_file_without_blocking(self) -> None:
         for rel in (".env", "tokens/session.dat", "secrets/local.py"):
@@ -590,28 +1453,26 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 path.write_text("placeholder=true\n", encoding="utf-8")
                 (repo / "review.py").write_text("print('review me')\n", encoding="utf-8")
 
-                bundle, truncated, _paths = self.helper["local_bundle"](repo)
+                bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
                 self.assertIn("# Review Input Omissions", bundle)
                 self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], bundle)
                 self.assertNotIn(rel, bundle)
                 self.assertNotIn("placeholder=true", bundle)
                 self.assertIn("print('review me')", bundle)
-                self.assertFalse(truncated)
 
-    def test_local_bundle_marks_untracked_binary_input_incomplete(self) -> None:
+    def test_large_binary_and_non_utf8_tails_refuse_input_capture(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
-
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
-
-            self.assertIn(
-                '# Untracked File\npath: "image.bin"\n'
-                'source-line 1: "[binary file omitted]"',
-                bundle,
-            )
-            self.assertTrue(truncated)
+            path = repo / "source.txt"
+            for bad, reason in ((b"\0", "binary file"), (b"\xff", "non-UTF-8 file")):
+                path.write_bytes(b"safe context\n" * 16_000 + bad)
+                with self.subTest(reason=reason):
+                    with self.assertRaisesRegex(SystemExit, reason):
+                        self.helper["local_bundle"](repo)
+                    for label in ("--prompt-file", "--dataset"):
+                        with self.subTest(label=label), self.assertRaisesRegex(SystemExit, reason):
+                            self.helper["validate_evidence_file"](repo, "source.txt", label)
 
     def test_local_bundle_rejects_non_utf8_untracked_text(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -625,21 +1486,21 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             (repo / "notes.txt").write_text("review me\n", encoding="utf-8")
-            original_read_prefix = self.helper["read_prefix"]
+            original_read_file_bytes = self.helper["read_file_bytes"]
             reads = 0
 
-            def read_once(path: Path, limit: int) -> tuple[bytes, bool]:
+            def read_once(path: Path) -> bytes:
                 nonlocal reads
                 reads += 1
                 if reads > 1:
                     raise AssertionError("untracked file was reopened after validation")
-                return original_read_prefix(path, limit)
+                return original_read_file_bytes(path)
 
             with mock.patch.dict(
                 self.helper["local_bundle"].__globals__,
-                {"read_prefix": read_once},
+                {"read_file_bytes": read_once},
             ):
-                bundle, truncated, _paths = self.helper["local_bundle"](repo)
+                bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             expected_record = json.dumps("review me" + os.linesep)
             self.assertIn(
@@ -647,40 +1508,224 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 f"source-line 1: {expected_record}",
                 bundle,
             )
-            self.assertFalse(truncated)
             self.assertEqual(reads, 1)
+
+    @contextlib.contextmanager
+    def nested_worktree_fixture(self, *, linked_root=False, name="scratch/review branch"):
+        with self.preparation_fixture() as (main, sends, scans, out, err):
+            repo = main
+            if linked_root:
+                repo = main.parent / "reviewed checkout"
+                git(main, "worktree", "add", "--detach", str(repo), "HEAD")
+                (repo / "source.md").write_text("outer linked change\n", encoding="utf-8")
+            child = repo / name
+            git(main, "worktree", "add", "--detach", str(child), "HEAD")
+            yield repo, child, sends, scans, out, err
+
+    def test_nested_worktree_keeps_neighboring_untracked_files_in_outgoing_scans(self):
+        names = ["scratch/review branch"]
+        if os.name != "nt":
+            names.append("scratch/review\nbranch")
+        for name in names:
+            with self.subTest(name=name), self.nested_worktree_fixture(name=name) as (
+                repo, child, sends, scans, _out, _err,
+            ):
+                ordinary = {
+                    ".worktrees/notes.md": "OUTER_WORKTREE_DIRECTORY_NOTE\n",
+                    f"{name}-copy/notes.md": "OUTER_PREFIX_NEIGHBOR_NOTE\n",
+                }
+                for rel, content in ordinary.items():
+                    path = repo / rel
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text(content, encoding="utf-8")
+                (child / "source.md").write_text("CHILD_SOURCE_NOT_REVIEWED\n", encoding="utf-8")
+                (child / "child-only.md").write_text("CHILD_UNTRACKED_NOT_REVIEWED\n", encoding="utf-8")
+
+                captured = self.helper["local_bundle"](repo)
+                self.assertEqual(captured.paths, {"source.md", *ordinary})
+                self.assertEqual(self.helper["main_impl"](), 0)
+                self.assertEqual(scans, sends)
+                self.assertTrue(scans)
+                for pack in scans:
+                    for marker in ordinary.values():
+                        self.assertIn(marker.strip(), pack)
+                    self.assertNotIn("CHILD_SOURCE_NOT_REVIEWED", pack)
+                    self.assertNotIn("CHILD_UNTRACKED_NOT_REVIEWED", pack)
+
+    def test_nested_worktree_alone_does_not_select_local_review(self):
+        with self.nested_worktree_fixture() as (repo, child, *_):
+            git(repo, "commit", "-qam", "finish outer changes")
+            git(repo, "branch", "-M", "main")
+            (child / "source.md").write_text("child dirty\n", encoding="utf-8")
+            (child / "new.md").write_text("child untracked\n", encoding="utf-8")
+
+            self.assertFalse(self.helper["is_dirty"](repo))
+            with self.assertRaisesRegex(SystemExit, "no review target: clean main checkout"):
+                self.helper["choose_target"](repo, "auto", None)
+            with self.assertRaisesRegex(SystemExit, "no local changes to review"):
+                self.helper["local_bundle"](repo)
+
+            (repo / ".worktrees").mkdir()
+            (repo / ".worktrees/notes.md").write_text("ordinary note\n", encoding="utf-8")
+            self.assertEqual(self.helper["choose_target"](repo, "auto", None), ("local", None))
+            self.assertEqual(self.helper["local_bundle"](repo).paths, {".worktrees/notes.md"})
+
+    def test_nested_worktree_snapshot_tracks_boundary_not_child_state(self):
+        for linked_root in (False, True):
+            with self.subTest(linked_root=linked_root), self.nested_worktree_fixture(
+                linked_root=linked_root,
+            ) as (repo, child, *_):
+                self.assertEqual(self.helper["local_bundle"](repo).paths, {"source.md"})
+                before = self.helper["source_tree_snapshot"](repo)
+                (child / "source.md").write_text("child staged change\n", encoding="utf-8")
+                git(child, "add", "source.md")
+                self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+                git(child, "commit", "-qm", "child-only commit")
+                (child / "untracked.md").write_text("child-only file\n", encoding="utf-8")
+                self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+
+                source = repo / "source.md"
+                original = source.read_bytes()
+                source.write_bytes(original + b"outer mutation\n")
+                self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+                source.write_bytes(original)
+                self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
+
+                pointer = child / ".git"
+                replacement = child / "replacement-pointer"
+                replacement.write_bytes(pointer.read_bytes())
+                os.replace(replacement, pointer)
+                self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+
+    def test_nested_worktree_cannot_hide_indexed_descendants_or_base_readditions(self):
+        with self.nested_worktree_fixture() as (repo, child, *_):
+            source = child / "source.md"
+            rel = source.relative_to(repo).as_posix()
+            oid = git(repo, "hash-object", "-w", str(source)).strip()
+            git(repo, "update-index", "--add", "--cacheinfo", f"100644,{oid},{rel}")
+            source.write_text("PARENT_INDEXED_DESCENDANT\n", encoding="utf-8")
+            captured = self.helper["local_bundle"](repo)
+            self.assertIn(rel, captured.paths)
+            self.assertIn("PARENT_INDEXED_DESCENDANT", captured.text)
+            before = self.helper["source_tree_snapshot"](repo)
+            source.write_text("PARENT_INDEXED_DESCENDANT_CHANGED\n", encoding="utf-8")
+            self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+
+            git(repo, "commit", "-qm", "parent owns a descendant")
+            base = git(repo, "rev-parse", "HEAD").strip()
+            git(repo, "update-index", "--force-remove", rel)
+            source.write_text("RE_ADDED_PARENT_SOURCE\n", encoding="utf-8")
+            for base_ref in (None, base):
+                with self.subTest(base=base_ref), self.assertRaisesRegex(
+                    SystemExit, "cannot safely include untracked file.*not a regular file",
+                ):
+                    self.helper["local_bundle"](repo, base_ref)
+            git(repo, "commit", "-qm", "remove parent index entry")
+            with self.assertRaisesRegex(
+                SystemExit, "cannot safely include untracked file.*not a regular file",
+            ):
+                self.helper["local_bundle"](repo, base)
+
+    def test_nested_worktree_exclusion_rejects_unowned_repository_boundaries(self):
+        for kind in ("standalone", "foreign", "fake", "alias", "mismatched", "unregistered-admin"):
+            with self.subTest(kind=kind), self.preparation_fixture() as (repo, *_):
+                child = repo / "scratch" / "unowned boundary"
+                child.parent.mkdir()
+                if kind == "foreign":
+                    foreign = repo.parent / "foreign"
+                    foreign.mkdir()
+                    git(foreign, "init", "-q")
+                    git(foreign, "commit", "--allow-empty", "-qm", "foreign root")
+                    git(foreign, "worktree", "add", "--detach", str(child), "HEAD")
+                elif kind == "unregistered-admin":
+                    git(repo, "worktree", "add", "--detach", str(child), "HEAD")
+                    registered = Path(git(child, "rev-parse", "--absolute-git-dir").strip())
+                    common = Path(git(repo, "rev-parse", "--absolute-git-dir").strip())
+                    copied = repo.parent / "unregistered-admin"
+                    shutil.copytree(registered, copied)
+                    (copied / "commondir").write_text(f"{common}\n", encoding="utf-8")
+                    (copied / "gitdir").write_text(f"{child / '.git'}\n", encoding="utf-8")
+                    (child / ".git").unlink()
+                    (child / ".git").write_text(f"gitdir: {copied}\n", encoding="utf-8")
+                    self.assertEqual(
+                        Path(git(child, "rev-parse", "--git-common-dir").strip()).resolve(),
+                        common.resolve(),
+                    )
+                elif kind in {"alias", "mismatched"}:
+                    owner = repo / "registered owner"
+                    git(repo, "worktree", "add", "--detach", str(owner), "HEAD")
+                    if kind == "mismatched":
+                        git(repo, "worktree", "add", "--detach", str(child), "HEAD")
+                        (child / ".git").unlink()
+                    else:
+                        child.mkdir()
+                    (child / ".git").write_bytes((owner / ".git").read_bytes())
+                else:
+                    child.mkdir()
+                    if kind == "standalone":
+                        git(child, "init", "-q")
+                        git(child, "commit", "--allow-empty", "-qm", "standalone root")
+                    else:
+                        (child / ".git").write_text(f"gitdir: {repo / '.git'}\n", encoding="utf-8")
+                (child / "ordinary.md").write_text("must not silently disappear\n", encoding="utf-8")
+
+                with self.assertRaisesRegex(
+                    SystemExit, "cannot safely include untracked file.*not a regular file",
+                ):
+                    self.helper["local_bundle"](repo)
+
+    def test_nested_worktree_validation_keeps_parent_git_trust_anchor(self):
+        with self.nested_worktree_fixture() as (repo, _child, *_):
+            hostile_bin = repo / "host-bin"
+            hostile_bin.mkdir()
+            marker = repo.parent / "hostile-git-executed"
+            write_executable(
+                hostile_bin / "git",
+                "#!/usr/bin/env python3\nfrom pathlib import Path\n"
+                f"Path({str(marker)!r}).write_text('executed')\nraise SystemExit(91)\n",
+            )
+            exclude = repo / ".git/info/exclude"
+            with exclude.open("a", encoding="utf-8") as stream:
+                stream.write("\nhost-bin/\n")
+            with mock.patch.dict(os.environ, {
+                "PATH": f"{hostile_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+            }):
+                self.assertEqual(self.helper["local_bundle"](repo).paths, {"source.md"})
+                self.helper["source_tree_snapshot"](repo)
+            self.assertFalse(marker.exists())
 
     def test_local_base_reviews_resolved_merge_without_upstream_binary(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             source = repo / "source.txt"
-            source.write_text("common\nretained line\n", encoding="utf-8")
+            source.write_bytes(b"common\nretained line\n")
             git(repo, "add", "source.txt")
             git(repo, "commit", "-q", "-m", "base")
             common = git(repo, "rev-parse", "HEAD").strip()
             git(repo, "checkout", "-q", "-b", "incoming")
             (repo / "proof.png").write_bytes(b"\x89PNG\r\n\0upstream-proof")
-            source.write_text("upstream\nretained line\n", encoding="utf-8")
+            source.write_bytes(b"upstream\nretained line\n")
             git(repo, "add", "source.txt", "proof.png")
             git(repo, "commit", "-q", "-m", "upstream")
             incoming = git(repo, "rev-parse", "HEAD").strip()
             git(repo, "checkout", "-q", "-b", "task", common)
-            source.write_text("task\nretained line\n", encoding="utf-8")
-            (repo / "committed.txt").write_text("committed task change\n", encoding="utf-8")
+            source.write_bytes(b"task\nretained line\n")
+            (repo / "committed.txt").write_bytes(b"committed task change\n")
             git(repo, "add", "source.txt", "committed.txt")
             git(repo, "commit", "-q", "-m", "task")
             with self.assertRaises(subprocess.CalledProcessError):
                 git(repo, "merge", "--no-ff", "--no-commit", "incoming")
             self.assertEqual(git(repo, "rev-parse", "MERGE_HEAD").strip(), incoming)
-            source.write_text("resolved staged task\n", encoding="utf-8")
+            source.write_bytes(b"resolved staged task\n")
             git(repo, "add", "source.txt")
             self.assertEqual(git(repo, "diff", "--name-only", "--diff-filter=U").strip(), "")
-            source.write_text("resolved staged task\nretained line\nunstaged task\n", encoding="utf-8")
-            (repo / "notes.md").write_text("untracked task note\n", encoding="utf-8")
+            source.write_bytes(b"resolved staged task\nretained line\nunstaged task\n")
+            (repo / "notes.md").write_bytes(b"untracked task note\n")
             # Review reads ignore host Git settings, including Windows autocrlf.
             # Expected patches must use the same protected Git policy.
             staged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"], "--cached", incoming)
             unstaged = self.helper["git"](repo, "diff", *self.helper["SAFE_DIFF_FLAGS"])
+            scanned: list[str] = []
             sent: list[str] = []
             report = {
                 "findings": [{
@@ -703,6 +1748,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             main = self.helper["main_impl"]
             with mock.patch.dict(main.__globals__, {
                 "repo_root": lambda: repo,
+                "scan_outgoing_review_pack": lambda _repo, prompt: scanned.append(prompt),
                 "run_engine": run_engine,
                 "resolve_engine_binary": lambda _reviewer, _repo: (True, None),
             }):
@@ -714,6 +1760,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         self.assertEqual(main(), 0 if dry_run else 1)
 
             self.assertEqual(len(sent), 1)
+            self.assertEqual(scanned, [sent[0], sent[0]])
             self.assertIn(f"# Staged Diff\nbase: {incoming}", sent[0])
             self.assertIn(staged.rstrip(), sent[0])
             self.assertIn(unstaged.rstrip(), sent[0])
@@ -750,8 +1797,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             snapshot = self.helper["source_tree_snapshot"](repo)
             git(repo, "update-ref", "refs/heads/review-base", "HEAD")
             self.assertEqual(self.helper["source_tree_snapshot"](repo), snapshot)
-            bundle, truncated, _paths = self.helper["local_bundle"](repo, pinned)
-            self.assertFalse(truncated)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo, pinned)
             self.assertIn("+committed task change", bundle)
             self.assertEqual(
                 self.helper["build_bundle"](repo, target, pinned, "HEAD").paths,
@@ -773,14 +1819,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 if staged:
                     git(repo, "add", safe)
                 with self.subTest(staged=staged):
-                    bundle, truncated, _paths = self.helper["local_bundle"](repo)
-                    self.assertFalse(truncated)
+                    bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
                     self.assertIn("struct CredentialFile", bundle)
                     self.assertIn(safe, self.helper["local_bundle"](repo).paths)
                     for label in ("--dataset", "--prompt-file"):
-                        _, content, truncated = self.helper["validate_evidence_file"](repo, safe, label)
+                        _, content = self.helper["validate_evidence_file"](repo, safe, label)
                         self.assertEqual(content, source.read_bytes().decode("utf-8"))
-                        self.assertFalse(truncated)
 
             blocked = (
                 "credentials.json", "config/prod-credentials.json", "credentials/store.json",
@@ -844,7 +1888,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             for engine in ("codex", "claude", "amp", "pi", "kimi"):
                 for mode, ref, accepted, expected_exit in cases:
                     with self.subTest(engine=engine, mode=mode, ref=bool(ref)):
-                        sends = []
+                        scans, sends = [], []
 
                         def run_engine(_args, _repo, prompt):
                             sends.append(prompt)
@@ -858,6 +1902,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         output = io.StringIO()
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo, "run_engine": run_engine,
+                            "scan_outgoing_review_pack": lambda _repo, prompt: scans.append(prompt),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(output), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), expected_exit)
                         result = json.loads((root / "result.json").read_text())
@@ -872,6 +1917,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         self.assertNotIn("clean:", text)
                         rejected = result.get("scope_rejected_findings", [])
                         self.assertEqual(len(rejected), 2 - len(accepted))
+                        self.assertEqual(scans, sends)
                         self.assertIn("# Dataset: " + str(Path(e2e)), sends[0])
                         self.assertNotIn("OMIT_STAGED_STORE", sends[0])
                         self.assertNotIn("OMIT_UNTRACKED_ENV", sends[0])
@@ -928,6 +1974,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         with mock.patch.dict(self.helper["main_impl"].__globals__, {
                             "repo_root": lambda: repo,
                             "build_review_prompts": lambda *_args: ["synthetic pack"] * count,
+                            "scan_outgoing_review_pack": lambda *_args: None,
                             "run_engine": lambda *_args: json.dumps(provider),
                         }), mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
                             self.assertEqual(self.helper["main_impl"](), exit_code)
@@ -945,47 +1992,70 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         if required and expected_status == "incomplete":
                             self.assertEqual(result["missing_required_findings"], required)
 
-    def test_credential_source_exception_keeps_review_material_and_credential_rule(self) -> None:
+    def test_credential_source_exception_still_scans_every_outgoing_input(self) -> None:
         source = "Sources/Configuration/CredentialFile.swift"
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             path = repo / source
             path.parent.mkdir(parents=True)
-            path.write_text("// DELETED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
+            path.write_text("// DELETED_SCAN_MARKER\n", encoding="utf-8")
             git(repo, "add", source)
             git(repo, "commit", "-q", "-m", "base")
-            path.write_text("// STAGED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
+            path.write_text("// STAGED_SCAN_MARKER\n", encoding="utf-8")
             git(repo, "add", source)
             untracked = repo / "Runtime/CredentialFile.swift"
             untracked.parent.mkdir()
-            untracked.write_text("// UNTRACKED_CREDENTIAL_CONTEXT\n", encoding="utf-8")
+            untracked.write_text("// UNTRACKED_SCAN_MARKER\n", encoding="utf-8")
             evidence = self.helper["capture_evidence_inputs"](argparse.Namespace(
-                prompt=["PROMPT_CREDENTIAL_CONTEXT"], prompt_file=[source],
+                prompt=["PROMPT_SCAN_MARKER"], prompt_file=[source],
                 dataset=[str(untracked.relative_to(repo))],
             ), repo)
             extra, datasets = evidence.prompt, evidence.datasets
-            bundle, _, _paths = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             pack, = self.helper["build_review_prompts"](repo, "local", None, bundle, extra, datasets)
             provider = mock.Mock(return_value=json.dumps({
                 "findings": [], "overall_correctness": "patch is correct",
                 "overall_explanation": "Synthetic review.", "overall_confidence": 0.8,
             }))
-            for token in (
-                "-// DELETED_CREDENTIAL_CONTEXT",
-                "+// STAGED_CREDENTIAL_CONTEXT",
-                "UNTRACKED_CREDENTIAL_CONTEXT",
-                "PROMPT_CREDENTIAL_CONTEXT",
-                "# Dataset:",
-                "# Prompt file:",
-                "Report every suspected real credential as a P0 security finding",
-            ):
-                self.assertIn(token, pack)
-            with mock.patch.dict(
-                self.helper["run_reviewer"].__globals__, {"run_engine": provider}
-            ):
-                args = argparse.Namespace(engine="codex", max_priority="P2")
-                self.helper["run_reviewer"](args, repo, pack, {source}, [])
-            provider.assert_called_once_with(args, repo, pack)
+            for marker in (None, "DELETED_SCAN_MARKER", "STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER"):
+                events = []
+
+                def scanner(command, _repo, **kwargs):
+                    source_kind = command[1]
+                    if source_kind == "filesystem":
+                        outgoing = Path(command[2])
+                        payload = outgoing.read_bytes()
+                    else:
+                        self.assertEqual(source_kind, "stdin")
+                        outgoing = Path(kwargs["stdin"].name)
+                        payload = kwargs["stdin"].read()
+                    self.assertEqual(payload, pack.encode("utf-8"))
+                    if os.name != "nt":
+                        self.assertEqual(stat.S_IMODE(outgoing.stat().st_mode), 0o600)
+                    self.assertIn("--results=verified,unknown", command)
+                    self.assertIn("--no-update", command)
+                    for token in ("-// DELETED_SCAN_MARKER", "+// STAGED_SCAN_MARKER", "UNTRACKED_SCAN_MARKER", "PROMPT_SCAN_MARKER", "# Dataset:", "# Prompt file:"):
+                        self.assertIn(token, pack)
+                    events.append(source_kind)
+                    if marker:
+                        line = next(i for i, text in enumerate(pack.splitlines(), 1) if marker in text)
+                        detected = {"SourceMetadata": {"Data": {"Filesystem": {"file": str(outgoing), "line": line}}}}
+                        return subprocess.CompletedProcess(command, self.helper["TRUFFLEHOG_FINDINGS_EXIT_CODE"], json.dumps(detected), "")
+                    return subprocess.CompletedProcess(command, 0, "", "")
+
+                provider.reset_mock()
+                with self.subTest(marker=marker), mock.patch.dict(self.helper["run_reviewer"].__globals__, {
+                    "find_command": lambda *_args: "/trusted/trufflehog", "run": scanner, "run_engine": provider,
+                }):
+                    args = argparse.Namespace(engine="codex", max_priority="P2")
+                    if marker:
+                        with self.assertRaisesRegex(SystemExit, "refusing to send review pack"):
+                            self.helper["run_reviewer"](args, repo, pack, {source}, [])
+                        provider.assert_not_called()
+                    else:
+                        self.helper["run_reviewer"](args, repo, pack, {source}, [])
+                        provider.assert_called_once_with(args, repo, pack)
+                    self.assertEqual(events, ["filesystem"] if marker else ["filesystem", "stdin"])
 
     def test_tracked_binary_changes_are_blocked_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1081,42 +2151,42 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
     def test_untracked_files_respect_trusted_global_excludes(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            root = Path(tempdir)
-            repo = init_repo(root)
-            home = root / "home"
-            home.mkdir()
-            excludes = root / "global-ignore"
-            excludes.write_text(
-                "ignored.local\n!settings.local\n",
-                encoding="utf-8",
-            )
-            (home / ".gitconfig").write_text(
-                f"[core]\n\texcludesFile = {excludes.as_posix()}\n",
-                encoding="utf-8",
-            )
-            (repo / "ignored.local").write_text("private notes\n", encoding="utf-8")
-            (repo / ".gitignore").write_text("settings.local\n", encoding="utf-8")
-            (repo / "settings.local").write_text("repo private\n", encoding="utf-8")
-            git(repo, "add", ".gitignore")
-            (repo / "visible.txt").write_text("review me\n", encoding="utf-8")
-            (repo / "hostile-gitconfig").write_text(
-                "[core]\n\texcludesFile = /does/not/exist\n",
-                encoding="utf-8",
-            )
-
-            with mock.patch.dict(
-                os.environ,
-                {
-                    "HOME": str(home),
-                    "USERPROFILE": str(home),
-                    "GIT_CONFIG_GLOBAL": str(repo / "hostile-gitconfig"),
-                },
-            ):
-                self.assertEqual(
-                    [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
-                    ["hostile-gitconfig", "visible.txt"],
+        cases = [("external", "global-ignore"), ("missing", "global-ignore"),
+                 ("inside", "global-ignore")]
+        if os.name != "nt":
+            cases.extend([("external", "global\rignore"), ("external", "global-ignore ")])
+        for location, name in cases:
+            with self.subTest(location=location, name=name), tempfile.TemporaryDirectory() as tempdir:
+                root = Path(tempdir)
+                repo = init_repo(root)
+                home = root / "home"
+                home.mkdir()
+                excludes = (repo if location == "inside" else root) / name
+                if location != "missing":
+                    excludes.write_text("ignored.local\n!settings.local\n", encoding="utf-8")
+                if location == "inside":
+                    git(repo, "add", "--", name)
+                git(repo, "config", "--file", str(home / ".gitconfig"),
+                    "core.excludesFile", str(excludes))
+                (repo / "ignored.local").write_text("private notes\n", encoding="utf-8")
+                (repo / ".gitignore").write_text("settings.local\n", encoding="utf-8")
+                (repo / "settings.local").write_text("repo private\n", encoding="utf-8")
+                git(repo, "add", ".gitignore")
+                (repo / "visible.txt").write_text("review me\n", encoding="utf-8")
+                (repo / "hostile-gitconfig").write_text(
+                    "[core]\n\texcludesFile = /does/not/exist\n", encoding="utf-8",
                 )
+                with mock.patch.dict(os.environ, {
+                    "HOME": str(home), "USERPROFILE": str(home),
+                    "GIT_CONFIG_GLOBAL": str(repo / "hostile-gitconfig"),
+                }):
+                    expected = ["hostile-gitconfig", "visible.txt"]
+                    if location != "external":
+                        expected.insert(1, "ignored.local")
+                    self.assertEqual(
+                        [rel for rel, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
+                        expected,
+                    )
 
     def test_dirty_check_respects_trusted_global_excludes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1141,30 +2211,20 @@ class AutoreviewHardeningTests(unittest.TestCase):
             ):
                 self.assertFalse(self.helper["is_dirty"](repo))
 
-    def test_oversized_text_is_rejected_without_scanning_binary_tail(self) -> None:
+    def test_large_untracked_text_is_captured_completely(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            detector_tail = "\ntoken=" + "A" * 24 + "\n"
-            content = "x" * (64_000 * 3 - 4) + detector_tail
-
+            content = "界\r\n" * 50_000 + "COMPLETE_UNTRACKED_TAIL\n"
             untracked = repo / "untracked.txt"
-            untracked.write_text(content, encoding="utf-8")
-            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
-                [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]]
-
-            untracked.unlink()
-            binary = repo / "binary.bin"
-            binary.write_bytes(b"\0" + content.encode())
-            self.assertEqual(
-                [rel for rel, _, _ in self.helper["collect_untracked_file_snapshots"](repo)[0]],
-                ["binary.bin"],
+            untracked.write_bytes(content.encode("utf-8"))
+            captured = self.helper["local_bundle"](repo)
+            records = re.findall(r"^source-line \d+: (.*)$", captured.text, re.MULTILINE)
+            self.assertEqual("".join(json.loads(record) for record in records), content)
+            passes = self.helper["build_review_prompts"](
+                repo, "local", None, captured, "", [], 50_000,
             )
-
-            binary.unlink()
-            evidence = repo / "evidence.txt"
-            evidence.write_text(content, encoding="utf-8")
-            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
-                self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
+            self.assertGreater(len(passes), 1)
+            self.assertEqual("".join(prompt.split("# Change Bundle\n", 1)[1] for prompt in passes), captured.text)
 
     def test_branch_bundle_rejects_unsafe_or_unknown_base_before_diff(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1236,7 +2296,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                                 self.helper["build_bundle"](checkout, "commit", None, "HEAD")
                         continue
                     captured = self.helper["build_bundle"](checkout, "commit", None, "HEAD")
-                    self.assertFalse(captured.truncated)
                     self.assertIn(f"parent: {expected_parent}\n", captured.text)
                     self.assertIn(expected_patch, captured.text)
                     self.assertNotIn("behavior.py", captured.text)
@@ -1248,7 +2307,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             self.assertNotIn("behavior.py", captured.text)
             self.assertEqual(captured.paths, {"unrelated.txt"})
             captured = self.helper["build_bundle"](repo, "commit", None, initial)
-            self.assertFalse(captured.truncated)
             self.assertIn("parent: none (verified raw root)\n", captured.text)
             self.assertIn("+def behavior(): return 'preexisting'", captured.text)
             self.assertEqual(captured.paths, {"behavior.py"})
@@ -1275,7 +2333,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertIn(f"author {name}".encode(), raw)
                 self.assertNotIn(b"\nparent ", raw.partition(b"\n\n")[0])
                 captured = self.helper["build_bundle"](repo, "commit", None, "HEAD")
-                self.assertFalse(captured.truncated)
                 self.assertIn("parent: none (verified raw root)\n", captured.text)
                 self.assertIn("+root_content = True", captured.text)
                 self.assertEqual(captured.paths, {"code.py"})
@@ -1314,7 +2371,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                                 self.helper["build_bundle"](repo, "commit", None, commit)
                             continue
                         captured = self.helper["build_bundle"](repo, "commit", None, commit)
-                        self.assertFalse(captured.truncated)
                         if label == "late":
                             self.assertEqual(git(repo, "rev-list", "--parents", "-n", "1", commit).split(), [commit])
                             self.assertIn("parent: none (verified raw root)\n", captured.text)
@@ -1324,18 +2380,38 @@ class AutoreviewHardeningTests(unittest.TestCase):
                             self.assertIn(f"parent: {parent.decode()}\n", captured.text)
                             self.assertEqual(captured.paths, set())
 
+    def test_repo_root_preserves_exact_native_paths(self) -> None:
+        names = ["repo"]
+        if os.name != "nt":
+            names.extend(["repo\rname", "repo "])
+        for name in names:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tempdir:
+                root = Path(tempdir)
+                repo = init_repo(root)
+                if name != repo.name:
+                    repo = repo.rename(root / name)
+                nested = repo / "nested"
+                nested.mkdir()
+                previous = Path.cwd()
+                try:
+                    os.chdir(nested)
+                    self.assertEqual(self.helper["repo_root"](), repo.resolve())
+                finally:
+                    os.chdir(previous)
+
     def test_git_path_list_preserves_newline_filenames(self) -> None:
         if os.name == "nt":
             self.skipTest("Windows filesystems do not support newline path components")
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            rel = "line\nbreak.txt"
-            (repo / rel).write_text("content\n", encoding="utf-8")
-            git(repo, "add", rel)
+            names = [f"line{separator}break.txt" for separator in ("\n", "\r", "\r\n", "\t")]
+            for rel in names:
+                (repo / rel).write_text("content\n", encoding="utf-8")
+                git(repo, "add", "--", rel)
 
             paths = self.helper["git_path_list"](repo, "ls-files", "-z")
 
-            self.assertIn(rel, paths)
+            self.assertCountEqual(paths, names)
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "requires raw non-UTF-8 filename support")
     def test_git_path_list_rejects_non_utf8_output(self) -> None:
@@ -1348,14 +2424,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             with self.assertRaisesRegex(SystemExit, "non-UTF-8 Git output"):
                 self.helper["git_path_list"](repo, "ls-files", "-z")
 
-    def test_review_patch_rejects_oversized_content(self) -> None:
-        with self.assertRaisesRegex(SystemExit, "too large to review safely"):
-            self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "x" * 25, 10)
-
-    def test_review_patch_limit_counts_utf8_bytes(self) -> None:
-        with self.assertRaisesRegex(SystemExit, r"12 bytes; limit 10"):
-            self.helper["validate_review_patch"]("local staged diff", ["safe.txt"], "界" * 4, 10)
-
     def test_review_patch_accepts_large_content_without_explicit_limit(self) -> None:
         patch = (
             "diff --git a/safe.txt b/safe.txt\n"
@@ -1367,7 +2435,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "local staged diff",
                 ["safe.txt"],
                 patch,
             ),
@@ -1658,7 +2725,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 path = f"evidence-{index}.txt"
                 lines = [
                     f"evidence-{index}-{line}: \U0001f99e{'x' * 70}"
-                    for line in range(1_400)
+                    for line in range(2_200)
                 ]
                 expected_lines.extend(lines)
                 (repo / path).write_bytes(("\n".join(lines) + "\n").encode("utf-8"))
@@ -1667,7 +2734,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 argparse.Namespace(prompt=[], prompt_file=[], dataset=paths), repo
             )
             datasets = evidence.datasets
-            self.assertFalse(evidence.truncated)
             bundle = "# Commit Diff\n" + "+changed line\n" * 40_000
             instructions = "Complete caller instructions must appear in every pass."
             for budget in (512_000, 120_000):
@@ -1747,15 +2813,51 @@ class AutoreviewHardeningTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             bundle = "diff --git a/code.py b/code.py\n" + "+review me\n" * 20_000
-            prompts = self.helper["prepare_review_prompts"](
-                repo, "local", None, bundle, "", [], 120_000
-            )
+            with mock.patch.dict(self.helper["prepare_review_prompts"].__globals__, {
+                "scan_outgoing_review_pack": mock.Mock(),
+            }):
+                prompts = self.helper["prepare_review_prompts"](
+                    repo, "local", None, bundle, "", [], 120_000
+                )
             self.assertGreater(len(prompts), 1)
             for prompt in prompts:
                 self.assertIn(
-                    "Report every suspected real credential as a P0 security finding",
+                    "Report suspected real credentials as P0 findings without reproducing their values.",
                     prompt,
                 )
+
+    def test_partitioned_input_scans_complete_content_before_any_send(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            sentinel = "synthetic scanner boundary " + "x" * 160_000 + " end sentinel"
+            for source in ("diff", "dataset"):
+                with self.subTest(source=source):
+                    bundle = "+" + (sentinel if source == "diff" else "safe") + "\n" * 30_000
+                    datasets = (
+                        [self.helper["ReviewDataset"]("evidence.txt", sentinel)]
+                        if source == "dataset" else []
+                    )
+                    prompts = self.helper["build_review_prompts"](
+                        repo, "local", None, bundle, "", datasets, 120_000
+                    )
+                    self.assertGreater(len(prompts), 1)
+                    self.assertFalse(any(sentinel in prompt for prompt in prompts))
+                    scanned = []
+
+                    def scan(_repo, prompt):
+                        scanned.append(prompt)
+                        if sentinel in prompt:
+                            raise SystemExit("complete input scanner rejection")
+
+                    with mock.patch.dict(
+                        self.helper["prepare_review_prompts"].__globals__,
+                        {"scan_outgoing_review_pack": scan},
+                    ), self.assertRaisesRegex(SystemExit, "complete input scanner rejection"):
+                        self.helper["prepare_review_prompts"](
+                            repo, "local", None, bundle, "", datasets, 120_000
+                        )
+                    self.assertEqual(len(scanned), 1)
+                    self.assertIn(sentinel, scanned[0])
 
     def test_review_prompt_preserves_bundle_ending_whitespace(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1789,10 +2891,15 @@ class AutoreviewHardeningTests(unittest.TestCase):
             "category": "bug",
             "code_location": {"file_path": "source.txt", "line": 1},
         }
-        for failure in (None, "engine"):
+        for failure in (None, "scan", "engine"):
             with self.subTest(failure=failure), tempfile.TemporaryDirectory() as tempdir:
                 repo = init_repo(Path(tempdir))
                 events = []
+
+                def scan(_repo, prompt):
+                    events.append(("scan", prompt))
+                    if failure == "scan" and prompt == prompts[8]:
+                        raise SystemExit("late scan failure")
 
                 def engine(_args, _repo, prompt):
                     events.append(("engine", prompt))
@@ -1812,16 +2919,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
                 with mock.patch.dict(
                     self.helper["run_review_passes"].__globals__,
-                    {"run_engine": engine},
+                    {"scan_outgoing_review_pack": scan, "run_engine": engine},
                 ), contextlib.redirect_stdout(io.StringIO()):
                     if failure:
                         with self.assertRaisesRegex(SystemExit, f"late {failure} failure"):
                             self.helper["run_review_passes"](
-                                args, [args], repo, prompts, {"source.txt"}, False
+                                args, [args], repo, prompts, {"source.txt"}
                             )
                     else:
                         reports = self.helper["run_review_passes"](
-                            args, [args], repo, prompts, {"source.txt"}, False
+                            args, [args], repo, prompts, {"source.txt"}
                         )
                         report = self.helper["merge_chunk_reports"](reports)
                         self.helper["require_findings"](report, args.require_finding)
@@ -1829,16 +2936,17 @@ class AutoreviewHardeningTests(unittest.TestCase):
                         self.assertEqual(
                             [item["title"] for item in report["findings"]], [finding["title"]]
                         )
-                expected = [("engine", prompt) for prompt in prompts]
+                expected = [
+                    (stage, prompt) for prompt in prompts for stage in ("scan", "engine")
+                ]
                 if failure:
-                    expected = expected[:9]
+                    expected = expected[:17 if failure == "scan" else 18]
                 self.assertEqual(events, expected)
 
     def test_review_patch_does_not_disclose_controls_in_omitted_paths(self) -> None:
         path = ".env.\x1b]52;c;VEVTVA==\x07\udc9b"
 
         redacted = self.helper["validate_review_patch"](
-            "local staged diff",
             [path],
             "",
         )
@@ -1862,7 +2970,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted = self.helper["validate_review_patch"](
-            "branch diff",
             [".env"],
             patch,
         )
@@ -1884,7 +2991,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         ):
             with self.subTest(patch=patch):
                 validated = self.helper["validate_review_patch"](
-                    "commit diff",
                     ["src/runtime.ts"],
                     patch,
                 )
@@ -1901,15 +3007,14 @@ class AutoreviewHardeningTests(unittest.TestCase):
             (repo / ".env").write_text("placeholder=true\n", encoding="utf-8")
             (repo / "base.txt").write_text("base\nreview me\n", encoding="utf-8")
             git(repo, "add", ".env", "base.txt")
-            local, local_truncated, _paths = self.helper["local_bundle"](repo)
+            local, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn(self.helper["REVIEW_SECURITY_OMISSION"], local)
             self.assertNotIn(".env", local)
             self.assertNotIn("placeholder=true", local)
             self.assertIn("+review me", local)
-            self.assertFalse(local_truncated)
 
             git(repo, "commit", "-q", "-m", "sensitive path")
-            for bundle, truncated, paths in (
+            for bundle, paths, _mixed, _spans in (
                 self.helper["branch_bundle"](repo, base),
                 self.helper["commit_bundle"](repo, "HEAD"),
             ):
@@ -1917,7 +3022,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertNotIn(".env", bundle)
                 self.assertNotIn("placeholder=true", bundle)
                 self.assertIn("+review me", bundle)
-                self.assertFalse(truncated)
 
     def test_secret_named_workflows_are_reviewable_in_all_modes(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -1930,16 +3034,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
             workflow = repo / ".github" / "workflows" / "secret-scan.yml"
             workflow.parent.mkdir(parents=True)
             workflow.write_text("name: Secret scan\n", encoding="utf-8")
-            untracked_bundle, _, _paths = self.helper["local_bundle"](repo)
+            untracked_bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", untracked_bundle)
 
             git(repo, "add", str(workflow.relative_to(repo)))
-            tracked_bundle, _, _paths = self.helper["local_bundle"](repo)
+            tracked_bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
             self.assertIn("secret-scan.yml", tracked_bundle)
 
             git(repo, "commit", "-q", "-m", "add secret scanner")
-            branch_bundle, _, _paths = self.helper["branch_bundle"](repo, base)
-            commit_bundle, _, _paths = self.helper["commit_bundle"](repo, "HEAD")
+            branch_bundle, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
+            commit_bundle, _paths, _mixed, _spans = self.helper["commit_bundle"](repo, "HEAD")
             self.assertIn("secret-scan.yml", branch_bundle)
             self.assertIn("secret-scan.yml", commit_bundle)
 
@@ -2007,10 +3111,9 @@ class AutoreviewHardeningTests(unittest.TestCase):
             path.parent.mkdir()
             path.write_text(source, encoding="utf-8")
 
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn("ordinary-hardcoded-value-12345", bundle)
-            self.assertFalse(truncated)
 
     def test_untracked_design_token_artifacts_remain_reviewable(self) -> None:
         for rel in (
@@ -2127,7 +3230,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "branch diff",
                 ["provider.ts"],
                 safe_patch,
             ),
@@ -2148,7 +3250,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             + "".join(f"+{line}\n" for line in source.splitlines())
         )
         validated = self.helper["validate_review_patch"](
-            "typescript credential plumbing fixture",
             ["src/credential-plumbing.ts"],
             patch,
         )
@@ -2183,12 +3284,34 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "branch diff",
                 ["apps/macos/MenuContentView.swift"],
                 patch,
             ),
             patch,
         )
+
+    @unittest.skipUnless(
+        shutil.which("trufflehog"), "TruffleHog binary not installed"
+    )
+    def test_outgoing_pack_scan_accepts_deleted_swift_status_literals(self) -> None:
+        # Live-scanner companion to the regression above: TruffleHog must not
+        # flag the benign "ok-token" status literal in a deleted-file bundle.
+        source = (FIXTURES / "swift-benign-status-literals.swift").read_text(
+            encoding="utf-8"
+        )
+        prompt = (
+            "# Change Bundle\n"
+            "diff --git a/apps/macos/MenuContentView.swift "
+            "b/apps/macos/MenuContentView.swift\n"
+            "deleted file mode 100644\n"
+            "--- a/apps/macos/MenuContentView.swift\n"
+            "+++ /dev/null\n"
+            f"@@ -1,{len(source.splitlines())} +0,0 @@\n"
+            + "".join(f"-{line}\n" for line in source.splitlines())
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            self.helper["scan_outgoing_review_pack"](repo, prompt)
 
     def test_review_bundle_preserves_typescript_config_paths(self) -> None:
         source = (FIXTURES / "typescript-benign-config-path-references.ts").read_text(
@@ -2204,7 +3327,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         validated = self.helper["validate_review_patch"](
-            "typescript config path references",
             ["src/config-path-references.ts"],
             patch,
         )
@@ -2232,7 +3354,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "typescript truncated credential calls fixture",
                 ["src/token.ts"],
                 truncated_call_patch,
             ),
@@ -2257,7 +3378,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 )
 
                 validated = self.helper["validate_review_patch"](
-                    "local unstaged diff",
                     ["fixture.py"],
                     patch,
                 )
@@ -2285,13 +3405,12 @@ class AutoreviewHardeningTests(unittest.TestCase):
             git(repo, "add", "-u")
             git(repo, "commit", "-q", "-m", "delete template")
 
-            bundle, truncated, _paths = self.helper["branch_bundle"](repo, base)
+            bundle, _paths, _mixed, _spans = self.helper["branch_bundle"](repo, base)
 
             self.assertIn("deleted file mode 100644", bundle)
             self.assertIn("------BEGIN [A-Z ]+-----", bundle)
             self.assertIn("-{{ _body }}", bundle)
             self.assertIn("------END [A-Z ]+-----", bundle)
-            self.assertFalse(truncated)
 
     def test_review_patch_preserves_redaction_placeholder_fallback(self) -> None:
         patch = (
@@ -2305,7 +3424,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "local unstaged diff",
                 ["runtime.py"],
                 patch,
             ),
@@ -2323,7 +3441,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["fixture.txt"],
             patch,
         )
@@ -2341,7 +3458,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -2360,7 +3476,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["vendor"],
             patch,
         )
@@ -2379,7 +3494,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -2397,7 +3511,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -2415,7 +3528,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -2437,7 +3549,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
         )
 
         redacted_patch = self.helper["validate_review_patch"](
-            "local unstaged diff",
             ["runtime.ts"],
             patch,
         )
@@ -2454,39 +3565,9 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
             path.write_text('const request = { token: String() };\n', encoding="utf-8")
 
-            bundle, truncated, _paths = self.helper["local_bundle"](repo)
+            bundle, _paths, _mixed, _spans = self.helper["local_bundle"](repo)
 
             self.assertIn('-const request = { token: "test-token" };', bundle)
-            self.assertFalse(truncated)
-
-    def test_pi_refuses_truncated_review_input(self) -> None:
-        reviewer = argparse.Namespace(engine="pi", tools=True)
-
-        with self.assertRaisesRegex(SystemExit, "pi engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                reviewer,
-                True,
-            )
-
-        self.helper["ensure_reviewer_input_complete"](
-            reviewer,
-            False,
-        )
-        with self.assertRaisesRegex(SystemExit, "codex engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                argparse.Namespace(engine="codex", tools=True),
-                True,
-            )
-        with self.assertRaisesRegex(SystemExit, "claude engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                argparse.Namespace(engine="claude", tools=True),
-                True,
-            )
-        with self.assertRaisesRegex(SystemExit, "kimi engine refused truncated review input"):
-            self.helper["ensure_reviewer_input_complete"](
-                argparse.Namespace(engine="kimi", tools=False),
-                True,
-            )
 
     def test_kimi_config_is_sanitized_without_losing_model_auth(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2645,7 +3726,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
             evidence = self.helper["capture_evidence_inputs"](args, repo)
 
             self.assertIn("# Prompt file: review.md", evidence.prompt)
-            self.assertFalse(evidence.truncated)
 
     def test_review_prompts_omit_absolute_repo_path_and_keep_instructions_whole(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2659,14 +3739,9 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     )
                     self.assertIn("Read-only tools cannot access unchanged repository files", prompt)
                     self.assertIn(
-                        "Do not report a missing import, symbol, definition, call site, config entry",
+                        "Missing context or omitted sensitive material is not evidence of a defect.",
                         prompt,
                     )
-                    for evidence_rule in (
-                        "raw commit parents", "^sha", "porcelain boundary", "missing parents",
-                        "parent-relative patch", "unknown", "carried forward", "merger",
-                    ):
-                        self.assertIn(evidence_rule, prompt)
                     self.assertNotIn(str(repo), prompt)
             with self.assertRaisesRegex(SystemExit, "too little room"):
                 self.helper["build_review_prompts"](
@@ -2677,26 +3752,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
                     "x" * self.helper["MAX_REVIEW_PROMPT_BYTES"],
                     [],
                 )
-
-    def test_read_text_truncates_without_scanning_tail(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            path = Path(tempdir) / "large.txt"
-            path.write_bytes(b"x" * 200_000 + b"\0tail")
-
-            text = self.helper["read_text"](path)
-
-            self.assertIn("[truncated at 180000 characters]", text)
-            self.assertNotEqual(text, "[binary file omitted]")
-
-    def test_read_text_marks_unreadable_input_incomplete(self) -> None:
-        with mock.patch.dict(
-            self.helper["read_text_with_status"].__globals__,
-            {"read_prefix": lambda *_args: (_ for _ in ()).throw(SystemExit("denied"))},
-        ):
-            text, incomplete = self.helper["read_text_with_status"](Path("blocked"))
-
-        self.assertIn("[unreadable:", text)
-        self.assertTrue(incomplete)
 
     def test_evidence_file_must_be_repo_relative_and_not_symlinked(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -2997,16 +4052,17 @@ class AutoreviewHardeningTests(unittest.TestCase):
         proc_b.wait.assert_called_once_with(timeout=0.5)
 
     def test_engine_interrupted_is_not_swallowed_by_except_system_exit(self) -> None:
-        # Regression: EngineInterrupted used to subclass SystemExit, so
-        # internal `except SystemExit` guards like read_text_with_status's
-        # converted an in-flight interrupt into an unreadable-file result
-        # and kept going instead of unwinding.
-        with mock.patch.dict(
-            self.helper["read_text_with_status"].__globals__,
-            {"read_prefix": mock.Mock(side_effect=self.helper["EngineInterrupted"](130))},
-        ):
-            with self.assertRaises(self.helper["EngineInterrupted"]) as ctx:
-                self.helper["read_text_with_status"](Path("irrelevant"))
+        # Input validation may translate unreadable-file errors, but an engine
+        # interrupt must unwind with its original exit code.
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "evidence.txt").write_text("evidence\n")
+            with mock.patch.dict(
+                self.helper["validate_evidence_file"].__globals__,
+                {"read_file_bytes": mock.Mock(side_effect=self.helper["EngineInterrupted"](130))},
+            ):
+                with self.assertRaises(self.helper["EngineInterrupted"]) as ctx:
+                    self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
         self.assertEqual(ctx.exception.code, 130)
 
     def test_main_converts_engine_interrupted_to_exit_code(self) -> None:
@@ -3019,36 +4075,32 @@ class AutoreviewHardeningTests(unittest.TestCase):
     def test_source_tree_snapshot_detects_mutations(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
-            source = repo / "source.txt"
-            source.write_text("before\n", encoding="utf-8")
-            git(repo, "add", "source.txt")
+            names = ["source.txt"]
+            if os.name != "nt":
+                names.extend(("source\r.txt", "source\r\n.txt"))
+            for name in names:
+                (repo / name).write_text("before\n", encoding="utf-8")
+                git(repo, "add", "--", name)
             git(repo, "commit", "-qm", "initial")
-            before = self.helper["source_tree_snapshot"](repo)
+            for name in names:
+                with self.subTest(name=name):
+                    source = repo / name
+                    before = self.helper["source_tree_snapshot"](repo)
+                    source.write_text("after\n", encoding="utf-8")
+                    self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
+                    source.write_text("before\n", encoding="utf-8")
+                    self.assertEqual(self.helper["source_tree_snapshot"](repo), before)
 
-            source.write_text("after\n", encoding="utf-8")
-            self.assertNotEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
-            source.write_text("before\n", encoding="utf-8")
-            self.assertEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
+                    source.write_text("after\n", encoding="utf-8")
+                    git(repo, "add", "--", name)
+                    git(repo, "commit", "-qm", "mutated")
+                    self.assertNotEqual(self.helper["source_tree_snapshot"](repo), before)
 
-            source.write_text("after\n", encoding="utf-8")
-            git(repo, "add", "source.txt")
-            git(repo, "commit", "-qm", "mutated")
-            self.assertNotEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
-
-            (repo / "generated.txt").write_text("generated\n", encoding="utf-8")
-            self.assertNotEqual(
-                self.helper["source_tree_snapshot"](repo),
-                before,
-            )
+                    generated = repo / ("generated-" + name)
+                    generated.write_text("generated\n", encoding="utf-8")
+                    generated_before = self.helper["source_tree_snapshot"](repo)
+                    generated.write_text("changed\n", encoding="utf-8")
+                    self.assertNotEqual(self.helper["source_tree_snapshot"](repo), generated_before)
 
     def test_rejects_output_paths_inside_reviewed_repository(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -3174,6 +4226,7 @@ class AutoreviewHardeningTests(unittest.TestCase):
             )
             record_path = root / "record.json"
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_MUTATE": str(source),
@@ -3217,9 +4270,8 @@ class AutoreviewHardeningTests(unittest.TestCase):
             tracked.write_bytes(b"\0tracked-before")
             git(repo, "add", "tracked.bin")
             git(repo, "commit", "-qm", "initial")
-            limit = self.helper["MAX_BUNDLE_TEXT_BYTES"]
             untracked = repo / "generated.bin"
-            untracked.write_bytes(b"\0" + b"a" * (limit + 16))
+            untracked.write_bytes(b"\0" + b"a" * 200_000)
             before = self.helper["source_tree_snapshot"](repo)
 
             tracked.write_bytes(b"\0tracked-after!")
@@ -3978,11 +5030,16 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 r"src\index.ts",
             )
 
-            report["findings"][0]["code_location"]["file_path"] = " "
-            with self.assertRaisesRegex(SystemExit, "invalid location"):
-                self.helper["validate_report"](report, repo, {"src/index.ts"}, [])
+            literal = copy.deepcopy(report)
+            literal["findings"][0]["code_location"]["file_path"] = " "
+            self.helper["validate_report"](literal, repo, {" "}, [])
+            self.assertEqual(literal["findings"][0]["code_location"]["file_path"], " ")
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.helper["validate_report"](literal, repo, {"src/index.ts"}, [])
+            self.assertEqual(literal["findings"], [])
+            self.assertEqual(self.helper["review_status"](literal), "incomplete")
 
-            for invalid_path in (123, None, True):
+            for invalid_path in ("", 123, None, True):
                 with self.subTest(invalid_path=invalid_path):
                     report["findings"][0]["code_location"] = {
                         "file_path": invalid_path,
@@ -4198,8 +5255,10 @@ class AutoreviewHardeningTests(unittest.TestCase):
         self.assertIn("streaming-reviewer engine timed out after 0.5s", result.stderr)
         self.assertLess(elapsed, 5)
         child_pid = int(result.stdout.splitlines()[0])
-        with self.assertRaises(ProcessLookupError):
-            os.kill(child_pid, 0)
+        deadline = time.monotonic() + 1
+        while posix_process_is_running(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertFalse(posix_process_is_running(child_pid))
 
     @unittest.skipUnless(os.name == "posix", "detached process groups require POSIX")
     def test_deadline_bounds_drain_when_descendant_retains_pipe(self) -> None:
@@ -4248,18 +5307,44 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertIn("retained-pipe-reviewer engine timed out", result.stderr)
                 self.assertLess(time.monotonic() - started, 2)
 
-    def test_large_repo_relative_evidence_file_is_rejected(self) -> None:
+    def test_large_prompt_and_dataset_files_are_captured_completely(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             repo = init_repo(Path(tempdir))
             evidence = repo / "evidence.txt"
-            evidence.write_text("x" * 600_000, encoding="utf-8")
+            content = "界\r\n" * 120_000 + "COMPLETE_EVIDENCE_TAIL\n"
+            evidence.write_bytes(content.encode("utf-8"))
+            captured = self.helper["capture_evidence_inputs"](
+                argparse.Namespace(prompt=[], prompt_file=["evidence.txt"], dataset=["evidence.txt"]), repo,
+            )
+            self.assertEqual(captured.prompt, "# Prompt file: evidence.txt\n" + content)
+            self.assertEqual(captured.datasets[0].content, content)
+            self.helper["verify_evidence"](repo, captured.files)
 
-            with self.assertRaisesRegex(SystemExit, "file too large to scan safely"):
-                self.helper["validate_evidence_file"](
-                    repo,
-                    "evidence.txt",
-                    "--dataset",
-                )
+    def test_evidence_capture_rejects_files_changed_during_open_or_read(self) -> None:
+        for operation in ("open", "read"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tempdir:
+                repo = init_repo(Path(tempdir))
+                path = repo / "evidence.txt"
+                path.write_bytes(b"review context\n" * 20_000)
+                original = getattr(os, operation)
+                changed = False
+
+                def mutate(*args, **kwargs):
+                    nonlocal changed
+                    if operation == "open" and not changed:
+                        replacement = repo / "replacement.txt"
+                        replacement.write_bytes(path.read_bytes())
+                        replacement.replace(path)
+                    result = original(*args, **kwargs)
+                    if operation == "read" and not changed:
+                        with path.open("ab") as stream:
+                            stream.write(b"new tail\n")
+                    changed = True
+                    return result
+
+                with mock.patch.object(os, operation, side_effect=mutate):
+                    with self.assertRaisesRegex(SystemExit, "file changed while opening|file changed while reading"):
+                        self.helper["capture_evidence_file"](repo, "evidence.txt", "--dataset")
 
     def test_claude_inventory_is_bundle_and_web_only(self) -> None:
         args = argparse.Namespace(
@@ -4306,7 +5391,6 @@ class AutoreviewHardeningTests(unittest.TestCase):
 
         self.assertEqual(
             self.helper["validate_review_patch"](
-                "local unstaged diff",
                 ["safe.py"],
                 patch,
             ),
@@ -4457,6 +5541,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
 ''',
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "CODEX_HOME": str(source_home),
@@ -4553,6 +5638,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             invocations = root / "codex-invocations.jsonl"
             record = root / "codex-record.json"
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env.update(
                 {
                     "AUTOREVIEW_FAKE_CODEX_INVOCATIONS": str(invocations),
@@ -4664,7 +5750,10 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 root / "codex",
                 fake_codex_script(),
             )
+            # Dry run scans the exact prompt too, so use a deterministic
+            # scanner instead of relying on the host installation.
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -4704,6 +5793,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             repo_temp = repo / "tmp"
             repo_temp.mkdir()
             env.update(
@@ -4734,12 +5824,54 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
 
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-            self.assertIn("prompt: OK", result.stdout)
+            self.assertIn("prompt: FAILED", result.stdout)
             self.assertIn("must be outside the reviewed repository", result.stdout)
             self.assertRegex(
                 result.stdout,
                 r"engine check: codex[^\n]* UNAVAILABLE",
             )
+
+    @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
+    def test_dry_run_flag_exits_nonzero_when_trufflehog_missing(self) -> None:
+        # Dry run applies the same exact-pack scan as a real provider call.
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            source = repo / "source.txt"
+            source.write_text("staged\n", encoding="utf-8")
+            git(repo, "add", "source.txt")
+            codex_bin = write_executable(
+                root / "codex",
+                fake_codex_script(),
+            )
+            env = os.environ.copy()
+            env["PATH"] = path_excluding_command("trufflehog")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--mode",
+                    "local",
+                    "--engine",
+                    "codex",
+                    "--codex-bin",
+                    str(codex_bin),
+                    "--dry-run",
+                ],
+                cwd=repo,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("prompt: FAILED", result.stdout)
+            self.assertIn("TruffleHog is required but was not found", result.stdout)
+            self.assertIn(self.helper["TRUFFLEHOG_INSTALL_URL"], result.stdout)
+            # The engine itself still resolves; only trufflehog should fail.
+            self.assertRegex(result.stdout, r"engine check: codex[^\n]* OK\b")
 
     def test_dry_run_flag_exits_nonzero_when_codex_no_tools(self) -> None:
         # run_codex() unconditionally refuses --no-tools; --dry-run must
@@ -4853,6 +5985,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 preflight.__globals__,
                 {
                     "build_review_prompts": capturing,
+                    "scan_outgoing_review_pack": lambda _repo, _prompt: None,
                 },
             ):
                 with contextlib.redirect_stdout(stdout):
@@ -4875,6 +6008,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -4916,6 +6050,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_PI_VERSION"] = "0.50.0"
 
             result = subprocess.run(
@@ -4954,6 +6089,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_pi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -4992,6 +6128,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["AUTOREVIEW_FAKE_KIMI_VERSION"] = "0.10.0"
 
             result = subprocess.run(
@@ -5030,6 +6167,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             # Isolate KIMI_CODE_HOME to an empty, hermetic directory instead
             # of leaking the host's real ~/.kimi-code (which may or may not
             # exist) into this test; an empty source share has no
@@ -5077,6 +6215,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(repo / ".kimi-code")
 
             result = subprocess.run(
@@ -5131,6 +6270,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "device_id").write_text("not-a-valid-id!!", encoding="utf-8")
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5183,6 +6323,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             source_share.mkdir()
             (source_share / "credentials").write_text("not-a-directory", encoding="utf-8")
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5234,6 +6375,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
             )
             (source_share / "credentials").mkdir()
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             env["KIMI_CODE_HOME"] = str(source_share)
 
             result = subprocess.run(
@@ -5278,6 +6420,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_claude_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5307,16 +6450,8 @@ os.execv(target, [str(target), *sys.argv[1:]])
 
     @unittest.skipIf(os.name == "nt", "the fake executable is POSIX-only")
     def test_dry_run_flag_exits_nonzero_when_prompt_unpartitionable(self) -> None:
-        # The real run does not stop at capture_evidence_inputs()'s per-file
-        # checks: main() also builds the final prompt(s) via
-        # build_review_prompts() and rejects context that cannot fit the
-        # aggregate prompt budget even after partitioning (see
-        # build_review_prompts's "leave too little room for change chunks"
-        # branch). Use the Kimi engine's smaller aggregate budget
-        # (KIMI_MAX_PROMPT_BYTES) so a single --prompt-file well under the
-        # per-file 180000-byte scan cap (MAX_BUNDLE_TEXT_BYTES) still blows
-        # the aggregate limit; --dry-run must reuse that same check instead
-        # of reporting readiness for a prompt the real run would refuse.
+        # Instructions remain whole in each pass. Dry-run must enforce the
+        # engine's aggregate prompt budget just like a real review.
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             repo = init_repo(root)
@@ -5328,6 +6463,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_kimi_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
             # Prompt limits must not depend on the host's Kimi configuration.
             env["KIMI_CODE_HOME"] = str(root / "kimi-empty-home")
             (root / "kimi-empty-home").mkdir()
@@ -5385,6 +6521,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5429,6 +6566,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [
@@ -5469,6 +6607,7 @@ os.execv(target, [str(target), *sys.argv[1:]])
                 fake_codex_script(),
             )
             env = os.environ.copy()
+            add_fake_trufflehog(self.helper, root, env)
 
             result = subprocess.run(
                 [


### PR DESCRIPTION
Related: #123858 and #104486. This addresses only the autoreview portion of #104486; the other five skills remain outside this PR.

Canonical changes: [mixed-source ownership (#212)](https://github.com/openclaw/agent-skills/pull/212), [single-checkout scope (#215)](https://github.com/openclaw/agent-skills/pull/215), [scanner/capture boundaries (#218)](https://github.com/openclaw/agent-skills/pull/218), [exact Git sources (#219)](https://github.com/openclaw/agent-skills/pull/219), [literal transport and empty-source attribution (#220)](https://github.com/openclaw/agent-skills/pull/220), and [machine-readable Git diff presentation (#221)](https://github.com/openclaw/agent-skills/pull/221).

## What Problem This Solves

Fixes an issue where developers reviewing a parent checkout could have a nested linked checkout treated as local changes, or have ordinary neighboring files rejected. Each autoreview invocation reviews one checkout, not every worktree in its repository.

OpenClaw's bundled skill also lags canonical mixed-source and scanning repairs. The complete update fixes credential-bearing refusal messages, inline ignore tags bypassing the scanner, valid file/directory replacements being rejected, and leading-colon filenames losing their base identity. It preserves CR/CRLF and literal whitespace in source paths and makes findings on genuinely empty sources representable. The final presentation repair prevents suppressed blank-context markers and forced Git colors from breaking mixed-source capture.

## Why This Change Was Made

This is the complete 13-entry canonical skill, pinned to #221 source `4ef507d51ce0ff2f20fc8899312b2771afe160b2`; canonical merge: [`0cdce5469d49509265333a0ef88e80a574ff8fb6`](https://github.com/openclaw/agent-skills/commit/0cdce5469d49509265333a0ef88e80a574ff8fb6), independently verified merged. It preserves executable modes and the `CLAUDE.md` symlink. The downstream update changes five existing files, without additions or deletions. Shared behavior remains owned by `openclaw/agent-skills`: no OpenClaw-only variant, ignore-rule changes, or automatic child review.

Only genuine registered nested linked checkouts from the same repository are excluded, with registry, private/common-directory, pointer/backlink, and boundary checks. Parent-owned indexed paths and neighboring files remain included. Child edits do not invalidate a parent snapshot; replacement of the excluded boundary does.

## User Impact

Mixed staged and unstaged changes retain base/index/working-tree source records, so an index-only defect is not hidden by a later working-tree fix. File/directory replacements preserve their parent and descendant changes. Git tree/index lookups use literal paths and treat directories as absent files at that exact path; symlinks, gitlinks, and conflicted stages retain their safety checks.

Git output travels through one binary reader with strict UTF-8 decoding. CR/CRLF bytes survive in filenames and patches; root/global-excludes paths lose only the command's final LF delimiter, and finding paths are not whitespace-trimmed. The review JSON excerpt constraint deliberately permits `""` only at column 1 of an exactly empty line, or virtual line 1 of a present zero-byte source. Record/source identity, mode/presence, pass membership, exact location, and genuinely removed-line checks still apply.

The Git diff producer now preserves space-prefixed empty context lines and disables Git-generated color. This repairs deletion line numbers and patch ownership without teaching consumers another presentation format or stripping source bytes. The command arguments reuse the existing seven-pair Git safety policy; the reviewer-engine configuration remains unchanged. External diff programs, text conversion, and rename handling keep their existing guards.

TruffleHog must successfully scan complete frozen input and every outgoing pack, including retries and dry-run preparation. Both filesystem and same-byte binary-descriptor stdin scans must pass: filesystem scanning retains read/extraction failures, while stdin prevents literal or decoded ignore tags from suppressing the gate. Credential refusals no longer echo input headings, filenames, or scanner findings.

File-count/size caps and truncation paths are removed; per-pass prompt/argument budgets and managed reviewer isolation remain. Invalid attribution or required context that cannot fit produces an explicit incomplete/capacity result, not a partial clean verdict. No autoreview CLI flags or environment knobs are added; no OpenClaw configuration, Gateway RPC, or SQLite schema changes.

## Evidence

**Current canonical identity.** Source `4ef507d51ce0ff2f20fc8899312b2771afe160b2` has skill tree `ee04607758dcc727caf82f9a16e8ff166ddab1c6` and helper SHA-256 `6006b3eb8da8bfc1ad7398e0d1106dfb58b48c09e590622f19a77d78bdc4b118`. The complete current copy was individually verified against all 13 canonical entries, including byte content, executable modes, and symlink target. Final verification against the merged canonical tree passed: actual merged skill tree equals the tested candidate, and every actual downstream entry was rechecked against its merged Git blob.

**Current canonical checks, separate from downstream proof.** The #221 source ran 247 Python tests: 42 unit tests plus 205 hardening tests, with 246 passed and one existing raw-non-UTF-8-filename macOS skip. The real TruffleHog companion passed. Eight skill validations, 15 repository tests, 96 Node tests, and syntax checks passed. Local runtime was Python 3.12.13 and Node 24.19.0. Final canonical P0–P2 review found no actionable findings.

[Canonical #221 exact-head CI](https://github.com/openclaw/agent-skills/actions/runs/33624530730): passed on both Linux and Windows, with all CodeQL checks green for head `4ef507d51`. Canonical merge is [`0cdce5469d49509265333a0ef88e80a574ff8fb6`](https://github.com/openclaw/agent-skills/commit/0cdce5469d49509265333a0ef88e80a574ff8fb6), independently verified merged; neither is inferred from local proof. Earlier [#220 Linux/Windows CI](https://github.com/openclaw/agent-skills/actions/runs/33621572500) passed on `0bd3d819`, but is not a substitute for the #221 run.

**Current #221 presentation proof, executed on helper `6006b3eb`.**

| Evidence | Observed behavior |
| --- | --- |
| New 16-case presentation regression | Reported 12 errors on the pre-fix helper; all 16 cases passed after the producer repair |
| Six native blank-context cases | Unset/false/true configuration across default and pinned bases: both true cases failed capture before repair, with deleted line 2 instead of 3 and continuation positions 3 instead of 4; all six passed after repair |
| Eighteen native presentation cases | All 18 passed on the complete frozen helper. The three forced-color cases had failed mixed-source ownership on the baseline; all now retain exact INDEX/WORKING identities and removed-line anchors. Ordinary prefix/context/algorithm/relative-path controls pass; protected capture does not invoke external diff or text-conversion programs |

The 18-case proof first exercised task-owned marker programs through unprotected native Git to show the external-command controls were effective, then verified that protected capture did not invoke them. It used an allowlisted environment and network denial. All children joined, fixtures were removed, and the source snapshot stayed unchanged. No provider or scanner was invoked in this presentation matrix; the real scanner result above comes from the separate full suite.

**Earlier native behavior, retained with its original revision boundary.**

| Evidence | Observed behavior |
| --- | --- |
| [#219 exact Git-source proof](https://github.com/openclaw/agent-skills/pull/219) | 36 checks: 22 valid captures and 14 expected refusals across default/pinned bases, both directory transitions, indexed descendants, conflict stages, symlinks/gitlinks, and literal/tab paths. Eight append-only colon/magic/glob/tab cases retained exact source contents and excluded distractors. This executed #219, not helper `6006b3eb`. |
| [#218 scanner execution records](https://github.com/openclaw/agent-skills/pull/218#inspectable-native-execution-proof) | 14 before/after admission cases and 20 actual TruffleHog 3.97.1 executions. Literal/encoded ignore tags, CRLF/Unicode, and 20 MiB inputs were blocked before dispatch after repair; benign controls passed, and the credential-positive control failed in both versions. Synthetic fixtures, custom detector, loopback verifier, and recording provider stub; no usable credentials or external model. |
| [#220 complete 65-case extract](https://github.com/openclaw/agent-skills/pull/220#inspectable-native-execution-proof) | 15 Git-path contracts met; four literal-whitespace finding paths accepted unchanged; six valid empty anchors accepted; all 40 invalid-anchor controls refused. Six empty-source positives had failed before repair. These 65 checks executed the #220 helper `d16c1a6a`, not a fresh rerun on #221. |
| #220 independent sibling proof | Ten additional native checks passed on the same #220 helper; the lead verified the complete report and process receipts. These ten checks were not rerun as part of the #221 presentation matrix. |

The #220 path checks used real Git and the whole immutable helper. Its empty-anchor cases used actual capture/build-pass/verification owners and TruffleHog, with only reviewer output supplied synthetically. All three 65-case runners exited zero under network denial; exact source identity, joined children, and removed fixtures were checked. These were native macOS behavior proofs, not live reviewer/model-access tests.

The lead compared the four complete scanner/dispatch functions again in the actual #221 copy: `scan_outgoing_review_pack`, `safe_trufflehog_env`, `run_reviewer`, and `run_codex` remain byte-identical to #218. This binds the older native scanner proof to its unchanged owners, not the entire helper; it is not a fresh execution of the older scanner matrix.

**Current actual downstream-copy verification.**

Submitted OpenClaw head: `aa6e5b780e610406c0d08adac4452ef5967108cf`. Its committed skill tree is exactly `ee04607758dcc727caf82f9a16e8ff166ddab1c6`, matching both the tested copy and the canonical merge; the pre-commit formatting hook did not change those bytes.

| Gate | Evidence |
| --- | --- |
| Complete current copy | Passed against #221 head `4ef507d51`: all 13 entries match, including executable modes and symlink target; merged-tree confirmation is passed: actual merged skill tree equals the tested candidate, and every actual downstream entry was rechecked against its merged Git blob |
| Actual-copy tests | Passed: 42 unit tests and 204 hardening tests, plus one existing macOS raw-non-UTF-8 filename skip. Real TruffleHog companion passed. All 13 source identities were unchanged; every child joined with no forced termination or process/fixture leftovers. The lead read the full report and verified all log hashes and current source bytes. |
| Actual-copy native scope | Passed on actual copied helper `6006b3eb`: child-only changes leave the parent clean; neighboring parent input is captured and scanned with real TruffleHog; child markers are excluded; child commit/index/source changes preserve the parent snapshot, while parent-neighbor edits invalidate it. Exit 0, empty stderr, network denied, joined children, removed fixtures, and unchanged source verified. No provider invoked. Boundary replacement retains source/unit coverage, not a claim from this native run. |
| Formatting and final identity | Passed: targeted oxfmt check and git diff --check; all 13 entries reverified after tests and review against the actual canonical merge, preserving modes and symlink target |
| Independent full-diff review | Passed: all three complete-diff review passes returned zero actionable P0–P2 findings (scoped-clean). This was static independent review, not execution of tests by the reviewer. |
| Exact downstream-head CI | [CI33626452257, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33626452257/attempts/2) passed on aa6e5b780e610406c0d08adac4452ef5967108cf; required openclaw/ci-gate is SUCCESS. The first attempt failed fetching pre-commit/pre-commit-hooks before the private-key check ran; a failed-job retry passed that check and the production dependency audit without changing source or scanner policy. |

Current actual-copy test report SHA-256: `b32aa93f772ce508c363654a13a7e0241c92b6f81e5f2dce9061b1deeb6cb06c`. Current native-scope process receipt SHA-256: `d2f3c21ae03d014fe959e06ac004588d3bd689014926b1c9bf5f06c6e2ffcc0f`. Earlier #220 downstream results are not being reused as completed gates for the new #221 copy.

<details>
<summary>Inspectable actual-copy native scope proof</summary>

```text
before_parent_dirty=true
after_parent_dirty=false
after_auto_target=no review target: clean main checkout and no forced mode
before_capture=cannot safely include untracked file scratch/review branch/: not a regular file
after_captured_paths=["scratch/notes.md"]
outgoing_pack_parent_marker=true child_markers=false
real_trufflehog_scan=PASS packs=1
child_head_index_source_change_keeps_parent_snapshot=true
parent_neighbor_change_invalidates_snapshot=true
native_scope_proof=PASS; temporary fixture removed; no provider invoked; source unchanged
```

Raw stdout SHA-256: `8173636efe2a1343418a3cbcd218dc21fd9a59eb3657a582eb0d96e244ccdce3`. The fresh run used complete helper `6006b3eb`, Git, and TruffleHog 3.97.1 under kernel-enforced network denial.

</details>

## Credit and scope

Thanks @jodok for #123858. The six-function comparison against its pinned head `ce0798cf3f0073b8e525439a5b0153758d5f3013`, rechecked in the actual #221 copy, found the retry launcher, zombie-state helper, and resistant-child cleanup test byte-identical. The shared scanner is stronger, and the contributor's two provider/retry tests now exercise both scans and their independent failure cases; refusals use constant diagnostics. The retry/scanning intent and zombie fixes are retained. All six relevant functions are unchanged between #220 and #221. This is source equivalence, not a new provider-runtime test or a fresh check of that PR's current head.

`Co-authored-by: Jodok Batlogg <jodok@batlogg.com>`

Close-out of #123858 follows verification of the replacement on main. #104486 remains only partially addressed: this PR syncs autoreview, not the other five skills.

Current downstream LOC against `719cac4f964d41fc7eae479842d4887cc1a09d52`:

| Surface | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production helper | 857 | 304 | +553 |
| Unit tests | 406 | 27 | +379 |
| Hardening tests | 1,448 | 309 | +1,139 |
| Test harness | 0 | 16 | -16 |
| Skill documentation | 90 | 379 | -289 |

The production growth imports canonical frozen-source ownership and scanning guarantees, including catch-up predating #215. The #220 owner cleanup itself was net −21 production lines; #221's presentation repair removes duplicate policy and is net −12. Removing source records or scans would lose those guarantees; rewriting only the downstream copy would split the owner. The second scan adds intentional work.

This does not promise constant-memory capture or fix trusted global Git line-ending handling. [Global line-ending settings (#216)](https://github.com/openclaw/agent-skills/issues/216) and [streaming capture (#217)](https://github.com/openclaw/agent-skills/issues/217) remain separate follow-ups.
