### PR TITLE
fix(skills): preserve canonical names through discovery and workshop

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -96,6 +96,11 @@ default agent.
 The skills table renders horizontal tabs as single spaces so descriptions
 stay aligned with the neighboring columns.
 
+`info` resolves an exact skill name before a metadata key. Key, case-insensitive,
+and separator-normalized matches must identify one skill; ambiguous selectors
+fail instead of choosing discovery order. Workshop reads and update targeting
+use the same lookup.
+
 `check` reports missing prerequisites independently of agent exclusion: a skill
 excluded by the agent allowlist can also appear under **Missing requirements**.
 Disabled skills and skills blocked by the bundled allowlist keep their separate

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -360,6 +360,11 @@ Other workspace parameters apply depending on the action:
 | `reason`                   | `apply`, `reject`, `quarantine`                                  | Optional                                                              |
 | `query`, `status`, `limit` | `list`                                                           | Filter/paginate; `limit` max 50, default 20                           |
 
+`read` and `prepare_patch` return the resolved `skillName`. Reuse that name as
+`skill_name` in follow-up calls; a metadata `skillKey` can match a different
+skill's exact name. Update proposals and revisions preserve the existing skill's
+frontmatter name.
+
 Only one prepared patch span may be active per skill. A second
 `prepare_patch` is rejected until a `patch` attempt consumes or invalidates the
 active authorization.

--- a/src/agents/tools/skill-workshop-tool-helpers.ts
+++ b/src/agents/tools/skill-workshop-tool-helpers.ts
@@ -1,6 +1,7 @@
 import { autonomousSkillSizeError } from "../../skills/workshop/collection-contracts.js";
 import {
   readProposalFrontmatter,
+  resolveSkillProposalName,
   stripProposalFrontmatterForSkill,
 } from "../../skills/workshop/frontmatter.js";
 import { prepareSkillProposalDraft } from "../../skills/workshop/proposal-draft.js";
