### PR TITLE
perf(markdown): skip prose lines when scanning code fences

### DIFF
--- a/packages/markdown-core/src/fences.test.ts
+++ b/packages/markdown-core/src/fences.test.ts
@@ -1,6 +1,6 @@
 // Tests fenced-code-block span scanning used to keep chunk breaks out of code blocks.
 import { describe, expect, it } from "vitest";
-import { isSafeFenceBreak, parseFenceSpans } from "./fences.js";
+import { isSafeFenceBreak, parseFenceSpans, scanFenceSpans } from "./fences.js";
 
 describe("parseFenceSpans closing-fence rules", () => {
   it("treats a marker line with trailing text as code content, not a closing fence", () => {
@@ -41,5 +41,41 @@ describe("parseFenceSpans closing-fence rules", () => {
     const closed = "```\ncode\n```\nafter\n";
     const spans = parseFenceSpans(closed);
     expect(isSafeFenceBreak(spans, closed.indexOf("after") + 1)).toBe(true);
+  });
+
+  it.each(["\n", "\r\n"])("preserves raw UTF-16 offsets with %j line endings", (newline) => {
+    const prefix = `😀${newline}`;
+    const openLine = "  ````ts `metadata`";
+    const text = `${prefix}${openLine}${newline}code${newline} \`\`\`\`\` \t${newline}tail`;
+
+    expect(parseFenceSpans(text)).toEqual([
+      {
+        start: prefix.length,
+        end: text.lastIndexOf("\n"),
+        openLine,
+        marker: "````",
+        indent: "  ",
+      },
+    ]);
+  });
+
+  it.each(["\r", "\u2028", "\u2029"])("does not treat %j as a scanner line break", (separator) => {
+    expect(parseFenceSpans(`intro${separator}\`\`\`ts\ncode`)).toEqual([]);
+    expect(parseFenceSpans(`\`\`\`ts${separator}info\ncode`)).toEqual([]);
+  });
+
+  it("carries an open fence through empty input and a continued line without mutating state", () => {
+    const { state } = scanFenceSpans("  ~~~sh\nbody");
+    Object.freeze(state.open);
+    Object.freeze(state);
+    const continued = "~~~\nbody\n~~~~ ";
+    const span = { start: 0, openLine: "  ~~~sh", marker: "~~~", indent: "  " };
+
+    expect(scanFenceSpans("", state)).toEqual({ spans: [{ ...span, end: 0 }], state });
+    expect(scanFenceSpans(continued, state)).toEqual({
+      spans: [{ ...span, end: continued.length }],
+      state: { atLineStart: false },
+    });
+    expect(state).toMatchObject({ atLineStart: false, open: { openLine: "  ~~~sh" } });
   });
 });

--- a/packages/markdown-core/src/fences.ts
+++ b/packages/markdown-core/src/fences.ts
@@ -19,6 +19,10 @@ export type FenceScanState = {
   };
 };
 
+// LF alone defines scanner lines; consume CRLF's CR for raw offsets, not opener text.
+const FENCE_LINE_RE = /(?:^|\n)( {0,3})(`{3,}|~{3,})([^\r\n\u2028\u2029]*)\r?(?=\n|$)/g;
+const SINGLE_LINE_FENCE_RE = new RegExp(FENCE_LINE_RE, "gy");
+
 /** Scans fenced-code spans incrementally so chunking can carry an open fence forward. */
 export function scanFenceSpans(
   buffer: string,
@@ -37,56 +41,45 @@ export function scanFenceSpans(
       }
     | undefined = state?.open ? { ...state.open, start: 0 } : undefined;
 
-  let offset = 0;
-  while (offset <= buffer.length) {
-    const nextNewline = buffer.indexOf("\n", offset);
-    const lineEnd = nextNewline === -1 ? buffer.length : nextNewline;
-    const line = buffer.slice(offset, lineEnd).replace(/\r$/, "");
-
-    const match = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
-    if (match && (offset > 0 || startsAtLineStart)) {
-      const [, indent, marker, trailing] = match;
-      if (indent === undefined || marker === undefined || trailing === undefined) {
-        if (nextNewline === -1) {
-          break;
-        }
-        offset = nextNewline + 1;
-        continue;
-      }
-      const markerChar = marker.charAt(0);
-      const markerLen = marker.length;
-      if (!open) {
-        open = {
-          start: offset,
-          markerChar,
-          markerLen,
-          openLine: line,
-          marker,
-          indent,
-        };
-      } else if (
-        open.markerChar === markerChar &&
-        markerLen >= open.markerLen &&
-        /^[ \t]*$/.test(trailing)
-      ) {
-        // CommonMark permits only spaces or tabs after a closing fence. A marker line carrying
-        // other trailing text is code content, not a close, so it must not end the block.
-        const end = lineEnd;
-        spans.push({
-          start: open.start,
-          end,
-          openLine: open.openLine,
-          marker: open.marker,
-          indent: open.indent,
-        });
-        open = undefined;
-      }
+  // Without LF, only offset zero can be a fence. Sticky matching skips long prose,
+  // including inline marker literals; matchAll leaves both shared patterns untouched.
+  const pattern = buffer.includes("\n") ? FENCE_LINE_RE : SINGLE_LINE_FENCE_RE;
+  for (const match of buffer.matchAll(pattern)) {
+    const [, indent, marker, trailing] = match;
+    if (indent === undefined || marker === undefined || trailing === undefined) {
+      continue;
     }
-
-    if (nextNewline === -1) {
-      break;
+    const start = match.index + (match[0].startsWith("\n") ? 1 : 0);
+    if (start === 0 && !startsAtLineStart) {
+      continue;
     }
-    offset = nextNewline + 1;
+    const markerChar = marker.charAt(0);
+    const markerLen = marker.length;
+    if (!open) {
+      open = {
+        start,
+        markerChar,
+        markerLen,
+        openLine: `${indent}${marker}${trailing}`,
+        marker,
+        indent,
+      };
+    } else if (
+      open.markerChar === markerChar &&
+      markerLen >= open.markerLen &&
+      /^[ \t]*$/.test(trailing)
+    ) {
+      // CommonMark permits only spaces or tabs after a closing fence. A marker line carrying
+      // other trailing text is code content, not a close, so it must not end the block.
+      spans.push({
+        start: open.start,
+        end: match.index + match[0].length,
+        openLine: open.openLine,
+        marker: open.marker,
+        indent: open.indent,
+      });
+      open = undefined;
+    }
   }
 
   if (open) {


### PR DESCRIPTION
## What Problem This Solves

Streaming and chunking long Markdown replies repeatedly scans ordinary prose lines just to locate code fences. A 4,096-line input caused 4,096 calls each to slice, replace, and match per scan, even when most lines contained no fence.

## Why This Change Was Made

The scanner now iterates fence-shaped lines directly while retaining the existing incremental state and span finalization. LF-free buffers use a sticky form of the same grammar so long prose and inline marker literals do not cause a full regex search. UTF-16 offsets, CRLF handling, closing-fence rules, carried state, and chunk bytes remain unchanged.

## User Impact

Lower CPU work while processing multiline streamed replies, with no formatting or public API change. Production LOC: −7; tests: +36.

## Evidence

- 309 existing/extended tests passed across seven files and four canonical shards, including streamed final tags, fenced chunking, media parsing, and canvas literal handling. The full changed gate and independent Codex review passed.
- Actual source comparison preserved nine explicit goldens, 9,168 scanner/state cases, 245 every-cut streamed code-index cases, and seven downstream caller cases. Supplied state remained immutable.
- Four fixed before/after pairs on Node 26.8.1: 512 multiline scans improved from 74.273 to 10.087 ms median; mixed input from 73.884 to 11.373 ms; dense fences from 23.542 to 17.623 ms. Actual block chunking improved from 35.435 to 17.984 ms per 128 calls.
- All samples are retained. Long single-line buffers cost about 0.45–0.60 µs more per call in this sample. Outbound chunking had mixed pair deltas. This establishes reduced scan work and multiline CPU cost, not a retained-heap or whole-Gateway RSS reduction.

Focused command: `node scripts/run-vitest.mjs packages/markdown-core/src/fences.test.ts src/auto-reply/chunk.test.ts src/agents/embedded-agent-block-chunker.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.chunking-fences.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-tag-streaming.test.ts src/media/parse.test.ts src/chat/canvas-render.test.ts`.

Inspectable follow-up: [actual-source and runtime evidence](https://github.com/openclaw/openclaw/pull/136389#issuecomment-5512287628).
