### PR TITLE
fix(ci): release validation fails during branch and tag checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -807,11 +807,13 @@ jobs:
               --base "$base_sha" --head HEAD --prefer-first-parent)"
           fi
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$RELEASE_GATE" != "true" ]; then
-            default_sha="$(python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --git 0 ls-remote origin "refs/heads/${DEFAULT_BRANCH}" | awk 'NR == 1 { print $1}')"
+            encoded_ref="$(jq -rn --arg value "refs/heads/${DEFAULT_BRANCH}" '$value | @uri')"
+            default_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha)"
             if [[ ! "$default_sha" =~ ^[0-9a-f]{40}$ ]]; then
               echo "Could not resolve the default branch head for the manual target." >&2
               exit 1
             fi
+            echo "default_sha=$default_sha" >> "$GITHUB_OUTPUT"
             base_sha="$(
               gh api --method GET \
                 "repos/${GITHUB_REPOSITORY}/compare/${default_sha}...${head_sha}" \
@@ -844,6 +846,7 @@ jobs:
         if: inputs.historical_target_tag != ''
         env:
           EXPECTED_SHA: ${{ steps.checkout_ref.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
           HISTORICAL_TARGET_TAG: ${{ inputs.historical_target_tag }}
         run: |
           set -euo pipefail
@@ -851,12 +854,8 @@ jobs:
             echo "historical_target_tag must be a canonical OpenClaw release tag." >&2
             exit 1
           fi
-          tag_ref="refs/tags/${HISTORICAL_TARGET_TAG}"
-          remote="$(git remote get-url origin)"
-          tag_sha="$(python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --git 0 ls-remote --tags "$remote" "${tag_ref}^{}" | awk 'NR == 1 { print $1 }')"
-          if [[ -z "$tag_sha" ]]; then
-            tag_sha="$(python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --git 0 ls-remote --tags "$remote" "$tag_ref" | awk 'NR == 1 { print $1 }')"
-          fi
+          encoded_ref="$(jq -rn --arg value "refs/tags/${HISTORICAL_TARGET_TAG}" '$value | @uri')"
+          tag_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha)"
           if [[ "$tag_sha" != "$EXPECTED_SHA" ]]; then
             echo "Historical release tag ${HISTORICAL_TARGET_TAG} does not resolve to ${EXPECTED_SHA}." >&2
             exit 1
@@ -868,6 +867,7 @@ jobs:
         if: inputs.release_candidate_ref != ''
         env:
           EXPECTED_SHA: ${{ steps.checkout_ref.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_CANDIDATE_REF: ${{ inputs.release_candidate_ref }}
         run: |
           set -euo pipefail
@@ -875,8 +875,8 @@ jobs:
             echo "release_candidate_ref must be a canonical OpenClaw release branch." >&2
             exit 1
           fi
-          remote="$(git remote get-url origin)"
-          branch_sha="$(python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --git 0 ls-remote --heads "$remote" "refs/heads/${RELEASE_CANDIDATE_REF}" | awk 'NR == 1 { print $1 }')"
+          encoded_ref="$(jq -rn --arg value "refs/heads/${RELEASE_CANDIDATE_REF}" '$value | @uri')"
+          branch_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha)"
           if [[ "$branch_sha" != "$EXPECTED_SHA" ]]; then
             echo "Release candidate branch ${RELEASE_CANDIDATE_REF} does not resolve to ${EXPECTED_SHA}." >&2
             exit 1
@@ -900,7 +900,8 @@ jobs:
             echo "target_context_ref requires target_ref to be a full commit SHA." >&2
             exit 1
           fi
-          branch_sha="$(python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --git 0 ls-remote --heads origin "refs/heads/${TARGET_CONTEXT_REF}" | awk 'NR == 1 { print $1 }')"
+          encoded_ref="$(jq -rn --arg value "refs/heads/${TARGET_CONTEXT_REF}" '$value | @uri')"
+          branch_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha)"
           if [[ ! "$branch_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "target_context_ref branch ${TARGET_CONTEXT_REF} does not exist." >&2
             exit 1
@@ -914,11 +915,38 @@ jobs:
           fi
           echo "eligible=true" >> "$GITHUB_OUTPUT"
 
+      - name: Setup manifest TypeScript runtime
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Resolve release correction base
+        id: release_correction_base
+        if: github.event_name == 'workflow_dispatch' && (inputs.release_scope == 'npm-beta' || inputs.release_scope == 'npm-stable')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_CONTEXT_REF: ${{ steps.target_context_target.outputs.eligible == 'true' && inputs.target_context_ref || steps.historical_target.outputs.eligible == 'true' && inputs.historical_target_tag || '' }}
+        run: |
+          # Keep the token outside the manifest step, which imports candidate-owned code.
+          node --input-type=module <<'NODE'
+          import { execFileSync } from 'node:child_process';
+          import { appendFileSync, readFileSync } from 'node:fs';
+          import { resolveReleaseContextIdentity } from './.ci-harness/scripts/lib/release-context.mjs';
+          const version = JSON.parse(readFileSync('package.json', 'utf8')).version;
+          const identity = resolveReleaseContextIdentity(process.env.TARGET_CONTEXT_REF, version);
+          if (identity?.baseTag) {
+            const ref = encodeURIComponent(`refs/tags/${identity.baseTag}`);
+            const sha = execFileSync('gh', ['api', `repos/${process.env.GITHUB_REPOSITORY}/commits/${ref}`, '--jq', '.sha'], { encoding: 'utf8' }).trim();
+            if (!/^[0-9a-f]{40}$/u.test(sha)) throw new Error(`Could not resolve correction base ${identity.baseTag}.`);
+            appendFileSync(process.env.GITHUB_OUTPUT, `sha=${sha}\n`);
+          }
+          NODE
+
       - name: Classify candidate cache trust
         id: candidate_trust
         env:
           CHECKOUT_REVISION: ${{ steps.checkout_ref.outputs.sha }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DEFAULT_SHA: ${{ steps.diff_base.outputs.default_sha }}
           HISTORICAL_TARGET: ${{ steps.historical_target.outputs.eligible || 'false' }}
           RELEASE_CANDIDATE_TARGET: ${{ steps.release_candidate_target.outputs.eligible || 'false' }}
           RELEASE_GATE: ${{ inputs.release_gate && 'true' || 'false' }}
@@ -940,7 +968,6 @@ jobs:
             trust=pull-request
             cache_mode=restore
           elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-            default_sha="$(python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --git 0 ls-remote origin "refs/heads/${DEFAULT_BRANCH}" | awk 'NR == 1 { print $1 }')"
             if [[ "$RELEASE_GATE" == "true" ]]; then
               trust=pull-request
               cache_mode=restore
@@ -952,7 +979,7 @@ jobs:
               trust=release
               cache_mode=restore
               cache_write_allowed=true
-            elif [[ -n "$default_sha" && "$CHECKOUT_REVISION" == "$default_sha" ]]; then
+            elif [[ -n "$DEFAULT_SHA" && "$CHECKOUT_REVISION" == "$DEFAULT_SHA" ]]; then
               trust=main
               cache_mode=restore
               cache_write_allowed=true
@@ -1003,11 +1030,6 @@ jobs:
             node scripts/ci-changed-scope.mjs --base "$BASE" --head "$HEAD_SHA"
           fi
 
-      - name: Setup manifest TypeScript runtime
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       # Current-revision preflight is dependency-free: the manifest planner
       # closure and protocol coverage import only node builtins and relative
       # files, and Node strips their types natively. Different-revision manual
@@ -1045,6 +1067,7 @@ jobs:
           OPENCLAW_CI_RUN_NATIVE_I18N: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.changed_scope.outputs.run_native_i18n || 'false' }}
           OPENCLAW_CI_CHANGED_PATHS_JSON: ${{ steps.changed_scope.outputs.changed_paths_json || 'null' }}
           OPENCLAW_CI_CHECKOUT_REVISION: ${{ steps.checkout_ref.outputs.sha }}
+          OPENCLAW_CI_CORRECTION_BASE_SHA: ${{ steps.release_correction_base.outputs.sha }}
           OPENCLAW_CI_HISTORICAL_TARGET: ${{ steps.historical_target.outputs.eligible || 'false' }}
           OPENCLAW_CI_RELEASE_GATE: ${{ inputs.release_gate && 'true' || 'false' }}
           OPENCLAW_CI_RELEASE_SCOPE: ${{ inputs.release_scope || 'full' }}
@@ -1065,7 +1088,6 @@ jobs:
             manifest_node_args+=(--import tsx)
           fi
           node "${manifest_node_args[@]}" --input-type=module <<'EOF'
-          import { execFileSync } from "node:child_process";
           import { appendFileSync, existsSync, readFileSync } from "node:fs";
           import { matchesGlob } from "node:path";
           import { resolveTestGitCommits } from "./.ci-harness/.github/actions/git-owner/test-prerequisites.mjs";
@@ -1216,16 +1238,7 @@ jobs:
             }
             if (identity.baseTag) {
               // Base-package corrections reuse the base tag's exact source; ancestry alone is insufficient.
-              const baseRef = `refs/tags/${identity.baseTag}`;
-              const remoteRefs = execFileSync("python3", [
-                "-I", "-S", `${process.env.RUNNER_TEMP}/ci-git-owner.py`, "--git", "120",
-                "ls-remote", "--tags", "https://github.com/openclaw/openclaw.git", baseRef, `${baseRef}^{}`,
-              ], { encoding: "utf8" });
-              const refs = new Map(remoteRefs.trim().split("\n").filter(Boolean).map((line) => {
-                const [sha, ref] = line.split(/\s+/u);
-                return [ref, sha];
-              }));
-              if (!refs.has(baseRef) || (refs.get(`${baseRef}^{}`) ?? refs.get(baseRef)) !== checkoutRevision) {
+              if (process.env.OPENCLAW_CI_CORRECTION_BASE_SHA !== checkoutRevision) {
                 throw new Error(`release_scope ${releaseScope} correction base ${identity.baseTag} does not resolve to ${checkoutRevision}`);
               }
             }

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -387,12 +387,14 @@ jobs:
           identity_kind="$(jq -r '.kind' <<< "$release_context")"
           release_tag="$(jq -r '.releaseTag' <<< "$release_context")"
           base_tag="$(jq -r '.baseTag // empty' <<< "$release_context")"
-          repository_url="https://github.com/${GITHUB_REPOSITORY}.git"
+          # The API uses this step's token and peels tags without persisting Git credentials.
+          resolve_release_ref() {
+            local encoded_ref
+            encoded_ref="$(jq -rn --arg value "$1" '$value | @uri')"
+            gh api "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}" --jq .sha
+          }
           if [[ -n "$base_tag" ]]; then
-            base_sha="$(git ls-remote --tags "$repository_url" "refs/tags/${base_tag}^{}" | awk 'NR == 1 { print $1 }')"
-            if [[ -z "$base_sha" ]]; then
-              base_sha="$(git ls-remote --tags "$repository_url" "refs/tags/${base_tag}" | awk 'NR == 1 { print $1 }')"
-            fi
+            base_sha="$(resolve_release_ref "refs/tags/${base_tag}")"
             if [[ "$base_sha" != "$TARGET_SHA" ]]; then
               echo "Correction source ${TARGET_SHA} must match base release tag ${base_tag}." >&2
               exit 1
@@ -407,16 +409,13 @@ jobs:
               exit 1
             fi
             if [[ "$identity_kind" == "release tag" ]]; then
-              remote_sha="$(git ls-remote --tags "$repository_url" "refs/tags/${context_ref}^{}" | awk 'NR == 1 { print $1 }')"
-              if [[ -z "$remote_sha" ]]; then
-                remote_sha="$(git ls-remote --tags "$repository_url" "refs/tags/${context_ref}" | awk 'NR == 1 { print $1 }')"
-              fi
+              remote_sha="$(resolve_release_ref "refs/tags/${context_ref}")"
               if [[ "$remote_sha" != "$TARGET_SHA" ]]; then
                 echo "Target SHA ${TARGET_SHA} does not match release tag ${context_ref} at ${remote_sha:-missing}." >&2
                 exit 1
               fi
             else
-              remote_sha="$(git ls-remote --heads "$repository_url" "refs/heads/${context_ref}" | awk 'NR == 1 { print $1 }')"
+              remote_sha="$(resolve_release_ref "refs/heads/${context_ref}")"
               if [[ -z "$remote_sha" ]]; then
                 echo "Release context branch ${context_ref} does not resolve." >&2
                 exit 1

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -12,6 +12,8 @@ import { promisify } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { terminateManagedChild } from "../../scripts/lib/managed-child-process.mts";
 import { hasErrnoCode } from "../../src/infra/errno.js";
+import { resolveMaxOutputBytes } from "../../src/process/exec-output.js";
+import { withEnvAsync } from "../../src/test-utils/env.js";
 import { createOpenClawTestInstance, testing } from "./openclaw-test-instance.js";
 import { isProcessAlive, waitForDead } from "./process-wait.js";
 import { createDeferred, withTestTimeout } from "./promise.js";
@@ -191,6 +193,14 @@ const port = Number(argv[argv.indexOf("--port") + 1]);
 const env = Object.fromEntries(["HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_STATE_DIR"].map((key) => [key, process.env[key]]));
 appendFileSync(tracePath, JSON.stringify({ argv, config: JSON.parse(readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8")), cwd: process.cwd(), env, pid: process.pid, port }) + "\\n");
 const kind = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[attempt - 1] || "ready";
+if (kind === "cli-json") {
+  const json = JSON.stringify({ first: "complete", payload: "é".repeat(Number(argv[0])), providerCredentialPresent: Object.hasOwn(process.env, "OPENAI_API_KEY"), last: "complete" });
+  await Promise.all([
+    new Promise((resolve) => process.stdout.write(json, resolve)),
+    new Promise((resolve) => process.stderr.write("discarded diagnostic " + "x".repeat(300 * 1024) + "\\nrecent cli diagnostic\\n", resolve)),
+  ]);
+  process.exit(0);
+}
 process.stdout.write("fake gateway attempt " + attempt + "\\n");
 if (kind === "cli") {
   process.stderr.write("cli diagnostic\\n");
@@ -294,6 +304,50 @@ function createGatewayProcessState(
 }
 
 describe("openclaw test instance", () => {
+  it.each(["complete", "overflow"] as const)(
+    "owns complete CLI JSON and diagnostic tails (%s)",
+    async (mode) => {
+      await withEnvAsync({ OPENAI_API_KEY: "ambient-provider-fixture" }, async () => {
+        const { instance, readAttempts } = await createFakeGateway("cli-json");
+        // The command must not merge a removed credential back from its parent.
+        delete instance.env.OPENAI_API_KEY;
+        const characters =
+          mode === "complete" ? 160 * 1024 : resolveMaxOutputBytes(undefined, "stdout") / 2;
+        const command = trackOperation(instance.cli([String(characters)]));
+        if (mode === "overflow") {
+          const outcome = await command.then(
+            (result) => ({
+              code: result.code,
+              stdoutBytes: Buffer.byteLength(result.stdout),
+            }),
+            (error: unknown) => error,
+          );
+          if (!(outcome instanceof Error)) {
+            throw new Error(`Expected command output overflow failure: ${JSON.stringify(outcome)}`);
+          }
+          expect(outcome.message).toContain("command stdout exceeded capture limit");
+          expect(Buffer.byteLength(outcome.message)).toBeLessThan(600 * 1024);
+        } else {
+          const result = await command;
+          expect({ code: result.code, signal: result.signal }).toEqual({ code: 0, signal: null });
+          expect(JSON.parse(result.stdout)).toEqual({
+            first: "complete",
+            payload: "é".repeat(characters),
+            providerCredentialPresent: false,
+            last: "complete",
+          });
+          expect(result.stderr).toContain("[output truncated to last");
+          expect(result.stderr).toContain("recent cli diagnostic");
+          expect(result.stderr).not.toContain("discarded diagnostic");
+          expect(Buffer.byteLength(result.stderr)).toBeLessThan(300 * 1024);
+        }
+        const attempts = await readAttempts();
+        expect(attempts).toHaveLength(1);
+        expect(isProcessAlive(attempts[0]!.pid)).toBe(false);
+      });
+    },
+  );
+
   it.each([
     { mode: "0", prepare: false },
     { mode: "7", prepare: false },
@@ -1091,24 +1145,6 @@ describe("openclaw test instance", () => {
 
     expect(fetchImpl).toHaveBeenCalledOnce();
     expect(Date.now() - startedAt).toBeLessThan(500);
-  });
-
-  it("signals test instance process groups on POSIX", () => {
-    const child = {
-      pid: 1234,
-      kill: vi.fn(() => true),
-    };
-    const killProcess = vi.fn(() => true);
-
-    testing.signalOpenClawTestProcess(child, "SIGKILL", killProcess);
-
-    if (process.platform === "win32") {
-      expect(killProcess).not.toHaveBeenCalled();
-      expect(child.kill).toHaveBeenCalledWith("SIGKILL");
-    } else {
-      expect(killProcess).toHaveBeenCalledWith(-1234, "SIGKILL");
-      expect(child.kill).not.toHaveBeenCalled();
-    }
   });
 
   it("creates isolated config and spawn env without mutating process env", async () => {

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -11,6 +11,7 @@ import {
   RUNTIME_POSTBUILD_STAMP_FILE,
 } from "../../scripts/lib/local-build-metadata-paths.mts";
 import { terminateManagedChild } from "../../scripts/lib/managed-child-process.mts";
+import { runUtf8CommandWithTimeout } from "../../src/process/exec-runner.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -85,7 +86,6 @@ type BoundedStringLog = string[] & {
   truncated?: boolean;
 };
 
-type OpenClawTestChildProcess = Pick<OpenClawTestProcess, "kill" | "pid">;
 type OpenClawTestProcessReadiness = Pick<OpenClawTestProcess, "exitCode" | "signalCode"> & {
   once: (event: "exit", listener: () => void) => unknown;
   off: (event: "exit", listener: () => void) => unknown;
@@ -413,7 +413,15 @@ function mergeConfig(
 }
 
 function formatLogs(stdout: string[], stderr: string[]): string {
-  return `--- stdout ---\n${readLogBuffer(stdout)}\n--- stderr ---\n${readLogBuffer(stderr)}`;
+  const diagnosticTail = (log: string[]): string => {
+    const tail = createBoundedStringLog() as BoundedStringLog;
+    for (const chunk of log) {
+      appendLogChunk(tail, chunk);
+    }
+    tail.truncated ||= (log as BoundedStringLog).truncated;
+    return readLogBuffer(tail);
+  };
+  return `--- stdout ---\n${diagnosticTail(stdout)}\n--- stderr ---\n${diagnosticTail(stderr)}`;
 }
 
 function createInstanceEnv(params: {
@@ -664,41 +672,30 @@ async function runCommand(params: {
   env: NodeJS.ProcessEnv;
   timeoutMs: number;
 }): Promise<OpenClawTestInstanceCommandResult> {
-  const [command, ...args] = params.args;
-  if (!command) {
-    throw new Error("missing command");
-  }
-  const stdout = createBoundedStringLog();
-  const stderr = createBoundedStringLog();
-  const child = spawn(command, args, {
+  const result = await runUtf8CommandWithTimeout(params.args, {
     cwd: params.cwd,
-    env: params.env,
-    stdio: ["ignore", "pipe", "pipe"],
-    detached: shouldUseOpenClawTestProcessGroup(),
+    // This is the complete isolated environment, not an overlay on the parent.
+    baseEnv: params.env,
+    timeoutMs: params.timeoutMs,
+    killProcessTree: true,
+    // CLI stdout is a machine-readable result; only diagnostics may lose their head.
+    outputCapture: { stdout: "head", stderr: "tail" },
+    maxOutputBytes: { stderr: LOG_TAIL_MAX_BYTES },
+    terminateOnOutputLimit: { stdout: true },
   });
-  child.stdout?.setEncoding("utf8");
-  child.stderr?.setEncoding("utf8");
-  child.stdout?.on("data", (d) => appendLogChunk(stdout, d));
-  child.stderr?.on("data", (d) => appendLogChunk(stderr, d));
-
-  const deadline = new AbortController();
-  const completed = await Promise.race([
-    new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("exit", (code, signal) => resolve({ code, signal }));
-    }),
-    sleep(params.timeoutMs, deadline.signal).then(() => null),
-  ]).finally(() => deadline.abort());
-  if (completed === null) {
-    signalOpenClawTestProcess(child, "SIGKILL");
-    await waitForGatewayClose(child, GATEWAY_STOP_TIMEOUT_MS);
-    throw new Error(
-      `command timed out after ${params.timeoutMs}ms: ${params.args.join(" ")}\n${formatLogs(stdout, stderr)}`,
-    );
+  const stderr = createBoundedStringLog();
+  appendLogChunk(stderr, result.stderr);
+  (stderr as BoundedStringLog).truncated ||= Boolean(result.stderrTruncatedBytes);
+  if (result.outputLimitExceeded || result.termination === "timeout") {
+    const failure = result.outputLimitExceeded
+      ? "command stdout exceeded capture limit"
+      : `command timed out after ${params.timeoutMs}ms`;
+    throw new Error(`${failure}: ${params.args.join(" ")}\n${formatLogs([result.stdout], stderr)}`);
   }
   return {
-    ...completed,
-    stdout: readLogBuffer(stdout),
+    code: result.code,
+    signal: result.signal,
+    stdout: result.stdout,
     stderr: readLogBuffer(stderr),
   };
 }
@@ -707,29 +704,11 @@ function shouldUseOpenClawTestProcessGroup(): boolean {
   return process.platform !== "win32";
 }
 
-function signalOpenClawTestProcess(
-  child: OpenClawTestChildProcess,
-  signal: NodeJS.Signals,
-  killProcess: (pid: number, signal: NodeJS.Signals) => boolean = (pid, nextSignal) =>
-    process.kill(pid, nextSignal),
-): void {
-  if (shouldUseOpenClawTestProcessGroup() && typeof child.pid === "number") {
-    try {
-      killProcess(-child.pid, signal);
-      return;
-    } catch {
-      // Fall back to the direct child if the process group already exited.
-    }
-  }
-  child.kill(signal);
-}
-
 export const testing = {
   appendLogChunk,
   createBoundedStringLog,
   formatLogs,
   isGatewayMigrationConvergenceRefusal,
-  signalOpenClawTestProcess,
   stopGatewayProcess,
   waitForGatewayReady,
 };

--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -322,99 +322,30 @@ sys.stdout.write(git_output(os.getcwd(), "rev-parse", "HEAD", env={"CI_OWNER_PRO
   55_000,
 );
 
-const lookups: { step: string; env: Record<string, string>; output: string }[] = [
-  {
-    step: "Resolve exact diff base",
-    env: { RELEASE_GATE: "false" },
-    output: `sha=${base}\nhead_sha=${head}\n`,
-  },
-  {
-    step: "Validate historical release target",
-    env: { HISTORICAL_TARGET_TAG: "v2026.8.1", EXPECTED_SHA: head },
-    output: "eligible=true\n",
-  },
-  {
-    step: "Validate release candidate target",
-    env: { RELEASE_CANDIDATE_REF: "release/2026.8.1", EXPECTED_SHA: head },
-    output: "eligible=true\n",
-  },
-  {
-    step: "Validate target context",
-    env: { TARGET_CONTEXT_REF: "release/2026.8.1", TARGET_REF: head },
-    output: "eligible=true\n",
-  },
-  {
-    step: "Classify candidate cache trust",
-    env: {
-      CHECKOUT_REVISION: head,
-      WORKFLOW_REVISION: head,
-      RELEASE_CANDIDATE_TARGET: "false",
-      TARGET_CONTEXT_TARGET: "false",
-      TARGET_REF: "",
-    },
-    output: "trust=main\ncache_mode=restore\ncache_write_allowed=true\n",
-  },
-];
-
-linuxIt.each(
-  lookups.flatMap((lookup) =>
-    ([0, 23, "cleanup-failure"] as const).map((code) => Object.assign({}, lookup, { code })),
-  ),
-)(
-  "$step drains lookup output before consumption ($code)",
-  async ({ step, env, output, code }) => {
+linuxIt.each([0, 23, "cleanup-failure"] as const)(
+  "generic Git output drains its writers before consumption (%s)",
+  async (code) => {
+    const output = `${head}\trefs/heads/main\n`;
     const report = await runCiGitStep({
-      job: "preflight",
-      step,
-      env: { GITHUB_EVENT_NAME: "workflow_dispatch", ...env },
-      prepare: true,
+      policy:
+        policyImport +
+        'import sys\nsys.stdout.write(git_output(os.getcwd(), "ls-remote", "origin", "refs/heads/main"))\n',
       fetchResults: [],
-      lsRemoteResults: [{ code, output: `${head}\trefs/heads/main\n` }],
+      lsRemoteResults: [{ code, output }],
     });
     expect(report.code, report.output).toBe(code === "cleanup-failure" ? 125 : code);
-    expect(report.githubOutput).toBe(code === 0 ? output : "");
-    expect(report.commands.filter(({ args }) => args[0] === "ls-remote")).toHaveLength(1);
-    if (code !== 0) {
-      expect(report.commands.some(({ tool }) => tool === "gh")).toBe(false);
+    expect(report.commands.map(({ args }) => args)).toEqual([
+      ["ls-remote", "origin", "refs/heads/main"],
+    ]);
+    expect(report.readyAttempts).toEqual([1]);
+    if (code === 0) {
+      expect(report.output).toBe(output);
+    } else {
+      expect(report.output).not.toContain(output);
     }
   },
   55_000,
 );
-
-linuxIt.each([0, 23, "cleanup-failure"] as const)(
-  "historical tag fallback follows only successful empty peeled lookup (%s)",
-  async (code) => {
-    const report = await runCiGitStep({
-      job: "preflight",
-      step: "Validate historical release target",
-      env: { HISTORICAL_TARGET_TAG: "v2026.8.1", EXPECTED_SHA: head },
-      prepare: true,
-      fetchResults: [],
-      lsRemoteResults: [
-        { code, output: "" },
-        { code: 0, output: `${head}\trefs/tags/v2026.8.1\n` },
-      ],
-    });
-    expect(report.code, report.output).toBe(code === "cleanup-failure" ? 125 : code);
-    expect(
-      report.commands.filter(({ args }) => args[0] === "ls-remote").map(({ args }) => args.at(-1)),
-    ).toEqual(
-      code === 0 ? ["refs/tags/v2026.8.1^{}", "refs/tags/v2026.8.1"] : ["refs/tags/v2026.8.1^{}"],
-    );
-    expect(report.githubOutput).toBe(code === 0 ? "eligible=true\n" : "");
-  },
-  55_000,
-);
-
-it("preserves no per-operation deadline on all six CI remote lookups", () => {
-  const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
-    jobs: { preflight: { steps: { run?: string }[] } };
-  };
-  const calls = workflow.jobs.preflight.steps.flatMap(({ run }) =>
-    Array.from((run ?? "").matchAll(/--git (\S+) ls-remote/gu)),
-  );
-  expect(calls.map((call) => call[1])).toEqual(Array(6).fill("0"));
-});
 
 const posixIt = it.skipIf(process.platform === "win32").concurrent;
 const auditFiles = [".pre-commit-config.yaml", ".github/zizmor.yml"];
@@ -917,9 +848,11 @@ posixIt.each([0, 2, 23, 125, 143, "hang", "cleanup-failure", "cancel"] as const)
       expect(report.githubOutput).toBe("");
       expect(report.githubSummary).toBe("");
       expect(report.commands.at(-1)?.args[0]).toBe("ls-remote");
-      if (typeof code === "number" || code === "hang")
+      if (typeof code === "number" || code === "hang") {
         expect(report.output).toContain(`(status ${code === "hang" ? 124 : code})`);
-      else expect(report.output).not.toContain("Unable to determine");
+      } else {
+        expect(report.output).not.toContain("Unable to determine");
+      }
     }
   },
   55_000,
@@ -932,7 +865,9 @@ posixIt.each(
     { match: "^rev-parse refs/remotes", occurrence: 1 },
     { match: "^rev-parse refs/remotes", occurrence: 2 },
     { match: "^diff ", occurrence: 1 },
-  ].flatMap((site) => (["cleanup-failure", "cancel"] as const).map((code) => ({ ...site, code }))),
+  ].flatMap((site) =>
+    (["cleanup-failure", "cancel"] as const).map((code) => Object.assign({}, site, { code })),
+  ),
 )(
   "maturity $code at $match/$occurrence stops before fallback/output",
   async ({ match, occurrence, code }) => {
@@ -1002,7 +937,7 @@ posixIt.each(
     { match: "^fetch ", occurrence: 2 },
     { match: "^ls-tree ", occurrence: 5 },
   ].flatMap((site) =>
-    ([23, "cleanup-failure", "cancel"] as const).map((code) => ({ ...site, code })),
+    ([23, "cleanup-failure", "cancel"] as const).map((code) => Object.assign({}, site, { code })),
   ),
 )(
   "generated publisher verify_publication $code at $match is terminal",
@@ -1239,7 +1174,9 @@ posixIt.each([
     expect(report.fetches).toHaveLength(fetches);
     expect(report.githubOutput).toBe("");
     expect(report.githubSummary).toBe("");
-    if (diagnostic) expect(report.output).toContain(diagnostic);
+    if (diagnostic) {
+      expect(report.output).toContain(diagnostic);
+    }
   },
   55_000,
 );

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -132,6 +132,7 @@ function evaluateWorkflowExpression(
     ref?: string;
     resolveTargetOutputs?: Record<string, string>;
     releaseGate?: boolean;
+    releaseScope?: string;
     repository: string;
     runCheck?: boolean;
     runnerBackend?: "" | "blacksmith" | "github" | "hybrid";
@@ -142,6 +143,7 @@ function evaluateWorkflowExpression(
     targetContextRef?: string;
     targetRef?: string;
     workflowSha?: string;
+    workflowToken?: string;
   },
 ) {
   if (typeof expression !== "string") {
@@ -174,6 +176,7 @@ function evaluateWorkflowExpression(
       ref: context.ref ?? "refs/heads/main",
       run_attempt: context.runAttempt,
       workflow_sha: context.workflowSha,
+      token: context.workflowToken,
       event:
         context.headRepository || context.eventName === "pull_request"
           ? {
@@ -188,6 +191,7 @@ function evaluateWorkflowExpression(
     inputs: {
       dispatch_id: context.dispatchId ?? "",
       release_gate: context.releaseGate ?? false,
+      release_scope: context.releaseScope ?? "full",
       target_context_ref: context.targetContextRef ?? "",
       target_ref: context.targetRef ?? "",
     },
@@ -592,29 +596,64 @@ function runCiManifestFixture(options: {
       writeFileSync(path.join(trustedReleasePolicy, name), readFileSync(`scripts/lib/${name}`));
     }
     const fixtureBin = path.join(root, "bin");
+    let correctionBaseSha = "";
     if (options.remoteTagRefs) {
       mkdirSync(fixtureBin);
-      writeFileSync(path.join(root, "ci-git-owner.py"), readFileSync(`${gitOwner}/owner.py`));
-      const gitFixture = path.join(root, "git.mjs");
+      const ghFixture = path.join(root, "gh.mjs");
       writeFileSync(
-        gitFixture,
+        ghFixture,
         `
-        const [directoryFlag, directory, command, tags, remote, ...requested] = process.argv.slice(2);
-        if (directoryFlag !== "-C" || !directory || command !== "ls-remote" || tags !== "--tags" || remote !== "https://github.com/openclaw/openclaw.git") {
-          throw new Error("Expected the owned canonical release tag query");
+        const [command, endpoint, queryFlag, query] = process.argv.slice(2);
+        const baseRef = ${JSON.stringify(`refs/tags/v${options.packageVersion}`)};
+        if (process.env.GH_TOKEN !== "test-token" || command !== "api" ||
+            endpoint !== "repos/openclaw/openclaw/commits/" + encodeURIComponent(baseRef) ||
+            queryFlag !== "--jq" || query !== ".sha") {
+          throw new Error("Expected authenticated, fully qualified correction base lookup");
         }
         const refs = ${JSON.stringify(options.remoteTagRefs)};
-        for (const ref of requested) {
-          if (refs[ref]) process.stdout.write(refs[ref] + "\\t" + ref + "\\n");
-        }
+        if (!refs[baseRef]) throw new Error("gh: Not Found (HTTP 404)");
+        process.stdout.write((refs[baseRef + "^{}"] ?? refs[baseRef]) + "\\n");
       `,
       );
-      const executable = path.join(fixtureBin, "git");
-      writeFileSync(
-        executable,
-        `#!/bin/sh\nexec ${quoteShell(process.execPath)} ${quoteShell(gitFixture)} "$@"\n`,
+      writeExecutable(path.join(fixtureBin, "gh"), [
+        "#!/bin/sh",
+        `exec ${quoteShell(process.execPath)} ${quoteShell(ghFixture)} "$@"`,
+      ]);
+      writeExecutable(path.join(fixtureBin, "git"), [
+        "#!/bin/sh",
+        "echo 'Anonymous Git transport is unavailable' >&2",
+        "exit 128",
+      ]);
+      const correctionStep = expectDefined(
+        readCiWorkflow().jobs.preflight.steps.find(
+          (step: WorkflowStep) => step.name === "Resolve release correction base",
+        ),
+        "trusted correction base producer",
       );
-      chmodSync(executable, 0o755);
+      const correctionOutput = path.join(root, "correction.out");
+      writeFileSync(correctionOutput, "");
+      const correction = runWorkflowShellScript(correctionStep.run, {
+        cwd: root,
+        env: {
+          PATH: `${fixtureBin}${path.delimiter}${process.env.PATH ?? ""}`,
+          GH_TOKEN: correctionStep.env?.GH_TOKEN === "${{ github.token }}" ? "test-token" : "",
+          GITHUB_REPOSITORY: "openclaw/openclaw",
+          GITHUB_OUTPUT: correctionOutput,
+          TARGET_CONTEXT_REF:
+            options.scopeEnv?.OPENCLAW_CI_TARGET_CONTEXT_TARGET === "true"
+              ? options.scopeEnv.OPENCLAW_CI_TARGET_CONTEXT_REF
+              : options.scopeEnv?.OPENCLAW_CI_HISTORICAL_TARGET_TAG,
+        },
+      });
+      if (correction.status !== 0) {
+        return {
+          output: `${correction.stdout}${correction.stderr}`,
+          outputs: {} as Record<string, string>,
+          status: correction.status,
+          summary: "",
+        };
+      }
+      correctionBaseSha = readWorkflowOutputs(correctionOutput).sha ?? "";
     }
     if (options.historicalReader) {
       const reader = path.join(root, "src/audit/message-delivery-progress-store.test.ts");
@@ -630,6 +669,8 @@ function runCiManifestFixture(options: {
       cwd: root,
       env: {
         ...process.env,
+        GH_TOKEN: "",
+        GITHUB_TOKEN: "",
         GITHUB_OUTPUT: outputPath,
         GITHUB_STEP_SUMMARY: summaryPath,
         RUNNER_TEMP: root,
@@ -638,6 +679,7 @@ function runCiManifestFixture(options: {
           : process.env.PATH,
         OPENCLAW_CI_CHANGED_PATHS_JSON: JSON.stringify(options.changedPaths ?? null),
         OPENCLAW_CI_CHECKOUT_REVISION: "a".repeat(40),
+        OPENCLAW_CI_CORRECTION_BASE_SHA: correctionBaseSha,
         OPENCLAW_CI_DOCS_CHANGED: "true",
         OPENCLAW_CI_DOCS_ONLY: "false",
         OPENCLAW_CI_EVENT_NAME: options.eventName ?? "workflow_dispatch",
@@ -746,15 +788,20 @@ function runRunnerProfileFixture(options: {
   }
 }
 
-function runTargetContextValidation(
-  targetContextRef: string,
-  targetRef: string,
-  comparisonStatus = "ahead",
-) {
+function runCiReleaseRefValidation(options: {
+  kind?: "context" | "historical" | "candidate";
+  ref: string;
+  targetSha: string;
+  resolvedSha?: string;
+  comparisonStatus?: string;
+  apiError?: "ref" | "comparison";
+}) {
   const root = tempDirs.make("openclaw-ci-target-context-");
   const outputPath = path.join(root, "github-output");
   const binPath = path.join(root, "bin");
-  const branchSha = "b".repeat(40);
+  const resolvedSha = options.resolvedSha ?? "b".repeat(40);
+  const kind = options.kind ?? "context";
+  const ref = `refs/${kind === "historical" ? "tags" : "heads"}/${options.ref}`;
   mkdirSync(binPath);
   writeFileSync(
     path.join(root, "ci-git-owner.py"),
@@ -765,12 +812,13 @@ function runTargetContextValidation(
     path.join(binPath, "git"),
     `#!/usr/bin/env bash
 set -euo pipefail
-[[ "$1" == "-C" ]]; shift 2
-if [[ "$1" == "ls-remote" && "$2" == "--heads" && "$3" == "origin" ]]; then
-  printf '%s\\t%s\\n' "$MOCK_BRANCH_SHA" "$4"
-  exit 0
+if [[ "$1" == "-C" ]]; then shift 2; fi
+if [[ "$*" == "remote get-url origin" ]]; then
+  printf '%s\\n' 'https://github.com/openclaw/openclaw.git'
+else
+  echo 'fatal: could not read Username for https://github.com: terminal prompts disabled' >&2
+  exit 128
 fi
-exit 2
 `,
     "utf8",
   );
@@ -778,20 +826,37 @@ exit 2
     path.join(binPath, "gh"),
     `#!/usr/bin/env bash
 set -euo pipefail
-[[ "$1" == "api" ]]
-[[ "$2" == "repos/openclaw/openclaw/compare/${targetRef}...${branchSha}" ]]
-[[ "$3" == "--jq" && "$4" == ".status" ]]
-printf '%s\\n' "$MOCK_COMPARE_STATUS"
+[[ "\${GH_TOKEN:-}" == "test-token" ]] || exit 4
+[[ "$1" == "api" ]] || exit 64
+shift
+if [[ "$1" == "--method" && "$2" == "GET" ]]; then shift 2; fi
+[[ "$#" == 3 && "$2" == "--jq" ]] || exit 64
+case "$1" in
+  "$MOCK_REF_ENDPOINT") kind=ref; value="$MOCK_REF_SHA"; query=.sha ;;
+  "$MOCK_COMPARE_ENDPOINT") kind=comparison; value="$MOCK_COMPARE_STATUS"; query=.status ;;
+  *) echo "Unexpected GitHub API endpoint: $1" >&2; exit 64 ;;
+esac
+[[ "$3" == "$query" ]] || exit 64
+if [[ "$MOCK_API_ERROR" == "$kind" ]]; then
+  echo 'gh: Service Unavailable (HTTP 503)' >&2
+  exit 1
+fi
+printf '%s\\n' "$value"
 `,
     "utf8",
   );
   chmodSync(path.join(binPath, "git"), 0o755);
   chmodSync(path.join(binPath, "gh"), 0o755);
+  const stepName = {
+    context: "Validate target context",
+    historical: "Validate historical release target",
+    candidate: "Validate release candidate target",
+  }[kind];
   const step = expectDefined(
     readCiWorkflow().jobs.preflight.steps.find(
-      (candidate: WorkflowStep) => candidate.name === "Validate target context",
+      (candidate: WorkflowStep) => candidate.name === stepName,
     ),
-    "target context validation step",
+    stepName,
   );
   const run = spawnSync(
     "bash",
@@ -800,14 +865,21 @@ printf '%s\\n' "$MOCK_COMPARE_STATUS"
       encoding: "utf8",
       env: {
         ...process.env,
+        GH_TOKEN: step.env?.GH_TOKEN === "${{ github.token }}" ? "test-token" : "",
         GITHUB_REPOSITORY: "openclaw/openclaw",
         GITHUB_OUTPUT: outputPath,
-        MOCK_BRANCH_SHA: branchSha,
-        MOCK_COMPARE_STATUS: comparisonStatus,
+        MOCK_REF_ENDPOINT: `repos/openclaw/openclaw/commits/${encodeURIComponent(ref)}`,
+        MOCK_REF_SHA: resolvedSha,
+        MOCK_COMPARE_ENDPOINT: `repos/openclaw/openclaw/compare/${options.targetSha}...${resolvedSha}`,
+        MOCK_COMPARE_STATUS: options.comparisonStatus ?? "ahead",
+        MOCK_API_ERROR: options.apiError ?? "",
         RUNNER_TEMP: root,
         PATH: `${binPath}:${process.env.PATH ?? ""}`,
-        TARGET_CONTEXT_REF: targetContextRef,
-        TARGET_REF: targetRef,
+        TARGET_CONTEXT_REF: options.ref,
+        TARGET_REF: options.targetSha,
+        EXPECTED_SHA: options.targetSha,
+        HISTORICAL_TARGET_TAG: options.ref,
+        RELEASE_CANDIDATE_REF: options.ref,
       },
     },
   );
@@ -835,22 +907,14 @@ function runCandidateTrustClassification(options: {
   const binPath = path.join(root, "bin");
   const defaultRevision = options.defaultRevision ?? "b".repeat(40);
   mkdirSync(binPath);
-  writeFileSync(
-    path.join(root, "ci-git-owner.py"),
-    readFileSync(".github/actions/git-owner/owner.py"),
-  );
   writeFileSync(outputPath, "", "utf8");
-  writeFileSync(
-    path.join(binPath, "git"),
-    `#!/usr/bin/env bash
-set -euo pipefail
-[[ "$1" == "-C" ]]; shift 2
-[[ "$1" == "ls-remote" && "$2" == "origin" && "$3" == "refs/heads/main" ]]
-printf '%s\\trefs/heads/main\\n' "$MOCK_DEFAULT_SHA"
-`,
-    "utf8",
-  );
-  chmodSync(path.join(binPath, "git"), 0o755);
+  for (const command of ["git", "gh"]) {
+    writeExecutable(path.join(binPath, command), [
+      "#!/bin/sh",
+      "echo 'Cache trust must consume the resolved default SHA without another lookup' >&2",
+      "exit 128",
+    ]);
+  }
   const step = expectDefined(
     readCiWorkflow().jobs.preflight.steps.find(
       (candidate: WorkflowStep) => candidate.name === "Classify candidate cache trust",
@@ -863,12 +927,11 @@ printf '%s\\trefs/heads/main\\n' "$MOCK_DEFAULT_SHA"
     env: {
       ...process.env,
       CHECKOUT_REVISION: options.checkoutRevision,
-      DEFAULT_BRANCH: "main",
+      DEFAULT_SHA: defaultRevision,
       GITHUB_EVENT_NAME: options.eventName,
       GITHUB_OUTPUT: outputPath,
       GITHUB_REF: options.ref ?? "",
       HISTORICAL_TARGET: String(options.historicalTarget ?? false),
-      MOCK_DEFAULT_SHA: defaultRevision,
       RUNNER_TEMP: root,
       PATH: `${binPath}:${process.env.PATH ?? ""}`,
       RELEASE_CANDIDATE_TARGET: String(options.releaseCandidateTarget ?? false),
@@ -1218,7 +1281,13 @@ function runGit(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
 }
 
-function runPushDiffBaseFixture(options: { commitCount: 1 | 2 | 3; eventBaseSha: string }) {
+function runDiffBaseFixture(options: {
+  commitCount: 1 | 2 | 3;
+  eventBaseSha: string;
+  defaultBranch?: string;
+  manual?: boolean;
+  apiError?: "ref" | "comparison";
+}) {
   const root = tempDirs.make("openclaw-ci-diff-base-");
   runGit(root, ["init", "-q", "-b", "main"]);
   runGit(root, ["config", "commit.gpgsign", "false"]);
@@ -1239,17 +1308,57 @@ function runPushDiffBaseFixture(options: { commitCount: 1 | 2 | 3; eventBaseSha:
   const diffBaseStep = readCiWorkflow().jobs.preflight.steps.find(
     (step: WorkflowStep) => step.name === "Resolve exact diff base",
   );
+  const defaultBranch = options.defaultBranch ?? "main";
+  const fixtureEnv: NodeJS.ProcessEnv = {};
+  if (options.manual) {
+    const bin = path.join(root, "bin");
+    mkdirSync(bin);
+    writeFileSync(
+      path.join(root, "ci-git-owner.py"),
+      readFileSync(".github/actions/git-owner/owner.py"),
+    );
+    writeExecutable(path.join(bin, "git"), [
+      "#!/bin/sh",
+      'if [ "$1" = -C ]; then shift 2; fi',
+      `[ "$*" = 'rev-parse HEAD' ] || { echo 'Anonymous Git transport is unavailable' >&2; exit 128; }`,
+      `printf '%s\\n' '${headSha}'`,
+    ]);
+    writeExecutable(path.join(bin, "gh"), [
+      "#!/bin/sh",
+      '[ "$GH_TOKEN" = test-token ] || exit 4',
+      '[ "$1" = api ] || exit 64',
+      "shift",
+      'if [ "$1" = --method ]; then [ "$2" = GET ] || exit 64; shift 2; fi',
+      'case "$*" in',
+      `  'repos/openclaw/openclaw/commits/${encodeURIComponent(`refs/heads/${defaultBranch}`)} --jq .sha') kind=ref ;;`,
+      `  'repos/openclaw/openclaw/compare/${parentSha}...${headSha} --jq .merge_base_commit.sha') kind=comparison ;;`,
+      "  *) exit 64 ;;",
+      "esac",
+      'if [ "$MOCK_API_ERROR" = "$kind" ]; then echo "gh: Service Unavailable (HTTP 503)" >&2; exit 1; fi',
+      `printf '%s\\n' '${parentSha}'`,
+    ]);
+    fixtureEnv.PATH = `${bin}${path.delimiter}${process.env.PATH ?? ""}`;
+    fixtureEnv.GH_TOKEN = evaluateWorkflowExpression(diffBaseStep.env.GH_TOKEN, {
+      eventName: "workflow_dispatch",
+      repository: "openclaw/openclaw",
+      runAttempt: 1,
+      workflowToken: "test-token",
+    });
+    fixtureEnv.RUNNER_TEMP = root;
+    fixtureEnv.MOCK_API_ERROR = options.apiError ?? "";
+  }
   const run = runWorkflowShellScript(diffBaseStep.run, {
     cwd: root,
     env: {
       ...process.env,
-      DEFAULT_BRANCH: "main",
+      DEFAULT_BRANCH: defaultBranch,
       EVENT_BASE_SHA: eventBaseSha,
-      GITHUB_EVENT_NAME: "push",
+      GITHUB_EVENT_NAME: options.manual ? "workflow_dispatch" : "push",
       GITHUB_OUTPUT: outputPath,
       GITHUB_REPOSITORY: "openclaw/openclaw",
       PULL_REQUEST_NUMBER: "",
       RELEASE_GATE: "false",
+      ...fixtureEnv,
     },
   });
   const rawOutputs = readFileSync(outputPath, "utf8").trim();
@@ -3574,12 +3683,6 @@ NODE
       type: "string",
     });
     expect(step.if).toBe("inputs.target_context_ref != ''");
-    expect(step.run).toContain("--git 0 ls-remote --heads origin");
-    expect(step.run).toContain(
-      'gh api "repos/${GITHUB_REPOSITORY}/compare/${TARGET_REF}...${branch_sha}"',
-    );
-    expect(step.run).toContain('"$comparison_status" != "ahead"');
-    expect(step.run).toContain('"$comparison_status" != "identical"');
 
     for (const contextRef of [
       "release/2026.8.1",
@@ -3587,7 +3690,12 @@ NODE
       "extended-stable/2026.8.33",
     ]) {
       for (const comparisonStatus of ["ahead", "identical"]) {
-        const result = runTargetContextValidation(contextRef, targetSha, comparisonStatus);
+        const result = runCiReleaseRefValidation({
+          ref: contextRef,
+          targetSha,
+          resolvedSha: comparisonStatus === "identical" ? targetSha : "b".repeat(40),
+          comparisonStatus,
+        });
         expect(result.status, `${contextRef}: ${result.output}`).toBe(0);
         expect(result.outputs.eligible).toBe("true");
       }
@@ -3600,7 +3708,7 @@ NODE
       "release/2026.8",
       "refs/heads/release/2026.8.1",
     ]) {
-      const result = runTargetContextValidation(contextRef, targetSha);
+      const result = runCiReleaseRefValidation({ ref: contextRef, targetSha });
       expect(result.status, contextRef).toBe(1);
       expect(result.output).toContain(
         "target_context_ref must be a canonical OpenClaw release branch.",
@@ -3608,7 +3716,7 @@ NODE
     }
 
     for (const targetRef of ["main", "a".repeat(39)]) {
-      const result = runTargetContextValidation("release/2026.8.1", targetRef);
+      const result = runCiReleaseRefValidation({ ref: "release/2026.8.1", targetSha: targetRef });
       expect(result.status, targetRef).toBe(1);
       expect(result.output).toContain(
         "target_context_ref requires target_ref to be a full commit SHA.",
@@ -3616,12 +3724,141 @@ NODE
     }
 
     for (const comparisonStatus of ["behind", "diverged"]) {
-      const result = runTargetContextValidation("release/2026.8.1", targetSha, comparisonStatus);
+      const result = runCiReleaseRefValidation({
+        ref: "release/2026.8.1",
+        targetSha,
+        comparisonStatus,
+      });
       expect(result.status, comparisonStatus).toBe(1);
       expect(result.output).toContain(
         "target_ref must be the declared release branch head or one of its ancestors.",
       );
     }
+  });
+
+  it.each([
+    { kind: "historical", ref: "v2026.8.1" },
+    { kind: "historical", ref: "v2026.8.1-beta.2" },
+    { kind: "historical", ref: "v2026.8.1-1" },
+    { kind: "candidate", ref: "release/2026.8.1" },
+    { kind: "candidate", ref: "release/2026.8.1-1" },
+    { kind: "candidate", ref: "extended-stable/2026.8.33" },
+  ] as const)("binds authenticated $kind ref $ref to its exact commit", (identity) => {
+    const targetSha = "a".repeat(40);
+    const accepted = runCiReleaseRefValidation({ ...identity, targetSha, resolvedSha: targetSha });
+    expect(accepted.status, accepted.output).toBe(0);
+    expect(accepted.outputs.eligible).toBe("true");
+
+    const mismatched = runCiReleaseRefValidation({ ...identity, targetSha });
+    expect(mismatched.status).not.toBe(0);
+    expect(mismatched.output).toContain(`does not resolve to ${targetSha}`);
+    expect(mismatched.outputs).not.toHaveProperty("eligible");
+  });
+
+  it.each([
+    { kind: "context", ref: "release/2026.8.1", apiError: "ref" },
+    { kind: "context", ref: "release/2026.8.1", apiError: "comparison" },
+    { kind: "historical", ref: "v2026.8.1", apiError: "ref" },
+    { kind: "candidate", ref: "release/2026.8.1", apiError: "ref" },
+  ] as const)("rejects unavailable authenticated $kind $apiError evidence", (identity) => {
+    const result = runCiReleaseRefValidation({ ...identity, targetSha: "a".repeat(40) });
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("HTTP 503");
+    expect(result.outputs).not.toHaveProperty("eligible");
+  });
+
+  it.each([
+    { kind: "historical", ref: "refs/heads/v2026.8.1" },
+    { kind: "historical", ref: "release/2026.8.1" },
+    { kind: "candidate", ref: "refs/tags/release/2026.8.1" },
+    { kind: "candidate", ref: "v2026.8.1" },
+  ] as const)("rejects wrong-namespace $kind ref $ref before remote admission", (identity) => {
+    const result = runCiReleaseRefValidation({ ...identity, targetSha: "a".repeat(40) });
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("must be a canonical OpenClaw release");
+    expect(result.outputs).not.toHaveProperty("eligible");
+  });
+
+  it("resolves trusted correction evidence before candidate scope code can run", () => {
+    const root = tempDirs.make("openclaw-ci-correction-order-");
+    const trusted = path.join(root, ".ci-harness/scripts/lib");
+    const eventsPath = path.join(root, "events");
+    const outputPath = path.join(root, "output");
+    const bin = path.join(root, "bin");
+    mkdirSync(trusted, { recursive: true });
+    mkdirSync(path.join(root, "scripts"));
+    mkdirSync(bin);
+    writeFileSync(eventsPath, "");
+    writeFileSync(outputPath, "");
+    writeFileSync(path.join(root, "package.json"), JSON.stringify({ version: "2026.9.1" }));
+    for (const name of ["release-context.mjs", "release-version.mjs"]) {
+      writeFileSync(path.join(trusted, name), readFileSync(`scripts/lib/${name}`));
+    }
+    writeFileSync(
+      path.join(trusted, "release-context-original.mjs"),
+      readFileSync("scripts/lib/release-context.mjs"),
+    );
+    const poisonedHelper = `
+      import { appendFileSync } from 'node:fs';
+      if (process.env.GH_TOKEN) appendFileSync(${JSON.stringify(eventsPath)}, 'token-exposed\\n');
+      export { resolveReleaseContextIdentity } from './release-context-original.mjs';
+    `;
+    writeFileSync(
+      path.join(root, "scripts/ci-changed-scope.mjs"),
+      `import { appendFileSync, writeFileSync } from 'node:fs';
+       appendFileSync(${JSON.stringify(eventsPath)}, 'candidate\\n');
+       writeFileSync(${JSON.stringify(path.join(trusted, "release-context.mjs"))}, ${JSON.stringify(poisonedHelper)});`,
+    );
+    writeExecutable(path.join(bin, "gh"), [
+      "#!/bin/sh",
+      '[ "$GH_TOKEN" = test-token ] || exit 4',
+      `[ "$*" = 'api repos/openclaw/openclaw/commits/refs%2Ftags%2Fv2026.9.1 --jq .sha' ] || exit 64`,
+      `printf 'lookup\\n' >> ${quoteShell(eventsPath)}`,
+      `printf '%s\\n' '${"a".repeat(40)}'`,
+    ]);
+    const context = {
+      eventName: "workflow_dispatch" as const,
+      releaseGate: true,
+      releaseScope: "npm-stable",
+      repository: "openclaw/openclaw",
+      runAttempt: 1,
+      targetContextRef: "release/2026.9.1-1",
+      workflowToken: "test-token",
+      steps: {
+        diff_base: { outputs: { sha: "b".repeat(40), head_sha: "a".repeat(40) } },
+        target_context_target: { outputs: { eligible: "true" } },
+      },
+    };
+    const steps = readCiWorkflow().jobs.preflight.steps.filter((step: WorkflowStep) =>
+      ["Resolve release correction base", "Detect changed scopes"].includes(step.name ?? ""),
+    );
+    expect(steps).toHaveLength(2);
+    for (const step of steps) {
+      const evaluate = (expression: string) => evaluateWorkflowExpression(expression, context);
+      expect(evaluate(`\${{ ${step.if} }}`), step.name).toBe(true);
+      const run = runWorkflowShellScript(
+        step.run.replace(/\$\{\{[\s\S]*?\}\}/gu, (expression: string) =>
+          String(evaluate(expression)),
+        ),
+        {
+          cwd: root,
+          env: {
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+            GITHUB_REPOSITORY: context.repository,
+            GITHUB_OUTPUT: outputPath,
+            ...Object.fromEntries(
+              Object.entries(step.env ?? {}).map(([name, value]) => [
+                name,
+                String(evaluate(String(value))),
+              ]),
+            ),
+          },
+        },
+      );
+      expect(run.status, `${step.name}: ${run.stdout}${run.stderr}`).toBe(0);
+    }
+    expect(readFileSync(eventsPath, "utf8").trim().split("\n")).toEqual(["lookup", "candidate"]);
+    expect(readWorkflowOutputs(outputPath).sha).toBe("a".repeat(40));
   });
 
   it("pins Swift 6.3 workflow jobs to Xcode 26.6-capable runners", () => {
@@ -7664,7 +7901,7 @@ server.listen(0, "127.0.0.1", () => {
     });
     expect(trustStep.env).toMatchObject({
       CHECKOUT_REVISION: "${{ steps.checkout_ref.outputs.sha }}",
-      DEFAULT_BRANCH: "${{ github.event.repository.default_branch }}",
+      DEFAULT_SHA: "${{ steps.diff_base.outputs.default_sha }}",
       TARGET_REF: "${{ inputs.target_ref }}",
       WORKFLOW_REVISION: "${{ github.workflow_sha }}",
     });
@@ -7673,7 +7910,7 @@ server.listen(0, "127.0.0.1", () => {
     expect(trustStep.run).toContain("cache_write_allowed=false");
     expect(trustStep.run).toContain('elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]');
     expect(trustStep.run).toContain('"$RELEASE_GATE" == "true"');
-    expect(trustStep.run).toContain('"$CHECKOUT_REVISION" == "$default_sha"');
+    expect(trustStep.run).toContain('"$CHECKOUT_REVISION" == "$DEFAULT_SHA"');
     expect(trustStep.run).toContain('"$CHECKOUT_REVISION" == "$WORKFLOW_REVISION"');
     expect(trustStep.run).toContain("cache_write_allowed=true");
 
@@ -8845,21 +9082,55 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     },
   );
 
+  it.each(["main", "trunk/release"])(
+    "resolves manual diff and cache bases from authenticated %s when anonymous Git is unavailable",
+    (defaultBranch) => {
+      const result = runDiffBaseFixture({
+        commitCount: 2,
+        eventBaseSha: "",
+        defaultBranch,
+        manual: true,
+      });
+      expect(result.status, result.output).toBe(0);
+      expect(result.outputs).toEqual({
+        default_sha: result.parentSha,
+        sha: result.parentSha,
+        head_sha: result.headSha,
+      });
+      expect(result.emittedBaseIsCommit).toBe(true);
+    },
+  );
+
+  it.each(["ref", "comparison"] as const)(
+    "rejects unavailable authenticated manual diff-base %s evidence",
+    (apiError) => {
+      const result = runDiffBaseFixture({
+        commitCount: 2,
+        eventBaseSha: "",
+        manual: true,
+        apiError,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.output).toContain("HTTP 503");
+      expect(result.outputs).not.toHaveProperty("sha");
+    },
+  );
+
   it("rejects ambiguous zero-before main pushes and preserves concrete bases", () => {
     const zeroSha = "0".repeat(40);
-    const threeCommit = runPushDiffBaseFixture({ commitCount: 3, eventBaseSha: zeroSha });
+    const threeCommit = runDiffBaseFixture({ commitCount: 3, eventBaseSha: zeroSha });
     expect(threeCommit.status, threeCommit.output).toBe(1);
     expect(threeCommit.output).toContain(AMBIGUOUS_MAIN_PUSH_DIAGNOSTIC);
     expect(threeCommit.outputs).not.toHaveProperty("sha");
     expect(threeCommit.emittedBaseIsCommit).toBe(false);
 
-    const rootCommit = runPushDiffBaseFixture({ commitCount: 1, eventBaseSha: zeroSha });
+    const rootCommit = runDiffBaseFixture({ commitCount: 1, eventBaseSha: zeroSha });
     expect(rootCommit.status, rootCommit.output).toBe(1);
     expect(rootCommit.output).toContain(AMBIGUOUS_MAIN_PUSH_DIAGNOSTIC);
     expect(rootCommit.outputs).not.toHaveProperty("sha");
     expect(rootCommit.emittedBaseIsCommit).toBe(false);
 
-    const concreteBase = runPushDiffBaseFixture({
+    const concreteBase = runDiffBaseFixture({
       commitCount: 3,
       eventBaseSha: "parent",
     });
@@ -9758,35 +10029,46 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     { label: "base branch correction", context: "branch", direct: "a", accepted: true },
     { label: "base tag correction", context: "tag", direct: "a", accepted: true },
     { label: "annotated base tag", context: "tag", direct: "c", peeled: "a", accepted: true },
+    {
+      label: "versioned correction without a base lookup",
+      context: "branch",
+      packageVersion: "2026.9.1-1",
+      accepted: true,
+    },
     { label: "missing base tag", context: "branch", accepted: false },
     { label: "different base source", context: "branch", direct: "c", accepted: false },
     { label: "different peeled source", context: "tag", direct: "a", peeled: "c", accepted: false },
-  ])("binds npm stable $label to the exact source", ({ context, direct, peeled, accepted }) => {
-    const result = runCiManifestFixture({
-      bundledPlanner: true,
-      packageVersion: "2026.9.1",
-      remoteTagRefs: {
-        ...(direct ? { "refs/tags/v2026.9.1": direct.repeat(40) } : {}),
-        ...(peeled ? { "refs/tags/v2026.9.1^{}": peeled.repeat(40) } : {}),
-      },
-      scopeEnv: {
-        OPENCLAW_CI_RELEASE_SCOPE: "npm-stable",
-        OPENCLAW_CI_TARGET_REF: "a".repeat(40),
-        OPENCLAW_CI_TARGET_CONTEXT_REF: context === "branch" ? "release/2026.9.1-1" : "",
-        OPENCLAW_CI_TARGET_CONTEXT_TARGET: String(context === "branch"),
-        OPENCLAW_CI_HISTORICAL_TARGET_TAG: context === "tag" ? "v2026.9.1-1" : "",
-        OPENCLAW_CI_HISTORICAL_TARGET: String(context === "tag"),
-      },
-    });
-    expect(result.status === 0, result.output).toBe(accepted);
-    if (accepted) {
-      expect(result.outputs.run_ios_build).toBe("false");
-      expect(result.outputs.run_node).toBe("true");
-    } else {
-      expect(result.output).toContain("correction base v2026.9.1 does not resolve");
-      expect(result.outputs).not.toHaveProperty("run_node");
-    }
-  });
+  ])(
+    "binds npm stable $label to the exact source",
+    ({ context, direct, peeled, packageVersion, accepted }) => {
+      const result = runCiManifestFixture({
+        bundledPlanner: true,
+        packageVersion: packageVersion ?? "2026.9.1",
+        remoteTagRefs: {
+          ...(direct ? { "refs/tags/v2026.9.1": direct.repeat(40) } : {}),
+          ...(peeled ? { "refs/tags/v2026.9.1^{}": peeled.repeat(40) } : {}),
+        },
+        scopeEnv: {
+          OPENCLAW_CI_RELEASE_SCOPE: "npm-stable",
+          OPENCLAW_CI_TARGET_REF: "a".repeat(40),
+          OPENCLAW_CI_TARGET_CONTEXT_REF: context === "branch" ? "release/2026.9.1-1" : "",
+          OPENCLAW_CI_TARGET_CONTEXT_TARGET: String(context === "branch"),
+          OPENCLAW_CI_HISTORICAL_TARGET_TAG: context === "tag" ? "v2026.9.1-1" : "",
+          OPENCLAW_CI_HISTORICAL_TARGET: String(context === "tag"),
+        },
+      });
+      expect(result.status === 0, result.output).toBe(accepted);
+      if (accepted) {
+        expect(result.outputs.run_ios_build).toBe("false");
+        expect(result.outputs.run_node).toBe("true");
+      } else {
+        expect(result.output).toContain(
+          direct ? "correction base v2026.9.1 does not resolve" : "HTTP 404",
+        );
+        expect(result.outputs).not.toHaveProperty("run_node");
+      }
+    },
+  );
 
   it.each<{ label: string } & Omit<Parameters<typeof runCiManifestFixture>[0], "bundledPlanner">>([
     { label: "stable target", packageVersion: "2026.9.1" },
@@ -10285,13 +10567,11 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       (step: { name?: string }) => step.name === "Validate historical release target",
     );
     expect(historicalTargetStep.if).toBe("inputs.historical_target_tag != ''");
-    expect(historicalTargetStep.run).toContain('--git 0 ls-remote --tags "$remote"');
     expect(historicalTargetStep.run).toContain('[[ "$tag_sha" != "$EXPECTED_SHA" ]]');
     const releaseCandidateStep = workflow.jobs.preflight.steps.find(
       (step: { name?: string }) => step.name === "Validate release candidate target",
     );
     expect(releaseCandidateStep.if).toBe("inputs.release_candidate_ref != ''");
-    expect(releaseCandidateStep.run).toContain('--git 0 ls-remote --heads "$remote"');
     expect(releaseCandidateStep.run).toContain('[[ "$branch_sha" != "$EXPECTED_SHA" ]]');
     expect(workflow.jobs["qa-smoke-ci-profile"].if).toBe(
       "needs.preflight.outputs.run_qa_smoke_ci == 'true'",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3779,7 +3779,8 @@ NODE
     expect(result.outputs).not.toHaveProperty("eligible");
   });
 
-  it("resolves trusted correction evidence before candidate scope code can run", () => {
+  // Native Windows Node cannot execute this fixture's POSIX gh child shim.
+  it.skipIf(process.platform === "win32")("protects correction credentials", () => {
     const root = tempDirs.make("openclaw-ci-correction-order-");
     const trusted = path.join(root, ".ci-harness/scripts/lib");
     const eventsPath = path.join(root, "events");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -837,11 +837,12 @@ case "$1" in
   *) echo "Unexpected GitHub API endpoint: $1" >&2; exit 64 ;;
 esac
 [[ "$3" == "$query" ]] || exit 64
+# Valid-looking partial output must not authorize a failed request.
+printf '%s\\n' "$value"
 if [[ "$MOCK_API_ERROR" == "$kind" ]]; then
   echo 'gh: Service Unavailable (HTTP 503)' >&2
   exit 1
 fi
-printf '%s\\n' "$value"
 `,
     "utf8",
   );
@@ -1334,8 +1335,8 @@ function runDiffBaseFixture(options: {
       `  'repos/openclaw/openclaw/compare/${parentSha}...${headSha} --jq .merge_base_commit.sha') kind=comparison ;;`,
       "  *) exit 64 ;;",
       "esac",
-      'if [ "$MOCK_API_ERROR" = "$kind" ]; then echo "gh: Service Unavailable (HTTP 503)" >&2; exit 1; fi',
       `printf '%s\\n' '${parentSha}'`,
+      'if [ "$MOCK_API_ERROR" = "$kind" ]; then echo "gh: Service Unavailable (HTTP 503)" >&2; exit 1; fi',
     ]);
     fixtureEnv.PATH = `${bin}${path.delimiter}${process.env.PATH ?? ""}`;
     fixtureEnv.GH_TOKEN = evaluateWorkflowExpression(diffBaseStep.env.GH_TOKEN, {
@@ -3761,7 +3762,12 @@ NODE
     { kind: "historical", ref: "v2026.8.1", apiError: "ref" },
     { kind: "candidate", ref: "release/2026.8.1", apiError: "ref" },
   ] as const)("rejects unavailable authenticated $kind $apiError evidence", (identity) => {
-    const result = runCiReleaseRefValidation({ ...identity, targetSha: "a".repeat(40) });
+    const targetSha = "a".repeat(40);
+    const result = runCiReleaseRefValidation({
+      ...identity,
+      targetSha,
+      resolvedSha: targetSha,
+    });
     expect(result.status).not.toBe(0);
     expect(result.output).toContain("HTTP 503");
     expect(result.outputs).not.toHaveProperty("eligible");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -507,6 +507,8 @@ function runFullReleaseInputValidation(
 }
 
 function runFullReleaseTargetIdentityValidation(params: {
+  anonymousGitUnavailable?: boolean;
+  apiError?: "base" | "context" | "comparison";
   baseTagSha?: string;
   comparisonStatus?: string;
   remoteSha?: string;
@@ -536,6 +538,10 @@ function runFullReleaseTargetIdentityValidation(params: {
     `#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$*" == *"ls-remote"* ]]; then
+  if [[ "$FAKE_ANONYMOUS_GIT_UNAVAILABLE" == "true" ]]; then
+    echo 'fatal: could not read Username for https://github.com: terminal prompts disabled' >&2
+    exit 128
+  fi
   ref="\${!#}"
   if [[ "$ref" == "refs/tags/v$FAKE_PACKAGE_VERSION" || "$ref" == "refs/tags/v$FAKE_PACKAGE_VERSION^{}" ]]; then
     printf '%s\\t%s\\n' "$FAKE_BASE_SHA" "$ref"
@@ -552,11 +558,23 @@ exit 64
     resolve(fakeBin, "gh"),
     `#!/usr/bin/env bash
 set -euo pipefail
-if [[ "$*" == *"api repos/"*"/compare/"* ]]; then
-  printf '%s\\n' "$FAKE_COMPARISON_STATUS"
-  exit 0
+[[ "\${GH_TOKEN:-}" == "test-token" ]] || exit 4
+[[ "$1" == "api" ]] || exit 64
+shift
+if [[ "$1" == "--method" && "$2" == "GET" ]]; then shift 2; fi
+[[ "$#" == 3 && "$2" == "--jq" ]] || exit 64
+case "$1" in
+  "$FAKE_BASE_ENDPOINT") kind=base; value="$FAKE_BASE_SHA"; query=.sha ;;
+  "$FAKE_CONTEXT_ENDPOINT") kind=context; value="$FAKE_REMOTE_SHA"; query=.sha ;;
+  "$FAKE_COMPARISON_ENDPOINT") kind=comparison; value="$FAKE_COMPARISON_STATUS"; query=.status ;;
+  *) echo "Unexpected GitHub API endpoint: $1" >&2; exit 64 ;;
+esac
+[[ "$3" == "$query" ]] || exit 64
+if [[ "$FAKE_API_ERROR" == "$kind" ]]; then
+  echo 'gh: Service Unavailable (HTTP 503)' >&2
+  exit 1
 fi
-exit 64
+printf '%s\\n' "$value"
 `,
     { mode: 0o755 },
   );
@@ -567,17 +585,25 @@ exit 64
   const remoteRef = normalizedContextRef.startsWith("v")
     ? `refs/tags/${normalizedContextRef}`
     : `refs/heads/${normalizedContextRef}`;
+  const remoteSha = params.remoteSha ?? targetSha;
+  const commitEndpoint = (ref: string) =>
+    `repos/openclaw/openclaw/commits/${encodeURIComponent(ref)}`;
   const outputPath = resolve(workdir, "output");
   const result = spawnSync("bash", ["-c", step.run ?? ""], {
     cwd: workdir,
     encoding: "utf8",
     env: {
+      FAKE_ANONYMOUS_GIT_UNAVAILABLE: String(params.anonymousGitUnavailable ?? false),
+      FAKE_API_ERROR: params.apiError ?? "",
+      FAKE_BASE_ENDPOINT: commitEndpoint(`refs/tags/v${params.version}`),
+      FAKE_CONTEXT_ENDPOINT: commitEndpoint(remoteRef),
+      FAKE_COMPARISON_ENDPOINT: `repos/openclaw/openclaw/compare/${targetSha}...${remoteSha}`,
       FAKE_COMPARISON_STATUS: params.comparisonStatus ?? "ahead",
       FAKE_REMOTE_REF: remoteRef,
-      FAKE_REMOTE_SHA: params.remoteSha ?? targetSha,
+      FAKE_REMOTE_SHA: remoteSha,
       FAKE_BASE_SHA: params.baseTagSha ?? params.remoteSha ?? targetSha,
       FAKE_PACKAGE_VERSION: params.version,
-      GH_TOKEN: "test-token",
+      GH_TOKEN: step.env?.GH_TOKEN === "${{ github.token }}" ? "test-token" : "",
       GITHUB_REPOSITORY: "openclaw/openclaw",
       GITHUB_OUTPUT: outputPath,
       PATH: `${fakeBin}:${process.env.PATH}`,
@@ -6760,6 +6786,67 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(rejected.status).toBe(1);
     expect(rejected.stderr).toContain("expected 2026.8.1 or a beta prerelease");
   });
+
+  it.each([
+    {
+      label: "branch head",
+      targetContextRef: "refs/heads/release/2026.8.1",
+      comparisonStatus: "identical",
+    },
+    {
+      label: "branch ancestor",
+      targetContextRef: "release/2026.8.1",
+      remoteSha: "b".repeat(40),
+      comparisonStatus: "ahead",
+    },
+    { label: "release tag commit", targetContextRef: "refs/tags/v2026.8.1" },
+    { label: "correction base commit", targetContextRef: "release/2026.8.1-1" },
+  ])("validates $label through authenticated refs when anonymous Git is unavailable", (entry) => {
+    const { label: _label, ...identity } = entry;
+    const result = runFullReleaseTargetIdentityValidation({
+      ...identity,
+      anonymousGitUnavailable: true,
+      targetRef: "a".repeat(40),
+      version: "2026.8.1",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.output).toContain("ci_release_scope=full\n");
+  });
+
+  it.each([
+    { apiError: "context", targetContextRef: "release/2026.8.1" },
+    { apiError: "comparison", targetContextRef: "release/2026.8.1" },
+    { apiError: "base", targetContextRef: "release/2026.8.1-1" },
+  ] as const)("fails closed on a $apiError API error", ({ apiError, targetContextRef }) => {
+    const result = runFullReleaseTargetIdentityValidation({
+      anonymousGitUnavailable: true,
+      apiError,
+      targetContextRef,
+      targetRef: "a".repeat(40),
+      version: "2026.8.1",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("HTTP 503");
+    expect(result.output).not.toContain("ci_release_scope=");
+  });
+
+  it.each(["refs/tags/release/2026.8.1", "refs/heads/v2026.8.1", "release-ci/2026.8.1"])(
+    "rejects the wrong release context namespace %s before ref lookup",
+    (targetContextRef) => {
+      const result = runFullReleaseTargetIdentityValidation({
+        anonymousGitUnavailable: true,
+        targetContextRef,
+        targetRef: "a".repeat(40),
+        version: "2026.8.1",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("must be a canonical OpenClaw release branch or tag");
+      expect(result.output).not.toContain("ci_release_scope=");
+    },
+  );
 
   it("validates an exact-SHA extended-stable successor against its canonical branch", () => {
     const result = runFullReleaseTargetIdentityValidation({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release validation stops while checking an exact source against its release branch or tag, even after authenticated checkout succeeds. The [first failed run](https://github.com/openclaw/openclaw/actions/runs/33641220334) and [fresh recovery run](https://github.com/openclaw/openclaw/actions/runs/33642158134) both failed in `Validate release inputs` with `could not read Username`, before product validation could start.

## Why This Change Was Made

`GH_TOKEN` authenticates `gh`, not a subsequent `git ls-remote`. Checkout intentionally uses `persist-credentials: false`, so those later Git reads were anonymous. Use the existing step-scoped token with GitHub's [commit API](https://docs.github.com/en/rest/commits/commits#get-a-commit), passing fully qualified, encoded branch/tag refs. Keep exact tag/correction-source equality and branch ancestry checks unchanged; resolve the default branch once and carry that verified SHA into cache classification.

Correction-base lookup now runs in a trusted producer before candidate-owned scope or manifest code. Only its SHA crosses into the manifest step; its token does not. The producer reads candidate package JSON as data and imports only trusted workflow helpers. This credential boundary accounts for the net **+12 workflow LOC**; there is no application-runtime growth. Workflow inputs, permissions, runner/timeout settings, and public CLI/config interfaces are unchanged. No credentials are persisted, no retries are added, and acceptance guards are not weakened.

## User Impact

Release operators can validate the declared immutable source through authenticated ref reads without relying on anonymous Git transport. Wrong sources and missing refs still fail closed. The runs do not establish why the Git endpoint issued an authentication challenge; this change removes that anonymous dependency rather than claiming a provider outage or credential rotation fixed it.

## Evidence

The original anonymous-Git failure is reproduced by existing executable workflow fixtures. New coverage checks fully qualified identities, annotated tags, API failures, default-branch fact reuse, and the trusted-producer ordering before candidate execution. The earlier local ordering attempt failed an executable synthetic-token test; the final ordering passes. Production orchestration is +51/-39 (net +12); tests and test support are +588/-262 (net +326).

Fifteen read-only live cases passed against five v2 workflow-step bodies executed without harness edits: CI and FRV accepted `release/2026.9.1` at `d3deb20a`, its `bdf508b8` ancestor, and annotated `v2026.8.2` peeled to `0965053f`. CI rejected wrong heads, wrong tag targets, unrelated ancestry, and missing refs. Missing refs returned HTTP422 with no eligibility output. Direct correction-producer and ordinary-version no-op cases also passed.

The Git-network negative control failed as intended; no workflow step used Git network access. Source/helper hashes and the index remained unchanged. This used the existing configured `gh` credential, not an Actions token; existing shared-cache routing was preserved. It is direct-step API proof, **not** a full Actions/FRV run or release-artifact proof. The complete two-file owner suite passed **669 tests with 2 skips** on the same frozen workflow bytes (`node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/package-acceptance-workflow.test.ts`). The changed-code gate and canonical workflow checks passed. The first workflow-check attempt used host Python 3.9, which cannot install the pinned pre-commit 4.6.2 (Python >=3.10); rerunning with the task's Python 3.12 passed without source changes. Independent Codex autoreview returned scoped-clean at its P0 threshold; it is not a full Actions or release qualification. The final test-only follow-up applies the existing Win32 POSIX-child-shim boundary to the credential-ordering fixture, preserving all assertions and Linux/macOS execution. Its complete owner-suite rerun again passed 669 tests with two existing skips on Node24.19/pnpm12.1; no Windows runtime proof is claimed. An initial follow-up run failed an existing partial-clone fixture because its launcher injected `GIT_NO_LAZY_FETCH=1`; removing only that operator-added setting restored the normal fixture contract and the full suite passed without a source change. The follow-up also passed the changed-code gate and a separate scoped P0 Codex review. That earlier CI run is retained below; the new exact-head run remains required before landing.

Named follow-up: audit named-ref authentication in `scripts/github/resolve-openclaw-ref.sh` while preserving its arbitrary `OPENCLAW_REF_REMOTE` contract. That generic resolver is unchanged here; the canonical full-SHA release path does not perform its remote lookup.

## CI closeout at 95eea60c

The [hosted recovery of the earlier head](https://github.com/openclaw/openclaw/actions/runs/33648156541/attempts/2) finished with 159 successful jobs, two test failures, the correctly failing aggregate, and ten skips. Security checks passed on an actual GitHub-hosted runner; the original screenshot was a dependency-fetch failure before the private-key scan, not a detected private key. No failed required check is waived.

This follow-up changes test/support code only. Obsolete Git-transport fixtures are consolidated under the authenticated API owner, retaining process-writer drain, identity, ancestry, error and credential-boundary coverage. The complete owner suite passed on real Linux: **479 tests, no failures or skips**. The final mechanical style delta also passed its affected cases and the combined changed-code gate.

The built SQLite lifecycle check exposed a separate helper defect: a successful CLI command returned 305,748 bytes of valid plugin JSON, but a 256-KiB diagnostic-tail helper corrupted it before the lifecycle test began. The helper now uses the existing bounded command-capture owner: complete stdout up to its existing 16-MiB budget, explicit overflow failure, bounded stderr diagnostics, exact environment isolation, and process-tree timeout cleanup. Two real-child regressions failed before the repair and passed after it. The six helper/process suites passed **123 tests with one existing Windows-only skip**, and the full unchanged built-CLI SQLite lifecycle passed. There is no application-runtime change.

The follow-up passed the combined changed-code gate and independent scoped P0 Codex autoreview with no findings. [Exact-head CI for 95eea60c](https://github.com/openclaw/openclaw/actions/runs/33662645011) is pending and must pass before native prepare/merge. These local proofs do not replace final release validation or publication verification.
