### PR TITLE
test: use prepared Gateway entrypoint for refusal proof

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-provider-refusal-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-provider-refusal-product-proof.e2e.test.ts
@@ -116,7 +116,7 @@ describe("Gateway provider refusal product proof", () => {
       repoRoot: process.cwd(),
       command: {
         executablePath: process.execPath,
-        argsPrefix: ["--import", "tsx", "src/entry.ts"],
+        argsPrefix: ["dist/entry.js"],
         cwd: process.cwd(),
         tempParentDir: process.env.TMPDIR ?? tmpdir(),
         usePackagedPlugins: false,


### PR DESCRIPTION
## What Problem This Solves

The Gateway refusal proof recompiles the source entrypoint for its child even though the canonical E2E setup has already prepared the runnable bundle. This adds about 17 seconds to a single refusal case.

## Why This Change Was Made

Start the real Gateway through `dist/entry.js`. Keep the existing QA command descriptor and unpackaged plugin mode, which own the synthetic authentication and staged plugin setup. All four assertions remain: one primary-provider request, an error terminal result, the expected visible refusal, and no raw provider explanation in the returned history.

## User Impact

Faster internal validation; no product behavior change. The existing 60-second case deadline, real loopback provider stream, retry/fallback configuration, Gateway calls and cleanup remain unchanged. Production delta is zero; test delta is +1/-1.

## Evidence

Three complete canonical runs on the same Linux Testbox, Node 24.19.0 and pnpm 12.1.0, each passed its one case:

| Run | Whole command | Case body |
| --- | ---: | ---: |
| Original, including cold preparation | 240.67 s | 20.39 s |
| Prepared entrypoint | 16.30 s | 3.59 s |
| Restored original control | 33.08 s | 21.01 s |

The matched warm control shows a 51% whole-command reduction and an 83% case-body reduction. Cold build time is excluded from that claim. Every invocation retained normal canonical build/setup; no prebuilt bypass or shorter timeout was used.

All 69 source guards restored, tracked source was clean afterward, no observed processes required rescue, and the exact Testbox was stopped. The observer covers owned groups and sampled descendants, not every possible detached process. Formatting, type-aware lint, diff checks and Codex P0 review passed; exact-head CI remains the integration gate.
