### PR TITLE
fix(deps): remove the Zod cooldown exception

### DIFF
--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@copilotkit/aimock": "1.39.0",
     "@modelcontextprotocol/sdk": "1.30.0",
-    "@openclaw/crabline": "0.1.20",
+    "@openclaw/crabline": "0.1.21",
     "playwright-core": "1.62.1",
     "semver": "7.8.5",
     "ws": "8.21.3",

--- a/package.json
+++ b/package.json
@@ -2143,7 +2143,7 @@
     "@lit/context": "1.1.6",
     "@lit/task": "1.0.3",
     "@mdx-js/mdx": "3.1.1",
-    "@openclaw/crabline": "0.1.20",
+    "@openclaw/crabline": "0.1.21",
     "@openclaw/session-url-contract": "workspace:*",
     "@opentelemetry/sdk-node": "0.221.0",
     "@shikijs/core": "4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(supports-color@10.2.2)
       '@openclaw/crabline':
-        specifier: 0.1.20
-        version: 0.1.20
+        specifier: 0.1.21
+        version: 0.1.21
       '@openclaw/session-url-contract':
         specifier: workspace:*
         version: link:packages/session-url-contract
@@ -1808,8 +1808,8 @@ importers:
         specifier: 1.30.0
         version: 1.30.0(supports-color@10.2.2)(zod@4.4.3)
       '@openclaw/crabline':
-        specifier: 0.1.20
-        version: 0.1.20
+        specifier: 0.1.21
+        version: 0.1.21
       playwright-core:
         specifier: 1.62.1
         version: 1.62.1
