### PR TITLE
fix(android): mask credentials and correct secret input behavior

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -271,6 +271,8 @@ pnpm openclaw gateway --port 18789 --verbose
 - Follow the first-run connection screen, or open **Settings → Gateway** to change a saved connection.
 - Scan a QR code, paste a setup code, or enter the Gateway manually.
 
+Gateway credentials and setup codes are masked and accept paste. The app requests password input with autocorrection disabled; this does not guarantee how a keyboard stores or learns from input.
+
 3. Approve pairing (on the gateway machine):
 
 ```bash

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1785,6 +1785,7 @@ private fun SetupCodeEntryScreen(
             value = setupCode,
             onValueChange = onSetupCodeChange,
             placeholder = nativeString("Paste setup code"),
+            secret = true,
           )
         }
         error?.let { message ->
@@ -1858,7 +1859,7 @@ private fun ManualGatewaySetupScreen(
         }
         item {
           LabeledField(label = nativeString("Token")) {
-            ClawTextField(value = token, onValueChange = onTokenChange, placeholder = nativeString("Paste token"))
+            ClawTextField(value = token, onValueChange = onTokenChange, placeholder = nativeString("Paste token"), secret = true)
             Text(
               text = nativeString("Paste a shared Gateway token or operator-issued token."),
               style = ClawTheme.type.caption,
@@ -1868,7 +1869,7 @@ private fun ManualGatewaySetupScreen(
         }
         item {
           LabeledField(label = nativeString("Password")) {
-            ClawTextField(value = password, onValueChange = onPasswordChange, placeholder = nativeString("Password optional"))
+            ClawTextField(value = password, onValueChange = onPasswordChange, placeholder = nativeString("Password optional"), secret = true)
           }
         }
         item {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -1905,7 +1905,7 @@ private fun GatewaySettingsScreen(
           overflow = TextOverflow.Ellipsis,
         )
         ClawSecondaryButton(text = nativeString("Scan QR"), onClick = viewModel::pairNewGateway, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.QrCode2)
-        ClawTextField(value = setupCode, onValueChange = { setupCode = it }, placeholder = nativeString("Setup code"))
+        ClawTextField(value = setupCode, onValueChange = { setupCode = it }, placeholder = nativeString("Setup code"), secret = true)
         ClawSecondaryButton(text = nativeString("Connect"), onClick = ::connectSetupCode, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.Cloud)
         TextButton(onClick = { showSetupCodeHelp = !showSetupCodeHelp }) {
           Text(nativeString("Where do I get a setup code?"))
@@ -2016,10 +2016,10 @@ private fun GatewaySettingsScreen(
           )
         }
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-          ClawTextField(value = tokenInput, onValueChange = { tokenInput = it }, placeholder = nativeString("Token"), modifier = Modifier.weight(1f))
-          ClawTextField(value = bootstrapTokenInput, onValueChange = { bootstrapTokenInput = it }, placeholder = nativeString("Bootstrap"), modifier = Modifier.weight(1.05f))
+          ClawTextField(value = tokenInput, onValueChange = { tokenInput = it }, placeholder = nativeString("Token"), modifier = Modifier.weight(1f), secret = true)
+          ClawTextField(value = bootstrapTokenInput, onValueChange = { bootstrapTokenInput = it }, placeholder = nativeString("Bootstrap"), modifier = Modifier.weight(1.05f), secret = true)
         }
-        ClawTextField(value = passwordInput, onValueChange = { passwordInput = it }, placeholder = nativeString("Password"))
+        ClawTextField(value = passwordInput, onValueChange = { passwordInput = it }, placeholder = nativeString("Password"), secret = true)
         validationText?.let {
           Text(text = it, style = ClawTheme.type.caption, color = ClawTheme.colors.warning)
         }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SystemAgentSettingsScreen.kt
@@ -11,11 +11,10 @@ import ai.openclaw.app.ui.design.ClawPlainIconButton
 import ai.openclaw.app.ui.design.ClawPrimaryButton
 import ai.openclaw.app.ui.design.ClawScaffold
 import ai.openclaw.app.ui.design.ClawSecondaryButton
+import ai.openclaw.app.ui.design.ClawTextField
 import ai.openclaw.app.ui.design.ClawTheme
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -26,8 +25,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Bolt
@@ -42,9 +39,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
@@ -280,39 +274,18 @@ private fun SystemAgentComposer(
   onSend: () -> Unit,
 ) {
   Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-    BasicTextField(
+    ClawTextField(
       value = state.input,
       onValueChange = onInputChange,
-      modifier =
-        Modifier
-          .fillMaxWidth()
-          .border(1.dp, ClawTheme.colors.border, RoundedCornerShape(ClawTheme.radii.control))
-          .background(ClawTheme.colors.surfaceRaised, RoundedCornerShape(ClawTheme.radii.control))
-          .padding(12.dp),
-      textStyle = ClawTheme.type.body.copy(color = ClawTheme.colors.text),
-      keyboardOptions = KeyboardOptions(keyboardType = if (state.expectsSensitiveReply) KeyboardType.Password else KeyboardType.Text),
-      visualTransformation = if (state.expectsSensitiveReply) PasswordVisualTransformation() else VisualTransformation.None,
-      minLines = 1,
+      placeholder =
+        if (state.expectsSensitiveReply) {
+          nativeString("Enter secret…")
+        } else {
+          nativeString("Reply to OpenClaw…")
+        },
+      secret = state.expectsSensitiveReply,
       maxLines = 5,
       enabled = !state.sending && state.errorText == null,
-      decorationBox = { inner ->
-        Box {
-          if (state.input.isEmpty()) {
-            val placeholder =
-              if (state.expectsSensitiveReply) {
-                nativeString("Enter secret…")
-              } else {
-                nativeString("Reply to OpenClaw…")
-              }
-            Text(
-              placeholder,
-              style = ClawTheme.type.body,
-              color = ClawTheme.colors.textSubtle,
-            )
-          }
-          inner()
-        }
-      },
     )
     ClawPrimaryButton(
       text = nativeString("Send"),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt
@@ -234,9 +234,6 @@ private fun QuestionSection(
       }
     }
     if (question.options.isEmpty() || question.isOther == true) {
-      // Secret answers must never render on screen or feed the keyboard's
-      // prediction/autocorrect stores; password transformation + keyboard type
-      // cover both, and single-line keeps the masked value one obscured run.
       val secret = question.isSecret == true
       OutlinedTextField(
         value = draft.otherText[question.questionId].orEmpty(),
@@ -246,7 +243,7 @@ private fun QuestionSection(
         label = { Text(if (secret) nativeString("Secret value") else nativeString("Other answer")) },
         visualTransformation = if (secret) PasswordVisualTransformation() else VisualTransformation.None,
         keyboardOptions =
-          if (secret) KeyboardOptions(keyboardType = KeyboardType.Password) else KeyboardOptions.Default,
+          if (secret) KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false) else KeyboardOptions.Default,
         minLines = 1,
         maxLines = if (secret) 1 else 4,
       )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.Home
@@ -40,6 +41,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -53,6 +55,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -564,7 +569,6 @@ internal fun ClawSegmentedControl(
   }
 }
 
-/** Token-styled text field used by settings and prototype screens. */
 @Composable
 internal fun ClawTextField(
   value: String,
@@ -574,47 +578,57 @@ internal fun ClawTextField(
   minLines: Int = 1,
   label: String? = null,
   enabled: Boolean = true,
+  secret: Boolean = false,
+  maxLines: Int = Int.MAX_VALUE,
 ) {
-  val fieldModifier =
-    if (label == null) modifier else modifier.semantics { contentDescription = label }
-  val interactionSource = remember { MutableInteractionSource() }
-  val focused by interactionSource.collectIsFocusedAsState()
-  BasicTextField(
-    value = value,
-    onValueChange = onValueChange,
-    enabled = enabled,
-    interactionSource = interactionSource,
-    modifier =
-      fieldModifier
-        .fillMaxWidth()
-        .heightIn(min = ClawTheme.spacing.touchTarget)
-        .clip(RoundedCornerShape(ClawTheme.radii.control))
-        .background(ClawTheme.colors.surface)
-        .border(
-          1.dp,
-          if (focused) ClawTheme.colors.accent else ClawTheme.colors.border,
-          RoundedCornerShape(ClawTheme.radii.control),
-        ).padding(horizontal = ClawTheme.spacing.xs, vertical = ClawTheme.spacing.xxs),
-    textStyle =
-      ClawTheme.type.body.copy(
-        color = if (enabled) ClawTheme.colors.text else ClawTheme.colors.textSubtle,
-      ),
-    cursorBrush = SolidColor(ClawTheme.colors.text),
-    minLines = minLines,
-    decorationBox = { innerTextField ->
-      Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        label?.let {
-          Text(text = it, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
-        }
-        Box(modifier = Modifier.fillMaxWidth()) {
-          if (value.isEmpty()) {
-            Text(text = placeholder, style = ClawTheme.type.body, color = ClawTheme.colors.textSubtle)
+  // Compose 1.12's String editor retains its initial password semantics.
+  // Recreate it when sensitivity changes; the caller still owns the text.
+  key(secret) {
+    val fieldModifier =
+      if (label == null) modifier else modifier.semantics { contentDescription = label }
+    val interactionSource = remember { MutableInteractionSource() }
+    val focused by interactionSource.collectIsFocusedAsState()
+    BasicTextField(
+      value = value,
+      onValueChange = onValueChange,
+      enabled = enabled,
+      interactionSource = interactionSource,
+      modifier =
+        fieldModifier
+          .fillMaxWidth()
+          .heightIn(min = ClawTheme.spacing.touchTarget)
+          .clip(RoundedCornerShape(ClawTheme.radii.control))
+          .background(ClawTheme.colors.surface)
+          .border(
+            1.dp,
+            if (focused) ClawTheme.colors.accent else ClawTheme.colors.border,
+            RoundedCornerShape(ClawTheme.radii.control),
+          ).padding(horizontal = ClawTheme.spacing.xs, vertical = ClawTheme.spacing.xxs),
+      textStyle =
+        ClawTheme.type.body.copy(
+          color = if (enabled) ClawTheme.colors.text else ClawTheme.colors.textSubtle,
+        ),
+      cursorBrush = SolidColor(ClawTheme.colors.text),
+      keyboardOptions =
+        if (secret) KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrectEnabled = false) else KeyboardOptions.Default,
+      visualTransformation = if (secret) PasswordVisualTransformation() else VisualTransformation.None,
+      minLines = minLines,
+      maxLines = maxLines,
+      decorationBox = { innerTextField ->
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+          label?.let {
+            Text(text = it, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
           }
-          innerTextField()
+          Box(modifier = Modifier.fillMaxWidth()) {
+            if (value.isEmpty()) {
+              Text(text = placeholder, style = ClawTheme.type.body, color = ClawTheme.colors.textSubtle)
+            }
+            innerTextField()
+          }
         }
-      }
-    },
-  )
+      },
+    )
+  }
 }
 
 /** Local design-system preview surface for visual smoke checks. */

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/InitialOnboardingLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/InitialOnboardingLayoutTest.kt
@@ -1,7 +1,12 @@
 package ai.openclaw.app.ui
 
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeApp
 import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.NodeRuntimeMode
 import ai.openclaw.app.R
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.closeNodeRuntimeTestFixture
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.ui.design.ClawDesignTheme
@@ -15,32 +20,50 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.DeviceConfigurationOverride
 import androidx.compose.ui.test.FontScale
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeUp
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
 import androidx.test.core.app.ApplicationProvider
+import com.google.mlkit.common.internal.MlKitInitProvider
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import java.util.UUID
 
 private const val OnboardingViewportTag = "initial-onboarding-viewport"
 
@@ -54,6 +77,39 @@ class InitialOnboardingLayoutTest {
   fun disableMascotAnimations() {
     val context = ApplicationProvider.getApplicationContext<Context>()
     Settings.Global.putFloat(context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+  }
+
+  @Test
+  fun gatewayCredentialsAndSetupCodeAreMasked() {
+    val app = ApplicationProvider.getApplicationContext<NodeApp>()
+    val prefs = SecurePrefs(app, app.getSharedPreferences("onboarding-input-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    val runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    val models = ViewModelStore()
+    try {
+      Robolectric.buildContentProvider(MlKitInitProvider::class.java).create()
+      val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+      models.put("onboarding", viewModel)
+      ReflectionHelpers.getField<MutableStateFlow<NodeRuntime?>>(viewModel, "runtimeRef").value = runtime
+      setContent(fontScale = 1f, viewportHeight = 720.dp) { OnboardingFlow(viewModel) }
+
+      composeRule.onNodeWithText("Continue").performClick()
+      composeRule.onNodeWithText("Set up manually").performClick()
+      assertInputPresentation("Host", "127.0.0.1", secret = false, scroll = true)
+      assertInputPresentation("18789", "18790", secret = false, scroll = true)
+      assertInputPresentation("Paste token", "synthetic-token", secret = true, scroll = true)
+      assertInputPresentation("Password optional", "synthetic-password", secret = true, scroll = true)
+      composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex)).performScrollToIndex(0)
+      composeRule.onNodeWithContentDescription("Back").performClick()
+      composeRule.onNodeWithText("Scan QR or setup code").performClick()
+      composeRule.onNodeWithText("Enter setup code").performClick()
+      assertInputPresentation("Paste setup code", "synthetic-setup-code", secret = true)
+    } finally {
+      try {
+        models.clear()
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
   }
 
   @Test
@@ -242,5 +298,29 @@ class InitialOnboardingLayoutTest {
     assertTrue("$label should stay inside the viewport's top edge", child.top >= parent.top)
     assertTrue("$label should stay inside the viewport's right edge", child.right <= parent.right)
     assertTrue("$label should stay inside the viewport's bottom edge", child.bottom <= parent.bottom)
+  }
+
+  private fun assertInputPresentation(
+    initialText: String,
+    value: String,
+    secret: Boolean,
+    scroll: Boolean = false,
+  ) {
+    val input = composeRule.onNode(hasSetTextAction() and hasText(initialText))
+    if (scroll) input.performScrollTo()
+    input.performClick().performTextReplacement(value)
+    val focusedInput = composeRule.onNode(hasSetTextAction() and isFocused())
+    val layouts = mutableListOf<TextLayoutResult>()
+    focusedInput.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+    assertEquals(
+      "$initialText must use the expected visible input presentation",
+      if (secret) "\u2022".repeat(value.length) else value,
+      layouts
+        .single()
+        .layoutInput.text.text,
+    )
+    focusedInput.assert(
+      if (secret) SemanticsMatcher.keyIsDefined(SemanticsProperties.Password) else SemanticsMatcher.keyNotDefined(SemanticsProperties.Password),
+    )
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsDetailInsetsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsDetailInsetsTest.kt
@@ -2,13 +2,21 @@ package ai.openclaw.app.ui
 
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NodeApp
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.NodeRuntimeMode
 import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.appearanceAccentPalette
+import ai.openclaw.app.closeNodeRuntimeTestFixture
+import ai.openclaw.app.gateway.GatewayMethod
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawPrimaryButton
 import ai.openclaw.app.ui.design.ClawTextField
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
+import android.text.InputType
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
@@ -22,20 +30,34 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.PlatformTextInputInterceptor
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
@@ -43,6 +65,14 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -51,7 +81,12 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
 import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], qualifiers = "w700dp-h1000dp-420dpi")
@@ -61,6 +96,179 @@ class SettingsDetailInsetsTest {
 
   // Mirrors the bottom inset SettingsDetailFrame reserves below its scroll viewport.
   private val settingsFrameBottomPadding = 4.dp
+
+  @Test
+  @Config(qualifiers = "w360dp-h800dp-420dpi")
+  fun gatewayCredentialsAreMaskedWhileHostAndPortRemainOrdinary() {
+    val app = RuntimeEnvironment.getApplication() as NodeApp
+    val prefs = SecurePrefs(app, app.getSharedPreferences("gateway-input-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    prefs.setManualHost("127.0.0.1")
+    prefs.setManualPort(18789)
+    val runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    val models = ViewModelStore()
+    try {
+      val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+      models.put("gateway", viewModel)
+      ReflectionHelpers.getField<MutableStateFlow<NodeRuntime?>>(viewModel, "runtimeRef").value = runtime
+      composeRule.setContent {
+        ClawDesignTheme {
+          SettingsDetailScreen(viewModel, SettingsRoute.Gateway, onBack = {})
+        }
+      }
+
+      assertGatewayInputPresentation("127.0.0.1", "192.168.0.25", secret = false)
+      assertGatewayInputPresentation("18789", "18790", secret = false)
+      assertGatewayInputPresentation("Setup code", "synthetic-setup-code", secret = true)
+      assertGatewayInputPresentation("Token", "synthetic-token", secret = true)
+      assertGatewayInputPresentation("Bootstrap", "synthetic-bootstrap", secret = true)
+      assertGatewayInputPresentation("Password", "synthetic-password", secret = true)
+    } finally {
+      try {
+        models.clear()
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w360dp-h800dp-420dpi")
+  fun systemAgentComposerUpdatesPasswordSemanticsAcrossSensitiveReplies() {
+    val app = RuntimeEnvironment.getApplication() as NodeApp
+    val prefs = SecurePrefs(app, app.getSharedPreferences("system-agent-input-" + UUID.randomUUID(), Context.MODE_PRIVATE))
+    val clipboard = requireNotNull(app.getSystemService(ClipboardManager::class.java))
+    val previousClip = clipboard.primaryClip
+    val runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    val models = ViewModelStore()
+    val requests = CopyOnWriteArrayList<JsonObject>()
+    val replies = listOf("Ordinary reply ready", "Enter the synthetic credential", "Ordinary reply restored")
+    val releaseReplies = List(2) { CountDownLatch(1) }
+    val editorInfo = AtomicReference<EditorInfo?>()
+    val interceptor =
+      PlatformTextInputInterceptor { request, _ ->
+        val info = EditorInfo()
+        val connection = request.createInputConnection(info)
+        editorInfo.set(info)
+        try {
+          awaitCancellation()
+        } finally {
+          connection.closeConnection()
+        }
+      }
+    try {
+      val originalRequester =
+        ReflectionHelpers.getField<Lazy<(String, String?) -> String>>(runtime, "screenshotRequester\$delegate").value
+      val requester: (String, String?) -> String = { method, params ->
+        if (method != GatewayMethod.OpenclawChat.rawValue) {
+          originalRequester(method, params)
+        } else {
+          val requestIndex = requests.size
+          requests.add(Json.parseToJsonElement(requireNotNull(params)).jsonObject)
+          if (requestIndex > 0) {
+            check(releaseReplies[requestIndex - 1].await(10, TimeUnit.SECONDS)) { "Sending frame was not released" }
+          }
+          buildJsonObject {
+            put("reply", replies[requestIndex])
+            put("action", "none")
+            put("sensitive", requestIndex == 1)
+          }.toString()
+        }
+      }
+      ReflectionHelpers.setField(runtime, "screenshotRequester\$delegate", lazyOf(requester))
+      val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+      models.put("system-agent", viewModel)
+      ReflectionHelpers.getField<MutableStateFlow<NodeRuntime?>>(viewModel, "runtimeRef").value = runtime
+      composeRule.setContent {
+        ClawDesignTheme {
+          InterceptPlatformTextInput(interceptor) {
+            SettingsDetailScreen(viewModel, SettingsRoute.SystemAgent, onBack = {})
+          }
+        }
+      }
+      // SetText disappears while disabled; EditableText still identifies the real composer.
+      val input = composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.EditableText), useUnmergedTree = true)
+      val send = composeRule.onNodeWithText("Send")
+
+      fun awaitReply(index: Int) {
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+          val state = runtime.systemAgentChatState.value
+          state.messages.lastOrNull()?.text == replies[index] && !state.sending && state.expectsSensitiveReply == (index == 1)
+        }
+        composeRule.onNodeWithText(replies[index]).assertIsDisplayed()
+      }
+
+      fun sendAndReleaseReply(
+        expectedMessage: String,
+        replyIndex: Int,
+      ) {
+        send.performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000) {
+          requests.size > replyIndex && runtime.systemAgentChatState.value.sending
+        }
+        input.assertIsNotEnabled()
+        send.assertIsNotEnabled()
+        assertEquals("", runtime.systemAgentChatState.value.input)
+        assertEquals(expectedMessage, requests[replyIndex]["message"]?.jsonPrimitive?.content)
+        composeRule.runOnIdle { editorInfo.set(null) }
+        releaseReplies[replyIndex - 1].countDown()
+      }
+
+      fun assertInputPresentation(
+        value: String,
+        secret: Boolean,
+      ) {
+        composeRule.waitUntil(timeoutMillis = 5_000) { editorInfo.get() != null }
+        val info = requireNotNull(editorInfo.get())
+        assertEquals(
+          InputType.TYPE_CLASS_TEXT or if (secret) InputType.TYPE_TEXT_VARIATION_PASSWORD else 0,
+          info.inputType and (InputType.TYPE_MASK_CLASS or InputType.TYPE_MASK_VARIATION),
+        )
+        assertEquals(!secret, info.inputType and InputType.TYPE_TEXT_FLAG_AUTO_CORRECT != 0)
+        val layouts = mutableListOf<TextLayoutResult>()
+        input.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+        assertEquals(
+          if (secret) "\u2022".repeat(value.length) else value,
+          layouts
+            .single()
+            .layoutInput.text.text,
+        )
+      }
+
+      awaitReply(0)
+      val sessionId = runtime.systemAgentChatState.value.sessionId
+      input.assert(SemanticsMatcher.keyNotDefined(SemanticsProperties.Password))
+      input.performClick().performTextReplacement("  ordinary request  ")
+      sendAndReleaseReply("ordinary request", 1)
+
+      awaitReply(1)
+      input.assert(SemanticsMatcher.keyIsDefined(SemanticsProperties.Password))
+      val pasted = "  synthetic café 🔑\t  "
+      input.performClick()
+      composeRule.runOnIdle { clipboard.setPrimaryClip(ClipData.newPlainText("synthetic credential", pasted)) }
+      input.performSemanticsAction(SemanticsActions.PasteText) { assertTrue(it()) }
+      composeRule.waitUntil(timeoutMillis = 5_000) { runtime.systemAgentChatState.value.input == pasted }
+      assertInputPresentation(pasted, secret = true)
+      sendAndReleaseReply(pasted, 2)
+
+      awaitReply(2)
+      input.assert(SemanticsMatcher.keyNotDefined(SemanticsProperties.Password))
+      input.performClick().performTextReplacement("ordinary draft")
+      assertInputPresentation("ordinary draft", secret = false)
+      assertEquals(listOf(sessionId, sessionId, sessionId), requests.map { it["sessionId"]?.jsonPrimitive?.content })
+    } finally {
+      // Release blocking fixture replies before runtime cleanup joins its IO scope.
+      releaseReplies.forEach { it.countDown() }
+      try {
+        models.clear()
+      } finally {
+        try {
+          closeNodeRuntimeTestFixture(runtime)
+        } finally {
+          if (previousClip == null) clipboard.clearPrimaryClip() else clipboard.setPrimaryClip(previousClip)
+        }
+      }
+    }
+  }
 
   @Test
   @Config(qualifiers = "w360dp-h800dp-420dpi")
@@ -178,5 +386,30 @@ class SettingsDetailInsetsTest {
       org.junit.Assert.assertTrue("Save must be reachable", button.bottom <= viewport.bottom)
       org.junit.Assert.assertTrue("Last field must be reachable with Save", editor.top >= viewport.top && editor.bottom <= viewport.bottom)
     }
+  }
+
+  private fun assertGatewayInputPresentation(
+    initialText: String,
+    value: String,
+    secret: Boolean,
+  ) {
+    composeRule
+      .onNode(hasSetTextAction() and hasText(initialText))
+      .performScrollTo()
+      .performClick()
+      .performTextReplacement(value)
+    val input = composeRule.onNode(hasSetTextAction() and isFocused())
+    val layouts = mutableListOf<TextLayoutResult>()
+    input.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+    assertEquals(
+      "$initialText must use the expected visible input presentation",
+      if (secret) "\u2022".repeat(value.length) else value,
+      layouts
+        .single()
+        .layoutInput.text.text,
+    )
+    input.assert(
+      if (secret) SemanticsMatcher.keyIsDefined(SemanticsProperties.Password) else SemanticsMatcher.keyNotDefined(SemanticsProperties.Password),
+    )
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SystemAnimationsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SystemAnimationsTest.kt
@@ -8,8 +8,10 @@ import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -19,6 +21,10 @@ import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class SystemAnimationsTest {
+  // Keep ActivityController lifecycle coverage while synchronizing Compose snapshots and frames.
+  @get:Rule
+  val composeRule = createEmptyComposeRule()
+
   private val uri = Settings.Global.getUriFor(Settings.Global.ANIMATOR_DURATION_SCALE)
 
   private fun idleMainLooper() = shadowOf(Looper.getMainLooper()).idle()
@@ -36,17 +42,17 @@ class SystemAnimationsTest {
         val enabled = rememberSystemAnimationsEnabled()
         SideEffect { observed.add(enabled) }
       }
-      idleMainLooper()
+      composeRule.waitForIdle()
       assertEquals(true, observed.last())
 
       Settings.Global.putFloat(resolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
       resolver.notifyChange(uri, null)
-      idleMainLooper()
+      composeRule.waitForIdle()
       assertEquals(false, observed.last())
 
       Settings.Global.putFloat(resolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
       resolver.notifyChange(uri, null)
-      idleMainLooper()
+      composeRule.waitForIdle()
       assertEquals(true, observed.last())
     } finally {
       controller.pause().stop().destroy()
@@ -68,7 +74,7 @@ class SystemAnimationsTest {
         val enabled = rememberSystemAnimationsEnabled()
         SideEffect { observed.add(enabled) }
       }
-      idleMainLooper()
+      composeRule.waitForIdle()
       assertEquals(false, observed.first())
       assertEquals(false, observed.last())
     } finally {
@@ -84,7 +90,7 @@ class SystemAnimationsTest {
     val resolver = RuntimeEnvironment.getApplication().contentResolver
 
     controller.get().setContent { rememberSystemAnimationsEnabled() }
-    idleMainLooper()
+    composeRule.waitForIdle()
     assertTrue(shadowOf(resolver).getContentObservers(uri).isNotEmpty())
 
     controller.pause().stop().destroy()
@@ -104,7 +110,7 @@ class SystemAnimationsTest {
         OpenClawMascot()
         TalkWaveform(phase = TalkWaveformPhase.Idle)
       }
-      idleMainLooper()
+      composeRule.waitForIdle()
 
       assertEquals(2, shadowOf(resolver).getContentObservers(uri).size)
     } finally {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatQuestionDraftLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatQuestionDraftLayoutTest.kt
@@ -10,6 +10,7 @@ import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.chat.ChatQuestionPrompt
 import ai.openclaw.app.chat.ChatQuestionStatus
+import ai.openclaw.app.closeNodeRuntimeTestFixture
 import ai.openclaw.app.gateway.QuestionListResult
 import ai.openclaw.app.gateway.QuestionRecord
 import ai.openclaw.app.gateway.QuestionSecretStore
@@ -18,6 +19,8 @@ import ai.openclaw.app.ui.design.ClawDesignTheme
 import android.content.Context
 import android.os.Looper
 import android.provider.Settings
+import android.text.InputType
+import android.view.inputmethod.EditorInfo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
@@ -25,6 +28,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.platform.InterceptPlatformTextInput
+import androidx.compose.ui.platform.PlatformTextInputInterceptor
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
@@ -47,6 +52,7 @@ import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -63,6 +69,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], qualifiers = "w360dp-h800dp-420dpi")
@@ -105,13 +112,18 @@ class ChatQuestionDraftLayoutTest {
 
   @After
   fun tearDown() {
-    runtime.disconnect()
-    composeRule.waitForIdle()
-    viewModelStore.clear()
-    setApplicationRuntime(originalRuntime)
-    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
-    Settings.Global.putString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, originalAnimatorScale)
-    shadowOf(Looper.getMainLooper()).idle()
+    try {
+      viewModelStore.clear()
+    } finally {
+      try {
+        closeNodeRuntimeTestFixture(runtime)
+      } finally {
+        setApplicationRuntime(originalRuntime)
+        AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
+        Settings.Global.putString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, originalAnimatorScale)
+        shadowOf(Looper.getMainLooper()).idle()
+      }
+    }
   }
 
   @Test
@@ -125,14 +137,28 @@ class ChatQuestionDraftLayoutTest {
       )
     var prompt by mutableStateOf(ChatQuestionPrompt(question.copy(questions = listOf(secret), agentId = "requester", sessionKey = "agent:requester:main")))
     var submitted: Map<String, List<String>>? = null
+    val editorInfo = AtomicReference<EditorInfo>()
+    val interceptor =
+      PlatformTextInputInterceptor { request, _ ->
+        val info = EditorInfo()
+        val connection = request.createInputConnection(info)
+        editorInfo.set(info)
+        try {
+          awaitCancellation()
+        } finally {
+          connection.closeConnection()
+        }
+      }
     composeRule.setContent {
       ClawDesignTheme {
-        ChatQuestionCard(
-          prompt = prompt,
-          onDraftChanged = { _, update -> prompt = prompt.copy(draft = update(prompt.draft)) },
-          onSubmit = { _, answers -> submitted = answers },
-          onSkip = {},
-        )
+        InterceptPlatformTextInput(interceptor) {
+          ChatQuestionCard(
+            prompt = prompt,
+            onDraftChanged = { _, update -> prompt = prompt.copy(draft = update(prompt.draft)) },
+            onSubmit = { _, answers -> submitted = answers },
+            onSkip = {},
+          )
+        }
       }
     }
     composeRule.onNodeWithText("Requested by requester", substring = true).assertIsDisplayed()
@@ -144,7 +170,17 @@ class ChatQuestionDraftLayoutTest {
     val hosts = composeRule.onNode(hasSetTextAction() and hasText("Allowed HTTPS hosts"))
     hosts.assertTextContains("api.example.test").performTextReplacement("uploads.example.test, api.example.test")
     hosts.assertTextContains("uploads.example.test, api.example.test")
-    composeRule.onNode(hasSetTextAction() and hasText("Secret value")).performTextReplacement("  synthetic-value  ")
+    val secretInput = composeRule.onNode(hasSetTextAction() and hasText("Secret value"))
+    secretInput.performClick()
+    composeRule.waitUntil {
+      editorInfo.get()?.inputType?.and(InputType.TYPE_MASK_VARIATION) == InputType.TYPE_TEXT_VARIATION_PASSWORD
+    }
+    assertEquals(
+      "Secret replies must not request autocorrection",
+      0,
+      editorInfo.get().inputType and InputType.TYPE_TEXT_FLAG_AUTO_CORRECT,
+    )
+    secretInput.performTextReplacement("  synthetic-value  ")
     composeRule.onNodeWithText("Submit").performClick()
     assertEquals(mapOf(secret.questionId to listOf("  synthetic-value  ")), submitted)
   }

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -21,6 +21,8 @@ The official Android app is available on [Google Play](https://play.google.com/s
   - Protocols: [Gateway protocol](/gateway/protocol) (nodes + control plane).
 - **Settings → OpenClaw** opens a dedicated Gateway settings assistant when the operator connection has `operator.admin` and the Gateway supports `openclaw.chat`. Its setup conversation stays separate from ordinary Chat, redacts secret replies locally, and moves to Chat only after you tap **Open Chat**.
 
+Its reply field switches to masked input for secret prompts. Tap it again if a prompt change closes the keyboard. Android sends sensitive replies without trimming them and clears unsent drafts when you leave this page or background the app.
+
 System control (launchd/systemd) lives on the Gateway host — see [Gateway](/gateway).
 
 ## Simultaneous gateway sessions
@@ -236,6 +238,8 @@ In the Android app:
 - After setup, open **Settings → Gateway**. **Add Gateway** lets you scan or paste a setup code, or connect to a discovered Gateway.
 - If discovery is blocked, use **Manual Gateway** on that page: enter the host and port, select **Connection security**, and tap **Save & Connect**. Private LAN hosts support `ws://`; for Tailscale/public hosts, use **Secure (TLS)** with a `wss://` / Tailscale Serve endpoint.
 
