### PR TITLE
fix(agent-core): anchor short user replies to the most recent assistant turn

### DIFF
--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -29,6 +29,7 @@ import {
   type AgentToolExecutionContext,
   runWithAgentToolExecutionContext,
 } from "./tool-execution-context.js";
+import { applyShortReplyAnchor } from "./harness/short-reply-anchor.js";
 import {
   appendInterruptedTurnMessage,
   createFailureMessage,
@@ -553,9 +554,16 @@ async function streamAssistantResponse(
   // Convert to LLM-compatible messages (AgentMessage[] → Message[])
   const llmMessages = await config.convertToLlm(messages);
 
+  // Short-reply anchor: when the trailing human user turn is a very short
+  // selection ("2", "yes", "that one"), append an ephemeral directive that
+  // binds the referent to the most recent assistant turn. This prevents the
+  // model from reaching back to a stale enumerated list surviving in
+  // compaction summaries or older context. No-op on every other turn.
+  const anchoredSystemPrompt = applyShortReplyAnchor(context.systemPrompt, llmMessages);
+
   // Build LLM context
   const llmContext: Context = {
-    systemPrompt: context.systemPrompt,
+    systemPrompt: anchoredSystemPrompt,
     messages: llmMessages,
     tools: context.tools,
   };

--- a/packages/agent-core/src/harness/short-reply-anchor.test.ts
+++ b/packages/agent-core/src/harness/short-reply-anchor.test.ts
@@ -1,0 +1,184 @@
+// Agent Core tests cover the short-reply anchor directive.
+import type {
+  AssistantMessage,
+  Message,
+  ToolResultMessage,
+  UserMessage,
+} from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import {
+  applyShortReplyAnchor,
+  matchesShortSelectionReply,
+  SHORT_REPLY_ANCHOR_DIRECTIVE,
+  shouldApplyShortReplyAnchor,
+} from "./short-reply-anchor.js";
+
+function user(text: string, extra: Partial<UserMessage> = {}): UserMessage {
+  return { role: "user", content: text, timestamp: 0, ...extra };
+}
+
+function assistant(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "test",
+    provider: "test",
+    model: "test",
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+      cacheWriteInputTokens: 0,
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  } as AssistantMessage;
+}
+
+function toolResult(text: string): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "call_1",
+    toolName: "test",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: 0,
+  };
+}
+
+describe("matchesShortSelectionReply", () => {
+  const truthy = [
+    "2",
+    " 2 ",
+    "12",
+    "2.",
+    "yes",
+    "YES",
+    "yep",
+    "no",
+    "nah",
+    "ok",
+    "okay",
+    "sure",
+    "the second",
+    "the second one",
+    "second option",
+    "that one",
+    "this",
+    "both",
+    "neither",
+    "a",
+    "b.",
+    "option c",
+  ];
+  for (const text of truthy) {
+    it(`matches ${JSON.stringify(text)}`, () => {
+      expect(matchesShortSelectionReply(text)).toBe(true);
+    });
+  }
+
+  const falsy = [
+    "",
+    "   ",
+    "please reset her password",
+    "2 sounds good but let's also send a TAP",
+    "yesterday we already did that",
+    "no because she is locked out and we need to unblock her now",
+    "123", // too many digits — not a plausible list index
+  ];
+  for (const text of falsy) {
+    it(`does not match ${JSON.stringify(text)}`, () => {
+      expect(matchesShortSelectionReply(text)).toBe(false);
+    });
+  }
+});
+
+describe("shouldApplyShortReplyAnchor", () => {
+  it("fires when trailing user turn is a short selection following an assistant turn", () => {
+    const messages: Message[] = [
+      user("can you check if she is locked"),
+      assistant(
+        "Account is not disabled. Options:\n1. Wait it out\n2. Reset her password\n3. Issue a TAP",
+      ),
+      user("2"),
+    ];
+    expect(shouldApplyShortReplyAnchor(messages)).toBe(true);
+  });
+
+  it("skips volatile runtime-context carrier user messages when finding the trailing turn", () => {
+    const messages: Message[] = [
+      user("earlier"),
+      assistant("1. do A\n2. do B"),
+      user("2"),
+      // Runtime-context carrier appended after the human's actual reply.
+      user("<runtime>time=2026-09-02T14:06Z</runtime>", { runtimeContextCarrier: true }),
+    ];
+    expect(shouldApplyShortReplyAnchor(messages)).toBe(true);
+  });
+
+  it("does not fire when the user reply is substantive", () => {
+    const messages: Message[] = [
+      assistant("1. do A\n2. do B"),
+      user("please reset her password via the entra admin center"),
+    ];
+    expect(shouldApplyShortReplyAnchor(messages)).toBe(false);
+  });
+
+  it("does not fire without a prior assistant turn", () => {
+    const messages: Message[] = [user("2")];
+    expect(shouldApplyShortReplyAnchor(messages)).toBe(false);
+  });
+
+  it("counts a prior assistant turn even across a tool result", () => {
+    const messages: Message[] = [
+      assistant("1. wait\n2. reset\n3. TAP"),
+      toolResult("some tool output"),
+      user("2"),
+    ];
+    expect(shouldApplyShortReplyAnchor(messages)).toBe(true);
+  });
+});
+
+describe("applyShortReplyAnchor", () => {
+  it("appends the anchor directive when the short-reply condition is met", () => {
+    const messages: Message[] = [assistant("1. wait\n2. reset\n3. TAP"), user("2")];
+    const anchored = applyShortReplyAnchor("You are DefCon.", messages);
+    expect(anchored.startsWith("You are DefCon.")).toBe(true);
+    expect(anchored).toContain(SHORT_REPLY_ANCHOR_DIRECTIVE);
+  });
+
+  it("is a no-op when the reply is not a short selection", () => {
+    const messages: Message[] = [
+      assistant("1. wait\n2. reset\n3. TAP"),
+      user("please reset her password"),
+    ];
+    expect(applyShortReplyAnchor("You are DefCon.", messages)).toBe("You are DefCon.");
+  });
+
+  it("returns just the directive when the base system prompt is empty and anchor fires", () => {
+    const messages: Message[] = [assistant("1. a\n2. b"), user("2")];
+    expect(applyShortReplyAnchor("", messages)).toBe(SHORT_REPLY_ANCHOR_DIRECTIVE);
+  });
+
+  // Regression test for the 2026-09-02 "short reply hijacks stale list" bug.
+  it("regression: short reply after fresh assistant list yields anchor even when older lists exist", () => {
+    const messages: Message[] = [
+      // Older, richer enumerated list (e.g. from a compaction summary or
+      // earlier turn about a completely unrelated topic).
+      assistant(
+        "For the HelloRetriever review:\n1. Rotate Secrets Manager entries\n2. Update the Trello card\n3. Tighten IAM policies\n4. Add SCP guardrails",
+      ),
+      user("thanks, let's come back to that later"),
+      assistant("Sounds good."),
+      user("can you check if she is locked"),
+      // Fresh assistant turn with the referent that MUST win.
+      assistant(
+        "Account is not disabled. Options:\n1. Wait it out\n2. Reset her password\n3. Issue a TAP",
+      ),
+      user("2"),
+    ];
+    const anchored = applyShortReplyAnchor("You are DefCon.", messages);
+    expect(anchored).toContain(SHORT_REPLY_ANCHOR_DIRECTIVE);
+    expect(anchored).toContain("MOST RECENT turn only");
+  });
+});

