### PR TITLE
fix: doctor maintenance fails on localized Windows

### DIFF
--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -574,11 +574,15 @@ export async function readScheduledTaskRuntime(
       };
     }
   }
+  const status =
+    derived.status === "unknown" && isScheduledTaskDefinitelyNotRunning(taskName)
+      ? "stopped"
+      : derived.status;
   return {
-    status: derived.status,
+    status,
     state: parsed.status,
     lastRunTime: parsed.lastRunTime,
     lastRunResult: parsed.lastRunResult,
-    ...(derived.detail ? { detail: derived.detail } : {}),
+    ...(status === derived.status && derived.detail ? { detail: derived.detail } : {}),
   };
 }

--- a/src/daemon/schtasks.integration.e2e.test.ts
+++ b/src/daemon/schtasks.integration.e2e.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 import { getWindowsPowerShellExePath } from "../infra/windows-install-roots.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { resolveGatewayWindowsTaskName } from "./constants.js";
-import { execSchtasks } from "./schtasks-exec.js";
+import * as schtasksExec from "./schtasks-exec.js";
 import { resolveStartupEntryPaths, resolveTaskLauncherScriptPath } from "./schtasks-layout.js";
 import { readWindowsProcessSnapshot } from "./schtasks-process.js";
 import { probeScheduledTaskExists } from "./schtasks-runtime.js";
