### PR TITLE
test(ui): accept equivalent round corner serialization

### DIFF
--- a/ui/src/styles/corner-shape.browser.test.ts
+++ b/ui/src/styles/corner-shape.browser.test.ts
@@ -260,7 +260,9 @@ async function probeCorners(browser: Browser, fixtureFile: string): Promise<Corn
             const style = getComputedStyle(element);
             const radius =
               corner === "bottomLeft" ? style.borderBottomLeftRadius : style.borderTopLeftRadius;
-            return [selector, { radius, shape: style.getPropertyValue("corner-shape") }];
+            const shape = style.getPropertyValue("corner-shape");
+            // CSS Borders 4 defines round as superellipse(1); engines serialize either form.
+            return [selector, { radius, shape: shape === "superellipse(1)" ? "round" : shape }];
           }),
         );
       },
@@ -332,11 +334,7 @@ describeCornerShape("Control UI corner curvature", () => {
           corner.selector,
           { radius: corner.superelliptical, shape: "superellipse(1.5)" },
         ]),
-        ...ROUND_CASES.map((corner) => [
-          corner.selector,
-          { radius: corner.superelliptical, shape: "round" },
-        ]),
-        ...EXCLUDED_CASES.map((corner) => [
+        ...[...ROUND_CASES, ...EXCLUDED_CASES].map((corner) => [
           corner.selector,
           { radius: corner.superelliptical, shape: "round" },
         ]),


### PR DESCRIPTION
## What Problem This Solves

The corner-curvature browser test fails when CSSOM returns `superellipse(1)` for the `round` curve, even though every computed radius and shape is unchanged.

## Why This Change Was Made

Normalize only that exact equivalent spelling in the shared observation helper. The [CSS Borders 4 draft](https://drafts.csswg.org/css-borders-4/#corner-shaping) defines `round` as `superellipse(1)` and computed corner values in superellipse form. All other values, radii, selectors and root-token checks retain exact assertions. Combine the identical round/excluded expectation maps while preserving their order.

## User Impact

This repairs a CI fixture without changing product styles or browser configuration. Production LOC is unchanged; test LOC is −2. The 20 surface selectors, directional corner, fully rounded controls, excluded descendants, unsupported-condition fixture and four root radius tokens remain covered.

## Evidence

The [original failed CI job](https://github.com/openclaw/openclaw/actions/runs/33655261513/job/100339365218) records two failing cases: exactly five shape fields in the supported fixture and twenty in the unsupported-condition fixture expected `round` and received `superellipse(1)`. No radius or `superellipse(1.5)` field differs. All 23 inspected source/config inputs match across that PR head, its CI base and the implementation base.

The existing real-browser test passes all three cases before and after the change on Chrome for Testing 151.0.7922.34, Playwright 1.62.1 and Node 26.8.1. That local browser still returns `round`, so this is preservation proof; the saved CI failure supplies the alternate-spelling evidence. The exact CI browser binary was not recorded. No computed-style mock, feature flag or forced serialization was used.

```sh
node scripts/run-vitest.mjs ui/src/styles/corner-shape.browser.test.ts
node scripts/check-changed.mjs -- ui/src/styles/corner-shape.browser.test.ts
```

The full changed gate and independent managed Codex P0–P2 review pass. Owned browser/test processes joined and temporary profiles and fixtures were removed. This uses real CSS and synthetic markup, with no Gateway/provider or performance claim. Reviewed test SHA-256: `0e4fd9f695858d1cd58d112eb87c45f90590c185d734ab479749be968f463d6f`.

Fresh Chrome152 proof: [actual before/after test output and all raw corner values](https://github.com/openclaw/openclaw/pull/136494#issuecomment-5514417482). The unchanged preimage fails2cases with `superellipse(1)`; this exact head passes3/3, and a separate source-bound observer records25 actual `superellipse(1)` values across the two fixtures with every radius/root token preserved. The original Chrome151 result remains historical proof of `round`. All latest ClawSweeper proof requests and the Rank-up move are addressed; hosted CI remains pending.

Merge composition was also tested against main `5c44832ecb35e9f15ddd81dc1a8af38c33dfc439` after its stylesheet split: the current ten-stylesheet fixture failed the same two assertions, and applying only this exact reviewed `+4/-6` test patch produced **3/3 passing browser cases**. All other 26 declared source files, including production CSS, remained unchanged. Both runs used the same signed Chrome152, joined normally and removed their private profiles. This supplements the PR-head raw-style proof above without changing the PR head or restarting CI.
