### PR TITLE
fix(test): join failed Gateway client acquisition cleanup

### DIFF
--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -7,6 +7,7 @@ import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { WebSocket } from "ws";
 import { type HelloOk, PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
 import {
@@ -78,24 +79,28 @@ export async function connectGatewayClient(params: {
         return path.join(identityRoot, "test-device-identities", `${safe}.sqlite`);
       })(),
     });
-  return await new Promise<InstanceType<typeof GatewayClient>>((resolve, reject) => {
+  return await new Promise<GatewayClient>((resolve, reject) => {
     let settled = false;
-    const stop = (err?: Error, connectedClient?: InstanceType<typeof GatewayClient>) => {
+    const settle = (outcome: { client: GatewayClient } | { error: unknown }) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timer);
-      if (err) {
-        void client?.stopAndWait({ timeoutMs: 1_000 }).catch(() => {
-          client?.stop();
-        });
-        reject(err);
+      if ("error" in outcome) {
+        // Failed acquisition still owns the client. Reject only after stop settles,
+        // preserving both errors when shutdown also fails.
+        void runQaGatewayFixture(
+          async () => {
+            throw outcome.error;
+          },
+          () => client.stopAndWait({ timeoutMs: 1_000 }),
+        ).catch(reject);
       } else {
-        resolve(connectedClient as InstanceType<typeof GatewayClient>);
+        resolve(outcome.client);
       }
     };
-    const client: InstanceType<typeof GatewayClient> | undefined = new GatewayClient({
+    const client = new GatewayClient({
       url: params.url,
       token: params.token,
       deviceToken: params.deviceToken,
@@ -124,18 +129,22 @@ export async function connectGatewayClient(params: {
       onEvent: params.onEvent,
       onHelloOk: (hello) => {
         params.onHelloOk?.(hello);
-        stop(undefined, client);
+        settle({ client });
       },
-      onConnectError: (err) => stop(err),
+      onConnectError: (error) => settle({ error }),
       onClose: (code, reason) =>
-        stop(new Error(`gateway closed during connect (${code}): ${reason}`)),
+        settle({ error: new Error(`gateway closed during connect (${code}): ${reason}`) }),
     });
     const timer = setTimeout(
-      () => stop(new Error(params.timeoutMessage ?? "gateway connect timeout")),
+      () => settle({ error: new Error(params.timeoutMessage ?? "gateway connect timeout") }),
       params.timeoutMs ?? 10_000,
     );
     timer.unref();
-    client.start();
+    try {
+      client.start();
+    } catch (error) {
+      settle({ error });
+    }
   });
 }
 

--- a/src/gateway/test-helpers.server-env.test.ts
+++ b/src/gateway/test-helpers.server-env.test.ts
@@ -1,11 +1,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { drainSystemEvents, enqueueSystemEvent } from "../infra/system-events.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { GatewayClient, GatewayClientRequestError } from "./client.js";
 import { createGatewayConfigOverrides } from "./test-helpers.config-runtime.js";
-import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+import {
+  connectGatewayClient,
+  disconnectGatewayClient,
+  startGatewayWithClient,
+} from "./test-helpers.e2e.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
   installGatewayTestHooks,
@@ -23,6 +29,70 @@ const envBeforeSuite = {
 installGatewayTestHooks();
 
 describe("Gateway test environment lifecycle", () => {
+  it.each(["connect error", "start error"] as const)(
+    "joins %s client cleanup before rejecting acquisition",
+    async (failureMode) => {
+      await withGatewayServer(async ({ port }) => {
+        // oxlint-disable-next-line typescript/unbound-method -- Each call binds the acquired client.
+        const { start, stopAndWait } = GatewayClient.prototype;
+        const startError = new Error("client start failed after allocating its socket");
+        let stopAcquiredClient: (() => Promise<void>) | undefined;
+        let stopping: Promise<void> | undefined;
+        let stopSettled = false;
+        const startSpy = vi
+          .spyOn(GatewayClient.prototype, "start")
+          .mockImplementation(function (this: GatewayClient) {
+            stopAcquiredClient = () => stopAndWait.call(this, { timeoutMs: 1_000 });
+            start.call(this);
+            if (failureMode === "start error") {
+              throw startError;
+            }
+          });
+        const stopSpy = vi
+          .spyOn(GatewayClient.prototype, "stopAndWait")
+          .mockImplementation(function (this: GatewayClient, options) {
+            // Observe the actual client completion without holding its socket.
+            stopping = stopAndWait.call(this, options).then(() => {
+              stopSettled = true;
+            });
+            return stopping;
+          });
+
+        await runQaGatewayFixture(
+          async () => {
+            const failure: unknown = await connectGatewayClient({
+              url: `ws://127.0.0.1:${port}`,
+              token:
+                failureMode === "connect error"
+                  ? "wrong-gateway-token-1234567890"
+                  : "test-gateway-token-1234567890",
+            }).then(
+              () => undefined,
+              (error: unknown) => error,
+            );
+            if (failureMode === "connect error") {
+              expect(failure).toBeInstanceOf(GatewayClientRequestError);
+              expect(failure).toMatchObject({
+                details: { code: "AUTH_TOKEN_MISMATCH" },
+              });
+            } else {
+              expect(failure).toBe(startError);
+            }
+            expect(stopSpy).toHaveBeenCalledExactlyOnceWith({ timeoutMs: 1_000 });
+            expect(stopSettled).toBe(true);
+          },
+          async () => {
+            // The pre-fix helper can reject without owning a stop at all.
+            await stopAcquiredClient?.();
+            await stopping;
+          },
+          () => stopSpy.mockRestore(),
+          () => startSpy.mockRestore(),
+        );
+      });
+    },
+  );
+
   it("records the process-wide startup environment", async () => {
     await withGatewayServer(async ({ port }) => {
       expect(process.env.OPENCLAW_GATEWAY_PORT).toBe(String(port));


### PR DESCRIPTION
Failed Gateway client acquisition could reject before its shutdown promise settled. A synchronous start failure skipped shutdown entirely. A caller could then begin fixture teardown while the rejected acquisition still owned a client.

Route every acquisition outcome through one settlement function. Success returns the client; failure clears the deadline, waits for the existing stopAndWait contract, and preserves both acquisition and shutdown errors through the shared QA cleanup helper. The old fire-and-forget stop and catch-and-discard fallback are removed. Catch synchronous start errors at the same owner.

The two regressions use a real Gateway and client. Call-through observers record the actual start and stop completion; they neither hold the socket nor replace shutdown behavior. One sends an invalid token. The other raises the same Error after real start has allocated its socket. Both retain explicit cleanup so the original failing implementation can also finish safely.

Validation: the unchanged full file passed all seven cases. With only the regressions added, both failed at the intended boundaries: authentication rejection arrived before stop settled, and synchronous start failure made zero stop calls. The full candidate passed all nine cases, retaining the original seven in order. Commands ran through the canonical Gateway-server Vitest wrapper on macOS, Node 24.19.0, with one worker and unchanged timeouts. All 99 source guards matched after restoring the originals, every command joined, and the owned temporary directory was empty. A post-run checker initially expected a success banner that this direct wrapper does not emit; the original raw nine-pass report and exit zero were preserved and adjudicated without rerunning.

Measured whole-command time was 26.21 seconds for the original and 17.46 seconds for the candidate. The candidate has two extra cases and compilation was warmer, so this is cleanup correctness evidence, not a claimed speedup. stopAndWait retains its existing bounded termination behavior; this change guarantees its promise settles before acquisition rejects, rather than strengthening its socket-close contract.

A final call-through refinement captures a cleanup closure instead of aliasing the client receiver. Both exact negative cases were reproduced again against the unchanged helper, and the final full nine-case run passed in 12.74 seconds. The same 99 source guards matched; the owned temporary root was empty and removed after both commands joined.

Production delta: zero. Test and test-support delta: +94/-15. Formatting, typed lint, independent source review and Codex P0 review passed. Exact-head CI remains required before landing.
