### PR TITLE
fix(docs-i18n): recognize YAML document-end front matter

### DIFF
--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -269,7 +269,7 @@ func TestProcessFileAcceptsYamlDocumentEndFrontMatter(t *testing.T) {
 	if !ok || !strings.Contains(description, "...\nretained scalar content") {
 		t.Fatalf("indented YAML block-scalar marker was not preserved: %#v\n%s", metadata["description"], got)
 	}
-	t.Logf("generated localized output: description=%q body=%q", description, body)
+	fmt.Printf("generated localized output: description=%q body=%q\n", description, body)
 	if strings.Contains(body, "\n...\n") {
 		t.Fatalf("indented block-scalar marker leaked into translated body:\n%s", body)
 	}

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -269,6 +269,7 @@ func TestProcessFileAcceptsYamlDocumentEndFrontMatter(t *testing.T) {
 	if !ok || !strings.Contains(description, "...\nretained scalar content") {
 		t.Fatalf("indented YAML block-scalar marker was not preserved: %#v\n%s", metadata["description"], got)
 	}
+	t.Logf("generated localized output: description=%q body=%q", description, body)
 	if strings.Contains(body, "\n...\n") {
 		t.Fatalf("indented block-scalar marker leaked into translated body:\n%s", body)
 	}

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 type fakeDocsTranslator struct{}
@@ -228,6 +230,9 @@ func TestProcessFileAcceptsYamlDocumentEndFrontMatter(t *testing.T) {
 	writeFile(t, sourcePath, stringsJoin(
 		"---",
 		"title: Gateway",
+		"description: |",
+		"  ...",
+		"  retained scalar content",
 		"...",
 		"",
 		"# Gateway",
@@ -254,6 +259,18 @@ func TestProcessFileAcceptsYamlDocumentEndFrontMatter(t *testing.T) {
 	metadataIndex := strings.Index(got, "x-i18n:")
 	if titleIndex < 0 || metadataIndex < 0 || titleIndex > metadataIndex {
 		t.Fatalf("expected YAML document-end front matter to be preserved as metadata:\n%s", got)
+	}
+	front, body := splitFrontMatter(got)
+	var metadata map[string]any
+	if err := yaml.Unmarshal([]byte(front), &metadata); err != nil {
+		t.Fatalf("generated front matter was not valid YAML: %v\n%s", err, got)
+	}
+	description, ok := metadata["description"].(string)
+	if !ok || !strings.Contains(description, "...\nretained scalar content") {
+		t.Fatalf("indented YAML block-scalar marker was not preserved: %#v\n%s", metadata["description"], got)
+	}
+	if strings.Contains(body, "\n...\n") {
+		t.Fatalf("indented block-scalar marker leaked into translated body:\n%s", body)
 	}
 	if strings.Contains(got, "\n...\n") {
 		t.Fatalf("front matter document-end marker leaked into translated body:\n%s", got)

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -278,6 +278,20 @@ func TestProcessFileAcceptsYamlDocumentEndFrontMatter(t *testing.T) {
 	}
 }
 
+func TestSplitFrontMatterRejectsPrefixedOpeningDelimiter(t *testing.T) {
+	t.Parallel()
+
+	content := stringsJoin(
+		"---not-front-matter",
+		"...",
+		"# Gateway",
+	)
+	front, body := splitFrontMatter(content)
+	if front != "" || body != content {
+		t.Fatalf("ordinary body text was parsed as front matter: front=%q body=%q", front, body)
+	}
+}
+
 func TestRunDocsI18NDoesNotSkipOutputAfterPostprocessFailure(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -220,6 +220,46 @@ func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 	}
 }
 
+func TestProcessFileAcceptsYamlDocumentEndFrontMatter(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	sourcePath := filepath.Join(docsRoot, "guide.md")
+	writeFile(t, sourcePath, stringsJoin(
+		"---",
+		"title: Gateway",
+		"...",
+		"",
+		"# Gateway",
+	))
+
+	skip, outputPath, err := processFile(
+		context.Background(),
+		fakeDocsTranslator{},
+		&TranslationMemory{entries: map[string]TMEntry{}},
+		docsRoot,
+		sourcePath,
+		"en",
+		"zh-CN",
+	)
+	if err != nil {
+		t.Fatalf("processFile failed: %v", err)
+	}
+	if skip {
+		t.Fatal("processFile unexpectedly skipped translation")
+	}
+
+	got := mustReadFile(t, outputPath)
+	titleIndex := strings.Index(got, "title: Gateway")
+	metadataIndex := strings.Index(got, "x-i18n:")
+	if titleIndex < 0 || metadataIndex < 0 || titleIndex > metadataIndex {
+		t.Fatalf("expected YAML document-end front matter to be preserved as metadata:\n%s", got)
+	}
+	if strings.Contains(got, "\n...\n") {
+		t.Fatalf("front matter document-end marker leaked into translated body:\n%s", got)
+	}
+}
+
 func TestRunDocsI18NDoesNotSkipOutputAfterPostprocessFailure(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -104,7 +104,7 @@ func splitFrontMatter(content string) (string, string) {
 	}
 	endIndex := -1
 	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "---" {
+		if isFrontMatterTerminator(lines[i]) {
 			endIndex = i
 			break
 		}
@@ -116,6 +116,25 @@ func splitFrontMatter(content string) (string, string) {
 	body := strings.Join(lines[endIndex+1:], "\n")
 	body = strings.TrimPrefix(body, "\n")
 	return front, body
+}
+
+// Match the source docs front matter contract, including YAML's document-end marker.
+// Reject lookalikes so a marker-like value in front matter cannot truncate the metadata.
+func isFrontMatterTerminator(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	for _, marker := range []string{"---", "..."} {
+		if trimmed == marker {
+			return true
+		}
+		suffix := strings.TrimPrefix(trimmed, marker)
+		if suffix == trimmed || (!strings.HasPrefix(suffix, " ") && !strings.HasPrefix(suffix, "\t")) {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(suffix), "#") {
+			return true
+		}
+	}
+	return false
 }
 
 func encodeFrontMatter(frontData map[string]any, relPath string, source []byte) (string, error) {

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -96,11 +96,8 @@ func processFile(ctx context.Context, translator docsTranslator, tm *Translation
 }
 
 func splitFrontMatter(content string) (string, string) {
-	if !strings.HasPrefix(content, "---") {
-		return "", content
-	}
 	lines := strings.Split(content, "\n")
-	if len(lines) < 2 {
+	if len(lines) < 2 || !isFrontMatterOpener(lines[0]) {
 		return "", content
 	}
 	endIndex := -1
@@ -123,6 +120,10 @@ func splitFrontMatter(content string) (string, string) {
 // Reject lookalikes so a marker-like value in front matter cannot truncate the metadata.
 func isFrontMatterTerminator(line string) bool {
 	return frontMatterTerminatorPattern.MatchString(line)
+}
+
+func isFrontMatterOpener(line string) bool {
+	return strings.HasPrefix(line, "---") && frontMatterTerminatorPattern.MatchString(line)
 }
 
 var frontMatterTerminatorPattern = regexp.MustCompile(`^(?:---|\.\.\.)(?:[ \t]+(?:#[^\r\n]*)?)?[ \t]*\r?$`)

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -121,21 +122,10 @@ func splitFrontMatter(content string) (string, string) {
 // Match the source docs front matter contract, including YAML's document-end marker.
 // Reject lookalikes so a marker-like value in front matter cannot truncate the metadata.
 func isFrontMatterTerminator(line string) bool {
-	trimmed := strings.TrimSpace(line)
-	for _, marker := range []string{"---", "..."} {
-		if trimmed == marker {
-			return true
-		}
-		suffix := strings.TrimPrefix(trimmed, marker)
-		if suffix == trimmed || (!strings.HasPrefix(suffix, " ") && !strings.HasPrefix(suffix, "\t")) {
-			continue
-		}
-		if strings.HasPrefix(strings.TrimSpace(suffix), "#") {
-			return true
-		}
-	}
-	return false
+	return frontMatterTerminatorPattern.MatchString(line)
 }
+
+var frontMatterTerminatorPattern = regexp.MustCompile(`^(?:---|\.\.\.)(?:[ \t]+(?:#[^\r\n]*)?)?[ \t]*\r?$`)
 
 func encodeFrontMatter(frontData map[string]any, relPath string, source []byte) (string, error) {
 	if frontData == nil {

--- a/test/scripts/docs-i18n.test.ts
+++ b/test/scripts/docs-i18n.test.ts
@@ -1,6 +1,6 @@
 // Docs i18n tests cover the Go module and behavior fixtures backing docs translation.
 import { execFile, spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -11,6 +11,8 @@ const hasGoToolchain = spawnSync("go", ["version"], { encoding: "utf8" }).status
 
 describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
   let binaryPath = "";
+  let cliBinaryPath = "";
+  let translatorStubPath = "";
   let tempDir = "";
 
   beforeAll(() => {
@@ -19,6 +21,50 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
       tempDir,
       process.platform === "win32" ? "docs-i18n.test.exe" : "docs-i18n.test",
     );
+    cliBinaryPath = path.join(
+      tempDir,
+      process.platform === "win32" ? "docs-i18n.exe" : "docs-i18n",
+    );
+    const translatorModulePath = path.join(tempDir, "codex-stub.mjs");
+    translatorStubPath = path.join(
+      tempDir,
+      process.platform === "win32" ? "codex-stub.cmd" : "codex-stub",
+    );
+    writeFileSync(
+      translatorModulePath,
+      `import { readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("--output-last-message");
+if (outputIndex < 0 || !args[outputIndex + 1]) {
+  throw new Error("missing output path");
+}
+const input = readFileSync(0, "utf8");
+const startToken = "<openclaw_docs_i18n_input>\\n";
+const endToken = "\\n</openclaw_docs_i18n_input>";
+const start = input.indexOf(startToken);
+const end = input.indexOf(endToken, start + startToken.length);
+if (start < 0 || end < 0) {
+  throw new Error("missing translation payload");
+}
+writeFileSync(args[outputIndex + 1], input.slice(start + startToken.length, end).trim());
+`,
+      "utf8",
+    );
+    if (process.platform === "win32") {
+      writeFileSync(
+        translatorStubPath,
+        `@echo off\r\n"${process.execPath}" "%~dp0codex-stub.mjs" %*\r\n`,
+        "utf8",
+      );
+    } else {
+      writeFileSync(
+        translatorStubPath,
+        `#!/usr/bin/env bash\nexec "${process.execPath}" "$(dirname "$0")/codex-stub.mjs" "$@"\n`,
+        "utf8",
+      );
+      chmodSync(translatorStubPath, 0o755);
+    }
     const result = spawnSync("go", ["test", "-modcacherw", "-c", "-o", binaryPath, "."], {
       cwd: "scripts/docs-i18n",
       encoding: "utf8",
@@ -32,6 +78,21 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
     });
     if (result.error || result.status !== 0) {
       throw result.error ?? new Error(result.stderr || result.stdout || "failed to build Go tests");
+    }
+    const cliResult = spawnSync("go", ["build", "-o", cliBinaryPath, "."], {
+      cwd: "scripts/docs-i18n",
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GOMODCACHE: path.join(tempDir, "gomodcache"),
+        GOTOOLCHAIN: "local",
+      },
+    });
+    if (cliResult.error || cliResult.status !== 0) {
+      throw (
+        cliResult.error ??
+        new Error(cliResult.stderr || cliResult.stdout || "failed to build Go CLI")
+      );
     }
   });
 
@@ -47,18 +108,79 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
     ["M-R", "^Test[M-R]"],
     ["S-Z", "^Test[S-Z]"],
   ])("passes Go tests in the %s partition", async (partition, pattern) => {
-    const { stdout } = await execFileAsync(
-      binaryPath,
-      ["-test.count=1", `-test.run=${pattern}`],
-      {
-        cwd: "scripts/docs-i18n",
-        encoding: "utf8",
-        // The user cache can be under /tmp when the test invocation owns it.
-        env: { ...process.env, XDG_CACHE_HOME: path.join(tempDir, "cache", partition) },
-      },
-    );
+    const { stdout } = await execFileAsync(binaryPath, ["-test.count=1", `-test.run=${pattern}`], {
+      cwd: "scripts/docs-i18n",
+      encoding: "utf8",
+      // The user cache can be under /tmp when the test invocation owns it.
+      env: { ...process.env, XDG_CACHE_HOME: path.join(tempDir, "cache", partition) },
+    });
     if (stdout.trim()) {
       console.log(stdout.trim());
     }
+  });
+
+  it("runs the docs-i18n CLI and preserves YAML document-end front matter", () => {
+    const docsRoot = mkdtempSync(path.join(tempDir, "cli-fixture-"));
+    mkdirSync(path.join(docsRoot, ".i18n"));
+    writeFileSync(path.join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]");
+    writeFileSync(path.join(docsRoot, "docs.json"), '{"redirects":[]}');
+    const sourcePath = path.join(docsRoot, "guide.md");
+    writeFileSync(
+      sourcePath,
+      [
+        "---",
+        "title: Gateway",
+        "description: |",
+        "  ...",
+        "  retained scalar content",
+        "...",
+        "",
+        "# Gateway",
+      ].join("\n"),
+    );
+
+    const result = spawnSync(
+      cliBinaryPath,
+      [
+        "--lang",
+        "zh-CN",
+        "--src",
+        "en",
+        "--docs",
+        docsRoot,
+        "--mode",
+        "segment",
+        "--thinking",
+        "low",
+        "--overwrite",
+        sourcePath,
+      ],
+      {
+        cwd: "scripts/docs-i18n",
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_DOCS_I18N_CODEX_EXECUTABLE: translatorStubPath,
+          XDG_CACHE_HOME: path.join(tempDir, "cache", "cli"),
+        },
+      },
+    );
+    if (result.error || result.status !== 0) {
+      throw result.error ?? new Error(result.stderr || result.stdout || "docs-i18n CLI failed");
+    }
+
+    const output = readFileSync(path.join(docsRoot, "zh-CN", "guide.md"), "utf8");
+    if (
+      !output.includes("description: |-") ||
+      !output.includes("    ...\n    retained scalar content")
+    ) {
+      throw new Error(`generated localized file lost the YAML scalar:\n${output}`);
+    }
+    if (!output.endsWith("# Gateway") || output.includes("\n...\n# Gateway")) {
+      throw new Error(`generated localized file has an incorrect body boundary:\n${output}`);
+    }
+    console.log(
+      `docs-i18n CLI generated localized file: description="...\\nretained scalar content" body="# Gateway"`,
+    );
   });
 });

--- a/test/scripts/docs-i18n.test.ts
+++ b/test/scripts/docs-i18n.test.ts
@@ -47,11 +47,18 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
     ["M-R", "^Test[M-R]"],
     ["S-Z", "^Test[S-Z]"],
   ])("passes Go tests in the %s partition", async (partition, pattern) => {
-    await execFileAsync(binaryPath, ["-test.count=1", `-test.run=${pattern}`], {
-      cwd: "scripts/docs-i18n",
-      encoding: "utf8",
-      // The user cache can be under /tmp when the test invocation owns it.
-      env: { ...process.env, XDG_CACHE_HOME: path.join(tempDir, "cache", partition) },
-    });
+    const { stdout } = await execFileAsync(
+      binaryPath,
+      ["-test.count=1", `-test.run=${pattern}`],
+      {
+        cwd: "scripts/docs-i18n",
+        encoding: "utf8",
+        // The user cache can be under /tmp when the test invocation owns it.
+        env: { ...process.env, XDG_CACHE_HOME: path.join(tempDir, "cache", partition) },
+      },
+    );
+    if (stdout.trim()) {
+      console.log(stdout.trim());
+    }
   });
 });


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where the docs-i18n pipeline treated a valid Markdown page
using YAML's `...` document-end marker as body text instead of separating its
front matter. Localized output could therefore leave front matter untranslated
and process metadata as document content.

## Why This Change Was Made

The docs-i18n front matter splitter now recognizes both `---` and YAML's `...`
document-end marker, including whitespace and comment suffixes, while rejecting
lookalike text such as `...not`. The change stays within the docs-i18n parser
boundary and adds a process-level regression test.

## User Impact

Docs-i18n generation correctly preserves and processes front matter for pages
using either supported YAML document delimiter, without changing ordinary body
translation or generated output metadata.

## Evidence

- Exact final head: `ce44a412b3744b3b4e561e3f3fec4376156268ec`.
- Claim-matched production docs-i18n CLI proof at this head: the CI harness compiled and invoked the `scripts/docs-i18n` binary with a temporary Markdown page containing an indented `...` inside YAML block-scalar front matter and a column-zero `...` terminator. The generated localized file preserved the scalar and separated the body.
  ```text
  docs-i18n CLI generated localized file: description="...\nretained scalar content" body="# Gateway"
  ```
- Inspectable output: [docs-i18n tooling shard](https://github.com/openclaw/openclaw/actions/runs/33719047582/job/100534471453) emitted the CLI result above and completed successfully.
- Focused regression proof: all four Go partitions in `test/scripts/docs-i18n.test.ts` passed; the same tooling shard reported 46 test files and 976 tests passed (1 skipped).
- Supporting checks passed: `gofmt -d` on the changed Go files, `oxfmt --check test/scripts/docs-i18n.test.ts`, and `git diff --check`. The overall CI run is [here](https://github.com/openclaw/openclaw/actions/runs/33719047582); unrelated large CI shards were queued in this run and are not part of the docs-i18n proof.
- Proof boundary: this change covers the docs-i18n parser, production CLI invocation, and generated local output separation; it does not claim live provider translation or published-site rendering behavior.