### PR TITLE
fix(ci): authenticate post-checkout base fetches

### DIFF
--- a/.github/actions/git-owner/owner.py
+++ b/.github/actions/git-owner/owner.py
@@ -219,6 +219,14 @@ def git_auth_environment(remote, token):
     return environment
 
 
+def take_checkout_auth_environment():
+    repository = os.environ.get("CHECKOUT_REPO")
+    token = os.environ.pop("CHECKOUT_TOKEN", "")
+    if not token or repository != os.environ.get("GITHUB_REPOSITORY"):
+        return {}
+    return git_auth_environment(f"https://github.com/{repository}.git", token)
+
+
 def run_git(directory, *arguments, timeout=None, stdout=None, stderr=None, env=None,
             reclaim_locks=False):
     global closed
@@ -460,8 +468,10 @@ def main():
             return
         if sys.argv[1] not in ("--git", "--checkout-git"):
             raise ValueError("Unknown Git owner command")
+        auth_environment = (take_checkout_auth_environment()
+                            if sys.argv[1] == "--checkout-git" else None)
         run_git(os.getcwd(), *sys.argv[3:], timeout=float(sys.argv[2]) or None,
-                reclaim_locks=sys.argv[1] == "--checkout-git")
+                env=auth_environment, reclaim_locks=sys.argv[1] == "--checkout-git")
         return
     if git is None:
         raise RuntimeError("Git unavailable")
@@ -471,10 +481,7 @@ def main():
     workspace = os.environ["GITHUB_WORKSPACE"]
     remote = f"https://github.com/{os.environ['CHECKOUT_REPO']}.git"
     # The workflow's token is repository-bound; never lend it to a sibling checkout.
-    token = os.environ.pop("CHECKOUT_TOKEN", "")
-    if token and os.environ["CHECKOUT_REPO"] == os.environ.get("GITHUB_REPOSITORY"):
-        checkout_environment.update(git_auth_environment(remote, token))
-    del token
+    checkout_environment.update(take_checkout_auth_environment())
     if kind == "clawhub":
         workspace = os.path.join(workspace, "clawhub-source")
     reset = kind in ("linux-node", "android", "clawhub")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,14 @@ jobs:
               return environment
 
 
+          def take_checkout_auth_environment():
+              repository = os.environ.get("CHECKOUT_REPO")
+              token = os.environ.pop("CHECKOUT_TOKEN", "")
+              if not token or repository != os.environ.get("GITHUB_REPOSITORY"):
+                  return {}
+              return git_auth_environment(f"https://github.com/{repository}.git", token)
+
+
           def run_git(directory, *arguments, timeout=None, stdout=None, stderr=None, env=None,
                       reclaim_locks=False):
               global closed
@@ -672,8 +680,10 @@ jobs:
                       return
                   if sys.argv[1] not in ("--git", "--checkout-git"):
                       raise ValueError("Unknown Git owner command")
+                  auth_environment = (take_checkout_auth_environment()
+                                      if sys.argv[1] == "--checkout-git" else None)
                   run_git(os.getcwd(), *sys.argv[3:], timeout=float(sys.argv[2]) or None,
-                          reclaim_locks=sys.argv[1] == "--checkout-git")
+                          env=auth_environment, reclaim_locks=sys.argv[1] == "--checkout-git")
                   return
               if git is None:
                   raise RuntimeError("Git unavailable")
@@ -683,10 +693,7 @@ jobs:
               workspace = os.environ["GITHUB_WORKSPACE"]
               remote = f"https://github.com/{os.environ['CHECKOUT_REPO']}.git"
               # The workflow's token is repository-bound; never lend it to a sibling checkout.
-              token = os.environ.pop("CHECKOUT_TOKEN", "")
-              if token and os.environ["CHECKOUT_REPO"] == os.environ.get("GITHUB_REPOSITORY"):
-                  checkout_environment.update(git_auth_environment(remote, token))
-              del token
+              checkout_environment.update(take_checkout_auth_environment())
               if kind == "clawhub":
                   workspace = os.path.join(workspace, "clawhub-source")
               reset = kind in ("linux-node", "android", "clawhub")
@@ -2579,6 +2586,8 @@ jobs:
       - name: Prepare release-gate ratchet merge tree
         if: (matrix.task == 'baseline-ratchets' || startsWith(matrix.task, 'release-lint-')) && github.event_name == 'workflow_dispatch' && inputs.release_gate
         env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ github.token }}
           PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
           TARGET_SHA: ${{ inputs.target_ref }}
@@ -2634,6 +2643,8 @@ jobs:
 
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
           OPENCLAW_TEST_PROJECTS_PARALLEL: 3
           PROTOCOL_SINCE_BASE_SHA: ${{ needs.preflight.outputs.diff_base_revision }}
           RATCHET_PR_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
@@ -2641,6 +2652,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          checkout_token="${CHECKOUT_TOKEN-}"
+          unset CHECKOUT_TOKEN
           has_package_script() {
             node -e '
               const scripts = require("./package.json").scripts ?? {};
@@ -2650,7 +2663,7 @@ jobs:
           case "$TASK" in
             bundled-protocol)
               pnpm test:bundled
-              python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 0 fetch --no-tags --no-recurse-submodules --depth=1 origin \
+              CHECKOUT_TOKEN="$checkout_token" python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 0 fetch --no-tags --no-recurse-submodules --depth=1 origin \
                 "+${PROTOCOL_SINCE_BASE_SHA}:refs/remotes/origin/protocol-since-base"
               pnpm protocol:check
               ;;
