### PR TITLE
fix(cli): reject a blank --account on channels add, remove, login, and logout

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -47,6 +47,11 @@ Without it, discovery uses the configured System Agent or the existing sole/lega
 An explicit fleet with no such owner requires `--agent`. Selecting a workspace
 does not create account routing bindings; guided setup asks about routing separately.
 
+`add`, `login`, `logout`, and `remove` also take `--account <id>`. Omitting it selects the
+default account. A blank value is rejected instead of falling back to the default, as with
+the dead-letter commands, so an unset shell variable cannot silently select an account you
+did not name.
+
 ## Status / capabilities / resolve / logs
 
 - `channels status`: `--channel <name>`, `--probe`, `--timeout <ms>` (default `10000`), `--json`

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -887,4 +887,46 @@ describe("channel-auth", () => {
       'Channel "whatsapp" does not support logout. Run `openclaw channels status --channel whatsapp` to inspect supported actions.',
     );
   });
+
+  it.each(
+    [
+      { account: "", label: "empty" },
+      { account: "   ", label: "whitespace" },
+    ].flatMap((accountCase) => [
+      { ...accountCase, mode: "login" as const },
+      { ...accountCase, mode: "logout" as const },
+    ]),
+  )("rejects a $label --account before $mode resolves the channel", async ({ account, mode }) => {
+    // Auto-enable changes make channel resolution persist config, so a late guard is visible.
+    mocks.applyPluginAutoEnable.mockReturnValue({
+      config: { channels: { whatsapp: {} }, plugins: { allow: ["whatsapp"] } },
+      changes: ["whatsapp"],
+    });
+    const run = mode === "login" ? runChannelLogin : runChannelLogout;
+    const action = mode === "login" ? mocks.login : mocks.logoutAccount;
+
+    await expect(run({ channel: "whatsapp", account }, runtime)).rejects.toThrow(
+      "--account must not be blank",
+    );
+
+    expect(mocks.commitConfigWithPendingPluginInstalls).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(mocks.resolveChannelDefaultAccountId).not.toHaveBeenCalled();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["login", runChannelLogin, mocks.login],
+    ["logout", runChannelLogout, mocks.logoutAccount],
+  ] as const)(
+    "still resolves an omitted --account to the plugin default for %s",
+    async (_mode, run, action) => {
+      mocks.callGateway.mockRejectedValue(new Error("gateway unreachable"));
+
+      await run({ channel: "whatsapp" }, runtime);
+
+      expect(mocks.resolveChannelDefaultAccountId).toHaveBeenCalledTimes(1);
+      expectFields(readFirstCallArg(action), { accountId: "default-account" });
+    },
+  );
 });

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -154,6 +154,14 @@ async function resolveChannelPluginForMode(
   };
 }
 
