### PR TITLE
test(ui): prove skipped-midnight usage boundaries in Chromium

### DIFF
--- a/ui/src/e2e/usage-calendar-boundaries.e2e.test.ts
+++ b/ui/src/e2e/usage-calendar-boundaries.e2e.test.ts
@@ -1,0 +1,129 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Usage calendar boundaries" });
+
+suite.define(() => {
+  it("ends a local range at the next calendar midnight after a skipped midnight", async () => {
+    const date = "2026-09-06";
+    const updatedAt = Date.parse("2026-09-06T15:00:00Z");
+    const totals = {
+      input: 100,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 100,
+      totalCost: 0,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    };
+    const points = [
+      "2026-09-06T03:59:59.999Z",
+      "2026-09-06T04:00:00.000Z",
+      "2026-09-07T02:59:59.999Z",
+      "2026-09-07T03:00:00.000Z",
+      "2026-09-07T03:30:00.000Z",
+    ].map((timestamp) => ({
+      timestamp: Date.parse(timestamp),
+      input: 100,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 100,
+      cost: 0,
+      cumulativeTokens: 100,
+      cumulativeCost: 0,
+    }));
+    await suite.withPage(
+      { locale: "en-US", timezoneId: "America/Santiago", serviceWorkers: "block" },
+      async ({ page }) => {
+        await page.clock.setFixedTime(new Date(updatedAt));
+        // Thread-local TZ cannot configure native Date; the browser context owns this zone.
+        expect(
+          await page.evaluate(() => {
+            const start = new Date(2026, 8, 6);
+            const end = new Date(2026, 8, 7);
+            return [
+              start.getHours(),
+              end.getHours(),
+              (end.getTime() - start.getTime()) / 3_600_000,
+            ];
+          }),
+        ).toEqual([1, 0, 23]);
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "sessions.usage": {
+              updatedAt,
+              startDate: date,
+              endDate: date,
+              sessions: [
+                {
+                  key: "agent:main:skipped-midnight",
+                  label: "Skipped midnight",
+                  agentId: "main",
+                  updatedAt,
+                  usage: { ...totals, activityDates: [date] },
+                },
+              ],
+              totals,
+              aggregates: {
+                messages: {
+                  total: 0,
+                  user: 0,
+                  assistant: 0,
+                  toolCalls: 0,
+                  toolResults: 0,
+                  errors: 0,
+                },
+                tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+                byModel: [],
+                byProvider: [],
+                byAgent: [],
+                byChannel: [],
+                daily: [],
+              },
+            },
+            "usage.cost": { updatedAt, days: 1, daily: [{ date, ...totals }], totals },
+            "usage.status": { updatedAt, providers: [] },
+            "sessions.usage.timeseries": { points },
+            "sessions.usage.logs": { logs: [] },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}usage`);
+        await page.locator(".usage-select").selectOption("local");
+        const dateInputs = await page.locator(".usage-date-input").all();
+        expect(dateInputs).toHaveLength(2);
+        for (const input of dateInputs) {
+          await input.fill(date);
+          await input.press("Tab");
+        }
+        await expect
+          .poll(async () => (await gateway.getRequests("sessions.usage")).at(-1)?.params)
+          .toMatchObject({
+            startDate: date,
+            endDate: date,
+            mode: "specific",
+            timeZone: "America/Santiago",
+          });
+        await page.getByRole("button", { name: "Skipped midnight", exact: true }).click();
+        await gateway.waitForRequest("sessions.usage.timeseries");
+        const bars = page.locator(".session-detail-panel .ts-bar");
+        await expect.poll(() => bars.count()).toBe(2);
+        await expect
+          .poll(() =>
+            bars.evaluateAll((elements) =>
+              elements.map((element) => element.getAttribute("aria-label")),
+            ),
+          )
+          .toEqual([
+            "Sep 6, 01:00 AM · 100 tokens · Out 0 · In 100 · CW 0 · CR 0",
+            "Sep 6, 11:59 PM · 100 tokens · Out 0 · In 100 · CW 0 · CR 0",
+          ]);
+      },
+    );
+  });
+});

--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -196,32 +196,6 @@ describe("renderSessionDetailPanel filtered usage", () => {
     }
   });
 
-  it("ends a local range at the next calendar midnight after a skipped midnight", () => {
-    const previousTimeZone = process.env.TZ;
-    process.env.TZ = "America/Santiago";
-    try {
-      const container = mount(
-        [
-          point({ timestamp: new Date(2026, 8, 6, 1).getTime() }),
-          point({ timestamp: new Date(2026, 8, 6, 12).getTime() }),
-          point({ timestamp: new Date(2026, 8, 7, 0, 30).getTime() }),
-        ],
-        null,
-        null,
-        "total",
-        { startDate: "2026-09-06", endDate: "2026-09-06", timeZone: "local" },
-      );
-
-      expect(container.querySelectorAll(".ts-bar")).toHaveLength(2);
-    } finally {
-      if (previousTimeZone === undefined) {
-        delete process.env.TZ;
-      } else {
-        process.env.TZ = previousTimeZone;
-      }
-    }
-  });
-
   it("aggregates token, cost, type, message, and duration data inside the selected range", () => {
     const container = mount(
       [


### PR DESCRIPTION
Related: #135153

## What Problem This Solves

The Usage detail test for a skipped midnight could pass even if the selected day leaked points from the following day. Its worker-local TZ assignment did not change native Date behavior, and its fixtures repeated the same local-date construction as production.

## Why This Change Was Made

Move that case to the existing bundled Control UI E2E route with a Chromium context set to America/Santiago. Establish the real 23-hour day, then use fixed UTC instants immediately before, at, and after both day boundaries. The rendered panel must keep exactly the first and last valid points. The ineffective jsdom case is removed; the other eight detail cases remain.

## User Impact

No runtime behavior changes. This maintainer-requested test audit makes the existing skipped-midnight regression detectable without changing the date owner, adding a production test seam, or changing the global test pool. Production LOC: +0/-0. Tests: +129/-26 (one stronger case replaces one ineffective case).

## Evidence

- Native Node worker probe: TZ reports America/Santiago while native Date remains UTC; inspected Node 26.5 and Vitest 4.1.11 environment ownership.
- Old case with correct owner: pass. Old case with deliberately incorrect normalized-midnight/setDate owner: also pass.
- Replacement Chromium case with unchanged owner: pass. Same incorrect owner: fails, four bars instead of two. Production restored byte-for-byte afterward.
- All eight retained detail tests pass.
- Independent Codex review through P2: no actionable findings.
- Configured changed checks on Testbox run 33655926793 passed both affected TypeScript graphs, i18n, structural guards and all dead-export scans. Final lint found an object spread in the new fixture; replaced it with the actual timeseries fields. The same canonical targeted lint command and formatter then passed, and the final Chromium case passed again.

Focused commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/usage/view-details.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/usage-calendar-boundaries.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/e2e/usage-calendar-boundaries.e2e.test.ts ui/src/pages/usage/view-details.test.ts
```

## Inspectable Chromium evidence

This is a test-only change: the production calendar filter is unchanged. The browser executes the bundled Control UI and Chromium's real America/Santiago timezone. The mock Gateway supplies synthetic session/timeseries data; this is not claimed as an authenticated Gateway end-to-end run. The fault is injected into the real renderer, not the mock response.

Final committed fixture at `6c85fd0336c61f9be374888dabbb28e13e958d00`, after the lint correction:

```text
✓ |ui-e2e-bundled| ui/src/e2e/usage-calendar-boundaries.e2e.test.ts > Usage calendar boundaries > ends a local range at the next calendar midnight after a skipped midnight 2359ms
Test Files  1 passed (1)
     Tests  1 passed (1)
```

That run passes the native `[1, 0, 23]` hour/day-length precondition, the [two-bar assertion and exact first/last point labels](https://github.com/openclaw/openclaw/blob/6c85fd0336c61f9be374888dabbb28e13e958d00/ui/src/e2e/usage-calendar-boundaries.e2e.test.ts#L115). The fixed point instants straddle both edges of the selected day.

Controlled fault: construct the starting local midnight first, then advance it with `setDate`. This wrongly retains 01:00 after Santiago's skipped midnight. With that fault, the original worker test still passes:

```text
✓ |ui| ui/src/pages/usage/view-details.test.ts > renderSessionDetailPanel filtered usage > ends a local range at the next calendar midnight after a skipped midnight 29ms
Test Files  1 passed (1)
     Tests  1 passed | 8 skipped (9)
```

The replacement browser test rejects the same fault:

```text
FAIL |ui-e2e-bundled| ui/src/e2e/usage-calendar-boundaries.e2e.test.ts > Usage calendar boundaries > ends a local range at the next calendar midnight after a skipped midnight
AssertionError: expected 4 to be 2 // Object.is equality
- Expected
+ Received
- 2
+ 4
await expect.poll(() => bars.count()).toBe(2);
Test Files  1 failed (1)
     Tests  1 failed (1)
```

The fault-control run used the same date inputs and assertions before the final lint-only fixture expansion; the final passing run above used the committed fixture. The production file was restored byte-for-byte. No failing fault code or proof-only source change is committed.
