### PR TITLE
fix(browser): isolate native action cancellation by page

### DIFF
--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -289,6 +289,7 @@ Notes:
   interception is available for managed Playwright profiles; existing-session
   profiles return an unsupported-operation error.
 - Prefer atomic chooser uploads: pass the trigger `--ref` with the upload so OpenClaw arms and clicks in one request. Paths-only `upload` remains supported when a later trigger is intentional. Use `--input-ref` or `--element` to set a file input directly. `dialog` is an arming call; run it before the click/press that triggers the dialog. If an action opens a modal, the action response includes `blockedByDialog` and `browserState.dialogs.pending`; pass that `dialogId` to respond directly. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
+- Cancelling a pending locator click, typing, or upload operation leaves other tabs connected. Upload waiters belong to the selected tab; a new upload on that tab replaces its previous waiter.
 - `click`/`type`/etc require a `ref` from `snapshot` (for example, Playwright ref `f1e12`, role ref `e12`, or actionable ARIA ref `ax12`). Copy the returned ref unchanged, including any frame prefix. CSS selectors are intentionally not supported for actions. Use `click-coords` when the visible viewport position is the only reliable target.
 - Download and trace paths are constrained to OpenClaw temp roots: `/tmp/openclaw{,/downloads}` (fallback: `${os.tmpdir()}/openclaw/...`).
 - `upload` accepts files from the OpenClaw temp uploads root and

--- a/extensions/browser/src/browser/pw-download-cancel.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-download-cancel.chromium.test.ts
@@ -5,10 +5,20 @@ import path from "node:path";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test-support.js";
+import { DEFAULT_UPLOAD_DIR } from "./paths.js";
 import { getPlaywrightCore } from "./playwright-core.runtime.js";
 import { ensurePageState } from "./pw-session-state.js";
 import { closePlaywrightBrowserConnection, getPageForTargetId } from "./pw-session.js";
-import { downloadViaPlaywright, waitForDownloadViaPlaywright } from "./pw-tools-core.downloads.js";
+import {
+  armDialogViaPlaywright,
+  downloadViaPlaywright,
+  uploadViaPlaywright,
+  waitForDownloadViaPlaywright,
+} from "./pw-tools-core.downloads.js";
+import { clickViaPlaywright, typeViaPlaywright } from "./pw-tools-core.interactions.actions.js";
+import { setInputFilesViaPlaywright } from "./pw-tools-core.interactions.content.js";
+import { executeActViaPlaywright } from "./pw-tools-core.interactions.execution.js";
+import { snapshotRoleViaPlaywright } from "./pw-tools-core.snapshot.js";
 import { getFreePort } from "./test-port.js";
 
 const runChromiumProof = process.env.OPENCLAW_BROWSER_DOWNLOAD_E2E === "1";
@@ -39,7 +49,7 @@ async function readTargetId(page: import("playwright-core").Page): Promise<strin
   }
 }
 
