### PR TITLE
perf(gateway): select observer model slots in one pass

### DIFF
--- a/src/gateway/session-observer-model-slots.test.ts
+++ b/src/gateway/session-observer-model-slots.test.ts
@@ -24,42 +24,52 @@ function modelState(index: number, terminalHealth?: "done" | "failed"): SessionO
 }
 
 describe("session observer model slots", () => {
-  it("demotes the oldest nonterminal model state", () => {
-    const states = new Map<string, SessionObserverState>();
-    const terminal = modelState(0, "done");
-    states.set(terminal.sessionKey, terminal);
-    for (let index = 1; index < 6; index += 1) {
-      const state = modelState(index);
-      states.set(state.sessionKey, state);
-    }
-    const demote = vi.fn();
-    const slots = createSessionObserverModelSlots({
-      states,
-      maxSessions: 6,
-      resolve: () => "openai/gpt-test",
-      demote,
-    });
+  it.each(["activity", "session-key"] as const)(
+    "demotes the oldest nonterminal model state by %s",
+    (order) => {
+      const states = new Map<string, SessionObserverState>();
+      const terminal = modelState(0, "done");
+      states.set(terminal.sessionKey, terminal);
+      for (const index of [5, 4, 3, 2, 1]) {
+        const state = modelState(index);
+        if (order === "session-key") {
+          state.lastActivityAt = 1;
+        }
+        states.set(state.sessionKey, state);
+      }
+      const demote = vi.fn();
+      const slots = createSessionObserverModelSlots({
+        states,
+        maxSessions: 6,
+        resolve: () => "openai/gpt-test",
+        demote,
+      });
 
-    expect(slots.claim("main")).toBe("openai/gpt-test");
-    expect(demote).toHaveBeenCalledWith(states.get("agent:main:session-1"));
-    expect(demote).not.toHaveBeenCalledWith(terminal);
-  });
+      expect(slots.claim("main")).toBe("openai/gpt-test");
+      expect(demote).toHaveBeenCalledWith(states.get("agent:main:session-1"));
+      expect(demote).not.toHaveBeenCalledWith(terminal);
+    },
+  );
 
-  it("does not evict terminal finalizations when every slot is protected", () => {
-    const states = new Map<string, SessionObserverState>();
-    for (let index = 0; index < 6; index += 1) {
-      const state = modelState(index, "done");
-      states.set(state.sessionKey, state);
-    }
-    const demote = vi.fn();
-    const slots = createSessionObserverModelSlots({
-      states,
-      maxSessions: 6,
-      resolve: () => "openai/gpt-test",
-      demote,
-    });
+  it.each(["terminal", "final-pending"] as const)(
+    "does not evict %s states when every slot is protected",
+    (kind) => {
+      const states = new Map<string, SessionObserverState>();
+      for (let index = 0; index < 6; index += 1) {
+        const state = modelState(index, kind === "terminal" ? "done" : undefined);
+        state.finalPending = kind === "final-pending";
+        states.set(state.sessionKey, state);
+      }
+      const demote = vi.fn();
+      const slots = createSessionObserverModelSlots({
+        states,
+        maxSessions: 6,
+        resolve: () => "openai/gpt-test",
+        demote,
+      });
 
-    expect(slots.claim("main")).toBeUndefined();
-    expect(demote).not.toHaveBeenCalled();
-  });
+      expect(slots.claim("main")).toBeUndefined();
+      expect(demote).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/gateway/session-observer-model-slots.ts
+++ b/src/gateway/session-observer-model-slots.ts
@@ -30,29 +30,31 @@ export function createSessionObserverModelSlots(params: {
       if (!resolved || current?.utilityModelRef === resolved) {
         return resolved;
       }
-      const occupied = [...params.states.values()].filter(
-        (state) => state !== current && state.utilityModelRef,
-      );
-      if (current && demoted.has(current)) {
-        if (occupied.length >= params.maxSessions) {
-          return undefined;
+      let occupied = 0;
+      let evicted: SessionObserverState | undefined;
+      for (const state of params.states.values()) {
+        if (state === current || !state.utilityModelRef) {
+          continue;
         }
-        demoted.delete(current);
-        return resolved;
+        occupied += 1;
+        if (
+          !state.terminalHealth &&
+          !state.finalPending &&
+          (!evicted ||
+            (state.lastActivityAt - evicted.lastActivityAt ||
+              state.sessionKey.localeCompare(evicted.sessionKey)) < 0)
+        ) {
+          evicted = state;
+        }
       }
-      if (occupied.length >= params.maxSessions) {
-        const evicted = occupied
-          .filter((state) => !state.terminalHealth && !state.finalPending)
-          .toSorted(
-            (left, right) =>
-              left.lastActivityAt - right.lastActivityAt ||
-              left.sessionKey.localeCompare(right.sessionKey),
-          )[0];
-        if (!evicted) {
+      if (occupied >= params.maxSessions) {
+        if ((current && demoted.has(current)) || !evicted) {
           return undefined;
         }
         demoted.add(evicted);
         params.demote(evicted);
+      } else if (current) {
+        demoted.delete(current);
       }
       return resolved;
     },


### PR DESCRIPTION
## What Problem This Solves

Claiming a utility-model slot copied every observed session, filtered that array, then filtered and sorted it again to select one eviction candidate. Busy observers paid for those temporary arrays even though the decision needs only a count and one oldest eligible state.

## Why This Change Was Made

Select the oldest eligible state and count occupied slots in one pass over the authoritative map. Preserve the existing activity/session-key ordering, terminal and finalization protection, current-state exemption, demoted-state readmission, and exact demotion callback. No cache, lifecycle or configuration change is introduced.

## User Impact

The same sessions receive model slots with less temporary array work. Production grows by two lines to express the single-pass count and selection; four temporary arrays and sorting are removed. Existing behavioral tests grow by ten lines to distinguish activity ordering from tied session-key ordering and terminal protection from pending-finalization protection.

## Evidence

35 focused observer tests and the full canonical changed gate passed. Managed Codex review found no actionable P0–P2 findings. An actual-source baseline/candidate probe matched 512 seeded scenarios of twelve serial claims, including state removal, protection changes, starvation/readmission and request-generation abort behavior.

The allocation-work probe ran 100 claims over 1,024 observed states, six of which occupied model slots:

```json
{"baseline":{"filterCalls":200,"filterOutputSlots":1200,"sortCalls":100,"sortOutputSlots":600},"candidate":{"filterCalls":0,"filterOutputSlots":0,"sortCalls":0,"sortOutputSlots":0}}
```

The prior full-map spread is also removed. These are operation/element counts, not backing-store bytes, retained heap or RSS measurements. Both source probes exited 0. The owner and full observer-service tests passed together:

```text
node scripts/run-vitest.mjs src/gateway/session-observer-model-slots.test.ts src/gateway/session-observer.test.ts
node scripts/check-changed.mjs -- src/gateway/session-observer-model-slots.ts src/gateway/session-observer-model-slots.test.ts
```

The reviewed patch is now on main revision `1e37a56c75289bd887bbb244965d4896b921b625`, including the browser-fixture repair from #136402. Refreshed head: `1466c6572804aad8447494440f3b415f8ec1dbe1`. The touched source bytes and stable patch identity match the previously reviewed `ea144356a1e0b52bd303d1db20c3ecc8d53e9a6f`; previously recorded behavior runs cover that identical owner source, and hosted CI validates the refreshed head.
The base already uses the selective `plugins inspect openai --json` lifecycle probe. Build readiness is checked by the refreshed CI run; this does not claim a separately measured inspect-output byte count.
