### PR TITLE
fix(zalo): journal polled updates before dispatch

### DIFF
--- a/extensions/zalo/src/monitor.image.polling.test-support.ts
+++ b/extensions/zalo/src/monitor.image.polling.test-support.ts
@@ -13,6 +13,7 @@ import {
 import {
   getUpdatesMock,
   getZaloRuntimeMock,
+  installLifecycleIngressState,
   loadCachedLifecycleMonitorModule,
   resetLifecycleTestState,
   sendMessageMock,
@@ -32,6 +33,7 @@ describe("Zalo polling image handling", () => {
   beforeEach(async () => {
     await resetLifecycleTestState();
     getZaloRuntimeMock.mockReturnValue(core);
+    await installLifecycleIngressState();
   });
 
   afterAll(async () => {

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -80,6 +80,9 @@ async function startLifecycleMonitor(
 
 describe("monitorZaloProvider lifecycle", () => {
   beforeEach(async () => {
+    // Warm the lazy ingress module so polling startup settles within the
+    // lifecycle settle helpers (and within fake-timer advancement).
+    await import("./webhook-spool.js");
     const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-monitor-"));
     testStateDir = await fs.realpath(createdDir);
     previousStateDir = process.env.OPENCLAW_STATE_DIR;
@@ -181,11 +184,16 @@ describe("monitorZaloProvider lifecycle", () => {
         lastError: expect.stringContaining("zalo poll transport failed"),
       });
       expect(getUpdatesMock).toHaveBeenCalledTimes(1);
-      expect(vi.getTimerCount()).toBe(1);
+      // Backoff sleep plus the durable-ingress drain pump; the exact count is an
+      // implementation detail, while the post-abort zero below is the contract.
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
 
       abort.abort();
       await run;
 
+      // The ingress queue opened the shared state DB; its WAL maintenance
+      // interval is process-level and clears when the DB handle closes.
+      closeOpenClawStateDatabaseForTest();
       expect(vi.getTimerCount()).toBe(0);
       await vi.advanceTimersByTimeAsync(5_000);
       expect(getUpdatesMock).toHaveBeenCalledTimes(1);

--- a/extensions/zalo/src/monitor.polling-ingress.test.ts
+++ b/extensions/zalo/src/monitor.polling-ingress.test.ts
@@ -1,0 +1,449 @@
+// Zalo tests cover the durable ingress journal on the polling transport.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createEmptyPluginRegistry,
+  createRuntimeEnv,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import type { ResolvedZaloAccount } from "./accounts.js";
+import type { ZaloUpdate } from "./api.js";
+import type { OpenClawConfig, PluginRuntime } from "./runtime-api.js";
+import {
+  createImageLifecycleCore,
+  createLifecycleMonitorSetup,
+  createTextUpdate,
+  settleAsyncWork,
+} from "./test-support/lifecycle-test-support.js";
+import {
+  getUpdatesMock,
+  getZaloRuntimeMock,
+  loadCachedLifecycleMonitorModule,
+  resetLifecycleTestState,
+} from "./test-support/monitor-mocks-test-support.js";
+import {
+  waitForZaloWebhookVerdict,
+  type ZaloWebhookTestPayload,
+} from "./webhook-spool.test-support.js";
+
+type ZaloPollingTestQueue = Parameters<typeof waitForZaloWebhookVerdict>[0];
+
+type DispatchReplyOptions = {
+  replyOptions?: {
+    turnAdoptionLifecycle?: { onAdopted: () => Promise<void> };
+  };
+};
+
+function createDeferred() {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function startPollingMonitor(setup: {
+  account: ResolvedZaloAccount;
+  config: OpenClawConfig;
+}) {
+  const { monitorZaloProvider } = await loadCachedLifecycleMonitorModule("zalo-polling-ingress");
+  const abort = new AbortController();
+  const runtime = createRuntimeEnv();
+  const run = monitorZaloProvider({
+    token: "zalo-token", // pragma: allowlist secret
+    account: setup.account,
+    config: setup.config,
+    runtime,
+    abortSignal: abort.signal,
+  });
+  return { abort, run, runtime };
+}
+
+describe("Zalo polling durable ingress", () => {
+  const { core } = createImageLifecycleCore();
+  const dispatchMock = core.channel.reply
+    .dispatchReplyWithBufferedBlockDispatcher as unknown as Mock;
+  let stateDir: string | undefined;
+  let queue: ZaloPollingTestQueue;
+
+  beforeAll(async () => {
+    // Install module mocks first, then warm the lazy ingress module so monitor
+    // startup does not pay module load inside the tests.
+    await loadCachedLifecycleMonitorModule("zalo-polling-ingress");
+    await import("./webhook-spool.js");
+  });
+
+  beforeEach(async () => {
+    await resetLifecycleTestState();
+    const createdDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zalo-poll-ingress-"));
+    stateDir = await fs.realpath(createdDir);
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    queue = createChannelIngressQueueForTests<ZaloWebhookTestPayload>({
+      channelId: "zalo",
+      accountId: "default",
+      stateDir,
+    });
+    core.state.openChannelIngressQueue = ((_options: { accountId?: string }) =>
+      queue) as unknown as PluginRuntime["state"]["openChannelIngressQueue"];
+    getZaloRuntimeMock.mockReturnValue(core);
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  afterAll(async () => {
+    await resetLifecycleTestState();
+  });
+
+  afterEach(async () => {
+    dispatchMock.mockReset();
+    await resetLifecycleTestState();
+    closeOpenClawStateDatabaseForTest();
+    if (stateDir) {
+      await fs.rm(stateDir, { recursive: true, force: true });
+      stateDir = undefined;
+    }
+    delete process.env.OPENCLAW_STATE_DIR;
+  });
+
+  it("journals a polled update durably before dispatch and tombstones it after adoption", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-journal-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const dispatchStarted = createDeferred();
+    const dispatchGate = createDeferred();
+    let durableIdsAtDispatch: string[] = [];
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      // The update must be durable before the agent turn starts.
+      const [claims, pending] = await Promise.all([queue.listClaims(), queue.listPending()]);
+      durableIdsAtDispatch = [...claims, ...pending].map((record) => record.id);
+      dispatchStarted.resolve();
+      await dispatchGate.promise;
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+
+    const { abort, run } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    await dispatchStarted.promise;
+    expect(durableIdsAtDispatch).toEqual(["poll-journal-1"]);
+
+    dispatchGate.resolve();
+    await waitForZaloWebhookVerdict(queue, "poll-journal-1", "completed");
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+    await run;
+  });
+
+  it("delivers journaled updates one at a time, even across chats", async () => {
+    // Pins the pre-journal polling semantics: in-order, one delivery at a
+    // time. Two updates from different chats would deliver concurrently under
+    // the webhook fan-out limit; the polling ingress must stay serial.
+    const first = createTextUpdate({
+      messageId: "poll-serial-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    const second = createTextUpdate({
+      messageId: "poll-serial-2",
+      userId: "user-2",
+      userName: "User Two",
+      chatId: "dm-chat-2",
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: first as ZaloUpdate })
+      .mockResolvedValueOnce({ ok: true, result: second as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const firstStarted = createDeferred();
+    const firstGate = createDeferred();
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      if (dispatchMock.mock.calls.length === 1) {
+        firstStarted.resolve();
+        await firstGate.promise;
+      }
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+
+    const { abort, run } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    await firstStarted.promise;
+    // The third getUpdates call proves the second update was accepted
+    // (journaled) behind the in-flight first delivery. Then give the drain
+    // two full intervals to (wrongly) start it — the serial limit must hold
+    // it back.
+    await vi.waitFor(() => {
+      expect(getUpdatesMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1_100);
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    firstGate.resolve();
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(2);
+    });
+    await waitForZaloWebhookVerdict(queue, "poll-serial-1", "completed");
+    await waitForZaloWebhookVerdict(queue, "poll-serial-2", "completed");
+
+    abort.abort();
+    await run;
+  });
+
+  it.each([
+    { eventName: "message.sticker.received", logFragment: "Received sticker" },
+    { eventName: "message.unsupported.received", logFragment: "Received unsupported message type" },
+  ])(
+    "keeps $eventName out of the journal but retains its verbose record",
+    async ({ eventName, logFragment }) => {
+      const update = {
+        ...createTextUpdate({
+          messageId: `poll-noop-${eventName}`,
+          userId: "user-1",
+          userName: "User One",
+          chatId: "dm-chat-1",
+        }),
+        event_name: eventName,
+      };
+      getUpdatesMock
+        .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+        .mockImplementation(() => new Promise(() => {}));
+      const verboseMock = core.logging.shouldLogVerbose as unknown as Mock;
+      verboseMock.mockReturnValue(true);
+
+      const { abort, run, runtime } = await startPollingMonitor(
+        createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+      );
+
+      // The intentional non-outcome stays recorded (pre-journal behavior)...
+      await vi.waitFor(() => {
+        expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(logFragment));
+      });
+      // ...while the event never enters the durable queue or dispatches.
+      const [claims, pending] = await Promise.all([queue.listClaims(), queue.listPending()]);
+      expect([...claims, ...pending]).toEqual([]);
+      expect(dispatchMock).not.toHaveBeenCalled();
+
+      verboseMock.mockReturnValue(false);
+      abort.abort();
+      await run;
+    },
+  );
+
+  it("dedupes a re-polled update after completion", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-dedupe-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      // Simulate a Bot API redelivery of the same consumed update.
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { abort, run } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    // Wait for the monitor's own admission before probing the row: the verdict
+    // probe enqueues, so it must never win the race against the polled admission.
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitForZaloWebhookVerdict(queue, "poll-dedupe-1", "completed");
+    await vi.waitFor(() => {
+      expect(getUpdatesMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+    await settleAsyncWork();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    abort.abort();
+    await run;
+  });
+
+  it("replays a journaled update exactly once after a crash between poll and dispatch", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-restart-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    const dispatchStarted = createDeferred();
+    const crashDispatch = createDeferred();
+    // First attempt dies mid-dispatch: the process is killed before a verdict.
+    dispatchMock.mockImplementationOnce(async () => {
+      dispatchStarted.resolve();
+      await crashDispatch.promise;
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const setup = createLifecycleMonitorSetup({
+      accountId: "default",
+      dmPolicy: "open",
+      webhookUrl: "",
+    });
+    const first = await startPollingMonitor(setup);
+
+    await dispatchStarted.promise;
+    // Crash while the delivery is in flight; the journaled row must survive the
+    // stop either as a dead-owner claim or as a released retry.
+    first.abort.abort();
+    crashDispatch.reject(new Error("simulated process crash"));
+    await first.run;
+
+    const [crashClaims, crashPending] = await Promise.all([
+      queue.listClaims(),
+      queue.listPending(),
+    ]);
+    expect([...crashClaims, ...crashPending].map((record) => record.id)).toEqual([
+      "poll-restart-1",
+    ]);
+
+    // Restart: a fresh monitor recovers the unfinished row and replays it.
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+    getUpdatesMock.mockReset();
+    getUpdatesMock
+      // The Bot API re-serves the consumed update once more after the restart.
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const second = await startPollingMonitor(setup);
+
+    await waitForZaloWebhookVerdict(queue, "poll-restart-1", "completed");
+    await vi.waitFor(() => {
+      expect(getUpdatesMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+    await settleAsyncWork();
+    // Exactly one successful dispatch across crash + replay + redelivery.
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    second.abort.abort();
+    await second.run;
+  });
+
+  it("journals a polled update on the abort path with durable-after-stop admission", async () => {
+    const updateA = createTextUpdate({
+      messageId: "poll-abort-a",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    const updateB = createTextUpdate({
+      messageId: "poll-abort-b",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+
+    // First update completes normally so the poll loop advances to the next
+    // getUpdates call, which stays in-flight past shutdown.
+    dispatchMock.mockImplementation(async ({ replyOptions }: DispatchReplyOptions) => {
+      await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+    });
+
+    const latePoll = createDeferred();
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: updateA as ZaloUpdate })
+      .mockImplementationOnce(() =>
+        latePoll.promise.then(() => ({ ok: true, result: updateB as ZaloUpdate })),
+      )
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { abort, run } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    // Wait for the first update to complete so the next poll is in-flight on
+    // getUpdates when abort fires.
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitForZaloWebhookVerdict(queue, "poll-abort-a", "completed");
+
+    // Abort while the second getUpdates is in-flight; the monitor shuts down
+    // before the poll response arrives.
+    abort.abort();
+    await run;
+
+    // Release the in-flight poll after the monitor has fully shut down.
+    latePoll.resolve();
+
+    // With durable-after-stop admission the abort branch must persist the
+    // consumed update into the durable ingress queue even after stop.
+    await vi.waitFor(async () => {
+      const [claims, pending] = await Promise.all([queue.listClaims(), queue.listPending()]);
+      const ids = [...claims, ...pending].map((record) => record.id);
+      expect(ids).toContain("poll-abort-b");
+    });
+  });
+
+  it("dead-letters an authentication failure from dispatch without retry", async () => {
+    const update = createTextUpdate({
+      messageId: "poll-deadletter-1",
+      userId: "user-1",
+      userName: "User One",
+      chatId: "dm-chat-1",
+    });
+    const { ZaloApiError } = await import("./api.js");
+    dispatchMock.mockImplementation(async () => {
+      throw new ZaloApiError("Unauthorized", 401, "Unauthorized");
+    });
+    getUpdatesMock
+      .mockResolvedValueOnce({ ok: true, result: update as ZaloUpdate })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { abort, run, runtime } = await startPollingMonitor(
+      createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" }),
+    );
+
+    // Wait for the monitor's own admission before probing the row (see dedupe test).
+    await vi.waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+    await waitForZaloWebhookVerdict(queue, "poll-deadletter-1", "failed");
+    await settleAsyncWork();
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("authentication-failed"));
+
+    abort.abort();
+    await run;
+  });
+});

--- a/extensions/zalo/src/monitor.polling-ingress.test.ts
+++ b/extensions/zalo/src/monitor.polling-ingress.test.ts
@@ -446,4 +446,92 @@ describe("Zalo polling durable ingress", () => {
     abort.abort();
     await run;
   });
+
+  type ProbeDispatchArgs = {
+    ctx?: { MessageSid?: string };
+    replyOptions?: { turnAdoptionLifecycle?: { onAdopted: () => Promise<void> } };
+  };
+  const probeSetup = () =>
+    createLifecycleMonitorSetup({ accountId: "default", dmPolicy: "open", webhookUrl: "" });
+  const makeProbeUpdate = (id: string, n: number) =>
+    createTextUpdate({
+      messageId: id,
+      userId: `user-${n}`,
+      userName: `User ${n}`,
+      chatId: `dm-chat-${n}`,
+    });
+
+  it("keeps poll order when two polled admissions land in the same millisecond", async () => {
+    // Pin Date.now only for the ingress monitor's admission clock (and the
+    // Zalo monitor itself) so the drain/lease/retry clocks keep advancing.
+    const realNow = Date.now;
+    let pinnedAt: number | undefined;
+    const isPinnedCaller = (stack: string) => {
+      const frames = stack.split("\n").slice(1);
+      const first = frames.find(
+        (f) => /channels[/]message[/]/.test(f) || /extensions[/]zalo[/]src[/]monitor\.ts/.test(f),
+      );
+      return (
+        first !== undefined && /ingress-monitor|extensions[/]zalo[/]src[/]monitor\.ts/.test(first)
+      );
+    };
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      if (pinnedAt !== undefined && isPinnedCaller(new Error().stack ?? "")) {
+        return pinnedAt;
+      }
+      return realNow();
+    });
+    try {
+      const held = makeProbeUpdate("poll-tie-0", 0);
+      const polledSecond = makeProbeUpdate("poll-tie-b", 1);
+      const polledThird = makeProbeUpdate("poll-tie-a", 2);
+      getUpdatesMock
+        .mockResolvedValueOnce({ ok: true, result: held as ZaloUpdate })
+        .mockResolvedValueOnce({ ok: true, result: polledSecond as ZaloUpdate })
+        .mockResolvedValueOnce({ ok: true, result: polledThird as ZaloUpdate })
+        .mockImplementation(() => new Promise(() => {}));
+      const order: string[] = [];
+      const firstGate = createDeferred();
+      dispatchMock.mockImplementation(async ({ ctx, replyOptions }: ProbeDispatchArgs) => {
+        order.push(ctx?.MessageSid ?? "?");
+        if (order.length === 1) {
+          await firstGate.promise;
+        }
+        await replyOptions?.turnAdoptionLifecycle?.onAdopted();
+      });
+
+      pinnedAt = realNow();
+      const { abort, run } = await startPollingMonitor(probeSetup());
+
+      await vi.waitFor(
+        async () => {
+          const pending = await queue.listPending();
+          expect(pending.map((r) => r.id).toSorted()).toEqual(["poll-tie-a", "poll-tie-b"]);
+        },
+        { timeout: 5_000 },
+      );
+      pinnedAt = undefined;
+      const pending = await queue.listPending();
+      console.log(
+        "PROBE-A pending (queue order):",
+        pending.map((r) => `${r.id}@${r.receivedAt}`).join(" "),
+        "| getUpdates calls:",
+        getUpdatesMock.mock.calls.length,
+      );
+
+      firstGate.resolve();
+      await vi.waitFor(() => {
+        expect(order).toHaveLength(3);
+      });
+      console.log("PROBE-A dispatch order:", order.join(" -> "));
+      for (const id of ["poll-tie-0", "poll-tie-b", "poll-tie-a"]) {
+        await waitForZaloWebhookVerdict(queue, id, "completed");
+      }
+      abort.abort();
+      await run;
+      expect(order).toEqual(["poll-tie-0", "poll-tie-b", "poll-tie-a"]);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });

--- a/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
+++ b/extensions/zalo/src/monitor.polling.media-reply.test-support.ts
@@ -23,6 +23,7 @@ import {
 import {
   getUpdatesMock,
   getZaloRuntimeMock,
+  installLifecycleIngressState,
   loadCachedLifecycleMonitorModule,
   resetLifecycleTestState,
   sendMessageMock,
@@ -164,6 +165,7 @@ describe("Zalo polling media replies", () => {
           createPluginStateKeyedStoreForTests<T>("zalo", options),
       } as PluginRuntime["state"],
     );
+    await installLifecycleIngressState();
   });
 
   afterAll(async () => {

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -111,9 +111,18 @@ type ZaloProcessingContext = {
   turnAdoptionLifecycle?: ZaloWebhookIngressLifecycle;
 };
 
-type ZaloPollingLoopParams = ZaloProcessingContext & {
+type ZaloPollingLoopParams = {
+  token: string;
+  account: ResolvedZaloAccount;
+  runtime: ZaloRuntimeEnv;
   abortSignal: AbortSignal;
   isStopped: () => boolean;
+  statusSink?: ZaloStatusSink;
+  fetcher?: ZaloFetch;
+  acceptUpdate: (rawEvent: string) => Promise<void>;
+  // No-op events (stickers, unsupported) skip the journal but still flow
+  // through processUpdate so their verbose record is preserved.
+  processNonJournaled: (update: ZaloUpdate) => Promise<void>;
 };
 type ZaloUpdateProcessingParams = ZaloProcessingContext & {
   update: ZaloUpdate;
@@ -227,32 +236,15 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
   const {
     token,
     account,
-    config,
     runtime,
-    core,
-    mediaMaxMb,
-    canHostMedia,
-    webhookUrl,
-    webhookPath,
     abortSignal,
     isStopped,
     statusSink,
     fetcher,
+    acceptUpdate,
+    processNonJournaled,
   } = params;
   const pollTimeout = 30;
-  const processingContext = {
-    token,
-    account,
-    config,
-    runtime,
-    core,
-    mediaMaxMb,
-    canHostMedia,
-    webhookUrl,
-    webhookPath,
-    statusSink,
-    fetcher,
-  };
 
   runtime.log?.(`[${account.accountId}] Zalo polling loop started timeout=${String(pollTimeout)}s`);
 
@@ -263,7 +255,27 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
 
     try {
       const response = await getUpdates(token, { timeout: pollTimeout }, fetcher);
+      // The Bot API consumes each polled update on response. When shutdown
+      // arrives while getUpdates is in-flight (the poll carries no abort
+      // signal and runs to its own 35 s timeout), still journal the update.
+      // This is best-effort — getUpdates outlives the 5 s channel-stop
+      // deadline, so the process may exit before the response lands. When
+      // it does land, durable-after-stop admission accepts the append after
+      // ingress.stop() has completed; the row is recovered on next restart.
+      const shouldJournal =
+        response.ok &&
+        response.result &&
+        response.result.message &&
+        response.result.event_name !== "message.sticker.received" &&
+        response.result.event_name !== "message.unsupported.received";
       if (isStopped() || abortSignal.aborted) {
+        if (shouldJournal) {
+          await acceptUpdate(JSON.stringify(response.result)).catch((err: unknown) =>
+            runtime.error?.(
+              `[${account.accountId}] failed to journal consumed update before shutdown: ${formatZaloError(err)}`,
+            ),
+          );
+        }
         return undefined;
       }
       if (response.ok) {
@@ -271,10 +283,14 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
       }
       if (response.ok && response.result) {
         statusSink?.({ lastInboundAt: Date.now() });
-        await processUpdate({
-          update: response.result,
-          ...processingContext,
-        });
+        // No-op message events (stickers, unsupported) carry a message field
+        // but produce no dispatch — keep them out of the durable queue while
+        // retaining their prior verbose record through processUpdate.
+        if (shouldJournal) {
+          await acceptUpdate(JSON.stringify(response.result));
+        } else {
+          await processNonJournaled(response.result);
+        }
       }
     } catch (err) {
       if (err instanceof ZaloApiError && err.isPollingTimeout) {
@@ -285,6 +301,12 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
         statusSink?.({ connected: false, lifecycle: "recovering", lastError: error });
         // Abort-aware backoff; bottom poll reschedule already checks stopped/aborted.
         await sleepWithAbort(5000, abortSignal).catch(() => undefined);
+      } else {
+        // getUpdates network error during shutdown: log instead of silently
+        // dropping it — the poll transport is in an indeterminate state.
+        runtime.error?.(
+          `[${account.accountId}] Zalo ingress error during shutdown: ${formatZaloError(err)}`,
+        );
       }
     }
 
@@ -1065,20 +1087,62 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
       );
     }
 
+    const { createZaloWebhookIngress } = await loadZaloWebhookIngressRuntime();
+    // Polling and webhook share one durable ingress per account: the Bot API
+    // consumes polled updates on response, so a crash between poll and dispatch
+    // is unrecoverable without the same append-before-dispatch journal.
+    // Serial drain preserves the pre-journal semantics of the polling loop
+    // (in-order, one delivery at a time); only the crash-loss window closes.
+    const ingress = createZaloWebhookIngress({
+      accountId: account.accountId,
+      runtime,
+      maxConcurrentDeliveries: 1,
+      deliver: async (update, turnAdoptionLifecycle) => {
+        await processUpdate({
+          update,
+          token,
+          account,
+          config,
+          runtime,
+          core,
+          mediaMaxMb: effectiveMediaMaxMb,
+          canHostMedia,
+          webhookUrl: effectiveWebhookUrl,
+          webhookPath: effectiveWebhookPath,
+          statusSink,
+          fetcher,
+          turnAdoptionLifecycle,
+        });
+      },
+    });
+    ingress.start();
+    asyncStopHandlers.push(ingress.stop);
+
     startPollingLoop({
       token,
       account,
-      config,
       runtime,
-      core,
-      canHostMedia,
-      webhookUrl: effectiveWebhookUrl,
-      webhookPath: effectiveWebhookPath,
       abortSignal,
       isStopped: () => stopped,
-      mediaMaxMb: effectiveMediaMaxMb,
       statusSink,
       fetcher,
+      acceptUpdate: ingress.accept,
+      processNonJournaled: async (update) => {
+        await processUpdate({
+          update,
+          token,
+          account,
+          config,
+          runtime,
+          core,
+          mediaMaxMb: effectiveMediaMaxMb,
+          canHostMedia,
+          webhookUrl: effectiveWebhookUrl,
+          webhookPath: effectiveWebhookPath,
+          statusSink,
+          fetcher,
+        });
+      },
     });
 
     await waitForAbortSignal(abortSignal);

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -119,7 +119,7 @@ type ZaloPollingLoopParams = {
   isStopped: () => boolean;
   statusSink?: ZaloStatusSink;
   fetcher?: ZaloFetch;
-  acceptUpdate: (rawEvent: string) => Promise<void>;
+  acceptUpdate: (rawEvent: string, admitOptions?: { receivedAt?: number }) => Promise<void>;
   // No-op events (stickers, unsupported) skip the journal but still flow
   // through processUpdate so their verbose record is preserved.
   processNonJournaled: (update: ZaloUpdate) => Promise<void>;
@@ -245,6 +245,14 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
     processNonJournaled,
   } = params;
   const pollTimeout = 30;
+  // The shared queue breaks equal received_at ties by event_id, which is not
+  // poll order. Keep polled admissions strictly monotonic so the serial drain
+  // replays them in receipt order even if two polls land in one millisecond.
+  let lastReceivedAt = 0;
+  const nextReceivedAt = () => {
+    lastReceivedAt = Math.max(Date.now(), lastReceivedAt + 1);
+    return lastReceivedAt;
+  };
 
   runtime.log?.(`[${account.accountId}] Zalo polling loop started timeout=${String(pollTimeout)}s`);
 
@@ -270,7 +278,9 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
         response.result.event_name !== "message.unsupported.received";
       if (isStopped() || abortSignal.aborted) {
         if (shouldJournal) {
-          await acceptUpdate(JSON.stringify(response.result)).catch((err: unknown) =>
+          await acceptUpdate(JSON.stringify(response.result), {
+            receivedAt: nextReceivedAt(),
+          }).catch((err: unknown) =>
             runtime.error?.(
               `[${account.accountId}] failed to journal consumed update before shutdown: ${formatZaloError(err)}`,
             ),
@@ -287,7 +297,7 @@ function startPollingLoop(params: ZaloPollingLoopParams) {
         // but produce no dispatch — keep them out of the durable queue while
         // retaining their prior verbose record through processUpdate.
         if (shouldJournal) {
-          await acceptUpdate(JSON.stringify(response.result));
+          await acceptUpdate(JSON.stringify(response.result), { receivedAt: nextReceivedAt() });
         } else {
           await processNonJournaled(response.result);
         }

--- a/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
+++ b/extensions/zalo/src/test-support/monitor-mocks-test-support.ts
@@ -140,7 +140,7 @@ export async function resetLifecycleTestState() {
   setActivePluginRegistry(createEmptyPluginRegistry());
 }
 
-async function installLifecycleWebhookIngressState(): Promise<void> {
+export async function installLifecycleIngressState(): Promise<void> {
   const runtime = getZaloRuntimeMock() as PluginRuntime;
   const createdDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-zalo-lifecycle-"),
@@ -197,7 +197,7 @@ export async function startWebhookLifecycleMonitor(params: {
   webhookSecret?: string;
   cacheKey?: string;
 }) {
-  await installLifecycleWebhookIngressState();
+  await installLifecycleIngressState();
   const registry = createEmptyPluginRegistry();
   setActivePluginRegistry(registry);
   const abort = new AbortController();

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -217,6 +217,9 @@ function createZaloWebhookIngress(options: {
   runtime: Pick<ZaloRuntimeEnv, "error" | "log">;
   deliver: (update: ZaloUpdate, lifecycle: ZaloWebhookIngressLifecycle) => Promise<void>;
   queue?: ChannelIngressQueue<ZaloWebhookSpoolPayload>;
+  // Webhook keeps the 8-delivery fan-out; polling passes 1 so drain order and
+  // one-at-a-time delivery match the pre-journal serial dispatch loop.
+  maxConcurrentDeliveries?: number;
 }): ZaloWebhookIngress {
   const queue =
     options.queue ??
@@ -253,9 +256,10 @@ function createZaloWebhookIngress(options: {
     waitForDeliveryIdleBeforeRepump: false,
     runPumpTask: runDetachedWebhookWork,
     deferredClaims: "wait-on-stop",
+    admissionMode: "durable-after-stop",
     drain: {
       adoptionStallTimeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
-      startLimit: ZALO_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
+      startLimit: options.maxConcurrentDeliveries ?? ZALO_WEBHOOK_MAX_CONCURRENT_DELIVERIES,
       retryPolicy: {
         maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
         deadLetterMinAgeMs: 0,

--- a/extensions/zalo/src/webhook-spool.ts
+++ b/extensions/zalo/src/webhook-spool.ts
@@ -32,7 +32,7 @@ export const ZaloWebhookPayloadError = createChannelIngressError("ZaloWebhookPay
 export type ZaloWebhookPayloadError = InstanceType<typeof ZaloWebhookPayloadError>;
 
 type ZaloWebhookIngress = {
-  accept: (rawEvent: string) => Promise<void>;
+  accept: (rawEvent: string, admitOptions?: { receivedAt?: number }) => Promise<void>;
   start: () => void;
   stop: () => Promise<void>;
 };
@@ -281,8 +281,8 @@ function createZaloWebhookIngress(options: {
   });
 
   return {
-    accept: async (rawEvent) => {
-      await monitor.admit(rawEvent);
+    accept: async (rawEvent, admitOptions) => {
+      await monitor.admit(rawEvent, admitOptions);
     },
     start: monitor.start,
     stop: monitor.stop,


### PR DESCRIPTION
## What Problem This Solves

On the Zalo polling transport — the **default deployment mode** (`docs/channels/zalo.md`: "Long-polling (`getUpdates`) by default") — the Bot API consumes each update on response (`getUpdates` has no offset/confirm parameter, `extensions/zalo/src/api.ts:256`), and the poll loop then awaits dispatch directly with no durable boundary (`extensions/zalo/src/monitor.ts`). A crash or gateway restart between the poll response and dispatch completion **permanently and silently loses the user's message**.

This is the polling leftover of the webhook-side repair in #110630 ("polling and webhook transports remain mutually exclusive"), and was previously attempted in #110803. That branch routed polling through the shared ingress at the webhook fan-out limit (8 concurrent cross-chat deliveries), which changed user-visible delivery semantics and required a channel-owner delivery-policy decision. This PR re-slices the same repair to be **behavior-preserving**.

Fixes #130566.

## Why This Change Was Made

Polling now shares the webhook transport's durable ingress (`createZaloWebhookIngress`, #110630), journaling each polled update before dispatch — including durable-after-stop admission for the shutdown race. The one new seam: `createZaloWebhookIngress` accepts an optional `maxConcurrentDeliveries` (default 8, webhook behavior unchanged), and the polling path passes **1**.

Why serial: the pre-journal polling loop dispatched one update at a time in poll order (the `await processUpdate` back-pressure). A serial drain keeps exactly that user-visible contract — in-order, one delivery at a time — so the only behavior change is the closed crash-loss window. The quantified difference vs. the 8-concurrent shape is in the proof matrix below.

Production delta: `monitor.ts` +73/−42, `webhook-spool.ts` +6/−1 (optional parameter + `admissionMode`), plus tests. No files outside `extensions/zalo`, no schema changes (reuses the shared `channel_ingress_events` table), no new config.

## User Impact

- Polling deployments (the default): a crash/restart mid-dispatch no longer loses the message; it replays exactly once after restart.
- Delivery order and concurrency are unchanged from current main: one delivery at a time, in poll order, per account.
- Webhook transport: unchanged (fan-out limit stays 8).
- Back-pressure note: the poll loop no longer back-pressures on dispatch — it journals and continues, matching the webhook admission model; the durable queue drains serially. Zalo chat rates make queue growth a non-issue, and rows survive restarts.

## Evidence

### Live behavior proof (real production `monitorZaloProvider`, real SQLite `channel_ingress_events`, protocol-compatible local Bot API stub)

Driver: production polling monitor pointed at a local stub Bot API via the existing `ZALO_API_URL` override (`api.ts:112`), throwaway `OPENCLAW_STATE_DIR`, driver-controlled `core.channel.inbound.dispatch` as the agent-turn boundary, real HTTP `sendMessage` back to the stub. Same accepted pattern as #109997; #110630's Evidence notes no real Zalo account is available even to maintainers. Proof date 2026-09-02 (UTC); after head `1ec0d27d605`; before control = detached `origin/main` worktree (`ce5d04fac71`), identical driver.

**Before (origin/main): crash between poll and dispatch — message gone.**

```
[stub] getUpdates -> serving proof-msg-1
[driver] dispatch #1 started MessageSid=proof-msg-1
[driver] dispatch is now in flight; process will be killed before it settles
[driver] sqlite rows before kill: []
--- kill -9; restart; stub serves nothing (update was consumed on response) ---
[driver] sqlite rows at restart: []
[driver] PROOF-FAIL: journaled update was never replayed after restart
```

**After (this PR): journaled before dispatch, survives kill -9, replays with zero redelivery.**

```
[driver] dispatch #1 started MessageSid=proof-msg-1
[driver] sqlite rows before kill: [{"event_id":"proof-msg-1"}]
--- kill -9; restart; stub serves nothing ---
[stub] sendMessage -> {"chat_id":"proof-chat-1","text":"reply to proof-msg-1"}
[driver] PROOF-REPLAY-OK (replayed from journal, no redelivery needed)
```

With the stub re-serving the identical update once after restart (dedupe probe): `PROOF-PHASE2-OK dispatchCount=1 (replay exactly once, duplicate deduped)`.

**Serial-semantics matrix (two cross-chat updates, first dispatch held ~3.5s):**

| Run | B started while A in flight | Reply order at stub | Verdict |
|---|---|---|---|
| origin/main (no journal) | no (serial via poll back-pressure) | A then B | reference behavior |
| #110803 shape (8-concurrent drain) | **yes (bStart−aDone = −3493 ms)** | **B then A (out of order)** | PROOF-SERIAL-FAIL |
| This PR (serial drain) | no (bStart−aDone = +8 ms) | A then B | PROOF-SERIAL-OK |

The 8-concurrent shape visibly reorders cross-chat replies; the serial drain is byte-identical to main's user-visible delivery semantics.

### Tests

- `extensions/zalo/src/monitor.polling-ingress.test.ts` (8 tests, real SQLite queue): journal-before-dispatch + tombstone after adoption; **serial one-at-a-time delivery across chats (new pin)**; **sticker and unsupported events stay out of the journal while retaining their verbose record (round-2 pin, table-driven)**; re-polled duplicate deduped; crash between poll and dispatch replays exactly once; abort-path journaling with in-flight `getUpdates`; 401 dispatch failure dead-letters without retry.
- Reverse verification: with `monitor.ts`'s `maxConcurrentDeliveries: 1` stashed (drain at 8), the serial pin fails on the exact assertion — `expected "vi.fn()" to be called 1 times, but got 2 times`; restored, all pass.
- Full `extensions/zalo` suite: 185/185 pass under `LC_ALL=C`. In a zh-CN shell locale one pre-existing test (`setup-surface.test.ts` prompt text) fails on any branch including `main` — a shell-locale issue being fixed separately in #133327, unrelated to this diff.

### Checks

- `node scripts/run-tsgo.mjs` — 0 errors. `oxlint` on changed files — clean. `oxfmt` — clean.
- Codex autoreview on the complete candidate (merge-base to working tree) — exit 0, no accepted findings.

### Relationship to #110803

This PR supersedes #110803 with the same journal/replay/dedupe core (its reviewed test suites carried over) plus the serial-drain re-slice. Credit to @Yigtwxx for the deep multi-round review on #110803 (real-SQLite probes, three-head hash verification, staleness measurements) that hardened the carried-over core, and to the #110803 ClawSweeper live verification runs of the ingress test suite. The Windows EBUSY teardown issue surfaced there was fixed separately in #119809.


---

## Update — round 2 (`9e25bcaf272`)

Addressed the P2 finding (keep ignored polling events observable): the `shouldJournal` gate still keeps sticker/unsupported updates out of the durable queue, but they now flow through `processUpdate` again via a `processNonJournaled` callback, restoring the pre-journal verbose record (`Received sticker` / `Received unsupported message type`). Regression coverage: table-driven pin asserting the verbose log fires while queue rows stay empty and no dispatch occurs; reverse-verified failing on the pre-fix head (`expected "vi.fn()" to be called with StringContaining "Received sticker"`). Full `extensions/zalo` suite green under `LC_ALL=C` (185/185; the locale-sensitive prompt test included). The durability/serial proof above was re-validated against this head's carried-over core; the round-2 delta touches only the non-journaled event path.
