### PR TITLE
fix(agents): release replaced histories during active runs

### DIFF
--- a/packages/agent-core/src/agent-loop.retention.test-support.ts
+++ b/packages/agent-core/src/agent-loop.retention.test-support.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { createAssistantMessageEventStream } from "@openclaw/ai/event-stream";
+import type { AssistantMessage, Model } from "@openclaw/llm-core";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { Agent } from "./agent.js";
+import type { AgentMessage } from "./types.js";
+
+export type ContextRetentionResult = {
+  calls: number;
+  replacements: number;
+  observedHistories: number;
+  retained: number[];
+  completed: boolean;
+};
+
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const model: Model = {
+  id: "test-model",
+  name: "Test Model",
+  api: "test-api",
+  provider: "test-provider",
+  baseUrl: "https://example.test",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1_000_000,
+  maxTokens: 1000,
+};
+const histories: WeakRef<AgentMessage>[] = [];
+function history(): AgentMessage {
+  const message: AgentMessage = {
+    role: "user",
+    content: `old-history-${histories.length}:` + "x".repeat(1024 * 1024),
+    timestamp: 0,
+  };
+  histories.push(new WeakRef(message));
+  return message;
+}
+function finalMessage(): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text: "complete" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    stopReason: "stop",
+    timestamp: 1,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+  };
+}
+const held = createDeferred();
+const parked = createAssistantMessageEventStream();
+let calls = 0;
+let replacements = 0;
+let runSignal: AbortSignal | undefined;
+const agent = new Agent({
+  initialState: { model, messages: [history()] },
+  streamFn: () => {
+    if (++calls === 5) {
+      held.resolve();
+      return parked;
+    }
+    const response = createAssistantMessageEventStream();
+    response.push({ type: "done", reason: "stop", message: finalMessage() });
+    response.end();
+    return response;
+  },
+  prepareNextTurnWithContext: (turn, signal) => {
+    if (runSignal) {
+      assert.equal(signal, runSignal);
+    } else {
+      runSignal = signal;
+    }
+    if (replacements === 4) {
+      return undefined;
+    }
+    replacements += 1;
+    const summary: AgentMessage =
+      replacements < 4 ? history() : { role: "user", content: "compact summary", timestamp: 0 };
+    const messages = [summary, ...turn.newMessages];
+    // The transcript owner must release history too; ordinary compaction runs after the core.
+    agent.state.messages = messages;
+    agent.steer({ role: "user", content: "continue", timestamp: replacements });
+    return { context: { ...turn.context, messages } };
+  },
+});
+const run = agent.prompt("begin");
+let retained: number[] = [];
+try {
+  await Promise.race([
+    held.promise,
+    run.then(() => {
+      throw new Error(
+        `Run ended before its retention checkpoint: ${agent.state.errorMessage ?? "no error"}`,
+      );
+    }),
+  ]);
+  // Do not dereference during collection: WeakRef.deref keeps its target alive for that job.
+  for (let pass = 0; pass < 8; pass += 1) {
+    gc();
+    await setImmediate();
+  }
+  retained = histories.flatMap((reference, index) => (reference.deref() ? [index] : []));
+} finally {
+  parked.push({ type: "done", reason: "stop", message: finalMessage() });
+  parked.end();
+  await run;
+}
+assert.equal(agent.state.errorMessage, undefined);
+const result: ContextRetentionResult = {
+  calls,
+  replacements,
+  observedHistories: histories.length,
+  retained,
+  completed: true,
+};
+process.stdout.write(JSON.stringify(result));

