### PR TITLE
test(auto-reply): remove redundant UTC timezone setup

### DIFF
--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -1,6 +1,5 @@
 /** Tests inbound envelope formatting, timestamps, and sender labels. */
 import { describe, expect, it } from "vitest";
-import { withEnv } from "../test-utils/env.js";
 import {
   formatAgentEnvelope,
   formatAgentEnvelopeTimestamp,
@@ -10,20 +9,18 @@ import {
 
 describe("formatAgentEnvelope", () => {
   it("includes channel, from, ip, host, and timestamp", () => {
-    withEnv({ TZ: "UTC" }, () => {
-      const ts = Date.UTC(2025, 0, 2, 3, 4, 5); // 2025-01-02T03:04:05Z
-      const body = formatAgentEnvelope({
-        channel: "WebChat",
-        from: "user1",
-        host: "mac-mini",
-        ip: "10.0.0.5",
-        timestamp: ts,
-        envelope: { timezone: "utc" },
-        body: "hello",
-      });
-
-      expect(body).toBe("[WebChat user1 mac-mini 10.0.0.5 Thu 2025-01-02T03:04:05Z] hello");
+    const ts = Date.UTC(2025, 0, 2, 3, 4, 5); // 2025-01-02T03:04:05Z
+    const body = formatAgentEnvelope({
+      channel: "WebChat",
+      from: "user1",
+      host: "mac-mini",
+      ip: "10.0.0.5",
+      timestamp: ts,
+      envelope: { timezone: "utc" },
+      body: "hello",
     });
+
+    expect(body).toBe("[WebChat user1 mac-mini 10.0.0.5 Thu 2025-01-02T03:04:05Z] hello");
   });
 
   it("formats timestamps in local timezone by default", () => {
@@ -39,17 +36,15 @@ describe("formatAgentEnvelope", () => {
   });
 
   it("formats timestamps in UTC when configured", () => {
-    withEnv({ TZ: "America/Los_Angeles" }, () => {
-      const ts = Date.UTC(2025, 0, 2, 3, 4, 5); // 2025-01-02T03:04:05Z (19:04:05 PST)
-      const body = formatAgentEnvelope({
-        channel: "WebChat",
-        timestamp: ts,
-        envelope: { timezone: "utc" },
-        body: "hello",
-      });
-
-      expect(body).toBe("[WebChat Thu 2025-01-02T03:04:05Z] hello");
+    const ts = Date.UTC(2025, 0, 2, 3, 4, 5); // 2025-01-02T03:04:05Z
+    const body = formatAgentEnvelope({
+      channel: "WebChat",
+      timestamp: ts,
+      envelope: { timezone: "utc" },
+      body: "hello",
     });
+
+    expect(body).toBe("[WebChat Thu 2025-01-02T03:04:05Z] hello");
   });
 
   it("formats timestamps in user timezone when configured", () => {


### PR DESCRIPTION
## What Problem This Solves

Two envelope tests wrap explicit UTC formatting checks in worker-local timezone mutations. Those mutations do not configure native Date/Intl in the threaded test runner, and neither case needs ambient timezone state to test its explicit UTC option.

## Why This Change Was Made

As part of the maintainer-requested test audit, remove the two ineffective environment wrappers and unused helper import. Keep every case and assertion at the envelope owner. Logs and session-memory timezone fixtures remain unchanged because their owners explicitly consume the environment value.

## User Impact

No production or protocol behavior changes. All 20 envelope cases remain; test/support code decreases by five lines (+19/-24, mostly unindentation). Production +0/-0.

## Evidence

- Existing suite: 20 passes with a New York process-startup timezone.
- Simplified suite: 20 passes with New York, then 20 passes with UTC.
- Deliberately treating the UTC option as local: the same four tests fail before and after simplification. Original production bytes restored exactly afterward.
- Formatter and diff check pass. Independent Codex review completed with no actionable findings. The normal full local changed gate passed, including the affected TypeScript graph, all three dead-export scans, typed lint and repository guards. The earlier Testbox attempt stopped during Git bootstrap before any checks ran; its lease and temporary checkout were cleaned up.

```sh
TZ=America/New_York node scripts/run-vitest.mjs src/auto-reply/envelope.test.ts
TZ=UTC node scripts/run-vitest.mjs src/auto-reply/envelope.test.ts
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/auto-reply/envelope.test.ts
```

## Inspectable after-change output

Both commands below were run on published commit `49e988cf45a4225397eedb9c70537999b5e30118`, with a clean tracked tree before and after. The test file SHA-256 is `aff2676325dbaafd0b71b5e40b800da6af847100114c53ee58a07c4bc9dadfc5`, identical to the reviewed and committed candidate. These are synthetic formatter cases; no live channel or provider is involved.

```text
$ TZ=America/New_York node scripts/run-vitest.mjs src/auto-reply/envelope.test.ts
 ✓ |unit-fast| src/auto-reply/envelope.test.ts > formatAgentEnvelope > formats timestamps in UTC when configured 4ms
 ✓ |unit-fast| src/auto-reply/envelope.test.ts > formatAgentEnvelope > formats the Unix epoch timestamp 2ms
 Test Files  1 passed (1)
      Tests  20 passed (20)
[test] passed 1 Vitest shard in 4.13s
exit 0
```

```text
$ TZ=UTC node scripts/run-vitest.mjs src/auto-reply/envelope.test.ts
 ✓ |unit-fast| src/auto-reply/envelope.test.ts > formatAgentEnvelope > formats timestamps in UTC when configured 0ms
 ✓ |unit-fast| src/auto-reply/envelope.test.ts > formatAgentEnvelope > formats the Unix epoch timestamp 0ms
 Test Files  1 passed (1)
      Tests  20 passed (20)
[test] passed 1 Vitest shard in 4.04s
exit 0
```

Hosted [CI run 33661741025](https://github.com/openclaw/openclaw/actions/runs/33661741025) passed on the unchanged published head. The initial security job failed fetching public pre-commit hooks before the private-key detector ran. After the workflow completed, one scoped retry succeeded, including the private-key detector; the required `openclaw/ci-gate` is green. No source change or check waiver was used.
