### PR TITLE
fix(terminal): keep tabbed table columns aligned

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -93,6 +93,9 @@ commands resolve the target workspace from `--agent <id>`, then the current
 working directory when it is inside a configured agent workspace, then the
 default agent.
 
+The skills table renders horizontal tabs as single spaces so descriptions
+stay aligned with the neighboring columns.
+
 `check` reports missing prerequisites independently of agent exclusion: a skill
 excluded by the agent allowlist can also appear under **Missing requirements**.
 Disabled skills and skills blocked by the bundled allowlist keep their separate

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -86,6 +86,48 @@ describe("renderTable", () => {
     expect(segment).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["plain", "a\tb", "| a b     |"],
+    ["styled", "\x1b[31ma\tb\x1b[39m", "| \x1b[31ma b\x1b[39m     |"],
+    ["wide", "表\t文", "| 表 文   |"],
+    ["ESC CSI", "a\x1b[31\tmb\x1b[0m", "| a\x1b[\x18 \x1b[31mb\x1b[0m     |"],
+    ["C1 CSI", "a\x9b31\tmb\x9b0m", "| a\x9b\x18 \x9b31mb\x9b0m     |"],
+    ["CSI control order", "a\x1b[31\t\x07\tmb\x1b[0m", "| a\x1b[\x18 \x07 \x1b[31mb\x1b[0m    |"],
+    ["cancelled CSI", "a\x1b[31\t\x18b", "| a\x1b[\x18 \x1b[31\x18b     |"],
+    ["CSI without text", "\x1b[31\tm", "|         |"],
+    [
+      "OSC payload",
+      "a\x1b]8;id=keep\tpayload;https://example.com/\x07b\x1b]8;;\x07",
+      "| a\x1b]8;id=keep\tpayload;https://example.com/\x07b\x1b]8;;\x07      |",
+    ],
+  ])("materializes executable tabs as table spacing in %s cells", (_label, value, expectedRow) => {
+    const out = renderTable({
+      border: "ascii",
+      columns: [{ key: "V", header: "V", minWidth: 9, maxWidth: 9 }],
+      rows: [{ V: value }],
+    });
+
+    expect(out).toBe(
+      ["+---------+", "| V       |", "+---------+", expectedRow, "+---------+", ""].join("\n"),
+    );
+  });
+
+  it.each([
+    ["ESC", "a\x1b[31\x1b[0\tmb", "| a b     |"],
+    ["C1", "a\x9b31\x9b0\tmb", "| a b     |"],
+    ["mixed chain", "a\x1b[31\x9b1\x1b[0\tmb", "| a b     |"],
+    ["C0 before restart", "a\x1b[31\t\x07\x9b0\tmb", "| a  b    |"],
+  ])("keeps materialized tabs visible after %s CSI restarts", (_label, value, expectedRow) => {
+    const out = renderTable({
+      border: "ascii",
+      columns: [{ key: "V", header: "V", minWidth: 9, maxWidth: 9 }],
+      rows: [{ V: value }],
+    });
+
+    expect(sanitizeForLog(out.split("\n")[3] ?? "")).toBe(expectedRow);
+    expect(stripAnsi(out)).not.toContain("\x18");
+  });
+
   it.each([0, 3])("renders all %i rows without an argument-count limit", (count) => {
     const out = renderTable({
       border: "ascii",
@@ -587,7 +629,7 @@ console.log(JSON.stringify({
       "\x1b]8;;\x07",
       1,
     ],
-    ["CR/CSI-HT/LF", "line1\r\x1b[31\tm\n東京 line2\x1b[39m", "\x1b[31\tm", "\x1b[39m", 1],
+    ["CR/CSI-HT/LF", "line1\r\x1b[31\tm\n東京 line2\x1b[39m", "\x1b[31m", "\x1b[39m", 1],
     ["CR/CSI-BEL/LF", "line1\r\x1b[31\x07m\n東京 line2\x1b[39m", "\x1b[31\x07m", "\x1b[39m", 1],
   ] as const)(
     "respects explicit %s newlines in cell values",
@@ -750,8 +792,6 @@ console.log(JSON.stringify({
   it.each([
     ["ESC CSI with BEL", "\x1b[31\x07m"],
     ["C1 CSI with BEL", "\x9b31\x07m"],
-    ["ESC CSI with HT", "\x1b[31\tm"],
-    ["C1 CSI with HT", "\x9b31\tm"],
   ])("keeps %s sequences with executable C0 controls atomic", (_label, sequence) => {
     const out = renderTable({
       width: 5,
@@ -767,7 +807,7 @@ console.log(JSON.stringify({
     }
   });
 
-  it("rechecks atomic control width after wrapping at an earlier break", () => {
+  it("wraps separately executed CSI tabs with the surrounding text", () => {
     const sequence = "\x1b[31\t\t\tm";
     const out = renderTable({
       width: 7,
@@ -777,10 +817,18 @@ console.log(JSON.stringify({
       rows: [{ V: `a bbb${sequence}d\x1b[0m` }],
     });
 
-    expect(out).toContain(sequence);
-    for (const line of out.trimEnd().split("\n")) {
-      expect(visibleWidth(line)).toBe(7);
-    }
+    expect(out).toBe(
+      [
+        "+-----+",
+        "|V    |",
+        "+-----+",
+        "|a    |",
+        "|bbb\x1b[\x18  |",
+        "|\x1b[31md\x1b[0m    |",
+        "+-----+",
+        "",
+      ].join("\n"),
+    );
   });
 
   it("does not interpret CSI intermediates as SGR state", () => {

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -287,15 +287,27 @@ function wrapLine(text: string, width: number): string[] {
   // must not leak styling into padding while the next continuation keeps it.
   const tokens: AnsiToken[] = [];
   for (const segment of splitAnsiSegments(text)) {
+    let value = segment.value;
     if (segment.kind === "ansi") {
-      tokens.push({
-        kind: "ansi",
-        value: segment.value,
-        width: visibleWidth(segment.controls.join("")),
-      });
+      if (segment.controls.includes("\t")) {
+        // Reset with the CSI introducer before printable controls can enter pending escape parsing.
+        tokens.push({
+          kind: "ansi",
+          value: value.slice(0, value[0] === ESC ? 2 : 1) + "\x18",
+          width: 0,
+        });
+        const controls = new Set(segment.controls);
+        for (const control of segment.controls) {
+          tokens.push({ kind: control === "\t" ? "char" : "ansi", value: control, width: 0 });
+        }
+        value = Array.from(value)
+          .filter((character) => !controls.has(character))
+          .join("");
+      }
+      tokens.push({ kind: "ansi", value, width: 0 });
       continue;
     }
-    for (const grapheme of splitGraphemes(segment.value)) {
+    for (const grapheme of splitGraphemes(value)) {
       tokens.push({ kind: "char", value: grapheme, width: 0 });
     }
   }
@@ -306,8 +318,7 @@ function wrapLine(text: string, width: number): string[] {
 
   const lines: string[] = [];
   const isBreakChar = (ch: string) =>
-    ch === " " || ch === "\t" || ch === "/" || ch === "-" || ch === "_" || ch === ".";
-  const isSpaceChar = (ch: string) => ch === " " || ch === "\t";
+    ch === " " || ch === "/" || ch === "-" || ch === "_" || ch === ".";
   let skipNextLf = false;
 
   const buf: AnsiToken[] = [];
@@ -315,9 +326,6 @@ function wrapLine(text: string, width: number): string[] {
   let lastBreakIndex: number | null = null;
 
   const bufToString = (slice?: AnsiToken[]) => (slice ?? buf).map((t) => t.value).join("");
-
-  const bufVisibleWidth = (slice: AnsiToken[]) =>
-    slice.reduce((acc, token) => acc + token.width, 0);
 
   const pushLine = (value: string) => {
     const cleaned = value.replace(/\s+$/, "");
@@ -352,7 +360,7 @@ function wrapLine(text: string, width: number): string[] {
       return;
     }
 
-    // breakAt follows the latest break character (including spaces/tabs), or is buf.length.
+    // breakAt follows the latest break character, or is buf.length.
     // The retained suffix therefore has no leading space tokens to trim.
     const rest = buf.slice(breakAt);
     pushLine(`${bufToString(left)}${closeOsc8}${closeSgr}`);
@@ -371,49 +379,41 @@ function wrapLine(text: string, width: number): string[] {
 
     buf.length = 0;
     buf.push(...rest);
-    bufVisible = bufVisibleWidth(buf);
+    bufVisible = buf.reduce((acc, token) => acc + token.width, 0);
     lastBreakIndex = null;
   };
 
-  const makeRoomFor = (tokenWidth: number) => {
-    if (bufVisible + tokenWidth <= width || bufVisible === 0) {
-      return;
-    }
-    flushAt(lastBreakIndex);
-    if (bufVisible + tokenWidth > width && bufVisible > 0) {
-      flushAt(null);
-    }
-  };
-
   for (const token of tokens) {
-    if (token.kind === "ansi") {
-      makeRoomFor(token.width);
-      buf.push(token);
-      bufVisible += token.width;
-      continue;
+    if (token.kind === "char") {
+      // Emit the one-cell space used by layout instead of following terminal tab stops.
+      token.value = token.value.replaceAll("\t", " ");
+      const ch = token.value;
+      if (skipNextLf && ch === "\n") {
+        skipNextLf = false;
+        continue;
+      }
+      // CRLF is one grapheme; separated CR/LF may retain intervening ANSI controls.
+      skipNextLf = ch === "\r";
+      if (ch === "\n" || ch === "\r" || ch === "\r\n") {
+        flushAt(buf.length);
+        continue;
+      }
+      // Soft-wrap remainders reuse the width measured when each token entered the buffer.
+      token.width = visibleWidth(ch);
     }
-
-    const ch = token.value;
-    if (skipNextLf && ch === "\n") {
-      skipNextLf = false;
-      continue;
+    if (bufVisible + token.width > width && bufVisible > 0) {
+      flushAt(lastBreakIndex);
+      if (bufVisible + token.width > width && bufVisible > 0) {
+        flushAt(null);
+      }
     }
-    // CRLF is one grapheme; separated CR/LF may retain intervening ANSI controls.
-    skipNextLf = ch === "\r";
-    if (ch === "\n" || ch === "\r" || ch === "\r\n") {
-      flushAt(buf.length);
-      continue;
-    }
-    // Soft-wrap remainders reuse the width measured when each token entered the buffer.
-    token.width = visibleWidth(ch);
-    makeRoomFor(token.width);
-    if (bufVisible === 0 && isSpaceChar(ch)) {
+    if (token.kind === "char" && bufVisible === 0 && token.value === " ") {
       continue;
     }
 
     buf.push(token);
     bufVisible += token.width;
-    if (isBreakChar(ch)) {
+    if (token.kind === "char" && isBreakChar(token.value)) {
       lastBreakIndex = buf.length;
     }
   }

--- a/src/cli/skills-cli.formatting.test.ts
+++ b/src/cli/skills-cli.formatting.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";
 import { writeWorkspaceSkills } from "../skills/test-support/e2e-test-helpers.js";
 import { createCanonicalFixtureSkill } from "../skills/test-support/test-helpers.js";
@@ -112,6 +113,35 @@ describe("skills-cli (e2e)", () => {
     expect(output).toContain("peekaboo");
     expect(output).toContain("Details:");
   });
+
+  it.each([
+    ["plain", "left\tright"],
+    ["ESC CSI", "left\x1b[31\tmright\x1b[0m"],
+    ["C1 CSI", "left\x9b31\tmright\x9b0m"],
+  ])(
+    "keeps %s tab-separated skill descriptions in their table cell",
+    async (_label, description) => {
+      const workspaceDir = fs.mkdtempSync(path.join(tempWorkspaceDir, "tab-spacing-"));
+      await writeWorkspaceSkills(workspaceDir, [
+        {
+          name: "tab-spacing",
+          description: JSON.stringify(description).replaceAll("\x9b", "\\u009b"),
+        },
+      ]);
+      const report = buildWorkspaceSkillStatus(workspaceDir, {
+        managedSkillsDir: path.join(workspaceDir, "managed"),
+        config: { plugins: { enabled: false } },
+      });
+      expect(report.skills.find((skill) => skill.name === "tab-spacing")?.description).toBe(
+        description,
+      );
+
+      const row = stripAnsi(formatSkillsList(report, {}))
+        .split("\n")
+        .find((line) => line.includes("tab-spacing"));
+      expect(row?.split(/[|│]/u)[3]?.trim()).toBe("left right");
+    },
+  );
 
   it("reports missing prerequisites for discovered agent-excluded skills", async () => {
     const missingBin = "qa35-fixture-absent-binary";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing CLI tables, including `openclaw skills list`, could see tab-containing descriptions push neighboring columns onto another terminal line. Ordinary tab stops could also make the displayed spacing disagree with the table's measured width.

## Why This Change Was Made

The shared table wrapper measured horizontal tabs as one cell but emitted the original control character. It now emits the space it measured. Tabs executed inside CSI sequences enter the same text-fitting path; an introducer plus cancellation preserves the terminal parser boundary before those spaces are emitted, including after interrupted escape sequences. Other controls keep their order, complete OSC payloads remain opaque, and styling is retained.

The common token-fitting loop replaces separate ANSI/text width and wrapping paths. This fixes the renderer's ownership boundary for all table callers instead of changing skill metadata or adding a formatter-specific filter. No configuration, dependency, public API, or persistent-state change is added.

## User Impact

Tab-containing table cells stay aligned with neighboring columns. The existing one-cell tab measurement becomes the actual displayed spacing. The skills CLI documentation now states that behavior.

## Evidence

The original reproduction had **13 failures and two passing controls** across 15 focused table/CLI cases; all 15 pass after repair. Review exposed four additional interrupted-CSI cases that lost the newly materialized space: all four fail before the amendment and pass after it. The complete current sibling suites pass **161 tests: 79 table, 76 ANSI, and six skills CLI tests**.

The real `node scripts/run-node.mjs skills list --agent qa-table-ht --eligible` flow was exercised in an isolated native 80×40 terminal with synthetic skill files. On the original baseline, the space control stayed aligned while ordinary-tab and ESC-CSI-tab rows wrapped the source column. The same command and three fixtures passed after the initial repair. A second five-fixture run then reproduced both interrupted-CSI and bare-ESC spacing failures on that first repair. With the final amendment, the same five fixtures all display `left right` with aligned source columns and no physical row wrapping; the styled CSI example remains red. Both runs used the normal watched-source build path and exited 0.

The figures render saved native terminal rows and their recorded physical wrap flags; they are data figures, not original screenshots. They retain complete table rows and continuations. The first pair shows the original defect and initial repair; the second pair shows the review amendment. Native terminal proof covers ordinary and ESC CSI controls. C1 CSI is covered by maintained owner and real-loader tests, not claimed as native terminal proof. No operator Gateway or provider was contacted.

All 29 selected static checks are complete across the original and resumed commands; `docs:list` also passes. Two separately invoked Codex reviews of the complete final change are clean through P2. Candidate commit: `81f410781648b36a1875b82b4d23c8d55080236a`. Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/33634561115) passed on attempt 2. Attempt 1 had three checkout-stage failures after five bounded fetch attempts; those jobs never reached Node setup or tests. The failed jobs and their dependent CI gate were rerun with the original limits and unchanged commit. The latest completed ClawSweeper review has no code/security findings or remaining rank-up moves. The completed test command exited 0; its evidence driver subsequently failed an aggregate-summary assertion because the runner prints separate shard totals. That metadata failure is retained, and separate source/index/dependency checks and process closure passed without rerunning the tests. An earlier selected-check command hit its original time limit during lint; completed checks remain recorded and only the nine unfinished checks were subsequently run, and all passed.

Production: **+44/−44, net 0**. Tests: **+86/−8**. Documentation: **+3/−0**. Existing mixed-width caching, OSC links, styles, explicit newlines, wrapping, and control behavior remain covered.

The defect is reproduced on `3661c68500d3ae49817f8037a030c594680f86c9`. Its introducing commit is unknown: available history has a shallow boundary, and comparison with that boundary's raw parent shows no table change. The width caching from https://github.com/openclaw/openclaw/pull/135473 is retained; this PR does not attribute the tab defect to it.

![table-tabs-recorded-grid](https://github.com/user-attachments/assets/d0c72a6f-3433-4b45-a1c6-fcbcd28a5340)

![table-tabs-restart-recorded-grid](https://github.com/user-attachments/assets/4e8645d5-83c7-4ebf-bcf7-d52570ee1954)
