### PR TITLE
perf: reduce repeated work during streaming event delivery

### DIFF
--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -84,7 +84,11 @@ export type AgentEventRuntimePayload = AgentEventPayload & {
 };
 
 type AgentEventListener = (evt: AgentEventRuntimePayload) => void;
-type AgentEventListeners = Map<AgentEventListener, number>;
+type AgentEventRegistration = {
+  readonly listener: AgentEventListener;
+  readonly id: number;
+};
+type AgentEventListeners = Map<AgentEventListener, AgentEventRegistration>;
 
 type AgentEventState = {
   seqByRun: Map<string, number>;
@@ -346,7 +350,7 @@ function* iterateAgentEventListeners(
   let lastId = -1;
   let revision = -1;
   let runId: string | undefined;
-  let pending: Array<[AgentEventListener, number]> = [];
+  let pending: AgentEventRegistration[] = [];
   let index = 0;
   while (true) {
     const currentRunId = enriched.runId;
@@ -355,17 +359,34 @@ function* iterateAgentEventListeners(
     if (revision !== state.listenerRevision || runId !== currentRunId) {
       revision = state.listenerRevision;
       runId = currentRunId;
-      pending = [...state.listeners, ...(state.runListeners.get(runId) ?? [])]
-        .filter(([, id]) => id > lastId)
-        .toSorted(([, left], [, right]) => left - right);
+      // Registration IDs follow Map insertion order. Finish the merge before
+      // yielding, when callbacks can mutate either map.
+      const globalRegistrations = state.listeners.values();
+      const runRegistrations = state.runListeners.get(runId)?.values();
+      let global = globalRegistrations.next().value;
+      let scoped = runRegistrations?.next().value;
+      pending = [];
+      while (global || scoped) {
+        if (global && (!scoped || global.id <= scoped.id)) {
+          if (global.id > lastId) {
+            pending.push(global);
+          }
+          global = globalRegistrations.next().value;
+        } else if (scoped) {
+          if (scoped.id > lastId) {
+            pending.push(scoped);
+          }
+          scoped = runRegistrations?.next().value;
+        }
+      }
       index = 0;
     }
     const next = pending[index++];
     if (!next) {
       return;
     }
-    lastId = next[1];
-    yield next[0];
+    lastId = next.id;
+    yield next.listener;
   }
 }
 
@@ -453,7 +474,7 @@ function registerAgentEventListener(listener: AgentEventListener, runId?: string
   const bucket: AgentEventListeners =
     runId === undefined ? state.listeners : (state.runListeners.get(runId) ?? new Map());
   if (!bucket.has(listener)) {
-    bucket.set(listener, state.nextListenerId++);
+    bucket.set(listener, { listener, id: state.nextListenerId++ });
     if (runId !== undefined) {
       state.runListeners.set(runId, bucket);
     }


### PR DESCRIPTION
## What Problem This Solves

Streaming agent events repeatedly rebuild and sort the combined global and selected-run listener lists. That work repeats for every delta even though registrations already have a stable order.

## Why This Change Was Made

Keep the listener and registration ID together when subscribing, then merge the two ordered registration streams before invoking callbacks. This removes per-dispatch entry tuples, filtering and sorting while retaining the existing revision/run-ID checks and independent nested-dispatch cursors. Complete the merge before yielding so callback-time additions, removals, retargeting and resets retain their existing behavior.

The event owner remains the only registration and dispatch path. There is no process cache, new API/configuration, persistence change or provider-specific behavior. Keeping a lazy Map iterator alive across callbacks would violate the current mutation semantics; the eager merged cohort preserves them. Production is 29 added / 8 removed lines (net +21); tests are unchanged. The added merge expresses the same ordering contract with linear work and prepares registration facts once.

## User Impact

Streaming-event delivery does less repeated dispatch work. Public events, delivery ordering, subscription identity and lifecycle fences are unchanged. This is a local dispatch improvement, not a claim about model or network latency.

## Evidence

All 72 cases in the three complete event/bridge test files pass before and after, with matching titles and no skips. `check:changed` passes. Independent Codex review found no actionable findings at its P0 threshold; direct source review covers the owner, global/run subscriptions, actual delivery bridge, shared listener notifier and registry lifecycle.

A native public-emitter/public-bridge experiment retained and compared 23 complete operations per variant, including 12 mutation/lifecycle/duplicate-module controls. Four fixed B0/C0/C1/B1 hosts then ran 836 operations (704 measured samples plus every first/warm observation). Every complete timed output was checked against the proof: event descriptors, sequence/ownership facts, selections, delivery queues, object aliases and teardown. No samples were discarded or rerun.

| Fixed workload | Forward median, before → candidate | Reverse median, before → candidate |
| --- | --- | --- |
| 32 events, two selected roles plus global observer | 98.855 → 80.105 µs (−18.97%) | 96.792 → 86.375 µs (−10.76%) |
| 32 events, eight selected roles plus global observer | 105.042 → 101.146 µs (−3.71%) | 110.063 → 96.021 µs (−12.76%) |

Both primary workloads pass the predeclared ≥3% median improvement in each order. Seven protected workloads and two setup/teardown workloads pass their frozen regression gates. Slower results are retained: the one-event setup workload regresses 3.66% (+187 ns) in the reverse order, and eight-role setup-only regresses 1.73% (+104 ns) there. Nine first-call and ten p95 comparisons are slower; p95 was descriptive, not an acceptance gate. The first one-event setup observation is 53%/128% slower across the two orders. No first-call/tail improvement is claimed.

Sampled process-group RSS is 3.25%/1.29% lower; the launcher’s child high-water mark stays under the separate 2 GiB cap. All six native hosts, observed process groups and isolated runtime/coordinator paths closed cleanly. Complete raw observations and adverse comparisons are retained locally. Independent raw-data readback verified every operation, state archive and measurement; the auditor authored the harness, while a separate root review checked its full implementation and outputs. The fixed callback-recording workload is part of the measured operation; this is not a pure dispatch kernel or private CLI-factory execution.

The same committed build passed four real OpenAI Gateway turns: READY, whole skill read and arithmetic, conversation recall, then two sequential uncached web fetches (markdown and text, both HTTP 200). The final audit checked all 43 captured events, 18 transcript rows, seven provider responses, complete skill/spill contents, and joined cleanup. Readiness was 3.555 seconds and total launcher time 19.819 seconds; this is unpaired behavior evidence, not a Gateway speedup comparison. Startup CPU health was degraded and a later 275.3 ms maximum event-loop delay is retained. The CPU profile does not resolve an isolated dispatch cost or prove heap savings. Raw diagnostic archives remain private.

Exact-head CI run 33630678249 passed on attempt 2. The first security-fast job lost its self-hosted runner before recording test steps; rerunning that job passed without a source change. ClawSweeper reviewed this exact head with no findings or rank-up moves.
