### PR TITLE
fix(doctor): report unowned routes and repair account bindings

### DIFF
--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -238,8 +238,8 @@ For a multi-agent roster defined directly in the main config file without a
 legacy `default: true` marker, Doctor adds `agents.ownership: "explicit"` for
 both keyed `agents.entries` and older `agents.list` rosters, including with
 `--fix --non-interactive`. Existing bindings and per-surface owners remain
-unchanged. If an account has no fallback route but its existing narrower bindings
-all target one configured agent, Doctor adds an account-scoped binding for that
+unchanged. If an account has no fallback route but its matchable narrower bindings
+all explicitly name one configured agent, Doctor adds an account-scoped binding for that
 agent. It does not borrow ownership from another account or channel, choose
 between conflicting owners, or assign other unowned surfaces.
 

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -238,7 +238,10 @@ For a multi-agent roster defined directly in the main config file without a
 legacy `default: true` marker, Doctor adds `agents.ownership: "explicit"` for
 both keyed `agents.entries` and older `agents.list` rosters, including with
 `--fix --non-interactive`. Existing bindings and per-surface owners remain
-unchanged; Doctor does not choose an agent for unowned surfaces.
+unchanged. If an account has no fallback route but its existing narrower bindings
+all target one configured agent, Doctor adds an account-scoped binding for that
+agent. It does not borrow ownership from another account or channel, choose
+between conflicting owners, or assign other unowned surfaces.
 
 When migrating a legacy `agents.list` roster without a default marker, Doctor
 also pins the first agent's inherited workspace to `agents.entries.<id>.workspace`. Its customized instructions

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -368,8 +368,8 @@ That stages grounded durable candidates into the short-term dreaming store while
     - If `channels.<channel>.defaultAccount` is set to an unknown account ID, doctor warns and lists configured account IDs.
 
     In multi-agent configs, `doctor --fix` adds a missing account-scoped routing
-    binding when all existing narrower bindings for that channel/account name
-    one configured agent. Existing routes remain unchanged. Accounts with no
+    binding when all matchable narrower bindings for that channel/account explicitly
+    name one configured agent. Existing routes remain unchanged. Accounts with no
     owner evidence or conflicting owners need an explicit binding; Doctor does
     not infer their owner from roster order or another channel/account.
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -556,6 +556,8 @@ That stages grounded durable candidates into the short-term dreaming store while
     Missing multi-agent DM routing ownership is reported as a finding. It does
     not stop the remaining channel security checks or pending state migrations.
     Configure the reported account binding before expecting that route to work.
+    Telegram account discovery preserves the legacy default-agent account choice
+    during upgrade previews without requiring an ambient agent.
 
   </Accordion>
   <Accordion title="10. systemd linger (Linux)">

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -367,6 +367,12 @@ That stages grounded durable candidates into the short-term dreaming store while
     - If two or more `channels.<channel>.accounts` entries are configured without `channels.<channel>.defaultAccount` or `accounts.default`, doctor warns that fallback routing can pick an unexpected account.
     - If `channels.<channel>.defaultAccount` is set to an unknown account ID, doctor warns and lists configured account IDs.
 
+    In multi-agent configs, `doctor --fix` adds a missing account-scoped routing
+    binding when all existing narrower bindings for that channel/account name
+    one configured agent. Existing routes remain unchanged. Accounts with no
+    owner evidence or conflicting owners need an explicit binding; Doctor does
+    not infer their owner from roster order or another channel/account.
+
   </Accordion>
   <Accordion title="2b. OpenCode provider overrides">
     If you have added `models.providers.opencode`, `opencode-zen`, or `opencode-go` manually while the matching official external plugin is installed and enabled, it overrides that plugin-provided catalog. That can force models onto the wrong API or zero out costs. Doctor warns so you can remove the override and restore per-model API routing + costs. Without the matching plugin, the entry remains a valid standalone custom provider.
@@ -546,6 +552,11 @@ That stages grounded durable candidates into the short-term dreaming store while
   </Accordion>
   <Accordion title="9. Security warnings">
     Doctor emits a Security note only when it finds a warning, such as a provider open to DMs without an allowlist or a dangerously configured policy. Use `openclaw security audit` for the full security inventory.
+
+    Missing multi-agent DM routing ownership is reported as a finding. It does
+    not stop the remaining channel security checks or pending state migrations.
+    Configure the reported account binding before expecting that route to work.
+
   </Accordion>
   <Accordion title="10. systemd linger (Linux)">
     If running as a systemd user service, doctor ensures lingering is enabled so the gateway stays alive after logout.

--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -9,20 +9,19 @@ import {
   normalizeAccountId,
   normalizeOptionalAccountId,
 } from "openclaw/plugin-sdk/account-id";
