### PR TITLE
fix(llama-cpp): reconcile managed router state before requests

### DIFF
--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -293,6 +293,7 @@ listed here.
 | `prepareExtraParams`              | Request-param normalization before generic stream option wrappers                                              | Provider needs default request params or per-provider param cleanup                                                                           |
 | `createStreamFn`                  | Fully replace the normal stream path with a custom transport                                                   | Provider needs a custom wire protocol, not just a wrapper                                                                                     |
 | `wrapStreamFn`                    | Stream wrapper after generic wrappers are applied                                                              | Provider needs request headers/body/model compat wrappers without a custom transport                                                          |
+| `reconcileLocalService`           | Reconcile provider-owned state after local-service health and before every request                             | A managed local router must reload durable provider state without moving provider policy into core                                            |
 | `resolveTransportTurnState`       | Attach native per-turn headers, metadata, or WebSocket policy                                                  | Provider wants generic transports to send provider-native turn identity or tune WebSocket headers and fallback cool-down                      |
 | `resolveWebSocketSessionPolicy`   | Deprecated compatibility hook for WebSocket policy                                                             | Existing plugins migrate WebSocket fields into `resolveTransportTurnState`                                                                    |
 | `formatApiKey`                    | Auth-profile formatter: stored profile becomes the runtime `apiKey` string                                     | Provider stores extra auth metadata and needs a custom runtime token shape                                                                    |
@@ -316,6 +317,11 @@ listed here.
 | `sanitizeReplayHistory`           | Rewrite replay history after generic transcript cleanup                                                        | Provider needs provider-specific replay rewrites beyond shared compaction helpers                                                             |
 | `validateReplayTurns`             | Final replay-turn validation or reshaping before the embedded runner                                           | Provider transport needs stricter turn validation after generic sanitation                                                                    |
 | `onModelSelected`                 | Run provider-owned post-selection side effects                                                                 | Provider needs telemetry or provider-owned state when a model becomes active                                                                  |
+
+`reconcileLocalService` runs only for configured local services, including a
+healthy process reused from outside the current Gateway process. Keep it cheap,
+idempotent, and abort-aware. A rejection blocks the provider request and
+releases its lease without classifying the healthy process as a startup failure.
 
 Normalization dispatch is hook-specific:
 

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -794,6 +794,7 @@ catalog, API-key auth, and dynamic model resolution.
       | `prepareExtraParams` | Default request params |
       | `createStreamFn` | Fully custom StreamFn transport |
       | `wrapStreamFn` | Custom headers/body wrappers on the normal stream path |
+      | `reconcileLocalService` | Cheap, idempotent managed-service repair after health and before every request |
       | `resolveTransportTurnState` | Native per-turn headers/metadata and WebSocket headers/cool-down |
       | `resolveWebSocketSessionPolicy` | Deprecated WebSocket compatibility hook; use `resolveTransportTurnState` |
       | `formatApiKey` | Custom runtime token shape |
@@ -818,6 +819,11 @@ catalog, API-key auth, and dynamic model resolution.
       | `sanitizeReplayHistory` | Provider-specific replay rewrites after generic cleanup |
       | `validateReplayTurns` | Strict replay-turn validation before the embedded runner |
       | `onModelSelected` | Post-selection callback (e.g. telemetry) |
+
+      `reconcileLocalService` is called only for a configured local service,
+      including a healthy process reused by a restarted Gateway. Honor its
+      abort signal and reject when reconciliation fails; OpenClaw blocks the
+      provider request and releases the request lease.
 
       Runtime fallback notes:
 

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   ensureModel: vi.fn(),
   ensureChat: vi.fn(),
   prepareServer: vi.fn(),
+  reconcileServer: vi.fn(),
   inspectRuntime: vi.fn(),
   genericCreate: vi.fn(),
   detectHardware: vi.fn(),
@@ -43,6 +44,7 @@ vi.mock("./src/managed-server.js", async (importOriginal) => ({
   ensureLlamaCppModel: mocks.ensureModel,
   ensureManagedLlamaServerForChat: mocks.ensureChat,
   prepareManagedLlamaServer: mocks.prepareServer,
+  reconcileManagedLlamaServer: mocks.reconcileServer,
   inspectLlamaServerRuntime: mocks.inspectRuntime,
 }));
 
