### PR TITLE
fix(ui): keep loaded chat images visible during gateway outages

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -996,6 +996,8 @@ When gateway auth is configured, assistant local-media previews use a two-step r
 
 This keeps media rendering compatible with browser-native media elements without putting reusable gateway credentials in visible media URLs.
 
+Uploaded and local chat image previews rendered with native image elements keep an already-loaded image visible during temporary connection or metadata-renewal failures. Retention applies only to that mounted image; it does not extend its media ticket or authorize fresh reads. An explicit missing or access-denied response, or a change to the source, credentials, or access scope, clears the retained image.
+
 Generated images under `/api/chat/media/outgoing/...` use the same capability
 principle through `artifacts.download`. The authenticated WebSocket request
 authorizes the transcript artifact and returns a short-lived URL. The HTTP media

--- a/ui/src/pages/chat/components/chat-message-attachment-availability.ts
+++ b/ui/src/pages/chat/components/chat-message-attachment-availability.ts
@@ -33,6 +33,7 @@ type AssistantAttachmentAvailability =
       checkedAt: number;
       recoverable: boolean;
       retryAttempted?: true;
+      unconfirmed?: true;
     };
 
 export type ManagedAttachmentAvailability =
@@ -66,12 +67,13 @@ export function resolveAssistantAttachmentAvailability(
     localMediaPreviewRoots.length > 0 &&
     !isLocalAttachmentPreviewAllowed(source, localMediaPreviewRoots)
   ) {
-    return {
-      status: "unavailable",
-      reason: t("chat.attachments.outsideAllowedFolders"),
-      checkedAt: Date.now(),
-      recoverable: false,
-    };
+    return createUnavailableAssistantAttachment(
+      t("chat.attachments.outsideAllowedFolders"),
+      false,
+      {
+        recoverable: false,
+      },
+    );
   }
   const normalizedAuthToken = authToken?.trim() ?? "";
   const cacheKey = `${resourceBasePath ?? ""}::${normalizedAuthToken}::${source}`;
