### PR TITLE
perf(terminal): normalize upload names without character arrays

### DIFF
--- a/src/infra/terminal-file-upload.ts
+++ b/src/infra/terminal-file-upload.ts
@@ -13,7 +13,7 @@ const TERMINAL_UPLOAD_PREFIX = "openclaw-terminal-upload-";
 const TERMINAL_UPLOAD_RETENTION_MS = 24 * 60 * 60 * 1000;
 const TERMINAL_UPLOAD_CLEANUP_RETRY_MS = 60 * 60 * 1000;
 const MAX_STAGED_NAME_BYTES = 180;
-const PORTABLE_NAME_FORBIDDEN = new Set(["<", ">", ":", '"', "/", "\\", "|", "?", "*", "%", "!"]);
+const PORTABLE_NAME_FORBIDDEN = new RegExp(String.raw`[\u0000-\u001f\u007f<>:"/\\|?*%!]`, "g");
 const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\.|$)/iu;
 const cleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const cleanupRecoveryTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -58,13 +58,8 @@ function truncateUtf8(value: string, maxBytes: number): string {
 
 function sanitizeTerminalUploadName(name: string): string {
   const basename = path.posix.basename(name.replaceAll("\\", "/"));
-  const cleaned = Array.from(basename, (char) => {
-    const codePoint = char.codePointAt(0) ?? 0;
-    return codePoint <= 0x1f || codePoint === 0x7f || PORTABLE_NAME_FORBIDDEN.has(char)
-      ? "_"
-      : char;
-  })
-    .join("")
+  const cleaned = basename
+    .replace(PORTABLE_NAME_FORBIDDEN, "_")
     .trim()
     .replace(/[. ]+$/u, "");
   const portable = WINDOWS_RESERVED_NAME.test(cleaned) ? `_${cleaned}` : cleaned;


### PR DESCRIPTION
## What Problem This Solves

Each terminal upload builds a character array and probes a Set for every filename character while replacing a fixed set of forbidden ASCII characters.

## Why This Change Was Made

Use one native character-class replacement for the same C0/DEL controls and eleven forbidden ASCII characters. This removes the Set, per-character callback and join. Basename selection, Unicode handling, reserved-name rules, the existing UTF-8 byte cap, permissions and cleanup remain unchanged. Production LOC is +3/−8, net −5; tests are unchanged.

## User Impact

Uploads retain their existing filenames and contents while filename sanitization creates less temporary work. The installed generic filename sanitizer has different substitution, Unicode, reserved-name and truncation semantics, so it cannot preserve this contract.

## Evidence

Before and after calls to the actual exported `stageTerminalUpload` wrote 295 real files, including 15 prewritten exact-name goldens. Filenames, raw directory entries, contents, sizes, private permissions, expiry and invalid-base64 outcomes match. The corpus includes all byte-range character values, astral/combining text, lone surrogates, reserved Windows names, separators, trailing dots/spaces and the UTF-8 truncation boundary. Every input fits the existing public filename ceiling.

Observed filename work: 295 `Array.from` arrays, 4,658 array slots and 4,624 `Set.has` calls became zero. Behavior digest: `353c0b0f24fd43fe88e7b12480b2b4defe2dec29e5a873932d244e99e2b1c01c`.

All 54 existing upload, terminal-session and protocol tests pass. The full canonical changed gate passes, including core/coreTests types, lint and all scheduled guards. Independent managed Codex P0–P2 review is scoped-clean. All owned processes joined, observers were restored and private proof roots were removed.

```sh
node scripts/run-vitest.mjs run src/infra/terminal-file-upload.test.ts src/gateway/terminal/session-manager.test.ts packages/gateway-protocol/src/schema/terminal.test.ts
node scripts/check-changed.mjs -- src/infra/terminal-file-upload.ts
```

The proof exercised actual files on macOS/Node 26. It does not claim Windows-host execution, a live Gateway GUI, speedup, retained-heap or RSS reduction. Reviewed owner SHA-256: `ca14e2c454fe7b59547faec22bf7db51f590f2134a1d58be5028c3497afd1e10`.

[Observed terminal file-staging output](https://github.com/openclaw/openclaw/pull/136479#issuecomment-5514074607) includes inspectable after-fix results, exact source binding and proof limitations.
