### PR TITLE
fix(ci): pin iOS screenshot evidence to workflow revision

### DIFF
--- a/.github/actions/git-owner/owner.py
+++ b/.github/actions/git-owner/owner.py
@@ -363,26 +363,30 @@ def checkout_selected_ref():
 
 def checkout_harness(sha):
     action = ".github/actions/setup-node-env/action.yml"
+    evidence_scripts = ("scripts/ios-screenshot-evidence.mjs", "scripts/lib/direct-run.mjs")
     if kind == "linux-node" and not os.path.isfile(os.path.join(workspace, action)):
         raise GitFailure(1)
     harness = os.path.join(workspace, ".ci-harness")
     os.makedirs(harness, exist_ok=True)
     if sha == os.environ["WORKFLOW_SHA"]:
         # Export the workflow revision from the freshly populated index, replacing
-        # retained platform files without updating the index or trusting later edits.
+        # retained harness files without updating the index or trusting later edits.
         pathspecs = [".github/actions"]
-        if kind == "preflight":
+        if kind in ("platform", "linux-node"):
+            pathspecs += evidence_scripts
+        elif kind == "preflight":
             pathspecs += ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"]
         paths = git_output(workspace, "ls-files", "-z", "--", *pathspecs).split("\0")[:-1]
         run_git(workspace, "checkout-index", "--force", f"--prefix={harness}/", "--", *paths)
     else:
         run_git(harness, "init", harness)
         run_git(harness, "remote", "add", "origin", remote)
-        # The harness only supplies .github/actions, so narrow the fetch before it runs:
-        # sparse first, then blob-less. A full snapshot here downloads a second copy of
-        # the repository that the checkout below immediately discards, and every extra
-        # byte is amplified by the shared runner egress.
-        run_git(harness, "sparse-checkout", "set", ".github/actions")
+        sparse_paths = ["/.github/actions/"]
+        if kind in ("platform", "linux-node"):
+            sparse_paths += [f"/{path}" for path in evidence_scripts]
+        # Rooted non-cone patterns keep the kind-owned workflow files exact.
+        # Sparse first, then blob-less avoids downloading a second repository snapshot.
+        run_git(harness, "sparse-checkout", "set", "--no-cone", *sparse_paths)
         fetch(harness, f"+{os.environ['WORKFLOW_SHA']}:refs/remotes/origin/ci-harness",
               max_attempts=1, blobless=True)
         # Checkout now materializes the sparse blobs over the network, so it carries the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,26 +575,30 @@ jobs:
 
           def checkout_harness(sha):
               action = ".github/actions/setup-node-env/action.yml"
+              evidence_scripts = ("scripts/ios-screenshot-evidence.mjs", "scripts/lib/direct-run.mjs")
               if kind == "linux-node" and not os.path.isfile(os.path.join(workspace, action)):
                   raise GitFailure(1)
               harness = os.path.join(workspace, ".ci-harness")
               os.makedirs(harness, exist_ok=True)
               if sha == os.environ["WORKFLOW_SHA"]:
                   # Export the workflow revision from the freshly populated index, replacing
-                  # retained platform files without updating the index or trusting later edits.
+                  # retained harness files without updating the index or trusting later edits.
                   pathspecs = [".github/actions"]
-                  if kind == "preflight":
+                  if kind in ("platform", "linux-node"):
+                      pathspecs += evidence_scripts
+                  elif kind == "preflight":
                       pathspecs += ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"]
                   paths = git_output(workspace, "ls-files", "-z", "--", *pathspecs).split("\0")[:-1]
                   run_git(workspace, "checkout-index", "--force", f"--prefix={harness}/", "--", *paths)
               else:
                   run_git(harness, "init", harness)
                   run_git(harness, "remote", "add", "origin", remote)
-                  # The harness only supplies .github/actions, so narrow the fetch before it runs:
-                  # sparse first, then blob-less. A full snapshot here downloads a second copy of
-                  # the repository that the checkout below immediately discards, and every extra
-                  # byte is amplified by the shared runner egress.
-                  run_git(harness, "sparse-checkout", "set", ".github/actions")
+                  sparse_paths = ["/.github/actions/"]
+                  if kind in ("platform", "linux-node"):
+                      sparse_paths += [f"/{path}" for path in evidence_scripts]
+                  # Rooted non-cone patterns keep the kind-owned workflow files exact.
+                  # Sparse first, then blob-less avoids downloading a second repository snapshot.
+                  run_git(harness, "sparse-checkout", "set", "--no-cone", *sparse_paths)
                   fetch(harness, f"+{os.environ['WORKFLOW_SHA']}:refs/remotes/origin/ci-harness",
                         max_attempts=1, blobless=True)
                   # Checkout now materializes the sparse blobs over the network, so it carries the
