### PR TITLE
fix(memory): correct isolated rebuild guidance

### DIFF
--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -240,7 +240,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       count,
       unit,
       "Large memory folders or extraPaths can make OpenClaw run out of file watchers or open files.",
-      "Remove large extraPaths, or set memory.search.sync.watch to false and refresh memory manually.",
+      "Reduce or remove large extraPaths. For an isolated manual rebuild, stop the Gateway, run `openclaw memory index --agent <id>`, then restart the Gateway.",
       (message) => log.warn(message),
     );
   }

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -1124,7 +1124,7 @@ describe("memory watcher config", () => {
     expect(memoryLoggerWarn).toHaveBeenCalledWith("memory watcher error: watcher error: ENOSPC");
   });
 
-  it("warns when chokidar memory watching tracks many paths", async () => {
+  it("warns with supported offline guidance when chokidar tracks many paths", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
     const cfg = createWatcherConfig();
     vi.useFakeTimers();
@@ -1143,8 +1143,13 @@ describe("memory watcher config", () => {
     );
     await vi.advanceTimersByTimeAsync(10_000);
 
-    expect(memoryLoggerWarn).toHaveBeenCalledWith(
-      expect.stringContaining("Memory file watching is tracking 2002 paths."),
-    );
+    const warning = memoryLoggerWarn.mock.calls
+      .map(([message]) => String(message))
+      .find((message) => message.includes("Memory file watching is tracking 2002 paths."));
+    expect(warning).toContain("Reduce or remove large extraPaths.");
+    expect(warning).toContain("stop the Gateway");
+    expect(warning).toContain("openclaw memory index --agent <id>");
+    expect(warning).toContain("restart the Gateway");
+    expect(warning).not.toContain("memory.search.sync");
   });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -161,6 +161,25 @@ describe("config schema regressions", () => {
     ).toBe(true);
   });
 
+  it("rejects unsupported memory.search.sync settings", () => {
+    const result = validateConfigObject({
+      memory: { search: { sync: { watch: false } } },
+      agents: { defaults: {} },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "memory.search",
+            message: expect.stringContaining('Unrecognized key: "sync"'),
+          }),
+        ]),
+      );
+    }
+  });
+
   it.each([
     { pattern: "**/*.md" },
     { path: "../shared", pattern: 42 },


### PR DESCRIPTION
## What Problem This Solves

The memory watch-pressure warning recommends `memory.search.sync.watch: false`, but `memory.search` is strict and rejects the unsupported `sync` key. Operators following the warning therefore receive invalid configuration guidance instead of a usable isolation procedure.

## What Changed

- replace the unsupported setting with the supported offline sequence: reduce or remove large `extraPaths`; for an isolated manual rebuild, stop the Gateway, run `openclaw memory index --agent <id>`, then restart the Gateway
- strengthen the watch-pressure regression so the warning must contain the supported guidance and no `memory.search.sync` reference
- add a config-schema regression proving `memory.search.sync` remains rejected

## Evidence

- focused Vitest files passed: 125/125 tests
- formatter check passed for all three changed files
- `git diff --check` passed
- current-upstream comparison is one commit changing exactly the three intended paths
- the three upstream `main` path blobs matched the validated v2026.8.2 source before the clean cherry-pick
