### PR TITLE
test: consolidate session diff browser scenarios

### DIFF
--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -1,29 +1,27 @@
 // Control UI tests cover the session diff panel (sessions.diff RPC).
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext } from "playwright";
-import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { BrowserContext } from "playwright";
+import { beforeEach, expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
-  canRunPlaywrightChromium,
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
   installMockGateway,
   navigateToControlUiSession,
-  resolvePlaywrightChromiumExecutablePath,
-  startControlUiE2eServer,
-  type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
 import {
   activateChatHeaderPanelAction,
   openChatSidePanelType,
 } from "./chat-side-panel.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
-const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
-const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const suite = createControlUiE2eSuite({
+  name: "session diff panel",
+  trackBrowserContexts: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 let artifactDir: string;
 beforeEach(() => {
@@ -32,25 +30,13 @@ beforeEach(() => {
   }
 });
 
-let server: ControlUiE2eServer;
-// Browser contexts preserve test isolation; keep one process warm for this file.
-let browser: Browser;
-const openContexts = new Set<BrowserContext>();
-
 async function newBrowserContext(): Promise<BrowserContext> {
-  const context = await browser.newContext({
+  return await suite.newBrowserContext({
     colorScheme: "light",
     locale: "en-US",
     serviceWorkers: "block",
     viewport: { height: 800, width: 1180 },
   });
-  openContexts.add(context);
-  return context;
-}
-
-async function closeContexts(): Promise<void> {
-  await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
-  openContexts.clear();
 }
 
 const APP_PATCH = [
@@ -152,34 +138,13 @@ async function seedPersistedReviewLayouts(
       );
     },
     {
-      key: controlUiBundledSettingsStorageKey(server.baseUrl),
+      key: controlUiBundledSettingsStorageKey(suite.server.baseUrl),
       persistedSessionKeys: sessionKeys,
     },
   );
 }
 
-describeControlUiE2e("session diff panel", () => {
-  beforeAll(async () => {
-    if (!chromiumAvailable) {
-      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    try {
-      server = await startControlUiE2eServer();
-    } catch (error) {
-      await browser.close();
-      throw error;
-    }
-  });
-
-  afterAll(async () => {
-    await closeContexts();
-    await browser?.close();
-    await server?.close();
-  });
-
-  afterEach(closeContexts);
-
+suite.define(() => {
   it("opens a renamed session diff when Review is added from the panel menu", async () => {
     const context = await newBrowserContext();
     const page = await context.newPage();
@@ -210,7 +175,7 @@ describeControlUiE2e("session diff panel", () => {
         },
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
 
     await openChatSidePanelType(page, "Files");
     await openChatSidePanelType(page, "Review");
@@ -242,7 +207,7 @@ describeControlUiE2e("session diff panel", () => {
         "sessions.diff": SESSION_DIFF_RESPONSE,
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
 
     await openChatSidePanelType(page, "Files");
     await openChatSidePanelType(page, "Review");
@@ -283,7 +248,7 @@ describeControlUiE2e("session diff panel", () => {
       },
     });
 
-    await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
 
     await waitForSessionDiff(page);
   });
@@ -349,7 +314,7 @@ describeControlUiE2e("session diff panel", () => {
         },
       },
     });
-    await page.goto(controlUiSessionUrl(server.baseUrl, firstSessionKey));
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, firstSessionKey));
     await waitForSessionDiff(page);
 
     await navigateToControlUiSession(page, secondSessionKey);
@@ -384,7 +349,7 @@ describeControlUiE2e("session diff panel", () => {
         "sessions.diff": SESSION_DIFF_RESPONSE,
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     let watchedKey = "";
     await expect
       .poll(async () => {
@@ -438,7 +403,7 @@ describeControlUiE2e("session diff panel", () => {
         },
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     expect(await gateway.getRequests("sessions.files.list")).toHaveLength(0);
     expect(await gateway.getRequests("sessions.diff")).toHaveLength(0);
 
@@ -564,7 +529,7 @@ describeControlUiE2e("session diff panel", () => {
         },
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
 
     await activateChatHeaderPanelAction(page, "Show session changes");
 
@@ -715,7 +680,7 @@ describeControlUiE2e("session diff panel", () => {
         },
       },
     });
-    await page.goto(`${server.baseUrl}chat`);
+    await page.goto(`${suite.server.baseUrl}chat`);
     expect(await gateway.getRequests("sessions.files.list")).toHaveLength(0);
     await activateChatHeaderPanelAction(page, "Show session changes");
     await expect
@@ -747,28 +712,5 @@ describeControlUiE2e("session diff panel", () => {
       .poll(() => page.locator(".session-diff__filename").allTextContents())
       .toEqual(["notes.md"]);
     expect(await gateway.getRequests("sessions.files.list")).toHaveLength(0);
-  });
-
-  it("keeps the panel fallback for gateways that omit checkout capability", async () => {
-    const context = await newBrowserContext();
-    const page = await context.newPage();
-    await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
-      methodResponses: {
-        "sessions.diff": {
-          sessionKey: "main",
-          files: [],
-          additions: 0,
-          deletions: 0,
-          unavailableReason: "not_git",
-        },
-      },
-    });
-    await page.goto(`${server.baseUrl}chat`);
-
-    await activateChatHeaderPanelAction(page, "Show session changes");
-    await expect
-      .poll(() => page.locator(".session-diff .session-diff__note").textContent())
-      .toContain("not a git checkout");
   });
 });


### PR DESCRIPTION
The session-diff browser suite repeated the same unversioned-workspace fallback scenario twice and owned its browser/server cleanup with a catch-and-discard block.

Use the shared browser suite fixture and remove the redundant standalone case. The retained refresh-after-checkout case already starts with the identical not-a-Git-worktree response, opens the same panel, and verifies the same fallback note before checking additional file/count and refresh behavior. The separate panel-menu scenario remains covered. All eight retained test bodies are unchanged apart from their fixture reference.

This removes one browser scenario and 58 net test lines while using the existing cleanup owner, which closes browser resources before the server and preserves cleanup failures. Production code is unchanged.

The complete original/candidate/restored-original browser runs passed: nine/eight/nine session-diff cases, alongside ten Activity and five Cloud cases. The session-diff case sums were 9.485 / 8.478 / 8.972 seconds. Across all three files the commands took 49.899 / 42.983 / 44.226 seconds; build warmup and small timing variation prevent a fixed speedup claim. The concrete reduction is one duplicate browser scenario.

Proof used the canonical bundled UI configuration, one worker, Google Chrome 152.0.7977.75, Node 24.19.0 and the pinned UI dependencies. All deadlines and retained case bodies stayed unchanged. Candidate and restored control ran the files in the same order. All three wrappers joined, temporary roots were empty, all 74 source guards matched after restoration, and no worker/cleanup retention or unhandled errors remained. The shared cleanup owner's existing 118 fault checks cover lifecycle/error composition. Formatting, typed lint and Codex P0 review passed. Exact-head CI remains required before landing.
