### PR TITLE
fix(feishu): unset groupPolicy resolved to open instead of the declared allowlist default

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1690,6 +1690,65 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
+  it("drops unlisted group messages when groupPolicy is unset", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg = createFeishuTestConfig({});
+    const event = createFeishuTestEvent({
+      messageId: "msg-unset-group-policy-unlisted",
+      chatId: "oc-group",
+      chatType: "group",
+    });
+
+    const runtime = await dispatchMessage({ cfg, event, botOpenId: "ou-bot" });
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("group oc-group not in groupAllowFrom (groupPolicy=allowlist)"),
+    );
+    expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("requires a mention in allowlisted groups when groupPolicy is unset", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg = createFeishuTestConfig({ groupAllowFrom: ["oc-group"] });
+    const unmentioned = createFeishuTestEvent({
+      messageId: "msg-unset-group-policy-unmentioned",
+      chatId: "oc-group",
+      chatType: "group",
+    });
+
+    const runtime = await dispatchMessage({ cfg, event: unmentioned, botOpenId: "ou-bot" });
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("message in group oc-group did not mention bot"),
+    );
+    expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+
+    const mentioned = createFeishuTestEvent({
+      messageId: "msg-unset-group-policy-mentioned",
+      chatId: "oc-group",
+      chatType: "group",
+      text: "@_user_1 hello",
+      message: {
+        mentions: [{ key: "@_user_1", id: { open_id: "ou-bot" }, name: "Bot", tenant_key: "" }],
+      },
+    });
+
+    await dispatchMessage({ cfg, event: mentioned, botOpenId: "ou-bot" });
+
+    const context = mockCallArg<{ ChatType?: string; GroupRequireMention?: boolean }>(
+      mockFinalizeInboundContext,
+      0,
+      0,
+    );
+    expect(context.ChatType).toBe("group");
+    expect(context.GroupRequireMention).toBe(true);
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
   it("verifies app-scoped bot mention ids before admitting bot-authored events", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     const baseFeishuConfig = {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -23,8 +23,8 @@ import {
 } from "openclaw/plugin-sdk/reply-history";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import {
+  resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
-  resolveOpenProviderRuntimeGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
@@ -583,11 +583,12 @@ export async function handleFeishuMessage(params: {
       return;
     }
     const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
-    const { groupPolicy, providerMissingFallbackApplied } = resolveOpenProviderRuntimeGroupPolicy({
-      providerConfigPresent: cfg.channels?.feishu !== undefined,
-      groupPolicy: feishuCfg?.groupPolicy,
-      defaultGroupPolicy,
-    });
+    const { groupPolicy, providerMissingFallbackApplied } =
+      resolveAllowlistProviderRuntimeGroupPolicy({
+        providerConfigPresent: cfg.channels?.feishu !== undefined,
+        groupPolicy: feishuCfg?.groupPolicy,
+        defaultGroupPolicy,
+      });
     warnMissingProviderGroupPolicyFallbackOnce({
       providerMissingFallbackApplied,
       providerKey: "feishu",

--- a/extensions/feishu/src/read-policy.test.ts
+++ b/extensions/feishu/src/read-policy.test.ts
@@ -249,6 +249,22 @@ describe("Feishu read policy", () => {
     ).toBe("oc_group");
   });
 
+  it("fails closed to allowlist for group reads when groupPolicy is unset", () => {
+    const account = createAccount();
+    account.config = { dmPolicy: "pairing" } as ResolvedFeishuAccount["config"];
+
+    expect(() =>
+      assertFeishuChatReadAllowed({
+        cfg,
+        account,
+        chatId: "oc_group",
+        chatType: "group",
+        ctx: {},
+      }),
+    ).toThrow("Feishu read target is not allowed.");
+    expect(canEnumerateAllFeishuGroups(cfg, account)).toBe(false);
+  });
+
   it("allows the trusted current DM when groups are disabled", () => {
     const account = createAccount();
     account.config = {

--- a/extensions/feishu/src/read-policy.ts
+++ b/extensions/feishu/src/read-policy.ts
@@ -7,8 +7,8 @@ import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-co
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
+  resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
-  resolveOpenProviderRuntimeGroupPolicy,
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeFeishuChatType } from "./chat-type.js";
@@ -89,7 +89,7 @@ function isCurrentChat(params: {
 }
 
 function resolveFeishuReadGroupPolicy(cfg: OpenClawConfig, account: ResolvedFeishuAccount) {
-  return resolveOpenProviderRuntimeGroupPolicy({
+  return resolveAllowlistProviderRuntimeGroupPolicy({
     providerConfigPresent: cfg.channels?.feishu !== undefined,
     groupPolicy: account.config.groupPolicy,
     defaultGroupPolicy: resolveDefaultGroupPolicy(cfg),


### PR DESCRIPTION
Related: #119740 (iMessage sibling: an externalized channel with no `groupPolicy` answered every group; not closed by this PR)
Related: #136267 (docs PR; it leaves the Feishu "default: allowlist" wording alone, which this PR makes true at runtime)

## What Problem This Solves

Fixes an issue where a Feishu operator who configures `channels.feishu` with `appId` and `appSecret` and never sets `groupPolicy` gets a bot that answers every message in every group it has been added to, with no @-mention required, while `openclaw security audit` stays silent.

`extensions/feishu/src/config-schema.ts` declares `groupPolicy: FeishuGroupPolicySchema.optional().default("allowlist")`, `docs/channels/feishu.md` documents "default: allowlist", and the Feishu security-audit collector in `extensions/feishu/src/channel.ts` is built with `createAllowlistProviderGroupPolicyWarningCollector`. The inbound handler in `extensions/feishu/src/bot.ts` and the read-action gate in `extensions/feishu/src/read-policy.ts` resolved the effective policy with `resolveOpenProviderRuntimeGroupPolicy`, which maps configured-provider plus unset key to `"open"` (`src/config/runtime-group-policy.ts`). `resolveFeishuReplyPolicy` in `extensions/feishu/src/policy.ts` then turns `"open"` into `requireMention: false`.

The declared schema default never reaches the runtime. The config loader applies channel defaults from each plugin's exported JSON schema (`src/config/validation.ts`, `validatePluginSchemaValue(... applyDefaults: true)`), and Feishu exports its schema with `jsonSchemaMode: "input"` (`extensions/feishu/src/config-schema.ts`, since #107336), so the transform-backed `groupPolicy` carries no `default` in the exported JSON schema. Discord, LINE and iMessage load with `groupPolicy: "allowlist"` materialized; Feishu loads with `groupPolicy` undefined and falls through to the resolver's open fallback.

## Why This Change Was Made

`extensions/feishu/src/bot.ts` and `extensions/feishu/src/read-policy.ts` now resolve with `resolveAllowlistProviderRuntimeGroupPolicy`, the resolver whose configured-provider fallback is `"allowlist"`. It is the resolver the Feishu audit collector already uses, and the one IRC, LINE, Matrix, Mattermost and Google Chat use for the same declared default. Explicit `channels.feishu.groupPolicy`, per-account overrides and `channels.defaults.groupPolicy` keep precedence exactly as before; only the case where nothing sets a policy changes, from `open` to `allowlist`. The missing-provider fail-closed path and its one-time warning are unchanged.

The runtime resolver is the right boundary. It is the single place that owns the effective Feishu policy for inbound messages and read actions, and it must not depend on whether the loader happened to materialize a JSON-schema default. Restoring the `default` in the exported input-mode schema would only help the Form editor and is left as a follow-up; it is not needed for the runtime to be safe. Zalo is untouched: its docs deliberately state open-when-configured and its schema declares no default.

Operators who relied on the undocumented open fallback must now set `channels.feishu.groupPolicy: "open"` explicitly, and `openclaw security audit` will then report it, as intended.

## User Impact

- Feishu groups fail closed by default, matching the docs, the schema and the security audit: unlisted groups are dropped and allowlisted groups require an @-mention unless `requireMention` is set.
- `channels.defaults.groupPolicy` and explicit Feishu policies behave as before.
- Read actions on Feishu groups that are neither the current chat nor allowlisted are denied by default instead of allowed.

## Evidence

See the Real behavior proof block below: real config loader, real account resolution and the real `handleFeishuMessage` handler driven on pristine main and on this patch with identical inputs, zero network attempts on either run.

## Verification

- `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts extensions/feishu/src/read-policy.test.ts`: 121 passed on this branch. The same two files with the three new tests copied onto pristine main `7ab7eb8aab5`: 3 failed, 118 passed (all three new tests fail on main).
- `node scripts/run-vitest.mjs extensions/feishu`: 101 files, 1972 tests passed.
- `./node_modules/.bin/oxfmt --check` on the four changed files: clean.
- `node scripts/run-oxlint.mjs` (with the plugin-sdk boundary prepare step) on the four changed files: clean. With `OPENCLAW_OXLINT_SKIP_PREPARE=1` the only report is a pre-existing type-resolution finding on an untouched line of `read-policy.ts` that reproduces identically on pristine main.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json`: one pre-existing error unrelated to this change (`extensions/browser/src/browser/chrome-mcp-options.ts` TS7016, missing `yargs-parser` types in this environment), identical on pristine main.
- `git diff --check`: clean.

Production LOC: +9/-8 in two files (two import swaps and two call-site swaps; the rest is the formatter reflowing one call). Tests: +75 across two existing suites.

## Real behavior proof
Behavior addressed: With `channels.feishu` configured and `groupPolicy` unset, a group message from any member in any group, with no @-mention, was dispatched to the agent; it is now dropped for unlisted groups and mention-gated for allowlisted groups.
Real environment tested: Real `loadConfig()` from `src/config/io.runtime.ts` on an `openclaw.json` under an isolated `OPENCLAW_STATE_DIR`, real `resolveFeishuAccount`, real `handleFeishuMessage` from `extensions/feishu/src/bot.ts` (account resolution, group policy resolution, ingress resolver, reply policy and sender activation all real), driven on pristine main `7ab7eb8aab5` and on this patch (head `7b8a39a40cf9a0b8ac6a79e61570a338c189a960`) with identical config and events. The only replaced seam is the core plugin runtime handed to the Feishu handler: the agent dispatch (`channel.inbound.run`) records that dispatch was reached and returns without running an agent, and the text chunking helpers are inert. `http.request`, `https.request` and `fetch` were replaced with throwing guards for the whole run and the Feishu group-name cache was pre-seeded, so no Feishu API call is attempted. Network attempts observed: 0 on both runs.
Exact steps or command run after this patch: `REPO=<worktree> STATE_DIR=<scratch> node --import ./scripts/tsx.mjs handler-probe.mts` with config `{"channels":{"feishu":{"appId":"cli_probe","appSecret":"probe-secret","resolveSenderNames":false,"groupAllowFrom":["oc_listed"]}}}` and three synthetic group events from `ou_member`: A in `oc_unlisted` with no mention, B in `oc_listed` with no mention, C in `oc_listed` mentioning the bot `ou_bot`.
Evidence after fix:
```
# BEFORE (pristine main 7ab7eb8aab5)
loadConfig() channels.feishu.groupPolicy = undefined
resolveFeishuAccount().config.groupPolicy = undefined
[A] group=oc_unlisted mention=false -> feishu[default]: dispatch complete (queuedFinal=false, replies=0)
[B] group=oc_listed mention=false -> feishu[default]: dispatch complete (queuedFinal=false, replies=0)
[C] group=oc_listed mention=true -> feishu[default]: dispatch complete (queuedFinal=false, replies=0)
network attempts during probe: 0
# AFTER (this patch, identical inputs)
loadConfig() channels.feishu.groupPolicy = undefined
resolveFeishuAccount().config.groupPolicy = undefined
[A] group=oc_unlisted mention=false -> feishu[default]: group oc_unlisted not in groupAllowFrom (groupPolicy=allowlist)
[B] group=oc_listed mention=false -> feishu[default]: message in group oc_listed did not mention bot
[C] group=oc_listed mention=true -> feishu[default]: dispatch complete (queuedFinal=false, replies=0)
network attempts during probe: 0
```
Observed result after fix: The loaded config still carries no `groupPolicy`, but the handler now resolves it to `allowlist`: the unlisted group is dropped, the allowlisted group without a mention is held back, and the mentioned message in the allowlisted group is still dispatched.
What was not tested: No live Feishu tenant or WebSocket event stream; the agent turn itself was not run. The Control UI Form editor still shows no default for `groupPolicy` because the exported input-mode schema carries none; that is a separate cosmetic follow-up.



