### PR TITLE
fix(sessions): decouple maintenance from entry writes

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -22,7 +22,8 @@ import {
 } from "./session-store.js";
 import { resolveSession } from "./session.js";
 
-const { listSessionEntriesCore, loadSessionEntry, replaceSessionEntry } = sessionAccessor;
+const { listSessionEntriesCore, loadSessionEntry, patchSessionEntryCore, replaceSessionEntry } =
+  sessionAccessor;
 
 vi.mock("../model-selection.js", () => ({
   isCliProvider: (provider: string, _cfg?: OpenClawConfig) =>
@@ -93,7 +94,11 @@ async function seedSessionStore(
   entries: Record<string, SessionEntry>,
 ): Promise<void> {
   for (const [sessionKey, entry] of Object.entries(entries)) {
-    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    await patchSessionEntryCore({ storePath, sessionKey }, () => entry, {
+      fallbackEntry: entry,
+      replaceEntry: true,
+      skipMaintenance: true,
+    });
   }
 }
 
@@ -470,10 +475,15 @@ describe("updateSessionStoreAfterAgentRun", () => {
         result,
       });
 
-      const persisted = loadPersistedSessionStore(storePath);
-      expect(Object.keys(persisted)).toHaveLength(42);
-      expect(persisted[sessionKey]?.sessionId).toBe(sessionId);
-      expect(persisted["agent:main:stale:44"]).toBeUndefined();
+      await vi.waitFor(
+        () => {
+          const persisted = loadPersistedSessionStore(storePath);
+          expect(Object.keys(persisted)).toHaveLength(42);
+          expect(persisted[sessionKey]?.sessionId).toBe(sessionId);
+          expect(persisted["agent:main:stale:44"]).toBeUndefined();
+        },
+        { timeout: 5_000 },
+      );
     });
   });
 

--- a/src/auto-reply/reply/session-fork.test.ts
+++ b/src/auto-reply/reply/session-fork.test.ts
@@ -2,12 +2,13 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   loadSessionEntry,
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.sqlite-entry.js";
 import { replaceTranscriptEvents } from "../../config/sessions/session-accessor.sqlite-transcript-write.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -96,7 +97,7 @@ describe("forkSessionEntryFromParent", () => {
     const sessionKey = "agent:main:subagent:child";
     const staleSessionKey = "agent:main:subagent:stale-child";
 
