### PR TITLE
fix(ui): allow renaming new MCP Env and Headers entries

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -798,7 +798,7 @@ describe("redactConfigSnapshot", () => {
     expect(restored).toEqual(snapshot.config);
   });
 
-  it("does not mangle raw when a sensitive field value is empty string", () => {
+  it("preserves empty sensitive field values without mangling raw", () => {
     const config = {
       gateway: { auth: { token: "" } },
       other: "",
@@ -806,9 +806,55 @@ describe("redactConfigSnapshot", () => {
     const raw = '{ "gateway": { "auth": { "token": "" } }, "other": "" }';
     const snapshot = makeSnapshot(config, raw);
     const result = redactConfigSnapshot(snapshot);
-    expect(result.config.gateway?.auth?.token).toBe(REDACTED_SENTINEL);
+    expect(result.config.gateway?.auth?.token).toBe("");
     expect(result.raw).toBe(raw);
     expect((result.raw ?? "").split(REDACTED_SENTINEL).length).toBe(1);
+  });
+
+  it("preserves empty MCP env and header entries while redacting populated values", () => {
+    const hints = buildConfigSchemaCore().uiHints;
+    const config = {
+      mcp: {
+        servers: {
+          remote: {
+            env: {
+              NEW_ENV: "",
+              EXISTING_ENV: "secret-env-value",
+            },
+            headers: {
+              NEW_HEADER: "",
+              EXISTING_HEADER: "secret-header-value",
+            },
+          },
+        },
+      },
+    };
+    const snapshot = makeSnapshot(config, JSON.stringify(config, null, 2));
+    const result = redactConfigSnapshot(snapshot, hints);
+    const redactedConfig = result.config as {
+      mcp: {
+        servers: Record<
+          string,
+          {
+            env: Record<string, string>;
+            headers: Record<string, string>;
+          }
+        >;
+      };
+    };
+    const remote = expectDefined(
+      redactedConfig.mcp.servers.remote,
+      "servers.remote test invariant",
+    );
+
+    expect(remote.env.NEW_ENV).toBe("");
+    expect(remote.env.EXISTING_ENV).toBe(REDACTED_SENTINEL);
+    expect(remote.headers.NEW_HEADER).toBe("");
+    expect(remote.headers.EXISTING_HEADER).toBe(REDACTED_SENTINEL);
+    expect(result.raw).toContain('"NEW_ENV": ""');
+    expect(result.raw).toContain('"NEW_HEADER": ""');
+    expect(result.raw).not.toContain("secret-env-value");
+    expect(result.raw).not.toContain("secret-header-value");
   });
 
   it("redacts each projection without using its secrets to rewrite another projection", () => {

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -34,6 +34,10 @@ function isEnvVarPlaceholder(value: string): boolean {
   return ENV_VAR_PLACEHOLDER_PATTERN.test(value.trim());
 }
 
+function shouldRedactSensitiveString(value: string): boolean {
+  return value !== "" && !isEnvVarPlaceholder(value);
+}
+
 function isWholeObjectSensitivePath(path: string): boolean {
   const lowered = normalizeLowercaseStringOrEmpty(path);
   return lowered.endsWith("serviceaccount") || lowered.endsWith("serviceaccountref");
@@ -48,7 +52,7 @@ function hasSensitiveUrlHintPath(hints: ConfigUiHints | undefined, paths: string
 
 function collectSensitiveStrings(value: unknown, values: string[]): void {
   if (typeof value === "string") {
-    if (!isEnvVarPlaceholder(value)) {
+    if (shouldRedactSensitiveString(value)) {
       values.push(value);
     }
     return;
@@ -64,7 +68,7 @@ function collectSensitiveStrings(value: unknown, values: string[]): void {
     // SecretRef objects include structural fields like source/provider that are
     // not secret material and may appear widely in config text.
     if (isSecretRefShape(obj)) {
-      if (!isEnvVarPlaceholder(obj.id)) {
+      if (shouldRedactSensitiveString(obj.id)) {
         values.push(obj.id);
       }
       return;
@@ -173,7 +177,7 @@ function redactValue(
     return obj.map((item) => {
       if (
         typeof item === "string" &&
-        !isEnvVarPlaceholder(item) &&
+        shouldRedactSensitiveString(item) &&
         (schemaMatched || heuristicSensitive)
       ) {
         values.push(item);
@@ -197,7 +201,7 @@ function redactValue(
       : undefined;
     if (candidate) {
       result[key] = value;
-      if (typeof value === "string" && !isEnvVarPlaceholder(value)) {
+      if (typeof value === "string" && shouldRedactSensitiveString(value)) {
         result[key] = REDACTED_SENTINEL;
         values.push(value);
       } else if (typeof value === "object" && value !== null) {
@@ -218,6 +222,7 @@ function redactValue(
           result[key] = redactValue(value, candidate, values, context);
         }
       } else if (
+        typeof value !== "string" &&
         context.hints?.[candidate]?.sensitive === true &&
         value !== undefined &&
         value !== null
@@ -233,7 +238,7 @@ function redactValue(
       typeof value === "string" &&
       !markedNonSensitive &&
       isSensitivePath(path) &&
-      !isEnvVarPlaceholder(value)
+      shouldRedactSensitiveString(value)
     ) {
       result[key] = REDACTED_SENTINEL;
       values.push(value);

--- a/ui/src/components/config-form-map-integrity.browser.test.ts
+++ b/ui/src/components/config-form-map-integrity.browser.test.ts
@@ -1,5 +1,6 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { REDACTED_SENTINEL } from "../lib/config-form-utils.ts";
 import {
   removeConfigFormValue,
   serializeFormForSubmit,
@@ -200,6 +201,61 @@ describe("config form map integrity", () => {
     nestedKey.dispatchEvent(new Event("change", { bubbles: true }));
     expect(onPatch).toHaveBeenCalledWith(["values", "primary"], { zone: "west" });
   });
+
+  it.each(["env", "headers"] as const)(
+    "allows blank MCP %s entries to be renamed but blocks redacted entries",
+    (section) => {
+      const analysis = analyzeConfigSchema({
+        type: "object",
+        properties: {
+          [section]: {
+            type: "object",
+            additionalProperties: { type: "string" },
+          },
+        },
+      });
+      const container = document.createElement("div");
+      const onPatch = vi.fn();
+      render(
+        renderConfigForm({
+          schema: analysis.schema,
+          uiHints: {},
+          unsupportedPaths: analysis.unsupportedPaths,
+          value: {
+            [section]: {
+              "custom-1": "",
+              stored: REDACTED_SENTINEL,
+            },
+          },
+          showAdvanced: true,
+          onShowAdvanced: () => {},
+          onPatch,
+        }),
+        container,
+      );
+
+      const blankKey = expectElement(
+        container.querySelector<HTMLInputElement>('[aria-label="Key: custom-1"]'),
+        `${section} blank entry key`,
+      );
+      const renamedKey = section === "env" ? "OPENAPI_MCP_HEADERS" : "X-OpenAPI-MCP";
+      blankKey.value = renamedKey;
+      blankKey.dispatchEvent(new Event("change", { bubbles: true }));
+      expect(onPatch).toHaveBeenCalledWith([section], {
+        [renamedKey]: "",
+        stored: REDACTED_SENTINEL,
+      });
+
+      const storedKey = expectElement(
+        container.querySelector<HTMLInputElement>('[aria-label="Key: stored"]'),
+        `${section} stored entry key`,
+      );
+      storedKey.value = "renamed-stored";
+      storedKey.dispatchEvent(new Event("change", { bubbles: true }));
+      expect(storedKey.value).toBe("stored");
+      expect(onPatch).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it.each([
     ["boolean", true],


### PR DESCRIPTION
Superseded by #135798, merged to `main` as `48c1c3683f2`.

## What Problem This Solves

This PR originally fixed an issue where users adding a new MCP server Env or Headers entry in Control UI could not rename the auto-created `custom-N` key. Snapshot redaction converted the blank value to the secret sentinel, so the existing safety guard treated the new entry like a stored secret and restored the old key.

## Why This Change Was Made

The repair moved the behavior to the snapshot-redaction producer: blank sensitive strings remain editable, while concrete secrets continue to be redacted and the Control UI rename guard remains intact.

The same producer-owned repair has now landed through #135798. That merged change is canonical and covers the same reporter path with broader current-main integration, so this PR should not be merged.

## User Impact

Issue #135649 is fixed on current `main` by #135798. Blank MCP Env and Headers entries remain editable after reload and can be renamed, while existing redacted secret entries remain protected from rename.

## Evidence

- #135798 merged on 2026-09-02 as `48c1c3683f2` and closed #135649.
- The merged implementation uses one positive concrete-sensitive-string predicate across schema-sensitive strings, heuristic paths, arrays, and SecretRef IDs.
- Its MCP snapshot regression covers blank values and populated secret redaction, projection consistency, restoration, and rename-safe editable server data.
- Its published live Gateway/browser proof covers blank-value reload and rename persistence, concrete-secret masking, and protected-entry rename rejection for the reporter path.
- This PR overlaps the same snapshot-redaction owner and no longer provides a distinct production fix that should be merged separately.
