### PR TITLE
test: share Doctor persistence fixture contexts

### DIFF
--- a/src/commands/doctor-config-flow.canvas-migration.test.ts
+++ b/src/commands/doctor-config-flow.canvas-migration.test.ts
@@ -4,39 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
-import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
-import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 
 const note = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
 
 async function repairConfig(configPath: string) {
-  const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
-  const options: DoctorOptions = { nonInteractive: true, repair: true };
-  const prompter = createDoctorPrompter({ runtime, options });
-  const configResult = await loadAndMaybeMigrateDoctorConfig({
-    options,
-    confirm: (params) => prompter.confirm(params),
-    runtime,
-    prompter,
-  });
-  const ctx: DoctorHealthFlowContext = {
-    runtime,
-    options,
-    prompter,
-    configResult,
-    cfg: configResult.cfg,
-    cfgForPersistence: structuredClone(configResult.cfg),
-    sourceConfigValid: configResult.sourceConfigValid ?? true,
-    configPath,
-    stateDirExistedAtStart: true,
-    ...(configResult.runWithPluginMetadataSnapshot
-      ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
-      : {}),
-  };
+  const ctx = await prepareDoctorContext(configPath);
   await runInitialConfigWriteHealth(ctx);
   return JSON.parse(await fs.readFile(configPath, "utf8"));
 }

--- a/src/commands/doctor-config-flow.gateway-bind-persistence.test.ts
+++ b/src/commands/doctor-config-flow.gateway-bind-persistence.test.ts
@@ -1,14 +1,11 @@
 // Verifies Doctor persists legacy gateway bind repairs through the real config writer.
 import fs from "node:fs/promises";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
