### PR TITLE
perf(agents): reuse prepared truncation byte counts

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -162,7 +162,7 @@ function buildTruncationResult(
     truncated: boolean;
     truncatedBy: TruncationResult["truncatedBy"];
     outputLines: number;
-    outputBytes?: number;
+    outputBytes: number;
     lastLinePartial?: boolean;
     firstLineExceedsLimit?: boolean;
   },
@@ -174,7 +174,7 @@ function buildTruncationResult(
     totalLines: input.totalLines,
     totalBytes: input.totalBytes,
     outputLines: params.outputLines,
-    outputBytes: params.outputBytes ?? utf8ByteLength(params.content),
+    outputBytes: params.outputBytes,
     lastLinePartial: params.lastLinePartial ?? false,
     firstLineExceedsLimit: params.firstLineExceedsLimit ?? false,
     maxLines: input.maxLines,
@@ -217,8 +217,8 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
   let outputBytesCount = 0;
   let truncatedBy: "lines" | "bytes" = input.totalLines > input.maxLines ? "lines" : "bytes";
 
-  for (const [i, line] of input.lines.slice(0, input.maxLines).entries()) {
-    const lineBytes = utf8ByteLength(line) + (i > 0 ? 1 : 0); // +1 for newline
+  for (const line of input.lines.slice(0, input.maxLines)) {
+    const lineBytes = utf8ByteLength(line) + (outputLinesArr.length > 0 ? 1 : 0); // +1 for newline
 
     if (outputBytesCount + lineBytes > input.maxBytes) {
       truncatedBy = "bytes";
@@ -237,13 +237,12 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
     truncatedBy = "lines";
   }
 
-  const outputContent = outputLinesArr.join("\n");
-
   return buildTruncationResult(input, {
-    content: outputContent,
+    content: outputLinesArr.join("\n"),
     truncated: true,
     truncatedBy,
     outputLines: outputLinesArr.length,
+    outputBytes: outputBytesCount,
   });
 }
 
@@ -303,13 +302,12 @@ export function truncateTail(content: string, options: TruncationOptions = {}): 
     truncatedBy = "lines";
   }
 
-  const outputContent = outputLinesArr.join("\n");
-
   return buildTruncationResult(input, {
-    content: outputContent,
+    content: outputLinesArr.join("\n"),
     truncated: true,
     truncatedBy,
     outputLines: outputLinesArr.length,
+    outputBytes: outputBytesCount,
     lastLinePartial,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Truncating tool output repeated UTF-8 counting after the head or tail collector had already computed the exact output size. The head collector also created an index/value pair for every visited line.

## Why This Change Was Made

Require the prepared byte count at the private result builder and pass it from both collectors. Iterate the existing head slice directly, using accepted-line count for newline accounting. The collector remains the single owner of output bytes; the redundant recount path disappears. Production and total LOC: −2; tests/support unchanged.

## User Impact

Read, find, ls and command-output tails keep identical text, metadata, continuation instructions and spill behavior. The change removes redundant work and temporary iteration objects. It does not change limits, configuration, persistence, or public tool contracts.

## Evidence

The actual before/after owner produced identical complete result objects across 1,500 cases in each of Node and the Buffer-free runtime, ten golden cases per runtime, eight larger owner workloads and five caller flows. Coverage includes empty/trailing-newline text, UTF-8/surrogate boundaries, partial tails, unusual numeric ceilings, option getter/error order and fresh result ownership.

Real read-tool execution and the real output accumulator preserved continuation text, the complete private spill file, close/cleanup behavior and byte metadata. Find and ls used their existing injected filesystem facts with actual tool construction. The fixed witness removed 3,801 observed native entry pairs and 12 final byte-count calls covering 210,544 UTF-16 units. Input slices, line arrays and joins remain. These are instrumented operation counts, not a V8 allocated-byte estimate.

```json
{"behaviorCasesPerRuntime":1500,"runtimesPerArm":2,"goldensPerRuntime":10,"callerFlows":5,"entryPairs":{"before":3801,"after":0},"finalByteCountCallsRemoved":12,"finalByteCountInputUtf16UnitsRemoved":210544,"resultObjectsEqual":true,"spillFileSha256":"77f27ffe90ba327f628ce2a7f33755166b8db4e18d94613088959fac49da658b"}
```

There is no demonstrated end-to-end latency or RSS improvement: the two complete instrumented invocations took 1.187/1.855 seconds and peaked at 258.3/268.4 MB RSS. They include imports, VM setup, corpus, instrumentation and filesystem work. No favorable timing reruns were selected, and this is not a Gateway/provider benchmark.

All 88 existing tests across the owner/facade, read, accumulator, find and ls passed. The full canonical changed gate passed in 304.8 seconds, and independent managed Codex review found no actionable P0–P2 defects. Complete behavior digest: `23be8611820886a4a6b596415e42fdb8b7df783f046b61901cf957cfbd7e9871`; caller digest: `ccad5e29ec325c44dde899019f5b164c476c8765bb7aba81baaf5d8008cd63f9`.

The reviewed patch is now on main revision `1e37a56c75289bd887bbb244965d4896b921b625`, including the browser-fixture repair from #136402. Refreshed head: `0e778ddec079ae3d96f8cce70c1adac772d2b195`. The touched source bytes and stable patch identity match the previously reviewed `77fb7672631061e1c306ba9901e533ae8e98caf9`; previously recorded behavior runs cover that identical owner source, and hosted CI validates the refreshed head.
