### PR TITLE
perf(catalog): reuse owned manifest planning collections

### DIFF
--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -15,8 +15,6 @@ import type {
 import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeUniqueStringEntries } from "../../packages/normalization-core/src/string-normalization.js";
 
-// Manifest planners convert plugin modelCatalog declarations into normalized
-// rows and suppression entries while enforcing plugin ownership boundaries.
 type ManifestModelCatalogPlugin = {
   id: string;
   providers?: readonly string[];
@@ -114,7 +112,6 @@ export function planManifestModelCatalogRows(params: {
     }
   }
 
-  const rowCandidates: NormalizedModelCatalogRow[] = [];
   const seenRows = new Map<
     string,
     {
@@ -147,30 +144,29 @@ export function planManifestModelCatalogRows(params: {
         row,
         discovery: entry.discovery,
       });
-      rowCandidates.push(row);
     }
   }
 
-  const conflictedMergeKeys = new Set(conflicts.keys());
-  const rows = rowCandidates.filter((row) => {
-    if (conflictedMergeKeys.has(row.mergeKey)) {
-      return false;
+  const rows: NormalizedModelCatalogRow[] = [];
+  for (const { row, discovery } of seenRows.values()) {
+    if (
+      conflicts.has(row.mergeKey) ||
+      (params.selection === "static"
+        ? discovery !== "static"
+        : params.selection === "supplemental" &&
+          discovery === "runtime" &&
+          row.source !== "runtime-refresh")
+    ) {
+      continue;
     }
-    const discovery = seenRows.get(row.mergeKey)?.discovery;
-    if (params.selection === "static") {
-      return discovery === "static";
-    }
-    return (
-      params.selection !== "supplemental" ||
-      discovery !== "runtime" ||
-      row.source === "runtime-refresh"
-    );
-  });
+    rows.push(row);
+  }
 
   return {
     entries,
     conflicts: [...conflicts.values()],
-    rows: rows.toSorted(
+    // oxlint-disable-next-line unicorn/no-array-sort -- Selection owns this array until publication.
+    rows: rows.sort(
       (left, right) =>
         left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),
     ),
@@ -244,7 +240,8 @@ function planManifestModelCatalogPluginEntries(params: {
             source: "runtime-refresh",
           })
         : [];
-      const rows = [...manifestRows, ...remoteRows].toSorted(
+      // oxlint-disable-next-line unicorn/no-array-sort -- The spread creates a private merge array.
+      const rows = [...manifestRows, ...remoteRows].sort(
         (left, right) =>
           left.provider.localeCompare(right.provider) || left.id.localeCompare(right.id),
       );
@@ -361,7 +358,8 @@ export function planManifestModelCatalogSuppressions(params: {
     }
   }
   return {
-    suppressions: suppressions.toSorted(
+    // oxlint-disable-next-line unicorn/no-array-sort -- This plan owns the newly collected array.
+    suppressions: suppressions.sort(
       (left, right) =>
         left.provider.localeCompare(right.provider) ||
         left.model.localeCompare(right.model) ||

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -229,6 +229,7 @@ describe("production lint suppressions", () => {
         "src/infra/outbound/sanitize-text.ts|eslint/no-control-regex|1",
         "src/infra/outbound/send-deps.ts|typescript/no-unnecessary-type-parameters|1",
         "src/logging/redact.ts|unicorn/no-new-array|1",
+        "src/model-catalog/manifest-planner.ts|unicorn/no-array-sort|3",
         "src/node-host/invoke.ts|typescript/no-unnecessary-type-parameters|1",
         "src/node-host/mcp.ts|unicorn/prefer-add-event-listener|1",
         "src/plugin-sdk/channel-config-helpers.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
Manifest catalog planning kept a duplicate array of rows already held by its first-seen map, copied conflict keys into another Set, and copied newly owned arrays before sorting. Reuse those existing planner facts and sort the private output arrays in place. Catalog values, order, conflict provenance, selection, alias ownership, transport precedence and shallow row references stay unchanged.

The source normalizer/planner/consumer corpus produced identical canonical bytes across both arms. The bundled 260-row call eliminated 42 observed array results, 780 tracked element slots, one Set and 260 Map.get calls. These operation counts do not establish lower RSS: one fixed eight-leg series had mixed RSS signs, positive elapsed medians (+1.78%, +4.67%, +1.08%) and released-after-GC heap endpoints about 7–8 KB higher. No speedup or retained-heap improvement is claimed.

Validation: 37 existing focused tests, four strict suppression-inventory tests, the full canonical changed gate and managed Codex review at P0 passed. The initial lint failure is preserved; its resolution uses three narrow private-array ownership comments and one explicit inventory entry, with no runtime-expression change from the measured source. Production −2 LOC, tests +1, total −1. No config, schema, dependency or persistence change.

```text
node scripts/run-vitest.mjs src/model-catalog/manifest-planner.test.ts src/model-catalog/remote-overlay.test.ts packages/model-catalog-core/src/model-catalog-normalize.test.ts src/plugins/provider-catalog.test.ts
node scripts/run-vitest.mjs test/scripts/lint-suppressions.test.ts
node scripts/check-changed.mjs -- src/model-catalog/manifest-planner.ts test/scripts/lint-suppressions.test.ts
```
