### PR TITLE
fix(logging): release payloads from evicted queue entries

### DIFF
--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -338,6 +338,8 @@ function enqueueFileLog(entry: FileLogQueueEntry): void {
   if (queue.length >= maxQueuedRecords) {
     const dropped = queue[queueStart];
     if (dropped) {
+      // The overflow marker retains this entry's metadata, so release its discarded text now.
+      dropped.payload = "";
       droppedTarget ??= dropped;
       droppedCount += 1;
     }


### PR DESCRIPTION
When file-log writes stall and the queue overflows, `droppedTarget` keeps the first discarded record until its count marker is claimed. The marker needs the record's file, hostname and rotation cap but replaces its payload. Retaining that text can keep an additional large discarded log record alive throughout the stall.

Clear the payload at eviction in the existing queue owner. The same entry still supplies marker metadata and every drop is counted. The canonical logger creates a fresh entry per enqueue, and claiming a batch detaches the queue before an append starts, so the evicted entry cannot be the active append or a surviving queued record. Generation fencing, forced drain, warning/rotation policy and output ordering stay unchanged. Production delta: **+2 lines** (one comment and the lifetime-ending assignment); tests unchanged. This addresses the eviction follow-up left by the earlier settled-batch release change, without adding a second path or metadata allocation.

Validation used the real `getLogger().info` producer and safe file appender, with the existing queue test cap set to 2. The first actual append completed filesystem I/O before its Promise settlement was held. An 8 MiB synthetic raw argument was then evicted while two small tail records remained queued. The baseline release assertion failed with **8,393,541 payload characters** retained; the same assertion passed with **0** after the change. Independent decoding of both raw snapshots verified the exact strong path:

```text
module context -> droppedTarget -> entry.payload
before: 32-byte concatenated string + 8,393,560-byte flat string + 0-byte newline
 after: shared empty string, 0 bytes
```

With that settlement still held, synchronous drain produced the following projections of real file bytes, identical before/after apart from log timestamps:

```text
active.log messages: ["active real append"]
tail.log messages: ["tail two survives", "tail three survives"]
target.1.log bytes: "existing target bytes\n"
target.log: {"hostname":"drop-host","message":"[openclaw] file log queue overflow; dropped 2 oldest records","dropped":2}
```

The first discarded target had a 128-byte rotation cap and a seeded file. These outputs check its target/host/cap inheritance, rotation, preserved tail order and absence of active-append replay. The hold and flush were then joined, hooks restored, all five entry WeakRefs collected, both Node groups absent, and both private fixture runtimes removed.

The one pair's main-isolate post-GC held heap was **25,290,624 → 16,895,192 bytes**; warmed heap was **16,804,344 → 16,802,536 bytes**. The strong-path string self-size sum was **8,393,592 → 0 bytes**. This establishes the discarded-payload release in this fixture, not a dominator retained-size calculation, whole-Gateway/RSS claim, or timing distribution. The hold follows completed real I/O; it does not simulate a pending OS write. Snapshot/GC coverage is the main isolate only, and later phase heap changes can include snapshot effects.

Existing transport and size-cap tests: **15 passed**. `git diff --check` passed. Canonical changed-file gate passed, including format/lint, core and core-test typechecking, boundary checks and dead-export scanning. Managed Codex review explicitly included **P0–P2** and returned scoped-clean with no findings. A separate source/evidence reviewer independently parsed both raw snapshots and saved log files without rerunning the application.
