### PR TITLE
fix(ci): run remaining trusted installs from tooling checkout

### DIFF
--- a/.github/workflows/openclaw-npm-preflight.yml
+++ b/.github/workflows/openclaw-npm-preflight.yml
@@ -596,7 +596,7 @@ jobs:
             scripts
 
       - name: Install trusted qualification dependencies
-        run: pnpm --dir .artifacts/plugin-sdk-release-tooling install --frozen-lockfile --ignore-scripts --filter openclaw
+        run: (cd .artifacts/plugin-sdk-release-tooling && pnpm install --frozen-lockfile --ignore-scripts --filter openclaw)
 
       - name: Generate dependency release evidence
         id: dependency_evidence
@@ -709,7 +709,7 @@ jobs:
             scripts
 
       - name: Install trusted qualification dependencies
-        run: pnpm --dir .artifacts/plugin-sdk-release-tooling install --frozen-lockfile --ignore-scripts --filter openclaw
+        run: (cd .artifacts/plugin-sdk-release-tooling && pnpm install --frozen-lockfile --ignore-scripts --filter openclaw)
 
       - name: Verify final npm package bytes and lifecycle
         env:

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3925,6 +3925,74 @@ NODE
     }
   });
 
+  it("runs trusted npm preflight pnpm commands from the tooling checkout", () => {
+    const root = tempDirs.make("npm-preflight-tooling-pnpm-");
+    const toolingDir = join(root, ".artifacts/plugin-sdk-release-tooling");
+    const binDir = join(root, "bin");
+    const logPath = join(root, "pnpm-cwds.log");
+    mkdirSync(toolingDir, { recursive: true });
+    mkdirSync(binDir);
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify({ private: true, packageManager: "pnpm@11.2.2" }),
+    );
+    writeFileSync(
+      join(toolingDir, "package.json"),
+      JSON.stringify({ private: true, packageManager: "pnpm@12.1.0" }),
+    );
+    const pnpmPath = join(binDir, "pnpm");
+    writeFileSync(
+      pnpmPath,
+      `#!/bin/sh
+set -eu
+package_manager="$(node -p 'require("./package.json").packageManager')"
+printf '%s\\t%s\\n' "$PWD" "$package_manager" >> "$PNPM_CWD_LOG"
+test "$package_manager" = "pnpm@12.1.0"
+`,
+    );
+    chmodSync(pnpmPath, 0o755);
+
+    const sdkStep = workflowStep(
+      workflowJob(OPENCLAW_NPM_PREFLIGHT_WORKFLOW, "check_sdk_npm"),
+      "Verify Plugin SDK API changes",
+    );
+    const sdkCommandBlock = (sdkStep.run ?? "").match(
+      /\(\n\s+cd "\$tooling_dir"\n\s+pnpm install --frozen-lockfile --ignore-scripts --filter openclaw\n\s+pnpm run plugin-sdk:api:diff -- "\$\{diff_args\[@\]\}"\n\s*\)/u,
+    )?.[0];
+    expect(sdkCommandBlock).toBeDefined();
+    const installSteps = ["check_dependencies_npm", "check_contents_npm"].map((jobName) =>
+      workflowStep(
+        workflowJob(OPENCLAW_NPM_PREFLIGHT_WORKFLOW, jobName),
+        "Install trusted qualification dependencies",
+      ),
+    );
+
+    for (const { trustedPnpmCommand, cwd } of [
+      { trustedPnpmCommand: sdkCommandBlock ?? "", cwd: root },
+      ...installSteps.map((step) => ({
+        trustedPnpmCommand: step.run ?? "",
+        cwd: resolve(root, step["working-directory"] ?? "."),
+      })),
+    ]) {
+      const result = spawnSync("bash", ["-c", trustedPnpmCommand], {
+        cwd,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_WORKSPACE: root,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          PNPM_CWD_LOG: logPath,
+          tooling_dir: toolingDir,
+        },
+      });
+      expect(result.status, result.stderr).toBe(0);
+    }
+
+    expect(readFileSync(logPath, "utf8").trim().split("\n")).toEqual(
+      Array.from({ length: 4 }, () => `${toolingDir}\tpnpm@12.1.0`),
+    );
+  });
+
   it("keeps Crabbox hydration compatible with local Actions replay", () => {
     const crabboxConfig = parse(readFileSync(CRABBOX_CONFIG, "utf8")) as {
       actions?: { job?: string };


### PR DESCRIPTION
## Summary

- build on https://github.com/openclaw/openclaw/pull/136233, which moved the two Plugin SDK pnpm commands into the trusted tooling checkout
- move the two remaining trusted install commands in `check_dependencies_npm` and `check_contents_npm` into that checkout
- keep target-owned pnpm commands at the release target root
- add executable owner-boundary coverage for all four canonical trusted-tooling sites

## Root cause

Full Release Validation run 33610645422 paired a historical release target pinned to pnpm 11.2.2 with trusted tooling pinned to pnpm 12.1.0. Corepack selects the package manager from the process working directory before pnpm processes `--dir`.

PR #136233 fixed that owner boundary for the two `check_sdk_npm` commands. Current main still invoked the trusted dependency and package-content installs as `pnpm --dir .artifacts/plugin-sdk-release-tooling ...` from the release target root, so those two jobs retained the same failure mode.

The release tooling checkout owns these installs and its package-manager version. This follow-up runs the two remaining installs from that checkout while leaving the landed SDK block and all target-owned commands unchanged.

## Credit and relationship

Dallin Romney's merged PR #136233 established the trusted-checkout owner boundary for SDK installation and API comparison. This PR is a narrow follow-up for the two remaining install sites and preserves the contributor's landed implementation unchanged.

## Verification

- current main comparison: the SDK block is fixed by #136233; the dependency and content install steps still use target-root `pnpm --dir`
- isolated executable regression: 1/1 passed
- focused workflow suites: 344/344 passed
- formatting and diff checks passed
- changed-file gate passed through conflict, attribution, dependency, formatting, patch, temp-file, and core graph checks; test-root typecheck was blocked by unrelated missing shared-worktree plugin dependencies
- autoreview: scoped-clean
- prior broader implementation Testbox evidence: `tbx_01m1h49x71m4pw2e65ywy8q2vv`, https://github.com/openclaw/openclaw/actions/runs/33634891448
- exact-head CI: pending after rebased push

## Test audit

The regression executes the merged SDK subshell and both follow-up install commands at the shell boundary with a target pinned to pnpm 11.2.2 and trusted tooling pinned to pnpm 12.1.0. Existing coverage statically protects the SDK block; this test adds executable four-site package-manager ownership proof without a production test seam.

## LOC

- production: net 0
- tests: +68

No changelog entry: this is an internal release-pipeline correctness fix.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted implementation session</summary>

```text
[user]
PR #136233 has merged the two SDK-tooling fixes. Rebase and narrow this PR to the two remaining trusted install commands, preserve useful owner-boundary coverage, and land it as a follow-up.

[assistant]
Rebased onto the contributor's merge, retained its SDK subshell unchanged, dropped the duplicate assertion follow-up, and kept only the dependency/content install repairs.

[assistant]
The executable four-site regression and focused workflow suites passed 344/344. Autoreview was scoped-clean. Production LOC remains net 0 and tests add 68 lines.
```

</details>
<!-- agent-transcript:end -->