-    await replaceSessionEntry(
+    replaceSessionEntrySync(
       {
         agentId: "main",
         sessionKey: staleSessionKey,
@@ -164,6 +165,14 @@ describe("forkSessionEntryFromParent", () => {
           targetId: "active-answer",
         },
       ],
+    );
+    await vi.waitFor(
+      () => {
+        expect(loadSessionEntry({ agentId: "main", sessionKey: staleSessionKey, storePath })).toBe(
+          undefined,
+        );
+      },
+      { timeout: 5_000 },
     );
 
     const fallbackEntry: InternalSessionEntry = {

--- a/src/config/sessions/incognito-session-transcript.test.ts
+++ b/src/config/sessions/incognito-session-transcript.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -335,11 +335,13 @@ describe("incognito transcript access", () => {
         },
       });
 
-      expect(
-        listSessionEntriesCore({ agentId: "main", env, storePath }).map(
-          (summary) => summary.sessionKey,
-        ),
-      ).toEqual([activeScope.sessionKey]);
+      await vi.waitFor(() => {
+        expect(
+          listSessionEntriesCore({ agentId: "main", env, storePath }).map(
+            (summary) => summary.sessionKey,
+          ),
+        ).toEqual([activeScope.sessionKey]);
+      });
       await expect(
         loadTranscriptEvents({
           ...staleScope,

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -728,10 +728,15 @@ describe.each([publicAccessorAdapter, sqliteAdapter])(
           ...scope,
           sessionKey: "agent:main:stale-under-cap",
         };
-        await replaceSessionEntry(staleScope, {
+        const staleEntry = {
           model: "stale",
           sessionId: "stale-under-cap",
           updatedAt: Date.now() - 31 * 24 * 60 * 60 * 1000,
+        };
+        await patchSessionEntryCore(staleScope, () => staleEntry, {
+          fallbackEntry: staleEntry,
+          replaceEntry: true,
+          skipMaintenance: true,
         });
 
         await upsertSessionEntryCore(scope, {
@@ -740,7 +745,9 @@ describe.each([publicAccessorAdapter, sqliteAdapter])(
           updatedAt: Date.now(),
         });
 
-        expect(loadSessionEntry(staleScope)).toBeUndefined();
+        await vi.waitFor(() => {
+          expect(loadSessionEntry(staleScope)).toBeUndefined();
+        });
         expect(loadSessionEntry(scope)).toMatchObject({
           model: "fresh",
           sessionId: "fresh-session",
@@ -1524,7 +1531,7 @@ describe("sqlite session normalization", () => {
     expect(route).toEqual({ current_session_id: "current-session" });
   });
 
-  it("applies SQLite session-entry maintenance inside entry write transactions", async () => {
+  it("applies SQLite session-entry maintenance after entry writes", async () => {
     vi.mocked(getRuntimeConfig).mockReturnValue({
       session: {
         maintenance: {
@@ -1604,11 +1611,20 @@ describe("sqlite session normalization", () => {
     await patchSessionEntryCore(scopeFor("agent:main:active"), () => ({
       providerOverride: "openai",
     }));
-    unsubscribe();
-
-    expect(new Set(notify.mock.calls.map(([mutation]) => mutation.previous.sessionId))).toEqual(
-      new Set(["older-session", "stale-session"]),
+    let archivedStale: string[] = [];
+    await vi.waitFor(
+      () => {
+        expect(new Set(notify.mock.calls.map(([mutation]) => mutation.previous.sessionId))).toEqual(
+          new Set(["older-session", "stale-session"]),
+        );
+        archivedStale = fs
+          .readdirSync(paths.tempDir)
+          .filter((file) => file.startsWith("stale-session.jsonl.deleted."));
+        expect(archivedStale).toHaveLength(1);
+      },
+      { timeout: 5_000 },
     );
+    unsubscribe();
     expect(
       listSessionEntryRows({
         agentId: "main",
@@ -1624,10 +1640,6 @@ describe("sqlite session normalization", () => {
         storePath: paths.sqlitePath,
       }),
     ).resolves.toEqual([]);
-    const archivedStale = fs
-      .readdirSync(paths.tempDir)
-      .filter((file) => file.startsWith("stale-session.jsonl.deleted."));
-    expect(archivedStale).toHaveLength(1);
     expect(
       readSessionArchiveContentSync(path.join(paths.tempDir, archivedStale[0] ?? ""))
         .trim()
@@ -1653,13 +1665,18 @@ describe("sqlite session normalization", () => {
       },
     );
 
-    expect(
-      listSessionEntryRows({
-        agentId: "main",
-        env,
-        storePath: paths.sqlitePath,
-      }).map((summary) => summary.sessionKey),
-    ).toEqual(["agent:main:newer", "agent:main:newest"]);
+    await vi.waitFor(
+      () => {
+        expect(
+          listSessionEntryRows({
+            agentId: "main",
+            env,
+            storePath: paths.sqlitePath,
+          }).map((summary) => summary.sessionKey),
+        ).toEqual(["agent:main:newer", "agent:main:newest"]);
+      },
+      { timeout: 5_000 },
+    );
   });
 
   it("commits unrelated channel sessions without invoking stored channel plugin resolvers", async () => {
@@ -1772,7 +1789,9 @@ describe("sqlite session normalization", () => {
       },
     );
 
-    expect(loadSessionEntry(scopeFor(dashboardKey))?.archivedAt).toEqual(expect.any(Number));
+    await vi.waitFor(() => {
+      expect(loadSessionEntry(scopeFor(dashboardKey))?.archivedAt).toEqual(expect.any(Number));
+    });
     await expect(
       loadTranscriptEvents({
         agentId: "main",
@@ -1937,13 +1956,15 @@ describe("sqlite session normalization", () => {
       pinnedAt: 2,
       sessionId: pinnedSessionId,
     });
-    expect(
-      listSessionEntryRows({
-        agentId: "main",
-        env,
-        storePath: paths.sqlitePath,
-      }).map((summary) => summary.sessionKey),
-    ).toEqual(["agent:main:maintenance-trigger", pinnedKey]);
+    await vi.waitFor(() => {
+      expect(
+        listSessionEntryRows({
+          agentId: "main",
+          env,
+          storePath: paths.sqlitePath,
+        }).map((summary) => summary.sessionKey),
+      ).toEqual(["agent:main:maintenance-trigger", pinnedKey]);
+    });
     await expect(
       loadTranscriptEvents({
         agentId: "main",

--- a/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts
@@ -862,7 +862,7 @@ describe("SQLite lifecycle cleanup races", () => {
       ids.toSorted((left, right) => left.localeCompare(right)).map((id) => [id]),
     );
   });
-  it("commits large maintenance cleanup in bounded retry-safe batches", async () => {
+  it("continues a maintenance batch after one entry changes", async () => {
     const entryCount = 66;
     const historicalSessionId = "maintenance-batch-historical-session";
     const sessionKeyById = new Map<string, string>();
@@ -926,10 +926,10 @@ describe("SQLite lifecycle cleanup races", () => {
     expect(batchSizes).toEqual([64, 2]);
     expect(result).toMatchObject({
       beforeCount: entryCount,
-      afterCount: 3,
+      afterCount: 2,
       modelRunPruned: 0,
       pruned: 0,
-      capped: 63,
+      capped: 64,
     });
     expect(loadSessionEntry({ sessionKey: racedKey ?? "", storePath })).toMatchObject({
       label: "changed during batch materialization",

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -44,11 +44,7 @@ import {
 } from "./session-accessor.sqlite-entry-store.js";
 import { listTranscriptInstancesFromDatabase } from "./session-accessor.sqlite-history.js";
 import { emitCommittedSessionIdentityDiff } from "./session-accessor.sqlite-identity.js";
-import type { SessionEntryMaintenancePlan } from "./session-accessor.sqlite-lifecycle-types.js";
-import {
-  applySessionEntryMaintenance,
-  finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
-} from "./session-accessor.sqlite-maintenance.js";
+import { kickSessionEntryMaintenanceAfterWrite } from "./session-accessor.sqlite-maintenance-kick.js";
 import {
   createFallbackSessionEntry,
   coerceSqliteNumber,
@@ -495,13 +491,14 @@ async function patchSqliteSessionEntrySnapshot(
   params: SqliteSessionEntrySnapshotPatchParams,
 ): Promise<SessionEntry | null> {
   const { options, resolved, sessionKey } = params;
+  let wrote = false;
   const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const prepared = params.readSnapshot(database);
     const existing = prepared[0]?.entry;
     const writeBase = existing ?? options.fallbackEntry;
     if (!writeBase) {
-      return { maintenancePlans: [], result: null };
+      return null;
     }
     const patch = await params.update(cloneSessionEntry(writeBase), {
       existingEntry: existing ? cloneSessionEntry(existing) : undefined,
@@ -525,7 +522,6 @@ async function patchSqliteSessionEntrySnapshot(
             previous: writeBase,
             sessionKey,
           });
-    const maintenancePlans: SessionEntryMaintenancePlan[] = [];
     let result: SessionEntry | null = null;
     let previousIdentity = new Map<string, SessionEntry>();
     let currentIdentity = new Map<string, SessionEntry>();
@@ -543,15 +539,7 @@ async function patchSqliteSessionEntrySnapshot(
       const persisted = writeSessionEntry(writeDatabase, sessionKey, next, {
         previousEntry: selectedPreviousEntry,
       });
-      maintenancePlans.push(
-        applySessionEntryMaintenance(writeDatabase, {
-          activeSessionKey: sessionKey,
-          archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-          maintenanceConfig: options.maintenanceConfig,
-          skipMaintenance: options.skipMaintenance,
-          storePath: params.storePath,
-        }),
-      );
+      wrote = true;
       currentIdentity = readSessionIdentitySnapshot(writeDatabase, [sessionKey]);
       result = cloneSessionEntry(persisted);
     }, toDatabaseOptions(resolved));
@@ -562,20 +550,24 @@ async function patchSqliteSessionEntrySnapshot(
     } finally {
       emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
     }
-    return { maintenancePlans, result };
+    return result;
   });
-  // Worker materialization runs after the initial write releases the lane;
-  // final deletion reacquires it and revalidates every planned row.
-  await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
-    resolved,
-    committed.maintenancePlans,
-  );
+  if (wrote) {
+    kickSessionEntryMaintenanceAfterWrite({
+      activeSessionKey: sessionKey,
+      archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+      maintenanceConfig: options.maintenanceConfig,
+      scope: resolved,
+      skipMaintenance: options.skipMaintenance,
+      storePath: params.storePath,
+    });
+  }
   kickSessionHistoryDiskBudgetMaintenance({
     ...(resolved.agentId ? { agentId: resolved.agentId } : {}),
     storePath: params.storePath,
     ...(options.maintenanceConfig ? { maintenanceConfig: options.maintenanceConfig } : {}),
   });
-  return committed.result;
+  return committed;
 }
 
 export async function recordInboundSessionMeta(params: {

--- a/src/config/sessions/session-accessor.sqlite-handle-lifecycle.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-handle-lifecycle.test.ts
@@ -13,11 +13,13 @@ import {
   loadSessionEntry,
   loadTranscriptEvents,
   loadTranscriptEventsSync,
+  patchSessionEntryCore,
   persistSessionTranscriptTurn,
   replaceSessionEntry,
   withTranscriptWriteLock,
 } from "./session-accessor.js";
 import { readSessionTranscriptMessageEventPage } from "./session-accessor.sqlite-active-events.js";
+import { replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
 import { applySessionEntryCanonicalReplacements } from "./session-accessor.sqlite-replacement-projection.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { enforceSqliteSessionHistoryDiskBudget } from "./session-history-eviction.js";
@@ -27,6 +29,7 @@ import {
   waitForSessionTranscriptIndexReconcile,
   waitForSessionTranscriptProjection,
 } from "./session-transcript-reconcile.js";
+import { SQLITE_SESSION_WRITER_QUEUES } from "./store-writer-state.js";
 
 const archiveMaterializationHook = vi.hoisted(() => ({
   afterMaterialize: undefined as (() => void) | undefined,
@@ -148,6 +151,52 @@ describe("SQLite session handle lifecycle", () => {
         message: expect.objectContaining({ content: "append after close" }),
       }),
     );
+  });
+
+  it("does not run automatic maintenance on a replacement database handle", async () => {
+    const staleDashboardScope = {
+      ...scope,
+      sessionId: "stale-dashboard",
+      sessionKey: "agent:main:dashboard:stale",
+    };
+    replaceSessionEntrySync(staleDashboardScope, {
+      sessionId: staleDashboardScope.sessionId,
+      updatedAt: 1,
+    });
+    let markWriterStarted!: () => void;
+    const writerStarted = new Promise<void>((resolve) => {
+      markWriterStarted = resolve;
+    });
+    let releaseWriter!: () => void;
+    const writerRelease = new Promise<void>((resolve) => {
+      releaseWriter = resolve;
+    });
+    const blockedWrite = patchSessionEntryCore(
+      scope,
+      async () => {
+        markWriterStarted();
+        await writerRelease;
+        return { label: "replacement handle write" };
+      },
+      { skipMaintenance: true },
+    );
+    await writerStarted;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    const drains = [...SQLITE_SESSION_WRITER_QUEUES.values()].flatMap((queue) =>
+      queue.drainPromise ? [queue.drainPromise] : [],
+    );
+    expect(drains).not.toHaveLength(0);
+
+    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+    const replacement = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    releaseWriter();
+    await Promise.all([blockedWrite, ...drains]);
+
+    expect(replacement.db.isOpen).toBe(true);
+    expect(loadSessionEntry(scope)).toMatchObject({ sessionId: scope.sessionId });
+    expect(loadSessionEntry(staleDashboardScope)?.archivedAt).toBeUndefined();
   });
 
   it("commits a lifecycle projection after its async builder loses the cached handle", async () => {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -709,3 +709,17 @@ export function assertPlannedLifecycleArtifactEntriesUnchanged(
     }
   }
 }
+
+/** Partition only optimistic entry conflicts; database and parse failures stay fatal. */
+export function partitionUnchangedPlannedLifecycleArtifactEntries(
+  database: OpenClawAgentDatabase,
+  entries: readonly SessionEntryRemovalPlan[],
+): { changed: SessionEntryRemovalPlan[]; unchanged: SessionEntryRemovalPlan[] } {
+  const changed: SessionEntryRemovalPlan[] = [];
+  const unchanged: SessionEntryRemovalPlan[] = [];
+  for (const planned of entries) {
+    const current = readExactSessionEntryRow(database, planned.sessionKey)?.entry;
+    (sqliteSessionEntriesEqual(current, planned.expectedEntry) ? unchanged : changed).push(planned);
+  }
+  return { changed, unchanged };
+}

--- a/src/config/sessions/session-accessor.sqlite-maintenance-candidates.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance-candidates.ts
@@ -1,0 +1,118 @@
+import { iterateSqliteQuerySync } from "../../infra/kysely-sync.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import {
+  parseSessionEntryJson,
+  sessionEntryMetadataJson,
+} from "./session-accessor.sqlite-status.js";
+import { normalizeStoreSessionKey } from "./store-entry.js";
+import { shouldPreserveMaintenanceEntry } from "./store-maintenance.js";
+import type { SessionEntry } from "./types.js";
+
+export function collectSqliteSessionMaintenanceBaseKeys(
+  store: Record<string, SessionEntry>,
+  activeSessionKeys: Iterable<string>,
+): string[] {
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (const activeSessionKey of activeSessionKeys) {
+    let currentKey = normalizeStoreSessionKey(activeSessionKey);
+    while (currentKey && !seen.has(currentKey)) {
+      seen.add(currentKey);
+      keys.push(currentKey);
+      currentKey = normalizeStoreSessionKey(store[currentKey]?.parentSessionKey ?? "");
+    }
+  }
+  return keys;
+}
+
+export function readSessionMaintenanceKeyProjection(
+  database: OpenClawAgentDatabase,
+): Record<string, SessionEntry> {
+  const db = getSessionKysely(database.db);
+  const store: Record<string, SessionEntry> = {};
+  for (const row of iterateSqliteQuerySync(
+    database.db,
+    db
+      .selectFrom("session_nodes")
+      .select(["current_session_id", "parent_session_key", "session_key", "updated_at"])
+      .orderBy("session_key", "asc"),
+  )) {
+    store[row.session_key] = {
+      sessionId: row.current_session_id,
+      updatedAt: row.updated_at,
+      ...(row.parent_session_key ? { parentSessionKey: row.parent_session_key } : {}),
+    };
+  }
+  return store;
+}
+
+export function readSessionMaintenanceAgeCandidates(params: {
+  database: OpenClawAgentDatabase;
+  minimumAgeMs: number | null;
+}): Record<string, SessionEntry> {
+  if (params.minimumAgeMs == null || params.minimumAgeMs <= 0) {
+    return {};
+  }
+  const db = getSessionKysely(params.database.db);
+  const store: Record<string, SessionEntry> = {};
+  for (const row of iterateSqliteQuerySync(
+    params.database.db,
+    db
+      .selectFrom("session_nodes")
+      .select([sessionEntryMetadataJson, "current_session_id", "session_key", "updated_at"])
+      .where("updated_at", "<", Date.now() - params.minimumAgeMs)
+      .where("archived_at", "is", null)
+      .orderBy("updated_at", "asc"),
+  )) {
+    const entry = parseSessionEntryJson(row);
+    if (entry) {
+      store[row.session_key] = entry;
+    }
+  }
+  return store;
+}
+
+export function readSessionMaintenanceCapCandidates(params: {
+  database: OpenClawAgentDatabase;
+  excludedKeys: ReadonlySet<string>;
+  overflow: number;
+  preserveKeys: ReadonlySet<string> | undefined;
+  preserveRecentMs: number | null | undefined;
+}): Record<string, SessionEntry> {
+  const db = getSessionKysely(params.database.db);
+  const store: Record<string, SessionEntry> = {};
+  let eligible = 0;
+  for (const row of iterateSqliteQuerySync(
+    params.database.db,
+    db
+      .selectFrom("session_nodes")
+      .select([sessionEntryMetadataJson, "current_session_id", "session_key", "updated_at"])
+      .orderBy("updated_at", "asc")
+      // Stable cap ties previously inherited full-store session-key order.
+      .orderBy("session_key", "asc"),
+  )) {
+    if (params.excludedKeys.has(row.session_key)) {
+      continue;
+    }
+    const entry = parseSessionEntryJson(row);
+    if (!entry) {
+      continue;
+    }
+    store[row.session_key] = entry;
+    if (
+      !shouldPreserveMaintenanceEntry({
+        key: row.session_key,
+        entry,
+        preserveKeys: params.preserveKeys,
+        preserveRecentMs: params.preserveRecentMs,
+      })
+    ) {
+      eligible += 1;
+      if (eligible >= params.overflow) {
+        break;
+      }
+    }
+  }
+  return store;
+}

--- a/src/config/sessions/session-accessor.sqlite-maintenance-kick.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance-kick.ts
@@ -1,0 +1,90 @@
+import { getChildLogger } from "../../logging/logger.js";
+import {
+  resolveOpenClawAgentSqlitePath,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import {
+  applySessionEntryMaintenance,
+  finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort,
+} from "./session-accessor.sqlite-maintenance.js";
+import {
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+  type ResolvedSqliteReadScope,
+} from "./session-accessor.sqlite-scope.js";
+import type { ResolvedSessionMaintenanceConfigInput } from "./store-maintenance.js";
+
+type SessionEntryMaintenanceRequest = {
+  activeSessionKey: string;
+  archiveDirectory: string;
+  maintenanceConfig?: ResolvedSessionMaintenanceConfigInput;
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">;
+  skipMaintenance?: boolean;
+  storePath: string;
+};
+type SessionEntryMaintenanceOwner = SessionEntryMaintenanceRequest & {
+  activeSessionKeys: Set<string>;
+  generation: number;
+};
+
+const maintenanceByStore = new Map<string, SessionEntryMaintenanceOwner>();
+
+/** Coalesce automatic logical maintenance outside ordinary entry-write latency. */
+export function kickSessionEntryMaintenanceAfterWrite(
+  params: SessionEntryMaintenanceRequest,
+): void {
+  if (params.skipMaintenance) {
+    return;
+  }
+  const databasePath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(params.scope));
+  const owner = maintenanceByStore.get(databasePath);
+  if (owner) {
+    owner.activeSessionKeys.add(params.activeSessionKey);
+    Object.assign(owner, params, { generation: owner.generation + 1 });
+    return;
+  }
+  const created: SessionEntryMaintenanceOwner = {
+    ...params,
+    activeSessionKeys: new Set([params.activeSessionKey]),
+    generation: 1,
+  };
+  maintenanceByStore.set(databasePath, created);
+  setImmediate(() => void runPendingMaintenance(databasePath, created));
+}
+
+async function runPendingMaintenance(
+  databasePath: string,
+  owner: SessionEntryMaintenanceOwner,
+): Promise<void> {
+  while (maintenanceByStore.get(databasePath) === owner) {
+    const generation = owner.generation;
+    const activeSessionKeys = [...owner.activeSessionKeys];
+    owner.activeSessionKeys.clear();
+    try {
+      const plan = await runExclusiveSqliteSessionWrite(owner.scope, async () =>
+        runOpenClawAgentWriteTransaction(
+          (database) =>
+            applySessionEntryMaintenance(database, {
+              activeSessionKeys,
+              archiveDirectory: owner.archiveDirectory,
+              maintenanceConfig: owner.maintenanceConfig,
+              storePath: owner.storePath,
+            }),
+          toDatabaseOptions(owner.scope),
+        ),
+      );
+      await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(owner.scope, [plan]);
+    } catch (error) {
+      getChildLogger({ subsystem: "session-sqlite" }).warn(
+        "SQLite automatic session maintenance failed",
+        { error, path: databasePath },
+      );
+    }
+    // Any write during awaited planning/finalization increments the generation.
+    // Keep this owner alive so that write gets a fresh maintenance snapshot.
+    if (owner.generation === generation) {
+      maintenanceByStore.delete(databasePath);
+      return;
+    }
+  }
+}

--- a/src/config/sessions/session-accessor.sqlite-maintenance-kick.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance-kick.ts
@@ -1,7 +1,9 @@
 import { getChildLogger } from "../../logging/logger.js";
 import {
+  getOpenClawAgentDatabaseIfOpen,
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import {
   applySessionEntryMaintenance,
@@ -24,6 +26,7 @@ type SessionEntryMaintenanceRequest = {
 };
 type SessionEntryMaintenanceOwner = SessionEntryMaintenanceRequest & {
   activeSessionKeys: Set<string>;
+  database: OpenClawAgentDatabase;
   generation: number;
 };
 
@@ -37,8 +40,12 @@ export function kickSessionEntryMaintenanceAfterWrite(
     return;
   }
   const databasePath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(params.scope));
+  const database = getOpenClawAgentDatabaseIfOpen(toDatabaseOptions(params.scope));
+  if (!database) {
+    return;
+  }
   const owner = maintenanceByStore.get(databasePath);
-  if (owner) {
+  if (owner?.database === database) {
     owner.activeSessionKeys.add(params.activeSessionKey);
     Object.assign(owner, params, { generation: owner.generation + 1 });
     return;
@@ -46,6 +53,7 @@ export function kickSessionEntryMaintenanceAfterWrite(
   const created: SessionEntryMaintenanceOwner = {
     ...params,
     activeSessionKeys: new Set([params.activeSessionKey]),
+    database,
     generation: 1,
   };
   maintenanceByStore.set(databasePath, created);
@@ -56,13 +64,20 @@ async function runPendingMaintenance(
   databasePath: string,
   owner: SessionEntryMaintenanceOwner,
 ): Promise<void> {
-  while (maintenanceByStore.get(databasePath) === owner) {
+  const isCurrent = () =>
+    maintenanceByStore.get(databasePath) === owner && owner.database.db.isOpen;
+  while (isCurrent()) {
     const generation = owner.generation;
     const activeSessionKeys = [...owner.activeSessionKeys];
     owner.activeSessionKeys.clear();
     try {
-      const plan = await runExclusiveSqliteSessionWrite(owner.scope, async () =>
-        runOpenClawAgentWriteTransaction(
+      const plan = await runExclusiveSqliteSessionWrite(owner.scope, async () => {
+        // The writer queue can outlive the handle that admitted this owner.
+        // Check inside the acquired lane so an evicted owner cannot reopen the path.
+        if (!isCurrent()) {
+          return undefined;
+        }
+        return runOpenClawAgentWriteTransaction(
           (database) =>
             applySessionEntryMaintenance(database, {
               activeSessionKeys,
@@ -71,9 +86,17 @@ async function runPendingMaintenance(
               storePath: owner.storePath,
             }),
           toDatabaseOptions(owner.scope),
-        ),
-      );
-      await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(owner.scope, [plan]);
+        );
+      });
+      if (!plan) {
+        if (maintenanceByStore.get(databasePath) === owner) {
+          maintenanceByStore.delete(databasePath);
+        }
+        return;
+      }
+      await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(owner.scope, [plan], {
+        isCurrent,
+      });
     } catch (error) {
       getChildLogger({ subsystem: "session-sqlite" }).warn(
         "SQLite automatic session maintenance failed",
@@ -82,9 +105,15 @@ async function runPendingMaintenance(
     }
     // Any write during awaited planning/finalization increments the generation.
     // Keep this owner alive so that write gets a fresh maintenance snapshot.
-    if (owner.generation === generation) {
+    if (maintenanceByStore.get(databasePath) !== owner) {
+      return;
+    }
+    if (!owner.database.db.isOpen || owner.generation === generation) {
       maintenanceByStore.delete(databasePath);
       return;
     }
+  }
+  if (maintenanceByStore.get(databasePath) === owner) {
+    maintenanceByStore.delete(databasePath);
   }
 }

--- a/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { recordInboundSession } from "../../channels/session.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -10,7 +11,6 @@ import {
   cleanupSessionLifecycleArtifactsCore,
   loadSessionEntry,
   loadTranscriptEventsSync,
-  recordInboundSessionMeta,
   replaceSessionEntrySync,
   replaceTranscriptEventsSync,
 } from "./session-accessor.js";
@@ -158,7 +158,7 @@ it("releases the store writer before maintenance archive sizing completes", asyn
   expect(writerCompletedBeforeMaterialization).toBe(true);
 });
 
-it("does not hold channel entry writes behind automatic session maintenance", async () => {
+it("does not hold channel recording behind automatic session maintenance", async () => {
   const tempDir = tempDirs.make("openclaw-session-maintenance-ingress-");
   const storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
   const staleSessionKey = "agent:main:maintenance-ingress-stale";
@@ -180,7 +180,7 @@ it("does not hold channel entry writes behind automatic session maintenance", as
     await materializationReleased;
   };
 
-  const entryWrite = recordInboundSessionMeta({
+  const entryWrite = recordInboundSession({
     storePath,
     sessionKey: "agent:main:discord:direct:maintenance-ingress",
     ctx: {
@@ -191,36 +191,58 @@ it("does not hold channel entry writes behind automatic session maintenance", as
       SenderId: "maintenance-ingress",
       To: "discord:bot",
     },
+    updateLastRoute: {
+      accountId: "default",
+      channel: "discord",
+      sessionKey: "agent:main:discord:direct:maintenance-ingress",
+      to: "user:maintenance-ingress",
+    },
+    onRecordError(error) {
+      throw error;
+    },
   });
   const firstCompleted = await Promise.race([
     entryWrite.then(() => "entry-write" as const),
     materializationStarted.then(() => "maintenance" as const),
   ]);
-  await materializationStarted;
   const laterStaleSessionKey = "agent:main:maintenance-ingress-later-stale";
-  replaceSessionEntrySync(
-    { sessionKey: laterStaleSessionKey, storePath },
-    { sessionId: "maintenance-ingress-later-stale", updatedAt: 1 },
-  );
-  await recordInboundSessionMeta({
-    storePath,
-    sessionKey: "agent:main:discord:direct:maintenance-ingress-later",
-    ctx: {
-      Body: "later maintenance ingress proof",
-      ChatType: "direct",
-      From: "discord:maintenance-ingress-later",
-      Provider: "discord",
-      SenderId: "maintenance-ingress-later",
-      To: "discord:bot",
-    },
-  });
+  if (firstCompleted === "entry-write") {
+    await materializationStarted;
+    replaceSessionEntrySync(
+      { sessionKey: laterStaleSessionKey, storePath },
+      { sessionId: "maintenance-ingress-later-stale", updatedAt: 1 },
+    );
+    await recordInboundSession({
+      storePath,
+      sessionKey: "agent:main:discord:direct:maintenance-ingress-later",
+      ctx: {
+        Body: "later maintenance ingress proof",
+        ChatType: "direct",
+        From: "discord:maintenance-ingress-later",
+        Provider: "discord",
+        SenderId: "maintenance-ingress-later",
+        To: "discord:bot",
+      },
+      updateLastRoute: {
+        accountId: "default",
+        channel: "discord",
+        sessionKey: "agent:main:discord:direct:maintenance-ingress-later",
+        to: "user:maintenance-ingress-later",
+      },
+      onRecordError(error) {
+        throw error;
+      },
+    });
+  }
   releaseMaterialization();
   await entryWrite;
 
   expect(firstCompleted).toBe("entry-write");
   await vi.waitFor(() => {
     expect(loadSessionEntry({ sessionKey: staleSessionKey, storePath })).toBeUndefined();
-    expect(loadSessionEntry({ sessionKey: laterStaleSessionKey, storePath })).toBeUndefined();
+    if (firstCompleted === "entry-write") {
+      expect(loadSessionEntry({ sessionKey: laterStaleSessionKey, storePath })).toBeUndefined();
+    }
   });
 });
 

--- a/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts
@@ -10,13 +10,14 @@ import {
   cleanupSessionLifecycleArtifactsCore,
   loadSessionEntry,
   loadTranscriptEventsSync,
+  recordInboundSessionMeta,
   replaceSessionEntrySync,
   replaceTranscriptEventsSync,
 } from "./session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
 const archiveMaterializationHook = vi.hoisted(() => ({
-  beforeMaterialize: undefined as (() => void) | undefined,
+  beforeMaterialize: undefined as (() => Promise<void> | void) | undefined,
 }));
 
 vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
@@ -26,7 +27,7 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
     materializeSessionStateDeletePlans: async (
       ...args: Parameters<typeof actual.materializeSessionStateDeletePlans>
     ) => {
-      archiveMaterializationHook.beforeMaterialize?.();
+      await archiveMaterializationHook.beforeMaterialize?.();
       return await actual.materializeSessionStateDeletePlans(...args);
     },
   };
@@ -155,6 +156,72 @@ it("releases the store writer before maintenance archive sizing completes", asyn
     label: "progressed",
   });
   expect(writerCompletedBeforeMaterialization).toBe(true);
+});
+
+it("does not hold channel entry writes behind automatic session maintenance", async () => {
+  const tempDir = tempDirs.make("openclaw-session-maintenance-ingress-");
+  const storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
+  const staleSessionKey = "agent:main:maintenance-ingress-stale";
+  replaceSessionEntrySync(
+    { sessionKey: staleSessionKey, storePath },
+    { sessionId: "maintenance-ingress-stale", updatedAt: 1 },
+  );
+
+  let signalMaterializationStarted = () => {};
+  const materializationStarted = new Promise<void>((resolve) => {
+    signalMaterializationStarted = resolve;
+  });
+  let releaseMaterialization = () => {};
+  const materializationReleased = new Promise<void>((resolve) => {
+    releaseMaterialization = resolve;
+  });
+  archiveMaterializationHook.beforeMaterialize = async () => {
+    signalMaterializationStarted();
+    await materializationReleased;
+  };
+
+  const entryWrite = recordInboundSessionMeta({
+    storePath,
+    sessionKey: "agent:main:discord:direct:maintenance-ingress",
+    ctx: {
+      Body: "maintenance ingress proof",
+      ChatType: "direct",
+      From: "discord:maintenance-ingress",
+      Provider: "discord",
+      SenderId: "maintenance-ingress",
+      To: "discord:bot",
+    },
+  });
+  const firstCompleted = await Promise.race([
+    entryWrite.then(() => "entry-write" as const),
+    materializationStarted.then(() => "maintenance" as const),
+  ]);
+  await materializationStarted;
+  const laterStaleSessionKey = "agent:main:maintenance-ingress-later-stale";
+  replaceSessionEntrySync(
+    { sessionKey: laterStaleSessionKey, storePath },
+    { sessionId: "maintenance-ingress-later-stale", updatedAt: 1 },
+  );
+  await recordInboundSessionMeta({
+    storePath,
+    sessionKey: "agent:main:discord:direct:maintenance-ingress-later",
+    ctx: {
+      Body: "later maintenance ingress proof",
+      ChatType: "direct",
+      From: "discord:maintenance-ingress-later",
+      Provider: "discord",
+      SenderId: "maintenance-ingress-later",
+      To: "discord:bot",
+    },
+  });
+  releaseMaterialization();
+  await entryWrite;
+
+  expect(firstCompleted).toBe("entry-write");
+  await vi.waitFor(() => {
+    expect(loadSessionEntry({ sessionKey: staleSessionKey, storePath })).toBeUndefined();
+    expect(loadSessionEntry({ sessionKey: laterStaleSessionKey, storePath })).toBeUndefined();
+  });
 });
 
 it.each([

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -1,6 +1,6 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { sql } from "kysely";
-import { executeSqliteQuerySync, iterateSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { runWithSqliteBusyTimeout } from "../../infra/sqlite-busy-timeout.js";
 import { getChildLogger } from "../../logging/logger.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
@@ -26,12 +26,12 @@ import {
 } from "./session-accessor.sqlite-entry-store.js";
 import { emitCommittedSessionEntryRemovals } from "./session-accessor.sqlite-identity.js";
 import {
-  assertPlannedLifecycleArtifactEntriesUnchanged,
   collectProjectedReferencedSessionIds,
   collectSessionStateIdsForEntry,
   deleteMaterializedSessionStatePlans,
   deletePlannedLifecycleArtifactEntries,
   planSessionStateDeleteIfUnreferenced,
+  partitionUnchangedPlannedLifecycleArtifactEntries,
   readSessionGenerationIdsForKeys,
 } from "./session-accessor.sqlite-lifecycle-state.js";
 import type {
@@ -39,18 +39,19 @@ import type {
   SessionEntryMaintenanceResult,
 } from "./session-accessor.sqlite-lifecycle-types.js";
 import {
+  collectSqliteSessionMaintenanceBaseKeys,
+  readSessionMaintenanceAgeCandidates,
+  readSessionMaintenanceCapCandidates,
+  readSessionMaintenanceKeyProjection,
+} from "./session-accessor.sqlite-maintenance-candidates.js";
+import {
   cloneSessionEntry,
   getSessionKysely,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
   type ResolvedSqliteReadScope,
 } from "./session-accessor.sqlite-scope.js";
-import { parseSessionEntryJson as parseSessionEntryRow } from "./session-accessor.sqlite-status.js";
-import { normalizeStoreSessionKey } from "./store-entry.js";
-import {
-  collectSessionMaintenancePreserveKeys,
-  collectSessionMaintenancePreserveKeysForStore,
-} from "./store-maintenance-preserve.js";
+import { collectSessionMaintenancePreserveKeysForStore } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   archiveStaleDashboardEntries,
@@ -58,12 +59,10 @@ import {
   pruneStaleModelRunEntries,
   pruneStaleEntries,
   normalizeResolvedMaintenanceConfigInput,
-  shouldPreserveMaintenanceEntry,
   shouldRunModelRunPrune,
   shouldRunSessionEntryMaintenance,
   type ResolvedSessionMaintenanceConfigInput,
 } from "./store-maintenance.js";
-import type { SessionEntry } from "./types.js";
 
 // Live-entry pruning owner. Produces plans inside writes; finalizes archives afterward.
 
@@ -276,49 +275,6 @@ function buildSessionMaintenanceBatches(params: {
   return batches;
 }
 
-function collectSqliteSessionMaintenanceBaseKeys(
-  store: Record<string, SessionEntry>,
-  activeSessionKey: string,
-): string[] {
-  const keys: string[] = [];
-  const seen = new Set<string>();
-  let currentKey = normalizeStoreSessionKey(activeSessionKey);
-  while (currentKey && !seen.has(currentKey)) {
-    seen.add(currentKey);
-    keys.push(currentKey);
-    currentKey = normalizeStoreSessionKey(store[currentKey]?.parentSessionKey ?? "");
-  }
-  return keys;
-}
-
-function hasStaleSqliteSessionEntryCandidate(
-  database: OpenClawAgentDatabase,
-  maxAgeMs: number,
-  isCandidate: (key: string, entry: SessionEntry) => boolean,
-): boolean {
-  if (maxAgeMs <= 0) {
-    return false;
-  }
-  const cutoffMs = Date.now() - maxAgeMs;
-  const db = getSessionKysely(database.db);
-  const rows = iterateSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("session_nodes")
-      .select(["entry_json", "session_key"])
-      .where("updated_at", "<", cutoffMs)
-      .where("archived_at", "is", null)
-      .orderBy("updated_at", "asc"),
-  );
-  for (const row of rows) {
-    const entry = parseSessionEntryRow(row);
-    if (entry && isCandidate(normalizeStoreSessionKey(row.session_key), entry)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 async function readSessionTranscriptJsonlBytes(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   sessionIds: readonly string[],
@@ -360,7 +316,8 @@ async function readSessionTranscriptJsonlBytes(
 export function applySessionEntryMaintenance(
   database: OpenClawAgentDatabase,
   params: {
-    activeSessionKey: string;
+    activeSessionKey?: string;
+    activeSessionKeys?: readonly string[];
     archiveDirectory: string;
     forceMaintenance?: boolean;
     maintenanceConfig?: ResolvedSessionMaintenanceConfigInput;
@@ -392,131 +349,73 @@ export function applySessionEntryMaintenance(
     };
   }
 
-  // Count readable rows without retaining their payloads. Protection controls eviction candidates,
-  // not whether a row consumes maxEntries; retain a full snapshot only when maintenance runs.
+  // Key projections and indexed age candidates keep unrelated entry payloads out
+  // of automatic maintenance. Exact full entries load only for rows selected to change.
   const entryCount = readSessionEntryCount(database);
-  const preserveCandidateKeys = collectSessionMaintenancePreserveKeys([params.activeSessionKey]);
-  const hasStaleCandidate = hasStaleSqliteSessionEntryCandidate(
-    database,
-    maintenance.pruneAfterMs,
-    (key, entry) =>
-      !shouldPreserveMaintenanceEntry({
-        key,
-        entry,
-        preserveKeys: preserveCandidateKeys,
-        preserveRecentMs: maintenance.preserveRecentMs ?? null,
-      }),
-  );
-  const hasStaleDashboardCandidate =
-    maintenance.archiveDashboardAfterMs != null &&
-    hasStaleSqliteSessionEntryCandidate(
-      database,
-      maintenance.archiveDashboardAfterMs,
-      (key, entry) =>
-        archiveStaleDashboardEntries({ [key]: entry }, maintenance.archiveDashboardAfterMs, {
-          log: false,
-          preserveKeys: preserveCandidateKeys,
-        }) > 0,
-    );
-  const shouldMaintainStore =
-    params.forceMaintenance === true ||
-    entryCount > maintenance.maxEntries ||
-    hasStaleDashboardCandidate ||
-    hasStaleCandidate ||
-    shouldRunModelRunPrune({
-      maintenance,
-      entryCount,
-      force: params.forceMaintenance,
-    }) ||
-    shouldRunSessionEntryMaintenance({
-      entryCount,
-      maxEntries: maintenance.maxEntries,
-      force: params.forceMaintenance,
-    });
-  if (!shouldMaintainStore) {
-    return {
-      entryRemovals: [],
-      stateDeletePlans: [],
-      archived: 0,
-      modelRunPruned: 0,
-      pruned: 0,
-      capped: 0,
-    };
-  }
-
-  const store = readSessionEntryStore(database);
+  const activeSessionKeys = uniqueStrings([
+    params.activeSessionKey ?? "",
+    ...(params.activeSessionKeys ?? []),
+  ]);
+  const keyProjection = readSessionMaintenanceKeyProjection(database);
   const preserveKeys =
     collectSessionMaintenancePreserveKeysForStore({
       storePath: params.storePath,
-      store,
-      baseKeys: collectSqliteSessionMaintenanceBaseKeys(store, params.activeSessionKey),
+      store: keyProjection,
+      baseKeys: collectSqliteSessionMaintenanceBaseKeys(keyProjection, activeSessionKeys),
     }) ?? new Set<string>();
-  const removals = new Map<string, SessionEntryMaintenancePlan["entryRemovals"][number]>();
-  const removedSessionIds = new Set<string>();
-  const rememberRemovedEntry =
+  const runModelRunPrune = shouldRunModelRunPrune({
+    maintenance,
+    entryCount,
+    force: params.forceMaintenance,
+  });
+  const candidateAges = [
+    maintenance.pruneAfterMs,
+    maintenance.archiveDashboardAfterMs,
+    runModelRunPrune ? maintenance.modelRunPruneAfterMs : null,
+  ].filter((age): age is number => age != null && age > 0);
+  const store = readSessionMaintenanceAgeCandidates({
+    database,
+    minimumAgeMs: candidateAges.length > 0 ? Math.min(...candidateAges) : null,
+  });
+  const removalReasons = new Map<
+    string,
+    NonNullable<SessionEntryMaintenancePlan["entryRemovals"][number]["maintenanceReason"]>
+  >();
+  const rememberRemoval =
     (
       maintenanceReason: NonNullable<
         SessionEntryMaintenancePlan["entryRemovals"][number]["maintenanceReason"]
       >,
     ) =>
-    (removed: { key: string; entry: SessionEntry }) => {
-      removals.set(removed.key, {
-        // The prune/cap owner removes this fresh entry from the private store immediately.
-        // Transfer it to the deletion fence instead of copying its saved prompt again.
-        expectedEntry: removed.entry,
-        maintenanceReason,
-        sessionKey: removed.key,
-      });
-      for (const sessionId of collectSessionStateIdsForEntry(removed.entry)) {
-        removedSessionIds.add(sessionId);
-      }
+    ({ key }: { key: string }) => {
+      removalReasons.set(key, maintenanceReason);
     };
   let remainingEntryCount = entryCount;
   let modelRunPruned = 0;
-  if (
-    shouldRunModelRunPrune({
-      maintenance,
-      entryCount: remainingEntryCount,
-      force: params.forceMaintenance,
-    })
-  ) {
+  if (runModelRunPrune) {
     modelRunPruned = pruneStaleModelRunEntries(store, maintenance.modelRunPruneAfterMs, {
       log: false,
-      onPruned: rememberRemovedEntry("model-run-pruned"),
+      onPruned: rememberRemoval("model-run-pruned"),
       preserveKeys,
       preserveRecentMs: maintenance.preserveRecentMs,
     });
     remainingEntryCount -= modelRunPruned;
   }
-  const archivedWorktrees: NonNullable<SessionEntryMaintenancePlan["archivedWorktrees"]> = [];
+  const archivedKeys = new Set<string>();
   const archived = archiveStaleDashboardEntries(store, maintenance.archiveDashboardAfterMs, {
     log: false,
-    onArchived: ({ key, entry }) => {
-      writeSessionEntry(database, key, entry);
-      if (entry.worktree) {
-        archivedWorktrees.push({
-          entry: cloneSessionEntry(entry),
-          sessionKey: key,
-          storePath: params.storePath,
-        });
-      }
+    onArchived: ({ key }) => {
+      archivedKeys.add(key);
     },
     preserveKeys,
   });
-  let pruned = 0;
-  if (
-    params.forceMaintenance === true ||
-    hasStaleCandidate ||
-    remainingEntryCount > maintenance.maxEntries
-  ) {
-    pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
-      log: false,
-      onPruned: rememberRemovedEntry("pruned"),
-      preserveKeys,
-      preserveRecentMs: maintenance.preserveRecentMs,
-    });
-    remainingEntryCount -= pruned;
-  }
+  const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
+    log: false,
+    onPruned: rememberRemoval("pruned"),
+    preserveKeys,
+    preserveRecentMs: maintenance.preserveRecentMs,
+  });
+  remainingEntryCount -= pruned;
   let capped = 0;
   if (
     shouldRunSessionEntryMaintenance({
@@ -525,20 +424,79 @@ export function applySessionEntryMaintenance(
       force: params.forceMaintenance,
     })
   ) {
-    capped = capEntryCount(store, maintenance.maxEntries, {
-      log: false,
-      onCapped: rememberRemovedEntry("capped"),
-      preserveKeys,
-      preserveRecentMs: maintenance.preserveRecentMs,
-    });
+    const overflow = Math.max(0, remainingEntryCount - maintenance.maxEntries);
+    if (overflow > 0) {
+      const capStore = readSessionMaintenanceCapCandidates({
+        database,
+        excludedKeys: new Set(removalReasons.keys()),
+        overflow,
+        preserveKeys,
+        preserveRecentMs: maintenance.preserveRecentMs,
+      });
+      for (const key of archivedKeys) {
+        const archivedEntry = store[key];
+        if (archivedEntry && capStore[key]) {
+          capStore[key] = archivedEntry;
+        }
+      }
+      capped = capEntryCount(capStore, Object.keys(capStore).length - overflow, {
+        log: false,
+        onCapped: rememberRemoval("capped"),
+        preserveKeys,
+        preserveRecentMs: maintenance.preserveRecentMs,
+      });
+    }
   }
-  for (const sessionId of readSessionGenerationIdsForKeys(database, removals.keys())) {
+  const selectedKeys = uniqueStrings([...archivedKeys, ...removalReasons.keys()]);
+  const selectedEntries = readSessionEntryStore(database, { sessionKeys: selectedKeys });
+  const archivedWorktrees: NonNullable<SessionEntryMaintenancePlan["archivedWorktrees"]> = [];
+  for (const key of archivedKeys) {
+    const entry = selectedEntries[key];
+    const planned = store[key];
+    if (!entry || !planned?.archivedAt) {
+      continue;
+    }
+    entry.archivedAt = planned.archivedAt;
+    writeSessionEntry(database, key, entry);
+    if (entry.worktree) {
+      archivedWorktrees.push({
+        entry: cloneSessionEntry(entry),
+        sessionKey: key,
+        storePath: params.storePath,
+      });
+    }
+  }
+  const removals = [...removalReasons].flatMap(([sessionKey, maintenanceReason]) => {
+    const expectedEntry = selectedEntries[sessionKey];
+    return expectedEntry ? [{ expectedEntry, maintenanceReason, sessionKey }] : [];
+  });
+  if (removals.length === 0) {
+    return {
+      ...(archivedWorktrees.length ? { archivedWorktrees } : {}),
+      entryRemovals: [],
+      stateDeletePlans: [],
+      archived,
+      modelRunPruned: 0,
+      pruned: 0,
+      capped: 0,
+    };
+  }
+  const removedSessionIds = new Set<string>();
+  for (const removal of removals) {
+    for (const sessionId of collectSessionStateIdsForEntry(removal.expectedEntry)) {
+      removedSessionIds.add(sessionId);
+    }
+  }
+  for (const sessionId of readSessionGenerationIdsForKeys(
+    database,
+    removals.map((removal) => removal.sessionKey),
+  )) {
     removedSessionIds.add(sessionId);
   }
   const referencedSessionIds = collectProjectedReferencedSessionIds({
     database,
-    excludedSessionKeys: removals.keys(),
-    projectedStore: store,
+    excludedSessionKeys: removals.map((removal) => removal.sessionKey),
+    projectedStore: {},
   });
   const deletePlans: SessionStateDeletePlan[] = [];
   for (const sessionId of removedSessionIds) {
@@ -555,7 +513,7 @@ export function applySessionEntryMaintenance(
   }
   return {
     ...(archivedWorktrees.length ? { archivedWorktrees } : {}),
-    entryRemovals: [...removals.values()],
+    entryRemovals: removals,
     stateDeletePlans: deletePlans,
     archived,
     modelRunPruned,
@@ -625,6 +583,8 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
     stateDeletePlans,
   })) {
     let archivedTranscripts: SessionLifecycleArchivedTranscript[];
+    let changedEntryRemovals: SessionEntryMaintenancePlan["entryRemovals"] = [];
+    let committedEntryRemovals = batch.entryRemovals;
     try {
       const materializedPlans = await materializeSessionStateDeletePlans(batch.stateDeletePlans);
       archivedTranscripts = await withSqliteSessionDeletions(
@@ -636,14 +596,19 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
           await runExclusiveSqliteSessionWrite(scope, async () => {
             let committed: SessionLifecycleArchivedTranscript[] = [];
             runOpenClawAgentWriteTransaction((database) => {
-              assertPlannedLifecycleArtifactEntriesUnchanged(database, batch.entryRemovals);
+              const partition = partitionUnchangedPlannedLifecycleArtifactEntries(
+                database,
+                batch.entryRemovals,
+              );
+              changedEntryRemovals = partition.changed;
+              committedEntryRemovals = partition.unchanged;
               committed = deleteMaterializedSessionStatePlans(
                 database,
                 materializedPlans,
                 undefined,
-                new Set(batch.entryRemovals.map((removal) => removal.sessionKey)),
+                new Set(committedEntryRemovals.map((removal) => removal.sessionKey)),
               );
-              deletePlannedLifecycleArtifactEntries(database, batch.entryRemovals);
+              deletePlannedLifecycleArtifactEntries(database, committedEntryRemovals);
             }, toDatabaseOptions(scope));
             return committed;
           }),
@@ -652,9 +617,20 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
       warn("SQLite session maintenance cleanup failed", error, batch.stateDeletePlans);
       break;
     }
-    deletedEntries += batch.workItems;
-    emitCommittedSessionEntryRemovals(batch.entryRemovals);
-    for (const removal of batch.entryRemovals) {
+    if (changedEntryRemovals.length > 0) {
+      getChildLogger({ subsystem: "session-sqlite" }).warn(
+        "SQLite session maintenance skipped changed entries",
+        {
+          agentId: scope.agentId,
+          path: scope.path,
+          sessionKeys: changedEntryRemovals.map((removal) => removal.sessionKey),
+        },
+      );
+    }
+    deletedEntries +=
+      batch.workItems - (batch.entryRemovals.length - committedEntryRemovals.length);
+    emitCommittedSessionEntryRemovals(committedEntryRemovals);
+    for (const removal of committedEntryRemovals) {
       if (removal.maintenanceReason === "model-run-pruned") {
         committedCounts.modelRunPruned += 1;
       } else if (removal.maintenanceReason === "pruned") {

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -79,8 +79,10 @@ const plannerMaintenanceByStore = new Map<string, Promise<void>>();
 export async function refreshSqliteSessionPlannerStatisticsBestEffort(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   deletedEntries: number,
+  options: { isCurrent?: () => boolean } = {},
 ): Promise<void> {
-  if (deletedEntries < SESSION_PLANNER_ANALYSIS_MIN_DELETED_ENTRIES) {
+  const isCurrent = options.isCurrent ?? (() => true);
+  if (deletedEntries < SESSION_PLANNER_ANALYSIS_MIN_DELETED_ENTRIES || !isCurrent()) {
     return;
   }
   const storePath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(scope));
@@ -90,6 +92,9 @@ export async function refreshSqliteSessionPlannerStatisticsBestEffort(
     return;
   }
   const completion = runExclusiveSqliteSessionWrite(scope, async () => {
+    if (!isCurrent()) {
+      return;
+    }
     const database = openOpenClawAgentDatabase(toDatabaseOptions(scope));
     // Planner maintenance must not inherit the normal 5s writer wait: a competing
     // process skips this best-effort pass instead of blocking the Gateway event loop.
@@ -278,6 +283,7 @@ function buildSessionMaintenanceBatches(params: {
 async function readSessionTranscriptJsonlBytes(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   sessionIds: readonly string[],
+  isCurrent: () => boolean,
 ): Promise<Map<string, number>> {
   const bytesBySessionId = new Map<string, number>();
   for (let offset = 0; offset < sessionIds.length; offset += SESSION_TRANSCRIPT_BYTE_QUERY_BATCH) {
@@ -286,6 +292,9 @@ async function readSessionTranscriptJsonlBytes(
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
+    if (!isCurrent()) {
+      return bytesBySessionId;
+    }
     const opened = withOpenClawAgentDatabaseReadOnly((database) => {
       const db = getSessionKysely(database.db);
       return executeSqliteQuerySync(
@@ -526,12 +535,26 @@ export function applySessionEntryMaintenance(
 export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
   scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "path">,
   plans: readonly SessionEntryMaintenancePlan[],
-  options: { deletedEntriesBeforeMaintenance?: number } = {},
+  options: { deletedEntriesBeforeMaintenance?: number; isCurrent?: () => boolean } = {},
 ): Promise<SessionEntryMaintenanceResult> {
+  const isCurrent = options.isCurrent ?? (() => true);
+  const committedCounts = {
+    archived: plans.reduce((count, plan) => count + plan.archived, 0),
+    modelRunPruned: 0,
+    pruned: 0,
+    capped: 0,
+  };
+  const emptyResult = () => ({ archivedTranscripts: [], ...committedCounts });
+  if (!isCurrent()) {
+    return emptyResult();
+  }
   const archivedWorktrees = plans.flatMap((plan) => plan.archivedWorktrees ?? []);
   if (archivedWorktrees.length) {
     const { cleanUpAutomaticallyArchivedWorktrees } =
       await import("../../sessions/session-worktree-lifecycle.js");
+    if (!isCurrent()) {
+      return emptyResult();
+    }
     await cleanUpAutomaticallyArchivedWorktrees(scope, archivedWorktrees);
   }
   const entryRemovals = plans.flatMap((plan) => plan.entryRemovals);
@@ -548,32 +571,35 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
       sessionIds: uniqueStrings(warnedStateDeletePlans.map((plan) => plan.sessionId)),
     });
   };
-  const committedCounts = {
-    archived: plans.reduce((count, plan) => count + plan.archived, 0),
-    modelRunPruned: 0,
-    pruned: 0,
-    capped: 0,
-  };
+  if (!isCurrent()) {
+    return emptyResult();
+  }
   if (entryRemovals.length === 0 && stateDeletePlans.length === 0) {
     await refreshSqliteSessionPlannerStatisticsBestEffort(
       scope,
       options.deletedEntriesBeforeMaintenance ?? 0,
+      { isCurrent },
     );
-    return { archivedTranscripts: [], ...committedCounts };
+    return emptyResult();
   }
   let archiveBytesBySessionId: Map<string, number>;
   try {
     archiveBytesBySessionId = await readSessionTranscriptJsonlBytes(
       scope,
       stateDeletePlans.filter((plan) => plan.archiveTranscript).map((plan) => plan.sessionId),
+      isCurrent,
     );
   } catch (error) {
     warn("SQLite session maintenance archive sizing failed", error, stateDeletePlans);
     await refreshSqliteSessionPlannerStatisticsBestEffort(
       scope,
       options.deletedEntriesBeforeMaintenance ?? 0,
+      { isCurrent },
     );
-    return { archivedTranscripts: [], ...committedCounts };
+    return emptyResult();
+  }
+  if (!isCurrent()) {
+    return emptyResult();
   }
   const publishedTranscripts: SessionLifecycleArchivedTranscript[] = [];
   let deletedEntries = options.deletedEntriesBeforeMaintenance ?? 0;
@@ -582,11 +608,17 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
     entryRemovals,
     stateDeletePlans,
   })) {
+    if (!isCurrent()) {
+      break;
+    }
     let archivedTranscripts: SessionLifecycleArchivedTranscript[];
     let changedEntryRemovals: SessionEntryMaintenancePlan["entryRemovals"] = [];
     let committedEntryRemovals = batch.entryRemovals;
     try {
       const materializedPlans = await materializeSessionStateDeletePlans(batch.stateDeletePlans);
+      if (!isCurrent()) {
+        break;
+      }
       archivedTranscripts = await withSqliteSessionDeletions(
         scope,
         batch.entryRemovals.flatMap(({ expectedEntry: entry, sessionKey }) =>
@@ -594,6 +626,9 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
         ),
         async () =>
           await runExclusiveSqliteSessionWrite(scope, async () => {
+            if (!isCurrent()) {
+              return [];
+            }
             let committed: SessionLifecycleArchivedTranscript[] = [];
             runOpenClawAgentWriteTransaction((database) => {
               const partition = partitionUnchangedPlannedLifecycleArtifactEntries(
@@ -615,6 +650,9 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
       );
     } catch (error) {
       warn("SQLite session maintenance cleanup failed", error, batch.stateDeletePlans);
+      break;
+    }
+    if (!isCurrent()) {
       break;
     }
     if (changedEntryRemovals.length > 0) {
@@ -645,6 +683,8 @@ export async function finalizeSessionEntryMaintenancePlansAfterWriterReleaseBest
       warn("SQLite session maintenance archive publication failed", error, batch.stateDeletePlans);
     }
   }
-  await refreshSqliteSessionPlannerStatisticsBestEffort(scope, deletedEntries);
+  if (isCurrent()) {
+    await refreshSqliteSessionPlannerStatisticsBestEffort(scope, deletedEntries, { isCurrent });
+  }
   return { archivedTranscripts: publishedTranscripts, ...committedCounts };
 }

--- a/src/gateway/server-worker-placement-startup-maintenance.test.ts
+++ b/src/gateway/server-worker-placement-startup-maintenance.test.ts
@@ -166,6 +166,16 @@ describe("worker placement session maintenance ownership", () => {
           replaceEntry: true,
           skipMaintenance: true,
         });
+        const sentinelKey = "agent:main:explicit:maintenance-sentinel";
+        const sentinelEntry = {
+          sessionId: "maintenance-sentinel",
+          updatedAt: now - 31 * 86_400_000,
+        };
+        await patchSessionEntryCore(sessionScope(sentinelKey), () => sentinelEntry, {
+          fallbackEntry: sentinelEntry,
+          replaceEntry: true,
+          skipMaintenance: true,
+        });
         const { forceDestroyEnvironment, runtime } = createMaintenanceRuntime({
           placements: [placement],
         });
@@ -191,6 +201,9 @@ describe("worker placement session maintenance ownership", () => {
 
         try {
           await triggerMaintenance();
+          await vi.waitFor(() => {
+            expect(loadSessionEntry(sessionScope(sentinelKey))).toBeUndefined();
+          });
           expect(loadSessionEntry(sessionScope(sessionKey))).toMatchObject({
             sessionId: placement.sessionId,
           });
@@ -202,11 +215,15 @@ describe("worker placement session maintenance ownership", () => {
           expect(collectSessionMaintenancePreserveKeys()?.has(sessionKey)).not.toBe(true);
           await triggerMaintenance();
           if (maintenance === "dashboard archive") {
-            expect(loadSessionEntry(sessionScope(sessionKey))?.archivedAt).toEqual(
-              expect.any(Number),
-            );
+            await vi.waitFor(() => {
+              expect(loadSessionEntry(sessionScope(sessionKey))?.archivedAt).toEqual(
+                expect.any(Number),
+              );
+            });
           } else {
-            expect(loadSessionEntry(sessionScope(sessionKey))).toBeUndefined();
+            await vi.waitFor(() => {
+              expect(loadSessionEntry(sessionScope(sessionKey))).toBeUndefined();
+            });
           }
         } finally {
           await sidecar.stop();

--- a/src/plugin-sdk/channel-inbound.test.ts
+++ b/src/plugin-sdk/channel-inbound.test.ts
@@ -1,11 +1,16 @@
 /**
  * Tests channel inbound context and dispatch helper behavior.
  */
-import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   configureChannelAdmissionEvidenceCollection,
   readChannelContextAdmissionEvidence,
 } from "../channels/message-access/admission-evidence.js";
+import { recordInboundSession } from "../channels/session.js";
+import { loadSessionEntry, replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   buildChannelInboundEventContext,
   buildChannelTurnContext,
@@ -48,6 +53,14 @@ function createInboundParams(
 }
 
 describe("channel-inbound public helpers", () => {
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+    afterEach(() => {
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      cleanup();
+    }),
+  );
+
   it("runs a lifecycle-less prepared turn through the published entry point", async () => {
     const events: string[] = [];
     const { runChannelInboundEvent } = await import("openclaw/plugin-sdk/channel-inbound");
@@ -90,6 +103,69 @@ describe("channel-inbound public helpers", () => {
 
     expect(events).toEqual(["record", "dispatch"]);
     expect(result.dispatched).toBe(true);
+  });
+
+  it("dispatches a published inbound event before automatic session maintenance", async () => {
+    const storePath = `${tempDirs.make("openclaw-channel-inbound-maintenance-")}/sessions.json`;
+    const staleSessionKey = "agent:main:published-inbound-stale";
+    const activeSessionKey = "agent:main:test:peer";
+    replaceSessionEntrySync(
+      { storePath, sessionKey: staleSessionKey },
+      { sessionId: "published-inbound-stale", updatedAt: 1 },
+    );
+    let staleEntryPresentAtDispatch = false;
+    const { runChannelInboundEvent } = await import("openclaw/plugin-sdk/channel-inbound");
+
+    const result = await runChannelInboundEvent({
+      channel: "test",
+      raw: { id: "msg-1", text: "hello" },
+      adapter: {
+        ingest: () => ({ id: "msg-1", rawText: "hello" }),
+        resolveTurn: () => ({
+          channel: "test",
+          routeSessionKey: activeSessionKey,
+          storePath,
+          ctxPayload: {
+            Body: "hello",
+            RawBody: "hello",
+            CommandBody: "hello",
+            From: "test:user:peer",
+            To: "test:bot",
+            SessionKey: activeSessionKey,
+            Provider: "test",
+            Surface: "test",
+          },
+          recordInboundSession,
+          record: {
+            updateLastRoute: {
+              accountId: "default",
+              channel: "test",
+              sessionKey: activeSessionKey,
+              to: "user:peer",
+            },
+            onRecordError: (error: unknown) => {
+              throw error;
+            },
+          },
+          runDispatch: async () => {
+            staleEntryPresentAtDispatch = Boolean(
+              loadSessionEntry({ storePath, sessionKey: staleSessionKey }),
+            );
+            return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+          },
+          runDispatchLifecycle: {
+            turnAdoptionLifecycle: undefined,
+            onDispatchSkipped: vi.fn(),
+          },
+        }),
+      },
+    });
+
+    expect(result.dispatched).toBe(true);
+    expect(staleEntryPresentAtDispatch).toBe(true);
+    await vi.waitFor(() => {
+      expect(loadSessionEntry({ storePath, sessionKey: staleSessionKey })).toBeUndefined();
+    });
   });
 
   it("builds inbound event kind into message context", async () => {

--- a/src/plugin-sdk/channel-inbound.test.ts
+++ b/src/plugin-sdk/channel-inbound.test.ts
@@ -127,6 +127,7 @@ describe("channel-inbound public helpers", () => {
           storePath,
           ctxPayload: {
             Body: "hello",
+            CommandAuthorized: false,
             RawBody: "hello",
             CommandBody: "hello",
             From: "test:user:peer",

--- a/src/plugin-sdk/session-store-runtime.maintenance.test.ts
+++ b/src/plugin-sdk/session-store-runtime.maintenance.test.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { getSessionEntry, patchSessionEntry, upsertSessionEntry } from "./session-store-runtime.js";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import { getSessionEntry, patchSessionEntry } from "./session-store-runtime.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -21,15 +22,13 @@ describe("plugin session store maintenance", () => {
       const activeSessionKey = "agent:main:active";
       const now = Date.now();
       const seed = (sessionKey: string, sessionId: string, updatedAt: number) =>
-        upsertSessionEntry({
-          agentId: "main",
-          sessionKey,
-          storePath,
-          entry: { sessionId, updatedAt },
-        });
-      await seed(modelRunSessionKey, "session-model-run", now - 2 * DAY_MS);
-      await seed(oldSessionKey, "session-old", now - 3 * DAY_MS);
-      await seed(activeSessionKey, "session-active", now);
+        replaceSessionEntrySync(
+          { agentId: "main", sessionKey, storePath },
+          { sessionId, updatedAt },
+        );
+      seed(modelRunSessionKey, "session-model-run", now - 2 * DAY_MS);
+      seed(oldSessionKey, "session-old", now - 3 * DAY_MS);
+      seed(activeSessionKey, "session-active", now);
 
       await patchSessionEntry({
         sessionKey: activeSessionKey,
@@ -46,8 +45,13 @@ describe("plugin session store maintenance", () => {
         update: () => ({ model: "gpt-5.6-luna" }),
       });
 
-      expect(getSessionEntry({ sessionKey: modelRunSessionKey, storePath }) != null).toBe(
-        modelRunSessionPresent,
+      await vi.waitFor(
+        () => {
+          expect(getSessionEntry({ sessionKey: modelRunSessionKey, storePath }) != null).toBe(
+            modelRunSessionPresent,
+          );
+        },
+        { timeout: 5_000 },
       );
     },
   );

--- a/src/plugin-sdk/session-store-runtime.test.ts
+++ b/src/plugin-sdk/session-store-runtime.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -56,11 +56,10 @@ describe("session-store-runtime compatibility surface", () => {
   });
 
   async function seedSessionEntry(sessionKey: string, entry: SessionEntry): Promise<void> {
-    await upsertSessionEntry({
-      agentId: "main",
-      sessionKey,
-      storePath,
-      entry,
+    await patchInternalSessionEntry({ agentId: "main", sessionKey, storePath }, () => entry, {
+      fallbackEntry: entry,
+      replaceEntry: true,
+      skipMaintenance: true,
     });
   }
 
@@ -850,9 +849,9 @@ describe("session-store-runtime compatibility surface", () => {
         update: () => ({ model: "gpt-5.5" }),
       });
 
-      expect(getSessionEntry({ sessionKey: staleSessionKey, storePath }) != null).toBe(
-        staleSessionPresent,
-      );
+      const hasStaleEntry = () =>
+        getSessionEntry({ sessionKey: staleSessionKey, storePath }) != null;
+      await vi.waitFor(() => expect(hasStaleEntry()).toBe(staleSessionPresent), { timeout: 5_000 });
     },
   );
 


### PR DESCRIPTION
## Summary

- Move automatic logical session maintenance out of ordinary entry-write latency.
- Coalesce writes per SQLite store and rerun from a fresh snapshot when another write lands during maintenance.
- Select indexed age and cap candidates before loading exact entry payloads.
- Continue independent cleanup after one planned entry changes.

## Problem

Discord and Telegram channel ingress records metadata and last-route state before dispatch. Both writes synchronously ran logical maintenance in the store-writer queue. One stale candidate caused each write to materialize every `session_nodes` payload.

The Control UI `chat.send` preparation path uses one exact-row lookup and does not run this two-write channel burst.

Closes #135905.

## Root cause

The entry accessor owned both the user write and the full maintenance plan. The maintenance owner first found a stale row, then called the unbounded full-store reader inside the serialized write transaction. The detached metadata write and awaited route write could both plan the same stale removal before finalization deleted it.

## Fix

- The entry accessor commits and publishes the entry, then kicks one process-local per-store maintenance owner.
- A generation counter retains one pending rerun when writes land during awaited planning or archive work.
- The planner reads lightweight key projections, indexed age candidates, and only enough oldest cap candidates.
- Full entry JSON loads only for selected archive or removal rows.
- Final deletion still reacquires the lifecycle and writer owners, rechecks the exact entries and references, and preserves archive-before-delete.
- A changed planned entry is skipped and logged while independent entries in the batch continue.
- Each deferred owner is bound to the exact open database handle. It cannot reopen a closed store, act on a replacement handle, or delete a replacement owner.

No configuration, schema, sidecar, freshness poll, production timeout, retry, or compatibility path was added. The implementation reuses the current SQLite projections, Kysely query layer, writer queue, and lifecycle fences; no external library or plugin fits this internal ownership repair.

## Proof

Baseline: `914059d0a630685954d16a992c4105f924dc0e64`.

- Independent 537 MB store, 256 rows, five warm samples: channel ingress averaged 1,864.23 ms; web preparation averaged 1.838 ms.
- Each baseline channel call ran two full-store materializations plus three full metadata projections; those queries accounted for 97.75% of latency.
- Production commit `b64e731b22584ca3030bfe8a96999e710f0a1d18`, 135 MB store: channel ingress completed in 199.10 ms with zero maintenance full-store materializations; stale cleanup completed at 332.63 ms.
- Final candidate `a2c9c7ae4886980692f47e163a064291297e3d71`: the published Plugin SDK ingress, shipped `recordInboundSession`, exact-handle lifecycle, and changed maintenance regressions passed.
- The published `runChannelInboundEvent` test fails on baseline because cleanup completes before dispatch; it passes on the repair and then observes stale cleanup complete.
- A 337 MB head run completed channel ingress in 452.56 ms with zero maintenance full-store materializations; stale cleanup completed at 925.88 ms.
- Independent final-runtime run on a 167 MB store, five samples: channel ingress averaged 5.438 ms; web preparation averaged 1.387 ms; full entry materializations stayed at zero; stale cleanup completed 5/5 at 169.37 ms mean.
- Detached maintenance still performs two reference metadata projections after dispatch, measured at 139.0 ms on the 167 MB store. They no longer run inside or delay entry writes; indexed selection bounds full entry payload loading to changed candidates.
- Input-size probes covered 33, 65, 129, 321, and 641 rows.

## Tests

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts src/config/sessions/session-history-eviction.test.ts src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts src/config/sessions/session-accessor.test.ts src/channels/session.test.ts src/channels/turn/run-channel-turn.pipeline.test.ts`
- `node scripts/run-vitest.mjs src/plugin-sdk/channel-inbound.test.ts`
- Focused CI repairs: 47 conformance, 88 agent session-store, 30 Plugin SDK session-store, 22 unchanged Gateway corruption/disposal, 11 handle-lifecycle, and 8 parent-fork tests passed.
- Direct Oxlint and Oxfmt checks for all changed files.
- Max-lines, assertion-safety, import-cycle, coercion-helper, deprecated-API, dead-export, database-first, schema-version, and conflict-marker guards.

Host policy forbids local OpenClaw type-check and build commands. CI owns those checks.

## Scope and risk

- Production: +464 / -205, net +259.
- Tests: +349 / -72, net +277.
- The production growth is the new coalesced owner, bounded candidate-query boundary, and exact-handle lifecycle fence. It removes 205 lines of synchronous and fail-stop paths; no smaller existing owner can retain fresh reruns, candidate selection, and archive-before-delete revalidation.
- Explicit `sessions cleanup --enforce` remains synchronous and preserves its immediate semantics.
- Sibling coverage includes shared channel ingress, Control UI/web preparation, explicit cleanup, physical disk-budget maintenance, dashboard archive ordering, protected sessions, lifecycle races, and session accessor behavior.
