### PR TITLE
fix(packaging): make built package imports side-effect free

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -718,7 +718,6 @@ src/logging/diagnostic-stability.ts
 src/logging/diagnostic-support-export.ts
 src/logging/diagnostic.test.ts
 src/logging/diagnostic.ts
-src/logging/logger.ts
 src/logging/redact.test.ts
 src/logging/redact.ts
 src/media-understanding/apply.test.ts

--- a/scripts/test-built-bundled-channel-entry-smoke.mts
+++ b/scripts/test-built-bundled-channel-entry-smoke.mts
@@ -60,16 +60,23 @@ function smokeInInstalledLayout() {
   const nodeModulesRoot = path.join(tempRoot, "node_modules");
   const installedPackageRoot = path.join(nodeModulesRoot, "openclaw");
   try {
-    fs.mkdirSync(nodeModulesRoot, { recursive: true });
-    fs.symlinkSync(packageRoot, installedPackageRoot, "dir");
+    fs.mkdirSync(installedPackageRoot, { recursive: true });
+    fs.copyFileSync(
+      path.join(packageRoot, "package.json"),
+      path.join(installedPackageRoot, "package.json"),
+    );
+    fs.cpSync(path.join(packageRoot, "dist"), path.join(installedPackageRoot, "dist"), {
+      recursive: true,
+      mode: fs.constants.COPYFILE_FICLONE,
+    });
+    fs.symlinkSync(
+      fs.realpathSync(path.join(packageRoot, "node_modules")),
+      path.join(installedPackageRoot, "node_modules"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
     const result = spawnSync(
       process.execPath,
-      [
-        "--preserve-symlinks",
-        fileURLToPath(import.meta.url),
-        "--package-root",
-        installedPackageRoot,
-      ],
+      [fileURLToPath(import.meta.url), "--package-root", installedPackageRoot],
       {
         env: { ...process.env, [installedLayoutEnv]: "1" },
         stdio: "inherit",

--- a/src/logging/logger.browser-import.test.ts
+++ b/src/logging/logger.browser-import.test.ts
@@ -1,4 +1,5 @@
 // Logger browser import tests cover safe import behavior in browser-like runtimes.
+import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -8,12 +9,14 @@ const originalGetBuiltinModule = (
   process as NodeJS.Process & { getBuiltinModule?: (id: string) => unknown }
 ).getBuiltinModule;
 
-async function importBrowserSafeLogger(params?: {
+async function importLoggerWithMockedTempResolver(params?: {
+  nodeFsAvailable?: boolean;
   resolvePreferredOpenClawTmpDir?: ReturnType<typeof vi.fn>;
 }): Promise<{
   module: LoggerModule;
   resolvePreferredOpenClawTmpDir: ReturnType<typeof vi.fn>;
 }> {
+  vi.resetModules();
   const resolvePreferredOpenClawTmpDir =
     params?.resolvePreferredOpenClawTmpDir ??
     vi.fn(() => {
@@ -32,17 +35,17 @@ async function importBrowserSafeLogger(params?: {
 
   Object.defineProperty(process, "getBuiltinModule", {
     configurable: true,
-    value: undefined,
+    value: params?.nodeFsAvailable ? (id: string) => (id === "fs" ? {} : undefined) : undefined,
   });
 
   const module = await importFreshModule<LoggerModule>(
     import.meta.url,
-    "./logger.js?scope=browser-safe",
+    `./logger.js?scope=${params?.nodeFsAvailable ? "node-safe" : "browser-safe"}`,
   );
   return { module, resolvePreferredOpenClawTmpDir };
 }
 
-describe("logging/logger browser-safe import", () => {
+describe("logging/logger import", () => {
   afterEach(() => {
     vi.doUnmock("../infra/tmp-openclaw-dir.js");
     Object.defineProperty(process, "getBuiltinModule", {
@@ -52,15 +55,32 @@ describe("logging/logger browser-safe import", () => {
   });
 
   it("does not resolve the preferred temp dir at import time when node fs is unavailable", async () => {
-    const { module, resolvePreferredOpenClawTmpDir } = await importBrowserSafeLogger();
+    const { module, resolvePreferredOpenClawTmpDir } = await importLoggerWithMockedTempResolver();
 
     expect(resolvePreferredOpenClawTmpDir).not.toHaveBeenCalled();
     expect(module.DEFAULT_LOG_DIR).toBe("/tmp/openclaw");
     expect(module.DEFAULT_LOG_FILE).toBe("/tmp/openclaw/openclaw.log");
   });
 
+  it("defers node temp resolution until active logger settings are requested", async () => {
+    const secureLogDir = path.join(process.cwd(), "secure-openclaw-temp");
+    const resolvePreferredOpenClawTmpDir = vi.fn(() => secureLogDir);
+    const { module } = await importLoggerWithMockedTempResolver({
+      nodeFsAvailable: true,
+      resolvePreferredOpenClawTmpDir,
+    });
+
+    expect(resolvePreferredOpenClawTmpDir).not.toHaveBeenCalled();
+    expect(module.DEFAULT_LOG_DIR).toBe("/tmp/openclaw");
+    expect(module.DEFAULT_LOG_FILE).toBe("/tmp/openclaw/openclaw.log");
+
+    module.setLoggerConfigLoaderForTests(() => undefined);
+    expect(path.dirname(module.getResolvedLoggerSettings().file)).toBe(secureLogDir);
+    expect(resolvePreferredOpenClawTmpDir).toHaveBeenCalledOnce();
+  });
+
   it("disables file logging when imported in a browser-like environment", async () => {
-    const { module, resolvePreferredOpenClawTmpDir } = await importBrowserSafeLogger();
+    const { module, resolvePreferredOpenClawTmpDir } = await importLoggerWithMockedTempResolver();
 
     expect(module.getResolvedLoggerSettings()).toStrictEqual({
       level: "silent",

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -20,10 +20,7 @@ import {
 } from "../infra/diagnostic-trace-context.js";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
-import {
-  DEFAULT_POSIX_TMP_ROOT,
-  resolvePreferredOpenClawTmpDir,
-} from "../infra/tmp-openclaw-dir.js";
+import { DEFAULT_POSIX_TMP_ROOT } from "../infra/tmp-openclaw-dir.js";
 import { invalidateLoggingConfigCache, readLoggingConfig } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
@@ -42,18 +39,8 @@ import { formatTimestamp } from "./timestamps.js";
 import type { LoggerSettings } from "./types.js";
 export type { LoggerSettings } from "./types.js";
 
-function resolveDefaultLogDir(): string {
-  return canUseNodeFs() ? resolvePreferredOpenClawTmpDir() : DEFAULT_POSIX_TMP_ROOT;
-}
-
-function resolveDefaultLogFile(defaultLogDir: string): string {
-  return canUseNodeFs()
-    ? path.join(defaultLogDir, "openclaw.log")
-    : `${DEFAULT_POSIX_TMP_ROOT}/openclaw.log`;
-}
-
-export const DEFAULT_LOG_DIR = resolveDefaultLogDir();
-export const DEFAULT_LOG_FILE = resolveDefaultLogFile(DEFAULT_LOG_DIR); // legacy single-file path
+export const DEFAULT_LOG_DIR = DEFAULT_POSIX_TMP_ROOT;
+export const DEFAULT_LOG_FILE = `${DEFAULT_LOG_DIR}/openclaw.log`; // legacy single-file path
 
 const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFAULT_MAX_LOG_FILE_BYTES = 100 * 1024 * 1024; // 100 MB
@@ -521,7 +508,7 @@ function resolveDefaultActiveLogFile(): string {
       `${LOG_PREFIX}-vitest-${process.pid}-${formatLocalDate(new Date())}${LOG_SUFFIX}`,
     );
   }
-  return resolveDefaultRollingLogFile({ logDir: DEFAULT_LOG_DIR });
+  return resolveDefaultRollingLogFile();
 }
 
 function resolveSettings(): ResolvedRuntimeSettings {
@@ -540,7 +527,7 @@ function resolveSettings(): ResolvedRuntimeSettings {
   if (canUseSilentVitestFileLogFastPath(envLevel)) {
     return {
       level: "silent",
-      file: resolveDefaultRollingLogFile({ logDir: DEFAULT_LOG_DIR }),
+      file: resolveDefaultRollingLogFile(),
       maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
       rolling: true,
     };

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -773,5 +773,3 @@ function pruneOldRollingLogs(dir: string): void {
     // ignore missing dir or read errors
   }
 }
-
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugin-sdk/browser-profiles.browser-import.test.ts
+++ b/src/plugin-sdk/browser-profiles.browser-import.test.ts
@@ -1,0 +1,28 @@
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type BrowserProfilesModule = typeof import("./browser-profiles.js");
+
+describe("plugin-sdk browser profiles import", () => {
+  afterEach(() => {
+    vi.doUnmock("../infra/tmp-openclaw-dir.js");
+    vi.resetModules();
+  });
+
+  it("keeps the SDK facade independent from secure temp resolution", async () => {
+    const resolvePreferredOpenClawTmpDir = vi.fn(() => {
+      throw new Error("secure temp resolution must stay lazy");
+    });
+    const loadTempResolver = vi.fn(() => ({ resolvePreferredOpenClawTmpDir }));
+    vi.doMock("../infra/tmp-openclaw-dir.js", loadTempResolver);
+
+    const browserProfiles = await importFreshModule<BrowserProfilesModule>(
+      import.meta.url,
+      "./browser-profiles.js?scope=browser-safe",
+    );
+
+    expect(loadTempResolver).not.toHaveBeenCalled();
+    expect(resolvePreferredOpenClawTmpDir).not.toHaveBeenCalled();
+    expect(browserProfiles.DEFAULT_UPLOAD_DIR).toBe("/tmp/openclaw/uploads");
+  });
+});

--- a/src/plugin-sdk/browser-profiles.ts
+++ b/src/plugin-sdk/browser-profiles.ts
@@ -1,10 +1,8 @@
 /**
  * Public SDK facade for browser profile defaults and activated profile resolution.
  */
-import path from "node:path";
 import type { BrowserConfig } from "../config/types.browser.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./browser-types.js";
 import { loadBundledPluginPublicSurfaceModuleSyncCore } from "./facade-loader.js";
 export type {
@@ -27,8 +25,10 @@ export const DEFAULT_BROWSER_DEFAULT_PROFILE_NAME = "openclaw";
 export const DEFAULT_BROWSER_ACTION_TIMEOUT_MS = 60_000;
 /** Default maximum AI snapshot text captured from browser pages. */
 export const DEFAULT_AI_SNAPSHOT_MAX_CHARS = 80_000;
-/** Default upload staging directory used by browser-backed file uploads. */
-export const DEFAULT_UPLOAD_DIR = path.join(resolvePreferredOpenClawTmpDir(), "uploads");
+/**
+ * Portable SDK compatibility default; the browser plugin owns platform-aware runtime paths.
+ */
+export const DEFAULT_UPLOAD_DIR = "/tmp/openclaw/uploads";
 
 type BrowserProfilesSurface = {
   resolveBrowserConfig: (

--- a/test/openclaw-prepack.test.ts
+++ b/test/openclaw-prepack.test.ts
@@ -4,8 +4,10 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  readlinkSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
   symlinkSync,
@@ -46,6 +48,22 @@ const standaloneBundledChannelSmokeFiles = [
   "scripts/process-warning-filter.mts",
 ];
 
+function linkFixtureParent(packageRoot: string) {
+  const nodeModulesRoot = path.join(packageRoot, "node_modules");
+  const parentRoot = path.join(
+    nodeModulesRoot,
+    ".pnpm",
+    "fixture-parent@1.0.0",
+    "node_modules",
+    "fixture-parent",
+  );
+  symlinkSync(
+    process.platform === "win32" ? parentRoot : path.relative(nodeModulesRoot, parentRoot),
+    path.join(nodeModulesRoot, "fixture-parent"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
+}
+
 function createBundledChannelSmokeFixture(entrySource: string, prepared = false) {
   const rootDir = tempDirs.make("openclaw-prepack-standalone-smoke-");
   for (const relativePath of standaloneBundledChannelSmokeFiles) {
@@ -67,12 +85,45 @@ function createBundledChannelSmokeFixture(entrySource: string, prepared = false)
   );
   writeFileSync(path.join(extensionRoot, "index.js"), entrySource);
 
-  return { rootDir, packageRoot };
+  const nodeModulesRoot = path.join(packageRoot, "node_modules");
+  const parentStoreRoot = path.join(
+    nodeModulesRoot,
+    ".pnpm",
+    "fixture-parent@1.0.0",
+    "node_modules",
+  );
+  const parentRoot = path.join(parentStoreRoot, "fixture-parent");
+  const siblingRoot = path.join(parentStoreRoot, "fixture-sibling");
+  mkdirSync(parentRoot, { recursive: true });
+  mkdirSync(siblingRoot);
+  writeFileSync(
+    path.join(parentRoot, "package.json"),
+    '{"name":"fixture-parent","version":"1.0.0","type":"module","exports":"./index.js"}\n',
+  );
+  writeFileSync(
+    path.join(parentRoot, "index.js"),
+    'import { value } from "fixture-sibling"; export const fixtureValue = value;\n',
+  );
+  writeFileSync(
+    path.join(siblingRoot, "package.json"),
+    '{"name":"fixture-sibling","version":"1.0.0","type":"module","exports":"./index.js"}\n',
+  );
+  writeFileSync(path.join(siblingRoot, "index.js"), 'export const value = "fixture-channel";\n');
+  linkFixtureParent(packageRoot);
+
+  return {
+    rootDir,
+    packageRoot,
+    dependencyFiles: {
+      parent: readFileSync(path.join(parentRoot, "index.js"), "utf8"),
+      sibling: readFileSync(path.join(siblingRoot, "index.js"), "utf8"),
+    },
+  };
 }
 
 function createPreparedPrepackFixture(entrySource: string) {
   const { rootDir } = createBundledChannelSmokeFixture(entrySource, true);
-  mkdirSync(path.join(rootDir, "node_modules"));
+  mkdirSync(path.join(rootDir, "node_modules"), { recursive: true });
   symlinkSync(
     path.dirname(fileURLToPath(import.meta.resolve("tsx/package.json"))),
     path.join(rootDir, "node_modules/tsx"),
@@ -185,13 +236,20 @@ type BundledChannelSmokeLayout = "source" | "installed-env" | "installed-path";
 
 function runStandaloneBundledChannelSmoke(entrySource: string, layout: BundledChannelSmokeLayout) {
   const fixture = createBundledChannelSmokeFixture(entrySource);
-  const { rootDir } = fixture;
+  const { dependencyFiles, rootDir } = fixture;
   let { packageRoot } = fixture;
   if (layout === "installed-path") {
     const installedRoot = path.join(rootDir, "node_modules", "openclaw");
     mkdirSync(path.dirname(installedRoot), { recursive: true });
     renameSync(packageRoot, installedRoot);
     packageRoot = installedRoot;
+    if (process.platform === "win32") {
+      rmSync(path.join(packageRoot, "node_modules/fixture-parent"), {
+        recursive: true,
+        force: true,
+      });
+      linkFixtureParent(packageRoot);
+    }
   }
   const temporaryRoot = path.join(rootDir, "smoke-temp");
   mkdirSync(temporaryRoot);
@@ -230,6 +288,27 @@ function runStandaloneBundledChannelSmoke(entrySource: string, layout: BundledCh
       path.join(packageRoot, "dist", "extensions", "fixture-channel", "index.js"),
       "utf8",
     ),
+    dependencyFiles: {
+      parent: readFileSync(
+        path.join(
+          packageRoot,
+          "node_modules/.pnpm/fixture-parent@1.0.0/node_modules/fixture-parent/index.js",
+        ),
+        "utf8",
+      ),
+      sibling: readFileSync(
+        path.join(
+          packageRoot,
+          "node_modules/.pnpm/fixture-parent@1.0.0/node_modules/fixture-sibling/index.js",
+        ),
+        "utf8",
+      ),
+    },
+    dependencyLink: {
+      target: readlinkSync(path.join(packageRoot, "node_modules/fixture-parent")),
+      resolved: realpathSync(path.join(packageRoot, "node_modules/fixture-parent")),
+    },
+    originalDependencyFiles: dependencyFiles,
   };
 }
 
@@ -244,10 +323,11 @@ describe("standalone bundled channel smoke", () => {
     "preserves the result and releases its layout for $layout with invalid=$invalid",
     ({ layout, invalid }) => {
       const entrySource = invalid
-        ? "export default [];\n"
-        : `export default {
+        ? 'import "fixture-parent"; export default [];\n'
+        : `import { fixtureValue } from "fixture-parent";
+          export default {
             kind: "bundled-channel-entry",
-            loadChannelPlugin() { return { id: "fixture-channel" }; },
+            loadChannelPlugin() { return { id: fixtureValue }; },
           };\n`;
       const observed = runStandaloneBundledChannelSmoke(entrySource, layout);
       const { result } = observed;
@@ -262,6 +342,11 @@ describe("standalone bundled channel smoke", () => {
         expect(result.stdout.match(/\[build-smoke\]/gu)).toHaveLength(1);
       }
       expect(observed.entrySource).toBe(entrySource);
+      expect(observed.dependencyFiles).toEqual(observed.originalDependencyFiles);
+      expect(observed.dependencyLink.target).toContain(".pnpm");
+      expect(observed.dependencyLink.resolved).toContain(
+        path.join(".pnpm", "fixture-parent@1.0.0", "node_modules", "fixture-parent"),
+      );
       expect(observed.sentinel).toBe("preserve caller-owned temporary sibling\n");
       expect(observed.temporaryEntries).toEqual(["unrelated.txt"]);
     },


### PR DESCRIPTION
## Summary

- defer secure temporary-directory resolution until logger runtime initialization
- keep the plugin SDK browser-profile facade free of import-time filesystem work
- model the installed package layout without preserving package-root symlinks
- add import and pnpm-shaped transitive-resolution regressions

## Root cause

Full Release Validation run 33623025793 failed the bundled-channel package smoke with `ERR_REQUIRE_ESM_RACE_CONDITION`. Importing the built package triggered secure temporary-directory filesystem work during module initialization.

After removing that import-time work, the smoke exposed a second harness defect: the installed-layout fixture preserved the package-root symlink globally, so Node resolved transitive dependencies from the logical package path and could not see pnpm's nested dependency layout.

The logger owns active log-path resolution, the browser plugin owns platform-aware upload paths, and the package smoke owns its installed-layout model. The fix moves work to those boundaries instead of adding retries or dependency fallbacks.

## Verification

- Node 24 full package build: `pnpm build:package`
- Node 24 built bundled-channel smoke: pass, `channel=3 setup=3 legacySetup=0`
- `pnpm exec vitest run test/openclaw-prepack.test.ts`
- focused logger, plugin SDK, temp-path, and browser-import tests
- plugin SDK export check
- formatting, oxlint, and `git diff --check`
- autoreview: clean, no actionable findings

## Test audit

The import tests fail if secure temp resolution returns to module initialization. The prepack fixture creates a pnpm-shaped unhoisted transitive dependency and fails if the smoke restores global symlink preservation or stops modeling the copied installed package.

## Scope

- production/tooling: net -8 lines
- tests: +145/-12
- removes import-time filesystem work and the obsolete preserve-symlinks execution path
- no changelog entry: repository policy reserves changelog edits for release preparation

FRV evidence: https://github.com/openclaw/openclaw/actions/runs/33623025793