@@ -3294,6 +3307,8 @@ jobs:
 
       - name: Run check shard
         env:
+          CHECKOUT_REPO: ${{ github.repository }}
+          CHECKOUT_TOKEN: ${{ github.token }}
           FROZEN_TARGET: ${{ needs.preflight.outputs.frozen_target }}
           HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
           FORMAT_CHECK: ${{ needs.preflight.outputs.run_format_check }}
@@ -3309,6 +3324,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          checkout_token="${CHECKOUT_TOKEN-}"
+          unset CHECKOUT_TOKEN
           has_package_script() {
             node -e '
               const scripts = require("./package.json").scripts ?? {};
@@ -3350,7 +3367,7 @@ jobs:
                 exit 1
               fi
               if [ -n "$PR_BASE_SHA" ]; then
-                python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/remotes/origin/ci-base"
+                CHECKOUT_TOKEN="$checkout_token" python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/remotes/origin/ci-base"
                 node scripts/report-test-temp-creations.mjs --base refs/remotes/origin/ci-base --head HEAD --no-merge-base
               fi
               pnpm deps:patches:check
@@ -3368,7 +3385,7 @@ jobs:
               npm_lock_base=""
               if [[ "${GITHUB_EVENT_NAME:-}" != "workflow_dispatch" && -n "$DIFF_BASE_SHA" ]] &&
                 has_package_script "deps:npm-lock:check:changed"; then
-                if python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 fetch --no-tags --depth=1 origin "+${DIFF_BASE_SHA}:refs/remotes/origin/npm-lock-base"; then
+                if CHECKOUT_TOKEN="$checkout_token" python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 fetch --no-tags --depth=1 origin "+${DIFF_BASE_SHA}:refs/remotes/origin/npm-lock-base"; then
                   npm_lock_base="refs/remotes/origin/npm-lock-base"
                 else
                   fetch_status="$?"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8756,8 +8756,12 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(checkShardStep.env.PR_BASE_SHA).toBe(
       "${{ github.event_name == 'pull_request' && needs.preflight.outputs.diff_base_revision || '' }}",
     );
+    expect(checkShardStep.env.CHECKOUT_REPO).toBe("${{ github.repository }}");
+    expect(checkShardStep.env.CHECKOUT_TOKEN).toBe("${{ github.token }}");
+    expect(checkShardStep.run).toContain('checkout_token="${CHECKOUT_TOKEN-}"');
+    expect(checkShardStep.run).toContain("unset CHECKOUT_TOKEN");
     expect(checkShardStep.run).toContain(
-      'python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/remotes/origin/ci-base"',
+      'CHECKOUT_TOKEN="$checkout_token" python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/remotes/origin/ci-base"',
     );
   });
 
@@ -9287,6 +9291,10 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(checksFastRun.env.PROTOCOL_SINCE_BASE_SHA).toBe(
       "${{ needs.preflight.outputs.diff_base_revision }}",
     );
+    expect(checksFastRun.env.CHECKOUT_REPO).toBe("${{ github.repository }}");
+    expect(checksFastRun.env.CHECKOUT_TOKEN).toBe("${{ github.token }}");
+    expect(checksFastRun.run).toContain('checkout_token="${CHECKOUT_TOKEN-}"');
+    expect(checksFastRun.run).toContain("unset CHECKOUT_TOKEN");
     expect(releaseGateMerge.run).toContain(
       'gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}"',
     );
@@ -9314,6 +9322,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       'echo "RATCHET_BASE_REF=${frozen_base_sha}" >> "$GITHUB_ENV"',
     );
     expect(checksFastRun.run).not.toContain("PROTOCOL_MANUAL_BASE_SHA");
+    expect(checksFastRun.run).toContain(
+      'CHECKOUT_TOKEN="$checkout_token" python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 0 fetch',
+    );
     expect(checksFastRun.run).toContain(
       '"+${PROTOCOL_SINCE_BASE_SHA}:refs/remotes/origin/protocol-since-base"',
     );


### PR DESCRIPTION
## What Problem This Solves

CI base fetches run after the maintained checkout removes persistent credentials. The direct Git owner path ignored the step's checkout token, so protocol and guard jobs passed their tests and then failed with `could not read Username for 'https://github.com'`.

This blocked PR #134819 and other pull requests.

## Why This Change Was Made

The Git owner now consumes an explicitly supplied checkout token for `--checkout-git` calls. It scopes the temporary authorization header to the current repository URL and removes the token before Git starts.

The affected workflow steps keep the token in a non-exported shell variable while candidate tests run. They pass it only to the later owned fetch process.

## User Impact

Pull request CI can fetch protocol, guard, and npm-lock base commits after tests without persisting credentials or exposing the token to candidate commands.

## Evidence

- Failure: [PR #134819 bundled-protocol job](https://github.com/openclaw/openclaw/actions/runs/33650286419/job/100321782517) passed 210 tests, then failed its base fetch with exit 128.
- Failure: [PR #134819 guard job](https://github.com/openclaw/openclaw/actions/runs/33646259242/job/100305352066) completed its checks, then failed the same fetch.
- `test/scripts/ci-git-owner-auth.test.ts` and `test/scripts/ci-workflow-guards.test.ts`: 315 tests passed.
- `node --import ./scripts/tsx.mjs scripts/check-workflows.mts`: passed.
- `node scripts/generate-ci-git-owner.mts --check`: passed.
- Formatting and `git diff --check`: passed.
- P0 Autoreview: clean.