+function assertAccountSelector(opts: ChannelAuthOptions): void {
+  // Channel resolution can install a plugin and persist config, so a blank
+  // selector must fail before it runs; only an omitted --account selects the default.
+  if (opts.account !== undefined && !opts.account.trim()) {
+    throw new Error("--account must not be blank");
+  }
+}
+
 function resolveAccountContext(
   plugin: ChannelPlugin,
   opts: ChannelAuthOptions,
@@ -269,6 +277,7 @@ export async function runChannelLogin(
   opts: ChannelAuthOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
+  assertAccountSelector(opts);
   const resolvedChannel = await resolveChannelPluginForMode(opts, "login", runtime);
   if (!resolvedChannel) {
     return;
@@ -307,6 +316,7 @@ export async function runChannelLogout(
   opts: ChannelAuthOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
+  assertAccountSelector(opts);
   const resolvedChannel = await resolveChannelPluginForMode(opts, "logout", runtime);
   if (!resolvedChannel) {
     return;

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -9,6 +9,7 @@ import {
   normalizeChannelId,
 } from "../channels/plugins/index.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
+import { assertAccountSelectorForMutation } from "../commands/channels/account-selector.js";
 import { requireValidConfigFileSnapshot } from "../commands/config-validation.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -103,6 +104,7 @@ async function resolveChannelPluginForMode(
   channelId: string;
   plugin: ChannelPlugin;
 } | null> {
+  assertAccountSelectorForMutation(opts.account);
   const snapshot = await requireValidConfigFileSnapshot(runtime);
   if (!snapshot) {
     return null;
@@ -152,14 +154,6 @@ async function resolveChannelPluginForMode(
     channelId,
     plugin,
   };
-}
-
-function assertAccountSelector(opts: ChannelAuthOptions): void {
-  // Channel resolution can install a plugin and persist config, so a blank
-  // selector must fail before it runs; only an omitted --account selects the default.
-  if (opts.account !== undefined && !opts.account.trim()) {
-    throw new Error("--account must not be blank");
-  }
 }
 
 function resolveAccountContext(
@@ -277,7 +271,6 @@ export async function runChannelLogin(
   opts: ChannelAuthOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  assertAccountSelector(opts);
   const resolvedChannel = await resolveChannelPluginForMode(opts, "login", runtime);
   if (!resolvedChannel) {
     return;
@@ -316,7 +309,6 @@ export async function runChannelLogout(
   opts: ChannelAuthOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  assertAccountSelector(opts);
   const resolvedChannel = await resolveChannelPluginForMode(opts, "logout", runtime);
   if (!resolvedChannel) {
     return;

--- a/src/cli/channels-account-selector.integration.test.ts
+++ b/src/cli/channels-account-selector.integration.test.ts
@@ -1,0 +1,59 @@
+// Proves the shipped Commander topology reaches each state-mutating channel owner.
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../runtime.js";
+import { registerChannelsCli } from "./channels-cli.js";
+
+const requireValidConfigFileSnapshot = vi.hoisted(() => vi.fn(async () => null));
+
+vi.mock("../commands/config-validation.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../commands/config-validation.js")>()),
+  requireValidConfigFileSnapshot,
+}));
+
+async function runChannelMutation(verb: string, account?: string) {
+  const args = ["channels", verb, "--channel", "telegram"];
+  if (account !== undefined) {
+    args.push("--account", account);
+  }
+  if (verb === "remove") {
+    args.push("--delete");
+  }
+  const program = new Command()
+    .name("openclaw")
+    .enablePositionalOptions()
+    .exitOverride()
+    .configureOutput({ writeErr: () => undefined });
+  await registerChannelsCli(program, ["node", "openclaw", ...args]);
+  await program.parseAsync(args, { from: "user" });
+}
+
+describe.each(["add", "remove", "login", "logout"])("channels %s account selection", (verb) => {
+  beforeEach(() => {
+    vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+    vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    requireValidConfigFileSnapshot.mockClear();
+  });
+
+  it.each(["", "   "])("rejects an explicit blank before loading config", async (account) => {
+    await runChannelMutation(verb, account);
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("--account must not be blank"),
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(requireValidConfigFileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps an omitted account on the default-selection path", async () => {
+    await runChannelMutation(verb);
+
+    expect(defaultRuntime.error).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
+    expect(requireValidConfigFileSnapshot).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -984,6 +984,43 @@ describe("channelsAddCommand", () => {
     expect(lifecycleMocks.onAccountConfigChanged).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { account: "", label: "empty" },
+    { account: "   ", label: "whitespace" },
+  ])(
+    "rejects a $label --account before installing a plugin or writing config",
+    async ({ account }) => {
+      configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+      setActivePluginRegistry(createTestRegistry());
+      catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
+        createExternalChatCatalogEntry(),
+      ]);
+      registerExternalChatSetupPlugin();
+
+      await expect(
+        channelsAddCommand({ channel: "external-chat", account, token: "token-1" }, runtime, {
+          hasFlags: true,
+        }),
+      ).rejects.toThrow("--account must not be blank");
+
+      expect(ensureChannelSetupPluginInstalled).not.toHaveBeenCalled();
+      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still resolves an omitted --account to the default account", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await channelsAddCommand({ channel: "lifecycle-chat", token: "new-token" }, runtime, {
+      hasFlags: true,
+    });
+
+    expect(writtenChannel("lifecycle-chat")).toEqual({ enabled: true, token: "new-token" });
+    expect(lifecycleMocks.onAccountConfigChanged).toHaveBeenCalledWith({
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+  });
+
   it("maps legacy Nextcloud Talk add flags to setup input fields", async () => {
     const prepareAccountConfigInput = vi.fn(({ input }: PrepareAccountConfigInputParams) => {
       const setupInput = input as NextcloudTalkSetupInput;

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -1008,19 +1008,6 @@ describe("channelsAddCommand", () => {
     },
   );
 
-  it("still resolves an omitted --account to the default account", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
-
-    await channelsAddCommand({ channel: "lifecycle-chat", token: "new-token" }, runtime, {
-      hasFlags: true,
-    });
-
-    expect(writtenChannel("lifecycle-chat")).toEqual({ enabled: true, token: "new-token" });
-    expect(lifecycleMocks.onAccountConfigChanged).toHaveBeenCalledWith({
-      accountId: DEFAULT_ACCOUNT_ID,
-    });
-  });
-
   it("maps legacy Nextcloud Talk add flags to setup input fields", async () => {
     const prepareAccountConfigInput = vi.fn(({ input }: PrepareAccountConfigInputParams) => {
       const setupInput = input as NextcloudTalkSetupInput;

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -250,6 +250,45 @@ describe("channelsRemoveCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith('Deleted external-chat account "default".');
   });
 
+  it.each([
+    { account: "", label: "empty" },
+    { account: "   ", label: "whitespace" },
+  ])("rejects a $label --account before deleting or writing config", async ({ account }) => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
+        channels: {
+          "external-chat": {
+            enabled: true,
+            token: "token-1",
+          },
+        },
+      }),
+    );
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
+      createExternalChatCatalogEntry(),
+    ]);
+    const scopedPlugin = createExternalChatDeletePlugin();
+    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
+      createTestRegistry([
+        {
+          pluginId: "@vendor/external-chat-plugin",
+          plugin: scopedPlugin,
+          source: "test",
+        },
+      ]),
+    );
+
+    await expect(
+      channelsRemoveCommand({ channel: "external-chat", account, delete: true }, runtime, {
+        hasFlags: true,
+      }),
+    ).rejects.toThrow("--account must not be blank");
+
+    expect(scopedPlugin.config.deleteAccount).not.toHaveBeenCalled();
+    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   it("stops an active gateway channel runtime before deleting a runtime-backed account", async () => {
     const callOrder: string[] = [];
     configMocks.readConfigFileSnapshot.mockResolvedValue(

--- a/src/commands/channels/account-selector.ts
+++ b/src/commands/channels/account-selector.ts
@@ -1,0 +1,8 @@
+// Owns strict CLI account selection for state-mutating channel commands.
+export function assertAccountSelectorForMutation(account: string | undefined): void {
+  // Only omission selects the default account. Blank input often comes from an unset
+  // shell variable and must fail before channel setup, auth, or removal mutates state.
+  if (account !== undefined && !account.trim()) {
+    throw new Error("--account must not be blank");
+  }
+}

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -173,6 +173,11 @@ async function channelsAddCommandImpl(
     return;
   }
 
+  // Catalog install below runs before account resolution, so a blank selector must
+  // fail here; letting it through would install and then write the default account.
+  if (opts.account !== undefined && !opts.account.trim()) {
+    throw new Error("--account must not be blank");
+  }
   const rawChannel = opts.channel ?? "";
   let channel = normalizeChannelId(rawChannel);
   let preparedWorkspaceDir: string | undefined;

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -26,6 +26,7 @@ import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { WizardCancelledError } from "../../wizard/prompts.js";
 import { normalizeExternalChannelSetupConfig } from "../channel-setup/config-compatibility.js";
 import { resolveChannelSetupOwner } from "../channel-setup/owner.js";
+import { assertAccountSelectorForMutation } from "./account-selector.js";
 import { channelLabel } from "./runtime-label.js";
 import { requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
 
@@ -131,6 +132,7 @@ async function channelsAddCommandImpl(
   runtime: RuntimeEnv,
   params?: { hasFlags?: boolean; beforePersistentEffect?: () => Promise<void> },
 ) {
+  assertAccountSelectorForMutation(opts.account);
   const configSnapshot = await requireValidConfigFileSnapshot(runtime);
   if (!configSnapshot) {
     return;
@@ -173,11 +175,6 @@ async function channelsAddCommandImpl(
     return;
   }
 
-  // Catalog install below runs before account resolution, so a blank selector must
-  // fail here; letting it through would install and then write the default account.
-  if (opts.account !== undefined && !opts.account.trim()) {
-    throw new Error("--account must not be blank");
-  }
   const rawChannel = opts.channel ?? "";
   let channel = normalizeChannelId(rawChannel);
   let preparedWorkspaceDir: string | undefined;

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -90,6 +90,10 @@ export async function channelsRemoveCommand(
   const rawChannel = normalizeOptionalString(opts.channel) ?? "";
   let lookupChannel = rawChannel;
   let channel: ChatChannel | null = normalizeChannelId(rawChannel);
+  // normalizeAccountId maps blank to the default account; only an omitted --account may.
+  if (opts.account !== undefined && !opts.account.trim()) {
+    throw new Error("--account must not be blank");
+  }
   let accountId = normalizeAccountId(opts.account);
   const deleteConfig = Boolean(opts.delete);
 

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -19,6 +19,7 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-ke
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
+import { assertAccountSelectorForMutation } from "./account-selector.js";
 import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { channelLabel } from "./runtime-label.js";
 import { type ChatChannel, requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
@@ -78,6 +79,7 @@ export async function channelsRemoveCommand(
   runtime: RuntimeEnv = defaultRuntime,
   params?: { hasFlags?: boolean },
 ) {
+  assertAccountSelectorForMutation(opts.account);
   const configSnapshot = await requireValidConfigFileSnapshot(runtime);
   if (!configSnapshot) {
     return;
@@ -90,10 +92,6 @@ export async function channelsRemoveCommand(
   const rawChannel = normalizeOptionalString(opts.channel) ?? "";
   let lookupChannel = rawChannel;
   let channel: ChatChannel | null = normalizeChannelId(rawChannel);
-  // normalizeAccountId maps blank to the default account; only an omitted --account may.
-  if (opts.account !== undefined && !opts.account.trim()) {
-    throw new Error("--account must not be blank");
-  }
   let accountId = normalizeAccountId(opts.account);
   const deleteConfig = Boolean(opts.delete);
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw channels add`, `remove`, `login`, and `logout` treated an explicit blank `--account` as omission. An unset shell variable could therefore select and mutate the default account without naming it.

## Product path

`openclaw channels add|remove|login|logout --account <id>`

## Root cause

The four state-mutating command paths passed blank values into shared account normalizers that intentionally map missing input to a default account. The command layer lost the difference between omission and an explicit blank before plugin setup, auth, deletion, or persistence.

## Fix

One channel-command guard now owns the selector rule and runs before every affected mutation path. Omission still selects the default account. Blank and whitespace-only values fail with `--account must not be blank`.

Read-only `channels` commands keep their existing behavior.

## Compatibility

Scripts that pass an unset or empty account variable now fail instead of selecting the default. Scripts that want the default account must omit `--account`.

## Evidence

- Current main `401ad5b14b485813b53c590801cf6394191168e2`: the real built CLI silently wrote default config on add, cleared default auth on logout, initialized default login state, and deleted default config on remove.
- Exact head `ce8b04ba2de2facf658c05d88aa98815aa739860`: the real built CLI rejected all four blank selectors before state changed. An omitted-account control still selected the default.
- Focused tests: 57 CLI tests and 59 channel-command tests passed, including parser-to-owner coverage for all four verbs.
- Changed-scope core, test, docs, formatting, lint, type, dependency, dead-export, and import-cycle gates passed.

This keeps @marmar9615-cloud's original behavior change, documentation, regression coverage, and contributor commits while centralizing the invariant at one owner.
