### PR TITLE
test(android): await outbox publication in branch fixture

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -1076,6 +1076,8 @@ class ChatControllerBranchCoordinationTest {
 
     suspend fun admit(): ChatOutboxItem {
       assertTrue(controller.sendMessageAwaitAcceptance("retained input", "off", listOf(attachment)))
+      // Admission owns durability; a newer refresh may still own the visible snapshot.
+      awaitBranchProgress { controller.outboxItems.value.isNotEmpty() }
       return controller.outboxItems.value.single().also {
         assertEquals(ChatOutboxStatus.Queued, it.status)
         assertEquals("retained input", it.text)


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Android branch-coordination CI could fail before exercising its history-replacement scenario, even though the submitted input was durably queued.

## Why This Change Was Made

`sendMessageAwaitAcceptance` confirms durable admission, not completion of the latest outbox presentation refresh. A newer refresh can supersede the send's own publication and still be loading when admission returns. The shared fixture now waits for a nonempty published outbox using its existing bounded `awaitBranchProgress` helper, then runs the unchanged single-row, Queued-state, text, attachment, branch-ownership, and exact-once-delivery assertions.

## User Impact

No application behavior changes. This is a two-line test correction: production +0/-0, tests +2/-0. It does not change timeouts, scheduler pumping, dispatch ownership, database behavior, or the deliberately blocked history/branch scenarios.

## Evidence

- **Observed CI failure:** [Android ThirdParty job 100255509018](https://github.com/openclaw/openclaw/actions/runs/33632313697/job/100255509018), at `39824f9ab80eed6e18f1206dcdb4b9f5b03ac568`, completed 2,710 tests with one failure. `inputAdmittedBeforeExternalFinalHistorySurvivesForExplicitRetry` threw `NoSuchElementException: List is empty` in the shared `admit()` helper at line 1079, immediately after successful durable admission.
- **Controlled contract proof:** one temporary native JUnit diagnostic passed against unchanged production at that commit, using the real Room outbox. Holding two completed reads proved that admission can return true while the original `.single()` throws, with the same queued row and attachment bytes still in Room. Releasing the newer read published that exact row. The diagnostic passed 1/1 with no failures or skips (4.19 seconds suite time) and was removed from the final patch.
- **Original two-line candidate:** complete `ChatControllerBranchCoordinationTest` and `ChatControllerOutboxTest` suites passed in both Play and ThirdParty: 45 + 77 tests per flavor, **244 executions, zero failures/errors/skips**. Both native test tasks used `--rerun`; compilation could reuse existing build caches. The recorded 759 source-file hashes stayed unchanged during the run, and the diagnostic was absent.

The complete app `ktlintCheck` passed without source changes. Independent Codex P0–P2 review found no actionable findings.

The counterexample proves the fixture's synchronous-publication assumption is invalid; it does not establish which competing refresh actually won in hosted CI or identify an introducing commit. These are native JVM/Room tests, not physical-device or provider proof. Exact-head hosted CI for this test-only change remains a separate check.

### Current-head verification

The CI-budget parent #136307 is merged. This PR now targets `main` at `76c145484aa89acd5de2e7c99a19f114a072414d`, with only the two reviewed test lines in its diff. All four affected production/test owner files are byte-identical across the mechanical rebase.

The complete branch-coordination and outbox suites were rerun on this exact clean commit: **244 actual executions, zero failures/errors/skips**, in 90.757 seconds. Both flavor test tasks used `--rerun`; all 759 captured source facts and HEAD remained unchanged. A fresh managed Codex P0–P2 review completed both evidence passes with no actionable findings. [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33641453340/attempts/2) passed, including [the selected-lane aggregate](https://github.com/openclaw/openclaw/actions/runs/33641453340/job/100299126583): 9 successful jobs and 26 intentional skips. This includes the full selected Play/ThirdParty/Wear test and build lanes plus lint and security; carried first-attempt successes are not claimed as fresh executions.


The first attempt's security job failed while Docker pulled the pinned scanner image from GHCR, before scanning began. The remaining lint job was unassigned with no steps; no job was executing when that already-failed attempt was cancelled. The normal failed-job retry reran security and lint on the existing hosted route and both passed. No scanner bypass, dependency change, global runner setting, or test assertion was introduced. The latest ClawSweeper review of this exact commit reports no actionable findings or remaining rank-up work.
