### PR TITLE
fix(gateway): load encoded and symlinked Control UI assets

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1022,6 +1022,8 @@ For bundled builds, the Gateway retains manifest-verified assets so already-open
 
 Non-index static assets use `Last-Modified` for conditional `GET` and `HEAD` requests. `If-None-Match` takes precedence over `If-Modified-Since`: `*` matches an existing asset, while other values receive the normal `200` response because static assets do not emit ETags. Date-only revalidation still returns `304` for unchanged assets. If no available content encoding is acceptable, the Gateway returns `406` before evaluating either condition.
 
+Static asset URLs support percent-encoded filenames. Contained symlinks retain the requested asset's MIME type, and a symlinked `index.html` receives the same base-path and document preparation as other entry routes.
+
 Optional absolute base (fixed asset URLs):
 
 ```bash

--- a/src/gateway/control-ui-artifact-paths.http.test.ts
+++ b/src/gateway/control-ui-artifact-paths.http.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import { createServer, request, type Server } from "node:http";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { handleControlUiHttpRequest } from "./control-ui.js";
+
+const files = {
+  "hello world.js": 'export const label = "space";\n',
+  "hello%20world.js": 'export const label = "literal percent";\n',
+  "été.js": 'export const label = "unicode";\n',
+  "100%.js": 'export const label = "percent";\n',
+};
+const scriptBody = 'console.log("contained alias");\n';
+
+describe.each(["", "/dashboard"])("Control UI artifact names under %j", (basePath) => {
+  const tempDirs = createTempDirTracker();
+  let server: Server;
+  let origin: string;
+
+  beforeAll(async () => {
+    const root = tempDirs.make("openclaw-ui-artifact-paths-");
+    await fs.mkdir(path.join(root, "assets"));
+    for (const [name, body] of Object.entries(files)) {
+      await fs.writeFile(path.join(root, "assets", name), body);
+    }
+    await fs.writeFile(path.join(root, "payload"), scriptBody);
+    await fs.writeFile(path.join(root, "payload.gz"), gzipSync(scriptBody));
+    await fs.symlink("../payload", path.join(root, "assets", "app.js"));
+    await fs.writeFile(
+      path.join(root, "document"),
+      '<!doctype html><html><head><script src="./assets/app.js"></script></head><body>Ready</body></html>',
+    );
+    await fs.symlink("document", path.join(root, "index.html"));
+    server = createServer((req, res) => {
+      void handleControlUiHttpRequest(req, res, {
+        basePath,
+        root: { kind: "bundled", path: root },
+      }).then(
+        (handled) => {
+          if (!handled) {
+            res.statusCode = 404;
+            res.end();
+          }
+        },
+        (error: unknown) => {
+          res.statusCode = 500;
+          res.end(String(error));
+        },
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a TCP fixture listener");
+    }
+    origin = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    } finally {
+      tempDirs.cleanup();
+    }
+  });
+
+  const read = (pathname: string, method = "GET", encoding = "identity") =>
+    new Promise<{
+      status: number | undefined;
+      headers: import("node:http").IncomingHttpHeaders;
+      body: Buffer;
+    }>((resolve, reject) => {
+      const req = request(
+        `${origin}${basePath}${pathname}`,
+        { method, headers: { "Accept-Encoding": encoding }, agent: false },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (chunk: Buffer) => chunks.push(chunk));
+          res.on("error", reject);
+          res.on("end", () =>
+            resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks) }),
+          );
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+
+  it.each(Object.entries(files))("decodes %s exactly once for GET and HEAD", async (name, body) => {
+    for (const method of ["GET", "HEAD"]) {
+      const result = await read(`/assets/${encodeURIComponent(name)}`, method);
+      expect(result.status).toBe(200);
+      expect(result.headers["content-type"]).toBe("application/javascript; charset=utf-8");
+      expect(result.headers["content-length"]).toBe(String(Buffer.byteLength(body)));
+      expect(result.body.toString()).toBe(method === "HEAD" ? "" : body);
+    }
+  });
+
+  it("preserves the logical script type and canonical sidecar for contained aliases", async () => {
+    for (const method of ["GET", "HEAD"]) {
+      const identity = await read("/assets/app.js", method);
+      expect(identity.status).toBe(200);
+      expect(identity.headers["content-type"]).toBe("application/javascript; charset=utf-8");
+      expect(identity.body.toString()).toBe(method === "HEAD" ? "" : scriptBody);
+      const compressed = await read("/assets/app.js", method, "gzip, identity;q=0");
+      expect(compressed.status).toBe(200);
+      expect(compressed.headers["content-encoding"]).toBe("gzip");
+      expect(compressed.headers["content-type"]).toBe(identity.headers["content-type"]);
+      expect(compressed.body).toEqual(method === "HEAD" ? Buffer.alloc(0) : gzipSync(scriptBody));
+    }
+  });
+
+  it("prepares a symlinked index for direct and fallback documents", async () => {
+    for (const route of ["/", "/chat"]) {
+      const get = await read(route);
+      expect(get.status).toBe(200);
+      expect(get.headers["content-type"]).toBe("text/html; charset=utf-8");
+      expect(get.body.toString()).toContain(`data-openclaw-control-ui-base-path="${basePath}"`);
+      expect(get.body.toString()).toContain(`src="${basePath}/assets/app.js"`);
+      const head = await read(route, "HEAD");
+      expect(head.status).toBe(200);
+      expect(head.headers["content-type"]).toBe(get.headers["content-type"]);
+      expect(head.body.length).toBe(0);
+    }
+  });
+
+  it.each([
+    "/assets/%zz.js",
+    "/assets/%FF.js",
+    "/assets/%00.js",
+    "/assets/%2e%2e%2f%2e%2e%2foutside.js",
+  ])("rejects invalid or escaping artifact name %s", async (route) => {
+    expect((await read(route)).status).toBe(404);
+  });
+});

--- a/src/gateway/control-ui-static.ts
+++ b/src/gateway/control-ui-static.ts
@@ -21,34 +21,28 @@ const CONTROL_UI_COMPRESSIBLE_EXTENSIONS = new Set([
 ]);
 const CONTROL_UI_PRECOMPRESSED_ASSET_EXTENSIONS = new Set([".br", ".gz"]);
 
-/**
- * Missing files with these extensions return 404 instead of the SPA index.
- * `.html` stays excluded because client-side routes may use that suffix.
- */
-const CONTROL_UI_STATIC_ASSET_EXTENSIONS = new Set([
-  ".js",
-  ".css",
-  ".json",
-  ".map",
-  ".svg",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".gif",
-  ".webp",
-  ".ico",
-  ".txt",
-  ".wasm",
-  ".webmanifest",
-  ".woff2",
-]);
+const CONTROL_UI_CONTENT_TYPES: Readonly<Record<string, string>> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".txt": "text/plain; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".webmanifest": "application/manifest+json; charset=utf-8",
+  ".woff2": "font/woff2",
+};
 
 export function isControlUiStaticAssetExtension(extension: string): boolean {
-  return CONTROL_UI_STATIC_ASSET_EXTENSIONS.has(extension);
-}
-
-function isControlUiCompressibleExtension(extension: string): boolean {
-  return CONTROL_UI_COMPRESSIBLE_EXTENSIONS.has(extension);
+  // Missing .html paths can be client-side routes; the other known types stay 404.
+  return extension !== ".html" && Object.hasOwn(CONTROL_UI_CONTENT_TYPES, extension);
 }
 
 export function isControlUiPrecompressedAssetExtension(extension: string): boolean {
@@ -61,43 +55,6 @@ type ControlUiEncodingSelection = ControlUiRepresentationEncoding | "not-accepta
 
 const CONTROL_UI_QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
 const controlUiHtmlCompressionCache = new Map<string, Promise<Buffer>>();
-
-function contentTypeForExtension(ext: string): string {
-  switch (ext) {
-    case ".html":
-      return "text/html; charset=utf-8";
-    case ".js":
-      return "application/javascript; charset=utf-8";
-    case ".css":
-      return "text/css; charset=utf-8";
-    case ".json":
-    case ".map":
-      return "application/json; charset=utf-8";
-    case ".svg":
-      return "image/svg+xml";
-    case ".png":
-      return "image/png";
-    case ".jpg":
-    case ".jpeg":
-      return "image/jpeg";
-    case ".gif":
-      return "image/gif";
-    case ".webp":
-      return "image/webp";
-    case ".ico":
-      return "image/x-icon";
-    case ".txt":
-      return "text/plain; charset=utf-8";
-    case ".wasm":
-      return "application/wasm";
-    case ".webmanifest":
-      return "application/manifest+json; charset=utf-8";
-    case ".woff2":
-      return "font/woff2";
-    default:
-      return "application/octet-stream";
-  }
-}
 
 function normalizedAcceptEncoding(req: IncomingMessage): string {
   const value = req.headers?.["accept-encoding"];
@@ -156,26 +113,26 @@ export function resolveControlUiHtmlEncoding(req: IncomingMessage): ControlUiEnc
 
 type OpenedControlUiRepresentation = {
   bodyFile: { path: string; fd: number; size: number };
-  contentPath: string;
   encoding?: ControlUiContentEncoding;
 };
 
 export function resolveOpenedControlUiRepresentation(params: {
   req: IncomingMessage;
   sourceFile: { path: string; fd: number; size: number };
+  contentPath: string;
   precompressed: boolean;
   openPrecompressedFile: (filePath: string) => { path: string; fd: number; size: number } | null;
 }): OpenedControlUiRepresentation | null {
   const { req, sourceFile, precompressed, openPrecompressedFile } = params;
-  const extension = path.extname(sourceFile.path).toLowerCase();
+  const extension = path.extname(params.contentPath).toLowerCase();
   const encodings = resolveControlUiContentEncodings(
     req,
-    precompressed && isControlUiCompressibleExtension(extension),
+    precompressed && CONTROL_UI_COMPRESSIBLE_EXTENSIONS.has(extension),
   );
   // A missing sidecar changes availability, not this request's encoding preferences.
   for (const selected of encodings) {
     if (selected === "identity") {
-      return { bodyFile: sourceFile, contentPath: sourceFile.path };
+      return { bodyFile: sourceFile };
     }
 
     const suffix = selected === "br" ? ".br" : ".gz";
@@ -188,7 +145,7 @@ export function resolveOpenedControlUiRepresentation(params: {
     }
     if (compressedFile) {
       fs.closeSync(sourceFile.fd);
-      return { bodyFile: compressedFile, contentPath: sourceFile.path, encoding: selected };
+      return { bodyFile: compressedFile, encoding: selected };
     }
   }
   fs.closeSync(sourceFile.fd);
@@ -215,7 +172,7 @@ function setControlUiFileHeaders(
   options?: { immutable?: boolean; encoding?: ControlUiContentEncoding; lastModifiedMs?: number },
 ) {
   const extension = path.extname(filePath).toLowerCase();
-  res.setHeader("Content-Type", contentTypeForExtension(extension));
+  res.setHeader("Content-Type", CONTROL_UI_CONTENT_TYPES[extension] ?? "application/octet-stream");
   res.setHeader(
     "Cache-Control",
     options?.immutable ? CONTROL_UI_IMMUTABLE_CACHE_CONTROL : "no-cache",

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -3533,6 +3533,7 @@ describe("handleControlUiHttpRequest", () => {
                 headers: { "accept-encoding": "br, identity;q=0" },
               } as IncomingMessage,
               sourceFile: { path: filePath, fd, size: fsSync.fstatSync(fd).size },
+              contentPath: filePath,
               precompressed: true,
               openPrecompressedFile: () => {
                 throw openError;

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -993,7 +993,14 @@ export async function handleControlUiHttpRequest(
     : rel && !rel.endsWith("/")
       ? rel
       : `${rel}index.html`;
-  const fileRel = requested || "index.html";
+  let fileRel: string;
+  try {
+    // Decode the artifact name once, after route ownership and before path validation.
+    fileRel = decodeURIComponent(requested);
+  } catch {
+    respondControlUiNotFound(res);
+    return true;
+  }
   if (!isSafeRelativePath(fileRel)) {
     respondControlUiNotFound(res);
     return true;
@@ -1029,13 +1036,20 @@ export async function handleControlUiHttpRequest(
       safeFile = resolveSafeControlUiFile(retained.rootRealPath, retained.filePath, true);
     }
   }
-  if (safeFile && path.basename(safeFile.path) !== "index.html") {
+  // An index alias still owns document preparation when its physical target has
+  // another name. Preserve existing aliases that resolve to a canonical index too.
+  if (
+    safeFile &&
+    path.basename(fileRel) !== "index.html" &&
+    path.basename(safeFile.path) !== "index.html"
+  ) {
     // Future filesystem clocks must not make later replacements look unmodified;
     // clamp to response origination as in resolveByteResponse.
     const lastModifiedMs = Math.floor(Math.min(safeFile.mtimeMs, Date.now()) / 1_000) * 1_000;
     const representation = resolveOpenedControlUiRepresentation({
       req,
       sourceFile: safeFile,
+      contentPath: fileRel,
       precompressed: immutableAsset,
       openPrecompressedFile: (compressedPath) =>
         resolveSafeControlUiFile(servingRootReal, compressedPath, rejectRepresentationHardlinks),
@@ -1052,7 +1066,7 @@ export async function handleControlUiHttpRequest(
     }
     if (req.method === "HEAD") {
       try {
-        respondHeadForControlUiFile(res, representation.contentPath, {
+        respondHeadForControlUiFile(res, fileRel, {
           immutable: immutableAsset,
           encoding: representation.encoding,
           contentLength: representation.bodyFile.size,
@@ -1064,7 +1078,7 @@ export async function handleControlUiHttpRequest(
       }
     }
     const body = await readAndCloseControlUiFile(representation.bodyFile);
-    await serveControlUiAsset(res, representation.contentPath, body, {
+    await serveControlUiAsset(res, fileRel, body, {
       immutable: immutableAsset,
       encoding: representation.encoding,
       lastModifiedMs,
@@ -1096,7 +1110,7 @@ export async function handleControlUiHttpRequest(
           respondControlUiNotAcceptable(res);
           return true;
         }
-        respondHeadForControlUiFile(res, safeFile.path, {
+        respondHeadForControlUiFile(res, "index.html", {
           encoding: encoding === "identity" ? undefined : encoding,
         });
         return true;


### PR DESCRIPTION
Closes #136442
Closes #136443

## What Problem This Solves

Control UI asset filenames containing spaces, Unicode or percent signs return 404 or load a different file. Contained symlinks also lose their requested MIME type: a JavaScript alias can be rejected by the browser, while a symlinked index can download instead of rendering the UI.

## Why This Change Was Made

Decode the requested artifact name exactly once before the existing path validation. Carry that logical name into MIME selection and index preparation, while keeping the safe-open physical path for pinned reads and compressed sidecars. A single content-type table replaces the duplicated static-extension list and MIME switch.

These are two independent root causes in the same static response owner. Script and index symlink failures are manifestations of the second cause, not separate issues.

## User Impact

Valid encoded asset URLs resolve the correct files at both root and subpath mounts. Contained JavaScript aliases load as JavaScript, and symlinked index pages receive normal document/base-path preparation. Existing canonical-index aliases, safe containment and hardlink rules, retained assets, compression negotiation, and conditional GET/HEAD handling are preserved.

## Evidence

- Actual HTTP reproduction on untouched main: **22 of 28 checks fail** across encoded names, filename collisions, symlinked scripts and index preparation; the same checks pass after the fix.
- Actual Chromium 151 executes the wrong module, refuses the symlinked script MIME, or starts a download for an extensionless index target before the fix. All six root/subpath browser cases load the intended module afterward.
- New HTTP regressions fail **12 cases** on original code with **8 negative controls passing**. All **252 targeted HTTP/static tests** pass on the candidate, including malformed encoding, traversal rejection, compressed sidecars and existing conditional responses.
- Full changed checks pass after correcting a Promise-executor style error in the new fixture. Independent Codex review through P2 is clean.
- Production **45 added / 74 removed (net −29)**; tests/support **142 added**; docs **2 added**. No dependency, config, protocol or persistence changes.
- Directly inspected the installed `@openclaw/fs-safe` 0.7.0 safe-open and pinned-file implementations. Those containment and descriptor owners remain unchanged.

Proof runs use the production HTTP handler, real loopback sockets, synthetic artifacts and real Chromium. They exercise static document/module loading rather than a full authenticated Gateway session. All created servers, browser contexts and temporary artifacts are cleaned up.

## Recorded behavior output

Inspectable excerpts from the actual loopback HTTP/Chromium run are below. They use synthetic files and the production static HTTP handler; no mocked fetch responses were used. Node v24.19.0 and Chromium 151.0.7922.34 ran against frozen base `65e5b2e19c9d` and the reviewed candidate sources now committed at `5be2c3c78974`.

Actual GET output at the root mount (the same cases and HEAD requests also passed under `/dashboard`):

```json
{"case": "encoded-file", "name": "hello world.js", "basePath": "", "method": "GET", "status": 200, "mime": "application/javascript; charset=utf-8", "passed": true}
{"case": "encoded-file", "name": "été.js", "basePath": "", "method": "GET", "status": 200, "mime": "application/javascript; charset=utf-8", "passed": true}
{"case": "encoded-file", "name": "100%.js", "basePath": "", "method": "GET", "status": 200, "mime": "application/javascript; charset=utf-8", "passed": true}
{"case": "encoded-file", "name": "hello%20world.js", "basePath": "", "method": "GET", "status": 200, "mime": "application/javascript; charset=utf-8", "passed": true}
{"case": "symlink-script", "requestPath": "/assets/app.js", "basePath": "", "method": "GET", "status": 200, "mime": "application/javascript; charset=utf-8", "passed": true}
{"case": "symlink-index", "requestPath": "/", "basePath": "", "method": "GET", "status": 200, "mime": "text/html; charset=utf-8", "passed": true}
{"case": "symlink-index", "requestPath": "/chat", "basePath": "", "method": "GET", "status": 200, "mime": "text/html; charset=utf-8", "passed": true}
```

Actual browser observations, projected from the recorded results:

```json
{"revision": "before", "scenario": "encoded-name", "basePath": "", "module": "wrong-file", "output": "Waiting for module", "passed": false}
{"revision": "before", "scenario": "symlink-script", "basePath": "", "module": null, "output": "Waiting for module", "passed": false}
{"revision": "before", "scenario": "symlink-index", "basePath": null, "module": null, "output": null, "passed": false}
{"revision": "before", "scenario": "encoded-name", "basePath": "/dashboard", "module": "wrong-file", "output": "Waiting for module", "passed": false}
{"revision": "before", "scenario": "symlink-script", "basePath": "/dashboard", "module": null, "output": "Waiting for module", "passed": false}
{"revision": "before", "scenario": "symlink-index", "basePath": null, "module": null, "output": null, "passed": false}
{"revision": "after", "scenario": "encoded-name", "basePath": "", "module": "loaded", "output": "Module loaded", "passed": true}
{"revision": "after", "scenario": "symlink-script", "basePath": "", "module": "loaded", "output": "Module loaded", "passed": true}
{"revision": "after", "scenario": "symlink-index", "basePath": "", "module": "loaded", "output": "Module loaded", "passed": true}
{"revision": "after", "scenario": "encoded-name", "basePath": "/dashboard", "module": "loaded", "output": "Module loaded", "passed": true}
{"revision": "after", "scenario": "symlink-script", "basePath": "/dashboard", "module": "loaded", "output": "Module loaded", "passed": true}
{"revision": "after", "scenario": "symlink-index", "basePath": "/dashboard", "module": "loaded", "output": "Module loaded", "passed": true}
```

The HTTP run changed from 22 failed checks out of 28 to zero; all six after-fix Chromium cases executed the intended module. Before-fix symlinked scripts produced Chromium's strict MIME error for `application/octet-stream`, and the symlinked index started a download. These are observed socket/browser results rather than unit-test assertions or a full authenticated Gateway session. This supplies the requested inspectable after-fix evidence without changing code or broadening the proof claim.

