### PR TITLE
fix(sessions): display ACP metadata from the selected agent

### DIFF
--- a/src/commands/sessions.acp-model-display.test.ts
+++ b/src/commands/sessions.acp-model-display.test.ts
@@ -2,144 +2,193 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
-import type { SessionEntry } from "../config/sessions/types.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import {
-  mockSessionsConfig,
-  resetMockSessionsConfig,
-  runSessionsJson,
-  setMockSessionsConfig,
-  writeStore,
-} from "./sessions.test-helpers.js";
-
-mockSessionsConfig();
-
-const { sessionsCommand } = await import("./sessions.js");
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import { enforceSqliteSessionHistoryDiskBudget } from "../config/sessions/session-history-eviction.js";
+import { resolveMaintenanceConfig } from "../config/sessions/store-maintenance-runtime.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawAgentDatabases } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { sessionsCommand } from "./sessions.js";
 
 const ACP_SESSION_KEY = "agent:copilot:acp:86b7b5af-3773-4a56-b244-069d6c5d3db9";
 const AGENT_CONFIGURED_MODEL = "gpt-5.3-codex";
 const AGENT_CONFIGURED_PROVIDER = "microsoft-foundry";
 
-let originalStateDir: string | undefined;
-let tempStateDirs: string[] = [];
+type SessionRow = {
+  key: string;
+  agentId: string;
+  model: string;
+  modelProvider: string;
+  acpRuntime: boolean;
+  agentRuntime: { id: string; source: string };
+};
 