-describe.runIf(runChromiumProof)("managed Chromium download cancellation", () => {
+describe.runIf(runChromiumProof)("managed Chromium action and download cancellation", () => {
   const cleanup: Array<() => Promise<void>> = [];
 
   afterEach(async () => {
@@ -51,6 +61,255 @@ describe.runIf(runChromiumProof)("managed Chromium download cancellation", () =>
       throw new AggregateError(errors, "Chromium download fixture cleanup failed");
     }
   });
+
+  async function createUploadFile() {
+    await fs.mkdir(DEFAULT_UPLOAD_DIR, { recursive: true });
+    const uploadDir = await fs.mkdtemp(path.join(DEFAULT_UPLOAD_DIR, "action-cancel-"));
+    cleanup.push(async () => await fs.rm(uploadDir, { recursive: true, force: true }));
+    const filePath = path.join(uploadDir, "proof.txt");
+    await fs.writeFile(filePath, "synthetic upload proof");
+    return filePath;
+  }
+
+  async function createActionPages(html: string[]) {
+    const rootDir = tempDirs.make("openclaw-action-cancel-");
+    const cdpPort = await getFreePort();
+    const context = await getPlaywrightCore().chromium.launchPersistentContext(
+      path.join(rootDir, "profile"),
+      {
+        headless: true,
+        executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+        args: [`--remote-debugging-port=${cdpPort}`],
+      },
+    );
+    cleanup.push(async () => await context.close());
+    const cdpUrl = `http://127.0.0.1:${cdpPort}`;
+    cleanup.push(async () => await closePlaywrightBrowserConnection({ cdpUrl }));
+    const pages = [];
+    for (const [index, content] of html.entries()) {
+      const owner = index === 0 ? context.pages()[0]! : await context.newPage();
+      await owner.setContent(content);
+      const targetId = await readTargetId(owner);
+      const controlled = await getPageForTargetId({ cdpUrl, targetId });
+      const snapshot = await snapshotRoleViaPlaywright({ cdpUrl, targetId });
+      pages.push({ owner, controlled, targetId, refs: snapshot.refs });
+    }
+    return { cdpUrl, pages };
+  }
+
+  function observeLocatorAction(page: import("playwright-core").Page, method: "click" | "fill") {
+    const started = createDeferred<void>();
+    const settled = createDeferred<void>();
+    const frame = page.mainFrame();
+    // Observe the real dependency promise so cancellation assertions cannot race
+    // ahead of native action admission or mistake an outer abort race for cleanup.
+    const observe = (pending: Promise<void>) => {
+      started.resolve();
+      void pending.then(settled.resolve, settled.resolve);
+      return pending;
+    };
+    if (method === "click") {
+      const click = frame.click.bind(frame);
+      frame.click = (selector, options) => observe(click(selector, options));
+    } else {
+      const fill = frame.fill.bind(frame);
+      frame.fill = (selector, value, options) => observe(fill(selector, value, options));
+    }
+    return { started: started.promise, settled: settled.promise };
+  }
+
+  async function waitForNativeAction(started: Promise<void>, outcome: Promise<unknown>) {
+    await Promise.race([
+      started,
+      outcome.then((result) => {
+        throw new Error("Action settled before native admission", { cause: result });
+      }),
+    ]);
+  }
+
+  it("cancels one page's click while another page's pending click completes", async () => {
+    const html = "<button onclick=\"this.textContent='Clicked'\">Target</button>";
+    const { cdpUrl, pages } = await createActionPages([html, html]);
+    const [first, second] = pages;
+    const firstRef = Object.keys(first!.refs)[0]!;
+    const secondRef = Object.keys(second!.refs)[0]!;
+    for (const page of pages) {
+      await page.owner
+        .locator("button")
+        .evaluate((element: HTMLButtonElement) => (element.disabled = true));
+    }
+    const firstNative = observeLocatorAction(first!.controlled, "click");
+    const secondNative = observeLocatorAction(second!.controlled, "click");
+    const controller = new AbortController();
+    const reason = new Error("only the first action was cancelled");
+    const firstClick = clickViaPlaywright({
+      cdpUrl,
+      targetId: first!.targetId,
+      ref: firstRef,
+      signal: controller.signal,
+      timeoutMs: 5_000,
+    }).catch((error: unknown) => error);
+    const secondClick = clickViaPlaywright({
+      cdpUrl,
+      targetId: second!.targetId,
+      ref: secondRef,
+      timeoutMs: 5_000,
+    }).then(
+      () => ({ ok: true }),
+      (error: unknown) => ({ ok: false, error }),
+    );
+    await Promise.all([
+      waitForNativeAction(firstNative.started, firstClick),
+      waitForNativeAction(secondNative.started, secondClick),
+    ]);
+    controller.abort(reason);
+    await expect(firstClick).resolves.toBe(reason);
+    await firstNative.settled;
+    await second!.owner
+      .locator("button")
+      .evaluate((element: HTMLButtonElement) => (element.disabled = false));
+
+    await expect(secondClick).resolves.toEqual({ ok: true });
+    await expect(second!.owner.locator("button").textContent()).resolves.toBe("Clicked");
+    expect(second!.controlled.context().browser()?.isConnected()).toBe(true);
+  }, 20_000);
+
+  it("does not type after a cancelled input becomes editable", async () => {
+    const { cdpUrl, pages } = await createActionPages(["<label>Entry<input></label>"]);
+    const page = pages[0]!;
+    const ref = Object.keys(page.refs)[0]!;
+    await page.owner
+      .locator("input")
+      .evaluate((element: HTMLInputElement) => (element.disabled = true));
+    const native = observeLocatorAction(page.controlled, "fill");
+    const controller = new AbortController();
+    const reason = new Error("typing was cancelled");
+    const typing = typeViaPlaywright({
+      cdpUrl,
+      targetId: page.targetId,
+      ref,
+      text: "cancelled input",
+      timeoutMs: 5_000,
+      signal: controller.signal,
+    }).catch((error: unknown) => error);
+    await waitForNativeAction(native.started, typing);
+    controller.abort(reason);
+    await expect(typing).resolves.toBe(reason);
+    await page.owner
+      .locator("input")
+      .evaluate((element: HTMLInputElement) => (element.disabled = false));
+    await native.settled;
+
+    await expect(page.owner.locator("input").inputValue()).resolves.toBe("");
+    expect(page.controlled.context().browser()?.isConnected()).toBe(true);
+  }, 20_000);
+
+  it("completes uploads on separate pages without superseding either request", async () => {
+    const filePath = await createUploadFile();
+    const html =
+      '<button onclick="document.querySelector(\'input\').click()">Upload</button><input type="file" hidden>';
+    const { cdpUrl, pages } = await createActionPages([html, html]);
+    const [first, second] = pages;
+    await first!.owner
+      .locator("button")
+      .evaluate((element: HTMLButtonElement) => (element.disabled = true));
+    const native = observeLocatorAction(first!.controlled, "click");
+    const firstUpload = uploadViaPlaywright({
+      cdpUrl,
+      targetId: first!.targetId,
+      ref: Object.keys(first!.refs)[0]!,
+      paths: [filePath],
+      timeoutMs: 5_000,
+    }).then(
+      () => ({ ok: true }),
+      (error: unknown) => ({ ok: false, error }),
+    );
+    await waitForNativeAction(native.started, firstUpload);
+    await uploadViaPlaywright({
+      cdpUrl,
+      targetId: second!.targetId,
+      ref: Object.keys(second!.refs)[0]!,
+      paths: [filePath],
+      timeoutMs: 5_000,
+    });
+    await first!.owner
+      .locator("button")
+      .evaluate((element: HTMLButtonElement) => (element.disabled = false));
+    await expect(firstUpload).resolves.toEqual({ ok: true });
+    for (const page of pages) {
+      await expect(
+        page.owner
+          .locator("input")
+          .evaluate((element: HTMLInputElement) => element.files?.[0]?.name),
+      ).resolves.toBe("proof.txt");
+    }
+  }, 20_000);
+
+  it("does not assign files to an input that appears after cancellation", async () => {
+    const filePath = await createUploadFile();
+    const { cdpUrl, pages } = await createActionPages(["<p>Waiting for a file input</p>"]);
+    const page = pages[0]!;
+    const started = createDeferred<void>();
+    const settled = createDeferred<void>();
+    const frame = page.controlled.mainFrame();
+    const setInputFiles = frame.setInputFiles.bind(frame);
+    frame.setInputFiles = (selector, files, options) => {
+      const pending = setInputFiles(selector, files, options);
+      started.resolve();
+      void pending.then(settled.resolve, settled.resolve);
+      return pending;
+    };
+    const controller = new AbortController();
+    const reason = new Error("direct upload cancelled");
+    const upload = setInputFilesViaPlaywright({
+      cdpUrl,
+      targetId: page.targetId,
+      element: "input[type=file]",
+      paths: [filePath],
+      signal: controller.signal,
+    }).catch((error: unknown) => error);
+    await started.promise;
+    controller.abort(reason);
+    await expect(upload).resolves.toBe(reason);
+    await page.owner.evaluate(() => {
+      const input = document.createElement("input");
+      input.type = "file";
+      document.body.append(input);
+    });
+    await settled.promise;
+    await expect(
+      page.owner.locator("input").evaluate((element: HTMLInputElement) => element.files?.length),
+    ).resolves.toBe(0);
+    expect(page.controlled.context().browser()?.isConnected()).toBe(true);
+  }, 20_000);
+
+  it("reports an open dialog while retaining the click until the dialog is answered", async () => {
+    const { cdpUrl, pages } = await createActionPages([
+      "<button onclick=\"this.textContent=confirm('Continue?') ? 'Accepted' : 'Dismissed'\">Confirm</button>",
+    ]);
+    const page = pages[0]!;
+    page.owner.on("dialog", () => {});
+    const native = observeLocatorAction(page.controlled, "click");
+    let settled = false;
+    void native.settled.then(() => {
+      settled = true;
+    });
+    const result = await executeActViaPlaywright({
+      cdpUrl,
+      targetId: page.targetId,
+      action: { kind: "click", ref: Object.keys(page.refs)[0]! },
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    });
+    expect(result).toMatchObject({
+      blockedByDialog: true,
+      browserState: { dialogs: { pending: [{ type: "confirm", message: "Continue?" }] } },
+    });
+    expect(settled).toBe(false);
+    expect(page.controlled.context().browser()?.isConnected()).toBe(true);
+    await armDialogViaPlaywright({ cdpUrl, targetId: page.targetId, accept: true });
+    await native.settled;
+    await expect(page.owner.locator("button").textContent()).resolves.toBe("Accepted");
+  }, 20_000);
 
   it.each(["caller abort", "invalid output directory"])(
     "cancels a streaming download after %s without publishing output",

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -544,7 +544,7 @@ describe("pw-tools-core browser SSRF guards", () => {
     expect(documentHandle.dispose).toHaveBeenCalledOnce();
   });
 
-  it("keeps the request guard alive until an aborted hover actually settles", async () => {
+  it("joins an aborted native hover before returning and releasing its request guard", async () => {
     const ctrl = new AbortController();
     const started = createDeferred<void>();
     const hover = createDeferred<void>();
@@ -572,13 +572,21 @@ describe("pw-tools-core browser SSRF guards", () => {
       signal: ctrl.signal,
     });
     await started.promise;
+    let settled = false;
+    void task
+      .finally(() => {
+        settled = true;
+      })
+      .catch(() => {});
     ctrl.abort(new Error("aborted by test"));
 
-    await expect(task).rejects.toThrow("aborted by test");
+    await Promise.resolve();
+    expect(settled).toBe(false);
     expect(guardSettled).toBe(false);
 
     hover.resolve();
-    await vi.waitFor(() => expect(guardSettled).toBe(true));
+    await expect(task).rejects.toThrow("aborted by test");
+    expect(guardSettled).toBe(true);
   });
 
   it("lets a request-policy denial observed before abort win", async () => {
@@ -732,8 +740,10 @@ describe("pw-tools-core browser SSRF guards", () => {
     expect(settled).toBe(false);
 
     policy.resolve();
-    await expect(task).rejects.toThrow("aborted while policy pending");
+    await Promise.resolve();
+    expect(settled).toBe(false);
     hover.resolve();
+    await expect(task).rejects.toThrow("aborted while policy pending");
   });
 
   it("quarantines immediately when a preserved denied source later becomes unsafe", async () => {
@@ -841,7 +851,7 @@ describe("pw-tools-core browser SSRF guards", () => {
     });
   });
 
-  it("quarantines a late unpreserved policy failure after abort already returned", async () => {
+  it("quarantines a late unpreserved policy failure before returning cancellation", async () => {
     const ctrl = new AbortController();
     const started = createDeferred<void>();
     const hover = createDeferred<void>();
@@ -871,9 +881,8 @@ describe("pw-tools-core browser SSRF guards", () => {
     });
     await started.promise;
     ctrl.abort(new Error("aborted by test"));
-    await expect(task).rejects.toThrow("aborted by test");
-
     hover.resolve();
+    await expect(task).rejects.toBe(blocked);
     await vi.waitFor(() =>
       expect(sessionMocks.quarantineBlockedNavigationTarget).toHaveBeenCalledWith({
         cdpUrl: "http://127.0.0.1:18792",
@@ -886,12 +895,15 @@ describe("pw-tools-core browser SSRF guards", () => {
   it("preserves SSRF policy when aborting a pending click", async () => {
     const ctrl = new AbortController();
     const clickStarted = createDeferred<void>();
+    const click = createDeferred<void>();
+    let nativeSignal: AbortSignal | undefined;
     installInteractionPage(
       { url: vi.fn(() => "https://example.com") },
       {
-        click: vi.fn(() => {
+        click: vi.fn((options: { signal?: AbortSignal }) => {
+          nativeSignal = options.signal;
           clickStarted.resolve();
-          return new Promise(() => {});
+          return click.promise;
         }),
       },
     );
@@ -906,14 +918,20 @@ describe("pw-tools-core browser SSRF guards", () => {
 
     await clickStarted.promise;
     ctrl.abort(new Error("aborted by test"));
+    expect(nativeSignal?.aborted).toBe(true);
+    click.reject(
+      Object.assign(new Error("cancelled", { cause: nativeSignal?.reason }), {
+        name: "AbortError",
+      }),
+    );
 
     await expect(task).rejects.toThrow("aborted by test");
-    expect(sessionMocks.forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith({
-      cdpUrl: "http://127.0.0.1:18792",
-      targetId: "tab-1",
-      ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
-      reason: "click aborted",
-    });
+    expect(sessionMocks.forceDisconnectPlaywrightForTarget).not.toHaveBeenCalled();
+    expect(sessionMocks.withPageNavigationRequestGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+      }),
+    );
   });
 
   it.each([
@@ -965,10 +983,10 @@ describe("pw-tools-core browser SSRF guards", () => {
 
     await started.promise;
     ctrl.abort(new Error("aborted by test"));
-    await expect(task).rejects.toThrow("aborted by test");
-
+    expect(guardSettled).toBe(false);
     firstStepPending.resolve();
-    await vi.waitFor(() => expect(guardSettled).toBe(true));
+    await expect(task).rejects.toThrow("aborted by test");
+    expect(guardSettled).toBe(true);
     expect(type).not.toHaveBeenCalled();
     expect(press).not.toHaveBeenCalled();
   });

--- a/extensions/browser/src/browser/pw-tools-core.clamps-timeoutms-scrollintoview.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.clamps-timeoutms-scrollintoview.test.ts
@@ -22,7 +22,10 @@ describe("pw-tools-core", () => {
       timeoutMs: 50,
     });
 
-    expect(scrollIntoViewIfNeeded).toHaveBeenCalledWith({ timeout: 500 });
+    expect(scrollIntoViewIfNeeded).toHaveBeenCalledWith({
+      timeout: 500,
+      signal: expect.any(AbortSignal),
+    });
   });
   it.each([
     {

--- a/extensions/browser/src/browser/pw-tools-core.downloads.ts
+++ b/extensions/browser/src/browser/pw-tools-core.downloads.ts
@@ -3,17 +3,16 @@
  * tools.
  */
 import path from "node:path";
-import type { FileChooser, Page } from "playwright-core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { Page } from "playwright-core";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS } from "./constants.js";
 import type { BrowserDownloadResult } from "./download-types.js";
-import type { BrowserNavigationPolicyOptions } from "./navigation-guard.js";
 import { resolveStrictExistingUploadPaths } from "./paths.js";
 import { createDownloadCaptureForPage } from "./pw-download-capture.js";
 import {
   armObservedDialogResponseOnPage,
   ensurePageState,
-  forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
   refLocator,
   respondToObservedDialogOnPage,
@@ -23,6 +22,11 @@ import {
   clickViaPlaywright,
   setFileChooserFilesViaPlaywright,
 } from "./pw-tools-core.interactions.js";
+import {
+  awaitActionWithAbort,
+  createAbortPromiseWithListener,
+  type NavigationTargetOptions,
+} from "./pw-tools-core.interactions.navigation.js";
 import {
   bumpDownloadArmId,
   bumpUploadArmId,
@@ -35,13 +39,12 @@ async function dismissFileChooser(page: Page): Promise<void> {
   await page.keyboard.press("Escape").catch(() => {});
 }
 
-type ActiveAtomicUpload = {
+type ActiveUpload = {
   controller: AbortController;
   settled: Promise<void>;
 };
 
-const activeAtomicUploads = new Map<string, ActiveAtomicUpload>();
-const pendingUploadClaims = new Map<string, number>();
+const activeUploads = new WeakMap<Page, ActiveUpload>();
 
 function createExplicitDownloadCapture(params: {
   page: Page;
@@ -70,270 +73,156 @@ function resolveImplicitDownloadRoot(): string {
   return path.join(resolvePreferredOpenClawTmpDir(), "downloads");
 }
 
-/** Arms the next page file chooser and fills it with strict existing paths. */
-export async function armFileUploadViaPlaywright(
-  opts: {
-    cdpUrl: string;
-    browserFilesystemLocal?: boolean;
-    targetId?: string;
-    paths?: string[];
-    timeoutMs?: number;
-  } & BrowserNavigationPolicyOptions,
-): Promise<void> {
-  const key = opts.cdpUrl;
-  const armId = bumpUploadArmId();
-  pendingUploadClaims.set(key, armId);
-  try {
-    const active = activeAtomicUploads.get(key);
-    if (active) {
-      active.controller.abort(new Error("File upload was superseded by another waiter"));
-      await active.settled;
-    }
-    if (pendingUploadClaims.get(key) !== armId) {
-      return;
-    }
-    const page = await getPageForTargetId(opts);
-    if (pendingUploadClaims.get(key) !== armId) {
-      return;
-    }
-    const state = ensurePageState(page);
-    const timeout = normalizeTimeoutMs(opts.timeoutMs, DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS);
-    state.armIdUpload = armId;
+type UploadOptions = NavigationTargetOptions & {
+  ref?: string;
+  paths?: string[];
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
 
-    // The waiter is intentionally detached: the tool call arms future browser UI,
-    // while the later user click opens the chooser.
-    void page
-      .waitForEvent("filechooser", { timeout })
-      .then(async (fileChooser) => {
-        if (state.armIdUpload !== armId) {
-          return;
+async function runFileUpload(opts: UploadOptions): Promise<void> {
+  opts.signal?.throwIfAborted();
+  const atomic = opts.ref !== undefined;
+  const armId = bumpUploadArmId();
+  const timeout = normalizeTimeoutMs(opts.timeoutMs, DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS);
+  const controller = new AbortController();
+  const signal = opts.signal
+    ? AbortSignal.any([opts.signal, controller.signal])
+    : controller.signal;
+  const { abortPromise, cleanup } = createAbortPromiseWithListener(signal);
+  const armed = createDeferred<void>();
+  let started = false;
+  let deadline = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const startDeadline = () => {
+    deadline = Date.now() + timeout;
+    timer = setTimeout(
+      () =>
+        controller.abort(new Error(`Timeout ${timeout}ms exceeded while completing file upload`)),
+      timeout,
+    );
+  };
+  if (atomic) {
+    startDeadline();
+  }
+  const completion = (async () => {
+    const page = await awaitActionWithAbort(getPageForTargetId(opts), abortPromise);
+    signal.throwIfAborted();
+    const state = ensurePageState(page);
+    // Page lookup may finish out of order. Only a newer request can replace
+    // this page's owner; unrelated tabs share no chooser or cleanup queue.
+    if (state.armIdUpload > armId) {
+      throw new Error("File upload was superseded by another waiter");
+    }
+    state.armIdUpload = armId;
+    const previous = activeUploads.get(page);
+    const execution = Promise.resolve().then(async () => {
+      // A cancelled queued caller may return early, but its successor must
+      // still join every older native action before installing a new waiter.
+      await previous?.settled;
+      signal.throwIfAborted();
+      started = true;
+      if (!atomic) {
+        startDeadline();
+      }
+      const chooser = page.waitForEvent("filechooser", { timeout: 0, signal });
+      void chooser.catch(() => {});
+      armed.resolve();
+      try {
+        if (atomic) {
+          await clickViaPlaywright({
+            ...opts,
+            ref: opts.ref!,
+            timeoutMs: Math.max(1, deadline - Date.now()),
+            resolvedPage: page,
+            signal,
+          });
         }
-        if (!opts.paths?.length) {
-          // Playwright removed `FileChooser.cancel()`; best-effort close the chooser instead.
-          await dismissFileChooser(page);
-          return;
-        }
-        const uploadPathsResult = await resolveStrictExistingUploadPaths({
-          requestedPaths: opts.paths,
-        });
-        if (!uploadPathsResult.ok) {
-          await dismissFileChooser(page);
-          return;
+        const fileChooser = await chooser;
+        signal.throwIfAborted();
+        let paths = opts.paths ?? [];
+        if (!atomic) {
+          const resolved = await awaitActionWithAbort(
+            resolveStrictExistingUploadPaths({ requestedPaths: paths }),
+            abortPromise,
+          );
+          signal.throwIfAborted();
+          if (!paths.length || !resolved.ok) {
+            await dismissFileChooser(page);
+            return;
+          }
+          paths = resolved.paths;
         }
         await setFileChooserFilesViaPlaywright({
-          cdpUrl: opts.cdpUrl,
-          targetId: opts.targetId,
+          ...opts,
           page,
           fileChooser,
-          paths: uploadPathsResult.paths,
-          timeoutMs: timeout,
-          browserFilesystemLocal: opts.browserFilesystemLocal,
-          ssrfPolicy: opts.ssrfPolicy,
-          browserProxyMode: opts.browserProxyMode,
+          paths,
+          timeoutMs: Math.max(1, deadline - Date.now()),
+          signal,
         });
-      })
-      .catch(() => {
-        // Ignore timeouts; the chooser may never appear.
-      });
-  } finally {
-    if (pendingUploadClaims.get(key) === armId) {
-      pendingUploadClaims.delete(key);
+        signal.throwIfAborted();
+      } catch (error) {
+        controller.abort(error);
+        if (
+          error instanceof Error &&
+          error.name === "AbortError" &&
+          error.cause === signal.reason
+        ) {
+          signal.throwIfAborted();
+        }
+        throw error;
+      } finally {
+        await chooser.catch(() => {});
+      }
+    });
+    const active = {
+      controller,
+      settled: execution.then(
+        () => {},
+        () => {},
+      ),
+    };
+    activeUploads.set(page, active);
+    previous?.controller.abort(new Error("File upload was superseded by another waiter"));
+    try {
+      await execution;
+    } finally {
+      if (activeUploads.get(page) === active) {
+        activeUploads.delete(page);
+      }
     }
+  })().finally(() => {
+    clearTimeout(timer);
+    cleanup();
+  });
+  // Passive arming intentionally outlives this call; its errors are contained.
+  void completion.catch(() => {});
+  try {
+    await awaitActionWithAbort(
+      atomic ? completion : Promise.race([armed.promise, completion]),
+      abortPromise,
+    );
+  } catch (error) {
+    if (atomic && started) {
+      await completion;
+    }
+    throw error;
   }
+}
+
+/** Arms the next page file chooser and fills it with strict existing paths. */
+export async function armFileUploadViaPlaywright(
+  opts: Omit<UploadOptions, "ref" | "signal">,
+): Promise<void> {
+  await runFileUpload(opts);
 }
 
 /** Clicks a ref and completes its file chooser as one request-owned operation. */
 export async function uploadViaPlaywright(
-  opts: {
-    cdpUrl: string;
-    browserFilesystemLocal?: boolean;
-    targetId?: string;
-    ref: string;
-    paths: string[];
-    timeoutMs?: number;
-    signal?: AbortSignal;
-  } & BrowserNavigationPolicyOptions,
+  opts: UploadOptions & { ref: string; paths: string[] },
 ): Promise<void> {
-  opts.signal?.throwIfAborted();
-  // Abort cleanup disconnects the shared Playwright connection, so ownership
-  // must cover every target on that connection before a successor reconnects.
-  const key = opts.cdpUrl;
-  const timeout = normalizeTimeoutMs(opts.timeoutMs, DEFAULT_BROWSER_DOWNLOAD_TIMEOUT_MS);
-  const armId = bumpUploadArmId();
-  pendingUploadClaims.set(key, armId);
-  const previous = activeAtomicUploads.get(key);
-  const controller = new AbortController();
-  const abortFromCaller = () =>
-    controller.abort(opts.signal?.reason ?? new Error("File upload aborted"));
-  opts.signal?.addEventListener("abort", abortFromCaller, { once: true });
-  if (opts.signal?.aborted) {
-    abortFromCaller();
-  }
-  const deadline = Date.now() + timeout;
-  const timer = setTimeout(
-    () => controller.abort(new Error(`Timeout ${timeout}ms exceeded while completing file upload`)),
-    timeout,
-  );
-  let rejectAborted!: (reason: unknown) => void;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAborted = reject;
-  });
-  void aborted.catch(() => {});
-  let started = false;
-  let rejectQueuedAbort!: (reason: unknown) => void;
-  const queuedAbort = new Promise<never>((_resolve, reject) => {
-    rejectQueuedAbort = reject;
-  });
-  void queuedAbort.catch(() => {});
-  const rejectOnAbort = () => {
-    const reason = controller.signal.reason ?? new Error("File upload aborted");
-    rejectAborted(reason);
-    if (!started) {
-      rejectQueuedAbort(reason);
-    }
-  };
-  controller.signal.addEventListener("abort", rejectOnAbort, { once: true });
-  if (controller.signal.aborted) {
-    rejectOnAbort();
-  }
-  const execution = Promise.resolve().then(async () => {
-    // Preserve the full predecessor cleanup chain even when this caller aborts
-    // while queued; later owners must never skip an older in-flight click.
-    await previous?.settled;
-    if (activeAtomicUploads.get(key) !== active || pendingUploadClaims.get(key) !== armId) {
-      throw controller.signal.reason ?? new Error("File upload was superseded by another waiter");
-    }
-    controller.signal.throwIfAborted();
-    const page = await Promise.race([getPageForTargetId(opts), aborted]);
-    if (activeAtomicUploads.get(key) !== active || pendingUploadClaims.get(key) !== armId) {
-      throw controller.signal.reason ?? new Error("File upload was superseded by another waiter");
-    }
-    controller.signal.throwIfAborted();
-    started = true;
-    const state = ensurePageState(page);
-    state.armIdUpload = armId;
-
-    let resolveChooser!: (chooser: FileChooser) => void;
-    let rejectChooser!: (reason: unknown) => void;
-    const chooserPromise = new Promise<FileChooser>((resolve, reject) => {
-      resolveChooser = resolve;
-      rejectChooser = reject;
-    });
-    void chooserPromise.catch(() => {});
-    let chooser: FileChooser | undefined;
-    let chooserListening = true;
-    const onChooser = (observed: FileChooser) => {
-      if (chooser) {
-        return;
-      }
-      chooser = observed;
-      page.off("filechooser", onChooser);
-      chooserListening = false;
-      resolveChooser(observed);
-    };
-    page.on("filechooser", onChooser);
-
-    let phase: "idle" | "click" | "chooser" | "validation" | "setFiles" = "idle";
-    let abortCleanup: Promise<void> | undefined;
-    const onAbort = () => {
-      const reason = controller.signal.reason ?? new Error("File upload aborted");
-      rejectChooser(reason);
-      if (phase === "click" || phase === "setFiles") {
-        // Playwright actions do not consume our AbortSignal. Disconnect so a
-        // successor cannot start until the raw operation has actually settled.
-        abortCleanup ??= forceDisconnectPlaywrightForTarget({
-          cdpUrl: opts.cdpUrl,
-          targetId: opts.targetId,
-          ssrfPolicy: opts.ssrfPolicy,
-          reason: "file upload aborted",
-        }).catch(() => {});
-      }
-    };
-    controller.signal.addEventListener("abort", onAbort, { once: true });
-    if (controller.signal.aborted) {
-      onAbort();
-    }
-
-    try {
-      controller.signal.throwIfAborted();
-      phase = "click";
-      await clickViaPlaywright({
-        cdpUrl: opts.cdpUrl,
-        targetId: opts.targetId,
-        ref: opts.ref,
-        timeoutMs: Math.max(1, deadline - Date.now()),
-        ssrfPolicy: opts.ssrfPolicy,
-        browserProxyMode: opts.browserProxyMode,
-        resolvedPage: page,
-      });
-      phase = "chooser";
-      chooser = await chooserPromise;
-      if (state.armIdUpload !== armId) {
-        throw new Error("File upload was superseded by another waiter");
-      }
-      controller.signal.throwIfAborted();
-      phase = "validation";
-      const uploadPathsResult = await Promise.race([
-        resolveStrictExistingUploadPaths({ requestedPaths: opts.paths }),
-        aborted,
-      ]);
-      if (!uploadPathsResult.ok) {
-        throw new Error(uploadPathsResult.error);
-      }
-      controller.signal.throwIfAborted();
-      phase = "setFiles";
-      try {
-        await setFileChooserFilesViaPlaywright({
-          cdpUrl: opts.cdpUrl,
-          targetId: opts.targetId,
-          page,
-          fileChooser: chooser,
-          paths: uploadPathsResult.paths,
-          timeoutMs: Math.max(1, deadline - Date.now()),
-          browserFilesystemLocal: opts.browserFilesystemLocal,
-          ssrfPolicy: opts.ssrfPolicy,
-          browserProxyMode: opts.browserProxyMode,
-        });
-      } finally {
-        phase = "idle";
-      }
-      controller.signal.throwIfAborted();
-    } catch (error) {
-      throw controller.signal.aborted ? controller.signal.reason : error;
-    } finally {
-      controller.signal.removeEventListener("abort", onAbort);
-      if (chooserListening) {
-        page.off("filechooser", onChooser);
-      }
-      if (state.armIdUpload === armId) {
-        state.armIdUpload = bumpUploadArmId();
-      }
-      await abortCleanup;
-    }
-  });
-
-  const settled = execution.then(
-    () => {},
-    () => {},
-  );
-  const active = { controller, settled };
-  activeAtomicUploads.set(key, active);
-  previous?.controller.abort(new Error("File upload was superseded by another waiter"));
-  void settled.then(() => {
-    controller.signal.removeEventListener("abort", rejectOnAbort);
-    if (activeAtomicUploads.get(key) === active) {
-      activeAtomicUploads.delete(key);
-    }
-    if (pendingUploadClaims.get(key) === armId) {
-      pendingUploadClaims.delete(key);
-    }
-  });
-  try {
-    await Promise.race([execution, queuedAbort]);
-  } finally {
-    clearTimeout(timer);
-    opts.signal?.removeEventListener("abort", abortFromCaller);
-  }
+  await runFileUpload(opts);
 }
 
 /** Accepts or dismisses a pending dialog, or arms the next matching dialog response. */

--- a/extensions/browser/src/browser/pw-tools-core.interactions.actions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.actions.ts
@@ -24,6 +24,7 @@ import {
   interactionNavigationPolicy,
   reconcileRemoteDialogAfterActionSettled,
   resolveBoundedDelayMs,
+  runCancellablePageInteraction,
   throwIfInteractionAborted,
   toFriendlyInteractionError,
 } from "./pw-tools-core.interactions.navigation.js";
@@ -58,73 +59,24 @@ export async function clickViaPlaywright(
     ensurePageState(page);
     restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
   }
-  const label = resolved.ref ?? resolved.selector!;
-  const locator = resolved.ref
-    ? refLocator(page, requireRef(resolved.ref))
-    : page.locator(resolved.selector!);
+  const { label, locator } = resolveInteractionElement(page, resolved);
   const timeout = resolveActInteractionTimeoutMs(opts.timeoutMs);
-  const signal = opts.signal;
-  const { abortPromise, cleanup } = createAbortPromiseWithListener(signal, (reason) => {
-    if (isBrowserObservedDialogBlockedError(reason)) {
-      return;
-    }
-    void forceDisconnectPlaywrightForTarget({
-      cdpUrl: opts.cdpUrl,
-      targetId: opts.targetId,
-      ssrfPolicy: opts.ssrfPolicy,
-      reason: "click aborted",
-    }).catch(() => {});
-  });
-  if (signal?.aborted) {
-    throw signal.reason ?? new Error("aborted");
-  }
-  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, signal);
-  try {
-    await awaitNavigationGuardedInteraction(
-      {
-        action: async () => {
-          const delayMs = resolveBoundedDelayMs(
-            opts.delayMs,
-            "click delayMs",
-            ACT_MAX_CLICK_DELAY_MS,
-          );
-          if (delayMs > 0) {
-            await locator.hover({ timeout });
-            throwIfInteractionAborted(signal);
-            // Abortable hold: a bare setTimeout would keep the orphaned action
-            // chain (and its navigation-guard teardown) alive for the full
-            // delayMs after the caller already lost the abort race.
-            await sleepWithAbort(delayMs, signal);
-            throwIfInteractionAborted(signal);
-          }
-          if (opts.doubleClick) {
-            await locator.dblclick({
-              timeout,
-              button: opts.button,
-              modifiers: opts.modifiers,
-            });
-            return;
-          }
-          await locator.click({
-            timeout,
-            button: opts.button,
-            modifiers: opts.modifiers,
-          });
-        },
-        cdpUrl: opts.cdpUrl,
-        page,
-        ...interactionNavigationPolicy(opts),
-        targetId: opts.targetId,
-      },
-      abortPromise,
-      signal,
-      reconcileRemoteDialog,
-    );
-  } catch (err) {
-    throw toFriendlyInteractionError(err, label);
-  } finally {
-    cleanup();
-  }
+  await runCancellablePageInteraction(
+    page,
+    opts,
+    async (signal) => {
+      const delayMs = resolveBoundedDelayMs(opts.delayMs, "click delayMs", ACT_MAX_CLICK_DELAY_MS);
+      if (delayMs > 0) {
+        await locator.hover({ timeout, signal });
+        throwIfInteractionAborted(opts.signal);
+        await sleepWithAbort(delayMs, opts.signal);
+        throwIfInteractionAborted(opts.signal);
+      }
+      const clickOptions = { timeout, signal, button: opts.button, modifiers: opts.modifiers };
+      await (opts.doubleClick ? locator.dblclick(clickOptions) : locator.click(clickOptions));
+    },
+    label,
+  );
 }
 
 export async function clickCoordsViaPlaywright(
@@ -150,8 +102,9 @@ async function runGuardedPageInteraction<T>(
   page: Page,
   opts: GuardedInteractionOptions,
   action: () => Promise<T>,
-  errorLabel?: string,
 ): Promise<T> {
+  // Mouse and keyboard primitives lack native cancellation. Keep their guard
+  // alive after foreground interruption until the underlying operation settles.
   const { abortPromise, cleanup } = createAbortPromiseWithListener(opts.signal);
   try {
     return await awaitNavigationGuardedInteraction(
@@ -166,11 +119,6 @@ async function runGuardedPageInteraction<T>(
       opts.signal,
       () => reconcileRemoteDialogAfterActionSettled(page, opts.signal),
     );
-  } catch (error) {
-    if (errorLabel !== undefined) {
-      throw toFriendlyInteractionError(error, errorLabel);
-    }
-    throw error;
   } finally {
     cleanup();
   }
@@ -189,10 +137,11 @@ export async function hoverViaPlaywright(opts: ElementInteractionOptions): Promi
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
   const { label, locator } = resolveInteractionElement(page, resolved);
-  await runGuardedPageInteraction(
+  await runCancellablePageInteraction(
     page,
     opts,
-    async () => await locator.hover({ timeout: resolveActInteractionTimeoutMs(opts.timeoutMs) }),
+    async (signal) =>
+      await locator.hover({ timeout: resolveActInteractionTimeoutMs(opts.timeoutMs), signal }),
     label,
   );
 }
@@ -214,12 +163,13 @@ export async function dragViaPlaywright(
     resolvedStart,
   );
   const { label: endLabel, locator: endLocator } = resolveInteractionElement(page, resolvedEnd);
-  await runGuardedPageInteraction(
+  await runCancellablePageInteraction(
     page,
     opts,
-    async () =>
+    async (signal) =>
       await startLocator.dragTo(endLocator, {
         timeout: resolveActInteractionTimeoutMs(opts.timeoutMs),
+        signal,
       }),
     `${startLabel} -> ${endLabel}`,
   );
@@ -236,12 +186,13 @@ export async function selectOptionViaPlaywright(
   }
   const page = await getRestoredPageForTarget(opts);
   const { label, locator } = resolveInteractionElement(page, resolved);
-  await runGuardedPageInteraction(
+  await runCancellablePageInteraction(
     page,
     opts,
-    async () => {
+    async (signal) => {
       await locator.selectOption(opts.values, {
         timeout: resolveActInteractionTimeoutMs(opts.timeoutMs),
+        signal,
       });
     },
     label,
@@ -279,20 +230,20 @@ export async function typeViaPlaywright(
   const page = await getRestoredPageForTarget(opts);
   const { label, locator } = resolveInteractionElement(page, resolved);
   const timeout = resolveActInteractionTimeoutMs(opts.timeoutMs);
-  await runGuardedPageInteraction(
+  await runCancellablePageInteraction(
     page,
     opts,
-    async () => {
+    async (signal) => {
       if (opts.slowly) {
-        await locator.click({ timeout });
+        await locator.click({ timeout, signal });
         throwIfInteractionAborted(opts.signal);
-        await locator.type(text, { timeout, delay: 75 });
+        await locator.type(text, { timeout, signal, delay: 75 });
       } else {
-        await locator.fill(text, { timeout });
+        await locator.fill(text, { timeout, signal });
       }
       if (opts.submit) {
         throwIfInteractionAborted(opts.signal);
-        await locator.press("Enter", { timeout });
+        await locator.press("Enter", { timeout, signal });
       }
     },
     label,
@@ -307,50 +258,34 @@ export async function fillFormViaPlaywright(
 ): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveActInteractionTimeoutMs(opts.timeoutMs);
-  const { abortPromise, cleanup } = createAbortPromiseWithListener(opts.signal);
-  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
-  try {
-    for (const field of opts.fields) {
-      const ref = field.ref.trim();
-      if (!ref) {
-        continue;
-      }
-      const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
-      const rawValue = field.value;
-      const value =
-        typeof rawValue === "string"
-          ? rawValue
-          : typeof rawValue === "number" || typeof rawValue === "boolean"
-            ? String(rawValue)
-            : "";
-      const locator = refLocator(page, ref);
-      try {
-        await awaitNavigationGuardedInteraction(
-          {
-            action: async () => {
-              if (type === "checkbox" || type === "radio") {
-                const checked =
-                  rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
-                await locator.setChecked(checked, { timeout });
-              } else {
-                await locator.fill(value, { timeout });
-              }
-            },
-            cdpUrl: opts.cdpUrl,
-            page,
-            ...interactionNavigationPolicy(opts),
-            targetId: opts.targetId,
-          },
-          abortPromise,
-          opts.signal,
-          reconcileRemoteDialog,
-        );
-      } catch (err) {
-        throw toFriendlyInteractionError(err, ref);
-      }
+  for (const field of opts.fields) {
+    const ref = field.ref.trim();
+    if (!ref) {
+      continue;
     }
-  } finally {
-    cleanup();
+    const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
+    const rawValue = field.value;
+    const value =
+      typeof rawValue === "string"
+        ? rawValue
+        : typeof rawValue === "number" || typeof rawValue === "boolean"
+          ? String(rawValue)
+          : "";
+    const locator = refLocator(page, ref);
+    await runCancellablePageInteraction(
+      page,
+      opts,
+      async (signal) => {
+        if (type === "checkbox" || type === "radio") {
+          const checked =
+            rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
+          await locator.setChecked(checked, { timeout, signal });
+        } else {
+          await locator.fill(value, { timeout, signal });
+        }
+      },
+      ref,
+    );
   }
 }
 
@@ -503,10 +438,10 @@ export async function scrollIntoViewViaPlaywright(opts: ElementInteractionOption
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 20_000);
 
   const { label, locator } = resolveInteractionElement(page, resolved);
-  await runGuardedPageInteraction(
+  await runCancellablePageInteraction(
     page,
     opts,
-    async () => await locator.scrollIntoViewIfNeeded({ timeout }),
+    async (signal) => await locator.scrollIntoViewIfNeeded({ timeout, signal }),
     label,
   );
 }

--- a/extensions/browser/src/browser/pw-tools-core.interactions.click-delay.abort.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.click-delay.abort.test.ts
@@ -38,6 +38,8 @@ describe("clickViaPlaywright (hold-delay abort)", () => {
       expect(hover).toHaveBeenCalledTimes(1);
       ctrl.abort(new Error("aborted by test"));
 
+      // Join the aborted hold and navigation grace without waiting out the hold.
+      await vi.advanceTimersByTimeAsync(1_000);
       const outcome = await settled;
       expect(outcome.status).toBe("rejected");
       if (outcome.status === "rejected") {
@@ -45,17 +47,9 @@ describe("clickViaPlaywright (hold-delay abort)", () => {
         expect((outcome.reason as Error).message).toContain("aborted by test");
       }
       expect(click).not.toHaveBeenCalled();
-      expect(getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget).toHaveBeenCalledWith({
-        cdpUrl: "http://127.0.0.1:18792",
-        targetId: "T1",
-        ssrfPolicy: { allowPrivateNetwork: false },
-        reason: "click aborted",
-      });
-
-      // The aborted action chain must unwind right away: the post-action
-      // navigation recheck runs after the 250ms delayed-navigation observation
-      // plus the 250ms grace, not after the remaining 4900ms of the hold.
-      await vi.advanceTimersByTimeAsync(1_000);
+      expect(
+        getPwToolsCoreSessionMocks().forceDisconnectPlaywrightForTarget,
+      ).not.toHaveBeenCalled();
       expect(
         getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely,
       ).toHaveBeenCalledTimes(1);

--- a/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.content.ts
@@ -24,8 +24,8 @@ import {
   type NavigationTargetOptions,
   reconcileRemoteDialogAfterActionSettled,
   resolveBoundedDelayMs,
+  runCancellablePageInteraction,
   throwIfInteractionAborted,
-  toFriendlyInteractionError,
 } from "./pw-tools-core.interactions.navigation.js";
 import { runPageEmulationTransition } from "./pw-tools-core.state.js";
 import {
@@ -73,6 +73,26 @@ function shouldUsePlaywrightFilePayloads(
   opts: Pick<NavigationTargetOptions, "browserFilesystemLocal" | "ssrfPolicy">,
 ): boolean {
   return Boolean(opts.ssrfPolicy) && opts.browserFilesystemLocal !== true;
+}
+
+async function resolvePlaywrightUploadFiles(opts: GuardedInteractionOptions & { paths: string[] }) {
+  const { abortPromise, cleanup } = createAbortPromiseWithListener(opts.signal);
+  try {
+    return await awaitActionWithAbort(
+      (async () => {
+        const resolved = await resolveStrictExistingUploadPaths({ requestedPaths: opts.paths });
+        if (!resolved.ok) {
+          throw new Error(resolved.error);
+        }
+        return shouldUsePlaywrightFilePayloads(opts)
+          ? await toPlaywrightFilePayloads(resolved.paths)
+          : resolved.paths;
+      })(),
+      abortPromise,
+    );
+  } finally {
+    cleanup();
+  }
 }
 
 type BrowserWaitPredicateState = {
@@ -491,35 +511,21 @@ async function screenshotWithLabelsOnPage(
 }
 
 export async function setFileChooserFilesViaPlaywright(
-  opts: NavigationTargetOptions & {
+  opts: GuardedInteractionOptions & {
     page: Page;
     fileChooser: FileChooser;
     paths: string[];
     timeoutMs: number;
   },
 ): Promise<void> {
-  const resolvedResult = await resolveStrictExistingUploadPaths({ requestedPaths: opts.paths });
-  if (!resolvedResult.ok) {
-    throw new Error(resolvedResult.error);
-  }
-  const resolvedPaths = resolvedResult.paths;
-  const resolvedFiles = shouldUsePlaywrightFilePayloads(opts)
-    ? await toPlaywrightFilePayloads(resolvedPaths)
-    : resolvedPaths;
-
-  await awaitNavigationGuardedInteraction({
-    action: async () => {
-      await opts.fileChooser.setFiles(resolvedFiles, { timeout: opts.timeoutMs });
-    },
-    cdpUrl: opts.cdpUrl,
-    page: opts.page,
-    ...interactionNavigationPolicy(opts),
-    targetId: opts.targetId,
+  const resolvedFiles = await resolvePlaywrightUploadFiles(opts);
+  await runCancellablePageInteraction(opts.page, opts, async (signal) => {
+    await opts.fileChooser.setFiles(resolvedFiles, { timeout: opts.timeoutMs, signal });
   });
 }
 
 export async function setInputFilesViaPlaywright(
-  opts: NavigationTargetOptions & {
+  opts: GuardedInteractionOptions & {
     inputRef?: string;
     element?: string;
     paths: string[];
@@ -541,26 +547,11 @@ export async function setInputFilesViaPlaywright(
   }
 
   const locator = inputRef ? refLocator(page, inputRef) : page.locator(element).first();
-  const resolvedResult = await resolveStrictExistingUploadPaths({ requestedPaths: opts.paths });
-  if (!resolvedResult.ok) {
-    throw new Error(resolvedResult.error);
-  }
-  const resolvedPaths = resolvedResult.paths;
-  const resolvedFiles = shouldUsePlaywrightFilePayloads(opts)
-    ? await toPlaywrightFilePayloads(resolvedPaths)
-    : resolvedPaths;
-
-  try {
-    await awaitNavigationGuardedInteraction({
-      action: async () => {
-        await locator.setInputFiles(resolvedFiles);
-      },
-      cdpUrl: opts.cdpUrl,
-      page,
-      ...interactionNavigationPolicy(opts),
-      targetId: opts.targetId,
-    });
-  } catch (err) {
-    throw toFriendlyInteractionError(err, inputRef || element);
-  }
+  const resolvedFiles = await resolvePlaywrightUploadFiles(opts);
+  await runCancellablePageInteraction(
+    page,
+    opts,
+    async (signal) => await locator.setInputFiles(resolvedFiles, { signal }),
+    inputRef || element,
+  );
 }

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -1014,11 +1014,12 @@ describe("pw-tools-core interaction navigation guard", () => {
     });
     await started;
     ctrl.abort(new Error("aborted by test"));
-
+    expect(drain).not.toHaveBeenCalled();
+    expect(dispose).not.toHaveBeenCalled();
+    releaseHover();
     await expect(task).rejects.toThrow("aborted by test");
     expect(drain).toHaveBeenCalledWith(DOWNLOAD_GRACE);
     expect(dispose).toHaveBeenCalledOnce();
-    releaseHover();
   });
 
   it("retains the download grace when an executable wait aborts", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation.ts
@@ -92,6 +92,57 @@ export function throwIfInteractionAborted(signal?: AbortSignal): void {
   }
 }
 
+export async function runCancellablePageInteraction<T>(
+  page: Page,
+  opts: GuardedInteractionOptions,
+  action: (signal: AbortSignal) => Promise<T>,
+  errorLabel?: string,
+): Promise<T> {
+  const cancellation = new AbortController();
+  const interruption = new AbortController();
+  const onAbort = () => {
+    // Dialogs interrupt the foreground call while the native action and its
+    // navigation guard remain live. Caller cancellation must join the native call.
+    const controller = isBrowserObservedDialogBlockedError(opts.signal?.reason)
+      ? interruption
+      : cancellation;
+    controller.abort(opts.signal?.reason);
+  };
+  opts.signal?.addEventListener("abort", onAbort, { once: true });
+  if (opts.signal?.aborted) {
+    onAbort();
+  }
+  const { abortPromise, cleanup } = createAbortPromiseWithListener(interruption.signal);
+  try {
+    const result = await awaitNavigationGuardedInteraction(
+      {
+        action: () => action(cancellation.signal),
+        cdpUrl: opts.cdpUrl,
+        page,
+        ...interactionNavigationPolicy(opts),
+        targetId: opts.targetId,
+      },
+      abortPromise,
+      opts.signal,
+      () => reconcileRemoteDialogAfterActionSettled(page, opts.signal),
+    );
+    throwIfInteractionAborted(opts.signal);
+    return result;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.name === "AbortError" &&
+      error.cause === cancellation.signal.reason
+    ) {
+      throwIfInteractionAborted(cancellation.signal);
+    }
+    throw errorLabel === undefined ? error : toFriendlyInteractionError(error, errorLabel);
+  } finally {
+    opts.signal?.removeEventListener("abort", onAbort);
+    cleanup();
+  }
+}
+
 // Returns true only when the URL change indicates a cross-document navigation
 // (i.e., a real network fetch occurred). Same-document hash-only mutations —
 // anchor clicks and history.pushState/replaceState that change only the

--- a/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
@@ -130,6 +130,7 @@ describe("setFileChooserFilesViaPlaywright", () => {
     expect(readFile).not.toHaveBeenCalled();
     expect(fileChooser.setFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"], {
       timeout: 250,
+      signal: expect.any(AbortSignal),
     });
   });
 
@@ -157,7 +158,7 @@ describe("setFileChooserFilesViaPlaywright", () => {
           lastModifiedMs: 1700000000000,
         },
       ],
-      { timeout: 250 },
+      { timeout: 250, signal: expect.any(AbortSignal) },
     );
   });
 });
@@ -193,7 +194,9 @@ describe("setInputFilesViaPlaywright", () => {
     expect(stat).not.toHaveBeenCalled();
     expect(readFile).not.toHaveBeenCalled();
     expect(detectMime).not.toHaveBeenCalled();
-    expect(setInputFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"]);
+    expect(setInputFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"], {
+      signal: expect.any(AbortSignal),
+    });
     expect(setInputFiles).toHaveBeenCalledTimes(1);
     expect(elementHandle).not.toHaveBeenCalled();
   });
@@ -215,14 +218,17 @@ describe("setInputFilesViaPlaywright", () => {
       buffer: Buffer.from("upload contents"),
       filePath: "/private/tmp/openclaw/uploads/ok.txt",
     });
-    expect(setInputFiles).toHaveBeenCalledWith([
-      {
-        name: "ok.txt",
-        mimeType: "text/plain",
-        buffer: Buffer.from("upload contents"),
-        lastModifiedMs: 1700000000000,
-      },
-    ]);
+    expect(setInputFiles).toHaveBeenCalledWith(
+      [
+        {
+          name: "ok.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from("upload contents"),
+          lastModifiedMs: 1700000000000,
+        },
+      ],
+      { signal: expect.any(AbortSignal) },
+    );
     expect(setInputFiles).toHaveBeenCalledTimes(1);
     expect(elementHandle).not.toHaveBeenCalled();
   });
@@ -239,14 +245,17 @@ describe("setInputFilesViaPlaywright", () => {
       ssrfPolicy: {},
     });
 
-    expect(setInputFiles).toHaveBeenCalledWith([
-      {
-        name: "ok.txt",
-        mimeType: "application/octet-stream",
-        buffer: Buffer.from("upload contents"),
-        lastModifiedMs: 1700000000000,
-      },
-    ]);
+    expect(setInputFiles).toHaveBeenCalledWith(
+      [
+        {
+          name: "ok.txt",
+          mimeType: "application/octet-stream",
+          buffer: Buffer.from("upload contents"),
+          lastModifiedMs: 1700000000000,
+        },
+      ],
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("checks the Playwright aggregate payload size cap before reading guarded remote upload files", async () => {
@@ -280,14 +289,17 @@ describe("setInputFilesViaPlaywright", () => {
     });
 
     expect(readFile).toHaveBeenCalledWith("/private/tmp/openclaw/uploads/ok.txt");
-    expect(setInputFiles).toHaveBeenCalledWith([
-      {
-        name: "ok.txt",
-        mimeType: "text/plain",
-        buffer: Buffer.from("upload contents"),
-        lastModifiedMs: 1700000000000,
-      },
-    ]);
+    expect(setInputFiles).toHaveBeenCalledWith(
+      [
+        {
+          name: "ok.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from("upload contents"),
+          lastModifiedMs: 1700000000000,
+        },
+      ],
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("checks the aggregate cap across multiple guarded remote upload payloads", async () => {
@@ -329,7 +341,9 @@ describe("setInputFilesViaPlaywright", () => {
     expect(stat).not.toHaveBeenCalled();
     expect(readFile).not.toHaveBeenCalled();
     expect(detectMime).not.toHaveBeenCalled();
-    expect(setInputFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"]);
+    expect(setInputFiles).toHaveBeenCalledWith(["/private/tmp/openclaw/uploads/ok.txt"], {
+      signal: expect.any(AbortSignal),
+    });
     expect(withPageNavigationRequestGuard).toHaveBeenCalledTimes(1);
     expect(setInputFiles).toHaveBeenCalledTimes(1);
     expect(assertPageNavigationCompletedSafely).toHaveBeenCalledTimes(1);
@@ -353,14 +367,17 @@ describe("setInputFilesViaPlaywright", () => {
       buffer: Buffer.from("upload contents"),
       filePath: "/private/tmp/openclaw/uploads/ok.txt",
     });
-    expect(setInputFiles).toHaveBeenCalledWith([
-      {
-        name: "ok.txt",
-        mimeType: "text/plain",
-        buffer: Buffer.from("upload contents"),
-        lastModifiedMs: 1700000000000,
-      },
-    ]);
+    expect(setInputFiles).toHaveBeenCalledWith(
+      [
+        {
+          name: "ok.txt",
+          mimeType: "text/plain",
+          buffer: Buffer.from("upload contents"),
+          lastModifiedMs: 1700000000000,
+        },
+      ],
+      { signal: expect.any(AbortSignal) },
+    );
     expect(withPageNavigationRequestGuard).toHaveBeenCalledTimes(1);
     expect(setInputFiles).toHaveBeenCalledTimes(1);
     expect(elementHandle).not.toHaveBeenCalled();

--- a/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
@@ -1,5 +1,6 @@
 // Browser tests cover pw tools core.last file chooser arm wins plugin behavior.
 import crypto from "node:crypto";
+import { EventEmitter, once } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -25,26 +26,17 @@ describe("pw-tools-core", () => {
     ]);
     const secondCanonicalPath = await fs.realpath(secondPath);
 
-    let resolve1: ((value: unknown) => void) | null = null;
-    let resolve2: ((value: unknown) => void) | null = null;
-
-    const fc1 = { setFiles: vi.fn(async () => {}) };
-    const fc2 = { setFiles: vi.fn(async () => {}) };
-
-    const waitForEvent = vi
-      .fn()
-      .mockImplementationOnce(
-        () =>
-          new Promise((r) => {
-            resolve1 = r;
-          }),
-      )
-      .mockImplementationOnce(
-        () =>
-          new Promise((r) => {
-            resolve2 = r;
-          }),
-      );
+    const chooserEvents = new EventEmitter();
+    const fileChooser = {
+      setFiles: vi.fn(
+        async (_paths: string[], _options: { timeout: number; signal: AbortSignal }) => {},
+      ),
+    };
+    // Native event waiters reject on abort and remove their old chooser listener.
+    const waitForEvent = vi.fn(async (_event: string, { signal }: { signal: AbortSignal }) => {
+      const [chooser] = await once(chooserEvents, "filechooser", { signal });
+      return chooser;
+    });
 
     setPwToolsCoreCurrentPage({
       waitForEvent,
@@ -61,18 +53,23 @@ describe("pw-tools-core", () => {
         paths: [secondPath],
       });
 
-      if (!resolve1 || !resolve2) {
-        throw new Error("file chooser handlers were not registered");
-      }
-      (resolve1 as (value: unknown) => void)(fc1);
-      (resolve2 as (value: unknown) => void)(fc2);
-      await Promise.resolve();
-
-      expect(fc1.setFiles).not.toHaveBeenCalled();
+      expect(waitForEvent).toHaveBeenCalledTimes(2);
+      expect(waitForEvent.mock.calls[0]![1].signal.aborted).toBe(true);
+      expect(chooserEvents.listenerCount("filechooser")).toBe(1);
+      chooserEvents.emit("filechooser", fileChooser);
       await vi.waitFor(() => {
-        expect(fc2.setFiles).toHaveBeenCalledWith([secondCanonicalPath], { timeout: 120_000 });
+        expect(fileChooser.setFiles).toHaveBeenCalledExactlyOnceWith([secondCanonicalPath], {
+          timeout: expect.any(Number),
+          signal: expect.any(AbortSignal),
+        });
       });
+      const { timeout, signal } = fileChooser.setFiles.mock.calls[0]![1];
+      expect(timeout).toBeGreaterThan(0);
+      expect(timeout).toBeLessThanOrEqual(120_000);
+      expect(signal.aborted).toBe(false);
+      expect(chooserEvents.listenerCount("filechooser")).toBe(0);
     } finally {
+      chooserEvents.emit("filechooser", fileChooser);
       await Promise.all([fs.rm(firstPath, { force: true }), fs.rm(secondPath, { force: true })]);
     }
   });
@@ -206,6 +203,6 @@ describe("pw-tools-core", () => {
       timeoutMs: 999_999,
     });
 
-    expect(click).toHaveBeenCalledWith({ timeout: 60_000 });
+    expect(click).toHaveBeenCalledWith({ timeout: 60_000, signal: expect.any(AbortSignal) });
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.screenshots-element-selector.test.ts
@@ -280,8 +280,14 @@ describe("pw-tools-core", () => {
     await fs.mkdir(path.dirname(uploadPath), { recursive: true });
     await fs.writeFile(uploadPath, "fixture", "utf8");
     const canonicalUploadPath = await fs.realpath(uploadPath);
-    const fileChooser = { setFiles: vi.fn(async () => {}) };
-    const waitForEvent = vi.fn(async (_eventValue: string, _opts: unknown) => fileChooser);
+    const fileChooser = {
+      setFiles: vi.fn(
+        async (_paths: string[], _options: { timeout: number; signal: AbortSignal }) => {},
+      ),
+    };
+    const waitForEvent = vi.fn(
+      async (_eventValue: string, _opts: { timeout: number; signal: AbortSignal }) => fileChooser,
+    );
     setPwToolsCoreCurrentPage({
       waitForEvent,
       keyboard: { press: vi.fn(async () => {}) },
@@ -298,13 +304,19 @@ describe("pw-tools-core", () => {
       await Promise.resolve();
 
       expect(waitForEvent).toHaveBeenCalledWith("filechooser", {
-        timeout: 120_000,
+        timeout: 0,
+        signal: expect.any(AbortSignal),
       });
       await vi.waitFor(() => {
-        expect(fileChooser.setFiles).toHaveBeenCalledWith([canonicalUploadPath], {
-          timeout: 120_000,
+        expect(fileChooser.setFiles).toHaveBeenCalledExactlyOnceWith([canonicalUploadPath], {
+          timeout: expect.any(Number),
+          signal: expect.any(AbortSignal),
         });
       });
+      const { timeout, signal } = fileChooser.setFiles.mock.calls[0]![1];
+      expect(timeout).toBeGreaterThan(0);
+      expect(timeout).toBeLessThanOrEqual(120_000);
+      expect(signal.aborted).toBe(false);
     } finally {
       await fs.rm(uploadPath, { force: true });
     }

--- a/extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.upload-paths.test.ts
@@ -1,4 +1,4 @@
-// Browser tests cover pw tools core.upload paths plugin behavior.
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getPwToolsCoreSessionMocks,
@@ -16,14 +16,7 @@ const pathMocks = vi.hoisted(() => ({
 }));
 
 const interactionMocks = vi.hoisted(() => ({
-  clickViaPlaywright: vi.fn(async () => {}),
-  setFileChooserFilesViaPlaywright: vi.fn(
-    async (opts: {
-      fileChooser: { setFiles: (paths: string[], options?: { timeout?: number }) => Promise<void> };
-      paths: string[];
-      timeoutMs: number;
-    }) => await opts.fileChooser.setFiles(opts.paths, { timeout: opts.timeoutMs }),
-  ),
+  clickViaPlaywright: vi.fn<(opts: { signal?: AbortSignal }) => Promise<void>>(async () => {}),
 }));
 
 vi.mock("./paths.js", async (importOriginal) => {
@@ -34,7 +27,10 @@ vi.mock("./paths.js", async (importOriginal) => {
   };
 });
 
-vi.mock("./pw-tools-core.interactions.js", () => interactionMocks);
+vi.mock("./pw-tools-core.interactions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./pw-tools-core.interactions.js")>()),
+  ...interactionMocks,
+}));
 
 installPwToolsCoreTestHooks();
 const sessionMocks = getPwToolsCoreSessionMocks();
@@ -55,33 +51,51 @@ function createFileChooserPageMocks() {
   return { fileChooser, press };
 }
 
+function nativeAbortError(signal: AbortSignal) {
+  return Object.assign(new Error("Operation aborted", { cause: signal.reason }), {
+    name: "AbortError",
+  });
+}
+
 function createAtomicFileChooserPageMocks() {
   const fileChooser = {
-    setFiles: vi.fn<(paths: string[], options?: { timeout?: number }) => Promise<void>>(
-      async () => {},
-    ),
+    setFiles: vi.fn<
+      (paths: string[], options: { timeout?: number; signal: AbortSignal }) => Promise<void>
+    >(async () => {}),
   };
-  type Listener = (chooser: typeof fileChooser) => void;
-  const listeners = new Set<Listener>();
-  const on = vi.fn((_event: "filechooser", listener: Listener) => {
-    listeners.add(listener);
-  });
-  const off = vi.fn((_event: "filechooser", listener: Listener) => {
-    listeners.delete(listener);
-  });
+  const events = new EventEmitter();
+  const waitForEvent = vi.fn(
+    async (_event: string, { signal }: { signal: AbortSignal }) =>
+      await new Promise<typeof fileChooser>((resolve, reject) => {
+        const cleanup = () => {
+          events.off("filechooser", onChooser);
+          signal.removeEventListener("abort", onAbort);
+        };
+        const onChooser = (chooser: typeof fileChooser) => {
+          cleanup();
+          resolve(chooser);
+        };
+        const onAbort = () => {
+          cleanup();
+          reject(nativeAbortError(signal));
+        };
+        events.once("filechooser", onChooser);
+        signal.addEventListener("abort", onAbort, { once: true });
+        if (signal.aborted) {
+          onAbort();
+        }
+      }),
+  );
   const press = vi.fn(async () => {});
-  const currentPage = { on, off, keyboard: { press } };
+  const currentPage = { waitForEvent, keyboard: { press } };
   setPwToolsCoreCurrentPage(currentPage);
   return {
     currentPage,
     emitChooser: (observed = fileChooser) => {
-      for (const listener of listeners) {
-        listener(observed);
-      }
+      events.emit("filechooser", observed);
     },
     fileChooser,
-    listenerCount: () => listeners.size,
-    off,
+    listenerCount: () => events.listenerCount("filechooser"),
     press,
   };
 }
@@ -90,7 +104,6 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     interactionMocks.clickViaPlaywright.mockReset().mockResolvedValue(undefined);
-    interactionMocks.setFileChooserFilesViaPlaywright.mockClear();
     pathMocks.resolveStrictExistingUploadPaths.mockResolvedValue({
       ok: true,
       paths: ["/home/user/.openclaw/media/inbound/report.pdf"],
@@ -110,7 +123,7 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
     await vi.waitFor(() => {
       expect(fileChooser.setFiles).toHaveBeenCalledWith(
         ["/home/user/.openclaw/media/inbound/report.pdf"],
-        { timeout: expect.any(Number) },
+        { timeout: expect.any(Number), signal: expect.any(AbortSignal) },
       );
     });
     expect(fileChooser.setFiles).toHaveBeenCalledTimes(1);
@@ -164,13 +177,12 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
     );
     expect(page.fileChooser.setFiles).toHaveBeenCalledWith(
       ["/home/user/.openclaw/media/inbound/report.pdf"],
-      { timeout: expect.any(Number) },
+      { timeout: expect.any(Number), signal: expect.any(AbortSignal) },
     );
     expect(settled).toBe(false);
     finishSetFiles();
     await upload;
     expect(page.listenerCount()).toBe(0);
-    expect(page.off).toHaveBeenCalledTimes(1);
   });
 
   it("accepts only the first chooser emitted by the guarded click", async () => {
@@ -276,7 +288,11 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
       page.fileChooser.setFiles.mockImplementation(
         async (_paths, options) =>
           await new Promise<void>((_resolve, reject) => {
-            setTimeout(() => reject(new Error("setFiles timed out")), options?.timeout ?? 0);
+            options.signal.addEventListener(
+              "abort",
+              () => reject(nativeAbortError(options.signal)),
+              { once: true },
+            );
           }),
       );
       interactionMocks.clickViaPlaywright.mockImplementation(async () => page.emitChooser());
@@ -325,27 +341,19 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
     }
   });
 
-  it("settles connection cleanup before an upload on another target starts", async () => {
+  it("joins native cancellation before another upload on the same page starts", async () => {
     const page = createAtomicFileChooserPageMocks();
-    let rejectFirstAssignment!: (reason: unknown) => void;
+    let firstSignal: AbortSignal | undefined;
+    let finishCancellation!: () => void;
     page.fileChooser.setFiles
       .mockImplementationOnce(
-        async () =>
+        async (_paths, options) =>
           await new Promise<void>((_resolve, reject) => {
-            rejectFirstAssignment = reject;
+            firstSignal = options.signal;
+            finishCancellation = () => reject(nativeAbortError(options.signal));
           }),
       )
       .mockResolvedValueOnce(undefined);
-    let finishDisconnect!: () => void;
-    sessionMocks.forceDisconnectPlaywrightForTarget.mockImplementationOnce(
-      async () =>
-        await new Promise<void>((resolve) => {
-          finishDisconnect = () => {
-            rejectFirstAssignment(new Error("Playwright disconnected"));
-            resolve();
-          };
-        }),
-    );
     interactionMocks.clickViaPlaywright
       .mockImplementationOnce(async () => page.emitChooser())
       .mockImplementationOnce(async () => page.emitChooser());
@@ -359,17 +367,15 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
     await vi.waitFor(() => expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(1));
     const second = uploadViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
-      targetId: "T2",
+      targetId: "T1",
       ref: "e2",
       paths: ["/home/user/.openclaw/media/inbound/second.pdf"],
     });
 
     const firstRejection = expect(first).rejects.toThrow("superseded by another waiter");
-    await vi.waitFor(() =>
-      expect(sessionMocks.forceDisconnectPlaywrightForTarget).toHaveBeenCalledTimes(1),
-    );
+    await vi.waitFor(() => expect(firstSignal?.aborted).toBe(true));
     expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(1);
-    finishDisconnect();
+    finishCancellation();
     await firstRejection;
     await second;
     expect(page.fileChooser.setFiles).toHaveBeenCalledTimes(2);
@@ -378,25 +384,17 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
 
   it("preserves the cleanup tail when a queued owner aborts", async () => {
     const page = createAtomicFileChooserPageMocks();
-    let rejectFirstAssignment!: (reason: unknown) => void;
+    let firstSignal: AbortSignal | undefined;
+    let finishCancellation!: () => void;
     page.fileChooser.setFiles
       .mockImplementationOnce(
-        async () =>
+        async (_paths, options) =>
           await new Promise<void>((_resolve, reject) => {
-            rejectFirstAssignment = reject;
+            firstSignal = options.signal;
+            finishCancellation = () => reject(nativeAbortError(options.signal));
           }),
       )
       .mockResolvedValueOnce(undefined);
-    let finishDisconnect!: () => void;
-    sessionMocks.forceDisconnectPlaywrightForTarget.mockImplementationOnce(
-      async () =>
-        await new Promise<void>((resolve) => {
-          finishDisconnect = () => {
-            rejectFirstAssignment(new Error("Playwright disconnected"));
-            resolve();
-          };
-        }),
-    );
     interactionMocks.clickViaPlaywright
       .mockImplementationOnce(async () => page.emitChooser())
       .mockImplementationOnce(async () => page.emitChooser());
@@ -416,9 +414,7 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
       paths: ["/home/user/.openclaw/media/inbound/second.pdf"],
       signal: secondController.signal,
     });
-    await vi.waitFor(() =>
-      expect(sessionMocks.forceDisconnectPlaywrightForTarget).toHaveBeenCalledTimes(1),
-    );
+    await vi.waitFor(() => expect(firstSignal?.aborted).toBe(true));
     secondController.abort(new Error("queued upload aborted"));
     await expect(second).rejects.toThrow("queued upload aborted");
 
@@ -430,7 +426,7 @@ describe("armFileUploadViaPlaywright upload path validation", () => {
     await Promise.resolve();
     expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(1);
 
-    finishDisconnect();
+    finishCancellation();
     await firstRejection;
     await third;
     expect(interactionMocks.clickViaPlaywright).toHaveBeenCalledTimes(2);

--- a/extensions/browser/src/browser/routes/agent.act.hooks.ts
+++ b/extensions/browser/src/browser/routes/agent.act.hooks.ts
@@ -98,6 +98,7 @@ export function registerBrowserAgentActHookRoutes(
             element,
             paths: resolvedPaths,
             ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+            signal,
           });
         } else if (ref) {
           await pw.uploadViaPlaywright({

--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -260,7 +260,9 @@ async function probeCorners(browser: Browser, fixtureFile: string): Promise<Corn
             const style = getComputedStyle(element);
             const radius =
               corner === "bottomLeft" ? style.borderBottomLeftRadius : style.borderTopLeftRadius;
-            return [selector, { radius, shape: style.getPropertyValue("corner-shape") }];
+            const shape = style.getPropertyValue("corner-shape");
+            // CSS defines round as superellipse(1); Chromium builds serialize both forms.
+            return [selector, { radius, shape: shape === "superellipse(1)" ? "round" : shape }];
           }),
         );
       },


### PR DESCRIPTION
## Summary

Fixes #136464.

Cancelling a blocked click on one tab could close the shared CDP connection and fail another tab's click. A cancelled fill could still write when its input later became editable, and an upload on a second tab could supersede the first. The adapter retained a global disconnect/queue workaround after its pinned Playwright dependency gained acknowledged per-operation cancellation.

Supported locator and file operations now pass a native signal and join native completion plus navigation-policy cleanup. Upload ownership follows the actual Page: same-page replacement joins its predecessor, while different tabs run independently. The change removes the shared-connection click/upload workaround, the global upload queue, custom chooser listener/phase machinery and duplicated file preparation.

Production **+285 / −418 = −133 LOC**. Tests **+472 / −173 = +299**; docs **+1**. One root-cause repair across actions and uploads.

## Verification

Actual Playwright 1.62.1 / Chromium 151.0.7922.34, native CDP operations and independent observation tabs were used before editing and after the fix:

| Original execution order | Before | After |
| --- | --- | --- |
| Block clicks on tabs A/B; cancel A; enable B | B fails with closed CDP socket | A cancels; B clicks successfully; connection retained |
| Block fill; cancel; make input editable | Cancelled text appears | Input remains empty; native operation settled |
| Start uploads on two tabs | Second supersedes first | Both assign the intended file |

The exact final-source batch passes **206 tests across 10 files**, including **8 real Chromium cases**. Coverage includes direct file-input cancellation, observed dialogs, native cleanup acknowledgment, same-page queued replacement, navigation denial/grace/quarantine, guarded upload payloads, streaming downloads and restart. The initial three regression failures are preserved. Full changed-file checks and independent Codex P2 review pass; source hashes match after commit.

The installed dependency source was inspected directly: client signals dispatch per-call `__abort__`, server `ProgressController` acknowledges completion, the client retains the original abort cause, and native event waiters dispose listeners. Public source for the same contract: [Playwright connection owner](https://github.com/microsoft/playwright/blob/v1.62.1/packages/playwright-core/src/client/connection.ts), [progress owner](https://github.com/microsoft/playwright/blob/v1.62.1/packages/playwright-core/src/server/progress.ts).

## Ownership and limits

Observed dialogs deliberately interrupt the foreground action while retaining native work and its navigation guard until the dialog is answered. A separate actual/counterfactual caller probe confirms the atomic upload route supplies request/profile cancellation, not the action executor's observed-dialog interruption signal. Existing raw keyboard/mouse and evaluate paths retain their dependency-specific behavior. Native cancellation does not roll back completed DOM effects or stop arbitrary JavaScript already scheduled by a page.

Strict paths, payload limits, navigation policy, configuration and dependencies retain their existing contracts. The browser-control documentation records tab isolation and same-tab upload replacement. All proof browsers, servers and task files were cleaned up.

## CI follow-up

The first exact-head run exposed three old option-object assertions and a chooser fixture that never acknowledged cancellation. The fixture now uses Node's abortable event waiter, checks that the superseded listener is removed, and observes one assignment to the current chooser. The exact 500 ms and 60,000 ms action clamps remain asserted; uploads assert a positive remaining deadline no greater than 120,000 ms and an active native signal. Existing cancellation and deadline tests remain intact.

The focused browser suite passes **40 tests**, including the previously failing cases. Three actual Chromium style checks also pass after normalizing only CSS's specified `superellipse(1)`/`round` equivalence. Typed lint, formatting and an independent Codex P2 review pass. These are test-only repairs (**+14 net test LOC**), with no additional production changes or issue count.

## Current-main CI refresh

A tree-identical CI refresh retains the complete reviewed source and proof. Earlier checks ran before the canonical main test split and CI runner/dependency acquisition fixes; the new PR event rebuilds the current merge ref through the normal required checks. There are no source, test, configuration or production-LOC changes in this refresh.

## Maintainer review disposition

The latest September 2 21:11 UTC review's dependency risk and rank-up request are resolved by direct inspection of installed Playwright 1.62.1, not an assumed AbortSignal contract. In `lib/coreBundle.js`, `Connection.sendMessageToServer`/dispatch (63393–63526) sends a per-call abort and waits for the response; server dispatch (18703–18810) awaits the operation's `ProgressController` (12057–12167). Locator/Frame/ElementHandle/FileChooser methods forward the signal, while native waiter cleanup removes its event/abort listeners. The already-recorded real Chromium cases exercise those paths and verify that aborted pending operations do not run later. Keyboard/mouse primitives and arbitrary page evaluation keep their existing separate behavior.

Root rechecked all five changed production files against main `8caf8146c60e12edee91b944fc2c9fb90564a6da`: their baseline owners are unchanged and the combined tree merges cleanly. Required exact-head CI, including `openclaw/ci-gate` (run 33680221533), is green. The reviewed source tree and full local proof remain unchanged by the CI refresh.