+Gateway tokens, bootstrap tokens, passwords, and setup codes are masked and accept paste. The app requests password input with autocorrection disabled, but cannot guarantee how a third-party keyboard stores or learns from input.
+
 After the first successful pairing, Android auto-reconnects on launch to the active paired gateway (best-effort for discovered gateways, which must be visible on the network).
 
 Android retries temporary connection losses automatically. For a fresh attempt with the saved endpoint, open **Settings → Gateway** and tap **Reconnect**. **Disconnect** stops the connections and suppresses automatic reconnect for the current app session; it does not forget the pairing. Authentication or pairing errors can pause retries until you address the reported problem.
@@ -401,6 +405,8 @@ multi-select options, option descriptions, free-text **Other** answers, and an
 expiry countdown. Reconnects reload pending questions from the Gateway. A card
 locks when this device answers it, another surface answers it first, or the
 question expires or is cancelled.
+
+Secret answer fields mask typed or pasted values and request password input with autocorrection disabled. Android submits secret answers without trimming leading or trailing whitespace.
 
 ## Assistant entrypoints
 


### PR DESCRIPTION
Related: #134939, #136173

## What Problem This Solves

Fixes an issue where users entering a Gateway setup code, token, bootstrap token, or password could see the credential in plain text and in the keyboard's suggestion strip. The Settings assistant had a second problem: changing between an ordinary question and a secret question could leave Android's input/accessibility state in the previous mode, even when the drawn text looked masked.

