### PR TITLE
fix(slack): deliver short replies before progress finalization

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1590,6 +1590,7 @@ Both surfaces link the session with **Open in OpenClaw**, but only when that lin
 - Custom outbound username/icon settings keep portable previews enabled. OpenClaw keeps the preview or session card app-authored and delivers the customized final separately. Slack does not allow impersonated messages to be deleted.
 - Media and non-text payloads fall back to normal delivery.
 - Media/error finals cancel pending preview edits; eligible text/block finals flush only when they can edit the preview in place.
+- Native streamed final answers wait for Slack's acknowledgement before delivery is marked successful. A later progress-card finalization failure does not discard an already acknowledged answer.
 - If streaming fails mid-reply, OpenClaw falls back to normal delivery for remaining payloads.
 
 Use draft preview instead of Slack native text streaming:

--- a/extensions/slack/src/__traces__/native-prose-then-exec-failed.trace.jsonl
+++ b/extensions/slack/src/__traces__/native-prose-then-exec-failed.trace.jsonl
@@ -2,8 +2,8 @@
 {"seq":2,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"is typing...","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
 {"seq":3,"at":0,"dir":"in","kind":"final","data":{"text":"The directory is missing."}}
 {"seq":4,"at":0,"dir":"out","kind":"users.info","data":{"payload":{"user":"U0TRACE"},"result":{"team_id":"T0TRACE"},"target":"U0TRACE"}}
-{"seq":5,"at":0,"dir":"in","kind":"final","data":{"text":"⚠️ 🛠️ Exec failed: "}}
-{"seq":6,"at":0,"dir":"in","kind":"idle"}
-{"seq":7,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
-{"seq":8,"at":0,"dir":"out","kind":"chat.startStream","data":{"payload":{"channel":"C0TRACE","recipient_team_id":"T0TRACE","recipient_user_id":"U0TRACE","thread_ts":"ts#1"},"result":{"ts":"ts#2"},"target":"C0TRACE"}}
-{"seq":9,"at":0,"dir":"out","kind":"chat.stopStream","data":{"payload":{"channel":"C0TRACE","chunks":[{"text":"The directory is missing.","type":"markdown_text"}],"ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
+{"seq":5,"at":0,"dir":"out","kind":"chat.startStream","data":{"payload":{"channel":"C0TRACE","chunks":[{"text":"The directory is missing.","type":"markdown_text"}],"recipient_team_id":"T0TRACE","recipient_user_id":"U0TRACE","thread_ts":"ts#1"},"result":{"ts":"ts#2"},"target":"C0TRACE"}}
+{"seq":6,"at":0,"dir":"in","kind":"final","data":{"text":"⚠️ 🛠️ Exec failed: "}}
+{"seq":7,"at":0,"dir":"in","kind":"idle"}
+{"seq":8,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":9,"at":0,"dir":"out","kind":"chat.stopStream","data":{"payload":{"channel":"C0TRACE","chunks":[],"ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}

--- a/extensions/slack/src/__traces__/progress-native-unified.trace.jsonl
+++ b/extensions/slack/src/__traces__/progress-native-unified.trace.jsonl
@@ -8,6 +8,7 @@
 {"seq":8,"at":2000,"dir":"in","kind":"tool-progress","data":{"name":"write","phase":"result"}}
 {"seq":9,"at":2000,"dir":"in","kind":"final","data":{"text":"The unified native Slack turn is complete."}}
 {"seq":10,"at":2000,"dir":"out","kind":"chat.appendStream","data":{"payload":{"channel":"C0TRACE","chunks":[{"title":"I’m checking the native Slack stream before applying the focused patch. I’m applying it now.","type":"plan_update"},{"id":"openclaw_summary","sources":[{"text":"Open in OpenClaw","type":"url_source","url":"https://team.openclaw.ai/openclaw/chat/trace-agent/slack/channel/c0trace"}],"status":"complete","title":"I’m checking the native Slack stream before applying the focused patch. I’m applying it now.","type":"task_update"}],"ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
-{"seq":11,"at":2000,"dir":"in","kind":"idle"}
-{"seq":12,"at":2000,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
-{"seq":13,"at":2000,"dir":"out","kind":"chat.stopStream","data":{"payload":{"channel":"C0TRACE","chunks":[{"text":"\nThe unified native Slack turn is complete.","type":"markdown_text"}],"ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
+{"seq":11,"at":2000,"dir":"out","kind":"chat.appendStream","data":{"payload":{"channel":"C0TRACE","chunks":[{"text":"\nThe unified native Slack turn is complete.","type":"markdown_text"}],"ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}
+{"seq":12,"at":2000,"dir":"in","kind":"idle"}
+{"seq":13,"at":2000,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":14,"at":2000,"dir":"out","kind":"chat.stopStream","data":{"payload":{"channel":"C0TRACE","chunks":[],"ts":"ts#2"},"result":{"ok":true},"target":"ts#2"}}

--- a/extensions/slack/src/__traces__/short-final-native-rejection.trace.jsonl
+++ b/extensions/slack/src/__traces__/short-final-native-rejection.trace.jsonl
@@ -1,0 +1,9 @@
+{"seq":1,"at":0,"dir":"in","kind":"reply-start"}
+{"seq":2,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"is typing...","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
+{"seq":3,"at":0,"dir":"in","kind":"partial","data":{"text":"All checks passed."}}
+{"seq":4,"at":300,"dir":"in","kind":"final","data":{"text":"All checks passed. Ship it."}}
+{"seq":5,"at":300,"dir":"out","kind":"users.info","data":{"payload":{"user":"U0TRACE"},"result":{"team_id":"T0TRACE"},"target":"U0TRACE"}}
+{"seq":6,"at":300,"dir":"out","kind":"chat.startStream","data":{"payload":{"channel":"C0TRACE","chunks":[{"text":"All checks passed. Ship it.","type":"markdown_text"}],"recipient_team_id":"T0TRACE","recipient_user_id":"U0TRACE","thread_ts":"ts#1"},"result":{"error":"method_not_supported_for_channel_type","ok":false},"target":"C0TRACE"}}
+{"seq":7,"at":300,"dir":"out","kind":"chat.postMessage","data":{"payload":{"channel":"C0TRACE","text":"All checks passed. Ship it.","thread_ts":"ts#1","unfurl_links":false},"result":{"ts":"ts#2"},"target":"C0TRACE"}}
+{"seq":8,"at":300,"dir":"in","kind":"idle"}
+{"seq":9,"at":300,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}

--- a/extensions/slack/src/__traces__/stream-stop-first-network-call.trace.jsonl
+++ b/extensions/slack/src/__traces__/stream-stop-first-network-call.trace.jsonl
@@ -1,9 +1,0 @@
-{"seq":1,"at":0,"dir":"in","kind":"reply-start"}
-{"seq":2,"at":0,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"is typing...","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
-{"seq":3,"at":0,"dir":"in","kind":"partial","data":{"text":"All checks passed."}}
-{"seq":4,"at":300,"dir":"in","kind":"final","data":{"text":"All checks passed. Ship it."}}
-{"seq":5,"at":300,"dir":"out","kind":"users.info","data":{"payload":{"user":"U0TRACE"},"result":{"team_id":"T0TRACE"},"target":"U0TRACE"}}
-{"seq":6,"at":300,"dir":"in","kind":"idle"}
-{"seq":7,"at":300,"dir":"out","kind":"assistant.threads.setStatus","data":{"payload":{"channel_id":"C0TRACE","status":"","thread_ts":"ts#1"},"result":{"ok":true},"target":"C0TRACE/ts#1"}}
-{"seq":8,"at":300,"dir":"out","kind":"chat.startStream","data":{"payload":{"channel":"C0TRACE","recipient_team_id":"T0TRACE","recipient_user_id":"U0TRACE","thread_ts":"ts#1"},"result":{"error":"method_not_supported_for_channel_type","ok":false},"target":"C0TRACE"}}
-{"seq":9,"at":300,"dir":"out","kind":"chat.postMessage","data":{"payload":{"channel":"C0TRACE","text":"All checks passed. Ship it.","thread_ts":"ts#1","unfurl_links":false},"result":{"ts":"ts#2"},"target":"C0TRACE"}}

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -6,9 +6,9 @@
 // the scripted steps stand in for the reply dispatcher callbacks (typing, partials,
 // tool progress, per-payload deliver). OUT events are the Slack Web API calls observed
 // at a recording WebClient stand-in. Native streaming runs through the REAL
-// @slack/web-api ChatStreamer so the SDK's buffered-ack contract is captured as-is:
-// append() returns null and issues NO network call until its local buffer crosses
-// buffer_size (256 chars), and stop() can be the first network call for short replies.
+// @slack/web-api ChatStreamer so the SDK's buffering contract is captured as-is:
+// previews may remain buffered below 256 chars, but finals flush before delivery
+// settles, including when native rejection requires ordinary-message fallback.
 // Refresh goldens with OPENCLAW_TRACE_UPDATE=1 (see delivery-trace harness docs).
 import { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
 import {
@@ -178,7 +178,7 @@ const INBOUND_TS = "1767225600.000100";
 
 type SlackTraceScenarioName =
   | "streaming-happy-native"
-  | "stream-stop-first-network-call"
+  | "short-final-native-rejection"
   | "final-blocks-and-text"
   | "cancel-mid-stream"
   | "preview-edit-fallback"
@@ -190,7 +190,7 @@ type SlackTraceScenarioName =
 
 const NATIVE_SCENARIOS = new Set<SlackTraceScenarioName>([
   "streaming-happy-native",
-  "stream-stop-first-network-call",
+  "short-final-native-rejection",
   "final-blocks-and-text",
   "native-prose-then-exec-failed",
 ]);
@@ -207,8 +207,7 @@ const NATIVE_FINAL_TEXT =
   "across the fleet. Rolling out to production now and watching the dashboards for " +
   "the next fifteen minutes before closing out the change.";
 
-// Short enough that every append stays inside the SDK's local buffer, so the
-// finalize stop() is the first Slack streaming network call of the turn.
+// Below the SDK's buffer threshold: final delivery must explicitly flush it.
 const SHORT_FINAL_TEXT = "All checks passed. Ship it.";
 
 const PREVIEW_PARTIAL_ONE = "Compiling the changelog";
@@ -252,7 +251,7 @@ const slackTraceScenarios: Record<SlackTraceScenarioName, readonly DeliveryTrace
     { kind: "final", text: NATIVE_FINAL_TEXT },
     { kind: "idle" },
   ],
-  "stream-stop-first-network-call": [
+  "short-final-native-rejection": [
     { kind: "reply-start" },
     { kind: "partial", text: "All checks passed." },
     { kind: "advance", ms: 300 },
@@ -627,10 +626,10 @@ async function setupSlackTrace(
   traceState.turn = null;
   traceState.turnStarted = createDeferred<void>();
   traceState.turnOutcome = createDeferred<{ queuedFinal: boolean; counts: TurnCounts }>();
-  // stop() rejections with a benign finalize code while text is still buffered
-  // must fall back to the durable full-text path (streaming.ts contract).
+  // Rejected native final delivery must complete ordinary-message fallback
+  // before the dispatcher settles the final payload.
   traceState.rejectStartStreamCode =
-    scenario === "stream-stop-first-network-call"
+    scenario === "short-final-native-rejection"
       ? "method_not_supported_for_channel_type"
       : undefined;
   traceState.client = createRecordingSlackClient();

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -390,6 +390,9 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
 
     const text = params.streamText ?? reply.trimmedText;
     const hookContent = reply.trimmedText;
+    // Even empty chunks force the SDK to flush short text. Final delivery must
+    // await Slack's receipt, not the later best-effort progress finalization.
+    const chunks = params.kind === "final" ? [] : undefined;
     let plannedThreadTs: string | undefined;
     try {
       if (!state.streamSession && state.nativeProgressStreamStartPromise) {
@@ -434,6 +437,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
           channel: message.channel,
           threadTs: streamThreadTs,
           text,
+          chunks,
           ...(params.taskDisplayMode ? { taskDisplayMode: params.taskDisplayMode } : {}),
           ...(slackIdentity ? { identity: slackIdentity } : {}),
           teamId: await resolveSlackStreamRecipientTeamId({
@@ -491,6 +495,7 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
       await appendSlackStream({
         session: state.streamSession,
         text: `${params.appendSeparator === false ? "" : "\n"}${text}`,
+        chunks,
       });
       refreshStreamedAcknowledgements(state.streamSession);
       // appendSlackStream also buffers locally below the SDK threshold; avoid

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -1,4 +1,5 @@
 // Slack tests cover streaming plugin behavior.
+import { WebClient } from "@slack/web-api";
 import { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -34,6 +35,41 @@ function slackApiError(code: string): Error {
 }
 
 describe("stopSlackStream finalize error handling", () => {
+  it("flushes short committed replies through the real SDK before stream finalization", async () => {
+    const client = new WebClient("xoxb-synthetic");
+    const start = vi.spyOn(client.chat, "startStream").mockResolvedValue({
+      ok: true,
+      ts: "1700000000.500300",
+    });
+    const append = vi.spyOn(client.chat, "appendStream").mockResolvedValue({ ok: true });
+    vi.spyOn(client.chat, "stopStream").mockRejectedValue(slackApiError("internal_error"));
+
+    const session = await startSlackStream({
+      client,
+      channel: "C123",
+      threadTs: "1700000000.000100",
+      text: "first short answer",
+      chunks: [],
+    });
+    expect(start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread_ts: "1700000000.000100",
+        chunks: [{ type: "markdown_text", text: "first short answer" }],
+      }),
+    );
+
+    await appendSlackStream({ session, text: "second short answer", chunks: [] });
+    expect(append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ts: "1700000000.500300",
+        chunks: [{ type: "markdown_text", text: "second short answer" }],
+      }),
+    );
+    expect(session.pendingText).toBe("");
+    await expect(stopSlackStream({ session })).rejects.toThrow("internal_error");
+    expect(session.delivered).toBe(true);
+  });
+
   it("starts and appends supported structured stream chunks without buffering markdown text", async () => {
     const append = vi.fn(async () => ({ ts: "1700000000.100205" }));
     const client = {

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -160,7 +160,7 @@ export async function startSlackStream(
     try {
       const result = await streamer.append({
         ...(text ? { markdown_text: text } : {}),
-        ...(chunks?.length ? { chunks } : {}),
+        ...(chunks ? { chunks } : {}),
       });
       if (result) {
         session.delivered = true;
@@ -208,7 +208,7 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
     // non-null means Slack accepted the pending buffer/chunks and it is visible.
     const result = await session.streamer.append({
       ...(text ? { markdown_text: text } : {}),
-      ...(chunks?.length ? { chunks } : {}),
+      ...(chunks ? { chunks } : {}),
     });
     if (result) {
       session.delivered = true;

--- a/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { startOpenClawCrablineAdapter } from "@openclaw/crabline";
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -81,7 +82,7 @@ async function startPresentationApi(
         wire.accepted = {
           id,
           action,
-          text: String(message?.text ?? message?.content ?? "").slice(0, 250),
+          text: (readStringValue(message?.text ?? message?.content) ?? "").slice(0, 250),
         };
       };
       const reply = (result: unknown, status = 200) => {
@@ -115,9 +116,9 @@ async function startPresentationApi(
           };
           const text = readChunks(body.chunks)
             .filter((chunk) => chunk.type === "markdown_text")
-            .map((chunk) => String(chunk.text ?? ""))
+            .map((chunk) => readStringValue(chunk.text) ?? "")
             .join("");
-          messages.set(ts, { ...previous, text: String(previous.text ?? "") + text });
+          messages.set(ts, { ...previous, text: (readStringValue(previous.text) ?? "") + text });
           recordAccepted(ts, operation);
           reply({ ok: true, channel: body.channel, ts });
           return;
@@ -240,7 +241,9 @@ async function startPresentationApi(
           listener,
         )
       : createServer(listener);
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
   const address = server.address();
   if (!address || typeof address === "string") {
     throw new Error("presentation API did not bind a loopback port");
@@ -276,7 +279,9 @@ async function startPresentationApi(
     socket.on("error", () => upstream.destroy());
     socket.on("close", () => upstream.destroy());
   });
-  await new Promise<void>((resolve) => proxy.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) => {
+    proxy.listen(0, "127.0.0.1", resolve);
+  });
   const proxyAddress = proxy.address();
   if (!proxyAddress || typeof proxyAddress === "string") {
     throw new Error("proxy failed to bind");
@@ -290,13 +295,13 @@ async function startPresentationApi(
       for (const socket of tunnelSockets) {
         socket.destroy();
       }
-      await new Promise<void>((resolve, reject) =>
-        proxy.close((error) => (error ? reject(error) : resolve())),
-      );
+      await new Promise<void>((resolve, reject) => {
+        proxy.close((error) => (error ? reject(error) : resolve()));
+      });
       server.closeAllConnections();
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      );
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
     },
   };
 }
@@ -402,12 +407,8 @@ describe("channel progress presentation through an isolated Gateway", () => {
         recorderPath: path.join(directory, "provider.jsonl"),
       });
       cleanups.push(() => adapter.close());
-      let clearOrigin: (() => Promise<void>) | undefined;
       let originCleared = false;
       const api = await startPresentationApi(adapter, writes, directory, rejectStop, async () => {
-        if (!clearOrigin) {
-          throw new Error("origin-loss gate has no admitted session");
-        }
         await clearOrigin();
         originCleared = true;
       });
@@ -462,7 +463,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
           })
         );
       }, `${channel} ready`);
-      clearOrigin = async () => {
+      const clearOrigin = async () => {
         const scope = {
           agentId: "qa",
           env: gateway.runtimeEnv,
@@ -530,7 +531,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
         writes.filter((write) => JSON.stringify(write.body).includes(FINAL_MARKER));
       const finalMessages = () =>
         [...api.messages.values()].filter((message) =>
-          String(message.text ?? message.content ?? "").includes(FINAL_MARKER),
+          (readStringValue(message.text ?? message.content) ?? "").includes(FINAL_MARKER),
         );
       if (!rejectStop) {
         await waitForFact(() => finalMessages().length > 0, "accepted final answer");
@@ -558,7 +559,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
       const progressText = progressWrites
         .map(({ body }) =>
           channel === "discord"
-            ? String(body.content ?? "")
+            ? (readStringValue(body.content) ?? "")
             : [
                 body.text,
                 JSON.stringify(readChunks(body.blocks)),
@@ -604,16 +605,17 @@ describe("channel progress presentation through an isolated Gateway", () => {
                   .filter((key) => body[key] !== undefined)
                   .map((key) => [
                     key,
-                    String(
-                      typeof body[key] === "string" ? body[key] : JSON.stringify(body[key]),
-                    ).slice(0, 250),
+                    (typeof body[key] === "string" ? body[key] : JSON.stringify(body[key])).slice(
+                      0,
+                      250,
+                    ),
                   ]),
               ),
-              ...(accepted ? { accepted } : {}),
+              accepted,
             })),
             acceptedMessages: [...api.messages].slice(-80).map(([id, message]) => ({
               id,
-              text: String(message.text ?? message.content ?? "").slice(0, 250),
+              text: (readStringValue(message.text ?? message.content) ?? "").slice(0, 250),
             })),
           },
           null,

--- a/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
@@ -15,6 +15,11 @@ import {
   createQaGatewayChild,
   startQaMockOpenAiServer,
 } from "../../../../extensions/qa-lab/api.js";
+import {
+  listSessionEntriesReadOnly,
+  loadSessionEntryReadOnly,
+  updateSessionEntry,
+} from "../../../../src/config/sessions/session-accessor.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 
 const MODEL = "mock-openai/progress-fixture";
@@ -51,6 +56,8 @@ async function startPresentationApi(
   adapter: CrablineAdapter,
   writes: WireWrite[],
   directory: string,
+  rejectStop = false,
+  clearOrigin?: () => Promise<void>,
 ) {
   const manifest = adapter.manifest;
   const messages = new Map<string, Record<string, unknown>>();
@@ -88,11 +95,24 @@ async function startPresentationApi(
             ? body.ts
             : `1800000000.${String(++nextMessage).padStart(6, "0")}`;
         if (["chat.startStream", "chat.appendStream", "chat.stopStream"].includes(operation)) {
+          // The admitted final waits for this progress stream to start, so route
+          // loss here is deterministic without changing the agent's tool call.
+          if (rejectStop && operation === "chat.startStream") {
+            await clearOrigin?.();
+          }
+          if (rejectStop && operation === "chat.stopStream") {
+            reply({ ok: false, error: "internal_error" });
+            return;
+          }
           if (operation !== "chat.startStream" && !messages.has(ts)) {
             reply({ ok: false, error: "message_not_found" });
             return;
           }
-          const previous = messages.get(ts) ?? { text: "" };
+          const previous = messages.get(ts) ?? {
+            text: "",
+            channel: body.channel,
+            thread_ts: body.thread_ts,
+          };
           const text = readChunks(body.chunks)
             .filter((chunk) => chunk.type === "markdown_text")
             .map((chunk) => String(chunk.text ?? ""))
@@ -307,7 +327,6 @@ function progressConfig(
     messages: {
       ackReaction: "eyes",
       ackReactionScope: "all",
-      removeAckAfterReply: true,
       statusReactions: { enabled: true },
     },
     channels: {
@@ -366,12 +385,13 @@ describe("channel progress presentation through an isolated Gateway", () => {
   });
 
   it.each([
-    { channel: "discord" as const, native: false },
-    { channel: "slack" as const, native: true },
-    { channel: "slack" as const, native: false },
+    { channel: "discord" as const, native: false, rejectStop: false },
+    { channel: "slack" as const, native: true, rejectStop: false },
+    { channel: "slack" as const, native: false, rejectStop: false },
+    { channel: "slack" as const, native: true, rejectStop: true },
   ])(
-    "keeps $channel progress quiet (native=$native)",
-    async ({ channel, native }) => {
+    "keeps $channel progress quiet (native=$native, rejectStop=$rejectStop)",
+    async ({ channel, native, rejectStop }) => {
       const directory = await fs.mkdtemp(
         path.join(await fs.realpath(os.tmpdir()), "channel-progress-"),
       );
@@ -382,7 +402,15 @@ describe("channel progress presentation through an isolated Gateway", () => {
         recorderPath: path.join(directory, "provider.jsonl"),
       });
       cleanups.push(() => adapter.close());
-      const api = await startPresentationApi(adapter, writes, directory);
+      let clearOrigin: (() => Promise<void>) | undefined;
+      let originCleared = false;
+      const api = await startPresentationApi(adapter, writes, directory, rejectStop, async () => {
+        if (!clearOrigin) {
+          throw new Error("origin-loss gate has no admitted session");
+        }
+        await clearOrigin();
+        originCleared = true;
+      });
       cleanups.push(() => api.stop());
       const provider = await startQaMockOpenAiServer({ modelRefs: [MODEL] });
       cleanups.push(() => provider.stop());
@@ -396,7 +424,14 @@ describe("channel progress presentation through an isolated Gateway", () => {
       }
       const gateway = await owner.start({
         repoRoot: process.cwd(),
-        useRepoCli: true,
+        // The E2E runner owns the build; child startups must not rebuild dist
+        // beneath already-running test workers when the source tree is dirty.
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: [path.join(process.cwd(), "openclaw.mjs")],
+          cwd: process.cwd(),
+          usePackagedPlugins: true,
+        },
         providerBaseUrl: `${provider.baseUrl}/v1`,
         providerMode: "mock-openai",
         primaryModel: MODEL,
@@ -427,6 +462,32 @@ describe("channel progress presentation through an isolated Gateway", () => {
           })
         );
       }, `${channel} ready`);
+      clearOrigin = async () => {
+        const scope = {
+          agentId: "qa",
+          env: gateway.runtimeEnv,
+          readConsistency: "latest" as const,
+        };
+        const sessions = listSessionEntriesReadOnly(scope).filter(
+          ({ entry }) =>
+            entry.delivery?.kind === "external" &&
+            entry.delivery.context.channel === "slack" &&
+            entry.delivery.context.to?.includes("C12345678"),
+        );
+        expect(sessions).toHaveLength(1);
+        const { sessionKey, entry } = sessions[0]!;
+        const target = { ...scope, sessionKey };
+        await updateSessionEntry(
+          target,
+          (current) => {
+            expect(current.sessionId).toBe(entry.sessionId);
+            return { delivery: { kind: "none" }, updatedAt: Date.now() };
+          },
+          { skipMaintenance: true, requireWriteSuccess: true },
+        );
+        expect(loadSessionEntryReadOnly(target)?.delivery).toEqual({ kind: "none" });
+      };
+      let expectedThreadTs: unknown;
       const inbound = adapter.createInbound({
         input: {
           conversation: {
@@ -445,6 +506,8 @@ describe("channel progress presentation through an isolated Gateway", () => {
       expect(injected.ok).toBe(true);
       if (adapter.manifest.provider === "slack") {
         const payload = asRecord(await injected.json());
+        const event = asRecord(asRecord(payload.event).event);
+        expectedThreadTs = event.thread_ts ?? event.ts;
         const body = JSON.stringify(payload.event);
         const timestamp = String(Math.floor(Date.now() / 1000));
         const signature = createHmac("sha256", adapter.manifest.signingSecret)
@@ -459,7 +522,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
           },
           body,
         });
-        expect(delivered.ok).toBe(true);
+        expect(delivered.ok, await delivered.text()).toBe(true);
       } else {
         await injected.arrayBuffer();
       }
@@ -469,7 +532,9 @@ describe("channel progress presentation through an isolated Gateway", () => {
         [...api.messages.values()].filter((message) =>
           String(message.text ?? message.content ?? "").includes(FINAL_MARKER),
         );
-      await waitForFact(() => finalMessages().length > 0, "accepted final answer");
+      if (!rejectStop) {
+        await waitForFact(() => finalMessages().length > 0, "accepted final answer");
+      }
       await waitForFact(
         () =>
           channel === "discord"
@@ -519,11 +584,14 @@ describe("channel progress presentation through an isolated Gateway", () => {
       );
       expect([...reactionNames]).toEqual([channel === "discord" ? "👀" : "eyes"]);
       const evidenceDir = path.join(process.cwd(), ".artifacts", "channel-progress-presentation");
+      const evidenceName = `${channel}-${native ? "native" : "draft"}${rejectStop ? "-stop-failure" : ""}`;
       await fs.mkdir(evidenceDir, { recursive: true });
       await fs.writeFile(
-        path.join(evidenceDir, `${channel}-${native ? "native" : "draft"}-diagnostic.json`),
+        path.join(evidenceDir, `${evidenceName}-diagnostic.json`),
         JSON.stringify(
           {
+            rejectStop,
+            originCleared,
             writes: writes.slice(-80).map(({ at, method, route, body, accepted }) => ({
               at,
               method,
@@ -554,6 +622,15 @@ describe("channel progress presentation through an isolated Gateway", () => {
       );
       expect(finalWrites()).toHaveLength(1);
       expect(finalMessages()).toHaveLength(1);
+      if (rejectStop) {
+        expect(originCleared).toBe(true);
+        expect(expectedThreadTs).toEqual(expect.any(String));
+        expect(finalMessages()[0]).toMatchObject({
+          channel: "C12345678",
+          thread_ts: expectedThreadTs,
+        });
+        expect(finalWrites()[0]?.accepted).toBeDefined();
+      }
       const tasks = writes
         .flatMap((write) => readChunks(write.body.chunks))
         .filter((chunk) => chunk.type === "task_update");
@@ -563,12 +640,14 @@ describe("channel progress presentation through an isolated Gateway", () => {
         expect(tasks.at(-1)?.status).toBe("complete");
       }
       await fs.writeFile(
-        path.join(evidenceDir, `${channel}-${native ? "native" : "draft"}.json`),
+        path.join(evidenceDir, `${evidenceName}.json`),
         JSON.stringify(
           {
             kind: "mock-gateway",
             channel,
             native,
+            rejectStop,
+            originCleared,
             status: "pass",
             progressWrites: progressWrites.length,
             finalWrites: finalWrites().length,


### PR DESCRIPTION
Related: #96692, #135305.

## What Problem This Solves

Short Slack answers could remain buffered locally after OpenClaw had already marked delivery successful. If progress-stream finalization then failed, the answer appeared in the session but never reached Slack.

Thanks @shannon0430 for the report. The independent announcement-receipt failure reported by @Cobblestone-Digital1 is being repaired separately.

## Why This Change Was Made

Final payloads now use the pinned Slack SDK's existing flush contract and await Slack's acknowledgement before the delivery callback resolves. Preview batching stays unchanged, multiple finals retain one stream, and progress finalization remains separate from delivery. No new fallback, configuration, dependency, storage schema, or protocol is introduced.

Current intake/recovery already records the admitted delivery target. The Gateway regression removes the mutable session delivery route after Slack accepts a progress card, then rejects stream finalization; the answer still reaches the admitted channel/thread. It removes mutable routing, not every durable admission fact. The fixture launches the runner-prepared CLI, avoiding development rebuilds during startup, and removes a retired fixture-only configuration key.

## User Impact

Native-streamed Slack answers are acknowledged before being marked delivered. A later progress-card finalization failure cannot discard an already acknowledged short answer. Existing thread placement and draft-preview behavior are preserved.

## Evidence

Pre-fix reproduction on `296b2ef4a28d0fd9767ba3b8f5c40eafab6033ae`:

```text
real Slack SDK regression: FAIL — no chat.startStream for a short final
real Gateway + mock Slack API + mock provider:
  progress card and task completion: accepted
  chat.stopStream: rejected internal_error; contained final answer
  accepted final answers: 0 (expected 1)
```

Owner regressions passed:

```text
node scripts/run-vitest.mjs extensions/slack/src/streaming.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
190 passed
```

The SDK regression covers short first/subsequent finals followed by failed stop. Existing dispatch coverage includes queued follow-ups, multiple finals, native/draft/block delivery and fallback.

Fresh-runtime proof at `efdb4cfe56260b257451783fe77bef333ffc06bd`: [Blacksmith Testbox run 33662837624](https://github.com/openclaw/openclaw/actions/runs/33662837624), task-owned lease `tbx_01m1hkg0stcnm59k4rpzarrxpe` (stopped):

```text
strict HEAD assertion: efdb4cfe56260b257451783fe77bef333ffc06bd
fresh runtime build: 4m17.4s
CI=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
4 passed (143.37s): Discord; Slack native; Slack draft; origin cleared + stop rejected
original channel/thread retained; exactly one accepted final; wrapper exit 0
```

```json
{"kind":"mock-gateway","channel":"slack","native":true,"rejectStop":true,"originCleared":true,"status":"pass","progressWrites":2,"finalWrites":1,"distinctWorkingReactions":1,"taskIds":1,"syntheticDecoration":false}
```

This runs the real Gateway, CLI and HTTP delivery against synthetic Slack/provider servers, with isolated state and a free port—not an authenticated Slack workspace. The later trace update and mechanical rebase preserve these runtime and Gateway-fixture bytes.

CI exposed three stale trace expectations that deferred short-final delivery until stop. The refreshed recordings put final text in start/append before idle, and verify ordinary-message fallback completes before settling a rejected native final. All 11 scenarios passed regeneration; normal verification of the three owner suites then passed 201/201 tests (wrapper exit0). The obsolete `stream-stop-first-network-call` scenario is renamed `short-final-native-rejection`.

The rebased head passed the same 201 owner/trace tests again (167s; wrapper exit0) and fresh committed-branch review found no actionable P0–P2 findings. Local formatting, focused root-test lint, preceding guards and doctor tests passed. The broad local check stopped at an untouched browser-plugin declaration link missing from this checkout (`@types/yargs-parser`, already declared and locked); dependencies were not edited or overridden. No complete local broad-check pass is claimed.

Current head is `a779248d206449fd13ef4ad83e0e33c76c771f47`; its exact-head CI is pending. [Run 33667327348](https://github.com/openclaw/openclaw/actions/runs/33667327348) used an older merge snapshot and failed the unrelated CLI test-file line cap. Main already repaired that in [aef65cc57490](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c); the branch is now rebased onto repaired main. All nine PR files are byte-identical to the prior head. The earlier [run 33662820809](https://github.com/openclaw/openclaw/actions/runs/33662820809) also failed `check-guards` at an unauthenticated late base fetch. Green exact-head CI remains required. The SDK-source access gap is addressed in [the pinned-source follow-up](https://github.com/openclaw/openclaw/pull/136460#issuecomment-5513545121).

Production delta: +7/-2, net +5 lines: the final-only acknowledgement boundary, not another delivery flow. Test code: +158/-42 (net +116); trace fixtures: +13/-12 (net +1, rename discounted). Docs: +1. Changelog unchanged.

Follow-up: a separate thread-target repair preserves the admitted root instead of an implicit child-message timestamp; its five Gateway scenarios now pass. Announcement receipt handling is owned by #136524. Neither defect is attributed to stream finalization. The unauthenticated changed-gate bootstrap/base fetch is also recorded as a validation-infrastructure follow-up.
