### PR TITLE
fix(sessions): stop decoding the SQLite session row four times per entry patch

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry-equality.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-equality.ts
@@ -2,6 +2,9 @@ import type { SessionEntry } from "./types.js";
 
 export type SqliteLifecycleTargetSnapshot = Array<{ entry: SessionEntry; sessionKey: string }>;
 
+/** Raw persisted-row identity for a patch target, compared cheaply at the commit edge. */
+export type SqliteSessionCommitFingerprint = string;
+
 class SqliteSessionMutationConflictError extends Error {
   constructor(operationLabel: string) {
     super(`SQLite session state changed while preparing ${operationLabel}`);
@@ -51,6 +54,16 @@ export function assertLifecycleTargetSnapshotUnchanged(
   operationLabel: string,
 ): void {
   if (!sqliteLifecycleTargetSnapshotsEqual(expected, current)) {
+    throw new SqliteSessionMutationConflictError(operationLabel);
+  }
+}
+
+export function assertSessionCommitFingerprintUnchanged(
+  expected: SqliteSessionCommitFingerprint,
+  current: SqliteSessionCommitFingerprint,
+  operationLabel: string,
+): void {
+  if (expected !== current) {
     throw new SqliteSessionMutationConflictError(operationLabel);
   }
 }

--- a/src/config/sessions/session-accessor.sqlite-entry-fingerprint.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-fingerprint.ts
@@ -1,0 +1,86 @@
+import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import type { SqliteSessionCommitFingerprint } from "./session-accessor.sqlite-entry-equality.js";
+import { normalizeLifecycleTarget } from "./session-accessor.sqlite-entry-store.js";
+import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import {
+  assertCanonicalSqliteSessionKeysCurrent,
+  canonicalSessionKeyMigrationRequiredError,
+} from "./session-canonical-key.js";
+
+type OpenClawAgentDatabaseReader = Pick<OpenClawAgentDatabase, "agentId" | "db">;
+
+/** Raw persisted columns that define one session row at the commit edge. */
+type SqliteSessionRowCommitTuple = [
+  sessionKey: string,
+  currentSessionId: string,
+  entryJson: string,
+  updatedAt: number,
+];
+
+function readExactSessionRowCommitTuple(
+  database: OpenClawAgentDatabaseReader,
+  sessionKey: string,
+): SqliteSessionRowCommitTuple | undefined {
+  const db = getSessionKysely(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_nodes")
+      .select(["session_key", "current_session_id", "entry_json", "updated_at"])
+      .where("session_key", "=", sessionKey),
+  );
+  return row
+    ? [row.session_key, row.current_session_id, row.entry_json, row.updated_at]
+    : undefined;
+}
+
+function toSessionCommitFingerprint(
+  tuples: ReadonlyArray<SqliteSessionRowCommitTuple | undefined>,
+): SqliteSessionCommitFingerprint {
+  return JSON.stringify(tuples);
+}
+
+/**
+ * Fingerprint mirror of readSessionEntrySelectionSnapshot: both select only the exact
+ * canonical row, so commit revalidation can compare raw columns without decoding them.
+ */
+export function readSessionEntrySelectionCommitFingerprint(
+  database: OpenClawAgentDatabase,
+  sessionKey: string,
+  exact: boolean,
+): SqliteSessionCommitFingerprint {
+  if (!exact) {
+    assertCanonicalSqliteSessionKeysCurrent(database);
+  }
+  const trimmedKey = sessionKey.trim();
+  return toSessionCommitFingerprint([
+    trimmedKey ? readExactSessionRowCommitTuple(database, trimmedKey) : undefined,
+  ]);
+}
+
+/** Fingerprint mirror of readLifecycleTargetSnapshot, keeping its duplicate and alias errors. */
+export function readLifecycleTargetCommitFingerprint(
+  database: OpenClawAgentDatabase,
+  target: { canonicalKey: string; storeKeys: string[] },
+  options: { allowCanonicalMove?: boolean } = {},
+): SqliteSessionCommitFingerprint {
+  assertCanonicalSqliteSessionKeysCurrent(database);
+  const normalized = normalizeLifecycleTarget(target);
+  const tuples = normalized.storeKeys.map((key) =>
+    readExactSessionRowCommitTuple(database, key.trim()),
+  );
+  const present = tuples.filter((tuple) => tuple !== undefined);
+  if (present.length > 1) {
+    throw canonicalSessionKeyMigrationRequiredError(
+      `duplicate rows resolve to canonical session key ${normalized.canonicalKey}`,
+    );
+  }
+  const [tuple] = present;
+  if (tuple && tuple[0] !== normalized.canonicalKey && options.allowCanonicalMove !== true) {
+    throw canonicalSessionKeyMigrationRequiredError(
+      `non-canonical persisted row resolves to session key ${normalized.canonicalKey}`,
+    );
+  }
+  return toSessionCommitFingerprint(tuples);
+}

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -560,6 +560,11 @@ export function writeSessionEntry(
     allowStoredAliases?: boolean;
     preserveNodeSuggestions?: boolean;
     previousEntry?: SessionEntry | null;
+    /**
+     * Caller-validated exact-row entry at the commit edge; skips the canonical re-read.
+     * `null` proves the row did not exist.
+     */
+    trustedCanonicalPreviousEntry?: SessionEntry | null;
     routeContext?: ConversationRouteContext | null;
   } = {},
 ): SessionEntry {
@@ -581,9 +586,11 @@ export function writeSessionEntry(
   // Doctor validated the raw rejected row before entering the transaction and passes its
   // hydrated snapshot explicitly; re-reading it through the runtime parser must stay fail-closed.
   const canonicalPreviousEntry =
-    options.allowStoredAliases && options.previousEntry !== undefined
-      ? (options.previousEntry ?? undefined)
-      : readExactSessionEntryRow(database, sessionKey)?.entry;
+    options.trustedCanonicalPreviousEntry !== undefined
+      ? (options.trustedCanonicalPreviousEntry ?? undefined)
+      : options.allowStoredAliases && options.previousEntry !== undefined
+        ? (options.previousEntry ?? undefined)
+        : readExactSessionEntryRow(database, sessionKey)?.entry;
   if (canonicalPreviousEntry?.sandbox === "required") {
     if (
       normalizedEntry.sandbox !== "required" ||

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -29,15 +29,20 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
 import {
-  assertLifecycleTargetSnapshotUnchanged,
+  assertSessionCommitFingerprintUnchanged,
   type SqliteLifecycleTargetSnapshot,
+  type SqliteSessionCommitFingerprint,
 } from "./session-accessor.sqlite-entry-equality.js";
+import {
+  readLifecycleTargetCommitFingerprint,
+  readSessionEntrySelectionCommitFingerprint,
+} from "./session-accessor.sqlite-entry-fingerprint.js";
 import {
   collectSessionEntryLookupKeys,
   parseReadableSqliteSessionEntryRow,
   readExactSessionEntryRowValidated,
-  readSessionEntryRow,
   readLifecycleTargetSnapshot,
+  readSessionEntryRow,
   readSessionEntrySelectionSnapshot,
   readSessionIdentitySnapshot,
   writeSessionEntry,
@@ -435,6 +440,12 @@ export async function patchSessionEntryCore(
   return await patchSqliteSessionEntrySnapshot({
     operationLabel: "session-entry.patch",
     options,
+    readCommitFingerprint: (database) =>
+      readSessionEntrySelectionCommitFingerprint(
+        database,
+        resolved.sessionKey,
+        options.replaceEntry === true,
+      ),
     readSnapshot: (database) =>
       readSessionEntrySelectionSnapshot(
         database,
@@ -461,6 +472,8 @@ export async function patchSessionEntryTarget(
   return await patchSqliteSessionEntrySnapshot({
     operationLabel: "session-entry-target.patch",
     options,
+    readCommitFingerprint: (database) =>
+      readLifecycleTargetCommitFingerprint(database, scope.target),
     readSnapshot: (database) => readLifecycleTargetSnapshot(database, scope.target),
     resolved,
     sessionKey: scope.target.canonicalKey,
@@ -476,6 +489,7 @@ export async function patchSessionEntryTarget(
 type SqliteSessionEntrySnapshotPatchParams = {
   operationLabel: string;
   options: SqliteSessionEntryPatchOptions;
+  readCommitFingerprint: (database: OpenClawAgentDatabase) => SqliteSessionCommitFingerprint;
   readSnapshot: (database: OpenClawAgentDatabase) => SqliteLifecycleTargetSnapshot;
   resolved: ResolvedSqliteScope;
   sessionKey: string;
@@ -495,6 +509,7 @@ async function patchSqliteSessionEntrySnapshot(
   const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const prepared = params.readSnapshot(database);
+    const preparedFingerprint = params.readCommitFingerprint(database);
     const existing = prepared[0]?.entry;
     const writeBase = existing ?? options.fallbackEntry;
     if (!writeBase) {
@@ -526,21 +541,28 @@ async function patchSqliteSessionEntrySnapshot(
     let previousIdentity = new Map<string, SessionEntry>();
     let currentIdentity = new Map<string, SessionEntry>();
     runOpenClawAgentWriteTransaction((writeDatabase) => {
-      const fresh = params.readSnapshot(writeDatabase);
-      assertLifecycleTargetSnapshotUnchanged(prepared, fresh, params.operationLabel);
+      // Cheap raw-row revalidation keeps the commit-edge conflict contract without
+      // re-decoding the hydrated snapshot.
+      assertSessionCommitFingerprintUnchanged(
+        preparedFingerprint,
+        params.readCommitFingerprint(writeDatabase),
+        params.operationLabel,
+      );
       options.assertCommitAllowed?.();
       if (!next) {
         result = cloneSessionEntry(writeBase);
         return;
       }
-      // Commit reads own these entries; update callbacks only receive detached copies.
-      previousIdentity = new Map(fresh.map((row) => [row.sessionKey, row.entry]));
-      const selectedPreviousEntry = fresh[0]?.entry ?? writeBase;
+      // The fingerprint proved the prepared rows are current; reuse their entries.
+      previousIdentity = new Map(prepared.map((row) => [row.sessionKey, row.entry]));
+      const selectedPreviousEntry = prepared[0]?.entry ?? writeBase;
       const persisted = writeSessionEntry(writeDatabase, sessionKey, next, {
         previousEntry: selectedPreviousEntry,
+        trustedCanonicalPreviousEntry: prepared[0]?.entry ?? null,
       });
       wrote = true;
-      currentIdentity = readSessionIdentitySnapshot(writeDatabase, [sessionKey]);
+      // The transaction just persisted this exact row; reuse it for identity publication.
+      currentIdentity = new Map([[sessionKey, persisted]]);
       result = cloneSessionEntry(persisted);
     }, toDatabaseOptions(resolved));
     try {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1189,6 +1189,39 @@ describe("session accessor seam", () => {
     }
   });
 
+  it("decodes the SQLite session row once across a successful entry patch", async () => {
+    const sessionKey = "agent:main:patch-decode-once";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey, storePath },
+      { sessionId: "patch-decode-once", updatedAt: 41 },
+    );
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      "patch decode database path",
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const preparedRow = database.db
+      .prepare("SELECT entry_json FROM session_nodes WHERE session_key = ?")
+      .get(sessionKey) as { entry_json: string } | undefined;
+    const preparedEntryJson = expectDefined(preparedRow?.entry_json, "prepared entry json");
+
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      await patchSessionEntryCore({ agentId: "main", sessionKey, storePath }, () => ({
+        model: "patch-decode-once",
+      }));
+      // The prepared row must be decoded exactly once (preparation), then cheaply
+      // revalidated at the commit edge instead of being re-decoded three more times.
+      expect(parse.mock.calls.filter(([value]) => value === preparedEntryJson)).toHaveLength(1);
+      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+        sessionId: "patch-decode-once",
+        model: "patch-decode-once",
+      });
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
   it("resolves non-main candidate entries from custom agent store templates", async () => {
     const storeTemplate = path.join(tempDir, "{agentId}.json");
     const supportStorePath = path.join(tempDir, "support.json");


### PR DESCRIPTION
Closes #136338

## What Problem This Solves

Resolves a problem where gateways running the SQLite session store lose roughly a third of saturated throughput compared to 2026.7.1-2: every session-entry patch decodes (JSON.parse + participants projection) the same session row four times and deep-compares two decoded copies via `JSON.stringify`, all synchronously on the gateway event loop. A normal streamed reply turn issues about eleven such patches, so with a production-shaped ~17 KB `entry_json` the session store consumed ~29% of a saturated gateway main thread.

## Why This Change Was Made

The patch path now decodes the session row exactly once at preparation and revalidates cheaply at the commit edge: instead of re-hydrating the row and `JSON.stringify`-comparing decoded entries, the transaction compares a raw persisted-row fingerprint (`session_key`, `current_session_id`, `entry_json`, `updated_at`) and keeps the same `SqliteSessionMutationConflictError` rejection contract when another writer changed the source row. `writeSessionEntry` reuses the commit-validated previous entry via an explicit opt-in (`trustedCanonicalPreviousEntry`) instead of re-reading the row, and post-write identity publication reuses the exact row the transaction just persisted instead of a fourth hydrated read. No schema or session-semantics changes; other write paths (lifecycle, recovery, transcript writes) are untouched.

## User Impact

Session-entry patches stop paying four full row decodes plus two decoded-entry stringifications per patch, restoring gateway main-thread capacity for multi-agent deployments. Behavior is unchanged: commit-edge conflict detection, creation-stamp preservation, and identity mutation events work exactly as before.

## Evidence

Regression test first (RED) — the prepared row was decoded 3 times during one successful patch (preparation, in-transaction revalidation, `writeSessionEntry` canonical re-read; the 4th decode reads the post-write row):

```text
FAIL session accessor seam > decodes the SQLite session row once across a successful entry patch
AssertionError: expected [ …(3) ] to have a length of 1 but got 3
```

After the fix, the same test asserts exactly one decode of the prepared row, and the issue's conformance contract ("rejects a prepared SQLite entry patch when its source row changes") still passes:

```text
Test Files  2 passed (2)   # session-accessor.test.ts + session-accessor.conformance.test.ts
     Tests  175 passed (175)
```

Stability: `session-accessor.conformance.test.ts` re-run 3 consecutive times after the final refactor, 47/47 each run. `validate.sh` (oxfmt + oxlint + same-directory tests + `pnpm tsgo:core`) passes on all changed files. CI lanes (`test-projects --changed`, full `check:test-types`) are pending on Actions.

Real environment tested: Node 26.7.0 on the repository worktree (Linux), vitest unit/conformance suites against a real `node:sqlite` database — not the 16-agent production gateway profile from the issue.

Exact steps or commands run after this patch:

```bash
node scripts/run-vitest.mjs run src/config/sessions/session-accessor.test.ts \
  src/config/sessions/session-accessor.conformance.test.ts
skills/fix-pr/scripts/validate.sh src/config/sessions/session-accessor.sqlite-entry-equality.ts \
  src/config/sessions/session-accessor.sqlite-entry-fingerprint.ts \
  src/config/sessions/session-accessor.sqlite-entry-store.ts \
  src/config/sessions/session-accessor.sqlite-entry.ts \
  src/config/sessions/session-accessor.test.ts
```

Evidence after fix: 175/175 tests pass across both suites; the decode-once regression test asserts `JSON.parse` of the persisted `entry_json` happens exactly once per successful patch; 3 consecutive conformance re-runs (47/47) confirm the commit-edge conflict contract is stable.

Observed result after fix: one decode at preparation, cheap raw-column fingerprint comparison at the commit edge, no row re-read inside `writeSessionEntry`, no post-write identity re-read — while a concurrent `replaceSessionEntrySync` between preparation and commit still rejects with `SqliteSessionMutationConflictError`.

What was not tested: the issue's full 16-concurrent-agent gateway throughput/profile scenario (requires containerized gateway images and a mock provider); only source-level decode counts and behavioral conformance were measured.