-import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
-import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 
 describe("Doctor gateway bind persistence", () => {
   afterEach(() => {
@@ -25,36 +22,7 @@ describe("Doctor gateway bind persistence", () => {
         const configPath = await writeOpenClawConfig(home, {
           gateway: { mode: "local", bind: legacyBind },
         });
-        const runtime: RuntimeEnv = {
-          error: vi.fn(),
-          exit: vi.fn(),
-          log: vi.fn(),
-        };
-        const options: DoctorOptions = { nonInteractive: true, repair: true };
-        const prompter = createDoctorPrompter({ runtime, options });
-        const configResult = await loadAndMaybeMigrateDoctorConfig({
-          options,
-          confirm: (params) => prompter.confirm(params),
-          runtime,
-          prompter,
-        });
-        const ctx: DoctorHealthFlowContext = {
-          runtime,
-          options,
-          prompter,
-          configResult,
-          cfg: configResult.cfg,
-          cfgForPersistence: structuredClone(configResult.cfg),
-          sourceConfigValid: configResult.sourceConfigValid ?? true,
-          configPath,
-          stateDirExistedAtStart: true,
-          ...(configResult.runWithPluginMetadataSnapshot
-            ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
-            : {}),
-          ...(configResult.invalidatePluginMetadataSnapshot
-            ? { invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot }
-            : {}),
-        };
+        const ctx = await prepareDoctorContext(configPath);
 
         await runInitialConfigWriteHealth(ctx);
 

--- a/src/commands/doctor-config-flow.legacy-composition.test.ts
+++ b/src/commands/doctor-config-flow.legacy-composition.test.ts
@@ -1,41 +1,17 @@
 // Exercises legacy values through the actual snapshot, Doctor, atomic write, and reread.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
-import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
-import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 
 async function repairConfig(configPath: string) {
-  const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
-  const options: DoctorOptions = { nonInteractive: true, repair: true };
-  const prompter = createDoctorPrompter({ runtime, options });
-  const configResult = await loadAndMaybeMigrateDoctorConfig({
-    options,
-    confirm: (params) => prompter.confirm(params),
-    runtime,
-    prompter,
-  });
-  const ctx: DoctorHealthFlowContext = {
-    runtime,
-    options,
-    prompter,
-    configResult,
-    cfg: configResult.cfg,
-    cfgForPersistence: structuredClone(configResult.cfg),
-    sourceConfigValid: configResult.sourceConfigValid ?? true,
-    configPath,
-    stateDirExistedAtStart: true,
-    runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot,
-    invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot,
-  };
+  const ctx = await prepareDoctorContext(configPath);
   await runInitialConfigWriteHealth(ctx);
-  return { ...configResult, configWriteRefusal: ctx.configWriteRefusal };
+  return { ...ctx.configResult, configWriteRefusal: ctx.configWriteRefusal };
 }
 
 describe("Doctor legacy config composition", () => {

--- a/src/commands/doctor-config-flow.test-support.ts
+++ b/src/commands/doctor-config-flow.test-support.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+
+export async function prepareDoctorContext(configPath: string): Promise<DoctorHealthFlowContext> {
+  const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+  const options: DoctorOptions = { nonInteractive: true, repair: true };
+  const prompter = createDoctorPrompter({ runtime, options });
+  const configResult = await loadAndMaybeMigrateDoctorConfig({
+    options,
+    confirm: (params) => prompter.confirm(params),
+    runtime,
+    prompter,
+  });
+  return {
+    runtime,
+    options,
+    prompter,
+    configResult,
+    cfg: configResult.cfg,
+    cfgForPersistence: structuredClone(configResult.cfg),
+    sourceConfigValid: configResult.sourceConfigValid ?? true,
+    configPath,
+    stateDirExistedAtStart: true,
+    runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot,
+    invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot,
+  };
+}

--- a/src/commands/doctor-config-flow.validation-refusal.test.ts
+++ b/src/commands/doctor-config-flow.validation-refusal.test.ts
@@ -6,11 +6,8 @@ import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { runWriteConfigHealth } from "../flows/doctor-health-contribution-runners.config.js";
-import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
-import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 
 const noteMock = vi.hoisted(() => vi.fn<(message: string, title?: string) => void>());
 
@@ -32,15 +29,8 @@ describe("doctor --fix with a validation-blocked candidate", () => {
           agents: { defaults: { heartbeat: { every: 5 } } },
         });
         const rawBefore = await fs.readFile(configPath, "utf-8");
-        const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
-        const options: DoctorOptions = { nonInteractive: true, repair: true };
-        const prompter = createDoctorPrompter({ runtime, options });
-        const configResult = await loadAndMaybeMigrateDoctorConfig({
-          options,
-          confirm: (params) => prompter.confirm(params),
-          runtime,
-          prompter,
-        });
+        const ctx = await prepareDoctorContext(configPath);
+        const { configResult } = ctx;
 
         // The unknown-key repair is computed, but held until the write commits.
         expect(configResult.shouldWriteConfig).toBe(true);
@@ -48,21 +38,6 @@ describe("doctor --fix with a validation-blocked candidate", () => {
           (configResult.pendingChangePanels ?? []).some((panel) => panel.includes("gatway")),
         ).toBe(true);
         expect(noteMock.mock.calls.some(([, title]) => title === "Doctor changes")).toBe(false);
-
-        const ctx: DoctorHealthFlowContext = {
-          runtime,
-          options,
-          prompter,
-          configResult,
-          cfg: configResult.cfg,
-          cfgForPersistence: structuredClone(configResult.cfg),
-          sourceConfigValid: configResult.sourceConfigValid ?? true,
-          configPath,
-          stateDirExistedAtStart: true,
-          ...(configResult.runWithPluginMetadataSnapshot
-            ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
-            : {}),
-        };
 
         // The write must refuse gracefully — no throw, no change panel, no file write.
         await expect(runWriteConfigHealth(ctx)).resolves.toBeUndefined();

--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
@@ -11,44 +11,12 @@ import {
   runInitialConfigWriteHealth,
   runWriteConfigHealth,
 } from "../flows/doctor-health-contribution-runners.config.js";
-import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
-import type { RuntimeEnv } from "../runtime.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
-import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
-import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
-
-async function prepareDoctorContext(configPath: string): Promise<DoctorHealthFlowContext> {
-  const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
-  const options: DoctorOptions = { nonInteractive: true, repair: true };
-  const prompter = createDoctorPrompter({ runtime, options });
-  const configResult = await loadAndMaybeMigrateDoctorConfig({
-    options,
-    confirm: (params) => prompter.confirm(params),
-    runtime,
-    prompter,
-  });
-  return {
-    runtime,
-    options,
-    prompter,
-    configResult,
-    cfg: configResult.cfg,
-    cfgForPersistence: structuredClone(configResult.cfg),
-    sourceConfigValid: configResult.sourceConfigValid ?? true,
-    configPath,
-    stateDirExistedAtStart: true,
-    ...(configResult.runWithPluginMetadataSnapshot
-      ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
-      : {}),
-    ...(configResult.invalidatePluginMetadataSnapshot
-      ? { invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot }
-      : {}),
-  };
-}
 
 describe("Doctor workspace persistence", () => {
   afterEach(() => {

--- a/src/commands/doctor-model-metadata-corruption.persistence.test.ts
+++ b/src/commands/doctor-model-metadata-corruption.persistence.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { readConfigFileSnapshot } from "../config/config.js";
 import {
   appendConfigAuditRecord,
@@ -9,40 +9,8 @@ import {
 } from "../config/io.audit.js";
 import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
-import type { DoctorHealthFlowContext } from "../flows/doctor-health-contribution-types.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
-import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
-
-async function prepareDoctorContext(configPath: string): Promise<DoctorHealthFlowContext> {
-  const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
-  const options: DoctorOptions = { nonInteractive: true, repair: true };
-  const prompter = createDoctorPrompter({ runtime, options });
-  const configResult = await loadAndMaybeMigrateDoctorConfig({
-    options,
-    confirm: (params) => prompter.confirm(params),
-    runtime,
-    prompter,
-  });
-  return {
-    runtime,
-    options,
-    prompter,
-    configResult,
-    cfg: configResult.cfg,
-    cfgForPersistence: structuredClone(configResult.cfg),
-    sourceConfigValid: configResult.sourceConfigValid ?? true,
-    configPath,
-    stateDirExistedAtStart: true,
-    ...(configResult.runWithPluginMetadataSnapshot
-      ? { runWithPluginMetadataSnapshot: configResult.runWithPluginMetadataSnapshot }
-      : {}),
-    ...(configResult.invalidatePluginMetadataSnapshot
-      ? { invalidatePluginMetadataSnapshot: configResult.invalidatePluginMetadataSnapshot }
-      : {}),
-  };
-}
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 
 describe("Doctor model metadata corruption persistence", () => {
   afterEach(() => {


### PR DESCRIPTION
## What Problem This Solves

Six Doctor persistence suites repeat the same real config-flow setup. Their copied contexts already differ in how they forward the plugin metadata callbacks, making future fixture changes easy to apply inconsistently.

## Why This Change Was Made

Share a test-only context constructor. Every call still creates a fresh runtime, real Doctor prompter, real migration result and independent persistence clone. Each suite keeps its own filesystem fixtures, write phase, rereads and assertions. Remove the six copied constructors and forward both callbacks from the config-flow owner.

No user-visible behavior changes. Production delta: 0. Tests and test support: +46/-186, net −140. All 51 cases, 157 assertion sites and 161 ordered filesystem/writer/fixture call expressions remain. No new mocks, cache, timeout, dependency, configuration or persistence contract.

## Evidence

Measured the complete six-file workload before editing, after the extraction, and after restoring the original files on one local macOS arm64 host with Node 24.19.0. Each invocation used the canonical commands config, fork pool, one worker, non-isolated runner, serial files and the normal setup. All three passed 51/51 cases, including all four permission-sensitive cases under a non-root user.

| Stage | Whole command | Case sum |
| --- | ---: | ---: |
| Original |98.79s|86.593s|
| Shared context |97.15s|89.268s|
| Restored original |101.24s|94.314s|

These measurements do not establish a speedup. Vitest's canonical sequencer changed cross-file order after the first run, and the total difference is small. The benefit is removing duplicated setup while keeping the real persistence coverage. Per-file case identities and order were identical; every wrapper joined successfully, the canonical temporary namespace was empty after each run, and all 76 source guards restored before the final patch was reapplied.

The baseline started from abb565ea5f9feacd89a571247adb96a799a0e3ce. No skipped cases or unhandled-error sections appeared. The exact workload was:

    CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts --configLoader runner src/commands/doctor-config-flow.canvas-migration.test.ts src/commands/doctor-config-flow.legacy-composition.test.ts src/commands/doctor-config-flow.workspace-persistence.test.ts src/commands/doctor-model-metadata-corruption.persistence.test.ts src/commands/doctor-config-flow.gateway-bind-persistence.test.ts src/commands/doctor-config-flow.validation-refusal.test.ts --maxWorkers=1 --no-fileParallelism --reporter=default --reporter=json

Formatting, type-aware lint, whitespace validation, independent source preservation review and Codex P0 review passed.