## Why This Change Was Made

Gateway and Settings-assistant credential fields now use one shared editor with password masking and autocorrection disabled. The Settings assistant uses that same editor, recreating only its editor/focus lifetime when sensitivity changes; the controller still owns the value, submission and cancellation. Host and port remain ordinary text fields. The existing secret-question card also disables autocorrection without changing consent, allowed hosts, or answer submission.

This removes the assistant's duplicate text-field implementation rather than adding another input path. Production: **+70 / −85 (net −15)** across five files. Tests: **+375 / −20** across four existing files. Documentation: **+8**. No dependency, configuration, permission, database, protocol, or RPC changes.

## User Impact

Credentials stay visually masked and request password input from Android. Paste stays available, and Android does not trim secret replies at the submission boundary. Normal replies become normal text again after a secret step is cancelled. A sensitivity change may require tapping the replacement editor to focus it. These flags are a request to the keyboard, not a guarantee about a third-party keyboard's learning or storage.

Existing route/background draft clearing and connection-saving behavior are unchanged. No entered credential was saved or submitted during the installed-app checks.

## Evidence

- **Paired regression proof:** four targeted cases fail for the intended reasons on the original source in both phone flavors, then pass with the fix: onboarding credentials, manual Gateway credentials, the Settings assistant's sensitivity transition, and the secret-question card's autocorrection flag. The tests also exercise actual input-connection construction, native clipboard paste, consent and whitespace/Unicode preservation.
- **Full native gate:** 5,469 tests across Play, third-party, Wear and shared modules; 430 XML reports; zero failures, errors or skips. All four ktlint checks, all four Android lint checks and both phone debug APK builds completed successfully.
- **Checks/review:** `node scripts/check-changed.mjs --staged` passed on the exact subsequently committed patch. Managed Codex review completed three P2 passes with no actionable findings. The signed commit and final APK inputs match the reviewed patch.
- **Installed API 36 app:** normal debug-APK upgrade preserved the checked appearance/sidebar/onboarding preferences and selected chat. All four Gateway settings credential fields exposed password semantics and actual `EditorInfo.inputType=0x20081`, with autocorrection off. In the real Gateway setup wizard, the same Settings composition changed from ordinary input to secret input and back to ordinary `0x28001` after cancellation. The synthetic secret was cleared before sending only `cancel`; route re-entry showed an empty draft, and the original chat was restored.