@@ -4149,8 +4149,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/crabline@0.1.20':
-    resolution: {integrity: sha512-2m2Vfmp6qvXKrpbaPKoTYx3s2VVeyVkWBcXnCe4Vpj1PhPXrLfE0rW7KZ9M+/+23tqAYGGzp8wKsqe0CHko+OQ==}
+  '@openclaw/crabline@0.1.21':
+    resolution: {integrity: sha512-jUu2ZNqthh2o7N2ZzIrztzjsAsta9v7WaYo07m9L+LbpWv41K9+ewEaXS/PRtuEGz9I4cB3qa7Jh6r5NpkRkWA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -9659,9 +9659,6 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
-  zod@4.5.2:
-    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
-
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -11447,7 +11444,7 @@ snapshots:
   '@openai/codex@0.152.1-win32-x64':
     optional: true
 
-  '@openclaw/crabline@0.1.20':
+  '@openclaw/crabline@0.1.21':
     dependencies:
       '@types/node': 22.20.1
       commander: 15.0.0
@@ -11458,7 +11455,7 @@ snapshots:
       re2js: 2.8.6
       ws: 8.21.3
       yaml: 2.9.0
-      zod: 4.5.2
+      zod: 4.4.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -17288,7 +17285,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
-
-  zod@4.5.2: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,8 @@ minimumReleaseAgeStrict: true
 
 # Trusted Codex runtimes are outside the dependency cooldown.
 minimumReleaseAgeExclude:
-  # Reviewed Crabline bundle fix and its required Zod version; remove after 2026-09-10.
-  - "@openclaw/crabline@0.1.20"
-  - "zod@4.5.2"
+  # Reviewed Crabline compatibility correction; remove after 2026-09-10.
+  - "@openclaw/crabline@0.1.21"
   - "@openai/codex"
   - "@openai/codex-*"
   # fs-safe 0.7.0 validates original ZIP names; remove after 2026-09-07.


### PR DESCRIPTION
Related: #136166

## What Problem This Solves

Resolves a problem where installing the bundle-safe Crabline update required a temporary Zod release-age exception. Dependency updates must observe the normal seven-day cooldown.

## Why This Change Was Made

Adopt corrective Crabline 0.1.21, whose supported Zod floor is restored to 4.4.3, and remove the `zod@4.5.2` exception and unused lockfile snapshot. Keep Crabline's bundle-safe crypto implementation and normal bundling path. There is no Zod override or replacement exception.

Crabline's own workspace now enforces seven days instead of 48 hours and restores the other too-young transitive locks from its prior refresh. Its packed-consumer regression installs with the seven-day policy, verifies actual resolution to Zod 4.4.3, parses the example manifest, and executes relocated native/JavaScript crypto bundles after deleting the installed package tree.

## User Impact

OpenClaw can use the fixed Crabline package with mature Zod 4.4.3 while enforcing its existing seven-day dependency policy. Only the exact-version exception for the explicitly requested fresh Crabline release remains; its removal note is retained.

## Evidence

- Owner correction: https://github.com/openclaw/crabline/pull/291.
- Published 0.1.20 fails an actual isolated seven-day consumer install with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` naming Zod 4.5.2.
- Corrected Crabline passes its 306-entry supply-chain policy check, 82 focused package/schema tests, formatting, typechecking, and type-aware lint.
- [Crabline 0.1.21 is published](https://github.com/openclaw/crabline/releases/tag/v0.1.21); npm version, latest tag, publication time, downloaded tarball integrity, and GitHub release/tag are verified. The tarball matches the verified CI artifact.
- [Crabline exact-head CI](https://github.com/openclaw/crabline/actions/runs/33659821509) passed 1,891 tests, with 69 existing skips; coverage and security checks passed. Production dependency audit reports zero known vulnerabilities.
- OpenClaw normal lockfile regeneration passed the 1,643-entry supply-chain policy check; `pnpm install --frozen-lockfile` then passed with no Zod exception. Direct inspection of the installed Crabline dependency resolves Zod 4.4.3 and confirms the package declares `^4.4.3`.
- OpenClaw focused tests: 75 passed on the original reviewed head (all four test files and the dependency patch are unchanged by the later rebase) across `test/scripts/tsdown-config.test.ts`, `extensions/qa-lab/src/crabline-transport.test.ts`, `extensions/qa-lab/src/crabline-transport-readiness.test.ts`, and `extensions/qa-lab/src/suite.test.ts`, with one test worker. This covers actual Crabline transport/schema use, readiness, suite cleanup, and package boundaries.
- Formatting, `git diff --check`, and fresh Codex P0 autoreview passed. Exact-head CI will be recorded before landing.
- Production-code delta: 0; test-code delta: 0. The OpenClaw patch only changes dependency/configuration/lock metadata; the new behavioral regression belongs to the Crabline package and is included in its release.

No production code, public API, protocol, or crypto algorithm changes. This is a dependency-floor/policy correction, not a workaround in the consuming runtime. No changelog edit is included in this ordinary OpenClaw PR.

CI first-attempt notes: `security-fast` failed before scanning because Git could not fetch the public pre-commit hooks repository (GitHub username/flush error). An unchanged startup-recovery/WebChat test also observed two queued items where it expected one; that gateway/queue path and its Zod 4.4.3 resolution are untouched by this patch. Failed-job retry results will be recorded before landing.

### Inspectable exact-head install proof (ClawSweeper follow-up)

Ran on the committed PR head with a clean worktree: `git rev-parse HEAD`, `pnpm install --frozen-lockfile`, then Node assertions reading the actual workspace YAML and the installed package manifests resolved from Crabline's ESM entrypoint. The assertions require `minimumReleaseAge === 10080`, `minimumReleaseAgeStrict === true`, no Zod entry in `minimumReleaseAgeExclude`, Crabline 0.1.21 declaring `^4.4.3`, its actual resolved Zod version 4.4.3, and a successful `await import("@openclaw/crabline")`.

```text
79e1a002ca652d8f5c073799e6939be1b8751fee
Scope: all 175 workspace projects
✓ Lockfile passes supply-chain policies (verified 44m ago)
Lockfile is up to date, resolution step is skipped
Done in 14.3s using pnpm v12.1.0
{
  "minimumReleaseAge": 10080,
  "minimumReleaseAgeStrict": true,
  "zodExceptions": [],
  "crablineVersion": "0.1.21",
  "declaredZodRange": "^4.4.3",
  "resolvedZodVersion": "4.4.3",
  "crablineImport": "ok"
}
All assertions passed; exit 0. git status --short produced no output.
```

The preceding normal lock regeneration performed the full 1,643-entry supply-chain policy verification in 11.1 seconds; the exact-head frozen run reused that still-valid verification. The original install also ran all package lifecycle steps successfully. This is an actual installed-package/import result, not a lockfile-only inference.

Published contract: [registry 0.1.21 manifest](https://registry.npmjs.org/@openclaw%2Fcrabline/0.1.21), [tagged package.json](https://github.com/openclaw/crabline/blob/v0.1.21/package.json), and [verified release/tarball integrity](https://github.com/openclaw/crabline/releases/tag/v0.1.21). This addresses the review's real-resolution proof request and rank-up move; no code or policy bypass was added.

### CI baseline correction

The first CI run's SQLite built-CLI failure reproduced on isolated Linux at the original head using Blacksmith Testbox `tbx_01m1hm9v1p1kq90fb92y8e9fm9` ([run](https://github.com/openclaw/openclaw/actions/runs/33664272083)): `pnpm build:ci-artifacts` succeeded, then the unchanged built-CLI SQLite proof failed to parse the full plugin inventory. The fixture's command output is bounded to 256 KiB. Main already contains [#136391 / 1212f991](https://github.com/openclaw/openclaw/commit/1212f991db46ad4ffe8c11198c175a5736392a15), which inspects only the bundled OpenAI plugin actually exercised instead of parsing the full inventory.

Rebased onto that existing fix to repair the CI baseline, not merely to chase main. `git range-diff` confirms the four-file dependency patch is identical (`8a8376cfb193` → `79e1a002ca65`). No unrelated test changes are included in this PR. The diagnostic Testbox has been stopped. Refreshed exact-head CI remains required before landing.

### Current landing gate

Fresh Codex P0 review of the rebased four-file patch is scoped-clean. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33665821074) is attached to `79e1a002ca652d8f5c073799e6939be1b8751fee`. The live jobs API currently shows `preflight` and `security-fast` queued for `ubuntu-24.04`, with no runner assigned. The PR remains open and unmerged; required checks are not bypassed. Native review records are refreshed for this head and preserve the pending CI gate.
