### PR TITLE
fix(install): npm 12 local archives and unpublished plugin validation

### DIFF
--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -1001,10 +1001,40 @@ jobs:
           run-id: ${{ needs.resolve_package.outputs.package_artifact_run_id }}
           github-token: ${{ github.token }}
 
+      - name: Validate prerelease plugin registry artifact identity
+        if: needs.resolve_package.outputs.prepublish_plugin_registry_json != ''
+        env:
+          ARTIFACT_DIGEST: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
+          ARTIFACT_ID: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+          ARTIFACT_NAME: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactName || '' }}
+          ARTIFACT_RUN_ATTEMPT: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunAttempt || '' }}
+          ARTIFACT_RUN_ID: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/docker/shared-image-artifact.sh \
+            verify-upload "Prerelease plugin registry" \
+            "$ARTIFACT_ID" "$ARTIFACT_NAME" "$ARTIFACT_DIGEST" \
+            "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
+
+      - name: Download prerelease plugin registry artifact
+        if: needs.resolve_package.outputs.prepublish_plugin_registry_json != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}
+          path: .artifacts/prepublish-plugin-registry
+          run-id: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactRunId || '' }}
+          github-token: ${{ github.token }}
+
       - name: Run install.sh with npm 12
         env:
           EXPECTED_PACKAGE_SHA256: ${{ needs.resolve_package.outputs.package_sha256 }}
           EXPECTED_PACKAGE_VERSION: ${{ needs.resolve_package.outputs.package_version }}
