### PR TITLE
fix(auth): recover billing-disabled profiles in minutes instead of hours

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -235,7 +235,9 @@ State is stored in the per-agent SQLite auth state under `usageStats`:
 
 ## Billing disables
 
-Billing/credit failures (for example "insufficient credits" / "credit balance too low") are treated as failover-worthy, but they're usually not transient. Instead of a short cooldown, OpenClaw marks the profile as **disabled** (with a longer backoff) and rotates to the next profile/provider.
+Billing/credit failures (for example "insufficient credits" / "credit balance too low") are treated as failover-worthy. OpenClaw marks the credential as **disabled** for ten minutes initially and rotates to the next eligible profile/provider.
+
+Configured inline API keys cannot retry during an active disable window. After the window expires, they become eligible again; another billing failure starts a new ten-minute window. Stored auth profiles can also recover through bounded primary-provider probes during a disable window. Recharging does not itself clear persisted state, and upgrading leaves an already-active window at its existing deadline.
 
 <Note>
 Not every billing-shaped response is `402`, and not every HTTP `402` lands here. OpenClaw keeps explicit billing text in the billing lane even when a provider returns `401` or `403` instead, but provider-specific matchers stay scoped to the provider that owns them (for example OpenRouter `403 Key limit exceeded`).
@@ -243,7 +245,7 @@ Not every billing-shaped response is `402`, and not every HTTP `402` lands here.
 Meanwhile temporary `402` usage-window and organization/workspace spend-limit errors are classified as `rate_limit` when the message looks retryable (for example `weekly usage limit exhausted`, `daily limit reached, resets tomorrow`, or `organization spending limit exceeded`). Those stay on the short cooldown/failover path instead of the long billing-disable path.
 </Note>
 
-High-confidence permanent-auth failures (revoked/deactivated keys, deactivated workspaces) get a similar disabled lane, but recover much sooner than billing since some providers surface auth-looking payloads transiently during incidents.
+High-confidence permanent-auth failures (revoked/deactivated keys, deactivated workspaces) use the same ten-minute initial disable window because some providers surface auth-looking payloads transiently during incidents.
 
 State is stored in the per-agent SQLite auth state:
 

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -150,7 +150,7 @@ describe("markAuthProfileFailure", () => {
     expect(typeof reloaded.usageStats?.["openai:default"]?.cooldownUntil).toBe("number");
   });
 
-  it("disables billing failures for ~5 hours by default", async () => {
+  it("disables billing failures for ~10 minutes by default (#135835)", async () => {
     await withAuthProfileStore(async ({ agentDir, store }) => {
       const startedAt = Date.now();
       await markAuthProfileFailure({
@@ -163,7 +163,7 @@ describe("markAuthProfileFailure", () => {
       const disabledUntil = store.usageStats?.["anthropic:default"]?.disabledUntil;
       expect(typeof disabledUntil).toBe("number");
       const remainingMs = (disabledUntil as number) - startedAt;
-      expectCooldownInRange(remainingMs, 4.5 * 60 * 60 * 1000, 5.5 * 60 * 60 * 1000);
+      expectCooldownInRange(remainingMs, 9 * 60 * 1000, 11 * 60 * 1000);
     });
   });
   it("records billing backoff for inline provider api keys without creating an auth profile", async () => {
@@ -182,7 +182,31 @@ describe("markAuthProfileFailure", () => {
       expect(stats?.disabledReason).toBe("billing");
       expect(typeof stats?.disabledUntil).toBe("number");
       const remainingMs = (stats?.disabledUntil as number) - startedAt;
-      expectCooldownInRange(remainingMs, 4.5 * 60 * 60 * 1000, 5.5 * 60 * 60 * 1000);
+      expectCooldownInRange(remainingMs, 9 * 60 * 1000, 11 * 60 * 1000);
+    });
+  });
+
+  it("keeps persisted billing disabledUntil unchanged across mid-window retries", async () => {
+    await withAuthProfileStore(async ({ agentDir, store }) => {
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "billing",
+        agentDir,
+      });
+
+      const firstDisabledUntil = store.usageStats?.["anthropic:default"]?.disabledUntil;
+      expect(typeof firstDisabledUntil).toBe("number");
+
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "billing",
+        agentDir,
+      });
+
+      // A retry inside the window must not extend the lockout.
+      expect(store.usageStats?.["anthropic:default"]?.disabledUntil).toBe(firstDisabledUntil);
     });
   });
 

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -968,8 +968,8 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         lastFailureAt: now - 60_000,
       }),
       // errorCount resets, billing count resets to 1 →
-      // calculateDisabledLaneBackoffMs(1, 5h, 24h) = 5h
-      expectedUntil: (now: number) => now + 5 * 60 * 60 * 1000,
+      // calculateDisabledLaneBackoffMs(1, 10m, 24h) = 10m (#135835)
+      expectedUntil: (now: number) => now + 10 * 60 * 1000,
       readUntil: (stats: WindowStats | undefined) => stats?.disabledUntil,
     },
     {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -769,12 +769,9 @@ const DISABLED_FAILURE_BACKOFF_POLICIES = {
   },
 } as const satisfies Record<DisabledFailureReason, DisabledFailureBackoffPolicy>;
 
