### PR TITLE
fix(cron): skip busy sessions in reaper sweep

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -475,6 +475,55 @@ describe("sweepCronRunSessions", () => {
     }
   });
 
+  it("prunes idle siblings while skipping rows claimed by an in-flight run", async () => {
+    const now = Date.now();
+    const busyKey = "agent:main:cron:job1:run:busy-run";
+    const idleKey = "agent:main:cron:job2:run:idle-run";
+    await seedSessionEntries(storePath, {
+      [busyKey]: {
+        sessionId: "busy-run",
+        updatedAt: now - 25 * 3_600_000,
+      },
+      [idleKey]: {
+        sessionId: "idle-run",
+        updatedAt: now - 25 * 3_600_000,
+      },
+    });
+
+    const admission = await beginSessionWorkAdmission({
+      scope: storePath,
+      identities: ["busy-run"],
+      assertAllowed: () => {},
+    });
+    const warn = vi.fn();
+    const busyLog: Logger = { ...log, warn };
+
+    try {
+      const result = await sweepCronRunSessions({
+        sessionStorePath: storePath,
+        nowMs: now,
+        log: busyLog,
+      });
+
+      expect(result.swept).toBe(true);
+      expect(result.pruned).toBe(1);
+      expect(warn).not.toHaveBeenCalled();
+      const remaining = readSessionEntries(storePath);
+      expect(remaining[busyKey]).toMatchObject({ sessionId: "busy-run" });
+      expect(remaining[idleKey]).toBeUndefined();
+    } finally {
+      admission.release();
+    }
+
+    const retry = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now + 5 * 60_000,
+      log: busyLog,
+    });
+    expect(retry).toEqual({ swept: true, pruned: 1 });
+    expect(readSessionEntries(storePath)[busyKey]).toBeUndefined();
+  });
+
   it("respects custom retention", async () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -12,6 +12,7 @@ import type { CronConfig } from "../config/types.cron.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCompetingSessionWorkAdmissionActive } from "../sessions/session-lifecycle-admission.js";
 import { buildPendingGeneratedMediaSessionKeySet } from "../tasks/task-status-access.js";
 import { resolveCronAgentSessionKey } from "./isolated-agent/session-key.js";
 import type { Logger } from "./service/state.js";
@@ -148,6 +149,14 @@ export async function sweepCronRunSessions(params: {
         if (pendingMediaSessionKeys.has(sessionKey)) {
           continue;
         }
+      }
+      // Skip known-busy rows so one active generation cannot abort idle sibling cleanup.
+      // The shared deletion guard still closes the race between selection and commit.
+      if (
+        entry.sessionId &&
+        isCompetingSessionWorkAdmissionActive(storePath, [sessionKey, entry.sessionId])
+      ) {
+        continue;
       }
       removals.push({
         sessionKey,


### PR DESCRIPTION
Closes #136339

## What Problem This Solves

The cron session reaper sent every expired run row in one lifecycle deletion batch. One row claimed by an active run made the shared deletion guard reject the full batch. Idle siblings then stayed until a later sweep, and the reaper logged an expected collision as a warning.

## Root cause

Cron run preparation claims the prior session generation before asynchronous work starts. The reaper did not apply that active-work fact when it selected retention candidates, even though the SQLite deletion owner correctly rejected the busy target before commit.

## Fix

- Skip expired rows with a competing work admission while building the cron reaper batch.
- Keep the shared deletion guard's commit-time revalidation for work admitted after selection.
- Cover one busy and one idle expired row, then release the admission and prove the deferred row reaps on the next sweep.

## Evidence

Current main `111ffb9e51aa16d2d1fdcb38515fdad3c58222a9`:

- First sweep: `{ swept: false, pruned: 0 }`.
- Busy row remained.
- Idle row remained.
- One warning was emitted.

This head:

- First sweep: `{ swept: true, pruned: 1 }`.
- Busy row remained intact.
- Idle row was removed.
- No warning was emitted.
- After admission release and the normal five-minute interval, the next sweep removed the deferred busy row.

Validation:

- `node scripts/run-vitest.mjs src/cron/session-reaper.test.ts --run` — 27 passed.
- Focused Oxlint, Oxfmt, max-lines, assertion-safety, and conflict-marker checks passed.
- Production: +9 lines. Tests: +49 lines.