- **Protected question, real agent path:** a fresh loopback Gateway and the canonical synthetic provider advertised the actual `secrets` function, then the admitted primary agent created one protected secret prompt. The installed app's empty focused editor exposed `0x20081` with `TYPE_TEXT_FLAG_AUTO_CORRECT` absent. One **Skip** produced the same request's cancelled readback, the real matching `no_answer` tool return, successful run completion and normal terminal-record cleanup. No secret was entered or submitted. The original Gateway/chat, checked preferences, node identity and permission flags were restored; the new saved entry, processes, reverse port and temporary state were removed.
- **Hosted CI:** [run 33640805529, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33640805529/attempts/1) completed successfully on `fefcbb37f750d35e441e8597eaeedf1ae21e3c27`: all six Android jobs and the required `openclaw/ci-gate` passed. No CI retry was needed.

The first full run exposed a pre-existing test synchronization failure: draining Robolectric's main looper did not apply a pending Compose snapshot. `SystemAnimationsTest` now uses the pinned Compose test rule's idle barrier for live observations, retaining every assertion and the post-destruction raw drains. The final full run passed with the original class/method start order in both phone flavors; no production animation change, larger timeout or weakened assertion was used.

### Before and after

All captures are from the owned synthetic emulator. Scroll positions differ; the manual-field after image hides the keyboard to show all three fields.

