### PR TITLE
perf(config): reuse the schema tag set for ordering

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2630,7 +2630,6 @@ src/config/runtime-overrides.ts	2
 src/config/runtime-snapshot.ts	1
 src/config/runtime-source-projection.ts	4
 src/config/schema.hints.ts	15
-src/config/schema.tags.ts	1
 src/config/schema.ts	1
 src/config/sessions/archive-compression.ts	1
 src/config/sessions/cleanup-service.ts	3

--- a/src/config/schema.tags.ts
+++ b/src/config/schema.tags.ts
@@ -3,25 +3,25 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { ConfigUiHint, ConfigUiHints } from "../shared/config-ui-hints-types.js";
 
 /** Stable config UI tag vocabulary and display order. */
-const TAG_PRIORITY = {
-  security: 0,
-  auth: 1,
-  access: 2,
-  network: 3,
-  privacy: 4,
-  observability: 5,
-  reliability: 6,
-  performance: 7,
-  storage: 8,
-  models: 9,
-  media: 10,
-  automation: 11,
-  channels: 12,
-  tools: 13,
-  advanced: 14,
-};
+const TAG_ORDER = [
+  "security",
+  "auth",
+  "access",
+  "network",
+  "privacy",
+  "observability",
+  "reliability",
+  "performance",
+  "storage",
+  "models",
+  "media",
+  "automation",
+  "channels",
+  "tools",
+  "advanced",
+] as const;
 
-type ConfigTag = keyof typeof TAG_PRIORITY;
+type ConfigTag = (typeof TAG_ORDER)[number];
 
 const TAG_OVERRIDES: Record<string, ConfigTag[]> = {
   worktreeRoot: ["storage", "advanced"],
@@ -97,19 +97,6 @@ const MEDIA_PATH_PATTERN = /(tools\.media\.|^audio\.|^talk\.|image|video|stt|tts
 const AUTOMATION_PATH_PATTERN = /(cron|heartbeat|schedule|onstart|watchdebounce)/i;
 const AUTH_KEYWORD_PATTERN = /(token|password|secret|api[_.-]?key|credential|oauth)/i;
 
-function normalizeTags(known: Set<ConfigTag>, tags: ReadonlyArray<string>): string[] {
-  const custom = new Set<string>();
-  for (const tag of tags) {
-    const normalized = normalizeLowercaseStringOrEmpty(tag);
-    if (Object.hasOwn(TAG_PRIORITY, normalized)) {
-      known.add(normalized as ConfigTag);
-    } else if (normalized) {
-      custom.add(normalized);
-    }
-  }
-  return [...[...known].toSorted((a, b) => TAG_PRIORITY[a] - TAG_PRIORITY[b]), ...custom];
-}
-
 function patternToRegExp(pattern: string): RegExp {
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^.]+");
   return new RegExp(`^${escaped}$`, "i");
@@ -175,9 +162,18 @@ export function applyDerivedTags(hints: ConfigUiHints): ConfigUiHints {
   const next: ConfigUiHints = {};
   for (const [path, hint] of Object.entries(hints)) {
     const existingTags = Array.isArray(hint?.tags) ? hint.tags : [];
-    const derivedTags = deriveTagsForPath(path, hint);
+    const derivedTags: Set<string> = deriveTagsForPath(path, hint);
+    for (const tag of existingTags) {
+      const normalized = normalizeLowercaseStringOrEmpty(tag);
+      if (normalized) {
+        derivedTags.add(normalized);
+      }
+    }
     // Preserve unknown tags after known tags so external/custom UI tags survive normalization.
-    const tags = normalizeTags(derivedTags, existingTags);
+    const tags: string[] = TAG_ORDER.filter((tag) => derivedTags.delete(tag));
+    for (const tag of derivedTags) {
+      tags.push(tag);
+    }
     next[path] = { ...hint, tags };
   }
   return next;


### PR DESCRIPTION
## What Problem This Solves

Schema hint normalization built a second Set and two temporary ordering arrays for every hint. The final merged schema in the source probe contains 6,319 hints, so this duplicated work across the complete schema and lookup flow.

## Why This Change Was Made

Consume the private Set already produced by the tag owner, emit the existing 15 known tags in canonical order, and append remaining custom tags in insertion order. This removes the one-use normalization helper and four production lines. The canonical assertion guard also removes its now-obsolete inventory entry (support −1; tests unchanged).

## User Impact

Schema contents, display order, custom tags, all tagging/tier passes, cache behavior and fresh output ownership remain unchanged. This is an allocation tradeoff: a fixed four-process B C C B series measured the early 1,104-hint pass 0.094–0.128 ms slower per call (+9.40–12.61%), while the larger merged schema improved 6.40–9.47%. Process RSS signs varied; no universal latency, retained-heap or Gateway memory improvement is claimed.

## Evidence

The before/after actual-source corpus matched 11 complete records and 9,463,587 canonical bytes (only separately retained generated timestamps were normalized). It covers complete schema construction, lookup, UI search, all known priorities, custom/prototype-named tags, getter/iterator/error ordering, and an accumulated advanced tag surviving a later tier change. All 188 other loaded source modules were unchanged.

Observed work for the merged 6,319-hint input:

```json
{"before":{"sets":12638,"knownSpreadArrays":6319,"sortedCopies":6319},"after":{"sets":6319,"knownSpreadArrays":0,"sortedCopies":0,"setDeletes":94785},"normalizationCallsUnchanged":true,"completeOutputEqual":true}
```

103 existing tests passed across schema, hints, Control UI schema contracts and UI search. The complete core/coreTests/tooling changed gate passed in 442.648 seconds; managed Codex review through P2 was scoped-clean. The initial stale-inventory gate failure and proof-loader setup failure remain in the local evidence packet, alongside all four timing legs; no favorable reruns or changed assertions.

Production +30/−34 = −4; tests 0; support −1. No configuration, schema, defaults, persistence or public API contract changes. Exact candidate owner SHA-256: `474fa5a6e1ddfcc151e34256cbaaa577dc05f809a40394dc7c9f646f60d7139c`.
