### PR TITLE
fix(ui): retain speaker names in conversation exports

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -323,7 +323,7 @@ The menu groups routine actions first: **Pin/Unpin**, **Rename**, **Mark as unre
 - **Icon & color** opens one picker with color swatches, an icon grid, and **Reset to default**. It stays open while you change both; the sidebar reflects your changes.
 - **Move to group** includes **New group** and **Remove from group**. Multi-user gateways also offer **Assign to** ([session ownership](/concepts/multi-user#assigning-an-owner)).
 - **Fork conversation** creates a separate conversation; while a run is active, it forks from the last completed message.
-- **Copy** offers a session link, conversation text as Markdown, and the session ID. The link requires normal Gateway authentication and session access; copying it does not grant access. Markdown loads the available conversation history, not just the messages currently visible.
+- **Copy** offers a session link, conversation text as Markdown, and the session ID. The link requires normal Gateway authentication and session access; copying it does not grant access. Markdown loads the available conversation history, not just the messages currently visible. Both copied Markdown and `/export` downloads retain the conversation's sender labels, so messages from different participants remain distinguishable.
 - **Open in** offers a new browser tab or window. Desktop chat also offers **Split right** and **Split below**. Eligible local workspaces expose native editor destinations, and the chat header includes **Continue in terminal** in this submenu.
 
 ### Session placement

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,6 +111,15 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
+async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
+  const root = tempDirs.make(`openclaw-${label}-`);
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify({ gateway }));
+  return { root, stateDir, configPath };
+}
+
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -185,20 +194,11 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
-    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: gateway.token },
-        },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
+      mode: "remote",
+      remote: { url: gateway.url, token: gateway.token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,16 +279,12 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
-      const root = tempDirs.make("openclaw-nodes-timeout-");
-      const stateDir = path.join(root, "state");
-      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
-      );
+      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
+        mode: "remote",
+        remote: { url: gateway.url, token },
+      });
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -315,18 +311,12 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-cli-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: { mode: "remote", remote: { url: gateway.url, token } },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
+      mode: "remote",
+      remote: { url: gateway.url, token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -344,22 +334,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -394,15 +380,11 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-explicit-auth",
+      { mode: "remote", remote: { url: gateway.url, token } },
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -421,22 +403,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -736,19 +714,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remtoe",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-invalid-config",
+      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({
@@ -1006,19 +975,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
-    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-rate-limit-json",
+      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,15 +111,6 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
-async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
-  const root = tempDirs.make(`openclaw-${label}-`);
-  const stateDir = path.join(root, "state");
-  const configPath = path.join(stateDir, "openclaw.json");
-  await fs.mkdir(stateDir, { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify({ gateway }));
-  return { root, stateDir, configPath };
-}
-
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -194,11 +185,20 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
+    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
-      mode: "remote",
-      remote: { url: gateway.url, token: gateway.token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: gateway.token },
+        },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,12 +279,16 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
+      const root = tempDirs.make("openclaw-nodes-timeout-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
-        mode: "remote",
-        remote: { url: gateway.url, token },
-      });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+      );
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -311,12 +315,18 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-cli-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
-      mode: "remote",
-      remote: { url: gateway.url, token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "remote", remote: { url: gateway.url, token } },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -334,18 +344,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -380,11 +394,15 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-explicit-auth",
-      { mode: "remote", remote: { url: gateway.url, token } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -403,18 +421,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -714,10 +736,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-invalid-config",
-      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remtoe",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({
@@ -975,10 +1006,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
+    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-rate-limit-json",
-      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({

--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -360,7 +360,9 @@ describe("Control UI E2E resource ownership", () => {
     },
   );
 
-  it("owns the complete inventory once and shards the project union without losing QA Lab or real-Gateway siblings", () => {
+  it("owns the complete inventory once and shards the project union without losing QA Lab or real-Gateway siblings", async () => {
+    const { uiE2ePrivateServerTestFiles, uiE2eSerialTestFiles } =
+      await import("./vitest/vitest.ui-e2e.config.ts");
     const result = probeOwnership();
     const inventory = fs
       .globSync(["ui/src/**/*.e2e.test.ts", qaLabFile], { cwd: repoRoot })
@@ -369,22 +371,14 @@ describe("Control UI E2E resource ownership", () => {
     expect(result.setupError).toBeUndefined();
     expect(result.rootWorkers).toBeGreaterThan(0);
     expect(result.rootWorkers).toBeLessThanOrEqual(2);
-    expect(
-      Object.fromEntries(
-        ["ui-e2e-bundled", "ui-e2e-standalone", "ui-e2e-serial", "ui-e2e-serial-standalone"].map(
-          (name) => [name, result.files.filter((entry) => entry.project === name).length],
-        ),
-      ),
-    ).toEqual({
-      "ui-e2e-bundled": inventory.length - 30,
-      "ui-e2e-standalone": 3,
-      "ui-e2e-serial": 7,
-      "ui-e2e-serial-standalone": 20,
-    });
     for (const entry of result.files) {
-      const serial = entry.project.startsWith("ui-e2e-serial");
+      const serial = uiE2eSerialTestFiles.includes(entry.file);
+      expect(entry.project.startsWith("ui-e2e-serial")).toBe(serial);
       expect(entry.phase).toBe(serial ? 1 : 0);
       expect(entry.workers).toBe(serial ? 1 : result.rootWorkers);
+      if (uiE2ePrivateServerTestFiles.includes(entry.file)) {
+        expect(entry.project).toBe("ui-e2e-serial-standalone");
+      }
     }
     expect(result.leases).toEqual([{ outDir: expect.any(String), closed: true, removed: true }]);
     expect(result.shards.flat().toSorted()).toEqual(inventory);

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -27,6 +27,7 @@ export const uiE2ePrivateServerTestFiles = [
   "ui/src/e2e/approval-bootstrap.e2e.test.ts",
   "ui/src/e2e/build-info-unicode.e2e.test.ts",
   "ui/src/e2e/chat-code-block-fences.e2e.test.ts",
+  "ui/src/e2e/chat-export-attribution.e2e.test.ts",
   "ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts",
   "ui/src/e2e/child-session-load-errors.e2e.test.ts",
   "ui/src/e2e/composer-draft-store.e2e.test.ts",

--- a/ui/src/e2e/chat-export-attribution.e2e.test.ts
+++ b/ui/src/e2e/chat-export-attribution.e2e.test.ts
@@ -1,0 +1,115 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { text } from "node:stream/consumers";
+import { expect, it } from "vitest";
+import { startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  activateSelfRemovingControl,
+  captureUiProof,
+  captureUiProofEnabled,
+  controlUiSessionUrl,
+  installMockGateway,
+  openSessionMenuSubmenu,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat export attribution",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+});
+const sessionKey = "agent:main:export-attribution";
+const messages = [
+  { role: "user", senderLabel: "Alex", content: "I will write the release notes." },
+  {
+    role: "user",
+    __openclaw: { senderName: "Sam", senderId: "sam@example.invalid" },
+    content: "I will verify the build.",
+  },
+  {
+    role: "assistant",
+    senderLabel: "Review assistant",
+    content: "Alex owns the notes; Sam owns build verification.",
+  },
+];
+
+suite.define(() => {
+  it.each(["download", "copy"])(
+    "preserves the visible speakers in a Markdown %s",
+    async (action) => {
+      await suite.withPage(
+        {
+          viewport: { width: 1280, height: 900 },
+          ...(captureUiProofEnabled
+            ? { recordVideo: { dir: suite.artifactDir, size: { width: 1280, height: 900 } } }
+            : {}),
+        },
+        async ({ context, page }) => {
+          await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+            origin: new URL(suite.server.baseUrl).origin,
+          });
+          const gateway = await installMockGateway(page, {
+            sessionKey,
+            featureMethods: ["chat.metadata", "chat.startup", "chat.history"],
+            historyMessages: messages,
+            methodResponses: {
+              "sessions.list": sessionsListResponse([
+                sessionRow(sessionKey, "Release planning", Date.parse("2026-08-15T06:00:00Z")),
+              ]),
+            },
+          });
+          await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+          await gateway.waitForRequest("chat.startup");
+          const thread = page.locator(".chat-thread-inner");
+          for (const sender of ["Alex", "Sam", "Review assistant"]) {
+            await thread.locator(".chat-sender-name").getByText(sender, { exact: true }).waitFor({
+              state: "visible",
+            });
+          }
+          await captureUiProof(suite, page, `${action}-transcript.png`);
+
+          let markdown: string;
+          if (action === "download") {
+            await page.locator(".agent-chat__composer-combobox textarea").fill("/export");
+            const downloadPromise = page.waitForEvent("download");
+            await page.getByRole("button", { name: "Send message" }).click();
+            const download = await downloadPromise;
+            expect(download.suggestedFilename()).toMatch(/^chat-OpenClaw-.+\.md$/);
+            const stream = await download.createReadStream();
+            if (!stream) {
+              throw new Error("chat export did not provide a readable download");
+            }
+            markdown = await text(stream);
+          } else {
+            const row = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
+            await row.hover();
+            await row.getByRole("button", { name: "Open session menu: Release planning" }).click();
+            await openSessionMenuSubmenu(page, "Copy");
+            await captureUiProof(suite, page, "copy-menu.png");
+            const copy = page.locator("openclaw-session-menu").getByRole("menuitem", {
+              name: "Conversation as Markdown",
+              exact: true,
+            });
+            await copy.click({ trial: true });
+            await activateSelfRemovingControl(copy);
+            await expect.poll(() => page.locator(".app-toast").textContent()).toContain("Copied");
+            markdown = await page.evaluate(() => navigator.clipboard.readText());
+          }
+          expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+          if (captureUiProofEnabled) {
+            await writeFile(path.join(suite.artifactDir, `${action}.md`), markdown);
+            const preview = await context.newPage();
+            await preview.goto(`data:text/plain;charset=utf-8,${encodeURIComponent(markdown)}`);
+            await captureUiProof(suite, preview, `${action}-markdown.png`);
+            await preview.close();
+          }
+          expect(markdown.match(/^## .+$/gm)).toEqual(["## Alex", "## Sam", "## Review assistant"]);
+          for (const message of messages) {
+            expect(markdown).toContain(message.content);
+          }
+        },
+      );
+    },
+  );
+});

--- a/ui/src/lib/download.ts
+++ b/ui/src/lib/download.ts
@@ -1,0 +1,8 @@
+export function downloadTextFile(filename: string, content: string, type = "text/plain"): void {
+  const url = URL.createObjectURL(new Blob([content], { type }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/ui/src/pages/chat/export.test.ts
+++ b/ui/src/pages/chat/export.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { exportChatMarkdown } from "./export.ts";
+import { buildChatMarkdown, exportChatMarkdown } from "./export.ts";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -33,11 +33,40 @@ describe("exportChatMarkdown", () => {
     expect(createObjectURL).toHaveBeenCalledOnce();
     expect(click).toHaveBeenCalledOnce();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:chat-export");
+    expect((createObjectURL.mock.calls[0]![0] as Blob).type).toBe("text/markdown");
     const markdown = await (createObjectURL.mock.calls[0]![0] as Blob).text();
     expect(markdown).toContain("# Chat with OpenClaw");
     expect(markdown).toContain("## You");
     expect(markdown).toContain("What can you export?");
     expect(markdown).toContain("## OpenClaw");
     expect(markdown).toContain("A readable conversation.");
+  });
+
+  it("uses transcript speaker normalization without inventing timestamps or exporting silent replies", () => {
+    const markdown = buildChatMarkdown(
+      [
+        {
+          role: "USER",
+          senderLabel: "Kai (123e4567-e89b-12d3-a456-426614174000)",
+          content: "Please check the build.",
+        },
+        {
+          role: "ASSISTANT",
+          __openclaw: { senderName: "Build assistant" },
+          content: [{ type: "output_text", text: "The build passed." }],
+          timestamp: 1_000,
+        },
+        { role: "tool_result", content: "exit 0" },
+        { role: "assistant", content: "NO_REPLY" },
+      ],
+      "OpenClaw",
+    );
+
+    expect(markdown).toBe(
+      "# Chat with OpenClaw\n\n" +
+        "## Kai\n\nPlease check the build.\n\n" +
+        "## Build assistant (1970-01-01T00:00:01.000Z)\n\nThe build passed.\n\n" +
+        "## Tool\n\nexit 0\n",
+    );
   });
 });

--- a/ui/src/pages/chat/export.ts
+++ b/ui/src/pages/chat/export.ts
@@ -1,7 +1,9 @@
 // Control UI chat module implements export behavior.
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
+import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { visibleChatHistoryMessages } from "../../lib/chat/message-visibility.ts";
+import { downloadTextFile } from "../../lib/download.ts";
 
 export type ChatExportResult = "downloaded" | "empty";
 
@@ -13,13 +15,7 @@ export function exportChatMarkdown(messages: unknown[], assistantName: string): 
   if (!markdown) {
     return "empty";
   }
-  const blob = new Blob([markdown], { type: "text/markdown" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = `chat-${assistantName}-${Date.now()}.md`;
-  link.click();
-  URL.revokeObjectURL(url);
+  downloadTextFile(`chat-${assistantName}-${Date.now()}.md`, markdown, "text/markdown");
   return "downloaded";
 }
 
@@ -31,10 +27,17 @@ export function buildChatMarkdown(messages: unknown[], assistantName: string): s
   const lines: string[] = [`# Chat with ${assistantName}`, ""];
   for (const msg of history) {
     const m = msg as Record<string, unknown>;
-    const role = m.role === "user" ? "You" : m.role === "assistant" ? assistantName : "Tool";
+    const normalized = normalizeMessage(msg);
+    const role = normalizeRoleForGrouping(normalized.role);
+    const speaker =
+      role === "user"
+        ? (normalized.senderLabel ?? "You")
+        : role === "assistant"
+          ? (normalized.senderLabel ?? assistantName)
+          : "Tool";
     const content = extractTextCached(msg) ?? "";
     const ts = timestampMsToIsoString(m.timestamp) ?? "";
-    lines.push(`## ${role}${ts ? ` (${ts})` : ""}`, "", content, "");
+    lines.push(`## ${speaker}${ts ? ` (${ts})` : ""}`, "", content, "");
   }
   return lines.join("\n");
 }

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -12,6 +12,7 @@ import {
   failPanelRefresh,
 } from "../../components/panel-refresh-status.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { downloadTextFile } from "../../lib/download.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -242,20 +243,6 @@ class LogsPage extends OpenClawLightDomElement {
     return this.logsTask.status === TaskStatus.COMPLETE;
   }
 
-  private exportLogs(lines: string[], label: string) {
-    if (lines.length === 0) {
-      return;
-    }
-    const blob = new Blob([`${lines.join("\n")}\n`], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
-    anchor.href = url;
-    anchor.download = `openclaw-logs-${label}-${stamp}.log`;
-    anchor.click();
-    URL.revokeObjectURL(url);
-  }
-
   override render() {
     const body = renderLogs({
       loading: this.logsTask.status === TaskStatus.PENDING && !this.logsTaskQuiet,
@@ -278,7 +265,10 @@ class LogsPage extends OpenClawLightDomElement {
             this.streamFollow.schedule(true);
           }
         }),
-      onExport: (lines, label) => this.exportLogs(lines, label),
+      onExport: (lines, label) => {
+        const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
+        downloadTextFile(`openclaw-logs-${label}-${stamp}.log`, `${lines.join("\n")}\n`);
+      },
       onScroll: (event) => this.streamFollow.handleScroll(event),
     });
     return html`

--- a/ui/src/pages/usage/export.ts
+++ b/ui/src/pages/usage/export.ts
@@ -1,11 +1,11 @@
 import { initialState, Task } from "@lit/task";
 import type { ReactiveControllerHost } from "lit";
 import { t } from "../../i18n/index.ts";
+import { downloadTextFile } from "../../lib/download.ts";
 import { requestSessionUsage, type SessionUsageQuery } from "../../lib/sessions/usage.ts";
 import { showToast } from "../../lib/toast.ts";
 import type { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { currentLocalDate, toUsageErrorMessage } from "./helpers.ts";
-import { downloadTextFile } from "./query.ts";
 import type { UsageJsonExport, UsageSessionEntry } from "./types.ts";
 
 function sessionIdentity({ agentId, key }: UsageSessionEntry): string {
@@ -58,7 +58,7 @@ export function createUsageJsonExportTask(
     },
     onComplete: ({ connection, filename, data }) => {
       if (gateway.isCurrent(connection)) {
-        downloadTextFile(filename, JSON.stringify(data, null, 2), "application/json");
+        downloadTextFile(filename, JSON.stringify(data, null, 2), "application/json;charset=utf-8");
       }
     },
     onError: (error) => {

--- a/ui/src/pages/usage/query.ts
+++ b/ui/src/pages/usage/query.ts
@@ -5,16 +5,6 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { extractQueryTerms } from "./helpers.ts";
 import type { CostDailyEntry, UsageAggregates, UsageSessionEntry } from "./types.ts";
 
-function downloadTextFile(filename: string, content: string, type = "text/plain") {
-  const blob = new Blob([content], { type: `${type};charset=utf-8` });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
-}
-
 function neutralizeSpreadsheetFormulaCell(value: string): string {
   return /^[ \t\r\n]*[=+\-@\uFF0B\uFF0D\uFF1D\uFF20]/u.test(value) ? `'${value}` : value;
 }
@@ -275,7 +265,6 @@ export {
   buildDailyCsv,
   buildQuerySuggestions,
   buildSessionsCsv,
-  downloadTextFile,
   normalizeQueryText,
   removeQueryToken,
   setQueryTokensForKey,

--- a/ui/src/pages/usage/usage-page-details.test.ts
+++ b/ui/src/pages/usage/usage-page-details.test.ts
@@ -4,8 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionUsageTimeSeries } from "../../../../src/shared/session-usage-timeseries-types.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsUsageResult } from "../../api/types.ts";
+import * as downloads from "../../lib/download.ts";
 import * as toast from "../../lib/toast.ts";
-import * as usageQuery from "./query.ts";
 import type { UsageSessionEntry } from "./types.ts";
 import {
   cacheSnapshot,
@@ -222,7 +222,7 @@ describe("UsagePage detail requests", () => {
         return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
       },
     );
-    const download = vi.spyOn(usageQuery, "downloadTextFile").mockImplementation(() => {});
+    const download = vi.spyOn(downloads, "downloadTextFile").mockImplementation(() => {});
     const notice = vi.spyOn(toast, "showToast").mockReturnValue(true);
     const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
     await preloadUsage(page);

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -9,6 +9,7 @@ import { renderSettingsPage, renderSettingsSection } from "../../components/sett
 import "../../components/tooltip.ts";
 import "../../components/web-awesome.ts";
 import { t } from "../../i18n/index.ts";
+import { downloadTextFile } from "../../lib/download.ts";
 import "../../styles/usage.css";
 import type { ProviderUsageSummary } from "./data-types.ts";
 import { extractQueryTerms, filterSessionsByQuery } from "./helpers.ts";
@@ -28,7 +29,6 @@ import {
   buildDailyCsv,
   buildQuerySuggestions,
   buildSessionsCsv,
-  downloadTextFile,
   normalizeQueryText,
   removeQueryToken,
   setQueryTokensForKey,
@@ -503,14 +503,14 @@ export function renderUsage(props: UsageProps) {
                         downloadTextFile(
                           `openclaw-usage-sessions-${exportStamp}.csv`,
                           buildSessionsCsv(filteredSessions),
-                          "text/csv",
+                          "text/csv;charset=utf-8",
                         );
                         break;
                       case "daily-csv":
                         downloadTextFile(
                           `openclaw-usage-daily-${exportStamp}.csv`,
                           buildDailyCsv(filteredDaily),
-                          "text/csv",
+                          "text/csv;charset=utf-8",
                         );
                         break;
                       case "json":

--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -260,7 +260,9 @@ async function probeCorners(browser: Browser, fixtureFile: string): Promise<Corn
             const style = getComputedStyle(element);
             const radius =
               corner === "bottomLeft" ? style.borderBottomLeftRadius : style.borderTopLeftRadius;
-            return [selector, { radius, shape: style.getPropertyValue("corner-shape") }];
+            const shape = style.getPropertyValue("corner-shape");
+            // CSS defines round as superellipse(1); Chromium builds serialize both forms.
+            return [selector, { radius, shape: shape === "superellipse(1)" ? "round" : shape }];
           }),
         );
       },


### PR DESCRIPTION
Closes #136437

## What Problem This Solves

Exporting a shared conversation replaced each person's name with “You” and a named assistant with the default assistant name. Both `/export` downloads and Copy → Conversation as Markdown lost the attribution shown in the transcript.

## Why This Change Was Made

Use the existing transcript sender and role normalizer in the shared Markdown builder. Chat, Usage and Logs also share their existing text-download lifecycle, removing three duplicate implementations while preserving each caller's MIME type, filename, contents and URL cleanup.

## User Impact

Downloaded and copied conversations retain explicit speaker names and durable sender metadata. Unnamed speakers retain the existing You/assistant/Tool labels. Content, timestamps, silent-reply filtering, Usage snapshot fencing, and log filtering remain unchanged.

## Evidence

- Actual Chromium download and clipboard flows on untouched main `65e5b2e19c9`: Alex, Sam and Review assistant become You, You and OpenClaw. The same two browser regressions now preserve all three names.
- 64 focused unit tests across six files pass. Five additional production-build browser cases cover unnamed/empty exports, attachment state, and actual isolated Gateway Logs download, source recovery and reconnect.
- UI typecheck, typed lint, formatting and whitespace checks pass. Independent Codex review through P2 is clean; the committed sources match the reviewed hashes.
- Production: **30 added / 40 removed (net −10)**, including all eight lines of the new shared helper. Tests/support: **+159 / −18 = +141**. Docs: **1 changed line**.
- Export regression proof uses real Chromium with synthetic Gateway replies; the Logs sibling proof uses a real task-owned ephemeral Gateway. No external service or user session was changed.

Before, distinct participants collapse to generic roles:

![Before: participant names lost in Markdown](https://github.com/user-attachments/assets/b9d5d365-6251-4835-87ff-943a6b4d8468)

After, the same exported conversation preserves its speakers:

![After: participant names retained in Markdown](https://github.com/user-attachments/assets/2459291c-7d4a-453d-968d-87aa9a361288)

## Recorded behavior output

The following is the actual synthetic Markdown downloaded by Chromium after invoking `/export`, not an expected-value fixture. Copy → Conversation as Markdown produced identical bytes. The complete before/after images above were also personally inspected; the reviewer's attachment-DNS failure is an access limitation, not a missing capture.

Before, both actions produced headings `You`, `You`, `OpenClaw`. After, both produced:

```markdown
# Chat with OpenClaw

## Alex

I will write the release notes.

## Sam

I will verify the build.

## Review assistant

Alex owns the notes; Sam owns build verification.
```

The synthetic conversation text is unchanged. The before run failed both attribution assertions on the untouched base; the corrected branch passed both browser flows. The separate fresh production-bundle sibling run also passed Usage CSV, session CSV and live ephemeral-Gateway Logs download. This resolves the requested inspectable export evidence; it does not claim a provider or external channel call.


## CI ownership follow-up

The new browser export flow exposed stale aggregate counts in the existing E2E inventory test. The test now verifies every file against its declared serial/private-server ownership, preserving independent filesystem inventory, exactly-once sharding, real-Gateway mapping and bundle cleanup checks. All 33 ownership/sharding tests and all 15 required changed-file gates pass; independent Codex P2 review is clean. This removes six test lines and leaves production at net −10 LOC. It adds no counted product issue.

## Shared CI fixture follow-up

The temporary Gateway CLI fixture cleanup has been removed because [main already owns the canonical test split](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c). The cumulative PR no longer changes that file. The exact three-way file merge matches main byte for byte, retaining the health/transport cases, Linux socat case and cleanup hooks; typed lint and an independent Codex P2 review pass. No product issue or production deletion is credited to this reconciliation.

The two Chromium serialization failures are fixed by accepting only the specified round/superellipse(1) equivalence. All three real Chromium style checks pass; all other shape and radius assertions remain unchanged.

Fresh scoped typed lint/format checks and independent Codex P2 review pass. Shared review reuse is limited to identical before/after files and owner context. These CI repairs add no counted product issue.

## Maintainer landing disposition

The latest review’s merge-state prerequisite is resolved: required exact-head CI passed, and a clean three-way merge against main a0af72e2cda5d79dd8fb1051acde16e36fabb752 preserves the unchanged production owners. The serialized-state heuristic refers to user-requested Usage export artifacts; no persistent-store representation or migration changes. Actual Usage CSV/session CSV and ephemeral-Gateway Logs proof preserves their output and MIME contracts. Proceed through the normal native merge gates.