@@ -162,7 +162,7 @@ function isProcessAlive(pid: number): boolean {
 }
 
 async function readTaskXml(taskName: string): Promise<string | null> {
-  const result = await execSchtasks(["/Query", "/TN", taskName, "/XML"]);
+  const result = await schtasksExec.execSchtasks(["/Query", "/TN", taskName, "/XML"]);
   return result.code === 0
     ? result.stdout.replace(/^\uFEFF/u, "").replaceAll(String.fromCharCode(0), "")
     : null;
@@ -485,7 +485,14 @@ async function readFailureDiagnosticSnapshot(params: {
   scriptPath: string;
   taskName: string;
 }): Promise<FailureDiagnosticSnapshot> {
-  const verboseQuery = await execSchtasks(["/Query", "/TN", params.taskName, "/V", "/FO", "LIST"]);
+  const verboseQuery = await schtasksExec.execSchtasks([
+    "/Query",
+    "/TN",
+    params.taskName,
+    "/V",
+    "/FO",
+    "LIST",
+  ]);
   const taskXml = await readTaskXml(params.taskName);
   let principal: ScheduledTaskPrincipal | null = null;
   let principalError: string | null = null;
@@ -585,10 +592,12 @@ async function cleanupNativeTask(params: {
       preCleanupError = error instanceof Error ? error.message : String(error);
     }
   }
-  const endResult = await execSchtasks(["/End", "/TN", params.taskName]).catch((error: unknown) => {
-    cleanupErrors.push(error);
-    return null;
-  });
+  const endResult = await schtasksExec
+    .execSchtasks(["/End", "/TN", params.taskName])
+    .catch((error: unknown) => {
+      cleanupErrors.push(error);
+      return null;
+    });
   if (params.preserveEvidence) {
     let postEnd: FailureDiagnosticSnapshot | null = null;
     let postEndError: string | null = null;
@@ -621,12 +630,12 @@ async function cleanupNativeTask(params: {
   } catch (error) {
     cleanupErrors.push(error);
   }
-  const deletion = await execSchtasks(["/Delete", "/F", "/TN", params.taskName]).catch(
-    (error: unknown) => {
+  const deletion = await schtasksExec
+    .execSchtasks(["/Delete", "/F", "/TN", params.taskName])
+    .catch((error: unknown) => {
       cleanupErrors.push(error);
       return null;
-    },
-  );
+    });
   const taskExists = probeScheduledTaskExists(params.taskName);
   if (taskExists === null) {
     cleanupErrors.push(new Error(`Could not verify Scheduled Task cleanup for ${params.taskName}`));
@@ -818,7 +827,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         const service = resolveGatewayService();
         const readRuntime = () => service.readRuntime(env);
 
-        expect((await execSchtasks(["/Query", "/TN", taskName])).code).not.toBe(0);
+        expect((await schtasksExec.execSchtasks(["/Query", "/TN", taskName])).code).not.toBe(0);
         expect(path.relative(stateDir, scriptPath)).not.toMatch(/^\.\.(?:[\\/]|$)/u);
         expect(await canBindLoopbackPort(gatewayPort)).toBe(true);
 
@@ -834,7 +843,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
           description: `OpenClaw CI Scheduled Task integration ${id}`,
         });
 
-        expect((await execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
+        expect((await schtasksExec.execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
         const taskXml = await readTaskXml(taskName);
         if (!taskXml) {
           throw new Error(`Could not export Scheduled Task XML for ${taskName}`);
@@ -889,7 +898,10 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         await clearActivePid(activePidPath, installedPid);
         await waitForLoopbackPortRelease(gatewayPort);
         await waitForRuntimeStatus(readRuntime, "stopped");
-        expect((await execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
+        await expect(
+          proof.readSpanishStoppedTaskRuntime(taskName, readRuntime),
+        ).resolves.toMatchObject({ status: "stopped" });
+        expect((await schtasksExec.execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
 
         const startMutations: string[] = [];
         await service.start({
@@ -954,7 +966,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         await waitForRuntimeStatus(readRuntime, "stopped");
 
         await service.uninstall({ env, stdout });
-        expect((await execSchtasks(["/Query", "/TN", taskName])).code).not.toBe(0);
+        expect((await schtasksExec.execSchtasks(["/Query", "/TN", taskName])).code).not.toBe(0);
         await expect(fs.access(scriptPath)).rejects.toThrow();
         await expect(fs.access(launcherPath)).rejects.toThrow();
         expect(await canBindLoopbackPort(gatewayPort)).toBe(true);
@@ -979,6 +991,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
                 lifecycle: ["install", "stop", "start", "restart", "stop", "uninstall"],
                 pids: lifecyclePids,
                 gatewayPort,
+                localizedRuntimeFallback: true,
                 portReleaseRebind: true,
                 startupFallback: false,
                 startupFallbackProof,

--- a/src/daemon/schtasks.integration.test-helpers.ts
+++ b/src/daemon/schtasks.integration.test-helpers.ts
@@ -1,13 +1,16 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { vi } from "vitest";
 import {
   getWindowsCmdExePath,
   getWindowsPowerShellExePath,
   getWindowsSystem32ExePath,
 } from "../infra/windows-install-roots.js";
+import * as schtasksExec from "./schtasks-exec.js";
 import { resolveTaskScriptPath } from "./schtasks-layout.js";
 import { launchFallbackTaskScript } from "./schtasks-runtime.js";
+import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type { GatewayServiceEnv } from "./service-types.js";
 
 const POLL_INTERVAL_MS = 200;
@@ -381,6 +384,30 @@ export async function proveNativeStartupFallbackLaunch(params: {
     existenceCheckIgnoredAcl: true,
     completedAfterLauncherExit: true,
   };
+}
+
+export async function readSpanishStoppedTaskRuntime(
+  taskName: string,
+  readRuntime: () => Promise<GatewayServiceRuntime>,
+): Promise<GatewayServiceRuntime> {
+  const localizedQuery = vi.spyOn(schtasksExec, "execSchtasks");
+  try {
+    localizedQuery
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        code: 0,
+        stdout: [
+          `Nombre de tarea: ${taskName}`,
+          "Estado: Listo",
+          "Última hora de ejecución: 1/8/2026 1:23:45 AM",
+          "Último resultado: 0",
+        ].join("\r\n"),
+        stderr: "",
+      });
+    return await readRuntime();
+  } finally {
+    localizedQuery.mockRestore();
+  }
 }
 
 async function readRunEvents(eventsPath: string): Promise<ProbeRunEvent[]> {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -14,6 +14,12 @@ const schtasksResponses = vi.hoisted(
   (): Array<{ code: number; stdout: string; stderr: string }> => [],
 );
 const resolveWindowsOemEncodingMock = vi.hoisted(() => vi.fn((): string | null => null));
+const spawnSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawnSync };
+});
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: async () => schtasksResponses.shift() ?? { code: 0, stdout: "", stderr: "" },
@@ -34,6 +40,8 @@ beforeEach(() => {
   schtasksResponses.length = 0;
   resolveWindowsOemEncodingMock.mockReset();
   resolveWindowsOemEncodingMock.mockReturnValue(null);
+  spawnSync.mockReset();
+  spawnSync.mockReturnValue({ status: 1, stdout: "-2147024891" });
 });
 
 describe("scheduled task runtime derivation", () => {
@@ -143,6 +151,21 @@ describe("scheduled task runtime derivation", () => {
       status: "stopped",
       detail: "Task Last Run Result=0x0; treating as not running.",
     });
+  });
+
+  it("uses native task state when Spanish field names hide runtime metadata", async () => {
+    spawnSync.mockReturnValueOnce({ status: 0, stdout: "3" });
+
+    await expect(
+      readRuntimeFromQueryOutput(
+        [
+          "Nombre de tarea: \\OpenClaw Gateway",
+          "Estado: Listo",
+          "Última hora de ejecución: 1/8/2026 1:23:45 AM",
+          "Último resultado: 0",
+        ].join("\r\n"),
+      ),
+    ).resolves.toMatchObject({ status: "stopped" });
   });
 
   it("treats localized status without result code as unknown", async () => {


### PR DESCRIPTION
Closes #135856

## What Problem This Solves

Fixes an issue where Windows users with localized Task Scheduler field names could not run `openclaw doctor --fix` after stopping the Gateway. The service runtime was reported as unknown even when the native task state proved that no task instance was queued or running.

## Why This Change Was Made

When localized `schtasks` output does not expose usable runtime metadata, service inspection now uses the existing locale-independent Task Scheduler COM state. Only `Disabled` and `Ready` are classified as stopped; listener-backed running evidence still takes precedence, while queued, running, malformed, missing, and unavailable native states continue to fail closed.

## User Impact

Operators can enter Doctor or update maintenance on localized Windows installations after the Gateway Scheduled Task has stopped. The change does not weaken ownership checks or allow maintenance while the task may still be queued or running.

## Evidence

- Regression RED: the Spanish-field runtime case returned `unknown` before the production change when COM reported Task Scheduler state `Ready`.
- Focused GREEN: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/daemon/schtasks.test.ts src/daemon/schtasks.stop.test.ts src/cli/update-cli/update-command-service-maintenance.test.ts src/daemon/schtasks.integration.e2e.test.ts` — 80 passed; the native Windows lifecycle case was skipped on macOS as expected.
- Changed gate: `node scripts/check-changed.mjs -- src/daemon/schtasks-runtime.ts src/daemon/schtasks.test.ts src/daemon/schtasks.integration.e2e.test.ts src/daemon/schtasks.integration.test-helpers.ts` — passed formatting, core/test tsgo, oxlint, deadcode, import-cycle, and repository guards.
- Native Windows exact-SHA proof: https://github.com/zhangguiping-xydt/openclaw/actions/runs/33629022747 (queued at PR creation; target commit `8da3de1694080b8220a67c89d25bc31b0f2d394a`).
- Autoreview was explicitly skipped by the operator after the isolated Codex reviewer discarded the configured custom provider and the default OpenAI endpoint returned HTTP 401. Local validation and native Windows proof remain independent of that reviewer infrastructure failure.