### PR TITLE
fix(llama-cpp): bound Hugging Face metadata responses

### DIFF
--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -30,14 +30,22 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const TEST_GGUF_SHA256 = "b83633aa785344791618f2fddf131b010ea04912a60430760b070bad293f65bd";
 
 async function withHuggingFaceMetadataFixture(
-  endpoint: "manifest" | "tree",
-  run: (params: { cacheDir: string; setPadding: (padding: string) => void }) => Promise<void>,
+  endpoint: "manifest" | "file" | "tree",
+  run: (params: {
+    cacheDir: string;
+    setPadding: (target: "manifest" | "file" | "tree", padding: string) => void;
+    pathInfoBodies: unknown[];
+    requestedUrls: string[];
+  }) => Promise<void>,
 ): Promise<void> {
   const cacheDir = tempDirs.make(`llama-cpp-hf-${endpoint}-`);
   await fs.writeFile(path.join(cacheDir, "hf_owner_repo_model.gguf"), "GGUF");
   let padding = "x".repeat(1024 * 1024);
+  const pathInfoBodies: unknown[] = [];
+  const requestedUrls: string[] = [];
   const server = http.createServer((req, res) => {
     res.setHeader("content-type", "application/json");
+    requestedUrls.push(req.url ?? "");
     if (req.url?.startsWith("/v2/owner/repo/manifests/latest")) {
       res.end(
         JSON.stringify({
@@ -45,6 +53,20 @@ async function withHuggingFaceMetadataFixture(
           ...(endpoint === "manifest" ? { padding } : {}),
         }),
       );
+      return;
+    }
+    if (req.url?.startsWith("/api/models/owner/repo/paths-info/main")) {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        pathInfoBodies.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+        res.end(
+          JSON.stringify([
+            { path: "model.gguf", size: 4, lfs: { oid: TEST_GGUF_SHA256 } },
+            ...(endpoint === "file" ? [padding] : []),
+          ]),
+        );
+      });
       return;
     }
     if (req.url?.startsWith("/api/models/owner/repo/tree/main")) {
@@ -76,7 +98,16 @@ async function withHuggingFaceMetadataFixture(
   });
   vi.stubGlobal("fetch", localFetch);
   try {
-    await run({ cacheDir, setPadding: (next) => (padding = next) });
+    await run({
+      cacheDir,
+      setPadding: (target, next) => {
+        if (target === endpoint) {
+          padding = next;
+        }
+      },
+      pathInfoBodies,
+      requestedUrls,
+    });
   } finally {
     vi.unstubAllGlobals();
   }
@@ -300,8 +331,8 @@ describe("managed llama-server", () => {
     ).rejects.toThrow("Run interactive llama.cpp setup or correct params.modelPath");
   });
 
-  it.each(["manifest", "tree"] as const)(
-    "bounds Hugging Face %s metadata while preserving a legitimate large response",
+  it.each(["manifest", "file"] as const)(
+    "bounds Hugging Face %s metadata while preserving a legitimate response",
     async (endpoint) => {
       await withHuggingFaceMetadataFixture(endpoint, async ({ cacheDir, setPadding }) => {
         await expect(
@@ -312,7 +343,7 @@ describe("managed llama-server", () => {
           }),
         ).resolves.toBe(path.join(cacheDir, "hf_owner_repo_model.gguf"));
 
-        setPadding("x".repeat(16 * 1024 * 1024 + 1));
+        setPadding(endpoint, "x".repeat(16 * 1024 * 1024 + 1));
         await expect(
           ensureLlamaCppModel({
             source: "hf:owner/repo",
@@ -320,11 +351,29 @@ describe("managed llama-server", () => {
             download: false,
           }),
         ).rejects.toThrow(
-          `llama.cpp Hugging Face ${endpoint}: JSON response exceeds 16777216 bytes`,
+          `llama.cpp Hugging Face ${endpoint === "manifest" ? "manifest" : "file metadata"}: JSON response exceeds 16777216 bytes`,
         );
       });
     },
   );
+
+  it("resolves a cached GGUF when unrelated repository tree metadata is oversized", async () => {
+    await withHuggingFaceMetadataFixture(
+      "tree",
+      async ({ cacheDir, setPadding, pathInfoBodies, requestedUrls }) => {
+        setPadding("tree", "x".repeat(16 * 1024 * 1024 + 1));
+        await expect(
+          ensureLlamaCppModel({
+            source: "hf:owner/repo",
+            cacheDir,
+            download: false,
+          }),
+        ).resolves.toBe(path.join(cacheDir, "hf_owner_repo_model.gguf"));
+        expect(pathInfoBodies).toEqual([{ paths: ["model.gguf"], expand: false }]);
+        expect(requestedUrls).not.toContain(expect.stringContaining("/tree/"));
+      },
+    );
+  });
 
   it("reports only facts observed from health, models, props, and metrics", async () => {
     const server = http.createServer((req, res) => {

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -15,6 +15,7 @@ vi.mock("./llama-server-install.js", async (importOriginal) => ({
   resolveManagedLlamaServerPaths: installMocks.resolveManagedLlamaServerPaths,
 }));
 
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { selectLlamaServerAsset } from "./llama-server-install.js";
 import {
   ensureLlamaCppModel,
@@ -24,6 +25,62 @@ import {
 } from "./managed-server.js";
 
 const servers: http.Server[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+const TEST_GGUF_SHA256 = "b83633aa785344791618f2fddf131b010ea04912a60430760b070bad293f65bd";
+
+async function withHuggingFaceMetadataFixture(
+  endpoint: "manifest" | "tree",
+  run: (params: { cacheDir: string; setPadding: (padding: string) => void }) => Promise<void>,
+): Promise<void> {
+  const cacheDir = tempDirs.make(`llama-cpp-hf-${endpoint}-`);
+  await fs.writeFile(path.join(cacheDir, "hf_owner_repo_model.gguf"), "GGUF");
+  let padding = "x".repeat(1024 * 1024);
+  const server = http.createServer((req, res) => {
+    res.setHeader("content-type", "application/json");
+    if (req.url?.startsWith("/v2/owner/repo/manifests/latest")) {
+      res.end(
+        JSON.stringify({
+          ggufFile: { rfilename: "model.gguf", size: 4 },
+          ...(endpoint === "manifest" ? { padding } : {}),
+        }),
+      );
+      return;
+    }
+    if (req.url?.startsWith("/api/models/owner/repo/tree/main")) {
+      res.end(
+        JSON.stringify([
+          { path: "model.gguf", size: 4, lfs: { oid: TEST_GGUF_SHA256 } },
+          ...(endpoint === "tree" ? [padding] : []),
+        ]),
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end("{}");
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("missing test server address");
+  }
+  const realFetch = globalThis.fetch;
+  const localFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const upstream = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+    );
+    return await realFetch(`http://127.0.0.1:${address.port}${upstream.pathname}`, init);
+  });
+  vi.stubGlobal("fetch", localFetch);
+  try {
+    await run({ cacheDir, setPadding: (next) => (padding = next) });
+  } finally {
+    vi.unstubAllGlobals();
+  }
+}
 
 afterEach(async () => {
   vi.clearAllMocks();
@@ -242,6 +299,32 @@ describe("managed llama-server", () => {
       }),
     ).rejects.toThrow("Run interactive llama.cpp setup or correct params.modelPath");
   });
+
+  it.each(["manifest", "tree"] as const)(
+    "bounds Hugging Face %s metadata while preserving a legitimate large response",
+    async (endpoint) => {
+      await withHuggingFaceMetadataFixture(endpoint, async ({ cacheDir, setPadding }) => {
+        await expect(
+          ensureLlamaCppModel({
+            source: "hf:owner/repo",
+            cacheDir,
+            download: false,
+          }),
+        ).resolves.toBe(path.join(cacheDir, "hf_owner_repo_model.gguf"));
+
+        setPadding("x".repeat(16 * 1024 * 1024 + 1));
+        await expect(
+          ensureLlamaCppModel({
+            source: "hf:owner/repo",
+            cacheDir,
+            download: false,
+          }),
+        ).rejects.toThrow(
+          `llama.cpp Hugging Face ${endpoint}: JSON response exceeds 16777216 bytes`,
+        );
+      });
+    },
+  );
 
   it("reports only facts observed from health, models, props, and metrics", async () => {
     const server = http.createServer((req, res) => {

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -36,7 +36,9 @@ async function withHuggingFaceMetadataFixture(
     setPadding: (target: "manifest" | "file" | "tree", padding: string) => void;
     pathInfoBodies: unknown[];
     requestedUrls: string[];
+    source: string;
   }) => Promise<void>,
+  source = "hf:owner/repo",
 ): Promise<void> {
   const cacheDir = tempDirs.make(`llama-cpp-hf-${endpoint}-`);
   await fs.writeFile(path.join(cacheDir, "hf_owner_repo_model.gguf"), "GGUF");
@@ -107,6 +109,7 @@ async function withHuggingFaceMetadataFixture(
       },
       pathInfoBodies,
       requestedUrls,
+      source,
     });
   } finally {
     vi.unstubAllGlobals();
@@ -360,18 +363,32 @@ describe("managed llama-server", () => {
   it("resolves a cached GGUF when unrelated repository tree metadata is oversized", async () => {
     await withHuggingFaceMetadataFixture(
       "tree",
-      async ({ cacheDir, setPadding, pathInfoBodies, requestedUrls }) => {
+      async ({ cacheDir, setPadding, pathInfoBodies, requestedUrls, source }) => {
         setPadding("tree", "x".repeat(16 * 1024 * 1024 + 1));
         await expect(
           ensureLlamaCppModel({
-            source: "hf:owner/repo",
+            source,
             cacheDir,
             download: false,
           }),
         ).resolves.toBe(path.join(cacheDir, "hf_owner_repo_model.gguf"));
         expect(pathInfoBodies).toEqual([{ paths: ["model.gguf"], expand: false }]);
-        expect(requestedUrls).not.toContain(expect.stringContaining("/tree/"));
+        expect(requestedUrls.some((url) => url.includes("/tree/"))).toBe(false);
       },
+    );
+  });
+
+  it("resolves an explicit Hugging Face GGUF file without a manifest request", async () => {
+    await withHuggingFaceMetadataFixture(
+      "file",
+      async ({ cacheDir, pathInfoBodies, requestedUrls, source }) => {
+        await expect(ensureLlamaCppModel({ source, cacheDir, download: false })).resolves.toBe(
+          path.join(cacheDir, "hf_owner_repo_model.gguf"),
+        );
+        expect(pathInfoBodies).toEqual([{ paths: ["model.gguf"], expand: false }]);
+        expect(requestedUrls).not.toContain("/v2/owner/repo/manifests/latest");
+      },
+      "hf:owner/repo/model.gguf",
     );
   });
 

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -151,27 +151,35 @@ async function resolveHuggingFaceArtifact(
   }
   const encodedFile = file.split("/").map(encodeURIComponent).join("/");
   const url = `https://huggingface.co/${encodeURIComponent(parsed.user)}/${encodeURIComponent(parsed.repository)}/resolve/${encodeURIComponent(parsed.revision)}/${encodedFile}?download=true`;
-  const treeUrl = `https://huggingface.co/api/models/${encodeURIComponent(parsed.user)}/${encodeURIComponent(parsed.repository)}/tree/${encodeURIComponent(parsed.revision)}?recursive=true&expand=true`;
-  const { response: treeResponse, release: releaseTree } = await fetchWithSsrFGuard({
-    url: treeUrl,
+  const fileInfoUrl = `https://huggingface.co/api/models/${encodeURIComponent(parsed.user)}/${encodeURIComponent(parsed.repository)}/paths-info/${encodeURIComponent(parsed.revision)}`;
+  const { response: fileInfoResponse, release: releaseFileInfo } = await fetchWithSsrFGuard({
+    url: fileInfoUrl,
+    init: {
+      method: "POST",
+      headers: { "content-type": "application/json", "user-agent": "llama-cpp" },
+      body: JSON.stringify({ paths: [file], expand: false }),
+    },
     signal,
     requireHttps: true,
-    policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(treeUrl),
+    policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(fileInfoUrl),
     auditContext: "llama-cpp-model-resolve",
   });
-  let tree: unknown;
+  let fileInfo: unknown;
   try {
-    if (!treeResponse.ok) {
+    if (!fileInfoResponse.ok) {
       throw new Error(
-        `Cannot read Hugging Face integrity metadata for ${source}: HTTP ${treeResponse.status}`,
+        `Cannot read Hugging Face integrity metadata for ${source}: HTTP ${fileInfoResponse.status}`,
       );
     }
-    tree = await readProviderJsonResponse(treeResponse, "llama.cpp Hugging Face tree");
+    fileInfo = await readProviderJsonResponse(
+      fileInfoResponse,
+      "llama.cpp Hugging Face file metadata",
+    );
   } finally {
-    await releaseTree();
+    await releaseFileInfo();
   }
-  const fileRow = Array.isArray(tree)
-    ? tree.map((entry) => asOptionalRecord(entry)).find((entry) => entry?.path === file)
+  const fileRow = Array.isArray(fileInfo)
+    ? fileInfo.map((entry) => asOptionalRecord(entry)).find((entry) => entry?.path === file)
     : undefined;
   const lfs = asOptionalRecord(fileRow?.lfs);
   const expectedSha256 =

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -135,7 +135,11 @@ async function resolveHuggingFaceArtifact(
       if (!response.ok) {
         throw new Error(`Cannot resolve ${source}: HTTP ${response.status}`);
       }
-      const ggufFile = asOptionalRecord(asOptionalRecord(await response.json())?.ggufFile);
+      const ggufFile = asOptionalRecord(
+        asOptionalRecord(
+          await readProviderJsonResponse(response, "llama.cpp Hugging Face manifest"),
+        )?.ggufFile,
+      );
       file = typeof ggufFile?.rfilename === "string" ? ggufFile.rfilename : undefined;
       expectedSize = typeof ggufFile?.size === "number" ? ggufFile.size : undefined;
       if (!file) {
@@ -162,7 +166,7 @@ async function resolveHuggingFaceArtifact(
         `Cannot read Hugging Face integrity metadata for ${source}: HTTP ${treeResponse.status}`,
       );
     }
-    tree = await treeResponse.json();
+    tree = await readProviderJsonResponse(treeResponse, "llama.cpp Hugging Face tree");
   } finally {
     await releaseTree();
   }


### PR DESCRIPTION
## What Problem This Solves

Managed llama.cpp rejected valid documented `hf:` GGUF file URIs when unrelated Hugging Face repository-tree metadata was too large for the provider path.

## Why This Change Was Made

The resolver now asks Hugging Face for integrity metadata for the selected file through `paths-info` instead of buffering the recursive repository tree. It keeps the existing 16 MiB bounded JSON reader for both the manifest and selected-file responses. It keeps the existing HTTPS, SSRF, size, SHA-256, cache, and GGUF checks.

## User Impact

Large repositories no longer fail because of unrelated metadata when an operator uses a documented `hf:` file URI. Oversized manifest and selected-file metadata still fail before unbounded buffering.

## Evidence

- Current `origin/main` at `6d763ee148d4ee62c2c1a39fd5726e1a4d0b94a2` uses `GET /api/models/<repo>/tree/main` and fails the reproduction when that recursive response returns HTTP 413.
- The repaired head at `47b769798c8eb4c8721e37246496c1c33e021041` uses `POST /api/models/<repo>/paths-info/main` with `{"paths":["model.gguf"],"expand":false}` and resolves the same cached GGUF.
- Loopback owner-boundary proof: normal metadata succeeded; oversized manifest metadata failed with the 16 MiB error; oversized selected-file metadata failed with the 16 MiB error; oversized unrelated-tree metadata succeeded because no tree request was made.
- Focused owner tests: `node scripts/run-vitest.mjs run extensions/llama-cpp/src/managed-server.test.ts` — 18 passed.
- Focused lint: `node scripts/run-oxlint.mjs --tsconfig tsconfig.json extensions/llama-cpp/src/managed-server.ts extensions/llama-cpp/src/managed-server.test.ts` — passed.
- Formatter: `oxfmt --check` on both changed files — passed.
- Live public-file metadata proof: `POST https://huggingface.co/api/models/ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/paths-info/main` with `{"paths":["embeddinggemma-300m-qat-Q8_0.gguf"],"expand":false}` returned HTTP 200 and a 319-byte response containing the selected file and its 64-character `lfs.oid`.
- Live OpenClaw resolver proof for `hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf` reached the real metadata contract and then reported the expected missing-cache result with downloads disabled. A nonexistent file returned the expected missing SHA-256 identity result.
- Maintained Hugging Face client contract: [`get_paths_info` in `huggingface_hub` v1.29.0](https://github.com/huggingface/huggingface_hub/blob/v1.29.0/src/huggingface_hub/hf_api.py#L4334-L4410) posts `paths`, defaults `expand` to false, uses the `paths-info` endpoint, and returns file records with `path`, `size`, and LFS metadata. The [Hugging Face API documentation](https://huggingface.co/docs/huggingface_hub/package_reference/hf_api#huggingface_hub.HfApi.get_paths_info) defines the same contract.
- The regression suite now also covers an explicit `hf:<owner>/<repo>/<file>` URI and uses a real substring assertion for the removed tree request.
