### PR TITLE
perf: speed up fence-aware message chunking

### DIFF
--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -1,7 +1,3 @@
-// Utilities for splitting outbound text into platform-sized chunks without
-// unintentionally breaking on newlines. Using [\s\S] keeps newlines inside
-// the chunk so messages are only split when they truly exceed the limit.
-
 import {
   findFenceSpanAt,
   isSafeFenceBreak,
@@ -417,9 +413,7 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
     const softBreak = pickSafeBreakIndex(text, start, windowEnd, spans);
     let breakIdx = softBreak > start ? softBreak : windowEnd;
 
-    const initialFence = isSafeFenceBreak(spans, breakIdx)
-      ? undefined
-      : findFenceSpanAt(spans, breakIdx);
+    const initialFence = findFenceSpanAt(spans, breakIdx);
 
     let fenceToSplit = initialFence;
     if (initialFence) {
@@ -530,8 +524,11 @@ function pickSafeBreakIndex(
   end: number,
   spans: ReturnType<typeof parseFenceSpans>,
 ): number {
-  const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(text, start, end, (index) =>
-    isSafeFenceBreak(spans, index),
+  const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(
+    text,
+    start,
+    end,
+    (index) => findFenceSpanAt(spans, index)?.end,
   );
 
   if (lastNewline > start) {
@@ -547,14 +544,17 @@ function scanParenAwareBreakpoints(
   text: string,
   start: number,
   end: number,
-  isAllowed: (index: number) => boolean = () => true,
+  skipTo?: (index: number) => number | undefined,
 ): { lastNewline: number; lastWhitespace: number } {
   let lastNewline = -1;
   let lastWhitespace = -1;
   let depth = 0;
 
   for (let i = start; i < end; i++) {
-    if (!isAllowed(i)) {
+    const skippedEnd = skipTo?.(i);
+    if (skippedEnd !== undefined) {
+      // The fence end remains an eligible breakpoint; resume there after the loop increment.
+      i = skippedEnd - 1;
       continue;
     }
     const char = text.charAt(i);


### PR DESCRIPTION
## What Problem This Solves

Splitting long replies with fenced code spends time inspecting every character inside regions that cannot be chosen as a split point. The work repeats for each chunk, even though the fence parser already knows each region's end.

## Why This Change Was Made

Carry that existing end position into the private breakpoint scanner and jump over the excluded interior. Resume at the fence end, which remains an eligible breakpoint. The old scanner rejected those same positions before reading characters or changing parenthesis depth, so skipping them preserves its decisions.

The change also removes a duplicate containing-fence lookup and a stale header comment describing a former regex implementation. Fence parsing, close/reopen budgets, Unicode boundaries, parenthesis handling and public APIs are unchanged. Production LOC: **+11/−11, net zero**; tests unchanged. No new dependency, cache, configuration, protocol or persistence surface.

## User Impact

Less local processing when preparing long fenced Markdown replies. Output text and reply-reference behavior remain unchanged. This does not claim faster provider responses, network delivery or whole agent turns.

## Evidence

Five complete existing test files passed **119 cases before and 119 after**, with no skipped tests: chunking, plugin-runtime chunking, fence spans, shared text chunking and outbound message planning. The changed-file checks passed. Independent Codex review through P2 found no actionable findings.

Native equality proof compared 46 complete public results per version, including boundary controls, all returned strings, property descriptors, alias relationships and reply-policy consumption. The fixed timing run then retained **1,064 calls / 896 measured samples**, using B0/C0/C1/B1 order, one complete public call per observation, one first call and two warm calls followed by 16 samples per row. No retries or discarded samples. Independent readback verified all results and recomputed every comparison.

| Primary workload | Forward median, before → after | Reverse median, before → after |
| --- | ---: | ---: |
| Complete Markdown chunker, 8,514 UTF-16 units, limit 4,000 | 100.73 → 15.50 µs (−84.61%) | 99.79 → 14.71 µs (−85.26%) |
| Complete outbound text planner for that message | 142.96 → 13.69 µs (−90.43%) | 143.56 → 13.15 µs (−90.84%) |

Both primaries passed the predeclared ≥3% improvement in each order. Protected controls rejected >3% regression in both orders; none met that condition. The short planner was slower in both orders (+17.57% / +2.89%, +124.5 / +20.5 ns); short Markdown and Unicode controls were slower in one order (+8.72% and +8.03%). All adverse observations remain retained. The short planner's forward maximum rose from 0.833 to 5.958 µs; nearest-rank p95 here is simply the maximum of 16 samples, not a population-tail estimate.

No memory improvement is claimed: most 1 Hz RSS samples caught only startup. Kernel high-water values were approximately 361–365 MB, with candidate increases of 0.62% / 0.75%. Full raw evidence stayed within the fixed resource limits; all owned processes and active paths closed.

The numerical source scope is commit `167481bcda23c2bd5103afa985e19cea33333871`, based on `dfe9bcdf5fc58d82eb88d33b5740161f8a36474b`. The chunker is unchanged on readable main `81c09f48fa625531eab465648b6da87c60fc3b7f`; its separate fence-parser optimization landed while this PR waited. A fresh integration checkout at `3b4d70216b8630e0ad343664213b30095f1be617` combines that current parser with each chunker variant: the same five complete test files pass **125 cases before and 125 after**, with no skips. Chunker/parser/planner bytes are unchanged between that integration base and `81c09f48fa625531eab465648b6da87c60fc3b7f`. These are fresh correctness checks, not new timing samples.

## Matrix delivery proof

Local Matrix approval proof passed on `167481bcda23c2bd5103afa985e19cea33333871`. The canonical full build, `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`, exited zero, followed by the unchanged existing scenario:

```sh
pnpm openclaw qa matrix --provider-mode mock-openai \
  --scenario matrix-approval-exec-metadata-chunked --concurrency 1 \
  --output-dir .artifacts/qa-e2e/skip-fence-interiors-matrix-approval-dfe9-r1
```

The completed report records **1 passed, 0 failed, 0 skipped** with Node 26.8.1, the mock OpenAI provider, and the real Matrix plugin against disposable local Tuwunel. The existing scenario accepted the exec approval request, observed the pending approval metadata, observed a separate command-bearing chunk without duplicated approval metadata, sent a real reaction, and received `allow-once`. Retained event details confirm the reaction targeted the exact approval event.

The full build took 174.10 seconds and the scenario process 22.52 seconds, including startup and shutdown; these are execution records, not performance measurements. All observed process groups closed. The exact disposable container and network were absent afterward, and both recorded listener ports refused connections. No personal channel account or real model-provider credentials were used.

This proves the native approval prompt and reaction flow at that commit. It does not claim full wire reconstruction, every chunk boundary, an ordinary model-generated final reply, or retained Gateway logs: successful native cleanup removed those logs. Complete outer logs and final summary/report/evidence remain available locally. The run also predates the subsequently changed `packages/markdown-core/src/fences.ts`; current-main integration is separately reviewed by the lead.

ClawSweeper follow-through: the requested Matrix trace and readable-main drift check are complete. The retained native scenario evidence records the exact reaction-to-approval-event correspondence and `allow-once`; successful cleanup removed Gateway logs as described above. Applicable exact-head CI remains required before native prepare/merge. No re-review was requested: the existing review is under 12 hours old, its requested evidence is supplied, and the only subsequent commit change is the patch-identical rebase described below.


## CI repair and current head

[CI run 33693158511](https://github.com/openclaw/openclaw/actions/runs/33693158511) finished the bundled tests and guards, then both jobs failed with Git authentication errors. The old workflow fetched comparison commits after authenticated checkout had discarded its credential. This is already repaired by [the CI cleanup included in #136178](https://github.com/openclaw/openclaw/pull/136178), which fetches those bases during authenticated checkout and uses local references afterward. No credential persistence or guard bypass was added here.

The branch is rebased onto `81c09f48fa625531eab465648b6da87c60fc3b7f`; current head is `5124fc70394c4333b347933ccc499e19f1f3ba83`. Git range-diff reports the patch unchanged, and `src/auto-reply/chunk.ts` retains SHA-256 `7b373f698cc461a3afa3692da0744be0863afeb2c16af8cf357bc7a91fe9c240`. The measured and Matrix source identities remain explicitly recorded above. Applicable CI must pass on this refreshed head before native landing.
