### PR TITLE
perf(logging): reuse prepared payload byte counts

### DIFF
--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -172,10 +172,10 @@ function claimQueuedEntries(): FileLogQueueEntry[] {
   return entries;
 }
 
-function rotateIfNeeded(entry: FileLogQueueEntry, cursor: FileCursor, synchronous: boolean): void {
+function prepareWrite(entry: FileLogQueueEntry, cursor: FileCursor, synchronous: boolean): number {
   const payloadBytes = Buffer.byteLength(entry.payload, "utf8");
   if (cursor.bytes === 0 || cursor.bytes + payloadBytes <= entry.maxFileBytes) {
-    return;
+    return payloadBytes;
   }
   if (rotateLogFile(entry.file)) {
     cursor.bytes = 0;
@@ -183,6 +183,7 @@ function rotateIfNeeded(entry: FileLogQueueEntry, cursor: FileCursor, synchronou
   } else {
     warnAboutRotationFailure(entry, synchronous);
   }
+  return payloadBytes;
 }
 
 async function writeEntries(entries: FileLogQueueEntry[], generation: number): Promise<void> {
@@ -203,8 +204,7 @@ async function writeEntries(entries: FileLogQueueEntry[], generation: number): P
       }
       cursors.set(entry.file, cursor);
     }
-    rotateIfNeeded(entry, cursor, false);
-    const payloadBytes = Buffer.byteLength(entry.payload, "utf8");
+    const payloadBytes = prepareWrite(entry, cursor, false);
     activeAppendInFlight = true;
     try {
       await appendFile({ filePath: entry.file, content: entry.payload });
@@ -233,8 +233,7 @@ function writeEntriesSync(entries: FileLogQueueEntry[]): void {
       cursor = { bytes: getCurrentLogFileBytesSync(entry.file) };
       cursors.set(entry.file, cursor);
     }
-    rotateIfNeeded(entry, cursor, true);
-    const payloadBytes = Buffer.byteLength(entry.payload, "utf8");
+    const payloadBytes = prepareWrite(entry, cursor, true);
     try {
       appendRegularFileSync({ filePath: entry.file, content: entry.payload });
       cursor.bytes += payloadBytes;


### PR DESCRIPTION
## What Problem This Solves

Each file-log record has its UTF-8 length counted twice by the transport: once to decide whether to rotate, then again immediately before appending. Unicode and large diagnostic records repeat the same work on both asynchronous writes and synchronous shutdown drains.

## Why This Change Was Made

The existing private preparation owner returns the length it already computed. Both writers carry that value through the append and update their cursor only after success. Rotation, warnings, queue limits, drain generations, issued-append exclusion, and payload release keep their existing ownership and ordering.

## User Impact

Less repeated work per file-log record; log contents and rollover behavior stay unchanged. Production LOC: −1; tests unchanged.

## Evidence

All 15 existing transport and file-cap tests passed before and after, including the real-child exit drain. Eight actual-owner cases used real safe filesystem appends and rotations: asynchronous/synchronous exact-cap and oversized records, rotation failures, append failure, and a completed append whose settlement was held while the queued tail was rescued synchronously. All file bytes, ordering, rotations, and warning outcomes matched.

Across 92 attempted records, direct transport byte-length calls fell from 184 to 92, and their total UTF-8 input volume from 3,397,376 to 1,698,688 bytes. The dependency's 46 independent checks remained unchanged. This is a repeated-work reduction; input byte volume is not an allocated-memory or RSS measurement.

`node scripts/run-vitest.mjs src/logging/logger-file-transport.test.ts src/logging/log-file-size-cap.test.ts` and the full canonical changed gate passed. Independent Codex review found no actionable P0–P2 issues. All proof processes joined and removed their temporary files.

Inspectable follow-up: [actual-source and runtime evidence](https://github.com/openclaw/openclaw/pull/136393#issuecomment-5512293364).

Proof identity after the mechanical refresh: the recorded filesystem trace used `4288b640397514b007fd8df5ee8cf0ec0fe9d607`; current head `ace08ea6cd69996f3595a86f08320b70631d7e50` has byte-identical `src/logging/logger-file-transport.ts` (SHA-256 `64200e21aa255d2c0b9e81de54d7789f9e2fce110bf39d42622147d2cda5110c`). This binds the retained owner proof across the refresh; it does not claim a second runtime run. The later queue-payload release in #136416 was also inspected for composition: queued eviction does not alter the detached active batch, and the fresh drop marker is built before its emitted bytes are counted.