| Setup code before | Setup code after |
| --- | --- |
| ![Synthetic setup code visible before](https://github.com/user-attachments/assets/255ca628-eaee-4ee9-aee3-dadbdce1d4a4) | ![Setup code masked with password keyboard after](https://github.com/user-attachments/assets/a79bc459-744e-47a7-8bfb-a4cc60beab68) |

| Manual credentials before | Manual credentials after |
| --- | --- |
| ![Synthetic manual credentials visible before](https://github.com/user-attachments/assets/3070023f-f14f-4bb3-9f26-238facf5f99d) | ![Manual credentials masked after](https://github.com/user-attachments/assets/47097fba-6e22-41cd-bc6f-e7602af05557) |

### Genuine secret-question flow on the installed candidate

The focused capture shows the empty secret editor and keyboard; the second shows the completed Skip. Input flags were separately read from Android's served `EditorInfo`, not inferred from the image.

| Empty protected editor | After Skip |
| --- | --- |
| ![Actual protected secret editor with password keyboard](https://github.com/user-attachments/assets/1a279bfc-e761-4222-b530-1b4e132f4a36) | ![Actual question skipped and agent run finished](https://github.com/user-attachments/assets/2e6405da-b53b-4b4c-9f1b-efa0d0e5a8e1) |

### Proof boundaries

The installed checks are a same-signer debug upgrade, not a Play/stable release-upgrade claim. Their real Gateway is the recertified `5fa8356483a8357e7c7bd0943caa52f1982beefe` build with a synthetic local provider; they do not claim live OpenAI or later server behavior. Onboarding is covered through its actual Compose screen; the secret-question card now also has genuine agent-produced installed-app proof. The new fixture required no Android permission grants; the operator connection was sufficient, and the separate node role was not paired.

The captured-main audit at `21e356c8945299e5da48bcc479199d54e44c3311` found all eleven preimages unchanged. Main's separate #136304 refresh fixes the inherited missing/obsolete translation IDs; this does not relabel the earlier strict-catalog failure or claim strict parity on this standalone branch.

### Review follow-through

The two pre-merge items in [ClawSweeper's review](https://github.com/openclaw/openclaw/pull/136352#issuecomment-5511072500) are closed. The pinned Compose 1.12.0 sources were directly inspected: `CoreTextFieldSemanticsModifierNode.updateNodeSemantics` invalidates when `isPassword` changes but does not update that field, and the Android `EditorInfo` bridge adds AUTO_CORRECT independently of password variation. The paired regressions and actual same-composition wizard round trip cover both contracts. Exact-head Android CI is terminal green; no code changed after that review.

### Reproducible local gate

Run from the repository root on the reviewed source:

```sh
node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts \
  --no-daemon --max-workers=2 --console=plain --continue --rerun-tasks \
  :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest \
  :wear:testDebugUnitTest :wear-shared:testDebugUnitTest \
  :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck \
  :app:lintPlayDebug :app:lintThirdPartyDebug :wear:lintDebug :wear-shared:lintDebug \
  :app:assemblePlayDebug :app:assembleThirdPartyDebug
node scripts/check-changed.mjs --staged
```

The staged check ran before the byte-identical final commit; the APK build likewise used those exact precommit source bytes.

The Settings assistant's existing conversation scrolling and narrow bubbles are a separate follow-up, not hidden by this input repair.