@@ -102,7 +103,7 @@ function completionResult() {
 }
 
 export function proposalMutationText(action: string, record: SkillProposalRecord): string {
-  return `${action} ${record.id} (${record.status}) for ${record.target.skillKey}.`;
+  return `${action} ${record.id} (${record.status}) for ${resolveSkillProposalName(record.kind, record.target)}.`;
 }
 
 export function actionResult(

--- a/src/agents/tools/skill-workshop-tool-patch.ts
+++ b/src/agents/tools/skill-workshop-tool-patch.ts
@@ -8,11 +8,7 @@ import type { SkillWorkshopPreparedPatch } from "../../skills/workshop/types.js"
 import { readWritableWorkspaceSkill } from "../../skills/workshop/workspace-skill-read.js";
 import { readToolStringParam, ToolInputError, type AnyAgentTool } from "./common.js";
 
-type WritableSkillPatchTarget = {
-  skillKey: string;
-  skillFile: string;
-  content: string;
-};
+type WritableSkillPatchTarget = Awaited<ReturnType<typeof readWritableWorkspaceSkill>>;
 
 const PATCH_CONTEXT_PREFIX = [
   "Prepared patch context. This is a bounded excerpt, not the complete skill.",
@@ -48,7 +44,7 @@ function prepareSkillPatch(params: {
   const targetLabel = "--- authorized old_string ---";
   const afterLabel = "--- bounded context after target ---";
   const fixedText = [
-    `Skill: ${params.skill.skillKey} (${sizeBytes} bytes)`,
+    `Skill: ${params.skill.skillName} (${sizeBytes} bytes)`,
     PATCH_CONTEXT_PREFIX,
     beforeLabel,
     targetLabel,
@@ -66,7 +62,7 @@ function prepareSkillPatch(params: {
   const before = sliceUtf16Safe(body, Math.max(0, span.start - beforeBudget), span.start);
   const after = sliceUtf16Safe(body, span.end, span.end + afterBudget);
   const text = [
-    `Skill: ${params.skill.skillKey} (${sizeBytes} bytes)`,
+    `Skill: ${params.skill.skillName} (${sizeBytes} bytes)`,
     PATCH_CONTEXT_PREFIX,
     beforeLabel,
     before,
@@ -111,7 +107,7 @@ export async function executePrepareSkillPatch(params: {
   );
   if (params.preparedSkillPatches.has(skill.skillKey)) {
     throw new ToolInputError(
-      `skill "${skill.skillKey}" already has a prepared patch: call action=patch to redeem or invalidate it before preparing another exact span`,
+      `skill "${skill.skillName}" already has a prepared patch: call action=patch to redeem or invalidate it before preparing another exact span`,
     );
   }
   try {
@@ -129,6 +125,7 @@ export async function executePrepareSkillPatch(params: {
     return {
       content: [{ type: "text", text: prepared.text }],
       details: {
+        skillName: skill.skillName,
         skillKey: skill.skillKey,
         sizeBytes: prepared.sizeBytes,
         patchPrepared: true,
@@ -155,7 +152,7 @@ function redeemPreparedSkillPatch(params: {
     prepared.contentHash !== sha256Hex(params.skill.content)
   ) {
     throw new ToolInputError(
-      `skill "${params.skill.skillKey}" changed since the patch was prepared: call action=prepare_patch again with the current exact old_string`,
+      `skill "${params.skill.skillName}" changed since the patch was prepared: call action=prepare_patch again with the current exact old_string`,
     );
   }
   if (prepared.oldString !== params.oldString) {
@@ -193,7 +190,7 @@ export function assertSkillPatchRunUsage(params: {
     })
   ) {
     throw new ToolInputError(
-      `skill "${params.skill.skillKey}" was not used in this run and cannot be repaired autonomously`,
+      `skill "${params.skill.skillName}" was not used in this run and cannot be repaired autonomously`,
     );
   }
 }

--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -1,5 +1,6 @@
 import { stableStringify } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveSkillProposalName } from "../../skills/workshop/frontmatter.js";
 import { PROPOSAL_DRAFT_FILE } from "../../skills/workshop/store-record.js";
 import type {
   SkillProposalEvaluation,
@@ -71,7 +72,7 @@ export function formatProposalList(proposals: readonly SkillProposalManifestEntr
   return proposals
     .map(
       (proposal) =>
-        `- ${proposal.id} [${proposal.status}, ${proposal.kind}, ${proposal.scanState}${proposal.workspaceMismatch ? ", previous workspace" : ""}${proposal.degradedState === "draft-missing" ? ", draft missing — reject and re-propose" : ""}] ${proposal.skillKey}: ${proposal.title}`,
+        `- ${proposal.id} [${proposal.status}, ${proposal.kind}, ${proposal.scanState}${proposal.workspaceMismatch ? ", previous workspace" : ""}${proposal.degradedState === "draft-missing" ? ", draft missing — reject and re-propose" : ""}] ${resolveSkillProposalName(proposal.kind, proposal)}: ${proposal.title}`,
     )
     .join("\n");
 }
@@ -161,7 +162,7 @@ export function formatProposalInspect(
     `Proposal: ${proposal.record.id}`,
     `Status: ${proposal.record.status}`,
     `Kind: ${proposal.record.kind}`,
-    `Skill: ${proposal.record.target.skillKey}`,
+    `Skill: ${resolveSkillProposalName(proposal.record.kind, proposal.record.target)}`,
     `Version: ${proposal.record.proposedVersion}`,
     `Scan: ${proposal.record.scan.state}`,
     ...evaluationLines,

--- a/src/agents/tools/skill-workshop-tool-schema.ts
+++ b/src/agents/tools/skill-workshop-tool-schema.ts
@@ -102,7 +102,7 @@ export function buildSkillWorkshopToolSchema(collectionOnly: boolean, proposalRe
       skill_name: Type.Optional(
         Type.String({
           description:
-            "Existing skill name or key for action=update, action=prepare_patch, action=patch, or action=read.",
+            "Existing skill name or key for action=update, action=prepare_patch, action=patch, or action=read. Reuse the returned skillName for follow-up calls.",
         }),
       ),
       old_string: Type.Optional(

--- a/src/agents/tools/skill-workshop-tool.skill-identity.test.ts
+++ b/src/agents/tools/skill-workshop-tool.skill-identity.test.ts
@@ -1,0 +1,182 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { writeWorkspaceSkills } from "../../skills/test-support/e2e-test-helpers.js";
+import { readProposalFrontmatter } from "../../skills/workshop/frontmatter.js";
+import { inspectSkillProposal } from "../../skills/workshop/service.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
+
+it.each([
+  { action: "update", preparation: "read" },
+  { action: "patch", preparation: "read" },
+  { action: "patch", preparation: "prepare_patch" },
+] as const)(
+  "keeps the $action target when following $preparation guidance",
+  async ({ action, preparation }) => {
+    await withOpenClawTestState(
+      { label: "workshop-guided-target", scenario: "minimal" },
+      async (state) => {
+        const oldString = "Check the starting conditions.";
+        const newString = "Check the starting conditions and record the result.";
+        await writeWorkspaceSkills(state.workspaceDir, [
+          {
+            name: "alpha-guide",
+            description: "Intended procedure",
+            metadata: '{"openclaw":{"skillKey":"beta-guide"}}',
+            body: `# Alpha\n\n${oldString}\n`,
+          },
+          {
+            name: "beta-guide",
+            description: "Other procedure",
+            metadata: '{"openclaw":{"skillKey":"beta-key"}}',
+            body: `# Beta\n\n${oldString}\n`,
+          },
+        ]);
+        const paths = ["alpha-guide", "beta-guide"].map((name) =>
+          path.join(state.workspaceDir, "skills", name, "SKILL.md"),
+        );
+        const originals = await Promise.all(paths.map((file) => fs.readFile(file, "utf8")));
+        const tool = createSkillWorkshopTool({
+          workspaceDir: state.workspaceDir,
+          config: {},
+          env: state.env,
+          proposalOnly: true,
+          updateProposals: true,
+          proposalMutationBudget: { remaining: 1 },
+        });
+        let selector: string | undefined;
+        let readText = "";
+        if (preparation === "prepare_patch") {
+          const prepared = await tool.execute("prepare", {
+            action: "prepare_patch",
+            skill_name: "alpha-guide",
+            old_string: oldString,
+          });
+          const text = prepared.content
+            .flatMap((part) => (part.type === "text" ? [part.text] : []))
+            .join("\n");
+          selector = /^Skill: (.+) \(\d+ bytes\)$/m.exec(text)?.[1];
+        } else {
+          const failure = await tool
+            .execute("without-read", {
+              action,
+              skill_name: "alpha-guide",
+              ...(action === "patch"
+                ? { old_string: oldString, new_string: newString }
+                : { proposal_content: "# Improve the procedure\n" }),
+            })
+            .then(
+              () => {
+                throw new Error("Expected a complete-read instruction");
+              },
+              (error: unknown) => {
+                if (!(error instanceof Error)) {
+                  throw error;
+                }
+                return error.message;
+              },
+            );
+          selector = /call action=read with skill_name "([^"]+)"/.exec(failure)?.[1];
+          const read = await tool.execute("guided-read", { action: "read", skill_name: selector });
+          readText = read.content
+            .flatMap((part) => (part.type === "text" ? [part.text] : []))
+            .join("\n");
+        }
+        if (!selector) {
+          throw new Error("Tool guidance omitted the skill selector");
+        }
+
+        const proposed = await tool.execute("guided-mutation", {
+          action,
+          skill_name: selector,
+          ...(action === "patch"
+            ? { old_string: oldString, new_string: newString }
+            : { proposal_content: `${readText}\nRecord the verified result.\n` }),
+        });
+        const proposalId = (proposed.details as { id: string }).id;
+        const stored = await inspectSkillProposal(proposalId, {
+          workspaceDir: state.workspaceDir,
+          env: state.env,
+        });
+        expect(stored?.record.target).toMatchObject({
+          skillName: "alpha-guide",
+          skillKey: "beta-guide",
+          skillFile: paths[0],
+        });
+        expect(readProposalFrontmatter(stored?.content ?? "")?.name).toBe("alpha-guide");
+        expect(proposed.content).toEqual([
+          { type: "text", text: expect.stringContaining("for alpha-guide.") },
+        ]);
+        const inspected = await tool.execute("inspect", {
+          action: "inspect",
+          proposal_id: proposalId,
+        });
+        expect(inspected.content).toEqual([
+          { type: "text", text: expect.stringContaining("Skill: alpha-guide\n") },
+        ]);
+        expect(await Promise.all(paths.map((file) => fs.readFile(file, "utf8")))).toEqual(
+          originals,
+        );
+      },
+    );
+  },
+);
+
+it("keeps an existing skill name through proposal revision and apply", async () => {
+  await withOpenClawTestState(
+    { label: "workshop-proposal-name", scenario: "minimal" },
+    async (state) => {
+      const tool = createSkillWorkshopTool({
+        workspaceDir: state.workspaceDir,
+        config: {},
+        env: state.env,
+        updateProposals: true,
+      });
+      const created = await tool.execute("seed-create", {
+        action: "create",
+        name: "alpha-guide",
+        description: "Intended procedure",
+        proposal_content:
+          '---\nmetadata: {"openclaw":{"skillKey":"beta-guide"}}\n---\n\n# Alpha\n\nCheck the starting conditions.\n',
+      });
+      await tool.execute("seed-apply", {
+        action: "apply",
+        proposal_id: (created.details as { id: string }).id,
+      });
+      await tool.execute("read", { action: "read", skill_name: "alpha-guide" });
+      const updated = await tool.execute("update", {
+        action: "update",
+        skill_name: "alpha-guide",
+        proposal_content: "# Alpha\n\nCheck the starting conditions and record the result.\n",
+      });
+      const proposalId = (updated.details as { id: string }).id;
+      const proposed = await inspectSkillProposal(proposalId, {
+        workspaceDir: state.workspaceDir,
+        env: state.env,
+      });
+      expect(readProposalFrontmatter(proposed?.content ?? "")?.name).toBe("alpha-guide");
+
+      const revised = await tool.execute("revise", {
+        action: "revise",
+        proposal_id: proposalId,
+        proposal_content: `${proposed?.content}\nVerify the saved outcome.\n`,
+      });
+      const revision = await inspectSkillProposal(proposalId, {
+        workspaceDir: state.workspaceDir,
+        env: state.env,
+      });
+      expect(readProposalFrontmatter(revision?.content ?? "")?.name).toBe("alpha-guide");
+      await tool.execute("apply", {
+        action: "apply",
+        proposal_id: proposalId,
+        expected_revision_hash: (revised.details as { revisionHash: string }).revisionHash,
+      });
+      await expect(
+        tool.execute("read-again", { action: "read", skill_name: "alpha-guide" }),
+      ).resolves.toMatchObject({
+        details: { skillName: "alpha-guide", skillKey: "beta-guide", contentIncluded: true },
+      });
+    },
+  );
+});

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -257,7 +257,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
           options.collectionReconcile &&
           !options.collectionReconcile.approvedSkillNames?.has(skill.skillKey)
         ) {
-          throw new ToolInputError(`skill is outside this collection review: ${skill.skillKey}`);
+          throw new ToolInputError(`skill is outside this collection review: ${skill.skillName}`);
         }
         const readMaxChars = projectionBudgets.artifactChars;
         const truncated = skill.content.length > readMaxChars;
@@ -281,7 +281,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         const text = truncated
           ? truncateUtf16Safe(
               [
-                `Skill: ${skill.skillKey} (${sizeBytes} bytes)`,
+                `Skill: ${skill.skillName} (${sizeBytes} bytes)`,
                 "Content omitted: the complete skill exceeds the selected-model read budget.",
                 options.collectionReconcile
                   ? "Next: leave this skill unlisted in the reconcile call; only the operator can change it."
@@ -291,6 +291,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
             )
           : skill.content;
         return textResult(text, {
+          skillName: skill.skillName,
           skillKey: skill.skillKey,
           sizeBytes,
           contentIncluded: !truncated,
@@ -512,15 +513,15 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
           throw new ToolInputError(
             target.content.length > projectionBudgets.artifactChars
               ? action === "patch"
-                ? `skill "${target.skillKey}" exceeds the reviewer read budget: call action=prepare_patch with the non-empty exact old_string before patching`
-                : `skill "${target.skillKey}" exceeds the reviewer read budget and cannot be updated autonomously`
-              : `read the live skill first: call action=read with skill_name "${target.skillKey}", then ${action === "patch" ? "quote its current text in the patch" : "rewrite it from the returned content"}`,
+                ? `skill "${target.skillName}" exceeds the reviewer read budget: call action=prepare_patch with the non-empty exact old_string before patching`
+                : `skill "${target.skillName}" exceeds the reviewer read budget and cannot be updated autonomously`
+              : `read the live skill first: call action=read with skill_name "${target.skillName}", then ${action === "patch" ? "quote its current text in the patch" : "rewrite it from the returned content"}`,
           );
         }
         if (readHash && readHash !== contentHash) {
           readSkillHashes.delete(target.skillKey);
           throw new ToolInputError(
-            `skill "${target.skillKey}" changed since it was read: call action=read again and redraft the ${action} from the current content`,
+            `skill "${target.skillName}" changed since it was read: call action=read again and redraft the ${action} from the current content`,
           );
         }
         expectedCurrentContentHash = readHash ?? preparedHash ?? contentHash;
@@ -603,7 +604,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
             evidence,
           });
           contentText = proposalMutationText("Created skill proposal", proposal.record);
-        } else if (action === "update") {
+        } else if (action === "update" || action === "patch") {
           proposal = await proposeUpdateSkill({
             workspaceDir: options.workspaceDir,
             agentId: options.agentId,
@@ -615,42 +616,24 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
               label: "skill_name",
             }),
             expectedCurrentContentHash,
-            description: readToolStringParam(params, "description"),
-            content: requireProposalContent(proposalContent),
-            supportFiles,
-            createdBy: "skill-workshop",
-            ...(options.autonomousCapture ? { autonomousCapture: true } : {}),
-            ...(options.origin ? { origin: options.origin } : {}),
-            goal,
-            evidence,
-          });
-          contentText = proposalMutationText("Created skill update proposal", proposal.record);
-        } else if (action === "patch") {
-          // No description forwarding: a patch may only change the quoted span, and
-          // proposal rendering would regenerate frontmatter from a new description.
-          proposal = await proposeUpdateSkill({
-            workspaceDir: options.workspaceDir,
-            agentId: options.agentId,
-            eventActor: skillWorkshopAgentEventActor(options.agentId),
-            config: options.config,
-            env: options.env,
-            skillName: readToolStringParam(params, "skill_name", {
-              required: true,
-              label: "skill_name",
-            }),
-            expectedCurrentContentHash,
-            composePatch: readSkillPatchText(params),
+            // A patch may only change its exact span, never description or support files.
+            ...(action === "patch"
+              ? { composePatch: readSkillPatchText(params) }
+              : {
+                  description: readToolStringParam(params, "description"),
+                  content: requireProposalContent(proposalContent),
+                  supportFiles,
+                }),
             createdBy: "skill-workshop",
             ...(options.autonomousCapture || foregroundRepair ? { autonomousCapture: true } : {}),
             ...(options.origin ? { origin: options.origin } : {}),
             goal,
             evidence,
           });
-          contentText = foregroundRepair
-            ? workshopConfig.autonomous.mode === "propose"
-              ? `Created skill patch proposal ${proposal.record.id} (pending) for ${proposal.record.target.skillKey}; autonomous mode propose requires operator review.`
-              : proposalMutationText("Created skill patch proposal", proposal.record)
-            : proposalMutationText("Created skill patch proposal", proposal.record);
+          contentText =
+            foregroundRepair && workshopConfig.autonomous.mode === "propose"
+              ? `Created skill patch proposal ${proposal.record.id} (pending) for ${proposal.record.target.skillName}; autonomous mode propose requires operator review.`
+              : proposalMutationText(`Created skill ${action} proposal`, proposal.record);
         } else if (action === "revise") {
           let proposalId = options.proposalRevision?.proposalId;
           let expectedRevisionHash = options.proposalRevision?.expectedRevisionHash;
@@ -718,12 +701,12 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
             return proposalResult(
               { ...proposal, record: autonomous.record },
               {
-                contentText: `Skill ${autonomous.record.target.skillKey} is user-authored; proposal ${autonomous.record.id} awaits operator review.`,
+                contentText: `Skill ${autonomous.record.target.skillName} is user-authored; proposal ${autonomous.record.id} awaits operator review.`,
               },
             );
           }
           return actionResult(autonomous.record, {
-            contentText: `Repaired used skill ${autonomous.record.target.skillKey} through proposal ${autonomous.record.id}.`,
+            contentText: `Repaired used skill ${autonomous.record.target.skillName} through proposal ${autonomous.record.id}.`,
             targetSkillFile: autonomous.targetSkillFile,
           });
         }

--- a/src/cli/skills-cli.test.ts
+++ b/src/cli/skills-cli.test.ts
@@ -273,6 +273,32 @@ describe("skills-cli", () => {
       expect(output).toContain("Spreadsheet helpers");
     });
 
+    it("prefers the exact skill name over another skill's key in either discovery order", () => {
+      const alias = createMockSkill({ name: "another-skill", skillKey: "requested-skill" });
+      const target = createMockSkill({ name: "requested-skill", skillKey: "target-key" });
+
+      for (const skills of [
+        [alias, target],
+        [target, alias],
+      ]) {
+        const output = formatSkillInfo(createMockReport(skills), "requested-skill", { json: true });
+        expect(JSON.parse(output).name).toBe("requested-skill");
+      }
+    });
+
+    it("rejects an ambiguous exact skill key instead of selecting the first discovered skill", () => {
+      const first = createMockSkill({ name: "first-skill", skillKey: "shared-key" });
+      const second = createMockSkill({ name: "second-skill", skillKey: "shared-key" });
+
+      for (const skills of [
+        [first, second],
+        [second, first],
+      ]) {
+        const output = formatSkillInfo(createMockReport(skills), "shared-key", { json: true });
+        expect(JSON.parse(output)).toMatchObject({ ok: false, skill: "shared-key" });
+      }
+    });
+
     it("returns not found for ambiguous case-insensitive matches", () => {
       const report = createMockReport([
         createMockSkill({ name: "First Skill", skillKey: "Excel-XLSX", description: "first" }),

--- a/src/gateway/server-methods/skills.proposals.test.ts
+++ b/src/gateway/server-methods/skills.proposals.test.ts
@@ -543,67 +543,84 @@ describe("skills proposal gateway handlers", () => {
     expect((invalid.error as { code?: string }).code).toBe("INVALID_REQUEST");
   });
 
-  it("starts revision chat turns with visible instructions and server-built context", async () => {
-    const create = await callHandler("skills.proposals.create", {
-      name: "Support File Sampler",
-      description: "Samples support files",
-      content: "# Support File Sampler\n\nSample support files.\n",
-    });
-    expect(create.ok).toBe(true);
-    const created = create.response as { record: { id: string } };
-    const inspected = await callHandler("skills.proposals.inspect", {
-      proposalId: created.record.id,
-    });
-    const expectedRevisionHash = (inspected.response as { revisionHash: string }).revisionHash;
+  it.each(["create", "update"])(
+    "starts %s revision chat turns with visible instructions and server-built context",
+    async (kind) => {
+      const create = await callHandler("skills.proposals.create", {
+        name: "Support File Sampler",
+        description: "Samples support files",
+        content:
+          '---\nmetadata: {"openclaw":{"skillKey":"different-key"}}\n---\n\n# Support File Sampler\n\nSample support files.\n',
+      });
+      expect(create.ok).toBe(true);
+      let created = create.response as { record: { id: string }; revisionHash: string };
+      if (kind === "update") {
+        const applied = await callHandler("skills.proposals.apply", {
+          proposalId: created.record.id,
+          expectedRevisionHash: created.revisionHash,
+        });
+        expect(applied.ok).toBe(true);
+        const update = await callHandler("skills.proposals.update", {
+          skillName: "support-file-sampler",
+          content: "# Support File Sampler\n\nSample the current support files.\n",
+        });
+        expect(update.ok).toBe(true);
+        created = update.response as typeof created;
+      }
+      const inspected = await callHandler("skills.proposals.inspect", {
+        proposalId: created.record.id,
+      });
+      const expectedRevisionHash = (inspected.response as { revisionHash: string }).revisionHash;
 
-    const result = await callHandler("skills.proposals.requestRevision", {
-      proposalId: created.record.id,
-      expectedRevisionHash,
-      instructions: "Make the support files 5",
-      sessionKey: "agent:main:session:skill-workshop",
-      targetAgentId: "revision-target",
-      idempotencyKey: "revision-run-1",
-    });
+      const result = await callHandler("skills.proposals.requestRevision", {
+        proposalId: created.record.id,
+        expectedRevisionHash,
+        instructions: "Make the support files 5",
+        sessionKey: "agent:main:session:skill-workshop",
+        targetAgentId: "revision-target",
+        idempotencyKey: "revision-run-1",
+      });
 
-    expect(result).toMatchObject({
-      ok: true,
-      response: { runId: "run-skill-workshop-revision", status: "started" },
-    });
-    expect(mocks.chatSend).toHaveBeenCalledTimes(1);
-    const forwarded = mocks.chatSend.mock.calls[0]?.[0] as {
-      params?: Record<string, unknown>;
-      req?: { method?: string; params?: Record<string, unknown> };
-    };
-    expect(forwarded.req?.method).toBe("chat.send");
-    expect(forwarded.params).toMatchObject({
-      agentId: "revision-target",
-      deliver: false,
-      idempotencyKey: "revision-run-1",
-      message: "Make the support files 5",
-      queueMode: "followup",
-      sessionKey: "agent:main:session:skill-workshop",
-      suppressCommandInterpretation: true,
-    });
-    expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
-      `Revise Skill Workshop proposal \`${created.record.id}\` (support-file-sampler).`,
-    );
-    expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
-      "Use `skill_workshop` with `action=inspect` first, then `action=revise`",
-    );
-    expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
-      "The proposal ID and expected revision hash are bound by this run",
-    );
-    expect(String(forwarded.params?.systemProvenanceReceipt)).not.toContain(expectedRevisionHash);
-    expect(String(forwarded.params?.systemProvenanceReceipt)).not.toContain(
-      "Make the support files 5",
-    );
-    expect(mocks.chatSend.mock.calls[0]?.[1]).toEqual({
-      agentId: "main",
-      workspaceDir: mocks.workspaceDir,
-      proposalId: created.record.id,
-      expectedRevisionHash,
-    });
-  });
+      expect(result).toMatchObject({
+        ok: true,
+        response: { runId: "run-skill-workshop-revision", status: "started" },
+      });
+      expect(mocks.chatSend).toHaveBeenCalledTimes(1);
+      const forwarded = mocks.chatSend.mock.calls[0]?.[0] as {
+        params?: Record<string, unknown>;
+        req?: { method?: string; params?: Record<string, unknown> };
+      };
+      expect(forwarded.req?.method).toBe("chat.send");
+      expect(forwarded.params).toMatchObject({
+        agentId: "revision-target",
+        deliver: false,
+        idempotencyKey: "revision-run-1",
+        message: "Make the support files 5",
+        queueMode: "followup",
+        sessionKey: "agent:main:session:skill-workshop",
+        suppressCommandInterpretation: true,
+      });
+      expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
+        `Revise Skill Workshop proposal \`${created.record.id}\` (support-file-sampler).`,
+      );
+      expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
+        "Use `skill_workshop` with `action=inspect` first, then `action=revise`",
+      );
+      expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
+        "The proposal ID and expected revision hash are bound by this run",
+      );
+      expect(String(forwarded.params?.systemProvenanceReceipt)).not.toContain(expectedRevisionHash);
+      expect(String(forwarded.params?.systemProvenanceReceipt)).not.toContain(
+        "Make the support files 5",
+      );
+      expect(mocks.chatSend.mock.calls[0]?.[1]).toEqual({
+        agentId: "main",
+        workspaceDir: mocks.workspaceDir,
+        proposalId: created.record.id,
+        expectedRevisionHash,
+      });
+    },
+  );
 
   it("does not start revision chat turns from a stale revision hash", async () => {
     const create = await callHandler("skills.proposals.create", {

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -57,6 +57,7 @@ import {
   getSkillCuratorStatus,
   SKILL_LIFECYCLE_CURATION_RETIRED_MESSAGE,
 } from "../../skills/workshop/curator.js";
+import { resolveSkillProposalName } from "../../skills/workshop/frontmatter.js";
 import { assertExpectedRevisionHash } from "../../skills/workshop/service-evaluation.js";
 import {
   applySkillProposal,
@@ -177,12 +178,9 @@ function collectClawHubTrustWarnings(results: Array<{ warning?: string }>): stri
     .filter((warning): warning is string => Boolean(warning));
 }
 
-function buildRevisionAgentInstruction(proposal: Awaited<ReturnType<typeof inspectSkillProposal>>) {
-  if (!proposal) {
-    return "";
-  }
+function buildRevisionAgentInstruction(proposal: SkillProposalReadResult) {
   return [
-    `Revise Skill Workshop proposal \`${proposal.record.id}\` (${proposal.record.target.skillKey}).`,
+    `Revise Skill Workshop proposal \`${proposal.record.id}\` (${resolveSkillProposalName(proposal.record.kind, proposal.record.target)}).`,
     "",
     "Use `skill_workshop` with `action=inspect` first, then `action=revise` for that pending proposal.",
     "The proposal ID and expected revision hash are bound by this run; do not substitute them.",

--- a/src/gateway/server.startup-recovery-webchat.test.ts
+++ b/src/gateway/server.startup-recovery-webchat.test.ts
@@ -4,7 +4,6 @@ import { writeOpenAiResponsesText } from "../../test/helpers/openai-responses-ss
 import { createDeferred } from "../../test/helpers/promise.js";
 import { MAIN_SESSION_RECOVERY_WORK_ADMISSION_OWNER } from "../agents/main-session-recovery/main-session-recovery-admission.js";
 import { recoverRestartAbortedMainSessions } from "../agents/main-session-recovery/main-session-restart-recovery.js";
-import { getFollowupQueueDepth } from "../auto-reply/reply/queue/enqueue.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "../auto-reply/reply/queue/state.js";
 import {
   appendTranscriptMessage,
@@ -17,6 +16,7 @@ import {
   getSessionWorkAdmissionOwnerRelease,
 } from "../sessions/session-lifecycle-admission.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { countPendingQueueItems } from "../utils/queue-helpers.js";
 import { getGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
 import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
@@ -184,11 +184,12 @@ it(
 
       const canceledRunId = "webchat-canceled-during-recovery";
       const survivorRunId = "webchat-survives-recovery";
+      const expectedQueuedMessages = new Map([
+        [canceledRunId, canceledMessage],
+        [survivorRunId, survivorMessage],
+      ]);
       await Promise.all(
-        [
-          [canceledRunId, canceledMessage],
-          [survivorRunId, survivorMessage],
-        ].map(async ([runId, message]) => {
+        Array.from(expectedQueuedMessages, async ([runId, message]) => {
           await expect(
             client.request("chat.send", {
               sessionKey,
@@ -203,8 +204,14 @@ it(
       );
       await vi.waitFor(() => {
         const queue = getExistingFollowupQueue(sessionKey);
+        // Active sources remain in items; started ACKs can precede queue admission.
+        expect(queue?.items).toHaveLength(expectedQueuedMessages.size);
+        expect(new Map(queue?.items.map(({ messageId, prompt }) => [messageId, prompt]))).toEqual(
+          expectedQueuedMessages,
+        );
         expect(queue?.inFlight).toHaveLength(1);
-        expect(getFollowupQueueDepth(sessionKey)).toBe(1);
+        expect(countPendingQueueItems(queue?.items ?? [], queue?.inFlight)).toBe(1);
+        expect(targetRequests).toHaveLength(1);
       });
       replacementOwner = await beginSessionWorkAdmission({
         scope: storePath,

--- a/src/gateway/server.startup-recovery-webchat.test.ts
+++ b/src/gateway/server.startup-recovery-webchat.test.ts
@@ -4,6 +4,7 @@ import { writeOpenAiResponsesText } from "../../test/helpers/openai-responses-ss
 import { createDeferred } from "../../test/helpers/promise.js";
 import { MAIN_SESSION_RECOVERY_WORK_ADMISSION_OWNER } from "../agents/main-session-recovery/main-session-recovery-admission.js";
 import { recoverRestartAbortedMainSessions } from "../agents/main-session-recovery/main-session-restart-recovery.js";
+import { getFollowupQueueDepth } from "../auto-reply/reply/queue/enqueue.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "../auto-reply/reply/queue/state.js";
 import {
   appendTranscriptMessage,
@@ -203,7 +204,7 @@ it(
       await vi.waitFor(() => {
         const queue = getExistingFollowupQueue(sessionKey);
         expect(queue?.inFlight).toHaveLength(1);
-        expect(queue?.items).toHaveLength(1);
+        expect(getFollowupQueueDepth(sessionKey)).toBe(1);
       });
       replacementOwner = await beginSessionWorkAdmission({
         scope: storePath,

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -97,42 +97,22 @@ export function resolveSkillStatusEntry(
 
   const lower = raw.toLowerCase();
   const normalized = normalizeSkillIndexName(raw);
-  let caseInsensitiveMatch: SkillStatusEntry | null = null;
-  let caseInsensitiveMatches = 0;
-  let normalizedMatch: SkillStatusEntry | null = null;
-  let normalizedMatches = 0;
-
-  for (const skill of skills) {
-    if (skill.name === raw || skill.skillKey === raw) {
-      return skill;
-    }
-
-    const nameLower = skill.name.toLowerCase();
-    const keyLower = skill.skillKey.toLowerCase();
-    if (nameLower === lower || keyLower === lower) {
-      caseInsensitiveMatch = skill;
-      caseInsensitiveMatches += 1;
-      continue;
-    }
-
-    if (
-      normalized &&
+  // Names outrank metadata aliases. A tie at the strongest matching level
+  // must not redirect inspection or Workshop updates to the first loaded skill.
+  const matchers: Array<(skill: SkillStatusEntry) => boolean> = [
+    (skill) => skill.name === raw,
+    (skill) => skill.skillKey === raw,
+    (skill) => skill.name.toLowerCase() === lower || skill.skillKey.toLowerCase() === lower,
+    (skill) =>
+      Boolean(normalized) &&
       (normalizeSkillIndexName(skill.name) === normalized ||
-        normalizeSkillIndexName(skill.skillKey) === normalized)
-    ) {
-      normalizedMatch = skill;
-      normalizedMatches += 1;
+        normalizeSkillIndexName(skill.skillKey) === normalized),
+  ];
+  for (const matches of matchers) {
+    const candidates = skills.filter(matches);
+    if (candidates.length > 0) {
+      return candidates.length === 1 ? candidates[0]! : null;
     }
-  }
-
-  if (caseInsensitiveMatches > 1) {
-    return null;
-  }
-  if (caseInsensitiveMatches === 1) {
-    return caseInsensitiveMatch;
-  }
-  if (normalizedMatches === 1) {
-    return normalizedMatch;
   }
   return null;
 }

--- a/src/skills/workshop/frontmatter.ts
+++ b/src/skills/workshop/frontmatter.ts
@@ -1,11 +1,21 @@
 // Workshop frontmatter helpers parse generated skill metadata before saving drafts.
 import { extractFrontmatterBlock } from "../../../packages/markdown-core/src/frontmatter.js";
 import { parseSkillFrontmatter } from "../loading/frontmatter.js";
+import type { SkillProposalRecord } from "./types.js";
 
 type ProposalFrontmatter = {
   name: string;
   description: string;
 };
+
+export function resolveSkillProposalName(
+  kind: SkillProposalRecord["kind"],
+  target: Pick<SkillProposalRecord["target"], "skillName" | "skillKey">,
+): string {
+  // New skills use the normalized key as their name; updates retain the live
+  // frontmatter name, which may differ from the metadata key.
+  return kind === "create" ? target.skillKey : target.skillName;
+}
 
 // JSON strings are valid YAML scalars and avoid ad hoc escaping.
 function yamlScalar(value: string): string {

--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -253,7 +253,7 @@ export async function proposeUpdateSkill(
 
   const now = new Date().toISOString();
   const prepared = prepareSkillProposalDraft({
-    name: targetSkill.skillKey,
+    name: targetSkill.name,
     description,
     content: draftContent,
     fallbackFrontmatterContent: currentContent,

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -9,6 +9,7 @@ import {
   readWorkspaceSkillFile,
 } from "../lifecycle/workspace-skill-write.js";
 import { transitionPendingSkillProposalToStale } from "./apply-transition.js";
+import { resolveSkillProposalName } from "./frontmatter.js";
 import { dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
@@ -153,7 +154,7 @@ export async function resolvePendingSkillProposal(input: {
   if (matches.length > 1) {
     const candidates = matches
       .slice(0, 8)
-      .map((proposal) => `${proposal.id} (${proposal.skillKey})`)
+      .map((proposal) => `${proposal.id} (${resolveSkillProposalName(proposal.kind, proposal)})`)
       .join(", ");
     throw new Error(`Multiple pending skill proposals matched ${name}: ${candidates}`);
   }

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -13,6 +13,7 @@ import {
   type SkillProposalTransitionInput,
 } from "./apply-transition.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
+import { resolveSkillProposalName } from "./frontmatter.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { nextProposalVersion, prepareSkillProposalDraft } from "./proposal-draft.js";
 import { createSkillProposalGenerationDraftFile } from "./proposal-generation.js";
@@ -124,7 +125,7 @@ export async function reviseSkillProposal(
     const description = normalizeOptionalString(input.description) ?? record.description;
     const now = new Date().toISOString();
     const prepared = prepareSkillProposalDraft({
-      name: record.target.skillKey,
+      name: resolveSkillProposalName(record.kind, record.target),
       description,
       content: requestedContent,
       fallbackFrontmatterContent: read.content,

--- a/src/skills/workshop/workspace-skill-read.test.ts
+++ b/src/skills/workshop/workspace-skill-read.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  listWritableWorkspaceSkillSummaries,
+  readWritableWorkspaceSkill,
+} from "./workspace-skill-read.js";
+
+it("reads the named workspace skill when an earlier skill aliases its name", async () => {
+  await withOpenClawTestState(
+    { label: "workshop-skill-name", scenario: "minimal" },
+    async (state) => {
+      for (const [folder, name, skillKey, body] of [
+        ["a-alias", "another-skill", "requested-skill", "Other skill instructions."],
+        ["b-target", "requested-skill", "target-key", "Requested skill instructions."],
+      ] as const) {
+        const directory = path.join(state.workspaceDir, "skills", folder);
+        await fs.mkdir(directory, { recursive: true });
+        await fs.writeFile(
+          path.join(directory, "SKILL.md"),
+          `---\nname: ${name}\ndescription: Workspace lookup fixture\nmetadata: {"openclaw":{"skillKey":"${skillKey}"}}\n---\n\n${body}\n`,
+        );
+      }
+
+      const result = await readWritableWorkspaceSkill(state.workspaceDir, "requested-skill", {
+        config: {},
+      });
+
+      expect(result.skillFile).toBe(
+        path.join(state.workspaceDir, "skills", "b-target", "SKILL.md"),
+      );
+      expect(result.skillKey).toBe("target-key");
+      expect(result.content).toContain("Requested skill instructions.");
+
+      const summaries = listWritableWorkspaceSkillSummaries(state.workspaceDir, { config: {} });
+      expect(summaries).toHaveLength(2);
+      for (const summary of summaries) {
+        const read = await readWritableWorkspaceSkill(state.workspaceDir, summary.name, {
+          config: {},
+        });
+        expect(read.skillFile).toBe(summary.filePath);
+      }
+    },
+  );
+});

--- a/src/skills/workshop/workspace-skill-read.ts
+++ b/src/skills/workshop/workspace-skill-read.ts
@@ -74,7 +74,7 @@ export async function readWritableWorkspaceSkill(
   workspaceDir: string,
   skillName: string,
   opts?: { config?: OpenClawConfig; agentId?: string },
-): Promise<{ skillKey: string; skillFile: string; content: string }> {
+): Promise<{ skillName: string; skillKey: string; skillFile: string; content: string }> {
   const name = normalizeOptionalString(skillName);
   if (!name) {
     throw new Error("Skill name is required.");
@@ -92,5 +92,10 @@ export async function readWritableWorkspaceSkill(
   if (content === null) {
     throw new Error(`Skill file is missing: ${targetSkill.filePath}`);
   }
-  return { skillKey: targetSkill.skillKey, skillFile: targetSkill.filePath, content };
+  return {
+    skillName: targetSkill.name,
+    skillKey: targetSkill.skillKey,
+    skillFile: targetSkill.filePath,
+    content,
+  };
 }

--- a/src/skills/workshop/workspace-skill-read.ts
+++ b/src/skills/workshop/workspace-skill-read.ts
@@ -59,24 +59,14 @@ export function listWritableWorkspaceSkillSummaries(
     agentId: opts?.agentId,
   });
   const ownedDirs = listWorkshopOwnedSkillDirs(workspaceDir, opts?.env ? { env: opts.env } : {});
-  const summaries: WritableWorkspaceSkillSummary[] = [];
-  for (const skill of status.skills) {
-    if (!WRITABLE_WORKSPACE_SOURCES.has(skill.source)) {
-      continue;
-    }
-    const userAuthored = !ownedDirs.has(path.resolve(skill.baseDir));
-    summaries.push(
-      skill.description
-        ? {
-            name: skill.skillKey,
-            description: skill.description,
-            filePath: skill.filePath,
-            userAuthored,
-          }
-        : { name: skill.skillKey, filePath: skill.filePath, userAuthored },
-    );
-  }
-  return summaries;
+  return status.skills
+    .filter((skill) => WRITABLE_WORKSPACE_SOURCES.has(skill.source))
+    .map((skill) => ({
+      name: skill.name,
+      description: skill.description,
+      filePath: skill.filePath,
+      userAuthored: !ownedDirs.has(path.resolve(skill.baseDir)),
+    }));
 }
 
 /** Reads the live SKILL.md of a writable workspace skill, resolved like an update target. */


### PR DESCRIPTION
Fixes #136493.

## What Problem This Solves

An exact skill name could silently select an earlier skill's metadata alias. Even after selecting the correct file, retry guidance could redirect the agent to the conflicting alias, and update/revision drafts could replace the live frontmatter name with that key. Inspection and Workshop now keep the requested skill's canonical name throughout the workflow.

## Why This Change Was Made

The shared resolver checks exact names, exact metadata keys, case-insensitive matches and normalized matches in order; ambiguity in the strongest matching tier stops selection. Writable summaries and read/prepare results expose the canonical name. Retry instructions, generated update/revision frontmatter, proposal projections and Gateway revision instructions carry that same name. Creation still uses its existing normalized name.

The repair deletes four match/count accumulators, duplicate summary construction, duplicate update/patch proposal construction, a copied patch-target type and a redundant nullable instruction branch. Metadata keys, target files, content/revision hashes, receipt maps and authority bindings keep their existing contracts.

Production **+82 / −115 = −33 LOC**; tests/support **+343 / −64 = +279**; docs **+10**. No new config option, dependency, schema or material store change.

## User Impact

`skills info` and Workshop select exact names consistently regardless of discovery order. Following read/patch guidance stays on the intended skill, and applying a revision preserves the name needed to read that skill again. Unique aliases and normalized lookup remain supported. Existing pending drafts are not silently rewritten; their normal revision owner changes draft content.

## Evidence

The original compiled CLI on `65e5b2e19c9db6460494682bacc4bee10db755fd` listed both synthetic skills, then selected `qa-alias-skill` for `skills info qa-exact-target --json --agent proof`. The rebuilt CLI selected `qa-exact-target` and its actual file in both JSON and text. Original owner/sibling validation passed 226 tests and the canonical runtime build.

The final native tool/filesystem/proposal flows reproduce the complete failure and repair:

| Flow | Before | After |
| --- | --- | --- |
| Follow read guidance for `alpha-guide`, whose metadata key is `beta-guide` | Update/patch proposal targets the other skill named `beta-guide` | Guidance and proposal retain `alpha-guide` and its original file |
| Update, revise and apply `alpha-guide` | Live name becomes `beta-guide`; reading `alpha-guide` fails | Proposed, revised and live names remain `alpha-guide`; read succeeds |
| Create and revise `Friendly New Guide` | Normalizes to `friendly-new-guide` | Same normalized name and successful read |

- Four final identity regressions fail before the follow-through and pass after. The Gateway revision-instruction regression also fails before while its creation control passes. Final recorded batches cover **174 distinct cases across twelve files**, including all 22 Gateway proposal cases and bound revision/identity siblings.
- The complete nineteen-file changed gate passes. One cumulative independent Codex review of all final source is clean through P2, with frozen source/index and one connected input. Root personally inspected the complete changed owners, shared proposal/name contracts, actual before/after results and preserved authorization bindings.
- The existing startup-recovery CI fixture uses the queue owner's pending-depth contract and both exact queued message identities, preserving replacement cancellation, surviving delivery and cleanup. Its actual Gateway regression passed; this test-only correction is not another product issue.

The original CLI proof uses the compiled CLI; final identity follow-through uses actual source tool/service operations and real synthetic files/proposals with a scripted guidance consumer. The Gateway instruction proof captures the existing handler dispatch, rather than claiming a live socket or model turn. UI autocomplete relevance in #123533 is a separate behavior.

## Compatibility and final review

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/136495#issuecomment-5514391917) confirms the prior retry-selector finding is fixed and reports no remaining correctness finding. Its sole remaining item flags `frontmatter.ts` for data-model compatibility. Seventeen complete record/schema/store/parser owners are byte-identical, as are the existing frontmatter renderer, reader and stripping functions. The change chooses between existing name/key values; it adds no field or migration.

Actual readers from original `65e5b2e19c9db6460494682bacc4bee10db755fd` and final `b09e55f6f1a8bd7e48869dd7eb3217fd6b7f79a4` each accepted the same 27 copied Markdown artifacts and seven stored proposal records with identical results. They read the exact newly generated, revised and applied skill bytes. Both retained two older pending drafts with identical content, stored JSON, pending status, draft hash and revision hash. Explicit revision regenerates the corrected name; reads and apply do not silently rewrite approved drafts. This is real source-reader compatibility proof, not a separately installed stable-release downgrade test or a whole-SQLite-file byte-identity claim.

The [required CI gate](https://github.com/openclaw/openclaw/actions/runs/33689362173/job/100449517964) passes on that final head, with no pending or failed checks in the final snapshot. The compatibility item is addressed and no Rank-up move remains.
