### PR TITLE
fix(memory-core): clean archived legacy reindex shadows

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -739,7 +739,7 @@ extensions/memory-core/src/dreaming.ts	1
 extensions/memory-core/src/memory/embeddings.ts	2
 extensions/memory-core/src/memory/hybrid.ts	1
 extensions/memory-core/src/memory/manager-cache.ts	4
-extensions/memory-core/src/memory/manager-db.ts	5
+extensions/memory-core/src/memory/manager-db.ts	4
 extensions/memory-core/src/memory/manager-embedding-cache.ts	1
 extensions/memory-core/src/memory/manager-embedding-errors.ts	2
 extensions/memory-core/src/memory/manager-embedding-ops.ts	2

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1451,6 +1451,40 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
+  it("removes aged legacy reindex shadows after the sidecar was already archived", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const archivedPath = `${legacyPath}.migrated`;
+    const agedShadow = `${legacyPath}.tmp-11111111-2222-3333-4444-555555555555`;
+    const youngShadow = `${legacyPath}.tmp-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`;
+    const aged = new Date(Date.now() - 48 * 60 * 60_000);
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(archivedPath, "archived");
+    for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+      await fs.writeFile(`${agedShadow}${suffix}`, "orphan");
+      await fs.utimes(`${agedShadow}${suffix}`, aged, aged);
+      await fs.writeFile(`${youngShadow}${suffix}`, "active");
+    }
+
+    const migration = legacyMemoryIndexMigration();
+    const preview = await migration.detectLegacyState(migrationParams());
+    expect(preview?.preview).toEqual([`- Aged Memory Core legacy reindex shadow: ${agedShadow}`]);
+
+    const result = await migration.migrateLegacyState(migrationParams());
+
+    expect(result).toEqual({
+      changes: [
+        `Removed 1 aged Memory Core legacy reindex shadow database(s) beside ${legacyPath}`,
+      ],
+      warnings: [],
+    });
+    for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+      await expect(fs.access(`${agedShadow}${suffix}`)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(`${youngShadow}${suffix}`)).resolves.toBeUndefined();
+    }
+    await expect(fs.readFile(archivedPath, "utf8")).resolves.toBe("archived");
+  });
+
   it("removes an empty legacy memory sidecar placeholder without warning", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");

--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -1,4 +1,5 @@
 // Memory Core tests cover shared agent database publication and shadow cleanup.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,13 +8,12 @@ import {
   ensureMemoryIndexSchema,
   loadSqliteVecExtension,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   configureMemoryCoreDreamingStateForTests,
   resetMemoryCoreDreamingStateForTests,
 } from "../test-helpers.js";
 import {
-  cleanupAgedMemoryReindexTempFiles,
   closeMemoryDatabase,
   openMemoryDatabaseAtPath,
   publishMemoryDatabaseTables,
@@ -22,6 +22,10 @@ import {
   resetMemoryDatabase,
 } from "./manager-db.js";
 import { waitForMemoryReindexLock } from "./manager-reindex-lock.js";
+import {
+  cleanupAgedLegacyMemoryReindexTempFiles,
+  cleanupAgedMemoryReindexTempFiles,
+} from "./manager-reindex-temp-files.js";
 
 function ensureTestMemorySchema(db: DatabaseSync, cacheEnabled = true, ftsEnabled = false): void {
   ensureMemoryIndexSchema({
@@ -521,5 +525,45 @@ describe("memory manager database publication", () => {
     await expectPathMissing(`${oldShadow}-wal`);
     await expectPathMissing(`${oldShadow}-journal`);
     await expect(fs.access(youngShadow)).resolves.toBeUndefined();
+  });
+
+  it("preserves a current-format shadow when the primary database is missing", async () => {
+    const databasePath = path.join(fixtureRoot, "missing.sqlite");
+    const shadow = `${databasePath}.memory-reindex-11111111-2222-3333-4444-555555555555`;
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+    await fs.writeFile(shadow, "orphan");
+    await fs.utimes(shadow, old, old);
+
+    cleanupAgedMemoryReindexTempFiles(databasePath);
+
+    await expect(fs.access(shadow)).resolves.toBeUndefined();
+  });
+
+  it("does not report a legacy shadow as removed when a file deletion fails", async () => {
+    const databasePath = path.join(fixtureRoot, "agent.sqlite");
+    const shadow = `${databasePath}.tmp-11111111-2222-3333-4444-555555555555`;
+    const failedPath = `${shadow}-wal`;
+    const old = new Date(Date.now() - 48 * 60 * 60_000);
+    for (const filePath of [shadow, failedPath]) {
+      await fs.writeFile(filePath, "orphan");
+      await fs.utimes(filePath, old, old);
+    }
+    const remove = fsSync.rmSync;
+    vi.spyOn(fsSync, "rmSync").mockImplementation((filePath, options) => {
+      if (filePath === failedPath) {
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+      }
+      remove(filePath, options);
+    });
+
+    try {
+      expect(cleanupAgedLegacyMemoryReindexTempFiles(databasePath)).toEqual({
+        removedBaseNames: [],
+        failedBaseNames: [path.basename(shadow)],
+      });
+      await expect(fs.access(failedPath)).resolves.toBeUndefined();
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 });

--- a/extensions/memory-core/src/memory/manager-db.ts
+++ b/extensions/memory-core/src/memory/manager-db.ts
@@ -1,5 +1,4 @@
 // Memory Core plugin module implements manager db behavior.
-import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import {
@@ -31,39 +30,6 @@ import { waitForMemoryReindexLock } from "./manager-reindex-lock.js";
 const MEMORY_REINDEX_SCHEMA = "memory_reindex";
 const MEMORY_INDEX_STATE_ID = 1;
 const READ_ONLY_MEMORY_DATABASES = new WeakMap<DatabaseSync, () => void>();
-const MEMORY_DATABASE_FILE_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
-const MEMORY_REINDEX_ENTRY_SUFFIXES = ["-wal", "-shm", "-journal", ""] as const;
-const MEMORY_REINDEX_UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-const MEMORY_REINDEX_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
-
-function resolveMemoryReindexBaseName(
-  databaseBaseName: string,
-  entryName: string,
-): string | undefined {
-  for (const suffix of MEMORY_REINDEX_ENTRY_SUFFIXES) {
-    if (!entryName.endsWith(suffix)) {
-      continue;
-    }
-    const baseName = entryName.slice(0, entryName.length - suffix.length);
-    const prefix = `${databaseBaseName}.memory-reindex-`;
-    if (
-      baseName.startsWith(prefix) &&
-      MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(prefix.length))
-    ) {
-      return baseName;
-    }
-  }
-  return undefined;
-}
-
-function isRegularFile(filePath: string): boolean {
-  try {
-    return fs.statSync(filePath).isFile();
-  } catch {
-    return false;
-  }
-}
 
 function tableExists(db: DatabaseSync, schema: string, tableName: string): boolean {
   const row = db
@@ -334,68 +300,6 @@ export async function publishMemoryDatabaseTables(params: {
     });
   } finally {
     params.targetDb.exec(`DETACH DATABASE ${MEMORY_REINDEX_SCHEMA}`);
-  }
-}
-
-/** Remove one closed shadow memory database and its journal-mode sidecars. */
-export function removeMemoryDatabaseFiles(dbPath: string): void {
-  for (const suffix of MEMORY_DATABASE_FILE_SUFFIXES) {
-    fs.rmSync(`${dbPath}${suffix}`, { force: true });
-  }
-}
-
-/** Remove crash-left shadows while the caller owns the reindex lease. */
-export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.now()): void {
-  if (!isRegularFile(dbPath)) {
-    return;
-  }
-  const dir = path.dirname(dbPath);
-  const databaseBaseName = path.basename(dbPath);
-  const shadowBaseNames = new Set<string>();
-  let entries: fs.Dirent[];
-  try {
-    entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-
-  for (const entry of entries) {
-    if (!entry.isFile()) {
-      continue;
-    }
-    const shadowBaseName = resolveMemoryReindexBaseName(databaseBaseName, entry.name);
-    if (shadowBaseName) {
-      shadowBaseNames.add(shadowBaseName);
-    }
-  }
-
-  for (const shadowBaseName of shadowBaseNames) {
-    const filePaths = MEMORY_DATABASE_FILE_SUFFIXES.map((suffix) =>
-      path.join(dir, `${shadowBaseName}${suffix}`),
-    );
-    const stats: fs.Stats[] = [];
-    let hasUnknownFileState = false;
-    for (const filePath of filePaths) {
-      try {
-        stats.push(fs.statSync(filePath));
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-          hasUnknownFileState = true;
-          break;
-        }
-      }
-    }
-    if (hasUnknownFileState || stats.length === 0) {
-      continue;
-    }
-    if (nowMs - Math.max(...stats.map((stat) => stat.mtimeMs)) < MEMORY_REINDEX_ORPHAN_MIN_AGE_MS) {
-      continue;
-    }
-    for (const filePath of filePaths) {
-      try {
-        fs.rmSync(filePath, { force: true });
-      } catch {}
-    }
   }
 }
 

--- a/extensions/memory-core/src/memory/manager-reindex-temp-files.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-temp-files.ts
@@ -1,0 +1,178 @@
+// Memory Core plugin module owns reindex shadow-file discovery and cleanup.
+import fs from "node:fs";
+import path from "node:path";
+
+const MEMORY_DATABASE_FILE_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
+const MEMORY_REINDEX_ENTRY_SUFFIXES = ["-wal", "-shm", "-journal", ""] as const;
+const MEMORY_REINDEX_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const MEMORY_REINDEX_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
+
+type MemoryReindexPrefix = ".memory-reindex-" | ".tmp-";
+
+export type MemoryReindexCleanupResult = {
+  removedBaseNames: string[];
+  failedBaseNames: string[];
+};
+
+function resolveMemoryReindexBaseName(
+  databaseBaseName: string,
+  entryName: string,
+  prefix: MemoryReindexPrefix,
+): string | undefined {
+  for (const suffix of MEMORY_REINDEX_ENTRY_SUFFIXES) {
+    if (!entryName.endsWith(suffix)) {
+      continue;
+    }
+    const baseName = entryName.slice(0, entryName.length - suffix.length);
+    const shadowPrefix = `${databaseBaseName}${prefix}`;
+    if (
+      baseName.startsWith(shadowPrefix) &&
+      MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(shadowPrefix.length))
+    ) {
+      return baseName;
+    }
+  }
+  return undefined;
+}
+
+function isRegularFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isMissingFile(filePath: string): boolean {
+  try {
+    fs.lstatSync(filePath);
+    return false;
+  } catch (err: unknown) {
+    return Boolean(err && typeof err === "object" && "code" in err && err.code === "ENOENT");
+  }
+}
+
+function findAgedMemoryReindexBaseNames(
+  dbPath: string,
+  prefix: MemoryReindexPrefix,
+  nowMs: number,
+): string[] {
+  const dir = path.dirname(dbPath);
+  const databaseBaseName = path.basename(dbPath);
+  const shadowBaseNames = new Set<string>();
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const shadowBaseName = resolveMemoryReindexBaseName(databaseBaseName, entry.name, prefix);
+    if (shadowBaseName) {
+      shadowBaseNames.add(shadowBaseName);
+    }
+  }
+
+  return [...shadowBaseNames].toSorted().filter((shadowBaseName) => {
+    const stats: fs.Stats[] = [];
+    for (const suffix of MEMORY_DATABASE_FILE_SUFFIXES) {
+      try {
+        stats.push(fs.statSync(path.join(dir, `${shadowBaseName}${suffix}`)));
+      } catch (err) {
+        // SAFETY: Node filesystem failures expose the optional errno code on Error objects.
+        if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+          return false;
+        }
+      }
+    }
+    return (
+      stats.length > 0 &&
+      nowMs - Math.max(...stats.map((stat) => stat.mtimeMs)) >= MEMORY_REINDEX_ORPHAN_MIN_AGE_MS
+    );
+  });
+}
+
+function removeMemoryReindexBaseNames(
+  dbPath: string,
+  shadowBaseNames: string[],
+): MemoryReindexCleanupResult {
+  const result: MemoryReindexCleanupResult = {
+    removedBaseNames: [],
+    failedBaseNames: [],
+  };
+  for (const shadowBaseName of shadowBaseNames) {
+    let removed = true;
+    for (const suffix of MEMORY_DATABASE_FILE_SUFFIXES) {
+      const filePath = path.join(path.dirname(dbPath), `${shadowBaseName}${suffix}`);
+      try {
+        fs.rmSync(filePath, { force: true });
+      } catch {
+        removed = false;
+      }
+      if (!isMissingFile(filePath)) {
+        removed = false;
+      }
+    }
+    (removed ? result.removedBaseNames : result.failedBaseNames).push(shadowBaseName);
+  }
+  return result;
+}
+
+/** Resolve the retired database basename from one strictly named legacy shadow entry. */
+export function resolveLegacyMemoryReindexDatabaseBaseName(entryName: string): string | undefined {
+  for (const suffix of MEMORY_REINDEX_ENTRY_SUFFIXES) {
+    if (!entryName.endsWith(suffix)) {
+      continue;
+    }
+    const baseName = entryName.slice(0, entryName.length - suffix.length);
+    const markerIndex = baseName.lastIndexOf(".tmp-");
+    if (markerIndex <= 0) {
+      continue;
+    }
+    const databaseBaseName = baseName.slice(0, markerIndex);
+    if (
+      databaseBaseName.endsWith(".sqlite") &&
+      MEMORY_REINDEX_UUID_PATTERN.test(baseName.slice(markerIndex + ".tmp-".length))
+    ) {
+      return databaseBaseName;
+    }
+  }
+  return undefined;
+}
+
+export function findAgedLegacyMemoryReindexTempFiles(dbPath: string, nowMs = Date.now()): string[] {
+  return findAgedMemoryReindexBaseNames(dbPath, ".tmp-", nowMs);
+}
+
+/** Doctor-only cleanup for retired shadow files whose primary database may be archived. */
+export function cleanupAgedLegacyMemoryReindexTempFiles(
+  dbPath: string,
+  nowMs = Date.now(),
+): MemoryReindexCleanupResult {
+  return removeMemoryReindexBaseNames(dbPath, findAgedLegacyMemoryReindexTempFiles(dbPath, nowMs));
+}
+
+/** Remove current crash-left shadows while the caller owns the reindex lease. */
+export function cleanupAgedMemoryReindexTempFiles(dbPath: string, nowMs = Date.now()): void {
+  // A missing primary can be an interrupted swap. Runtime cleanup must not delete
+  // the only complete current-format shadow while that state is unresolved.
+  if (!isRegularFile(dbPath)) {
+    return;
+  }
+  removeMemoryReindexBaseNames(
+    dbPath,
+    findAgedMemoryReindexBaseNames(dbPath, ".memory-reindex-", nowMs),
+  );
+}
+
+/** Remove one closed shadow memory database and its journal-mode sidecars. */
+export function removeMemoryDatabaseFiles(dbPath: string): void {
+  for (const suffix of MEMORY_DATABASE_FILE_SUFFIXES) {
+    fs.rmSync(`${dbPath}${suffix}`, { force: true });
+  }
+}

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -21,12 +21,10 @@ import {
 } from "./embeddings.js";
 import { MemoryIndexDatabase } from "./manager-database-context.js";
 import {
-  cleanupAgedMemoryReindexTempFiles,
   closeMemoryDatabase,
   openMemoryDatabaseAtPath,
   publishMemoryDatabaseTables,
   readMemoryDatabaseRevision,
-  removeMemoryDatabaseFiles,
 } from "./manager-db.js";
 import { isMemoryEmbeddingOperationError } from "./manager-embedding-errors.js";
 import { withMemoryIndexPublishGeneration } from "./manager-index-generation-lease.js";
