### PR TITLE
fix: release publication loses standalone preflight artifacts

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -125,6 +125,7 @@ jobs:
     outputs:
       sha: ${{ steps.manifest.outputs.sha || steps.ref.outputs.sha }}
       preflight_artifact_name: ${{ steps.preflight_artifact.outputs.name }}
+      preflight_artifact_run_id: ${{ steps.preflight_artifact.outputs.run_id }}
       preflight_tarball_sha256: ${{ steps.manifest.outputs.tarball_sha256 }}
       full_release_validation_run_attempt: ${{ steps.full_run.outputs.attempt }}
       focused_release_evidence_run_attempt: ${{ steps.focused_run.outputs.attempt }}
@@ -1175,6 +1176,9 @@ jobs:
     name: Publish plugins, then OpenClaw
     needs: [resolve_release_target]
     if: ${{ !inputs.publish_docker_only }}
+    env:
+      # Artifact bytes may belong to an FRV child; the input run still authorizes npm dispatch.
+      PREFLIGHT_ARTIFACT_RUN_ID: ${{ needs.resolve_release_target.outputs.preflight_artifact_run_id }}
     permissions:
       actions: write
       attestations: write

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -589,7 +589,7 @@ resolve_openclaw_npm_publish_state() {
   manifest_dir="${RUNNER_TEMP}/openclaw-npm-resume-preflight"
   rm -rf "${manifest_dir}"
   mkdir -p "${manifest_dir}"
-  gh run download "${PREFLIGHT_RUN_ID}" \
+  gh run download "${PREFLIGHT_ARTIFACT_RUN_ID}" \
     --repo "${GITHUB_REPOSITORY}" \
     --name "${artifact_name}" \
     --dir "${manifest_dir}"
@@ -597,7 +597,7 @@ resolve_openclaw_npm_publish_state() {
   manifest_sha="$(jq -er '.releaseSha' "${manifest_path}")"
   manifest_tarball_sha="$(jq -er '.tarballSha256' "${manifest_path}")"
   if [[ "${manifest_sha}" != "${TARGET_SHA}" ]]; then
-    echo "openclaw@${release_version} is already on npm but preflight ${PREFLIGHT_RUN_ID} was built from ${manifest_sha}, not ${TARGET_SHA}; refusing to resume." >&2
+    echo "openclaw@${release_version} is already on npm but preflight ${PREFLIGHT_ARTIFACT_RUN_ID} was built from ${manifest_sha}, not ${TARGET_SHA}; refusing to resume." >&2
     exit 1
   fi
   published_tarball_url="$(npm view "openclaw@${release_version}" dist.tarball)"
@@ -1002,7 +1002,7 @@ upload_dependency_evidence_release_asset() {
 
   rm -rf "${download_dir}" "${asset_path}"
   mkdir -p "${download_dir}"
-  gh run download "${PREFLIGHT_RUN_ID}" \
+  gh run download "${PREFLIGHT_ARTIFACT_RUN_ID}" \
     --repo "${GITHUB_REPOSITORY}" \
     --name "${artifact_name}" \
     --dir "${download_dir}"
@@ -1279,7 +1279,7 @@ append_release_proof_to_github_release() {
     RELEASE_TARBALL="${tarball}" \
     RELEASE_INTEGRITY="${integrity}" \
     RELEASE_PUBLISH_RUN_ID="${GITHUB_RUN_ID}" \
-    PREFLIGHT_RUN_ID="${PREFLIGHT_RUN_ID}" \
+    PREFLIGHT_ARTIFACT_RUN_ID="${PREFLIGHT_ARTIFACT_RUN_ID}" \
     RELEASE_VALIDATION_LABEL="${proof_label}" \
     RELEASE_VALIDATION_RUN_ID="${proof_run_id}" \
     PLUGIN_NPM_RUN_ID="${plugin_npm_run_id}" \
@@ -1306,7 +1306,7 @@ const section = [
   `- release SHA: \`${process.env.RELEASE_SHA}\``,
   `- full release CI report: https://github.com/openclaw/releases/blob/main/evidence/${process.env.RELEASE_VERSION}/release-evidence.md`,
   `- release publish: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.RELEASE_PUBLISH_RUN_ID}`,
-  `- npm preflight: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.PREFLIGHT_RUN_ID}`,
+  `- npm preflight: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.PREFLIGHT_ARTIFACT_RUN_ID}`,
   `- ${process.env.RELEASE_VALIDATION_LABEL}: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.RELEASE_VALIDATION_RUN_ID}`,
   `- plugin npm publish: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.PLUGIN_NPM_RUN_ID}`,
   process.env.CLAWHUB_LINE,

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -294,7 +294,10 @@ function releasePublishOrchestration(job: WorkflowJob): WorkflowStep {
   return { ...dispatch, run: [functions, ...(phases ?? []).map((step) => step.run)].join("\n") };
 }
 
-function createReleasePublishFixture(overrides: Record<string, string> = {}) {
+function createReleasePublishFixture(
+  overrides: Record<string, string> = {},
+  { functions = "", mockEvidence = true } = {},
+) {
   const root = tempDirs.make("release-publish-phases-");
   const eventsPath = join(root, "events");
   const outputPath = join(root, "output");
@@ -336,9 +339,10 @@ promote_windows_release_assets() { record windows; }
 verify_published_release() {
   record "verify:$clawhub_failed:bootstrap=$plugin_clawhub_bootstrap_completed:workflow=$openclaw_npm_expected_workflow_ref"
 }
-upload_dependency_evidence_release_asset() { record dependency-evidence; }
+${mockEvidence ? "upload_dependency_evidence_release_asset() { record dependency-evidence; }" : ""}
 upload_release_evidence_assets() { record release-evidence; }
-append_release_proof_to_github_release() { record proof; }
+${mockEvidence ? "append_release_proof_to_github_release() { record proof; }" : ""}
+${functions}
 `,
   );
   const outputs = () =>
@@ -349,6 +353,7 @@ append_release_proof_to_github_release() { record proof; }
         .map((line) => [line.slice(0, line.indexOf("=")), line.slice(line.indexOf("=") + 1)]),
     );
   return {
+    root,
     events: () => readFileSync(eventsPath, "utf8").trim().split("\n"),
     outputs,
     record: (event: string) => writeFileSync(eventsPath, `${event}\n`, { flag: "a" }),
@@ -1725,7 +1730,7 @@ exit 64
 `,
     { mode: 0o755 },
   );
-  return spawnSync("bash", ["-c", script], {
+  const result = spawnSync("bash", ["-c", script], {
     cwd: workdir,
     encoding: "utf8",
     env: {
@@ -1759,6 +1764,7 @@ exit 64
       WORKFLOW_SHA: params.currentWorkflowSha,
     },
   });
+  return { ...result, outputPath: resolve(workdir, "github-output") };
 }
 
 async function runOpenClawNpmPreflightConsumerGuard(params: ProtectedPreflightConsumerParams) {
@@ -2610,6 +2616,154 @@ describe("package acceptance workflow", () => {
       }
     },
   );
+
+  it.each([
+    { name: "standalone FRV", fullReleasePreflight: true, independentProducer: true },
+    { name: "direct FRV", fullReleasePreflight: true, independentProducer: false },
+    { name: "historical NPM", fullReleasePreflight: false, independentProducer: false },
+  ])("carries the $name artifact owner without replacing publication authority", async (mode) => {
+    const producerRunId = mode.independentProducer ? "333" : "111";
+    const fullReleaseRunId = mode.fullReleasePreflight ? "111" : "222";
+    const resolved = await runReleasePublishPreflightConsumerGuard({
+      ...mode,
+      currentRef: "refs/heads/main",
+      currentWorkflowSha: "b".repeat(40),
+      preflightHeadBranch: "main",
+      preflightHeadSha: "a".repeat(40),
+    });
+    expect(resolved.status, resolved.stderr).toBe(0);
+    const stepOutputs = Object.fromEntries(
+      readFileSync(resolved.outputPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => line.split("=")),
+    );
+    const target = workflowJob(RELEASE_PUBLISH_WORKFLOW, "resolve_release_target");
+    const expressions: Record<string, string> = {
+      "${{ inputs.preflight_run_id }}": "111",
+      "${{ inputs.full_release_validation_run_id }}": fullReleaseRunId,
+    };
+    for (const [name, value] of Object.entries(target.outputs ?? {})) {
+      const field = value.match(/^\$\{\{ steps\.preflight_artifact\.outputs\.(\w+) \}\}$/u)?.[1];
+      if (field) {
+        expressions[`\${{ needs.resolve_release_target.outputs.${name} }}`] = stepOutputs[field];
+      }
+    }
+    const publish = workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish");
+    const stepEnv = (step: WorkflowStep) =>
+      Object.fromEntries(
+        Object.entries({ ...publish.env, ...step.env })
+          .filter(([, value]) => value in expressions)
+          .map(([key, value]) => [key, expressions[value]]),
+      );
+    const fixture = createReleasePublishFixture(
+      {
+        EXPECTED_PRODUCER_RUN_ID: producerRunId,
+        RELEASE_TAG: "v2026.8.1-beta.3",
+        TARGET_SHA: "d".repeat(40),
+        OPENCLAW_NPM_RESUME_RUN_ID: "777",
+        NPM_TELEGRAM_RUN_ID: "",
+      },
+      {
+        mockEvidence: false,
+        functions: `
+gh() {
+  if [[ "$1 $2" == "run download" ]]; then
+    record "download:$3"
+    if [[ "$3" != "$EXPECTED_PRODUCER_RUN_ID" ]]; then
+      echo "artifact belongs to $EXPECTED_PRODUCER_RUN_ID, not $3" >&2
+      return 41
+    fi
+    shift 3
+    local destination=""
+    while (( $# )); do
+      if [[ "$1" == "--dir" ]]; then destination="$2"; shift; fi
+      shift
+    done
+    cp "$RUNNER_TEMP/preflight-manifest.json" "$destination/"
+    cp -R "$RUNNER_TEMP/dependency-evidence" "$destination/"
+  elif [[ "$1 $2" == "release edit" ]]; then
+    record notes
+  else return 99; fi
+}
+npm() { printf '%s\\n' 'https://example.invalid/openclaw.tgz'; }
+curl() {
+  while [[ "$1" != "-o" ]]; do shift; done
+  cp "$RUNNER_TEMP/registry.tgz" "$2"
+}
+node() {
+  if [[ "\${3:-}" == "$GITHUB_WORKSPACE/.release-harness/scripts/openclaw-npm-resume-run.mts" ]]; then
+    printf '%s\\n' '{"url":"https://example.invalid/runs/777","workflowRef":"refs/tags/release-publish-verified","workflowSha":"${"a".repeat(40)}"}'
+  else command node "$@"; fi
+}
+zip() { cat > "$3"; }
+attach_or_verify_release_asset() { record "asset:$(cat "$1")"; }
+write_clawhub_runtime_state() { printf '%s\\n' '{"proofLines":{"normal":"normal","bootstrap":"bootstrap"}}' > "$1"; }
+render_github_release_notes() { cp "$2" "$1"; printf '%s\\n' '{"verificationIncluded":true}' > "$3"; }
+`,
+      },
+    );
+    const tarball = Buffer.from("published candidate bytes");
+    writeFileSync(join(fixture.root, "registry.tgz"), tarball);
+    writeFileSync(
+      join(fixture.root, "preflight-manifest.json"),
+      JSON.stringify({
+        releaseSha: "d".repeat(40),
+        tarballSha256: createHash("sha256").update(tarball).digest("hex"),
+      }),
+    );
+    mkdirSync(join(fixture.root, "dependency-evidence"));
+    writeFileSync(join(fixture.root, "dependency-evidence/report.json"), "{}");
+    writeFileSync(
+      join(fixture.root, "release-postpublish-evidence.json"),
+      JSON.stringify({
+        openclawNpmTarball: "https://example.invalid/openclaw.tgz",
+        openclawNpmIntegrity: "sha512-fixture",
+      }),
+    );
+    const resume = fixture.run(
+      {
+        run: 'set -euo pipefail; source "$GITHUB_WORKSPACE/.release-harness/scripts/lib/release-publish-children.sh"; resolve_openclaw_npm_publish_state; [[ "$openclaw_npm_already_published" == true ]]',
+      },
+      stepEnv(workflowStep(publish, "Dispatch publish workflows")),
+    );
+    expect.soft(resume.status, resume.stderr).toBe(0);
+    const evidence = fixture.run(
+      {
+        run: 'set -euo pipefail; source "$GITHUB_WORKSPACE/.release-harness/scripts/lib/release-publish-children.sh"; upload_dependency_evidence_release_asset',
+      },
+      stepEnv(workflowStep(publish, "Complete publish workflows")),
+    );
+    expect.soft(evidence.status, evidence.stderr).toBe(0);
+    expect.soft(fixture.events()).toContain("asset:dependency-evidence/report.json");
+
+    const core = workflowStep(publish, "Start core npm publication");
+    const dispatched = fixture.run(core, stepEnv(core));
+    expect(dispatched.status, dispatched.stderr).toBe(0);
+    const dispatch = fixture.events().find((event) => event.startsWith("dispatch:"));
+    expect(dispatch).toContain("-f preflight_run_id=111");
+    expect(dispatch).toContain(`-f full_release_validation_run_id=${fullReleaseRunId}`);
+
+    const proof = fixture.run(
+      {
+        run: 'set -euo pipefail; source "$GITHUB_WORKSPACE/.release-harness/scripts/lib/release-publish-children.sh"; plugin_npm_run_id=101; openclaw_npm_run_id=404; windows_node_run_id=""; android_release_note=""; append_release_proof_to_github_release',
+      },
+      {
+        ...stepEnv(workflowStep(publish, "Complete publish workflows")),
+        POSTPUBLISH_EVIDENCE_DIR: fixture.root,
+      },
+    );
+    expect(proof.status, proof.stderr).toBe(0);
+    const proofText = readFileSync(join(fixture.root, "release-verification.md"), "utf8");
+    expect
+      .soft(proofText)
+      .toContain(
+        `- npm preflight: https://github.com/openclaw/openclaw/actions/runs/${producerRunId}`,
+      );
+    expect(proofText).toContain(
+      `- full release validation: https://github.com/openclaw/openclaw/actions/runs/${fullReleaseRunId}`,
+    );
+  });
 
   it("uses the canonical tooling identity verifier for token-bootstrap evidence", () => {
     const publishJob = workflowJob(PLUGIN_NPM_RELEASE_WORKFLOW, "publish_plugins_npm");


### PR DESCRIPTION
Related: #136105

## What Problem This Solves

Resolves a problem where release publication or resume would look for the npm preflight archive in the parent validation run after Full Release Validation moved artifact preparation into standalone child runs. The final dependency-evidence download would fail, and the npm-preflight proof link pointed to the wrong run.

## Why This Change Was Made

The resolver already authenticates the producer and records its run ID. This change carries that fact across the Actions job output to the two artifact consumers and the proof renderer. The original Full Release Validation parent remains the npm dispatch authority: replacing that input with a child ID would break its manifest-admission contract.

There is one producer-resolution path and no fallback, artifact rebuild, new workflow input, or relaxed verification. Direct-FRV and historical direct-NPM producers retain their existing behavior.

## User Impact

Release operators can complete publication and resume with the exact preflight archive selected by validation, and release notes link to the run that actually produced it. This changes publication tooling only, not the released application or candidate bytes.

## Evidence

- Captured RED before production edits: the standalone-producer case failed both real helper download bodies with producer 333 versus parent 111 and rendered the incorrect parent proof link. Direct-FRV and historical-NPM controls passed.
- After the repair, all three producer modes pass through the canonical resolver, workflow output/environment wiring, actual resume/download/proof bodies, and actual core-dispatch step. Core dispatch still receives the original authorizing parent.
- 460 tests passed across the existing package-acceptance workflow, prepared-bundle, npm-resume identity, and release-approval suites.
- Canonical changed-file gate, pinned workflow lint, shell syntax, and whitespace checks passed.
- Managed Codex autoreview returned scoped-clean at the repository-default P0 scope. Root independently reviewed the producer resolver, consuming helpers, authorization boundary, tests and retained RED/GREEN outputs.

These are local boundary tests with external GitHub/npm/archive operations stubbed. They do not claim a live artifact download or completed publication; hosted exact-head CI and the real release remain separate gates.

## Scope and release-note context

The repair adds four workflow lines to forward an existing authenticated fact; shell changes are net zero (+5/-5). Test/support changes are +158/-4 in the existing suite. No configuration, protocol, database, dependency, approval-policy or package-source changes. No old path is retained alongside the fix.

Release-note context: preserve the standalone npm preflight producer when downloading release dependency evidence, resuming publication and linking validation proof.
