### PR TITLE
perf(terminal): normalize SGR parameters without character arrays

### DIFF
--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -76,6 +76,7 @@ const C1_CSI = "\u009b";
 const C1_OSC = "\u009d";
 const C1_ST = "\u009c";
 const BEL = "\u0007";
+const SGR_CONTROL_CHARS_REGEX = new RegExp(String.raw`[\u0000-\u001f\u007f]`, "g");
 
 type AnsiToken = { kind: "ansi" | "char"; value: string; width: number };
 
@@ -135,16 +136,9 @@ function parseSgrSequence(value: string): { introducer: string; parameters: stri
   } else {
     return undefined;
   }
-  const parameters = Array.from(value.slice(introducer.length, -1))
-    .filter((character) => {
-      const code = character.charCodeAt(0);
-      return code > 0x1f && code !== 0x7f;
-    })
-    .join("");
-  const hasOnlySgrParameters = Array.from(parameters).every(
-    (character) => (character >= "0" && character <= "9") || character === ";" || character === ":",
-  );
-  if (!hasOnlySgrParameters) {
+  // C0 and DEL execute separately inside CSI; exclude them only from stored SGR parameters.
+  const parameters = value.slice(introducer.length, -1).replace(SGR_CONTROL_CHARS_REGEX, "");
+  if (/[^0-9;:]/u.test(parameters)) {
     return undefined;
   }
   return { introducer, parameters };


### PR DESCRIPTION
## What Problem This Solves

The table renderer expanded every SGR parameter string into two character arrays and a filtered array, then joined and checked those characters again. Colored cells repeat this normalization when wrapping and reopening styles.

## Why This Change Was Made

Normalize the existing parameter string directly: remove C0/DEL controls from stored style parameters, then reject anything outside the same digits/semicolon/colon grammar. The original escape tokens remain unchanged. This deletes six production lines and all three temporary character arrays per normalization.

## User Impact

Table output, style reset/reopen order, extended colors, OSC-8 links, embedded controls and Unicode wrapping remain byte-identical. No configuration or public API changes.

## Evidence

The frozen actual-source before/after corpus matched all 1,264 table cases, eight exact-output goldens and seven workloads, including the real skills-list formatter in default, verbose and eligible modes.

```json
{"normalizationsBoth":1280,"returnedCharacterArrays":{"before":3840,"after":0},"arraySlots":{"before":25100,"after":0},"parameterJoins":{"before":1280,"after":0},"completeOutputsEqual":true}
```

These are observed native-operation counts from the changed owner, not allocated-byte or retained-heap measurements. Whole-process figures include imports and instrumentation; no latency or RSS improvement is claimed.

161 existing tests passed across ANSI, table and skills formatting suites. The full core/core-test changed gate passed in 301.99 seconds. Managed Codex review through P2 was scoped-clean; an independent parent review checked the complete owner and ANSI scanner/terminal contracts. All owned proof, gate and review processes were joined and absent afterward.

Production +4/−10 = −6; tests/support unchanged. Candidate source SHA-256: `27a49ae1be0aed1f318b7faa54af3dfd55534f626eca0eee004883324dc4c2b0`. Complete corpus output SHA-256: `2ba7de1a67025bfeb5c3241cdc6a79a367dc3c4416b64597059dfacd38f40b8a`.

The reviewed patch is now on main revision `1e37a56c75289bd887bbb244965d4896b921b625`, including the browser-fixture repair from #136402. Refreshed head: `f5621aee9d46b2f7d8d16b801b2e6c397482b447`. The touched source bytes and stable patch identity match the previously reviewed `0b7c6a7317d5bb23db412f785ccaccdc4ea1abcf`; previously recorded behavior runs cover that identical owner source, and hosted CI validates the refreshed head.
