### PR TITLE
perf(agents): encode modifiers from prepared PTY sequences

### DIFF
--- a/src/agents/pty-keys.test.ts
+++ b/src/agents/pty-keys.test.ts
@@ -90,17 +90,19 @@ test("encodeKeySequence uses SS3 sequences in application cursor key mode", () =
   expect(end.data).toBe(`${ESC}OF`);
 });
 
-test("encodeKeySequence applies xterm modifiers to arrows in application mode", () => {
-  // Modified arrow keys use xterm modifier scheme even in application mode.
-  // DECCKM only affects unmodified cursor keys.
-  const altUp = encodeKeySequence({ keys: ["M-up"] }, "application");
-  expect(altUp.data).toBe(`${ESC}[1;3A`);
-
-  const ctrlRight = encodeKeySequence({ keys: ["C-right"] }, "application");
-  expect(ctrlRight.data).toBe(`${ESC}[1;5C`);
-
-  const shiftDown = encodeKeySequence({ keys: ["S-down"] }, "application");
-  expect(shiftDown.data).toBe(`${ESC}[1;2B`);
+test.each([
+  ["M-up", `${ESC}[1;3A`],
+  ["C-right", `${ESC}[1;5C`],
+  ["S-down", `${ESC}[1;2B`],
+  ["C-home", `${ESC}[1;5~`],
+  ["M-C-End", `${ESC}[4;7~`],
+  ["S-M-C-PgDn", `${ESC}[6;8~`],
+  ["S-insert", `${ESC}[2;2~`],
+  ["S-M-del", `${ESC}[3;4~`],
+])("encodeKeySequence applies xterm modifiers to %s in every cursor mode", (key, data) => {
+  for (const mode of [undefined, "normal", "application"] as const) {
+    expect(encodeKeySequence({ keys: [key] }, mode)).toEqual({ data, warnings: [] });
+  }
 });
 
 test("encodeKeySequence supports hex + literal with warnings", () => {

--- a/src/agents/pty-keys.ts
+++ b/src/agents/pty-keys.ts
@@ -4,7 +4,6 @@
  * cursor mode.
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { escapeRegExp } from "../utils.js";
 
 const ESC = "\x1b";
 const CR = "\r";
@@ -217,21 +216,13 @@ function encodeKeyToken(
 
   const baseSeq = namedKeyMap.get(baseLower);
   if (baseSeq) {
-    let seq = baseSeq;
     if (modifiableNamedKeys.has(baseLower) && hasAnyModifier(parsed.mods)) {
-      const mod = xtermModifier(parsed.mods);
-      if (mod > 1) {
-        const modified = applyXtermModifier(seq, mod);
-        if (modified) {
-          seq = modified;
-          return seq;
-        }
-      }
+      // Every modifiable named key is a CSI sequence from namedKeyMap.
+      // Bare cursor sequences omit the first parameter; xterm modifiers require it.
+      const parameter = baseSeq.slice(2, -1) || "1";
+      return `${ESC}[${parameter};${xtermModifier(parsed.mods)}${baseSeq.at(-1)}`;
     }
-    if (parsed.mods.alt) {
-      return `${ESC}${seq}`;
-    }
-    return seq;
+    return parsed.mods.alt ? `${ESC}${baseSeq}` : baseSeq;
   }
 
   if (base.length === 1) {
@@ -310,24 +301,6 @@ function xtermModifier(mods: Modifiers): number {
     mod += 4;
   }
   return mod;
-}
-
-function applyXtermModifier(sequence: string, modifier: number): string | null {
-  const escPattern = escapeRegExp(ESC);
-  const csiNumber = new RegExp(`^${escPattern}\\[(\\d+)([~A-Z])$`);
-  const csiArrow = new RegExp(`^${escPattern}\\[(A|B|C|D|H|F)$`);
-
-  const numberMatch = sequence.match(csiNumber);
-  if (numberMatch) {
-    return `${ESC}[${numberMatch[1]};${modifier}${numberMatch[2]}`;
-  }
-
-  const arrowMatch = sequence.match(csiArrow);
-  if (arrowMatch) {
-    return `${ESC}[1;${modifier}${arrowMatch[1]}`;
-  }
-
-  return null;
 }
 
 function hasAnyModifier(mods: Modifiers): boolean {


### PR DESCRIPTION
## What Problem This Solves

Modified named PTY keys were parsed back out of private CSI strings using two new regular expressions per key.

## Why This Change Was Made

The owning map already prepares the CSI sequence and the modifier branch guarantees a value from 2–8. Encode directly from those facts and remove the parser, unreachable fallback branches and broad utility import. Production LOC: −27; tests: +2; total: −25.

## User Impact

Modified key encoding does less work while preserving terminal bytes. Unmodified cursor/application mode, Alt prefixes, function keys, literals, hex input and warnings keep their existing behavior.

## Evidence

The xterm modifier contract is documented in [PC-style function keys](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-PC-Style-Function-Keys). The existing modifier regression now covers eight combinations across normal, application and default modes. An actual-source comparison preserved 4,691 outputs and five golden cases; 500 modified keys create 1,000 regular expressions before this change and zero afterward.

Real-flow proof exercised the actual send-keys handler and PTY adapter against a synthetic raw PTY receiver. Both versions delivered the same 77 bytes across five requests, with identical notices. The receiver exited successfully and the owned child/runtime were removed. This verifies terminal transport bytes; it does not claim interactive editor or terminal-emulator coverage.

```json
{"requests":5,"receivedBytes":77,"receivedHex":"1b5b313b33411b5b313b35431b5b313b32421b5b313b357e1b5b343b377e1b5b363b387e1b4f411b4f481b4f4d1b5b323b327e1b5b333b347e1b1b5b31357e03e4bda0e5a5bdf09f9880000a0d","exitCode":0,"childGone":true,"runtimeRemoved":true}
```

A fixed baseline/candidate/candidate/baseline run on Node 26.8.1 encoded 250,000 modified keys per process after the same warmup. All four runs are included: baseline 87.825/91.113 ms; candidate 23.977/23.945 ms. Median elapsed time fell from 89.469 to 23.961 ms (73.2%). Released heap was about 13.57 MB versus 11.40 MB in these isolated source-entrypoint processes; this includes avoiding the broad utility import and is not a whole-Gateway memory claim. No concurrent full gates or other timed workload ran during this measurement.

Validation: 19 focused tests in two suites passed, the full canonical changed gate passed, and an independent managed Codex review found no actionable P0–P2 defects. Canonical checks:

```sh
node scripts/run-vitest.mjs src/agents/pty-keys.test.ts src/agents/bash-tools.process-send-keys.test.ts
node scripts/check-changed.mjs -- src/agents/pty-keys.ts src/agents/pty-keys.test.ts
```

The complete comparison output digest is `c371fbcfdceb4f4c5c53492154b654f2c1757fe194e658927fe3f8dcbbfd6a50`. No configuration, protocol, persistence or user instructions change.
