### PR TITLE
perf(infra): consume complete JSONL lines without copying

### DIFF
--- a/src/infra/jsonl-socket.ts
+++ b/src/infra/jsonl-socket.ts
@@ -25,7 +25,7 @@ export async function requestJsonlSocket<T>(params: JsonlSocketRequest<T>): Prom
     let settled = false;
     // Keep raw bytes until a line is complete so chunk boundaries cannot split
     // a UTF-8 code point before JSON parsing.
-    let lineChunks: Buffer[] = [];
+    const lineChunks: Buffer[] = [];
     let lineBytes = 0;
 
     const finish = (value: T | null) => {
@@ -49,13 +49,6 @@ export async function requestJsonlSocket<T>(params: JsonlSocketRequest<T>): Prom
         lineBytes += chunk.byteLength;
       }
       return true;
-    };
-
-    const takeLine = (): string => {
-      const line = Buffer.concat(lineChunks, lineBytes).toString("utf8").trim();
-      lineChunks = [];
-      lineBytes = 0;
-      return line;
     };
 
     const timer = setNodeTimeout(() => finish(null), timeoutMs);
@@ -88,7 +81,12 @@ export async function requestJsonlSocket<T>(params: JsonlSocketRequest<T>): Prom
         if (!appendLineChunk(data.subarray(offset, newlineIndex))) {
           return;
         }
-        const line = takeLine();
+        const line =
+          (lineChunks.length > 1 ? Buffer.concat(lineChunks, lineBytes) : lineChunks[0])
+            ?.toString("utf8")
+            .trim() ?? "";
+        lineChunks.length = 0;
+        lineBytes = 0;
         offset = newlineIndex + 1;
         if (!line) {
           continue;


### PR DESCRIPTION
## What Problem This Solves

The local JSONL response reader concatenates every completed line into a fresh Buffer, including lines already contained in one chunk, then creates a replacement chunk array. Complete response lines need neither operation.

## Why This Change Was Made

Consume each line in the existing data loop: decode a sole chunk directly, keep the same concatenation for fragmented lines, and clear the private collector before invoking the accept callback. Empty lines remain empty. This removes the single-use `takeLine` wrapper and reduces production by **2 lines** (+7/−9); tests are unchanged. Byte limits still run before decoding/parsing, and UTF-8 handling, request half-close, timeout, abort, error and acceptance ordering stay the same. No raw buffer or collector array is exposed to callers.

## User Impact

Local JSONL callers keep identical responses and lifecycle behavior while complete lines avoid a redundant buffer copy. Fragmented lines retain the existing decode and byte-limit path.

## Evidence

A before-edit baseline and the frozen change were exercised through actual local Unix sockets. The eight cases had identical recorded requests, return values, callback sequences, received chunk lengths, deadline observations and cleanup. In the case with 128 complete 8 KiB lines plus a terminal response, **129 concatenations / 1,048,483 copied bytes became 0 / 0**. Across the corpus, **139 → 2 concatenations** and **17,825,901 → 16,777,257 copied bytes**; the required fragmented UTF-8 and exact 16 MiB line copies remain.

Selected actual observations:

```text
complete UTF-8:       café😀é终; concat 1 → 0
split UTF-8:          café😀é终; concat 1 → 1 (41 bytes)
empty/invalid/throw:  accepted; callbacks [ignore, throw, done]
128 complete lines:  after-128; concat 129 → 0
unterminated EOF:     null; no accept callback
exact 16 MiB line:    after-exact-cap; deadline did not fire
oversized +/- LF:     null; no accept callback or deadline firing
```

The counter wraps only the actual owner's Buffer.concat calls; client data observation acknowledges the first delivered UTF-8 fragment before the peer sends its suffix. It does not fabricate socket data or change source. All peer sockets/servers and abort listeners were cleaned, both process groups joined and were absent, and their private socket directories were removed. These are copied-byte/work counts, not retained-heap, RSS, latency or native Swift-policy measurements.

The same **15 existing tests pass before and after**, including real exec-host peers/children, HMAC envelope preservation, half-close, malformed response, abort, timeout and close behavior. Format and `git diff --check` pass. Canonical changed-file gate passed, including format/lint, core and core-test typechecks, boundary checks and dead-export scanning. Managed Codex review explicitly through **P0–P2** returned scoped-clean with no actionable findings.

The reviewed patch is now on main revision `1e37a56c75289bd887bbb244965d4896b921b625`, including the browser-fixture repair from #136402. Refreshed head: `5ff31b82dee567457f757df4f82b4524da39e5a5`. The touched source bytes and stable patch identity match the previously reviewed `21a7357ded9feb4cb738ccd9e3190f78c7e2f710`; previously recorded behavior runs cover that identical owner source, and hosted CI validates the refreshed head.
