### PR TITLE
refactor: isolate update config snapshot imports

### DIFF
--- a/src/cli/update-cli/update-command-config-snapshot.test-support.ts
+++ b/src/cli/update-cli/update-command-config-snapshot.test-support.ts
@@ -130,7 +130,7 @@ export async function runUpdateSnapshotIsolationProof(
   const { CONFIG_PATH } = await import("../../config/paths.js");
   assert.equal(CONFIG_PATH, configA);
   checkTarget(CONFIG_PATH);
-  const { createUpdateConfigSnapshot } = await import("./update-command-config.js");
+  const { createUpdateConfigSnapshot } = await import("./update-command-config-snapshot.js");
   selectHome(homeB);
   if (selection === "home") {
     delete process.env.OPENCLAW_STATE_DIR;

--- a/src/cli/update-cli/update-command-config-snapshot.ts
+++ b/src/cli/update-cli/update-command-config-snapshot.ts
@@ -1,0 +1,13 @@
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import { createPreUpdateConfigSnapshot } from "../../config/backup-rotation.js";
+import { resolveConfigPath } from "../../config/paths.js";
+
+export async function createUpdateConfigSnapshot(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  await createPreUpdateConfigSnapshot({
+    configPath: resolveConfigPath(env),
+    fs: { writeFile: fs.writeFile, readFile: fs.readFile, existsSync },
+  });
+}

--- a/src/cli/update-cli/update-command-config.ts
+++ b/src/cli/update-cli/update-command-config.ts
@@ -1,9 +1,7 @@
 // Config snapshots and pre/post-update config restoration.
-import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import { createPreUpdateConfigSnapshot } from "../../config/backup-rotation.js";
 import {
   mutateConfigFileWithRetry,
   parseConfigJson5,
@@ -12,7 +10,7 @@ import {
 import { resolveConfigEnvVars } from "../../config/env-substitution.js";
 import { resolveConfigIncludes } from "../../config/includes.js";
 import { asResolvedSourceConfig, asRuntimeConfig } from "../../config/materialize.js";
-import { resolveConfigPath, resolveIncludeRoots } from "../../config/paths.js";
+import { resolveIncludeRoots } from "../../config/paths.js";
 import { parsePluginInstallRecordMap } from "../../config/plugin-install-record-map.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
@@ -24,15 +22,6 @@ import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 
 const PRE_UPDATE_CONFIG_SNAPSHOT_MAX_AGE_MS = 6 * 60 * 60 * 1000;
-
-export async function createUpdateConfigSnapshot(
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<void> {
-  await createPreUpdateConfigSnapshot({
-    configPath: resolveConfigPath(env),
-    fs: { writeFile: fs.writeFile, readFile: fs.readFile, existsSync },
-  });
-}
 
 export function normalizePluginInstallRecordMap(
   value: unknown,

--- a/src/cli/update-cli/update-command-finalize.ts
+++ b/src/cli/update-cli/update-command-finalize.ts
@@ -26,8 +26,8 @@ import {
   type UpdateFinalizeOptions,
 } from "./shared.js";
 import { suppressDeprecations } from "./suppress-deprecations.js";
+import { createUpdateConfigSnapshot } from "./update-command-config-snapshot.js";
 import {
-  createUpdateConfigSnapshot,
   persistRequestedUpdateChannel,
   persistValidatedDowngradeConfig,
   readPostCorePreUpdateSourceConfig,

--- a/src/cli/update-cli/update-command-lifecycle.test.ts
+++ b/src/cli/update-cli/update-command-lifecycle.test.ts
@@ -86,11 +86,14 @@ vi.mock("./shared.js", async (importOriginal) => ({
   tryWriteCompletionCache: vi.fn(async () => "completed"),
 }));
 
-vi.mock("./update-command-config.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./update-command-config.js")>()),
+vi.mock("./update-command-config-snapshot.js", () => ({
   createUpdateConfigSnapshot: vi.fn(async () => {
     record("config-snapshot");
   }),
+}));
+
+vi.mock("./update-command-config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./update-command-config.js")>()),
   persistRequestedUpdateChannel: vi.fn(async (params: { configSnapshot: unknown }) => {
     record("persist-channel");
     return params.configSnapshot;

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -34,7 +34,7 @@ import {
   resolveNodeRunner,
   runUpdateStep,
 } from "./shared.js";
-import { createUpdateConfigSnapshot } from "./update-command-config.js";
+import { createUpdateConfigSnapshot } from "./update-command-config-snapshot.js";
 import { resolveUpdateTargetEnv } from "./update-command-service-env.js";
 
 const CLI_NAME = resolveCliName();

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -14,8 +14,8 @@ import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.j
 import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 import { readPackageVersion, type UpdateCommandOptions } from "./shared.js";
+import { createUpdateConfigSnapshot } from "./update-command-config-snapshot.js";
 import {
-  createUpdateConfigSnapshot,
   persistRequestedUpdateChannel,
   persistValidatedDowngradeConfig,
   readPostCorePreUpdateSourceConfig,

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -131,8 +131,7 @@ vi.mock("../../infra/gateway-processes.js", async (importOriginal) => ({
   signalVerifiedGatewayPidSync: mocks.signal,
 }));
 vi.mock("../../commands/doctor.js", () => ({ doctorCommand: mocks.doctor }));
-vi.mock("./update-command-config.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./update-command-config.js")>()),
+vi.mock("./update-command-config-snapshot.js", () => ({
   createUpdateConfigSnapshot: mocks.configSnapshot,
 }));
 vi.mock("./restart-helper.js", () => ({ runRestartScript: mocks.script }));

--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -32,8 +32,7 @@ vi.mock("./restart-helper.js", async (importOriginal) => ({
   runRestartScript: mocks.runRestartScript,
 }));
 
-vi.mock("./update-command-config.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./update-command-config.js")>()),
+vi.mock("./update-command-config-snapshot.js", () => ({
   createUpdateConfigSnapshot: mocks.createUpdateConfigSnapshot,
 }));
 

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -24,7 +24,7 @@ import {
 } from "../daemon-cli/restart-health.js";
 import { runRestartScript } from "./restart-helper.js";
 import type { UpdateCommandOptions } from "./shared.js";
-import { createUpdateConfigSnapshot } from "./update-command-config.js";
+import { createUpdateConfigSnapshot } from "./update-command-config-snapshot.js";
 import {
   DEFINITION_DENIAL,
   runUpdatedInstallGatewayCommand,

--- a/src/cli/update-finalization-output.test-support.ts
+++ b/src/cli/update-finalization-output.test-support.ts
@@ -80,8 +80,12 @@ const stubs = new Map<string, string>([
     "export const withPluginLifecycleLease = async (_options, run) => await run();",
   ],
   [
+    sourceUrl("./update-cli/update-command-config-snapshot.ts"),
+    "export const createUpdateConfigSnapshot = async () => {};",
+  ],
+  [
     sourceUrl("./update-cli/update-command-config.ts"),
-    "export const createUpdateConfigSnapshot = async () => {}; export const readPostCorePreUpdateSourceConfig = async () => undefined; export const persistRequestedUpdateChannel = async ({configSnapshot}) => configSnapshot; export const persistValidatedDowngradeConfig = async () => {}; export const restoreDroppedPreUpdateChannels = snapshot => ({snapshot, changed: false});",
+    "export const readPostCorePreUpdateSourceConfig = async () => undefined; export const persistRequestedUpdateChannel = async ({configSnapshot}) => configSnapshot; export const persistValidatedDowngradeConfig = async () => {}; export const restoreDroppedPreUpdateChannels = snapshot => ({snapshot, changed: false});",
   ],
   [
     sourceUrl("./update-cli/update-command-plugins.ts"),

--- a/src/commands/doctor-update.test-support.ts
+++ b/src/commands/doctor-update.test-support.ts
@@ -64,7 +64,7 @@ vi.mock("../cli/daemon-cli.js", () => ({
   runDaemonInstall: vi.fn(),
   runDaemonRestart: vi.fn(),
 }));
-vi.mock("../cli/update-cli/update-command-config.js", () => ({
+vi.mock("../cli/update-cli/update-command-config-snapshot.js", () => ({
   createUpdateConfigSnapshot: mocks.createUpdateConfigSnapshot,
 }));
 vi.mock("../cli/daemon-cli/restart-health.js", () => ({


### PR DESCRIPTION
## What Problem This Solves

The four update-snapshot process tests load the full update configuration restoration graph just to copy a pre-update config file. Each fresh process pays that unrelated import cost.

## Why This Change Was Made

Move the existing snapshot function, unchanged, into its own small owner module. Update every production caller and test stub to use it, and remove the former export. The function still resolves configuration paths when called, copies through the existing backup owner, and uses the same filesystem operations. There is one snapshot implementation and no compatibility alias.

## User Impact

Faster internal validation, with unchanged update behavior. All four process tests retain separate Node processes, disabled compilation caching, import-under-home-A then snapshot-under-home-B behavior, filesystem write guards and snapshot permissions. No configuration, schema, dependency or public API change.

## Evidence

Complete canonical runs on one Linux Testbox, Node24.19.0 and pnpm12.1.0:

| Four snapshot cases | Whole command | Test span |
| --- | ---: | ---: |
| Original | 22.55 s | 20.80 s |
| Extracted snapshot owner | 1.74 s | 0.76 s |
| Restored original control | 19.63 s | 18.64 s |

The candidate reduced the matched warm command by 91%. All original case names, assertions and fresh-process isolation remain.

Related suites also passed:97 service/lifecycle cases,44 Doctor/recovery cases,14 process-output cases and357 update CLI cases. The seven stages produced524 passing case executions with no skips or retries. All86 source guards and the new module's original absence restored; all observed process groups joined without rescue; the exact Testbox was stopped. [Remote proof](https://github.com/openclaw/openclaw/actions/runs/33629913900).

Production net +2 lines reflects the separate module imports after discounting the moved function; test net +5 routes existing mocks to the new owner. Formatting, type-aware lint, diff checks and Codex P0 review passed. Main has since strengthened package rollback verification and its existing test; this change preserves that work and changes only its snapshot import. Exact-head CI covers those current contracts.
