### PR TITLE
fix(feishu): fall back to post mode over table limit

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -1202,6 +1202,77 @@ describe("feishuPlugin actions", () => {
     expect(details.chatId).toBe("oc_group_1");
   });
 
+  it("falls back to text delivery when presentation text exceeds the card table limit", async () => {
+    feishuOutboundSendPayloadMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_fallback",
+      chatId: "oc_group_1",
+    });
+    const sixTables = Array.from(
+      { length: 6 },
+      (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+    ).join("\n\n");
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: sixTables,
+        presentation: {
+          title: "Status",
+          blocks: [{ type: "text", text: "Build completed" }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendPayloadMock).toHaveBeenCalledTimes(1);
+    const payloadArgs = requireRecord(
+      mockCallArg(feishuOutboundSendPayloadMock, 0, 0, "feishuOutbound.sendPayload"),
+      "sendPayload args",
+    );
+    expect(payloadArgs.to).toBe("chat:oc_group_1");
+    expect(payloadArgs.text).toBe(sixTables);
+    const details = resultDetails(result);
+    expect(details.ok).toBe(true);
+    expect(details.messageId).toBe("om_fallback");
+  });
+
+  it("falls back when a presentation text block embeds 6 tables", async () => {
+    feishuOutboundSendPayloadMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_fallback",
+      chatId: "oc_group_1",
+    });
+    const sixTables = Array.from(
+      { length: 6 },
+      (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+    ).join("\n\n");
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        presentation: {
+          title: "Report",
+          blocks: [{ type: "text", text: sixTables }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendPayloadMock).toHaveBeenCalledTimes(1);
+    const details = resultDetails(result);
+    expect(details.ok).toBe(true);
+    expect(details.messageId).toBe("om_fallback");
+  });
+
   it("hides prefixed native-card JSON in oversized presentation fallbacks", async () => {
     feishuOutboundSendPayloadMock.mockResolvedValueOnce({
       channel: "feishu",

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -92,6 +92,7 @@ import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import {
   assertFeishuCardWithinEnvelope,
   buildFeishuPresentationCard,
+  feishuCardWithinTableLimit,
   FEISHU_PRESENTATION_CAPABILITIES,
   isFeishuCardWithinEnvelope,
   resolveFeishuRichReply,
@@ -1261,7 +1262,9 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 })
               : undefined;
             const presentationCard =
-              generatedCard && isFeishuCardWithinEnvelope(generatedCard)
+              generatedCard &&
+              feishuCardWithinTableLimit(generatedCard) &&
+              isFeishuCardWithinEnvelope(generatedCard)
                 ? generatedCard
                 : undefined;
             const presentationFellBack = Boolean(generatedCard && !presentationCard);

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -3682,4 +3682,128 @@ describe("feishuOutbound.sendMedia renderMode", () => {
     expect(sendMessageCall()?.accountId).toBe("main");
   });
 });
+
+describe("feishuOutbound table-limit routing", () => {
+  beforeEach(() => {
+    resetOutboundMocks();
+  });
+
+  function makeTableText(count: number): string {
+    return Array.from({ length: count }, (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`).join(
+      "\n\n",
+    );
+  }
+
+  it("routes 5 markdown tables to structured card when renderMode=auto", async () => {
+    const text = makeTableText(5);
+    await sendText({ cfg: emptyConfig, to: "chat_1", text, accountId: "main" });
+
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to post mode for 6 markdown tables when renderMode=auto", async () => {
+    const text = makeTableText(6);
+    await sendText({ cfg: emptyConfig, to: "chat_1", text, accountId: "main" });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to post mode for 6 tables even with explicit renderMode=card", async () => {
+    const text = makeTableText(6);
+    await sendText({ cfg: cardRenderConfig, to: "chat_1", text, accountId: "main" });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("excludes tables inside code blocks from the table count", async () => {
+    const text = "```\n| a | b |\n| - | - |\n| 1 | 2 |\n```\n\n" + makeTableText(5);
+    await sendText({ cfg: emptyConfig, to: "chat_1", text, accountId: "main" });
+
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to post mode for 6 pipeless GFM tables", async () => {
+    const text = Array.from({ length: 6 }, (_, i) => `a${i} | b${i}\n--- | ---\n1 | 2`).join(
+      "\n\n",
+    );
+    await sendText({ cfg: emptyConfig, to: "chat_1", text, accountId: "main" });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("feishuOutbound presentation card table-limit", () => {
+  beforeEach(() => {
+    resetOutboundMocks();
+  });
+
+  function makeTableText(count: number): string {
+    return Array.from({ length: count }, (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`).join(
+      "\n\n",
+    );
+  }
+
+  function makeActionPresentation(): MessagePresentation {
+    return {
+      title: "Confirm",
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [{ label: "Confirm", action: { type: "command", command: "/ok" } }],
+        },
+      ],
+    };
+  }
+
+  it("refuses the presentation card and falls back to post mode for 6 markdown tables", async () => {
+    const text = makeTableText(6);
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text, presentation: makeActionPresentation() },
+    });
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+    expect(sendMessageCall()?.text).toContain("```");
+  });
+
+  it("still builds the presentation card for 5 markdown tables", async () => {
+    const text = makeTableText(5);
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text, presentation: makeActionPresentation() },
+    });
+
+    expect(sendCardFeishuMock).toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses the card when a presentation text block embeds 6 tables", async () => {
+    const presentation: MessagePresentation = {
+      title: "Report",
+      blocks: [{ type: "text", text: makeTableText(6) }],
+    };
+    await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "",
+      accountId: "main",
+      payload: { text: "", presentation },
+    });
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalled();
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -54,6 +54,7 @@ import {
   renderFeishuPresentationPayload,
   renderFeishuPresentationFallbackText,
   resolveFeishuRichReply,
+  withinCardTableLimit,
 } from "./presentation-card.js";
 import {
   createFeishuPartialReplyDeliveryError,
@@ -320,7 +321,9 @@ async function sendOutboundText(params: {
   // Decide card routing on the original text so card content is never
   // modified by post-md newline normalization. Only the post path below
   // materializes CommonMark soft breaks for Feishu rendering.
-  const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+  const useCard =
+    (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) &&
+    withinCardTableLimit(text);
 
   // Tables need contiguous source rows, so convert them before the parser
   // materializes prose soft breaks for Feishu post rendering.

--- a/extensions/feishu/src/presentation-card.test.ts
+++ b/extensions/feishu/src/presentation-card.test.ts
@@ -1,6 +1,11 @@
 import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { describe, expect, it } from "vitest";
-import { buildFeishuPresentationCard, isFeishuCardWithinEnvelope } from "./presentation-card.js";
+import {
+  buildFeishuPresentationCard,
+  feishuCardWithinTableLimit,
+  isFeishuCardWithinEnvelope,
+  withinCardTableLimit,
+} from "./presentation-card.js";
 
 describe("buildFeishuPresentationCard", () => {
   it("renders table blocks through the portable text fallback", () => {
@@ -45,5 +50,81 @@ describe("isFeishuCardWithinEnvelope", () => {
 
     expect(isFeishuCardWithinEnvelope(buildCard(200))).toBe(true);
     expect(isFeishuCardWithinEnvelope(buildCard(201))).toBe(false);
+  });
+});
+
+describe("withinCardTableLimit (parser-backed table counting)", () => {
+  const pipedTable = "| a | b |\n| - | - |\n| 1 | 2 |";
+  const pipelessTable = "a | b\n--- | ---\n1 | 2";
+  const repeat = (table: string, count: number) =>
+    Array.from({ length: count }, () => table).join("\n\n");
+
+  it("accepts piped and pipe-less GFM tables at the 5-table boundary", () => {
+    expect(withinCardTableLimit(repeat(pipedTable, 5))).toBe(true);
+    expect(withinCardTableLimit(repeat(pipedTable, 6))).toBe(false);
+    expect(withinCardTableLimit(repeat(pipelessTable, 5))).toBe(true);
+    expect(withinCardTableLimit(repeat(pipelessTable, 6))).toBe(false);
+  });
+
+  it("counts alignment-colon delimiters toward the limit", () => {
+    const alignPiped = "| a | b |\n|:--|--:|\n| 1 | 2 |";
+    const alignPipeless = "c | d\n:---: | ---\n3 | 4";
+    expect(withinCardTableLimit(repeat(alignPiped, 6))).toBe(false);
+    expect(withinCardTableLimit(repeat(alignPipeless, 6))).toBe(false);
+    expect(withinCardTableLimit(repeat(alignPiped, 5))).toBe(true);
+  });
+
+  it("does not count tables inside fenced code blocks", () => {
+    expect(withinCardTableLimit("```\n" + repeat(pipedTable, 6) + "\n```")).toBe(true);
+    expect(
+      withinCardTableLimit("```\n" + repeat(pipedTable, 2) + "\n```\n\n" + repeat(pipedTable, 6)),
+    ).toBe(false);
+  });
+
+  it("does not count thematic breaks or plain pipes in prose", () => {
+    expect(withinCardTableLimit("---\n\nhello | world\n\n2024 | 2025")).toBe(true);
+  });
+
+  it("does not treat tables inside an HTML font wrapper as card table components", () => {
+    expect(withinCardTableLimit(`<font color='grey'>${repeat(pipedTable, 6)}</font>`)).toBe(true);
+  });
+});
+
+describe("feishuCardWithinTableLimit", () => {
+  const table = "| a | b |\n| - | - |\n| 1 | 2 |";
+
+  it("sums tables across all markdown elements of the card", () => {
+    const card = {
+      schema: "2.0",
+      body: {
+        elements: [
+          { tag: "markdown", content: `${table}\n\n${table}\n\n${table}` },
+          { tag: "hr" },
+          { tag: "markdown", content: `${table}\n\n${table}\n\n${table}` },
+        ],
+      },
+    };
+    expect(feishuCardWithinTableLimit(card)).toBe(false);
+  });
+
+  it("accepts cards with at most 5 tables across elements", () => {
+    const card = {
+      schema: "2.0",
+      body: {
+        elements: [
+          { tag: "markdown", content: `${table}\n\n${table}\n\n${table}` },
+          { tag: "markdown", content: `${table}\n\n${table}` },
+        ],
+      },
+    };
+    expect(feishuCardWithinTableLimit(card)).toBe(true);
+  });
+
+  it("accepts cards without markdown tables", () => {
+    const card = {
+      schema: "2.0",
+      body: { elements: [{ tag: "markdown", content: "plain | pipes but no table" }] },
+    };
+    expect(feishuCardWithinTableLimit(card)).toBe(true);
   });
 });

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -13,6 +13,7 @@ import {
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { markdownToIRWithMeta } from "openclaw/plugin-sdk/text-chunking";
 import type { OutboundIdentity, ReplyPayload } from "../runtime-api.js";
 import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
@@ -132,6 +133,44 @@ export function assertFeishuCardWithinEnvelope(
   if (!isFeishuCardWithinEnvelope(card)) {
     throw new Error(`${label} exceeds the 30 KB or 200-element API limit.`);
   }
+}
+
+/** Feishu allows at most five table components per static interactive card. */
+const FEISHU_CARD_TABLE_LIMIT = 5;
+
+function countMarkdownTables(text: string): number {
+  return text ? markdownToIRWithMeta(text, { tableMode: "block" }).tables.length : 0;
+}
+
+export function withinCardTableLimit(text: string): boolean {
+  return countMarkdownTables(text) <= FEISHU_CARD_TABLE_LIMIT;
+}
+
+function collectFeishuCardMarkdownTexts(value: unknown, output: string[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectFeishuCardMarkdownTexts(item, output);
+    }
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  if (value.tag === "markdown" && typeof value.content === "string") {
+    output.push(value.content);
+  }
+  for (const child of Object.values(value)) {
+    collectFeishuCardMarkdownTexts(child, output);
+  }
+}
+
+export function feishuCardWithinTableLimit(card: Record<string, unknown>): boolean {
+  const markdownTexts: string[] = [];
+  collectFeishuCardMarkdownTexts(card, markdownTexts);
+  return (
+    markdownTexts.reduce((total, text) => total + countMarkdownTables(text), 0) <=
+    FEISHU_CARD_TABLE_LIMIT
+  );
 }
 
 function resolveFeishuButtonUrl(button: MessagePresentationButton): string | undefined {
@@ -425,8 +464,11 @@ export function buildFeishuPayloadCard(params: {
   }
   if (isNativeCard) {
     assertFeishuCardWithinEnvelope(card, "Feishu native card");
+    return markRenderedFeishuCard(card);
   }
-  return isFeishuCardWithinEnvelope(card) ? markRenderedFeishuCard(card) : undefined;
+  return isFeishuCardWithinEnvelope(card) && feishuCardWithinTableLimit(card)
+    ? markRenderedFeishuCard(card)
+    : undefined;
 }
 
 type FeishuPresentationContext = {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -337,6 +337,12 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   }
 
+  function makeTableText(count: number): string {
+    return Array.from({ length: count }, (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`).join(
+      "\n\n",
+    );
+  }
+
   function setupNonStreamingAutoDispatcher() {
     useNonStreamingAutoAccount();
 
@@ -2169,6 +2175,43 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("keeps an over-limit block in its active streaming card", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: { mode: "partial", block: { enabled: true } },
+      },
+    });
+    const text = makeTableText(6);
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text });
+    const delivery = await options.deliver({ text }, { kind: "block" });
+    await options.onIdle?.();
+    const finalized = await delivery?.finalization;
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(requireStreamingInstance(0).start).toHaveBeenCalledTimes(1);
+    expect(requireStreamingInstance(0).closeWithResult).toHaveBeenCalledOnce();
+    expect(requireStreamingInstance(0).closeWithResult).toHaveBeenCalledWith(text, {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(finalized).toMatchObject({
+      visibleReplySent: true,
+      content: text,
+      messageIds: ["om_stream"],
+    });
+  });
+
   it("preserves previous generation blocks when partial snapshots reset after tools", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -2842,6 +2885,39 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({ text: "second" }),
     );
+  });
+
+  it("uses post fallback for an over-limit final arriving during an unrelated close", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om-post" });
+    const { options } = createDispatcherHarness();
+    const firstDelivery = await options.deliver({ text: "first" }, { kind: "final" });
+    const instance = requireStreamingInstance(0);
+    let resolveClose!: (result: StreamingCloseResult) => void;
+    const closePromise = new Promise<StreamingCloseResult>((resolve) => {
+      resolveClose = resolve;
+    });
+    instance.closeWithResult.mockReturnValueOnce(closePromise);
+    const firstIdle = Promise.resolve(options.onIdle?.());
+    await vi.waitFor(() => expect(instance.closeWithResult).toHaveBeenCalledOnce());
+
+    const text = makeTableText(6);
+    const nextDelivery = await options.deliver({ text }, { kind: "final" });
+    instance.active = false;
+    resolveClose({ visibleReplySent: true, content: "first", messageId: "om-stream" });
+
+    await firstIdle;
+    await expect(firstDelivery?.finalization).resolves.toMatchObject({
+      content: "first",
+      messageIds: ["om-stream"],
+      visibleReplySent: true,
+    });
+    expect(nextDelivery).toMatchObject({
+      content: text,
+      messageIds: ["om-post"],
+      visibleReplySent: true,
+    });
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("reuses a closing card for an identical concurrent final", async () => {
@@ -4422,54 +4498,65 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     }
   });
 
-  it("falls back to post mode when streaming start fails for 6 tables", async () => {
-    const errorMock = vi.fn();
-    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om-post" });
-    const origPush = streamingInstances.push.bind(streamingInstances);
-    streamingInstances.push = (...args: StreamingSessionStub[]) => {
-      const instance = args[0];
-      if (instance) {
-        instance.start = vi
-          .fn()
-          .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
+  it.each([
+    { kind: "final", blockStreamingEnabled: false },
+    { kind: "block", blockStreamingEnabled: true },
+  ] as const)(
+    "falls back to post mode when $kind streaming start fails for 6 tables",
+    async ({ kind, blockStreamingEnabled }) => {
+      if (blockStreamingEnabled) {
+        resolveFeishuAccountMock.mockReturnValue({
+          accountId: "main",
+          appId: "app_id",
+          appSecret: "app_secret",
+          domain: "feishu",
+          config: {
+            renderMode: "auto",
+            streaming: { mode: "partial", block: { enabled: true } },
+          },
+        });
       }
-      return origPush(...args);
-    };
+      const errorMock = vi.fn();
+      sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om-post" });
+      const origPush = streamingInstances.push.bind(streamingInstances);
+      streamingInstances.push = (...args: StreamingSessionStub[]) => {
+        const instance = args[0];
+        if (instance) {
+          instance.start = vi
+            .fn()
+            .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
+        }
+        return origPush(...args);
+      };
 
-    try {
-      const result = createFeishuReplyDispatcher({
-        cfg: {} as never,
-        agentId: "agent",
-        runtime: { log: vi.fn(), error: errorMock } as never,
-        chatId: "oc_chat",
-        sendTarget: "oc_chat",
-      });
-      const options = toTypingDispatcherOptions(result);
-      const text = Array.from(
-        { length: 6 },
-        (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
-      ).join("\n\n");
+      try {
+        const result = createFeishuReplyDispatcher({
+          cfg: {} as never,
+          agentId: "agent",
+          runtime: { log: vi.fn(), error: errorMock } as never,
+          chatId: "oc_chat",
+          sendTarget: "oc_chat",
+        });
+        const options = toTypingDispatcherOptions(result);
+        const text = Array.from(
+          { length: 6 },
+          (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+        ).join("\n\n");
 
-      await options.deliver({ text }, { kind: "final" });
+        await options.deliver({ text }, { kind });
 
-      expect(errorMock.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
-        "streaming start failed",
-      );
-      expect(sendMessageFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
-      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
-    } finally {
-      streamingInstances.push = origPush;
-    }
-  });
+        expect(errorMock.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
+          "streaming start failed",
+        );
+        expect(sendMessageFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+        expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+      } finally {
+        streamingInstances.push = origPush;
+      }
+    },
+  );
 
   describe("table-limit routing", () => {
-    function makeTableText(count: number): string {
-      return Array.from(
-        { length: count },
-        (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
-      ).join("\n\n");
-    }
-
     function setupDispatcher() {
       const result = createFeishuReplyDispatcher({
         cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -4422,6 +4422,46 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     }
   });
 
+  it("falls back to post mode when streaming start fails for 6 tables", async () => {
+    const errorMock = vi.fn();
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om-post" });
+    const origPush = streamingInstances.push.bind(streamingInstances);
+    streamingInstances.push = (...args: StreamingSessionStub[]) => {
+      const instance = args[0];
+      if (instance) {
+        instance.start = vi
+          .fn()
+          .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
+      }
+      return origPush(...args);
+    };
+
+    try {
+      const result = createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: { log: vi.fn(), error: errorMock } as never,
+        chatId: "oc_chat",
+        sendTarget: "oc_chat",
+      });
+      const options = toTypingDispatcherOptions(result);
+      const text = Array.from(
+        { length: 6 },
+        (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+      ).join("\n\n");
+
+      await options.deliver({ text }, { kind: "final" });
+
+      expect(errorMock.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
+        "streaming start failed",
+      );
+      expect(sendMessageFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    } finally {
+      streamingInstances.push = origPush;
+    }
+  });
+
   describe("table-limit routing", () => {
     function makeTableText(count: number): string {
       return Array.from(

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2734,6 +2734,34 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back to post mode when over-limit streaming content was never accepted", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om-post" });
+    const { options } = createDispatcherHarness();
+    const text = Array.from(
+      { length: 6 },
+      (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+    ).join("\n\n");
+    const delivery = await options.deliver({ text }, { kind: "final" });
+    requireStreamingInstance(0).closeWithResult.mockRejectedValueOnce(
+      new FeishuStreamingFinalizationError(new Error("final update failed"), {
+        visibleReplySent: false,
+        messageId: "om-empty-stream",
+      }),
+    );
+
+    await expect(options.onIdle?.()).rejects.toThrow("final update failed");
+    await expect(delivery?.finalization).rejects.toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        content: text,
+        messageIds: ["om-post"],
+        visibleReplySent: true,
+      },
+    });
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("does not repeat an earlier static fallback when a later fallback fails", async () => {
     sendStructuredCardFeishuMock
       .mockResolvedValueOnce({ messageId: "om-first-static" })
@@ -4392,6 +4420,62 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       streamingInstances.push = origPush;
       nowSpy.mockRestore();
     }
+  });
+
+  describe("table-limit routing", () => {
+    function makeTableText(count: number): string {
+      return Array.from(
+        { length: count },
+        (_, i) => `| a${i} | b${i} |\n| - | - |\n| 1 | 2 |`,
+      ).join("\n\n");
+    }
+
+    function setupDispatcher() {
+      const result = createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: { log: vi.fn(), error: vi.fn() } as never,
+        chatId: "oc_chat",
+        sendTarget: "oc_chat",
+      });
+      return toTypingDispatcherOptions(result);
+    }
+
+    it("routes 5 markdown tables to static card when streaming is off", async () => {
+      useNonStreamingAutoAccount();
+      const options = setupDispatcher();
+      const text = makeTableText(5);
+      await options.deliver({ text }, { kind: "final" });
+
+      expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(expect.objectContaining({ text }));
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to post mode for 6 markdown tables when streaming is off", async () => {
+      useNonStreamingAutoAccount();
+      const options = setupDispatcher();
+      const text = makeTableText(6);
+      await options.deliver({ text }, { kind: "final" });
+
+      expect(sendMessageFeishuMock).toHaveBeenCalled();
+      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to post mode for 6 tables with explicit renderMode=card", async () => {
+      resolveFeishuAccountMock.mockReturnValue({
+        accountId: "main",
+        appId: "app_id",
+        appSecret: "app_secret",
+        domain: "feishu",
+        config: { renderMode: "card", streaming: { mode: "off" } },
+      });
+      const options = setupDispatcher();
+      const text = makeTableText(6);
+      await options.deliver({ text }, { kind: "final" });
+
+      expect(sendMessageFeishuMock).toHaveBeenCalled();
+      expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1406,7 +1406,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         streamingEnabled &&
         !finalTextExceedsStreamingLimit &&
         (info?.kind === "final" || useStaticCard);
-      const useCard = useStaticCard || useStreamingCard;
       const skipTextForDuplicateFinal =
         !hasIndependentPresentation &&
         info?.kind === "final" &&
@@ -1574,7 +1573,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           );
         }
 
-        if (useCard) {
+        const useFallbackCard =
+          useStaticCard || (useStreamingCard && !isStreamingStartBackedOff(account.accountId));
+        if (useFallbackCard) {
           const cardHeader = resolveCardHeader(agentId, identity);
           const cardNote = resolveCardNote(agentId, identity, responsePrefixContextProvider());
           deliveredResults.push(

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1395,17 +1395,18 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         );
       const finalTextExceedsStreamingLimit =
         info?.kind === "final" && hasText && text.length > textChunkLimit;
-      const useStaticCard =
-        hasText &&
-        (renderMode === "card" ||
-          (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
-          (renderMode === "auto" && shouldUseCard(text))) &&
-        withinCardTableLimit(text);
+      // Feishu's table ceiling applies to static card elements, not CardKit's streamed markdown.
+      // Keep the intents separate so an active preview cannot fork into an independent post.
+      const cardRenderingRequested =
+        renderMode === "card" ||
+        (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
+        (renderMode === "auto" && shouldUseCard(text));
+      const useStaticCard = hasText && cardRenderingRequested && withinCardTableLimit(text);
       const useStreamingCard =
         hasText &&
         streamingEnabled &&
         !finalTextExceedsStreamingLimit &&
-        (info?.kind === "final" || useStaticCard);
+        (info?.kind === "final" || cardRenderingRequested);
       const skipTextForDuplicateFinal =
         !hasIndependentPresentation &&
         info?.kind === "final" &&
@@ -1573,8 +1574,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           );
         }
 
+        // Streaming eligibility can still fall back to a static card, so the provider ceiling
+        // also applies when startup is unavailable or another generation is closing.
         const useFallbackCard =
-          useStaticCard || (useStreamingCard && !isStreamingStartBackedOff(account.accountId));
+          useStaticCard ||
+          (useStreamingCard &&
+            !isStreamingStartBackedOff(account.accountId) &&
+            withinCardTableLimit(text));
         if (useFallbackCard) {
           const cardHeader = resolveCardHeader(agentId, identity);
           const cardNote = resolveCardNote(agentId, identity, responsePrefixContextProvider());

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -33,6 +33,7 @@ import type { MentionTarget } from "./mention-target.types.js";
 import {
   consumeFeishuPresentationFallbackMarker,
   renderFeishuReplyPayload,
+  withinCardTableLimit,
 } from "./presentation-card.js";
 import {
   createFeishuPartialReplyDeliveryError,
@@ -998,26 +999,39 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     const cardHeader = resolveCardHeader(agentId, identity);
     const cardNote = resolveCardNote(agentId, identity, responsePrefixContextProvider());
+    const useRecoveryCard = withinCardTableLimit(content);
     return await sendChunkedTextReply({
       text: content,
-      useCard: true,
+      useCard: useRecoveryCard,
       infoKind,
       header: cardHeader,
       note: cardNote,
       chunkMentions: requiredMentionTargets,
       sendChunk: async ({ chunk, mentions }) =>
-        await sendStructuredCardFeishu({
-          cfg,
-          to: sendTarget,
-          text: chunk,
-          replyToMessageId: sendReplyToMessageId,
-          replyInThread: effectiveReplyInThread,
-          allowTopLevelReplyFallback,
-          accountId,
-          header: cardHeader,
-          note: cardNote,
-          ...(mentions ? { mentions } : {}),
-        }),
+        useRecoveryCard
+          ? await sendStructuredCardFeishu({
+              cfg,
+              to: sendTarget,
+              text: chunk,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              allowTopLevelReplyFallback,
+              accountId,
+              header: cardHeader,
+              note: cardNote,
+              ...(mentions ? { mentions } : {}),
+            })
+          : await sendMessageFeishu({
+              cfg,
+              to: sendTarget,
+              text: chunk,
+              preparedPostText: true,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              allowTopLevelReplyFallback,
+              accountId,
+              ...(mentions ? { mentions } : {}),
+            }),
     });
   };
 
@@ -1385,7 +1399,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         hasText &&
         (renderMode === "card" ||
           (info?.kind === "block" && coreBlockStreamingEnabled && renderMode !== "raw") ||
-          (renderMode === "auto" && shouldUseCard(text)));
+          (renderMode === "auto" && shouldUseCard(text))) &&
+        withinCardTableLimit(text);
       const useStreamingCard =
         hasText &&
         streamingEnabled &&


### PR DESCRIPTION
## What problem this solves

Feishu rejects static interactive cards containing more than five table components with error `11310`. OpenClaw could still route generated Markdown and presentation cards with six or more parsed tables to that rejected path, leaving users without the reply.

Closes #43690.

## What changed

- Count GFM tables with the existing Markdown parser instead of pipe/string heuristics.
- Keep static cards at five tables or fewer.
- Route over-limit generated cards through the existing post fallback in outbound text, presentation actions, normal replies, failed-stream recovery, and CardKit startup backoff.
- Preserve the existing structured-card fallback for unrelated concurrent streaming handoffs.
- Leave active CardKit streaming and caller-supplied native cards unchanged.
- Cover pipe-less/aligned tables, fenced code, multi-element cards, HTML font wrappers, and six-table CardKit startup failure.

Production diff: `+94/-24` (`+70` net); test diff: `+488/-1` (`+487` net).

## Attribution

This is a current-`main` rescue and rework of the original implementation in #86901 by [name5566](https://github.com/name5566). The first two commits retain `name5566 <name5566@gmail.com>` as the Git author, with `ltspace` as the GitHub-linked committer. The review follow-up is authored and committed by `ltspace`.

## User impact

A response with up to five Markdown tables remains an interactive card. A response with six or more tables is delivered as a Feishu post instead of failing at the provider boundary, including when CardKit startup fails.

## Evidence

- Focused Feishu routing suites: 616 tests passed across `presentation-card`, `outbound`, `channel`, and `reply-dispatcher`.
- Review follow-up: all 182 `reply-dispatcher` tests passed, including six-table CardKit startup failure and existing concurrent handoff cases.
- `pnpm tsgo:extensions`
- `pnpm exec oxfmt --check` on changed files
- `pnpm exec oxlint` on changed files
- Live Feishu API verification from this branch:
  - 5 tables -> `interactive`, accepted as `om_x100b66b78c862cacb1b71ffd5af9070`
  - 6 tables -> `post`, accepted as `om_x100b66b78c9324a0b1b499d6025584e`

