### PR TITLE
perf(process): stop parsing preserved output after its quota fills

### DIFF
--- a/src/process/exec-output.ts
+++ b/src/process/exec-output.ts
@@ -156,10 +156,6 @@ export function finalizeCapturedOutput(
   return trimmed;
 }
 
-function trimPreservedPendingLine(value: string, maxBytes: number): string {
-  return truncateUtf8Suffix(value, maxBytes);
-}
-
 export function appendPreservedOutputLines(params: {
   capture: CapturedOutputBuffers;
   chunk: Buffer | string;
@@ -168,26 +164,23 @@ export function appendPreservedOutputLines(params: {
   maxPreservedOutputLines: number;
   maxPendingLineBytes: number;
 }): void {
-  if (!params.preserveOutputLine || params.maxPreservedOutputLines <= 0) {
+  const { capture, maxPreservedOutputLines, preserveOutputLine } = params;
+  // The command's quota is fixed, so later text cannot reach a full preserved result.
+  if (!preserveOutputLine || capture.preservedLines.length >= maxPreservedOutputLines) {
     return;
   }
-  const text = Buffer.isBuffer(params.chunk)
-    ? params.capture.decoder.write(params.chunk)
-    : params.chunk;
+  const text = Buffer.isBuffer(params.chunk) ? capture.decoder.write(params.chunk) : params.chunk;
   if (!text) {
     return;
   }
-  const lines = (params.capture.pendingLine + text).split(/\r?\n/);
-  params.capture.pendingLine = trimPreservedPendingLine(
-    lines.pop() ?? "",
-    params.maxPendingLineBytes,
-  );
+  const lines = (capture.pendingLine + text).split(/\r?\n/);
+  capture.pendingLine = truncateUtf8Suffix(lines.pop() ?? "", params.maxPendingLineBytes);
   for (const line of lines) {
     if (
-      params.capture.preservedLines.length < params.maxPreservedOutputLines &&
-      params.preserveOutputLine(line, params.stream)
+      capture.preservedLines.length < maxPreservedOutputLines &&
+      preserveOutputLine(line, params.stream)
     ) {
-      params.capture.preservedLines.push(line);
+      capture.preservedLines.push(line);
     }
   }
 }
@@ -199,19 +192,20 @@ export function flushPreservedOutputLine(params: {
   maxPreservedOutputLines: number;
   maxPendingLineBytes: number;
 }): void {
-  if (!params.preserveOutputLine || params.maxPreservedOutputLines <= 0) {
+  const { capture, maxPreservedOutputLines, preserveOutputLine } = params;
+  if (!preserveOutputLine || maxPreservedOutputLines <= 0) {
     return;
   }
-  const trailing = trimPreservedPendingLine(
-    params.capture.pendingLine + params.capture.decoder.end(),
+  const trailing = truncateUtf8Suffix(
+    capture.pendingLine + capture.decoder.end(),
     params.maxPendingLineBytes,
   );
-  params.capture.pendingLine = "";
+  capture.pendingLine = "";
   if (
     trailing &&
-    params.capture.preservedLines.length < params.maxPreservedOutputLines &&
-    params.preserveOutputLine(trailing, params.stream)
+    capture.preservedLines.length < maxPreservedOutputLines &&
+    preserveOutputLine(trailing, params.stream)
   ) {
-    params.capture.preservedLines.push(trailing);
+    capture.preservedLines.push(trailing);
   }
 }

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -246,56 +246,60 @@ describe("runCommandWithTimeout", () => {
     },
   );
 
-  it("preserves matching output lines even when tail capture truncates them", async () => {
-    const result = await runCommandWithTimeout(
-      [
-        process.execPath,
-        "-e",
+  it.each([
+    [undefined, 2],
+    [0, 0],
+    [-1, 0],
+    [1, 1],
+    [2, 2],
+  ])(
+    "preserves matching output up to quota %s while tail capture continues",
+    async (limit, count) => {
+      const result = await runCommandWithTimeout(
         [
-          "process.stdout.write('Visit https://example.com/device and enter code ABCD-EFGH\\n')",
-          "process.stdout.write('x'.repeat(200))",
-        ].join(";"),
-      ],
-      {
-        timeoutMs: 3_000,
-        maxOutputBytes: 24,
-        preserveOutputLine: (line) => line.includes("enter code"),
-      },
-    );
+          process.execPath,
+          "-e",
+          [
+            "process.stdout.write('Visit https://example.com/device and enter code ABCD-EFGH\\n')",
+            "process.stdout.write('x'.repeat(200) + 'enter code TAIL')",
+          ].join(";"),
+        ],
+        {
+          timeoutMs: 3_000,
+          maxOutputBytes: 24,
+          maxPreservedOutputLines: limit,
+          preserveOutputLine: (line) => line.includes("enter code"),
+        },
+      );
 
-    expect(result.stdout).toBe("x".repeat(24));
-    expect(result.stdoutTruncatedBytes).toBeGreaterThan(0);
-    expect(result.preservedStdoutLines).toEqual([
-      "Visit https://example.com/device and enter code ABCD-EFGH",
-    ]);
-  });
+      const tail = `${"x".repeat(9)}enter code TAIL`;
+      expect(result.stdout).toBe(tail);
+      expect(result.stdoutTruncatedBytes).toBeGreaterThan(0);
+      expect(result.preservedStdoutLines).toEqual(
+        count
+          ? ["Visit https://example.com/device and enter code ABCD-EFGH", tail].slice(0, count)
+          : undefined,
+      );
+    },
+  );
 
-  it("bounds preserved matching output for long lines without newlines", async () => {
+  it.each([
+    ["long unterminated", "x".repeat(10_000), "x".repeat(24)],
+    ["UTF-8 boundary", `😀${"x".repeat(22)}`, "x".repeat(22)],
+  ])("bounds preserved %s line tails", async (_name, input, expected) => {
     const result = await runCommandWithTimeout(
-      [process.execPath, "-e", "process.stdout.write('x'.repeat(10_000))"],
+      [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
       {
+        input,
         timeoutMs: 3_000,
         maxOutputBytes: 24,
         preserveOutputLine: () => true,
       },
     );
 
-    expect(result.stdout).toBe("x".repeat(24));
+    expect(result.stdout).toBe(expected);
     expect(result.stdoutTruncatedBytes).toBeGreaterThan(0);
-    expect(result.preservedStdoutLines).toEqual(["x".repeat(24)]);
-  });
-
-  it("keeps preserved line tails on a UTF-8 boundary", async () => {
-    const result = await runCommandWithTimeout(
-      [process.execPath, "-e", "process.stdout.write('😀' + 'x'.repeat(22))"],
-      {
-        timeoutMs: 3_000,
-        maxOutputBytes: 24,
-        preserveOutputLine: () => true,
-      },
-    );
-
-    expect(result.preservedStdoutLines).toEqual(["x".repeat(22)]);
+    expect(result.preservedStdoutLines).toEqual([expected]);
   });
 
   it("supports independent stdout head and stderr tail caps", async () => {


### PR DESCRIPTION
## What Problem This Solves

Noisy commands continue decoding, splitting and trimming output after their preserved action-line quota is already full. That work cannot add another preserved line, but still allocates text for every later chunk.

## Why This Change Was Made

Stop discarded preparation at the preserved-output owner using the command's existing fixed per-stream quota. Use the canonical UTF-8 suffix helper directly and remove its private wrapper. Raw output capture, truncation accounting, observers, activity timers and final flush retain their existing behavior.

Production: **−6 lines** (+17/−23). Tests: **+4 lines** (+42/−38), consolidating existing fixtures and exercising default, disabled, one-line and two-line quotas.

## User Impact

Less allocation and CPU work while collecting output from commands that have already preserved enough action-critical lines. Command results and limits remain the same.

## Evidence

- Existing real-child command and cron suites: **66 passed, 1 Windows-only skip** across `src/process/exec.test.ts`, `src/cron/command-runner.test.ts` and `src/cron/command-output-summary.test.ts`; the unchanged baseline also passed.
- Actual-owner comparison: **153 cases** retain identical callback traces, preserved lines, UTF-8 tail bytes and truncation counts across stdout/stderr, CRLF/EOF and split multibyte chunks.
- After quota saturation, a 512-chunk/17 MiB workload performs **512 → 0** decoder calls and **17,825,792 → 0** decoded bytes. Seven alternating uninstrumented samples: median **34.509 → 0.0274 ms**. Unsaturated median **36.933 → 37.378 ms**; this small sample does not establish significance.
- Full `node scripts/check-changed.mjs -- src/process/exec-output.ts src/process/exec.test.ts` passed. Independent Codex review through P2 and parent source/caller/dependency review found no actionable issue.

The microbenchmark measures preserved-output work, not whole-command latency, Gateway RSS or retained heap. The runtime proof uses actual child processes; no provider request is needed for this behavior-neutral command-output change.
