### PR TITLE
fix: preserve remote iMessage attachments during materialization

### DIFF
--- a/src/auto-reply/reply/stage-remote-inbound-media.owner.test.ts
+++ b/src/auto-reply/reply/stage-remote-inbound-media.owner.test.ts
@@ -13,7 +13,7 @@ it.each([
   { agentId: "work", remoteMediaMode: "sandbox-or-cache" },
   { agentId: undefined, remoteMediaMode: "cache" },
 ] as const)(
-  "stages remote global media for $agentId in $remoteMediaMode mode",
+  "stages remote global media after a transient SCP failure for $agentId in $remoteMediaMode mode",
   async ({ agentId, remoteMediaMode }) => {
     await withOpenClawTestState({ label: "remote-media-owner" }, async (state) => {
       const cfg = {
@@ -35,17 +35,31 @@ it.each([
       vi.spyOn(mediaRoots, "resolveChannelRemoteInboundAttachmentRoots").mockReturnValue([
         "/synthetic/attachments",
       ]);
-      vi.spyOn(processExec, "runCommandWithTimeout").mockImplementation(async (argv) => {
-        await fs.writeFile(argv.at(-1)!, "remote attachment");
-        return {
-          code: 0,
-          stdout: "",
-          stderr: "",
-          signal: null,
-          killed: false,
-          termination: "exit",
-        };
-      });
+      let scpAttempts = 0;
+      const runScp = vi
+        .spyOn(processExec, "runCommandWithTimeout")
+        .mockImplementation(async (argv) => {
+          scpAttempts += 1;
+          if (scpAttempts === 1) {
+            return {
+              code: 1,
+              stdout: "",
+              stderr: "remote attachment is still materializing",
+              signal: null,
+              killed: false,
+              termination: "exit",
+            };
+          }
+          await fs.writeFile(argv.at(-1)!, "remote attachment");
+          return {
+            code: 0,
+            stdout: "",
+            stderr: "",
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        });
       const ctx = {
         MediaRemoteHost: "user@gateway-host",
         media: [{ path: "/synthetic/attachments/report.txt" }],
@@ -60,6 +74,7 @@ it.each([
           remoteMediaMode,
         }),
       ).toBe(true);
+      expect(runScp).toHaveBeenCalledTimes(2);
       const fact = ctx.media[0] as { path: string; workspaceDir?: string; staged?: boolean };
       expect(fact.staged).toBe(true);
       const staged = path.isAbsolute(fact.path)

--- a/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
@@ -56,6 +56,7 @@ describe("scpFile", () => {
     } catch (error) {
       message = error instanceof Error ? error.message : String(error);
     }
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(3);
     expect(message).toMatch(/^scp failed \(1\):/);
     expect(message).toContain("fail");
     expect(message).not.toContain("🤖");

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { root as fsRoot, FsSafeError, readLocalFileSafely } from "../../infra/fs-safe.js";
 import { safeFileURLToPath } from "../../infra/local-file-access.js";
+import { retryAsync } from "../../infra/retry.js";
 import { normalizeScpRemoteHost, normalizeScpRemotePath } from "../../infra/scp-host.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { resolveChannelRemoteInboundAttachmentRoots } from "../../media/channel-inbound-roots.js";
@@ -379,27 +380,32 @@ async function scpFile(remoteHost: string, remotePath: string, localPath: string
   if (!safeRemotePath) {
     throw new Error("invalid remote path for SCP");
   }
-  const result = await runCommandWithTimeout(
-    [
-      "scp",
-      "-o",
-      "BatchMode=yes",
-      "-o",
-      "StrictHostKeyChecking=yes",
-      "--",
-      `${safeRemoteHost}:${safeRemotePath}`,
-      localPath,
-    ],
-    {
-      // Four UTF-8 bytes per code point preserves enough data for the existing
-      // UTF-16 diagnostic tail contract without retaining unbounded stderr.
-      maxOutputBytes: { stdout: 1, stderr: SCP_STDERR_TAIL_CHARS * 4 },
+  await retryAsync(
+    async () => {
+      const result = await runCommandWithTimeout(
+        [
+          "scp",
+          "-o",
+          "BatchMode=yes",
+          "-o",
+          "StrictHostKeyChecking=yes",
+          "--",
+          `${safeRemoteHost}:${safeRemotePath}`,
+          localPath,
+        ],
+        {
+          // Four UTF-8 bytes per code point preserves enough data for the existing
+          // UTF-16 diagnostic tail contract without retaining unbounded stderr.
+          maxOutputBytes: { stdout: 1, stderr: SCP_STDERR_TAIL_CHARS * 4 },
+        },
+      );
+      if (result.code !== 0) {
+        const stderr = appendScpStderrTail("", result.stderr).trim();
+        throw new Error(`scp failed (${result.code}): ${stderr}`);
+      }
     },
+    { attempts: 3, label: "remote inbound media SCP" },
   );
-  if (result.code !== 0) {
-    const stderr = appendScpStderrTail("", result.stderr).trim();
-    throw new Error(`scp failed (${result.code}): ${stderr}`);
-  }
 }
 
 function appendScpStderrTail(


### PR DESCRIPTION
Closes #135860

## What Problem This Solves

Fixes an issue where remote-host iMessage users could lose an image or document when the Messages attachment was still materializing during inbound processing. If both existing staging phases reached the file too early, the agent received a text-only turn and could answer without the attachment's contents.

## Why This Change Was Made

Remote inbound staging now retries only the SCP copy operation, with the existing canonical retry helper and a three-attempt bound. Host and path normalization, configured attachment-root validation, size checks, local safe reads, and temporary-directory cleanup remain outside the retry and unchanged; this adds no config, schema, protocol, migration, or channel-specific behavior.

The production change is six net lines: the existing one-shot copy is wrapped at the shared staging owner rather than adding an iMessage-only fallback or another staging path.

## User Impact

Remote iMessage images, PDFs, audio, video, and other attachments can now survive a short remote-file materialization delay and reach the agent without requiring a resend. Persistent SCP, authentication, path, or size failures remain bounded and continue through the existing explicit attachment-failure behavior.

## Evidence

### Isolated Gateway reporter-path proof

A production-mode isolated OpenClaw Gateway loaded the bundled iMessage plugin and exercised this path end to end:

`remote iMessage notification -> shared remote staging -> model image input -> outbound iMessage send`

The synthetic remote file returned the same materialization error on the first two SCP calls and became readable on the third.

Before the fix, the two existing Gateway staging invocations each made one attempt in different staging directories:

```text
SCP attempts: 2
same staging invocation: false
model image inputs: 0
model outcome: success
outbound reply described the image: false
reply: "Protocol note: acknowledged. Continue with the QA scenario plan..."
```

With the fix, all three attempts stayed in the same owning staging invocation and destination; the third copied a real 2x2 PNG whose top half was red and bottom half blue:

```json
{
  "gatewayReady": true,
  "watchSubscribed": true,
  "inboundPromptObserved": true,
  "scpAttempts": 3,
  "transientScpRecovered": true,
  "modelImageInputCount": 1,
  "modelOutcome": "success",
  "outboundReplySent": true,
  "outboundReplyDescribedImage": true
}
```

The outbound iMessage RPC contained:

```text
Protocol note: the attached image is split horizontally, with red on top and blue on the bottom.
```

### Regression and repository checks

The owner-boundary regression failed before the production change because transient SCP failure returned `false` for all three staging modes. The retry-bound regression also failed with `expected 3 calls, received 1`.

After the fix:

```text
node scripts/run-vitest.mjs \
  src/auto-reply/reply/stage-remote-inbound-media.owner.test.ts \
  src/auto-reply/reply/stage-sandbox-media.scp.test.ts

Test Files  2 passed (2)
Tests       6 passed (6)
```

```text
node scripts/check-changed.mjs -- \
  src/auto-reply/reply/stage-sandbox-media.ts \
  src/auto-reply/reply/stage-remote-inbound-media.owner.test.ts \
  src/auto-reply/reply/stage-sandbox-media.scp.test.ts

passed
```

```text
pnpm build

passed
```

## Bounded failure cost

Each staging invocation is limited to three attempts with 300 ms and 600 ms backoff delays. The ordinary reply path can stage once before media understanding and again before final agent staging when every first-pass attempt fails. A permanent failure can therefore start up to six SCP commands and add 1.8 seconds of backoff per attachment in one turn. OpenSSH reports only success or a nonzero error and provides no stable transient-error class, so stderr or exit-code filtering would be brittle across versions and locales. Maintainer review accepts this bounded cost because the retry stays inside the remote copy owner and does not repeat validation, model execution, fact publication, or cleanup.