-// Billing (402) and auth_permanent are both operator-fixable states: the key is
-// valid, the operator recharges or replaces it. While a disabled window is
-// active the profile is never selected, so an observed success cannot clear it
-// early — the base backoff IS the post-recharge recovery time (#135835), so it
-// stays in minutes, not hours. maxMs stays generous so provider incident noise
-// misclassified as billing cannot spin hot.
+// While a disabled window is active the profile is never selected, so the base
+// backoff is the whole post-recharge recovery time; billing stays minutes like
+// auth_permanent, and maxMs keeps misclassified incident noise from spinning hot.
 const DEFAULT_BILLING_BACKOFF_MINUTES = 10;
 const DEFAULT_BILLING_MAX_HOURS = 24;
 const DEFAULT_AUTH_PERMANENT_BACKOFF_MINUTES = 10;

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -762,15 +762,20 @@ const DISABLED_FAILURE_BACKOFF_POLICIES = {
     maxMs: (cfg) => cfg.billingMaxMs,
   },
   auth_permanent: {
-    // Keep high-confidence permanent-auth failures in the disabled lane, but
-    // recover much sooner than billing because some providers surface
-    // auth-looking payloads transiently during incidents.
+    // Recover quickly because some providers surface auth-looking payloads
+    // transiently during incidents.
     baseMs: (cfg) => cfg.authPermanentBackoffMs,
     maxMs: (cfg) => cfg.authPermanentMaxMs,
   },
 } as const satisfies Record<DisabledFailureReason, DisabledFailureBackoffPolicy>;
 
-const DEFAULT_BILLING_BACKOFF_HOURS = 5;
+// Billing (402) and auth_permanent are both operator-fixable states: the key is
+// valid, the operator recharges or replaces it. While a disabled window is
+// active the profile is never selected, so an observed success cannot clear it
+// early — the base backoff IS the post-recharge recovery time (#135835), so it
+// stays in minutes, not hours. maxMs stays generous so provider incident noise
+// misclassified as billing cannot spin hot.
+const DEFAULT_BILLING_BACKOFF_MINUTES = 10;
 const DEFAULT_BILLING_MAX_HOURS = 24;
 const DEFAULT_AUTH_PERMANENT_BACKOFF_MINUTES = 10;
 const DEFAULT_AUTH_PERMANENT_MAX_MINUTES = 60;