@@ -4905,10 +4909,10 @@ jobs:
             --fastlane-version "$fastlane_version"
             --node-version "$(node --version)"
           )
-          node scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
+          node .ci-harness/scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
           if [[ "$DEVICE_FAMILY" == "ipad-13" ]]; then
             collect_args[2]="watch"
-            node scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
+            node .ci-harness/scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
           fi
 
       - name: Upload iOS screenshot shard evidence
@@ -4965,7 +4969,7 @@ jobs:
           TARGET_SHA: ${{ needs.preflight.outputs.checkout_revision }}
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
-          node scripts/ios-screenshot-evidence.mjs reduce \
+          node .ci-harness/scripts/ios-screenshot-evidence.mjs reduce \
             --input apps/ios/build/ScreenshotEvidenceInputs \
             --output . \
             --target-sha "$TARGET_SHA" \

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -84,6 +84,8 @@ const repositoryScriptEntries = [
   "scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs!",
   "scripts/embedded-run-abort-leak.ts!",
   "scripts/fixtures/packed-plugin-sdk-type-smoke.ts!",
+  // CI executes screenshot evidence from the workflow-owned harness copy.
+  "scripts/ios-screenshot-evidence.mjs!",
   "scripts/ios-release-cut.ts!",
   "scripts/ios-release-plan.ts!",
   "scripts/ios-release-signing.mts!",

--- a/scripts/ios-screenshot-evidence.d.mts
+++ b/scripts/ios-screenshot-evidence.d.mts
@@ -31,8 +31,3 @@ export function reduceIosScreenshotEvidence(options: {
   outputRoot: string;
   expectedProvenance: IosScreenshotProvenance;
 }): Record<string, unknown>;
-
-export function parseIosScreenshotEvidenceArgs(argv: string[]): {
-  command: string | undefined;
-  options: Record<string, string>;
-};

--- a/scripts/ios-screenshot-evidence.mjs
+++ b/scripts/ios-screenshot-evidence.mjs
@@ -714,7 +714,7 @@ export function reduceIosScreenshotEvidence({ inputDirectory, outputRoot, expect
   return combinedManifest;
 }
 
-export function parseIosScreenshotEvidenceArgs(argv) {
+function parseIosScreenshotEvidenceArgs(argv) {
   const [command, ...rest] = argv;
   const options = {};
   for (let index = 0; index < rest.length; index += 2) {

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -215,7 +215,9 @@ it.concurrent.each([
           );
           expect(
             report.commands.some(
-              ({ args }) => args.join(" ") === "sparse-checkout set .github/actions",
+              ({ args }) =>
+                args.join(" ") ===
+                "sparse-checkout set --no-cone /.github/actions/ /scripts/ios-screenshot-evidence.mjs /scripts/lib/direct-run.mjs",
             ),
           ).toBe(true);
           expect(report.commands.at(-1)?.args).toEqual([
@@ -234,16 +236,23 @@ it.concurrent.each([
 it.concurrent.each([
   ...[
     ...(process.platform === "win32" ? [] : [{ kind: "linux-node", retained: false }]),
+    ...(process.platform === "win32"
+      ? []
+      : [{ kind: "linux-node", retained: false, workflow: "previous", fetches: 2 }]),
     { kind: "platform", retained: false },
     { kind: "platform", retained: true },
+    { kind: "platform", retained: false, workflow: "previous", fetches: 2 },
   ].map((entry) =>
-    Object.assign(entry, {
-      event: "push",
-      workflow: "same",
-      target: "selected",
-      code: 0,
-      fetches: 1,
-    }),
+    Object.assign(
+      {
+        event: "push",
+        workflow: "same",
+        target: "selected",
+        code: 0,
+        fetches: 1,
+      },
+      entry,
+    ),
   ),
   ...(process.platform === "win32"
     ? []
@@ -297,6 +306,10 @@ it.concurrent.each([
       ".github/actions/tool/with space.txt": "literal action bytes\n",
       ...(posix ? { [executable]: "#!/bin/sh\nexit 0\n" } : {}),
     };
+    const evidenceScripts = {
+      "scripts/ios-screenshot-evidence.mjs": "workflow evidence script\n",
+      "scripts/lib/direct-run.mjs": "workflow direct-run script\n",
+    };
     const releasePolicy = Object.fromEntries(
       ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"].map((name) => [
         name,
@@ -312,6 +325,7 @@ it.concurrent.each([
     let revision = "";
     let workflowRevision = "";
     let candidateAction = files[action];
+    let candidateEvidenceScripts: Record<string, string> = evidenceScripts;
     await withCiCheckoutFixture(
       `${linux ? "linux:" : ""}configured`,
       (root) => {
@@ -341,6 +355,7 @@ it.concurrent.each([
         run("init");
         for (const [name, contents] of Object.entries({
           ...files,
+          ...evidenceScripts,
           ...releasePolicy,
           ...candidateFiles,
         })) {
@@ -363,7 +378,16 @@ it.concurrent.each([
         if (workflow === "previous") {
           candidateAction = "name: candidate action must not replace the trusted workflow\n";
           writeFileSync(path.join(source, action), candidateAction);
-          run("add", action);
+          candidateEvidenceScripts = Object.fromEntries(
+            Object.keys(evidenceScripts).map((name) => [
+              name,
+              `candidate ${path.basename(name)} must not replace the trusted workflow\n`,
+            ]),
+          );
+          for (const [name, contents] of Object.entries(candidateEvidenceScripts)) {
+            writeFileSync(path.join(source, name), contents);
+          }
+          run("add", action, ...Object.keys(evidenceScripts));
           run("commit", "--no-gpg-sign", "-m", "selected candidate");
           revision = run("rev-parse", "HEAD");
         } else if (workflow === "missing") {
@@ -438,6 +462,12 @@ it.concurrent.each([
           expect(readFileSync(path.join(workspace, name), "utf8")).toBe(contents);
           expect(existsSync(path.join(harness, name))).toBe(false);
         }
+        const workflowOwnsEvidence = kind === "platform" || kind === "linux-node";
+        for (const name of Object.keys(evidenceScripts)) {
+          expect(readFileSync(path.join(workspace, name), "utf8")).toBe(
+            candidateEvidenceScripts[name],
+          );
+        }
         if (workflow === "missing-action") {
           expect(existsSync(path.join(workspace, action))).toBe(false);
           expect(existsSync(path.join(harness, action))).toBe(false);
@@ -449,9 +479,17 @@ it.concurrent.each([
           expect(existsSync(harness)).toBe(false);
           return;
         }
-        expect(existsSync(path.join(harness, ".git"))).toBe(false);
+        if (workflow === "same") {
+          expect(existsSync(path.join(harness, ".git"))).toBe(false);
+        }
         for (const [name, contents] of Object.entries(files)) {
           expect(readFileSync(path.join(harness, name), "utf8")).toBe(contents);
+        }
+        for (const [name, contents] of Object.entries(evidenceScripts)) {
+          expect(existsSync(path.join(harness, name))).toBe(workflowOwnsEvidence);
+          if (workflowOwnsEvidence) {
+            expect(readFileSync(path.join(harness, name), "utf8")).toBe(contents);
+          }
         }
         for (const [name, contents] of Object.entries(releasePolicy)) {
           expect(existsSync(path.join(harness, name))).toBe(preflight);
@@ -464,6 +502,16 @@ it.concurrent.each([
         if (posix) {
           expect(statSync(path.join(harness, executable)).mode & 0o111).toBe(0o111);
           expect(readlinkSync(path.join(harness, link))).toBe("line\nbreak.sh");
+        }
+        if (workflow !== "same" && workflowOwnsEvidence) {
+          expect(report.commands.find(({ args }) => args[0] === "sparse-checkout")?.args).toEqual([
+            "sparse-checkout",
+            "set",
+            "--no-cone",
+            "/.github/actions/",
+            "/scripts/ios-screenshot-evidence.mjs",
+            "/scripts/lib/direct-run.mjs",
+          ]);
         }
         writeFileSync(path.join(workspace, action), "later candidate edit\n");
         expect(readFileSync(path.join(harness, action), "utf8")).toBe(files[action]);

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -500,7 +500,8 @@ it.concurrent.each([
           }
         }
         if (posix) {
-          expect(statSync(path.join(harness, executable)).mode & 0o111).toBe(0o111);
+          // Git tracks only executable state; checkout materialization applies the process umask.
+          expect(statSync(path.join(harness, executable)).mode & 0o111).not.toBe(0);
           expect(readlinkSync(path.join(harness, link))).toBe("line\nbreak.sh");
         }
         if (workflow !== "same" && workflowOwnsEvidence) {

--- a/test/scripts/ios-release-fastlane-gates.test.ts
+++ b/test/scripts/ios-release-fastlane-gates.test.ts
@@ -625,6 +625,11 @@ describe("iOS Fastlane release upload gates", () => {
     expect(shardJob).toContain("run_ios_fastlane ios watch_screenshot");
     expect(shardJob).toContain("run: pnpm ios:screenshots");
     expect(shardJob).toContain("id: package_screenshot_evidence");
+    expect(shardJob).toContain('if [[ "$DEVICE_FAMILY" == "ipad-13" ]]; then');
+    expect(
+      shardJob.match(/node \.ci-harness\/scripts\/ios-screenshot-evidence\.mjs/g),
+    ).toHaveLength(2);
+    expect(shardJob).not.toContain("node scripts/ios-screenshot-evidence.mjs");
     expect(shardJob).toContain("steps.package_screenshot_evidence.outcome == 'failure'");
     expect(shardJob).toContain("apps/ios/build/SnapshotTestResults/capture-attempts.json");
     expect(shardJob).not.toContain("IOS_SCREENSHOT_FASTLANE_VERSION");
@@ -639,7 +644,8 @@ describe("iOS Fastlane release upload gates", () => {
     expect(reducerJob).toContain("Setup screenshot evidence Node");
     expect(reducerJob).toContain("node-version: ${{ env.IOS_SCREENSHOT_NODE_VERSION }}");
     expect(reducerJob).toContain("id: reduce_screenshot_evidence");
-    expect(reducerJob).toContain("scripts/ios-screenshot-evidence.mjs reduce");
+    expect(reducerJob).toContain("node .ci-harness/scripts/ios-screenshot-evidence.mjs reduce");
+    expect(reducerJob).not.toContain("node scripts/ios-screenshot-evidence.mjs");
     expect(reducerJob).toContain('--workflow-sha "$WORKFLOW_SHA"');
     expect(reducerJob).toContain('--run-id "$RUN_ID"');
     expect(reducerJob).toContain('--run-attempt "$RUN_ATTEMPT"');


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Full Release Validation run targeting an older commit could package iOS screenshot evidence with the target commit's parser even though screenshot-family ownership came from the newer workflow revision. When Watch capture moved from the iPhone shard to the iPad shard, that split-SHA mismatch made valid evidence fail topology validation.

Failure evidence: https://github.com/openclaw/openclaw/actions/runs/33627219129

## Why This Change Was Made

The workflow revision now owns the screenshot evidence parser and its direct runtime dependency through `.ci-harness`, alongside the existing workflow-owned actions. Both same-revision and split-revision platform/Linux checkout paths materialize those exact files, while the candidate workspace remains unchanged.

The shard collector and Linux reducer execute the workflow-owned parser. Target-side parser invocations are removed.

## User Impact

Maintainers can run Full Release Validation against historical tags or SHAs without screenshot evidence being interpreted by stale target-side topology rules.

## Evidence

- Red-before proof on pre-fix `main`: the focused split-revision checkout cases and iOS workflow assertion fail because the harness does not own the evidence parser.
- Green-after proof: `75 passed` across:
  - `test/scripts/ci-platform-checkout.test.ts`
  - `test/scripts/ios-release-fastlane-gates.test.ts`
- `actionlint .github/workflows/ci.yml`
- `oxfmt --check` on all three changed files
- `git diff --check origin/main...HEAD`
- Exact-head autoreview: scoped clean at P1
- `scripts/check-workflows.mts` reached its Python tool bootstrap but the configured package mirror does not yet provide `pre-commit==4.6.2`; no workflow validation defect was reported.

Architectural owner: workflow-revision checkout harness.

Sibling coverage: both `platform` and `linux-node`, same-revision index export and split-revision sparse fetch.

LOC: workflow/tooling `+14/-10` (net `+4`); tests `+65/-11` (net `+54`).
