### PR TITLE
fix(media): preserve size errors for fractional byte limits

### DIFF
--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -186,6 +186,16 @@ describe("readResponseWithLimit", () => {
     await expect(readResponseWithLimit(response, 100)).resolves.toEqual(Buffer.from([1, 2, 3, 4]));
   });
 
+  it.each([0.5, 3.5])("reports overflow for a fractional byte budget of %s", async (maxBytes) => {
+    const response = new Response(makeStream([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]));
+
+    await expect(
+      readResponseWithLimit(response, maxBytes, {
+        onOverflow: ({ maxBytes: limit }) => new Error(`Exceeded ${limit} bytes`),
+      }),
+    ).rejects.toThrow(`Exceeded ${maxBytes} bytes`);
+  });
+
   it.each([
     {
       name: "throws when total exceeds maxBytes",
@@ -502,6 +512,21 @@ describe("readResponseTextSnippet", () => {
       truncated: true,
     });
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { maxBytes: 0.5, text: "", size: 3 },
+    { maxBytes: 3.5, text: "abc", size: 6 },
+  ])("returns whole bytes under a fractional prefix budget of $maxBytes", async (expected) => {
+    const response = new Response(
+      makeStream([new TextEncoder().encode("abc"), new TextEncoder().encode("def")]),
+    );
+
+    await expect(readResponseTextPrefix(response, expected.maxBytes)).resolves.toEqual({
+      text: expected.text,
+      size: expected.size,
+      truncated: true,
+    });
   });
 
   it("applies the idle timeout while reading snippets", async () => {

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -159,19 +159,12 @@ type ReadResponsePrefixOptions = ReadResponseTextPrefixOptions & {
   stopAtLimit?: boolean;
 };
 
-function validateMaxBytes(maxBytes: number): void {
-  if (!Number.isFinite(maxBytes) || maxBytes < 0) {
-    throw new RangeError(`maxBytes must be a non-negative finite number: ${maxBytes}`);
-  }
-}
-
 async function readResponsePrefixFromReader(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   maxBytes: number,
   options?: ReadResponsePrefixOptions,
 ): Promise<ReadResponsePrefixResult> {
   const chunks: Uint8Array[] = [];
-  let total = 0;
   let size = 0;
   let truncated = false;
   try {
@@ -180,28 +173,23 @@ async function readResponsePrefixFromReader(
         ? await readChunkWithIdleTimeout(reader, options.chunkTimeoutMs, options.onIdleTimeout)
         : await reader.read();
       if (done) {
-        size = total;
         break;
       }
       if (!value?.length) {
         continue;
       }
-      const nextTotal = total + value.length;
-      if (nextTotal > maxBytes || (options?.stopAtLimit && nextTotal === maxBytes)) {
-        const remaining = maxBytes - total;
+      const remaining = maxBytes - size;
+      size += value.length;
+      if (size > maxBytes || (options?.stopAtLimit && size === maxBytes)) {
         if (remaining > 0) {
           chunks.push(value.subarray(0, remaining));
-          total += remaining;
         }
-        size = nextTotal;
         truncated = true;
         // A capture tee can retain cancellation until the caller releases its request.
         void reader.cancel().catch(() => undefined);
         break;
       }
       chunks.push(value);
-      total = nextTotal;
-      size = total;
     }
   } finally {
     try {
@@ -210,7 +198,8 @@ async function readResponsePrefixFromReader(
   }
 
   return {
-    buffer: Buffer.concat(chunks, total),
+    // MiB limits can yield fractional bytes; retained slices contain only whole bytes.
+    buffer: Buffer.concat(chunks, Math.floor(Math.min(size, maxBytes))),
     size,
     truncated,
   };
@@ -221,7 +210,9 @@ async function readResponsePrefix(
   maxBytes: number,
   options?: ReadResponsePrefixOptions,
 ): Promise<ReadResponsePrefixResult> {
-  validateMaxBytes(maxBytes);
+  if (!Number.isFinite(maxBytes) || maxBytes < 0) {
+    throw new RangeError(`maxBytes must be a non-negative finite number: ${maxBytes}`);
+  }
   let timeoutMs: number | undefined;
   try {
     timeoutMs = typeof options?.timeoutMs === "function" ? options.timeoutMs() : options?.timeoutMs;
@@ -289,10 +280,7 @@ export async function readResponseWithLimit(
     onOverflow?: (params: { size: number; maxBytes: number; res: Response }) => Error;
   },
 ): Promise<Buffer> {
-  const onOverflow =
-    options?.onOverflow ??
-    ((params: { size: number; maxBytes: number }) =>
-      new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
+  const onOverflow = options?.onOverflow;
   const prefix = await readResponsePrefix(response, maxBytes, {
     chunkTimeoutMs: options?.chunkTimeoutMs,
     onIdleTimeout: options?.onIdleTimeout,
@@ -300,7 +288,9 @@ export async function readResponseWithLimit(
     onTimeout: options?.onTimeout,
   });
   if (prefix.truncated) {
-    throw onOverflow({ size: prefix.size, maxBytes, res: response });
+    throw onOverflow
+      ? onOverflow({ size: prefix.size, maxBytes, res: response })
+      : new Error(`Content too large: ${prefix.size} bytes (limit: ${maxBytes} bytes)`);
   }
   return prefix.buffer;
 }

--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -260,7 +260,9 @@ async function probeCorners(browser: Browser, fixtureFile: string): Promise<Corn
             const style = getComputedStyle(element);
             const radius =
               corner === "bottomLeft" ? style.borderBottomLeftRadius : style.borderTopLeftRadius;
-            return [selector, { radius, shape: style.getPropertyValue("corner-shape") }];
+            const shape = style.getPropertyValue("corner-shape");
+            // CSS defines round as superellipse(1); Chromium builds serialize both forms.
+            return [selector, { radius, shape: shape === "superellipse(1)" ? "round" : shape }];
           }),
         );
       },


### PR DESCRIPTION
Closes #136397
Related: #135418

## What Problem This Solves

Fixes an issue where users downloading media under a decimal MiB limit receive a generic fetch failure instead of the size-limit error. Bounded diagnostic text reads can also throw instead of returning their truncated prefix.

## Why This Change Was Made

The shared HTTP response reader tracked a sliced chunk using a fractional budget remainder, then passed that fractional length to `Buffer.concat`. It now counts observed bytes once and derives the retained whole-byte length. The redundant counter, single-use validation wrapper, and success-path error factory are removed; timeout forwarding, cancellation, and configured limits retain their existing behavior.

This is a maintainer-owned replacement approach for the fractional-limit problem investigated by @ly85206559 in #135418. Repairing the reader covers all valid fractional byte-budget callers without adding channel fallback policy or changing positive sub-byte limits. Contributor credit is preserved in the commit.

## User Impact

Oversized chunked downloads are correctly classified as size-limit failures. Downloads within the limit still succeed, and diagnostic prefixes return only complete retained bytes. No configuration or migration is required.

## Evidence

- Real Node 24.19.0 HTTP/Fetch reproduction: a `0.1` MiB budget resolves to `104857.6` bytes. A `104857`-byte chunked response succeeds before and after; a `104858`-byte response changes from `fetch_failed`/`RangeError` to `max_bytes`.
- Four new regression cases fail on the original code. All **134 tests** pass across bounded response reads, guarded-fetch release/capture behavior, and media fetches.
- `node scripts/check-changed.mjs` passes, including production and test type checks, lint, boundary checks, and runtime guards.
- Independent Codex review through P2 reports no accepted/actionable findings. Production: **12 added, 22 deleted (net −10)**. Tests: **28 added, 1 deleted (net +27)**.
- Current head: `e3a8c87f40058206d36babd6233b22b613ed112d`; production is unchanged from the original reviewed head.

## CI follow-up

[The hosted retry](https://github.com/openclaw/openclaw/actions/runs/33651518030/job/100332565873) exposed two unrelated corner-style assertions that distinguished `round` from the equivalent computed value `superellipse(1)`. The [CSS Borders draft](https://www.w3.org/TR/css-borders-4/#valdef-corner-shape-round) defines them as the same shape. The existing browser probe now normalizes that exact alias; distinct curvature, radii, and root-token expectations are unchanged. Local Chromium reports both assignments as `round`, while the retained hosted log reports `superellipse(1)`.

All three corner browser cases pass locally after the correction; formatting and an independent P2 supplement are clean. The new head still requires hosted CI. This is test portability maintenance, with no additional product bug claimed.
