### PR TITLE
test(gateway): wait for both queued recovery inputs

### DIFF
--- a/src/gateway/server.startup-recovery-webchat.test.ts
+++ b/src/gateway/server.startup-recovery-webchat.test.ts
@@ -16,6 +16,7 @@ import {
   getSessionWorkAdmissionOwnerRelease,
 } from "../sessions/session-lifecycle-admission.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { countPendingQueueItems } from "../utils/queue-helpers.js";
 import { getGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
 import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
@@ -183,11 +184,12 @@ it(
 
       const canceledRunId = "webchat-canceled-during-recovery";
       const survivorRunId = "webchat-survives-recovery";
+      const expectedQueuedMessages = new Map([
+        [canceledRunId, canceledMessage],
+        [survivorRunId, survivorMessage],
+      ]);
       await Promise.all(
-        [
-          [canceledRunId, canceledMessage],
-          [survivorRunId, survivorMessage],
-        ].map(async ([runId, message]) => {
+        Array.from(expectedQueuedMessages, async ([runId, message]) => {
           await expect(
             client.request("chat.send", {
               sessionKey,
@@ -202,8 +204,14 @@ it(
       );
       await vi.waitFor(() => {
         const queue = getExistingFollowupQueue(sessionKey);
+        // Active sources remain in items; started ACKs can precede queue admission.
+        expect(queue?.items).toHaveLength(expectedQueuedMessages.size);
+        expect(new Map(queue?.items.map(({ messageId, prompt }) => [messageId, prompt]))).toEqual(
+          expectedQueuedMessages,
+        );
         expect(queue?.inFlight).toHaveLength(1);
-        expect(queue?.items).toHaveLength(1);
+        expect(countPendingQueueItems(queue?.items ?? [], queue?.inFlight)).toBe(1);
+        expect(targetRequests).toHaveLength(1);
       });
       replacementOwner = await beginSessionWorkAdmission({
         scope: storePath,


### PR DESCRIPTION
## What Problem This Solves

The startup-recovery WebChat test could advance before both browser turns reached the queue. An active source remains in `items`, so one item and one `inFlight` entry can refer to the same object. The intended two-source state could also fail the old one-item assertion.

## Why This Change Was Made

Wait for the exact two ID/prompt pairs, one active source, one pending source through the existing queue helper, and the unchanged recovery-provider request count before releasing recovery. The same map supplies the submitted messages and expected queue contents. Production code, deadlines, cancellation, and survivor-once assertions are unchanged.

## User Impact

This makes the existing recovery integration test verify its intended precondition and removes a race in CI. Production LOC is unchanged; test LOC is +8. No runtime performance or memory claim is made.

## Evidence

The original Linux CI assertion failure is retained in [the failed recovery test job](https://github.com/openclaw/openclaw/actions/runs/33650942636/job/100321815633). A fresh unchanged local Gateway run passed; a separate read-only identity capture showed that it advanced with just one unique source. The corrected canonical Gateway run and identity capture both passed with the two exact sources retained under the original recovery owner. This is a local reproduction of the premature barrier, not a claimed repeat of the Linux assertion failure.

The real ephemeral Gateway, authenticated WebSocket client, and embedded dispatch ran against a synthetic localhost Responses provider. All 15 queue-helper tests and the full changed gate passed. Independent managed Codex P0–P2 review completed with no findings. Owned processes joined and private runtime state was removed. Local proof used macOS/Node 26; no Windows execution, statistical flake-rate estimate, or real provider call is claimed.

```sh
node scripts/run-vitest.mjs src/gateway/server.startup-recovery-webchat.test.ts src/utils/queue-helpers.test.ts
node scripts/check-changed.mjs -- src/gateway/server.startup-recovery-webchat.test.ts
```

Reviewed test SHA-256: `d19570aa26620198236b6f18a977add371b563b486beacacd4b533779a4e4c05`.
