### PR TITLE
fix(mattermost): bound slash callback body reads

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -577,6 +577,7 @@ Account values override top-level fields; `channels.mattermost.defaultAccount` p
       - the callback is hitting the wrong gateway/account
       - Mattermost still has old commands pointing at a previous callback target
       - the gateway restarted without reactivating slash commands
+    - HTTP 429 under load: callbacks using an outgoing OAuth connection or a proxy that strips the `Authorization` header carry the command token only in the body. They share the bounded anonymous request pool and can be throttled when it is saturated. Preserve Mattermost's original `Authorization: Token` header through proxies so recognized command credentials receive separate capacity.
     - If native slash commands stop working, check logs for `mattermost: failed to register slash commands` or `mattermost: native slash commands enabled but no commands could be registered`.
     - If `callbackUrl` is omitted and logs warn that the callback resolved to a loopback URL like `http://localhost:18789/...`, that URL is probably only reachable when Mattermost runs on the same host/network namespace as OpenClaw. Set an explicit externally reachable `commands.callbackUrl` instead.
 

--- a/extensions/mattermost/src/mattermost/runtime-api.ts
+++ b/extensions/mattermost/src/mattermost/runtime-api.ts
@@ -34,6 +34,7 @@ export {
 export { registerPluginHttpRoute } from "openclaw/plugin-sdk/webhook-targets";
 export { isRequestBodyLimitError } from "openclaw/plugin-sdk/webhook-ingress";
 export {
+  createWebhookInFlightLimiter,
   readRequestBodyWithLimit,
   sendHttpRequestRejection,
 } from "openclaw/plugin-sdk/webhook-request-guards";

--- a/extensions/mattermost/src/mattermost/slash-http.boundary.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.boundary.test.ts
@@ -1,0 +1,340 @@
+// Mattermost tests prove slash admission through the production plugin entry and real HTTP sockets.
+import { createServer, request, type IncomingMessage, type ServerResponse } from "node:http";
+import { connect, type Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setMattermostRuntime } from "../runtime.js";
+import type { ResolvedMattermostAccount } from "./accounts.js";
+import type { MattermostRegisteredCommand } from "./slash-commands.js";
+import {
+  activateSlashCommands,
+  deactivateSlashCommands,
+  registerSlashCommandRoute,
+} from "./slash-state.js";
+
+type SlashRouteHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+
+type HeldRequest = {
+  socket: Socket;
+  statusCode: number | undefined;
+  endedByServer: boolean;
+  closedByServer: boolean;
+};
+
+const CALLBACK_PATH = "/mattermost/slash";
+const TOKEN = "boundary-token";
+
+function createRuntime(dispatch: ReturnType<typeof vi.fn>) {
+  return {
+    channel: {
+      commands: {
+        shouldHandleTextCommands: () => true,
+      },
+      inbound: { dispatch },
+      pairing: {
+        readAllowFromStore: async () => [],
+        upsertPairingRequest: async () => ({ code: "unused" }),
+        buildPairingReply: () => "unused",
+      },
+      routing: {
+        resolveAgentRoute: () => ({
+          accountId: "default",
+          agentId: "main",
+          dmScope: "main",
+          sessionKey: "agent:main:mattermost:channel:channel-1",
+        }),
+      },
+      text: {
+        hasControlCommand: () => false,
+        resolveMarkdownTableMode: () => "off",
+        resolveTextChunkLimit: () => 4_000,
+      },
+    },
+  };
+}
+
+function openHeldRequest(params: { port: number; localAddress: string }): HeldRequest {
+  const held: HeldRequest = {
+    socket: connect({
+      host: "127.0.0.1",
+      port: params.port,
+      localAddress: params.localAddress,
+    }),
+    statusCode: undefined,
+    endedByServer: false,
+    closedByServer: false,
+  };
+  const chunks: Buffer[] = [];
+  held.socket.on("connect", () => {
+    held.socket.write(
+      [
+        `POST ${CALLBACK_PATH} HTTP/1.1`,
+        `Host: 127.0.0.1:${params.port}`,
+        "Content-Type: application/x-www-form-urlencoded",
+        "Content-Length: 1",
+        "Connection: close",
+        "",
+        "",
+      ].join("\r\n"),
+    );
+  });
+  held.socket.on("data", (chunk: Buffer) => {
+    chunks.push(chunk);
+    const match = Buffer.concat(chunks)
+      .toString("latin1")
+      .match(/^HTTP\/1\.1 (\d{3})/u);
+    held.statusCode = match ? Number(match[1]) : undefined;
+  });
+  held.socket.on("end", () => {
+    held.endedByServer = true;
+  });
+  held.socket.on("close", () => {
+    held.closedByServer = true;
+  });
+  held.socket.on("error", () => {});
+  return held;
+}
+
+async function postForm(params: {
+  port: number;
+  body: string;
+  localAddress: string;
+}): Promise<{ statusCode: number; body: string }> {
+  return await new Promise((resolve, reject) => {
+    const req = request(
+      {
+        host: "127.0.0.1",
+        port: params.port,
+        localAddress: params.localAddress,
+        path: CALLBACK_PATH,
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "content-length": Buffer.byteLength(params.body),
+          connection: "close",
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end(params.body);
+  });
+}
+
+describe("Mattermost slash HTTP boundary", () => {
+  afterEach(() => {
+    deactivateSlashCommands();
+  });
+
+  it("bounds pre-auth bodies at the registered route, closes overflow, and recovers", async () => {
+    const routes = new Map<string, SlashRouteHandler>();
+    const registrations: Array<{ path: string; auth: string | undefined }> = [];
+    const dispatch = vi.fn(async (_params: unknown) => undefined);
+    const registerHttpRoute = (route: {
+      path: string;
+      auth?: string;
+      handler: SlashRouteHandler;
+    }) => {
+      registrations.push({ path: route.path, auth: route.auth });
+      routes.set(route.path, route.handler);
+    };
+
+    setMattermostRuntime(createRuntime(dispatch) as never);
+    registerSlashCommandRoute({
+      config: {
+        channels: {
+          mattermost: {
+            commands: { native: true, callbackPath: CALLBACK_PATH },
+          },
+        },
+      },
+      logger: { warn() {} },
+      registerHttpRoute,
+    } as never);
+
+    expect(registrations).toContainEqual({ path: CALLBACK_PATH, auth: "plugin" });
+    const slashRoute = routes.get(CALLBACK_PATH);
+    if (!slashRoute) {
+      throw new Error("expected the Mattermost plugin entry to register its slash route");
+    }
+
+    let callbackUrl = "";
+    const callbackSourceAddresses: string[] = [];
+    const server = createServer((req, res) => {
+      if (req.url === "/api/v4/commands/command-1") {
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            id: "command-1",
+            team_id: "team-1",
+            trigger: "oc_status",
+            method: "P",
+            url: callbackUrl,
+            token: TOKEN,
+            delete_at: 0,
+          }),
+        );
+        return;
+      }
+      if (req.url === "/api/v4/channels/channel-1") {
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            id: "channel-1",
+            name: "town-square",
+            display_name: "Town Square",
+            type: "O",
+            team_id: "team-1",
+          }),
+        );
+        return;
+      }
+      if (req.url === CALLBACK_PATH) {
+        callbackSourceAddresses.push(req.socket.remoteAddress ?? "unknown");
+        void slashRoute(req, res).catch((error: unknown) => {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        });
+        return;
+      }
+      res.statusCode = 404;
+      res.end("Not Found");
+    });
+
+    const sockets = new Set<Socket>();
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          server.removeListener("error", reject);
+          resolve();
+        });
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected the Mattermost boundary server to have a TCP address");
+      }
+      callbackUrl = `http://127.0.0.1:${address.port}${CALLBACK_PATH}`;
+
+      const account: ResolvedMattermostAccount = {
+        accountId: "default",
+        enabled: true,
+        botToken: "bot-token",
+        botTokenSource: "config",
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        baseUrlSource: "config",
+        streamingMode: "partial",
+        config: {
+          groupPolicy: "open",
+          network: { dangerouslyAllowPrivateNetwork: true },
+        },
+      };
+      const command: MattermostRegisteredCommand = {
+        id: "command-1",
+        teamId: "team-1",
+        trigger: "oc_status",
+        token: TOKEN,
+        url: callbackUrl,
+        managed: false,
+      };
+      activateSlashCommands({
+        account,
+        commandTokens: [TOKEN],
+        registeredCommands: [command],
+        api: { cfg: {}, runtime: { log() {}, error() {}, exit() {} } },
+      });
+
+      const held = Array.from({ length: 12 }, (_, index) =>
+        openHeldRequest({
+          port: address.port,
+          localAddress: `127.0.0.${index + 2}`,
+        }),
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(held.filter((entry) => entry.statusCode === 429)).toHaveLength(4);
+        },
+        { timeout: 3_000 },
+      );
+      const overflow = held.filter((entry) => entry.statusCode === 429);
+      const admitted = held.filter((entry) => entry.statusCode === undefined);
+      expect(admitted).toHaveLength(8);
+      expect(callbackSourceAddresses).toHaveLength(12);
+      expect(new Set(callbackSourceAddresses).size).toBe(12);
+      await vi.waitFor(
+        () => {
+          expect(overflow.every((entry) => entry.endedByServer && entry.closedByServer)).toBe(true);
+        },
+        { timeout: 3_000 },
+      );
+
+      for (const entry of admitted) {
+        entry.socket.write("x");
+      }
+      await vi.waitFor(
+        () => {
+          expect(admitted.every((entry) => entry.statusCode === 400)).toBe(true);
+        },
+        { timeout: 3_000 },
+      );
+
+      const recovered = await postForm({
+        port: address.port,
+        body: "x",
+        localAddress: "127.0.0.20",
+      });
+      expect(recovered.statusCode).toBe(400);
+
+      const validBody = new URLSearchParams({
+        token: TOKEN,
+        team_id: "team-1",
+        channel_id: "channel-1",
+        user_id: "user-1",
+        user_name: "boundary-user",
+        command: "/oc_status",
+        text: "hello",
+        trigger_id: "trigger-1",
+      }).toString();
+      const valid = await postForm({
+        port: address.port,
+        body: validBody,
+        localAddress: "127.0.0.21",
+      });
+      expect(valid).toEqual({
+        statusCode: 200,
+        body: JSON.stringify({ response_type: "ephemeral", text: "Processing..." }),
+      });
+      await vi.waitFor(() => expect(dispatch).toHaveBeenCalledOnce());
+      expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+        channel: "mattermost",
+        accountId: "default",
+        ctxPayload: {
+          Body: "/status hello",
+          SenderId: "user-1",
+          InboundAccessAuthorized: true,
+        },
+      });
+    } finally {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }, 15_000);
+});

