### PR TITLE
fix(ci): define trusted scanner contract

### DIFF
--- a/.github/actions/security-fast-scanners/compile.py
+++ b/.github/actions/security-fast-scanners/compile.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT_KEYS = {
+    "schemaVersion",
+    "preCommitPackage",
+    "zizmorConfigPath",
+    "config",
+    "scanners",
+}
+CONFIG_KEYS = {
+    "minimum_pre_commit_version",
+    "default_install_hook_types",
+    "default_language_version",
+    "default_stages",
+    "files",
+    "exclude",
+    "fail_fast",
+}
+SCANNER_KEYS = {"package", "source", "hook"}
+SOURCE_KEYS = {"repository", "revision"}
+HOOK_KEYS = {
+    "id",
+    "name",
+    "entry",
+    "language",
+    "alias",
+    "files",
+    "exclude",
+    "types",
+    "types_or",
+    "exclude_types",
+    "additional_dependencies",
+    "args",
+    "always_run",
+    "fail_fast",
+    "pass_filenames",
+    "description",
+    "language_version",
+    "log_file",
+    "minimum_pre_commit_version",
+    "require_serial",
+    "stages",
+    "verbose",
+}
+STRING_HOOK_KEYS = {
+    "id",
+    "name",
+    "entry",
+    "language",
+    "alias",
+    "files",
+    "exclude",
+    "description",
+    "language_version",
+    "log_file",
+    "minimum_pre_commit_version",
+}
+STRING_LIST_HOOK_KEYS = {
+    "types",
+    "types_or",
+    "exclude_types",
+    "additional_dependencies",
+    "args",
+    "stages",
+}
+BOOL_HOOK_KEYS = {
+    "always_run",
+    "fail_fast",
+    "pass_filenames",
+    "require_serial",
+    "verbose",
+}
+PACKAGE_RE = re.compile(r"^[A-Za-z0-9_.-]+==[A-Za-z0-9_.+!-]+$")
+
+
+def require_object(value: Any, label: str, keys: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    actual = set(value)
+    if actual != keys:
+        missing = sorted(keys - actual)
+        extra = sorted(actual - keys)
+        raise ValueError(f"{label} schema mismatch: missing={missing}, extra={extra}")
+    return value
+
+
+def require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def require_string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValueError(f"{label} must be a string array")
+    return value
+
+
+def require_package(value: Any, label: str) -> str:
+    package = require_string(value, label)
+    if not PACKAGE_RE.fullmatch(package):
+        raise ValueError(f"{label} must be an exact package pin")
+    return package
+
+
+def validate_contract(raw: Any, trusted_zizmor_config: Path) -> tuple[dict[str, Any], str]:
+    contract = require_object(raw, "contract", ROOT_KEYS)
+    if contract["schemaVersion"] != 1:
+        raise ValueError("contract schemaVersion must be 1")
+
+    pre_commit_package = require_package(contract["preCommitPackage"], "preCommitPackage")
+    zizmor_config_path = require_string(contract["zizmorConfigPath"], "zizmorConfigPath")
+    config = require_object(contract["config"], "config", CONFIG_KEYS)
+    require_string(config["minimum_pre_commit_version"], "config.minimum_pre_commit_version")
+    require_string_list(config["default_install_hook_types"], "config.default_install_hook_types")
+    if not isinstance(config["default_language_version"], dict):
+        raise ValueError("config.default_language_version must be an object")
+    require_string_list(config["default_stages"], "config.default_stages")
+    if not isinstance(config["files"], str) or not isinstance(config["exclude"], str):
+        raise ValueError("config files and exclude must be strings")
+    if not isinstance(config["fail_fast"], bool):
+        raise ValueError("config.fail_fast must be a boolean")
+
+    scanners = contract["scanners"]
+    if not isinstance(scanners, list) or not scanners:
+        raise ValueError("scanners must be a non-empty array")
+
+    packages = [pre_commit_package]
+    hooks: list[dict[str, Any]] = []
+    hook_ids: set[str] = set()
+    zizmor_path_rewrites = 0
+    for index, raw_scanner in enumerate(scanners):
+        scanner = require_object(raw_scanner, f"scanners[{index}]", SCANNER_KEYS)
+        packages.append(require_package(scanner["package"], f"scanners[{index}].package"))
+
+        source = require_object(scanner["source"], f"scanners[{index}].source", SOURCE_KEYS)
+        repository = require_string(source["repository"], f"scanners[{index}].source.repository")
+        if not repository.startswith("https://github.com/"):
+            raise ValueError(f"scanners[{index}].source.repository must be a GitHub HTTPS URL")
+        require_string(source["revision"], f"scanners[{index}].source.revision")
+
+        hook = require_object(scanner["hook"], f"scanners[{index}].hook", HOOK_KEYS)
+        for key in STRING_HOOK_KEYS:
+            if not isinstance(hook[key], str):
+                raise ValueError(f"scanners[{index}].hook.{key} must be a string")
+        for key in STRING_LIST_HOOK_KEYS:
+            require_string_list(hook[key], f"scanners[{index}].hook.{key}")
+        for key in BOOL_HOOK_KEYS:
+            if not isinstance(hook[key], bool):
+                raise ValueError(f"scanners[{index}].hook.{key} must be a boolean")
+        if hook["language"] != "python":
+            raise ValueError(f"scanners[{index}].hook.language must be python")
+        if hook["language_version"] != "default":
+            raise ValueError(f"scanners[{index}].hook.language_version must be default")
+        if hook["additional_dependencies"]:
+            raise ValueError(f"scanners[{index}].hook.additional_dependencies must be empty")
+
+        hook_id = require_string(hook["id"], f"scanners[{index}].hook.id")
+        if hook_id in hook_ids:
+            raise ValueError(f"duplicate hook id: {hook_id}")
+        hook_ids.add(hook_id)
+
+        adapted_hook = dict(hook)
+        adapted_hook["language"] = "system"
+        adapted_args = []
+        for argument in hook["args"]:
+            if argument == zizmor_config_path:
+                adapted_args.append(str(trusted_zizmor_config))
+                zizmor_path_rewrites += 1
+            else:
+                adapted_args.append(argument)
+        adapted_hook["args"] = adapted_args
+        hooks.append(adapted_hook)
+
+    package_names = [package.partition("==")[0].lower() for package in packages]
+    if len(package_names) != len(set(package_names)):
+        raise ValueError("package names must be unique")
+    if zizmor_path_rewrites != 1:
+        raise ValueError("trusted zizmor config path must appear exactly once")
+
+    output_config = dict(config)
+    output_config["repos"] = [{"repo": "local", "hooks": hooks}]
+    requirements = "".join(f"{package}\n" for package in packages)
+    return output_config, requirements
+
+
+def write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        delete=False,
+    ) as handle:
+        handle.write(content)
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--contract", type=Path, required=True)
+    parser.add_argument("--trusted-zizmor-config", type=Path, required=True)
+    parser.add_argument("--output-config", type=Path, required=True)
+    parser.add_argument("--output-requirements", type=Path, required=True)
+    args = parser.parse_args()
+
+    contract = json.loads(args.contract.read_text(encoding="utf-8"))
+    output_config, requirements = validate_contract(contract, args.trusted_zizmor_config)
+    write_atomic(args.output_config, json.dumps(output_config, indent=2) + "\n")
+    write_atomic(args.output_requirements, requirements)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/security-fast-scanners.json
+++ b/.github/security-fast-scanners.json
@@ -1,0 +1,120 @@
+{
+  "schemaVersion": 1,
+  "preCommitPackage": "pre-commit==4.6.2",
+  "zizmorConfigPath": ".github/zizmor.yml",
+  "config": {
+    "minimum_pre_commit_version": "0",
+    "default_install_hook_types": ["pre-commit"],
+    "default_language_version": {},
+    "default_stages": [
+      "commit-msg",
+      "post-checkout",
+      "post-commit",
+      "post-merge",
+      "post-rewrite",
+      "pre-commit",
+      "pre-merge-commit",
+      "pre-push",
+      "pre-rebase",
+      "prepare-commit-msg",
+      "manual"
+    ],
+    "files": "",
+    "exclude": "^$",
+    "fail_fast": false
+  },
+  "scanners": [
+    {
+      "package": "pre-commit-hooks==6.0.0",
+      "source": {
+        "repository": "https://github.com/pre-commit/pre-commit-hooks",
+        "revision": "v6.0.0"
+      },
+      "hook": {
+        "id": "detect-private-key",
+        "name": "detect private key",
+        "entry": "detect-private-key",
+        "language": "python",
+        "alias": "",
+        "files": "",
+        "exclude": "(^|/)(\\.pre-commit-config\\.yaml$|apps/ios/fastlane/Fastfile$|.*\\.test\\.ts$)",
+        "types": ["text"],
+        "types_or": [],
+        "exclude_types": [],
+        "additional_dependencies": [],
+        "args": [],
+        "always_run": false,
+        "fail_fast": false,
+        "pass_filenames": true,
+        "description": "detects the presence of private keys.",
+        "language_version": "default",
+        "log_file": "",
+        "minimum_pre_commit_version": "0",
+        "require_serial": false,
+        "stages": [
+          "commit-msg",
+          "post-checkout",
+          "post-commit",
+          "post-merge",
+          "post-rewrite",
+          "pre-commit",
+          "pre-merge-commit",
+          "pre-push",
+          "pre-rebase",
+          "prepare-commit-msg",
+          "manual"
+        ],
+        "verbose": false
+      }
+    },
+    {
+      "package": "zizmor==1.29.0",
+      "source": {
+        "repository": "https://github.com/zizmorcore/zizmor-pre-commit",
+        "revision": "451b56af716f9f0d0c2b816503a3fd0cf8b036fa"
+      },
+      "hook": {
+        "id": "zizmor",
+        "name": "zizmor",
+        "entry": "zizmor",
+        "language": "python",
+        "alias": "",
+        "files": "(\\.github/(workflows/.*|dependabot.ya?ml))|(action\\.ya?ml)$",
+        "exclude": "^(vendor/|apps/swabble/)",
+        "types": ["yaml"],
+        "types_or": [],
+        "exclude_types": [],
+        "additional_dependencies": [],
+        "args": [
+          "--config",
+          ".github/zizmor.yml",
+          "--persona=regular",
+          "--min-severity=medium",
+          "--min-confidence=medium"
+        ],
+        "always_run": false,
+        "fail_fast": false,
+        "pass_filenames": true,
+        "description": "Find security issues in GitHub Actions CI/CD setups",
+        "language_version": "default",
+        "log_file": "",
+        "minimum_pre_commit_version": "0",
+        "require_serial": true,
+        "stages": [
+          "commit-msg",
+          "post-checkout",
+          "post-commit",
+          "post-merge",
+          "post-rewrite",
+          "pre-commit",
+          "pre-merge-commit",
+          "pre-push",
+          "pre-rebase",
+          "prepare-commit-msg",
+          "manual"
+        ],
+        "verbose": false
+      }
+    }
+  ]
+}

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2184,6 +2184,8 @@ const pluginSdkEntryOwners = [
 // unambiguous scripts and direct imports without a second inventory.
 const EXACT_TOOLING_TARGETS = new Map<string, string[]>([
   [".github/workflows/ci.yml", ["ci-platform-checkout", "ci-linux-git", "ci-git-owner"]],
+  [".github/security-fast-scanners.json", ["ci-security-fast-scanner-contract"]],
+  [".github/actions/security-fast-scanners/compile.py", ["ci-security-fast-scanner-contract"]],
   [".github/workflows/docs-sync-publish.yml", ["docs-sync-publish"]],
   [".github/workflows/docs-agent.yml", ["docs-agent-workflow"]],
   ["scripts/generate-ci-git-owner.mts", ["ci-git-owner"]],

--- a/test/scripts/ci-security-fast-scanner-contract.test.ts
+++ b/test/scripts/ci-security-fast-scanner-contract.test.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const contractPath = ".github/security-fast-scanners.json";
+const compilerPath = ".github/actions/security-fast-scanners/compile.py";
+
+function compile(contract = contractPath) {
+  const root = tempDirs.make("security-fast-scanner-contract-");
+  const outputConfig = join(root, "pre-commit.json");
+  const outputRequirements = join(root, "requirements.txt");
+  const trustedZizmorConfig = join(root, "zizmor.yml");
+  writeFileSync(trustedZizmorConfig, "rules: {}\n");
+  const result = spawnSync(
+    "python3",
+    [
+      compilerPath,
+      "--contract",
+      contract,
+      "--trusted-zizmor-config",
+      trustedZizmorConfig,
+      "--output-config",
+      outputConfig,
+      "--output-requirements",
+      outputRequirements,
+    ],
+    { encoding: "utf8" },
+  );
+  return { outputConfig, outputRequirements, result, root, trustedZizmorConfig };
+}
+
+describe("security-fast scanner contract", () => {
+  it("materializes the pinned effective hooks with only the system adapter applied", () => {
+    const contract = JSON.parse(readFileSync(contractPath, "utf8")) as {
+      preCommitPackage: string;
+      scanners: Array<{
+        hook: Record<string, unknown>;
+        package: string;
+        source: { repository: string; revision: string };
+      }>;
+    };
+    expect(contract.preCommitPackage).toBe("pre-commit==4.6.2");
+    expect(contract.scanners.map((scanner) => scanner.package)).toEqual([
+      "pre-commit-hooks==6.0.0",
+      "zizmor==1.29.0",
+    ]);
+    expect(contract.scanners.map((scanner) => scanner.source)).toEqual([
+      {
+        repository: "https://github.com/pre-commit/pre-commit-hooks",
+        revision: "v6.0.0",
+      },
+      {
+        repository: "https://github.com/zizmorcore/zizmor-pre-commit",
+        revision: "451b56af716f9f0d0c2b816503a3fd0cf8b036fa",
+      },
+    ]);
+
+    const compiled = compile();
+    expect(compiled.result.status, compiled.result.stderr).toBe(0);
+    expect(readFileSync(compiled.outputRequirements, "utf8")).toBe(
+      "pre-commit==4.6.2\npre-commit-hooks==6.0.0\nzizmor==1.29.0\n",
+    );
+
+    const output = JSON.parse(readFileSync(compiled.outputConfig, "utf8")) as {
+      repos: Array<{ hooks: Array<Record<string, unknown>>; repo: string }>;
+    };
+    expect(output.repos).toHaveLength(1);
+    expect(output.repos[0]?.repo).toBe("local");
+    expect(output.repos[0]?.hooks).toHaveLength(contract.scanners.length);
+    for (const [index, scanner] of contract.scanners.entries()) {
+      const adapted = output.repos[0]?.hooks[index];
+      expect(adapted).toEqual({
+        ...scanner.hook,
+        language: "system",
+        args:
+          scanner.hook.id === "zizmor"
+            ? [
+                "--config",
+                compiled.trustedZizmorConfig,
+                "--persona=regular",
+                "--min-severity=medium",
+                "--min-confidence=medium",
+              ]
+            : scanner.hook.args,
+      });
+    }
+  });
+
+  it("rejects incomplete contracts before publishing scanner outputs", () => {
+    const root = tempDirs.make("security-fast-scanner-contract-invalid-");
+    const invalidContract = join(root, "contract.json");
+    mkdirSync(root, { recursive: true });
+    const contract = JSON.parse(readFileSync(contractPath, "utf8")) as Record<string, unknown>;
+    delete contract.scanners;
+    writeFileSync(invalidContract, JSON.stringify(contract));
+
+    const compiled = compile(invalidContract);
+    expect(compiled.result.status).not.toBe(0);
+    expect(compiled.result.stderr).toContain("contract schema mismatch");
+    expect(() => readFileSync(compiled.outputConfig, "utf8")).toThrow();
+    expect(() => readFileSync(compiled.outputRequirements, "utf8")).toThrow();
+  });
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -885,6 +885,13 @@ describe("scripts/test-projects changed-target routing", () => {
     );
   });
 
+  it.each([
+    ".github/security-fast-scanners.json",
+    ".github/actions/security-fast-scanners/compile.py",
+  ])("keeps security-fast scanner contract edits on their boundary test", (changedPath) => {
+    expectChangedTargets([changedPath], ["test/scripts/ci-security-fast-scanner-contract.test.ts"]);
+  });
+
   it("keeps full release validation workflow edits on FRV contract tests", () => {
     expectChangedTargets(
       [".github/workflows/full-release-validation.yml"],


### PR DESCRIPTION
## What Problem This Solves

Security-fast needs to replace remote pre-commit hook clones without moving scanner policy into a pull request's candidate workflow. The existing base configuration does not materialize inherited hook definitions, executable pins, filters, or thresholds as one immutable contract.

Related: #136388

## Why This Change Was Made

This adds an exact, normalized scanner contract and a stdlib-only compiler. The compiler validates a closed schema, converts only the trusted Python hooks to local/system execution, rewrites the trusted zizmor config path, emits exact package requirements, and fails before publishing outputs when the contract is incomplete.

The contract preserves pre-commit 4.6.2, pre-commit-hooks 6.0.0 detect-private-key behavior, zizmor-pre-commit revision 451b56af716f9f0d0c2b816503a3fd0cf8b036fa, and zizmor 1.29.0 behavior.

## User Impact

No runtime user behavior changes. This creates the trusted base artifact required for #136388 to remove anonymous pre-commit Git bootstrap without weakening security-fast policy.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-security-fast-scanner-contract.test.ts test/scripts/test-projects.test.ts` (435 passed)
- `node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json test/scripts/ci-security-fast-scanner-contract.test.ts test/scripts/test-projects.test.ts`
- Direct upstream inspection at pre-commit 4.6.2, pre-commit-hooks 6.0.0, zizmor-pre-commit `451b56af716f9f0d0c2b816503a3fd0cf8b036fa`, and zizmor 1.29.0
- Autoreview: scoped clean through P1
- `node scripts/check-changed.mjs -- ...` reached unrelated missing linked workspace dependencies during `tsgo:scripts`; all preceding focused guards passed. No dependency installation or unrelated source change was made.
