### PR TITLE
test(ui): join placement dialog work before fixture teardown

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -7,7 +7,9 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getContextWindowCaches } from "../agents/context-cache.js";
 import {
@@ -3217,7 +3219,9 @@ test.each([
         await expect(fs.readFile(dirtyFile, "utf8")).resolves.toBe("preserve my work\n");
         expect(warnSpy).toHaveBeenCalledOnce();
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(worktree.branch));
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(worktree.path));
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(truncateUtf16Safe(sanitizeForLog(worktree.path), 256)),
+        );
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("retained-dirty"));
       } else if (outcome === "failed") {
         expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toBeUndefined();

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -1284,6 +1284,8 @@ export async function rpcReq<T extends Record<string, unknown>>(
   // Refresh mutable config fixtures, but leave in-flight session writers owned
   // by the running Gateway; their producers publish SQLite cache updates.
   resetConfigRuntimeState();
+  // Republish fixture overrides before in-flight readers can pin the disk config.
+  getRuntimeConfig();
   if (method === "agent" || method === "chat.send") {
     await prepareGatewayReplyRuntimeForTest();
   }

--- a/ui/src/pages/chat/chat-pane-placement-restart.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement-restart.test.ts
@@ -4,23 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
-import { installDialogPolyfill } from "../../test-helpers/modal-dialog.ts";
+import { createModalDialogTestFixture } from "../../test-helpers/modal-dialog.ts";
 import { createTestChatPane } from "./chat-pane.test-support.ts";
 
-let restoreDialogPolyfill: () => void;
+let dialogs: ReturnType<typeof createModalDialogTestFixture>;
 
 beforeEach(() => {
-  restoreDialogPolyfill = installDialogPolyfill();
+  dialogs = createModalDialogTestFixture();
 });
 
-afterEach(() => {
-  document.body.replaceChildren();
-  restoreDialogPolyfill();
-});
+afterEach(() => dialogs.cleanup());
 
 describe("chat pane placement restart", () => {
   it("restarts a failed placement on a selected profile without creating a session", async () => {
-    const request = vi.fn(async (method: string) => {
+    const request = dialogs.mockRequest(async (method: string) => {
       if (method === "environments.list") {
         return {
           profiles: [{ id: "aws", providerId: "crabbox" }],
@@ -57,7 +54,7 @@ describe("chat pane placement restart", () => {
       },
     };
 
-    const restarting = pane.restartHeaderPlacement(session);
+    const restarting = dialogs.track(pane.restartHeaderPlacement(session));
     await vi.waitFor(() => {
       expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
     });

--- a/ui/src/pages/chat/chat-pane-placement.test.ts
+++ b/ui/src/pages/chat/chat-pane-placement.test.ts
@@ -6,7 +6,7 @@ import type { GatewaySessionRow } from "../../api/types.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
   answerConfirmDialog,
-  installDialogPolyfill,
+  createModalDialogTestFixture,
   waitForConfirmDialogActions,
 } from "../../test-helpers/modal-dialog.ts";
 import {
@@ -15,21 +15,23 @@ import {
   createTestChatPane,
 } from "./chat-pane.test-support.ts";
 
-let restoreDialogPolyfill: () => void;
+let dialogs: ReturnType<typeof createModalDialogTestFixture>;
 
 beforeEach(() => {
-  restoreDialogPolyfill = installDialogPolyfill();
+  dialogs = createModalDialogTestFixture();
 });
 
-afterEach(() => {
-  document.body.replaceChildren();
-  restoreDialogPolyfill();
-  vi.unstubAllGlobals();
+afterEach(async () => {
+  try {
+    await dialogs.cleanup();
+  } finally {
+    vi.unstubAllGlobals();
+  }
 });
 
 describe("chat pane placement", () => {
   it("shows authoritative device targets to writers and moves to the selected device", async () => {
-    const request = vi.fn(async (method: string) => {
+    const request = dialogs.mockRequest(async (method: string) => {
       if (method === "environments.list") {
         return {
           profiles: [{ id: "aws", providerId: "crabbox" }],
@@ -80,7 +82,7 @@ describe("chat pane placement", () => {
     } as never;
     const session = { ...activePlacementSession(), hasActiveRun: true };
 
-    const moving = pane.moveHeaderPlacement(session);
+    const moving = dialogs.track(pane.moveHeaderPlacement(session));
     await vi.waitFor(() => {
       expect(document.body.querySelector('[data-value="device:runner"]')).not.toBeNull();
     });
@@ -120,7 +122,7 @@ describe("chat pane placement", () => {
   });
 
   it("moves an active placement to a selected profile machine", async () => {
-    const request = vi.fn(async (method: string) => {
+    const request = dialogs.mockRequest(async (method: string) => {
       if (method === "environments.list") {
         return {
           profiles: [
@@ -152,7 +154,7 @@ describe("chat pane placement", () => {
     } as never;
     const session = activePlacementSession();
 
-    const moving = pane.moveHeaderPlacement(session);
+    const moving = dialogs.track(pane.moveHeaderPlacement(session));
     await vi.waitFor(() => {
       expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
     });
@@ -193,7 +195,7 @@ describe("chat pane placement", () => {
   ] as const)(
     "moves $runtimeId to the same two-mode cloud profile while preserving machine selection",
     async ({ runtimeId, executionMode, compatibleSingleMode, incompatibleSingleMode }) => {
-      const request = vi.fn(async (method: string) => {
+      const request = dialogs.mockRequest(async (method: string) => {
         if (method === "environments.list") {
           return {
             profiles: [
@@ -249,57 +251,48 @@ describe("chat pane placement", () => {
         },
       } satisfies GatewaySessionRow;
 
-      const moving = pane.moveHeaderPlacement(session);
-      try {
-        await vi.waitFor(() => {
-          expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
-        });
-        const incompatible = document.body.querySelector<HTMLButtonElement>(
-          `[data-value="cloud:${incompatibleSingleMode}"]`,
-        );
-        expect(incompatible?.disabled).toBe(true);
-        expect(incompatible?.title).toMatch(/compatible cloud worker|cannot use/i);
-        const lifecycleOnly = document.body.querySelector<HTMLButtonElement>(
-          '[data-value="cloud:lifecycle-only"]',
-        );
-        expect(lifecycleOnly?.disabled).toBe(true);
-        expect(lifecycleOnly?.title).toMatch(/compatible cloud worker|cannot use/i);
-        const compatibleSingle = document.body.querySelector<HTMLButtonElement>(
-          `[data-value="cloud:${compatibleSingleMode}"]`,
-        );
-        expect(compatibleSingle?.disabled).toBe(false);
-        const multiMode = document.body.querySelector<HTMLButtonElement>(
-          '[data-value="cloud:aws"]',
-        );
-        expect(multiMode?.disabled).toBe(false);
-        multiMode?.click();
-        document.body.querySelector<HTMLButtonElement>('[data-value="machine:beast"]')?.click();
-        [...document.body.querySelectorAll<HTMLButtonElement>("button")]
-          .find((button) => button.textContent?.trim() === "Move session")
-          ?.click();
-        await moving;
+      const moving = dialogs.track(pane.moveHeaderPlacement(session));
+      await vi.waitFor(() => {
+        expect(document.body.querySelector('[data-value="cloud:aws"]')).not.toBeNull();
+      });
+      const incompatible = document.body.querySelector<HTMLButtonElement>(
+        `[data-value="cloud:${incompatibleSingleMode}"]`,
+      );
+      expect(incompatible?.disabled).toBe(true);
+      expect(incompatible?.title).toMatch(/compatible cloud worker|cannot use/i);
+      const lifecycleOnly = document.body.querySelector<HTMLButtonElement>(
+        '[data-value="cloud:lifecycle-only"]',
+      );
+      expect(lifecycleOnly?.disabled).toBe(true);
+      expect(lifecycleOnly?.title).toMatch(/compatible cloud worker|cannot use/i);
+      const compatibleSingle = document.body.querySelector<HTMLButtonElement>(
+        `[data-value="cloud:${compatibleSingleMode}"]`,
+      );
+      expect(compatibleSingle?.disabled).toBe(false);
+      const multiMode = document.body.querySelector<HTMLButtonElement>('[data-value="cloud:aws"]');
+      expect(multiMode?.disabled).toBe(false);
+      multiMode?.click();
+      document.body.querySelector<HTMLButtonElement>('[data-value="machine:beast"]')?.click();
+      [...document.body.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent?.trim() === "Move session")
+        ?.click();
+      await moving;
 
-        expect(request).toHaveBeenCalledWith(
-          "sessions.move",
-          expect.objectContaining({
-            target: {
-              kind: "profile",
-              profileId: "aws",
-              machineClass: "beast",
-            },
-          }),
-        );
-      } finally {
-        [...document.body.querySelectorAll<HTMLButtonElement>("button")]
-          .find((button) => button.textContent?.trim() === "Cancel")
-          ?.click();
-        await moving;
-      }
+      expect(request).toHaveBeenCalledWith(
+        "sessions.move",
+        expect.objectContaining({
+          target: {
+            kind: "profile",
+            profileId: "aws",
+            machineClass: "beast",
+          },
+        }),
+      );
     },
   );
 
   it("cancels offline-device continuation without opening a picker or sending an RPC", async () => {
-    const request = vi.fn(async () => ({ ok: true }));
+    const request = dialogs.mockRequest(async () => ({ ok: true }));
     const { pane } = createTestChatPane({
       client: { request } as unknown as GatewayBrowserClient,
       sessions: {} as SessionCapability,
@@ -309,7 +302,7 @@ describe("chat pane placement", () => {
       auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
     } as never;
 
-    const moving = pane.moveHeaderPlacement(offlineDeviceSession());
+    const moving = dialogs.track(pane.moveHeaderPlacement(offlineDeviceSession()));
     const actions = await waitForConfirmDialogActions();
     expect(document.body.textContent).toContain(
       "Unsynced device files and in-flight work may be lost",
@@ -322,7 +315,7 @@ describe("chat pane placement", () => {
   });
 
   it("continues an offline device placement on the Gateway with exact abandonment", async () => {
-    const request = vi.fn(async () => ({ ok: true }));
+    const request = dialogs.mockRequest(async () => ({ ok: true }));
     const refreshReplacement = vi.fn(async () => undefined);
     const { pane } = createTestChatPane({
       client: { request } as unknown as GatewayBrowserClient,
@@ -334,7 +327,7 @@ describe("chat pane placement", () => {
     } as never;
     const session = offlineDeviceSession();
 
-    const moving = pane.moveHeaderPlacement(session);
+    const moving = dialogs.track(pane.moveHeaderPlacement(session));
     answerConfirmDialog(await waitForConfirmDialogActions(), "confirm");
     await moving;
 
@@ -355,7 +348,7 @@ describe("chat pane placement", () => {
   });
 
   it("keeps the offline placement visible when continuation fails", async () => {
-    const request = vi.fn(async () => {
+    const request = dialogs.mockRequest(async () => {
       throw new Error("device teardown is still pending; retry Continue on Gateway");
     });
     const refreshReplacement = vi.fn(async () => undefined);
@@ -369,7 +362,7 @@ describe("chat pane placement", () => {
     } as never;
     const session = offlineDeviceSession();
 
-    const moving = pane.moveHeaderPlacement(session);
+    const moving = dialogs.track(pane.moveHeaderPlacement(session));
     answerConfirmDialog(await waitForConfirmDialogActions(), "confirm");
     await moving;
 
@@ -379,7 +372,7 @@ describe("chat pane placement", () => {
   });
 
   it("disables paired-device moves for a runtime that cannot dispatch there", async () => {
-    const request = vi.fn(async (method: string) => {
+    const request = dialogs.mockRequest(async (method: string) => {
       if (method === "environments.list") {
         return {
           profiles: [],
@@ -417,7 +410,7 @@ describe("chat pane placement", () => {
       },
     } satisfies GatewaySessionRow;
 
-    const moving = pane.moveHeaderPlacement(session);
+    const moving = dialogs.track(pane.moveHeaderPlacement(session));
     await vi.waitFor(() => {
       expect(document.body.querySelector('[data-value="device:build-mac"]')).not.toBeNull();
     });
@@ -442,7 +435,7 @@ describe("chat pane placement", () => {
   ] as const)(
     "moves a $runtimeId session to a supported paired device",
     async ({ runtimeId, executionMode }) => {
-      const request = vi.fn(async (method: string) => {
+      const request = dialogs.mockRequest(async (method: string) => {
         if (method === "environments.list") {
           return {
             profiles: [],
@@ -488,7 +481,7 @@ describe("chat pane placement", () => {
         },
       } satisfies GatewaySessionRow;
 
-      const moving = pane.moveHeaderPlacement(session);
+      const moving = dialogs.track(pane.moveHeaderPlacement(session));
       await vi.waitFor(() => {
         expect(document.body.querySelector('[data-value="device:build-mac"]')).not.toBeNull();
       });
@@ -550,7 +543,7 @@ describe("chat pane placement", () => {
       reason: /enable|approv/i,
     },
   ] as const)("$name in the Move Session picker", async (scenario) => {
-    const request = vi.fn(async (method: string) => {
+    const request = dialogs.mockRequest(async (method: string) => {
       if (method === "environments.list") {
         return {
           profiles: [],
@@ -595,24 +588,21 @@ describe("chat pane placement", () => {
       },
     } satisfies GatewaySessionRow;
 
-    const moving = pane.moveHeaderPlacement(session);
-    try {
-      await vi.waitFor(() => {
-        expect(document.body.querySelector('[data-value="device:build-mac"]')).not.toBeNull();
-      });
-      const device = document.body.querySelector<HTMLButtonElement>(
-        '[data-value="device:build-mac"]',
-      );
-      expect(device?.disabled).toBe(scenario.disabled);
-      if (scenario.reason !== undefined) {
-        expect(device?.title).toMatch(scenario.reason);
-      }
-    } finally {
-      [...document.body.querySelectorAll<HTMLButtonElement>("button")]
-        .find((button) => button.textContent?.trim() === "Cancel")
-        ?.click();
-      await moving;
+    const moving = dialogs.track(pane.moveHeaderPlacement(session));
+    await vi.waitFor(() => {
+      expect(document.body.querySelector('[data-value="device:build-mac"]')).not.toBeNull();
+    });
+    const device = document.body.querySelector<HTMLButtonElement>(
+      '[data-value="device:build-mac"]',
+    );
+    expect(device?.disabled).toBe(scenario.disabled);
+    if (scenario.reason !== undefined) {
+      expect(device?.title).toMatch(scenario.reason);
     }
+    [...document.body.querySelectorAll<HTMLButtonElement>("button")]
+      .find((button) => button.textContent?.trim() === "Cancel")
+      ?.click();
+    await moving;
 
     expect(request).not.toHaveBeenCalledWith("sessions.move", expect.anything());
   });

--- a/ui/src/test-helpers/modal-dialog.ts
+++ b/ui/src/test-helpers/modal-dialog.ts
@@ -43,6 +43,69 @@ export function installDialogPolyfill(): () => void {
   };
 }
 
+export function createModalDialogTestFixture() {
+  const restoreDialogPolyfill = installDialogPolyfill();
+  const operations: Promise<unknown>[] = [];
+  const requests: Promise<unknown>[] = [];
+  const modals = new Set<HTMLElement>();
+  const captureModals = () => {
+    for (const modal of document.body.querySelectorAll("openclaw-modal-dialog")) {
+      modals.add(modal);
+    }
+  };
+  const observer = new MutationObserver(captureModals);
+  observer.observe(document.body, { childList: true, subtree: true });
+  let pendingCleanup: Promise<void> | undefined;
+
+  function track<T>(completion: Promise<T>, work: Promise<unknown>[]) {
+    work.push(completion);
+    void completion.catch(() => {});
+    return completion;
+  }
+
+  async function cleanup() {
+    let joined = false;
+    try {
+      // An assertion can fail before the lazy dialog exists. Catalog completion
+      // can repaint its host, so join those responses before cancelling the owner.
+      await vi.dynamicImportSettled();
+      await Promise.allSettled(requests);
+      await vi.dynamicImportSettled();
+      captureModals();
+      for (const modal of modals) {
+        if (modal.parentElement) {
+          modal.dispatchEvent(new CustomEvent("modal-cancel", { cancelable: true }));
+        }
+      }
+      const results = await Promise.allSettled(operations);
+      await vi.dynamicImportSettled();
+      joined = true;
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "Dialog operations failed during fixture cleanup");
+      }
+    } finally {
+      observer.disconnect();
+      if (joined) {
+        document.body.replaceChildren();
+        restoreDialogPolyfill();
+      }
+    }
+  }
+
+  return {
+    track: <T>(completion: Promise<T>) => track(completion, operations),
+    mockRequest: <Args extends unknown[], Result>(request: (...args: Args) => Promise<Result>) =>
+      vi.fn((...args: Args) => track(request(...args), requests)),
+    cleanup: () => (pendingCleanup ??= cleanup()),
+  };
+}
+
 /**
  * Wait for the confirm dialog `showConfirmDialog` renders into `document.body`.
  * Returned separately from answering it so tests can mutate owner state (a


### PR DESCRIPTION
After a placement test failed while waiting for its catalog, teardown removed the dialog DOM and restored the native-dialog polyfill while the real move remained pending. Web Awesome closed its native dialog on disconnect, but that did not cancel the placement owner. The retained operation could suppress a later restart in the non-isolated UI test worker.

Give the placement and restart tests one modal fixture that tracks their actual action and request promises. Cleanup settles lazy imports and catalog responses, cancels still-owned dialogs through the existing modal-cancel event, joins callers, then removes the DOM and restores the polyfill. Keep cleanup in afterEach so Vitest preserves the original assertion failure alongside a cleanup failure. Remove the duplicated in-body finally blocks and retain the existing successful Cancel-button interactions.

The original failure-path probe reproduced the pending move and suppressed restart, then recovered them by cancelling the retained owner. The candidate probe exercised delayed-catalog move, restart and offline confirmation. In all three flows, real connected-host cancellation preceded caller settlement, and caller settlement preceded DOM/polyfill release. The delayed catalog painted before cancellation. All three original assertion errors were preserved, all six caller/cleanup observations settled, RPC counts stayed move=1/restart=1/offline=0, and no rescue was used. The initial CI wait failure's trigger remains unknown; this repairs the observed teardown cascade.

All 14 original and 14 candidate placement/restart cases passed, along with seven confirmation sibling cases and the three-flow probe. Whole commands took 6.440 / 6.417 seconds; no normal-path speedup is claimed. Existing one-second waits, polling intervals, real imports, Lit/Web Awesome components, request arguments and assertions remain. Proof used the canonical UI/jsdom configuration, Node 24.19.0 and Web Awesome 3.12.0.

All wrappers joined, temporary roots were empty, all 74 source guards were restored and the private probe was removed. Formatting, typed lint and Codex P0 review passed. Production delta is zero; five test/support files add 151 and remove 95 lines. The 63-line fixture supplies the missing lifetime owner without changing product dialogs, requests, protocols or persistence. Exact-head CI remains required before landing.

CI also exposed a separate shared Gateway test-fixture race. `rpcReq` cleared the runtime config snapshot and yielded before publishing the mutable fixture overrides. A real in-flight config reader could pin the fixture's on-disk main-only config, making an admitted worktree run fail with an unknown-agent error. The RPC helper now publishes the fixture config synchronously after resetting it. This changes only test support.

A controlled probe kept the existing real command preparation and first `agent.wait` assertion. With the original helper, the snapshot became empty during the RPC yield, the real loader pinned main-only config, and the existing assertion failed with the same unknown-agent error. With the two-line fix and identical probe, both initial and follow-up turns passed; all preparation, lease-release and wait promises joined. The disk config remained unchanged in each run. This proves the race mechanism; the exact competing reader in the original CI run was not captured.

The complete Gateway selection also exposed an overstrict retained-worktree warning assertion under a long temporary path: the production warning intentionally sanitizes and caps paths at 256 characters. The test now derives its expected displayed path with the existing formatter. It retains the warning count, branch and outcome checks and the actual file-preservation and registry assertions.

Final Gateway validation passed all 323 cases across the original 19-file CI selection and the nine-case server-environment sibling. The focused dirty-checkout case also passed with a 274-character worktree path. The preceding complete run's only failure was the old full-path warning assertion; all 323 case identities and existing timeouts are retained. Formatting, typed lint and a fresh Codex P0 review passed for both CI repairs.
