### PR TITLE
fix(codex): explain legacy managed policy failures

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -2985,13 +2985,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
   it.each([
     {
       expectedError:
-        'migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
+        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromFile; migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
       name: "legacy managed file",
       layer: { name: { type: "legacyManagedConfigTomlFromFile" } },
     },
     {
       expectedError:
-        'replace the legacy managed-config MDM payload with Codex requirements policy before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
+        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromMdm; replace the legacy managed-config MDM payload with Codex requirements policy before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
       name: "legacy managed MDM",
       layer: { name: { type: "legacyManagedConfigTomlFromMdm" } },
     },

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -2983,36 +2983,53 @@ describe("Codex app-server thread lifecycle bindings", () => {
   });
 
   it.each([
-    { name: "legacy managed file", layer: { name: { type: "legacyManagedConfigTomlFromFile" } } },
-    { name: "legacy managed MDM", layer: { name: { type: "legacyManagedConfigTomlFromMdm" } } },
-    { name: "unknown future", layer: { name: { type: "futureManaged" } } },
-    { name: "malformed", layer: { name: {} } },
-  ])("fails closed on $name config layers before OpenClaw thread/start", async ({ layer }) => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    const params = createParams(sessionFile, workspaceDir);
-    params.toolsAllow = ["openclaw"];
-    const request = vi.fn(async (method: string) => {
-      if (method === "config/read") {
-        return { config: {}, layers: [layer] };
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
+    {
+      expectedError:
+        'migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
+      name: "legacy managed file",
+      layer: { name: { type: "legacyManagedConfigTomlFromFile" } },
+    },
+    {
+      expectedError:
+        'replace the legacy managed-config MDM payload with Codex requirements policy before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
+      name: "legacy managed MDM",
+      layer: { name: { type: "legacyManagedConfigTomlFromMdm" } },
+    },
+    {
+      expectedError: /config layer/u,
+      name: "unknown future",
+      layer: { name: { type: "futureManaged" } },
+    },
+    { expectedError: /config layers/u, name: "malformed", layer: { name: {} } },
+  ])(
+    "fails closed on $name config layers before OpenClaw thread/start",
+    async ({ expectedError, layer }) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(sessionFile, workspaceDir);
+      params.toolsAllow = ["openclaw"];
+      const request = vi.fn(async (method: string) => {
+        if (method === "config/read") {
+          return { config: {}, layers: [layer] };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      });
 
-    await expect(
-      startOrResumeThread({
-        client: { request } as never,
-        params,
-        cwd: workspaceDir,
-        dynamicTools: [createNamedDynamicTool("openclaw")],
-        appServer: createThreadLifecycleAppServerOptions(),
-        nativeCodeModeEnabled: false,
-        userMcpServersEnabled: false,
-        hostSystemAgentActive: true,
-      }),
-    ).rejects.toThrow(/config layer|config layers/u);
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["config/read"]);
-  });
+      await expect(
+        startOrResumeThread({
+          client: { request } as never,
+          params,
+          cwd: workspaceDir,
+          dynamicTools: [createNamedDynamicTool("openclaw")],
+          appServer: createThreadLifecycleAppServerOptions(),
+          nativeCodeModeEnabled: false,
+          userMcpServersEnabled: false,
+          hostSystemAgentActive: true,
+        }),
+      ).rejects.toThrow(expectedError);
+      expect(request.mock.calls.map(([method]) => method)).toEqual(["config/read"]);
+    },
+  );
 
   it.each(["hooks", "managed_hooks"] as const)(
     "fails closed on non-empty %s requirements before OpenClaw thread/start",

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -2991,7 +2991,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     },
     {
       expectedError:
-        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromMdm; replace the legacy managed-config MDM payload with Codex requirements policy before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
+        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromMdm; replace the legacy MDM payload with base64-encoded TOML requirements in the com.openai.codex managed preference requirements_toml_base64 before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
       name: "legacy managed MDM",
       layer: { name: { type: "legacyManagedConfigTomlFromMdm" } },
     },

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -2985,13 +2985,18 @@ describe("Codex app-server thread lifecycle bindings", () => {
   it.each([
     {
       expectedError:
-        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromFile; migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
+        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromFile; migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in /etc/codex/requirements.toml.',
       name: "legacy managed file",
-      layer: { name: { type: "legacyManagedConfigTomlFromFile" } },
+      layer: {
+        name: {
+          file: "/etc/codex/managed_config.toml",
+          type: "legacyManagedConfigTomlFromFile",
+        },
+      },
     },
     {
       expectedError:
-        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromMdm; replace the legacy MDM payload with base64-encoded TOML requirements in the com.openai.codex managed preference requirements_toml_base64 before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.',
+        'Codex restricted tool surface cannot override config layer legacyManagedConfigTomlFromMdm; replace the legacy MDM payload with base64-encoded TOML requirements in the com.openai.codex managed preference requirements_toml_base64 before running restricted or isolated turns. For ChatGPT-only authentication, include allowed_login_methods = ["chatgpt"] in that TOML payload.',
       name: "legacy managed MDM",
       layer: { name: { type: "legacyManagedConfigTomlFromMdm" } },
     },

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -549,7 +549,7 @@ export async function readCodexInheritedMcpServerNames(
       const migrationTarget =
         layer.name.type === "legacyManagedConfigTomlFromFile"
           ? "migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml"
-          : "replace the legacy managed-config MDM payload with Codex requirements policy";
+          : "replace the legacy MDM payload with base64-encoded TOML requirements in the com.openai.codex managed preference requirements_toml_base64";
       throw new Error(
         `Codex restricted tool surface cannot override config layer ${layer.name.type}; ${migrationTarget} before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.`,
       );

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -546,8 +546,12 @@ export async function readCodexInheritedMcpServerNames(
       layer.name.type === "legacyManagedConfigTomlFromFile" ||
       layer.name.type === "legacyManagedConfigTomlFromMdm"
     ) {
+      const migrationTarget =
+        layer.name.type === "legacyManagedConfigTomlFromFile"
+          ? "migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml"
+          : "replace the legacy managed-config MDM payload with Codex requirements policy";
       throw new Error(
-        `Codex restricted tool surface cannot override config layer ${layer.name.type}`,
+        `Codex restricted tool surface cannot override config layer ${layer.name.type}; ${migrationTarget} before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.`,
       );
     }
     if (!CODEX_RING_ZERO_OVERRIDABLE_LAYER_TYPES.has(layer.name.type)) {

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -546,12 +546,12 @@ export async function readCodexInheritedMcpServerNames(
       layer.name.type === "legacyManagedConfigTomlFromFile" ||
       layer.name.type === "legacyManagedConfigTomlFromMdm"
     ) {
-      const migrationTarget =
+      const migrationGuidance =
         layer.name.type === "legacyManagedConfigTomlFromFile"
-          ? "migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml"
-          : "replace the legacy MDM payload with base64-encoded TOML requirements in the com.openai.codex managed preference requirements_toml_base64";
+          ? 'migrate /etc/codex/managed_config.toml to /etc/codex/requirements.toml before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in /etc/codex/requirements.toml'
+          : 'replace the legacy MDM payload with base64-encoded TOML requirements in the com.openai.codex managed preference requirements_toml_base64 before running restricted or isolated turns. For ChatGPT-only authentication, include allowed_login_methods = ["chatgpt"] in that TOML payload';
       throw new Error(
-        `Codex restricted tool surface cannot override config layer ${layer.name.type}; ${migrationTarget} before running restricted or isolated turns. For ChatGPT-only authentication, use allowed_login_methods = ["chatgpt"] in requirements.toml.`,
+        `Codex restricted tool surface cannot override config layer ${layer.name.type}; ${migrationGuidance}.`,
       );
     }
     if (!CODEX_RING_ZERO_OVERRIDABLE_LAYER_TYPES.has(layer.name.type)) {


### PR DESCRIPTION
## What Problem This Solves

Restricted and isolated Codex turns intentionally fail closed when Codex reports a legacy managed-policy layer. The previous error exposed only the internal layer name, so operators had no supported recovery path after an upgrade.

## Root cause

The shared restricted-thread preflight rejected Codex's two legacy layer variants before `thread/start`, but its error stopped at the wire-layer identifier.

## Fix

- File-managed policy now points from `/etc/codex/managed_config.toml` to `/etc/codex/requirements.toml`.
- MDM-managed policy now points to base64-encoded TOML in the `com.openai.codex` managed preference `requirements_toml_base64`.
- Each path tells ChatGPT-only operators where to put `allowed_login_methods = ["chatgpt"]`.
- The fail-closed boundary remains unchanged. OpenClaw does not edit administrator policy.

## Product path

A restricted scheduled turn, message-only turn, plugin-policy-restricted turn, or bounded turn reads the same Codex config-layer owner before model start.

## Evidence

- Current-main red at `3100ba535f1d003d67a6a7536deacf8666367b38`: both legacy variants returned only their internal layer names.
- Real-process red: Codex 0.149.1 loaded a temporary `/etc/codex/managed_config.toml`; current main failed before model start without migration guidance.
- Exact-head green at `e0a3bfd5174ce63a126ff60fc24a4c7df388d786`: the same no-network container emitted the full file migration and ChatGPT-only guidance.
- Anti-cheat: the same exact head returned normally when the legacy file was absent.
- Owner suite: 177/177 tests passed.
- Pull-request validation runs on the Blacksmith matrix.
- Formatting, lint, conflict-marker, line-count, assertion, coercion, import-cycle, and whitespace checks passed.

Direct Codex source at `cac96cd7b1756ab42e8925d938817a2ac10ebb6e` confirms the two wire variants, Unix policy paths, managed preference domain and key, base64 decoding, and `allowed_login_methods` requirement.

## Worked on by

- @pfrederiksen
- @obviyus

Closes #136447
