### PR TITLE
perf(plugins): return cached values without result wrappers

### DIFF
--- a/src/plugins/plugin-cache-primitives.test.ts
+++ b/src/plugins/plugin-cache-primitives.test.ts
@@ -26,13 +26,13 @@ describe("PluginLruCache", () => {
     expect(cache.get("c")).toBe("charlie");
   });
 
-  it("returns hit state for cached null values", () => {
+  it("distinguishes cached null values from misses", () => {
     const cache = new PluginLruCache<string | null>(2);
 
     cache.set("missing", null);
 
-    expect(cache.getResult("missing")).toEqual({ hit: true, value: null });
-    expect(cache.getResult("unknown")).toEqual({ hit: false });
+    expect(cache.get("missing")).toBeNull();
+    expect(cache.get("unknown")).toBeUndefined();
   });
 });
 

--- a/src/plugins/plugin-cache-primitives.ts
+++ b/src/plugins/plugin-cache-primitives.ts
@@ -3,9 +3,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 
-/** Result shape for cache lookups that need to distinguish a miss from cached `undefined`. */
-type PluginLruCacheResult<T> = { hit: true; value: T } | { hit: false };
-
 /** Small process-local LRU cache for runtime registries and compiled validators. */
 export class PluginLruCache<T> {
   readonly #maxEntries: number;
@@ -33,19 +30,13 @@ export class PluginLruCache<T> {
 
   /** Returns a cached value and refreshes its recency when present. */
   get(cacheKey: string): T | undefined {
-    const cached = this.getResult(cacheKey);
-    return cached.hit ? cached.value : undefined;
-  }
-
-  /** Returns a hit/miss result and promotes hits to the newest LRU position. */
-  getResult(cacheKey: string): PluginLruCacheResult<T> {
     if (!this.#entries.has(cacheKey)) {
-      return { hit: false };
+      return undefined;
     }
     const cached = this.#entries.get(cacheKey) as T;
     this.#entries.delete(cacheKey);
     this.#entries.set(cacheKey, cached);
-    return { hit: true, value: cached };
+    return cached;
   }
 
   /** Stores a value as the newest entry and evicts oldest entries past capacity. */

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -350,9 +350,9 @@ export function resolveProviderRuntimePlugin(
     : !registryState?.key
       ? load()
       : (() => {
-          const cached = defaultProviderRuntimePluginCache.getResult(cacheKey);
-          if (cached.hit) {
-            return cached.value;
+          const cached = defaultProviderRuntimePluginCache.get(cacheKey);
+          if (cached !== undefined) {
+            return cached;
           }
           const loaded = load();
           defaultProviderRuntimePluginCache.set(cacheKey, loaded);


### PR DESCRIPTION
## What Problem This Solves

Plugin cache reads construct a temporary hit/miss object and immediately unwrap it, including registry reuse, compiled schema validation and provider hook lookup.

## Why This Change Was Made

Keep one canonical value-returning LRU lookup and remove the unused result type and wrapper method. The sole direct result-method consumer stores provider objects or `null`, so `undefined` already identifies a miss. Existing recency, capacity and lifecycle invalidation are preserved, including promotion of a stored `undefined` value in the generic cache.

Production: **−9 lines**. Test LOC is unchanged.

## User Impact

Less transient preparation in plugin cache lookups. Provider selection, negative caching and public behavior remain unchanged.

## Evidence

- **136 tests passed** across plugin cache primitives, loader-cache lifecycle, provider runtime and schema validation using the repository test wrapper.
- Full changed checks passed for all three edited files.
- Actual-owner corpus covers null, undefined, false, zero, empty string and object values, recency, eviction, deletion and clear. A warm 500,000-hit workload measured **17.701 → 16.285 ms median** across two processes per revision and five samples per process; this is a small microbenchmark, not a retained-memory or Gateway-speed claim.
- Independent subagent inspection and managed Codex review through P2 found no actionable issue. The old internal method has no remaining callers or SDK export.
