### PR TITLE
fix(apple): restore builds in linked worktrees

### DIFF
--- a/scripts/prepare-apple-mermaid.mjs
+++ b/scripts/prepare-apple-mermaid.mjs
@@ -7,7 +7,7 @@ import { createPnpmRunnerSpawnSpec } from "./pnpm-runner.mts";
 const root = fileURLToPath(new URL("../", import.meta.url));
 const spec = createPnpmRunnerSpawnSpec({
   cwd: root,
-  pnpmArgs: ["--filter", "@openclaw/mermaid-renderer", "build"],
+  pnpmArgs: ["--dir", "packages/mermaid-renderer", "build"],
   stdio: "inherit",
 });
 const result = spawnSync(spec.command, spec.args, spec.options);

--- a/test/scripts/build-and-run-mac.test.ts
+++ b/test/scripts/build-and-run-mac.test.ts
@@ -137,7 +137,7 @@ describe("scripts/build-and-run-mac.sh", () => {
       mkdirSync(resources, { recursive: true });
       writeFileSync(join(resources, "stale.js"), "stale");
       symlinkSync(process.execPath, join(binDir, "node"));
-      const expectedArgs = ["--filter", "@openclaw/mermaid-renderer", "build"];
+      const expectedArgs = ["--dir", "packages/mermaid-renderer", "build"];
       if (runner === "corepack") {
         expectedArgs.unshift("pnpm");
       }


### PR DESCRIPTION
## What Problem This Solves

Apple app builds from linked worktrees failed while preparing Mermaid assets because pnpm attempted to create recursive task state through the symlinked workspace dependency tree.

## Why This Change Was Made

Run the Mermaid renderer build from its package directory while retaining the shared pnpm runner selection. Update the existing Apple build contract test to protect the package-local invocation; shared pnpm runner behavior is unchanged.

## User Impact

Developers can run iOS and macOS build flows from supported linked worktrees without the Mermaid preparation step failing before Xcode or SwiftPM starts.

## Evidence

- Before: `pnpm ios:build` failed with `ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH`.
- The regression assertion failed before the production fix: 2 failures, 5 passes.
- `node scripts/run-vitest.mjs test/scripts/build-and-run-mac.test.ts test/scripts/pnpm-runner.test.ts`: 33/33 passed.
- `node scripts/prepare-apple-mermaid.mjs`: passed.
- `pnpm ios:build`: passed with `BUILD SUCCEEDED` on the rebased head.
- SwiftFormat: 0 changes across 382 files.
- SwiftLint: 0 violations across 382 files.
- Fresh scoped autoreview: clean.
- The broad changed-scope root test typecheck could not complete because the authorized sparse checkout intentionally omits unrelated Android, UI, and QA sources; file-local checks passed.

Punchcard-Session: brisk-river-workshop-b1
