### PR TITLE
fix(tui): preserve authored hyperlink destinations

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -51,6 +51,7 @@ openclaw tui --local
 
 - Header: connection URL, current agent, current session.
 - Chat log: user messages, assistant replies, system notices, tool cards.
+- On terminals with hyperlink support, Markdown links open their authored destination, including wrapped links and URL-shaped labels.
 - Status line: connection/run state (connecting, running, streaming, idle, error).
 - Footer: agent + session + model + goal state + think/fast/verbose/trace/reasoning + token counts + deliver.
 - Input: text editor with autocomplete.

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,6 +111,15 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
+async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
+  const root = tempDirs.make(`openclaw-${label}-`);
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify({ gateway }));
+  return { root, stateDir, configPath };
+}
+
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -185,20 +194,11 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
-    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: gateway.token },
-        },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
+      mode: "remote",
+      remote: { url: gateway.url, token: gateway.token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,16 +279,12 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
-      const root = tempDirs.make("openclaw-nodes-timeout-");
-      const stateDir = path.join(root, "state");
-      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
-      );
+      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
+        mode: "remote",
+        remote: { url: gateway.url, token },
+      });
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -315,18 +311,12 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-cli-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: { mode: "remote", remote: { url: gateway.url, token } },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
+      mode: "remote",
+      remote: { url: gateway.url, token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -344,22 +334,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -394,15 +380,11 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-explicit-auth",
+      { mode: "remote", remote: { url: gateway.url, token } },
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -421,22 +403,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -736,19 +714,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remtoe",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-invalid-config",
+      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({
@@ -1006,19 +975,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
-    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-rate-limit-json",
+      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,15 +111,6 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
-async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
-  const root = tempDirs.make(`openclaw-${label}-`);
-  const stateDir = path.join(root, "state");
-  const configPath = path.join(stateDir, "openclaw.json");
-  await fs.mkdir(stateDir, { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify({ gateway }));
-  return { root, stateDir, configPath };
-}
-
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -194,11 +185,20 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
+    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
-      mode: "remote",
-      remote: { url: gateway.url, token: gateway.token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: gateway.token },
+        },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,12 +279,16 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
+      const root = tempDirs.make("openclaw-nodes-timeout-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
-        mode: "remote",
-        remote: { url: gateway.url, token },
-      });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+      );
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -311,12 +315,18 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-cli-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
-      mode: "remote",
-      remote: { url: gateway.url, token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "remote", remote: { url: gateway.url, token } },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -334,18 +344,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -380,11 +394,15 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-explicit-auth",
-      { mode: "remote", remote: { url: gateway.url, token } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -403,18 +421,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -714,10 +736,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-invalid-config",
-      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remtoe",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({
@@ -975,10 +1006,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
+    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-rate-limit-json",
-      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/gateway/server.startup-recovery-webchat.test.ts
+++ b/src/gateway/server.startup-recovery-webchat.test.ts
@@ -4,7 +4,6 @@ import { writeOpenAiResponsesText } from "../../test/helpers/openai-responses-ss
 import { createDeferred } from "../../test/helpers/promise.js";
 import { MAIN_SESSION_RECOVERY_WORK_ADMISSION_OWNER } from "../agents/main-session-recovery/main-session-recovery-admission.js";
 import { recoverRestartAbortedMainSessions } from "../agents/main-session-recovery/main-session-restart-recovery.js";
-import { getFollowupQueueDepth } from "../auto-reply/reply/queue/enqueue.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "../auto-reply/reply/queue/state.js";
 import {
   appendTranscriptMessage,
@@ -17,6 +16,7 @@ import {
   getSessionWorkAdmissionOwnerRelease,
 } from "../sessions/session-lifecycle-admission.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { countPendingQueueItems } from "../utils/queue-helpers.js";
 import { getGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
 import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
@@ -184,11 +184,12 @@ it(
 
       const canceledRunId = "webchat-canceled-during-recovery";
       const survivorRunId = "webchat-survives-recovery";
+      const expectedQueuedMessages = new Map([
+        [canceledRunId, canceledMessage],
+        [survivorRunId, survivorMessage],
+      ]);
       await Promise.all(
-        [
-          [canceledRunId, canceledMessage],
-          [survivorRunId, survivorMessage],
-        ].map(async ([runId, message]) => {
+        Array.from(expectedQueuedMessages, async ([runId, message]) => {
           await expect(
             client.request("chat.send", {
               sessionKey,
@@ -203,8 +204,14 @@ it(
       );
       await vi.waitFor(() => {
         const queue = getExistingFollowupQueue(sessionKey);
+        // Active sources remain in items; started ACKs can precede queue admission.
+        expect(queue?.items).toHaveLength(expectedQueuedMessages.size);
+        expect(new Map(queue?.items.map(({ messageId, prompt }) => [messageId, prompt]))).toEqual(
+          expectedQueuedMessages,
+        );
         expect(queue?.inFlight).toHaveLength(1);
-        expect(getFollowupQueueDepth(sessionKey)).toBe(1);
+        expect(countPendingQueueItems(queue?.items ?? [], queue?.inFlight)).toBe(1);
+        expect(targetRequests).toHaveLength(1);
       });
       replacementOwner = await beginSessionWorkAdmission({
         scope: storePath,

--- a/src/gateway/server.startup-recovery-webchat.test.ts
+++ b/src/gateway/server.startup-recovery-webchat.test.ts
@@ -4,6 +4,7 @@ import { writeOpenAiResponsesText } from "../../test/helpers/openai-responses-ss
 import { createDeferred } from "../../test/helpers/promise.js";
 import { MAIN_SESSION_RECOVERY_WORK_ADMISSION_OWNER } from "../agents/main-session-recovery/main-session-recovery-admission.js";
 import { recoverRestartAbortedMainSessions } from "../agents/main-session-recovery/main-session-restart-recovery.js";
+import { getFollowupQueueDepth } from "../auto-reply/reply/queue/enqueue.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "../auto-reply/reply/queue/state.js";
 import {
   appendTranscriptMessage,
@@ -203,7 +204,7 @@ it(
       await vi.waitFor(() => {
         const queue = getExistingFollowupQueue(sessionKey);
         expect(queue?.inFlight).toHaveLength(1);
-        expect(queue?.items).toHaveLength(1);
+        expect(getFollowupQueueDepth(sessionKey)).toBe(1);
       });
       replacementOwner = await beginSessionWorkAdmission({
         scope: storePath,

--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -41,6 +41,7 @@ describe("e2e vitest config", () => {
       "src/tui/tui-reset-transition-pty.e2e.test.ts",
       "src/tui/tui-task-suggestions-pty.e2e.test.ts",
       "src/tui/tui-error-pty.e2e.test.ts",
+      "src/tui/tui-hyperlinks-pty.e2e.test.ts",
       "src/tui/tui-pty-local.e2e.test.ts",
     ];
 

--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -1,4 +1,5 @@
 // Verifies OSC8 hyperlink formatting for TUI terminal output.
+import { getOsc8LinkAtColumn } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import { addOsc8Hyperlinks, extractUrls } from "./osc8-hyperlinks.js";
 
@@ -106,6 +107,27 @@ describe("extractUrls", () => {
 });
 
 describe("addOsc8Hyperlinks", () => {
+  it.each([
+    { name: "BEL", params: "", terminator: "\x07" },
+    { name: "ST with link identity", params: "id=docs", terminator: "\x1b\\" },
+  ])("preserves authored spans alongside unlinked URLs ($name)", ({ params, terminator }) => {
+    const label = "https://example.test/label";
+    const target = "https://example.test/destination";
+    const bare = "https://example.test/bare";
+    const prefix = "See ";
+    const authored = `\x1b]8;${params};${target}${terminator}\x1b[32m${label}\x1b[0m\x1b]8;;${terminator}`;
+    const line = `${prefix}${authored} then ${bare}`;
+
+    const [rendered] = addOsc8Hyperlinks([line], [target, bare]);
+
+    expect(rendered).toContain(authored);
+    expect(getOsc8LinkAtColumn(rendered!, prefix.length)).toBe(target);
+    expect(getOsc8LinkAtColumn(rendered!, prefix.length + label.length)).toBeUndefined();
+    expect(getOsc8LinkAtColumn(rendered!, prefix.length + label.length + " then ".length)).toBe(
+      bare,
+    );
+  });
+
   it("returns lines unchanged when no URLs", () => {
     const lines = ["Hello world", "No links here"];
     expect(addOsc8Hyperlinks(lines, [])).toEqual(lines);

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -1,11 +1,6 @@
-// Regex patterns for ANSI escape sequences (constructed from strings to
 import { expectDefined } from "@openclaw/normalization-core";
-// satisfy the no-control-regex lint rule).
-const SGR_PATTERN = "\\x1b\\[[0-9;]*m";
-const OSC8_PATTERN = "\\x1b\\]8;;.*?(?:\\x07|\\x1b\\\\)";
-const ANSI_RE = new RegExp(`${SGR_PATTERN}|${OSC8_PATTERN}`, "g");
-const SGR_START_RE = new RegExp(`^${SGR_PATTERN}`);
-const OSC8_START_RE = new RegExp(`^${OSC8_PATTERN}`);
+import { splitAnsiSegments } from "../../packages/terminal-core/src/ansi-sequences.js";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 
 /** Allow one level of balanced parentheses inside a URL so markdown link
  *  targets like `https://en.wikipedia.org/wiki/URL_(disambiguation)` are
@@ -76,11 +71,6 @@ export function extractUrls(markdown: string): string[] {
   }
 
   return [...urls];
-}
-
-/** Strip ANSI SGR and OSC 8 sequences to get visible text. */
-function stripAnsi(input: string): string {
-  return input.replace(ANSI_RE, "");
 }
 
 interface UrlRange {
@@ -211,62 +201,54 @@ function findUrlRanges(
 
 /**
  * Apply OSC 8 hyperlink sequences to a line based on visible-text URL ranges.
- * Walks through the raw string character by character, inserting OSC 8
- * open/close sequences at URL range boundaries while preserving ANSI codes.
+ * Preserve renderer-owned hyperlinks while linking remaining visible URL ranges.
  */
 function applyOsc8Ranges(line: string, ranges: UrlRange[]): string {
   if (ranges.length === 0) {
     return line;
   }
 
-  // Build a lookup: visible position → URL
-  const urlAt = new Map<number, string>();
-  for (const r of ranges) {
-    for (let p = r.start; p < r.end; p++) {
-      urlAt.set(p, r.url);
-    }
-  }
-
   let result = "";
   let visiblePos = 0;
   let activeUrl: string | null = null;
-  let i = 0;
+  let rendererLink = false;
+  let rangeIndex = 0;
+  let range = ranges[rangeIndex];
 
-  while (i < line.length) {
-    // Fast path: only check for escape sequences when we see ESC
-    if (line.charCodeAt(i) === 0x1b) {
-      // ANSI SGR sequence
-      const sgr = line.slice(i).match(SGR_START_RE);
-      if (sgr) {
-        result += sgr[0];
-        i += sgr[0].length;
-        continue;
+  for (const segment of splitAnsiSegments(line)) {
+    if (segment.kind === "ansi") {
+      let code = segment.value;
+      if (code.startsWith("\x1b]8;")) {
+        if (activeUrl !== null) {
+          result += "\x1b]8;;\x07";
+        }
+        code = code.replace(/[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/g, "");
+        const body = code.slice(4, code.endsWith("\x1b\\") ? -2 : -1);
+        rendererLink = body.slice(body.indexOf(";") + 1).length > 0;
+        // The parsed Markdown href owns this span, even when its label is another URL.
+        activeUrl = null;
       }
-
-      // Existing OSC 8 sequence (pass through)
-      const osc = line.slice(i).match(OSC8_START_RE);
-      if (osc) {
-        result += osc[0].replace(/[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/g, "");
-        i += osc[0].length;
-        continue;
-      }
+      result += code;
+      continue;
     }
 
-    // Visible character — toggle OSC 8 at range boundaries
-    const targetUrl = urlAt.get(visiblePos) ?? null;
-    if (targetUrl !== activeUrl) {
-      if (activeUrl !== null) {
-        result += "\x1b]8;;\x07";
+    for (const char of segment.value) {
+      while (range && visiblePos >= range.end) {
+        range = ranges[++rangeIndex];
       }
-      if (targetUrl !== null) {
-        result += `\x1b]8;;${targetUrl}\x07`;
+      const targetUrl = !rendererLink && range && visiblePos >= range.start ? range.url : null;
+      if (targetUrl !== activeUrl) {
+        if (activeUrl !== null) {
+          result += "\x1b]8;;\x07";
+        }
+        if (targetUrl !== null) {
+          result += `\x1b]8;;${targetUrl}\x07`;
+        }
+        activeUrl = targetUrl;
       }
-      activeUrl = targetUrl;
+      result += char;
+      visiblePos += char.length;
     }
-
-    result += line[i];
-    visiblePos++;
-    i++;
   }
 
   if (activeUrl !== null) {

--- a/src/tui/tui-hyperlinks-pty.e2e.test.ts
+++ b/src/tui/tui-hyperlinks-pty.e2e.test.ts
@@ -1,0 +1,111 @@
+import { expect, it } from "vitest";
+import { splitAnsiSegments } from "../../packages/terminal-core/src/ansi-sequences.js";
+import {
+  objectFieldEquals,
+  startTuiFixture,
+  waitForSynchronizedFrameRows,
+} from "./tui-pty-harness-fixture-test-support.js";
+
+function linkedText(output: string) {
+  let target = "";
+  const spans: Array<{ target: string; text: string }> = [];
+  for (const segment of splitAnsiSegments(output)) {
+    if (segment.kind === "ansi") {
+      if (segment.value.startsWith("\x1b]8;;")) {
+        const terminatorLength = segment.value.endsWith("\x1b\\") ? 2 : 1;
+        target = segment.value.slice(5, -terminatorLength);
+      }
+    } else if (target) {
+      spans.push({ target, text: segment.value });
+    }
+  }
+  return spans;
+}
+
+it.each([
+  { label: "VS Code", termProgram: "vscode", cols: 100, labelPath: "label" },
+  {
+    label: "wrapped VS Code",
+    termProgram: "vscode",
+    cols: 36,
+    labelPath: "label/with/a/long/path",
+  },
+  { label: "unidentified terminal", termProgram: "", cols: 36, labelPath: "label" },
+])(
+  "preserves authored link targets in $label",
+  async ({ label, termProgram, cols, labelPath }) => {
+    const target = "https://example.test/actual-destination";
+    const plainTarget = "https://example.test/documentation";
+    const visibleUrl = `https://example.test/${labelPath}`;
+    const message = `[${visibleUrl}](${target}) and [Documentation](${plainTarget})`;
+    const fixture = await startTuiFixture({
+      env: {
+        TERM_PROGRAM: termProgram,
+        TMUX: undefined,
+        KITTY_WINDOW_ID: undefined,
+        GHOSTTY_RESOURCES_DIR: undefined,
+        WEZTERM_PANE: undefined,
+        ITERM_SESSION_ID: undefined,
+        WT_SESSION: undefined,
+        WARP_SESSION_ID: undefined,
+        WARP_TERMINAL_SESSION_UUID: undefined,
+        TERMINAL_EMULATOR: undefined,
+        OPENCLAW_TUI_PTY_COLS: String(cols),
+        OPENCLAW_TUI_PTY_ROWS: "30",
+      },
+    });
+    try {
+      await fixture.run.waitForOutput("local ready", 20_000);
+      await fixture.run.write(`${message}\r`, { delay: false });
+      await fixture.waitForLogEntry(
+        (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", message),
+      );
+      await fixture.run.waitForOutput("PTY_RESPONSE:", 20_000);
+      const raw = fixture.run.output();
+      const response = raw.slice(raw.lastIndexOf("PTY_RESPONSE:"));
+      const links = linkedText(response);
+      console.log(
+        `[behavior-evidence] ${JSON.stringify({
+          label,
+          columns: cols,
+          links,
+          terminal: "real PTY",
+        })}`,
+      );
+      if (termProgram) {
+        expect(links.filter((span) => span.target === visibleUrl)).toEqual([]);
+        if (visibleUrl.length > cols) {
+          expect(links.filter((span) => span.target === target).length).toBeGreaterThan(1);
+        }
+        expect(
+          links
+            .filter((span) => span.target === target)
+            .map((span) => span.text)
+            .join(""),
+        ).toContain(visibleUrl);
+        expect(
+          links
+            .filter((span) => span.target === plainTarget)
+            .map((span) => span.text)
+            .join(""),
+        ).toContain("Documentation");
+      } else {
+        expect(links.some((span) => span.target === target)).toBe(true);
+        expect(links.some((span) => span.target === plainTarget)).toBe(true);
+      }
+      const rows = await waitForSynchronizedFrameRows(
+        fixture.run,
+        (frame) =>
+          frame.some((row) => row.includes("PTY_RESPONSE:")) &&
+          frame.some((row) => row.includes("idle")),
+        20_000,
+      );
+      console.log(`[terminal-frame] ${JSON.stringify({ label, columns: cols, rows })}`);
+      await fixture.run.write("/exit\r", { delay: false });
+      expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+    } finally {
+      await fixture.cleanup();
+    }
+  },
+  30_000,
+);

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -19,6 +19,7 @@ export const tuiPtyTestFiles = [
   "src/tui/tui-reset-transition-pty.e2e.test.ts",
   "src/tui/tui-task-suggestions-pty.e2e.test.ts",
   "src/tui/tui-error-pty.e2e.test.ts",
+  "src/tui/tui-hyperlinks-pty.e2e.test.ts",
   "src/tui/tui-pty-local.e2e.test.ts",
 ];
 


### PR DESCRIPTION
## Summary

Fixes #136468.

A Markdown link such as `[https://example.test/label](https://example.test/actual-destination)` could open the label URL instead of its authored destination in hyperlink-capable terminals. Pi TUI had already emitted the correct native OSC8 span; OpenClaw's subsequent visible-URL pass overrode it.

Keep the renderer's existing hyperlink authoritative and infer targets only for unlinked text. Reuse the canonical terminal ANSI parser and replace the per-character URL map with a range cursor. The shipped bare/wrapped URL fallback remains intact.

Production **+35 / −53 = -18 LOC**; tests/support **+148 / −5 = +143**; docs **+1**.

## Actual terminal proof

The real `runTui` loop runs in a native PTY with a synthetic backend. Before: the URL-shaped label emits `/label` as its target. After: it emits `/actual-destination`; the ordinary Documentation sibling remains correct. The 36-column case wraps across two rows and both retain the authored target. The unidentified-terminal path still prints and links the destination.

These pictures render the recorded 100×30 PTY frames and show diagnostics extracted from the recorded OSC8 stream. They are explicitly labeled renderings, not graphical terminal screenshots.

| Before | After |
| --- | --- |
| ![Recorded PTY before: wrong target](https://github.com/user-attachments/assets/3e9fc743-bf2c-474d-90c2-636d0bfa0ffc) | ![Recorded PTY after: authored target](https://github.com/user-attachments/assets/19c4533c-b44d-492a-acd1-caf6c1ec5a36) |

- Three native PTY scenarios pass and exit normally; the original failing before trace is retained.
- 165 tests across six owner/sibling files pass, including BEL/ST terminators, link identity parameters, adjacent bare URLs, wrapping, punctuation, RTL isolation, user/assistant/tool/side-question rendering and render-cache invalidation.
- All 30 required changed-file checks, typed lint and formatting pass. Independent Codex P2 review is clean; source hashes match after commit.
- Installed Pi TUI 0.84.2 source was inspected directly: parsed Markdown href emission, terminal capability routing, OSC8 parsing and wrap close/reopen behavior.

The proof exercises actual terminal bytes with a fake backend. It does not claim a graphical VS Code launch, browser navigation, provider/Gateway transport or persistence. The separate picker cancellation defect is being repaired independently.

## Dependency inspection and CI follow-up

The maintainer directly inspected the installed Pi TUI 0.84.2 renderer and ANSI output contract, the shared terminal parser and the complete caller/fallback owner. The raw native-PTY output and fully inspected synthetic renderings show the authored destination is retained; the reviewer’s missing dependency files/DNS access is an environment limitation, accepted with that direct inspection and recorded evidence.

The serial PTY inventory includes the new hyperlink integration test; all four inventory checks pass. Canonical startup-recovery coverage and its real-Gateway proof are described below. These CI corrections add no counted product issue.

## CI follow-up and review disposition

The temporary Gateway CLI fixture cleanup has been removed because [main already owns the canonical test split](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c). The cumulative PR no longer changes that file. The exact three-way file merge matches main byte for byte, retaining the health/transport cases, Linux socat case and cleanup hooks; typed lint and an independent Codex P2 review pass. No product issue or production deletion is credited to this reconciliation.

## Shared CI fixture follow-up

Startup-recovery coverage now uses the canonical fixture already landed in [#136473](https://github.com/openclaw/openclaw/pull/136473): await both exact queued message identities, assert one pending item alongside the active source, then retain cancellation, survivor and cleanup checks. This replaces the earlier pending-only assertion where present. The exact real-Gateway scenario passes after adoption; no production recovery behavior changes.

Fresh scoped typed lint/format checks and independent Codex P2 review pass. Shared review reuse is limited to identical before/after files and owner context. These CI repairs add no counted product issue.

## Maintainer landing disposition

The latest review’s required-check rank-up move is complete: exact-head CI passed. Root directly inspected installed Pi TUI0.84.2 components/markdown.js:529, terminal-image.js and utils.js:397/610 for authored href emission, capability routing and OSC8 close/reopen behavior. The previously recorded native-PTY proof and dependency inspection address the reviewer’s missing-source/DNS limitation. Production owners remain unchanged on main a0af72e2cda5d79dd8fb1051acde16e36fabb752, and its three-way merge is clean.
