### PR TITLE
perf(msteams): reduce reply formatting work

### DIFF
--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -1,5 +1,7 @@
+import crypto, { randomUUID } from "node:crypto";
+import { syncBuiltinESMExports } from "node:module";
 import MarkdownIt from "markdown-it";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { formatMSTeamsMarkdown } from "./format.js";
 
 describe("formatMSTeamsMarkdown", () => {
@@ -306,10 +308,32 @@ describe("formatMSTeamsMarkdown", () => {
     expect(formatMSTeamsMarkdown(table, "off")).toBe(table);
   });
 
-  it("does not restore forged placeholders decoded from character references", () => {
-    const source = "&#xE000;msteamsformat&#xE001;m0&#xE002; @[Alice](29:abc)";
-    const output = formatMSTeamsMarkdown(source, "off");
-    expect(output.match(/@\[Alice\]/gu)).toHaveLength(1);
-    expect(output).toContain("&#xE000;msteamsformat&#xE001;m0&#xE002;");
+  const collisionUuid = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const authoredToken = `\u{E000}msteamsformat-${collisionUuid}\u{E001}m0\u{E002}`;
+  const encodedToken = `&#xE000;msteamsformat-${collisionUuid}&#xE001;m0&#xE002;`;
+  const mention = "@[Alice](29:abc)";
+  it.each([
+    ["literal text", `${authoredToken} ${mention}`, `${authoredToken} ${mention}`],
+    [
+      "adjacent bold spans",
+      `**\u{E000}msteams**__format-${collisionUuid}\u{E001}m0\u{E002}__ ${mention}`,
+      `**${authoredToken}** ${mention}`,
+    ],
+    ["character references", `${encodedToken} ${mention}`, `${encodedToken} ${mention}`],
+  ])("preserves forged placeholders in %s", (_name, source, expected) => {
+    const entropy = vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
+      throw new Error("unexpected extra entropy request");
+    });
+    entropy
+      .mockReturnValueOnce(collisionUuid)
+      .mockReturnValueOnce("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+    try {
+      syncBuiltinESMExports();
+      expect(randomUUID).toBe(entropy);
+      expect(formatMSTeamsMarkdown(source, "off")).toBe(expected);
+    } finally {
+      entropy.mockRestore();
+      syncBuiltinESMExports();
+    }
   });
 });

--- a/extensions/msteams/src/format.ts
+++ b/extensions/msteams/src/format.ts
@@ -35,7 +35,10 @@ const MSTEAMS_MARKERS = {
 } as const;
 
 function createTokenPrefix(text: string, label: string): string {
-  const normalized = markdownToIR(text, { autolink: false, linkify: false }).text;
+  // With these parser options, the leading marker must be literal or entity-decoded.
+  const normalized = /[\u{E000}&]/u.test(text)
+    ? markdownToIR(text, { autolink: false, linkify: false }).text
+    : "";
   let prefix: string;
   do {
     prefix = `\u{E000}${label}-${randomUUID()}\u{E001}`;

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -549,12 +549,6 @@ describe("sendMessageMSTeams", () => {
   });
 });
 
-describe("MSTeams continueConversation failure handling", () => {
-  beforeEach(() => {
-    mockState.resolveMSTeamsSendContext.mockReset();
-  });
-});
-
 describe("editMessageMSTeams", () => {
   beforeEach(() => {
     mockState.resolveMSTeamsSendContext.mockReset();


### PR DESCRIPTION
## What Problem This Solves

The Teams plugin spends unnecessary CPU preparing ordinary Markdown replies, including replies that need text chunking. This adds local work before messages reach the transport.

## Why This Change Was Made

The formatter parses Markdown once to detect collisions with its private token prefix, then parses the protected text for rendering. The prefix starts with U+E000. With the collision parser's autolink and linkify options disabled, normalized text can contain that character only when the source contains it literally or contains an ampersand introducing an entity. Keep the original collision parse for both categories and skip it otherwise. UUID generation, collision retries, later parsing, chunking and media order stay unchanged; no cache or configuration is added.

Strengthen collision tests with complete expected output for literal, adjacent-bold-span and character-reference inputs. The adjacent-bold case protects a collision introduced by normalization. Also remove an abandoned empty send-test suite that made Vitest fail without containing any assertions. Production changes are **4 added / 1 removed (+3)**; tests are **30 added / 12 removed (+18)**. The small production guard removes an entire unnecessary parse without duplicating parser policy.

## User Impact

Less local CPU work for Teams text formatting and block/proactive reply rendering, with identical output. Successful personal preview streams may consume text before this renderer, so this does not claim every Teams stream or edit benefits. Transport, provider latency and whole-turn latency are outside the measurement.

## Evidence

Node 26.8.1, real exported formatter and reply renderer, real default plugin runtime and canonical Markdown chunker. Fresh processes ran baseline, candidate, candidate, baseline. Each of six rows had one first call, two warm calls and 16 measured calls per process: **456 timing calls**, with all outputs and timing vectors retained.

| Complete operation | Forward median | Reverse median | Improvement |
| --- | --- | --- | --- |
| Format a roughly 4 KB Markdown reply | 1.508 → 1.090 ms | 1.470 → 1.031 ms | 27.7% / 29.8% |
| Render that reply into text chunks | 1.588 → 1.079 ms | 1.589 → 1.101 ms | 32.0% / 30.7% |

Both primary cases passed the predeclared 3% improvement requirement in both orders. All protected cases passed: short replies, entity-heavy text, literal private markers/malformed delimiters, and three mixed-media payloads. Adverse values remain in the record: entity and marker controls were 1.62% and 1.24% slower in the reverse median; the marker control's reverse p95 rose 11.04%, and four first calls were slower. Firsts and tails are descriptive, not filtered or used to select runs. No memory improvement is claimed.

Before timing, **40 ordinary correctness calls plus 12 controlled collision calls** passed complete authored output, property/alias, input-mutation and UUID-restoration checks. Normal UUID generation was untouched during every timing call. The full family completed in 466.8 seconds within its frozen resource limits; all observed native processes/groups closed and source bytes were restored.

The three complete formatter/messenger/send test files passed **118 cases before and 118 after**. Full changed-file formatting, type, lint and boundary checks passed. Managed Codex review found no actionable P0–P2 defects. The initial canonical run's empty-suite failure is retained; removing that empty shell deleted no assertion.

No live Teams transport was exercised: no task-owned Teams test tenant/channel is available. Native proof covers the actual formatting/rendering flow without network calls or provider credentials. CI and final independent measurement audit are checked before landing.

### Final verification

CI [33646387968](https://github.com/openclaw/openclaw/actions/runs/33646387968) passed on `457613b8c34437537d5740c4ec463c794f6ca3e0` (attempt 3). Earlier attempts stopped on runner disconnects and a pnpm binary-download failure before the affected plugin checks; the targeted retries passed without source changes. The fresh managed Codex review found no actionable P0–P2 issues. An independent numeric audit recomputed all 508 native calls, including all retained adverse samples, and confirmed the fixed gates.

The latest ClawSweeper follow-up requested completion of review after exact-head checks. Those checks and the maintainer-authorized review workflow are complete. The owner-local +3 production lines are accepted because the guard removes a complete parse while preserving both raw and normalized collision checks. No live Teams tenant or network-latency improvement is claimed.