+          OPENCLAW_DOCKER_E2E_SELECTED_SHA: ${{ needs.resolve_package.outputs.package_source_sha }}
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION: ${{ needs.resolve_package.outputs.package_version }}
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: ${{ needs.resolve_package.outputs.prepublish_plugin_registry_json != '' && format('{0}/.artifacts/prepublish-plugin-registry', github.workspace) || '' }}
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: ${{ fromJSON(needs.resolve_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1021,7 +1051,8 @@ jobs:
             NPM_CONFIG_CACHE="$RUNNER_TEMP/openclaw-npm12-cache" \
             NPM_CONFIG_PREFIX="$install_prefix" \
             OPENCLAW_VERSION="$package" \
-            bash scripts/install.sh --install-method npm --no-prompt --no-onboard
+            bash scripts/e2e/lib/prepublish-plugin-registry.sh \
+              bash scripts/install.sh --install-method npm --no-prompt --no-onboard
           source scripts/docker/install-sh-common/version-parse.sh
           installed_version="$(extract_openclaw_semver "$("$install_prefix/bin/openclaw" --version)")"
           [[ "$installed_version" == "$EXPECTED_PACKAGE_VERSION" ]] || {

--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -19,6 +19,8 @@ All three support Node **22.22.3+, 24.15+, or 25.9+** with a WAL-reset-safe link
 
 Before changing packages, every installer probes the exact npm executable it will use. npm 11.15 and earlier installs normally; npm 11.16 and later, including npm 12, receives `--allow-scripts` for only the npm-resolved OpenClaw candidate identity. An unreadable npm version stops before package mutation. A remaining `.openclaw-lifecycle-pending` marker or legacy `dist/openclaw-install-guard` makes the install fail instead of reporting a lifecycle-skipped package as successful.
 
+On npm 12, local `.tgz` and `.tar.gz` installs and updates need a comma-free archive filename and parent path. npm uses commas to separate lifecycle approvals, so move the archive to a comma-free path before retrying. Relative tarball arguments are still supported; the installer resolves their full path for approval.
+
 Install-method switches verify the replacement before retiring the current owner. Source wrappers use a same-directory atomic replacement; when an npm shim shares that path, the installer moves only an identity-matched source wrapper aside and restores it if npm installation, lifecycle checks, or candidate verification fails. On upgrades, `install.sh` and `install.ps1` run `openclaw doctor --fix`; repair or final verification failure exits nonzero, and the success banner appears only after those steps complete.
 
 ## Source build toolchain

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -301,6 +301,9 @@ This avoids npm overlaying a new package onto stale files from the old one. If
 the install command fails, OpenClaw retries once with `--omit=optional`, which
 helps hosts where native optional dependencies cannot compile.
 
+For local tarball targets on npm 12, the archive filename and every parent
+directory must be comma-free. See [Installer path requirements](/install/installer).
+
 OpenClaw-managed npm update and plugin-update commands also clear npm's
 `min-release-age` supply-chain quarantine (or the older `before` config key)
 for the child npm process. That policy exists for general protection, but an

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1340,11 +1340,32 @@ const normalized = spec.trim();
 const unaliased = normalized.toLowerCase().startsWith("openclaw@") ? normalized.slice(9).trim() : normalized;
 const explicit = (value) => /\.(?:tgz|tar\.gz)$/i.test(value) || value.includes("://") || value.includes("#") || /^(?:file|github|git\+(?:ssh|https|http|file)|npm):/i.test(value);
 let identity = !normalized || explicit(normalized) || explicit(unaliased) || /^\.{1,2}(?:[\\/]|$)/.test(unaliased) || path.isAbsolute(normalized) || path.isAbsolute(unaliased) ? unaliased : "openclaw";
-if (/^npm:/i.test(identity)) identity = /^npm:(@[^/]+\/[^@]+|[^@]+?)(?:@.*)?$/i.exec(identity)?.[1] ?? "";
-const relative = cwd && path.isAbsolute(identity) ? path.relative(cwd, identity) || "." : "";
-if (relative) identity = path.isAbsolute(relative) || relative === "." || relative === ".." || relative.startsWith(`..${path.sep}`) ? relative : `.${path.sep}${relative}`;
+const alias = /^npm:/i.test(identity);
+if (alias) identity = /^npm:(@[^/]+\/[^@]+|[^@]+?)(?:@.*)?$/i.exec(identity)?.[1] ?? "";
+const filePrefix = /^file:/i.test(identity) ? "file:" : "";
+const archivePath = identity.slice(filePrefix.length);
+const gitShorthand = !/^~[\\/]/.test(identity) && /^[^./@\s:#][^/\s:@#]*\/[^/\s:@#]+(?:#[\s\S]*)?$/.test(identity);
+const localArchive = !alias && !gitShorthand && /\.(?:tgz|tar\.gz|tar)$/i.test(archivePath) && (filePrefix || path.isAbsolute(archivePath) || !/^[a-z][a-z0-9+.-]*:/i.test(archivePath));
+let absoluteArchive = "";
+if (localArchive) {
+  const npmPath = process.platform === "win32" ? archivePath.replaceAll("\\", "/") : archivePath;
+  // Escape raw paths before URL normalization so literal %, #, and ? retain their identity.
+  let fileUrl = `file:${encodeURI(npmPath).replace(/[?#]/g, encodeURIComponent)}`;
+  fileUrl = fileUrl.replace(/^file:\/\/(?=[^/])/, "file:/").replace(/^file:\/{1,3}(?=\.\.?(?:\/|$))/, "file:");
+  const specPath = decodeURIComponent(new URL(fileUrl).pathname);
+  let resolvedPath = decodeURIComponent(new URL(fileUrl, `${require("node:url").pathToFileURL(path.resolve(cwd || process.cwd())).href}/`).pathname);
+  if (process.platform === "win32") resolvedPath = resolvedPath.replace(/^\/+([a-z]:\/)/i, "$1");
+  absoluteArchive = /^\/~(?:\/|$)/.test(specPath) ? path.resolve(require("node:os").homedir(), specPath.slice(3)) : path.resolve(cwd || process.cwd(), resolvedPath);
+}
+// Tarballs match the absolute npm resolved identity; directory links accept relative paths.
+// Keep the npm 11 comma-path identity: its advisory/strict decision stays npm-owned.
+if (absoluteArchive && (+parsed[1] >= 12 || !absoluteArchive.includes(","))) identity = `${filePrefix}${absoluteArchive}`;
+else {
+  const relative = cwd && path.isAbsolute(identity) ? path.relative(cwd, identity) || "." : "";
+  if (relative) identity = path.isAbsolute(relative) || relative === "." || relative === ".." || relative.startsWith(`..${path.sep}`) ? relative : `.${path.sep}${relative}`;
+}
 if (exactIdentity) identity = exactIdentity;
-if (!identity || identity.includes(",")) fail(`npm cannot allow lifecycle scripts for install target '${spec}'.`);
+if (!identity || identity.includes(",")) fail(`npm cannot allow lifecycle scripts for install target '${spec}'; use a package URL or local path without commas.`);
 process.stdout.write(`--allow-scripts=${identity}\n`);
 NODE
 )" || return 1

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1481,11 +1481,32 @@ const normalized = spec.trim();
 const unaliased = normalized.toLowerCase().startsWith("openclaw@") ? normalized.slice(9).trim() : normalized;
 const explicit = (value) => /\.(?:tgz|tar\.gz)$/i.test(value) || value.includes("://") || value.includes("#") || /^(?:file|github|git\+(?:ssh|https|http|file)|npm):/i.test(value);
 let identity = !normalized || explicit(normalized) || explicit(unaliased) || /^\.{1,2}(?:[\\/]|$)/.test(unaliased) || path.isAbsolute(normalized) || path.isAbsolute(unaliased) ? unaliased : "openclaw";
-if (/^npm:/i.test(identity)) identity = /^npm:(@[^/]+\/[^@]+|[^@]+?)(?:@.*)?$/i.exec(identity)?.[1] ?? "";
-const relative = cwd && path.isAbsolute(identity) ? path.relative(cwd, identity) || "." : "";
-if (relative) identity = path.isAbsolute(relative) || relative === "." || relative === ".." || relative.startsWith(`..${path.sep}`) ? relative : `.${path.sep}${relative}`;
+const alias = /^npm:/i.test(identity);
+if (alias) identity = /^npm:(@[^/]+\/[^@]+|[^@]+?)(?:@.*)?$/i.exec(identity)?.[1] ?? "";
+const filePrefix = /^file:/i.test(identity) ? "file:" : "";
+const archivePath = identity.slice(filePrefix.length);
+const gitShorthand = !/^~[\\/]/.test(identity) && /^[^./@\s:#][^/\s:@#]*\/[^/\s:@#]+(?:#[\s\S]*)?$/.test(identity);
+const localArchive = !alias && !gitShorthand && /\.(?:tgz|tar\.gz|tar)$/i.test(archivePath) && (filePrefix || path.isAbsolute(archivePath) || !/^[a-z][a-z0-9+.-]*:/i.test(archivePath));
+let absoluteArchive = "";
+if (localArchive) {
+  const npmPath = process.platform === "win32" ? archivePath.replaceAll("\\", "/") : archivePath;
+  // Escape raw paths before URL normalization so literal %, #, and ? retain their identity.
+  let fileUrl = `file:${encodeURI(npmPath).replace(/[?#]/g, encodeURIComponent)}`;
+  fileUrl = fileUrl.replace(/^file:\/\/(?=[^/])/, "file:/").replace(/^file:\/{1,3}(?=\.\.?(?:\/|$))/, "file:");
+  const specPath = decodeURIComponent(new URL(fileUrl).pathname);
+  let resolvedPath = decodeURIComponent(new URL(fileUrl, `${require("node:url").pathToFileURL(path.resolve(cwd || process.cwd())).href}/`).pathname);
+  if (process.platform === "win32") resolvedPath = resolvedPath.replace(/^\/+([a-z]:\/)/i, "$1");
+  absoluteArchive = /^\/~(?:\/|$)/.test(specPath) ? path.resolve(require("node:os").homedir(), specPath.slice(3)) : path.resolve(cwd || process.cwd(), resolvedPath);
+}
+// Tarballs match the absolute npm resolved identity; directory links accept relative paths.
+// Keep the npm 11 comma-path identity: its advisory/strict decision stays npm-owned.
+if (absoluteArchive && (+parsed[1] >= 12 || !absoluteArchive.includes(","))) identity = `${filePrefix}${absoluteArchive}`;
+else {
+  const relative = cwd && path.isAbsolute(identity) ? path.relative(cwd, identity) || "." : "";
+  if (relative) identity = path.isAbsolute(relative) || relative === "." || relative === ".." || relative.startsWith(`..${path.sep}`) ? relative : `.${path.sep}${relative}`;
+}
 if (exactIdentity) identity = exactIdentity;
-if (!identity || identity.includes(",")) fail(`npm cannot allow lifecycle scripts for install target '${spec}'.`);
+if (!identity || identity.includes(",")) fail(`npm cannot allow lifecycle scripts for install target '${spec}'; use a package URL or local path without commas.`);
 process.stdout.write(`--allow-scripts=${identity}\n`);
 '@
     $kernelOutput = @($kernel | & $nodeCommand - $versionOutput[-1].ToString() $InstallSpec $NpmCwd $ExactIdentity 2>&1)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1064,11 +1064,32 @@ const normalized = spec.trim();
 const unaliased = normalized.toLowerCase().startsWith("openclaw@") ? normalized.slice(9).trim() : normalized;
 const explicit = (value) => /\.(?:tgz|tar\.gz)$/i.test(value) || value.includes("://") || value.includes("#") || /^(?:file|github|git\+(?:ssh|https|http|file)|npm):/i.test(value);
 let identity = !normalized || explicit(normalized) || explicit(unaliased) || /^\.{1,2}(?:[\\/]|$)/.test(unaliased) || path.isAbsolute(normalized) || path.isAbsolute(unaliased) ? unaliased : "openclaw";
-if (/^npm:/i.test(identity)) identity = /^npm:(@[^/]+\/[^@]+|[^@]+?)(?:@.*)?$/i.exec(identity)?.[1] ?? "";
-const relative = cwd && path.isAbsolute(identity) ? path.relative(cwd, identity) || "." : "";
-if (relative) identity = path.isAbsolute(relative) || relative === "." || relative === ".." || relative.startsWith(`..${path.sep}`) ? relative : `.${path.sep}${relative}`;
+const alias = /^npm:/i.test(identity);
+if (alias) identity = /^npm:(@[^/]+\/[^@]+|[^@]+?)(?:@.*)?$/i.exec(identity)?.[1] ?? "";
+const filePrefix = /^file:/i.test(identity) ? "file:" : "";
+const archivePath = identity.slice(filePrefix.length);
+const gitShorthand = !/^~[\\/]/.test(identity) && /^[^./@\s:#][^/\s:@#]*\/[^/\s:@#]+(?:#[\s\S]*)?$/.test(identity);
+const localArchive = !alias && !gitShorthand && /\.(?:tgz|tar\.gz|tar)$/i.test(archivePath) && (filePrefix || path.isAbsolute(archivePath) || !/^[a-z][a-z0-9+.-]*:/i.test(archivePath));
+let absoluteArchive = "";
+if (localArchive) {
+  const npmPath = process.platform === "win32" ? archivePath.replaceAll("\\", "/") : archivePath;
+  // Escape raw paths before URL normalization so literal %, #, and ? retain their identity.
+  let fileUrl = `file:${encodeURI(npmPath).replace(/[?#]/g, encodeURIComponent)}`;
+  fileUrl = fileUrl.replace(/^file:\/\/(?=[^/])/, "file:/").replace(/^file:\/{1,3}(?=\.\.?(?:\/|$))/, "file:");
+  const specPath = decodeURIComponent(new URL(fileUrl).pathname);
+  let resolvedPath = decodeURIComponent(new URL(fileUrl, `${require("node:url").pathToFileURL(path.resolve(cwd || process.cwd())).href}/`).pathname);
+  if (process.platform === "win32") resolvedPath = resolvedPath.replace(/^\/+([a-z]:\/)/i, "$1");
+  absoluteArchive = /^\/~(?:\/|$)/.test(specPath) ? path.resolve(require("node:os").homedir(), specPath.slice(3)) : path.resolve(cwd || process.cwd(), resolvedPath);
+}
+// Tarballs match the absolute npm resolved identity; directory links accept relative paths.
+// Keep the npm 11 comma-path identity: its advisory/strict decision stays npm-owned.
+if (absoluteArchive && (+parsed[1] >= 12 || !absoluteArchive.includes(","))) identity = `${filePrefix}${absoluteArchive}`;
+else {
+  const relative = cwd && path.isAbsolute(identity) ? path.relative(cwd, identity) || "." : "";
+  if (relative) identity = path.isAbsolute(relative) || relative === "." || relative === ".." || relative.startsWith(`..${path.sep}`) ? relative : `.${path.sep}${relative}`;
+}
 if (exactIdentity) identity = exactIdentity;
-if (!identity || identity.includes(",")) fail(`npm cannot allow lifecycle scripts for install target '${spec}'.`);
+if (!identity || identity.includes(",")) fail(`npm cannot allow lifecycle scripts for install target '${spec}'; use a package URL or local path without commas.`);
 process.stdout.write(`--allow-scripts=${identity}\n`);
 NODE
 )" || return 1

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -922,7 +922,7 @@ describe("update-cli", () => {
       expect(packagePackCommandCall()).toBeUndefined();
     }
     const allowScriptsIdentity = isNpmGitPackageSpec(spec)
-      ? `./${path.basename(installSpec)}`
+      ? installSpec
       : spec.toLowerCase().startsWith("openclaw@")
         ? "openclaw"
         : spec;

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -400,7 +400,7 @@ describe("runGlobalPackageUpdateSteps", () => {
           "npm",
           "i",
           "-g",
-          "--allow-scripts=./openclaw-2.0.0.tgz",
+          `--allow-scripts=${path.join(packDir, "openclaw-2.0.0.tgz")}`,
           "--prefix",
           stagePrefix,
           path.join(packDir, "openclaw-2.0.0.tgz"),

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -86,7 +86,7 @@ const NPM_PACK_QUIET_FLAGS = ["--json", "--loglevel=error"] as const;
 async function resolveNpmUpdateLifecyclePolicy(params: {
   installTarget: ResolvedGlobalInstallTarget;
 }): Promise<{
-  policy: "unflagged" | "allow-scripts" | null;
+  policy: ReturnType<typeof resolveNpmLifecyclePolicyGate>["policy"];
   failedStep: PackageUpdateStepResult | null;
 }> {
   const gate = resolveNpmLifecyclePolicyGate(params.installTarget);

--- a/src/infra/update-global-lifecycle.test.ts
+++ b/src/infra/update-global-lifecycle.test.ts
@@ -1,0 +1,157 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { globalInstallArgs, globalInstallFallbackArgs } from "./update-global.js";
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: vi.fn(() => "/tmp/openclaw-test-global-npmrc\n"),
+}));
+
+describe("npm global install lifecycle policy", () => {
+  it("applies an unflagged npm policy to primary and retry argv", () => {
+    expect(
+      globalInstallArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
+    ).not.toContain("--allow-scripts=openclaw");
+    expect(
+      globalInstallFallbackArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
+    ).toEqual(expect.arrayContaining(["--omit=optional"]));
+    expect(
+      globalInstallFallbackArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
+    ).not.toContain("--allow-scripts=openclaw");
+  });
+
+  it("builds npm staged install argv with an explicit prefix", () => {
+    expect(globalInstallArgs("npm", "openclaw@latest", null, "/tmp/stage")).toEqual([
+      "npm",
+      "i",
+      "-g",
+      "--allow-scripts=openclaw",
+      "--prefix",
+      "/tmp/stage",
+      "openclaw@latest",
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+      "--min-release-age=0",
+    ]);
+    expect(globalInstallFallbackArgs("npm", "openclaw@latest", null, "/tmp/stage")).toEqual([
+      "npm",
+      "i",
+      "-g",
+      "--allow-scripts=openclaw",
+      "--prefix",
+      "/tmp/stage",
+      "openclaw@latest",
+      "--omit=optional",
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+      "--min-release-age=0",
+    ]);
+  });
+
+  it("omits npm's lifecycle allowlist before npm 11.16", () => {
+    expect(
+      globalInstallArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
+    ).not.toContain("--allow-scripts=openclaw");
+  });
+
+  it("allows only the resolved npm candidate lifecycle identity", () => {
+    const archive = path.resolve("/tmp/openclaw-2026.7.2.tgz");
+    expect(globalInstallArgs("npm", archive)).toContain(`--allow-scripts=${archive}`);
+    expect(globalInstallArgs("npm", "openclaw@npm:@vendor/openclaw@1.2.3")).toContain(
+      "--allow-scripts=@vendor/openclaw",
+    );
+    expect(globalInstallArgs("npm", "openclaw@npm:vendor-openclaw@1.2.3")).toContain(
+      "--allow-scripts=vendor-openclaw",
+    );
+    expect(globalInstallArgs("npm", "openclaw@npm:@vendor/client.tgz@1.2.3")).toContain(
+      "--allow-scripts=@vendor/client.tgz",
+    );
+    expect(globalInstallArgs("npm", "./openclaw-candidate")).toContain(
+      "--allow-scripts=./openclaw-candidate",
+    );
+    for (const spec of ["vendor/repo.tgz", "vendor/repo#release.tgz"]) {
+      expect(globalInstallArgs("npm", spec)).toContain(`--allow-scripts=${spec}`);
+    }
+  });
+
+  it("keeps commas in ancestor directories out of npm's lifecycle policy", () => {
+    expect(
+      globalInstallArgs(
+        "npm",
+        "/tmp/build,cache/openclaw-candidate",
+        null,
+        null,
+        "/tmp/build,cache",
+      ),
+    ).toContain("--allow-scripts=./openclaw-candidate");
+  });
+
+  it.each(["absolute", "relative", "file:absolute", "file:relative"])(
+    "uses the absolute npm tarball identity for %s input",
+    (form) => {
+      const cwd = path.resolve("/tmp/openclaw-update-identity/work");
+      const candidate = path.resolve(cwd, "../candidate.tgz");
+      const protocol = form.startsWith("file:") ? "file:" : "";
+      const spec = `${protocol}${form.endsWith("relative") ? "../candidate.tgz" : candidate}`;
+      for (const buildArgs of [globalInstallArgs, globalInstallFallbackArgs]) {
+        const args = buildArgs("npm", spec, null, null, cwd);
+        expect(args).toContain(`--allow-scripts=${protocol}${candidate}`);
+        expect(args).toContain(spec);
+      }
+    },
+  );
+
+  it("rejects comma tarball identities before building npm install commands", () => {
+    const cwd = path.resolve("/tmp/build,cache");
+    for (const buildArgs of [globalInstallArgs, globalInstallFallbackArgs]) {
+      expect(() => buildArgs("npm", path.join(cwd, "candidate.tgz"), null, null, cwd)).toThrow(
+        "without commas",
+      );
+    }
+  });
+
+  it.each([
+    "file:/../candidate.tgz",
+    "file:///../candidate.tgz",
+    "file:~/candidate.tgz",
+    "file:/~/candidate.tgz",
+    "file:///~/candidate.tgz",
+    "file:./~/candidate.tgz",
+  ])("preserves npm's local archive resolution for %s", (spec) => {
+    const cwd = path.resolve("/tmp/openclaw-update-identity/work");
+    const expected = spec.includes("~")
+      ? path.join(os.homedir(), "candidate.tgz")
+      : path.resolve(cwd, "../candidate.tgz");
+    expect(globalInstallArgs("npm", spec, null, null, cwd)).toContain(
+      `--allow-scripts=file:${expected}`,
+    );
+  });
+
+  it.each(["tgz", "tar.gz", "tar"])(
+    "normalizes file URLs while preserving literal archive characters for .%s",
+    (extension) => {
+      const archive = path.resolve(`/tmp/openclaw/a%2C#b.${extension}`);
+      const spec = `file:///${archive.replaceAll("\\", "/").replace(/^\/+/u, "")}`;
+      expect(globalInstallArgs("npm", spec)).toContain(`--allow-scripts=file:${archive}`);
+    },
+  );
+
+  it("preserves npm 11 advisory comma-archive identity without changing npm policy", () => {
+    const cwd = path.resolve("/tmp/build,cache");
+    for (const buildArgs of [globalInstallArgs, globalInstallFallbackArgs]) {
+      expect(
+        buildArgs(
+          "npm",
+          path.join(cwd, "candidate.tgz"),
+          null,
+          null,
+          cwd,
+          "allow-scripts-advisory",
+        ),
+      ).toContain("--allow-scripts=./candidate.tgz");
+    }
+  });
+});

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -115,18 +115,6 @@ describe("update global helpers", () => {
     ).toBe("openclaw@next");
   });
 
-  it("applies an unflagged npm policy to primary and retry argv", () => {
-    expect(
-      globalInstallArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
-    ).not.toContain("--allow-scripts=openclaw");
-    expect(
-      globalInstallFallbackArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
-    ).toEqual(expect.arrayContaining(["--omit=optional"]));
-    expect(
-      globalInstallFallbackArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
-    ).not.toContain("--allow-scripts=openclaw");
-  });
-
   it("maps main and explicit package targets to install specs", () => {
     expect(resolveGlobalInstallSpec({ packageName: "openclaw", tag: "main" })).toBe(
       "github:openclaw/openclaw#main",
@@ -215,7 +203,7 @@ describe("update global helpers", () => {
     ["11.13.0", "unflagged"],
     ["11.14.0", "unflagged"],
     ["11.15.9", "unflagged"],
-    ["11.16.0", "allow-scripts"],
+    ["11.16.0", "allow-scripts-advisory"],
     ["12.0.0", "allow-scripts"],
   ] as const)("binds npm %s lifecycle policy to the owning executable", async (version, policy) => {
     await withTestDir({ prefix: "openclaw-npm-owner-" }, async (prefix) => {
@@ -744,69 +732,6 @@ describe("update global helpers", () => {
         packageRoot: path.join(customGlobalRoot, "openclaw"),
       });
     });
-  });
-
-  it("builds npm staged install argv with an explicit prefix", () => {
-    expect(globalInstallArgs("npm", "openclaw@latest", null, "/tmp/stage")).toEqual([
-      "npm",
-      "i",
-      "-g",
-      "--allow-scripts=openclaw",
-      "--prefix",
-      "/tmp/stage",
-      "openclaw@latest",
-      "--no-fund",
-      "--no-audit",
-      "--loglevel=error",
-      "--min-release-age=0",
-    ]);
-    expect(globalInstallFallbackArgs("npm", "openclaw@latest", null, "/tmp/stage")).toEqual([
-      "npm",
-      "i",
-      "-g",
-      "--allow-scripts=openclaw",
-      "--prefix",
-      "/tmp/stage",
-      "openclaw@latest",
-      "--omit=optional",
-      "--no-fund",
-      "--no-audit",
-      "--loglevel=error",
-      "--min-release-age=0",
-    ]);
-  });
-
-  it("omits npm's lifecycle allowlist before npm 11.16", () => {
-    expect(
-      globalInstallArgs("npm", "openclaw@latest", null, null, null, "unflagged"),
-    ).not.toContain("--allow-scripts=openclaw");
-  });
-
-  it("allows only the resolved npm candidate lifecycle identity", () => {
-    expect(globalInstallArgs("npm", "/tmp/openclaw-2026.7.2.tgz")).toContain(
-      "--allow-scripts=/tmp/openclaw-2026.7.2.tgz",
-    );
-    expect(globalInstallArgs("npm", "openclaw@npm:@vendor/openclaw@1.2.3")).toContain(
-      "--allow-scripts=@vendor/openclaw",
-    );
-    expect(globalInstallArgs("npm", "openclaw@npm:vendor-openclaw@1.2.3")).toContain(
-      "--allow-scripts=vendor-openclaw",
-    );
-    expect(globalInstallArgs("npm", "./openclaw-candidate")).toContain(
-      "--allow-scripts=./openclaw-candidate",
-    );
-  });
-
-  it("keeps commas in ancestor directories out of npm's lifecycle policy", () => {
-    expect(
-      globalInstallArgs(
-        "npm",
-        "/tmp/build,cache/openclaw-candidate",
-        null,
-        null,
-        "/tmp/build,cache",
-      ),
-    ).toContain("--allow-scripts=./openclaw-candidate");
   });
 
   it("builds global install argv for each supported manager", () => {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { valid as validSemver } from "semver";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.js";
@@ -85,7 +86,7 @@ export type NpmGlobalPrefixLayout = {
   binDir: string;
 };
 
-type NpmLifecyclePolicy = "unflagged" | "allow-scripts";
+type NpmLifecyclePolicy = "unflagged" | "allow-scripts-advisory" | "allow-scripts";
 
 type SupportedNpmLifecyclePolicy = NpmLifecyclePolicy;
 
@@ -99,9 +100,11 @@ function resolveNpmLifecyclePolicy(version: string): NpmLifecyclePolicy | null {
   if (!parsed) {
     return null;
   }
-  return parsed.major >= 12 || (parsed.major === 11 && parsed.minor >= 16)
+  return parsed.major >= 12
     ? "allow-scripts"
-    : "unflagged";
+    : parsed.major === 11 && parsed.minor >= 16
+      ? "allow-scripts-advisory"
+      : "unflagged";
 }
 
 /** Resolves the owning npm policy once, before any update mutation. */
@@ -112,7 +115,7 @@ export function resolveNpmLifecyclePolicyGate(
     return { policy: null, error: null };
   }
   const policy = installTarget.npmOwner?.lifecyclePolicy ?? null;
-  if (policy === "unflagged" || policy === "allow-scripts") {
+  if (policy === "unflagged" || policy === "allow-scripts-advisory" || policy === "allow-scripts") {
     return { policy, error: null };
   }
   return {
@@ -191,7 +194,11 @@ function isRelativePackageInstallPath(value: string): boolean {
   return /^(?:\.{1,2})(?:[\\/]|$)/u.test(value);
 }
 
-function resolveNpmInstallScriptsAllowFlag(spec: string, installCwd?: string | null): string {
+function resolveNpmInstallScriptsAllowFlag(
+  spec: string,
+  installCwd: string | null | undefined,
+  policy: SupportedNpmLifecyclePolicy,
+): string {
   const normalized = normalizePackageTarget(spec);
   const unaliased = stripPrimaryPackageAlias(normalized);
   let identity =
@@ -202,10 +209,42 @@ function resolveNpmInstallScriptsAllowFlag(spec: string, installCwd?: string | n
     path.isAbsolute(unaliased)
       ? unaliased
       : PRIMARY_PACKAGE_NAME;
-  identity = resolveNpmAliasPackageName(identity) ?? identity;
-  if (installCwd && path.isAbsolute(identity)) {
-    // npm resolves relative allow-scripts identities against its cwd. Relativize
-    // first so commas in ancestor directories do not split the policy value.
+  const alias = resolveNpmAliasPackageName(identity);
+  identity = alias ?? identity;
+  const filePrefix = /^file:/iu.test(identity) ? "file:" : "";
+  const archivePath = identity.slice(filePrefix.length);
+  const gitShorthand =
+    !/^~[\\/]/u.test(identity) && /^[^./@\s:#][^/\s:@#]*\/[^/\s:@#]+(?:#[\s\S]*)?$/u.test(identity);
+  const localArchive =
+    !alias &&
+    !gitShorthand &&
+    /\.(?:tgz|tar\.gz|tar)$/iu.test(archivePath) &&
+    (filePrefix || path.isAbsolute(archivePath) || !/^[a-z][a-z0-9+.-]*:/iu.test(archivePath));
+  let absoluteArchive = "";
+  if (localArchive) {
+    const npmPath = process.platform === "win32" ? archivePath.replaceAll("\\", "/") : archivePath;
+    // Escape raw paths before URL normalization so literal %, #, and ? retain their identity.
+    let fileUrl = `file:${encodeURI(npmPath).replace(/[?#]/gu, encodeURIComponent)}`;
+    fileUrl = fileUrl
+      .replace(/^file:\/\/(?=[^/])/u, "file:/")
+      .replace(/^file:\/{1,3}(?=\.\.?(?:\/|$))/u, "file:");
+    const specPath = decodeURIComponent(new URL(fileUrl).pathname);
+    let resolvedPath = decodeURIComponent(
+      new URL(fileUrl, `${pathToFileURL(path.resolve(installCwd || process.cwd())).href}/`)
+        .pathname,
+    );
+    if (process.platform === "win32") {
+      resolvedPath = resolvedPath.replace(/^\/+([a-z]:\/)/iu, "$1");
+    }
+    absoluteArchive = /^\/~(?:\/|$)/u.test(specPath)
+      ? path.resolve(os.homedir(), specPath.slice(3))
+      : path.resolve(installCwd || process.cwd(), resolvedPath);
+  }
+  // Tarballs match the absolute npm resolved identity; directory links accept relative paths.
+  // Keep the npm 11 comma-path identity: its advisory/strict decision stays npm-owned.
+  if (absoluteArchive && (policy !== "allow-scripts-advisory" || !absoluteArchive.includes(","))) {
+    identity = `${filePrefix}${absoluteArchive}`;
+  } else if (installCwd && path.isAbsolute(identity)) {
     const relativeIdentity = path.relative(installCwd, identity) || ".";
     identity =
       path.isAbsolute(relativeIdentity) ||
@@ -217,7 +256,7 @@ function resolveNpmInstallScriptsAllowFlag(spec: string, installCwd?: string | n
   }
   if (identity.includes(",")) {
     throw new Error(
-      "npm cannot allow lifecycle scripts for an install target containing a comma; rename the package or source path",
+      "npm cannot allow lifecycle scripts for this install target; use a package URL or local path without commas",
     );
   }
   return `--allow-scripts=${identity || PRIMARY_PACKAGE_NAME}`;
@@ -1328,8 +1367,8 @@ export function globalInstallArgs(
     resolved.command,
     "i",
     "-g",
-    ...(npmLifecyclePolicy === "allow-scripts"
-      ? [resolveNpmInstallScriptsAllowFlag(spec, installCwd)]
+    ...(npmLifecyclePolicy !== "unflagged"
+      ? [resolveNpmInstallScriptsAllowFlag(spec, installCwd, npmLifecyclePolicy)]
       : []),
     ...(installPrefix ? ["--prefix", installPrefix] : []),
     spec,
@@ -1360,8 +1399,8 @@ export function globalInstallFallbackArgs(
     resolved.command,
     "i",
     "-g",
-    ...(npmLifecyclePolicy === "allow-scripts"
-      ? [resolveNpmInstallScriptsAllowFlag(spec, installCwd)]
+    ...(npmLifecyclePolicy !== "unflagged"
+      ? [resolveNpmInstallScriptsAllowFlag(spec, installCwd, npmLifecyclePolicy)]
       : []),
     ...(installPrefix ? ["--prefix", installPrefix] : []),
     spec,

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -3070,7 +3070,7 @@ describe("runGatewayUpdate", () => {
         argv[0] === "npm" &&
         argv[1] === "i" &&
         argv[2] === "-g" &&
-        argv[3] === "--allow-scripts=./openclaw-2.0.0.tgz" &&
+        argv[3] === `--allow-scripts=${argv[4]}` &&
         path.basename(argv[4] ?? "") === "openclaw-2.0.0.tgz" &&
         argv.slice(5).join(" ") === "--no-fund --no-audit --loglevel=error --min-release-age=0",
       tag: "main",
@@ -3078,6 +3078,7 @@ describe("runGatewayUpdate", () => {
 
     expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
+    expect(result.after?.version).toBe("2.0.0");
     expect(result.steps.map((step) => step.name)).toContain("global update pack");
     expect(
       calls.some((call) => call.startsWith(`npm pack ${sourceSpec} --pack-destination `)),

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1324,7 +1324,9 @@ HOOK
       const repo = join(tmp, "repo");
       const outer = join(tmp, "outer");
       const temp = join(tmp, "temp");
-      for (const dir of [bin, repo, outer, temp]) mkdirSync(dir, { recursive: true });
+      for (const dir of [bin, repo, outer, temp]) {
+        mkdirSync(dir, { recursive: true });
+      }
       writeFileSync(
         join(repo, "package.json"),
         JSON.stringify({ packageManager: `pnpm@${version}` }),
@@ -2128,7 +2130,10 @@ HOOK
 
   it.each([
     ["openclaw@npm:@scope/candidate@1.0.0", "--allow-scripts=@scope/candidate"],
+    ["openclaw@npm:@scope/candidate.tgz@1.0.0", "--allow-scripts=@scope/candidate.tgz"],
     ["file:/tmp/openclaw.tgz", "--allow-scripts=file:/tmp/openclaw.tgz"],
+    ["vendor/repo.tgz", "--allow-scripts=vendor/repo.tgz"],
+    ["vendor/repo#release.tgz", "--allow-scripts=vendor/repo#release.tgz"],
     [
       "https://example.invalid/openclaw.tgz",
       "--allow-scripts=https://example.invalid/openclaw.tgz",
@@ -2153,11 +2158,73 @@ HOOK
     }
   });
 
-  it("relativizes absolute npm path identities against the command cwd", () => {
+  it.each(["absolute", "relative", "file:absolute", "file:relative"])(
+    "uses the absolute npm tarball identity for %s input",
+    (form) => {
+      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-archive-identity-"));
+      const npm = join(tmp, "npm");
+      const commandCwd = join(tmp, "work");
+      const candidate = join(tmp, "candidate.tgz");
+      const protocol = form.startsWith("file:") ? "file:" : "";
+      const spec = `${protocol}${form.endsWith("relative") ? "../candidate.tgz" : candidate}`;
+      mkdirSync(commandCwd);
+      writeNpmLifecycleFixture(npm);
+      try {
+        const result = runInstallCliShell(
+          [
+            `source ${JSON.stringify(SCRIPT_PATH)}`,
+            `node_bin() { printf '%s\\n' ${JSON.stringify(process.execPath)}; }`,
+            `cd ${JSON.stringify(commandCwd)}`,
+            `npm_lifecycle_allow_arg ${JSON.stringify(npm)} ${JSON.stringify(spec)} "$PWD"`,
+          ].join("\n"),
+          { NPM_FAKE_VERSION: "12.0.0" },
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe(`--allow-scripts=${protocol}${candidate}`);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    { version: "11.16.0", advisory: true },
+    { version: "12.0.0", advisory: false },
+  ])(
+    "handles comma tarball identity under npm $version before mutation",
+    ({ version, advisory }) => {
+      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-archive-comma,"));
+      const npm = join(tmp, "npm");
+      const args = join(tmp, "args");
+      writeNpmLifecycleFixture(npm);
+      try {
+        const result = runInstallCliShell(
+          [
+            `source ${JSON.stringify(SCRIPT_PATH)}`,
+            `node_bin() { printf '%s\\n' ${JSON.stringify(process.execPath)}; }`,
+            `cd ${JSON.stringify(tmp)}`,
+            `npm_lifecycle_allow_arg ${JSON.stringify(npm)} ${JSON.stringify(join(tmp, "candidate.tgz"))} "$PWD"`,
+          ].join("\n"),
+          { NPM_FAKE_VERSION: version, NPM_FAKE_ARGS: args },
+        );
+        expect(result.status).toBe(advisory ? 0 : 1);
+        if (advisory) {
+          expect(result.stdout).toBe("--allow-scripts=./candidate.tgz");
+        } else {
+          expect(result.stderr).toContain("without commas");
+        }
+        expect(existsSync(args)).toBe(false);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("retains relative directory identities under comma ancestors", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cli-identity-comma,"));
     const npm = join(tmp, "npm");
     const commandCwd = join(tmp, "safe");
-    const candidate = join(tmp, "candidate.tgz");
+    const candidate = join(tmp, "candidate");
     mkdirSync(commandCwd);
     writeNpmLifecycleFixture(npm);
     try {
@@ -2171,7 +2238,7 @@ HOOK
         { NPM_FAKE_VERSION: "12.0.0" },
       );
       expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe("--allow-scripts=../candidate.tgz");
+      expect(result.stdout.trim()).toBe("--allow-scripts=../candidate");
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -241,13 +241,34 @@ try {
           'if ($tool -ne "--allow-scripts=pnpm@12.0.0") { throw "tool=$tool" }',
           "$alias = Get-NpmLifecycleAllowArgument -NpmCommand 'npm.cmd' -InstallSpec 'openclaw@npm:@scope/candidate@1.0.0'",
           "if ($alias -ne '--allow-scripts=@scope/candidate') { throw \"alias=$alias\" }",
+          "$archiveAlias = Get-NpmLifecycleAllowArgument -NpmCommand 'npm.cmd' -InstallSpec 'openclaw@npm:@scope/candidate.tgz@1.0.0'",
+          "if ($archiveAlias -ne '--allow-scripts=@scope/candidate.tgz') { throw \"alias=$archiveAlias\" }",
           "$tarball = Get-NpmLifecycleAllowArgument -NpmCommand 'npm.cmd' -InstallSpec 'https://example.invalid/openclaw.tgz'",
           "if ($tarball -ne '--allow-scripts=https://example.invalid/openclaw.tgz') { throw \"tarball=$tarball\" }",
+          '$archiveRoot = Join-Path ([System.IO.Path]::GetTempPath()) "openclaw-archive-identity"',
+          '$safeCwd = Join-Path $archiveRoot "work"',
+          '$candidate = Join-Path $archiveRoot "candidate.tgz"',
+          '$archiveUrl = "file:///" + $candidate.Replace("\\", "/").TrimStart("/")',
+          'foreach ($spec in @($candidate, "../candidate.tgz", "file:$candidate", "file:../candidate.tgz", "file:/../candidate.tgz", "file:///../candidate.tgz", $archiveUrl)) {',
+          '  $protocol = if ($spec.StartsWith("file:")) { "file:" } else { "" }',
+          "  $actual = Get-NpmLifecycleAllowArgument -NpmCommand 'npm.cmd' -InstallSpec $spec -NpmCwd $safeCwd",
+          '  if ($actual -ne "--allow-scripts=$protocol$candidate") { throw "archive=$actual" }',
+          "}",
           '$commaRoot = Join-Path ([System.IO.Path]::GetTempPath()) "openclaw,identity"',
+          "$caught = $false",
+          "try { Get-NpmLifecycleAllowArgument -NpmCommand 'npm.cmd' -InstallSpec (Join-Path $commaRoot 'candidate.tgz') -NpmCwd $commaRoot } catch {",
+          "  if ($_.Exception.Message -notmatch 'without commas') { throw }",
+          "  $caught = $true",
+          "}",
+          "if (-not $caught) { throw 'comma archive policy was accepted' }",
+          "$script:NpmVersion = '11.16.0'",
+          "$legacy = Get-NpmLifecycleAllowArgument -NpmCommand 'npm.cmd' -InstallSpec (Join-Path $commaRoot 'candidate.tgz') -NpmCwd $commaRoot",
+          "if ($legacy -notmatch '^--allow-scripts=\\.[\\\\/]candidate\\.tgz$') { throw \"legacy=$legacy\" }",
+          "$script:NpmVersion = '12.0.0'",
           '$safeCwd = Join-Path $commaRoot "safe"',
-          '$candidate = Join-Path $commaRoot "candidate.tgz"',
+          '$candidate = Join-Path $commaRoot "candidate"',
           "$relative = Get-NpmLifecycleAllowArgument -NpmCommand 'npm.cmd' -InstallSpec $candidate -NpmCwd $safeCwd",
-          "if ($relative -match ',' -or $relative -notmatch '^--allow-scripts=\\.\\.[\\\\/]candidate\\.tgz$') { throw \"relative=$relative\" }",
+          "if ($relative -match ',' -or $relative -notmatch '^--allow-scripts=\\.\\.[\\\\/]candidate$') { throw \"relative=$relative\" }",
           "foreach ($invalidVersion in @('invalid', 'npm 12.0.0 warning')) {",
           "  $script:NpmVersion = $invalidVersion",
           "  $caught = $false",
@@ -1153,12 +1174,12 @@ try {
           throw new Error(`Missing PowerShell fixture ${name}`);
         }
         const invocation = `$ErrorActionPreference = 'Stop'; & ([scriptblock]::Create((Get-Content -LiteralPath ${toPowerShellSingleQuotedLiteral(fixture.scriptPath)} -Raw)))`;
-        const result = spawnSync(engine, ["-NoLogo", "-NoProfile", "-Command", invocation], {
+        const engineResult = spawnSync(engine, ["-NoLogo", "-NoProfile", "-Command", invocation], {
           encoding: "utf8",
         });
         batchedPowerShellResults.set(`${name}:${engine}`, {
-          ok: result.status === 0,
-          error: result.status === 0 ? "" : result.stdout + result.stderr,
+          ok: engineResult.status === 0,
+          error: engineResult.status === 0 ? "" : engineResult.stdout + engineResult.stderr,
         });
       }
     }

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1137,11 +1137,75 @@ NODE
     }
   });
 
-  it("relativizes absolute npm path identities against the command cwd", () => {
+  it.each(["absolute", "relative", "file:absolute", "file:relative"])(
+    "uses the absolute npm tarball identity for %s input",
+    (form) => {
+      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-archive-identity-"));
+      const npm = join(tmp, "npm");
+      const commandCwd = join(tmp, "work");
+      const candidate = join(tmp, "candidate.tgz");
+      const protocol = form.startsWith("file:") ? "file:" : "";
+      const spec = `${protocol}${form.endsWith("relative") ? "../candidate.tgz" : candidate}`;
+      mkdirSync(commandCwd);
+      writeNpmLifecycleFixture(npm);
+      try {
+        const result = runInstallShell(
+          [
+            `source ${JSON.stringify(SCRIPT_PATH)}`,
+            `cd ${JSON.stringify(commandCwd)}`,
+            `npm_lifecycle_allow_arg ${JSON.stringify(npm)} ${JSON.stringify(spec)} "$PWD"`,
+          ].join("\n"),
+          { NPM_FAKE_VERSION: "12.0.0" },
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout.trim()).toBe(`--allow-scripts=${protocol}${candidate}`);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    { version: "11.16.0", advisory: true },
+    { version: "12.0.0", advisory: false },
+  ])(
+    "handles comma tarball identity under npm $version before mutation",
+    ({ version, advisory }) => {
+      const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-archive-comma,"));
+      const npm = join(tmp, "npm");
+      const args = join(tmp, "args");
+      writeNpmLifecycleFixture(npm);
+      try {
+        const result = runInstallShell(
+          [
+            `source ${JSON.stringify(SCRIPT_PATH)}`,
+            `npm_command_path() { printf '%s\\n' ${JSON.stringify(npm)}; }`,
+            `cd ${JSON.stringify(tmp)}`,
+            `run_verified_npm_global_install ${JSON.stringify(join(tmp, "candidate.tgz"))} ${JSON.stringify(join(tmp, "log"))}`,
+          ].join("\n"),
+          {
+            NPM_FAKE_VERSION: version,
+            NPM_FAKE_ARGS: args,
+            NPM_FAKE_ROOT: join(tmp, "lib/node_modules"),
+            NPM_FAKE_PACKAGE_DIR: join(tmp, "lib/node_modules/openclaw"),
+          },
+        );
+        expect(result.status).toBe(advisory ? 0 : 1);
+        expect(existsSync(args)).toBe(advisory);
+        if (!advisory) {
+          expect(result.stderr).toContain("without commas");
+        }
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("retains relative directory identities under comma ancestors", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-lifecycle-comma,"));
     const npm = join(tmp, "npm");
     const commandCwd = join(tmp, "work");
-    const candidate = join(tmp, "candidate.tgz");
+    const candidate = join(tmp, "candidate");
     mkdirSync(commandCwd);
     writeNpmLifecycleFixture(npm);
     try {
@@ -1154,7 +1218,7 @@ NODE
         { NPM_FAKE_VERSION: "12.0.0" },
       );
       expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe("--allow-scripts=../candidate.tgz");
+      expect(result.stdout.trim()).toBe("--allow-scripts=../candidate");
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3578,6 +3578,46 @@ printf 'core_failed=%s\n' "$failed"
     expect(JSON.stringify(npm12Job)).not.toContain("secrets.");
   });
 
+  it("binds npm 12 installation to the supplied prerelease dependency artifact", () => {
+    const job = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "npm_12_install_sh");
+    const validate = workflowStep(job, "Validate prerelease plugin registry artifact identity");
+    const download = workflowStep(job, "Download prerelease plugin registry artifact");
+    const install = workflowStep(job, "Run install.sh with npm 12");
+    const tuple = "needs.resolve_package.outputs.prepublish_plugin_registry_json";
+    const field = (name: string) =>
+      `\${{ fromJSON(${tuple} || '{}').prepublishPluginRegistry${name} || '' }}`;
+
+    expect(validate.if).toBe(`${tuple} != ''`);
+    expect(validate.env).toMatchObject({
+      ARTIFACT_DIGEST: field("ArtifactDigest"),
+      ARTIFACT_ID: field("ArtifactId"),
+      ARTIFACT_NAME: field("ArtifactName"),
+      ARTIFACT_RUN_ATTEMPT: field("ArtifactRunAttempt"),
+      ARTIFACT_RUN_ID: field("ArtifactRunId"),
+    });
+    expect(validate.run).toContain('verify-upload "Prerelease plugin registry"');
+    expect(download.if).toBe(validate.if);
+    expect(download.uses).toBe(DOWNLOAD_ARTIFACT_V8);
+    expect(download.with).toMatchObject({
+      "artifact-ids": field("ArtifactId"),
+      "run-id": field("ArtifactRunId"),
+      path: ".artifacts/prepublish-plugin-registry",
+    });
+    expect(install.env).toMatchObject({
+      OPENCLAW_DOCKER_E2E_SELECTED_SHA: "${{ needs.resolve_package.outputs.package_source_sha }}",
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION:
+        "${{ needs.resolve_package.outputs.package_version }}",
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: `\${{ ${tuple} != '' && format('{0}/.artifacts/prepublish-plugin-registry', github.workspace) || '' }}`,
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: field("ManifestSha256"),
+    });
+    expect(install.run).toMatch(
+      /bash scripts\/e2e\/lib\/prepublish-plugin-registry\.sh\s*\\\s*bash scripts\/install\.sh/u,
+    );
+    const steps = job.steps ?? [];
+    expect(steps.indexOf(validate)).toBeLessThan(steps.indexOf(download));
+    expect(steps.indexOf(download)).toBeLessThan(steps.indexOf(install));
+  });
+
   it("keeps ref packaging independent of workflow-checkout dependencies", () => {
     const workflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");
     const resolveJob = workflow.slice(

--- a/test/scripts/prepublish-plugin-registry-shell.test.ts
+++ b/test/scripts/prepublish-plugin-registry-shell.test.ts
@@ -1,10 +1,11 @@
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { once } from "node:events";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse } from "yaml";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SOURCE_SHA = "a".repeat(40);
@@ -273,6 +274,110 @@ docker_e2e_prepare_package_context "$ROOT_TARBALL"
     expect(readFileSync(join(context, "openclaw-current.tgz"))).toEqual(
       readFileSync(join(fixture.artifactDir, "openclaw.tgz")),
     );
+  });
+
+  it.each([
+    { name: "prepared dependencies", registry: true, fault: "" },
+    { name: "public registry without a tuple", registry: false, fault: "" },
+    { name: "mismatched registry source", registry: true, fault: "source" },
+    { name: "mismatched registry digest", registry: true, fault: "manifest" },
+    { name: "mismatched root package digest", registry: true, fault: "package" },
+  ])("runs the native npm 12 workflow with $name", async ({ registry, fault }) => {
+    const root = tempDirs.make("openclaw-npm12-workflow-registry-");
+    const fixture = registryFixture(root, ["@openclaw/ai"]);
+    const packageDir = join(root, ".artifacts/docker-e2e-package");
+    const bin = join(root, "bin");
+    mkdirSync(packageDir, { recursive: true });
+    mkdirSync(bin);
+    const packageTgz = createTarball(root, packageDir, "openclaw", "openclaw-current.tgz");
+    const installed = join(root, "installed");
+    for (const file of [
+      SCRIPT,
+      "scripts/prepublish-plugin-registry-artifact.mjs",
+      "scripts/e2e/lib/plugins/npm-registry-server.mjs",
+      "scripts/lib/bounded-response.mjs",
+      "scripts/docker/install-sh-common/version-parse.sh",
+    ]) {
+      mkdirSync(dirname(join(root, file)), { recursive: true });
+      copyFileSync(file, join(root, file));
+    }
+    // Bootstrap is outside this wiring test; the registry and child lifetime are real.
+    writeFileSync(
+      join(bin, "npm"),
+      '#!/bin/sh\nif [ "$1" = --version ]; then printf "12.0.2\\n"; fi\n',
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      join(root, "scripts/install.sh"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+node --input-type=module <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+const registry = process.env.NPM_CONFIG_REGISTRY;
+const response = await fetch(registry + "/@openclaw%2Fai");
+const metadata = await response.json();
+if (!metadata.versions[process.env.EXPECTED_DEPENDENCY_VERSION]) {
+  throw new Error("Installer cannot resolve its exact dependency");
+}
+fs.writeFileSync(process.env.INSTALL_MARKER, registry);
+const bin = path.join(process.env.NPM_CONFIG_PREFIX, "bin");
+fs.mkdirSync(bin, { recursive: true });
+fs.writeFileSync(path.join(bin, "openclaw"), "#!/bin/sh\\nprintf '%s\\\\n' \\"$EXPECTED_PACKAGE_VERSION\\"\\n", { mode: 0o755 });
+NODE
+`,
+    );
+    const workflow = parse(readFileSync(".github/workflows/package-acceptance.yml", "utf8")) as {
+      jobs: { npm_12_install_sh: { steps: Array<{ name: string; run?: string }> } };
+    };
+    const script = workflow.jobs.npm_12_install_sh.steps.find(
+      (step) => step.name === "Run install.sh with npm 12",
+    )?.run;
+    if (!script) {
+      throw new Error("Missing native npm 12 installer step");
+    }
+    await withPublishedRegistry(root, async (upstream) => {
+      const result = spawnSync("bash", ["-c", script], {
+        cwd: root,
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          ...fixture.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          RUNNER_TEMP: join(root, "runner-temp"),
+          NPM_CONFIG_REGISTRY: upstream,
+          npm_config_registry: upstream,
+          OPENCLAW_NPM_REGISTRY_UPSTREAM: upstream,
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: registry ? fixture.artifactDir : "",
+          OPENCLAW_DOCKER_E2E_SELECTED_SHA: fault === "source" ? "b".repeat(40) : SOURCE_SHA,
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256:
+            fault === "manifest" ? "b".repeat(64) : sha256(fixture.manifestPath),
+          EXPECTED_PACKAGE_SHA256: fault === "package" ? "b".repeat(64) : sha256(packageTgz),
+          EXPECTED_PACKAGE_VERSION: VERSION,
+          EXPECTED_DEPENDENCY_VERSION: registry ? VERSION : BASELINE_VERSION,
+          INSTALL_MARKER: installed,
+        },
+      });
+      if (fault) {
+        expect(result.status, result.stdout + result.stderr).not.toBe(0);
+        expect(existsSync(installed)).toBe(false);
+        if (fault !== "package") {
+          expect(result.stderr).toContain(
+            fault === "source" ? "source SHA differs" : "manifest SHA-256 differs",
+          );
+        }
+        return;
+      }
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      const registryUrl = readFileSync(installed, "utf8");
+      if (registry) {
+        expect(registryUrl).not.toBe(upstream);
+        await expect(fetch(registryUrl, { signal: AbortSignal.timeout(1_000) })).rejects.toThrow();
+      } else {
+        expect(registryUrl).toBe(upstream);
+      }
+    });
   });
 
   it("derives the immutable Docker mount contract from the registry artifact", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing or updating from local package archives with npm 12 would fail the required postinstall check. Also fixes the mandatory package-acceptance installer lane failing to resolve prepared official-plugin dependencies before their first publication.

## Why This Change Was Made

The acceptance job now verifies and downloads the exact prepared-registry artifact and runs the existing registry wrapper around the real installer. Public-registry runs remain unchanged when no prepared artifact is selected. The resolved source SHA, package version, manifest SHA, producer run/attempt, artifact ID and service digest remain bound to the selected package; no package is rebuilt or published to satisfy the test.

The shell installers, PowerShell installer and global updater now use npm's absolute resolved identity for local archives. Directory links retain their relative identity. The npm 11.16 comma-path behavior is preserved without overriding its strict/advisory policy; npm 12 rejects an unrepresentable comma-containing archive path before installation with instructions to move it. Registry aliases, hosted Git shorthand, file-URL/home resolution and literal path characters retain their existing meaning. The updater carries the npm policy already discovered from its owning executable rather than probing another npm.

## User Impact

Local-archive installation and updates complete with npm 12's lifecycle policy, while npm 11 retains its existing strict/advisory behavior. Unpublished release candidates can be tested against their exact prepared plugin bytes without publishing dependencies early.

## Evidence

- Full shell-installer suites: 310 passed; 27 PowerShell-runtime tests are skipped locally and remain for hosted Windows CI.
- Full infrastructure/update sibling suites: 323 passed across 9 files. Full update CLI suite: 357 passed. The Git-source tests now check absolute archive approval, and the runner test checks that the installed version actually changes; its previous unknown-command mock could otherwise return a false success.
- Package-acceptance and registry-owner suites: 334 passed. The new registry wiring and installer identities failed before the repair and passed afterward; the three old Git-pack expectations also have captured RED results.
- Actual npm 11.16.0 / npm 12.0.2 matrix: all 8 required cases and 3 encoding/home cases passed. npm 12 comma paths reject before any install; npm 11 default comma installs still work, while strict policy still rejects the unmatched identity.
- Separate full `install.sh` entry point under the canonical registry wrapper: passed with real npm 12, a prepared unpublished synthetic AI dependency, completed postinstall, executable CLI and registry cleanup. Source/package/manifest bytes stayed unchanged. This is a real installer flow using synthetic packages, not a final release-artifact attestation.
- Canonical workflow lint passed using the pinned pre-commit 4.6.2 with Python 3.12; the initial system-Python 3.9 bootstrap could not satisfy its Python requirement. No dependency pin was changed.
- Independent Codex autoreview: scoped-clean at the repository-default P0 scope, with no accepted findings. Root and an independent reader also reviewed actual npm 11/12 NPA, HostedGit and Arborist contracts and the four identity producers.
- Final canonical 18-file changed gate: passed, including formatting, lint, source/test boundaries and test-size checks.

## Scope and release notes

No new configuration, environment variables, lifecycle-policy overrides, speculative compatibility fallback, package publication, protocol or database changes. The pending-postinstall guard remains mandatory. Installer/update documentation explains npm 12's comma-path limitation. The standalone installer kernels cannot import a repository helper after download; their matching normalization stays aligned with the updater's owner. Production delta is +102 runtime lines and +31 workflow lines to enforce these public/dependency contracts. Existing lifecycle tests move into a focused sibling to satisfy the unchanged file-size cap; pure moves are not new coverage.

Release-note context: fix npm 12 installation/update of local package archives and allow unpublished prepared official plugins to participate in the mandatory package-acceptance installer lane.
