### PR TITLE
perf(normalization): reuse prepared string entries

### DIFF
--- a/packages/normalization-core/src/string-normalization.ts
+++ b/packages/normalization-core/src/string-normalization.ts
@@ -26,7 +26,7 @@ export function normalizeStringEntries(list?: ReadonlyArray<unknown>) {
 
 /** Normalizes string entries and lowercases each retained value. */
 export function normalizeStringEntriesLower(list?: ReadonlyArray<unknown>) {
-  return normalizeStringEntries(list).map((entry) => normalizeOptionalLowercaseString(entry) ?? "");
+  return normalizeStringEntries(list).map((entry) => entry.toLowerCase());
 }
 
 /** Returns first-seen unique values while preserving insertion order. */
@@ -53,14 +53,12 @@ export function normalizeUniqueStringEntries(values?: Iterable<unknown>): string
 
 /** Lowercases normalized entries, removes empties/duplicates, and preserves first-seen order. */
 export function normalizeUniqueStringEntriesLower(values?: Iterable<unknown>): string[] {
-  return uniqueStrings(
-    normalizeStringEntriesLower(values ? [...values] : undefined).filter(Boolean),
-  );
+  return uniqueStrings(normalizeStringEntriesLower(values ? [...values] : undefined));
 }
 
 /** Normalizes entries, removes duplicates, and returns sorted output. */
 export function normalizeSortedUniqueStringEntries(values?: Iterable<unknown>): string[] {
-  return sortUniqueStrings(normalizeUniqueStringEntries(values));
+  return sortUniqueStrings(normalizeStringEntries(values ? [...values] : undefined));
 }
 
 /** Normalizes array-backed string lists and rejects non-array input as empty. */


### PR DESCRIPTION
The shared string normalizer repeated work on values it had already prepared: lowercase normalization trimmed again, its unique variant filtered retained strings again, and sorted normalization deduplicated twice. Reuse the prepared strings and let the existing sorting helper perform the only deduplication. Complete iterable snapshots still precede coercion; normalization and lowercasing remain separate phases, with the same order, Unicode behavior and fresh output arrays. Production and total LOC: −2; tests unchanged.

An actual-source before/after corpus produced identical values and event traces across 21 records. For 128 input entries, sorted normalization removes one Set and one 24-slot array; unique lowercase normalization removes one 120-slot filter array and 120 repeat trim calls. The actual diagnostic-flags caller also removes one filter array and six trim calls while preserving this output:

```json
{"flags":["telegram.http","cache.*","foo"],"matches":[true,true,true,false],"disableOverrides":4,"wildcard":["*"]}
```

The four match targets are `telegram.http`, `cache.hit`, `cache`, and `other`, with explicit synthetic config/environment inputs. The probe also preserves iterator/coercion error identity and order, sparse-array behavior, case expansion/final sigma, UTF-16 sorting, input/output ownership and SDK function identity. These are source-operation counts, not measured RSS, retained memory or speed; this is source/caller proof, not a Gateway run.

Validation: 83 existing tests across normalization, coercion, diagnostic flags, active registry and runtime capabilities passed. The full canonical changed gate and managed Codex P0–P2 review passed. Canonical observed output SHA256: `9224608339f5981deea78fc05330484ea2c2f82d05e7d7780d59ef2d03bca7fc`.