@@ -778,7 +783,7 @@ const DEFAULT_FAILURE_WINDOW_HOURS = 24;
 
 function resolveAuthCooldownConfig(): ResolvedAuthCooldownConfig {
   return {
-    billingBackoffMs: DEFAULT_BILLING_BACKOFF_HOURS * 60 * 60 * 1000,
+    billingBackoffMs: DEFAULT_BILLING_BACKOFF_MINUTES * 60 * 1000,
     billingMaxMs: DEFAULT_BILLING_MAX_HOURS * 60 * 60 * 1000,
     authPermanentBackoffMs: DEFAULT_AUTH_PERMANENT_BACKOFF_MINUTES * 60 * 1000,
     authPermanentMaxMs: DEFAULT_AUTH_PERMANENT_MAX_MINUTES * 60 * 1000,

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -769,9 +769,8 @@ const DISABLED_FAILURE_BACKOFF_POLICIES = {
   },
 } as const satisfies Record<DisabledFailureReason, DisabledFailureBackoffPolicy>;
 
-// While a disabled window is active the profile is never selected, so the base
-// backoff is the whole post-recharge recovery time; billing stays minutes like
-// auth_permanent, and maxMs keeps misclassified incident noise from spinning hot.
+// Keep the initial billing disable short so inline API keys can retry soon
+// after recharge, even though they cannot probe during an active window.
 const DEFAULT_BILLING_BACKOFF_MINUTES = 10;
 const DEFAULT_BILLING_MAX_HOURS = 24;
 const DEFAULT_AUTH_PERMANENT_BACKOFF_MINUTES = 10;


### PR DESCRIPTION
## What Problem This Solves

A billing (402) failure — key valid, account out of credit — moves an auth profile (including inline provider API keys, the shape reported in #135835) into the disabled lane for a **5-hour base backoff** (`DEFAULT_BILLING_BACKOFF_HOURS = 5`). Inline API keys are rejected before a provider request while `disabledUntil` is active: after recharging, operators stay locked out for hours (reporter: ~255 minutes remaining on the window), and the state persists across gateway restarts from the agent SQLite store. For contrast, `auth_permanent` already starts with a 10-minute disable window.

Fixes #135835.

## Why This Change Was Made

Billing and permanent-auth failures can require an operator action, such as recharging an account or replacing a key. Billing's five-hour base keeps an inline API key unavailable even after the account is recharged, because that path cannot probe during its active window. Stored profiles already support bounded primary-provider recovery probes.

This change aligns the initial billing window with `auth_permanent` (10 minutes). Active windows keep their original deadline, so retries inside a window cannot extend a lockout. The 24-hour maximum constant is unchanged, but an expired billing window resets its failure counter: an unrecovered inline key starts another ten-minute window after its next billing failure.

## User Impact

New billing failures use a ten-minute initial disable window instead of five hours. Inline API keys become eligible for another request after that window expires. Recharging does not itself clear persisted state, and upgrading leaves already-active windows at their existing deadlines. No config, schema, doctor, or migration surface changes.

## Evidence

- Regression proof fails pre-fix: with the fix stashed, the two updated billing assertions (profile lane + inline-key lane) fail against the old 5-hour constant — `2 failed | 14 passed`; with the fix restored, all pass.
- `pnpm test src/agents/auth-profiles/ src/agents/auth-profiles.markauthprofilefailure.test.ts` → 470 passed (includes the updated `usage.test.ts` expired-window table case and a new disabled-lane immutability test mirroring the existing cooldown-lane one).
- Type/lint/format: `pnpm tsgo`, `pnpm check:test-types`, `oxfmt`, `scripts/run-oxlint.mjs` clean; `git diff --check` clean.
- Second-model review: autoreview (pi, `zai-coding-cn/glm-5.3`, thinking=high) → **scoped-clean**, no accepted/actionable findings.
- LOC: production +10/−5 in `src/agents/auth-profiles/usage.ts` (constant rename + policy comment; no logic-path change), tests +32/−5.

## Real behavior proof (post-review addendum)

Runtime trace from an ephemeral embedded-agent harness on implementation head `975978003a1` (subsequent changes only correct comments and documentation): isolated `OPENCLAW_STATE_DIR`, `openclaw agent --local` turns, and a local mock OpenAI-compatible provider on `127.0.0.1` (fake key `sk-mock-redacted-not-real`, provider id `mockbill` — nothing real is exposed).

| Step (clock) | Action | Observable |
|---|---|---|
| 08:42:10 | Turn 1 → provider returns **402** | `auth profile failure state updated: provider=mockbill reason=billing window=disabled`; SQLite `usageStats["inline-api-key:mockbill"]`: `disabledUntil − lastFailureAt = 600,000 ms` — **exactly 10 minutes** (pre-fix base: 18,000,000 ms = 5 h) |
| 08:43:56 | Turn 2, still in-window | **Zero provider requests** — routing rejects locally: `Inline API key for provider "mockbill" is temporarily disabled after a provider auth/billing failure. Retry after about 9 minutes, or switch to a different auth profile/API key.` |
| 08:55:09 | Turn 3, after window expiry | Credential **re-selected by routing** (request reaches provider again); provider still 402 (recharge not yet simulated) → window re-armed at exactly `600,000 ms` with `errorCount`/`failureCounts` reset to 1 per incident |
| 09:05:09+ | Recharge simulated (mock switched to 200) | — |
| 09:05:33 | Turn 4 after second window expiry | Turn succeeds: `stopReason=stop`, `fallbackUsed=false`, reply `MOCK-RECOVERY-OK: billing-disabled credential was selected again` |

Verdict JSON summary:

```json
{
  "proof": "billing failure → 10-minute disabled window → in-window routing rejection → recovery through the real routing path",
  "window_ms_observed": 600000,
  "window_ms_prefix": 18000000,
  "in_window_provider_requests": 0,
  "in_window_user_error": "temporarily disabled ... Retry after about 9 minutes",
  "post_window_credential_reselected": true,
  "post_recharge_turn": { "stopReason": "stop", "fallbackUsed": false, "reply": "MOCK-RECOVERY-OK: billing-disabled credential was selected again" },
  "secrets": "none — mock key and loopback endpoint only"
}
```


## Maintainer verification

[Commit c44f8118](https://github.com/openclaw/openclaw/commit/c44f81187bd745c70b23a360fe15496c40251bf9) corrects the recovery-policy documentation and source comment. No runtime behavior changed in this follow-up.

- Cloudflare: the real SQLite persistence/eligibility fixture passes on the corrected tree; both credential lanes persist 600,000 ms and become eligible after expiry. Immediate rejection and an unaffected-provider control pass. The same fixture previously failed on unmodified main with 18,000,000 ms windows.
- Focused auth and fallback suites: **598 tests across 32 files passed**.
- Full `pnpm check:docs`: passed, including 7,249 internal links with zero broken links.
- Native pre-commit formatting hook: passed.
- Independent review of the complete corrected PR: no findings.

This is synthetic-credential proof using real persistence and eligibility code, not a live DeepSeek recharge test. Already-active windows retain their original deadlines.