--- a/extensions/mattermost/src/mattermost/slash-http.boundary.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.boundary.test.ts
@@ -1,6 +1,7 @@
-// Mattermost tests prove slash admission through the production plugin entry and real HTTP sockets.
+// Mattermost tests prove slash admission through the production route and handler over real HTTP sockets.
 import { createServer, request, type IncomingMessage, type ServerResponse } from "node:http";
 import { connect, type Socket } from "node:net";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setMattermostRuntime } from "../runtime.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
@@ -56,6 +57,7 @@ function openHeldRequest(params: {
   port: number;
   localAddress: string;
   authorization?: string;
+  contentLength?: number;
 }): HeldRequest {
   const held: HeldRequest = {
     socket: connect({
@@ -74,7 +76,7 @@ function openHeldRequest(params: {
         `POST ${CALLBACK_PATH} HTTP/1.1`,
         `Host: 127.0.0.1:${params.port}`,
         "Content-Type: application/x-www-form-urlencoded",
-        "Content-Length: 1",
+        `Content-Length: ${params.contentLength ?? 1}`,
         ...(params.authorization ? [`Authorization: ${params.authorization}`] : []),
         "Connection: close",
         "",
@@ -136,63 +138,93 @@ async function postForm(params: {
   });
 }
 
-describe("Mattermost slash HTTP boundary", () => {
-  afterEach(() => {
-    deactivateSlashCommands();
-  });
+type Boundary = {
+  address: { port: number };
+  account: ResolvedMattermostAccount;
+  command: MattermostRegisteredCommand;
+  commandB: MattermostRegisteredCommand;
+  currentCommands: Map<string, MattermostRegisteredCommand>;
+  runtime: ReturnType<typeof createRuntime>;
+  dispatch: ReturnType<typeof vi.fn>;
+  errors: unknown[];
+  routeRuns: Set<Promise<void>>;
+  callbackSourceAddresses: string[];
+  validBody: string;
+  bodyFor: (command?: MattermostRegisteredCommand) => string;
+  channelRequests: ReturnType<typeof vi.fn>;
+  holdChannel: (gate: Promise<void>) => void;
+};
 
-  it("reserves authenticated capacity and bounds each pre-authentication pool at eight", async () => {
-    const routes = new Map<string, SlashRouteHandler>();
-    const registrations: Array<{ path: string; auth: string | undefined }> = [];
-    const dispatch = vi.fn(async (_params: unknown) => undefined);
-    const registerHttpRoute = (route: {
-      path: string;
-      auth?: string;
-      handler: SlashRouteHandler;
-    }) => {
-      registrations.push({ path: route.path, auth: route.auth });
-      routes.set(route.path, route.handler);
-    };
+async function withBoundary(runBoundary: (boundary: Boundary) => Promise<void>) {
+  const routes = new Map<string, SlashRouteHandler>();
+  const registrations: Array<{ path: string; auth: string | undefined }> = [];
+  const dispatch = vi.fn(async (_params: unknown) => undefined);
+  const runtime = createRuntime(dispatch);
+  const currentCommands = new Map<string, MattermostRegisteredCommand>();
+  const routeRuns = new Set<Promise<void>>();
+  const errors: unknown[] = [];
+  const channelRequests = vi.fn();
+  let channelGate: Promise<void> = Promise.resolve();
+  const registerHttpRoute = (route: {
+    path: string;
+    auth?: string;
+    handler: SlashRouteHandler;
+  }) => {
+    registrations.push({ path: route.path, auth: route.auth });
+    routes.set(route.path, route.handler);
+  };
 
-    setMattermostRuntime(createRuntime(dispatch) as never);
-    registerSlashCommandRoute({
-      config: {
-        channels: {
-          mattermost: {
-            commands: { native: true, callbackPath: CALLBACK_PATH },
-          },
+  setMattermostRuntime(runtime as never);
+  registerSlashCommandRoute({
+    config: {
+      channels: {
+        mattermost: {
+          commands: { native: true, callbackPath: CALLBACK_PATH },
         },
       },
-      logger: { warn() {} },
-      registerHttpRoute,
-    } as never);
+    },
+    logger: { warn() {} },
+    registerHttpRoute,
+  } as never);
 
-    expect(registrations).toContainEqual({ path: CALLBACK_PATH, auth: "plugin" });
-    const slashRoute = routes.get(CALLBACK_PATH);
-    if (!slashRoute) {
-      throw new Error("expected the Mattermost plugin entry to register its slash route");
+  expect(registrations).toContainEqual({ path: CALLBACK_PATH, auth: "plugin" });
+  const slashRoute = routes.get(CALLBACK_PATH);
+  if (!slashRoute) {
+    throw new Error("expected Mattermost to register its slash route");
+  }
+
+  const callbackSourceAddresses: string[] = [];
+  const server = createServer((req, res) => {
+    if (req.url?.startsWith("/api/v4/commands/")) {
+      const command = currentCommands.get(req.url.slice("/api/v4/commands/".length));
+      res.setHeader("content-type", "application/json");
+      res.statusCode = command ? 200 : 404;
+      res.end(
+        JSON.stringify(
+          command
+            ? {
+                id: command.id,
+                team_id: command.teamId,
+                trigger: command.trigger,
+                method: "P",
+                url: command.url,
+                token: command.token,
+                delete_at: 0,
+              }
+            : {},
+        ),
+      );
+      return;
     }
-
-    let callbackUrl = "";
-    const callbackSourceAddresses: string[] = [];
-    const server = createServer((req, res) => {
-      if (req.url === "/api/v4/commands/command-1") {
-        res.setHeader("content-type", "application/json");
-        res.end(
-          JSON.stringify({
-            id: "command-1",
-            team_id: "team-1",
-            trigger: "oc_status",
-            method: "P",
-            url: callbackUrl,
-            token: TOKEN,
-            delete_at: 0,
-          }),
-        );
-        return;
-      }
-      if (req.url === "/api/v4/channels/channel-1") {
-        res.setHeader("content-type", "application/json");
+    if (req.url?.startsWith("/api/v4/commands?")) {
+      res.setHeader("content-type", "application/json");
+      res.end("[]");
+      return;
+    }
+    if (req.url === "/api/v4/channels/channel-1") {
+      channelRequests();
+      res.setHeader("content-type", "application/json");
+      void channelGate.then(() =>
         res.end(
           JSON.stringify({
             id: "channel-1",
@@ -201,79 +233,159 @@ describe("Mattermost slash HTTP boundary", () => {
             type: "O",
             team_id: "team-1",
           }),
-        );
-        return;
-      }
-      if (req.url === CALLBACK_PATH) {
-        callbackSourceAddresses.push(req.socket.remoteAddress ?? "unknown");
-        void slashRoute(req, res).catch((error: unknown) => {
-          res.destroy(error instanceof Error ? error : new Error(String(error)));
-        });
-        return;
-      }
-      res.statusCode = 404;
-      res.end("Not Found");
+        ),
+      );
+      return;
+    }
+    if (req.url === CALLBACK_PATH) {
+      callbackSourceAddresses.push(req.socket.remoteAddress ?? "unknown");
+      const run = slashRoute(req, res)
+        .catch((error: unknown) => {
+          errors.push(error);
+          res.statusCode = 500;
+          res.end("Injected handler failure");
+        })
+        .finally(() => routeRuns.delete(run));
+      routeRuns.add(run);
+      return;
+    }
+    res.statusCode = 404;
+    res.end("Not Found");
+  });
+
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.removeListener("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected the Mattermost boundary server to have a TCP address");
+    }
+    const callbackUrl = `http://127.0.0.1:${address.port}${CALLBACK_PATH}`;
+
+    const account: ResolvedMattermostAccount = {
+      accountId: "default",
+      enabled: true,
+      botToken: "bot-token",
+      botTokenSource: "config",
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      baseUrlSource: "config",
+      streamingMode: "partial",
+      config: {
+        groupPolicy: "open",
+        network: { dangerouslyAllowPrivateNetwork: true },
+      },
+    };
+    const command: MattermostRegisteredCommand = {
+      id: "command-1",
+      teamId: "team-1",
+      trigger: "oc_status",
+      token: TOKEN,
+      url: callbackUrl,
+      managed: false,
+    };
+    const commandB = { ...command, id: "command-2", trigger: "oc_help", token: "boundary-token-b" };
+    currentCommands.set(command.id, command);
+    currentCommands.set(commandB.id, commandB);
+    activateSlashCommands({
+      account,
+      commandTokens: [TOKEN, commandB.token],
+      registeredCommands: [command, commandB],
+      api: { cfg: {}, runtime: { log() {}, error() {}, exit() {} } },
     });
 
-    const sockets = new Set<Socket>();
-    server.on("connection", (socket) => {
-      sockets.add(socket);
-      socket.once("close", () => sockets.delete(socket));
-    });
-
-    try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-          server.removeListener("error", reject);
-          resolve();
-        });
-      });
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected the Mattermost boundary server to have a TCP address");
-      }
-      callbackUrl = `http://127.0.0.1:${address.port}${CALLBACK_PATH}`;
-
-      const account: ResolvedMattermostAccount = {
-        accountId: "default",
-        enabled: true,
-        botToken: "bot-token",
-        botTokenSource: "config",
-        baseUrl: `http://127.0.0.1:${address.port}`,
-        baseUrlSource: "config",
-        streamingMode: "partial",
-        config: {
-          groupPolicy: "open",
-          network: { dangerouslyAllowPrivateNetwork: true },
-        },
-      };
-      const command: MattermostRegisteredCommand = {
-        id: "command-1",
-        teamId: "team-1",
-        trigger: "oc_status",
-        token: TOKEN,
-        url: callbackUrl,
-        managed: false,
-      };
-      activateSlashCommands({
-        account,
-        commandTokens: [TOKEN],
-        registeredCommands: [command],
-        api: { cfg: {}, runtime: { log() {}, error() {}, exit() {} } },
-      });
-
-      const validBody = new URLSearchParams({
-        token: TOKEN,
+    const bodyFor = (selected = command) =>
+      new URLSearchParams({
+        token: selected.token,
         team_id: "team-1",
         channel_id: "channel-1",
         user_id: "user-1",
         user_name: "boundary-user",
-        command: "/oc_status",
+        command: `/${selected.trigger}`,
         text: "hello",
         trigger_id: "trigger-1",
       }).toString();
 
+    const validBody = bodyFor();
+    await runBoundary({
+      address,
+      account,
+      command,
+      commandB,
+      currentCommands,
+      runtime,
+      dispatch,
+      errors,
+      routeRuns,
+      callbackSourceAddresses,
+      validBody,
+      bodyFor,
+      channelRequests,
+      holdChannel: (gate: Promise<void>) => {
+        channelGate = gate;
+      },
+    });
+  } finally {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    server.closeAllConnections();
+    await Promise.all(routeRuns);
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+async function fillCredentialPool(boundary: Boundary): Promise<HeldRequest[]> {
+  const seen = boundary.callbackSourceAddresses.length;
+  const held = Array.from({ length: 8 }, () =>
+    openHeldRequest({
+      port: boundary.address.port,
+      localAddress: "127.0.0.1",
+      authorization: `Token ${TOKEN}`,
+    }),
+  );
+  await vi.waitFor(() => expect(boundary.callbackSourceAddresses).toHaveLength(seen + 8));
+  expect(held.every((entry) => entry.statusCode === undefined)).toBe(true);
+  await expectCredentialOverflow(boundary);
+  return held;
+}
+
+async function expectCredentialOverflow(boundary: Boundary) {
+  const response = await postForm({
+    port: boundary.address.port,
+    localAddress: "127.0.0.1",
+    authorization: `Token ${TOKEN}`,
+    body: boundary.validBody,
+  });
+  expect(response.statusCode).toBe(429);
+}
+
+async function drainCredentialPool(held: HeldRequest[]) {
+  for (const entry of held) {
+    entry.socket.write("x");
+  }
+  await vi.waitFor(() => expect(held.map((entry) => entry.statusCode)).toEqual(Array(8).fill(400)));
+}
+
+describe("Mattermost slash HTTP boundary", () => {
+  afterEach(() => {
+    deactivateSlashCommands();
+  });
+
+  it("reserves authenticated capacity and bounds each pre-authentication pool at eight", async () => {
+    await withBoundary(async ({ address, callbackSourceAddresses, validBody, dispatch }) => {
       const sharedHeld = Array.from({ length: 8 }, (_, index) =>
         openHeldRequest({
           port: address.port,
@@ -387,14 +499,127 @@ describe("Mattermost slash HTTP boundary", () => {
           InboundAccessAuthorized: true,
         },
       });
-    } finally {
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+    });
   }, 20_000);
+  it.each(["current", "revoked", "rotated"])(
+    "keeps B admitted when eight stalled %s A credentials fill A capacity in one account",
+    async (state) => {
+      await withBoundary(async (boundary) => {
+        const { command, commandB, currentCommands, bodyFor, address, dispatch } = boundary;
+        if (state === "revoked") {
+          currentCommands.delete(command.id);
+        }
+        if (state === "rotated") {
+          currentCommands.set(command.id, { ...command, token: "rotated-a-token" });
+        }
+        // Upstream changes leave the activation token snapshot intact until restart.
+        const oldA = await postForm({
+          port: address.port,
+          localAddress: "127.0.0.1",
+          authorization: `Token ${TOKEN}`,
+          body: bodyFor(command),
+        });
+        expect(oldA.statusCode).toBe(state === "current" ? 200 : 401);
+        const held = await fillCredentialPool(boundary);
+        const result = await postForm({
+          port: address.port,
+          localAddress: "127.0.0.1",
+          authorization: `Token ${commandB.token}`,
+          body: bodyFor(commandB),
+        });
+        expect(result).toEqual({
+          statusCode: 200,
+          body: JSON.stringify({ response_type: "ephemeral", text: "Processing..." }),
+        });
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(state === "current" ? 2 : 1));
+        await drainCredentialPool(held);
+      });
+    },
+  );
+
+  it.each(["completion", "throw after authentication"])(
+    "releases exactly once when overlapping authenticated work exits by %s",
+    async (exit) => {
+      await withBoundary(async (boundary) => {
+        const gate = createDeferred<void>();
+        boundary.holdChannel(gate.promise);
+        if (exit === "throw after authentication") {
+          boundary.runtime.channel.commands.shouldHandleTextCommands = () => {
+            throw new Error("injected post-authentication failure");
+          };
+        }
+        const pending = Array.from({ length: 2 }, () =>
+          postForm({
+            port: boundary.address.port,
+            localAddress: "127.0.0.1",
+            authorization: `Token ${TOKEN}`,
+            body: boundary.validBody,
+          }),
+        );
+        try {
+          await vi.waitFor(() => expect(boundary.channelRequests).toHaveBeenCalledTimes(2));
+          const oldRuns = [...boundary.routeRuns];
+          expect(oldRuns).toHaveLength(2);
+          // Both old handlers have authenticated but are still awaiting channel work.
+          const held = await fillCredentialPool(boundary);
+          gate.resolve();
+          const completed = await Promise.all(pending);
+          expect(completed.map((response) => response.statusCode)).toEqual(
+            Array(2).fill(exit === "completion" ? 200 : 500),
+          );
+          await Promise.all(oldRuns);
+          expect(boundary.errors).toHaveLength(exit === "completion" ? 0 : 2);
+          // Old finally blocks must not release any of the eight newer admissions.
+          await expectCredentialOverflow(boundary);
+          await drainCredentialPool(held);
+          await drainCredentialPool(await fillCredentialPool(boundary));
+        } finally {
+          gate.resolve();
+          await Promise.allSettled(pending);
+        }
+      });
+    },
+  );
+
+  it.each(["throw before authentication", "timeout", "oversize", "disconnect"])(
+    "refills authenticated capacity to eight after %s",
+    async (fault) => {
+      await withBoundary(async (boundary) => {
+        if (fault === "throw before authentication") {
+          const baseUrl = boundary.account.baseUrl;
+          boundary.account.baseUrl = "";
+          const result = await postForm({
+            port: boundary.address.port,
+            localAddress: "127.0.0.1",
+            authorization: `Token ${TOKEN}`,
+            body: boundary.validBody,
+          });
+          boundary.account.baseUrl = baseUrl;
+          expect(result.statusCode).toBe(500);
+          expect(boundary.errors).toHaveLength(1);
+        } else {
+          const failed = openHeldRequest({
+            port: boundary.address.port,
+            localAddress: "127.0.0.1",
+            authorization: `Token ${TOKEN}`,
+            contentLength: fault === "oversize" ? 65_537 : 1,
+          });
+          await vi.waitFor(() => expect(boundary.callbackSourceAddresses).toHaveLength(1));
+          if (fault === "disconnect") {
+            failed.socket.destroy();
+          } else {
+            await vi.waitFor(
+              () => expect(failed.statusCode).toBe(fault === "timeout" ? 408 : 413),
+              { timeout: 7_000 },
+            );
+            await vi.waitFor(() => expect(failed.closedByServer).toBe(true));
+          }
+        }
+        await vi.waitFor(() => expect(boundary.routeRuns.size).toBe(0));
+        expect(boundary.channelRequests).not.toHaveBeenCalled();
+        await drainCredentialPool(await fillCredentialPool(boundary));
+      });
+    },
+    15_000,
+  );
 });

--- a/extensions/mattermost/src/mattermost/slash-http.boundary.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.boundary.test.ts
@@ -52,7 +52,11 @@ function createRuntime(dispatch: ReturnType<typeof vi.fn>) {
   };
 }
 
-function openHeldRequest(params: { port: number; localAddress: string }): HeldRequest {
+function openHeldRequest(params: {
+  port: number;
+  localAddress: string;
+  authorization?: string;
+}): HeldRequest {
   const held: HeldRequest = {
     socket: connect({
       host: "127.0.0.1",
@@ -71,6 +75,7 @@ function openHeldRequest(params: { port: number; localAddress: string }): HeldRe
         `Host: 127.0.0.1:${params.port}`,
         "Content-Type: application/x-www-form-urlencoded",
         "Content-Length: 1",
+        ...(params.authorization ? [`Authorization: ${params.authorization}`] : []),
         "Connection: close",
         "",
         "",
@@ -98,6 +103,7 @@ async function postForm(params: {
   port: number;
   body: string;
   localAddress: string;
+  authorization?: string;
 }): Promise<{ statusCode: number; body: string }> {
   return await new Promise((resolve, reject) => {
     const req = request(
@@ -111,6 +117,7 @@ async function postForm(params: {
           "content-type": "application/x-www-form-urlencoded",
           "content-length": Buffer.byteLength(params.body),
           connection: "close",
+          ...(params.authorization ? { authorization: params.authorization } : {}),
         },
       },
       (res) => {
@@ -134,7 +141,7 @@ describe("Mattermost slash HTTP boundary", () => {
     deactivateSlashCommands();
   });
 
-  it("bounds pre-auth bodies at the registered route, closes overflow, and recovers", async () => {
+  it("reserves authenticated capacity and bounds each pre-authentication pool at eight", async () => {
     const routes = new Map<string, SlashRouteHandler>();
     const registrations: Array<{ path: string; auth: string | undefined }> = [];
     const dispatch = vi.fn(async (_params: unknown) => undefined);
@@ -256,48 +263,6 @@ describe("Mattermost slash HTTP boundary", () => {
         api: { cfg: {}, runtime: { log() {}, error() {}, exit() {} } },
       });
 
-      const held = Array.from({ length: 12 }, (_, index) =>
-        openHeldRequest({
-          port: address.port,
-          localAddress: `127.0.0.${index + 2}`,
-        }),
-      );
-
-      await vi.waitFor(
-        () => {
-          expect(held.filter((entry) => entry.statusCode === 429)).toHaveLength(4);
-        },
-        { timeout: 3_000 },
-      );
-      const overflow = held.filter((entry) => entry.statusCode === 429);
-      const admitted = held.filter((entry) => entry.statusCode === undefined);
-      expect(admitted).toHaveLength(8);
-      expect(callbackSourceAddresses).toHaveLength(12);
-      expect(new Set(callbackSourceAddresses).size).toBe(12);
-      await vi.waitFor(
-        () => {
-          expect(overflow.every((entry) => entry.endedByServer && entry.closedByServer)).toBe(true);
-        },
-        { timeout: 3_000 },
-      );
-
-      for (const entry of admitted) {
-        entry.socket.write("x");
-      }
-      await vi.waitFor(
-        () => {
-          expect(admitted.every((entry) => entry.statusCode === 400)).toBe(true);
-        },
-        { timeout: 3_000 },
-      );
-
-      const recovered = await postForm({
-        port: address.port,
-        body: "x",
-        localAddress: "127.0.0.20",
-      });
-      expect(recovered.statusCode).toBe(400);
-
       const validBody = new URLSearchParams({
         token: TOKEN,
         team_id: "team-1",
@@ -308,16 +273,111 @@ describe("Mattermost slash HTTP boundary", () => {
         text: "hello",
         trigger_id: "trigger-1",
       }).toString();
+
+      const sharedHeld = Array.from({ length: 8 }, (_, index) =>
+        openHeldRequest({
+          port: address.port,
+          localAddress: `127.0.0.${index + 2}`,
+        }),
+      );
+      await vi.waitFor(
+        () => {
+          expect(callbackSourceAddresses).toHaveLength(8);
+        },
+        { timeout: 3_000 },
+      );
+      expect(sharedHeld.every((entry) => entry.statusCode === undefined)).toBe(true);
+
+      const sharedOverflow = openHeldRequest({
+        port: address.port,
+        localAddress: "127.0.0.10",
+      });
+      await vi.waitFor(() => expect(sharedOverflow.statusCode).toBe(429), { timeout: 3_000 });
+      await vi.waitFor(
+        () => {
+          expect(sharedOverflow.endedByServer && sharedOverflow.closedByServer).toBe(true);
+        },
+        { timeout: 3_000 },
+      );
+
       const valid = await postForm({
         port: address.port,
         body: validBody,
-        localAddress: "127.0.0.21",
+        localAddress: "127.0.0.11",
+        authorization: `Token ${TOKEN}`,
       });
       expect(valid).toEqual({
         statusCode: 200,
         body: JSON.stringify({ response_type: "ephemeral", text: "Processing..." }),
       });
       await vi.waitFor(() => expect(dispatch).toHaveBeenCalledOnce());
+
+      for (const entry of sharedHeld) {
+        entry.socket.write("x");
+      }
+      await vi.waitFor(
+        () => {
+          expect(sharedHeld.every((entry) => entry.statusCode === 400)).toBe(true);
+        },
+        { timeout: 3_000 },
+      );
+
+      const sharedVariants = Array.from({ length: 8 }, (_, index) =>
+        openHeldRequest({
+          port: address.port,
+          localAddress: `127.0.0.${index + 12}`,
+          authorization:
+            index === 6 ? "Token wrong-token" : index === 7 ? `Bearer ${TOKEN}` : undefined,
+        }),
+      );
+      await vi.waitFor(() => expect(callbackSourceAddresses).toHaveLength(18), { timeout: 3_000 });
+      expect(sharedVariants.every((entry) => entry.statusCode === undefined)).toBe(true);
+      const variantOverflow = openHeldRequest({
+        port: address.port,
+        localAddress: "127.0.0.20",
+      });
+      await vi.waitFor(() => expect(variantOverflow.statusCode).toBe(429), { timeout: 3_000 });
+      for (const entry of sharedVariants) {
+        entry.socket.write("x");
+      }
+      await vi.waitFor(
+        () => expect(sharedVariants.every((entry) => entry.statusCode === 400)).toBe(true),
+        { timeout: 3_000 },
+      );
+
+      const authenticatedHeld = Array.from({ length: 8 }, (_, index) =>
+        openHeldRequest({
+          port: address.port,
+          localAddress: `127.0.0.${index + 21}`,
+          authorization: `Token ${TOKEN}`,
+        }),
+      );
+      await vi.waitFor(() => expect(callbackSourceAddresses).toHaveLength(27), { timeout: 3_000 });
+      expect(authenticatedHeld.every((entry) => entry.statusCode === undefined)).toBe(true);
+      const authenticatedOverflow = openHeldRequest({
+        port: address.port,
+        localAddress: "127.0.0.29",
+        authorization: `Token ${TOKEN}`,
+      });
+      await vi.waitFor(() => expect(authenticatedOverflow.statusCode).toBe(429), {
+        timeout: 3_000,
+      });
+
+      const recovered = await postForm({
+        port: address.port,
+        body: "x",
+        localAddress: "127.0.0.30",
+      });
+      expect(recovered.statusCode).toBe(400);
+      for (const entry of authenticatedHeld) {
+        entry.socket.write("x");
+      }
+      await vi.waitFor(
+        () => expect(authenticatedHeld.every((entry) => entry.statusCode === 400)).toBe(true),
+        { timeout: 3_000 },
+      );
+
+      expect(new Set(callbackSourceAddresses).size).toBe(callbackSourceAddresses.length);
       expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
         channel: "mattermost",
         accountId: "default",
@@ -336,5 +396,5 @@ describe("Mattermost slash HTTP boundary", () => {
         server.close((error) => (error ? reject(error) : resolve()));
       });
     }
-  }, 15_000);
+  }, 20_000);
 });

--- a/extensions/mattermost/src/mattermost/slash-http.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.test.ts
@@ -197,6 +197,7 @@ async function validateMattermostSlashCommandToken(params: {
   registeredCommand: MattermostRegisteredCommand;
   payload: MattermostSlashCommandPayload;
   log?: (message: string) => void;
+  onRequestAuthenticated?: () => void;
 }): Promise<boolean> {
   clientMocks.createMattermostClient.mockReturnValue(params.client);
   const handler = createSlashCommandHttpHandler({
@@ -213,7 +214,7 @@ async function validateMattermostSlashCommandToken(params: {
   });
   const response = createResponse();
   try {
-    await handler(req, response.res);
+    await handler(req, response.res, undefined, params.onRequestAuthenticated);
   } catch (error) {
     if (error instanceof Error && error.message === "Mattermost runtime not initialized") {
       return true;
@@ -230,6 +231,7 @@ async function expectTokenValidation(params: {
   accountId?: string;
   payload?: MattermostSlashCommandPayload;
   log?: (message: string) => void;
+  onRequestAuthenticated?: () => void;
 }): Promise<void> {
   await expect(
     validateMattermostSlashCommandToken({
@@ -238,6 +240,7 @@ async function expectTokenValidation(params: {
       registeredCommand: params.registeredCommand,
       payload: params.payload ?? createSlashPayload({ token: params.registeredCommand.token }),
       log: params.log,
+      onRequestAuthenticated: params.onRequestAuthenticated,
     }),
   ).resolves.toBe(params.expected);
 }
@@ -397,10 +400,17 @@ describe("slash-http", () => {
     const client = createCommandLookupClient({
       command: createCurrentCommand({ token: "new-token" }),
     });
+    const onRequestAuthenticated = vi.fn();
 
-    await expectTokenValidation({ client, registeredCommand, expected: false });
+    await expectTokenValidation({
+      client,
+      registeredCommand,
+      expected: false,
+      onRequestAuthenticated,
+    });
 
     expect(registeredCommand.token).toBe("old-token");
+    expect(onRequestAuthenticated).not.toHaveBeenCalled();
   });
 
   it("accepts the startup token while the current Mattermost command still matches", async () => {
@@ -408,8 +418,15 @@ describe("slash-http", () => {
     const client = createCommandLookupClient({
       command: createCurrentCommand(),
     });
+    const onRequestAuthenticated = vi.fn();
 
-    await expectTokenValidation({ client, registeredCommand, expected: true });
+    await expectTokenValidation({
+      client,
+      registeredCommand,
+      expected: true,
+      onRequestAuthenticated,
+    });
+    expect(onRequestAuthenticated).toHaveBeenCalledOnce();
   });
 
   it("rate-limits sequential current-command lookups without caching successes", async () => {

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -583,6 +583,7 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
     req: IncomingMessage,
     res: ServerResponse,
     bufferedBody?: string,
+    onRequestAuthenticated?: () => void,
   ): Promise<void> => {
     if (req.method !== "POST") {
       res.statusCode = 405;
@@ -655,6 +656,10 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       });
       return;
     }
+
+    // The route-level pre-authentication slot only protects body parsing and
+    // token validation; release it before user authorization or command work.
+    onRequestAuthenticated?.();
 
     // Extract command info
     const trigger = normalizeSlashCommandTrigger(payload.command);

--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -1,5 +1,7 @@
 // Mattermost tests cover slash state plugin behavior.
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { EventEmitter } from "node:events";
+import { IncomingMessage, type ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import { createMockIncomingRequest, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
@@ -82,15 +84,25 @@ function createRequest(body: string): IncomingMessage {
   return req;
 }
 
+function createStalledRequest(remoteAddress: string): IncomingMessage {
+  const req = new IncomingMessage(new Socket());
+  req.method = "POST";
+  req.headers = { "content-type": "application/x-www-form-urlencoded" };
+  Object.defineProperty(req.socket, "remoteAddress", { value: remoteAddress });
+  return req;
+}
+
 function createResponse(): { res: ServerResponse; getBody: () => string } {
   let body = "";
-  const res = {
+  const res = Object.assign(new EventEmitter(), {
     statusCode: 200,
     setHeader() {},
-    end(chunk?: string | Buffer) {
+    removeHeader() {},
+    end(chunk?: string | Buffer, callback?: () => void) {
       body = chunk ? String(chunk) : "";
+      callback?.();
     },
-  } as unknown as ServerResponse;
+  }) as unknown as ServerResponse;
   return { res, getBody: () => body };
 }
 
@@ -213,6 +225,40 @@ describe("slash-state request routing", () => {
         });
       },
     );
+  });
+
+  it("bounds concurrent pre-authentication body reads across the slash route", async () => {
+    activateSlashCommands({
+      account: createResolvedMattermostAccount("a1"),
+      commandTokens: ["token-1"],
+      registeredCommands: [createRegisteredCommand()],
+      api: slashApi,
+    });
+    const route = createSlashRoute();
+    const requests = Array.from({ length: 12 }, (_, index) =>
+      createStalledRequest(`203.0.113.${index + 1}`),
+    );
+    const responses = requests.map(() => createResponse());
+    const runs = requests.map((req, index) => route.handler(req, responses[index]!.res));
+
+    try {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(responses.filter(({ res }) => res.statusCode === 200)).toHaveLength(8);
+      expect(responses.filter(({ res }) => res.statusCode === 429)).toHaveLength(4);
+    } finally {
+      for (const req of requests) {
+        req.complete = true;
+        req.push(null);
+      }
+      await Promise.all(runs);
+    }
+
+    const followUp = createResponse();
+    await route.handler(createRequest(""), followUp.res);
+    expect(followUp.res.statusCode).toBe(400);
   });
 
   it("routes a token owned by one account", async () => {

--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -2,6 +2,7 @@
 import { EventEmitter } from "node:events";
 import { IncomingMessage, type ServerResponse } from "node:http";
 import { Socket } from "node:net";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { createMockIncomingRequest, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
@@ -12,6 +13,11 @@ import {
   deactivateSlashCommands,
   registerSlashCommandRoute,
 } from "./slash-state.js";
+
+vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/security-runtime")>();
+  return { ...actual, safeEqualSecret: vi.fn(actual.safeEqualSecret) };
+});
 
 function createResolvedMattermostAccount(accountId: string): ResolvedMattermostAccount {
   return {
@@ -77,17 +83,17 @@ function replaceAccountHandler(accountId: string): void {
   };
 }
 
-function createRequest(body: string): IncomingMessage {
+function createRequest(body: string, authorization?: string): IncomingMessage {
   const req = createMockIncomingRequest([body]);
   req.method = "POST";
-  req.headers = { "content-type": "application/x-www-form-urlencoded" };
+  req.headers = { "content-type": "application/x-www-form-urlencoded", authorization };
   return req;
 }
 
-function createStalledRequest(remoteAddress: string): IncomingMessage {
+function createStalledRequest(remoteAddress: string, authorization?: string): IncomingMessage {
   const req = new IncomingMessage(new Socket());
   req.method = "POST";
-  req.headers = { "content-type": "application/x-www-form-urlencoded" };
+  req.headers = { "content-type": "application/x-www-form-urlencoded", authorization };
   Object.defineProperty(req.socket, "remoteAddress", { value: remoteAddress });
   return req;
 }
@@ -126,11 +132,12 @@ function createSlashRoute(register = registerSlashCommandRoute) {
 
 async function routeSlashRequest(params: {
   body: string;
+  authorization?: string;
   register?: typeof registerSlashCommandRoute;
 }): Promise<{ statusCode: number; body: string; warn: ReturnType<typeof vi.fn> }> {
   const { handler, warn } = createSlashRoute(params.register);
   const response = createResponse();
-  await handler(createRequest(params.body), response.res);
+  await handler(createRequest(params.body, params.authorization), response.res);
   return { statusCode: response.res.statusCode, body: response.getBody(), warn };
 }
 
@@ -177,6 +184,92 @@ describe("slash-state global singleton", () => {
 describe("slash-state request routing", () => {
   afterEach(() => {
     deactivateSlashCommands();
+    vi.mocked(safeEqualSecret).mockClear();
+  });
+
+  it("accepts the Token scheme case-insensitively and compares every known token", async () => {
+    activate({ accountId: "a1", tokens: ["tok-a", "tok-a-alt"] });
+    activate({ accountId: "a2", tokens: ["tok-b"] });
+
+    const matched = await routeSlashRequest({
+      body: "token=tok-a",
+      authorization: "tOkEn tok-a",
+    });
+
+    expect(matched.statusCode).toBe(200);
+    expect(vi.mocked(safeEqualSecret).mock.calls).toEqual([
+      ["tok-a", "tok-a"],
+      ["tok-a", "tok-a-alt"],
+      ["tok-a", "tok-b"],
+    ]);
+
+    for (const authorization of [
+      "Bearer tok-a",
+      "Token tok-a extra",
+      "Token tok-a,Token tok-b",
+      "garbage",
+    ]) {
+      vi.mocked(safeEqualSecret).mockClear();
+      const ignored = await routeSlashRequest({ body: "token=tok-a", authorization });
+      expect(ignored.statusCode).toBe(200);
+      expect(safeEqualSecret).not.toHaveBeenCalled();
+    }
+  });
+
+  it("isolates unique authenticated capacity by account", async () => {
+    activate({ accountId: "a1", tokens: ["tok-a"] });
+    activate({ accountId: "a2", tokens: ["tok-b"] });
+    const route = createSlashRoute();
+    const requests = Array.from({ length: 8 }, (_, index) =>
+      createStalledRequest(`203.0.113.${index + 1}`, "Token tok-a"),
+    );
+    const responses = requests.map(() => createResponse());
+    const runs = requests.map((req, index) => route.handler(req, responses[index]!.res));
+
+    const overflow = createResponse();
+    await route.handler(createRequest("", "Token tok-a"), overflow.res);
+    const accountB = createStalledRequest("203.0.113.20", "Token tok-b");
+    const accountBResponse = createResponse();
+    const accountBRun = route.handler(accountB, accountBResponse.res);
+
+    try {
+      expect(overflow.res.statusCode).toBe(429);
+      expect(accountBResponse.res.statusCode).toBe(200);
+    } finally {
+      for (const req of [...requests, accountB]) {
+        req.complete = true;
+        req.push(null);
+      }
+      await Promise.all([...runs, accountBRun]);
+    }
+  });
+
+  it("shares authenticated capacity when a token matches multiple accounts", async () => {
+    activate({ accountId: "a1", tokens: ["tok-a", "tok-shared"] });
+    activate({ accountId: "a2", tokens: ["tok-shared"] });
+    const route = createSlashRoute();
+    const requests = Array.from({ length: 8 }, (_, index) =>
+      createStalledRequest(`203.0.113.${index + 1}`, "Token tok-shared"),
+    );
+    const responses = requests.map(() => createResponse());
+    const runs = requests.map((req, index) => route.handler(req, responses[index]!.res));
+
+    const overflow = createResponse();
+    await route.handler(createRequest("", "Token tok-shared"), overflow.res);
+    const unique = createStalledRequest("203.0.113.20", "Token tok-a");
+    const uniqueResponse = createResponse();
+    const uniqueRun = route.handler(unique, uniqueResponse.res);
+
+    try {
+      expect(overflow.res.statusCode).toBe(429);
+      expect(uniqueResponse.res.statusCode).toBe(200);
+    } finally {
+      for (const req of [...requests, unique]) {
+        req.complete = true;
+        req.push(null);
+      }
+      await Promise.all([...runs, uniqueRun]);
+    }
   });
 
   it.each([

--- a/extensions/mattermost/src/mattermost/slash-state.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.test.ts
@@ -216,7 +216,7 @@ describe("slash-state request routing", () => {
     }
   });
 
-  it("isolates unique authenticated capacity by account", async () => {
+  it("isolates distinct credentials across accounts", async () => {
     activate({ accountId: "a1", tokens: ["tok-a"] });
     activate({ accountId: "a2", tokens: ["tok-b"] });
     const route = createSlashRoute();
@@ -244,9 +244,9 @@ describe("slash-state request routing", () => {
     }
   });
 
-  it("shares authenticated capacity when a token matches multiple accounts", async () => {
-    activate({ accountId: "a1", tokens: ["tok-a", "tok-shared"] });
-    activate({ accountId: "a2", tokens: ["tok-shared"] });
+  it("collapses duplicate credentials without merging distinct duplicate groups", async () => {
+    activate({ accountId: "a1", tokens: ["tok-a", "tok-shared", "tok-shared-other"] });
+    activate({ accountId: "a2", tokens: ["tok-shared", "tok-shared-other"] });
     const route = createSlashRoute();
     const requests = Array.from({ length: 8 }, (_, index) =>
       createStalledRequest(`203.0.113.${index + 1}`, "Token tok-shared"),
@@ -256,7 +256,7 @@ describe("slash-state request routing", () => {
 
     const overflow = createResponse();
     await route.handler(createRequest("", "Token tok-shared"), overflow.res);
-    const unique = createStalledRequest("203.0.113.20", "Token tok-a");
+    const unique = createStalledRequest("203.0.113.20", "Token tok-shared-other");
     const uniqueResponse = createResponse();
     const uniqueRun = route.handler(unique, uniqueResponse.res);
 

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -14,6 +14,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { MattermostConfig } from "../types.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import {
+  createWebhookInFlightLimiter,
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
   sendHttpRequestRejection,
@@ -32,6 +33,8 @@ import {
 
 const MULTI_ACCOUNT_BODY_MAX_BYTES = 64 * 1024;
 const MULTI_ACCOUNT_BODY_TIMEOUT_MS = 5_000;
+const slashRouteInFlightLimiter = createWebhookInFlightLimiter();
+const SLASH_ROUTE_IN_FLIGHT_KEY = "mattermost:slash";
 type SlashHandler = ReturnType<typeof createSlashCommandHttpHandler>;
 type SlashHandlerMatchSource = "token" | "command";
 type SlashHandlerMatch =
@@ -291,7 +294,11 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
     addCallbackPaths(accountCommandsRaw);
   }
 
-  const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
+  const dispatchRoute = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    onRequestAuthenticated: () => void,
+  ) => {
     if (accountStates.size === 0) {
       res.statusCode = 503;
       res.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -322,7 +329,7 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
         );
         return;
       }
-      await state.handler(req, res);
+      await state.handler(req, res, undefined, onRequestAuthenticated);
       return;
     }
 
@@ -406,7 +413,30 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
 
     // Routing already enforced the body limit. Retain the original transport
     // and pass those bytes forward instead of replaying a socket-less request.
-    await match.handler(req, res, bodyStr);
+    await match.handler(req, res, bodyStr, onRequestAuthenticated);
+  };
+
+  const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
+    // Mattermost commonly fans all users through shared provider addresses, so one
+    // route-global key bounds ingress without partitioning capacity by source IP.
+    if (!slashRouteInFlightLimiter.tryAcquire(SLASH_ROUTE_IN_FLIGHT_KEY)) {
+      await sendHttpRequestRejection(req, res, 429, "Too Many Requests");
+      return;
+    }
+
+    let released = false;
+    const release = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      slashRouteInFlightLimiter.release(SLASH_ROUTE_IN_FLIGHT_KEY);
+    };
+    try {
+      await dispatchRoute(req, res, release);
+    } finally {
+      release();
+    }
   };
 
   for (const callbackPath of callbackPaths) {

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -11,6 +11,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import type { MattermostConfig } from "../types.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import {
@@ -35,6 +36,7 @@ const MULTI_ACCOUNT_BODY_MAX_BYTES = 64 * 1024;
 const MULTI_ACCOUNT_BODY_TIMEOUT_MS = 5_000;
 const slashRouteInFlightLimiter = createWebhookInFlightLimiter();
 const SLASH_ROUTE_IN_FLIGHT_KEY = "mattermost:slash";
+const SLASH_AUTHENTICATED_IN_FLIGHT_KEY = `${SLASH_ROUTE_IN_FLIGHT_KEY}:authenticated`;
 type SlashHandler = ReturnType<typeof createSlashCommandHttpHandler>;
 type SlashHandlerMatchSource = "token" | "command";
 type SlashHandlerMatch =
@@ -89,6 +91,30 @@ function getSlashAccountStates(): Map<string, SlashCommandAccountState> {
 }
 
 const accountStates = getSlashAccountStates();
+
+function resolveSlashRouteInFlightKey(authorization: string | undefined): string {
+  const token = authorization?.match(/^Token ([^,\s]+)$/iu)?.[1];
+  if (!token) {
+    return SLASH_ROUTE_IN_FLIGHT_KEY;
+  }
+
+  const matchingAccountIds: string[] = [];
+  for (const [accountId, state] of accountStates) {
+    let matched = false;
+    for (const commandToken of state.commandTokens) {
+      matched = safeEqualSecret(token, commandToken) || matched;
+    }
+    if (matched) {
+      matchingAccountIds.push(accountId);
+    }
+  }
+
+  return matchingAccountIds.length === 1
+    ? `${SLASH_AUTHENTICATED_IN_FLIGHT_KEY}:${matchingAccountIds[0]}`
+    : matchingAccountIds.length > 1
+      ? SLASH_AUTHENTICATED_IN_FLIGHT_KEY
+      : SLASH_ROUTE_IN_FLIGHT_KEY;
+}
 
 function resolveSlashHandlerForToken(token: string): SlashHandlerMatch {
   const matches: Array<{
@@ -417,9 +443,10 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
   };
 
   const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
-    // Mattermost commonly fans all users through shared provider addresses, so one
-    // route-global key bounds ingress without partitioning capacity by source IP.
-    if (!slashRouteInFlightLimiter.tryAcquire(SLASH_ROUTE_IN_FLIGHT_KEY)) {
+    // Header matching only selects a capacity pool. The handler still authenticates
+    // the body token and current command before releasing this admission guard.
+    const inFlightKey = resolveSlashRouteInFlightKey(req.headers.authorization);
+    if (!slashRouteInFlightLimiter.tryAcquire(inFlightKey)) {
       await sendHttpRequestRejection(req, res, 429, "Too Many Requests");
       return;
     }
@@ -430,7 +457,7 @@ export function registerSlashCommandRoute(api: OpenClawPluginApi) {
         return;
       }
       released = true;
-      slashRouteInFlightLimiter.release(SLASH_ROUTE_IN_FLIGHT_KEY);
+      slashRouteInFlightLimiter.release(inFlightKey);
     };
     try {
       await dispatchRoute(req, res, release);

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -10,6 +10,7 @@
  * overwrite each other's tokens, registered commands, or handlers.
  */
 
+import { createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import type { MattermostConfig } from "../types.js";
@@ -98,22 +99,20 @@ function resolveSlashRouteInFlightKey(authorization: string | undefined): string
     return SLASH_ROUTE_IN_FLIGHT_KEY;
   }
 
-  const matchingAccountIds: string[] = [];
-  for (const [accountId, state] of accountStates) {
-    let matched = false;
+  let matched = false;
+  for (const state of accountStates.values()) {
     for (const commandToken of state.commandTokens) {
       matched = safeEqualSecret(token, commandToken) || matched;
     }
-    if (matched) {
-      matchingAccountIds.push(accountId);
-    }
   }
 
-  return matchingAccountIds.length === 1
-    ? `${SLASH_AUTHENTICATED_IN_FLIGHT_KEY}:${matchingAccountIds[0]}`
-    : matchingAccountIds.length > 1
-      ? SLASH_AUTHENTICATED_IN_FLIGHT_KEY
-      : SLASH_ROUTE_IN_FLIGHT_KEY;
+  // Only known credentials create keys, never arbitrary headers or raw secrets.
+  // Distinct credentials stay isolated even when one startup token is later revoked.
+  return matched
+    ? `${SLASH_AUTHENTICATED_IN_FLIGHT_KEY}:${createHash("sha256")
+        .update(`${SLASH_AUTHENTICATED_IN_FLIGHT_KEY}:${token}`)
+        .digest("hex")}`
+    : SLASH_ROUTE_IN_FLIGHT_KEY;
 }
 
 function resolveSlashHandlerForToken(token: string): SlashHandlerMatch {


### PR DESCRIPTION
> Devin Robison · GPT-5 Codex · via @drobison00

## What Problem This Solves

Slash callbacks need bounded admission without blocking unrelated valid commands. Eight stalled anonymous uploads can exhaust a shared pool, and reserving capacity by account lets one command credential exhaust capacity for other commands in that account. A revoked startup credential could retain that capacity privilege until restart even though body authentication correctly rejects it.

## Why This Change Was Made

The route selects capacity before reading the body:

- A recognized `Authorization: Token <value>` credential uses `mattermost:slash:authenticated:<digest>`, where the digest is a prefixed SHA-256 hash. Raw credentials never appear in admission keys.
- Duplicate registrations of the same credential share one reservation; distinct credentials have separate reservations even within one account.
- Missing, malformed, unknown, and Bearer headers all use the single `mattermost:slash` anonymous pool.

Every known command token is compared through `safeEqualSecret`, without an early exit. Header recognition only selects capacity. Body-token validation, current-command lookup, and user authorization remain unchanged. Admission is released exactly once, after token authentication or on a fault/return, before potentially slow command work.

The existing SDK provides eight concurrent admissions per key and retains at most 4,096 active keys. Reserved-key cardinality depends on configured credentials, not arbitrary header values. Aggregate capacity grows with distinct credentials; exceeding the SDK's tracked-key bound can evict active counters and reset their counts. This change retains that existing SDK limitation.

[Mattermost sets the command Token header and replaces it when an outgoing OAuth credential is present](https://github.com/mattermost/mattermost/blob/f45e25d54b17da5ec666c68c0e807b84a1078414/server/channels/app/command.go#L573-L578). OAuth callbacks and callbacks passing through a proxy that strips that header carry the command token only in the body and share the anonymous pool. The [Mattermost troubleshooting caveat](https://docs.openclaw.ai/channels/mattermost#troubleshooting) explains saturation and preserving the original Token header through proxies.

## User Impact

A callback with a recognized header credential remains admissible while anonymous traffic, another account, or a different current or revoked command credential fills its own capacity. Each reservation remains bounded at eight. Oversize bodies, body deadlines, disconnects, and handler faults release capacity; overflowing requests receive HTTP 429 and their connections close.

## Evidence

Real-socket tests exercise the production route and callback handler with stub Mattermost REST responses. They do not launch the complete gateway or plugin entrypoint.

```text
anonymous uploads pending: 8
ninth anonymous request: 429 Too Many Requests
recognized Token callback: 200 Processing...
revoked A uploads pending: 8
current B callback in the same account: 200 Processing...
authenticated handlers pending: 2
new uploads admitted after authentication: 8
old handlers complete or throw; ninth new upload: 429
```

Coverage includes current, deleted, and rotated A credentials; separate duplicate-credential groups; exhaustive token comparisons; wrong Token and Bearer headers in the anonymous pool; bounded body reads; overflow connection closure; and refill to eight after timeout, oversize, disconnect, and exceptions before or after authentication.

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/mattermost`: 55 files, 854 tests passed.
- Production and test typechecks, changed-file lint, remaining changed-file guards, formatting, and `git diff --check` passed.
- Extension lint stripe 5/6 (Mattermost in shard 10) and paired core stripe 5/5 passed.
- `pnpm check:changed -- <changed files>` stopped at the existing `sdk-untrusted-context-identifier-aliases` compatibility record, whose removal date was September 8, 2026. The same boundary check fails with the original production code restored. All remaining checks from its plan were run directly and passed. Removing those public SDK aliases requires a separate compatibility decision.
- Reverting only the credential-keying production change makes the revoked-A/B regression fail: B receives 429 instead of 200. Removing the release-once guard makes the overlapping-completion test fail: an extra request receives 200 instead of 429. Both mutations were restored before final validation.

Current revision: `b7723fd4f16d394c205b929b1cfac6ddf4c64643`.

This evidence does not include a live Mattermost server; the test server supplies stub REST responses for current-command and channel validation.