--- a/packages/agent-core/src/harness/short-reply-anchor.ts
+++ b/packages/agent-core/src/harness/short-reply-anchor.ts
@@ -1,0 +1,169 @@
+// Agent Core module implements the short-reply anchor directive.
+//
+// Background
+// ==========
+// When a user answers with a very short selection like "2", "yes", or
+// "that one", the model has to resolve the referent. In long transcripts
+// (especially after one or more compaction summaries) a stronger/older
+// enumerated list can out-rank the assistant's most recent list and the
+// model happily binds the short reply to the stale referent.
+//
+// This module produces a deterministic, ephemeral system-prompt suffix
+// that only fires when the trailing user message actually looks like a
+// short selection reply. It costs zero tokens on every other turn.
+//
+// The fix is at the framework layer (not a workspace-file suggestion)
+// because the failure mode is a property of how the LLM resolves
+// coreference across the assembled context, not of any one deployment.
+
+import type { Message, TextContent, UserMessage } from "@openclaw/llm-core";
+
+/** Max characters of user text we still consider a "short reply". */
+export const SHORT_REPLY_MAX_CHARS = 40;
+
+/**
+ * Ephemeral system-prompt suffix appended when the trailing user turn is a
+ * short selection. Instructs the model to bind the reply to the most recent
+ * assistant turn (or ask for clarification) instead of reaching back to an
+ * earlier enumerated list that survived in the context window.
+ *
+ * Exported so tests and downstream tooling can assert on the exact string.
+ */
+export const SHORT_REPLY_ANCHOR_DIRECTIVE = [
+  "<short_reply_anchor>",
+  "The user's most recent turn is a very short selection or acknowledgement",
+  '(for example "2", "yes", "that one", "the second"). Resolve it against',
+  "the assistant's MOST RECENT turn only — typically the last enumerated",
+  "list, question, or set of options the assistant offered. Do not reach",
+  "back to earlier turns, tool results, or compaction summaries to pick a",
+  "referent, even if an older list feels like a better match.",
+  "",
+  "If the most recent assistant turn does not contain a plausible referent",
+  "for the short reply, ask the user for clarification rather than guess.",
+  "Never silently bind the reply to a stale list.",
+  "</short_reply_anchor>",
+].join("\n");
+
+// Case-insensitive short-selection lexicon. Kept intentionally narrow: we
+// want false negatives (do nothing) rather than false positives (nudge the
+// model when the user actually wrote a substantive reply).
+const SHORT_SELECTION_PATTERNS: readonly RegExp[] = [
+  // Bare digits, 1–2 digits, with optional trailing punctuation. Covers "2", "2.", "12)".
+  /^\d{1,2}[.)!?]?$/,
+  // Ordinal words on their own or with "one" / "option".
+  /^(?:the\s+)?(?:first|second|third|fourth|fifth|last|other|next|previous)(?:\s+one|\s+option)?[.!?]?$/,
+  // Deictic selection.
+  /^(?:this|that|these|those)(?:\s+one)?[.!?]?$/,
+  // Yes/no family and short acknowledgements.
+  /^(?:y|n|yes|no|yep|nope|yeah|nah|ok|okay|k|sure|please|do it|go|go ahead|sounds good|works for me)[.!?]?$/,
+  // Quantifier picks.
+  /^(?:both|all|none|neither|either)[.!?]?$/,
+  // Letter picks like "a", "b." or "option c".
+  /^(?:option\s+)?[a-e][.)!?]?$/,
+];
+
+/**
+ * True when the given user text should be treated as a short selection reply.
+ *
+ * Exported so downstream code (custom `transformContext` implementations,
+ * tests) can share the classifier instead of drifting from it.
+ */
+export function matchesShortSelectionReply(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0 || trimmed.length > SHORT_REPLY_MAX_CHARS) {
+    return false;
+  }
+  const normalized = trimmed.toLowerCase();
+  for (const pattern of SHORT_SELECTION_PATTERNS) {
+    if (pattern.test(normalized)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function extractUserText(message: UserMessage): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  const parts: string[] = [];
+  for (const block of message.content) {
+    if (block.type === "text") {
+      parts.push((block as TextContent).text);
+    }
+  }
+  return parts.join("\n");
+}
+
+/**
+ * True when `messages` contains at least one assistant turn ahead of the
+ * given index. Without a prior assistant turn there is no "most recent list"
+ * for the anchor to point at, so the directive would be noise.
+ */
+function hasPriorAssistantTurn(messages: readonly Message[], userIndex: number): boolean {
+  for (let i = userIndex - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === "assistant") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Locate the last "real" user message (skipping OpenClaw runtime-context
+ * carrier messages, which are volatile per-turn framing rather than the
+ * human's actual reply).
+ */
+function findTrailingUserMessage(
+  messages: readonly Message[],
+): { message: UserMessage; index: number } | undefined {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (!message || message.role !== "user") {
+      continue;
+    }
+    const userMessage = message as UserMessage;
+    if (userMessage.runtimeContextCarrier) {
+      continue;
+    }
+    return { message: userMessage, index: i };
+  }
+  return undefined;
+}
+
+/**
+ * Returns `true` when the given messages array ends in a short-selection
+ * user reply that a coreference-resolving model could plausibly bind to a
+ * stale earlier list.
+ */
+export function shouldApplyShortReplyAnchor(messages: readonly Message[]): boolean {
+  const trailing = findTrailingUserMessage(messages);
+  if (!trailing) {
+    return false;
+  }
+  if (!hasPriorAssistantTurn(messages, trailing.index)) {
+    return false;
+  }
+  return matchesShortSelectionReply(extractUserText(trailing.message));
+}
+
+/**
+ * Append {@link SHORT_REPLY_ANCHOR_DIRECTIVE} to `systemPrompt` when the
+ * trailing user message is a short selection reply. Otherwise returns
+ * `systemPrompt` unchanged.
+ *
+ * This is applied at the LLM-call boundary and does not mutate persisted
+ * transcript state; the directive is ephemeral and rebuilt each turn.
+ */
+export function applyShortReplyAnchor(
+  systemPrompt: string,
+  messages: readonly Message[],
+): string {
+  if (!shouldApplyShortReplyAnchor(messages)) {
+    return systemPrompt;
+  }
+  if (systemPrompt.length === 0) {
+    return SHORT_REPLY_ANCHOR_DIRECTIVE;
+  }
+  return `${systemPrompt}\n\n${SHORT_REPLY_ANCHOR_DIRECTIVE}`;
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -8,6 +8,13 @@ export * from "./types.js";
 export * from "./validation.js";
 export * from "./harness/env/kill-tree.js";
 export * from "./harness/messages.js";
+export {
+  applyShortReplyAnchor,
+  matchesShortSelectionReply,
+  shouldApplyShortReplyAnchor,
+  SHORT_REPLY_ANCHOR_DIRECTIVE,
+  SHORT_REPLY_MAX_CHARS,
+} from "./harness/short-reply-anchor.js";
 export * from "./harness/prompt-template-arguments.js";
 export { buildSessionContext } from "./harness/session/session.js";
 export { uuidv7 } from "./harness/session/uuid.js";


### PR DESCRIPTION
## Summary

Fix a coreference-resolution failure where a short user reply (e.g. `2`, `yes`, `that one`) gets bound to a stale enumerated list from an earlier, unrelated part of the transcript instead of the assistant's most recent list.

## Bug (real transcript)

```
User:      can you just check to see if he is locked
Assistant: [reports account not disabled, offers]
             1. Wait it out
             2. Reset her password
             3. Issue a TAP
           Want me to walk her through anything, or push a password reset?
User:      2
Assistant: [reaches back to a MUCH earlier list about a totally unrelated
           project — an old security-review checklist — and asks the user
           to confirm which item they meant]
User:      2. Reset her password via the Entra admin center...
Assistant: "That '2' was from a much earlier conversation... That context
           is stale and I don't have the active numbered list in front of
           us right now."
```

That last admission is the smoking gun: the immediate prior list was in context but got out-ranked by an older, more "vivid" list — very common when compaction summaries preserve older enumerated content verbatim.

## Root cause

- `packages/agent-core/src/agent-loop.ts::streamAssistantResponse` assembles the LLM request with `systemPrompt` + `llmMessages` in order and hands it off to the provider. There is no explicit recency-anchoring rule for the model.
- `packages/agent-core/src/harness/messages.ts::convertToLlm` faithfully inlines `compactionSummary` and `branchSummary` entries as user-role text. Older enumerated lists can survive inside those summaries and compete with the latest live list for referent resolution.
- Without a directive, the model performs best-guess coreference and can lock onto the wrong list, especially when the older list is longer or more detailed.

Verdict: primarily **C** (LLM coreference failure under adversarial context ordering), with framework-level context assembly making the failure mode reachable in normal operation. The fix must therefore live in the framework — a workspace-file suggestion cannot cover all deployments.

## Fix

New helper `packages/agent-core/src/harness/short-reply-anchor.ts`:
- `matchesShortSelectionReply(text)` — narrow classifier for bare selections/acknowledgements. Intentionally biased toward false negatives to avoid nudging on substantive replies.
- `applyShortReplyAnchor(systemPrompt, messages)` — when the trailing non-carrier user message is a short selection and there is a prior assistant turn, appends a small `<short_reply_anchor>` directive to the system prompt:
  > "The user's most recent turn is a very short selection... Resolve it against the assistant's MOST RECENT turn only... Do not reach back to earlier turns, tool results, or compaction summaries to pick a referent... If the most recent assistant turn does not contain a plausible referent, ask for clarification rather than guess."

Wire-up in `streamAssistantResponse`:
```ts
const anchoredSystemPrompt = applyShortReplyAnchor(context.systemPrompt, llmMessages);
const llmContext: Context = { systemPrompt: anchoredSystemPrompt, messages: llmMessages, tools: context.tools };
```

The directive is applied at the LLM-call boundary and is not persisted; it is rebuilt each turn.

## Why this design over alternatives

- **Recency boundary marker in the messages array** — would mutate per-turn message bytes and disrupt provider prompt-caching breakpoints already carefully guarded by `runtimeContextCarrier` handling.
- **Structured recent-turn digest** ("current_options: [...]") — requires parsing assistant output for enumerated lists, which is fragile across markdown/table/inline formats.
- **Always-on preamble in the base system prompt** — adds tokens to every turn and dilutes other instructions.
- **Ephemeral system-prompt suffix (this PR)** — zero cost on every non-short-reply turn, no transcript mutation, no provider-cache impact, deterministic classifier, upstreamable.

## Properties

- Deterministic (no extra model calls, no LLM-authored disambiguation step).
- Cheap: 0 tokens on turns where the classifier doesn't match; a small directive otherwise.
- Skips OpenClaw `runtimeContextCarrier` user messages so the human's actual short reply is the one that anchors.
- No public API changes. Helpers are exported for downstream reuse in custom `transformContext` implementations.

## Tests

- `packages/agent-core/src/harness/short-reply-anchor.test.ts` — 38 tests covering the classifier lexicon, trailing-user selection (including carrier-skip and tool-result interleaving), no-op paths, and a regression test that mirrors the exact 2026-09-02 failure mode (older richer list + fresh list + `"2"`).
- Existing `packages/agent-core/src/agent-loop.test.ts` — 79 tests, all still passing.

## Performance / context-size impact

None on turns that don't match the classifier. On matching turns, the directive is ~12 short lines and lives in the system prompt slot (typically cached upstream when supported).

## Follow-ups (out of scope)

- The classifier lexicon is intentionally narrow; extending it (e.g. to non-English selections or emoji `1️⃣`) is easy but should be done with real-world telemetry.
- If desired, downstream apps can call `applyShortReplyAnchor` themselves from a custom `transformContext` to inject the directive at a different layer.
