### PR TITLE
fix(backup): keep Nix-managed config symlinks in verified archives

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -306,7 +306,7 @@ The state directory's `plugin-skills/` root is a generated, OpenClaw-owned symli
 
 Agent-scoped temporary trees under `agents/<agentId>/agent/**/{tmp,.tmp}/` are also omitted and reported as regenerable. This includes temporary files directly below an agent directory and temporary trees inside agent runtime homes; durable sibling directories remain included. An explicitly configured config file, credentials directory, or workspace nested below an omitted temporary root remains included.
 
-Symbolic links are archived as link metadata and are never followed. Relative links are retained only when both the link and its lexical target remain within backup assets declared in `manifest.json`; links between declared assets and dangling links within an asset are allowed. Absolute links, links containing backslashes, and links escaping the archive root or every declared asset are rejected during both creation and verification.
+Symbolic links are archived as link metadata and are never followed. Relative links are retained only when both the link and its lexical target remain within backup assets declared in `manifest.json`; links between declared assets and dangling links within an asset are allowed. An absolute link whose real target is contained by a declared asset, such as a Nix-managed `openclaw.json` symlink, is rewritten to a portable relative archive link. Other absolute links, links containing backslashes, and links escaping the archive root or every declared asset are rejected during both creation and verification.
 
 Installer-managed and rebuildable runtime roots under the state directory are
 also skipped: `dev/`, `git/`, `npm/`, legacy `npm-runtime/`, `tmp/`, and

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -196,10 +196,12 @@ async function resolveBackupPlanFromPaths(params: {
   const configInsideState = params.configInsideState ?? false;
   const oauthInsideState = params.oauthInsideState ?? false;
   const canonicalStateDir = await canonicalizePathForContainment(stateDir);
+  const containmentConfigPath = await canonicalizePathForContainment(configPath);
+  const containmentOauthDir = await canonicalizePathForContainment(oauthDir);
   const inventory = await createBackupResourceInventory({
     stateDir: canonicalStateDir,
-    configPath: await canonicalizePathForContainment(configPath),
-    oauthDir: await canonicalizePathForContainment(oauthDir),
+    configPath: containmentConfigPath,
+    oauthDir: containmentOauthDir,
     workspaceDirs: await Promise.all(
       workspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
     ),
@@ -265,10 +267,13 @@ async function resolveBackupPlanFromPaths(params: {
 
   const rawCandidates: Array<Pick<BackupAssetCandidate, "kind" | "sourcePath">> = [
     { kind: "state", sourcePath: path.resolve(stateDir) },
-    ...(configInsideState
+    // Lexical in-state config/credentials can still resolve outside state,
+    // such as a Nix store symlink. Canonical coverage keeps those targets as
+    // declared assets instead of omitting them.
+    ...(configInsideState && isPathWithin(containmentConfigPath, canonicalStateDir)
       ? []
       : [{ kind: "config" as const, sourcePath: path.resolve(configPath) }]),
-    ...(oauthInsideState
+    ...(oauthInsideState && isPathWithin(containmentOauthDir, canonicalStateDir)
       ? []
       : [{ kind: "credentials" as const, sourcePath: path.resolve(oauthDir) }]),
     ...workspaceDirs.map((workspaceDir) => ({

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -2978,6 +2978,70 @@ describe("createBackupArchive", () => {
     },
   );
 
+  it.each([
+    { label: "direct", hops: 1 },
+    { label: "chained", hops: 2 },
+  ])(
+    "archives a $label absolute config symlink whose real target is a declared asset",
+    async ({ hops }) => {
+      if (process.platform === "win32") {
+        return;
+      }
+
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-declared-config-symlink-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const outputPath = state.path("declared-config-symlink.tar.gz");
+          const externalConfigPath = state.path("nix-store", "openclaw-default.json");
+          await fs.mkdir(path.dirname(externalConfigPath), { recursive: true });
+          await fs.rename(state.configPath, externalConfigPath);
+          let linkTarget = externalConfigPath;
+          if (hops > 1) {
+            const intermediatePath = state.path("nix-store", "openclaw-link.json");
+            await fs.symlink(externalConfigPath, intermediatePath);
+            linkTarget = intermediatePath;
+          }
+          await fs.symlink(linkTarget, state.configPath);
+          const canonicalExternalConfigPath = await fs.realpath(externalConfigPath);
+
+          const result = await createBackupArchive({
+            output: outputPath,
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 8, 2, 13, 0, 0),
+          });
+          const entries = await listArchiveEntryDetails(result.archivePath);
+          const configLink = expectDefined(
+            entries.find((entry) => entry.path.endsWith("/state/openclaw.json")),
+            "archived config symlink",
+          );
+          const externalConfigEntry = expectDefined(
+            entries.find((entry) => entry.path.endsWith("/nix-store/openclaw-default.json")),
+            "archived external config target",
+          );
+
+          expect(configLink.type).toBe("SymbolicLink");
+          expect(configLink.linkpath).toBe(
+            path.posix.relative(path.posix.dirname(configLink.path), externalConfigEntry.path),
+          );
+          expect(result.assets).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ kind: "config", sourcePath: canonicalExternalConfigPath }),
+            ]),
+          );
+
+          const runtime: RuntimeEnv = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+          await expect(
+            backupVerifyCommand(runtime, { archive: result.archivePath }),
+          ).resolves.toMatchObject({ ok: true });
+        },
+      );
+    },
+  );
+
   it("skips managed absolute runtime symlinks while preserving adjacent state", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,4 +1,5 @@
 // Creates backup archives while filtering volatile runtime state.
+import { realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -341,6 +342,41 @@ function remapArchiveEntryPath(params: {
   return buildBackupArchivePath(params.archiveRoot, normalizedEntry);
 }
 
+function remapDeclaredAbsoluteSymbolicLinkTarget(params: {
+  linkpath: string | undefined;
+  archiveEntryPath: string;
+  assets: readonly BackupAsset[];
+}): string | undefined {
+  if (!params.linkpath || !path.isAbsolute(params.linkpath)) {
+    return params.linkpath;
+  }
+  // tar supplies the first-hop readlink, while declared assets use the final
+  // realpath. Canonicalize before containment so a configured multi-hop
+  // absolute link still maps onto its declared asset; undeclared targets stay
+  // absolute and fail closed at the archive guard.
+  let canonicalTarget: string;
+  try {
+    canonicalTarget = realpathSync(params.linkpath);
+  } catch {
+    return params.linkpath;
+  }
+  const targetAsset = params.assets.find((asset) =>
+    isPathWithin(canonicalTarget, asset.sourcePath),
+  );
+  if (!targetAsset) {
+    return params.linkpath;
+  }
+  const targetAssetRelativePath = path
+    .relative(targetAsset.sourcePath, canonicalTarget)
+    .split(path.sep)
+    .join(path.posix.sep);
+  const targetArchivePath =
+    targetAssetRelativePath === "" || targetAssetRelativePath === "."
+      ? targetAsset.archivePath
+      : path.posix.join(targetAsset.archivePath, targetAssetRelativePath);
+  return path.posix.relative(path.posix.dirname(params.archiveEntryPath), targetArchivePath);
+}
+
 function isBackupTarFilterFile(entry: import("node:fs").Stats | import("tar").ReadEntry): boolean {
   return "isFile" in entry ? entry.isFile() : entry.type === "File";
 }
@@ -582,6 +618,11 @@ export async function createBackupArchive(
                   });
                   if (entry.type === "SymbolicLink" && !archiveSymlinkViolation) {
                     try {
+                      entry.linkpath = remapDeclaredAbsoluteSymbolicLinkTarget({
+                        linkpath: entry.linkpath,
+                        archiveEntryPath,
+                        assets: result.assets,
+                      });
                       assertArchiveSymbolicLinkTarget({
                         archiveRoot,
                         entryPath: archiveEntryPath,


### PR DESCRIPTION
Closes #136326

## What Problem This Solves

Fixes an issue where operators using NixOS or Home Manager could not create a native OpenClaw backup when `openclaw.json` was an absolute symlink to an immutable store file.

## Why This Change Was Made

Backup coverage now uses canonical paths, so a lexically in-state config or credentials link that resolves outside the state directory becomes a declared backup asset. During archive write, an absolute symbolic link is rewritten to a portable relative archive link only when its real target is contained by a declared asset. The remapper canonicalizes first-hop `readlink` values so a chained store symlink still maps onto that declared asset. Arbitrary absolute links still fail closed at the existing archive guard.

Related: #136343

## User Impact

Nix-managed installations can create and verify native backups without replacing the managed config link. Undeclared or escaping symbolic links remain rejected.

## Evidence

- New regressions reproduced the 2026.8.2 failure (`Archive symbolic link target must be relative`) for both a direct absolute config symlink and a two-hop absolute chain.
- `node scripts/run-vitest.mjs src/infra/backup-create.test.ts`: 96 passed.
- `node scripts/run-vitest.mjs src/commands/backup-verify.test.ts`: 47 passed, 1 skipped.
- `node scripts/check-changed.mjs --base upstream/main -- src/commands/backup-shared.ts src/infra/backup-create.ts src/infra/backup-create.test.ts docs/cli/backup.md`: conflict markers, max-lines, assertion SAFETY, format, typecheck core, and typecheck core tests passed. The dead-export Knip scan could not prepare its pnpm dlx cache in this environment.
- Targeted `oxlint` on the changed TypeScript files passed.
- Isolated autoreview (`--mode local --base upstream/main --max-priority P2`): scoped-clean, patch judged correct at 0.86 confidence.

Real NixOS/Home Manager CLI create-and-verify remains a user-owned proof lane; the regressions use the same layout (in-state absolute symlink to an external file) and call `backupVerifyCommand` on the published archive.