--- a/packages/agent-core/src/agent-loop.retention.test.ts
+++ b/packages/agent-core/src/agent-loop.retention.test.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { runNodeScript } from "../../../test/helpers/run-node-script.js";
+import type { ContextRetentionResult } from "./agent-loop.retention.test-support.js";
+
+it("releases replaced histories while the next model request is pending", async ({ signal }) => {
+  const result = await runNodeScript(
+    [
+      "--expose-gc",
+      "--import",
+      "tsx",
+      fileURLToPath(new URL("./agent-loop.retention.test-support.ts", import.meta.url)),
+    ],
+    { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+    15_000,
+    {
+      cwd: fileURLToPath(new URL("../../../", import.meta.url)),
+      signal,
+      maxBuffer: 64 * 1024,
+      requireProcessTreeExit: process.platform !== "win32",
+    },
+  );
+  expect(result.error, result.stderr).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  const observed: ContextRetentionResult = JSON.parse(result.stdout);
+  expect(observed).toEqual({
+    calls: 5,
+    replacements: 4,
+    observedHistories: 4,
+    retained: [],
+    completed: true,
+  });
+}, 30_000);

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -236,7 +236,7 @@ async function runAgentLoopCore(
   runtime?: AgentCoreStreamRuntimeDeps,
 ): Promise<AgentMessage[]> {
   const newMessages: AgentMessage[] = [];
-  const currentContext = { ...context, messages: [...context.messages] };
+  const state = { context: { ...context, messages: [...context.messages] } };
   await emit({ type: "agent_start" });
   await emit({ type: "turn_start" });
   for (const prompt of prompts) {
@@ -248,7 +248,7 @@ async function runAgentLoopCore(
       continue;
     }
     await emit({ type: "message_end", message: prompt });
-    currentContext.messages.push(prompt);
+    state.context.messages.push(prompt);
     newMessages.push(prompt);
   }
   if (prompts.length > 0 && newMessages.length === 0) {
@@ -257,8 +257,7 @@ async function runAgentLoopCore(
     await emit({ type: "agent_end", messages: [] });
     return [];
   }
-  await runLoop(currentContext, newMessages, config, signal, emit, streamFn, runtime);
-  return newMessages;
+  return runLoop(state, newMessages, config, signal, emit, streamFn, runtime);
 }
 
 function createAgentStream(): EventStream<AgentEvent, AgentMessage[]> {
@@ -290,22 +289,22 @@ function pushLoopFailure(
 }
 
 /**
- * Main loop logic shared by agentLoop and agentLoopContinue.
+ * Own one replaceable context slot so this async frame does not retain earlier
+ * contexts after a next-turn hook replaces them.
  */
 async function runLoop(
-  initialContext: AgentContext,
+  state: { context: AgentContext },
   newMessages: AgentMessage[],
   initialConfig: AgentLoopConfig,
   signal: AbortSignal | undefined,
   emit: AgentEventSink,
   streamFn?: StreamFn,
   runtime?: AgentCoreStreamRuntimeDeps,
-): Promise<void> {
-  let currentContext = initialContext;
+): Promise<AgentMessage[]> {
   let config = initialConfig;
   let firstTurn = true;
   let turnOpen = true;
-  let turnTainted = isActiveTurnTainted(initialContext.messages);
+  let turnTainted = isActiveTurnTainted(state.context.messages);
   const toolLoopRecoveryState = initialConfig.toolLoopRecoveryState ?? {
     criticalToolLoopSeen: false,
   };
@@ -351,7 +350,7 @@ async function runLoop(
     // Inner loop: process tool calls and steering messages
     while (hasMoreToolCalls || pendingMessages.length > 0) {
       if (await stopIfAborted()) {
-        return;
+        return newMessages;
       }
 
       if (!firstTurn) {
@@ -378,7 +377,7 @@ async function runLoop(
             turnTainted = false;
           }
           await emit({ type: "message_end", message });
-          currentContext.messages.push(message);
+          state.context.messages.push(message);
           newMessages.push(message);
           injectedMessage = true;
         }
@@ -390,12 +389,12 @@ async function runLoop(
       }
 
       if (await stopIfAborted()) {
-        return;
+        return newMessages;
       }
 
       // Stream assistant response
       const message = await streamAssistantResponse(
-        currentContext,
+        state.context,
         config,
         signal,
         emit,
@@ -411,14 +410,14 @@ async function runLoop(
           await appendInterruptedTurnMessage(newMessages, emit);
         }
         await emit({ type: "agent_end", messages: newMessages });
-        return;
+        return newMessages;
       }
 
       // Only completed toolUse turns dispatch; length/stop can carry partial stream blocks.
       const executedToolBatch =
         message.stopReason === "toolUse" && message.content.some((c) => c.type === "toolCall")
           ? await executeToolCalls(
-              currentContext,
+              state.context,
               message,
               config,
               signal,
@@ -434,7 +433,7 @@ async function runLoop(
         toolLoopRecoveryState.criticalToolLoopSeen = true;
       }
       for (const result of toolResults) {
-        currentContext.messages.push(result);
+        state.context.messages.push(result);
         newMessages.push(result);
       }
 
@@ -444,7 +443,7 @@ async function runLoop(
         throw executedToolBatch.fatal.error;
       }
       if (await stopIfAborted()) {
-        return;
+        return newMessages;
       }
       if (executedToolBatch?.terminateRun) {
         const terminalMessage = {
@@ -455,7 +454,7 @@ async function runLoop(
           ),
           content: [{ type: "text" as const, text: TOOL_LOOP_RECOVERY_TERMINATED_MESSAGE }],
         };
-        currentContext.messages.push(terminalMessage);
+        state.context.messages.push(terminalMessage);
         newMessages.push(terminalMessage);
         await emit({ type: "turn_start" });
         turnOpen = true;
@@ -464,18 +463,17 @@ async function runLoop(
         await emit({ type: "turn_end", message: terminalMessage, toolResults: [] });
         turnOpen = false;
         await emit({ type: "agent_end", messages: newMessages });
-        return;
+        return newMessages;
       }
 
-      const nextTurnContext = {
+      const nextTurnSnapshot = await config.prepareNextTurn?.({
         message,
         toolResults,
-        context: currentContext,
+        context: state.context,
         newMessages,
-      };
-      const nextTurnSnapshot = await config.prepareNextTurn?.(nextTurnContext);
+      });
       if (nextTurnSnapshot) {
-        currentContext = nextTurnSnapshot.context ?? currentContext;
+        state.context = nextTurnSnapshot.context ?? state.context;
         const nextModel = nextTurnSnapshot.model ?? config.model;
         const nextThinkingLevel = nextTurnSnapshot.thinkingLevel ?? config.thinkingLevel;
         const shouldResolveReasoning =
@@ -492,7 +490,7 @@ async function runLoop(
         });
       }
       if (await stopIfAborted()) {
-        return;
+        return newMessages;
       }
 
       if (pendingMessages.length === 0) {
@@ -500,19 +498,19 @@ async function runLoop(
           await config.shouldStopAfterTurn?.({
             message,
             toolResults,
-            context: currentContext,
+            context: state.context,
             newMessages,
           })
         ) {
           await emit({ type: "agent_end", messages: newMessages });
-          return;
+          return newMessages;
         }
 
         const steering = getSteeringAtCheckpoint(config);
         pendingMessages = Array.isArray(steering) ? steering : await steering;
       }
       if (await stopIfAborted()) {
-        return;
+        return newMessages;
       }
     }
 
@@ -528,6 +526,7 @@ async function runLoop(
   }
 
   await emit({ type: "agent_end", messages: newMessages });
+  return newMessages;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running agents could keep superseded histories alive after a next-turn hook replaced the active context. The old history remained reachable while a later model request was pending, even after the transcript owner had released it.

Related: #136180, #136249, #136359. This is the active-context memory repair in the concurrent-agent performance series.

## Why This Change Was Made

The asynchronous loop retained its original context parameter and a saved next-turn argument object. Updating the active local context did not release those other references. One private, replaceable context slot now owns the active context, the checkpoint argument is passed directly, and the loop returns its completed message list to its caller.

The hook still receives the exact replacement context, the same signal and the same accumulated message list. Event delivery, queue ordering, cancellation, terminal joins, provider execution and tools retain their existing owners. No public API, configuration, database or protocol changes.

Production **+27/−28 (net −1)**. Test/support **+159/−0**.

## User Impact

Integrations that replace context during an active run can release the previous history before the run finishes. The transcript owner must also release its reference. Ordinary automatic compaction runs after core completion; this PR does not claim a default Gateway RSS improvement from that path.

## Evidence

Current candidate `e31ab9ff5bb4ab5741b9684d10101af684c10518`, based on `ae22204e7a20391ede4fb1ffb88d74709ff4af6f` after #136359 landed. The refresh is patch-identical: all three memory PR files match the previously proved `ca0b97eb91612f1433a304077ffb62f83bb3c858`, and the core/session interfaces remain unchanged. The base includes the async-maintenance CI fixture repairs from #136359. The matched memory numbers below remain historical observations for `ec8fb8fec5c9a8ae1f13caafbb412b6f2366f9e5` → `ca0b97eb91612f1433a304077ffb62f83bb3c858`; they are not relabeled as new-base measurements.

- The new regression runs the real Agent in an isolated Node child, replaces four marked histories, and holds its fifth model request open. After eight explicit GC/macrotask passes, the exact pre-fix owner still retains histories `[0,3]`; the candidate retains `[]`. Both scenarios complete normally. The final committed fixture was run on both versions with source hashes recorded; a loader failure or timeout is not counted as negative proof.
- **123 tests across four files passed again on the refreshed head**, covering the new regression plus existing context identity, live prompt/tool/model updates, queued steering, disposal, cancellation, transcript projection and session lifecycle behavior. The final fixture was rerun after a return-style lint correction. Its collection assertion and complete five-request/four-replacement scenario remain unchanged.
- The complete changed-file gate passed again on the refreshed head, including core and core-test typechecks, graph and plugin boundaries, formatting, coercion/deprecation checks and dead-export scans. Final typed lint on all three files passed after the fixture correction. An earlier command accidentally selected remote Testbox routing and failed before running checks; the normal local checks and their actual results are recorded separately.
- Both independent Codex autoreview rounds were scoped-clean at the configured P0 threshold, including the refreshed full PR diff. Independent owner and regression-fixture source reviews found no concrete semantic regression.

The durable regression checks object reachability, not retained megabytes or RSS. Its repeated-string payload is not used as a physical-memory estimate.

The earlier `ca0b97eb` candidate also passed a real OpenAI Responses run with two concurrent Agents: **12 actual HTTP requests, 11 completed replies, eight within-loop context replacements**, both fifth responses held after HTTP acceptance, cancellation after accepted headers with the same abort reason, and successful reuse with a fresh signal. Async final listeners settled before the next checkpoint. Complete streamed/final text and positive usage matched; all owned children terminated and before/after source, dependency and native-binary guards passed. This exercises the actual Agent and canonical HTTP/SSE transport, not a Gateway or SQLite run.

**Fresh current-head C2 also passed**, using the same probe and oracle with the newly landed Responses owner: 12 real HTTP 200 responses, 11 complete stream/final matches with positive usage, eight context replacements, two held fifth responses, cancellation and same-Agent reuse. The complete 377-event sequence, source/dependency/native before/after guards and process cleanup were independently verified. Result SHA256 `5d44de8644e54cc97a1f9a9ce41df4a9c1dc6b04fd35daf56ded59599761bd7e`; report SHA256 `d2904daa2a7b11c63442de6ba8efd717dae80281ca283b8eae3ba3b79c72c79b`. This verifies refreshed source/runtime composition; it does not supply new memory or performance measurements.

Matched memory measurements used the real Agent with four **4 MiB JSON-decoded histories** per agent and a held fifth request. Explicit-GC and natural-collection modes were separate processes. All eight serial arms passed their functional oracle, exact request/history equality, cleanup, strict idle deadlines and full input guards. An independent audit recomputed all 440 numeric comparisons from the saved reports.

| Observation, baseline → candidate | 8 active agents | 32 active agents |
| --- | ---: | ---: |
| Held heap after explicit GC | 89.943 → 24.895 MiB | 285.552 → 25.291 MiB |
| Observed peak RSS, explicit-GC run | 447.609 → 457.219 MiB | 901.188 → 765.969 MiB |
| Observed peak RSS, natural-collection run | 453.891 → 456.938 MiB | 816.406 → 646.813 MiB |
| RSS after ≥5 seconds idle, natural-collection run | 428.750 → 414.281 MiB | 816.406 → 646.813 MiB |

At the held explicit-GC checkpoint, every baseline agent retained representatives of histories `[0,3]`; every candidate retained none. Both versions released the observed representatives after completion and teardown. The fixture explicitly releases the separate `Agent.state.messages` owner. It checks one ToolResult representative per history, not every object or backing string.

**Measurement limits:** one descriptive pair per concurrency/mode, not repeated estimates. Peaks include setup through final idle and use 25 ms sampling plus explicit checkpoints. C8 peak RSS increased; work-to-checkpoint CPU increased in three pairs. No general speed, uniform RSS, default-compaction or native Codex improvement is claimed. Natural-mode WeakRefs remained accessible in both versions at the held/immediate-teardown checks and were not rechecked after idle; those RSS samples do not establish prompt reclamation.

Reproducible local evidence: memory summary SHA256 `a6ecedb8cb88e5a1760df2d2193e43d9ad58df267546667fb8c006171eef7db2`; live result SHA256 `f9aa324df3dcdf461977b291dc6c0a766e59a43fc52c6635f22877b78608bdab`; sealed fixture manifest SHA256 `a2009ad3c65a2087929b6dc361ae627094b549df1413647e601c6c6b727178a8`. Both source runtimes own frozen installs of the same application lock and pinned Node v24.19.0.

The latest ClawSweeper review covers the current `e31ab9ff` head and found no actionable code or security defect. Its green-check rank-up move is satisfied: [CI33653361888](https://github.com/openclaw/openclaw/actions/runs/33653361888) passed on the exact head, with **149 successful jobs and 17 skipped**. The required aggregate passed after waiting for a GitHub-hosted runner; no rerun or CI change was needed for this refreshed run. Fresh real-provider integration passed, and the preserved before/after regression, matched memory epoch and independent audit cover the reachability boundary. Prior-head CI failures included the archive/migration fixtures now repaired in the base, plus runner/security infrastructure failures. No old failed run is counted as current passing proof.

Local evidence is under `.artifacts/threading/replaced-agent-contexts-20260902/`; the original discovery and rejected intermediate fixes remain under `.artifacts/threading/stream-redesign-20260902/pr3-proposals/`. These are local evidence paths, not hosted artifacts.