-import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
+import { listAgentIds } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { resolveDefaultAgentBoundAccountId } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 function resolveBindingAccount(params: {
   binding: unknown;
   channelId: string;
-}): { agentId: string; accountId: string } | null {
+}): { accountId: string } | null {
   if (!params.binding || typeof params.binding !== "object") {
     return null;
   }
   const binding = params.binding as {
-    agentId?: unknown;
     match?: { channel?: unknown; accountId?: unknown };
   };
   if (normalizeLowercaseStringOrEmpty(binding.match?.channel) !== params.channelId) {
@@ -33,7 +32,6 @@ function resolveBindingAccount(params: {
     return null;
   }
   return {
-    agentId: normalizeAgentId(typeof binding.agentId === "string" ? binding.agentId : undefined),
     accountId: normalizeAccountId(accountId),
   };
 }
@@ -47,20 +45,6 @@ function listBoundAccountIds(cfg: OpenClawConfig, channelId: string): string[] {
     }
   }
   return [...ids].toSorted((left, right) => left.localeCompare(right));
-}
-
-function resolveDefaultAgentBoundAccountId(cfg: OpenClawConfig, channelId: string): string | null {
-  if (cfg.agents?.ownership === "explicit" && listAgentIds(cfg).length !== 1) {
-    return null;
-  }
-  const defaultAgentId = resolveDefaultAgentId(cfg);
-  for (const binding of cfg.bindings ?? []) {
-    const resolved = resolveBindingAccount({ binding, channelId });
-    if (resolved?.agentId === defaultAgentId) {
-      return resolved.accountId;
-    }
-  }
-  return null;
 }
 
 function hasImplicitDefaultTelegramAccount(cfg: OpenClawConfig): boolean {
@@ -88,7 +72,11 @@ export function resolveDefaultTelegramAccountSelection(cfg: OpenClawConfig): {
   accountIds: string[];
   shouldWarnMissingDefault: boolean;
 } {
-  const boundDefault = resolveDefaultAgentBoundAccountId(cfg, "telegram");
+  // Explicit fleets use channel defaults, not a retained legacy migration owner.
+  const boundDefault =
+    cfg.agents?.ownership === "explicit" && listAgentIds(cfg).length !== 1
+      ? null
+      : resolveDefaultAgentBoundAccountId(cfg, "telegram");
   if (boundDefault) {
     return {
       accountId: boundDefault,

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -1,7 +1,10 @@
 // Telegram tests cover accounts plugin behavior.
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { readConfigFileSnapshotForWrite } from "openclaw/plugin-sdk/config-mutation";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import { withEnv } from "openclaw/plugin-sdk/test-env";
+import { withEnv, withTempHome } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTelegramActionGate,
@@ -250,6 +253,50 @@ describe("resolveDefaultTelegramAccountId", () => {
   afterEach(() => {
     warnMock.mockClear();
     resetMissingDefaultWarnFlag();
+  });
+
+  it("selects an account without requiring an ambient agent during legacy repair", () => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: {}, research: {} } },
+      channels: {
+        telegram: {
+          defaultAccount: "work",
+          accounts: { alerts: {}, work: {} },
+        },
+      },
+    };
+
+    expect(resolveDefaultTelegramAccountId(cfg)).toBe("work");
+  });
+
+  it("preserves a loaded legacy owner's account until explicit fleet ownership is applied", async () => {
+    await withTempHome(
+      async (home) => {
+        const config: OpenClawConfig = {
+          agents: { entries: { main: { default: true }, research: {} } },
+          channels: {
+            telegram: {
+              defaultAccount: "alerts",
+              accounts: { alerts: {}, work: {} },
+            },
+          },
+          bindings: [{ agentId: "main", match: { channel: "telegram", accountId: "work" } }],
+        };
+        await fs.writeFile(path.join(home, ".openclaw", "openclaw.json"), JSON.stringify(config));
+        const { snapshot } = await readConfigFileSnapshotForWrite();
+
+        expect(snapshot.valid).toBe(true);
+        expect(resolveDefaultTelegramAccountId(snapshot.config)).toBe("work");
+        snapshot.config.agents!.ownership = "explicit";
+        expect(resolveDefaultTelegramAccountId(snapshot.config)).toBe("alerts");
+      },
+      {
+        env: {
+          OPENCLAW_CONFIG_PATH: (home) => path.join(home, ".openclaw", "openclaw.json"),
+          TELEGRAM_BOT_TOKEN: "",
+        },
+      },
+    );
   });
 
   it("warns when accounts.default is missing in multi-account setup (#32137)", () => {

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
@@ -78,6 +78,7 @@ describe("doctor missing default account binding warning", () => {
 
 type OwnershipRepairCase = {
   name: string;
+  agents?: OpenClawConfig["agents"];
   envToken?: boolean;
   discord: NonNullable<OpenClawConfig["channels"]>["discord"];
   bindings: NonNullable<OpenClawConfig["bindings"]>;
@@ -160,6 +161,21 @@ describe("doctor channel account ownership repair", () => {
       added: [],
     },
     {
+      name: "blank owner even when main is configured",
+      agents: { ownership: "explicit", entries: { main: {}, research: {} } },
+      discord: {},
+      bindings: [{ agentId: "   ", match: { channel: "discord", guildId: "guild-a" } }],
+      added: [],
+    },
+    {
+      name: "empty peer that cannot match a route",
+      discord: {},
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", peer: { kind: "direct", id: " " } } },
+      ],
+      added: [],
+    },
+    {
       name: "ambiguous guild owners",
       discord: {},
       bindings: [
@@ -193,7 +209,7 @@ describe("doctor channel account ownership repair", () => {
       "envToken" in testCase && testCase.envToken ? "synthetic-discord-token" : undefined,
     );
     const config: OpenClawConfig = {
-      agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+      agents: testCase.agents ?? { ownership: "explicit", entries: { ops: {}, research: {} } },
       channels: { discord },
       bindings,
     };

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
@@ -1,6 +1,11 @@
 // Doctor default-account integration tests cover binding warnings across realistic config shapes.
-import { describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { readConfigFileSnapshot, type OpenClawConfig } from "../config/config.js";
+import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 import {
   collectMissingDefaultAccountBindingWarnings,
   collectMissingExplicitDefaultAccountWarnings,
@@ -58,5 +63,116 @@ describe("doctor missing default account binding warning", () => {
     expect(warnings).toEqual([
       '- channels.telegram: defaultAccount is set to "missing" but does not match configured accounts (alerts, work). Set channels.telegram.defaultAccount to one of these accounts, or add channels.telegram.accounts.default to avoid fallback routing.',
     ]);
+  });
+});
+
+describe("doctor channel account ownership repair", () => {
+  afterEach(() => closeOpenClawStateDatabaseForTest());
+
+  it.each([
+    {
+      name: "implicit default account",
+      discord: {},
+      bindings: [{ agentId: "ops", match: { channel: "discord", guildId: "guild-a" } }],
+      added: [{ agentId: "ops", match: { channel: "discord", accountId: "default" } }],
+    },
+    {
+      name: "named account without widening other account or guild owners",
+      discord: { accounts: { alerts: {}, work: {} } },
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", accountId: "alerts", guildId: "guild-a" } },
+        { agentId: "ops", match: { channel: "discord", accountId: "alerts", guildId: "guild-b" } },
+        { agentId: "research", match: { channel: "discord", accountId: "work" } },
+      ],
+      added: [{ agentId: "ops", match: { channel: "discord", accountId: "alerts" } }],
+    },
+    {
+      name: "narrow wildcard ownership without inventing a default account",
+      discord: { accounts: { alerts: {}, work: { enabled: false } } },
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", accountId: "*", guildId: "guild-a" } },
+      ],
+      added: [{ agentId: "ops", match: { channel: "discord", accountId: "alerts" } }],
+    },
+    {
+      name: "disabled default account alongside an active account",
+      discord: { accounts: { default: { enabled: false }, work: {} } },
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", guildId: "guild-a" } },
+        {
+          agentId: "research",
+          match: { channel: "discord", accountId: "work", guildId: "guild-b" },
+        },
+      ],
+      added: [{ agentId: "research", match: { channel: "discord", accountId: "work" } }],
+    },
+    {
+      name: "disabled channel",
+      discord: { enabled: false },
+      bindings: [{ agentId: "ops", match: { channel: "discord", guildId: "guild-a" } }],
+      added: [],
+    },
+    {
+      name: "unconfigured legacy main owner",
+      discord: {},
+      bindings: [{ agentId: "main", match: { channel: "discord", guildId: "guild-a" } }],
+      added: [],
+    },
+    {
+      name: "ambiguous guild owners",
+      discord: {},
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", guildId: "guild-a" } },
+        { agentId: "research", match: { channel: "discord", guildId: "guild-b" } },
+      ],
+      added: [],
+    },
+    {
+      name: "missing owner despite bindings on another account and channel",
+      discord: { accounts: { default: {}, work: {} } },
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", accountId: "work" } },
+        { agentId: "ops", match: { channel: "telegram", accountId: "default" } },
+      ],
+      added: [],
+    },
+    {
+      name: "existing channel-wide route",
+      discord: { accounts: { default: {}, work: {} } },
+      bindings: [
+        { agentId: "research", match: { channel: "discord", accountId: "*" } },
+        { agentId: "ops", match: { channel: "discord", guildId: "guild-a" } },
+      ],
+      added: [],
+    },
+  ] satisfies Array<{
+    name: string;
+    discord: NonNullable<OpenClawConfig["channels"]>["discord"];
+    bindings: NonNullable<OpenClawConfig["bindings"]>;
+    added: NonNullable<OpenClawConfig["bindings"]>;
+  }>)("persists only proven ownership for $name", async ({ discord, bindings, added }) => {
+    await withTempHome(async (home) => {
+      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        const configPath = await writeOpenClawConfig(home, {
+          agents: { entries: { ops: {}, research: {} } },
+          channels: { discord },
+          bindings,
+          gateway: { mode: "local" },
+          plugins: { enabled: false },
+        });
+        const ctx = await prepareDoctorContext(configPath);
+        await runInitialConfigWriteHealth(ctx);
+        expect(ctx.configWriteRefusal).toBeUndefined();
+
+        const saved = await readConfigFileSnapshot();
+        expect(saved.config.bindings).toEqual([...bindings, ...added]);
+        for (const binding of added) {
+          expect(resolveAgentRoute({ cfg: saved.config, ...binding.match }).agentId).toBe(
+            binding.agentId,
+          );
+        }
+        expect((await prepareDoctorContext(configPath)).configResult.shouldWriteConfig).toBe(false);
+      });
+    });
   });
 });

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
@@ -76,10 +76,18 @@ describe("doctor missing default account binding warning", () => {
   });
 });
 
+type OwnershipRepairCase = {
+  name: string;
+  envToken?: boolean;
+  discord: NonNullable<OpenClawConfig["channels"]>["discord"];
+  bindings: NonNullable<OpenClawConfig["bindings"]>;
+  added: NonNullable<OpenClawConfig["bindings"]>;
+};
+
 describe("doctor channel account ownership repair", () => {
   afterEach(() => vi.unstubAllEnvs());
 
-  it.each([
+  it.each<OwnershipRepairCase>([
     {
       name: "implicit default account",
       discord: {},
@@ -178,13 +186,7 @@ describe("doctor channel account ownership repair", () => {
       ],
       added: [],
     },
-  ] satisfies Array<{
-    name: string;
-    envToken?: boolean;
-    discord: NonNullable<OpenClawConfig["channels"]>["discord"];
-    bindings: NonNullable<OpenClawConfig["bindings"]>;
-    added: NonNullable<OpenClawConfig["bindings"]>;
-  }>)("repairs only proven ownership for $name", (testCase) => {
+  ])("repairs only proven ownership for $name", (testCase) => {
     const { discord, bindings, added } = testCase;
     vi.stubEnv(
       "DISCORD_BOT_TOKEN",

--- a/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
+++ b/src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts
@@ -1,15 +1,25 @@
 // Doctor default-account integration tests cover binding warnings across realistic config shapes.
-import { afterEach, describe, expect, it } from "vitest";
-import { readConfigFileSnapshot, type OpenClawConfig } from "../config/config.js";
-import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
-import { runInitialConfigWriteHealth } from "../flows/doctor-health-contribution-runners.config.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { prepareDoctorContext } from "./doctor-config-flow.test-support.js";
 import {
   collectMissingDefaultAccountBindingWarnings,
   collectMissingExplicitDefaultAccountWarnings,
 } from "./doctor/shared/default-account-warnings.js";
+import { repairUnownedChannelAccountBindings } from "./doctor/shared/legacy-config-binding-repair.js";
+
+vi.mock("../channels/plugins/read-only.js", () => ({
+  resolveReadOnlyChannelPluginsForConfig: () => {
+    const { listAccountIds } = createAccountListHelpers("discord", {
+      implicitDefaultAccount: { channelKeys: ["token"], envVars: ["DISCORD_BOT_TOKEN"] },
+    });
+    return {
+      configuredChannelIds: ["discord"],
+      plugins: [{ id: "discord", config: { listAccountIds } }],
+    };
+  },
+}));
 
 describe("doctor missing default account binding warning", () => {
   it("warns when named accounts have no valid account-scoped bindings", () => {
@@ -67,7 +77,7 @@ describe("doctor missing default account binding warning", () => {
 });
 
 describe("doctor channel account ownership repair", () => {
-  afterEach(() => closeOpenClawStateDatabaseForTest());
+  afterEach(() => vi.unstubAllEnvs());
 
   it.each([
     {
@@ -85,6 +95,29 @@ describe("doctor channel account ownership repair", () => {
         { agentId: "research", match: { channel: "discord", accountId: "work" } },
       ],
       added: [{ agentId: "ops", match: { channel: "discord", accountId: "alerts" } }],
+    },
+    {
+      name: "environment-only default account alongside a named account",
+      envToken: true,
+      discord: { accounts: { alerts: {} } },
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", accountId: "*", guildId: "guild-a" } },
+      ],
+      added: [
+        { agentId: "ops", match: { channel: "discord", accountId: "alerts" } },
+        { agentId: "ops", match: { channel: "discord", accountId: "default" } },
+      ],
+    },
+    {
+      name: "root-token default account alongside a named account",
+      discord: { token: "synthetic-discord-token", accounts: { alerts: {} } },
+      bindings: [
+        { agentId: "ops", match: { channel: "discord", accountId: "*", guildId: "guild-a" } },
+      ],
+      added: [
+        { agentId: "ops", match: { channel: "discord", accountId: "alerts" } },
+        { agentId: "ops", match: { channel: "discord", accountId: "default" } },
+      ],
     },
     {
       name: "narrow wildcard ownership without inventing a default account",
@@ -147,32 +180,30 @@ describe("doctor channel account ownership repair", () => {
     },
   ] satisfies Array<{
     name: string;
+    envToken?: boolean;
     discord: NonNullable<OpenClawConfig["channels"]>["discord"];
     bindings: NonNullable<OpenClawConfig["bindings"]>;
     added: NonNullable<OpenClawConfig["bindings"]>;
-  }>)("persists only proven ownership for $name", async ({ discord, bindings, added }) => {
-    await withTempHome(async (home) => {
-      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
-        const configPath = await writeOpenClawConfig(home, {
-          agents: { entries: { ops: {}, research: {} } },
-          channels: { discord },
-          bindings,
-          gateway: { mode: "local" },
-          plugins: { enabled: false },
-        });
-        const ctx = await prepareDoctorContext(configPath);
-        await runInitialConfigWriteHealth(ctx);
-        expect(ctx.configWriteRefusal).toBeUndefined();
-
-        const saved = await readConfigFileSnapshot();
-        expect(saved.config.bindings).toEqual([...bindings, ...added]);
-        for (const binding of added) {
-          expect(resolveAgentRoute({ cfg: saved.config, ...binding.match }).agentId).toBe(
-            binding.agentId,
-          );
-        }
-        expect((await prepareDoctorContext(configPath)).configResult.shouldWriteConfig).toBe(false);
-      });
-    });
+  }>)("repairs only proven ownership for $name", (testCase) => {
+    const { discord, bindings, added } = testCase;
+    vi.stubEnv(
+      "DISCORD_BOT_TOKEN",
+      "envToken" in testCase && testCase.envToken ? "synthetic-discord-token" : undefined,
+    );
+    const config: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+      channels: { discord },
+      bindings,
+    };
+    const repaired = repairUnownedChannelAccountBindings(config);
+    expect(repaired.config.bindings).toEqual([...bindings, ...added]);
+    for (const binding of added) {
+      expect(resolveAgentRoute({ cfg: repaired.config, ...binding.match }).agentId).toBe(
+        binding.agentId,
+      );
+    }
+    const secondPass = repairUnownedChannelAccountBindings(repaired.config);
+    expect(secondPass.config).toBe(repaired.config);
+    expect(secondPass.changes).toEqual([]);
   });
 });

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -416,9 +416,14 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
 
   const { repairUnownedChannelAccountBindings } =
     await import("./doctor/shared/legacy-config-binding-repair.js");
-  applyConfigMutation(repairUnownedChannelAccountBindings(state.candidate), {
-    fixHint: `Run "${doctorFixCommand}" to bind channel accounts with a single existing route owner.`,
-  });
+  applyConfigMutation(
+    runWithCurrentPluginMetadata(state.candidate, () =>
+      repairUnownedChannelAccountBindings(state.candidate),
+    ),
+    {
+      fixHint: `Run "${doctorFixCommand}" to bind channel accounts with a single existing route owner.`,
+    },
+  );
 
   const { prepareTailscaleConfigMigration } = await import("./doctor-tailscale.js");
   applyConfigMutation(

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -414,6 +414,12 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     emitWarnings: true,
   });
 
+  const { repairUnownedChannelAccountBindings } =
+    await import("./doctor/shared/legacy-config-binding-repair.js");
+  applyConfigMutation(repairUnownedChannelAccountBindings(state.candidate), {
+    fixHint: `Run "${doctorFixCommand}" to bind channel accounts with a single existing route owner.`,
+  });
+
   const { prepareTailscaleConfigMigration } = await import("./doctor-tailscale.js");
   applyConfigMutation(
     await prepareTailscaleConfigMigration({

--- a/src/commands/doctor/shared/legacy-config-binding-repair.ts
+++ b/src/commands/doctor/shared/legacy-config-binding-repair.ts
@@ -2,12 +2,13 @@
 import { asNullableRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import { AgentSelectionRequiredError, listAgentIds } from "../../../agents/agent-scope-config.js";
 import { resolveReadOnlyChannelPluginsForConfig } from "../../../channels/plugins/read-only.js";
-import { listRouteBindings } from "../../../config/bindings.js";
 import type { AgentRouteBinding } from "../../../config/types.agents.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveNormalizedAccountEntry } from "../../../routing/account-lookup.js";
-import { normalizeRouteBindingChannelId } from "../../../routing/binding-scope.js";
-import { resolveAgentRoute } from "../../../routing/resolve-route.js";
+import {
+  listChannelAccountRouteBindings,
+  resolveAgentRoute,
+} from "../../../routing/resolve-route.js";
 import {
   DEFAULT_AGENT_ID,
   normalizeAccountId,
@@ -61,7 +62,7 @@ export function repairUnownedChannelAccountBindings(
 ): DoctorConfigMutationResult {
   const agentIds = new Set(listAgentIds(cfg));
   const additions: AgentRouteBinding[] = [];
-  // Leave malformed binding input to config validation; it cannot establish an owner.
+  // Malformed or ownerless bindings cannot establish an explicit repair owner.
   if (
     agentIds.size < 2 ||
     cfg.plugins?.enabled === false ||
@@ -72,13 +73,13 @@ export function repairUnownedChannelAccountBindings(
         isRecord(binding) &&
         isRecord(binding.match) &&
         typeof binding.agentId === "string" &&
+        binding.agentId.trim().length > 0 &&
         typeof binding.match.channel === "string" &&
         (binding.match.accountId === undefined || typeof binding.match.accountId === "string"),
     )
   ) {
     return { config: cfg, changes: [] };
   }
-  const bindings = listRouteBindings(cfg);
   const inventory = resolveReadOnlyChannelPluginsForConfig(cfg, {
     includePersistedAuthState: false,
     includeSetupFallbackPlugins: true,
@@ -90,9 +91,6 @@ export function repairUnownedChannelAccountBindings(
     if (!plugin || channel?.enabled === false) {
       continue;
     }
-    const channelBindings = bindings.filter(
-      (binding) => normalizeRouteBindingChannelId(binding.match.channel) === channelId,
-    );
     const accounts = asNullableRecord(channel?.accounts) ?? undefined;
     const accountIds = [
       ...new Set(plugin.config.listAccountIds(cfg).map(normalizeAccountId)),
@@ -102,8 +100,9 @@ export function repairUnownedChannelAccountBindings(
       if (asNullableRecord(account)?.enabled === false) {
         continue;
       }
+      const routeInput = { cfg, channel: channelId, accountId };
       try {
-        resolveAgentRoute({ cfg, channel: channelId, accountId });
+        resolveAgentRoute(routeInput);
         continue;
       } catch (error) {
         if (!(error instanceof AgentSelectionRequiredError)) {
@@ -111,13 +110,9 @@ export function repairUnownedChannelAccountBindings(
         }
       }
       const owners = new Set(
-        channelBindings
-          .filter(
-            (binding) =>
-              binding.match.accountId?.trim() === "*" ||
-              normalizeAccountId(binding.match.accountId) === accountId,
-          )
-          .map((binding) => normalizeAgentId(binding.agentId)),
+        listChannelAccountRouteBindings(routeInput).map((binding) =>
+          normalizeAgentId(binding.agentId),
+        ),
       );
       const [agentId] = owners;
       if (owners.size === 1 && agentId && agentIds.has(agentId)) {

--- a/src/commands/doctor/shared/legacy-config-binding-repair.ts
+++ b/src/commands/doctor/shared/legacy-config-binding-repair.ts
@@ -1,19 +1,19 @@
 // Repairs canonical binding references after agent config migration.
 import { asNullableRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import { AgentSelectionRequiredError, listAgentIds } from "../../../agents/agent-scope-config.js";
+import { resolveReadOnlyChannelPluginsForConfig } from "../../../channels/plugins/read-only.js";
 import { listRouteBindings } from "../../../config/bindings.js";
 import type { AgentRouteBinding } from "../../../config/types.agents.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveNormalizedAccountEntry } from "../../../routing/account-lookup.js";
 import { normalizeRouteBindingChannelId } from "../../../routing/binding-scope.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import {
-  DEFAULT_ACCOUNT_ID,
   DEFAULT_AGENT_ID,
   normalizeAccountId,
   normalizeAgentId,
 } from "../../../routing/session-key.js";
 import type { DoctorConfigMutationResult } from "./config-mutation-state.js";
-import { listDoctorConfiguredChannelIds } from "./configured-channel-ids.js";
 
 export function pruneBindingsForMissingAgents(
   cfg: OpenClawConfig,
@@ -64,7 +64,9 @@ export function repairUnownedChannelAccountBindings(
   // Leave malformed binding input to config validation; it cannot establish an owner.
   if (
     agentIds.size < 2 ||
+    cfg.plugins?.enabled === false ||
     !Array.isArray(cfg.bindings) ||
+    cfg.bindings.length === 0 ||
     !cfg.bindings.every(
       (binding) =>
         isRecord(binding) &&
@@ -77,38 +79,27 @@ export function repairUnownedChannelAccountBindings(
     return { config: cfg, changes: [] };
   }
   const bindings = listRouteBindings(cfg);
-  const channelKeys = listDoctorConfiguredChannelIds(cfg, {
-    configEntryPolicy: "enabled",
-    sort: "codepoint",
+  const inventory = resolveReadOnlyChannelPluginsForConfig(cfg, {
+    includePersistedAuthState: false,
+    includeSetupFallbackPlugins: true,
   });
-  for (const channelKey of channelKeys) {
-    const channel = asNullableRecord(cfg.channels?.[channelKey]);
-    const channelId = normalizeRouteBindingChannelId(channelKey);
-    if (!channel || !channelId) {
+  const plugins = new Map(inventory.plugins.map((plugin) => [plugin.id, plugin]));
+  for (const channelId of [...inventory.configuredChannelIds].toSorted()) {
+    const plugin = plugins.get(channelId);
+    const channel = asNullableRecord(cfg.channels?.[channelId]);
+    if (!plugin || channel?.enabled === false) {
       continue;
     }
     const channelBindings = bindings.filter(
       (binding) => normalizeRouteBindingChannelId(binding.match.channel) === channelId,
     );
-    const accounts = new Map(
-      Object.entries(asNullableRecord(channel.accounts) ?? {}).map(([id, account]) => [
-        normalizeAccountId(id),
-        account,
-      ]),
-    );
-    if (
-      !accounts.has(DEFAULT_ACCOUNT_ID) &&
-      (accounts.size === 0 ||
-        channelBindings.some(
-          (binding) =>
-            binding.match.accountId?.trim() !== "*" &&
-            normalizeAccountId(binding.match.accountId) === DEFAULT_ACCOUNT_ID,
-        ))
-    ) {
-      accounts.set(DEFAULT_ACCOUNT_ID, {});
-    }
-    for (const accountId of [...accounts.keys()].toSorted()) {
-      if (asNullableRecord(accounts.get(accountId))?.enabled === false) {
+    const accounts = asNullableRecord(channel?.accounts) ?? undefined;
+    const accountIds = [
+      ...new Set(plugin.config.listAccountIds(cfg).map(normalizeAccountId)),
+    ].toSorted();
+    for (const accountId of accountIds) {
+      const account = resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId);
+      if (asNullableRecord(account)?.enabled === false) {
         continue;
       }
       try {

--- a/src/commands/doctor/shared/legacy-config-binding-repair.ts
+++ b/src/commands/doctor/shared/legacy-config-binding-repair.ts
@@ -1,6 +1,19 @@
 // Repairs canonical binding references after agent config migration.
+import { asNullableRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
+import { AgentSelectionRequiredError, listAgentIds } from "../../../agents/agent-scope-config.js";
+import { listRouteBindings } from "../../../config/bindings.js";
+import type { AgentRouteBinding } from "../../../config/types.agents.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../../routing/session-key.js";
+import { normalizeRouteBindingChannelId } from "../../../routing/binding-scope.js";
+import { resolveAgentRoute } from "../../../routing/resolve-route.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  DEFAULT_AGENT_ID,
+  normalizeAccountId,
+  normalizeAgentId,
+} from "../../../routing/session-key.js";
+import type { DoctorConfigMutationResult } from "./config-mutation-state.js";
+import { listDoctorConfiguredChannelIds } from "./configured-channel-ids.js";
 
 export function pruneBindingsForMissingAgents(
   cfg: OpenClawConfig,
@@ -39,5 +52,94 @@ export function pruneBindingsForMissingAgents(
   return {
     ...cfg,
     ...(nextBindings.length > 0 ? { bindings: nextBindings } : { bindings: undefined }),
+  };
+}
+
+/** Materialize only channel-account owners already established by narrower route bindings. */
+export function repairUnownedChannelAccountBindings(
+  cfg: OpenClawConfig,
+): DoctorConfigMutationResult {
+  const agentIds = new Set(listAgentIds(cfg));
+  const additions: AgentRouteBinding[] = [];
+  // Leave malformed binding input to config validation; it cannot establish an owner.
+  if (
+    agentIds.size < 2 ||
+    !Array.isArray(cfg.bindings) ||
+    !cfg.bindings.every(
+      (binding) =>
+        isRecord(binding) &&
+        isRecord(binding.match) &&
+        typeof binding.agentId === "string" &&
+        typeof binding.match.channel === "string" &&
+        (binding.match.accountId === undefined || typeof binding.match.accountId === "string"),
+    )
+  ) {
+    return { config: cfg, changes: [] };
+  }
+  const bindings = listRouteBindings(cfg);
+  const channelKeys = listDoctorConfiguredChannelIds(cfg, {
+    configEntryPolicy: "enabled",
+    sort: "codepoint",
+  });
+  for (const channelKey of channelKeys) {
+    const channel = asNullableRecord(cfg.channels?.[channelKey]);
+    const channelId = normalizeRouteBindingChannelId(channelKey);
+    if (!channel || !channelId) {
+      continue;
+    }
+    const channelBindings = bindings.filter(
+      (binding) => normalizeRouteBindingChannelId(binding.match.channel) === channelId,
+    );
+    const accounts = new Map(
+      Object.entries(asNullableRecord(channel.accounts) ?? {}).map(([id, account]) => [
+        normalizeAccountId(id),
+        account,
+      ]),
+    );
+    if (
+      !accounts.has(DEFAULT_ACCOUNT_ID) &&
+      (accounts.size === 0 ||
+        channelBindings.some(
+          (binding) =>
+            binding.match.accountId?.trim() !== "*" &&
+            normalizeAccountId(binding.match.accountId) === DEFAULT_ACCOUNT_ID,
+        ))
+    ) {
+      accounts.set(DEFAULT_ACCOUNT_ID, {});
+    }
+    for (const accountId of [...accounts.keys()].toSorted()) {
+      if (asNullableRecord(accounts.get(accountId))?.enabled === false) {
+        continue;
+      }
+      try {
+        resolveAgentRoute({ cfg, channel: channelId, accountId });
+        continue;
+      } catch (error) {
+        if (!(error instanceof AgentSelectionRequiredError)) {
+          throw error;
+        }
+      }
+      const owners = new Set(
+        channelBindings
+          .filter(
+            (binding) =>
+              binding.match.accountId?.trim() === "*" ||
+              normalizeAccountId(binding.match.accountId) === accountId,
+          )
+          .map((binding) => normalizeAgentId(binding.agentId)),
+      );
+      const [agentId] = owners;
+      if (owners.size === 1 && agentId && agentIds.has(agentId)) {
+        // An exact account fallback preserves narrower precedence and never assigns sibling accounts.
+        additions.push({ agentId, match: { channel: channelId, accountId } });
+      }
+    }
+  }
+  return {
+    config: additions.length ? { ...cfg, bindings: [...cfg.bindings, ...additions] } : cfg,
+    changes: additions.map(
+      ({ agentId, match }) =>
+        `Bound ${match.channel}:${match.accountId} to its sole configured route owner "${agentId}".`,
+    ),
   };
 }

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -256,6 +256,10 @@ function buildEvaluatedBindingsByChannel(
       continue;
     }
     const match = normalizeBindingMatch(binding.match);
+    // Unmatchable peers cannot establish routing or account-ownership evidence.
+    if (match.peer.state === "invalid") {
+      continue;
+    }
     const evaluated: EvaluatedBinding = {
       binding,
       match,
@@ -486,6 +490,17 @@ function getEvaluatedBindingIndexForChannelAccount(
   return built;
 }
 
+/** @internal Lists matchable candidates from the canonical channel/account binding index. */
+export function listChannelAccountRouteBindings(
+  input: Pick<ResolveAgentRouteInput, "cfg" | "channel" | "accountId">,
+) {
+  return getEvaluatedBindingsForChannelAccount(
+    input.cfg,
+    normalizeLowercaseStringOrEmpty(input.channel),
+    normalizeAccountId(input.accountId),
+  ).map(({ binding }) => binding);
+}
+
 /** @internal Lists exact DM peers from the canonical channel/account binding index. */
 export function listExactDirectMessageBindingPeerIds(
   input: Pick<ResolveAgentRouteInput, "cfg" | "channel" | "accountId">,
@@ -593,9 +608,6 @@ function buildResolvedRouteCacheKey(params: {
 }
 
 function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope): boolean {
-  if (match.peer.state === "invalid") {
-    return false;
-  }
   if (match.peer.state === "valid") {
     if (
       !scope.peer ||

--- a/src/security/audit-channel-dm-policy.test.ts
+++ b/src/security/audit-channel-dm-policy.test.ts
@@ -81,6 +81,45 @@ function createDmPlugin(
 }
 
 describe("security audit channel dm policy", () => {
+  it.each(["doctor", "audit"] as const)(
+    "reports unowned DM routes without losing sibling findings in %s mode",
+    async (mode) => {
+      const findings = await collectChannelSecurityFindingsCore({
+        mode,
+        cfg: {
+          agents: { entries: { main: {}, research: {} } },
+          bindings: [{ agentId: "research", match: { channel: "whatsapp", accountId: "owned" } }],
+        },
+        plugins: [
+          createDmPlugin({
+            accounts: {
+              finite: { allowFrom: ["user-a", "user-b"] },
+              open: { policy: "open", allowFrom: ["*"] },
+              owned: { allowFrom: ["user-c", "user-d"] },
+            },
+          }),
+        ],
+      });
+
+      for (const account of ["finite", "open"]) {
+        const finding = requireFinding(
+          findings,
+          `channels.whatsapp.routing.owner_missing.${account}`,
+        );
+        expect(finding).toMatchObject({
+          severity: "warn",
+          remediation: expect.stringContaining(`whatsapp:${account}`),
+        });
+      }
+      expect(
+        findings.filter((finding) => finding.checkId.includes(".routing.owner_missing.")),
+      ).toHaveLength(2);
+      expect(requireFinding(findings, "channels.whatsapp.dm.open").severity).toBe("critical");
+      expect(collisionFindings(findings)).toHaveLength(1);
+      expect(collisionFindings(findings)[0]?.detail).toContain("owned");
+    },
+  );
+
   it("keeps producer-owned channel severity through the audit summary", async () => {
     const pluginOptions = {
       accounts: { default: { policy: "disabled", allowFrom: [] } },

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -2,6 +2,7 @@ import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 // Audits channel configuration for exposure, auth, and trust risks.
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { AgentSelectionRequiredError } from "../agents/agent-scope-config.js";
 import {
   hasConfiguredUnavailableCredentialStatus,
   hasResolvedCredentialValue,
@@ -19,7 +20,6 @@ import { formatErrorMessage } from "../infra/errors.js";
 import {
   listExactDirectMessageBindingPeerIds,
   resolveAgentRoute,
-  resolveUnknownDirectMessageRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
 import { parseSessionDeliveryRoute, resolveLinkedDirectPeerId } from "../routing/session-key.js";
@@ -405,44 +405,62 @@ export async function collectChannelSecurityFindingsCore(params: {
                 })
               : []),
           ]);
-          for (const principalId of admittedPrincipals) {
-            const principalContext = { cfg: params.cfg, accountId, account, principalId };
+          // Missing ownership is an audit finding, not an execution request. Keep
+          // checking bound principals and sibling accounts without inventing a route.
+          for (const principalId of [
+            ...admittedPrincipals,
+            ...(auditState.hasWildcard ? [undefined] : []),
+          ]) {
+            const principalContext = {
+              cfg: params.cfg,
+              accountId,
+              account,
+              ...(principalId === undefined ? {} : { principalId }),
+            };
             const channelDmScope = dmRouting?.resolveDmScope?.(principalContext);
-            const route = resolveAgentRoute({
-              cfg: params.cfg,
-              channel: plugin.id,
-              accountId,
-              peer: { kind: "direct", id: principalId },
-              dmScope: channelDmScope,
-            });
+            let route: ResolvedAgentRoute;
+            try {
+              route = resolveAgentRoute({
+                cfg: params.cfg,
+                channel: plugin.id,
+                accountId,
+                peer: { kind: "direct", id: principalId ?? "" },
+                dmScope: channelDmScope,
+              });
+            } catch (error) {
+              if (!(error instanceof AgentSelectionRequiredError)) {
+                throw error;
+              }
+              findings.push({
+                checkId: `channels.${plugin.id}.routing.owner_missing.${accountId}`,
+                severity: "warn",
+                title: `${plugin.meta.label ?? plugin.id}${accountNote} routing has no explicit owner`,
+                detail: error.message,
+                remediation: error.hint,
+              });
+              continue;
+            }
             const result = dmRouting?.resolveDmRoute?.({ ...principalContext, route });
-            const sessionKey =
-              result && "sessionKey" in result ? result.sessionKey : route.sessionKey;
-            const linkedIdentity = resolveLinkedDirectPeerId({
-              identityLinks: params.cfg.session?.identityLinks,
-              channel: plugin.id,
-              peerId: principalId,
-            });
-            recordPrincipal(
-              plugin,
-              route,
-              sessionKey,
-              linkedIdentity
-                ? `linked:${normalizeLowercaseStringOrEmpty(linkedIdentity)}`
-                : `direct:${plugin.id}:${route.accountId}:${normalizeLowercaseStringOrEmpty(principalId)}`,
-              true,
-            );
-          }
-          if (auditState.hasWildcard) {
-            const unknownContext = { cfg: params.cfg, accountId, account };
-            const route = resolveUnknownDirectMessageRoute({
-              cfg: params.cfg,
-              channel: plugin.id,
-              accountId,
-              dmScope: dmRouting?.resolveDmScope?.(unknownContext),
-            });
+            if (principalId !== undefined) {
+              const sessionKey =
+                result && "sessionKey" in result ? result.sessionKey : route.sessionKey;
+              const linkedIdentity = resolveLinkedDirectPeerId({
+                identityLinks: params.cfg.session?.identityLinks,
+                channel: plugin.id,
+                peerId: principalId,
+              });
+              recordPrincipal(
+                plugin,
+                route,
+                sessionKey,
+                linkedIdentity
+                  ? `linked:${normalizeLowercaseStringOrEmpty(linkedIdentity)}`
+                  : `direct:${plugin.id}:${route.accountId}:${normalizeLowercaseStringOrEmpty(principalId)}`,
+                true,
+              );
+              continue;
+            }
             const customRoute = dmRouting?.resolveDmRoute;
-            const result = customRoute?.({ ...unknownContext, route });
             if (customRoute && !result) {
               findings.push({
                 checkId: `channels.${plugin.id}.dm.wildcard_routing_unverified.${route.accountId}`,


### PR DESCRIPTION
## What Problem This Solves

Fixes lost channel-security findings when an admitted DM route has no explicit agent owner, and adds a Doctor repair for accounts whose existing narrower routes identify one unambiguous owner. It also fixes Telegram account selection throwing after config loading removes a legacy agent-default marker.

Reported by **cesura2k** in Discord #general on 2026-09-02 while upgrading a Linux multi-agent Discord installation to 2026.8.2.

Related: #134896, #128637, #126360, and #134570. These broader trackers contain separate setup, RPC, plugin-consent, Tailscale, and upgrade concerns; **all four remain open**.

## Why This Change Was Made

The shared channel-security collector used execution routing for finite and wildcard DM principals. An `AgentSelectionRequiredError` escaped and discarded subsequent audit findings. Both principal kinds now share one routing path that reports that precise missing-owner condition and continues checking bound principals and sibling accounts. Runtime routing remains strict.

Doctor adds an **exact-account** fallback only when all matchable existing routes explicitly identify one configured agent. The channel plugin owns account enumeration, including environment-backed accounts; Doctor reuses its current metadata snapshot and the canonical router's candidate index. Blank owners and invalid peers cannot become owner evidence. Disabled accounts, missing/conflicting owners, and unrelated accounts/channels remain unchanged. Existing narrow routes keep precedence; legacy default-marker materialization is preserved. Skill Workshop already iterates explicit agent IDs and needs no ambient fallback.

Telegram had a second instance of the same owner-boundary defect: its private account-selection loop called the deprecated throwing default-agent resolver. A valid loaded legacy config keeps its default owner out-of-band after removing the marker, so that resolver could throw despite the retained owner. Telegram now uses the existing SDK bound-account helper, preserving the explicit-fleet guard and the legacy owner's named-account preference. This removes the duplicate owner loop and an unused agent-ID projection; account inventory is unchanged. No new SDK API, config keys, environment variables, database schema, protocol, or dependencies.

## User Impact

Operators retain actionable ownership findings and the rest of the security report. `doctor --fix` repairs unambiguous accounts; missing or conflicting owners remain an operator choice. Telegram Doctor preview no longer fails on a valid included legacy roster whose retained owner already selects a named account.

The field report's suspected complete migration abort was **not reproduced on current main**: the original baseline already imported the legacy session and exited 0 while printing the security-check failure. The included Telegram `--fix` baseline likewise exited 0 and imported one session. This PR repairs narrower audit/account-selection defects, not every reported upgrade blocker or the migration runner itself.

## Evidence

Current revision: `7ce34f66f5b3120204346b2ffb35ca7b06baf248`.

- **170 focused tests passed:** 71 routing, 43 audit/repair-flow, 16 binding/warning, and 40 Telegram account tests. The 20-test Discord DM authorization suite also passed on the preceding revision.
- Shipped-source check: stable `v2026.8.2` contains both failing call paths, the throwing sole-agent resolver, and the existing retained-owner helper. Doctor orchestration changed after that tag, so current-main baseline execution is not represented as a complete replay of the released CLI.
- Original audit/binding regressions failed before repair. Blank-owner and invalid-peer regressions failed before the canonical-index refinement. Two Telegram regressions failed with `AgentSelectionRequiredError` before the SDK-helper change, including a valid legacy config loaded through the public config snapshot API.
- The current locked-dependency `qaRuntime` build passed in 1m7.7s. Scoped Telegram review is clean. The fresh required branch review is clean, with no actionable P0/P1 findings.
- The full changed-files gate passed on `dcb5888cb4b199af4737b19c8ec4b582569de23b`. The incremental Telegram/docs gate passed after a frozen local-only install restored missing, already-declared browser dependencies. Production/test types, all three unused-export scans, lint, storage/media/sidecar guards, and runtime-cycle checks passed. No source or lockfile changed. The prior full core gate and this final incremental gate cover the final diff; no single full final-head run is claimed.
- Exact-head CI is green on attempt 2 of run 33673657694. The first attempt failed only while fetching a public security-hook repository; the hosted retry passed. Native review artifacts validate with zero findings. The earlier head's cancelled run is not used as proof.

```sh
node scripts/run-vitest.mjs src/security/audit-channel-dm-policy.test.ts src/commands/doctor-config-flow.missing-default-account-bindings.integration.test.ts src/flows/doctor-repair-flow.test.ts src/routing/resolve-route.test.ts
node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts
node scripts/run-vitest.mjs extensions/discord/src/monitor/dm-command-auth.test.ts
node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime
node scripts/check-changed.mjs
node scripts/check-changed.mjs --base dcb5888cb4b199af4737b19c8ec4b582569de23b
```

### Current-head live proof

Fresh synthetic HOME, state, config and temporary directories, explicit per-agent workspaces, and dynamically allocated loopback ports were used. No operator state or service was touched. The Telegram fixture has `main` marked as the legacy default plus `research`, named accounts `alerts`/`work`, a configured account default of `alerts`, and an existing `main → work` binding. A nested include owns the roster. The supported explicit load path selects the compiled Telegram plugin, not mutable source.

```text
pre-fix, included legacy roster, Doctor preview:
  exit=1 at 24.800s; canonical missing-agent-owner error
  existing work binding unchanged
fixed, same preview contract:
  exit=0 at 10.802s; Doctor complete=true
  existing work binding unchanged
pre-fix, included roster, doctor --fix:
  exit=0; imported rows=1; legacy source absent
  existing work binding retained; legacy wildcard owner materialized
current-head doctor --fix twice:
  exits=0/0 at 11.728s/14.438s; imported rows=1; legacy source absent
  bindings converge; existing work binding and legacy wildcard preserved
current-head Gateway:
  /startupz HTTP 200 at 7.363s; clean shutdown exit=0
```

### Post-Doctor Discord delivery boundary

A fresh synthetic two-agent fixture starts with only a narrower guild binding to `main`, DM policy `allowlist`, and `allowFrom: ["123"]`. The real compiled `doctor --fix` exits 0 and persists the exact `discord:default → main` fallback while leaving both admission-policy fields unchanged.

The supported Vitest wrapper then drives the real Discord preflight, message processor, core channel dispatcher, and delivery path against the saved config. Core SDK modules are the exact-head `qaRuntime` build; Discord source is the same head. Synthetic generation and Discord transport/channel lookup are the test seams. No admission, routing, dispatch, or authority assertion is replaced with a no-op.

```text
Doctor: exit=0; exact-account binding added; allowlist unchanged
allowed sender 123:
  preflight=admitted; matchedBy=binding.account; agentId=main
  sessionKey=agent:main:discord:default:direct:123
  generation calls=1; final POST /channels/<synthetic-channel>/messages=1
  payload=SYNTHETIC_ADMISSION_OK
then forbidden sender 124:
  preflight=rejected; additional dispatches=0
  generation calls=0; additional REST calls=0; final sends=0
proof wrapper: 1/1 passed; behavior=21.097s; total=69.97s
```

This proves the persisted repair's allowed/forbidden delivery boundary, not a live Discord exchange or every session-writer custody branch. The earlier source-only harness hit its unchanged 120-second test timeout while loading the broad runtime and remains incomplete evidence; the frozen built-runtime run above passed without raising timeouts or weakening assertions.

### Earlier primary-repair live proof

The earlier frozen candidates exercised narrower same-account ownership, absent ownership evidence, legacy default markers, and an environment-backed default account alongside a named account. Each migration fixture ran Doctor twice and verified the canonical SQLite session row and converged bindings. Missing ownership remained a finding; no owner was invented. The environment-only baseline omitted the implicit default binding; the repaired inventory persisted both accounts.

On `dcb5888cb4b199af4737b19c8ec4b582569de23b`, blank-owner and invalid-peer fixtures each completed two Doctor passes with exits 0/0, imported one session, archived the legacy source, retained bindings unchanged, and reported missing ownership without throwing. An isolated Gateway returned `/startupz` HTTP 200 at 34.316s and shut down with exit 0. The new-head `/startupz` probe above separately passed at 7.363s.

Earlier cold starts exceeded the unchanged 60-second observation window. Diagnostic traces located most delay in shared CLI/config/plugin bootstrap; one reached readiness at 96.8s. Those raised-window diagnostics are not counted as 60-second proof. The final prior-head `/startupz` probe above passed within 60 seconds. No production timeout or bypass changed. Synthetic credentials prove local startup/migration, not an authenticated channel message round trip.

Cold full-config test expansions hit the existing timeout and were replaced with focused repair-boundary tests: only discovery is mocked; enumeration, routing and mutations remain real. CLI fixtures supply the persistence/discovery proof. An early full-build attempt correctly rejected source changes during declaration compilation; subsequent frozen runtime builds passed.

**Named coverage follow-up:** cold setup-only Telegram security audits returned zero channel-specific checks. Their CLI exit 0 therefore does **not** prove the full Telegram DM-routing security hook. The throwing account owner is covered by the public-config regression tests and real Doctor preview. Investigating setup-only audit coverage is separate and is not claimed fixed here.

Production delta: **+117** (+176/-59); tests: **+251** (+253/-2); docs: **+16** (+17/-1). Telegram's refinement removes 12 net production lines relative to `dcb5888`. Remaining growth implements the missing Doctor-owned migration and report-only findings, including disabled/account-scope and malformed best-effort boundaries. It reuses canonical routing, plugin account inventory, configuration mutation, and bound-account helpers rather than adding runtime fallbacks. Invalid-peer exclusion now belongs to the canonical index producer; Doctor's duplicate candidate filters are deleted.

**Ownership tradeoff:** the repaired account fallback deliberately gives already-admitted, previously unowned traffic a destination. Narrow bindings retain precedence, and DM pairing/allowlists and guild/channel/member admission policy are unchanged. This is the expressly requested sole-owner migration, not a claim that routing is behavior-preserving.

**Follow-ups:** remove the unused internal empty-DM routing wrapper in a separate behavior-preserving PR while retaining routing/cache-order assertions; investigate cold shared bootstrap latency and the setup-only Telegram audit coverage gap separately.

**Security-owner decision:** the approved migration scope is recorded in [the current maintainer confirmation](https://github.com/openclaw/openclaw/pull/136463#issuecomment-5515254807), backed by a live active-maintainer membership check for the listed SecOps team. The post-Doctor allowed/forbidden production-boundary trace above passed; startup alone is not used as message-delivery proof.

**ClawSweeper disposition:** the request to remove sole-owner inference is intentionally not applied under the explicitly approved repair scope. The routing expansion and repeated related checklist entries are addressed by [the maintainer disposition](https://github.com/openclaw/openclaw/pull/136463#issuecomment-5514506370); invalid owner evidence is independently rejected. [A re-review was requested](https://github.com/openclaw/openclaw/pull/136463#issuecomment-5515189403). A missing or late refresh is not substituted for exact-head CI or the required native gates.