@@ -173,6 +175,7 @@ describe("llama.cpp provider plugin", () => {
         label: "llama.cpp",
         normalizeToolSchemas: expect.any(Function),
         inspectToolSchemas: expect.any(Function),
+        reconcileLocalService: mocks.reconcileServer,
         auth: expect.arrayContaining([
           expect.objectContaining({ id: "local" }),
           expect.objectContaining({ id: "existing-server" }),
@@ -184,6 +187,23 @@ describe("llama.cpp provider plugin", () => {
       "llama-cpp",
       "llama-cpp-existing-server",
     ]);
+    expect(
+      provider.wrapSimpleCompletionStreamFn?.({
+        config: {
+          models: {
+            providers: {
+              [LLAMA_CPP_PROVIDER_ID]: {
+                baseUrl: "http://127.0.0.1:8080/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        provider: LLAMA_CPP_PROVIDER_ID,
+        modelId: "external",
+        streamFn: vi.fn(),
+      } as never),
+    ).toBeUndefined();
     expect(provider).not.toHaveProperty("createStreamFn");
   });
 
@@ -347,6 +367,48 @@ describe("llama.cpp provider plugin", () => {
     });
   });
 
+  it("reapplies embedding A to B to A and injects preset reconciliation", async () => {
+    const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
+    const options = Object.assign(configuredOptions(), { acquireLocalService });
+    const provider = options.config.models.providers[LLAMA_CPP_PROVIDER_ID];
+    provider.baseUrl = "http://127.0.0.1:29434/v1";
+    provider.params = { modelCacheDir: "/models/embedding-transition-cache" };
+    mocks.ensureModel.mockImplementation(async ({ source }) => source);
+    await llamaCppEmbeddingProviderAdapter.create({
+      ...options,
+      local: { modelPath: "/models/first-embedding.gguf" },
+    });
+    await llamaCppEmbeddingProviderAdapter.create({
+      ...options,
+      local: { modelPath: "/models/second-embedding.gguf" },
+    });
+    await llamaCppEmbeddingProviderAdapter.create({
+      ...options,
+      local: { modelPath: "/models/first-embedding.gguf" },
+    });
+    expect(mocks.prepareServer).toHaveBeenCalledTimes(3);
+    expect(mocks.prepareServer.mock.calls.map(([call]) => call.embeddingModelPath)).toEqual([
+      "/models/first-embedding.gguf",
+      "/models/second-embedding.gguf",
+      "/models/first-embedding.gguf",
+    ]);
+    const forwarded = mocks.genericCreate.mock.calls[0]?.[0] as {
+      acquireLocalService?: (
+        target: { providerId: string; baseUrl: string },
+        signal?: AbortSignal,
+      ) => Promise<unknown>;
+    };
+    const target = {
+      providerId: LLAMA_CPP_PROVIDER_ID,
+      baseUrl: "http://127.0.0.1:19432/v1",
+    };
+    await forwarded.acquireLocalService?.(target);
+    expect(acquireLocalService).toHaveBeenCalledWith(
+      { ...target, reconcile: mocks.reconcileServer },
+      undefined,
+    );
+  });
+
   it.each([
     ["uses an active custom local model", { enabled: true, provider: "local" }],
     ["uses another memory provider", { enabled: true, provider: "openai" }],
@@ -369,8 +431,49 @@ describe("llama.cpp provider plugin", () => {
       const provider = registerTextProvider();
       const selectedModel = expectDefined(providerConfig.models[0], "managed chat model");
       const inner = vi.fn(() => ({}) as never);
-      const wrapped = provider.wrapStreamFn?.({
-        config,
+      for (const hook of ["wrapStreamFn", "wrapSimpleCompletionStreamFn"] as const) {
+        const wrapped = provider[hook]?.({
+          config,
+          provider: LLAMA_CPP_PROVIDER_ID,
+          modelId: selectedModel.id,
+          model: {
+            ...selectedModel,
+            provider: LLAMA_CPP_PROVIDER_ID,
+            baseUrl: providerConfig.baseUrl,
+          },
+          streamFn: inner,
+        } as never);
+        await wrapped?.({} as never, { messages: [] } as never, {});
+      }
+
+      expect(mocks.ensureChat).toHaveBeenCalledWith({
+        provider: providerConfig,
+        model: expect.objectContaining({ id: selectedModel.id }),
+      });
+      expect(mocks.ensureChat).toHaveBeenCalledTimes(2);
+      expect(inner).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("prepares managed chat before simple-completion transport", async () => {
+    const configured = configuredOptions();
+    const providerConfig = configured.config.models.providers[LLAMA_CPP_PROVIDER_ID];
+    const selectedModel = expectDefined(providerConfig.models[0], "managed chat model");
+    const order: string[] = [];
+    mocks.ensureChat.mockImplementationOnce(async () => {
+      order.push("prepare");
+    });
+    const transport = vi.fn(() => {
+      order.push("transport");
+      return {} as never;
+    });
+    const wrap = expectDefined(
+      registerTextProvider().wrapSimpleCompletionStreamFn,
+      "simple completion wrapper",
+    );
+    const wrapped = expectDefined(
+      wrap({
+        config: configured.config,
         provider: LLAMA_CPP_PROVIDER_ID,
         modelId: selectedModel.id,
         model: {
@@ -378,18 +481,16 @@ describe("llama.cpp provider plugin", () => {
           provider: LLAMA_CPP_PROVIDER_ID,
           baseUrl: providerConfig.baseUrl,
         },
-        streamFn: inner,
-      } as never);
+        streamFn: transport,
+      } as never),
+      "wrapped simple completion transport",
+    );
 
-      await wrapped?.({} as never, { messages: [] } as never, {});
+    await wrapped({} as never, { messages: [] } as never, {});
 
-      expect(mocks.ensureChat).toHaveBeenCalledWith({
-        provider: providerConfig,
-        model: expect.objectContaining({ id: selectedModel.id }),
-      });
-      expect(inner).toHaveBeenCalledOnce();
-    },
-  );
+    expect(order).toEqual(["prepare", "transport"]);
+    expect(transport).toHaveBeenCalledOnce();
+  });
 
   it("keeps registered text setup chat-capable when local memory is enabled", async () => {
     const provider = registerTextProvider();

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -15,7 +15,10 @@ import {
   getRegisteredEmbeddingProvider,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+  ModelProviderConfig,
+  ProviderPlugin,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -370,7 +373,7 @@ describe("llama.cpp provider plugin", () => {
   it("reapplies embedding A to B to A and injects preset reconciliation", async () => {
     const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
     const options = Object.assign(configuredOptions(), { acquireLocalService });
-    const provider = options.config.models.providers[LLAMA_CPP_PROVIDER_ID];
+    const provider: ModelProviderConfig = options.config.models.providers[LLAMA_CPP_PROVIDER_ID];
     provider.baseUrl = "http://127.0.0.1:29434/v1";
     provider.params = { modelCacheDir: "/models/embedding-transition-cache" };
     mocks.ensureModel.mockImplementation(async ({ source }) => source);

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -132,6 +132,7 @@ async function prepareEmbeddingServer(
     embeddingModelIsDefault,
     embeddingModelPath,
     port: resolveProviderPort(provider),
+    reconcileBaseUrl: provider.baseUrl,
     localService: provider.localService,
   });
 }

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -5,6 +5,7 @@ import {
   type EmbeddingProviderAdapter,
   type EmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/embedding-providers";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
@@ -20,6 +21,7 @@ import {
   ensureLlamaCppModel,
   inspectLlamaServerRuntime,
   prepareManagedLlamaServer,
+  reconcileManagedLlamaServer as reconcileLocalService,
   type LlamaServerRuntimeFacts,
 } from "./managed-server.js";
 
@@ -28,8 +30,12 @@ type LlamaCppLocalOptions = {
   modelCacheDir?: string;
 };
 
+type AcquireLocalService = OpenClawPluginApi["runtime"]["llm"]["acquireLocalService"];
+type LocalServiceAwareOptions = EmbeddingProviderCreateOptions & {
+  acquireLocalService?: AcquireLocalService;
+};
+
 const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
-const preparedEmbeddingServers = new Map<string, Promise<void>>();
 
 type LlamaCppModelIdentity = {
   model: string;
@@ -115,32 +121,19 @@ async function prepareEmbeddingServer(
 ): Promise<void> {
   const provider = resolveConfiguredProvider(options);
   const cacheDir = resolveLlamaCppModelCacheDir(provider);
-  const key = JSON.stringify([provider.baseUrl, provider.localService, embeddingSource, cacheDir]);
-  const pending =
-    preparedEmbeddingServers.get(key) ??
-    (async () => {
-      const embeddingModelPath = await ensureLlamaCppModel({
-        source: embeddingSource,
-        cacheDir,
-        download: true,
-      });
-      await prepareManagedLlamaServer({
-        chatModel: { mode: "preserve" },
-        embeddingModelIsDefault,
-        embeddingModelPath,
-        port: resolveProviderPort(provider),
-        localService: provider.localService,
-      });
-    })();
-  preparedEmbeddingServers.set(key, pending);
-  try {
-    await pending;
-  } catch (error) {
-    if (preparedEmbeddingServers.get(key) === pending) {
-      preparedEmbeddingServers.delete(key);
-    }
-    throw error;
-  }
+  const embeddingModelPath = await ensureLlamaCppModel({
+    source: embeddingSource,
+    cacheDir,
+    download: true,
+  });
+  await prepareManagedLlamaServer({
+    chatModel: { mode: "preserve" },
+    configuredChatModelIds: provider.models.map((model) => model.id),
+    embeddingModelIsDefault,
+    embeddingModelPath,
+    port: resolveProviderPort(provider),
+    localService: provider.localService,
+  });
 }
 
 function wrapProvider(params: {
@@ -203,11 +196,18 @@ export const llamaCppEmbeddingProviderAdapter: EmbeddingProviderAdapter = {
     if (!genericAdapter) {
       throw new Error("OpenAI-compatible embedding transport is unavailable.");
     }
+    const acquireLocalService = (options as LocalServiceAwareOptions).acquireLocalService; // SAFETY: core runtime owns this injected option.
     const result = await genericAdapter.create({
       ...options,
       provider: LLAMA_CPP_PROVIDER_ID,
       model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
       remote: undefined,
+      ...(acquireLocalService
+        ? {
+            acquireLocalService: (...[target, signal]: Parameters<AcquireLocalService>) =>
+              acquireLocalService({ ...target, reconcile: reconcileLocalService }, signal),
+          }
+        : {}),
     });
     if (!result.provider) {
       return result;

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -1,3 +1,4 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type {
   OpenClawPluginApi,
   ProviderAuthMethodNonInteractiveContext,
@@ -35,7 +36,7 @@ import { wrapLlamaServerStream } from "./external-server/stream.js";
 import { ensureManagedLlamaServerForChat, reconcileManagedLlamaServer } from "./managed-server.js";
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
-function wrapManagedLlamaCppStream(ctx: ProviderWrapStreamFnContext) {
+function wrapManagedLlamaCppStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
   const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   if (!providerConfig?.localService) {
     return undefined;

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -1,4 +1,3 @@
-import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type {
   OpenClawPluginApi,
   ProviderAuthMethodNonInteractiveContext,
@@ -36,7 +35,7 @@ import { wrapLlamaServerStream } from "./external-server/stream.js";
 import { ensureManagedLlamaServerForChat, reconcileManagedLlamaServer } from "./managed-server.js";
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
-function wrapManagedLlamaCppStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
+function wrapManagedLlamaCppStream(ctx: ProviderWrapStreamFnContext) {
   const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   if (!providerConfig?.localService) {
     return undefined;
@@ -46,12 +45,12 @@ function wrapManagedLlamaCppStream(ctx: ProviderWrapStreamFnContext): StreamFn |
   if (!inner || !selectedModel) {
     return undefined;
   }
-  return async (model, context, options) => {
+  return async (...args: Parameters<typeof inner>) => {
     await ensureManagedLlamaServerForChat({
       provider: providerConfig,
       model: selectedModel,
     });
-    return inner(model, context, options);
+    return inner(...args);
   };
 }
 

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -36,12 +36,15 @@ import { wrapLlamaServerStream } from "./external-server/stream.js";
 import { ensureManagedLlamaServerForChat, reconcileManagedLlamaServer } from "./managed-server.js";
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
-function wrapManagedLlamaCppStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {
+function wrapManagedLlamaCppStream(
+  ctx: ProviderWrapStreamFnContext,
+  streamFn = ctx.streamFn,
+): StreamFn | undefined {
   const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   if (!providerConfig?.localService) {
     return undefined;
   }
-  const inner = ctx.streamFn;
+  const inner = streamFn;
   const selectedModel = ctx.model;
   if (!inner || !selectedModel) {
     return undefined;
@@ -150,10 +153,12 @@ export function registerLlamaCppProvider(api: OpenClawPluginApi): void {
         : await prepareLlamaServerDynamicModel(ctx),
     reconcileLocalService: reconcileManagedLlamaServer,
     wrapSimpleCompletionStreamFn: wrapManagedLlamaCppStream,
-    wrapStreamFn: (ctx) =>
-      ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.localService
-        ? wrapManagedLlamaCppStream(ctx)
-        : wrapLlamaServerStream(ctx),
+    wrapStreamFn: (ctx) => {
+      const streamFn = wrapLlamaServerStream(ctx);
+      return ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.localService
+        ? wrapManagedLlamaCppStream(ctx, streamFn)
+        : streamFn;
+    },
     ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
     wizard: {
       modelPicker: {

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -1,6 +1,7 @@
 import type {
   OpenClawPluginApi,
   ProviderAuthMethodNonInteractiveContext,
+  ProviderWrapStreamFnContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
@@ -31,8 +32,27 @@ import {
   validateLlamaServerNonInteractive,
 } from "./external-server/setup.js";
 import { wrapLlamaServerStream } from "./external-server/stream.js";
-import { ensureManagedLlamaServerForChat } from "./managed-server.js";
+import { ensureManagedLlamaServerForChat, reconcileManagedLlamaServer } from "./managed-server.js";
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
+
+function wrapManagedLlamaCppStream(ctx: ProviderWrapStreamFnContext) {
+  const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+  if (!providerConfig?.localService) {
+    return undefined;
+  }
+  const inner = ctx.streamFn;
+  const selectedModel = ctx.model;
+  if (!inner || !selectedModel) {
+    return undefined;
+  }
+  return async (model, context, options) => {
+    await ensureManagedLlamaServerForChat({
+      provider: providerConfig,
+      model: selectedModel,
+    });
+    return inner(model, context, options);
+  };
+}
 
 export function registerLlamaCppProvider(api: OpenClawPluginApi): void {
   api.registerProvider({
@@ -127,24 +147,12 @@ export function registerLlamaCppProvider(api: OpenClawPluginApi): void {
       ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.localService
         ? undefined
         : await prepareLlamaServerDynamicModel(ctx),
-    wrapStreamFn: (ctx) => {
-      const providerConfig = ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-      const inner = wrapLlamaServerStream(ctx);
-      if (!providerConfig?.localService) {
-        return inner;
-      }
-      const selectedModel = ctx.model;
-      if (!selectedModel) {
-        return undefined;
-      }
-      return async (model, context, options) => {
-        await ensureManagedLlamaServerForChat({
-          provider: providerConfig,
-          model: selectedModel,
-        });
-        return inner(model, context, options);
-      };
-    },
+    reconcileLocalService: reconcileManagedLlamaServer,
+    wrapSimpleCompletionStreamFn: wrapManagedLlamaCppStream,
+    wrapStreamFn: (ctx) =>
+      ctx.config?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.localService
+        ? wrapManagedLlamaCppStream(ctx)
+        : wrapLlamaServerStream(ctx),
     ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
     wizard: {
       modelPicker: {

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -34,6 +34,7 @@ async function withHuggingFaceMetadataFixture(
   endpoint: "manifest" | "file" | "tree",
   run: (params: {
     cacheDir: string;
+    setMetadataAvailable: (available: boolean) => void;
     setPadding: (target: "manifest" | "file" | "tree", padding: string) => void;
     pathInfoBodies: unknown[];
     requestedUrls: string[];
@@ -44,11 +45,17 @@ async function withHuggingFaceMetadataFixture(
   const cacheDir = tempDirs.make(`llama-cpp-hf-${endpoint}-`);
   await fs.writeFile(path.join(cacheDir, "hf_owner_repo_model.gguf"), "GGUF");
   let padding = "x".repeat(1024 * 1024);
+  let metadataAvailable = true;
   const pathInfoBodies: unknown[] = [];
   const requestedUrls: string[] = [];
   const server = http.createServer((req, res) => {
     res.setHeader("content-type", "application/json");
     requestedUrls.push(req.url ?? "");
+    if (!metadataAvailable) {
+      res.statusCode = 503;
+      res.end("{}");
+      return;
+    }
     if (req.url?.startsWith("/v2/owner/repo/manifests/latest")) {
       res.end(
         JSON.stringify({
@@ -58,7 +65,7 @@ async function withHuggingFaceMetadataFixture(
       );
       return;
     }
-    if (req.url?.startsWith("/api/models/owner/repo/paths-info/main")) {
+    if (req.url?.startsWith("/api/models/owner/repo/paths-info/")) {
       const chunks: Buffer[] = [];
       req.on("data", (chunk: Buffer) => chunks.push(chunk));
       req.on("end", () => {
@@ -72,7 +79,7 @@ async function withHuggingFaceMetadataFixture(
       });
       return;
     }
-    if (req.url?.startsWith("/api/models/owner/repo/tree/main")) {
+    if (req.url?.startsWith("/api/models/owner/repo/tree/")) {
       res.end(
         JSON.stringify([
           { path: "model.gguf", size: 4, lfs: { oid: TEST_GGUF_SHA256 } },
@@ -103,6 +110,9 @@ async function withHuggingFaceMetadataFixture(
   try {
     await run({
       cacheDir,
+      setMetadataAvailable: (available) => {
+        metadataAvailable = available;
+      },
       setPadding: (target, next) => {
         if (target === endpoint) {
           padding = next;
@@ -747,7 +757,7 @@ describe("managed llama-server", () => {
         setPadding(endpoint, "x".repeat(16 * 1024 * 1024 + 1));
         await expect(
           ensureLlamaCppModel({
-            source: "hf:owner/repo",
+            source: `hf:owner/repo#oversized-${endpoint}`,
             cacheDir,
             download: false,
           }),
@@ -785,6 +795,38 @@ describe("managed llama-server", () => {
         );
         expect(pathInfoBodies).toEqual([{ paths: ["model.gguf"], expand: false }]);
         expect(requestedUrls).not.toContain("/v2/owner/repo/manifests/latest");
+      },
+      "hf:owner/repo/model.gguf",
+    );
+  });
+
+  it("keeps a verified custom Hugging Face artifact available while refreshing its preset", async () => {
+    await withHuggingFaceMetadataFixture(
+      "file",
+      async ({ cacheDir, setMetadataAvailable, source }) => {
+        const presetPath = path.join(cacheDir, "models.ini");
+        const localService = {
+          command: path.join(cacheDir, "llama-server"),
+          args: ["--models-preset", presetPath],
+        };
+        const model = {
+          id: "custom-chat",
+          params: { modelPath: source, contextSize: 8192 },
+          maxTokens: 1024,
+        };
+        const provider = {
+          baseUrl: "http://127.0.0.1:19432/v1",
+          localService,
+          models: [model],
+          params: { modelCacheDir: cacheDir },
+        };
+
+        await ensureManagedLlamaServerForChat({ provider, model });
+        setMetadataAvailable(false);
+        model.maxTokens = 2048;
+        await ensureManagedLlamaServerForChat({ provider, model });
+
+        expect(await fs.readFile(presetPath, "utf8")).toContain("n-predict = 2048");
       },
       "hf:owner/repo/model.gguf",
     );

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -22,6 +22,7 @@ import {
   ensureManagedLlamaServerForChat,
   inspectLlamaServerRuntime,
   prepareManagedLlamaServer,
+  reconcileManagedLlamaServer,
 } from "./managed-server.js";
 
 const servers: http.Server[] = [];
@@ -116,7 +117,35 @@ async function withHuggingFaceMetadataFixture(
   }
 }
 
+async function listen(server: http.Server, port = 0): Promise<number> {
+  await new Promise<void>((resolve) => {
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("missing test server address");
+  }
+  return address.port;
+}
+
+async function createPresetFixture(label: string) {
+  const tempRoot = tempDirs.make(`llama-server-${label}-`);
+  const presetPath = path.join(tempRoot, "models.ini");
+  const asset = selectLlamaServerAsset("darwin", "arm64");
+  installMocks.ensureLlamaServerInstalled.mockResolvedValue({
+    command: path.join(tempRoot, "llama-server"),
+    asset,
+  });
+  installMocks.resolveManagedLlamaServerPaths.mockReturnValue({
+    installDir: tempRoot,
+    command: path.join(tempRoot, "llama-server"),
+    presetPath,
+  });
+  return { tempRoot, presetPath };
+}
+
 afterEach(async () => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
   await Promise.all(
     servers.splice(0).map(
@@ -389,6 +418,213 @@ describe("managed llama-server", () => {
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it("retains the chat inventory across A to B to A and reapplies changed limits", async () => {
+    const { tempRoot, presetPath } = await createPresetFixture("chat-transitions");
+    const firstPath = path.join(tempRoot, "first.gguf");
+    const secondPath = path.join(tempRoot, "second.gguf");
+    const first = {
+      id: "first",
+      params: { modelPath: firstPath, contextSize: 16_384 },
+      maxTokens: 1024,
+    };
+    const second = {
+      id: "second",
+      params: { modelPath: secondPath, contextSize: 32_768 },
+      maxTokens: 2048,
+    };
+    const provider = {
+      baseUrl: "http://127.0.0.1:29432/v1",
+      localService: { command: path.join(tempRoot, "llama-server"), args: [] },
+      models: [first, second],
+      params: { modelCacheDir: tempRoot },
+    };
+    await Promise.all([fs.writeFile(firstPath, "GGUF"), fs.writeFile(secondPath, "GGUF")]);
+    for (const model of [
+      first,
+      second,
+      { ...first, params: { ...first.params, contextSize: 32_768 }, maxTokens: 4096 },
+    ]) {
+      await ensureManagedLlamaServerForChat({ provider, model });
+    }
+    const preset = await fs.readFile(presetPath, "utf8");
+    expect(preset).toContain(
+      `[first]\nmodel = ${firstPath}\nctx-size = 32768\nn-predict = 4096\njinja = true`,
+    );
+    expect(preset).toContain(
+      `[second]\nmodel = ${secondPath}\nctx-size = 32768\nn-predict = 2048\njinja = true`,
+    );
+    expect(preset.indexOf("[first]")).toBeLessThan(preset.indexOf("[second]"));
+  });
+
+  it("prunes and orders sections without rewriting or reloading unchanged bytes", async () => {
+    const { presetPath } = await createPresetFixture("chat-prune");
+    let reloads = 0;
+    const server = http.createServer((req, res) => {
+      reloads += Number(req.url === "/models?reload=1");
+      res.end("{}");
+    });
+    servers.push(server);
+    const port = await listen(server);
+    const rename = vi.spyOn(fs, "rename");
+    const params = {
+      chatModel: { mode: "preserve" as const },
+      configuredChatModelIds: ["zeta", "alpha"],
+      port,
+    };
+    await fs.writeFile(
+      presetPath,
+      [
+        "version = 1",
+        "",
+        "[stale]",
+        "model = /models/stale.gguf",
+        "",
+        "[zeta]",
+        "model = /models/zeta.gguf",
+        "",
+        "[alpha]",
+        "model = /models/alpha.gguf",
+        "",
+        "[embeddinggemma-300m-qat-q8_0]",
+        "model = /models/embedding.gguf",
+        "embedding = true",
+        "",
+      ].join("\n"),
+    );
+    await prepareManagedLlamaServer(params);
+    await prepareManagedLlamaServer(params);
+    const baseUrl = `http://127.0.0.1:${port}/v1`;
+    await reconcileManagedLlamaServer({ baseUrl });
+    await reconcileManagedLlamaServer({ baseUrl });
+    expect(await fs.readFile(presetPath, "utf8")).toBe(
+      [
+        "version = 1",
+        "",
+        "[alpha]",
+        "model = /models/alpha.gguf",
+        "",
+        "[zeta]",
+        "model = /models/zeta.gguf",
+        "",
+        "[embeddinggemma-300m-qat-q8_0]",
+        "model = /models/embedding.gguf",
+        "embedding = true",
+        "",
+      ].join("\n"),
+    );
+    expect(rename).toHaveBeenCalledTimes(1);
+    expect(reloads).toBe(1);
+  });
+
+  it("reloads an unchanged preset when the managed origin changes and changes back", async () => {
+    await createPresetFixture("origin-transition");
+    const reloads = [0, 0];
+    const createReloadServer = (index: number) =>
+      http.createServer((req, res) => {
+        reloads[index]! += Number(req.url === "/models?reload=1");
+        res.end("{}");
+      });
+    const firstServer = createReloadServer(0);
+    const secondServer = createReloadServer(1);
+    servers.push(firstServer, secondServer);
+    const firstPort = await listen(firstServer);
+    const secondPort = await listen(secondServer);
+    await prepareManagedLlamaServer({
+      chatModel: { mode: "remove" },
+      configuredChatModelIds: [],
+      embeddingModelPath: "/models/embedding.gguf",
+      port: firstPort,
+    });
+    const firstBaseUrl = `http://127.0.0.1:${firstPort}/v1`;
+    const secondBaseUrl = `http://127.0.0.1:${secondPort}/v1`;
+
+    await reconcileManagedLlamaServer({ baseUrl: firstBaseUrl });
+    await reconcileManagedLlamaServer({ baseUrl: secondBaseUrl });
+    await reconcileManagedLlamaServer({ baseUrl: firstBaseUrl });
+
+    expect(reloads).toEqual([2, 1]);
+  });
+
+  it("retains a failed reload revision for the next reconciliation", async () => {
+    await createPresetFixture("reload-failure");
+    let status = 500;
+    let reloads = 0;
+    const server = http.createServer((_req, res) => {
+      reloads += 1;
+      res.statusCode = status;
+      res.end("{}");
+    });
+    servers.push(server);
+    const port = await listen(server);
+    await prepareManagedLlamaServer({
+      chatModel: { mode: "remove" },
+      configuredChatModelIds: [],
+      embeddingModelPath: "/models/embedding.gguf",
+      port,
+    });
+    await expect(
+      reconcileManagedLlamaServer({ baseUrl: `http://127.0.0.1:${port}/v1` }),
+    ).rejects.toThrow("llama.cpp preset reload failed: HTTP 500");
+    const controller = new AbortController();
+    controller.abort(new Error("reload aborted"));
+    await expect(
+      reconcileManagedLlamaServer({
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(controller.signal.reason);
+    status = 200;
+    await reconcileManagedLlamaServer({ baseUrl: `http://127.0.0.1:${port}/v1` });
+    expect(reloads).toBe(2);
+  });
+
+  it("reconciles a mutation after the child reads the preset but before it listens", async () => {
+    const { presetPath } = await createPresetFixture("startup-race");
+    const probe = http.createServer();
+    const port = await listen(probe);
+    await new Promise<void>((resolve) => {
+      probe.close(() => {
+        resolve();
+      });
+    });
+    const prepare = async (contextSize: number) =>
+      await prepareManagedLlamaServer({
+        chatModel: {
+          mode: "configure",
+          id: "chat",
+          path: "/models/chat.gguf",
+          contextSize,
+          maxTokens: 2048,
+        },
+        configuredChatModelIds: ["chat"],
+        defaultEmbeddingModelPath: "/models/embedding.gguf",
+        port,
+      });
+    await prepare(8192);
+    let loadedPreset = await fs.readFile(presetPath, "utf8");
+    await prepare(16_384);
+
+    let reloads = 0;
+    const server = http.createServer((req, res) => {
+      if (req.url === "/models?reload=1") {
+        reloads += 1;
+        void fs.readFile(presetPath, "utf8").then((contents) => {
+          loadedPreset = contents;
+          res.end("{}");
+        });
+        return;
+      }
+      res.end("{}");
+    });
+    servers.push(server);
+    await listen(server, port);
+    await reconcileManagedLlamaServer({ baseUrl: `http://127.0.0.1:${port}/v1` });
+    await reconcileManagedLlamaServer({ baseUrl: `http://127.0.0.1:${port}/v1` });
+
+    expect(reloads).toBe(1);
+    expect(loadedPreset).toContain("ctx-size = 16384");
   });
 
   it("reports a missing local GGUF with the setup repair path", async () => {

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -811,6 +811,10 @@ describe("managed llama-server", () => {
         };
         const model = {
           id: "custom-chat",
+          name: "Custom Chat",
+          reasoning: false,
+          input: ["text" as const],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           params: { modelPath: source, contextSize: 8192 },
           maxTokens: 1024,
         };

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -426,11 +426,19 @@ describe("managed llama-server", () => {
     const secondPath = path.join(tempRoot, "second.gguf");
     const first = {
       id: "first",
+      name: "First",
+      reasoning: false,
+      input: ["text" as const],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       params: { modelPath: firstPath, contextSize: 16_384 },
       maxTokens: 1024,
     };
     const second = {
       id: "second",
+      name: "Second",
+      reasoning: false,
+      input: ["text" as const],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       params: { modelPath: secondPath, contextSize: 32_768 },
       maxTokens: 2048,
     };

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -295,6 +295,30 @@ describe("managed llama-server", () => {
     },
   );
 
+  it("does not reconcile a configured direct-model service without a router preset", async () => {
+    const root = tempDirs.make("llama-server-direct-model-");
+    let reloads = 0;
+    const server = http.createServer((req, res) => {
+      reloads += Number(req.url === "/models?reload=1");
+      res.end("{}");
+    });
+    servers.push(server);
+    const port = await listen(server);
+
+    await prepareManagedLlamaServer({
+      localService: {
+        command: path.join(root, "custom-server"),
+        args: ["--model", "/models/chat.gguf", "--alias", "chat"],
+      },
+      port,
+      chatModel: { mode: "configure", id: "chat", path: "/models/chat.gguf" },
+      embeddingModelPath: "/models/embedding.gguf",
+    });
+    await reconcileManagedLlamaServer({ baseUrl: `http://127.0.0.1:${port}/v1` });
+
+    expect(reloads).toBe(0);
+  });
+
   it("writes a 2048-token physical batch in the combined preset", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-preset-"));
     const presetPath = path.join(tempRoot, "models.ini");
@@ -444,7 +468,10 @@ describe("managed llama-server", () => {
     };
     const provider = {
       baseUrl: "http://127.0.0.1:29432/v1",
-      localService: { command: path.join(tempRoot, "llama-server"), args: [] },
+      localService: {
+        command: path.join(tempRoot, "llama-server"),
+        args: ["--models-preset", presetPath],
+      },
       models: [first, second],
       params: { modelCacheDir: tempRoot },
     };
@@ -526,7 +553,7 @@ describe("managed llama-server", () => {
     expect(reloads).toBe(1);
   });
 
-  it("reloads an unchanged preset when the managed origin changes and changes back", async () => {
+  it("tracks applied preset revisions independently by managed origin", async () => {
     await createPresetFixture("origin-transition");
     const reloads = [0, 0];
     const createReloadServer = (index: number) =>
@@ -545,6 +572,12 @@ describe("managed llama-server", () => {
       embeddingModelPath: "/models/embedding.gguf",
       port: firstPort,
     });
+    await prepareManagedLlamaServer({
+      chatModel: { mode: "remove" },
+      configuredChatModelIds: [],
+      embeddingModelPath: "/models/embedding.gguf",
+      port: secondPort,
+    });
     const firstBaseUrl = `http://127.0.0.1:${firstPort}/v1`;
     const secondBaseUrl = `http://127.0.0.1:${secondPort}/v1`;
 
@@ -552,7 +585,36 @@ describe("managed llama-server", () => {
     await reconcileManagedLlamaServer({ baseUrl: secondBaseUrl });
     await reconcileManagedLlamaServer({ baseUrl: firstBaseUrl });
 
-    expect(reloads).toEqual([2, 1]);
+    expect(reloads).toEqual([1, 1]);
+  });
+
+  it("reconciles using the configured managed-service origin", async () => {
+    await createPresetFixture("configured-origin");
+    let reloads = 0;
+    const server = http.createServer((req, res) => {
+      reloads += Number(req.url === "/models?reload=1");
+      res.end("{}");
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => {
+      server.listen(0, resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing test server address");
+    }
+    const baseUrl = `http://localhost:${address.port}/v1`;
+    await prepareManagedLlamaServer({
+      chatModel: { mode: "remove" },
+      configuredChatModelIds: [],
+      embeddingModelPath: "/models/embedding.gguf",
+      port: address.port,
+      reconcileBaseUrl: baseUrl,
+    });
+
+    await reconcileManagedLlamaServer({ baseUrl });
+
+    expect(reloads).toBe(1);
   });
 
   it("retains a failed reload revision for the next reconciliation", async () => {
@@ -586,6 +648,31 @@ describe("managed llama-server", () => {
     status = 200;
     await reconcileManagedLlamaServer({ baseUrl: `http://127.0.0.1:${port}/v1` });
     expect(reloads).toBe(2);
+  });
+
+  it("allows reloads to use llama.cpp's pinned model shutdown window", async () => {
+    await createPresetFixture("reload-shutdown-window");
+    let reloads = 0;
+    const server = http.createServer((req, res) => {
+      if (req.url === "/models?reload=1") {
+        reloads += 1;
+        setTimeout(() => res.end("{}"), 2_600);
+        return;
+      }
+      res.end("{}");
+    });
+    servers.push(server);
+    const port = await listen(server);
+    await prepareManagedLlamaServer({
+      chatModel: { mode: "remove" },
+      configuredChatModelIds: [],
+      embeddingModelPath: "/models/embedding.gguf",
+      port,
+    });
+
+    await reconcileManagedLlamaServer({ baseUrl: `http://127.0.0.1:${port}/v1` });
+
+    expect(reloads).toBe(1);
   });
 
   it("reconciles a mutation after the child reads the preset but before it listens", async () => {

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -82,15 +82,14 @@ export type LlamaServerRuntimeFacts = {
 };
 
 const modelPromises = new Map<string, Promise<string>>();
+const resolvedModelArtifacts = new Map<string, ModelArtifact>(); // Presets remain request-scoped.
 const presetState = {
   appliedRevisions: new Map<string, string>(),
   desiredRevisions: new Map<string, string>(),
   transition: Promise.resolve(),
 };
-// Bound embedding KV memory and fit one input in one physical batch.
-const LLAMA_CPP_EMBEDDING_UBATCH_SIZE = 2048;
-// b10534 can synchronously wait 10 seconds for a model to unload during reload.
-const LLAMA_CPP_PRESET_RELOAD_TIMEOUT_MS = 15_000;
+const LLAMA_CPP_EMBEDDING_UBATCH_SIZE = 2048; // Fit one input in one physical batch.
+const LLAMA_CPP_PRESET_RELOAD_TIMEOUT_MS = 15_000; // b10534 unload window: 10 seconds.
 
 function parseHuggingFaceSource(source: string): {
   user: string;
@@ -276,42 +275,45 @@ export async function ensureLlamaCppModel(params: {
     await assertGguf(localPath);
     return localPath;
   }
-  const artifact = await resolveModelArtifact(localSource, params.signal);
+  const artifactCacheKey = `${path.resolve(params.cacheDir)}\0${localSource}`;
+  const artifact =
+    resolvedModelArtifacts.get(artifactCacheKey) ??
+    (await resolveModelArtifact(localSource, params.signal));
+  resolvedModelArtifacts.set(artifactCacheKey, artifact);
   const destination = path.join(params.cacheDir, artifact.fileName);
-  const pending = modelPromises.get(destination);
-  if (pending) {
-    return await pending;
-  }
-  const load = (async () => {
-    const exists = await fsp
-      .stat(destination)
-      .then((stat) => stat.isFile())
-      .catch(() => false);
-    if (exists) {
-      if (artifact.expectedSha256) {
-        if ((await sha256File(destination, params.signal)) === artifact.expectedSha256) {
-          return destination;
-        }
-      } else {
+  const load =
+    modelPromises.get(destination) ??
+    (async () => {
+      const exists = await fsp
+        .stat(destination)
+        .then((stat) => stat.isFile())
+        .catch(() => false);
+      if (
+        exists &&
+        artifact.expectedSha256 &&
+        (await sha256File(destination, params.signal)) === artifact.expectedSha256
+      ) {
+        return destination;
+      }
+      if (exists && !artifact.expectedSha256) {
         await assertGguf(destination);
         return destination;
       }
-    }
-    if (!params.download) {
-      throw new Error(`Model is not cached at ${destination}`);
-    }
-    await downloadVerifiedFile({
-      url: artifact.url,
-      destination,
-      expectedSha256: artifact.expectedSha256,
-      expectedSize: artifact.expectedSize,
-      requireServerDigest: !artifact.expectedSha256,
-      signal: params.signal,
-      onProgress: params.onProgress,
-    });
-    await assertGguf(destination);
-    return destination;
-  })();
+      if (!params.download) {
+        throw new Error(`Model is not cached at ${destination}`);
+      }
+      await downloadVerifiedFile({
+        url: artifact.url,
+        destination,
+        expectedSha256: artifact.expectedSha256,
+        expectedSize: artifact.expectedSize,
+        requireServerDigest: !artifact.expectedSha256,
+        signal: params.signal,
+        onProgress: params.onProgress,
+      });
+      await assertGguf(destination);
+      return destination;
+    })();
   modelPromises.set(destination, load);
   try {
     return await load;

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -82,11 +82,12 @@ export type LlamaServerRuntimeFacts = {
 };
 
 const modelPromises = new Map<string, Promise<string>>();
-const chatPreparationPromises = new Map<string, Promise<void>>();
-// Chat and embedding share one restart preset. Serialize read-modify-write updates so neither
-// path can discard the other model stanza during concurrent preparation.
-const presetWritePromises = new Map<string, Promise<void>>();
-// Pooled embeddings must fit one input in one physical batch. Match llama.cpp's EmbeddingGemma preset.
+const presetState = {
+  appliedRevision: "",
+  desiredRevision: "",
+  transition: Promise.resolve(),
+};
+// Bound embedding KV memory and fit one input in one physical batch.
 const LLAMA_CPP_EMBEDDING_UBATCH_SIZE = 2048;
 
 function parseHuggingFaceSource(source: string): {
@@ -328,7 +329,7 @@ function assertIniValue(value: string, label: string): string {
 
 function renderChatModelSection(params: {
   id: string;
-  modelPath: string;
+  path: string;
   contextSize?: number;
   maxTokens?: number;
 }): string {
@@ -338,7 +339,7 @@ function renderChatModelSection(params: {
   }
   return [
     `[${id}]`,
-    `model = ${assertIniValue(params.modelPath, "llama.cpp model path")}`,
+    `model = ${assertIniValue(params.path, "llama.cpp model path")}`,
     `ctx-size = ${params.contextSize ?? DEFAULT_LLAMA_CPP_CONTEXT_SIZE}`,
     `n-predict = ${params.maxTokens ?? 2048}`,
     "jinja = true",
@@ -354,38 +355,27 @@ function renderEmbeddingModelSection(params: { isDefault?: boolean; modelPath: s
   ].join("\n");
 }
 
-function readModelSection(contents: string | undefined, id: string): string | undefined {
-  if (!contents) {
-    return undefined;
+function readModelSections(contents: string | undefined): Map<string, string> {
+  const sections = new Map<string, string>();
+  for (const block of contents?.split(/(?=^\[[^\]]+\]$)/mu) ?? []) {
+    const match = /^\[([^\]]+)\]$/mu.exec(block);
+    if (match) {
+      sections.set(match[1]!, block.slice(match.index).trimEnd());
+    }
   }
-  const lines = contents.split(/\r?\n/u);
-  const start = lines.indexOf(`[${id}]`);
-  if (start < 0) {
-    return undefined;
-  }
-  let end = start + 1;
-  while (end < lines.length && !/^\[[^\]]+\]$/u.test(lines[end] ?? "")) {
-    end += 1;
-  }
-  return lines.slice(start, end).join("\n").trimEnd();
-}
-
-function readChatModelSection(contents: string | undefined): string | undefined {
-  const id = contents
-    ?.split(/\r?\n/u)
-    .map((line) => /^\[([^\]]+)\]$/u.exec(line)?.[1])
-    .find((candidate) => candidate && candidate !== DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID);
-  return id ? readModelSection(contents, id) : undefined;
+  return sections;
 }
 
 function renderLlamaServerPreset(params: {
-  chatSection?: string;
+  chatSections: Map<string, string>;
   embeddingSection: string;
 }): string {
   return [
     "version = 1",
     "",
-    ...(params.chatSection ? [params.chatSection, ""] : []),
+    ...[...params.chatSections]
+      .toSorted(([left], [right]) => Number(left > right) - Number(left < right))
+      .flatMap(([, section]) => [section, ""]),
     params.embeddingSection,
     "",
   ].join("\n");
@@ -394,65 +384,104 @@ function renderLlamaServerPreset(params: {
 async function writePreset(presetPath: string, contents: string): Promise<void> {
   await fsp.mkdir(path.dirname(presetPath), { recursive: true });
   const temporary = `${presetPath}.tmp-${randomUUID()}`;
-  await fsp.writeFile(temporary, contents, { mode: 0o600 });
-  await fsp.rename(temporary, presetPath);
+  try {
+    await fsp.writeFile(temporary, contents, { mode: 0o600 });
+    await fsp.rename(temporary, presetPath);
+  } finally {
+    await fsp.rm(temporary, { force: true });
+  }
+}
+
+async function runPresetTransition(run: () => Promise<void>): Promise<void> {
+  const pending = presetState.transition.catch(() => undefined).then(run);
+  presetState.transition = pending;
+  await pending;
 }
 
 async function updatePreset(
   presetPath: string,
   params: {
     chatModel: ManagedLlamaChatModel;
+    configuredChatModelIds?: readonly string[];
     embeddingModelIsDefault?: boolean;
     embeddingModelPath?: string;
     defaultEmbeddingModelPath?: string;
   },
 ): Promise<void> {
-  const previous = presetWritePromises.get(presetPath) ?? Promise.resolve();
-  const pending = previous
-    .catch(() => undefined)
-    .then(async () => {
-      const existing = await fsp.readFile(presetPath, "utf8").catch((error: unknown) => {
-        if (asOptionalRecord(error)?.code === "ENOENT") {
-          return undefined;
-        }
-        throw error;
-      });
-      const chatSection =
-        params.chatModel.mode === "preserve"
-          ? readChatModelSection(existing)
-          : params.chatModel.mode === "configure"
-            ? renderChatModelSection({
-                id: params.chatModel.id,
-                modelPath: params.chatModel.path,
-                contextSize: params.chatModel.contextSize,
-                maxTokens: params.chatModel.maxTokens,
-              })
-            : undefined;
-      const embeddingSection = params.embeddingModelPath
-        ? renderEmbeddingModelSection({
-            isDefault: params.embeddingModelIsDefault,
-            modelPath: params.embeddingModelPath,
-          })
-        : (readModelSection(existing, DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID) ??
-          (params.defaultEmbeddingModelPath
-            ? renderEmbeddingModelSection({
-                isDefault: true,
-                modelPath: params.defaultEmbeddingModelPath,
-              })
-            : undefined));
-      if (!embeddingSection) {
-        throw new Error("llama.cpp embedding model path is required for a new managed preset");
+  await runPresetTransition(async () => {
+    const existing = await fsp.readFile(presetPath, "utf8").catch((error: unknown) => {
+      if (asOptionalRecord(error)?.code === "ENOENT") {
+        return undefined;
       }
-      await writePreset(presetPath, renderLlamaServerPreset({ chatSection, embeddingSection }));
+      throw error;
     });
-  presetWritePromises.set(presetPath, pending);
-  try {
-    await pending;
-  } finally {
-    if (presetWritePromises.get(presetPath) === pending) {
-      presetWritePromises.delete(presetPath);
+    const existingSections = readModelSections(existing);
+    const embedding = existingSections.get(DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID);
+    const configuredIds = params.configuredChatModelIds
+      ? new Set(params.configuredChatModelIds)
+      : undefined;
+    const sections = new Map(
+      [...existingSections].filter(
+        ([id]) =>
+          id !== DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID &&
+          params.chatModel.mode !== "remove" &&
+          (!configuredIds || configuredIds.has(id)),
+      ),
+    );
+    if (params.chatModel.mode === "configure") {
+      sections.set(params.chatModel.id, renderChatModelSection(params.chatModel));
     }
-  }
+    const embeddingSection = params.embeddingModelPath
+      ? renderEmbeddingModelSection({
+          isDefault: params.embeddingModelIsDefault,
+          modelPath: params.embeddingModelPath,
+        })
+      : (embedding ??
+        (params.defaultEmbeddingModelPath
+          ? renderEmbeddingModelSection({
+              isDefault: true,
+              modelPath: params.defaultEmbeddingModelPath,
+            })
+          : undefined));
+    if (!embeddingSection) {
+      throw new Error("llama.cpp embedding model path is required for a new managed preset");
+    }
+    const next = renderLlamaServerPreset({ chatSections: sections, embeddingSection });
+    if (next !== existing) {
+      await writePreset(presetPath, next);
+    }
+    // A revision becomes applied only after b10534 acknowledges reload; failures stay dirty.
+    presetState.desiredRevision = `${presetPath}\0${next}`;
+  });
+}
+
+export async function reconcileManagedLlamaServer(params: {
+  baseUrl: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await runPresetTransition(async () => {
+    const origin = new URL(params.baseUrl).origin;
+    const revision = `${origin}\0${presetState.desiredRevision}`;
+    if (presetState.appliedRevision === revision) {
+      return;
+    }
+    const { response, release } = await fetchConfiguredLocalOriginWithSsrFGuard({
+      url: `${origin}/models?reload=1`,
+      configuredLocalOriginBaseUrl: origin,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(origin),
+      signal: params.signal,
+      timeoutMs: 2_500,
+      auditContext: "llama-server-preset-reload",
+    });
+    try {
+      if (!response.ok) {
+        throw new Error(`llama.cpp preset reload failed: HTTP ${response.status}`);
+      }
+      presetState.appliedRevision = revision;
+    } finally {
+      await release();
+    }
+  });
 }
 
 async function findAvailableLlamaServerPort(preferred = LLAMA_CPP_DEFAULT_PORT): Promise<number> {
@@ -477,6 +506,7 @@ async function findAvailableLlamaServerPort(preferred = LLAMA_CPP_DEFAULT_PORT):
 export async function prepareManagedLlamaServer(params: {
   // Runtime embedding refreshes preserve chat. Explicit embedding-only setup removes it.
   chatModel: ManagedLlamaChatModel;
+  configuredChatModelIds?: readonly string[];
   embeddingModelIsDefault?: boolean;
   embeddingModelPath?: string;
   defaultEmbeddingModelPath?: string;
@@ -522,6 +552,7 @@ export async function prepareManagedLlamaServer(params: {
     : defaultPreset;
   await updatePreset(presetPath, {
     chatModel: params.chatModel,
+    configuredChatModelIds: params.configuredChatModelIds,
     embeddingModelIsDefault: params.embeddingModelIsDefault,
     embeddingModelPath: params.embeddingModelPath,
     defaultEmbeddingModelPath: params.defaultEmbeddingModelPath,
@@ -560,69 +591,47 @@ export async function ensureManagedLlamaServerForChat(params: {
     return;
   }
   const cacheDir = resolveLlamaCppModelCacheDir(params.provider);
-  const key = JSON.stringify([
-    params.provider.baseUrl,
-    params.provider.localService,
-    params.model.id,
-    params.model.params,
-    cacheDir,
-  ]);
-  const pending =
-    chatPreparationPromises.get(key) ??
-    (async () => {
-      let chatModelPath = resolveCachedLlamaCppModelPath({
-        model: params.model,
-        provider: params.provider,
-      });
-      if (
-        !chatModelPath &&
-        resolveLlamaCppModelSource(params.model) === DEFAULT_LLAMA_CPP_MODEL_URI
-      ) {
-        const legacy = path.join(
-          resolveLegacyLlamaCppModelCacheDir(),
-          DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
-        );
-        if (
-          await fsp
-            .stat(legacy)
-            .then((stat) => stat.isFile())
-            .catch(() => false)
-        ) {
-          chatModelPath = legacy;
-        }
-      }
-      chatModelPath = await ensureLlamaCppModel({
-        source: chatModelPath ?? resolveLlamaCppModelSource(params.model),
-        cacheDir,
-        download: false,
-      });
-      const configuredContext = params.model.params?.contextSize;
-      const port = Number(new URL(params.provider.baseUrl).port);
-      await prepareManagedLlamaServer({
-        chatModel: {
-          mode: "configure",
-          id: params.model.id,
-          path: chatModelPath,
-          contextSize:
-            typeof configuredContext === "number" && configuredContext > 0
-              ? Math.floor(configuredContext)
-              : params.model.contextTokens,
-          maxTokens: params.model.maxTokens,
-        },
-        defaultEmbeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
-        port: Number.isInteger(port) && port > 0 ? port : undefined,
-        localService: params.provider.localService,
-      });
-    })();
-  chatPreparationPromises.set(key, pending);
-  try {
-    await pending;
-  } catch (error) {
-    if (chatPreparationPromises.get(key) === pending) {
-      chatPreparationPromises.delete(key);
+  let chatModelPath = resolveCachedLlamaCppModelPath({
+    model: params.model,
+    provider: params.provider,
+  });
+  if (!chatModelPath && resolveLlamaCppModelSource(params.model) === DEFAULT_LLAMA_CPP_MODEL_URI) {
+    const legacy = path.join(
+      resolveLegacyLlamaCppModelCacheDir(),
+      DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
+    );
+    if (
+      await fsp
+        .stat(legacy)
+        .then((stat) => stat.isFile())
+        .catch(() => false)
+    ) {
+      chatModelPath = legacy;
     }
-    throw error;
   }
+  chatModelPath = await ensureLlamaCppModel({
+    source: chatModelPath ?? resolveLlamaCppModelSource(params.model),
+    cacheDir,
+    download: false,
+  });
+  const configuredContext = params.model.params?.contextSize;
+  const port = Number(new URL(params.provider.baseUrl).port);
+  await prepareManagedLlamaServer({
+    chatModel: {
+      mode: "configure",
+      id: params.model.id,
+      path: chatModelPath,
+      contextSize:
+        typeof configuredContext === "number" && configuredContext > 0
+          ? Math.floor(configuredContext)
+          : params.model.contextTokens,
+      maxTokens: params.model.maxTokens,
+    },
+    configuredChatModelIds: params.provider.models.map((model) => model.id),
+    defaultEmbeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
+    port: Number.isInteger(port) && port > 0 ? port : undefined,
+    localService: params.provider.localService,
+  });
 }
 
 async function fetchEndpoint(

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -83,12 +83,14 @@ export type LlamaServerRuntimeFacts = {
 
 const modelPromises = new Map<string, Promise<string>>();
 const presetState = {
-  appliedRevision: "",
-  desiredRevision: "",
+  appliedRevisions: new Map<string, string>(),
+  desiredRevisions: new Map<string, string>(),
   transition: Promise.resolve(),
 };
 // Bound embedding KV memory and fit one input in one physical batch.
 const LLAMA_CPP_EMBEDDING_UBATCH_SIZE = 2048;
+// b10534 can synchronously wait 10 seconds for a model to unload during reload.
+const LLAMA_CPP_PRESET_RELOAD_TIMEOUT_MS = 15_000;
 
 function parseHuggingFaceSource(source: string): {
   user: string;
@@ -406,6 +408,7 @@ async function updatePreset(
     embeddingModelIsDefault?: boolean;
     embeddingModelPath?: string;
     defaultEmbeddingModelPath?: string;
+    reconcileOrigin?: string;
   },
 ): Promise<void> {
   await runPresetTransition(async () => {
@@ -450,8 +453,10 @@ async function updatePreset(
     if (next !== existing) {
       await writePreset(presetPath, next);
     }
-    // A revision becomes applied only after b10534 acknowledges reload; failures stay dirty.
-    presetState.desiredRevision = `${presetPath}\0${next}`;
+    if (params.reconcileOrigin) {
+      // A revision becomes applied only after b10534 acknowledges reload; failures stay dirty.
+      presetState.desiredRevisions.set(params.reconcileOrigin, `${presetPath}\0${next}`);
+    }
   });
 }
 
@@ -461,8 +466,8 @@ export async function reconcileManagedLlamaServer(params: {
 }): Promise<void> {
   await runPresetTransition(async () => {
     const origin = new URL(params.baseUrl).origin;
-    const revision = `${origin}\0${presetState.desiredRevision}`;
-    if (presetState.appliedRevision === revision) {
+    const revision = presetState.desiredRevisions.get(origin);
+    if (!revision || presetState.appliedRevisions.get(origin) === revision) {
       return;
     }
     const { response, release } = await fetchConfiguredLocalOriginWithSsrFGuard({
@@ -470,14 +475,14 @@ export async function reconcileManagedLlamaServer(params: {
       configuredLocalOriginBaseUrl: origin,
       policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(origin),
       signal: params.signal,
-      timeoutMs: 2_500,
+      timeoutMs: LLAMA_CPP_PRESET_RELOAD_TIMEOUT_MS,
       auditContext: "llama-server-preset-reload",
     });
     try {
       if (!response.ok) {
         throw new Error(`llama.cpp preset reload failed: HTTP ${response.status}`);
       }
-      presetState.appliedRevision = revision;
+      presetState.appliedRevisions.set(origin, revision);
     } finally {
       await release();
     }
@@ -511,6 +516,7 @@ export async function prepareManagedLlamaServer(params: {
   embeddingModelPath?: string;
   defaultEmbeddingModelPath?: string;
   port?: number;
+  reconcileBaseUrl?: string;
   localService?: ModelProviderConfig["localService"];
   asset?: LlamaServerAsset;
   isolated?: boolean;
@@ -529,6 +535,9 @@ export async function prepareManagedLlamaServer(params: {
     ).command;
   const port = params.port ?? (await findAvailableLlamaServerPort(params.isolated ? 0 : undefined));
   const rootUrl = `http://127.0.0.1:${port}`;
+  const reconcileOrigin = params.reconcileBaseUrl
+    ? new URL(params.reconcileBaseUrl).origin
+    : rootUrl;
   const endpoint = {
     command,
     baseUrl: `${rootUrl}/v1`,
@@ -540,6 +549,10 @@ export async function prepareManagedLlamaServer(params: {
   // Existing services may own a direct --model command instead of a router preset.
   // Keep that public localService contract; only setup creates a new router.
   if (params.localService && !configuredPreset && !params.isolated) {
+    await runPresetTransition(async () => {
+      presetState.desiredRevisions.delete(reconcileOrigin);
+      presetState.appliedRevisions.delete(reconcileOrigin);
+    });
     return { ...endpoint, args: params.localService.args ?? [] };
   }
   const defaultPreset = configuredPreset
@@ -556,6 +569,7 @@ export async function prepareManagedLlamaServer(params: {
     embeddingModelIsDefault: params.embeddingModelIsDefault,
     embeddingModelPath: params.embeddingModelPath,
     defaultEmbeddingModelPath: params.defaultEmbeddingModelPath,
+    reconcileOrigin: params.isolated ? undefined : reconcileOrigin,
   });
   params.signal?.throwIfAborted();
   return {
@@ -630,6 +644,7 @@ export async function ensureManagedLlamaServerForChat(params: {
     configuredChatModelIds: params.provider.models.map((model) => model.id),
     defaultEmbeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
     port: Number.isInteger(port) && port > 0 ? port : undefined,
+    reconcileBaseUrl: params.provider.baseUrl,
     localService: params.provider.localService,
   });
 }

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -402,6 +402,7 @@ describe("llama.cpp managed setup", () => {
     expect(mocks.prepareServer).toHaveBeenCalledWith(
       expect.objectContaining({
         chatModel: { mode: "remove" },
+        configuredChatModelIds: [],
         embeddingModelIsDefault: true,
         embeddingModelPath: path.join(tempRoot, "embedding.gguf"),
         isolated: true,

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -439,6 +439,8 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
     });
     const managed = await prepareManagedLlamaServer({
       chatModel,
+      configuredChatModelIds:
+        plan.kind === "chat" ? plan.candidate.provider.models.map((model) => model.id) : [],
       embeddingModelIsDefault: embeddingModel.isDefault,
       embeddingModelPath,
       asset,

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -353,7 +353,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
       // +1: retained runtime config reader preserves channel owner and scoped config identity.
       // +1: shared session-catalog host publication with completion ownership.
-      4435,
+      // +1: provider-owned local-service reconciliation context.
+      4436,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -353,8 +353,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
       // +1: retained runtime config reader preserves channel owner and scoped config identity.
       // +1: shared session-catalog host publication with completion ownership.
-      // +2: provider-owned local-service reconciliation context and model carrier.
-      4437,
+      // +1: provider-owned local-service reconciliation context.
+      4436,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -353,8 +353,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: canonical paragraph grouping and UTF-16 boundaries for channel-owned chunking.
       // +1: retained runtime config reader preserves channel owner and scoped config identity.
       // +1: shared session-catalog host publication with completion ownership.
-      // +1: provider-owned local-service reconciliation context.
-      4436,
+      // +2: provider-owned local-service reconciliation context and model carrier.
+      4437,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -2482,6 +2482,7 @@ describe("runBtwSideQuestion", () => {
     expect(result).toEqual({ text: "Ollama Cloud answer." });
     const registerParams = expectRecordFields(mockArg(registerProviderStreamForModelMock, 0, 0), {
       workspaceDir: "/tmp/workspace",
+      wrapProviderStream: true,
     });
     expectRecordFields(registerParams.model, {
       provider: "ollama",

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -1269,6 +1269,7 @@ export async function runBtwSideQuestion(
       agentDir: params.agentDir,
       workspaceDir,
       env: process.env,
+      wrapProviderStream: true,
       apiRegistry: modelRegistryRuntime.apiRegistry,
     });
     const { streamFn } = resolveEmbeddedAgentStream({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3312,75 +3312,33 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
-  it.each([
-    { label: "reloads before", reconcileError: undefined, expectedRequests: 1 },
-    {
-      label: "fails closed before",
-      reconcileError: new Error("llama.cpp preset reload failed"),
-      expectedRequests: 0,
-    },
-  ])(
-    "$label the first direct-compaction provider request",
-    async ({ reconcileError, expectedRequests }) => {
-      const events: string[] = [];
-      const reconcile = vi.fn(async () => {
-        events.push("reload");
-        if (reconcileError) {
-          throw reconcileError;
-        }
-      });
-      registerProviderStreamForModelMock.mockImplementation((params) => {
-        const model = (params as { model: { baseUrl: string } }).model;
-        return async () => {
-          await getModelProviderLocalServiceReconciler(model)?.({ baseUrl: model.baseUrl });
-          events.push("provider-request");
-          return undefined as never;
-        };
-      });
-      attemptServerEndpointCompactionMock.mockImplementationOnce(async (input) => {
-        try {
-          await input.streamFn(input.model, { messages: [] } as never, {});
-        } catch {
-          return undefined;
-        }
-        input.onCompactionCommitted?.();
-        return {
-          item: { type: "compaction", encrypted_content: "opaque" },
-          usage: { input_tokens: 120, output_tokens: 50 },
-        };
-      });
+  it("carries the prepared provider reconciler into direct compaction", async () => {
+    mockResolvedModel();
+    const reconcile = vi.fn(async () => undefined);
+    const buildDefaultPlan = buildAgentRuntimePlanMock.getMockImplementation();
+    if (!buildDefaultPlan) {
+      throw new Error("Compaction runtime plan fixture is not configured");
+    }
+    buildAgentRuntimePlanMock.mockImplementation((params) => ({
+      ...buildDefaultPlan(params),
+      providerRuntimeHandle: {
+        provider: params.provider,
+        modelId: params.modelId,
+        workspaceDir: params.workspaceDir,
+        prepared: true,
+        plugin: { reconcileLocalService: reconcile },
+      },
+    }));
 
-      mockResolvedModel();
-      const buildDefaultPlan = buildAgentRuntimePlanMock.getMockImplementation();
-      if (!buildDefaultPlan) {
-        throw new Error("Compaction runtime plan fixture is not configured");
-      }
-      buildAgentRuntimePlanMock.mockImplementation((params) => ({
-        ...buildDefaultPlan(params),
-        providerRuntimeHandle: {
-          provider: params.provider,
-          modelId: params.modelId,
-          workspaceDir: params.workspaceDir,
-          prepared: true,
-          plugin: { reconcileLocalService: reconcile },
-        },
-      }));
+    await expect(compactEmbeddedAgentSessionDirect(wrappedCompactionArgs())).resolves.toMatchObject(
+      { ok: true },
+    );
 
-      await expect(
-        compactEmbeddedAgentSessionDirect(wrappedCompactionArgs()),
-      ).resolves.toMatchObject({ ok: true });
-
-      const streamRegistration = mockCallArg(registerProviderStreamForModelMock) as {
-        model: object;
-      };
-      expect(getModelProviderLocalServiceReconciler(streamRegistration.model)).toBe(reconcile);
-      expect(events.filter((event) => event === "provider-request")).toHaveLength(expectedRequests);
-      expect(events.indexOf("reload")).toBeGreaterThanOrEqual(0);
-      if (expectedRequests > 0) {
-        expect(events.indexOf("reload")).toBeLessThan(events.indexOf("provider-request"));
-      }
-    },
-  );
+    const streamRegistration = mockCallArg(registerProviderStreamForModelMock) as {
+      model: object;
+    };
+    expect(getModelProviderLocalServiceReconciler(streamRegistration.model)).toBe(reconcile);
+  });
 
   it("aborts in-flight compaction when the caller abort signal fires", async () => {
     const { compactWithSafetyTimeout } = await vi.importActual<

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -24,6 +24,7 @@ import {
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { getRegisteredAgentHarness, registerAgentHarness } from "../harness/registry.js";
 import type { AgentHarness } from "../harness/types.js";
+import { getModelProviderLocalServiceReconciler } from "../provider-local-service-reconcile.js";
 import {
   createAssistant,
   createAssistantResultStream,
@@ -3309,6 +3310,34 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       api: "ollama",
       id: "qwen3:8b",
     });
+  });
+
+  it("carries the prepared provider reconciler into direct compaction", async () => {
+    mockResolvedModel();
+    const reconcile = vi.fn(async () => undefined);
+    const buildDefaultPlan = buildAgentRuntimePlanMock.getMockImplementation();
+    if (!buildDefaultPlan) {
+      throw new Error("Compaction runtime plan fixture is not configured");
+    }
+    buildAgentRuntimePlanMock.mockImplementation((params) => ({
+      ...buildDefaultPlan(params),
+      providerRuntimeHandle: {
+        provider: params.provider,
+        modelId: params.modelId,
+        workspaceDir: params.workspaceDir,
+        prepared: true,
+        plugin: { reconcileLocalService: reconcile },
+      },
+    }));
+
+    await expect(compactEmbeddedAgentSessionDirect(wrappedCompactionArgs())).resolves.toMatchObject(
+      { ok: true },
+    );
+
+    const streamRegistration = mockCallArg(registerProviderStreamForModelMock) as {
+      model: object;
+    };
+    expect(getModelProviderLocalServiceReconciler(streamRegistration.model)).toBe(reconcile);
   });
 
   it("aborts in-flight compaction when the caller abort signal fires", async () => {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3312,33 +3312,75 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
-  it("carries the prepared provider reconciler into direct compaction", async () => {
-    mockResolvedModel();
-    const reconcile = vi.fn(async () => undefined);
-    const buildDefaultPlan = buildAgentRuntimePlanMock.getMockImplementation();
-    if (!buildDefaultPlan) {
-      throw new Error("Compaction runtime plan fixture is not configured");
-    }
-    buildAgentRuntimePlanMock.mockImplementation((params) => ({
-      ...buildDefaultPlan(params),
-      providerRuntimeHandle: {
-        provider: params.provider,
-        modelId: params.modelId,
-        workspaceDir: params.workspaceDir,
-        prepared: true,
-        plugin: { reconcileLocalService: reconcile },
-      },
-    }));
+  it.each([
+    { label: "reloads before", reconcileError: undefined, expectedRequests: 1 },
+    {
+      label: "fails closed before",
+      reconcileError: new Error("llama.cpp preset reload failed"),
+      expectedRequests: 0,
+    },
+  ])(
+    "$label the first direct-compaction provider request",
+    async ({ reconcileError, expectedRequests }) => {
+      const events: string[] = [];
+      const reconcile = vi.fn(async () => {
+        events.push("reload");
+        if (reconcileError) {
+          throw reconcileError;
+        }
+      });
+      registerProviderStreamForModelMock.mockImplementation((params) => {
+        const model = (params as { model: { baseUrl: string } }).model;
+        return async () => {
+          await getModelProviderLocalServiceReconciler(model)?.({ baseUrl: model.baseUrl });
+          events.push("provider-request");
+          return undefined as never;
+        };
+      });
+      attemptServerEndpointCompactionMock.mockImplementationOnce(async (input) => {
+        try {
+          await input.streamFn(input.model, { messages: [] } as never, {});
+        } catch {
+          return undefined;
+        }
+        input.onCompactionCommitted?.();
+        return {
+          item: { type: "compaction", encrypted_content: "opaque" },
+          usage: { input_tokens: 120, output_tokens: 50 },
+        };
+      });
 
-    await expect(compactEmbeddedAgentSessionDirect(wrappedCompactionArgs())).resolves.toMatchObject(
-      { ok: true },
-    );
+      mockResolvedModel();
+      const buildDefaultPlan = buildAgentRuntimePlanMock.getMockImplementation();
+      if (!buildDefaultPlan) {
+        throw new Error("Compaction runtime plan fixture is not configured");
+      }
+      buildAgentRuntimePlanMock.mockImplementation((params) => ({
+        ...buildDefaultPlan(params),
+        providerRuntimeHandle: {
+          provider: params.provider,
+          modelId: params.modelId,
+          workspaceDir: params.workspaceDir,
+          prepared: true,
+          plugin: { reconcileLocalService: reconcile },
+        },
+      }));
 
-    const streamRegistration = mockCallArg(registerProviderStreamForModelMock) as {
-      model: object;
-    };
-    expect(getModelProviderLocalServiceReconciler(streamRegistration.model)).toBe(reconcile);
-  });
+      await expect(
+        compactEmbeddedAgentSessionDirect(wrappedCompactionArgs()),
+      ).resolves.toMatchObject({ ok: true });
+
+      const streamRegistration = mockCallArg(registerProviderStreamForModelMock) as {
+        model: object;
+      };
+      expect(getModelProviderLocalServiceReconciler(streamRegistration.model)).toBe(reconcile);
+      expect(events.filter((event) => event === "provider-request")).toHaveLength(expectedRequests);
+      expect(events.indexOf("reload")).toBeGreaterThanOrEqual(0);
+      if (expectedRequests > 0) {
+        expect(events.indexOf("reload")).toBeLessThan(events.indexOf("provider-request"));
+      }
+    },
+  );
 
   it("aborts in-flight compaction when the caller abort signal fires", async () => {
     const { compactWithSafetyTimeout } = await vi.importActual<

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -13,6 +13,10 @@ import {
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-registry-state.js";
+import {
+  attachModelProviderRuntimePluginHandle,
+  type ProviderRuntimePluginHandle,
+} from "../../plugins/provider-hook-runtime.js";
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { transformProviderSystemPrompt } from "../../plugins/provider-runtime.js";
@@ -242,7 +246,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       requestedTokenBudget: params.contextTokenBudget,
       fallbackTokenBudget: params.tokenBudget,
     });
-    const effectiveModel = applyAuthHeaderOverride(
+    const effectiveModelWithoutRuntimeHandle = applyAuthHeaderOverride(
       applyLocalNoAuthHeaderOverride(
         contextTokenBudget < (runtimeModelWithContext.contextWindow ?? Infinity)
           ? { ...runtimeModelWithContext, contextWindow: contextTokenBudget }
@@ -261,8 +265,8 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       buildAgentRuntimePlan({
         provider,
         modelId,
-        model: effectiveModel,
-        modelApi: effectiveModel.api,
+        model: effectiveModelWithoutRuntimeHandle,
+        modelApi: effectiveModelWithoutRuntimeHandle.api,
         harnessId: preparedHarnessRuntime,
         harnessRuntime: preparedHarnessRuntime,
         authProfileMode: resolvedRuntimeAuthPlan.selectedAuthMode,
@@ -279,6 +283,13 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     const runtimePlan = reuseFullRuntimePlan
       ? preparedRuntimePlan
       : { ...preparedRuntimePlan, auth: resolvedRuntimeAuthPlan };
+    const effectiveModel = runtimePlan.providerRuntimeHandle
+      ? attachModelProviderRuntimePluginHandle(
+          effectiveModelWithoutRuntimeHandle,
+          // SAFETY: runtime plans use canonical plugin handles; public types omit plugin internals.
+          runtimePlan.providerRuntimeHandle as ProviderRuntimePluginHandle,
+        )
+      : effectiveModelWithoutRuntimeHandle;
 
     const runAbortController = new AbortController();
     const spawnWorkspaceDir =

--- a/src/agents/provider-local-service-reconcile.ts
+++ b/src/agents/provider-local-service-reconcile.ts
@@ -20,6 +20,7 @@ export function attachModelProviderLocalServiceReconciler<TModel extends object>
   model: TModel,
   reconcile: ProviderLocalServiceReconciler | undefined,
 ): TModel {
+  // SAFETY: the spread preserves TModel; the intersection exposes only the symbol assigned below.
   const next = { ...model } as TModel & ModelWithProviderLocalServiceReconciler;
   next[MODEL_PROVIDER_LOCAL_SERVICE_RECONCILER_SYMBOL] = reconcile;
   return next;
@@ -28,6 +29,7 @@ export function attachModelProviderLocalServiceReconciler<TModel extends object>
 export function getModelProviderLocalServiceReconciler(
   model: object,
 ): ProviderLocalServiceReconciler | undefined {
+  // SAFETY: only the attach helper writes this optional symbol; absent carriers read as undefined.
   return (model as ModelWithProviderLocalServiceReconciler)[
     MODEL_PROVIDER_LOCAL_SERVICE_RECONCILER_SYMBOL
   ];

--- a/src/agents/provider-local-service-reconcile.ts
+++ b/src/agents/provider-local-service-reconcile.ts
@@ -1,0 +1,34 @@
+export type ProviderLocalServiceReconcileContext = {
+  baseUrl: string;
+  signal?: AbortSignal;
+};
+
+export type ProviderLocalServiceReconciler = (
+  ctx: ProviderLocalServiceReconcileContext,
+) => Promise<void>;
+
+const MODEL_PROVIDER_LOCAL_SERVICE_RECONCILER_SYMBOL = Symbol.for(
+  "openclaw.modelProviderLocalServiceReconciler",
+);
+
+type ModelWithProviderLocalServiceReconciler = {
+  [MODEL_PROVIDER_LOCAL_SERVICE_RECONCILER_SYMBOL]?: ProviderLocalServiceReconciler;
+};
+
+/** Carry the prepared provider's reconcile hook through the model transport boundary. */
+export function attachModelProviderLocalServiceReconciler<TModel extends object>(
+  model: TModel,
+  reconcile: ProviderLocalServiceReconciler | undefined,
+): TModel {
+  const next = { ...model } as TModel & ModelWithProviderLocalServiceReconciler;
+  next[MODEL_PROVIDER_LOCAL_SERVICE_RECONCILER_SYMBOL] = reconcile;
+  return next;
+}
+
+export function getModelProviderLocalServiceReconciler(
+  model: object,
+): ProviderLocalServiceReconciler | undefined {
+  return (model as ModelWithProviderLocalServiceReconciler)[
+    MODEL_PROVIDER_LOCAL_SERVICE_RECONCILER_SYMBOL
+  ];
+}

--- a/src/agents/provider-local-service-target.ts
+++ b/src/agents/provider-local-service-target.ts
@@ -1,0 +1,93 @@
+import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderReconcileLocalServiceContext } from "../plugins/provider-transport.types.js";
+
+/** Exact provider endpoint whose optional local process should be leased. */
+export type ProviderLocalServiceTarget = {
+  providerId: string;
+  baseUrl: string;
+  headers?: HeadersInit;
+  service?: ModelProviderLocalServiceConfig;
+  reconcile?: (ctx: ProviderReconcileLocalServiceContext) => Promise<void>;
+};
+
+/** Configured provider endpoint whose host-owned local service may be leased. */
+export type ConfiguredProviderLocalServiceTarget = Omit<ProviderLocalServiceTarget, "service">;
+
+/** Lease returned for a started or already-running local provider service. */
+export type ProviderLocalServiceLease = { release: () => void };
+
+/** Host-injected acquisition hook that cannot supply process configuration. */
+export type AcquireConfiguredProviderLocalService = (
+  target: ConfiguredProviderLocalServiceTarget,
+  signal?: AbortSignal | null,
+) => Promise<ProviderLocalServiceLease | undefined>;
+
+export function resolveConfiguredProviderLocalServiceTarget(
+  config: OpenClawConfig,
+  target: ConfiguredProviderLocalServiceTarget,
+): ProviderLocalServiceTarget | undefined {
+  const provider = config.models?.providers?.[target.providerId];
+  if (!provider?.localService) {
+    return undefined;
+  }
+  if (!isConfiguredProviderBaseUrl(target.baseUrl, readConfiguredProviderBaseUrl(provider))) {
+    throw new Error(`Local endpoint must match models.providers.${target.providerId}.baseUrl`);
+  }
+  return { ...target, service: provider.localService };
+}
+
+function readConfiguredProviderBaseUrl(
+  provider: { baseUrl?: string; baseURL?: unknown } | undefined,
+): string | undefined {
+  const baseUrl = provider?.baseUrl?.trim();
+  const baseURL = typeof provider?.baseURL === "string" ? provider.baseURL.trim() : "";
+  return baseUrl || baseURL || undefined;
+}
+
+function normalizeProviderBaseUrl(value: string): string | undefined {
+  const trimmed = value.trim();
+  const candidate = /^[a-z][a-z\d+.-]*:\/\//iu.test(trimmed) ? trimmed : `http://${trimmed}`;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return undefined;
+    }
+    url.search = "";
+    url.hash = "";
+    url.pathname = url.pathname.replace(/\/+$/u, "") || "/";
+    return url.toString().replace(/\/$/u, "");
+  } catch {
+    return undefined;
+  }
+}
+
+function configuredProviderBaseUrlVariants(value: string): Set<string> {
+  const root = normalizeProviderBaseUrl(value)?.replace(/\/v1$/iu, "");
+  return root ? new Set([root, `${root}/v1`]) : new Set();
+}
+
+function isLoopbackProviderBaseUrl(value: string): boolean {
+  const normalized = normalizeProviderBaseUrl(value);
+  if (!normalized) {
+    return false;
+  }
+  const hostname = new URL(normalized).hostname.toLowerCase();
+  if (hostname === "localhost" || hostname === "[::1]") {
+    return true;
+  }
+  return isCanonicalDottedDecimalIPv4(hostname) && isLoopbackIpAddress(hostname);
+}
+
+function isConfiguredProviderBaseUrl(targetBaseUrl: string, configuredBaseUrl?: string): boolean {
+  const target = normalizeProviderBaseUrl(targetBaseUrl);
+  if (!target) {
+    return false;
+  }
+  const configured = configuredBaseUrl?.trim();
+  if (!configured) {
+    return isLoopbackProviderBaseUrl(target);
+  }
+  return configuredProviderBaseUrlVariants(configured).has(target);
+}

--- a/src/agents/provider-local-service-target.ts
+++ b/src/agents/provider-local-service-target.ts
@@ -1,7 +1,7 @@
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ProviderReconcileLocalServiceContext } from "../plugins/provider-transport.types.js";
+import type { ProviderLocalServiceReconciler } from "./provider-local-service-reconcile.js";
 
 /** Exact provider endpoint whose optional local process should be leased. */
 export type ProviderLocalServiceTarget = {
@@ -9,7 +9,7 @@ export type ProviderLocalServiceTarget = {
   baseUrl: string;
   headers?: HeadersInit;
   service?: ModelProviderLocalServiceConfig;
-  reconcile?: (ctx: ProviderReconcileLocalServiceContext) => Promise<void>;
+  reconcile?: ProviderLocalServiceReconciler;
 };
 
 /** Configured provider endpoint whose host-owned local service may be leased. */

--- a/src/agents/provider-local-service-target.ts
+++ b/src/agents/provider-local-service-target.ts
@@ -64,8 +64,9 @@ function normalizeProviderBaseUrl(value: string): string | undefined {
 }
 
 function configuredProviderBaseUrlVariants(value: string): Set<string> {
-  const root = normalizeProviderBaseUrl(value)?.replace(/\/v1$/iu, "");
-  return root ? new Set([root, `${root}/v1`]) : new Set();
+  const normalized = normalizeProviderBaseUrl(value);
+  const root = normalized?.replace(/\/v1$/iu, "");
+  return normalized && root ? new Set([normalized, root, `${root}/v1`]) : new Set();
 }
 
 function isLoopbackProviderBaseUrl(value: string): boolean {

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -11,8 +11,9 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { attachModelProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
-import { getDeterministicFreePortBlock } from "../test-utils/ports.js";
+import { getDeterministicFreePortBlock, getFreePort } from "../test-utils/ports.js";
 import { killPidIfAlive, readPidFile, waitForPidToExit } from "../test-utils/process-tree.js";
 import {
   attachModelProviderLocalService,
@@ -29,24 +30,6 @@ import { hasManagedProviderLocalServices } from "./provider-runtime-lifecycle.js
 const ONE_SHOT_HOST_READY_TIMEOUT_MS = 30_000;
 const ONE_SHOT_HOST_EXIT_TIMEOUT_MS = 5_000;
 const ONE_SHOT_HOST_READY_KIND = "ready-for-exit";
-
-async function freePort(): Promise<number> {
-  // Allocate a real loopback port to exercise child process health probes.
-  return await new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      server.close(() => {
-        if (address && typeof address === "object") {
-          resolve(address.port);
-        } else {
-          reject(new Error("missing test port"));
-        }
-      });
-    });
-  });
-}
 
 async function waitForProbeFailure(url: string): Promise<void> {
   // Idle-stop assertions wait until the local service no longer responds.
@@ -206,42 +189,75 @@ describe("provider local service", () => {
   });
 
   it("starts an on-demand local service and stops it after idle", async () => {
-    expect(hasManagedProviderLocalServices()).toBe(false);
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
-    const model = attachModelProviderLocalService(
-      {
-        id: "demo",
-        provider: "local-demo",
-        api: "openai-completions",
-        baseUrl: `http://127.0.0.1:${port}/v1`,
-      } as unknown as Model<"openai-completions">,
-      {
-        command: process.execPath,
-        args: [
-          "-e",
-          `const http=require("http");http.createServer((req,res)=>{res.writeHead(200,{"content-type":"application/json"});res.end('{"ok":true}');}).listen(${port},"127.0.0.1");`,
-        ],
-        healthUrl,
-        readyTimeoutMs: 5_000,
-        idleStopMs: 1,
-      },
+    const reconcile = vi.fn(async () => {
+      expect((await fetch(healthUrl)).ok).toBe(true);
+    });
+    const model = attachModelProviderRuntimePluginHandle(
+      attachModelProviderLocalService(
+        {
+          provider: "local-demo",
+          baseUrl: `http://127.0.0.1:${port}/v1`,
+        } as unknown as Model<"openai-completions">,
+        {
+          command: process.execPath,
+          args: [
+            "-e",
+            `const http=require("http");http.createServer((req,res)=>{res.writeHead(200,{"content-type":"application/json"});res.end('{"ok":true}');}).listen(${port},"127.0.0.1");`,
+          ],
+          healthUrl,
+          readyTimeoutMs: 5_000,
+          idleStopMs: 1,
+        },
+      ),
+      { plugin: { reconcileLocalService: reconcile } } as never,
     );
 
-    const lease = await withSpawnReadyHealthProbe(() => ensureModelProviderLocalService(model));
-
-    if (!lease) {
+    const acquire = (signal?: AbortSignal) =>
+      ensureModelProviderLocalService(model, undefined, signal);
+    const firstLease = await withSpawnReadyHealthProbe(acquire);
+    const secondLease = await acquire();
+    if (!firstLease || !secondLease) {
       throw new Error("Expected provider local service lease");
     }
-    expect(hasManagedProviderLocalServices()).toBe(true);
+    reconcile.mockImplementationOnce(() => {
+      throw new Error("reconcile failed");
+    });
+    await expect(acquire()).rejects.toThrow("reconcile failed");
+    const controller = new AbortController();
+    const abort = new Error("reconcile aborted");
+    reconcile.mockImplementationOnce(async ({ signal }) => {
+      controller.abort(abort);
+      throw signal?.reason;
+    });
+    await expect(acquire(controller.signal)).rejects.toThrow(abort.message);
+
+    const reconciliation = Promise.withResolvers<void>();
+    const reconcileStarted = Promise.withResolvers<void>();
+    const lateController = new AbortController();
+    const lateAbort = new Error("late reconcile abort");
+    reconcile.mockImplementationOnce(() => {
+      reconcileStarted.resolve();
+      return reconciliation.promise;
+    });
+    const lateAcquire = acquire(lateController.signal);
+    await reconcileStarted.promise;
+    lateController.abort(lateAbort);
+    reconciliation.resolve();
+    await expect(lateAcquire).rejects.toThrow(lateAbort.message);
+
+    expect(reconcile).toHaveBeenCalledTimes(5);
     expect((await fetch(healthUrl)).ok).toBe(true);
-    lease.release();
+    firstLease.release();
+    expect((await fetch(healthUrl)).ok).toBe(true);
+    secondLease.release();
     await waitForProbeFailure(healthUrl);
     expect(hasManagedProviderLocalServices()).toBe(false);
   });
 
   it("resolves process configuration from the host config", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const acquire = createConfiguredProviderLocalServiceAcquirer(
       () =>
@@ -283,7 +299,7 @@ describe("provider local service", () => {
   });
 
   it("allows a default loopback endpoint when provider baseUrl is empty", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const acquire = createConfiguredProviderLocalServiceAcquirer(() => ({
       models: {
@@ -368,7 +384,7 @@ describe("provider local service", () => {
 
   it("caps oversized local service idle stop timers", async () => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const model = attachModelProviderLocalService(
       {
@@ -404,7 +420,7 @@ describe("provider local service", () => {
   });
 
   it("sends provider request headers on local service health probes", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const model = attachModelProviderLocalService(
       {
@@ -448,7 +464,7 @@ describe("provider local service", () => {
   });
 
   it("rejects unknown sentinels before starting a local service", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const unknown = "oc-sent-v2.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.end";
     const model = attachModelProviderLocalService(
       {
@@ -471,7 +487,7 @@ describe("provider local service", () => {
     );
   });
 
-  it("cancels local service health probe response bodies", async () => {
+  it("reconciles a healthy external process and cancels its health response body", async () => {
     let socketClosed = false;
     const sockets = new Set<net.Socket>();
     const server = net.createServer((socket) => {
@@ -496,24 +512,29 @@ describe("provider local service", () => {
     if (!address || typeof address === "string") {
       throw new Error("missing test server port");
     }
-    const model = attachModelProviderLocalService(
-      {
-        id: "demo",
-        provider: "local-body-cleanup",
-        api: "openai-completions",
-        baseUrl: `http://127.0.0.1:${address.port}/v1`,
-      } as unknown as Model<"openai-completions">,
-      {
-        command: process.execPath,
-        args: ["--version"],
-        healthUrl: `http://127.0.0.1:${address.port}/v1/models`,
-        readyTimeoutMs: 1_000,
-        idleStopMs: 1,
-      },
+    const reconcile = vi.fn(async () => undefined);
+    const model = attachModelProviderRuntimePluginHandle(
+      attachModelProviderLocalService(
+        {
+          provider: "local-body-cleanup",
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        } as unknown as Model<"openai-completions">,
+        {
+          command: process.execPath,
+          args: ["--version"],
+          healthUrl: `http://127.0.0.1:${address.port}/v1/models`,
+          readyTimeoutMs: 1_000,
+          idleStopMs: 1,
+        },
+      ),
+      { plugin: { reconcileLocalService: reconcile } } as never,
     );
 
     try {
-      await expect(ensureModelProviderLocalService(model)).resolves.toBeUndefined();
+      const lease = await ensureModelProviderLocalService(model);
+      expect(lease).toBeDefined();
+      expect(reconcile).toHaveBeenCalledOnce();
+      lease?.release();
       await expect.poll(() => socketClosed, { timeout: 1000, interval: 20 }).toBe(true);
     } finally {
       for (const socket of sockets) {
@@ -526,7 +547,7 @@ describe("provider local service", () => {
   });
 
   it("serializes concurrent chat and embedding starts with independent leases", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-service-"));
     const startsPath = path.join(tempDir, "starts.txt");
@@ -637,7 +658,7 @@ describe("provider local service", () => {
   });
 
   it("restarts an OpenClaw-managed local service when its health endpoint is down", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-service-restart-"));
     const startsPath = path.join(tempDir, "starts.txt");
@@ -699,7 +720,7 @@ describe("provider local service", () => {
   });
 
   it("reports a local service startup exit without waiting for readiness timeout", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const target = {
       providerId: "local-fast-exit",
       baseUrl: `http://127.0.0.1:${port}/v1`,
@@ -718,7 +739,7 @@ describe("provider local service", () => {
   });
 
   it("preserves UTF-8 split across local service startup diagnostic chunks", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const expected = "startup-😀-failure";
     const serviceScript = [
       `const bytes=Buffer.from(${JSON.stringify(expected)},"utf8");`,
@@ -742,7 +763,7 @@ describe("provider local service", () => {
   });
 
   it("reports a local service startup signal exit without waiting for readiness timeout", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const model = attachModelProviderLocalService(
       {
         id: "demo",
@@ -765,7 +786,7 @@ describe("provider local service", () => {
   });
 
   it("does not keep one-shot hosts alive through diagnostic pipes", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const tempDir = tempDirs.make("openclaw-local-service-unref-");
     const servicePidPath = path.join(tempDir, "service.pid");
     const moduleUrl = new URL("./provider-local-service.ts", import.meta.url).href;
@@ -821,7 +842,7 @@ describe("provider local service", () => {
   });
 
   it("does not keep failed one-shot hosts alive through diagnostic pipes", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const tempDir = tempDirs.make("openclaw-local-service-failed-unref-");
     const servicePidPath = path.join(tempDir, "service.pid");
     const moduleUrl = new URL("./provider-local-service.ts", import.meta.url).href;
@@ -897,7 +918,7 @@ describe("provider local service", () => {
   });
 
   it("honors request aborts while waiting for local service readiness", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const controller = new AbortController();
     const target = {
@@ -927,7 +948,7 @@ describe("provider local service", () => {
   });
 
   it("reports only bounded redacted startup diagnostics", async () => {
-    const port = await freePort();
+    const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const diagnosticSecret = "local-service-diagnostic-secret";
     const inheritedDiagnosticSecret = "inherited-local-service-diagnostic-secret";

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -17,6 +17,7 @@ import { mintSecretSentinel } from "../secrets/sentinel.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { getDeterministicFreePortBlock, getFreePort } from "../test-utils/ports.js";
 import { killPidIfAlive, readPidFile, waitForPidToExit } from "../test-utils/process-tree.js";
+import { getModelProviderLocalServiceReconciler } from "./provider-local-service-reconcile.js";
 import {
   attachModelProviderLocalService,
   createConfiguredProviderLocalServiceAcquirer,
@@ -182,6 +183,20 @@ describe("provider local service", () => {
       command: process.execPath,
       args: ["--version"],
     });
+  });
+
+  it("clears a stale reconciler when the prepared provider changes", () => {
+    const reconcile = vi.fn(async () => undefined);
+    const withReconciler = attachModelProviderRuntimePluginHandle(
+      { id: "demo", provider: "local", baseUrl: "http://127.0.0.1:1/v1" },
+      { plugin: { reconcileLocalService: reconcile } } as never,
+    );
+    const withoutReconciler = attachModelProviderRuntimePluginHandle(withReconciler, {
+      plugin: {},
+    } as never);
+
+    expect(getModelProviderLocalServiceReconciler(withReconciler)).toBe(reconcile);
+    expect(getModelProviderLocalServiceReconciler(withoutReconciler)).toBeUndefined();
   });
 
   it("treats signaled local service children as exited", () => {

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -12,7 +12,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { attachModelProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
+import type { ProviderPlugin } from "../plugins/provider-plugin.types.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { getDeterministicFreePortBlock, getFreePort } from "../test-utils/ports.js";
 import { killPidIfAlive, readPidFile, waitForPidToExit } from "../test-utils/process-tree.js";
 import {
@@ -191,7 +193,7 @@ describe("provider local service", () => {
   it("starts an on-demand local service and stops it after idle", async () => {
     const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
-    const reconcile = vi.fn(async () => {
+    const reconcile = vi.fn<NonNullable<ProviderPlugin["reconcileLocalService"]>>(async () => {
       expect((await fetch(healthUrl)).ok).toBe(true);
     });
     const model = attachModelProviderRuntimePluginHandle(
@@ -233,8 +235,8 @@ describe("provider local service", () => {
     });
     await expect(acquire(controller.signal)).rejects.toThrow(abort.message);
 
-    const reconciliation = Promise.withResolvers<void>();
-    const reconcileStarted = Promise.withResolvers<void>();
+    const reconciliation = createDeferredCore();
+    const reconcileStarted = createDeferredCore();
     const lateController = new AbortController();
     const lateAbort = new Error("late reconcile abort");
     reconcile.mockImplementationOnce(() => {

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -17,7 +17,6 @@ import { mintSecretSentinel } from "../secrets/sentinel.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { getDeterministicFreePortBlock, getFreePort } from "../test-utils/ports.js";
 import { killPidIfAlive, readPidFile, waitForPidToExit } from "../test-utils/process-tree.js";
-import { getModelProviderLocalServiceReconciler } from "./provider-local-service-reconcile.js";
 import {
   attachModelProviderLocalService,
   createConfiguredProviderLocalServiceAcquirer,
@@ -183,20 +182,6 @@ describe("provider local service", () => {
       command: process.execPath,
       args: ["--version"],
     });
-  });
-
-  it("clears a stale reconciler when the prepared provider changes", () => {
-    const reconcile = vi.fn(async () => undefined);
-    const withReconciler = attachModelProviderRuntimePluginHandle(
-      { id: "demo", provider: "local", baseUrl: "http://127.0.0.1:1/v1" },
-      { plugin: { reconcileLocalService: reconcile } } as never,
-    );
-    const withoutReconciler = attachModelProviderRuntimePluginHandle(withReconciler, {
-      plugin: {},
-    } as never);
-
-    expect(getModelProviderLocalServiceReconciler(withReconciler)).toBe(reconcile);
-    expect(getModelProviderLocalServiceReconciler(withoutReconciler)).toBeUndefined();
   });
 
   it("treats signaled local service children as exited", () => {

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -260,7 +260,10 @@ describe("provider local service", () => {
 
   it("resolves process configuration for root and exact legacy baseURL endpoints", async () => {
     const port = await getFreePort();
-    const healthUrl = `http://127.0.0.1:${port}/v1/models`;
+    const providerId = "gpu-spark";
+    const rootBaseUrl = `http://127.0.0.1:${port}`;
+    const healthUrl = `${rootBaseUrl}/v1/models`;
+    const serverScript = `const http=require("http");http.createServer((req,res)=>{res.writeHead(200);res.end("ok");}).listen(${port},"127.0.0.1");`;
     const acquire = createConfiguredProviderLocalServiceAcquirer(
       () =>
         ({
@@ -272,10 +275,7 @@ describe("provider local service", () => {
                 models: [],
                 localService: {
                   command: process.execPath,
-                  args: [
-                    "-e",
-                    `const http=require("http");http.createServer((req,res)=>{res.writeHead(200);res.end("ok");}).listen(${port},"127.0.0.1");`,
-                  ],
+                  args: ["-e", serverScript],
                   healthUrl,
                   readyTimeoutMs: 5_000,
                   idleStopMs: 1,
@@ -288,21 +288,16 @@ describe("provider local service", () => {
 
     const rootLease = await withSpawnReadyHealthProbe(() =>
       acquire({
-        providerId: "gpu-spark",
-        baseUrl: `http://127.0.0.1:${port}`,
+        providerId,
+        baseUrl: rootBaseUrl,
         service: { command: "caller-controlled" },
       } as Parameters<typeof acquire>[0]),
     );
-    const configuredLease = await acquire({
-      providerId: "gpu-spark",
-      baseUrl: `http://127.0.0.1:${port}/V1`,
-    });
+    const configuredLease = await acquire({ providerId, baseUrl: `${rootBaseUrl}/V1` });
 
-    expect(rootLease).toBeDefined();
-    expect(configuredLease).toBeDefined();
+    expect(rootLease && configuredLease).toBeDefined();
     expect((await fetch(healthUrl)).ok).toBe(true);
-    rootLease?.release();
-    configuredLease?.release();
+    [rootLease, configuredLease].forEach((lease) => lease?.release());
     await waitForProbeFailure(healthUrl);
   });
 

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -258,7 +258,7 @@ describe("provider local service", () => {
     expect(hasManagedProviderLocalServices()).toBe(false);
   });
 
-  it("resolves process configuration from the host config", async () => {
+  it("resolves process configuration for root and exact legacy baseURL endpoints", async () => {
     const port = await getFreePort();
     const healthUrl = `http://127.0.0.1:${port}/v1/models`;
     const acquire = createConfiguredProviderLocalServiceAcquirer(
@@ -268,7 +268,7 @@ describe("provider local service", () => {
             providers: {
               "gpu-spark": {
                 baseUrl: "",
-                baseURL: `127.0.0.1:${port}/v1`,
+                baseURL: `127.0.0.1:${port}/V1`,
                 models: [],
                 localService: {
                   command: process.execPath,
@@ -286,17 +286,23 @@ describe("provider local service", () => {
         }) as OpenClawConfig,
     );
 
-    const lease = await withSpawnReadyHealthProbe(() =>
+    const rootLease = await withSpawnReadyHealthProbe(() =>
       acquire({
         providerId: "gpu-spark",
         baseUrl: `http://127.0.0.1:${port}`,
         service: { command: "caller-controlled" },
       } as Parameters<typeof acquire>[0]),
     );
+    const configuredLease = await acquire({
+      providerId: "gpu-spark",
+      baseUrl: `http://127.0.0.1:${port}/V1`,
+    });
 
-    expect(lease).toBeDefined();
+    expect(rootLease).toBeDefined();
+    expect(configuredLease).toBeDefined();
     expect((await fetch(healthUrl)).ok).toBe(true);
-    lease?.release();
+    rootLease?.release();
+    configuredLease?.release();
     await waitForProbeFailure(healthUrl);
   });
 

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -14,7 +14,6 @@ import { mergeProcessEnv } from "../infra/process-env.js";
 import type { Model } from "../llm/types.js";
 import { isSensitiveFieldKey, redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getModelProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import {
   forceKillChildProcessTree,
   isChildProcessTreeAlive,
@@ -22,6 +21,7 @@ import {
   shouldDetachChildForProcessTree,
 } from "../process/child-process-tree.js";
 import { prepareOomScoreAdjustedSpawnPreservingExecEnv as prepareLocalServiceSpawn } from "../process/linux-oom-score.js";
+import { getModelProviderLocalServiceReconciler } from "./provider-local-service-reconcile.js";
 import type {
   AcquireConfiguredProviderLocalService,
   ProviderLocalServiceLease,
@@ -118,7 +118,7 @@ export async function ensureModelProviderLocalService(
       baseUrl: model.baseUrl,
       headers: buildHealthProbeHeaders((model as { headers?: HeadersInit }).headers, probeHeaders),
       service,
-      reconcile: getModelProviderRuntimePluginHandle(model)?.plugin?.reconcileLocalService,
+      reconcile: getModelProviderLocalServiceReconciler(model),
     },
     signal,
   );

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -1,11 +1,7 @@
-/**
- * Manages optional local provider sidecar processes attached to models. Leases
- * keep shared services alive while requests run and stop them after idle.
- */
+/** Manages optional local provider processes; request leases keep shared services alive. */
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import path from "node:path";
-import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import {
   clampPositiveTimerTimeoutMs,
   resolvePositiveTimerTimeoutMs,
@@ -18,6 +14,7 @@ import { mergeProcessEnv } from "../infra/process-env.js";
 import type { Model } from "../llm/types.js";
 import { isSensitiveFieldKey, redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getModelProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import {
   forceKillChildProcessTree,
   isChildProcessTreeAlive,
@@ -25,6 +22,12 @@ import {
   shouldDetachChildForProcessTree,
 } from "../process/child-process-tree.js";
 import { prepareOomScoreAdjustedSpawnPreservingExecEnv as prepareLocalServiceSpawn } from "../process/linux-oom-score.js";
+import type {
+  AcquireConfiguredProviderLocalService,
+  ProviderLocalServiceLease,
+  ProviderLocalServiceTarget,
+} from "./provider-local-service-target.js";
+import { resolveConfiguredProviderLocalServiceTarget } from "./provider-local-service-target.js";
 import { setManagedProviderLocalServicesActive } from "./provider-runtime-lifecycle.js";
 import { unwrapHeadersInitSentinelsForProviderEgress } from "./provider-secret-egress.js";
 
@@ -72,109 +75,14 @@ type LocalServiceDiagnostics = {
   lastExit?: LocalServiceExit;
 };
 
-/** Exact provider endpoint whose optional local process should be leased. */
-export type ProviderLocalServiceTarget = {
-  providerId: string;
-  baseUrl: string;
-  headers?: HeadersInit;
-  service?: ModelProviderLocalServiceConfig;
-};
-
-/** Configured provider endpoint whose host-owned local service may be leased. */
-export type ConfiguredProviderLocalServiceTarget = Omit<ProviderLocalServiceTarget, "service">;
-
-/** Lease returned for a started or already-running local provider service. */
-export type ProviderLocalServiceLease = {
-  release: () => void;
-};
-
-/** Host-injected acquisition hook that cannot supply process configuration. */
-export type AcquireConfiguredProviderLocalService = (
-  target: ConfiguredProviderLocalServiceTarget,
-  signal?: AbortSignal | null,
-) => Promise<ProviderLocalServiceLease | undefined>;
-
 /** Bind local-service acquisition to a host-owned config snapshot. */
 export function createConfiguredProviderLocalServiceAcquirer(
   getConfig: () => OpenClawConfig,
 ): AcquireConfiguredProviderLocalService {
   return async (target, signal) => {
-    const provider = getConfig().models?.providers?.[target.providerId];
-    const service = provider?.localService;
-    if (!service) {
-      return undefined;
-    }
-    if (!isConfiguredProviderBaseUrl(target.baseUrl, readConfiguredProviderBaseUrl(provider))) {
-      throw new Error(
-        `Local service target must match models.providers.${target.providerId}.baseUrl`,
-      );
-    }
-    return await ensureProviderLocalService({ ...target, service }, signal);
+    const resolved = resolveConfiguredProviderLocalServiceTarget(getConfig(), target);
+    return resolved ? await ensureProviderLocalService(resolved, signal) : undefined;
   };
-}
-
-function readConfiguredProviderBaseUrl(
-  provider: { baseUrl?: string; baseURL?: unknown } | undefined,
-): string | undefined {
-  const canonical = provider?.baseUrl?.trim();
-  if (canonical) {
-    return canonical;
-  }
-  const alternate = provider?.baseURL;
-  return typeof alternate === "string" && alternate.trim() ? alternate.trim() : undefined;
-}
-
-function normalizeProviderBaseUrl(value: string): string | undefined {
-  const trimmed = value.trim();
-  const candidates = /^[a-z][a-z\d+.-]*:\/\//iu.test(trimmed) ? [trimmed] : [`http://${trimmed}`];
-  for (const candidate of candidates) {
-    try {
-      const url = new URL(candidate);
-      if (url.protocol !== "http:" && url.protocol !== "https:") {
-        continue;
-      }
-      url.search = "";
-      url.hash = "";
-      url.pathname = url.pathname.replace(/\/+$/u, "") || "/";
-      return url.toString().replace(/\/$/u, "");
-    } catch {
-      continue;
-    }
-  }
-  return undefined;
-}
-
-function configuredProviderBaseUrlVariants(value: string): Set<string> {
-  const normalized = normalizeProviderBaseUrl(value);
-  if (!normalized) {
-    return new Set();
-  }
-  const withoutOpenAiPath = normalized.replace(/\/v1$/iu, "");
-  return new Set([normalized, withoutOpenAiPath, `${withoutOpenAiPath}/v1`]);
-}
-
-function isLoopbackProviderBaseUrl(value: string): boolean {
-  const normalized = normalizeProviderBaseUrl(value);
-  if (!normalized) {
-    return false;
-  }
-  const hostname = new URL(normalized).hostname.toLowerCase();
-  return (
-    hostname === "localhost" ||
-    hostname === "[::1]" ||
-    (isCanonicalDottedDecimalIPv4(hostname) && isLoopbackIpAddress(hostname))
-  );
-}
-
-function isConfiguredProviderBaseUrl(targetBaseUrl: string, configuredBaseUrl?: string): boolean {
-  const target = normalizeProviderBaseUrl(targetBaseUrl);
-  if (!target) {
-    return false;
-  }
-  const configured = configuredBaseUrl?.trim();
-  return configured
-    ? configuredProviderBaseUrlVariants(configured).has(target)
-    : isLoopbackProviderBaseUrl(target);
 }
 
 /** Attach local-service startup metadata to a model without mutating the original object. */
@@ -210,6 +118,7 @@ export async function ensureModelProviderLocalService(
       baseUrl: model.baseUrl,
       headers: buildHealthProbeHeaders((model as { headers?: HeadersInit }).headers, probeHeaders),
       service,
+      reconcile: getModelProviderRuntimePluginHandle(model)?.plugin?.reconcileLocalService,
     },
     signal,
   );
@@ -217,6 +126,24 @@ export async function ensureModelProviderLocalService(
 
 /** Ensure a provider endpoint's local service is healthy and return a request lease. */
 export async function ensureProviderLocalService(
+  target: ProviderLocalServiceTarget,
+  signal?: AbortSignal | null,
+): Promise<ProviderLocalServiceLease | undefined> {
+  const lease = await acquireProviderLocalService(target, signal);
+  if (!lease || !target.reconcile) {
+    return lease;
+  }
+  try {
+    await target.reconcile({ baseUrl: target.baseUrl, signal: signal ?? undefined });
+    throwIfAborted(signal);
+  } catch (error) {
+    lease.release();
+    throw error;
+  }
+  return lease;
+}
+
+async function acquireProviderLocalService(
   target: ProviderLocalServiceTarget,
   signal?: AbortSignal | null,
 ): Promise<ProviderLocalServiceLease | undefined> {
@@ -274,11 +201,14 @@ export async function ensureProviderLocalService(
       });
     }
     await waitForAbort(managed.starting, signal);
-    if (!managed.process || hasLocalServiceProcessExited(managed.process)) {
-      release();
-      return undefined;
+    if (
+      (managed.process && !hasLocalServiceProcessExited(managed.process)) ||
+      (await probeHealth(healthUrl, healthHeaders, signal))
+    ) {
+      return { release };
     }
-    return { release };
+    release();
+    return undefined;
   } catch (error) {
     const abortingStartup = isAbortForSignal(error, signal) && Boolean(managed.starting);
     release();
@@ -368,8 +298,7 @@ async function probeHealth(
   signal?: AbortSignal | null,
 ): Promise<boolean> {
   throwIfAborted(signal);
-  // Local-service orchestration retains sentinel headers across retries. Only
-  // the actual health request may materialize credentials.
+  // Only the actual health request may materialize retained sentinel headers.
   const egressHeaders = unwrapHeadersInitSentinelsForProviderEgress(
     headers,
     "to probe local model provider health",
@@ -421,8 +350,7 @@ async function startAndWaitForLocalService(params: {
     stderrTail: "",
   };
   managed.diagnostics = diagnostics;
-  // The last lease can disappear while the health probe or restart settles.
-  // Recheck at the spawn boundary so cleanup cannot orphan a newly created child.
+  // Recheck after health/restart so the last lease cannot disappear before spawn.
   throwIfAborted(signal);
   log.info(`starting ${provider} local service: ${service.command}`);
   const serviceEnv = service.env ? mergeProcessEnv([process.env, service.env]) : process.env;
@@ -491,8 +419,7 @@ async function startAndWaitForLocalService(params: {
     if (await probeHealth(healthUrl, healthHeaders, signal)) {
       diagnostics.readyAt = Date.now();
       diagnostics.lastHealthyAt = diagnostics.readyAt;
-      // Pipes keep startup alive while readiness is pending, then stop
-      // diagnostics from retaining runtime output or pinning one-shot hosts.
+      // Drain readiness diagnostics so pipes cannot pin one-shot hosts.
       diagnostics.stdoutTail = "";
       diagnostics.stderrTail = "";
       drainLocalServiceOutput(child);

--- a/src/agents/provider-stream.lifecycle.test.ts
+++ b/src/agents/provider-stream.lifecycle.test.ts
@@ -1,14 +1,21 @@
 import { createApiRegistry, createLlmRuntime } from "@openclaw/ai";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { bindModelLlmRuntime } from "../llm/model-runtime-binding.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
+import { resolveCompactionProviderStream } from "./embedded-agent-runner/compaction-diagnostics.js";
 import { getModelProviderLocalServiceReconciler } from "./provider-local-service-reconcile.js";
+import {
+  attachModelProviderLocalService,
+  stopManagedProviderLocalServices,
+} from "./provider-local-service.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
+import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 
-const { prepare, providerStream, reconcile, runtimeHandle } = vi.hoisted(() => {
+const { fetchWithSsrFGuard, prepare, providerStream, reconcile, runtimeHandle } = vi.hoisted(() => {
   const prepareMock = vi.fn(async () => undefined);
   const reconcileMock = vi.fn(async () => undefined);
   return {
+    fetchWithSsrFGuard: vi.fn(),
     prepare: prepareMock,
     providerStream: vi.fn(),
     reconcile: reconcileMock,
@@ -28,6 +35,11 @@ const { prepare, providerStream, reconcile, runtimeHandle } = vi.hoisted(() => {
   };
 });
 
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard,
+  withTrustedEnvProxyGuardedFetchMode: vi.fn((params) => params),
+}));
+
 vi.mock("../plugins/provider-runtime.js", () => ({
   resolveProviderStreamFn: () => providerStream,
 }));
@@ -41,6 +53,26 @@ vi.mock("../plugins/provider-hook-runtime.js", async (importOriginal) => {
 });
 
 describe("provider stream lifecycle registration", () => {
+  beforeEach(() => {
+    fetchWithSsrFGuard.mockReset().mockResolvedValue({
+      response: new Response("ok"),
+      finalUrl: "http://127.0.0.1:19432/v1/responses",
+      release: vi.fn(async () => undefined),
+    });
+    prepare.mockClear();
+    providerStream.mockReset();
+    reconcile.mockReset().mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await stopManagedProviderLocalServices();
+  });
+
   it("registers provider streams with the resolved runtime lifecycle handle", async () => {
     providerStream.mockReturnValue(createAssistantMessageEventStream());
     const apiRegistry = createApiRegistry();
@@ -72,5 +104,71 @@ describe("provider stream lifecycle registration", () => {
     expect(prepare.mock.invocationCallOrder[0]).toBeLessThan(
       providerStream.mock.invocationCallOrder[0]!,
     );
+  });
+
+  it.each([
+    { label: "reloads before", reconcileError: undefined },
+    { label: "fails closed before", reconcileError: new Error("preset reload failed") },
+  ])("$label the first direct-compaction provider request", async ({ reconcileError }) => {
+    const events: string[] = [];
+    reconcile.mockImplementation(async () => {
+      events.push("reload");
+      if (reconcileError) {
+        throw reconcileError;
+      }
+    });
+    fetchWithSsrFGuard.mockImplementation(async () => {
+      events.push("provider-request");
+      return {
+        response: new Response("ok"),
+        finalUrl: "http://127.0.0.1:19432/v1/responses",
+        release: vi.fn(async () => undefined),
+      };
+    });
+    providerStream.mockImplementation(async (requestModel) => {
+      const response = await buildGuardedModelFetch(requestModel)(
+        "http://127.0.0.1:19432/v1/responses",
+        { method: "POST", body: "{}" },
+      );
+      await response.text();
+      return createAssistantMessageEventStream();
+    });
+    const apiRegistry = createApiRegistry();
+    const llmRuntime = createLlmRuntime(apiRegistry);
+    const model = attachModelProviderLocalService(
+      bindModelLlmRuntime(
+        {
+          api: "test-lifecycle-provider",
+          provider: "test-provider",
+          id: "test-model",
+          name: "Test Model",
+          baseUrl: "http://127.0.0.1:19432/v1",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 1024,
+          maxTokens: 512,
+        },
+        llmRuntime,
+      ),
+      {
+        command: process.execPath,
+        args: ["-e", "setInterval(() => {}, 1000)"],
+        healthUrl: "http://127.0.0.1:19432/health",
+      },
+    );
+    const streamFn = resolveCompactionProviderStream({
+      effectiveModel: model,
+      agentDir: "/tmp/test-agent",
+      effectiveWorkspace: "/tmp/test-workspace",
+      apiRegistry,
+    });
+
+    if (reconcileError) {
+      await expect(streamFn?.(model, {} as never, {})).rejects.toThrow(reconcileError.message);
+    } else {
+      await streamFn?.(model, {} as never, {});
+    }
+    expect(events).toEqual(reconcileError ? ["reload"] : ["reload", "provider-request"]);
   });
 });

--- a/src/agents/provider-stream.lifecycle.test.ts
+++ b/src/agents/provider-stream.lifecycle.test.ts
@@ -2,18 +2,46 @@ import { createApiRegistry, createLlmRuntime } from "@openclaw/ai";
 import { describe, expect, it, vi } from "vitest";
 import { bindModelLlmRuntime } from "../llm/model-runtime-binding.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
+import { getModelProviderLocalServiceReconciler } from "./provider-local-service-reconcile.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 
-const { providerStream } = vi.hoisted(() => ({
-  providerStream: vi.fn(),
-}));
+const { prepare, providerStream, reconcile, runtimeHandle } = vi.hoisted(() => {
+  const prepare = vi.fn(async () => undefined);
+  const reconcile = vi.fn(async () => undefined);
+  return {
+    prepare,
+    providerStream: vi.fn(),
+    reconcile,
+    runtimeHandle: {
+      provider: "test-provider",
+      modelId: "test-model",
+      plugin: {
+        reconcileLocalService: reconcile,
+        wrapStreamFn: ({ streamFn }: { streamFn: typeof providerStream }) => {
+          return async (...args: Parameters<typeof providerStream>) => {
+            await prepare();
+            return streamFn(...args);
+          };
+        },
+      },
+    },
+  };
+});
 
 vi.mock("../plugins/provider-runtime.js", () => ({
   resolveProviderStreamFn: () => providerStream,
 }));
 
+vi.mock("../plugins/provider-hook-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/provider-hook-runtime.js")>();
+  return {
+    ...actual,
+    resolveProviderRuntimePluginHandle: () => runtimeHandle,
+  };
+});
+
 describe("provider stream lifecycle registration", () => {
-  it("registers provider streams into the prepared model runtime", () => {
+  it("registers provider streams with the resolved runtime lifecycle handle", async () => {
     providerStream.mockReturnValue(createAssistantMessageEventStream());
     const apiRegistry = createApiRegistry();
     const llmRuntime = createLlmRuntime(apiRegistry);
@@ -33,7 +61,16 @@ describe("provider stream lifecycle registration", () => {
       llmRuntime,
     );
 
-    expect(registerProviderStreamForModel({ model })).toBeTypeOf("function");
+    const streamFn = registerProviderStreamForModel({ model, wrapProviderStream: true });
+    expect(streamFn).toBeTypeOf("function");
     expect(apiRegistry.getApiProvider("test-lifecycle-provider")).toBeDefined();
+    await streamFn?.(model, {} as never, {});
+    expect(getModelProviderLocalServiceReconciler(providerStream.mock.calls[0]![0])).toBe(
+      reconcile,
+    );
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(prepare.mock.invocationCallOrder[0]).toBeLessThan(
+      providerStream.mock.invocationCallOrder[0]!,
+    );
   });
 });

--- a/src/agents/provider-stream.lifecycle.test.ts
+++ b/src/agents/provider-stream.lifecycle.test.ts
@@ -6,20 +6,20 @@ import { getModelProviderLocalServiceReconciler } from "./provider-local-service
 import { registerProviderStreamForModel } from "./provider-stream.js";
 
 const { prepare, providerStream, reconcile, runtimeHandle } = vi.hoisted(() => {
-  const prepare = vi.fn(async () => undefined);
-  const reconcile = vi.fn(async () => undefined);
+  const prepareMock = vi.fn(async () => undefined);
+  const reconcileMock = vi.fn(async () => undefined);
   return {
-    prepare,
+    prepare: prepareMock,
     providerStream: vi.fn(),
-    reconcile,
+    reconcile: reconcileMock,
     runtimeHandle: {
       provider: "test-provider",
       modelId: "test-model",
       plugin: {
-        reconcileLocalService: reconcile,
+        reconcileLocalService: reconcileMock,
         wrapStreamFn: ({ streamFn }: { streamFn: typeof providerStream }) => {
           return async (...args: Parameters<typeof providerStream>) => {
-            await prepare();
+            await prepareMock();
             return streamFn(...args);
           };
         },

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -36,6 +36,7 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   wrapProviderStream?: boolean;
   apiRegistry?: ApiRegistry;
 }): StreamFn | undefined {
+  const apiRegistry = params.apiRegistry ?? getModelLlmRuntime(params.model)?.registry;
   const runtimeHandle =
     getModelProviderRuntimePluginHandle(params.model) ??
     (params.allowRuntimePluginLoad === false
@@ -115,7 +116,6 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
     : providerWrappedStreamFn;
   // Register custom APIs only after a concrete stream exists, so later callers
   // can route by model.api without reloading provider runtime hooks.
-  const apiRegistry = params.apiRegistry ?? getModelLlmRuntime(runtimeModel)?.registry;
   if (apiRegistry) {
     ensureCustomApiRegistered(apiRegistry, runtimeModel.api, preparedStreamFn);
   }

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -9,6 +9,13 @@ import { createTransportAwareStreamFnForModel } from "@openclaw/ai/transports";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getModelLlmRuntime } from "../llm/model-runtime-binding.js";
 import type { Api, Model } from "../llm/types.js";
+import {
+  attachModelProviderRuntimePluginHandle,
+  getModelProviderRuntimePluginHandle,
+  resolveProviderRuntimePluginHandle,
+  type ProviderRuntimePluginHandle,
+  wrapProviderStreamFn,
+} from "../plugins/provider-hook-runtime.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import {
@@ -26,33 +33,49 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   allowRuntimePluginLoad?: boolean;
+  wrapProviderStream?: boolean;
   apiRegistry?: ApiRegistry;
 }): StreamFn | undefined {
+  const runtimeHandle =
+    getModelProviderRuntimePluginHandle(params.model) ??
+    (params.allowRuntimePluginLoad === false
+      ? undefined
+      : resolveProviderRuntimePluginHandle({
+          provider: params.model.provider,
+          modelId: params.model.id,
+          config: params.cfg,
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+        }));
+  const runtimeModel = runtimeHandle
+    ? attachModelProviderRuntimePluginHandle(params.model, runtimeHandle)
+    : params.model;
   // Plugin stream factories may capture model headers, so construction is the
   // last safe boundary for providers that do not expose the host fetch seam.
   const pluginModel = unwrapModelHeaderSentinelsForProviderEgress(
-    params.model,
+    runtimeModel,
     "plugin provider stream construction",
   );
   const providerStreamFn = resolveProviderStreamFn({
-    provider: params.model.provider,
+    provider: runtimeModel.provider,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    runtimeHandle,
     allowRuntimePluginLoad: params.allowRuntimePluginLoad,
     context: {
       config: params.cfg,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
-      provider: params.model.provider,
-      modelId: params.model.id,
+      provider: runtimeModel.provider,
+      modelId: runtimeModel.id,
       model: pluginModel,
     },
   });
   const transportFallback = providerStreamFn
     ? undefined
     : createTransportAwareStreamFnForModel(
-        params.model.api === "google-generative-ai" ? pluginModel : params.model,
+        runtimeModel.api === "google-generative-ai" ? pluginModel : runtimeModel,
         {
           cfg: params.cfg,
           agentDir: params.agentDir,
@@ -68,13 +91,43 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   if (!streamFn) {
     return undefined;
   }
+  const providerWrappedStreamFn =
+    params.wrapProviderStream && runtimeHandle
+      ? (wrapProviderStreamFn({
+          provider: runtimeModel.provider,
+          config: params.cfg,
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+          runtimeHandle,
+          context: {
+            config: params.cfg,
+            agentDir: params.agentDir,
+            workspaceDir: params.workspaceDir,
+            provider: runtimeModel.provider,
+            modelId: runtimeModel.id,
+            model: runtimeModel,
+            streamFn,
+          },
+        }) ?? streamFn)
+      : streamFn;
+  const preparedStreamFn = runtimeHandle
+    ? bindProviderRuntimeHandle(providerWrappedStreamFn, runtimeHandle)
+    : providerWrappedStreamFn;
   // Register custom APIs only after a concrete stream exists, so later callers
   // can route by model.api without reloading provider runtime hooks.
-  const apiRegistry = params.apiRegistry ?? getModelLlmRuntime(params.model)?.registry;
+  const apiRegistry = params.apiRegistry ?? getModelLlmRuntime(runtimeModel)?.registry;
   if (apiRegistry) {
-    ensureCustomApiRegistered(apiRegistry, params.model.api, streamFn);
+    ensureCustomApiRegistered(apiRegistry, runtimeModel.api, preparedStreamFn);
   }
-  return streamFn;
+  return preparedStreamFn;
+}
+
+function bindProviderRuntimeHandle(
+  streamFn: StreamFn,
+  runtimeHandle: ProviderRuntimePluginHandle,
+): StreamFn {
+  return (model, context, options) =>
+    streamFn(attachModelProviderRuntimePluginHandle(model, runtimeHandle), context, options);
 }
 
 function wrapPluginProviderStream(streamFn: StreamFn): StreamFn {

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -530,6 +530,48 @@ describe("buildGuardedModelFetch", () => {
     await vi.waitFor(() => expect(release).toHaveBeenCalledTimes(1));
   });
 
+  it("waits for local service reconciliation before starting the provider fetch", async () => {
+    let finishReconciliation: (() => void) | undefined;
+    ensureModelProviderLocalServiceMock.mockImplementation(
+      async () =>
+        await new Promise((resolve) => {
+          finishReconciliation = () => resolve({ release: vi.fn() });
+        }),
+    );
+    const model = makeProviderModelFixture<"openai-completions">({
+      id: "local-model",
+      provider: "local-provider",
+      api: "openai-completions",
+      baseUrl: "http://127.0.0.1:18000/v1",
+    });
+
+    const pending = buildGuardedModelFetch(model)("http://127.0.0.1:18000/v1/chat/completions", {
+      method: "POST",
+    });
+    await vi.waitFor(() => expect(ensureModelProviderLocalServiceMock).toHaveBeenCalledOnce());
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    finishReconciliation?.();
+    await pending;
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not start the provider fetch when local service reconciliation fails", async () => {
+    ensureModelProviderLocalServiceMock.mockRejectedValue(new Error("reconciliation failed"));
+    const model = makeProviderModelFixture<"openai-completions">({
+      id: "local-model",
+      provider: "local-provider",
+      api: "openai-completions",
+      baseUrl: "http://127.0.0.1:18000/v1",
+    });
+
+    await expect(
+      buildGuardedModelFetch(model)("http://127.0.0.1:18000/v1/chat/completions", {
+        method: "POST",
+      }),
+    ).rejects.toThrow("reconciliation failed");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
   it("releases guarded fetch slots when streamed bodies are abandoned", async () => {
     const release = vi.fn(async () => undefined);
     const encoder = new TextEncoder();

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -40,10 +40,8 @@ import {
   swapSecretSentinelsInText,
 } from "../secrets/sentinel.js";
 import { ProviderHttpError, readResponseTextLimited } from "./provider-http-errors.js";
-import {
-  ensureModelProviderLocalService,
-  type ProviderLocalServiceLease,
-} from "./provider-local-service.js";
+import type { ProviderLocalServiceLease } from "./provider-local-service-target.js";
+import { ensureModelProviderLocalService } from "./provider-local-service.js";
 import {
   buildProviderRequestDispatcherPolicy,
   getModelProviderRequestRouteFacts,

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -28,6 +28,7 @@ vi.mock("../plugins/runtime/generation-scope.js", async () => {
   const generation = new AsyncLocalStorage<string>();
   mocks.readGeneration = () => generation.getStore() ?? mocks.publishedGeneration;
   return {
+    getPluginRuntimeGenerationRegistry: () => undefined,
     withPluginRuntimeGenerationScope: (snapshot: { testGeneration?: string }, run: () => unknown) =>
       generation.run(snapshot.testGeneration ?? "unknown", run),
   };

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -3,6 +3,7 @@ import { createServer } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getModelCompletionTransport } from "../llm/model-runtime-binding.js";
 import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
@@ -19,6 +20,8 @@ import {
   type PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+import { getModelProviderLocalServiceReconciler } from "./provider-local-service-reconcile.js";
+import { getModelProviderLocalService } from "./provider-local-service.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 import {
   completeWithPreparedSimpleCompletionModel,
@@ -28,18 +31,34 @@ import {
 
 const tempRoots = createSyncSuiteTempRootTracker("openclaw-simple-completion-plugin-scope");
 
-function createTransportOwnerFixture(rootDir: string, owner: "A" | "B") {
+function createTransportOwnerFixture(
+  rootDir: string,
+  owner: "A" | "B",
+  registerProviderStream = true,
+) {
   fs.mkdirSync(rootDir);
   const fixture = createColdPluginFixture({
     rootDir,
     pluginId: `completion-owner-${owner.toLowerCase()}`,
     providerId: "completion-owner-provider",
   });
+  const reconcileFailureMarker = path.join(rootDir, "fail-reconcile");
+  const createStreamSource = registerProviderStream
+    ? `createStreamFn() {
+        const source = getApiProvider("openai-completions");
+        if (!source) throw new Error("OpenAI completion transport is not registered");
+        return (model, context, options) => source.streamSimple(
+          { ...model, api: "openai-completions" }, context,
+          { ...options, headers: { ...options?.headers, "x-completion-stream": owner } },
+        );
+      },`
+    : "";
   fs.writeFileSync(
     fixture.runtimeSource,
     `const fs = require("node:fs");
 const { getApiProvider } = require("openclaw/plugin-sdk/llm");
 const owner = ${JSON.stringify(owner)};
+const reconcileFailureMarker = ${JSON.stringify(reconcileFailureMarker)};
 fs.writeFileSync(${JSON.stringify(fixture.runtimeMarker)}, "loaded", "utf8");
 module.exports = {
   id: ${JSON.stringify(fixture.pluginId)},
@@ -47,13 +66,14 @@ module.exports = {
     api.registerProvider({
       id: ${JSON.stringify(fixture.providerId)}, label: owner, auth: [],
       async prepareRuntimeAuth() { return { apiKey: "fixture-auth-" + owner }; },
-      createStreamFn() {
-        const source = getApiProvider("openai-completions");
-        if (!source) throw new Error("OpenAI completion transport is not registered");
-        return (model, context, options) => source.streamSimple(
-          { ...model, api: "openai-completions" }, context,
-          { ...options, headers: { ...options?.headers, "x-completion-stream": owner } },
-        );
+      ${createStreamSource}
+      async reconcileLocalService({ baseUrl, signal }) {
+        if (fs.existsSync(reconcileFailureMarker)) {
+          throw new Error("fixture reconciliation failed");
+        }
+        const origin = new URL(baseUrl).origin;
+        const response = await fetch(origin + "/models?reload=1", { signal });
+        if (!response.ok) throw new Error("fixture reload failed: HTTP " + response.status);
       },
       wrapSimpleCompletionStreamFn({ streamFn }) {
         return (model, context, options) => streamFn(model, context, {
@@ -66,7 +86,7 @@ module.exports = {
 `,
     "utf8",
   );
-  return fixture;
+  return { ...fixture, reconcileFailureMarker };
 }
 
 afterEach(() => {
@@ -380,4 +400,147 @@ module.exports = {
       }
     },
   );
+
+  it.each([
+    { name: "reloads before the request", failReconciliation: false },
+    { name: "fails closed before the request", failReconciliation: true },
+  ])("$name for managed simple completions", async ({ failReconciliation }) => {
+    const tempRoot = fs.realpathSync(tempRoots.makeTempDir());
+    const selected = createTransportOwnerFixture(path.join(tempRoot, "selected"), "A", false);
+    const requestPaths: string[] = [];
+    const server = createServer((request, response) => {
+      request.resume();
+      const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+      requestPaths.push(`${requestUrl.pathname}${requestUrl.search}`);
+      if (requestUrl.pathname === "/health" || requestUrl.pathname === "/models") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end('{"ok":true}');
+        return;
+      }
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      response.end(
+        `data: ${JSON.stringify({
+          id: "managed-completion-response",
+          object: "chat.completion.chunk",
+          model: "selected-model",
+          choices: [{ index: 0, delta: { content: "done" }, finish_reason: "stop" }],
+        })}\n\ndata: [DONE]\n\n`,
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.removeListener("error", reject);
+        resolve();
+      });
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Managed completion fixture did not expose a TCP port");
+      }
+      const origin = `http://127.0.0.1:${address.port}`;
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: selected.rootDir, model: `${selected.providerId}/selected-model` },
+        },
+        models: {
+          providers: {
+            [selected.providerId]: {
+              api: "openai-completions",
+              apiKey: "fixture-auth-source",
+              baseUrl: `${origin}/v1`,
+              localService: {
+                command: process.execPath,
+                args: ["--version"],
+                healthUrl: `${origin}/health`,
+                idleStopMs: 1,
+              },
+              models: [
+                {
+                  id: "selected-model",
+                  name: "Selected",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 1024,
+                },
+              ],
+            },
+          },
+        },
+        plugins: {
+          load: { paths: [selected.rootDir] },
+          slots: { memory: "none" },
+          entries: { [selected.pluginId]: { enabled: true } },
+        },
+      };
+      const env = {
+        ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: tempRoots.makeTempDir() }),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+      };
+      await withEnvAsync(env, async () => {
+        const prepared = await prepareSimpleCompletionModel({
+          cfg,
+          agentId: "main",
+          agentDir: path.join(tempRoot, "agent"),
+          workspaceDir: selected.rootDir,
+          provider: selected.providerId,
+          modelId: "selected-model",
+        });
+        if ("error" in prepared) {
+          throw new Error(prepared.error);
+        }
+        const completionTransport = getModelCompletionTransport(prepared.model);
+        if (!completionTransport) {
+          throw new Error("Managed completion transport was not prepared");
+        }
+        expect(getModelProviderLocalService(prepared.model)).toBeDefined();
+        expect(getModelProviderLocalService(completionTransport)).toBeDefined();
+        expect(getModelProviderLocalServiceReconciler(prepared.model)).toBeTypeOf("function");
+        expect(getModelProviderLocalServiceReconciler(completionTransport)).toBeTypeOf("function");
+        if (failReconciliation) {
+          fs.writeFileSync(selected.reconcileFailureMarker, "fail", "utf8");
+          await expect(
+            completeWithPreparedSimpleCompletionModel({
+              model: prepared.model,
+              auth: prepared.auth,
+              cfg,
+              context: { messages: [{ role: "user", content: "Complete", timestamp: 1 }] },
+            }),
+          ).resolves.toMatchObject({ stopReason: "error", content: [] });
+        } else {
+          await expect(
+            completeWithPreparedSimpleCompletionModel({
+              model: prepared.model,
+              auth: prepared.auth,
+              cfg,
+              context: { messages: [{ role: "user", content: "Complete", timestamp: 1 }] },
+            }),
+          ).resolves.toMatchObject({
+            stopReason: "stop",
+            content: [{ type: "text", text: "done" }],
+          });
+        }
+      });
+      const reloadIndex = requestPaths.indexOf("/models?reload=1");
+      const modelRequestIndex = requestPaths.findIndex(
+        (requestPath) => requestPath !== "/health" && requestPath !== "/models?reload=1",
+      );
+      if (failReconciliation) {
+        expect(reloadIndex).toBe(-1);
+        expect(modelRequestIndex).toBe(-1);
+      } else {
+        expect(reloadIndex).toBeGreaterThanOrEqual(0);
+        expect(modelRequestIndex).toBeGreaterThan(reloadIndex);
+      }
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -38,6 +38,7 @@ vi.mock("./prepared-model-runtime.js", () => ({
 }));
 
 vi.mock("../plugins/runtime/generation-scope.js", () => ({
+  getPluginRuntimeGenerationRegistry: () => undefined,
   withPluginRuntimeGenerationScope: (_snapshot: unknown, run: () => unknown) => run(),
 }));
 

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -30,6 +30,10 @@ import type {
 } from "../llm/types.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import {
+  attachModelProviderRuntimePluginHandle,
+  resolveProviderRuntimePluginHandle,
+} from "../plugins/provider-hook-runtime.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import {
@@ -456,16 +460,28 @@ async function prepareSimpleCompletionModelCore(
     applyLocalNoAuthHeaderOverride(resolvedModel, resolvedAuth),
     params.cfg,
   );
+  const providerRuntimeHandle = resolveProviderRuntimePluginHandle({
+    provider: model.provider,
+    modelId: model.id,
+    config: params.cfg,
+    workspaceDir,
+    env: process.env,
+    pluginMetadataSnapshot: context.preparedModelRuntime.metadataSnapshot,
+  });
+  const preparedModel = attachModelProviderRuntimePluginHandle(model, providerRuntimeHandle);
   // Select transport hooks before releasing this generation. Keep the logical
   // model API visible to callers that build prompts before dispatch.
-  const completionTransport = prepareModelForSimpleCompletion({
-    apiRegistry: modelRuntime.apiRegistry,
-    model,
-    cfg: params.cfg,
-  });
+  const completionTransport = attachModelProviderRuntimePluginHandle(
+    prepareModelForSimpleCompletion({
+      apiRegistry: modelRuntime.apiRegistry,
+      model: preparedModel,
+      cfg: params.cfg,
+    }),
+    providerRuntimeHandle,
+  );
 
   return {
-    model: bindModelLlmRuntime(model, modelRuntime.llmRuntime, completionTransport),
+    model: bindModelLlmRuntime(preparedModel, modelRuntime.llmRuntime, completionTransport),
     auth: resolvedAuth,
     ...(sourceAuthFingerprint ? { sourceAuthFingerprint } : {}),
   };

--- a/src/agents/tools/pdf-tool.test-support.ts
+++ b/src/agents/tools/pdf-tool.test-support.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { type Mock, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as webMedia from "../../media/web-media.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
 import * as modelAuth from "../model-auth.js";
 import * as modelsConfig from "../models-config.js";
 import * as preparedModelRuntime from "../prepared-model-runtime.js";
@@ -19,6 +20,7 @@ type StubPreparedRuntimeSnapshot = {
   agentDir: string;
   config: OpenClawConfig;
   workspaceDir?: string;
+  pluginRegistry?: PluginRegistry;
   createStores: () => { authStorage: unknown; modelRegistry: unknown };
 };
 
@@ -83,6 +85,7 @@ export function createPdfToolInfraStub(completeMock: Mock) {
       input?: string[];
       api?: string;
       modelFound?: boolean;
+      pluginRegistry?: PluginRegistry;
     },
   ) {
     // Keep PDF tool tests focused on orchestration; provider discovery, auth, and
@@ -119,6 +122,7 @@ export function createPdfToolInfraStub(completeMock: Mock) {
             agentDir: input.agentDir,
             config: input.config,
             workspaceDir: input.workspaceDir,
+            pluginRegistry: params?.pluginRegistry,
             createStores: () => ({ authStorage, modelRegistry }),
           }),
           release,

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -8,6 +8,8 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
 import * as webMedia from "../../media/web-media.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { getPluginRuntimeGenerationRegistry } from "../../plugins/runtime/generation-scope.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import * as modelAuth from "../model-auth.js";
@@ -686,10 +688,12 @@ describe("createPdfTool", () => {
 
   it("uses the prepared provider stream for extraction fallback", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
+      const pluginRegistry = createEmptyPluginRegistry();
       await stubPdfToolInfra(agentDir, {
         provider: "openai",
         api: "openai-completions",
         input: ["text"],
+        pluginRegistry,
       });
       vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
         text: "Managed model content",
@@ -708,6 +712,7 @@ describe("createPdfTool", () => {
       });
       registerProviderStreamForModelMock.mockImplementationOnce(() => {
         order.push("prepare");
+        expect(getPluginRuntimeGenerationRegistry()).toBe(pluginRegistry);
         return providerStreamFn;
       });
       completeMock.mockImplementationOnce(() => {

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -684,6 +684,53 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("uses the prepared provider stream for extraction fallback", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-completions",
+        input: ["text"],
+      });
+      vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Managed model content",
+        images: [],
+      });
+      const order: string[] = [];
+      const providerStreamFn = vi.fn(async () => {
+        order.push("request");
+        return {
+          result: async () => ({
+            role: "assistant",
+            stopReason: "stop",
+            content: [{ type: "text", text: "managed summary" }],
+          }),
+        };
+      });
+      registerProviderStreamForModelMock.mockImplementationOnce(() => {
+        order.push("prepare");
+        return providerStreamFn;
+      });
+      completeMock.mockImplementationOnce(() => {
+        throw new Error("unprepared completion dispatched");
+      });
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+      });
+
+      expect(order).toEqual(["prepare", "request"]);
+      expect(registerProviderStreamForModelMock).toHaveBeenCalledWith(
+        expect.objectContaining({ wrapProviderStream: true }),
+      );
+      expect(providerStreamFn).toHaveBeenCalledOnce();
+      expect(completeMock).not.toHaveBeenCalled();
+      expect(result.content).toEqual([{ type: "text", text: "managed summary" }]);
+    });
+  });
+
   it("uses the AWS SDK credential chain for Bedrock PDF models", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       const { setRuntimeApiKey } = await stubPdfToolInfra(agentDir, {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -18,6 +18,7 @@ import {
 } from "../../media/media-reference.js";
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
 import { loadWebMediaRaw } from "../../media/web-media.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { resolveModelAsync } from "../embedded-agent-runner/model.js";
@@ -301,14 +302,16 @@ async function runPdfPrompt(params: {
 
         // Provider hooks may own request preparation such as managed preset reloads.
         // Registration alone is insufficient when a built-in API already owns dispatch.
-        const providerStreamFn = registerProviderStreamForModel({
-          model,
-          cfg: effectiveCfg,
-          agentDir: runtimeAgentDir,
-          wrapProviderStream: true,
-          apiRegistry: modelRuntime.apiRegistry,
-          ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
-        });
+        const providerStreamFn = withPluginRuntimeGenerationScope(preparedRuntime, () =>
+          registerProviderStreamForModel({
+            model,
+            cfg: effectiveCfg,
+            agentDir: runtimeAgentDir,
+            wrapProviderStream: true,
+            apiRegistry: modelRuntime.apiRegistry,
+            ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
+          }),
+        );
 
         const extractions = await getExtractions();
         const completeExtraction = async (context: Context) => {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -299,17 +299,31 @@ async function runPdfPrompt(params: {
           }
         }
 
-        // PDF-only model selections may not have loaded their provider plugin yet.
-        // Register before complete() so plugin-owned APIs resolve on first use.
-        registerProviderStreamForModel({
+        // Provider hooks may own request preparation such as managed preset reloads.
+        // Registration alone is insufficient when a built-in API already owns dispatch.
+        const providerStreamFn = registerProviderStreamForModel({
           model,
           cfg: effectiveCfg,
           agentDir: runtimeAgentDir,
+          wrapProviderStream: true,
           apiRegistry: modelRuntime.apiRegistry,
           ...(runtimeWorkspaceDir ? { workspaceDir: runtimeWorkspaceDir } : {}),
         });
 
         const extractions = await getExtractions();
+        const completeExtraction = async (context: Context) => {
+          // A run cancelled mid-dispatch must not buy another provider call.
+          params.signal?.throwIfAborted();
+          const streamOptions = {
+            apiKey,
+            maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
+            signal: params.signal,
+          };
+          const completion = providerStreamFn
+            ? (async () => await (await providerStreamFn(model, context, streamOptions)).result())()
+            : complete(model, context, streamOptions);
+          return params.signal ? await abortable(params.signal, completion) : await completion;
+        };
         const hasImages = extractions.some((e) => e.images.length > 0);
         if (hasImages && !model.input?.includes("image")) {
           const hasText = extractions.some((e) => e.text.trim().length > 0);
@@ -323,31 +337,13 @@ async function runPdfPrompt(params: {
             images: [],
           }));
           const context = buildPdfExtractionContext(params.prompt, textOnlyExtractions, model);
-          // A run cancelled mid-dispatch must not buy another provider call.
-          params.signal?.throwIfAborted();
-          const completion = complete(model, context, {
-            apiKey,
-            maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
-            signal: params.signal,
-          });
-          const message = params.signal
-            ? await abortable(params.signal, completion)
-            : await completion;
+          const message = await completeExtraction(context);
           const text = coercePdfAssistantText({ message, provider, model: modelId });
           return { text, provider, model: modelId, native: false };
         }
 
         const context = buildPdfExtractionContext(params.prompt, extractions, model);
-        // A run cancelled mid-dispatch must not buy another provider call.
-        params.signal?.throwIfAborted();
-        const completion = complete(model, context, {
-          apiKey,
-          maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
-          signal: params.signal,
-        });
-        const message = params.signal
-          ? await abortable(params.signal, completion)
-          : await completion;
+        const message = await completeExtraction(context);
         const text = coercePdfAssistantText({ message, provider, model: modelId });
         return { text, provider, model: modelId, native: false };
       },

--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -19,7 +19,12 @@ import { providerUsesCredentialScopedModelMetadata } from "../agents/runtime-pla
 import { getModelRegistryRuntime } from "../agents/sessions/model-registry-runtime.js";
 import { bindModelLlmRuntime } from "../llm/model-runtime-binding.js";
 import type { Model } from "../llm/types.js";
+import {
+  attachModelProviderRuntimePluginHandle,
+  resolveProviderRuntimePluginHandle,
+} from "../plugins/provider-hook-runtime.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import type { ImageDescriptionRequest } from "./types.js";
 
 type ImageRuntimeParams = {
@@ -98,12 +103,28 @@ function requireImageCapableModel(params: {
 
 async function prepareResolvedImageRuntime(
   params: ImageRuntimeParams,
+  preparedRuntime: PreparedModelRuntimeSnapshot,
   resolvedModel: Model,
   authStorage: Awaited<ReturnType<typeof resolveModelAsync>>["authStorage"],
   modelRegistry: Awaited<ReturnType<typeof resolveModelAsync>>["modelRegistry"],
 ): Promise<PreparedImageRuntime> {
   let model = resolvedModel;
   const modelRuntime = getModelRegistryRuntime(modelRegistry);
+  const bindPreparedModel = (candidate: Model): Model => {
+    const requestModel = applySecretRefHeaderSentinels(candidate, params.cfg);
+    const providerRuntimeHandle = resolveProviderRuntimePluginHandle({
+      provider: requestModel.provider,
+      modelId: requestModel.id,
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env: process.env,
+      pluginMetadataSnapshot: preparedRuntime.metadataSnapshot,
+    });
+    return bindModelLlmRuntime(
+      attachModelProviderRuntimePluginHandle(requestModel, providerRuntimeHandle),
+      modelRuntime.llmRuntime,
+    );
+  };
   const apiKeyInfo = await getApiKeyForModelCore({
     model,
     cfg: params.cfg,
@@ -158,14 +179,7 @@ async function prepareResolvedImageRuntime(
     apiKeyInfo.mode === "aws-sdk" &&
     model.api === "bedrock-converse-stream"
   ) {
-    return bindResolvedImageRuntime(
-      params,
-      "",
-      bindModelLlmRuntime(
-        applySecretRefHeaderSentinels(model, params.cfg),
-        modelRuntime.llmRuntime,
-      ),
-    );
+    return bindResolvedImageRuntime(params, "", bindPreparedModel(model));
   }
   let apiKey = requireApiKey(apiKeyInfo, model.provider);
   const preparedAuth = protectPreparedProviderRuntimeAuth({
@@ -191,11 +205,7 @@ async function prepareResolvedImageRuntime(
   apiKey = preparedAuth?.apiKey?.trim() || apiKey;
   model = applyPreparedRuntimeAuthToModel(model, preparedAuth);
   authStorage.setRuntimeApiKey(model.provider, apiKey);
-  return bindResolvedImageRuntime(
-    params,
-    apiKey,
-    bindModelLlmRuntime(applySecretRefHeaderSentinels(model, params.cfg), modelRuntime.llmRuntime),
-  );
+  return bindResolvedImageRuntime(params, apiKey, bindPreparedModel(model));
 }
 
 export async function resolveImageRuntime(
@@ -262,28 +272,31 @@ export async function resolveImageRuntime(
       ...(preparedParams.workspaceDir ? { workspaceDir: preparedParams.workspaceDir } : {}),
       ...authProfileOptions,
     };
-    const resolved = await resolveModelAsync(
-      resolvedRef.provider,
-      resolvedRef.model,
-      preparedParams.agentDir,
-      preparedParams.cfg,
-      resolveOptions,
-    );
-    const model = requireImageCapableModel({
-      model: resolved.model,
-      resolvedProvider: resolvedRef.provider,
-      resolvedModel: resolvedRef.model,
-      requestedProvider: params.provider,
-      requestedModel: params.model,
+    return await withPluginRuntimeGenerationScope(preparedRuntime, async () => {
+      const resolved = await resolveModelAsync(
+        resolvedRef.provider,
+        resolvedRef.model,
+        preparedParams.agentDir,
+        preparedParams.cfg,
+        resolveOptions,
+      );
+      const model = requireImageCapableModel({
+        model: resolved.model,
+        resolvedProvider: resolvedRef.provider,
+        resolvedModel: resolvedRef.model,
+        requestedProvider: params.provider,
+        requestedModel: params.model,
+      });
+      return retainLease(
+        await prepareResolvedImageRuntime(
+          preparedParams,
+          preparedRuntime,
+          model,
+          resolved.authStorage,
+          resolved.modelRegistry,
+        ),
+      );
     });
-    return retainLease(
-      await prepareResolvedImageRuntime(
-        preparedParams,
-        model,
-        resolved.authStorage,
-        resolved.modelRegistry,
-      ),
-    );
   } finally {
     if (!leaseRetained) {
       preparedRuntimeLease.release();

--- a/src/media-understanding/image.runtime-profile.test.ts
+++ b/src/media-understanding/image.runtime-profile.test.ts
@@ -3,6 +3,7 @@
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core/expect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginMetadataSnapshot } from "../agents/test-helpers/embedded-agent-runner-e2e-mocks.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   looksLikeSecretSentinel,
@@ -13,6 +14,9 @@ import {
 const API_KEY_FIELD = ["api", "Key"].join("") as "apiKey";
 const REQUIRE_API_KEY_FIELD = ["require", "ApiKey"].join("");
 const SET_RUNTIME_API_KEY_FIELD = ["setRuntime", "ApiKey"].join("");
+const MODEL_PROVIDER_RUNTIME_PLUGIN_HANDLE_SYMBOL = Symbol.for(
+  "openclaw.modelProviderRuntimePluginHandle",
+);
 
 const hoisted = vi.hoisted(() => ({
   completeMock: vi.fn(),
@@ -45,6 +49,7 @@ const hoisted = vi.hoisted(() => ({
   releasePreparedModelRuntimeMock: vi.fn(),
   resolveModelAsyncMock: vi.fn(),
   resolveModelWithRegistryMock: vi.fn(),
+  resolveProviderRuntimePluginHandleMock: vi.fn(),
   shouldPreferProviderRuntimeResolvedModelMock: vi.fn(() => false),
   unwrapSecretSentinelsForProviderEgressMock: vi.fn((value: string) => value),
 }));
@@ -64,6 +69,7 @@ const {
   releasePreparedModelRuntimeMock,
   resolveModelAsyncMock,
   resolveModelWithRegistryMock,
+  resolveProviderRuntimePluginHandleMock,
   shouldPreferProviderRuntimeResolvedModelMock,
   unwrapSecretSentinelsForProviderEgressMock,
 } = hoisted;
@@ -141,6 +147,13 @@ vi.mock("../plugins/provider-runtime.runtime.js", () => ({
   prepareProviderRuntimeAuth: prepareProviderRuntimeAuthMock,
 }));
 
+vi.mock("../plugins/provider-hook-runtime.js", async () => ({
+  ...(await vi.importActual<typeof import("../plugins/provider-hook-runtime.js")>(
+    "../plugins/provider-hook-runtime.js",
+  )),
+  resolveProviderRuntimePluginHandle: hoisted.resolveProviderRuntimePluginHandleMock,
+}));
+
 vi.mock("../agents/embedded-agent-runner/model.js", () => ({
   resolveModelAsync: resolveModelAsyncMock,
 }));
@@ -172,12 +185,17 @@ describe("describeImageWithModelCore", () => {
     vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(process.cwd(), "extensions"));
     vi.stubGlobal("fetch", fetchMock);
     vi.clearAllMocks();
+    resolveProviderRuntimePluginHandleMock.mockImplementation((params) => ({
+      ...params,
+      plugin: undefined,
+    }));
     acquireAgentRunPreparedModelRuntimeMock.mockImplementation(
       async (input: { agentDir: string; config: object; workspaceDir?: string }) => ({
         snapshot: {
           agentDir: input.agentDir,
           config: input.config,
           workspaceDir: input.workspaceDir,
+          metadataSnapshot: createEmptyPluginMetadataSnapshot(input.workspaceDir),
           createStores: () => ({
             authStorage: preparedAuthStorage,
             modelRegistry: {},
@@ -773,11 +791,19 @@ describe("describeImageWithModelCore", () => {
   it("uses one committed prepared generation for image setup and streaming", async () => {
     const requestedCfg: OpenClawConfig = { logging: { level: "info" } };
     const committedCfg: OpenClawConfig = { logging: { level: "debug" } };
+    const metadataSnapshot = createEmptyPluginMetadataSnapshot("/tmp/committed-workspace");
+    const providerRuntimeHandle = {
+      provider: "google",
+      modelId: "gemini-2.5-flash",
+      plugin: { id: "generation-a" },
+    };
+    resolveProviderRuntimePluginHandleMock.mockReturnValueOnce(providerRuntimeHandle);
     acquireAgentRunPreparedModelRuntimeMock.mockResolvedValueOnce({
       snapshot: {
         agentDir: "/tmp/committed-agent",
         config: committedCfg,
         workspaceDir: "/tmp/committed-workspace",
+        metadataSnapshot,
         createStores: () => ({
           authStorage: preparedAuthStorage,
           modelRegistry: {},
@@ -792,6 +818,12 @@ describe("describeImageWithModelCore", () => {
         api: "google-generative-ai",
         input: ["text", "image"],
       })),
+    });
+    registerProviderStreamForModelMock.mockImplementationOnce(({ model }) => {
+      expect((model as Record<symbol, unknown>)[MODEL_PROVIDER_RUNTIME_PLUGIN_HANDLE_SYMBOL]).toBe(
+        providerRuntimeHandle,
+      );
+      return undefined;
     });
     completeMock.mockResolvedValue({
       role: "assistant",
@@ -828,7 +860,15 @@ describe("describeImageWithModelCore", () => {
       cfg: committedCfg,
       agentDir: "/tmp/committed-agent",
       workspaceDir: "/tmp/committed-workspace",
+      wrapProviderStream: true,
     });
+    expect(resolveProviderRuntimePluginHandleMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "google",
+        modelId: "gemini-2.5-flash",
+        pluginMetadataSnapshot: metadataSnapshot,
+      }),
+    );
   });
 
   it("reuses a parent run generation without acquiring another image lease", async () => {
@@ -854,6 +894,7 @@ describe("describeImageWithModelCore", () => {
       agentDir: "/tmp/parent-agent",
       config: cfg,
       workspaceDir: "/tmp/parent-workspace",
+      metadataSnapshot: createEmptyPluginMetadataSnapshot("/tmp/parent-workspace"),
       configuredRuntimeModels: [],
       inlineProviderModels: [],
       createStores: () => ({ authStorage: preparedAuthStorage, modelRegistry: {} }),

--- a/src/media-understanding/image.runtime-timeout.test.ts
+++ b/src/media-understanding/image.runtime-timeout.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core/expect";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginMetadataSnapshot } from "../agents/test-helpers/embedded-agent-runner-e2e-mocks.js";
 
 const API_KEY_FIELD = ["api", "Key"].join("") as "apiKey";
 const REQUIRE_API_KEY_FIELD = ["require", "ApiKey"].join("");
@@ -167,6 +168,7 @@ describe("describeImageWithModelCore", () => {
           agentDir: input.agentDir,
           config: input.config,
           workspaceDir: input.workspaceDir,
+          metadataSnapshot: createEmptyPluginMetadataSnapshot(input.workspaceDir),
           createStores: () => ({
             authStorage: preparedAuthStorage,
             modelRegistry: {},
@@ -304,12 +306,14 @@ describe("describeImageWithModelCore", () => {
     expect(completeMock).toHaveBeenCalledOnce();
     const firstCall = expectDefined(completeMock.mock.calls[0], "image completion call 0");
     const [completionModel, context, options] = firstCall;
-    expect(completionModel).toEqual({
-      provider: "openai",
-      id: "gpt-5.4",
-      input: ["text", "image"],
-      baseUrl: "https://chatgpt.com/backend-api",
-    });
+    expect(completionModel).toEqual(
+      expect.objectContaining({
+        provider: "openai",
+        id: "gpt-5.4",
+        input: ["text", "image"],
+        baseUrl: "https://chatgpt.com/backend-api",
+      }),
+    );
     expect(context.systemPrompt).toBe("Describe the image.");
     expect(context.messages).toHaveLength(1);
     expect(Object.keys(options).toSorted()).toEqual(["apiKey", "maxTokens", "signal", "timeoutMs"]);

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core/expect";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { attachModelProviderRequestTransport } from "../agents/provider-request-config.js";
+import { createEmptyPluginMetadataSnapshot } from "../agents/test-helpers/embedded-agent-runner-e2e-mocks.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 
 const API_KEY_FIELD = ["api", "Key"].join("") as "apiKey";
@@ -177,6 +178,7 @@ describe("describeImageWithModelCore", () => {
           agentDir: input.agentDir,
           config: input.config,
           workspaceDir: input.workspaceDir,
+          metadataSnapshot: createEmptyPluginMetadataSnapshot(input.workspaceDir),
           createStores: () => ({
             authStorage: preparedAuthStorage,
             modelRegistry: {},
@@ -440,12 +442,12 @@ describe("describeImageWithModelCore", () => {
       "provider stream registration call 0",
     );
     expect(streamRequest).toEqual({
-      model: {
+      model: expect.objectContaining({
         provider: "minimax-portal",
         id: "custom-vision",
         input: ["text", "image"],
         baseUrl: "https://api.minimax.io/anthropic",
-      },
+      }),
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
       wrapProviderStream: true,
@@ -748,12 +750,12 @@ describe("describeImageWithModelCore", () => {
       },
     );
     expect(registerProviderStreamForModelMock).toHaveBeenCalledWith({
-      model: {
+      model: expect.objectContaining({
         provider: "google",
         id: "gemini-2.5-flash",
         api: "google-generative-ai",
         input: ["text", "image"],
-      },
+      }),
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
       workspaceDir: "/tmp/openclaw-workspace",
@@ -860,12 +862,12 @@ describe("describeImageWithModelCore", () => {
       model: "llava:latest",
     });
     expect(registerProviderStreamForModelMock).toHaveBeenCalledWith({
-      model: {
+      model: expect.objectContaining({
         provider: "ollama",
         id: "llava:latest",
         api: "ollama",
         input: ["text", "image"],
-      },
+      }),
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
       wrapProviderStream: true,

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -448,6 +448,7 @@ describe("describeImageWithModelCore", () => {
       },
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
+      wrapProviderStream: true,
     });
     expect(completeMock).toHaveBeenCalledOnce();
     expect(fetchMock).not.toHaveBeenCalled();
@@ -756,6 +757,7 @@ describe("describeImageWithModelCore", () => {
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
       workspaceDir: "/tmp/openclaw-workspace",
+      wrapProviderStream: true,
     });
   });
 
@@ -866,6 +868,7 @@ describe("describeImageWithModelCore", () => {
       },
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
+      wrapProviderStream: true,
     });
     expect(streamFn).toHaveBeenCalledOnce();
     expect(completeMock).not.toHaveBeenCalled();

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -504,6 +504,7 @@ async function describeImagesWithModelInternal(
       model: requestModel,
       cfg: resolvedRuntimeContext?.cfg ?? params.cfg,
       agentDir: resolvedRuntimeContext?.agentDir ?? params.agentDir,
+      wrapProviderStream: true,
       ...(resolvedRuntimeContext?.workspaceDir
         ? { workspaceDir: resolvedRuntimeContext.workspaceDir }
         : params.workspaceDir

--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -110,6 +110,7 @@ export type {
   ProviderPrepareExtraParamsContext,
   ProviderPrepareRuntimeAuthContext,
   ProviderPreparedRuntimeAuth,
+  ProviderReconcileLocalServiceContext,
   ProviderReasoningOutputMode,
   ProviderReasoningOutputModeContext,
   ProviderReplayPolicy,

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -8,7 +8,7 @@ import { readProviderJsonArrayFieldResponse } from "../agents/provider-http-erro
 import type {
   AcquireConfiguredProviderLocalService,
   ConfiguredProviderLocalServiceTarget,
-} from "../agents/provider-local-service.js";
+} from "../agents/provider-local-service-target.js";
 import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import { readResponseTextPrefix } from "../infra/http-body.js";

--- a/src/plugins/provider-hook-runtime.test.ts
+++ b/src/plugins/provider-hook-runtime.test.ts
@@ -1,0 +1,17 @@
+import { expect, it, vi } from "vitest";
+import { getModelProviderLocalServiceReconciler } from "../agents/provider-local-service-reconcile.js";
+import { attachModelProviderRuntimePluginHandle } from "./provider-hook-runtime.js";
+
+it("clears a stale local-service reconciler when the prepared provider changes", () => {
+  const reconcile = vi.fn(async () => undefined);
+  const withReconciler = attachModelProviderRuntimePluginHandle(
+    { id: "demo", provider: "local", baseUrl: "http://127.0.0.1:1/v1" },
+    { plugin: { reconcileLocalService: reconcile } } as never,
+  );
+  const withoutReconciler = attachModelProviderRuntimePluginHandle(withReconciler, {
+    plugin: {},
+  } as never);
+
+  expect(getModelProviderLocalServiceReconciler(withReconciler)).toBe(reconcile);
+  expect(getModelProviderLocalServiceReconciler(withoutReconciler)).toBeUndefined();
+});

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -4,6 +4,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { attachModelProviderLocalServiceReconciler } from "../agents/provider-local-service-reconcile.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   getLoadedRuntimePluginRegistry,
@@ -74,7 +75,10 @@ export function attachModelProviderRuntimePluginHandle<TModel extends object>(
   model: TModel,
   runtimeHandle: ProviderRuntimePluginHandle,
 ): TModel {
-  const next = { ...model } as TModel & ModelWithProviderRuntimePluginHandle;
+  const next = attachModelProviderLocalServiceReconciler(
+    model,
+    runtimeHandle.plugin?.reconcileLocalService,
+  ) as TModel & ModelWithProviderRuntimePluginHandle;
   next[MODEL_PROVIDER_RUNTIME_PLUGIN_HANDLE_SYMBOL] = runtimeHandle;
   return next;
 }

--- a/src/plugins/provider-plugin.types.ts
+++ b/src/plugins/provider-plugin.types.ts
@@ -88,6 +88,7 @@ import type {
   ProviderCacheTtlEligibilityContext,
   ProviderBuildMissingAuthMessageContext,
   ProviderBuildUnknownModelHintContext,
+  ProviderReconcileLocalServiceContext,
 } from "./provider-transport.types.js";
 
 export type ProviderPlugin = {
@@ -321,6 +322,8 @@ export type ProviderPlugin = {
    * the embedded agent runtime.
    */
   wrapSimpleCompletionStreamFn?: (ctx: ProviderWrapStreamFnContext) => StreamFn | null | undefined;
+  /** Cheap, idempotent provider repair after local-service health and before each request. */
+  reconcileLocalService?: (ctx: ProviderReconcileLocalServiceContext) => Promise<void>;
   /**
    * Provider-owned native transport turn identity.
    *

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -566,11 +566,13 @@ export function resolveProviderStreamFn(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   allowRuntimePluginLoad?: boolean;
   context: ProviderCreateStreamFnContext;
 }) {
-  const plugin =
-    params.allowRuntimePluginLoad === false
+  const plugin = params.runtimeHandle
+    ? ensureProviderRuntimePluginHandle(params).plugin
+    : params.allowRuntimePluginLoad === false
       ? resolveLoadedProviderRuntimePlugin(params)
       : resolveProviderRuntimePlugin(params);
   return plugin?.createStreamFn?.(params.context) ?? undefined;

--- a/src/plugins/provider-transport.types.ts
+++ b/src/plugins/provider-transport.types.ts
@@ -33,6 +33,12 @@ export type ProviderWrapStreamFnContext = ProviderPrepareExtraParamsContext & {
   streamFn?: StreamFn;
 };
 
+/** Healthy local service boundary before the provider request is sent. */
+export type ProviderReconcileLocalServiceContext = {
+  baseUrl: string;
+  signal?: AbortSignal;
+};
+
 /**
  * Provider-owned WebSocket session policy.
  */

--- a/src/plugins/provider-transport.types.ts
+++ b/src/plugins/provider-transport.types.ts
@@ -1,3 +1,4 @@
+import type { ProviderLocalServiceReconcileContext } from "../agents/provider-local-service-reconcile.js";
 import type { StreamFn } from "../agents/runtime/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
@@ -34,10 +35,7 @@ export type ProviderWrapStreamFnContext = ProviderPrepareExtraParamsContext & {
 };
 
 /** Healthy local service boundary before the provider request is sent. */
-export type ProviderReconcileLocalServiceContext = {
-  baseUrl: string;
-  signal?: AbortSignal;
-};
+export type ProviderReconcileLocalServiceContext = ProviderLocalServiceReconcileContext;
 
 /**
  * Provider-owned WebSocket session policy.

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -541,6 +541,7 @@ export type PluginRuntimeCore = {
         providerId: string;
         baseUrl: string;
         headers?: HeadersInit;
+        reconcile?: import("../provider-plugin.types.js").ProviderPlugin["reconcileLocalService"];
       },
       signal?: AbortSignal | null,
     ) => Promise<{ release: () => void } | undefined>;


### PR DESCRIPTION
## What Problem This Solves

Managed llama.cpp preset state could be stale when a request bypassed the normal
agent dispatch path. Simple completion, compaction, PDF fallback, and image
description could prepare a provider but lose the prepared local-service
reconciler before completion or streaming. A guarded fetch could then reach a
healthy router before the plugin had applied the current preset.

This was most visible across model or limit transitions, Gateway restart, and
router-origin changes. Reload failure also needed to fail closed rather than
dispatch against stale state.

## Canonical Fix

- The provider runtime owns one prepared handle carrying the exact
  local-service reconciler and provider generation.
- Normal dispatch preserves that handle.
- Simple completion and compaction attach it before completion.
- PDF and image direct paths use the same prepared handle for direct streams.
- Guarded fetch consumes the attached generic local-service reconciler after
  service health acquisition; it does not resolve plugins on the request path.
- The llama.cpp plugin remains the sole owner of canonical preset writes and
  serialized router reloads.

The preset lifecycle retains and deterministically orders configured chat
sections, preserves embedding state, prunes sections outside the configured
inventory, writes atomically only when canonical bytes change, and keeps the
desired revision dirty until reload succeeds. Direct-model local services do
not perform router reloads.

There is no stale-state fallback: reconciliation failure or cancellation blocks
the provider request and releases its request lease.

The endpoint matcher preserves all three accepted forms for one configured
service: the original normalized URL, its root, and lowercase `/v1`. A configured
legacy `/V1` URL therefore remains an exact acquisition target while the root and
canonical lowercase alias also work.

## Scope And Compatibility

- No configuration, database, SQLite schema/version, persisted state,
  migration, upgrade, or Gateway protocol change.
- No Code Mode or Talk changes.
- Public SDK additions are one optional provider reconciliation hook, one
  context export, and one optional acquisition callback. There are no removals
  or signature changes.
- `pnpm plugin-sdk:surface:check`: 152 public entrypoints, 4,436 exports,
  2,620 callable exports, and zero package-exported forbidden subpaths.

### Maintainer Decision

Accepted: the optional provider reconciliation hook and fail-closed reload
behavior are intentional compatibility tradeoffs. Serving against stale router
state is worse than surfacing the reload failure. Endpoint compatibility and
direct-model behavior remain covered.

The ClawSweeper embedding-provider data-model classification is a false
positive. `extensions/llama-cpp/src/embedding-provider.ts` only threads prepared
runtime and reconciliation state. It does not change SQLite schema, serialized
state, vector metadata, migrations, or upgrade semantics.

## Exact Candidate

- Head: `4fc265e91c1403fe6996d54d2a90e9f5b365ca3b`
- Tree: `9d51145036cfa13c260543286b6f2df91e27c2f3`
- 15 signed Vincent Koc commits.
- 42 files, raw `+1762/-541`.
- Reviewed surface: source `+620/-413` (net `+207`), tests/support
  `+1128/-127` (net `+1001`), docs `+12`, tooling `+2/-1` (net `+1`).

At the final guard, live `main` was
`bd381bffb29df6994e78353be688d8a552e4b4bb`. Its only changed-path
intersection with the PR is three files touched by the unrelated Workshop cron
refactor `efa4b5dfbb3a87ba973f2fb53ba4f454e345ed4e`. The edits are in disjoint
hunks, and `git merge-tree --write-tree` succeeds without conflicts.

## Verification

### Exact-Head Hosted CI

Head `4fc265e91c1403fe6996d54d2a90e9f5b365ca3b` is fully green:

- `openclaw/ci-gate`
- production and test type checks
- core lint shards
- source, architecture, dependency, and prompt guards
- changed and compact test shards
- build artifacts and Control UI performance
- both Windows Node test shards
- CodeQL, OpenGrep, and dependency security checks

### Focused And Testbox Proof

- Exact-head focused local proof: provider local-service suite `22/22`,
  changed-file formatting/lint, and `git diff --check`.
- Blacksmith Testbox at signed candidate `d67e4265b061e53a5a4a9fc16b069dd418906b2e`
  passed production lint, `pnpm tsgo`, `pnpm check:test-types`, formatting, and
  the provider local-service suite `22/22`. The final test-only commit compacts
  that proof below the line-count lint budget; exact-head hosted CI covers it.
- Earlier full Blacksmith Testbox validation:
  https://github.com/openclaw/openclaw/actions/runs/33970834644
  covered `pnpm check:changed`, llama.cpp and provider contracts, SDK surface,
  production/test types, build, PDF, image, compaction, and normal dispatch.

Focused coverage proves ordering, fail-closed behavior, prepared-generation
preservation, request-lease release, same-generation reuse, simple completion,
compaction, normal dispatch, PDF, image, `/btw`, configured-origin changes,
direct-model behavior, root alias acquisition, and exact configured `/V1`
acquisition.

## Native Windows ARM64

The exact head and tree were exercised on a native Windows ARM64 host with Node
24:

- Verified pinned llama.cpp release `b10534`, build `10534`, commit
  `2b5621094ef383cdcd8428ef6d22efe5df976532`, using the Windows CPU ARM64
  archive.
- Verified a pinned Qwen2.5 0.5B GGUF artifact before serving.
- Direct llama.cpp completion returned HTTP 200 server-sent events with a
  terminal `[DONE]`.
- Local-service acquisition passed for both the root alias and the exact
  configured `/V1` endpoint.
- A real source Gateway listed the model, completed `chat.send` and
  `agent.wait` with status `ok`, received HTTP 200 SSE from the provider, wrote
  five chat events, and retained two history messages byte-for-byte across a
  Gateway restart.
- The source Control UI returned HTTP 200. Its real model picker rendered
  llama.cpp and Ollama rows from an intentional mock catalog, and unique search
  filtered to the llama.cpp row.

The native live Gateway dispatch used the configured generic llama.cpp provider;
managed-plugin lifecycle and reconciliation are covered by the hosted and WSL2
test suites. Ollama was not installed on the host, so no live Ollama inference
claim is made. The pinned Windows ARM64 llama.cpp asset is CPU-only, so this is
not NVIDIA/GPU parity proof.

The native source build connection dropped after producing the unified bundle;
exact-head hosted `build-artifacts` completed successfully.

## WSL2 ARM64

An exact-head task worktree on WSL2 ARM64 with Node 24.15 passed:

- provider local-service suite: `22/22`
- llama.cpp managed-server suite: `30/30`
- total: `52/52`

The Windows model artifact was not available through the WSL mount during this
run, so WSL2 establishes source/runtime parity rather than live model throughput
or GPU parity.

## Dependency Contracts

OpenClaw pins llama.cpp release `b10534`, commit
[`2b5621094ef383cdcd8428ef6d22efe5df976532`](https://github.com/ggml-org/llama.cpp/commit/2b5621094ef383cdcd8428ef6d22efe5df976532).
Direct source inspection confirmed:

- `GET /models?reload=1` synchronously reloads before responding:
  https://github.com/ggml-org/llama.cpp/blob/2b5621094ef383cdcd8428ef6d22efe5df976532/tools/server/server-models.cpp#L1963-L1967
- the model stop timeout defaults to 10 seconds:
  https://github.com/ggml-org/llama.cpp/blob/2b5621094ef383cdcd8428ef6d22efe5df976532/tools/server/server-models.cpp#L42

The sibling Codex runtime source at
`5f49aba876922d6f2f55caa153bbb0ed1b46feba` was inspected before verdict and
change, including app-server protocol request shape, thread request processing,
remote compaction, and provider client dispatch.

## Review

- Fresh structured autoreview: scoped-clean, no P0/P1 findings.
- Independent exact-head audit: clean two-file endpoint follow-up, signed
  commits, no privacy or SDK-surface drift.
- Exact-head ClawSweeper review:
  https://github.com/openclaw/openclaw/pull/136363#issuecomment-5511377139
  found no actionable code, security, or correctness findings. The two
  maintainer decisions requested there are explicitly accepted and documented
  above.
