### PR TITLE
test(markdown): remove test-local membership checks

### DIFF
--- a/packages/markdown-core/src/code-spans.test.ts
+++ b/packages/markdown-core/src/code-spans.test.ts
@@ -1,4 +1,3 @@
-// Code span tests cover CommonMark block ownership and streamed lookup behavior.
 import { describe, expect, it } from "vitest";
 import { findMarkdownCodeSpans } from "./reasoning-tags.js";
 
@@ -7,19 +6,6 @@ describe("markdown-core code spans", () => {
     const regions = findMarkdownCodeSpans(text);
     expect(regions).toHaveLength(expectedSlices.length);
     expect(regions.map(([start, end]) => text.slice(start, end))).toEqual(expectedSlices);
-  }
-
-  function expectInsideCodeCase(params: {
-    positionSelector: (text: string, regionEnd: number) => number;
-    expected: boolean;
-  }) {
-    const text = "plain `code` done";
-    const regions = findMarkdownCodeSpans(text);
-    const regionEnd = regions[0]?.[1] ?? -1;
-    const position = params.positionSelector(text, regionEnd);
-    expect(regions.some(([start, end]) => position >= start && position < end)).toBe(
-      params.expected,
-    );
   }
 
   it.each([
@@ -122,26 +108,6 @@ describe("markdown-core code spans", () => {
     },
   ] as const)("follows CommonMark block ownership: $name", ({ text, expectedSlices }) => {
     expectCodeRegionSlices(text, expectedSlices);
-  });
-
-  it.each([
-    {
-      name: "inside code",
-      positionSelector: (text: string) => text.indexOf("code"),
-      expected: true,
-    },
-    {
-      name: "outside code",
-      positionSelector: (text: string) => text.indexOf("plain"),
-      expected: false,
-    },
-    {
-      name: "at region end",
-      positionSelector: (_text: string, regionEnd: number) => regionEnd,
-      expected: false,
-    },
-  ] as const)("reports whether positions are inside discovered regions: $name", (testCase) => {
-    expectInsideCodeCase(testCase);
   });
 
   it("walks deeply nested Markdown without exhausting the JavaScript stack", () => {


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested test-audit cleanup removes three Markdown code-span membership checks that exercise a predicate recreated inside the test rather than the production lookup. They add maintenance cost without independently protecting the behavior.

## Why This Change Was Made

Remove that test-local helper, its three cases, and the misleading streamed-lookup header. Keep the exact scanner-span fixtures and real reasoning-tag preservation tests at their existing owners.

## User Impact

No runtime behavior changes. Maintainers retain meaningful coverage with 34 fewer test/support lines and three fewer redundant test executions.

## Evidence

- The same focused command passed before and after: `node scripts/run-vitest.mjs packages/markdown-core/src/code-spans.test.ts src/shared/text/reasoning-tags.test.ts` — 96 tests before, 93 after (19 scanner and 74 reasoning-tag cases).
- `node scripts/check-changed.mjs --base origin/main -- packages/markdown-core/src/code-spans.test.ts` passed through the configured Blacksmith Testbox route: [run 33656765033](https://github.com/openclaw/openclaw/actions/runs/33656765033), wrapper exit 0. The owned one-shot lease stopped successfully.
- Targeted formatting and `git diff --check` passed. Fresh structured Codex autoreview returned scoped-clean through P2 with no actionable findings.
- Production: +0/-0. Tests/support: +0/-34.

### Mechanical refresh onto current main

Signed head `5bd37d2dfc4c837a7f1e6f28c6806d60248fe7db` rebases the same cleanup onto `0df437f0071c53e95cbe1fd3d7a6e28079b67984`. The complete one-file patch and test afterimage are byte-identical to the originally tested `4ae4026`; the production CommonMark parser, sanitizer consumer, dependency manifests, and lockfile are also unchanged. The existing proof below remains recorded at its original head.

The refresh includes main's [circular-corner serialization repair](https://github.com/openclaw/openclaw/commit/f7c821733ff1b61e565b5f47eebf5fd5cf24b540) and [Gateway CLI test-file split](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c). The [previous exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33659340719) failed only the two corner-shape assertions repaired by that main commit; the required aggregate failed as a consequence. This refresh has no production or additional test changes. Signature verification and `git diff --check` passed.

### Observed production-consumer behavior

This is @steipete's maintainer-requested test audit: production **+0/-0**, tests **+0/-34**. The production parser and consumer are unchanged. To make the retained behavior inspectable, the following standalone run invoked `stripReasoningTagsFromText` from the production source at head `4ae40266937c91e5643a80df4f2a5da183e13b0f`, using the repository TypeScript loader, without Vitest or mocks.

Observed on macOS arm64, Node v26.8.1, `TZ=UTC`: **exit 0**, empty stderr, exact output assertion passed. Synthetic reasoning in prose is removed, final-tag contents remain visible, and inline/fenced code literals preserve their tags. This is a local text-sanitizing consumer check; the existing 93 retained tests and changed-path gate provide the broader proof.

<details>
<summary>Exact command and observed output</summary>

Run from the repository root at the reviewed head:

````sh
test "$(git rev-parse HEAD)" = 4ae40266937c91e5643a80df4f2a5da183e13b0f &&
env -u GITHUB_TOKEN -u GH_TOKEN -u HOMEBREW_GITHUB_API_TOKEN TZ=UTC \
  node --import ./scripts/tsx.mjs --input-type=module <<'NODE'
import assert from "node:assert/strict";
import { stripReasoningTagsFromText } from "./src/shared/text/reasoning-tags.js";

const input = [
  "Before.",
  "<think>synthetic hidden reasoning</think><final>Visible answer.</final>",
  "Inline: `<think>literal inline</think>` and `<final>literal final</final>`.",
  "```xml",
  "<think>literal fenced</think>",
  "<final>literal fenced final</final>",
  "```",
  "After.",
].join("\n");
const expected = [
  "Before.",
  "Visible answer.",
  "Inline: `<think>literal inline</think>` and `<final>literal final</final>`.",
  "```xml",
  "<think>literal fenced</think>",
  "<final>literal fenced final</final>",
  "```",
  "After.",
].join("\n");
const output = stripReasoningTagsFromText(input);
assert.equal(output, expected);
console.log(JSON.stringify({ input, output, exactMatch: true }, null, 2));
NODE
````

Observed stdout:

````json
{
  "input": "Before.\n<think>synthetic hidden reasoning</think><final>Visible answer.</final>\nInline: `<think>literal inline</think>` and `<final>literal final</final>`.\n```xml\n<think>literal fenced</think>\n<final>literal fenced final</final>\n```\nAfter.",
  "output": "Before.\nVisible answer.\nInline: `<think>literal inline</think>` and `<final>literal final</final>`.\n```xml\n<think>literal fenced</think>\n<final>literal fenced final</final>\n```\nAfter.",
  "exactMatch": true
}
````

</details>
