### PR TITLE
fix(ui): request one usage row for Model Providers cost aggregates

### DIFF
--- a/ui/src/e2e/model-providers-progressive.e2e.test.ts
+++ b/ui/src/e2e/model-providers-progressive.e2e.test.ts
@@ -178,7 +178,13 @@ describeControlUiE2e("Control UI progressive Model Providers loading", () => {
         await gateway.resolveDeferred(moduleState === "cold" ? "models.authStatus" : "config.get");
         await waitForControlUiRoute(page, { routeId: "model-providers" });
         await gateway.waitForRequest("usage.status");
-        await gateway.waitForRequest("sessions.usage");
+        const usageRequest = await gateway.waitForRequest("sessions.usage");
+        expect(usageRequest.params).toMatchObject({
+          agentScope: "all",
+          groupBy: "family",
+          limit: 1,
+          includeContextWeight: false,
+        });
         const provider = page.locator('[data-provider-id="openai"]');
         await provider.waitFor();
         await expect.poll(async () => provider.textContent()).toContain("Credentials configured");

--- a/ui/src/lib/sessions/usage.test.ts
+++ b/ui/src/lib/sessions/usage.test.ts
@@ -88,47 +88,6 @@ describe("requestSessionUsage", () => {
     });
   });
 
-  it("threads an explicit limit through for aggregate-only callers", async () => {
-    const result = { sessions: [] };
-    const request = vi.fn().mockResolvedValue(result);
-
-    await requestSessionUsage(
-      { request } as never,
-      {
-        startDate: "2026-07-01",
-        endDate: "2026-07-28",
-        scope: "family",
-        timeZone: "utc",
-      },
-      { limit: 1 },
-    );
-    expect(request).toHaveBeenCalledWith("sessions.usage", {
-      startDate: "2026-07-01",
-      endDate: "2026-07-28",
-      agentScope: "all",
-      mode: "utc",
-      groupBy: "family",
-      limit: 1,
-      includeContextWeight: false,
-    });
-  });
-
-  it("keeps the detailed 1000-row default when no limit is given", async () => {
-    const result = { sessions: [] };
-    const request = vi.fn().mockResolvedValue(result);
-
-    await requestSessionUsage({ request } as never, {
-      startDate: "2026-07-01",
-      endDate: "2026-07-28",
-      scope: "family",
-      timeZone: "utc",
-    });
-    expect(request).toHaveBeenCalledWith(
-      "sessions.usage",
-      expect.objectContaining({ limit: 1000 }),
-    );
-  });
-
   it("surfaces a rejected request without retrying an older Gateway shape", async () => {
     const error = new GatewayRequestError({
       code: "INVALID_REQUEST",

--- a/ui/src/lib/sessions/usage.test.ts
+++ b/ui/src/lib/sessions/usage.test.ts
@@ -88,6 +88,47 @@ describe("requestSessionUsage", () => {
     });
   });
 
+  it("threads an explicit limit through for aggregate-only callers", async () => {
+    const result = { sessions: [] };
+    const request = vi.fn().mockResolvedValue(result);
+
+    await requestSessionUsage(
+      { request } as never,
+      {
+        startDate: "2026-07-01",
+        endDate: "2026-07-28",
+        scope: "family",
+        timeZone: "utc",
+      },
+      { limit: 1 },
+    );
+    expect(request).toHaveBeenCalledWith("sessions.usage", {
+      startDate: "2026-07-01",
+      endDate: "2026-07-28",
+      agentScope: "all",
+      mode: "utc",
+      groupBy: "family",
+      limit: 1,
+      includeContextWeight: false,
+    });
+  });
+
+  it("keeps the detailed 1000-row default when no limit is given", async () => {
+    const result = { sessions: [] };
+    const request = vi.fn().mockResolvedValue(result);
+
+    await requestSessionUsage({ request } as never, {
+      startDate: "2026-07-01",
+      endDate: "2026-07-28",
+      scope: "family",
+      timeZone: "utc",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "sessions.usage",
+      expect.objectContaining({ limit: 1000 }),
+    );
+  });
+
   it("surfaces a rejected request without retrying an older Gateway shape", async () => {
     const error = new GatewayRequestError({
       code: "INVALID_REQUEST",

--- a/ui/src/lib/sessions/usage.ts
+++ b/ui/src/lib/sessions/usage.ts
@@ -10,6 +10,7 @@ export type SessionUsageQuery = {
   scope: "instance" | "family";
   timeZone: "local" | "utc";
   agentId?: string;
+  limit?: number;
 };
 
 function formatUtcOffset(timezoneOffsetMinutes: number): string {
@@ -33,18 +34,14 @@ export function buildSessionUsageDateParams(timeZone: "local" | "utc") {
       };
 }
 
-function buildSessionUsageParams(
-  query: SessionUsageQuery,
-  key?: string,
-  limit?: number,
-): Record<string, unknown> {
+function buildSessionUsageParams(query: SessionUsageQuery, key?: string): Record<string, unknown> {
   return {
     startDate: query.startDate,
     endDate: query.endDate,
     ...(query.agentId ? { agentId: query.agentId } : key ? {} : { agentScope: "all" }),
     ...buildSessionUsageDateParams(query.timeZone),
     groupBy: query.scope,
-    ...(key ? { key, limit: 1 } : { limit: limit ?? 1000 }),
+    ...(key ? { key, limit: 1 } : { limit: query.limit ?? 1000 }),
     includeContextWeight: false,
   };
 }
@@ -52,10 +49,10 @@ function buildSessionUsageParams(
 export function requestSessionUsage(
   client: SessionRequestClient,
   query: SessionUsageQuery,
-  options?: { key?: string; limit?: number; includeContextWeight?: boolean; signal?: AbortSignal },
+  options?: { key?: string; includeContextWeight?: boolean; signal?: AbortSignal },
 ): Promise<SessionsUsageResult> {
   const params = {
-    ...buildSessionUsageParams(query, options?.key, options?.limit),
+    ...buildSessionUsageParams(query, options?.key),
     includeContextWeight: options?.includeContextWeight === true,
   };
   return options?.signal

--- a/ui/src/lib/sessions/usage.ts
+++ b/ui/src/lib/sessions/usage.ts
@@ -33,14 +33,18 @@ export function buildSessionUsageDateParams(timeZone: "local" | "utc") {
       };
 }
 
-function buildSessionUsageParams(query: SessionUsageQuery, key?: string): Record<string, unknown> {
+function buildSessionUsageParams(
+  query: SessionUsageQuery,
+  key?: string,
+  limit?: number,
+): Record<string, unknown> {
   return {
     startDate: query.startDate,
     endDate: query.endDate,
     ...(query.agentId ? { agentId: query.agentId } : key ? {} : { agentScope: "all" }),
     ...buildSessionUsageDateParams(query.timeZone),
     groupBy: query.scope,
-    ...(key ? { key, limit: 1 } : { limit: 1000 }),
+    ...(key ? { key, limit: 1 } : { limit: limit ?? 1000 }),
     includeContextWeight: false,
   };
 }
@@ -48,10 +52,10 @@ function buildSessionUsageParams(query: SessionUsageQuery, key?: string): Record
 export function requestSessionUsage(
   client: SessionRequestClient,
   query: SessionUsageQuery,
-  options?: { key?: string; includeContextWeight?: boolean; signal?: AbortSignal },
+  options?: { key?: string; limit?: number; includeContextWeight?: boolean; signal?: AbortSignal },
 ): Promise<SessionsUsageResult> {
   const params = {
-    ...buildSessionUsageParams(query, options?.key),
+    ...buildSessionUsageParams(query, options?.key, options?.limit),
     includeContextWeight: options?.includeContextWeight === true,
   };
   return options?.signal

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -266,6 +266,28 @@ describe("loadModelProvidersData", () => {
     });
   });
 
+  it("requests one detail row and returns complete provider cost aggregates", async () => {
+    const byProvider = [
+      { provider: "openai", count: 3, totals: { totalCost: 4.2, totalTokens: 1_500_000 } },
+    ];
+    const request = vi.fn().mockResolvedValue({ aggregates: { byProvider } });
+    const signal = new AbortController().signal;
+
+    await expect(
+      loadModelProviderCost({ request } as unknown as GatewayBrowserClient, signal),
+    ).resolves.toBe(byProvider);
+    expect(request).toHaveBeenCalledWith(
+      "sessions.usage",
+      expect.objectContaining({
+        agentScope: "all",
+        groupBy: "family",
+        limit: 1,
+        includeContextWeight: false,
+      }),
+      { signal },
+    );
+  });
+
   it.each(["before dispatch", "while pending"] as const)(
     "retires both supplemental requests when aborted %s",
     async (when) => {
@@ -295,15 +317,7 @@ describe("loadModelProvidersData", () => {
         if (when === "while pending") {
           expect(sent.map(({ method }) => method)).toEqual(["usage.status", "sessions.usage"]);
           expect(sent[0]?.params).toBeUndefined();
-          expect(sent[1]?.params).toMatchObject({
-            agentScope: "all",
-            groupBy: "family",
-            // Cost card consumes only aggregates.byProvider; request the
-            // smallest legal row set (schema minimum) instead of the
-            // shared Usage page's detailed 1000-row default.
-            limit: 1,
-            includeContextWeight: false,
-          });
+          expect(sent[1]?.params).toMatchObject({ agentScope: "all", groupBy: "family" });
           expect(sent[1]?.params).not.toHaveProperty("agentId");
           expect(pending.hasPending).toBe(true);
           controller.abort();

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -295,7 +295,15 @@ describe("loadModelProvidersData", () => {
         if (when === "while pending") {
           expect(sent.map(({ method }) => method)).toEqual(["usage.status", "sessions.usage"]);
           expect(sent[0]?.params).toBeUndefined();
-          expect(sent[1]?.params).toMatchObject({ agentScope: "all", groupBy: "family" });
+          expect(sent[1]?.params).toMatchObject({
+            agentScope: "all",
+            groupBy: "family",
+            // Cost card consumes only aggregates.byProvider; request the
+            // smallest legal row set (schema minimum) instead of the
+            // shared Usage page's detailed 1000-row default.
+            limit: 1,
+            includeContextWeight: false,
+          });
           expect(sent[1]?.params).not.toHaveProperty("agentId");
           expect(pending.hasPending).toBe(true);
           controller.abort();

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -140,12 +140,9 @@ export function loadModelProviderCost(
       endDate: localDate(0),
       scope: "family",
       timeZone: "local",
+      limit: 1,
     },
-    // This card only consumes aggregates.byProvider, which the Gateway
-    // computes over every matched row before applying `limit` (schema
-    // minimum 1) — request the smallest legal row set. The shared Usage
-    // page keeps its detailed 1000-row default untouched.
-    { signal, limit: 1 },
+    { signal },
   )
     .then((result) => result?.aggregates?.byProvider ?? null)
     .catch((error: unknown) => {

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -141,7 +141,11 @@ export function loadModelProviderCost(
       scope: "family",
       timeZone: "local",
     },
-    { signal },
+    // This card only consumes aggregates.byProvider, which the Gateway
+    // computes over every matched row before applying `limit` (schema
+    // minimum 1) — request the smallest legal row set. The shared Usage
+    // page keeps its detailed 1000-row default untouched.
+    { signal, limit: 1 },
   )
     .then((result) => result?.aggregates?.byProvider ?? null)
     .catch((error: unknown) => {


### PR DESCRIPTION
## What Problem This Solves

The Model Providers cost card (`ui/src/pages/model-providers/load.ts` `loadModelProviderCost`) only reads `result.aggregates.byProvider` from `sessions.usage`, but `buildSessionUsageParams` in `ui/src/lib/sessions/usage.ts` defaulted every no-key caller — including this aggregate-only one — to `limit: 1000`. The Gateway's `sessions.usage` handler (`src/gateway/server-methods/usage.ts`) aggregates every matched session row before applying `limit`: the accumulator runs unconditionally, while `limit` only bounds detailed `sessions[]` rows. Every Model Providers page load therefore serialized and transmitted up to 1000 rows that the caller immediately discarded. This is the remaining defect from #127245 after main already disabled context weight and added the route-data guard.

## Why This Change Was Made

`SessionUsageQuery` now accepts the existing protocol's optional `limit`, and the Model Providers cost query sets it to `1`, the smallest value allowed by `packages/gateway-protocol/src/schema/sessions.ts`. The shared Usage page omits this field and keeps its existing `limit: 1000` default. This reuses the current Gateway contract; no protocol, configuration, persistence, or dependency surface changes.

## User Impact

The Models settings page no longer asks the Gateway to return up to 1000 detailed session rows merely to read provider aggregates. The provider totals stay complete, while detailed response construction, serialization, and transfer are reduced to one row. The Usage page's detailed session list is unaffected.

## Evidence

### Built Control UI against a mock Gateway

Two independent production Control UI builds were served through the repository's Control UI E2E harness: the PR's main base (`cd8c74889d21`) and exact PR head (`20038d5ac3e3`). Each build was exercised separately in Chromium at desktop (`1440x1000`) and mobile (`390x844`). All four uploaded files have distinct MD5s and source-SHA provenance. Each viewport made exactly one `sessions.usage` request and rendered Anthropic at `$4.20` / `1.5M tokens · 9 sessions` and OpenAI JSON at `$2.50` / `750k tokens · 5 sessions`. The mobile viewport is scrolled so both aggregates are in frame.

#### Main production build — desktop 1440

![Model Providers desktop from main production build](https://github.com/user-attachments/assets/32fdad11-7840-4ec0-abe2-1e0122bfa1a2)
```text
sessions.usage {"startDate":"2026-08-06","endDate":"2026-09-04","agentScope":"all","mode":"specific","timeZone":"UTC","utcOffset":"UTC+0","groupBy":"family","limit":1000,"includeContextWeight":false}
```

Source: `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb` (also visible in the build footer). Rendered cost: `$4.20`.

#### In this PR — desktop 1440

![Model Providers desktop from this PR's production build](https://github.com/user-attachments/assets/5a4975ce-27fb-49b3-b471-4b2920b59de6)
```text
sessions.usage {"startDate":"2026-08-06","endDate":"2026-09-04","agentScope":"all","mode":"specific","timeZone":"UTC","utcOffset":"UTC+0","groupBy":"family","limit":1,"includeContextWeight":false}
```

Source: `20038d5ac3e3ef7b2f574cf90dcff2afeb8db86c` (also visible in the build footer). Rendered cost: `$4.20`.

#### Main production build — mobile 390

![Model Providers mobile from main production build, scrolled to provider costs](https://github.com/user-attachments/assets/2fd9bf57-794a-4fd4-814d-8f82ffa6a349)
```text
sessions.usage {"startDate":"2026-08-06","endDate":"2026-09-04","agentScope":"all","mode":"specific","timeZone":"UTC","utcOffset":"UTC+0","groupBy":"family","limit":1000,"includeContextWeight":false}
```

Source: `cd8c74889d21ddcc9f3a2d47fe868224a0e44acb`. The scrolled frame visibly renders Anthropic `$4.20` and OpenAI JSON `$2.50`.

#### In this PR — mobile 390

![Model Providers mobile from this PR's production build, scrolled to provider costs](https://github.com/user-attachments/assets/6c02145f-a1aa-4bfc-8cd1-62bf850faa70)
```text
sessions.usage {"startDate":"2026-08-06","endDate":"2026-09-04","agentScope":"all","mode":"specific","timeZone":"UTC","utcOffset":"UTC+0","groupBy":"family","limit":1,"includeContextWeight":false}
```

Source: `20038d5ac3e3ef7b2f574cf90dcff2afeb8db86c`. The scrolled frame visibly renders Anthropic `$4.20` and OpenAI JSON `$2.50`.

The progressive E2E now asserts this request shape while covering cold, prewarmed, and cached navigation; all three modes pass.

### Regression and repository checks

The loader regression was first run with the production fix removed. It failed at the owner boundary as intended: expected `limit: 1`, received `limit: 1000` (`1 failed, 12 passed`). After restoring the fix:

- `node scripts/run-vitest.mjs ui/src/pages/model-providers/load.test.ts ui/src/lib/sessions/usage.test.ts` → 2 files, 19 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-providers-progressive.e2e.test.ts` → 3 tests passed; production UI built and served
- `OPENCLAW_VITEST_MAX_WORKERS=2 pnpm check:changed` → exit 0 (format, translations, UI/core typecheck, lint, dead-code and repository guards)

### Live Gateway payload comparison

The contributor's read-only live Gateway comparison used the same 30-day aggregate query issued by Model Providers:

| limit | response bytes | wall time |
|---|---:|---:|
| 1000 | 2,387,058 | 2.30s |
| 1 | 79,925 | 2.95s |

Because that live window was actively accruing sessions, a closed historical window (`2026-06-01` through `2026-06-28`) isolated the limit variable:

| limit | response bytes | `sessions[]` length | `aggregates.byProvider` |
|---|---:|---:|---|
| 1000 | 782,647 | 1000 | baseline |
| 1 | 3,122 | 1 | identical (`diff` clean) |

This agrees with the Gateway owner: it aggregates before limiting detailed rows.

### Prior CI failure classification

The prior-head run [33637688946](https://github.com/openclaw/openclaw/actions/runs/33637688946) failed from runner infrastructure, not this change: five jobs lost the checkout fetch with `fetch-pack: unexpected disconnect`, and 17 self-hosted jobs lost runner communication in the same minute. No source or test assertion failed; the gate failure was derivative. This branch has since been rebased onto current main to trigger exact-head CI.

Fresh exact-head [CI run 33822741510](https://github.com/openclaw/openclaw/actions/runs/33822741510) completed with 122 successful and 13 intentionally skipped jobs. All three UI suites, all 12 Control UI E2E shards, the real-Gateway UI lane, UI performance, and UI i18n passed. Three unrelated prerequisites failed, plus the derivative aggregate gate:

- `security-fast`: the external bulk advisory request exceeded its 60-second timeout. The exact command reproduced the same network timeout twice locally; it reported no dependency advisory.
- browser-extension E2E: Chrome MCP's existing-session handshake to its local CDP endpoint timed out in `extensions/browser/chrome-extension/bootstrap.chromium.test.ts`.
- core Node shard: the untouched `src/gateway/local-request-context.session-tools.test.ts` “unchanged” case hit its 120-second test timeout after 2,552 sibling tests passed.

None intersects this PR's four-file UI diff. A CI retry is still required for a green aggregate gate.

### Diff size

Production LOC: `+3/-1` (net `+2`); tests: `+29/-1`. The two net production lines are the optional query field and its caller value. No new helper or parallel request path was added.

## Risk and coverage

- Aggregate completeness: the Gateway accumulates every matched row before applying the detail limit; the unit regression retains the exact aggregate object, and before/after built UI proof renders the same costs.
- Usage-page behavior: its query does not set `limit`, so the helper's existing `1000` default and existing request-shape test remain unchanged.
- Navigation/lifecycle: the focused Control UI E2E covers cold, prewarmed, and cached navigation; the loader suite retains abort and stale-request coverage.
- Remaining scope: this reduces detailed-row construction/serialization/transfer. The Gateway must still scan matched usage records to compute complete aggregates.

## Provenance

In this PR, @Grynn reported #127245 and authored the original fix. The maintainer follow-up preserves that contributor commit and authorship, rebases it onto main, removes duplicate implementation-coupled tests, and adds loader-boundary plus built-Control-UI coverage.

Refs #127245

