### PR TITLE
test(e2e): report the inspect command outcome when the built-CLI proof fails

### DIFF
--- a/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
+++ b/test/helpers/sqlite-sessions-transcripts-flip-proof.ts
@@ -160,7 +160,7 @@ export async function runSqliteSessionsTranscriptsFlipProof(options: RunOptions 
           throw new Error(`expected built CLI entrypoint, got ${gatewayEntrypoint.join(" ")}`);
         }
         if (options.requireBuiltCli === true) {
-          // Only this provider is exercised; the full inventory can exceed the CLI log-tail bound.
+          // Only this provider is exercised, so inspect it instead of listing every plugin.
           const inspection = await inst.cli(["plugins", "inspect", "openai", "--json"]);
           const plugin = asRecord(parseJsonObject(inspection.stdout)?.plugin);
           if (
@@ -169,7 +169,11 @@ export async function runSqliteSessionsTranscriptsFlipProof(options: RunOptions 
             plugin.origin !== "bundled" ||
             typeof plugin.source !== "string"
           ) {
-            throw new Error("built CLI could not inspect the bundled OpenAI artifact");
+            // The Gateway has not started, so its log tail is empty; the command outcome
+            // is the only evidence a CI reader gets.
+            throw new Error(
+              `built CLI could not inspect the bundled OpenAI artifact (code=${String(inspection.code)} signal=${String(inspection.signal)})\n--- plugins inspect stdout ---\n${tail(inspection.stdout, 2_000)}\n--- plugins inspect stderr ---\n${tail(inspection.stderr, 4_000)}`,
+            );
           }
           bundledPlugins = [{ id: plugin.id, source: plugin.source }];
         }


### PR DESCRIPTION
Related: #136211, #136391, #136434

## What Problem This Solves

Fixes an issue where the built-CLI SQLite lifecycle proof (`test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts`) reported an unreadable failure when the built CLI could not inspect the bundled OpenAI plugin: the thrown message carried only a "Gateway diagnostics" block, which is always empty at that point because the Gateway has not started. CI readers of `main` runs 33636023408 and 33642826781 and PR run 33638802946 (2026-09-02) saw exactly that empty block and nothing about the command that failed.

The original version of this PR also repaired the shared test-instance `cli()` capture, which silently dropped the head of `plugins list --json` once #136211 grew that payload past the 256 KiB log-tail buffer. That owner repair has since landed on `main` in #136434 (`a8fe1a587bb`: head-captured stdout, loud overflow failure, tail-bounded stderr, complete/overflow regression cases), so this PR is reduced to the residual the proof still lacked.

## Why This Change Was Made

Record the fact where it happens: when the inspect command fails or returns an unexpected shape, the proof now throws with the command's exit code, signal, and bounded stdout/stderr tails. The comment no longer claims a log-tail bound applies to command results; the proof inspects one plugin because that is the provider it exercises.

## User Impact

No user-facing behavior change. The next failure of this proof names the built-CLI command outcome instead of an empty Gateway log.

## Evidence

- Head is a single six-line change on top of `main` (test support +6/-2, production LOC 0).
- Previous heads of this PR (7c59eddd7d4, 1e58d65b80f, 92ffaa5ff57) carried the now-superseded capture repair; on 7c59eddd7d4 the `build-artifacts` job ran the sqlite lifecycle verifier against the original `plugins list --json` path and passed in 42 s (run 33661564208), and 92ffaa5ff57 had a fully green exact-head run (33675679586, attempt 2 after two Blacksmith runner drops).
- Root-cause measurement on a full source build: `plugins list --json` is 296,257 bytes with `dependencyStatus` and 226,390 bytes without, against a 262,144-byte cap; all 151 plugins in a source checkout are bundled-origin and 90 gained `dependencyStatus` in #136211.
- Exact-head CI for this head is linked in the landing comment.
