### PR TITLE
improve(gateway): reduce session metadata read costs

### DIFF
--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -430,8 +430,3 @@ export async function patchSessionEntryWithKey(
   const entry = await patchSessionEntryCore(scope, update, options);
   return entry ? { sessionKey: normalizeStoreSessionKey(scope.sessionKey), entry } : null;
 }
-
-/**
- * Copies one parent transcript into a new child transcript target.
- * This is for guarded callers that already own the eventual entry commit.
- */

--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -22,6 +22,7 @@ import {
   hasSessionEntriesByStatusReadOnly,
   listSessionEntriesCore,
   listSessionEntriesReadOnly,
+  loadExactSessionEntryReadOnly,
   openSessionEntryReadView,
   readSessionTranscriptTitleProbeBatch,
   readSessionTranscriptWatermark,
@@ -191,6 +192,24 @@ describe("session accessor readonly listing", () => {
       recent: [],
       byAgent: new Map([[scope.agentId, { count: 5, recent: [] }]]),
     });
+
+    const retainedScope = { ...scope, sessionKey: "agent:main:retained" };
+    for (const projection of ["full", "list"] as const) {
+      expect(loadExactSessionEntryReadOnly({ ...retainedScope, projection })).toBeUndefined();
+      for (const key of ["bad-json", "bad-timestamp"]) {
+        expect(() =>
+          loadExactSessionEntryReadOnly({ ...scope, sessionKey: `agent:main:${key}`, projection }),
+        ).toThrow("openclaw doctor --fix");
+      }
+    }
+    update.run(
+      JSON.stringify({ skillsSnapshot: { prompt: "invalid prompt-only row" } }),
+      2000,
+      retainedScope.sessionKey,
+    );
+    expect(() => loadExactSessionEntryReadOnly({ ...retainedScope, projection: "list" })).toThrow(
+      "openclaw doctor --fix",
+    );
 
     closeOpenClawAgentDatabasesForTest();
     expect(() => readSessionStoreSummaryReadOnly(scope, options)).toThrow("openclaw doctor --fix");

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -1,5 +1,3 @@
-import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import type { OpenClawConfig } from "../types.openclaw.js";
 import type {
   DeletedAgentSessionEntryPurgeParams,
   DeleteSessionEntryLifecycleParams,
@@ -12,58 +10,9 @@ import type {
   SessionLifecycleArchivedTranscript,
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
-  SessionLifecycleStoreTarget,
 } from "./session-accessor.lifecycle-types.js";
-import type { TranscriptEvent } from "./session-accessor.types.js";
-import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
-import type { TranscriptEntryAnchor } from "./transcript-entry-anchor.js";
+import type { SessionEntrySummary } from "./session-accessor.types.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
-
-export type SessionAccessScope = {
-  agentId?: string;
-  clone?: boolean;
-  /** Fixed-store ownership is explicit; omitted values use the storage resolver's legacy-main contract. */
-  defaultAgentId?: string;
-  env?: NodeJS.ProcessEnv;
-  hydrateSkillPromptRefs?: boolean;
-  readConsistency?: "latest";
-  sessionKey: string;
-  storePath?: string;
-};
-
-export type SessionTranscriptAccessScope = Omit<SessionAccessScope, "sessionKey"> & {
-  sessionFile?: string;
-  sessionId: string;
-  sessionKey?: string;
-  threadId?: string | number;
-};
-
-type SessionTranscriptRuntimeScope = SessionAccessScope & {
-  sessionFile?: string;
-  sessionId: string;
-  threadId?: string | number;
-};
-
-export type SessionTranscriptReadScope = Omit<SessionTranscriptRuntimeScope, "sessionKey"> & {
-  sessionKey?: string;
-  sessionEntry?: Partial<Pick<SessionEntry, "sessionId">>;
-};
-
-export type SessionTranscriptWriteScope = Omit<SessionTranscriptAccessScope, "sessionId"> & {
-  sessionId?: string;
-  expectedLifecycleRevision?: string;
-  expectedWriterRunId?: string;
-};
-
-export type ExactSessionEntry = {
-  sessionKey: string;
-  entry: SessionEntry;
-};
-
-export type SessionEntrySummary = {
-  sessionKey: string;
-  entry: SessionEntry;
-};
 
 export type SessionEntryStatus = NonNullable<SessionEntry["status"]>;
 
@@ -114,19 +63,6 @@ export type TranscriptAppendRefusal =
       sessionKeyHash: string;
     };
 
-export type SessionTranscriptStats = {
-  eventCount: number;
-  lastMutationAtMs?: number;
-  lastObservedMutationAtMs?: number;
-  maxSeq: number;
-  sizeBytes: number;
-};
-
-export type SessionTranscriptEventRow = {
-  event: TranscriptEvent;
-  seq: number;
-};
-
 export type {
   ForkSessionEntryFromParentTargetParams,
   ForkSessionEntryFromParentTargetResult,
@@ -140,90 +76,9 @@ export type {
   TranscriptEvent,
 } from "./session-accessor.types.js";
 
-export type TranscriptMessageAppendOptions<TMessage> = {
-  appendIntent?: "active-branch";
-  config?: OpenClawConfig;
-  cwd?: string;
-  idempotencyLookup?: "scan" | "scan-assistant" | "caller-checked";
-  message: TMessage;
-  now?: number;
-  eventId?: string;
-  parentId?: string | null;
-  prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
-  useRawWhenLinear?: boolean;
-};
-
-export type TranscriptMessageAppendResult<TMessage> = {
-  appended: boolean;
-  anchor?: TranscriptEntryAnchor;
-  effectiveParentId?: string | null;
-  message: TMessage;
-  messageId: string;
-};
-
-export type TranscriptUpdatePayload = Partial<SessionTranscriptUpdate>;
-
-export type LatestTranscriptAssistantText = {
-  id?: string;
-  text: string;
-  timestamp?: number;
-};
-
 export type LatestTranscriptAssistantMessage = {
   id?: string;
   message: unknown;
-};
-
-export type SessionTranscriptTurnMessageAppend = TranscriptMessageAppendOptions<unknown> & {
-  shouldAppend?: (context: SessionTranscriptTurnWriteContext) => Promise<boolean> | boolean;
-  /**
-   * Rechecks the newest assistant row after the write transaction begins.
-   * Direct synchronous writers bypass the process queue, so prepared facts can be stale.
-   */
-  shouldAppendInTransaction?: (latestAssistantMessage: unknown) => boolean;
-};
-
-export type SessionTranscriptTurnWriteContext = {
-  agentId?: string;
-  sessionId?: string;
-  sessionKey?: string;
-  storePath?: string;
-};
-
-export type SessionEntryPatchOptions = {
-  assertCommitAllowed?: () => void;
-  fallbackEntry?: SessionEntry;
-  maintenanceConfig?: ResolvedSessionMaintenanceConfig;
-  preserveActivity?: boolean;
-  requireWriteSuccess?: boolean;
-  replaceEntry?: boolean;
-  skipMaintenance?: boolean;
-  takeCacheOwnership?: boolean;
-};
-
-export type SessionEntryPatchContext = {
-  existingEntry?: SessionEntry;
-};
-
-export type SessionEntryTargetPatchScope = {
-  agentId?: string;
-  storePath: string;
-  target: SessionLifecycleStoreTarget;
-};
-
-export type SessionEntryReplacementSnapshot = {
-  entry: SessionEntry;
-  sessionKey: string;
-};
-
-type SessionEntryReplacement = {
-  entry: SessionEntry;
-  sessionKey: string;
-};
-
-export type SessionEntryReplacementUpdate<T> = {
-  replacements?: Iterable<SessionEntryReplacement>;
-  result: T;
 };
 
 type SessionEntryBatchProjectionMutation = {
@@ -250,3 +105,25 @@ export type {
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
 };
+
+export type {
+  ExactSessionEntry,
+  LatestTranscriptAssistantText,
+  SessionAccessScope,
+  SessionEntryPatchContext,
+  SessionEntryPatchOptions,
+  SessionEntryReplacementSnapshot,
+  SessionEntryReplacementUpdate,
+  SessionEntrySummary,
+  SessionEntryTargetPatchScope,
+  SessionTranscriptAccessScope,
+  SessionTranscriptEventRow,
+  SessionTranscriptReadScope,
+  SessionTranscriptStats,
+  SessionTranscriptTurnMessageAppend,
+  SessionTranscriptTurnWriteContext,
+  SessionTranscriptWriteScope,
+  TranscriptMessageAppendOptions,
+  TranscriptMessageAppendResult,
+  TranscriptUpdatePayload,
+} from "./session-accessor.types.js";

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -29,9 +29,13 @@ vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-status.js")>();
   return {
     ...actual,
-    parseSessionEntryJson: (row: Parameters<typeof actual.parseSessionEntryJson>[0]) => {
-      parseSessionEntryCalls(row.entry_json);
-      return actual.parseSessionEntryJson(row);
+    parseSessionEntryJson: (...args: Parameters<typeof actual.parseSessionEntryJson>) => {
+      // Snapshot/publication rows omit the current-id column; exact writer CAS reads
+      // share this decoder but are outside the cache work measured here.
+      if (args[0].current_session_id === undefined) {
+        parseSessionEntryCalls(args[0].entry_json);
+      }
+      return actual.parseSessionEntryJson(...args);
     },
   };
 });
@@ -734,7 +738,7 @@ describe("SQLite session entry cache", () => {
   it("bypasses the cache in a transaction and reuses the persisted snapshot after rollback", async () => {
     const scope = createSessionScope("transaction-rollback");
     await upsertSessionEntryCore(scope, { label: "before", sessionId: "rollback", updatedAt: 1 });
-    const borrowedBefore = openSessionEntryReadView(scope).get(scope.sessionKey);
+    const borrowedBefore = listSessionEntriesCore({ ...scope, clone: false })[0]?.entry;
     expect(borrowedBefore?.label).toBe("before");
     if (!borrowedBefore) {
       throw new Error("missing seeded rollback entry");
@@ -752,7 +756,7 @@ describe("SQLite session entry cache", () => {
     ).toThrow("roll back cache probe");
 
     parseSessionEntryCalls.mockClear();
-    const borrowedAfter = openSessionEntryReadView(scope).get(scope.sessionKey);
+    const borrowedAfter = listSessionEntriesCore({ ...scope, clone: false })[0]?.entry;
     expect(borrowedAfter).toStrictEqual(borrowedBefore);
     expect(borrowedAfter?.label).toBe("before");
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -10,10 +10,7 @@ import {
   projectSqliteSessionParticipantsBatch,
 } from "./session-accessor.sqlite-participant-projection.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
-import {
-  parseSessionEntryJson,
-  sessionEntryMetadataJson,
-} from "./session-accessor.sqlite-status.js";
+import { parseSessionEntryJson, selectSessionEntryRows } from "./session-accessor.sqlite-status.js";
 import type { SessionEntry } from "./types.js";
 
 type SessionEntryCacheDatabase = Pick<OpenClawAgentDatabase, "agentId" | "db">;
@@ -127,55 +124,20 @@ export function trackSessionEntryCacheWrite(
     : { before, after: readSessionNodesGeneration(database.db) };
 }
 
-function parseSessionEntryProjection(
-  row: Parameters<typeof parseSessionEntryJson>[0],
-  projection: "full" | "list" = "list",
-): SessionEntry | null {
-  const entry = parseSessionEntryJson(row);
-  if (entry && projection === "list") {
-    // Drop caller-owned prompt payloads before either a reload or a tracked write publishes.
-    delete entry.skillsSnapshot;
-    delete entry.systemPromptReport;
-  }
-  return entry;
-}
-
-function selectSessionEntrySnapshotRows(
-  database: SessionEntryCacheDatabase,
-  projection: "full" | "list" = "list",
-) {
-  const db = getSessionKysely(database.db);
-  return db
-    .selectFrom("session_nodes")
-    .select("session_key")
-    .select(projection === "full" ? "entry_json" : sessionEntryMetadataJson)
-    .$if(hasSqliteSessionOwnerColumns(database.db), (query) =>
-      query.select([
-        "owner_actor_type",
-        "owner_actor_id",
-        "owner_assigned_by_type",
-        "owner_assigned_by_id",
-        "owner_assigned_at",
-      ]),
-    );
-}
-
 function loadSessionEntrySnapshot(
   database: SessionEntryCacheDatabase,
   projection: "full" | "list" = "list",
 ): SessionEntryCacheSnapshot {
   const rows = iterateSqliteQuerySync(
     database.db,
-    selectSessionEntrySnapshotRows(database, projection)
-      .select("updated_at")
-      .orderBy("session_key"),
+    selectSessionEntryRows(database, projection).select("updated_at").orderBy("session_key"),
   );
   const parsedEntries = new Map<string, SessionEntry>();
   const keys: string[] = [];
   // Stream raw JSON so a full read never holds both serialized and parsed store-wide payloads.
   for (const row of rows) {
     keys.push(row.session_key);
-    const entry = parseSessionEntryProjection(row, projection);
+    const entry = parseSessionEntryJson(row, projection);
     if (!entry) {
       continue;
     }
@@ -250,10 +212,7 @@ function publishSqliteSessionEntryCacheUpsert(
           .limit(1),
       ).rows[0]
     : undefined;
-  const parsedEntry = parseSessionEntryProjection({
-    entry_json: JSON.stringify(metadata),
-    ...ownerRow,
-  });
+  const parsedEntry = parseSessionEntryJson({ entry_json: JSON.stringify(metadata), ...ownerRow });
   if (!parsedEntry) {
     publishTrackedCacheUpdate(database, () => sessionEntryCaches.delete(database.db));
     return;

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -32,7 +32,6 @@ import {
 } from "./session-accessor.sqlite-node-artifacts.js";
 import {
   hasSqliteSessionOwnerColumns,
-  projectSqliteSessionOwner,
   type SqliteSessionOwnerRow,
 } from "./session-accessor.sqlite-owner-projection.js";
 import { projectSqliteSessionParticipants } from "./session-accessor.sqlite-participant-projection.js";
@@ -49,6 +48,7 @@ import {
   parseSessionEntryJson as parseSessionEntryRow,
   sessionEntryMetadataJson,
   sessionEntryInventoryJson,
+  selectSessionEntryRows,
 } from "./session-accessor.sqlite-status.js";
 import { readTranscriptMutationStateInTransaction } from "./session-accessor.sqlite-transcript-state.js";
 import {
@@ -57,9 +57,7 @@ import {
   assertCanonicalSessionKeyWriteMatchesDatabase,
   canonicalSessionKeyMigrationRequiredError,
 } from "./session-canonical-key.js";
-import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
 import { preserveCreationStamp } from "./session-entry-provenance.js";
-import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
 import {
   collectSessionEntryLookupKeys,
   resolveDeliveryProvenCanonicalSessionKey,
@@ -71,22 +69,19 @@ type OpenClawAgentDatabaseReader = Pick<OpenClawAgentDatabase, "agentId" | "db">
 type SessionEntryRow = Selectable<OpenClawAgentKyselyDatabase["session_nodes"]>;
 export type ResolvedSessionEntryRow = {
   entry: SessionEntry;
-  row: SessionEntryRow;
+  row: Pick<SessionEntryRow, "current_session_id" | "entry_json" | "session_key" | "updated_at"> &
+    SqliteSessionOwnerRow;
 };
 
 /** Decodes a fresh owned entry, including its nested JSON, owner and participant values. */
 export function parseReadableSqliteSessionEntryRow(
   database: Pick<OpenClawAgentDatabase, "db">,
-  row: Pick<SessionEntryRow, "current_session_id" | "entry_json" | "session_key" | "updated_at"> &
-    SqliteSessionOwnerRow,
+  row: ResolvedSessionEntryRow["row"],
+  projection: "full" | "list" = "full",
 ): SessionEntry | null {
-  const record = parseSqliteSessionEntryRecord(row);
-  if (record) {
-    const entry = projectSqliteSessionParticipants(
-      database.db,
-      row.session_key,
-      projectSqliteSessionOwner(projectCanonicalSessionEntryShape(record), row),
-    );
+  const parsed = parseSessionEntryRow(row, projection);
+  if (parsed) {
+    const entry = projectSqliteSessionParticipants(database.db, row.session_key, parsed);
     if (resolveDeliveryProvenCanonicalSessionKey(row.session_key, entry) !== row.session_key) {
       throw canonicalSessionKeyMigrationRequiredError(
         `non-canonical persisted row resolves to session key ${row.session_key}`,
@@ -180,16 +175,21 @@ export function readSessionEntrySelectionSnapshot(
 export function readExactSessionEntryRow(
   database: OpenClawAgentDatabaseReader,
   sessionKey: string,
+  projection: "full" | "list" = "full",
 ): ResolvedSessionEntryRow | undefined {
   const db = getSessionKysely(database.db);
+  const query =
+    projection === "list"
+      ? selectSessionEntryRows(database, projection).select(["current_session_id", "updated_at"])
+      : db.selectFrom("session_nodes").selectAll();
   const row = executeSqliteQueryTakeFirstSync(
     database.db,
-    db.selectFrom("session_nodes").selectAll().where("session_key", "=", sessionKey),
+    query.where("session_key", "=", sessionKey),
   );
   if (!row) {
     return undefined;
   }
-  const entry = parseReadableSqliteSessionEntryRow(database, row);
+  const entry = parseReadableSqliteSessionEntryRow(database, row, projection);
   return entry ? { entry, row } : undefined;
 }
 
@@ -207,9 +207,10 @@ export function readExactSessionEntryJson(
 export function readExactSessionEntryRowValidated(
   database: OpenClawAgentDatabaseReader,
   sessionKey: string,
+  projection: "full" | "list" = "full",
 ): ResolvedSessionEntryRow | undefined {
   assertCanonicalSqliteSessionKeysCurrent(database);
-  return readExactSessionEntryRow(database, sessionKey);
+  return readExactSessionEntryRow(database, sessionKey, projection);
 }
 
 export function readSessionEntryStore(

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -60,8 +60,11 @@ import {
   toDatabaseOptions,
   type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
-import { readSessionEntriesByStatus } from "./session-accessor.sqlite-status.js";
-import type { SessionEntryListScope } from "./session-accessor.types.js";
+import {
+  readSessionEntriesByStatus,
+  selectSessionEntryRows,
+} from "./session-accessor.sqlite-status.js";
+import type { SessionEntryListScope, SessionEntryReadScope } from "./session-accessor.types.js";
 import {
   assertCanonicalSessionKeyWrite,
   assertCanonicalSqliteSessionKeysCurrent,
@@ -133,15 +136,28 @@ export function loadSessionEntryReadOnly(scope: SessionAccessScope): SessionEntr
 }
 
 /** Loads one exact persisted-key entry from the additive SQLite session store. */
-export function loadExactSessionEntry(scope: SessionAccessScope): ExactSessionEntry | undefined {
+export function loadExactSessionEntry(scope: SessionEntryReadScope): ExactSessionEntry | undefined {
+  return loadExactSessionEntryWithMode(scope, false);
+}
+
+function loadExactSessionEntryWithMode(
+  scope: SessionEntryReadScope,
+  readOnly: boolean,
+): ExactSessionEntry | undefined {
   const sessionKey = scope.sessionKey.trim();
   if (!sessionKey) {
     return undefined;
   }
   const resolved = resolveSqliteScope(scope);
-  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  const entry = readExactSessionEntryRowValidated(database, sessionKey)?.entry;
-  return entry ? { sessionKey, entry } : undefined;
+  const read = (database: Pick<OpenClawAgentDatabase, "agentId" | "db">) => {
+    const entry = readExactSessionEntryRowValidated(database, sessionKey, scope.projection)?.entry;
+    return entry ? { sessionKey, entry } : undefined;
+  };
+  if (!readOnly) {
+    return read(openOpenClawAgentDatabase(toDatabaseOptions(resolved)));
+  }
+  const result = withOpenClawAgentDatabaseReadOnly(read, toDatabaseOptions(resolved));
+  return result.found ? result.value : undefined;
 }
 
 /** Lists persisted session keys without materializing their entry JSON. */
@@ -161,36 +177,29 @@ export function listSessionEntryKeysReadOnly(
 
 /** Exact persisted-key probe on the read-only handle, for per-row hot paths. */
 export function loadExactSessionEntryReadOnly(
-  scope: SessionAccessScope,
+  scope: SessionEntryReadScope,
 ): ExactSessionEntry | undefined {
-  const sessionKey = scope.sessionKey.trim();
-  if (!sessionKey) {
-    return undefined;
-  }
-  const resolved = resolveSqliteScope(scope);
-  const result = withOpenClawAgentDatabaseReadOnly(
-    (database) => readExactSessionEntryRowValidated(database, sessionKey)?.entry,
-    toDatabaseOptions(resolved),
-  );
-  return result.found && result.value
-    ? {
-        sessionKey,
-        entry: result.value,
-      }
-    : undefined;
+  return loadExactSessionEntryWithMode(scope, true);
 }
 
 /** Lists direct child rows without cloning or rebuilding the complete session store. */
-export function listSessionChildEntriesReadOnly(scope: SessionAccessScope): SessionEntrySummary[] {
+export function listSessionChildEntriesReadOnly(
+  scope: SessionEntryReadScope,
+): SessionEntrySummary[] {
   const resolved = resolveSqliteScope(scope);
   const result = withOpenClawAgentDatabaseReadOnly((database) => {
     assertCanonicalSqliteSessionKeysCurrent(database);
     const db = getSessionKysely(database.db);
+    const query =
+      scope.projection === "list"
+        ? selectSessionEntryRows(database, scope.projection).select([
+            "current_session_id",
+            "updated_at",
+          ])
+        : db.selectFrom("session_nodes").selectAll();
     const childRows = executeSqliteQuerySync(
       database.db,
-      db
-        .selectFrom("session_nodes")
-        .selectAll()
+      query
         .where((expression) =>
           expression.or([
             expression("parent_session_key", "=", resolved.sessionKey),
@@ -204,7 +213,7 @@ export function listSessionChildEntriesReadOnly(scope: SessionAccessScope): Sess
       if (isInternalSessionEffectsKey(row.session_key)) {
         return [];
       }
-      const entry = parseReadableSqliteSessionEntryRow(database, row);
+      const entry = parseReadableSqliteSessionEntryRow(database, row, scope.projection);
       return entry ? [{ sessionKey: row.session_key, entry }] : [];
     });
   }, toDatabaseOptions(resolved));

--- a/src/config/sessions/session-accessor.sqlite-status.ts
+++ b/src/config/sessions/session-accessor.sqlite-status.ts
@@ -7,6 +7,7 @@ import type {
   SessionEntrySummary,
 } from "./session-accessor.sqlite-contract.js";
 import {
+  hasSqliteSessionOwnerColumns,
   projectSqliteSessionOwner,
   type SqliteSessionOwnerRow,
 } from "./session-accessor.sqlite-owner-projection.js";
@@ -20,11 +21,33 @@ import type { SessionEntry } from "./types.js";
 type SessionStatusDatabase = Pick<OpenClawAgentKyselyDatabase, "session_nodes">;
 
 // Metadata readers do not own prompt snapshots. Strip those bytes before JS allocation;
-// malformed or SQLite-overdepth JSON still reaches the existing parser unchanged.
+// Malformed/overdepth JSON reaches the parser unchanged. Requiring an identity keeps
+// corrupt prompt-only objects distinct from the retained-window "{}" sentinel.
 export const sessionEntryMetadataJson =
   /* kysely-allow-raw: preserve raw-row parsing while omitting unused prompt payloads. */ sql<string>`CASE WHEN json_valid(entry_json)
-  THEN json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')
+  THEN CASE WHEN json_type(entry_json, '$.sessionId') = 'text'
+    THEN json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')
+    ELSE entry_json END
   ELSE entry_json END`.as("entry_json");
+
+export function selectSessionEntryRows(
+  database: Pick<OpenClawAgentDatabase, "db">,
+  projection: "full" | "list",
+) {
+  return getNodeSqliteKysely<SessionStatusDatabase>(database.db)
+    .selectFrom("session_nodes")
+    .select("session_key")
+    .select(projection === "full" ? "entry_json" : sessionEntryMetadataJson)
+    .$if(hasSqliteSessionOwnerColumns(database.db), (query) =>
+      query.select([
+        "owner_actor_type",
+        "owner_actor_id",
+        "owner_assigned_by_type",
+        "owner_assigned_by_id",
+        "owner_assigned_at",
+      ]),
+    );
+}
 
 // Canonical writers settle entry_valid; raw writes clear it. Inventory readers need
 // no payload for settled rows, but must retain parser semantics for pending/retained rows.
@@ -53,9 +76,18 @@ export function parseSessionEntryJson(
     entry_json: string;
     updated_at?: number;
   } & SqliteSessionOwnerRow,
+  projection: "full" | "list" = "full",
 ): SessionEntry | null {
   const record = parseSqliteSessionEntryRecord(row);
-  return record ? projectSqliteSessionOwner(projectCanonicalSessionEntryShape(record), row) : null;
+  if (!record) {
+    return null;
+  }
+  if (projection === "list") {
+    // SQLite-overdepth JSON bypasses SQL projection but must keep the same metadata contract.
+    delete record.skillsSnapshot;
+    delete record.systemPromptReport;
+  }
+  return projectSqliteSessionOwner(projectCanonicalSessionEntryShape(record), row);
 }
 
 export function readSessionEntriesByStatus(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -706,14 +706,16 @@ describe("session accessor seam", () => {
 
   it("opens a borrowed read view with raw exact-key probes and deferred enumeration", async () => {
     const mixedKey = "agent:main:matrix:channel:!RoomAbC:example.org";
+    const skillsSnapshot = { prompt: "saved skill prompt", skills: [] };
     await upsertSessionEntryCore(
       { sessionKey: mixedKey, storePath },
-      { sessionId: "mixed-session", updatedAt: 10 },
+      { sessionId: "mixed-session", updatedAt: 10, skillsSnapshot },
     );
 
     const view = openSessionEntryReadView({ storePath });
 
     expect(view.get(mixedKey)?.sessionId).toBe("mixed-session");
+    expect(view.get(mixedKey)?.skillsSnapshot).toEqual(skillsSnapshot);
     // Raw probe contract: unlike loadSessionEntry, no folded-alias or
     // canonical-key resolution happens on get.
     expect(view.get(mixedKey.toLowerCase())).toBeUndefined();
@@ -723,6 +725,9 @@ describe("session accessor seam", () => {
         entry: expect.objectContaining({ sessionId: "mixed-session" }),
       },
     ]);
+    const metadata = openSessionEntryReadView({ storePath, projection: "list" });
+    expect(metadata.get(mixedKey)?.skillsSnapshot).toBeUndefined();
+    expect(metadata.entries()).toEqual([{ sessionKey: mixedKey, entry: metadata.get(mixedKey) }]);
   });
 
   it("keeps case-distinct Matrix sessions separate under nested agent ownership", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -70,6 +70,7 @@ export type {
   SessionEntryPatchContext,
   SessionEntryPatchOptions,
   SessionEntryPatchResult,
+  SessionEntryReadScope,
   SessionEntryReadView,
   SessionEntryReplacement,
   SessionEntryReplacementSnapshot,

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -70,10 +70,12 @@ export type LogicalSessionAccessScope = {
   sessionKey: string;
 };
 
-export type SessionEntryListScope = Partial<Omit<SessionAccessScope, "sessionKey">> & {
-  /** Listing views do not consume the large per-run prompt snapshots. */
+export type SessionEntryReadScope = SessionAccessScope & {
+  /** Metadata views omit the large per-run prompt snapshots before decoding. */
   projection?: "full" | "list";
 };
+
+export type SessionEntryListScope = Partial<Omit<SessionEntryReadScope, "sessionKey">>;
 
 export type ResolvedSessionEntryAccessTarget = {
   /** Agent owner inferred from the canonical session key. */

--- a/src/gateway/server-methods/chat-history-handler.test.ts
+++ b/src/gateway/server-methods/chat-history-handler.test.ts
@@ -272,11 +272,13 @@ describe("chat history exact-entry snapshots", () => {
         };
         const childScope = { agentId: "main", sessionKey: "agent:main:subagent:history-child" };
         const toolOverrides = { mcpToolsDeny: { synthetic: ["blocked"] } };
+        const skillsSnapshot = { prompt: "history unused saved prompt", skills: [] };
         await upsertSessionEntryCore(scope, {
           sessionId: scope.sessionId,
           updatedAt: now,
           thinkingLevel: "high",
           toolOverrides,
+          skillsSnapshot,
         });
         await upsertSessionEntryCore(childScope, {
           sessionId: "history-child",
@@ -284,12 +286,14 @@ describe("chat history exact-entry snapshots", () => {
           parentSessionKey: scope.sessionKey,
           spawnedBy: scope.sessionKey,
           status: "running",
+          skillsSnapshot,
         });
         const context = createDirectChatContext();
         const handler = expectDefined(chatHistoryHandlers[method], "history handler");
         const call = async () => {
           const respond = vi.fn();
           const cloneSpy = vi.spyOn(globalThis, "structuredClone");
+          const parseSpy = vi.spyOn(JSON, "parse");
           try {
             const pending = handler({
               params: { sessionKey: scope.sessionKey },
@@ -303,6 +307,9 @@ describe("chat history exact-entry snapshots", () => {
             const preparationCopies = cloneSpy.mock.calls.filter(
               ([value]) => asOptionalRecord(value)?.sessionId === scope.sessionId,
             ).length;
+            expect(
+              parseSpy.mock.calls.some(([value]) => value.includes(skillsSnapshot.prompt)),
+            ).toBe(false);
             await pending;
             const [ok, payload, error] = expectDefined(respond.mock.calls[0], "history response");
             expect(error).toBeUndefined();
@@ -311,6 +318,7 @@ describe("chat history exact-entry snapshots", () => {
             return expectDefined(asOptionalRecord(payload), "history payload");
           } finally {
             cloneSpy.mockRestore();
+            parseSpy.mockRestore();
           }
         };
 

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -133,6 +133,7 @@ async function handleChatMetadataRequest({
     // The router authorizes the session selector; only the persisted entry supplies auth profiles.
     const session = loadGatewaySessionEntryReadOnly(metadataParams.sessionKey, {
       agentId: requested.agentId,
+      projection: "list",
     });
     respond(
       true,
@@ -244,6 +245,7 @@ async function handleChatHistoryRequest({
         // Exact reads own their nested JSON; history only projects that snapshot.
         clone: false,
         includeStoreChildEntries: true,
+        projection: "list",
       }),
     {
       config: requestConfig,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -3216,7 +3216,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
     expect(mockState.loadSessionEntryCalls).toContainEqual({
       rawKey: "agent:work:main",
-      opts: { agentId: "work", clone: false, includeStoreChildEntries: true },
+      opts: { agentId: "work", clone: false, includeStoreChildEntries: true, projection: "list" },
     });
   });
 

--- a/src/gateway/session-utils-store-lookup.ts
+++ b/src/gateway/session-utils-store-lookup.ts
@@ -229,14 +229,11 @@ function loadGatewaySessionLookupStoreUncached(
         const match = loadExact({
           ...(agentId ? { agentId } : {}),
           clone: false,
+          projection: options.projection,
           sessionKey,
           storePath,
         });
         if (match) {
-          if (options.projection === "list") {
-            delete match.entry.skillsSnapshot;
-            delete match.entry.systemPromptReport;
-          }
           store[match.sessionKey] = match.entry;
         }
       }
@@ -486,7 +483,11 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });
   if (explicitDeletedMainTarget) {
-    return includeDirectChildEntries(explicitDeletedMainTarget, params.includeStoreChildEntries);
+    return includeDirectChildEntries(
+      explicitDeletedMainTarget,
+      params.includeStoreChildEntries,
+      params.projection,
+    );
   }
 
   const requestedAgentId = normalizeOptionalString(params.agentId);
@@ -519,6 +520,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
         store,
       },
       params.includeStoreChildEntries,
+      params.projection,
     );
   }
   const { canonicalValidationError, storePath, store } = resolveGatewaySessionStoreLookup({
@@ -547,6 +549,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
         ...(canonicalValidationError ? { canonicalValidationError } : {}),
       },
       params.includeStoreChildEntries,
+      params.projection,
     );
   }
 
@@ -563,12 +566,14 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
       ...(canonicalValidationError ? { canonicalValidationError } : {}),
     },
     params.includeStoreChildEntries,
+    params.projection,
   );
 }
 
 function includeDirectChildEntries(
   target: GatewaySessionStoreTargetWithStore,
   include: boolean | undefined,
+  projection: SessionEntryListScope["projection"],
 ): GatewaySessionStoreTargetWithStore {
   if (!include) {
     return target;
@@ -579,6 +584,7 @@ function includeDirectChildEntries(
       for (const { sessionKey, entry } of listSessionChildEntriesReadOnly({
         agentId: target.agentId,
         clone: false,
+        projection,
         sessionKey: parentKey,
         storePath: target.storePath,
       })) {

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -198,11 +198,9 @@ export function loadGatewaySessionEntry(
 export function loadGatewaySessionEntryReadOnly(
   sessionKey: string,
   opts?: {
-    agentId?: string;
-    clone?: boolean;
     includeStoreChildEntries?: boolean;
     targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
-  },
+  } & Pick<SessionEntryListScope, "agentId" | "clone" | "projection">,
 ) {
   return loadSessionEntryWithMode(sessionKey, opts, true);
 }

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -273,6 +273,9 @@ describe("single gateway session row child projections", () => {
             });
             expect(metadata.entry?.skillsSnapshot).toBeUndefined();
             expect(metadata.entry?.systemPromptReport).toBeUndefined();
+            expect(parse.mock.calls.some(([value]) => value.includes("saved skill prompt"))).toBe(
+              false,
+            );
             expect(loadSessionEntry("main", { agentId: MAIN_AGENT_ID, clone })).toMatchObject({
               agentId: metadata.agentId,
               canonicalKey: metadata.canonicalKey,
@@ -324,11 +327,10 @@ describe("single gateway session row child projections", () => {
       async ({ now, storePath }) => {
         const store: Record<string, SessionEntry> = {
           "agent:main:subagent:parent-a": parentSession("parent-a", now),
-          "agent:main:subagent:child-a": runningChildSession(
-            "child-a",
-            "agent:main:subagent:parent-a",
-            now,
-          ),
+          "agent:main:subagent:child-a": {
+            ...runningChildSession("child-a", "agent:main:subagent:parent-a", now),
+            skillsSnapshot: { prompt: "child saved skill prompt", skills: [] },
+          },
           "agent:main:subagent:parent-b": parentSession("parent-b", now),
           "agent:main:subagent:child-b": runningChildSession(
             "child-b",
@@ -351,7 +353,9 @@ describe("single gateway session row child projections", () => {
           const loaded = loadGatewaySessionEntryReadOnly("agent:main:subagent:parent-a", {
             clone: false,
             includeStoreChildEntries: true,
+            projection: "list",
           });
+          expect(loaded.store["agent:main:subagent:child-a"]?.skillsSnapshot).toBeUndefined();
           const entriesSpy = vi.spyOn(Object, "entries");
           try {
             const row = buildGatewaySessionInfo({ ...loaded, key: loaded.canonicalKey, now });

--- a/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
+++ b/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
@@ -160,21 +160,18 @@ export async function runSqliteSessionsTranscriptsFlipProof(options: RunOptions 
           throw new Error(`expected built CLI entrypoint, got ${gatewayEntrypoint.join(" ")}`);
         }
         if (options.requireBuiltCli === true) {
-          const inventory = await inst.cli(["plugins", "list", "--json"]);
-          const plugins = parseJsonObject(inventory.stdout)?.plugins;
-          if (inventory.code !== 0 || !Array.isArray(plugins)) {
-            throw new Error("built CLI could not list bundled plugin artifacts");
+          // Only this provider is exercised; the full inventory can exceed the CLI log-tail bound.
+          const inspection = await inst.cli(["plugins", "inspect", "openai", "--json"]);
+          const plugin = asRecord(parseJsonObject(inspection.stdout)?.plugin);
+          if (
+            inspection.code !== 0 ||
+            plugin?.id !== "openai" ||
+            plugin.origin !== "bundled" ||
+            typeof plugin.source !== "string"
+          ) {
+            throw new Error("built CLI could not inspect the bundled OpenAI artifact");
           }
-          bundledPlugins = plugins.flatMap((value) => {
-            const plugin = asRecord(value);
-            if (plugin?.origin !== "bundled") {
-              return [];
-            }
-            if (typeof plugin.id !== "string" || typeof plugin.source !== "string") {
-              throw new Error("bundled plugin inventory omitted its identity or source artifact");
-            }
-            return [{ id: plugin.id, source: plugin.source }];
-          });
+          bundledPlugins = [{ id: plugin.id, source: plugin.source }];
         }
 
         await startMockOpenAiServer(context, {


### PR DESCRIPTION
## What Problem This Solves

Gateway session metadata reads decode saved skills and system-prompt snapshots that the UI never consumes. Exact metadata lookups discard those fields only after parsing, and a borrowed metadata view's `get` ignores the projection that its `entries` method honors. History/startup reads also hydrate the full parent and direct-child entries.

## Why This Change Was Made

Move metadata projection into the shared SQLite query/parser boundary and carry it through exact, child, history, startup, and chat-metadata reads. Reuse the existing listing projection instead of maintaining consumer-side stripping. Consolidate 19 duplicated accessor type definitions into their canonical definitions, retaining SQLite-specific contracts separately.

Full reads and raw JSON comparison bytes remain intact. Canonical-key checks, owner/participant projections, read-only missing-store behavior, cache freshness, and corrupt/retained-row handling are preserved. The SQL projection retains corrupt prompt-only objects rather than converting them into the retained-window `{}` sentinel; overdepth JSON still reaches the original parser. No schema, index, transaction, concurrency policy, configuration, dependency, or protocol change.

**Production LOC:** +134 / -252, net **-118**. Tests and test support: +63 / -26, net +37.

## User Impact

Less work and allocation when session metadata contains large saved prompts. This fixes inconsistent metadata projection and reduces duplication; it does **not** claim to eliminate Gateway saturation.

## Evidence

The original 148 focused cases passed. New assertions failed on the parent for both writable/borrowed Gateway prompt decoding and exact borrowed-view projection. The final owner and sibling proof totals **637 passing cases across nine files**, plus the built-CLI lifecycle proof, including history/startup, ownership/participants, canonical routing, corruption, retained windows, same-timestamp updates, and rollback. One cache-test observer needed to forward the new parser argument and exclude exact CAS reads now sharing the decoder; its count/byte budgets remain, and rollback now exercises the actual list cache. Independent Codex review is scoped-clean through P2 for the production refactor and both CI fixture corrections.

Controlled [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33648190162): command exit 0; worker stopped after artifact verification. Baseline `e9f322ff2326abcf4cea736786827e1b737c4774`; final production afterimages exactly match the measured candidate. Each revision installed and built `sourcePerformance` separately, with all 36,679 source entries and 8,783 build entries verified unchanged. Node 24, four-CPU affinity, fresh HOME/state and loopback ports. Synthetic streaming provider; real Gateway HTTP/RPC. No operator or production Gateway was used.

All **10 load runs** passed the unchanged **2000ms** control/handshake budgets with zero operation failures and zero plugin metadata rescans. Workload: 32/64 turns, 48 seed sessions, 128 updates/4 clients, 3 history clients × 5 burst, 6 visible subscribers, 100ms cadence, 1000ms stream delay. Before/after/after/before at each concurrency, plus separate 64-turn CPU profiles.

At 64 turns, candidate history p99 was **624.6 / 626.6ms**, versus **993.5 / 627.0ms** before. Candidate `sessions.list` maxima were **599.9 / 606.9ms**, versus **985.0 / 608.6ms** before. Typical tails are similar; the slower first baseline repetition is not attributed wholly to this patch.

Component medians over 12 rounds of 100 reads, same worker, 48 rows:

| Saved prompt bytes | Read | Before | After |
|---:|---|---:|---:|
| 65,536 | Parent + eight children | 0.483ms | 0.392ms |
| 524,288 | Single metadata row | 0.414ms | 0.228ms |
| 524,288 | Parent + eight children | 5.016ms | 1.507ms |

The fixture uses one long prompt string, not every real prompt shape. Small-row metadata overhead increased by roughly 9µs; full-read timings were close. No universal speedup or memory-leak claim is made.

Residual saturation remains: candidate readiness degraded in 283/283 samples and median event-loop utilization stayed 1. Profiled transaction stacks occupied 17.57% before / 16.27% after, history handlers 11.95% / 11.43%; inclusive costs overlap and are not additive. RSS varied across repetitions.

Artifact bundle SHA-256: `80d62b3f1c3f12cd9a73e258edee2403319caf9355427aa4a4b8a7d18b46ca5e`. The full [changed-code gate](https://github.com/openclaw/openclaw/actions/runs/33647994055) and final local cache-fixture gate both exited 0. The one-shot worker stopped. Final [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33654319698) passed on `4f421e2036e7721330cc37461f1654a08622ee78`, including the aggregate gate, both Windows jobs, and the built-artifact lifecycle proof.


On initial head `d70dd0e`, CI run `33649514321` attempt 1 lost its self-hosted runners before any test step; one unchanged-head retry used the workflow’s existing hosted fallback. Attempt 2 passed 227 checks and exposed two failures (plus the aggregate gate). The exact history-alias expectation now includes the metadata projection, preserving all other arguments; its complete 213-case file passed in original order. The built-CLI lifecycle proof requested a 293,362-byte all-plugin inventory through a 256 KiB log-tail helper. It now inspects only its explicit OpenAI provider artifact (4,097 bytes), retaining the bundled identity and built-path assertion without changing any limit. The complete real Gateway/mock-provider lifecycle proof passed in 147 seconds. No failed assertion, test, buffer bound, or latency budget was removed or relaxed.


## Maintainer Disposition

Accepted for landing as the requested internal session-read refactor. The latest completed ClawSweeper review covers this exact head and found no code or security defect; its outstanding CI condition is now satisfied. The read-only projection preserves existing storage semantics, and the residual saturation and measurement limitations above remain explicit. No required check or review rule is bypassed.