@@ -43,6 +41,10 @@ import {
   type MemoryIndexMeta,
   type MemoryIndexProviderIdentity,
 } from "./manager-reindex-state.js";
+import {
+  cleanupAgedMemoryReindexTempFiles,
+  removeMemoryDatabaseFiles,
+} from "./manager-reindex-temp-files.js";
 import { MemoryManagerSourceSyncOps } from "./manager-source-sync-ops.js";
 import { MEMORY_INDEX_META_KEY, type MemorySyncProgressState } from "./manager-sync-base.js";
 import {

--- a/extensions/memory-core/src/migration/doctor-memory-reindex-shadows.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-reindex-shadows.ts
@@ -1,0 +1,76 @@
+import path from "node:path";
+import {
+  cleanupAgedLegacyMemoryReindexTempFiles,
+  findAgedLegacyMemoryReindexTempFiles,
+} from "../memory/manager-reindex-temp-files.js";
+
+export type LegacyMemoryReindexOrphan = {
+  dbPath: string;
+  shadowBaseNames: string[];
+};
+
+export function collectAgedLegacyMemoryReindexShadows(
+  databasePaths: Iterable<string>,
+): LegacyMemoryReindexOrphan[] {
+  return [...databasePaths]
+    .map((dbPath) => ({
+      dbPath,
+      shadowBaseNames: findAgedLegacyMemoryReindexTempFiles(dbPath),
+    }))
+    .filter((candidate) => candidate.shadowBaseNames.length > 0)
+    .toSorted((left, right) => left.dbPath.localeCompare(right.dbPath));
+}
+
+export function formatLegacyMemoryReindexShadowPreviews(
+  orphans: LegacyMemoryReindexOrphan[],
+): string[] {
+  return orphans.flatMap(({ dbPath, shadowBaseNames }) =>
+    shadowBaseNames.map(
+      (shadowBaseName) =>
+        `- Aged Memory Core legacy reindex shadow: ${path.join(path.dirname(dbPath), shadowBaseName)}`,
+    ),
+  );
+}
+
+export async function cleanupLegacyMemoryReindexShadows(
+  orphans: LegacyMemoryReindexOrphan[],
+): Promise<{ changes: string[]; warnings: string[] }> {
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  if (orphans.length === 0) {
+    return { changes, warnings };
+  }
+  const { waitForMemoryReindexLock } = await import("../memory/manager-reindex-lock.js");
+  for (const { dbPath } of orphans) {
+    let lock: Awaited<ReturnType<typeof waitForMemoryReindexLock>> | undefined;
+    try {
+      // Detection is advisory: reacquire the database lease and rescan before deletion
+      // so a shadow that became active after Doctor preview cannot be removed.
+      lock = await waitForMemoryReindexLock(dbPath);
+      const result = cleanupAgedLegacyMemoryReindexTempFiles(dbPath);
+      if (result.removedBaseNames.length > 0) {
+        changes.push(
+          `Removed ${result.removedBaseNames.length} aged Memory Core legacy reindex shadow database(s) beside ${dbPath}`,
+        );
+      }
+      for (const failedBaseName of result.failedBaseNames) {
+        warnings.push(
+          `Failed removing aged Memory Core legacy reindex shadow database ${path.join(path.dirname(dbPath), failedBaseName)}`,
+        );
+      }
+    } catch (err) {
+      warnings.push(
+        `Skipped aged Memory Core legacy reindex shadow cleanup beside ${dbPath}: ${String(err)}`,
+      );
+    } finally {
+      try {
+        lock?.release();
+      } catch (err) {
+        warnings.push(
+          `Failed releasing Memory Core legacy reindex cleanup lock beside ${dbPath}: ${String(err)}`,
+        );
+      }
+    }
+  }
+  return { changes, warnings };
+}

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -13,6 +13,13 @@ import {
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 // This doctor closure must stay dependency-light while accepting legacy array-backed objects.
 import { asOptionalObjectRecord as readLegacyObjectRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveLegacyMemoryReindexDatabaseBaseName } from "../memory/manager-reindex-temp-files.js";
+import {
+  cleanupLegacyMemoryReindexShadows,
+  collectAgedLegacyMemoryReindexShadows,
+  formatLegacyMemoryReindexShadowPreviews,
+  type LegacyMemoryReindexOrphan,
+} from "./doctor-memory-reindex-shadows.js";
 // sqlite-runtime re-exports the agent-db/kysely graph; keep it lazy so doctor
 // enumeration does not cold-load it with this closure.
 import {
@@ -164,18 +171,28 @@ async function isCanonicalAgentDatabaseSymlink(params: {
   }
 }
 
-async function collectLegacyMemorySidecarSources(params: {
+async function collectLegacyMemorySidecarState(params: {
   config: unknown;
   env: NodeJS.ProcessEnv;
   stateDir: string;
-}): Promise<LegacyMemorySidecarSource[]> {
+}): Promise<{
+  reindexOrphans: LegacyMemoryReindexOrphan[];
+  sources: LegacyMemorySidecarSource[];
+}> {
   const { resolveOpenClawAgentSqlitePath } = await import("openclaw/plugin-sdk/sqlite-runtime");
   const agentIds = new Set(resolveConfiguredAgentIds(params.config));
   const legacyDir = path.join(params.stateDir, "memory");
   const retrySidecars: Array<{ agentId: string; legacyPath: string }> = [];
+  const reindexCandidatePaths = new Set<string>();
   try {
     const entries = await fs.readdir(legacyDir, { withFileTypes: true });
     for (const entry of entries) {
+      const reindexDatabaseBaseName = entry.isFile()
+        ? resolveLegacyMemoryReindexDatabaseBaseName(entry.name)
+        : undefined;
+      if (reindexDatabaseBaseName) {
+        reindexCandidatePaths.add(path.join(legacyDir, reindexDatabaseBaseName));
+      }
       if (entry.isFile() && entry.name.endsWith(".sqlite")) {
         const stem = entry.name.slice(0, -".sqlite".length);
         const retryMarker = ".retry-";
@@ -192,6 +209,9 @@ async function collectLegacyMemorySidecarSources(params: {
   const migrationEnv = { ...params.env, OPENCLAW_STATE_DIR: params.stateDir };
   const sources: LegacyMemorySidecarSource[] = [];
   const seen = new Set<string>();
+  function addReindexCandidate(legacyPath: string): void {
+    reindexCandidatePaths.add(path.resolve(legacyPath));
+  }
   async function addSource(agentId: string, legacyPath: string): Promise<void> {
     const normalizedPath = path.resolve(legacyPath);
     const key = `${agentId}\0${normalizedPath}`;
@@ -220,17 +240,23 @@ async function collectLegacyMemorySidecarSources(params: {
   }
   for (const agentId of agentIds) {
     for (const configuredPath of readLegacyMemorySearchStorePaths(params.config, agentId)) {
-      await addSource(
-        agentId,
-        resolveUserPath(configuredPath.replaceAll("{agentId}", agentId), migrationEnv),
+      const legacyPath = resolveUserPath(
+        configuredPath.replaceAll("{agentId}", agentId),
+        migrationEnv,
       );
+      addReindexCandidate(legacyPath);
+      await addSource(agentId, legacyPath);
     }
-    await addSource(agentId, path.join(legacyDir, `${agentId}.sqlite`));
+    const defaultLegacyPath = path.join(legacyDir, `${agentId}.sqlite`);
+    addReindexCandidate(defaultLegacyPath);
+    await addSource(agentId, defaultLegacyPath);
   }
   for (const retrySidecar of retrySidecars) {
+    addReindexCandidate(retrySidecar.legacyPath);
     await addSource(retrySidecar.agentId, retrySidecar.legacyPath);
   }
-  return sources;
+  const reindexOrphans = collectAgedLegacyMemoryReindexShadows(reindexCandidatePaths);
+  return { reindexOrphans, sources };
 }
 
 async function archiveLegacyMemorySidecar(params: {
@@ -535,34 +561,39 @@ export const memorySidecarStateMigration: PluginDoctorStateMigration = {
   id: "memory-core-legacy-sidecar-index-to-agent-sqlite",
   label: "Memory Core legacy memory index sidecar",
   async detectLegacyState(params) {
-    const sources = await collectLegacyMemorySidecarSources({
+    const { reindexOrphans, sources } = await collectLegacyMemorySidecarState({
       config: params.config,
       env: params.env,
       stateDir: params.stateDir,
     });
-    if (sources.length === 0) {
+    if (sources.length === 0 && reindexOrphans.length === 0) {
       return null;
     }
     return {
-      preview: sources.map(
-        (source) =>
-          `- Memory Core legacy memory index: ${source.legacyPath} -> ${source.agentDatabasePath}`,
-      ),
+      preview: [
+        ...sources.map(
+          (source) =>
+            `- Memory Core legacy memory index: ${source.legacyPath} -> ${source.agentDatabasePath}`,
+        ),
+        ...formatLegacyMemoryReindexShadowPreviews(reindexOrphans),
+      ],
     };
   },
   async migrateLegacyState(params) {
     const changes: string[] = [];
     const warnings: string[] = [];
-    const groups = groupLegacyMemorySidecarSourcesByPath(
-      await collectLegacyMemorySidecarSources({
-        config: params.config,
-        env: params.env,
-        stateDir: params.stateDir,
-      }),
-    );
-    for (const sources of groups) {
+    const { reindexOrphans, sources } = await collectLegacyMemorySidecarState({
+      config: params.config,
+      env: params.env,
+      stateDir: params.stateDir,
+    });
+    const reindexCleanup = await cleanupLegacyMemoryReindexShadows(reindexOrphans);
+    changes.push(...reindexCleanup.changes);
+    warnings.push(...reindexCleanup.warnings);
+    const groups = groupLegacyMemorySidecarSourcesByPath(sources);
+    for (const sourceGroup of groups) {
       let archiveReady = true;
-      for (const source of sources) {
+      for (const source of sourceGroup) {
         try {
           const result = await migrateLegacyMemorySidecarSource({
             source,
@@ -580,9 +611,9 @@ export const memorySidecarStateMigration: PluginDoctorStateMigration = {
           );
         }
       }
-      if (archiveReady && sources[0]) {
+      if (archiveReady && sourceGroup[0]) {
         await archiveLegacyMemorySidecar({
-          source: sources[0],
+          source: sourceGroup[0],
           changes,
           warnings,
         });


### PR DESCRIPTION
Closes #136284

## What Problem This Solves

Fixes an issue where users upgrading from the pre-per-agent memory database layout could retain aged `.tmp-<uuid>` reindex databases indefinitely after Doctor had already archived the retired primary database.

## Why This Change Was Made

The runtime cleanup intentionally keeps requiring the current primary database, because a missing primary can mean an interrupted current-format swap. Retired `.tmp-<uuid>` cleanup therefore moves to the memory-core Doctor migration owner, which can discover strictly named aged shadows even when the old primary is absent or renamed, acquire the reindex lock, revalidate them, and report deletion failures truthfully.

This also extracts the shared shadow-family primitives from the database manager so Doctor can reuse the exact suffix, UUID, age, and removal rules without cold-loading the runtime SQLite graph. Doctor-specific preview, locking, and reporting now live in a focused migration module. No configuration, schema, or persistent-data contract changes.

Compared with #136310, this covers the archived-primary upgrade state and preserves the current-format missing-primary safety invariant. It also avoids reporting failed removals as successful.

## User Impact

`openclaw doctor --fix` now removes legacy reindex shadow databases older than 24 hours, including `-wal`, `-shm`, and `-journal` companions, after the retired base database has already been archived. Young shadows, unrelated files, and current-format shadows whose primary is missing remain untouched. Operators receive warnings for files that could not be removed.

## Evidence

- Regression test fails on `main`: after `main.sqlite` is archived to `main.sqlite.migrated`, Doctor detection returns no migration and leaves the aged `.tmp-<uuid>` family behind.
- The same full Doctor detect/migrate fixture passes after this change and preserves the archive plus a young shadow family.
- Exact-head focused suite: `77 passed` across `manager-db.test.ts` and `doctor-contract-api.test.ts`.
- Exact-head Doctor declaration and dependency-closure suite: `5 passed`; the new migration module keeps Kysely and the runtime state database graph out of Doctor enumeration.
- Exact-head extension typecheck, type-aware lint, formatting, diff integrity, assertion-safety ratchet, plugin-boundary checks, and dead-export scans passed.
- Unit coverage preserves a current-format shadow when its primary is missing and verifies deletion errors are returned as failures, not successes.
- Production/test LOC at `efbedecef7a`: production `+313/-122` (net `+191`), tests `+80/-2` (net `+78`), baseline `+1/-1`. The production growth owns the new Doctor-only discovery/locking/reporting path and extracts one canonical shadow-family implementation; no compatibility path or duplicate runtime cleanup was added.

### Direct Doctor operator-flow proof

Reproduced with the built CLI at exact head `efbedecef7a` in an isolated state directory:

1. Preserved archived primary: `memory/main.sqlite.migrated`.
2. Created an aged `main.sqlite.tmp-11111111-2222-3333-4444-555555555555` family with base, WAL, SHM, and journal files (all older than 24 hours).
3. Created a young `main.sqlite.tmp-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee` family with the same four files.
4. Ran `openclaw doctor --fix --non-interactive --yes`.

Observed output:

```text
[state-migrations] Auto-migrated legacy state:
- Removed 1 aged Memory Core legacy reindex shadow database(s) beside <state>/memory/main.sqlite
```

Postconditions:

- archived primary retained: `1`
- aged shadow-family files retained: `0`
- young shadow-family files retained: `4`
- Doctor completed successfully and created only its expected reindex lock database

This is an isolated built-CLI operator-flow proof using synthetic filesystem state; it does not claim migration of a live user database.
