### PR TITLE
fix(ui): show named requesting session in projected approval cards

### DIFF
--- a/ui/src/components/exec-approval-card.ts
+++ b/ui/src/components/exec-approval-card.ts
@@ -28,6 +28,7 @@ type ExecApprovalCardProps = {
   error: string | null;
   variant: "inline" | "modal";
   queueCount?: number;
+  sourceSessionDisplayName?: string;
   onDecision: (approvalId: string, decision: ExecApprovalDecision) => void | Promise<void>;
 };
 
@@ -384,7 +385,8 @@ export function renderExecApprovalCard(props: ExecApprovalCardProps) {
     ${props.variant === "inline" && active.sourceSessionKey
       ? html`<div class="exec-approval-warning" role="note">
           ${t("execApproval.requestedBySession", {
-            session: resolveSessionDisplayName(active.sourceSessionKey),
+            session:
+              props.sourceSessionDisplayName ?? resolveSessionDisplayName(active.sourceSessionKey),
           })}
         </div>`
       : nothing}

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -24,8 +24,10 @@ import {
   resolveChatPaneObserverRunId,
 } from "../../lib/observer-digest.ts";
 import { hasSessionPresenceViewers } from "../../lib/presence-users.ts";
+import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
+  areUiSessionKeysEquivalent,
   buildAgentMainSessionKey,
   resolveUiConfiguredMainKey,
 } from "../../lib/sessions/session-key.ts";
@@ -149,6 +151,16 @@ export class ChatPane extends ChatPaneLayoutRender {
     const inlineApproval =
       findInlineApproval(state.chatSessionApprovalQueue ?? [], state.sessionKey) ??
       findInlineApproval(overlays?.snapshot?.approvalQueue ?? [], state.sessionKey);
+    // Resolve the source session display name for the inline approval card
+    const sourceSessionKey = inlineApproval?.sourceSessionKey?.trim();
+    const sourceSessionRow = sourceSessionKey
+      ? state.sessionsResult?.sessions?.find((row) =>
+          areUiSessionKeysEquivalent(row.key, sourceSessionKey),
+        )
+      : undefined;
+    const inlineApprovalSourceSessionDisplayName = sourceSessionKey
+      ? resolveSessionDisplayName(sourceSessionKey, sourceSessionRow)
+      : undefined;
     // Tool rows consult the global title store while rendering. Requests capture
     // session + agent at schedule time, so another pane cannot re-route them.
     configureToolTitleFetcher({
@@ -416,6 +428,9 @@ export class ChatPane extends ChatPaneLayoutRender {
       diskSpace,
       runError: catalogKey ? null : (state.chatRunError ?? placementRunError),
       inlineApproval: sessionParticipationBlocked ? null : inlineApproval,
+      inlineApprovalSourceSessionDisplayName: sessionParticipationBlocked
+        ? undefined
+        : inlineApprovalSourceSessionDisplayName,
       approvalBusy: overlays?.snapshot?.approvalBusy,
       approvalCanGrant: overlays?.snapshot?.approvalCanGrant ?? false,
       approvalErrors: overlays?.snapshot?.approvalErrors,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -74,6 +74,7 @@ export type ChatProps = Omit<
     error: string | null;
     diskSpace?: SessionPlacementDiskSpace;
     inlineApproval?: ExecApprovalRequest | null;
+    inlineApprovalSourceSessionDisplayName?: string;
     approvalBusy?: boolean;
     approvalCanGrant: boolean;
     approvalErrors?: ReadonlyMap<string, string>;
@@ -356,6 +357,7 @@ export function renderChat(props: ChatProps) {
                           canGrant: props.approvalCanGrant,
                           error: props.approvalErrors?.get(props.inlineApproval.id) ?? null,
                           variant: "inline",
+                          sourceSessionDisplayName: props.inlineApprovalSourceSessionDisplayName,
                           onDecision: props.onApprovalDecision,
                         })}
                       </div>`


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Control UI approval shown in a different presentation session says "Approval requested by session New session" even when the requesting dashboard session already has a name.

## Why This Change Was Made

The inline approval card called `resolveSessionDisplayName(sourceSessionKey)` with only the key, without passing the existing session metadata (`label`, `displayName`, `derivedTitle`). The resolver then fell through to the "New session" fallback for dashboard keys.

The fix threads the resolved display name from the session list through the component tree as a separate prop, preserving routing and permission decisions while using the already-loaded canonical session metadata.

## User Impact

Operators reviewing approvals projected into another session now see the correct requesting session name (e.g., "Release checklist" instead of "New session"), improving clarity about where the request originated.

## Evidence

- Sidebar already follows this pattern (`sidebar-issue-item.ts:57-71`) - this fix applies the same pattern to the inline card
- The new prop is optional, so backward compatibility is preserved
- Uses the canonical `resolveSessionDisplayName` with full `SessionDisplayRow` metadata

Closes #136083