-function useTempStateDir(): void {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-acp-sessions-state-"));
-  tempStateDirs.push(stateDir);
-  process.env.OPENCLAW_STATE_DIR = stateDir;
+let stateDir: string;
+let cfg: OpenClawConfig;
+const stores = new Map<string, string>();
+
+function configureAgents(agentIds: string[]): void {
+  cfg = {
+    agents: {
+      ownership: "explicit",
+      entries: Object.fromEntries(agentIds.map((id) => [id, {}])),
+      defaults: {
+        model: { primary: `${AGENT_CONFIGURED_PROVIDER}/${AGENT_CONFIGURED_MODEL}` },
+        models: {
+          [`${AGENT_CONFIGURED_PROVIDER}/${AGENT_CONFIGURED_MODEL}`]: {
+            agentRuntime: { id: "openclaw" },
+          },
+        },
+      },
+    },
+  };
+  setRuntimeConfigSnapshot(cfg);
 }
 
-function writeAcpRuntimeMeta(sessionKey: string): void {
-  writeAcpSessionMetaForMigration({
+function writeSession(agentId: string, sessionKey: string, sessionId = `${agentId}-session`): void {
+  const storePath = path.join(stateDir, "agents", agentId, "agent", "openclaw-agent.sqlite");
+  stores.set(agentId, storePath);
+  replaceSessionEntrySync(
+    { agentId, sessionKey, storePath },
+    {
+      sessionId,
+      lifecycleRevision: `${sessionId}-revision`,
+      updatedAt: Date.now() - 4 * 60_000,
+    },
+  );
+}
+
+async function writeAcpRuntimeMeta(agentId: string, sessionKey: string): Promise<void> {
+  await upsertAcpSessionMeta({
+    cfg,
+    agentId,
     sessionKey,
-    lifecycleRevision: undefined,
-    meta: {
-      backend: "copilot",
-      agent: "copilot",
-      runtimeSessionName: "acp-runtime-session-1",
+    mutate: () => ({
+      backend: agentId,
+      agent: agentId,
+      runtimeSessionName: `${agentId}-runtime-session`,
       mode: "persistent",
       state: "idle",
-      lastActivityAt: Date.now() - 2 * 60_000,
-    },
+      lastActivityAt: Date.now(),
+    }),
   });
 }
 
-function mockAgentConfigWithCopilotModel(): void {
-  setMockSessionsConfig(() => ({
-    agents: {
-      list: [
-        {
-          id: "copilot",
-          model: { primary: `${AGENT_CONFIGURED_PROVIDER}/${AGENT_CONFIGURED_MODEL}` },
-        },
-      ],
-      defaults: {},
+async function readSessions(): Promise<SessionRow[]> {
+  const logs: string[] = [];
+  await sessionsCommand(
+    { json: true, allAgents: true },
+    {
+      log: (message: unknown) => logs.push(String(message)),
+      error: (message: unknown) => {
+        throw new Error(String(message));
+      },
+      exit: (code) => {
+        throw new Error(`Unexpected exit ${code}`);
+      },
     },
-  }));
-}
-
-function buildAcpBridgeSessionEntry(): SessionEntry {
-  return {
-    sessionId: "acp-bridge-session-id",
-    updatedAt: Date.now() - 4 * 60_000,
-  };
-}
-
-async function readSessionRow(sessionKey: string, store: string) {
-  const payload = await runSessionsJson<{
-    sessions?: Array<{
-      key: string;
-      model?: string | null;
-      modelProvider?: string | null;
-    }>;
-  }>(sessionsCommand, store);
-  return payload.sessions?.find((entry) => entry.key === sessionKey);
+  );
+  return (JSON.parse(logs.join("\n")) as { sessions: SessionRow[] }).sessions;
 }
 
 describe("sessionsCommand ACP model display", () => {
   beforeEach(() => {
-    originalStateDir = process.env.OPENCLAW_STATE_DIR;
-    mockAgentConfigWithCopilotModel();
+    stateDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-acp-sessions-")));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    configureAgents(["copilot"]);
   });
 
-  afterEach(() => {
-    closeOpenClawStateDatabaseForTest();
-    for (const stateDir of tempStateDirs) {
+  afterEach(async () => {
+    try {
+      // The native ACP writer schedules maintenance; settle its FIFO before closing the fixture.
+      const maintenance = resolveMaintenanceConfig();
+      await Promise.all(
+        [...stores].map(([agentId, storePath]) =>
+          enforceSqliteSessionHistoryDiskBudget({
+            agentId,
+            storePath,
+            mode: maintenance.mode,
+            maintenance,
+          }),
+        ),
+      );
+    } finally {
+      closeOpenClawAgentDatabases(stateDir);
+      closeOpenClawStateDatabase();
+      clearRuntimeConfigSnapshot();
+      stores.clear();
       fs.rmSync(stateDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
     }
-    tempStateDirs = [];
-    if (originalStateDir === undefined) {
-      delete process.env.OPENCLAW_STATE_DIR;
-    } else {
-      process.env.OPENCLAW_STATE_DIR = originalStateDir;
-    }
-    resetMockSessionsConfig();
   });
 
-  it("reports the ACP runtime sentinel for control-plane sessions", async () => {
-    useTempStateDir();
-    writeAcpRuntimeMeta(ACP_SESSION_KEY);
-    const store = await writeStore(
-      { [ACP_SESSION_KEY]: buildAcpBridgeSessionEntry() },
-      "sessions-acp-model-display",
-      { agentId: "copilot" },
-    );
+  it.each([ACP_SESSION_KEY, "agent:copilot:acp:binding:discord:default:feedface"])(
+    "reports native ACP metadata for %s",
+    async (sessionKey) => {
+      writeSession("copilot", sessionKey);
+      await writeAcpRuntimeMeta("copilot", sessionKey);
 
-    const row = await readSessionRow(ACP_SESSION_KEY, store);
-
-    expect(row).toMatchObject({ model: "copilot-acp", modelProvider: "acpx" });
-  });
-
-  it("reads canonical ACP store keys before querying runtime metadata", async () => {
-    useTempStateDir();
-    const sessionKey = "agent:copilot:acp:binding:discord:default:feedface";
-    const store = await writeStore(
-      { [sessionKey]: buildAcpBridgeSessionEntry() },
-      "sessions-acp-model-display-canonical",
-      { agentId: "copilot" },
-    );
-    writeAcpRuntimeMeta(sessionKey);
-
-    const row = await readSessionRow(sessionKey, store);
-
-    expect(row).toMatchObject({ model: "copilot-acp", modelProvider: "acpx" });
-  });
+      expect(await readSessions()).toMatchObject([
+        {
+          key: sessionKey,
+          model: "copilot-acp",
+          modelProvider: "acpx",
+          acpRuntime: true,
+          agentRuntime: { id: "copilot", source: "session-key" },
+        },
+      ]);
+    },
+  );
 
   it("keeps the configured model for ACP-shaped bridge sessions without runtime metadata", async () => {
     const sessionKey = "agent:copilot:acp:bridge-session-1";
-    const store = await writeStore(
-      { [sessionKey]: buildAcpBridgeSessionEntry() },
-      "sessions-acp-model-display-bridge",
-      { agentId: "copilot" },
-    );
+    writeSession("copilot", sessionKey);
 
-    const row = await readSessionRow(sessionKey, store);
+    expect(await readSessions()).toMatchObject([
+      {
+        key: sessionKey,
+        model: AGENT_CONFIGURED_MODEL,
+        modelProvider: AGENT_CONFIGURED_PROVIDER,
+        acpRuntime: false,
+        agentRuntime: { id: "openclaw", source: "model" },
+      },
+    ]);
+  });
 
-    expect(row).toMatchObject({
+  it("keeps each selected owner's metadata and rejects a replaced lifecycle", async () => {
+    configureAgents(["copilot", "reviewer"]);
+    const reviewerSessionKey = "agent:reviewer:acp:current-session";
+    for (const [agentId, sessionKey] of [
+      ["copilot", ACP_SESSION_KEY],
+      ["reviewer", reviewerSessionKey],
+    ] as const) {
+      writeSession(agentId, sessionKey);
+      await writeAcpRuntimeMeta(agentId, sessionKey);
+    }
+    const before = await readSessions();
+    for (const agentId of ["copilot", "reviewer"]) {
+      expect(before.find((row) => row.agentId === agentId)).toMatchObject({
+        model: `${agentId}-acp`,
+        modelProvider: "acpx",
+        acpRuntime: true,
+        agentRuntime: { id: agentId, source: "session-key" },
+      });
+    }
+
+    writeSession("reviewer", reviewerSessionKey, "reviewer-replacement");
+    const after = await readSessions();
+    expect(after.find((row) => row.agentId === "copilot")).toMatchObject({
+      acpRuntime: true,
+      agentRuntime: { id: "copilot", source: "session-key" },
+    });
+    expect(after.find((row) => row.agentId === "reviewer")).toMatchObject({
       model: AGENT_CONFIGURED_MODEL,
       modelProvider: AGENT_CONFIGURED_PROVIDER,
+      acpRuntime: false,
+      agentRuntime: { id: "openclaw", source: "model" },
     });
   });
 });

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -367,8 +367,10 @@ export async function sessionsCommand(
       });
   });
   const acpSessionMetaByEntry = readAcpSessionMetaBatch({
-    entries: sessionEntries.map(({ acpSessionKey, entry }) => ({
+    cfg,
+    entries: sessionEntries.map(({ acpSessionKey, agentId, entry }) => ({
       sessionKey: acpSessionKey,
+      agentId,
       entry,
     })),
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users listing ACP sessions could see the configured model instead of the active ACP runtime and model, even though the normal ACP writer had saved the metadata successfully.

## Why This Change Was Made

The sessions command already knows the selected agent and configuration, but dropped both when loading ACP metadata in a batch. The canonical writer stores metadata under the agent-qualified identity, so the ownerless read missed it. Pass those existing facts to the reader, matching the Gateway listing path. No schema, migration, configuration, API, or fallback changes are needed.

The regression tests now use normal session and ACP writers instead of migration-only seeds. They cover both ACP key shapes, an ACP-shaped session without metadata, multiple selected agents, and replacement of one agent's lifecycle without disturbing another.

## User Impact

Session listings correctly display the persisted ACP runtime and model. Sessions without current ACP metadata retain their existing configured-model behavior. Listing does not change durable session entries.

## Evidence

- The same five complete test files produce 62 passing cases and three expected failures before the fix, then 65 passing cases after it, with no skips. All 65 also pass after rebasing onto current main.
- A real source flow loads a config file, writes a canonical session and ACP metadata through normal producers, and calls `sessionsCommand`: the resulting row reports the ACP model, provider, runtime, and attribution correctly. Maintenance was awaited and database handles closed. This is local source-flow proof, not an external ACP runtime, provider request, or Gateway transport test.
- `check:changed` passes. Its initial new-test type errors were corrected and the complete before/after proof rerun.
- Independent Codex review returned no actionable findings in its selected scope. Direct review covered the command, canonical metadata producer/reader, lifecycle fence, and Gateway sibling.

Production changes are 3 added / 1 removed lines (net +2) to carry the two required existing owner facts. Tests are 154 added / 105 removed (net +49), replacing the misleading fixtures. This is a correctness repair discovered during performance work; no speed improvement is claimed or counted.
