### PR TITLE
test(gateway): exercise usage dates in native timezones

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -176,16 +176,8 @@ const BASE_USAGE_RANGE = {
   limit: 10,
 } as const;
 
-function mockCall(mockFn: ReturnType<typeof vi.fn>, callIndex = 0): ReadonlyArray<unknown> {
-  const call = mockFn.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`expected mock call ${callIndex + 1}`);
-  }
-  return call;
-}
-
-function mockArg(mockFn: ReturnType<typeof vi.fn>, callIndex: number, argIndex: number) {
-  return mockCall(mockFn, callIndex)[argIndex];
+function mockArg(mockFn: ReturnType<typeof vi.fn>, callIndex: number, argIndex: number): unknown {
+  return expectDefined(mockFn.mock.calls[callIndex], `mock call ${callIndex + 1}`)[argIndex];
 }
 
 function expectSuccessfulSessionsUsage(
@@ -473,6 +465,8 @@ describe("sessions.usage", () => {
 
   it("keeps explicit gateway response date labels on DST-short days", async () => {
     await withEnvAsync({ TZ: "America/New_York" }, async () => {
+      expect(new Date("2026-03-08T05:00:00.000Z").getTimezoneOffset()).toBe(300);
+      expect(new Date("2026-03-09T04:00:00.000Z").getTimezoneOffset()).toBe(240);
       const respond = await runSessionsUsage({
         ...BASE_USAGE_RANGE,
         startDate: "2026-03-08",
@@ -482,6 +476,13 @@ describe("sessions.usage", () => {
 
       expect(respond).toHaveBeenCalledTimes(1);
       expect(mockArg(respond, 0, 0)).toBe(true);
+      expect(vi.mocked(loadSessionCostSummariesFromCache)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startMs: Date.parse("2026-03-08T05:00:00.000Z"),
+          endMs: Date.parse("2026-03-09T04:00:00.000Z") - 1,
+          dayBucket: undefined,
+        }),
+      );
       const result = mockArg(respond, 0, 1) as { startDate: string; endDate: string };
       expect(result.startDate).toBe("2026-03-08");
       expect(result.endDate).toBe("2026-03-08");

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
-import { withEnvAsync } from "../../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../../test-utils/env.js";
 
 vi.mock("../../infra/session-cost-usage.js", async () => {
   const actual = await vi.importActual<typeof import("../../infra/session-cost-usage.js")>(
@@ -110,20 +110,6 @@ describe("gateway usage helpers", () => {
       throw new Error(result.error);
     }
     return result.value;
-  }
-
-  function withTimeZone<T>(timeZone: string, run: () => T): T {
-    const previous = process.env.TZ;
-    process.env.TZ = timeZone;
-    try {
-      return run();
-    } finally {
-      if (previous === undefined) {
-        delete process.env.TZ;
-      } else {
-        process.env.TZ = previous;
-      }
-    }
   }
 
   beforeEach(() => {
@@ -416,7 +402,7 @@ describe("gateway usage helpers", () => {
 
   it("resolveDateRange uses gateway local day boundaries in gateway mode", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-02-05T12:34:56.000Z"));
+    vi.setSystemTime(new Date(2026, 1, 5, 12, 34, 56));
     const range = expectDateRange(testApi.resolveDateRange({ days: 1, mode: "gateway" }));
     const expectedStart = new Date(2026, 1, 5).getTime();
     expect(range.startMs).toBe(expectedStart);
@@ -424,7 +410,9 @@ describe("gateway usage helpers", () => {
   });
 
   it("resolveDateRange uses gateway calendar end boundaries for explicit DST-short days", () => {
-    withTimeZone("America/New_York", () => {
+    withEnv({ TZ: "America/New_York" }, () => {
+      expect(new Date("2026-03-08T05:00:00.000Z").getTimezoneOffset()).toBe(300);
+      expect(new Date("2026-03-09T04:00:00.000Z").getTimezoneOffset()).toBe(240);
       const range = expectDateRange(
         testApi.resolveDateRange({
           startDate: "2026-03-08",
@@ -432,13 +420,15 @@ describe("gateway usage helpers", () => {
           mode: "gateway",
         }),
       );
-      expect(range.startMs).toBe(new Date(2026, 2, 8).getTime());
-      expect(range.endMs).toBe(new Date(2026, 2, 9).getTime() - 1);
+      expect(range.startMs).toBe(Date.parse("2026-03-08T05:00:00.000Z"));
+      expect(range.endMs).toBe(Date.parse("2026-03-09T04:00:00.000Z") - 1);
     });
   });
 
   it("resolveDateRange keeps trailing gateway ranges on calendar days across DST", () => {
-    withTimeZone("America/New_York", () => {
+    withEnv({ TZ: "America/New_York" }, () => {
+      expect(new Date("2026-03-08T05:00:00.000Z").getTimezoneOffset()).toBe(300);
+      expect(new Date("2026-03-09T04:00:00.000Z").getTimezoneOffset()).toBe(240);
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-03-09T12:00:00.000Z"));
       const range = expectDateRange(
@@ -447,8 +437,8 @@ describe("gateway usage helpers", () => {
           mode: "gateway",
         }),
       );
-      expect(range.startMs).toBe(new Date(2026, 2, 8).getTime());
-      expect(range.endMs).toBe(new Date(2026, 2, 10).getTime() - 1);
+      expect(range.startMs).toBe(Date.parse("2026-03-08T05:00:00.000Z"));
+      expect(range.endMs).toBe(Date.parse("2026-03-10T04:00:00.000Z") - 1);
     });
   });
 

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -53,6 +53,8 @@ const patternFiles = createPatternFileHelper("openclaw-vitest-projects-config-")
 const scopedGatewayMethodsIsolatedTestFiles = [
   "server-methods/agent.test.ts",
   "server-methods/board.runtime-boundaries.test.ts",
+  "server-methods/usage.test.ts",
+  "server-methods/usage.sessions-usage.test.ts",
 ];
 
 function requireTestConfig<T extends { test?: unknown }>(config: T): NonNullable<T["test"]> {

--- a/test/vitest/vitest.gateway-methods-isolated.config.ts
+++ b/test/vitest/vitest.gateway-methods-isolated.config.ts
@@ -13,6 +13,8 @@ export function createGatewayMethodsIsolatedVitestConfig(
     isolate: true,
     name: "gateway-methods-isolated",
     passWithNoTests: true,
+    // Native Date timezone changes require a process rather than a worker's copied environment.
+    pool: "forks",
     useNonIsolatedRunner: true,
   });
 }

--- a/test/vitest/vitest.gateway-server-paths.mjs
+++ b/test/vitest/vitest.gateway-server-paths.mjs
@@ -7,11 +7,13 @@ export const gatewayServerBackedHttpTestFiles = [
   "src/gateway/probe.auth.integration.test.ts",
 ];
 
-// Gateway method tests whose deep module mocks can be defeated by a neighbour's
-// shared cache. These keep the shared methods runner but use a fresh module graph.
+// Gateway methods needing native process state or a private module graph keep
+// the shared methods runner in isolated forks.
 export const gatewayMethodsIsolatedTestFiles = [
   "src/gateway/server-methods/agent.test.ts",
   "src/gateway/server-methods/board.runtime-boundaries.test.ts",
+  "src/gateway/server-methods/usage.test.ts",
+  "src/gateway/server-methods/usage.sessions-usage.test.ts",
 ];
 
 // Gateway server tests that replace a module the Gateway reaches only through


### PR DESCRIPTION
## What Problem This Solves

Gateway usage DST tests changed `process.env.TZ` inside Vitest thread workers, where native `Date` remained in UTC. A gateway-only fixed-24-hour fault therefore passed all three supposed DST regressions.

## Why This Change Was Made

Run the two usage files in the existing isolated gateway project with forks, verify native New York offsets, and assert independent UTC boundaries. Existing helpers replace the redundant timezone and mock-call wrappers.

## User Impact

This strengthens regression coverage while preserving gateway-mode handler success, response labels, loader ranges, explicit-IANA coverage, and test lifecycle. Production delta: **0 lines**; runtime behavior is unchanged.

## Evidence

- All 436 affected, neighboring, and routing tests passed. After the final mock-helper consolidation, all 90 usage tests passed again.
- The repaired tests reject the same fixed-24-hour fault that the original UTC/thread tests missed; a separate UTC-label fault fails the retained handler response assertion.
- Cumulative local changed-file checks: the first full five-file run passed its guard/typecheck/dead-export stages, then failed the 1,000-line lint limit. The helper consolidation fixes that failure; exact typed lint, the canonical affected `gateway-other` type graph, and every previously unrun tooling/root lint stage passed. This is cumulative validation, not a claimed second full-run success.
- Fresh Codex autoreview found no actionable P0–P2 findings. Formatting and whitespace checks passed.

The attempted Testbox changed gate failed during HTTPS Git bootstrap before executing checks; it supplies no remote validation. All reported checks above ran locally.

The mechanical refresh `f8896a6b122d68d695979bdf27a7f919acd428b6` is based on `0df437f0071c53e95cbe1fd3d7a6e28079b67984`. The entire five-file patch and all five file contents are byte-identical to `e5220e1198cf42c1b66eb824c8d0b3c20f63983a`; the relevant date owners, callers, helpers, gateway test routing, and dependency manifests/lockfile are unchanged. The prior local proof and review apply to this identical patch. No new local full gate or test run is claimed for the refreshed commit; refreshed exact-head CI remains pending.

[CI run 33665748090](https://github.com/openclaw/openclaw/actions/runs/33665748090) tested the original head through merge `d64fe0c281c260b619b8b024898292845f9ad5f9`. Its completed failure logs show an unrelated CLI test exceeding the line limit and two CSS corner assertions comparing `round` with `superellipse(1)`. The new base contains the canonical CLI split (`aef65cc57490a5c67ca8dc934ac24225c6d1069c`) and CSS serialization repair (`f7c821733ff1b61e565b5f47eebf5fd5cf24b540`); neither repair is added to this PR's patch. The original run has not been rerun.

### Inspectable proof

The final source rerun for the patch committed as `e5220e1198cf42c1b66eb824c8d0b3c20f63983a` reaches the real date-range owner and Gateway handler with mocked storage dependencies; it is not a claim of a live network Gateway session.

```text
$ TZ=UTC OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts
 Test Files  2 passed (2)
      Tests  90 passed (90)
[test] passed 1 Vitest shard in 53.71s
exit 0
```

The temporary fixed-duration control passed the three original regressions plus a diagnostic proving that native offsets stayed at zero. With repaired fork routing and independent bounds, the same control fails all three regressions:

```text
Original UTC/thread control:
 Test Files  3 passed (3)
      Tests  4 passed | 87 skipped (91)

Repaired UTC/fork control:
AssertionError: expected 1773032399999 to be 1773028799999 // Object.is equality
AssertionError: expected 1772942400000 to be 1772946000000 // Object.is equality
 Test Files  2 failed (2)
      Tests  3 failed | 87 skipped (90)
exit 1 (expected)
```

A separate UTC-label control fails after the handler's exact loader-range assertion succeeds:

```text
Expected: "2026-03-08"
Received: "2026-03-09"
      Tests  1 failed | 89 skipped (90)
exit 1 (expected)
```

Faults and the diagnostic-only test were removed before review. The fault controls used the initial candidate; the final candidate only consolidates the mock-call helper, with all assertions and routing unchanged, and passes the complete 90-case rerun above. No fault is present in the commit.
