### PR TITLE
fix(slack): keep prototype-named emoji shortcodes intact

### DIFF
--- a/extensions/slack/src/actions.reactions.test.ts
+++ b/extensions/slack/src/actions.reactions.test.ts
@@ -132,6 +132,10 @@ describe("reactSlackMessage emoji normalization", () => {
     { input: "🦄", expected: "🦄" },
     { input: "👍🏽", expected: "thumbsup::skin-tone-4" },
     { input: "⚠️", expected: "warning" },
+    // Custom emoji names that collide with Object.prototype keys are still just names.
+    { input: ":constructor:", expected: "constructor" },
+    { input: "__proto__", expected: "__proto__" },
+    { input: ":toString:", expected: "toString" },
   ])("normalizes $input to $expected", async ({ input, expected }) => {
     const client = createClient();
 

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -120,39 +120,39 @@ const SLACK_EMOJI_SKIN_TONE_BY_MODIFIER = new Map([
 // Unicode glyph. Models keep passing the glyph because the `emoji` param
 // reads as "an emoji"; map the common ones so the reaction is not silently
 // dropped. Unknown glyphs still pass through unchanged (no regression).
-const SLACK_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
-  "✅": "white_check_mark",
-  "❌": "x",
-  "👍": "thumbsup",
-  "👎": "thumbsdown",
-  "🎉": "tada",
-  "❤": "heart",
-  "😄": "smile",
-  "😂": "joy",
-  "🚀": "rocket",
-  "👀": "eyes",
-  "🙏": "pray",
-  "🔥": "fire",
-  "💯": "100",
-  "⚠": "warning",
-  "➕": "heavy_plus_sign",
-  "➖": "heavy_minus_sign",
-  "🤔": "thinking_face",
-  "👨‍💻": "male-technologist",
-  "👨💻": "male-technologist",
-  "👩‍💻": "female-technologist",
-  "⚡": "zap",
-  "🌐": "globe_with_meridians",
-  "😱": "scream",
-  "🥱": "yawning_face",
-  "😨": "fearful",
-  "⏳": "hourglass_flowing_sand",
-  "✍": "writing_hand",
-  "🗜": "compression",
-  "🧠": "brain",
-  "🛠": "hammer_and_wrench",
-  "💻": "computer",
-};
+const SLACK_EMOJI_SHORTNAME_BY_GLYPH = new Map([
+  ["✅", "white_check_mark"],
+  ["❌", "x"],
+  ["👍", "thumbsup"],
+  ["👎", "thumbsdown"],
+  ["🎉", "tada"],
+  ["❤", "heart"],
+  ["😄", "smile"],
+  ["😂", "joy"],
+  ["🚀", "rocket"],
+  ["👀", "eyes"],
+  ["🙏", "pray"],
+  ["🔥", "fire"],
+  ["💯", "100"],
+  ["⚠", "warning"],
+  ["➕", "heavy_plus_sign"],
+  ["➖", "heavy_minus_sign"],
+  ["🤔", "thinking_face"],
+  ["👨‍💻", "male-technologist"],
+  ["👨💻", "male-technologist"],
+  ["👩‍💻", "female-technologist"],
+  ["⚡", "zap"],
+  ["🌐", "globe_with_meridians"],
+  ["😱", "scream"],
+  ["🥱", "yawning_face"],
+  ["😨", "fearful"],
+  ["⏳", "hourglass_flowing_sand"],
+  ["✍", "writing_hand"],
+  ["🗜", "compression"],
+  ["🧠", "brain"],
+  ["🛠", "hammer_and_wrench"],
+  ["💻", "computer"],
+]);
 
 function normalizeSlackEmojiName(raw: string): string {
   const trimmed = raw.trim();
@@ -164,7 +164,7 @@ function normalizeSlackEmojiName(raw: string): string {
   const glyphKey = withoutColons
     .replace(SLACK_EMOJI_SKIN_TONE_MODIFIER_RE, "")
     .replace(SLACK_EMOJI_VARIATION_SELECTOR_RE, "");
-  const shortname = SLACK_EMOJI_SHORTNAME_BY_GLYPH[glyphKey];
+  const shortname = SLACK_EMOJI_SHORTNAME_BY_GLYPH.get(glyphKey);
   const skinTone = modifier ? SLACK_EMOJI_SKIN_TONE_BY_MODIFIER.get(modifier) : undefined;
   if (!shortname || !skinTone) {
     return shortname ?? withoutColons;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reacting with a Slack custom emoji whose name collides with an `Object.prototype` key sent a broken `reactions.add` request. `constructor`, `__proto__` and `toString` are legal custom emoji names. Reacting with `constructor` or `toString` put the inherited function in the `name` field, which the WebClient's form encoder drops, so the request reached Slack with no `name` at all. `__proto__` went out as `name={}`.

## Why This Change Was Made

`normalizeSlackEmojiName` indexed the glyph-to-shortcode object literal with the caller-supplied name, so an inherited value came back instead of `undefined`. Inherited values are truthy, so the `shortname ?? withoutColons` pass-through never ran. The table is now a `Map`, matching `SLACK_EMOJI_SKIN_TONE_BY_MODIFIER` twelve lines above it, which never had the problem. It is module-private with one reader.

## User Impact

Custom emoji named `constructor`, `toString` and the rest react like any other name. Known glyphs and skin-tone variants are unchanged.

## Evidence

Rebased onto `b6a4d0dad43`. The two red checks on the previous head were `security-fast` and the `ci-gate` that mirrors it, both the "Audit production dependencies" advisory timeout.

Real behavior through `reactSlackMessage` and `removeSlackReaction` in `extensions/slack/src/actions.ts`, with the real `@slack/web-api` 8.0.0 `WebClient` from the extension's own `getSlackWriteClient` factory. The only stand-in is the Slack host: `slackApiUrl` points at a local `http.createServer` that records each raw request and answers `{"ok":true}`. Nothing in the reaction path is mocked. Same script, same inputs, run once with `actions.ts` from `b6a4d0dad43` and once on this branch.

Before, `actions.ts` from main:

```console
$ git checkout upstream/main -- extensions/slack/src/actions.ts
$ node --import ./scripts/tsx.mjs EVIDENCE/reaction-trace.mts
slack stand-in listening at http://127.0.0.1:45607/api/

reactSlackMessage("constructor")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100

reactSlackMessage(":toString:")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100

reactSlackMessage("__proto__")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=%7B%7D

reactSlackMessage("thumbsup")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=thumbsup

reactSlackMessage("👍")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=thumbsup

reactSlackMessage("👍🏽")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=thumbsup%3A%3Askin-tone-4

removeSlackReaction("constructor")
  POST /api/reactions.remove [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100
```

After, this branch (`git checkout HEAD -- extensions/slack/src/actions.ts` first):

```console
$ node --import ./scripts/tsx.mjs EVIDENCE/reaction-trace.mts
slack stand-in listening at http://127.0.0.1:35981/api/

reactSlackMessage("constructor")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=constructor

reactSlackMessage(":toString:")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=toString

reactSlackMessage("__proto__")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=__proto__

reactSlackMessage("thumbsup")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=thumbsup

reactSlackMessage("👍")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=thumbsup

reactSlackMessage("👍🏽")
  POST /api/reactions.add [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=thumbsup%3A%3Askin-tone-4

removeSlackReaction("constructor")
  POST /api/reactions.remove [application/x-www-form-urlencoded] channel=C0TRACE&timestamp=1700000000.000100&name=constructor
```

The three prototype-named rows are the only lines that differ. `thumbsup`, the `👍` glyph and the `👍🏽` skin-tone variant encode the same way before and after.

The script, unchanged between the two runs:

```ts
import http from "node:http";
import { reactSlackMessage, removeSlackReaction } from "../extensions/slack/src/actions.ts";
import { getSlackWriteClient } from "../extensions/slack/src/client.ts";

const requests: string[] = [];
const server = http.createServer((req, res) => {
  let body = "";
  req.on("data", (chunk) => (body += chunk));
  req.on("end", () => {
    requests.push(`${req.method} ${req.url} [${req.headers["content-type"]}] ${body}`);
    res.setHeader("content-type", "application/json");
    res.end(JSON.stringify({ ok: true }));
  });
});
await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
const port = (server.address() as { port: number }).port;
const slackApiUrl = `http://127.0.0.1:${port}/api/`;
console.log(`slack stand-in listening at ${slackApiUrl}`);

const client = getSlackWriteClient("xoxb-trace-token", { slackApiUrl });
const channel = "C0TRACE";
const timestamp = "1700000000.000100";

const inputs = ["constructor", ":toString:", "__proto__", "thumbsup", "👍", "👍🏽"];
for (const emoji of inputs) {
  const before = requests.length;
  try {
    await reactSlackMessage(channel, timestamp, emoji, { client });
  } catch (err) {
    requests.push(`ERROR ${String(err)}`);
  }
  console.log(`\nreactSlackMessage(${JSON.stringify(emoji)})`);
  for (const line of requests.slice(before)) console.log(`  ${line}`);
}
{
  const before = requests.length;
  await removeSlackReaction(channel, timestamp, "constructor", { client });
  console.log(`\nremoveSlackReaction("constructor")`);
  for (const line of requests.slice(before)) console.log(`  ${line}`);
}
server.close();
```

The three rows added to `actions.reactions.test.ts` pin the same thing at the client boundary. On the old lookup `:toString:` reached the client as `name: [Function toString]` and all three fail; they pass on the Map.

```console
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts \
    extensions/slack/src/actions.reactions.test.ts
 ✓ normalizes ':constructor:' to 'constructor'
 ✓ normalizes '__proto__' to '__proto__'
 ✓ normalizes ':toString:' to 'toString'

 Test Files  1 passed (1)
      Tests  16 passed (16)
```

`actions.reactions-limit.test.ts` next to it also passes, 16 of 16.

No live Slack workspace behind this. I don't have one where I can add a custom emoji named `constructor`, so the Slack host above is a local stand-in and the request it recorded is the proof, not a workspace response. The mock-gateway harness goes through qa-channel and never reaches the Slack reaction path.

AI-assisted. Fully tested.