@@ -105,6 +107,7 @@ export function resolveAssistantAttachmentAvailability(
       const unavailable = createUnavailableAssistantAttachment(
         "Attachment unavailable",
         resource.retryAttempted,
+        { unconfirmed: true },
       );
       setAssistantAttachmentAvailability(resource, unavailable);
       return unavailable;
@@ -142,13 +145,11 @@ export function resolveAssistantAttachmentAvailability(
     ) {
       return null;
     }
-    const retryAvailability: AssistantAttachmentAvailability = {
+    return {
       ...refreshingAvailability,
       refreshAfter: Math.min(now + ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS, expiresAt),
       refreshAttempts: refreshAttempts + 1,
     };
-    setAssistantAttachmentAvailability(resource, retryAvailability);
-    return retryAvailability;
   };
   if (typeof fetch === "function") {
     const headers = new Headers({ Accept: "application/json" });
@@ -170,8 +171,17 @@ export function resolveAssistantAttachmentAvailability(
       credentials: "same-origin",
       signal: controller.signal,
     })
-      .then(async (res) => {
-        const payload = (await res.json().catch(() => null)) as {
+      .then(async (res): Promise<AssistantAttachmentAvailability> => {
+        if (res.status === 408 || res.status === 429 || res.status >= 500) {
+          throw new Error("Attachment metadata temporarily unavailable");
+        }
+        if (!res.ok) {
+          return createUnavailableAssistantAttachment(
+            t("chat.attachments.unavailable"),
+            resource.retryAttempted,
+          );
+        }
+        const payload = (await res.json()) as {
           available?: boolean;
           mediaTicket?: string;
           mediaTicketExpiresAt?: string;
@@ -183,22 +193,21 @@ export function resolveAssistantAttachmentAvailability(
           reason?: string;
           retryable?: boolean;
         } | null;
+        if (payload?.available === false) {
+          return createUnavailableAssistantAttachment(
+            formatUiExternalText(payload.reason, t("chat.attachments.unavailable")),
+            resource.retryAttempted,
+            { recoverable: payload.retryable !== false },
+          );
+        }
         if (payload?.available === true) {
           const mediaTicket = payload.mediaTicket?.trim();
           const mediaTicketExpiresAt = Date.parse(payload.mediaTicketExpiresAt ?? "");
           if (mediaTicket && !Number.isFinite(mediaTicketExpiresAt)) {
-            const retryAvailability = keepPlayableTicketForRetry();
-            if (retryAvailability) {
-              return retryAvailability;
-            }
-            const unavailable = createUnavailableAssistantAttachment(
-              t("chat.attachments.unavailable"),
-              resource.retryAttempted,
-            );
-            setAssistantAttachmentAvailability(resource, unavailable);
-            return unavailable;
+            throw new Error("Attachment metadata has an invalid ticket expiry");
           }
-          const availability: AssistantAttachmentAvailability = {
+          resource.retryAttempted = false;
+          return {
             status: "available",
             ...(mediaTicket ? { mediaTicket, mediaTicketExpiresAt } : {}),
             ...(payload.playback === "native" || payload.playback === "transcode"
@@ -209,29 +218,21 @@ export function resolveAssistantAttachmentAvailability(
             ...(typeof payload.width === "number" ? { width: payload.width } : {}),
             ...(typeof payload.height === "number" ? { height: payload.height } : {}),
           };
-          resource.retryAttempted = false;
-          setAssistantAttachmentAvailability(resource, availability);
-          return availability;
         }
-        const unavailable = createUnavailableAssistantAttachment(
-          formatUiExternalText(payload?.reason, t("chat.attachments.unavailable")),
-          resource.retryAttempted,
-          payload?.retryable !== false,
-        );
-        setAssistantAttachmentAvailability(resource, unavailable);
-        return unavailable;
+        throw new Error("Attachment metadata has no availability result");
       })
-      .catch(() => {
-        const retryAvailability = keepPlayableTicketForRetry();
-        if (retryAvailability) {
-          return retryAvailability;
-        }
-        const unavailable = createUnavailableAssistantAttachment(
-          t("chat.attachments.unavailable"),
-          resource.retryAttempted,
-        );
-        setAssistantAttachmentAvailability(resource, unavailable);
-        return unavailable;
+      .catch(
+        () =>
+          keepPlayableTicketForRetry() ??
+          createUnavailableAssistantAttachment(
+            t("chat.attachments.unavailable"),
+            resource.retryAttempted,
+            { unconfirmed: true },
+          ),
+      )
+      .then((availability) => {
+        setAssistantAttachmentAvailability(resource, availability);
+        return availability;
       })
       .finally(() => {
         clearTimeout(timeout);
@@ -279,13 +280,14 @@ export function retryAssistantAttachmentAvailability(
 function createUnavailableAssistantAttachment(
   reason: string,
   retryAttempted: boolean,
-  recoverable = true,
+  options: { recoverable?: boolean; unconfirmed?: true } = {},
 ): Extract<AssistantAttachmentAvailability, { status: "unavailable" }> {
   return {
     status: "unavailable",
     reason,
     checkedAt: Date.now(),
-    recoverable,
+    recoverable: options.recoverable !== false,
+    ...(options.unconfirmed ? { unconfirmed: true } : {}),
     ...(retryAttempted ? { retryAttempted: true } : {}),
   };
 }
@@ -325,12 +327,8 @@ function scheduleAssistantAttachmentRefresh(
     if (resource.value !== availability) {
       return;
     }
-    // Keep the failed generation until its retry can inherit the one-attempt
-    // budget. A ticket refresh keeps the playable generation mounted while
-    // its replacement is minted, otherwise the checking card resets playback.
-    if (availability.status === "checking") {
-      resource.value = undefined;
-    }
+    // Preserve this generation's retry budget and playable ticket while the
+    // replacement is minted; a checking card would reset native playback.
     notifyChatMediaResourceSubscribers(resource);
   });
 }

--- a/ui/src/pages/chat/components/chat-message-attachments.test.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.test.ts
@@ -1,7 +1,8 @@
 /* @vitest-environment jsdom */
 
+import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { renderAssistantAttachments } from "./chat-message-attachments.ts";
 import { releaseChatMediaResourceSubscriber, type AttachmentItem } from "./chat-message-media.ts";
 import type { SidebarContent } from "./chat-sidebar-content-types.ts";
@@ -62,10 +63,15 @@ afterEach(() => {
 
 describe("attachment sidebar source ownership", () => {
   it.each([
-    ["sample-image.png", "image/png"],
-    ["photo.jpg", "image/jpeg"],
-  ])("renders document-shaped %s attachments as expandable images", (label, mimeType) => {
-    const source = `https://example.com/${label}`;
+    ["sample-image.png", "image/png", "https://example.com/sample-image.png"],
+    ["photo.jpg", "image/jpeg", "https://example.com/photo.jpg"],
+    ["photo.png", "application/octet-stream", `${window.location.origin}/download/opaque`],
+    [
+      "photo",
+      "application/octet-stream; charset=binary",
+      `${window.location.origin}/download/photo.png`,
+    ],
+  ])("renders document-shaped %s attachments as expandable images", (label, mimeType, source) => {
     const container = document.body.appendChild(document.createElement("div"));
     const onOpenImage = vi.fn();
     render(
@@ -90,34 +96,87 @@ describe("attachment sidebar source ownership", () => {
     container.remove();
   });
 
-  it("keeps a raster filename image-shaped when its source URL is opaque", () => {
-    const source = `${window.location.origin}/download/opaque`;
-    const container = document.body.appendChild(document.createElement("div"));
-    const onOpenImage = vi.fn();
-    render(
-      renderAssistantAttachments(
-        [
-          {
-            type: "attachment",
-            attachment: {
-              kind: "document",
-              label: "photo.png",
-              mimeType: "application/octet-stream",
-              url: source,
-            },
-          },
-        ],
-        { onOpenImage },
-      ),
-      container,
-    );
-
-    expect(container.querySelector(".chat-assistant-attachment-card")).toBeNull();
-    expect(container.querySelector("img.chat-message-image")?.getAttribute("src")).toBe(source);
-    container.querySelector<HTMLButtonElement>(".chat-message-image-button")?.click();
-    expect(onOpenImage).toHaveBeenCalledWith(expect.objectContaining({ src: source }));
-    container.remove();
-  });
+  it.each([
+    { kind: "image", outcome: "offline" },
+    { kind: "document", outcome: "offline" },
+    { kind: "image", outcome: "missing" },
+    { kind: "document", outcome: "denied" },
+  ] as const)(
+    "handles $outcome renewal after a local $kind raster has loaded",
+    async ({ kind, outcome }) => {
+      vi.useFakeTimers();
+      const availableResponse = (mediaTicket: string) =>
+        Response.json({
+          available: true,
+          mediaTicket,
+          mediaTicketExpiresAt: new Date(Date.now() + 31_000).toISOString(),
+        });
+      const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(availableResponse("loaded"));
+      vi.stubGlobal("fetch", fetchMock);
+      const container = document.body.appendChild(document.createElement("div"));
+      onTestFinished(() => {
+        render(null, container);
+      });
+      const attachment: AttachmentItem = {
+        type: "attachment",
+        attachment: {
+          kind,
+          label: "photo.png",
+          mimeType: "image/png",
+          url: `/tmp/openclaw/${crypto.randomUUID()}.png`,
+        },
+      };
+      const rerender = () =>
+        render(
+          renderAssistantAttachments([attachment], {
+            authToken: "test-token",
+            localMediaPreviewRoots: ["/tmp/openclaw"],
+            onRequestUpdate: rerender,
+          }),
+          container,
+        );
+      subscribers.add(rerender);
+      rerender();
+      await vi.advanceTimersByTimeAsync(0);
+      const displayed = expectDefined(container.querySelector("img"), "loaded raster image");
+      expect(displayed.getAttribute("src")).toContain("mediaTicket=loaded");
+      Object.defineProperty(displayed, "naturalWidth", { value: 1 });
+      displayed.dispatchEvent(new Event("load"));
+      if (outcome === "offline") {
+        fetchMock.mockRejectedValue(new TypeError("Gateway offline"));
+        await vi.advanceTimersByTimeAsync(11_000);
+        expect(container.querySelector("img")).toBe(displayed);
+        await vi.advanceTimersByTimeAsync(20_001);
+        expect(container.querySelector("img")).toBe(displayed);
+        expect(container.querySelector(".chat-assistant-attachment-card")).toBeNull();
+      } else {
+        const retryable = outcome === "missing";
+        fetchMock.mockResolvedValueOnce(
+          Response.json({ available: false, reason: "Attachment removed", retryable }),
+        );
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(container.querySelector("img")).toBeNull();
+        displayed.dispatchEvent(new Event("load"));
+        displayed.dispatchEvent(new Event("error"));
+        expect(container.querySelector("img")).toBeNull();
+        const retry = container.querySelector<HTMLButtonElement>(
+          ".chat-assistant-attachment-card__retry",
+        );
+        if (outcome === "missing") {
+          expect(container.textContent).toContain("Attachment removed");
+          fetchMock.mockResolvedValueOnce(availableResponse("recovered"));
+          expectDefined(retry, "Retry action for a recoverable missing image").click();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(container.querySelector("img")?.getAttribute("src")).toContain(
+            "mediaTicket=recovered",
+          );
+        } else {
+          expect(container.textContent).toContain("Unavailable");
+          expect(retry).toBeNull();
+        }
+      }
+    },
+  );
 
   it("routes an SVG filename with an opaque source through the bounded SVG renderer", () => {
     const container = document.body.appendChild(document.createElement("div"));
@@ -166,32 +225,6 @@ describe("attachment sidebar source ownership", () => {
 
     expect(container.querySelector("openclaw-chat-svg-attachment")).toBeNull();
     expect(container.querySelector(".chat-assistant-attachment-card")).not.toBeNull();
-    container.remove();
-  });
-
-  it("infers a raster URL when generic MIME includes parameters", () => {
-    const source = `${window.location.origin}/download/photo.png`;
-    const container = document.body.appendChild(document.createElement("div"));
-    render(
-      renderAssistantAttachments(
-        [
-          {
-            type: "attachment",
-            attachment: {
-              kind: "document",
-              label: "photo",
-              mimeType: "application/octet-stream; charset=binary",
-              url: source,
-            },
-          },
-        ],
-        {},
-      ),
-      container,
-    );
-
-    expect(container.querySelector("img.chat-message-image")?.getAttribute("src")).toBe(source);
-    expect(container.querySelector(".chat-assistant-attachment-card")).toBeNull();
     container.remove();
   });
 

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -24,6 +24,7 @@ import {
   renderAssistantAttachmentStatusCard,
 } from "./chat-message-attachment-status.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
+import { renderMessageImages } from "./chat-message-images.ts";
 import {
   buildAssistantAttachmentUrl,
   isLocalAssistantAttachmentSource,
@@ -441,6 +442,25 @@ export function renderAssistantAttachments(
       });
     }
     const { attachment } = item;
+    const normalizedMimeType = attachment.mimeType?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+    const inferTypeFromExtension =
+      !normalizedMimeType || normalizedMimeType === "application/octet-stream";
+    const imageAttachment =
+      attachment.kind === "image" ||
+      (attachment.kind === "document" &&
+        (isImageMediaPath(attachment.url, normalizedMimeType) ||
+          (inferTypeFromExtension && isImageMediaPath(attachment.label, undefined))));
+    const svgImage =
+      normalizedMimeType === "image/svg+xml" ||
+      (inferTypeFromExtension &&
+        (isSvgImageMediaPath(attachment.url, undefined) ||
+          isSvgImageMediaPath(attachment.label, undefined)));
+    if (imageAttachment && !svgImage && !isManagedOutgoingMediaSource(attachment.url)) {
+      return renderMessageImages(
+        [{ ...attachment, alt: attachment.label, fileName: attachment.label }],
+        options,
+      );
+    }
     const resolved = resolveAttachmentSource(attachment, options);
     if (resolved.status !== "available") {
       return renderAssistantAttachmentStatusCard({
@@ -502,27 +522,7 @@ export function renderAssistantAttachments(
                 : {}),
             })
         : undefined;
-    const normalizedMimeType = attachment.mimeType?.split(";", 1)[0]?.trim().toLowerCase() ?? "";
-    const inferTypeFromExtension =
-      !normalizedMimeType || normalizedMimeType === "application/octet-stream";
-    const svgImage =
-      normalizedMimeType === "image/svg+xml" ||
-      (inferTypeFromExtension &&
-        (isSvgImageMediaPath(attachment.url, undefined) ||
-          isSvgImageMediaPath(attachmentUrl, undefined) ||
-          isSvgImageMediaPath(attachment.label, undefined)));
-    if (
-      attachment.kind === "image" ||
-      (attachment.kind === "document" &&
-        (svgImage ||
-          isImageMediaPath(
-            attachment.url,
-            inferTypeFromExtension ? undefined : attachment.mimeType,
-          ) ||
-          (inferTypeFromExtension &&
-            !isSvgImageMediaPath(attachment.label, undefined) &&
-            isImageMediaPath(attachment.label, undefined))))
-    ) {
+    if (imageAttachment) {
       const title = attachment.label.trim() || t("chat.imageLightbox.untitled");
       if (svgImage) {
         return html`<openclaw-chat-svg-attachment

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -17,6 +17,7 @@ import {
   isManagedOutgoingMediaSource,
   resolveAssistantAttachmentAvailability,
   resolveManagedOutgoingMediaSessionKey,
+  retryAssistantAttachmentAvailability,
 } from "./chat-message-attachment-availability.ts";
 import { renderAssistantAttachmentStatusCard } from "./chat-message-attachment-status.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
@@ -66,13 +67,17 @@ class MessageImageResourceDirective extends AsyncDirective {
   private onRequestUpdate: (() => void) | undefined;
   private readonly requestUpdate = () => this.onRequestUpdate?.();
   private readonly onSettled = (event: Event, source: string) => {
-    if (!this.isConnected || this.image?.url !== source) {
+    // A removed IMG may finish after denial; it no longer owns displayed pixels.
+    const element = event.currentTarget;
+    if (
+      !this.isConnected ||
+      this.image?.url !== source ||
+      !(element instanceof HTMLImageElement) ||
+      !element.isConnected
+    ) {
       return;
     }
-    this.element =
-      event.type === "load" && event.currentTarget instanceof HTMLImageElement
-        ? event.currentTarget
-        : undefined;
+    this.element = event.type === "load" ? element : undefined;
     if (
       this.retained?.status === "retaining" &&
       this.element?.getAttribute("src") !== this.retained.previewUrl
@@ -119,15 +124,14 @@ class MessageImageResourceDirective extends AsyncDirective {
       releaseChatMediaResourceSubscriber(this.requestUpdate);
       return noChange;
     }
-    if (this.onRequestUpdate !== options?.onRequestUpdate) {
-      releaseChatMediaResourceSubscriber(this.requestUpdate);
-    }
     this.onRequestUpdate = options?.onRequestUpdate;
 
-    // A transcript shares one pane callback across many guarded rows. Lit owns
-    // each image part, so only disconnecting that part may release its resource.
+    // Lit owns each image part. Reparent its stable subscription when the pane
+    // callback changes without discarding its loaded resource.
     if (this.onRequestUpdate) {
       observeChatMediaResourceSubscriber(this.onRequestUpdate, this.requestUpdate);
+    } else {
+      releaseChatMediaResourceSubscriber(this.requestUpdate);
     }
     const subscriptionOptions = this.onRequestUpdate
       ? { ...options, onRequestUpdate: this.requestUpdate }
@@ -140,13 +144,23 @@ class MessageImageResourceDirective extends AsyncDirective {
       subscriptionOptions?.onRequestUpdate,
     );
     const decodeFailed = this.retained?.status === "unavailable";
-    if (availability.status !== "available" || decodeFailed) {
-      if (availability.status === "checking" && this.retained?.status === "retaining") {
-        const previewUrl = this.retained.previewUrl;
-        return this.present(
-          this.renderImageElement({ ...image, displayUrl: previewUrl }, previewUrl, options),
-        );
-      }
+    // Tickets authorize new reads, not already decoded pixels. Only this
+    // mounted image can survive an unconfirmed renewal; denial still clears it.
+    const unconfirmed =
+      availability.status === "checking" ||
+      (availability.status === "unavailable" && availability.unconfirmed);
+    const displayUrl =
+      availability.status === "available"
+        ? buildAssistantAttachmentUrl(
+            image.url,
+            options?.resourceBasePath,
+            availability.mediaTicket,
+          )
+        : unconfirmed
+          ? this.element?.getAttribute("src")
+          : undefined;
+    if (!displayUrl || decodeFailed) {
+      this.element = undefined;
       if (!decodeFailed) {
         this.releaseRetainedImage();
       }
@@ -160,17 +174,26 @@ class MessageImageResourceDirective extends AsyncDirective {
         label: image.fileName ?? image.alt ?? t("chat.imageLightbox.untitled"),
         badge: reason === undefined ? "" : t("chat.attachments.unavailable"),
         reason,
+        onRetry:
+          !decodeFailed && availability.status === "unavailable" && availability.recoverable
+            ? () =>
+                retryAssistantAttachmentAvailability(
+                  image.url,
+                  options?.resourceBasePath,
+                  options?.authToken,
+                  subscriptionOptions?.onRequestUpdate,
+                )
+            : undefined,
       });
     }
-    const displayUrl = buildAssistantAttachmentUrl(
-      image.url,
-      options?.resourceBasePath,
-      availability.mediaTicket,
-    );
     const renderable = { ...image, displayUrl };
     if (!isManagedOutgoingMediaSource(displayUrl)) {
       const retained = this.retained;
-      if (retained?.status === "retaining" && retained.timeout === undefined) {
+      if (
+        availability.status === "available" &&
+        retained?.status === "retaining" &&
+        retained.timeout === undefined
+      ) {
         // IMG keeps its current decoded request while the new src loads. One
         // native load/error boundary replaces the detached decode preloader.
         retained.timeout = setTimeout(
@@ -233,9 +256,6 @@ class MessageImageResourceDirective extends AsyncDirective {
   private releaseRetainedImage() {
     const retained = this.retained;
     this.retained = undefined;
-    if (retained) {
-      this.element = undefined;
-    }
     if (retained?.status === "retaining") {
       clearTimeout(retained.timeout);
     }

--- a/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
@@ -23,18 +23,30 @@ function expectSameImageNodes(actual: HTMLImageElement[], expected: HTMLImageEle
   }
 }
 
-function mediaMetadataResponse(available = true, mediaTicket?: string): Response {
-  return {
-    ok: true,
-    json: async () => ({
-      available,
-      reason: available ? undefined : "Attachment removed",
-      retryable: false,
-      ...(mediaTicket
-        ? { mediaTicket, mediaTicketExpiresAt: new Date(Date.now() + 31_000).toISOString() }
-        : {}),
+function mediaMetadataResponse(
+  available = true,
+  mediaTicket?: string,
+  retryable = false,
+): Response {
+  return Response.json({
+    available,
+    reason: available ? undefined : "Attachment removed",
+    retryable,
+    ...(mediaTicket
+      ? { mediaTicket, mediaTicketExpiresAt: new Date(Date.now() + 31_000).toISOString() }
+      : {}),
+  });
+}
+
+function unreadableMetadataResponse(status = 200): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.error(new TypeError("Connection closed while reading metadata"));
+      },
     }),
-  } as Response;
+    { status },
+  );
 }
 
 function mountTranscriptPane(props: Parameters<typeof renderChatThread>[0]) {
@@ -467,9 +479,30 @@ describe("canonical image presentation handoff", () => {
     },
   );
 
-  it.each(["renewal", "denial"] as const)(
-    "updates native image presentation after metadata ticket %s",
-    async (change) => {
+  it.each([
+    {
+      name: "renewal",
+      response: () => mediaMetadataResponse(true, "after-refresh"),
+      reason: undefined,
+    },
+    {
+      name: "denial",
+      response: () => mediaMetadataResponse(false),
+      reason: "Attachment removed",
+    },
+    {
+      name: "retryable denial",
+      response: () => mediaMetadataResponse(false, undefined, true),
+      reason: "Attachment removed",
+    },
+    ...[401, 403].map((status) => ({
+      name: `HTTP ${status} with an unreadable body`,
+      response: () => unreadableMetadataResponse(status),
+      reason: "Unavailable",
+    })),
+  ])(
+    "updates native image presentation after metadata ticket $name",
+    async ({ response, reason }) => {
       vi.useFakeTimers();
       try {
         const fixture = createCanonicalImageTranscript();
@@ -477,19 +510,69 @@ describe("canonical image presentation handoff", () => {
         fixture.requests[0]?.resolve(mediaMetadataResponse(true, "before-refresh"));
         await vi.advanceTimersByTimeAsync(0);
         const displayed = expectDefined(fixture.displayed[0], "displayed image");
+        displayed.dispatchEvent(new Event("load"));
         await vi.advanceTimersByTimeAsync(1_000);
-        fixture.requests[1]?.resolve(mediaMetadataResponse(change === "renewal", "after-refresh"));
+        fixture.requests[1]?.resolve(response());
         await vi.advanceTimersByTimeAsync(0);
-        if (change === "denial") {
+        if (reason) {
           displayed.dispatchEvent(new Event("load"));
-          displayed.dispatchEvent(new Event("error"));
           expect(fixture.images()).toHaveLength(0);
-          expect(fixture.container.textContent).toContain("Attachment removed");
+          expect(fixture.container.textContent).toContain(reason);
+          await vi.advanceTimersByTimeAsync(5_000);
+          expect(fixture.images()).toHaveLength(0);
         } else {
           expectSameImageNodes(fixture.images(), fixture.displayed);
           expect(displayed.getAttribute("src")).toContain("mediaTicket=after-refresh");
           displayed.dispatchEvent(new Event("load"));
         }
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    { presentation: "canonical", failure: "network rejection", responseStatus: null },
+    { presentation: "inline-handoff", failure: "network rejection", responseStatus: null },
+    { presentation: "canonical", failure: "body read rejection", responseStatus: 200 },
+    { presentation: "canonical", failure: "HTTP 408 non-JSON", responseStatus: 408 },
+    { presentation: "canonical", failure: "HTTP 429 non-JSON", responseStatus: 429 },
+    { presentation: "canonical", failure: "HTTP 503 non-JSON", responseStatus: 503 },
+  ])(
+    "keeps a loaded $presentation image through $failure renewal and expiry",
+    async ({ presentation, responseStatus }) => {
+      vi.useFakeTimers();
+      try {
+        const fixture = createCanonicalImageTranscript(
+          undefined,
+          presentation === "canonical" ? [] : undefined,
+        );
+        fixture.publish();
+        fixture.requests[0]?.resolve(mediaMetadataResponse(true, "before-offline"));
+        await vi.advanceTimersByTimeAsync(0);
+        const displayed = expectDefined(fixture.images()[0], "loaded canonical image");
+        expect(displayed.getAttribute("src")).toContain("mediaTicket=before-offline");
+        Object.defineProperty(displayed, "naturalWidth", { value: 1 });
+        displayed.dispatchEvent(new Event("load"));
+        vi.mocked(fetch).mockImplementation(async () => {
+          if (responseStatus === null) {
+            throw new TypeError("Gateway offline");
+          }
+          if (responseStatus === 200) {
+            return unreadableMetadataResponse();
+          }
+          return new Response("Service temporarily unavailable", { status: responseStatus });
+        });
+
+        // Exhaust renewals before the 31-second fixture ticket expires.
+        await vi.advanceTimersByTimeAsync(11_000);
+        expectSameImageNodes(fixture.images(), [displayed]);
+        expect(fixture.container.querySelector(".chat-assistant-attachment-card")).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(20_001);
+        expectSameImageNodes(fixture.images(), [displayed]);
+        expect(fixture.container.querySelector(".chat-assistant-attachment-card")).toBeNull();
       } finally {
         vi.clearAllTimers();
         vi.useRealTimers();


### PR DESCRIPTION
Related: #136072

## What Problem This Solves

Fixes an issue where users viewing uploaded or local chat images would see an already-loaded image replaced by “Attachment unavailable” when the Gateway stayed offline or media-ticket renewal failed. The initial send/history continuity repair did not cover this later lifecycle: a longer live test reproduced the reported unavailable cards on current main.

## Why This Change Was Made

The metadata owner treated an unconfirmed renewal failure like an explicit missing/denied result, and the image renderer discarded its loaded element. Media tickets authorize future reads; their renewal is not a lease on pixels already decoded by that mounted image.

Record unconfirmed outcomes at the metadata owner and let the existing image presenter retain only its own loaded element. Explicit missing/denied responses, source/auth/access-scope changes, and decode failures still clear it; expired tickets remain unavailable to fresh reads. Ignore late load events from removed images so Retry cannot resurrect a denied preview. Preserve subscriptions when the parent callback changes instead of dropping the resource.

Parsed local raster attachments now use that same presenter, retaining their Retry action. This removes duplicate availability publishing and image classification paths. SVG, audio/video/documents, and explicit managed-artifact transport keep their existing owners. No dependency, configuration, persistence, protocol, or ticket-lifetime change.

## User Impact

Already-loaded images remain visible through temporary metadata/network failures and ticket expiry within the same mounted access scope. Duplicate attachments remain distinct and recover normally after reconnect/reload. The existing access-scope reset on disconnect can still briefly remount images; this is not a claim of zero flicker across connection or authorization changes.

## Evidence

- Unmodified main (`ad3268ecccbc7758878662b31adcd72475343d3e`) reproduced the failure in real Chrome with an isolated, normally authenticated Gateway and a real image prompt/reply. It also failed canonical/inline-handoff and parsed-local-raster regressions. A strengthened late-load-only denial test failed before the removed-element guard.
- Final focused/sibling suite: **334 passed across 5 files**; `check:changed` passed, including UI/core-test types, formatting, lint, i18n, and dead exports. Independent Codex review: no actionable P0–P2 findings. A test fixture type error was corrected to use native Responses, then the final suite and checks were rerun successfully.
- Stress: **10 × 334 unit executions plus 2 × 3 browser executions = 3,346 passing executions**. These are repeated runs, not 3,346 distinct tests. The stress runs preceded that test-only fixture correction; production bytes were unchanged.
- After-build live proof: four synthetic images, including duplicate uploads, and a real three-image reply. Verified all 400 served JS/CSS assets against the candidate build. After the initial connection-scope remount, **48,668 consecutive frame samples over 423.315 seconds** retained the same four decoded images with unchanged positive geometry. All four image regions were also pixel-identical in online/offline endpoint captures. Reconnection, persisted media history, and full reload passed.
- Measurement limits: two early after-run samples showed checking cards during the existing scope reset; frame sampling is not continuous paint proof. The before recording had a 20.447-second recorder gap, followed by 101.162 seconds of consecutive missing-image samples. Neither gap is hidden in the comparison.

| Before: prolonged outage | After: prolonged outage, four images |
| --- | --- |
| ![Before: loaded image replaced by an unavailable card](https://github.com/user-attachments/assets/42d1d9f8-013a-43c4-8f7f-a5bb879d7c16) | ![After: four already-loaded synthetic images remain visible offline](https://github.com/user-attachments/assets/d6206a2c-fdd1-4f35-8eef-530befd2eb5d) |

Production delta: **+116/−98, net +18**; tests **+193/−77, net +116**; docs **+2**. The growth preserves the explicit unconfirmed-vs-denied state, mounted-element fencing, and existing Retry behavior while consolidating the raster path. Combined with the original repair’s −24 production lines, this request remains net −6 production lines.

Named follow-up: consolidate the explicit managed-raster attachment path only after proving full-ticket/error/Retry parity. Standard generated images already use the blob-gallery owner; this PR does not claim to repair every managed-artifact lifecycle. The earlier short-duration live proof was valid for send/handoff/reload but insufficient for a prolonged renewal outage.
