### PR TITLE
fix(android): restore local release validation gates

### DIFF
--- a/apps/android/fastlane/Fastfile
+++ b/apps/android/fastlane/Fastfile
@@ -446,8 +446,16 @@ def prepare_android_release_signing!
 end
 
 def validate_android_release_signing!
+  build_commit = release_git_sha
+  build_timestamp = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
   Dir.chdir(android_root) do
-    sh(shell_join(["./gradlew", ":app:bundlePlayRelease", ":wear:bundleRelease", "--dry-run"]))
+    sh(shell_join([
+      "./gradlew",
+      ":app:validateSigningPlayRelease",
+      ":wear:validateSigningRelease",
+      "-PopenclawBuildCommit=#{build_commit}",
+      "-PopenclawBuildTimestamp=#{build_timestamp}"
+    ]))
   end
 end
 

--- a/scripts/android-screenshots.sh
+++ b/scripts/android-screenshots.sh
@@ -345,11 +345,7 @@ device_count() {
 running_avd_name() {
   local adb="$1"
   local serial="$2"
-  local output
-  if ! output="$("$adb" -s "$serial" emu avd name 2>/dev/null)"; then
-    return 0
-  fi
-  printf '%s\n' "$output" | tr -d '\r' | sed -n '1p'
+  "$adb" -s "$serial" emu avd name 2>/dev/null | tr -d '\r' | sed -n '1p'
 }
 
 wait_for_single_device() {
@@ -530,11 +526,12 @@ resolve_device() {
   devices="$(connected_devices "$adb")"
   count="$(device_count "$devices")"
   if [[ "$count" == "1" ]]; then
-    connected_avd="$(running_avd_name "$adb" "$devices")"
-    if [[ "$connected_avd" != "$AVD" ]]; then
-      echo "Connected emulator '${connected_avd:-unknown}' is not the screenshot AVD '${AVD}'." >&2
-      echo "Stop it so the script can boot '${AVD}', or pass --device '${devices}' to override the no-cutout profile." >&2
-      return 1
+    if connected_avd="$(running_avd_name "$adb" "$devices")"; then
+      if [[ "$connected_avd" != "$AVD" ]]; then
+        echo "Connected emulator '${connected_avd:-unknown}' is not the screenshot AVD '${AVD}'." >&2
+        echo "Stop it so the script can boot '${AVD}', or pass --device '${devices}' to override the no-cutout profile." >&2
+        return 1
+      fi
     fi
     ADB_SERIAL="$devices"
     return

--- a/scripts/android-screenshots.sh
+++ b/scripts/android-screenshots.sh
@@ -345,7 +345,11 @@ device_count() {
 running_avd_name() {
   local adb="$1"
   local serial="$2"
-  "$adb" -s "$serial" emu avd name 2>/dev/null | tr -d '\r' | sed -n '1p'
+  local output
+  if ! output="$("$adb" -s "$serial" emu avd name 2>/dev/null)"; then
+    return 0
+  fi
+  printf '%s\n' "$output" | tr -d '\r' | sed -n '1p'
 }
 
 wait_for_single_device() {

--- a/test/scripts/android-release-fastlane-gates.test.ts
+++ b/test/scripts/android-release-fastlane-gates.test.ts
@@ -41,6 +41,18 @@ describe("Android Fastlane release upload gates", () => {
     expect(wearTrack).not.toContain('"qa"');
   });
 
+  it("executes the app and Wear signing validators during release preflight", () => {
+    const validation = functionBody(readFastfile(), "validate_android_release_signing!");
+
+    expect(validation).toContain('":app:validateSigningPlayRelease"');
+    expect(validation).toContain('":wear:validateSigningRelease"');
+    expect(validation).toContain('"-PopenclawBuildCommit=#{build_commit}"');
+    expect(validation).toContain('"-PopenclawBuildTimestamp=#{build_timestamp}"');
+    expect(validation).not.toContain("--dry-run");
+    expect(validation).not.toContain(":app:bundlePlayRelease");
+    expect(validation).not.toContain(":wear:bundleRelease");
+  });
+
   it("preflights and records mobile release refs around Play build upload", () => {
     const fastfile = readFastfile();
     const uploadBuild = functionBody(fastfile, "upload_play_store_build!");

--- a/test/scripts/android-screenshots.test.ts
+++ b/test/scripts/android-screenshots.test.ts
@@ -71,7 +71,7 @@ describe("android screenshots script", () => {
     }
   });
 
-  it("reports the screenshot AVD mismatch when a physical device is connected", () => {
+  it("rejects a physical device selected during screenshot discovery", () => {
     const root = tempDirs.make("openclaw-android-screenshot-adb-");
     const adb = path.join(root, "adb");
     writeFileSync(
@@ -83,6 +83,10 @@ if [[ "$1" == "devices" ]]; then
 fi
 if [[ "$1" == "-s" && "$2" == "physical-serial" && "$3" == "emu" && "$4" == "avd" && "$5" == "name" ]]; then
   exit 1
+fi
+if [[ "$1" == "-s" && "$2" == "physical-serial" && "$3" == "shell" && "$4" == "getprop" && "$5" == "ro.kernel.qemu" ]]; then
+  printf '0\\n'
+  exit 0
 fi
 printf 'unexpected adb invocation: %s\\n' "$*" >&2
 exit 97
@@ -98,9 +102,10 @@ exit 97
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "Connected emulator 'unknown' is not the screenshot AVD 'OpenClaw_Screenshots_API36'.",
+      "Android screenshot capture requires an emulator; 'physical-serial' is not an emulator.",
     );
-    expect(result.stderr).toContain("pass --device 'physical-serial'");
+    expect(result.stderr).toContain("Pass --avd <name> or --device <emulator-serial>.");
+    expect(result.stderr).not.toContain("Connected emulator 'unknown'");
     expect(result.stderr).not.toContain("unexpected adb invocation");
   });
 

--- a/test/scripts/android-screenshots.test.ts
+++ b/test/scripts/android-screenshots.test.ts
@@ -1,8 +1,11 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT = "scripts/android-screenshots.sh";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runAndroidScreenshots(args: string[], env: NodeJS.ProcessEnv = {}) {
   return spawnSync("bash", [SCRIPT, ...args], {
@@ -66,6 +69,39 @@ describe("android screenshots script", () => {
     ]) {
       expect(script).toContain(marker);
     }
+  });
+
+  it("reports the screenshot AVD mismatch when a physical device is connected", () => {
+    const root = tempDirs.make("openclaw-android-screenshot-adb-");
+    const adb = path.join(root, "adb");
+    writeFileSync(
+      adb,
+      `#!/usr/bin/env bash
+if [[ "$1" == "devices" ]]; then
+  printf 'List of devices attached\\nphysical-serial\\tdevice\\n'
+  exit 0
+fi
+if [[ "$1" == "-s" && "$2" == "physical-serial" && "$3" == "emu" && "$4" == "avd" && "$5" == "name" ]]; then
+  exit 1
+fi
+printf 'unexpected adb invocation: %s\\n' "$*" >&2
+exit 97
+`,
+      "utf8",
+    );
+    chmodSync(adb, 0o755);
+
+    const result = runAndroidScreenshots(
+      ["--form-factor", "phone", "--skip-build", "--skip-install"],
+      { ADB: adb },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Connected emulator 'unknown' is not the screenshot AVD 'OpenClaw_Screenshots_API36'.",
+    );
+    expect(result.stderr).toContain("pass --device 'physical-serial'");
+    expect(result.stderr).not.toContain("unexpected adb invocation");
   });
 
   it.each(["../escape", "en/US", ".hidden", "en..US", ""])(


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes Android release validation issues where screenshot capture could exit silently when a physical device was connected and signing preflight could accept nonexistent signing material.

## Why This Change Was Made

Physical-device AVD discovery now returns control to the owning diagnostic path, and release preflight executes the real app and Wear signing validators. This does not change versions, signing material, store state, or release workflows.

## User Impact

Android maintainers receive an actionable screenshot-device error instead of a silent stop, and invalid keystores fail before release work proceeds.

## Evidence

- Screenshot reproduction: a failed AVD-name query on a physical device now reaches the existing emulator guard and emits the physical-device diagnostic with emulator-only recovery guidance.
- Signing reproduction: `:app:validateSigningPlayRelease` and `:wear:validateSigningRelease` both execute and reject a nonexistent keystore.
- Tracked regressions: fake-ADB coverage proves failed AVD-query status reaches the physical-device diagnostic, and Fastlane coverage asserts the exact app and Wear validators replace dry-run.
- Exact head: `213f2fa24b840f70edb8367ec1ae0657cdb18962`.
- Diff after canonical locale PR #136304: 4 files, 70 insertions, 8 deletions. The 23 generated Android locale files are absent because main owns them.
- `pnpm android:i18n:check`: passed with 1,673 app keys across 21 translated locales.
- Focused P2 tests: 16 passed across the screenshot and Fastlane regression suites.
- Focused Android script matrix: 106 passed across 9 test files.
- Direct Gradle matrix: phone and Wear unit tests, phone play/third-party assemblies and lint, benchmark, Wear shared, Wear assemblies and lint, and all ktlint tasks passed; 295 tasks completed.
- Physical Pixel install: play debug APK installed successfully.
- Physical Pixel launch: cold launch succeeded in 543 ms; the app process remained alive and `MainActivity` was focused.
- Installed build: version `2026.7.4-debug`, version code `2026070401`.
- Android release owner decision: retain fail-fast signing validation so missing or unusable app/Wear signing material stops preflight before artifact creation.

Remaining environment gaps:

- No Wear device or Wear emulator was available for runtime launch proof.
- `:app:generateMermaidAssets` was excluded from direct Gradle proof because pnpm rejects the required symlinked worktree `node_modules` task-state path. This is a separate worktree/pnpm infrastructure issue.

Punchcard-Session: brisk-river-workshop-b1

Punchcard-Session: quiet-brook-meadow-cb

