### PR TITLE
perf(logging): trim owned log-tail arrays in place

### DIFF
--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -148,10 +148,10 @@ async function readLogSlice(params: {
     const bytesRead = await readFileWindowFully(handle, buffer, start);
     const text = buffer.toString("utf8", 0, bytesRead);
     let lines = text.split("\n");
-    lines = lines.slice(0, -1);
+    lines.pop();
     if (start > 0 && prefix !== "\n") {
       // Drop the first partial line when starting in the middle of a file.
-      lines = lines.slice(1);
+      lines.shift();
     }
     if (params.filter) {
       // Sparse consumers inspect the full byte-bounded window before the shared line cap.


### PR DESCRIPTION
## What Problem This Solves

Each log-tail read copied the entire split-line array to remove its last incomplete or empty entry, then sometimes copied it again to remove a leading partial record. A maximum-size dense window could copy 500,000 line references before applying the requested line cap.

## Why This Change Was Made

Pop and shift those entries from the reader's fresh, exclusively owned array before passing it to any filter or consumer. Keep the existing filtering, final cap copy, redaction, parsing, cursor metadata and file-handle lifecycle.

## Evidence

39 existing tail, redaction and channel-log tests passed before and after. A 25-case actual-reader probe used real private files and matched returned records, cursor/reset/truncation metadata, callback indices/array contents and completion of a previously partial record. Short positional reads were the only injected I/O behavior.

```json
{"cases":25,"observationsEqual":true,"observableSha256":"e04fbb37baa5a124f8a5dace1f9a9f5f77d5671bfc21eb22875f051ef46861a1","baseline":{"sliceArrays":40,"sliceOutputSlots":881061,"opens":24,"closes":24},"candidate":{"sliceArrays":9,"sliceOutputSlots":6007,"opens":24,"closes":24},"cleanup":{"temporaryFilesRemoved":true,"instrumentationRestored":true},"exitCodes":[0,0]}
```

The default 250,000-byte window avoids one 125,000-slot temporary array; a partial 250,001-byte window avoids two arrays totaling 250,001 slots. The maximum 1,000,000-byte window avoids 500,000 slots. Final line-cap copies remain. These are logical array-result counts, not measured backing-store bytes, retained heap, RSS or latency.

The complete canonical changed gate and managed Codex P0–P2 review passed. Production +2/−2, tests unchanged. The first offline analysis misclassified a final-cap slice as a removed partial-line slice; correcting that classifier preserved the original raw observations and required no source or runtime rerun.
