### PR TITLE
perf(infra): refresh dedupe entries without replacement records

### DIFF
--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -29,15 +29,6 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
   const maxSize = resolveNonNegativeIntegerOption(options.maxSize, 0);
   const cache = new Map<string, { ownerToken?: object; recordedAt: number }>();
 
-  const record = (key: string, recordedAt: number, ownerToken?: object) => {
-    cache.delete(key);
-    cache.set(key, { recordedAt, ...(ownerToken ? { ownerToken } : {}) });
-  };
-
-  const touch = (key: string, now: number) => {
-    record(key, now, cache.get(key)?.ownerToken);
-  };
-
   const prune = (now: number) => {
     const cutoff = ttlMs > 0 ? now - ttlMs : undefined;
     if (cutoff !== undefined) {
@@ -64,8 +55,10 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
       return false;
     }
     if (touchOnRead) {
-      // check() refreshes recency so active duplicate bursts keep their key near the LRU tail.
-      touch(key, now);
+      // Keep the original claim owner while refreshing TTL and LRU recency.
+      existing.recordedAt = now;
+      cache.delete(key);
+      cache.set(key, existing);
     }
     return true;
   };
@@ -79,7 +72,7 @@ export function createDedupeCache(options: DedupeCacheOptions): DedupeCache {
       if (hasUnexpired(key, checkedAt, true)) {
         return true;
       }
-      record(key, checkedAt, ownerToken);
+      cache.set(key, { recordedAt: checkedAt, ...(ownerToken ? { ownerToken } : {}) });
       prune(checkedAt);
       return false;
     },


### PR DESCRIPTION
## What Problem This Solves

Every duplicate-cache hit read the same map entry twice and allocated a replacement record simply to refresh its timestamp and LRU position. Repeated callbacks pay that cost even though the owner token and cache entry are already available.

## Why This Change Was Made

Refresh the private entry returned by the canonical expiry lookup, then move that same entry to the end of the map. Inline the miss write and remove the one-use touch/record wrappers. The expiry lookup already removes expired entries, so the miss path also drops its redundant delete. Production shrinks by seven lines.

## User Impact

Duplicate detection, exact TTL boundaries, zero-TTL behavior, LRU eviction, original owner-token protection and the public SDK facade remain unchanged. Persistent dedupe storage is untouched.

## Evidence

The same actual-source corpus preserved all 11,760 operations across 49 TTL/capacity combinations, including non-monotonic clocks, empty and prototype-named keys, owner-bound deletion and clear. Separate checks cover option access/default-clock order, SDK identity, global singleton reuse and the real interactive-callback claim/commit/release caller.

```json
{"duplicateHits":10000,"before":{"mapGets":20000,"freshEntryObjects":10000,"mapSets":10000,"mapDeletes":10000},"after":{"mapGets":10000,"freshEntryObjects":0,"mapSets":10000,"mapDeletes":10000},"behaviorEqual":true}
```

Map observations use the actual cache instance; weak identity tracking does not retain entries. These are operation/object counts, not allocated-byte, retained-heap, RSS or latency measurements.

32 existing core/SDK/persistent-dedupe tests passed before and after. The full core/core-test changed gate passed in 297.353 seconds. Managed Codex review through P2 was scoped-clean with no findings; source inputs remained unchanged and all owned command groups were joined. The evidence packet preserves the initial proof-summary label correction separately from the final witness; no product behavior or timing inputs changed.

Production +5/−12 = −7; tests/support unchanged. Complete behavior SHA-256: `da9605b41adff3937bbe9facf962f493c02a3d5399f94273d143f8ab06052cd3`. Candidate owner SHA-256: `aebad036f28e75f6ed8e43af1e79c61203dcb051accc550e2c64e3557dac164f`.

[Observed core/SDK callback, TTL and LRU trace](https://github.com/openclaw/openclaw/pull/136457#issuecomment-5514071030) includes inspectable after-fix results, exact source binding and proof limitations.

The branch is now based on main revision `1e37a56c75289bd887bbb244965d4896b921b625`, including the browser-fixture repair from #136402. Refreshed head: `d1dcd039b46de8f46b66a6fd1c55480d835accec`. The touched source bytes and stable patch identity match the previously reviewed `94e42508e51d83743ff7ce9e3a690ecc52e3118d`; previously recorded behavior runs cover that identical owner source, and hosted CI validates the refreshed head.
The base also includes the separately reviewed interactive-state hydration cleanup (#136481). Fresh combined coverage passed 65 core/SDK/replay/interactive/singleton tests plus the existing loader cache/restore case. Fresh managed Codex review through P2 completed both input packs without findings. Review JSON SHA-256: `afe19f846e96e4da2b3e1fdb90e0844cbb0b5f7434d479d73f8d685165475163`. These runs validate source composition; they are not new Gateway or memory measurements.
