### PR TITLE
perf(plugins): project only selected provider entries

### DIFF
--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -194,7 +194,7 @@ function findProviderRuntimePluginInRegistry(params: {
   provider: string;
   ownerRefs: readonly string[];
 }): ProviderPlugin | undefined {
-  return listProviderRuntimePluginsInRegistry(params.registry).find((plugin) => {
+  const entry = params.registry.providers.find(({ provider: plugin }) => {
     if (params.ownerRefs.length > 0) {
       return (
         matchesProviderLiteralId(plugin, params.provider) ||
@@ -203,14 +203,7 @@ function findProviderRuntimePluginInRegistry(params: {
     }
     return matchesProviderPluginRef(plugin, params.provider);
   });
-}
-
-function listProviderRuntimePluginsInRegistry(
-  registry: PluginRegistry,
-): Array<ProviderPlugin & { pluginId: string }> {
-  return registry.providers.map((entry) =>
-    Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
-  );
+  return entry ? Object.assign({}, entry.provider, { pluginId: entry.pluginId }) : undefined;
 }
 
 function hasConfiguredModelProvider(params: {
@@ -234,12 +227,16 @@ export function resolveLoadedProviderPluginsForHooks(params: {
 }): ProviderPlugin[] | undefined {
   const filterRegistryPlugins = (registry: PluginRegistry) => {
     const onlyPluginIds = params.onlyPluginIds ? new Set(params.onlyPluginIds) : undefined;
-    return listProviderRuntimePluginsInRegistry(registry).filter(
-      (plugin) =>
-        (!onlyPluginIds || onlyPluginIds.has(plugin.pluginId)) &&
-        (!params.providerRefs?.length ||
-          params.providerRefs.some((providerRef) => matchesProviderPluginRef(plugin, providerRef))),
-    );
+    return registry.providers
+      .filter(
+        ({ pluginId, provider }) =>
+          (!onlyPluginIds || onlyPluginIds.has(pluginId)) &&
+          (!params.providerRefs?.length ||
+            params.providerRefs.some((providerRef) =>
+              matchesProviderPluginRef(provider, providerRef),
+            )),
+      )
+      .map(({ pluginId, provider }) => Object.assign({}, provider, { pluginId }));
   };
   const generationRegistry = getPluginRuntimeGenerationRegistry();
   if (generationRegistry) {

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -689,13 +689,14 @@ describe("provider-runtime", () => {
   it("uses the prepared run registry without repeating provider discovery", () => {
     const provider: ProviderPlugin = {
       id: DEMO_PROVIDER_ID,
+      pluginId: "embedded-owner",
       label: "Prepared demo",
       auth: [],
       classifyFailoverReason: () => "overloaded",
     };
     const registry = createEmptyPluginRegistry();
     registry.providers.push({
-      pluginId: DEMO_PROVIDER_ID,
+      pluginId: "registered-owner",
       provider,
       source: "test",
     });
@@ -717,7 +718,10 @@ describe("provider-runtime", () => {
       ),
     ).toBe("overloaded");
     expect(resolved?.id).toBe(DEMO_PROVIDER_ID);
-    expect(resolved?.pluginId).toBe(DEMO_PROVIDER_ID);
+    expect(resolved?.pluginId).toBe("registered-owner");
+    expect(resolved).not.toBe(provider);
+    expect(resolved?.auth).toBe(provider.auth);
+    expect(resolved?.classifyFailoverReason).toBe(provider.classifyFailoverReason);
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
@@ -1075,15 +1079,30 @@ describe("provider-runtime", () => {
   });
 
   it("serves hook plugin lists from the active loaded registry without a scoped load", () => {
-    const provider: ProviderPlugin = { id: DEMO_PROVIDER_ID, label: "Demo", auth: [] };
+    const provider: ProviderPlugin = {
+      id: DEMO_PROVIDER_ID,
+      pluginId: "embedded-owner",
+      aliases: ["demo-alias"],
+      label: "Demo",
+      auth: [],
+    };
     const registry = createEmptyPluginRegistry();
     registry.plugins.push({ id: "demo-plugin", status: "loaded" } as never);
-    registry.providers.push({ pluginId: "demo-plugin", provider, source: "demo-plugin/index.js" });
+    registry.providers.push(
+      { pluginId: "other-plugin", provider, source: "other-plugin/index.js" },
+      { pluginId: "demo-plugin", provider, source: "demo-plugin/index.js" },
+    );
     setActivePluginRegistry(registry, "workspace-one", "default", "/tmp/work");
 
-    const plugins = resolveProviderPluginsForHooks({ onlyPluginIds: ["demo-plugin"] });
+    const plugins = resolveProviderPluginsForHooks({
+      onlyPluginIds: ["demo-plugin"],
+      providerRefs: ["demo-alias"],
+    });
 
     expect(plugins.map((plugin) => plugin.id)).toEqual([DEMO_PROVIDER_ID]);
+    expect(plugins[0]?.pluginId).toBe("demo-plugin");
+    expect(plugins[0]).not.toBe(provider);
+    expect(plugins[0]?.auth).toBe(provider.auth);
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

A loaded provider lookup copied every provider in its registry before selecting one. Filtered hook lists likewise copied providers they would immediately discard. Repeated lookups therefore allocated a full registry's outward objects even for one result or a miss.

## Why This Change Was Made

The runtime now matches normalized registry entries first and creates the same shallow outward copies only for selected entries. Registration-owned plugin IDs still override embedded IDs; returned objects remain fresh and share their existing nested auth/hook references. Generation, request, active-registry, and discovery precedence are unchanged. The redundant eager projection helper is removed.

## User Impact

Fewer temporary provider objects during runtime hook resolution, with the same selection and hook behavior. Production LOC: −3; tests: +19.

## Evidence

89 focused tests passed across provider runtime, shared matching, and external policy. Existing tests now also protect the registry owner override, shallow reference contract, and combined owner/alias filtering. The full canonical changed gate and independent Codex review passed; a separate subagent inspected registration, normalization, callers, and registry scope ownership.

An actual-owner probe used a 64-entry provider registry and counted object enumeration during projection. Every lookup result matched the baseline: first/last/alias/hook/explicit-owner hits copied 64→1 objects, misses copied 64→0, a two-result filtered list copied 64→2, and the unfiltered list remained 64→64. Empty generation authority, symbol values, source immutability, and nested reference identity also passed. Both source processes joined cleanly. This is projection-work evidence, not a retained-heap or RSS claim.

`OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/provider-runtime.test.ts src/plugins/provider-registry-shared.test.ts src/plugins/provider-runtime.external-policy.test.ts`
