### PR TITLE
fix(sms): reject excess concurrent webhook reads

### DIFF
--- a/extensions/sms/src/webhook.boundary.test.ts
+++ b/extensions/sms/src/webhook.boundary.test.ts
@@ -1,0 +1,303 @@
+import { createHmac } from "node:crypto";
+import {
+  createServer,
+  request,
+  type ClientRequest,
+  type IncomingHttpHeaders,
+  type Server,
+} from "node:http";
+import { createConnection } from "node:net";
+import {
+  createEmptyPluginRegistry,
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startSmsGatewayAccount } from "./gateway.js";
+import type { SmsChannelRuntime } from "./inbound.js";
+import type { ResolvedSmsAccount } from "./types.js";
+
+const enqueueSmsIngress = vi.hoisted(() =>
+  vi.fn(async (_form: Record<string, string>) => ({ kind: "accepted" as const, duplicate: false })),
+);
+const startSmsIngress = vi.hoisted(() => vi.fn());
+const pauseSmsIngress = vi.hoisted(() => vi.fn(async () => {}));
+const stopSmsIngress = vi.hoisted(() => vi.fn(async () => {}));
+const createSmsIngressSpool = vi.hoisted(() =>
+  vi.fn(() => ({
+    enqueue: enqueueSmsIngress,
+    start: startSmsIngress,
+    pause: pauseSmsIngress,
+    stop: stopSmsIngress,
+  })),
+);
+
+vi.mock("./ingress-spool.js", () => ({ createSmsIngressSpool }));
+
+type HttpResult = {
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+  body: string;
+};
+
+type HeldRequest = {
+  request: ClientRequest;
+  finish: () => void;
+  result: Promise<HttpResult>;
+};
+
+function createAccount(): ResolvedSmsAccount {
+  return {
+    accountId: "boundary",
+    enabled: true,
+    accountSid: "AC123",
+    authToken: "secret",
+    fromNumber: "+15557654321",
+    messagingServiceSid: "",
+    defaultTo: "",
+    webhookPath: "/webhooks/sms",
+    publicWebhookUrl: "https://gateway.example.com/webhooks/sms",
+    dangerouslyDisableSignatureValidation: false,
+    dmPolicy: "pairing",
+    allowFrom: [],
+    textChunkLimit: 1500,
+  };
+}
+
+function listen(server: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected the SMS boundary server to have a TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function readResponse(req: ClientRequest): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    req.once("response", (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.once("end", () => {
+        resolve({
+          statusCode: res.statusCode ?? 0,
+          headers: res.headers,
+          body: Buffer.concat(chunks).toString("utf8"),
+        });
+      });
+    });
+    req.once("error", reject);
+  });
+}
+
+function holdIncompletePost(port: number, index: number): HeldRequest {
+  const body = new URLSearchParams({ incomplete: String(index) }).toString();
+  const req = request({
+    host: "127.0.0.1",
+    port,
+    path: "/webhooks/sms",
+    method: "POST",
+    agent: false,
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "content-length": Buffer.byteLength(body),
+    },
+  });
+  const result = readResponse(req);
+  void result.catch(() => {});
+  req.write(body.slice(0, 1));
+  return {
+    request: req,
+    finish: () => req.end(body.slice(1)),
+    result,
+  };
+}
+
+function postForm(params: { port: number; body: string; signature: string }): Promise<HttpResult> {
+  const req = request({
+    host: "127.0.0.1",
+    port: params.port,
+    path: "/webhooks/sms",
+    method: "POST",
+    agent: false,
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "content-length": Buffer.byteLength(params.body),
+      "x-twilio-signature": params.signature,
+    },
+  });
+  const result = readResponse(req);
+  req.end(params.body);
+  return result;
+}
+
+function sendIncompleteRawPost(
+  port: number,
+): Promise<{ response: string; endedByServer: boolean }> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ host: "127.0.0.1", port, allowHalfOpen: true });
+    const chunks: Buffer[] = [];
+    let endedByServer = false;
+    socket.once("connect", () => {
+      socket.write(
+        "POST /webhooks/sms HTTP/1.1\r\n" +
+          `Host: 127.0.0.1:${port}\r\n` +
+          "Content-Type: application/x-www-form-urlencoded\r\n" +
+          "Content-Length: 1024\r\n" +
+          "Connection: keep-alive\r\n\r\n",
+      );
+    });
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.once("end", () => {
+      endedByServer = true;
+      socket.end();
+    });
+    socket.once("close", () => {
+      resolve({ response: Buffer.concat(chunks).toString("utf8"), endedByServer });
+    });
+    socket.once("error", reject);
+  });
+}
+
+function computeTwilioSignature(params: {
+  account: ResolvedSmsAccount;
+  form: Record<string, string>;
+}): string {
+  const input =
+    params.account.publicWebhookUrl +
+    Object.keys(params.form)
+      .toSorted()
+      .map((key) => `${key}${params.form[key] ?? ""}`)
+      .join("");
+  return createHmac("sha1", params.account.authToken).update(input).digest("base64");
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe("SMS webhook real route boundary", () => {
+  afterEach(() => {
+    enqueueSmsIngress.mockReset();
+    enqueueSmsIngress.mockResolvedValue({ kind: "accepted", duplicate: false });
+    startSmsIngress.mockClear();
+    pauseSmsIngress.mockClear();
+    stopSmsIngress.mockClear();
+    createSmsIngressSpool.mockClear();
+  });
+
+  it("closes overflow uploads and recovers capacity for a signed callback", async () => {
+    const account = createAccount();
+    const registry = createEmptyPluginRegistry();
+    const previousRegistry = getActivePluginRegistry();
+    setActivePluginRegistry(registry);
+    const abortController = new AbortController();
+    const lifecycle = startSmsGatewayAccount({
+      cfg: {},
+      account,
+      channelRuntime: {} as SmsChannelRuntime,
+      abortSignal: abortController.signal,
+    });
+    await vi.waitFor(() => expect(registry.httpRoutes).toHaveLength(1));
+    const route = registry.httpRoutes[0];
+    if (!route) {
+      throw new Error("expected the SMS gateway to register its account route");
+    }
+
+    let receivedRequests = 0;
+    let heldBodyReaders = 0;
+    let overflowRequestComplete: boolean | undefined;
+    const server = createServer((req, res) => {
+      receivedRequests += 1;
+      const requestNumber = receivedRequests;
+      if (requestNumber <= 64) {
+        req.once("data", () => {
+          heldBodyReaders += 1;
+        });
+      }
+      void Promise.resolve(route.handler(req, res))
+        .then(() => {
+          if (requestNumber === 65) {
+            overflowRequestComplete = req.complete;
+          }
+        })
+        .catch((error: unknown) => {
+          if (!res.writableEnded) {
+            res.statusCode = 500;
+            res.end(error instanceof Error ? error.message : String(error));
+          }
+        });
+    });
+    const held: HeldRequest[] = [];
+
+    try {
+      const port = await listen(server);
+      for (let index = 0; index < 64; index += 1) {
+        held.push(holdIncompletePost(port, index));
+      }
+      await vi.waitFor(
+        () => {
+          expect(receivedRequests).toBe(64);
+          expect(heldBodyReaders).toBe(64);
+        },
+        { timeout: 10_000 },
+      );
+
+      const overflow = await sendIncompleteRawPost(port);
+      expect(overflow.response).toContain("HTTP/1.1 429 Too Many Requests\r\n");
+      expect(overflow.response).toMatch(/\r\nConnection: close\r\n/iu);
+      expect(overflow.response).toContain("\r\n\r\nRate limit exceeded");
+      expect(overflow.endedByServer).toBe(true);
+      await vi.waitFor(() => expect(overflowRequestComplete).toBe(false));
+      expect(enqueueSmsIngress).not.toHaveBeenCalled();
+
+      for (const pending of held) {
+        pending.finish();
+      }
+      const released = await Promise.all(held.map((pending) => pending.result));
+      expect(released.every((result) => result.statusCode === 403)).toBe(true);
+
+      const form = {
+        AccountSid: account.accountSid,
+        From: "+15551234567",
+        To: account.fromNumber,
+        Body: "boundary proof",
+        MessageSid: "SM00000000000000000000000000000985",
+      };
+      const body = new URLSearchParams(form).toString();
+      const admitted = await postForm({
+        port,
+        body,
+        signature: computeTwilioSignature({ account, form }),
+      });
+
+      expect(admitted.statusCode).toBe(200);
+      expect(admitted.headers["x-openclaw-delivery-accepted"]).toBe("durable");
+      expect(enqueueSmsIngress).toHaveBeenCalledOnce();
+      expect(enqueueSmsIngress).toHaveBeenCalledWith(form);
+    } finally {
+      for (const pending of held) {
+        pending.request.destroy();
+      }
+      await Promise.allSettled(held.map((pending) => pending.result));
+      await closeServer(server);
+      abortController.abort();
+      await lifecycle;
+      if (previousRegistry) {
+        setActivePluginRegistry(previousRegistry);
+      } else {
+        resetPluginRuntimeStateForTest();
+      }
+    }
+  });
+});

--- a/extensions/sms/src/webhook.ts
+++ b/extensions/sms/src/webhook.ts
@@ -6,7 +6,10 @@ import {
   isRequestBodyLimitError,
   resolveRequestClientIp,
 } from "openclaw/plugin-sdk/webhook-ingress";
-import { sendHttpRequestRejection } from "openclaw/plugin-sdk/webhook-request-guards";
+import {
+  createWebhookInFlightLimiter,
+  sendHttpRequestRejection,
+} from "openclaw/plugin-sdk/webhook-request-guards";
 import { assertSmsCredentialOwnerAvailable } from "./credential-availability.js";
 import {
   createSmsDeliveryRecorder,
@@ -25,6 +28,7 @@ import {
 import type { ResolvedSmsAccount } from "./types.js";
 
 const INVALID_REQUEST_MAX_REQUESTS = 300;
+const PRE_AUTH_MAX_IN_FLIGHT = 64;
 const INBOUND_DISPATCH_MAX_REQUESTS = 30;
 const DELIVERY_CALLBACK_MAX_REQUESTS = 3_000;
 const DELIVERY_CALLBACK_WINDOW_MS = 60_000;
@@ -107,6 +111,11 @@ function rejectInvalidRequestRateLimit(params: {
 // Each account route owns one durable ingress adapter.
 export function createSmsWebhookHandler(params: SmsWebhookHandlerParams) {
   let deliveryRecorder = params.delivery;
+  const preAuthInFlightLimiter = createWebhookInFlightLimiter({
+    maxInFlightPerKey: PRE_AUTH_MAX_IN_FLIGHT,
+    maxTrackedKeys: 1,
+  });
+  const preAuthInFlightKey = accountRouteRateLimitKey(params.account);
   // Status persistence gets a separate route-level safety fuse. It stays much
   // looser than inbound quotas; overflow gets a visible 5xx instead of a false ack.
   const deliveryCallbackRateLimiter = createFixedWindowRateLimiter({
@@ -124,52 +133,62 @@ export function createSmsWebhookHandler(params: SmsWebhookHandlerParams) {
     const clientAddressKey = rateLimitKey({ account: params.account, subject: clientAddress });
     const invalidRequestRateLimited = invalidRequestRateLimiter.isRateLimited(clientAddressKey);
 
+    if (!preAuthInFlightLimiter.tryAcquire(preAuthInFlightKey)) {
+      params.log?.warn?.("SMS webhook pre-authentication concurrency limit exceeded");
+      await sendHttpRequestRejection(req, res, 429, "Rate limit exceeded", TWIML_CONTENT_TYPE);
+      return true;
+    }
+
     let form: Record<string, string>;
     try {
-      form = await readTwilioWebhookForm(req);
-    } catch (error) {
-      if (isRequestBodyLimitError(error, "PAYLOAD_TOO_LARGE")) {
-        await sendHttpRequestRejection(req, res, 413, "Payload too large", TWIML_CONTENT_TYPE);
-        return true;
-      }
-      if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
-        // Twilio retries 5xx responses. Keep that outcome while the shared owner closes in order.
-        res.setHeader("cache-control", "no-store");
-        await sendHttpRequestRejection(
-          req,
-          res,
-          500,
-          "Internal Server Error",
-          "text/plain; charset=utf-8",
-        );
-        return true;
-      }
-      throw error;
-    }
-    assertSmsCredentialOwnerAvailable(params.account);
-
-    if (!params.account.dangerouslyDisableSignatureValidation) {
-      const ok = verifyTwilioSignature({
-        signature: headerValue(req.headers["x-twilio-signature"]),
-        url: resolveTwilioWebhookSignatureUrl({
-          req,
-          publicWebhookUrl: params.account.publicWebhookUrl,
-        }),
-        authToken: params.account.authToken,
-        form,
-      });
-      if (!ok) {
-        if (invalidRequestRateLimited) {
-          return rejectInvalidRequestRateLimit({ key: clientAddressKey, log: params.log, res });
+      try {
+        form = await readTwilioWebhookForm(req);
+      } catch (error) {
+        if (isRequestBodyLimitError(error, "PAYLOAD_TOO_LARGE")) {
+          await sendHttpRequestRejection(req, res, 413, "Payload too large", TWIML_CONTENT_TYPE);
+          return true;
         }
-        params.log?.warn?.("SMS webhook rejected invalid Twilio signature");
-        respondTwiml(res, 403, "Invalid signature");
-        return true;
+        if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
+          // Twilio retries 5xx responses. Keep that outcome while the shared owner closes in order.
+          res.setHeader("cache-control", "no-store");
+          await sendHttpRequestRejection(
+            req,
+            res,
+            500,
+            "Internal Server Error",
+            "text/plain; charset=utf-8",
+          );
+          return true;
+        }
+        throw error;
       }
-    }
+      assertSmsCredentialOwnerAvailable(params.account);
 
-    if (invalidRequestRateLimited && params.account.dangerouslyDisableSignatureValidation) {
-      return rejectInvalidRequestRateLimit({ key: clientAddressKey, log: params.log, res });
+      if (!params.account.dangerouslyDisableSignatureValidation) {
+        const ok = verifyTwilioSignature({
+          signature: headerValue(req.headers["x-twilio-signature"]),
+          url: resolveTwilioWebhookSignatureUrl({
+            req,
+            publicWebhookUrl: params.account.publicWebhookUrl,
+          }),
+          authToken: params.account.authToken,
+          form,
+        });
+        if (!ok) {
+          if (invalidRequestRateLimited) {
+            return rejectInvalidRequestRateLimit({ key: clientAddressKey, log: params.log, res });
+          }
+          params.log?.warn?.("SMS webhook rejected invalid Twilio signature");
+          respondTwiml(res, 403, "Invalid signature");
+          return true;
+        }
+      }
+
+      if (invalidRequestRateLimited && params.account.dangerouslyDisableSignatureValidation) {
+        return rejectInvalidRequestRateLimit({ key: clientAddressKey, log: params.log, res });
+      }
+    } finally {
+      preAuthInFlightLimiter.release(preAuthInFlightKey);
     }
 
     // Provider delivery transitions use a separate route quota from inbound messages.


### PR DESCRIPTION
> Devin Robison · GPT-5 Codex · via @drobison00

## What Problem This Solves

Incomplete SMS webhook uploads could remain in pre-authentication body parsing without a route-level concurrency bound. Enough simultaneous incomplete uploads could occupy SMS webhook handling capacity, while a bare overflow response could leave the unread connection open.

## Why This Change Was Made

The SMS account route now uses the public `createWebhookInFlightLimiter` with one account-route key and a 64-request limit. Admission occurs before the Twilio form body is read, and the slot is released in a `finally` after signature verification. Existing post-authentication sender, aggregate, delivery, and invalid-request accounting remains separate.

Overflow is rejected through `sendHttpRequestRejection`, preserving the shared HTTP rejection lifecycle: the response is HTTP 429 with `Connection: close`, the socket is half-closed after the response is written, and subsequent unread input remains bounded.

The rebase also preserves the newer shared rejection handling for oversized and timed-out SMS webhook bodies.

## User Impact

SMS webhook handling remains available when many clients hold form uploads incomplete. Up to 64 pre-authentication reads may proceed for an account route; excess requests receive a closed HTTP 429 response. Capacity returns as soon as admitted requests finish parsing and verification, and valid signed Twilio callbacks continue into the existing durable inbound path.

## Evidence

Added a real-boundary test that starts the SMS account through `startSmsGatewayAccount`, obtains the production-created route from the plugin HTTP registry, and hosts that real route handler on a Node HTTP server. It uses real HTTP and TCP clients to exercise overflow, connection closure, capacity recovery, signature verification, and durable ingress admission.

Redacted executed trace:

```text
held incomplete POSTs: 64/64 body readers active
65th incomplete POST: HTTP/1.1 429 Too Many Requests
65th response header: Connection: close
65th client event: server end observed=true
65th request complete: false
durable ingress calls before release: 0
held requests completed: 64; expected invalid-signature responses: 64 x HTTP 403
next signed POST: HTTP 200
next signed POST header: x-openclaw-delivery-accepted=durable
durable ingress calls after recovery: 1
```

This proves the production-owned SMS account route bounds incomplete pre-authentication uploads, closes overflow connections, recovers capacity, and admits a validly signed form into durable ingress. This evidence does not include a live Twilio callback.

Validation:

- `pnpm test extensions/sms/src/webhook.boundary.test.ts` — 1 test passed.
- `pnpm test extensions/sms` — 18 files and 359 tests passed.
- Path-scoped changed-file checks passed, including format, production/test typechecks, lint, public SDK boundaries, dead-export scans, and import-cycle checks.
- `git diff --check` passed.
- `pnpm build` passed.

Final commit: `52bfb7faaafadb805d5f8f4e426cab3f6aed5803`
