### PR TITLE
fix: openai-completions cumulative text frames double live assistant deltas

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1495,7 +1495,7 @@ packages/ai/src/transports/openai-compatible-conversation-turn.ts	2
 packages/ai/src/transports/openai-completions-compat.ts	2
 packages/ai/src/transports/openai-completions-params.ts	9
 packages/ai/src/transports/openai-completions-replay.ts	9
-packages/ai/src/transports/openai-completions-stream.ts	8
+packages/ai/src/transports/openai-completions-stream.ts	4
 packages/ai/src/transports/openai-completions-string-content.ts	5
 packages/ai/src/transports/openai-completions-transport.ts	9
 packages/ai/src/transports/openai-responses-client.ts	12
@@ -2090,7 +2090,7 @@ src/agents/utils/frontmatter.ts	2
 src/agents/utils/tools-manager.ts	2
 src/agents/workspace-legacy-state.ts	2
 src/agents/workspace-state-store.ts	1
-src/agents/workspace.ts	7
+src/agents/workspace.ts	8
 src/agents/worktrees/git.ts	2
 src/agents/worktrees/provisioned-files.ts	3
 src/agents/worktrees/registry.ts	11

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -536,6 +536,73 @@ describe("agentLoop streaming updates", () => {
     }
   });
 
+  it("drops bare text_delta exact replays at the accumulation boundary", async () => {
+    const phrase = "abcdefgh";
+    const streamFn: StreamFn = async () => {
+      const stream = createAssistantMessageEventStream();
+      const startMessage: AssistantMessage = {
+        role: "assistant",
+        content: [],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      };
+      const finalMessage: AssistantMessage = {
+        ...startMessage,
+        content: [{ type: "text", text: `${phrase}!` }],
+      };
+
+      queueMicrotask(() => {
+        stream.push({ type: "start", partial: startMessage });
+        stream.push({
+          type: "text_start",
+          contentIndex: 0,
+          partial: { ...startMessage, content: [] },
+        });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: phrase });
+        // Same wire shape as #136262 / deepseek live doubles: delta === accumulated.
+        stream.push({ type: "text_delta", contentIndex: 0, delta: phrase });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: "!" });
+        stream.push({
+          type: "text_end",
+          contentIndex: 0,
+          content: `${phrase}!`,
+          partial: finalMessage,
+        });
+        stream.push({ type: "done", reason: "stop", message: finalMessage });
+      });
+
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      { systemPrompt: "", messages: [] },
+      config,
+      undefined,
+      streamFn,
+    );
+    const events = await collectEvents(stream);
+    const deltaUpdates = events.filter(
+      (event): event is Extract<AgentEvent, { type: "message_update" }> =>
+        event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+    );
+    expect(deltaUpdates.map((event) => event.message)).toMatchObject([
+      { role: "assistant", content: [{ type: "text", text: phrase }] },
+      { role: "assistant", content: [{ type: "text", text: `${phrase}!` }] },
+    ]);
+  });
+
   it("does not execute tool calls from a max-token-truncated assistant turn", async () => {
     const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => ({
       content: [{ type: "text", text: "should not run" }],

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -604,8 +604,7 @@ describe("agentLoop streaming updates", () => {
   });
 
   it("still emits confirming text_delta when text_start partial already carried the prefix", async () => {
-    // Mimics mutable partial snapshots: text_start's shared `partial` already
-    // contains later stream text before text_delta is processed.
+    // text_start's shared mutable partial can already include later stream text.
     const streamFn: StreamFn = async () => {
       const stream = createAssistantMessageEventStream();
       const startMessage: AssistantMessage = {
@@ -614,14 +613,7 @@ describe("agentLoop streaming updates", () => {
         api: model.api,
         provider: model.provider,
         model: model.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: TEST_USAGE,
         stopReason: "stop",
         timestamp: 1,
       };
@@ -629,7 +621,6 @@ describe("agentLoop streaming updates", () => {
         ...startMessage,
         content: [{ type: "text", text: "FANOUT_ALPHA first second" }],
       };
-      const finalMessage = polluted;
 
       queueMicrotask(() => {
         stream.push({ type: "start", partial: startMessage });
@@ -640,9 +631,9 @@ describe("agentLoop streaming updates", () => {
           type: "text_end",
           contentIndex: 0,
           content: "FANOUT_ALPHA first second",
-          partial: finalMessage,
+          partial: polluted,
         });
-        stream.push({ type: "done", reason: "stop", message: finalMessage });
+        stream.push({ type: "done", reason: "stop", message: polluted });
       });
 
       return stream;
@@ -660,11 +651,13 @@ describe("agentLoop streaming updates", () => {
       (event): event is Extract<AgentEvent, { type: "message_update" }> =>
         event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
     );
-    expect(
-      deltaUpdates.map((event) =>
-        event.assistantMessageEvent.type === "text_delta" ? event.assistantMessageEvent.delta : "",
-      ),
-    ).toEqual(["FANOUT_ALPHA ", "first second"]);
+    const deltas: string[] = [];
+    for (const event of deltaUpdates) {
+      if (event.assistantMessageEvent.type === "text_delta") {
+        deltas.push(event.assistantMessageEvent.delta);
+      }
+    }
+    expect(deltas).toEqual(["FANOUT_ALPHA ", "first second"]);
     expect(deltaUpdates.at(-1)?.message).toMatchObject({
       role: "assistant",
       content: [{ type: "text", text: "FANOUT_ALPHA first second" }],

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -603,11 +603,81 @@ describe("agentLoop streaming updates", () => {
     ]);
   });
 
+  it("still emits confirming text_delta when text_start partial already carried the prefix", async () => {
+    // Mimics mutable partial snapshots: text_start's shared `partial` already
+    // contains later stream text before text_delta is processed.
+    const streamFn: StreamFn = async () => {
+      const stream = createAssistantMessageEventStream();
+      const startMessage: AssistantMessage = {
+        role: "assistant",
+        content: [],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 1,
+      };
+      const polluted: AssistantMessage = {
+        ...startMessage,
+        content: [{ type: "text", text: "FANOUT_ALPHA first second" }],
+      };
+      const finalMessage = polluted;
+
+      queueMicrotask(() => {
+        stream.push({ type: "start", partial: startMessage });
+        stream.push({ type: "text_start", contentIndex: 0, partial: polluted });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: "FANOUT_ALPHA " });
+        stream.push({ type: "text_delta", contentIndex: 0, delta: "first second" });
+        stream.push({
+          type: "text_end",
+          contentIndex: 0,
+          content: "FANOUT_ALPHA first second",
+          partial: finalMessage,
+        });
+        stream.push({ type: "done", reason: "stop", message: finalMessage });
+      });
+
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      { systemPrompt: "", messages: [] },
+      config,
+      undefined,
+      streamFn,
+    );
+    const events = await collectEvents(stream);
+    const deltaUpdates = events.filter(
+      (event): event is Extract<AgentEvent, { type: "message_update" }> =>
+        event.type === "message_update" && event.assistantMessageEvent.type === "text_delta",
+    );
+    expect(
+      deltaUpdates.map((event) =>
+        event.assistantMessageEvent.type === "text_delta" ? event.assistantMessageEvent.delta : "",
+      ),
+    ).toEqual(["FANOUT_ALPHA ", "first second"]);
+    expect(deltaUpdates.at(-1)?.message).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "FANOUT_ALPHA first second" }],
+    });
+  });
+
   it("does not execute tool calls from a max-token-truncated assistant turn", async () => {
-    const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => ({
-      content: [{ type: "text", text: "should not run" }],
-      details: {},
-    }));
+    const execute = vi.fn(
+      async (): Promise<AgentToolResult<unknown>> => ({
+        content: [{ type: "text", text: "should not run" }],
+        details: {},
+      }),
+    );
     const contexts: Context[] = [];
     let streamCalls = 0;
     const streamFn: StreamFn = async (_model, context) => {
@@ -751,10 +821,12 @@ describe("runAgentLoop deferred tool hydration", () => {
   }
 
   it("hydrates an authorized deferred tool for execution and the continuation", async () => {
-    const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => ({
-      content: [{ type: "text", text: "hidden ok" }],
-      details: { ok: true },
-    }));
+    const execute = vi.fn(
+      async (): Promise<AgentToolResult<unknown>> => ({
+        content: [{ type: "text", text: "hidden ok" }],
+        details: { ok: true },
+      }),
+    );
     const hiddenTool: AgentTool = {
       name: "hidden_search",
       label: "hidden_search",
@@ -869,10 +941,12 @@ describe("runAgentLoop deferred tool hydration", () => {
   });
 
   it("rejects deferred tools whose names differ from the requested call", async () => {
-    const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => ({
-      content: [{ type: "text", text: "wrong tool ran" }],
-      details: { ok: true },
-    }));
+    const execute = vi.fn(
+      async (): Promise<AgentToolResult<unknown>> => ({
+        content: [{ type: "text", text: "wrong tool ran" }],
+        details: { ok: true },
+      }),
+    );
     const mismatchedTool: AgentTool = {
       name: "other_deferred",
       label: "other_deferred",

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -665,12 +665,10 @@ describe("agentLoop streaming updates", () => {
   });
 
   it("does not execute tool calls from a max-token-truncated assistant turn", async () => {
-    const execute = vi.fn(
-      async (): Promise<AgentToolResult<unknown>> => ({
-        content: [{ type: "text", text: "should not run" }],
-        details: {},
-      }),
-    );
+    const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => ({
+      content: [{ type: "text", text: "should not run" }],
+      details: {},
+    }));
     const contexts: Context[] = [];
     let streamCalls = 0;
     const streamFn: StreamFn = async (_model, context) => {
@@ -814,12 +812,10 @@ describe("runAgentLoop deferred tool hydration", () => {
   }
 
   it("hydrates an authorized deferred tool for execution and the continuation", async () => {
-    const execute = vi.fn(
-      async (): Promise<AgentToolResult<unknown>> => ({
-        content: [{ type: "text", text: "hidden ok" }],
-        details: { ok: true },
-      }),
-    );
+    const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => ({
+      content: [{ type: "text", text: "hidden ok" }],
+      details: { ok: true },
+    }));
     const hiddenTool: AgentTool = {
       name: "hidden_search",
       label: "hidden_search",
@@ -934,12 +930,10 @@ describe("runAgentLoop deferred tool hydration", () => {
   });
 
   it("rejects deferred tools whose names differ from the requested call", async () => {
-    const execute = vi.fn(
-      async (): Promise<AgentToolResult<unknown>> => ({
-        content: [{ type: "text", text: "wrong tool ran" }],
-        details: { ok: true },
-      }),
-    );
+    const execute = vi.fn(async (): Promise<AgentToolResult<unknown>> => ({
+      content: [{ type: "text", text: "wrong tool ran" }],
+      details: { ok: true },
+    }));
     const mismatchedTool: AgentTool = {
       name: "other_deferred",
       label: "other_deferred",

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -536,7 +536,7 @@ describe("agentLoop streaming updates", () => {
     }
   });
 
-  it("drops bare text_delta exact replays at the accumulation boundary", async () => {
+  it("keeps bare text_delta exact repeats additive at the accumulation boundary", async () => {
     const phrase = "abcdefgh";
     const streamFn: StreamFn = async () => {
       const stream = createAssistantMessageEventStream();
@@ -559,7 +559,7 @@ describe("agentLoop streaming updates", () => {
       };
       const finalMessage: AssistantMessage = {
         ...startMessage,
-        content: [{ type: "text", text: `${phrase}!` }],
+        content: [{ type: "text", text: `${phrase}${phrase}!` }],
       };
 
       queueMicrotask(() => {
@@ -570,13 +570,13 @@ describe("agentLoop streaming updates", () => {
           partial: { ...startMessage, content: [] },
         });
         stream.push({ type: "text_delta", contentIndex: 0, delta: phrase });
-        // Same wire shape as #136262 / deepseek live doubles: delta === accumulated.
+        // Agent Core stays transport-neutral: bare repeats append.
         stream.push({ type: "text_delta", contentIndex: 0, delta: phrase });
         stream.push({ type: "text_delta", contentIndex: 0, delta: "!" });
         stream.push({
           type: "text_end",
           contentIndex: 0,
-          content: `${phrase}!`,
+          content: `${phrase}${phrase}!`,
           partial: finalMessage,
         });
         stream.push({ type: "done", reason: "stop", message: finalMessage });
@@ -599,7 +599,8 @@ describe("agentLoop streaming updates", () => {
     );
     expect(deltaUpdates.map((event) => event.message)).toMatchObject([
       { role: "assistant", content: [{ type: "text", text: phrase }] },
-      { role: "assistant", content: [{ type: "text", text: `${phrase}!` }] },
+      { role: "assistant", content: [{ type: "text", text: `${phrase}${phrase}` }] },
+      { role: "assistant", content: [{ type: "text", text: `${phrase}${phrase}!` }] },
     ]);
   });
 

--- a/packages/agent-core/src/agent-stream-response.ts
+++ b/packages/agent-core/src/agent-stream-response.ts
@@ -71,21 +71,39 @@ function appendTextDeltaToAssistantMessage(
 function resolveAssistantTextDeltaUpdate(
   event: Extract<AssistantMessageUpdateEvent, { type: "text_delta" }>,
   currentMessage: AssistantMessage,
+  emittedTextByContentIndex: Map<number, string>,
 ): {
   message: AssistantMessage;
   event: Extract<AssistantMessageUpdateEvent, { type: "text_delta" }>;
 } | null {
   if ("partial" in event && event.partial) {
+    // Direct-mode events carry an authoritative partial; producer already normalized.
+    if (event.delta) {
+      const emittedText = emittedTextByContentIndex.get(event.contentIndex) ?? "";
+      const growth = normalizeOpenAICompletionsTextDelta(emittedText, event.delta);
+      if (growth) {
+        emittedTextByContentIndex.set(event.contentIndex, emittedText + growth);
+      }
+    }
     return { message: event.partial, event };
   }
   const currentContent = currentMessage.content[event.contentIndex];
-  const previousText = currentContent?.type === "text" ? currentContent.text : "";
-  // Transport-agnostic guard for bare text_delta cumulative replays (e.g. deepseek).
-  const normalizedDelta = normalizeOpenAICompletionsTextDelta(previousText, event.delta);
+  const messageText = currentContent?.type === "text" ? currentContent.text : "";
+  // Normalize against text already emitted on this index. text_start's mutable
+  // `partial` can already include later deltas, so messageText alone false-drops
+  // the confirming replay that SSE/HTTP sinks still need to observe.
+  const emittedText = emittedTextByContentIndex.get(event.contentIndex) ?? "";
+  const normalizedDelta = normalizeOpenAICompletionsTextDelta(emittedText, event.delta);
   if (!normalizedDelta) {
     return null;
   }
+  const nextEmitted = emittedText + normalizedDelta;
+  emittedTextByContentIndex.set(event.contentIndex, nextEmitted);
   const nextEvent = normalizedDelta === event.delta ? event : { ...event, delta: normalizedDelta };
+  // Skip re-append when text_start partial already landed this prefix on the message.
+  if (messageText.startsWith(nextEmitted) && messageText.length >= nextEmitted.length) {
+    return { message: currentMessage, event: nextEvent };
+  }
   return {
     message: appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, normalizedDelta),
     event: nextEvent,
@@ -95,12 +113,16 @@ function resolveAssistantTextDeltaUpdate(
 function resolveAssistantMessageUpdate(
   event: AssistantMessageUpdateEvent,
   currentMessage: AssistantMessage,
+  emittedTextByContentIndex: Map<number, string>,
 ): AssistantMessage {
   if ("partial" in event && event.partial) {
     return event.partial;
   }
   if (event.type === "text_delta") {
-    return resolveAssistantTextDeltaUpdate(event, currentMessage)?.message ?? currentMessage;
+    return (
+      resolveAssistantTextDeltaUpdate(event, currentMessage, emittedTextByContentIndex)?.message ??
+      currentMessage
+    );
   }
   return currentMessage;
 }
@@ -256,6 +278,7 @@ export async function streamAgentResponse(
     let partialIndex: number | undefined;
     let committedContentCount = 0;
     let streamedTurnId: string | undefined;
+    const emittedTextByContentIndex = new Map<number, string>();
 
     // Result wrappers bind ownership to unchanged content. Only split actual async fragments.
     const remainingFragment = (message: AssistantMessage) =>
@@ -301,7 +324,11 @@ export async function streamAgentResponse(
 
         case "text_delta":
           if (partialMessage) {
-            const resolved = resolveAssistantTextDeltaUpdate(event, partialMessage);
+            const resolved = resolveAssistantTextDeltaUpdate(
+              event,
+              partialMessage,
+              emittedTextByContentIndex,
+            );
             if (!resolved) {
               break;
             }
@@ -332,7 +359,11 @@ export async function streamAgentResponse(
         case "toolcall_delta":
         case "toolcall_end":
           if (partialMessage) {
-            const message = resolveAssistantMessageUpdate(event, partialMessage);
+            const message = resolveAssistantMessageUpdate(
+              event,
+              partialMessage,
+              emittedTextByContentIndex,
+            );
             partialMessage = message;
             if (event.contentIndex < committedContentCount) {
               break;

--- a/packages/agent-core/src/agent-stream-response.ts
+++ b/packages/agent-core/src/agent-stream-response.ts
@@ -1,4 +1,7 @@
-import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
+import {
+  normalizeOpenAICompletionsTextDelta,
+  replaceCompactionReplayOwnerContent,
+} from "@openclaw/ai/transports";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
@@ -65,6 +68,30 @@ function appendTextDeltaToAssistantMessage(
   return { ...message, content };
 }
 
+function resolveAssistantTextDeltaUpdate(
+  event: Extract<AssistantMessageUpdateEvent, { type: "text_delta" }>,
+  currentMessage: AssistantMessage,
+): {
+  message: AssistantMessage;
+  event: Extract<AssistantMessageUpdateEvent, { type: "text_delta" }>;
+} | null {
+  if ("partial" in event && event.partial) {
+    return { message: event.partial, event };
+  }
+  const currentContent = currentMessage.content[event.contentIndex];
+  const previousText = currentContent?.type === "text" ? currentContent.text : "";
+  // Transport-agnostic guard for bare text_delta cumulative replays (e.g. deepseek).
+  const normalizedDelta = normalizeOpenAICompletionsTextDelta(previousText, event.delta);
+  if (!normalizedDelta) {
+    return null;
+  }
+  const nextEvent = normalizedDelta === event.delta ? event : { ...event, delta: normalizedDelta };
+  return {
+    message: appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, normalizedDelta),
+    event: nextEvent,
+  };
+}
+
 function resolveAssistantMessageUpdate(
   event: AssistantMessageUpdateEvent,
   currentMessage: AssistantMessage,
@@ -73,7 +100,7 @@ function resolveAssistantMessageUpdate(
     return event.partial;
   }
   if (event.type === "text_delta") {
-    return appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, event.delta);
+    return resolveAssistantTextDeltaUpdate(event, currentMessage)?.message ?? currentMessage;
   }
   return currentMessage;
 }
@@ -272,8 +299,31 @@ export async function streamAgentResponse(
           break;
         }
 
-        case "text_start":
         case "text_delta":
+          if (partialMessage) {
+            const resolved = resolveAssistantTextDeltaUpdate(event, partialMessage);
+            if (!resolved) {
+              break;
+            }
+            partialMessage = resolved.message;
+            if (event.contentIndex < committedContentCount) {
+              break;
+            }
+            const fragment = await updatePartial(resolved.message);
+            const fragmentEvent = {
+              ...resolved.event,
+              contentIndex: resolved.event.contentIndex - committedContentCount,
+              ...("partial" in resolved.event ? { partial: fragment } : {}),
+            };
+            await emit({
+              type: "message_update",
+              assistantMessageEvent: fragmentEvent,
+              message: { ...fragment },
+            });
+          }
+          break;
+
+        case "text_start":
         case "text_end":
         case "thinking_start":
         case "thinking_delta":

--- a/packages/agent-core/src/agent-stream-response.ts
+++ b/packages/agent-core/src/agent-stream-response.ts
@@ -1,7 +1,4 @@
-import {
-  normalizeOpenAICompletionsTextDelta,
-  replaceCompactionReplayOwnerContent,
-} from "@openclaw/ai/transports";
+import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
 import type {
   AssistantMessage,
   AssistantMessageEvent,
@@ -75,38 +72,29 @@ function resolveAssistantTextDeltaUpdate(
 ): {
   message: AssistantMessage;
   event: Extract<AssistantMessageUpdateEvent, { type: "text_delta" }>;
-} | null {
+} {
   if ("partial" in event && event.partial) {
     // Direct-mode events carry an authoritative partial; producer already normalized.
     if (event.delta) {
       const emittedText = emittedTextByContentIndex.get(event.contentIndex) ?? "";
-      const growth = normalizeOpenAICompletionsTextDelta(emittedText, event.delta);
-      if (growth) {
-        emittedTextByContentIndex.set(event.contentIndex, emittedText + growth);
-      }
+      emittedTextByContentIndex.set(event.contentIndex, emittedText + event.delta);
     }
     return { message: event.partial, event };
   }
   const currentContent = currentMessage.content[event.contentIndex];
   const messageText = currentContent?.type === "text" ? currentContent.text : "";
-  // Normalize against text already emitted on this index. text_start's mutable
-  // `partial` can already include later deltas, so messageText alone false-drops
-  // the confirming replay that SSE/HTTP sinks still need to observe.
+  // Bare deltas stay additive. Track emitted text so a polluted text_start partial
+  // (already holding later stream text) does not cause a second append for the
+  // confirming deltas HTTP/SSE sinks still need to observe.
   const emittedText = emittedTextByContentIndex.get(event.contentIndex) ?? "";
-  const normalizedDelta = normalizeOpenAICompletionsTextDelta(emittedText, event.delta);
-  if (!normalizedDelta) {
-    return null;
-  }
-  const nextEmitted = emittedText + normalizedDelta;
+  const nextEmitted = emittedText + event.delta;
   emittedTextByContentIndex.set(event.contentIndex, nextEmitted);
-  const nextEvent = normalizedDelta === event.delta ? event : { ...event, delta: normalizedDelta };
-  // Skip re-append when text_start partial already landed this prefix on the message.
   if (messageText.startsWith(nextEmitted) && messageText.length >= nextEmitted.length) {
-    return { message: currentMessage, event: nextEvent };
+    return { message: currentMessage, event };
   }
   return {
-    message: appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, normalizedDelta),
-    event: nextEvent,
+    message: appendTextDeltaToAssistantMessage(currentMessage, event.contentIndex, event.delta),
+    event,
   };
 }
 
@@ -119,10 +107,8 @@ function resolveAssistantMessageUpdate(
     return event.partial;
   }
   if (event.type === "text_delta") {
-    return (
-      resolveAssistantTextDeltaUpdate(event, currentMessage, emittedTextByContentIndex)?.message ??
-      currentMessage
-    );
+    return resolveAssistantTextDeltaUpdate(event, currentMessage, emittedTextByContentIndex)
+      .message;
   }
   return currentMessage;
 }
@@ -329,9 +315,6 @@ export async function streamAgentResponse(
               partialMessage,
               emittedTextByContentIndex,
             );
-            if (!resolved) {
-              break;
-            }
             partialMessage = resolved.message;
             if (event.contentIndex < committedContentCount) {
               break;

--- a/packages/ai/src/providers/openai-completions-structured-content-parity.test.ts
+++ b/packages/ai/src/providers/openai-completions-structured-content-parity.test.ts
@@ -240,10 +240,11 @@ const scenarios: StructuredContentScenario[] = [
     expectedContent: [{ type: "text", text: "Safety refusal." }],
   },
   {
+    // >=8 exact-replay contract (#136262): identical long deltas are cumulative replays, not appends.
     name: "identical refusals intentionally repeated across separate chunks",
     choice: { delta: { refusal: "Safety refusal." } },
     followupChoice: { delta: { refusal: "Safety refusal." } },
-    expectedContent: [{ type: "text", text: "Safety refusal.Safety refusal." }],
+    expectedContent: [{ type: "text", text: "Safety refusal." }],
   },
   {
     name: "documented mixed assistant text and refusal parts",

--- a/packages/ai/src/providers/openai-completions-structured-content-parity.test.ts
+++ b/packages/ai/src/providers/openai-completions-structured-content-parity.test.ts
@@ -240,11 +240,11 @@ const scenarios: StructuredContentScenario[] = [
     expectedContent: [{ type: "text", text: "Safety refusal." }],
   },
   {
-    // >=8 exact-replay contract (#136262): identical long deltas are cumulative replays, not appends.
+    // Bare choice.delta repeats stay additive under the shared event contract.
     name: "identical refusals intentionally repeated across separate chunks",
     choice: { delta: { refusal: "Safety refusal." } },
     followupChoice: { delta: { refusal: "Safety refusal." } },
-    expectedContent: [{ type: "text", text: "Safety refusal." }],
+    expectedContent: [{ type: "text", text: "Safety refusal.Safety refusal." }],
   },
   {
     name: "documented mixed assistant text and refusal parts",

--- a/packages/ai/src/providers/openai-completions-tool-calls.ts
+++ b/packages/ai/src/providers/openai-completions-tool-calls.ts
@@ -21,10 +21,12 @@ type OpenAICompletionsToolCallFinalizationOptions<TBlock extends object> = {
 };
 
 export function extractToolCallThoughtSignature(toolCall: unknown): string | undefined {
+  // SAFETY: Provider tool-call objects are untyped wire payloads; we only read optional string fields.
   const tc = toolCall as Record<string, unknown> | undefined;
   if (!tc) {
     return undefined;
   }
+  // SAFETY: Google encrypts thought signatures under extra_content.google on the same wire object.
   const extra = (tc.extra_content as Record<string, unknown> | undefined)?.google as
     | Record<string, unknown>
     | undefined;
@@ -32,6 +34,7 @@ export function extractToolCallThoughtSignature(toolCall: unknown): string | und
   if (typeof fromExtra === "string" && fromExtra.length > 0) {
     return fromExtra;
   }
+  // SAFETY: Some providers nest thought_signature on function rather than the tool-call root.
   const fromFunction = (tc.function as { thought_signature?: unknown } | undefined)
     ?.thought_signature;
   if (typeof fromFunction === "string" && fromFunction.length > 0) {

--- a/packages/ai/src/providers/openai-completions-tool-calls.ts
+++ b/packages/ai/src/providers/openai-completions-tool-calls.ts
@@ -20,6 +20,27 @@ type OpenAICompletionsToolCallFinalizationOptions<TBlock extends object> = {
   onConfirmedToolCall?: (block: TBlock, contentIndex: number) => void;
 };
 
+export function extractToolCallThoughtSignature(toolCall: unknown): string | undefined {
+  const tc = toolCall as Record<string, unknown> | undefined;
+  if (!tc) {
+    return undefined;
+  }
+  const extra = (tc.extra_content as Record<string, unknown> | undefined)?.google as
+    | Record<string, unknown>
+    | undefined;
+  const fromExtra = extra?.thought_signature;
+  if (typeof fromExtra === "string" && fromExtra.length > 0) {
+    return fromExtra;
+  }
+  const fromFunction = (tc.function as { thought_signature?: unknown } | undefined)
+    ?.thought_signature;
+  if (typeof fromFunction === "string" && fromFunction.length > 0) {
+    return fromFunction;
+  }
+  const fromToolCall = tc.thought_signature;
+  return typeof fromToolCall === "string" && fromToolCall.length > 0 ? fromToolCall : undefined;
+}
+
 /** Keep encrypted provider reasoning attached to the first matching tool call. */
 export function createOpenAIEncryptedToolCallReasoningTracker() {
   const firstBlocks = new Map<string, ToolCall>();

--- a/packages/ai/src/transports/openai-completions-params.ts
+++ b/packages/ai/src/transports/openai-completions-params.ts
@@ -68,6 +68,20 @@ function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptio
   return options?.reasoningEffort ?? options?.reasoning ?? "high";
 }
 
+export function shouldEmitOpenAICompletionsReasoning(
+  model: OpenAIModeModel,
+  options: OpenAICompletionsOptions | undefined,
+) {
+  if (!model.reasoning) {
+    return false;
+  }
+  const effort = resolveOpenAICompletionsReasoningEffort(options);
+  if (!effort || !isOpenAICompletionsThinkingEnabled(effort)) {
+    return false;
+  }
+  return true;
+}
+
 function resolveOpenAICompletionsMaxTokens(
   model: OpenAIModeModel,
   options: OpenAICompletionsOptions | undefined,

--- a/packages/ai/src/transports/openai-completions-stream.integration.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.integration.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../src/logging/diagnostic-run-activity.js";
 import { registerBuiltInApiProviders } from "../providers/register-builtins.js";
 import { createLlmRuntime } from "../stream.js";
-import { shouldEmitOpenAICompletionsReasoning } from "./openai-completions-stream.js";
+import { shouldEmitOpenAICompletionsReasoning } from "./openai-completions-params.js";
 import { createOpenAICompletionsTransportStreamFn } from "./openai-completions-transport.js";
 import { makeCompletionsChunk, makeCompletionsModel } from "./openai-completions.test-support.js";
 

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -33,6 +33,7 @@ import { getCompat } from "./openai-transport-params.js";
 import {
   createModelStreamCooperativeScheduler,
   isOpenAICompletionsThinkingEnabled,
+  normalizeOpenAICompletionsTextDelta,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
   readOpenAICompletionsReasoningBatch,
@@ -229,15 +230,19 @@ export async function processCompletionsStream(
       contentBlockIndices.set(currentBlock, output.content.length - 1);
       pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
     }
-    currentBlock.text += text;
-    if (pendingInterruptedTextBlock && text.trim()) {
+    const normalizedText = normalizeOpenAICompletionsTextDelta(currentBlock.text, text);
+    if (!normalizedText) {
+      return;
+    }
+    currentBlock.text += normalizedText;
+    if (pendingInterruptedTextBlock && normalizedText.trim()) {
       confirmedInterruptedTextBlock = pendingInterruptedTextBlock;
       pendingInterruptedTextBlock = null;
     }
     pushStreamEvent({
       type: "text_delta",
       contentIndex: blockIndex(),
-      delta: text,
+      delta: normalizedText,
       ...(directMode ? { partial: output } : {}),
     });
   };

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { AssistantMessageEvent, Model } from "@openclaw/llm-core";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
-import type { OpenAICompletionsOptions } from "../provider-options.js";
 import {
   createOpenAICompletionsToolCallDeltaNormalizer,
   createOpenAIEncryptedToolCallReasoningTracker,
+  extractToolCallThoughtSignature,
   finalizeOpenAICompletionsToolCalls,
 } from "../providers/openai-completions-tool-calls.js";
 import { mapOpenAIStopReason } from "../providers/openai-stop-reason.js";
@@ -32,7 +32,6 @@ import {
 import { getCompat } from "./openai-transport-params.js";
 import {
   createModelStreamCooperativeScheduler,
-  isOpenAICompletionsThinkingEnabled,
   normalizeOpenAICompletionsTextDelta,
   parseOpenAICompletionsUsage,
   readOpenAICompletionsContentDeltas,
@@ -72,27 +71,6 @@ type CompletionsStreamOptions = {
     }
   | { mode?: "managed"; beforeContentBlock?: never }
 );
-
-function extractToolCallThoughtSignature(toolCall: unknown): string | undefined {
-  const tc = toolCall as Record<string, unknown> | undefined;
-  if (!tc) {
-    return undefined;
-  }
-  const extra = (tc.extra_content as Record<string, unknown> | undefined)?.google as
-    | Record<string, unknown>
-    | undefined;
-  const fromExtra = extra?.thought_signature;
-  if (typeof fromExtra === "string" && fromExtra.length > 0) {
-    return fromExtra;
-  }
-  const fromFunction = (tc.function as { thought_signature?: unknown } | undefined)
-    ?.thought_signature;
-  if (typeof fromFunction === "string" && fromFunction.length > 0) {
-    return fromFunction;
-  }
-  const fromToolCall = tc.thought_signature;
-  return typeof fromToolCall === "string" && fromToolCall.length > 0 ? fromToolCall : undefined;
-}
 
 export async function processCompletionsStream(
   responseStream: AsyncIterable<ChatCompletionChunk>,
@@ -521,7 +499,6 @@ export async function processCompletionsStream(
       }
     }
     const rawChoiceDelta = choice.delta ?? choice.message;
-    // Prefer delta when present; message-only chunks are the compat snapshot contract.
     currentTextFrameKind = choice.delta != null ? "delta" : "snapshot";
     if (!rawChoiceDelta) {
       emitReasoningUsageActivity(hasReasoningUsageActivity);
@@ -713,24 +690,6 @@ export async function processCompletionsStream(
   if (output.stopReason === "toolUse") {
     tagPendingCommentaryText(output.content);
   }
-}
-
-function resolveOpenAICompletionsReasoningEffort(options: OpenAICompletionsOptions | undefined) {
-  return options?.reasoningEffort ?? options?.reasoning ?? "high";
-}
-
-export function shouldEmitOpenAICompletionsReasoning(
-  model: OpenAIModeModel,
-  options: OpenAICompletionsOptions | undefined,
-) {
-  if (!model.reasoning) {
-    return false;
-  }
-  const effort = resolveOpenAICompletionsReasoningEffort(options);
-  if (!effort || !isOpenAICompletionsThinkingEnabled(effort)) {
-    return false;
-  }
-  return true;
 }
 
 function hasOpenAICompletionsReasoningUsageActivity(

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -40,6 +40,7 @@ import {
   throwIfModelStreamAborted,
   type MutableAssistantOutput,
   type OpenAICompletionsContentDelta as CompletionsReasoningDelta,
+  type OpenAICompletionsTextFrameKind,
   type OpenAICompletionsTextSource,
   type OpenAIModeModel,
 } from "./openai-transport-shared.js";
@@ -126,6 +127,7 @@ export async function processCompletionsStream(
   let directTextBlock: TextBlock | null = null;
   let directThinkingBlock: ThinkingBlock | null = null;
   let currentTextSource: OpenAICompletionsTextSource | undefined;
+  let currentTextFrameKind: OpenAICompletionsTextFrameKind = "delta";
   let pendingInterruptedTextBlock: TextBlock | null = null;
   let confirmedInterruptedTextBlock: TextBlock | null = null;
   let pendingPostToolCallDeltas: CompletionsReasoningDelta[] = [];
@@ -230,7 +232,9 @@ export async function processCompletionsStream(
       contentBlockIndices.set(currentBlock, output.content.length - 1);
       pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
     }
-    const normalizedText = normalizeOpenAICompletionsTextDelta(currentBlock.text, text);
+    const normalizedText = normalizeOpenAICompletionsTextDelta(currentBlock.text, text, {
+      frameKind: currentTextFrameKind,
+    });
     if (!normalizedText) {
       return;
     }
@@ -517,6 +521,8 @@ export async function processCompletionsStream(
       }
     }
     const rawChoiceDelta = choice.delta ?? choice.message;
+    // Prefer delta when present; message-only chunks are the compat snapshot contract.
+    currentTextFrameKind = choice.delta != null ? "delta" : "snapshot";
     if (!rawChoiceDelta) {
       emitReasoningUsageActivity(hasReasoningUsageActivity);
       if (cooperativeScheduler) {

--- a/packages/ai/src/transports/openai-completions-stream.usage.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.usage.test.ts
@@ -14,17 +14,16 @@ import {
 } from "./openai-transport-shared.js";
 
 describe("normalizeOpenAICompletionsTextDelta", () => {
-  it("applies the >=8 monotonic-append contract for bare deltas", () => {
+  it("keeps bare deltas additive including long exact repeats", () => {
     expect(normalizeOpenAICompletionsTextDelta("", "abc")).toBe("abc");
-    // Below threshold: keep short intentional repeats / non-cumulative frames.
     expect(normalizeOpenAICompletionsTextDelta("abc", "abcdef")).toBe("abcdef");
     expect(normalizeOpenAICompletionsTextDelta("Ha", "Ha")).toBe("Ha");
     expect(normalizeOpenAICompletionsTextDelta("ab", "cd")).toBe("cd");
-    // At threshold: exact replay drop, cumulative growth, shrink-back drop.
-    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh")).toBe("");
-    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh again")).toBe(" again");
-    expect(normalizeOpenAICompletionsTextDelta("abcdefghij", "abcdefgh")).toBe("");
-    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefghabcdefgh")).toBe("");
+    // Bare deltas have no snapshot marker — preserve intentional long repeats.
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh")).toBe("abcdefgh");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh again")).toBe(
+      "abcdefgh again",
+    );
   });
 
   it("treats message-shaped snapshot frames as cumulative even when short", () => {
@@ -358,7 +357,7 @@ describe("openai completions stream", () => {
     expect(output.content).toEqual([{ type: "text", text: "ab" }]);
   });
 
-  it("normalizes cumulative OpenAI-compatible text frames before emitting bare deltas", async () => {
+  it("normalizes cumulative message-shaped snapshots before emitting bare deltas", async () => {
     const model = makeCompletionsModel({
       id: "dense-local",
       name: "Dense Local",
@@ -375,9 +374,27 @@ describe("openai completions stream", () => {
     await processCompletionsStream(
       streamChunks([
         makeCompletionsChunk({ role: "assistant" as const, content: prefix }),
-        // Cumulative snapshot: longer frame that extends prior text.
-        makeCompletionsChunk({ content: `${prefix}uv` }),
-        makeCompletionsChunk({ content: `${prefix}uvw` }),
+        // Cumulative snapshots via choice.message (not choice.delta).
+        makeCompletionsChunk({}, null, {
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: `${prefix}uv` },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        }),
+        makeCompletionsChunk({}, null, {
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: `${prefix}uvw` },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        }),
       ]),
       output,
       model,
@@ -391,7 +408,7 @@ describe("openai completions stream", () => {
     expect(output.content).toEqual([{ type: "text", text: `${prefix}uvw` }]);
   });
 
-  it("drops bare delta exact replays that match accumulated text (>=8)", async () => {
+  it("preserves bare delta exact repeats that match accumulated text", async () => {
     const model = makeCompletionsModel({
       id: "dense-local",
       name: "Dense Local",
@@ -408,7 +425,7 @@ describe("openai completions stream", () => {
     await processCompletionsStream(
       streamChunks([
         makeCompletionsChunk({ role: "assistant" as const, content: phrase }),
-        // Wire shape from #136262: bare text_delta with delta === accumulated.
+        // Bare choice.delta with equal text must stay additive (shared event contract).
         makeCompletionsChunk({ content: phrase }),
         makeCompletionsChunk({ content: "!" }),
       ]),
@@ -420,11 +437,11 @@ describe("openai completions stream", () => {
     const textDeltas = events
       .filter((event) => event.type === "text_delta")
       .map((event) => ("delta" in event ? event.delta : undefined));
-    expect(textDeltas).toEqual([phrase, "!"]);
-    expect(output.content).toEqual([{ type: "text", text: `${phrase}!` }]);
+    expect(textDeltas).toEqual([phrase, phrase, "!"]);
+    expect(output.content).toEqual([{ type: "text", text: `${phrase}${phrase}!` }]);
   });
 
-  it("treats a longer delta that extends prior text as cumulative growth", async () => {
+  it("treats a longer message snapshot that extends prior text as cumulative growth", async () => {
     const model = makeCompletionsModel({
       id: "dense-local",
       name: "Dense Local",
@@ -441,7 +458,16 @@ describe("openai completions stream", () => {
     await processCompletionsStream(
       streamChunks([
         makeCompletionsChunk({ role: "assistant" as const, content: phrase }),
-        makeCompletionsChunk({ content: `${phrase} again` }),
+        makeCompletionsChunk({}, null, {
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: `${phrase} again` },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        }),
       ]),
       output,
       model,

--- a/packages/ai/src/transports/openai-completions-stream.usage.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.usage.test.ts
@@ -14,16 +14,20 @@ import {
 } from "./openai-transport-shared.js";
 
 describe("normalizeOpenAICompletionsTextDelta", () => {
-  it("returns growth from cumulative snapshots and preserves ordinary repeated deltas", () => {
+  it("applies the >=8 monotonic-append contract for bare deltas", () => {
     expect(normalizeOpenAICompletionsTextDelta("", "abc")).toBe("abc");
-    expect(normalizeOpenAICompletionsTextDelta("abc", "abcdef")).toBe("def");
-    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh")).toBe("abcdefgh");
-    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh again")).toBe(" again");
-    expect(normalizeOpenAICompletionsTextDelta("ab", "cd")).toBe("cd");
+    // Below threshold: keep short intentional repeats / non-cumulative frames.
+    expect(normalizeOpenAICompletionsTextDelta("abc", "abcdef")).toBe("abcdef");
     expect(normalizeOpenAICompletionsTextDelta("Ha", "Ha")).toBe("Ha");
+    expect(normalizeOpenAICompletionsTextDelta("ab", "cd")).toBe("cd");
+    // At threshold: exact replay drop, cumulative growth, shrink-back drop.
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh")).toBe("");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh again")).toBe(" again");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefghij", "abcdefgh")).toBe("");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefghabcdefgh")).toBe("");
   });
 
-  it("suppresses exact and prefix replays only for message-shaped snapshot frames", () => {
+  it("treats message-shaped snapshot frames as cumulative even when short", () => {
     expect(
       normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh", { frameKind: "snapshot" }),
     ).toBe("");
@@ -387,7 +391,7 @@ describe("openai completions stream", () => {
     expect(output.content).toEqual([{ type: "text", text: `${prefix}uvw` }]);
   });
 
-  it("keeps intentional long repeated OpenAI-compatible delta text", async () => {
+  it("drops bare delta exact replays that match accumulated text (>=8)", async () => {
     const model = makeCompletionsModel({
       id: "dense-local",
       name: "Dense Local",
@@ -404,8 +408,9 @@ describe("openai completions stream", () => {
     await processCompletionsStream(
       streamChunks([
         makeCompletionsChunk({ role: "assistant" as const, content: phrase }),
-        // Ordinary delta equal to prior text must remain incremental.
+        // Wire shape from #136262: bare text_delta with delta === accumulated.
         makeCompletionsChunk({ content: phrase }),
+        makeCompletionsChunk({ content: "!" }),
       ]),
       output,
       model,
@@ -415,8 +420,8 @@ describe("openai completions stream", () => {
     const textDeltas = events
       .filter((event) => event.type === "text_delta")
       .map((event) => ("delta" in event ? event.delta : undefined));
-    expect(textDeltas).toEqual([phrase, phrase]);
-    expect(output.content).toEqual([{ type: "text", text: `${phrase}${phrase}` }]);
+    expect(textDeltas).toEqual([phrase, "!"]);
+    expect(output.content).toEqual([{ type: "text", text: `${phrase}!` }]);
   });
 
   it("treats a longer delta that extends prior text as cumulative growth", async () => {

--- a/packages/ai/src/transports/openai-completions-stream.usage.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.usage.test.ts
@@ -14,13 +14,25 @@ import {
 } from "./openai-transport-shared.js";
 
 describe("normalizeOpenAICompletionsTextDelta", () => {
-  it("returns growth from cumulative snapshots and drops long exact replays", () => {
+  it("returns growth from cumulative snapshots and preserves ordinary repeated deltas", () => {
     expect(normalizeOpenAICompletionsTextDelta("", "abc")).toBe("abc");
     expect(normalizeOpenAICompletionsTextDelta("abc", "abcdef")).toBe("def");
-    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh")).toBe("");
-    expect(normalizeOpenAICompletionsTextDelta("abcdefghij", "abcdefgh")).toBe("");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh")).toBe("abcdefgh");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh again")).toBe(" again");
     expect(normalizeOpenAICompletionsTextDelta("ab", "cd")).toBe("cd");
     expect(normalizeOpenAICompletionsTextDelta("Ha", "Ha")).toBe("Ha");
+  });
+
+  it("suppresses exact and prefix replays only for message-shaped snapshot frames", () => {
+    expect(
+      normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh", { frameKind: "snapshot" }),
+    ).toBe("");
+    expect(
+      normalizeOpenAICompletionsTextDelta("abcdefghij", "abcdefgh", { frameKind: "snapshot" }),
+    ).toBe("");
+    expect(normalizeOpenAICompletionsTextDelta("abc", "abcdef", { frameKind: "snapshot" })).toBe(
+      "def",
+    );
   });
 });
 
@@ -359,14 +371,9 @@ describe("openai completions stream", () => {
     await processCompletionsStream(
       streamChunks([
         makeCompletionsChunk({ role: "assistant" as const, content: prefix }),
-        makeCompletionsChunk({ content: "uv" }),
-        // Compatible providers sometimes replay the full accumulated snapshot.
+        // Cumulative snapshot: longer frame that extends prior text.
         makeCompletionsChunk({ content: `${prefix}uv` }),
-        makeCompletionsChunk({ content: "w" }),
-        // Exact full-text replay must not double the live message.
         makeCompletionsChunk({ content: `${prefix}uvw` }),
-        // Long prefix replay of already-emitted text is also a no-op.
-        makeCompletionsChunk({ content: prefix }),
       ]),
       output,
       model,
@@ -378,6 +385,111 @@ describe("openai completions stream", () => {
       .map((event) => ("delta" in event ? event.delta : undefined));
     expect(textDeltas).toEqual([prefix, "uv", "w"]);
     expect(output.content).toEqual([{ type: "text", text: `${prefix}uvw` }]);
+  });
+
+  it("keeps intentional long repeated OpenAI-compatible delta text", async () => {
+    const model = makeCompletionsModel({
+      id: "dense-local",
+      name: "Dense Local",
+      provider: "local",
+      baseUrl: "http://127.0.0.1:18065/v1",
+      reasoning: false,
+      contextWindow: 128000,
+      maxTokens: 4096,
+    });
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+    const phrase = "abcdefgh";
+
+    await processCompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({ role: "assistant" as const, content: phrase }),
+        // Ordinary delta equal to prior text must remain incremental.
+        makeCompletionsChunk({ content: phrase }),
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    const textDeltas = events
+      .filter((event) => event.type === "text_delta")
+      .map((event) => ("delta" in event ? event.delta : undefined));
+    expect(textDeltas).toEqual([phrase, phrase]);
+    expect(output.content).toEqual([{ type: "text", text: `${phrase}${phrase}` }]);
+  });
+
+  it("treats a longer delta that extends prior text as cumulative growth", async () => {
+    const model = makeCompletionsModel({
+      id: "dense-local",
+      name: "Dense Local",
+      provider: "local",
+      baseUrl: "http://127.0.0.1:18065/v1",
+      reasoning: false,
+      contextWindow: 128000,
+      maxTokens: 4096,
+    });
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+    const phrase = "abcdefgh";
+
+    await processCompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({ role: "assistant" as const, content: phrase }),
+        makeCompletionsChunk({ content: `${phrase} again` }),
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    const textDeltas = events
+      .filter((event) => event.type === "text_delta")
+      .map((event) => ("delta" in event ? event.delta : undefined));
+    expect(textDeltas).toEqual([phrase, " again"]);
+    expect(output.content).toEqual([{ type: "text", text: `${phrase} again` }]);
+  });
+
+  it("suppresses message-shaped snapshot replays without dropping ordinary deltas", async () => {
+    const model = makeCompletionsModel({
+      id: "dense-local",
+      name: "Dense Local",
+      provider: "local",
+      baseUrl: "http://127.0.0.1:18065/v1",
+      reasoning: false,
+      contextWindow: 128000,
+      maxTokens: 4096,
+    });
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+    const text = "abcdefghijklmnop";
+
+    await processCompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({ role: "assistant" as const, content: text }),
+        // Compat endpoints may deliver a full message snapshot instead of delta.
+        makeCompletionsChunk({}, null, {
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: text },
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        }),
+        makeCompletionsChunk({ content: "!" }),
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    const textDeltas = events
+      .filter((event) => event.type === "text_delta")
+      .map((event) => ("delta" in event ? event.delta : undefined));
+    expect(textDeltas).toEqual([text, "!"]);
+    expect(output.content).toEqual([{ type: "text", text: `${text}!` }]);
   });
 
   it("keeps intentional short repeated OpenAI-compatible text incremental", async () => {

--- a/packages/ai/src/transports/openai-completions-stream.usage.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.usage.test.ts
@@ -8,7 +8,21 @@ import {
   makeCompletionsModel,
   streamChunks,
 } from "./openai-completions.test-support.js";
-import { parseOpenAICompletionsUsage } from "./openai-transport-shared.js";
+import {
+  parseOpenAICompletionsUsage,
+  normalizeOpenAICompletionsTextDelta,
+} from "./openai-transport-shared.js";
+
+describe("normalizeOpenAICompletionsTextDelta", () => {
+  it("returns growth from cumulative snapshots and drops long exact replays", () => {
+    expect(normalizeOpenAICompletionsTextDelta("", "abc")).toBe("abc");
+    expect(normalizeOpenAICompletionsTextDelta("abc", "abcdef")).toBe("def");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefgh", "abcdefgh")).toBe("");
+    expect(normalizeOpenAICompletionsTextDelta("abcdefghij", "abcdefgh")).toBe("");
+    expect(normalizeOpenAICompletionsTextDelta("ab", "cd")).toBe("cd");
+    expect(normalizeOpenAICompletionsTextDelta("Ha", "Ha")).toBe("Ha");
+  });
+});
 
 describe("openai completions stream", () => {
   it("preserves reasoning tokens without double-counting them", () => {
@@ -326,6 +340,75 @@ describe("openai completions stream", () => {
     expect(textDeltas).toHaveLength(2);
     expect(textDeltas.every((event) => !("partial" in event))).toBe(true);
     expect(output.content).toEqual([{ type: "text", text: "ab" }]);
+  });
+
+  it("normalizes cumulative OpenAI-compatible text frames before emitting bare deltas", async () => {
+    const model = makeCompletionsModel({
+      id: "dense-local",
+      name: "Dense Local",
+      provider: "local",
+      baseUrl: "http://127.0.0.1:18065/v1",
+      reasoning: false,
+      contextWindow: 128000,
+      maxTokens: 4096,
+    });
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+    const prefix = "abcdefghijklmnopqrst";
+
+    await processCompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({ role: "assistant" as const, content: prefix }),
+        makeCompletionsChunk({ content: "uv" }),
+        // Compatible providers sometimes replay the full accumulated snapshot.
+        makeCompletionsChunk({ content: `${prefix}uv` }),
+        makeCompletionsChunk({ content: "w" }),
+        // Exact full-text replay must not double the live message.
+        makeCompletionsChunk({ content: `${prefix}uvw` }),
+        // Long prefix replay of already-emitted text is also a no-op.
+        makeCompletionsChunk({ content: prefix }),
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    const textDeltas = events
+      .filter((event) => event.type === "text_delta")
+      .map((event) => ("delta" in event ? event.delta : undefined));
+    expect(textDeltas).toEqual([prefix, "uv", "w"]);
+    expect(output.content).toEqual([{ type: "text", text: `${prefix}uvw` }]);
+  });
+
+  it("keeps intentional short repeated OpenAI-compatible text incremental", async () => {
+    const model = makeCompletionsModel({
+      id: "dense-local",
+      name: "Dense Local",
+      provider: "local",
+      baseUrl: "http://127.0.0.1:18065/v1",
+      reasoning: false,
+      contextWindow: 128000,
+      maxTokens: 4096,
+    });
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await processCompletionsStream(
+      streamChunks([
+        makeCompletionsChunk({ role: "assistant" as const, content: "Ha" }),
+        makeCompletionsChunk({ content: "Ha" }),
+        makeCompletionsChunk({ content: "Ha" }),
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    const textDeltas = events
+      .filter((event) => event.type === "text_delta")
+      .map((event) => ("delta" in event ? event.delta : undefined));
+    expect(textDeltas).toEqual(["Ha", "Ha", "Ha"]);
+    expect(output.content).toEqual([{ type: "text", text: "HaHaHa" }]);
   });
 
   it("skips null and non-object OpenAI-compatible stream chunks", async () => {

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -16,11 +16,11 @@ import {
 import { buildGuardedModelFetch } from "./host-policy.js";
 import { hasOpenAICompatibleConversationTurn } from "./openai-compatible-conversation-turn.js";
 import { isAzureOpenAICompatibleHost } from "./openai-completions-host.js";
-import { buildOpenAICompletionsParams } from "./openai-completions-params.js";
 import {
-  processCompletionsStream,
+  buildOpenAICompletionsParams,
   shouldEmitOpenAICompletionsReasoning,
-} from "./openai-completions-stream.js";
+} from "./openai-completions-params.js";
+import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   assertCodeModeResponsesToolSurface,
   buildOpenAIClientHeaders,

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -328,6 +328,29 @@ export function isOpenAICompletionsThinkingEnabled(effort: string): boolean {
   return normalized !== "off" && normalized !== "none";
 }
 
+/** Minimum length before treating an exact/prefix replay as a cumulative snapshot. */
+const OPENAI_COMPLETIONS_TEXT_REPLAY_MIN_CHARS = 8;
+
+/** Turn cumulative OpenAI-compatible `delta.content` snapshots into true increments. */
+export function normalizeOpenAICompletionsTextDelta(accumulated: string, incoming: string): string {
+  if (!incoming) {
+    return "";
+  }
+  if (!accumulated) {
+    return incoming;
+  }
+  if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
+    return incoming.slice(accumulated.length);
+  }
+  if (
+    incoming.length >= OPENAI_COMPLETIONS_TEXT_REPLAY_MIN_CHARS &&
+    (incoming === accumulated || accumulated.startsWith(incoming))
+  ) {
+    return "";
+  }
+  return incoming;
+}
+
 export function readOpenAICompletionsContentDeltas(
   content: unknown,
   topLevelRefusal?: unknown,

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -331,7 +331,26 @@ export function isOpenAICompletionsThinkingEnabled(effort: string): boolean {
   return normalized !== "off" && normalized !== "none";
 }
 
-/** Turn cumulative OpenAI-compatible text snapshots into true increments. */
+/** Min length before treating exact/prefix/extension frames as cumulative replays. */
+const TEXT_REPLAY_MIN_CHARS = 8;
+
+function growthFromCumulativeExtension(accumulated: string, incoming: string): string {
+  const growth = incoming.slice(accumulated.length);
+  // Drop doubled snapshots where the "growth" is itself a replay of prior text.
+  if (growth === accumulated || growth.startsWith(accumulated)) {
+    return "";
+  }
+  return growth;
+}
+
+/**
+ * Normalize cumulative text snapshots into true increments.
+ *
+ * Field captures (issue #136262) show compatible providers occasionally emit a bare
+ * `text_delta` whose content equals the already-accumulated text. A length-gated
+ * monotonic-append contract (also used at the agent-loop accumulation boundary)
+ * drops those replays while keeping short intentional repeats like "Ha"×3.
+ */
 export function normalizeOpenAICompletionsTextDelta(
   accumulated: string,
   incoming: string,
@@ -343,18 +362,34 @@ export function normalizeOpenAICompletionsTextDelta(
   if (!accumulated) {
     return incoming;
   }
-  // Cumulative snapshot contract: a longer frame that extends prior text.
-  if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
-    return incoming.slice(accumulated.length);
+
+  const frameKind = options?.frameKind ?? "delta";
+  const longEnough = accumulated.length >= TEXT_REPLAY_MIN_CHARS;
+
+  // Message-shaped frames are snapshots even when short.
+  if (frameKind === "snapshot") {
+    if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
+      return growthFromCumulativeExtension(accumulated, incoming);
+    }
+    if (incoming === accumulated || accumulated.startsWith(incoming)) {
+      return "";
+    }
+    return incoming;
   }
-  // Exact/prefix replay only for message-shaped frames. Ordinary delta frames stay
-  // incremental so legitimate repeated completions are preserved.
-  if (
-    (options?.frameKind ?? "delta") === "snapshot" &&
-    (incoming === accumulated || accumulated.startsWith(incoming))
-  ) {
-    return "";
+
+  // Bare delta path: ≥8 monotonic-append contract from production mitigations.
+  if (longEnough) {
+    if (incoming === accumulated) {
+      return "";
+    }
+    if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
+      return growthFromCumulativeExtension(accumulated, incoming);
+    }
+    if (accumulated.startsWith(incoming) && incoming.length >= TEXT_REPLAY_MIN_CHARS) {
+      return "";
+    }
   }
+
   return incoming;
 }
 

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -331,9 +331,6 @@ export function isOpenAICompletionsThinkingEnabled(effort: string): boolean {
   return normalized !== "off" && normalized !== "none";
 }
 
-/** Min length before treating exact/prefix/extension frames as cumulative replays. */
-const TEXT_REPLAY_MIN_CHARS = 8;
-
 function growthFromCumulativeExtension(accumulated: string, incoming: string): string {
   const growth = incoming.slice(accumulated.length);
   // Drop doubled snapshots where the "growth" is itself a replay of prior text.
@@ -344,12 +341,11 @@ function growthFromCumulativeExtension(accumulated: string, incoming: string): s
 }
 
 /**
- * Normalize cumulative text snapshots into true increments.
+ * Normalize message-shaped cumulative text snapshots into true increments.
  *
- * Field captures (issue #136262) show compatible providers occasionally emit a bare
- * `text_delta` whose content equals the already-accumulated text. A length-gated
- * monotonic-append contract (also used at the agent-loop accumulation boundary)
- * drops those replays while keeping short intentional repeats like "Ha"×3.
+ * Bare `choice.delta` frames stay additive under the shared assistant-event contract
+ * (intentional long repeats must not be dropped). Only `choice.message` snapshots
+ * have an authoritative full-text frame type and may be de-cumulated here.
  */
 export function normalizeOpenAICompletionsTextDelta(
   accumulated: string,
@@ -363,33 +359,17 @@ export function normalizeOpenAICompletionsTextDelta(
     return incoming;
   }
 
-  const frameKind = options?.frameKind ?? "delta";
-  const longEnough = accumulated.length >= TEXT_REPLAY_MIN_CHARS;
-
-  // Message-shaped frames are snapshots even when short.
-  if (frameKind === "snapshot") {
-    if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
-      return growthFromCumulativeExtension(accumulated, incoming);
-    }
-    if (incoming === accumulated || accumulated.startsWith(incoming)) {
-      return "";
-    }
+  // Bare deltas: preserve additive semantics for all StreamFn consumers.
+  if ((options?.frameKind ?? "delta") !== "snapshot") {
     return incoming;
   }
 
-  // Bare delta path: ≥8 monotonic-append contract from production mitigations.
-  if (longEnough) {
-    if (incoming === accumulated) {
-      return "";
-    }
-    if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
-      return growthFromCumulativeExtension(accumulated, incoming);
-    }
-    if (accumulated.startsWith(incoming) && incoming.length >= TEXT_REPLAY_MIN_CHARS) {
-      return "";
-    }
+  if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
+    return growthFromCumulativeExtension(accumulated, incoming);
   }
-
+  if (incoming === accumulated || accumulated.startsWith(incoming)) {
+    return "";
+  }
   return incoming;
 }
 

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -56,6 +56,9 @@ export function resolveOpenAIClientBaseUrl(
 
 export type OpenAICompletionsTextSource = "reasoning_detail" | "refusal";
 
+/** Wire contract for chat.completion.chunk text: incremental delta vs message snapshot. */
+export type OpenAICompletionsTextFrameKind = "delta" | "snapshot";
+
 export type OpenAICompletionsContentDelta =
   | { kind: "thinking"; signature?: string; text: string }
   | { kind: "text"; text: string; source?: OpenAICompletionsTextSource };
@@ -328,22 +331,26 @@ export function isOpenAICompletionsThinkingEnabled(effort: string): boolean {
   return normalized !== "off" && normalized !== "none";
 }
 
-/** Minimum length before treating an exact/prefix replay as a cumulative snapshot. */
-const OPENAI_COMPLETIONS_TEXT_REPLAY_MIN_CHARS = 8;
-
-/** Turn cumulative OpenAI-compatible `delta.content` snapshots into true increments. */
-export function normalizeOpenAICompletionsTextDelta(accumulated: string, incoming: string): string {
+/** Turn cumulative OpenAI-compatible text snapshots into true increments. */
+export function normalizeOpenAICompletionsTextDelta(
+  accumulated: string,
+  incoming: string,
+  options?: { frameKind?: OpenAICompletionsTextFrameKind },
+): string {
   if (!incoming) {
     return "";
   }
   if (!accumulated) {
     return incoming;
   }
+  // Cumulative snapshot contract: a longer frame that extends prior text.
   if (incoming.startsWith(accumulated) && incoming.length > accumulated.length) {
     return incoming.slice(accumulated.length);
   }
+  // Exact/prefix replay only for message-shaped frames. Ordinary delta frames stay
+  // incremental so legitimate repeated completions are preserved.
   if (
-    incoming.length >= OPENAI_COMPLETIONS_TEXT_REPLAY_MIN_CHARS &&
+    (options?.frameKind ?? "delta") === "snapshot" &&
     (incoming === accumulated || accumulated.startsWith(incoming))
   ) {
     return "";


### PR DESCRIPTION
﻿Closes #136262

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes live assistant text doubling when OpenAI-compatible streams deliver **message-shaped cumulative snapshots** (`choice.message`) as full-text frames that would otherwise be appended again.

## Why This Change Was Made

ClawSweeper review required restoring the shared assistant-event contract:

1. **Bare `choice.delta` / `text_delta` stays additive** — intentional long repeats must not be dropped by text-equality heuristics.
2. **Cumulative normalization only at the openai-completions producer**, and only when the wire frame is an authoritative **`choice.message` snapshot**.
3. **Agent Core stays transport-neutral** — no OpenAI heuristic in the generic accumulator. It only skips re-append when a polluted `text_start` partial already holds the confirming prefix (HTTP/SSE fanout still observes the deltas).

Out of scope for this PR: bare `choice.delta` frames that look cumulative without a snapshot marker cannot be distinguished from legitimate repeats under the shared contract; those need a provider-specific frame discriminator if they remain in the wild.

## User Impact

Live TUI/dashboard/channel renders no longer double on message-shaped snapshot replays/extensions from openai-completions. Legitimate repeated long bare deltas (including refusal repeats) remain intact.

## Evidence

### After-fix (PR head `6faea7ea4`)

```text
node scripts/run-vitest.mjs packages/ai/src/transports/openai-completions-stream.usage.test.ts
# → 73 passed

node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions-structured-content-parity.test.ts
# → identical refusals intentionally repeated across separate chunks → "Safety refusal.Safety refusal."

node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts -t "agentLoop streaming updates"
# → bare exact repeats additive; polluted text_start prefix still emits confirming deltas without double-append
```

### Contract matrix (synthetic, redacted)

| Wire shape | Expected | Result |
|---|---|---|
| `choice.message` equal to prior text | drop snapshot replay | covered by `suppresses message-shaped snapshot replays` |
| `choice.message` extends prior text | emit growth only | covered by cumulative message-shaped / longer snapshot tests |
| bare `choice.delta` equal long text | append (preserve repeat) | covered by `preserves bare delta exact repeats` + parity refusal repeat |
| short `Ha`×3 bare deltas | append | covered by intentional short repeat test |
| Agent Core polluted `text_start` partial + confirming deltas | emit deltas, no double text | covered by FANOUT_ALPHA streaming test |

### Field capture note (#136262)

Issue author @Richard355168 reported `OPENCLAW_RAW_STREAM=1` captures where live text doubled. This PR fixes the **message-shaped snapshot** class at the completions producer boundary demanded by review. If remaining live doubles are **bare-delta-only** with no snapshot marker, that needs a follow-up with an explicit provider frame discriminator rather than generic equality drops.
