### PR TITLE
fix(voice-call): bind realtime streams to signed calls

### DIFF
--- a/extensions/voice-call/src/runtime.realtime-routing.test.ts
+++ b/extensions/voice-call/src/runtime.realtime-routing.test.ts
@@ -159,6 +159,7 @@ describe("voice-call realtime route ownership", () => {
       for (const route of routes) {
         const { streamUrl } = handler.issueStreamSession({
           providerName: "twilio",
+          callId: route.callSid,
           direction: "inbound",
           from: "+15550009999",
           to: route.to,

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -796,6 +796,12 @@ export class VoiceCallWebhookServer {
 
         const realtimeParams = this.getRealtimeTwimlParams(ctx);
         if (realtimeParams) {
+          // Never mint stream authority without a signature-verified call identity.
+          const callSid = realtimeParams.get("CallSid")?.trim();
+          if (!callSid) {
+            this.logger.info("Realtime Twilio call rejected before stream setup");
+            return buildRealtimeRejectedTwiML();
+          }
           const direction = realtimeParams.get("Direction");
           const isInboundRealtimeRequest = !direction || direction === "inbound";
           if (
@@ -808,7 +814,7 @@ export class VoiceCallWebhookServer {
           this.logger.info(
             `Serving realtime TwiML for Twilio call ${realtimeParams.get("CallSid") ?? "unknown"} (direction=${direction ?? "unknown"})`,
           );
-          return this.realtimeHandler!.buildTwiMLPayload(req, realtimeParams);
+          return this.realtimeHandler!.buildTwiMLPayload(req, realtimeParams, callSid);
         }
 
         const parsed = this.provider.parseWebhookEvent(ctx, {

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -143,7 +143,10 @@ function createCarrierLifecycleHarness(
 }
 
 async function connectCarrierStream(handler: RealtimeCallHandler) {
-  const { streamUrl } = handler.issueStreamSession();
+  const { streamUrl } = handler.issueStreamSession({
+    providerName: "twilio",
+    callId: "CA-startup",
+  });
   const server = await startUpgradeWsServer({
     urlPath: new URL(streamUrl).pathname,
     onUpgrade: (request, socket, head) => {
@@ -274,7 +277,7 @@ describe("RealtimeCallHandler lifecycle", () => {
       const closed = waitForClose(ws);
       const closing = handler.close(shutdownBarrier.promise);
       const concurrentClose = handler.close();
-      handler.issueStreamSession();
+      handler.issueStreamSession({ providerName: "twilio", callId: "CA-shutdown-pending" });
       let closeSettled = false;
       void closing.then(() => {
         closeSettled = true;
@@ -317,6 +320,7 @@ describe("RealtimeCallHandler lifecycle", () => {
 
     try {
       handler.issueStreamSession({
+        providerName: "twilio",
         callId: "call-never-connected",
         from: "+15550001111",
         to: "+15550002222",
@@ -344,7 +348,10 @@ describe("RealtimeCallHandler lifecycle", () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { handler } = createCarrierLifecycleHarness(() => createBridge(vi.fn()));
-    const { token } = handler.issueStreamSession({ callId: "call-connected" });
+    const { token } = handler.issueStreamSession({
+      providerName: "twilio",
+      callId: "call-connected",
+    });
 
     try {
       (
@@ -868,7 +875,10 @@ describe("RealtimeCallHandler lifecycle", () => {
     );
     const consult = vi.fn(async () => ({ text: "This should not run." }));
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const { streamUrl } = handler.issueStreamSession();
+    const { streamUrl } = handler.issueStreamSession({
+      providerName: "twilio",
+      callId: "CA-settling-consult",
+    });
     const server = await startUpgradeWsServer({
       urlPath: new URL(streamUrl).pathname,
       onUpgrade: (request, socket, head) => {
@@ -982,7 +992,10 @@ describe("RealtimeCallHandler lifecycle", () => {
         );
       });
     });
-    const { streamUrl } = handler.issueStreamSession();
+    const { streamUrl } = handler.issueStreamSession({
+      providerName: "twilio",
+      callId: "CA-consult",
+    });
     const server = await startUpgradeWsServer({
       urlPath: new URL(streamUrl).pathname,
       onUpgrade: (request, socket, head) => {

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -440,6 +440,65 @@ describe("RealtimeCallHandler path routing", () => {
     );
   });
 
+  it("binds normal TwiML stream sessions to the normalized signed CallSid", () => {
+    const handler = makeHandler();
+    const payload = handler.buildTwiMLPayload(
+      makeRequest("/voice/webhook"),
+      new URLSearchParams({ CallSid: "  CA-signed  " }),
+    );
+    const token = payload.body.match(/\/([0-9a-f-]{36})"/)?.[1];
+
+    expect(token).toBeDefined();
+    const callerMeta = (
+      handler as unknown as {
+        consumeStreamToken(token: string): { callId?: string; providerName?: string } | null;
+      }
+    ).consumeStreamToken(expectDefined(token, "stream token"));
+    expect(callerMeta).toMatchObject({ callId: "CA-signed", providerName: "twilio" });
+  });
+
+  it("rejects Twilio stream starts that do not match the signed TwiML call", async () => {
+    const processEvent = vi.fn();
+    const getCall = vi.fn();
+    const getCallByProviderCallId = vi.fn(() => makeCallRecord("CA-other"));
+    const createBridge = vi.fn(() => makeBridge());
+    const handler = makeHandler(undefined, {
+      manager: { processEvent, getCall, getCallByProviderCallId },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const payload = handler.buildTwiMLPayload(
+      makeRequest("/voice/webhook"),
+      new URLSearchParams({ CallSid: "CA-signed" }),
+    );
+    const streamUrl = payload.body.match(/url="([^"]+)"/)?.[1];
+    const server = await startStreamSessionServer(
+      handler,
+      expectDefined(streamUrl, "realtime stream URL"),
+    );
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-other", callSid: "CA-other" },
+        }),
+      );
+      const close = await waitForClose(ws);
+
+      expect(close.code).toBe(1008);
+      expect(getCall).not.toHaveBeenCalled();
+      expect(getCallByProviderCallId).not.toHaveBeenCalled();
+      expect(processEvent).not.toHaveBeenCalled();
+      expect(createBridge).not.toHaveBeenCalled();
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await server.close();
+    }
+  });
+
   it("preserves a public path prefix ahead of serve.path", () => {
     const handler = makeHandler({ streamPath: "/custom/stream/realtime" });
     handler.setPublicUrl("https://public.example:8443/api/voice/webhook");
@@ -489,6 +548,7 @@ describe("RealtimeCallHandler path routing", () => {
     const payload = handler.buildTwiMLPayload(
       makeRequest("/voice/webhook"),
       new URLSearchParams({
+        CallSid: "CA-outbound",
         Direction: "outbound-dial",
         From: "+15550001234",
         To: "+15550009999",

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -174,11 +174,16 @@ function makeHandler(
 
 const startRealtimeServer = async (
   handler: RealtimeCallHandler,
+  callId: string,
 ): Promise<{
   url: string;
   close: () => Promise<void>;
 }> => {
-  const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook"));
+  const payload = handler.buildTwiMLPayload(
+    makeRequest("/voice/webhook"),
+    new URLSearchParams({ CallSid: callId }),
+    callId,
+  );
   const match = payload.body.match(/wss:\/\/[^/]+(\/[^"]+)/);
   if (!match) {
     throw new Error("Failed to extract realtime stream path");
@@ -318,7 +323,7 @@ async function withBargeInHarness(
       id: params.handlesProviderBargeIn ? "openai" : "test",
     }),
   });
-  const server = await startRealtimeServer(handler);
+  const server = await startRealtimeServer(handler, params.providerCallId);
 
   try {
     const ws = await connectWs(server.url);
@@ -432,7 +437,11 @@ describe("RealtimeCallHandler path routing", () => {
 
   it("uses the request host and stream path in TwiML", () => {
     const handler = makeHandler();
-    const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook", "gateway.ts.net"));
+    const payload = handler.buildTwiMLPayload(
+      makeRequest("/voice/webhook", "gateway.ts.net"),
+      new URLSearchParams({ CallSid: "CA-host" }),
+      "CA-host",
+    );
 
     expect(payload.statusCode).toBe(200);
     expect(payload.body).toMatch(
@@ -445,6 +454,7 @@ describe("RealtimeCallHandler path routing", () => {
     const payload = handler.buildTwiMLPayload(
       makeRequest("/voice/webhook"),
       new URLSearchParams({ CallSid: "  CA-signed  " }),
+      "CA-signed",
     );
     const token = payload.body.match(/\/([0-9a-f-]{36})"/)?.[1];
 
@@ -469,6 +479,7 @@ describe("RealtimeCallHandler path routing", () => {
     const payload = handler.buildTwiMLPayload(
       makeRequest("/voice/webhook"),
       new URLSearchParams({ CallSid: "CA-signed" }),
+      "CA-signed",
     );
     const streamUrl = payload.body.match(/url="([^"]+)"/)?.[1];
     const server = await startStreamSessionServer(
@@ -502,7 +513,11 @@ describe("RealtimeCallHandler path routing", () => {
   it("preserves a public path prefix ahead of serve.path", () => {
     const handler = makeHandler({ streamPath: "/custom/stream/realtime" });
     handler.setPublicUrl("https://public.example:8443/api/voice/webhook");
-    const payload = handler.buildTwiMLPayload(makeRequest("/voice/webhook", "127.0.0.1:3334"));
+    const payload = handler.buildTwiMLPayload(
+      makeRequest("/voice/webhook", "127.0.0.1:3334"),
+      new URLSearchParams({ CallSid: "CA-prefix" }),
+      "CA-prefix",
+    );
 
     expect(handler.getStreamPathPattern()).toBe("/api/custom/stream/realtime");
     expect(payload.body).toMatch(
@@ -553,6 +568,7 @@ describe("RealtimeCallHandler path routing", () => {
         From: "+15550001234",
         To: "+15550009999",
       }),
+      "CA-outbound",
     );
     const match = payload.body.match(/wss:\/\/[^/]+(\/[^"]+)/);
     if (!match) {
@@ -807,7 +823,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-silent");
 
     try {
       const ws = await connectWs(server.url);
@@ -859,7 +875,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-speak");
 
     try {
       const ws = await connectWs(server.url);
@@ -947,7 +963,7 @@ describe("RealtimeCallHandler path routing", () => {
       realtimeProvider: makeRealtimeProvider(createBridge),
       streamDisconnectLifecycle,
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-complete");
 
     try {
       const ws = await connectWs(server.url);
@@ -1037,7 +1053,7 @@ describe("RealtimeCallHandler path routing", () => {
       realtimeProvider: makeRealtimeProvider(createBridge),
       streamDisconnectLifecycle,
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, providerCallId);
     const ws = await connectWs(server.url);
 
     try {
@@ -1116,7 +1132,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-talk-events");
 
     try {
       const ws = await connectWs(server.url);
@@ -1427,7 +1443,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-end-current");
     const ws = await connectWs(server.url);
 
     try {
@@ -1482,7 +1498,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-end-failed");
     const ws = await connectWs(server.url);
 
     try {
@@ -1543,7 +1559,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const predecessorServer = await startRealtimeServer(handler);
+    const predecessorServer = await startRealtimeServer(handler, "CA-end-replacement");
     const predecessorWs = await connectWs(predecessorServer.url);
     let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
     let replacementWs: WebSocket | undefined;
@@ -1557,7 +1573,7 @@ describe("RealtimeCallHandler path routing", () => {
       );
       await waitForRealtimeTest(() => expect(createBridge).toHaveBeenCalledTimes(1));
 
-      replacementServer = await startRealtimeServer(handler);
+      replacementServer = await startRealtimeServer(handler, "CA-end-replacement");
       replacementWs = await connectWs(replacementServer.url);
       replacementWs.send(
         JSON.stringify({
@@ -1693,7 +1709,7 @@ describe("RealtimeCallHandler path routing", () => {
     );
     handler.registerToolHandler("openclaw_agent_consult", consultHandler);
     handler.registerToolHandler("custom_lookup", async () => ({ ok: true }));
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-tool");
 
     try {
       const ws = await connectWs(server.url);
@@ -1885,7 +1901,7 @@ describe("RealtimeCallHandler path routing", () => {
       });
       const name = path === "general" ? "custom_lookup" : "openclaw_agent_consult";
       handler.registerToolHandler(name, hostTool);
-      const server = await startRealtimeServer(handler);
+      const server = await startRealtimeServer(handler, call.providerCallId!);
       const ws = await connectWs(server.url);
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const log = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -2003,7 +2019,7 @@ describe("RealtimeCallHandler path routing", () => {
     });
     const consult = vi.fn(async () => ({ text: "should not run" }));
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, call.providerCallId!);
 
     try {
       const ws = await connectWs(server.url);
@@ -2099,7 +2115,7 @@ describe("RealtimeCallHandler path routing", () => {
       (args: unknown, callId: string, context: Record<string, unknown>) => Promise<{ text: string }>
     >(async () => ({ text: "I created the smoke test file." }));
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-force");
 
     try {
       const ws = await connectWs(server.url);
@@ -2165,7 +2181,7 @@ describe("RealtimeCallHandler path routing", () => {
     });
     const consult = vi.fn(async () => ({ text: "fresh consult answer" }));
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-continuity-consult");
 
     try {
       const ws = await connectWs(server.url);
@@ -2267,7 +2283,7 @@ describe("RealtimeCallHandler path routing", () => {
     );
     handler.registerToolHandler("openclaw_agent_consult", consult);
     const clearAudio = vi.spyOn(RealtimeAudioPacer.prototype, "clearAudio");
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-forced-close");
 
     try {
       const ws = await connectWs(server.url);
@@ -2358,7 +2374,7 @@ describe("RealtimeCallHandler path routing", () => {
       .mockImplementationOnce(() => replacementResult.promise);
     handler.registerToolHandler("openclaw_agent_consult", consult);
     const clearAudio = vi.spyOn(RealtimeAudioPacer.prototype, "clearAudio");
-    const oldServer = await startRealtimeServer(handler);
+    const oldServer = await startRealtimeServer(handler, "CA-forced-old");
     let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
     let oldWs: WebSocket | undefined;
 
@@ -2399,7 +2415,7 @@ describe("RealtimeCallHandler path routing", () => {
       });
       expect(consult).toHaveBeenCalledTimes(1);
 
-      replacementServer = await startRealtimeServer(handler);
+      replacementServer = await startRealtimeServer(handler, "CA-forced-replacement");
       const replacementWs = await connectWs(replacementServer.url);
       try {
         replacementWs.send(
@@ -2504,7 +2520,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const oldServer = await startRealtimeServer(handler);
+    const oldServer = await startRealtimeServer(handler, sharedCallSid);
     let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
     let oldWs: WebSocket | undefined;
 
@@ -2521,7 +2537,7 @@ describe("RealtimeCallHandler path routing", () => {
       });
       callbacks[0]?.onTranscript?.("user", "Old ", false);
 
-      replacementServer = await startRealtimeServer(handler);
+      replacementServer = await startRealtimeServer(handler, sharedCallSid);
       const replacementWs = await connectWs(replacementServer.url);
       const replacementOutboundMessages: Array<Record<string, unknown>> = [];
       replacementWs.on("message", (data) => {
@@ -2656,7 +2672,7 @@ describe("RealtimeCallHandler path routing", () => {
         },
         realtimeProvider: makeRealtimeProvider(createBridge),
       });
-      const oldServer = await startRealtimeServer(handler);
+      const oldServer = await startRealtimeServer(handler, sharedCallSid);
       let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
       let oldWs: WebSocket | undefined;
 
@@ -2673,7 +2689,7 @@ describe("RealtimeCallHandler path routing", () => {
         });
         callbacks[0]?.onTranscript?.("user", "Old ", false);
 
-        replacementServer = await startRealtimeServer(handler);
+        replacementServer = await startRealtimeServer(handler, sharedCallSid);
         const replacementWs = await connectWs(replacementServer.url);
         try {
           const replacementClosed = waitForClose(replacementWs);
@@ -2743,7 +2759,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-transcript-initial-failure");
     const ws = await connectWs(server.url);
 
     try {
@@ -2790,7 +2806,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-transcript-synchronous-close");
     const ws = await connectWs(server.url);
 
     try {
@@ -2852,7 +2868,7 @@ describe("RealtimeCallHandler path routing", () => {
       .mockImplementationOnce(() => oldResult.promise)
       .mockImplementationOnce(() => replacementResult.promise);
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const oldServer = await startRealtimeServer(handler);
+    const oldServer = await startRealtimeServer(handler, "CA-native-old");
     let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
     let oldWs: WebSocket | undefined;
 
@@ -2878,7 +2894,7 @@ describe("RealtimeCallHandler path routing", () => {
         expect(oldSubmitToolResult).toHaveBeenCalledTimes(1);
       });
 
-      replacementServer = await startRealtimeServer(handler);
+      replacementServer = await startRealtimeServer(handler, "CA-native-replacement");
       const replacementWs = await connectWs(replacementServer.url);
       try {
         replacementWs.send(
@@ -2969,7 +2985,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-direct-turns");
 
     try {
       const ws = await connectWs(server.url);
@@ -3063,7 +3079,7 @@ describe("RealtimeCallHandler path routing", () => {
       (args: unknown, callId: string, context: Record<string, unknown>) => Promise<{ text: string }>
     >(async () => ({ text: "I sent it." }));
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-settle");
 
     try {
       const ws = await connectWs(server.url);
@@ -3168,7 +3184,7 @@ describe("RealtimeCallHandler path routing", () => {
     );
     const consult = vi.fn(async () => ({ text: "Native consult result." }));
     handler.registerToolHandler("openclaw_agent_consult", consult);
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-native");
 
     try {
       const ws = await connectWs(server.url);
@@ -3261,7 +3277,7 @@ describe("RealtimeCallHandler path routing", () => {
       },
     );
     handler.registerToolHandler("openclaw_agent_consult", async () => ({ text: "Fast context." }));
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-fast");
 
     try {
       const ws = await connectWs(server.url);
@@ -3331,7 +3347,7 @@ describe("RealtimeCallHandler websocket hardening", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-backpressure");
 
     try {
       const ws = await connectWs(server.url);
@@ -3377,7 +3393,7 @@ describe("RealtimeCallHandler websocket hardening", () => {
       },
       realtimeProvider: makeRealtimeProvider(createBridge),
     });
-    const server = await startRealtimeServer(handler);
+    const server = await startRealtimeServer(handler, "CA-oversized");
 
     try {
       const ws = await connectWs(server.url);

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -238,22 +238,15 @@ function buildForcedConsultSpeechPrompt(result: string): string {
   ].join("\n");
 }
 
-type PendingStreamToken = {
-  expiry: number;
+type StreamSessionMetadata = {
+  providerName: "twilio" | "telnyx";
+  callId: string;
   from?: string;
   to?: string;
   direction?: "inbound" | "outbound";
-  providerName?: "twilio" | "telnyx";
-  callId?: string;
 };
 
-type StreamSessionRequest = {
-  providerName?: "twilio" | "telnyx";
-  callId?: string;
-  from?: string;
-  to?: string;
-  direction?: "inbound" | "outbound";
-};
+type PendingStreamToken = StreamSessionMetadata & { expiry: number };
 
 export type StreamSession = {
   token: string;
@@ -405,8 +398,12 @@ export class RealtimeCallHandler {
     return `${this.publicPathPrefix}${normalizeWebhookPath(this.config.streamPath ?? "/voice/stream/realtime")}`;
   }
 
-  buildTwiMLPayload(req: http.IncomingMessage, params?: URLSearchParams): WebhookResponsePayload {
-    const rawDirection = params?.get("Direction");
+  buildTwiMLPayload(
+    req: http.IncomingMessage,
+    params: URLSearchParams,
+    callId: string,
+  ): WebhookResponsePayload {
+    const rawDirection = params.get("Direction");
     const previousOrigin = this.publicOrigin;
     if (!previousOrigin) {
       this.publicOrigin = req.headers.host ?? DEFAULT_HOST;
@@ -414,8 +411,9 @@ export class RealtimeCallHandler {
     try {
       const { streamUrl } = this.issueStreamSession({
         providerName: "twilio",
-        from: params?.get("From") ?? undefined,
-        to: params?.get("To") ?? undefined,
+        callId,
+        from: params.get("From") ?? undefined,
+        to: params.get("To") ?? undefined,
         direction: rawDirection?.startsWith("outbound") ? "outbound" : "inbound",
       });
       const twiml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -450,7 +448,7 @@ export class RealtimeCallHandler {
       return;
     }
 
-    const providerName = callerMeta.providerName ?? "twilio";
+    const providerName = callerMeta.providerName;
     const adapter: StreamFrameAdapter =
       providerName === "telnyx" ? new TelnyxStreamFrameAdapter() : new TwilioStreamFrameAdapter();
 
@@ -476,6 +474,10 @@ export class RealtimeCallHandler {
           }
           if (frame.kind === "start") {
             if (initialized) {
+              return;
+            }
+            if (providerName === "twilio" && frame.providerCallId !== callerMeta.callId) {
+              ws.close(1008, "Call identity does not match stream session");
               return;
             }
             initialized = true;
@@ -607,9 +609,9 @@ export class RealtimeCallHandler {
     }
   }
 
-  issueStreamSession(request: StreamSessionRequest = {}): StreamSession {
+  issueStreamSession(request: StreamSessionMetadata): StreamSession {
     const token = this.issueStreamToken({
-      providerName: request.providerName ?? "twilio",
+      providerName: request.providerName,
       callId: request.callId,
       from: request.from,
       to: request.to,
@@ -620,7 +622,7 @@ export class RealtimeCallHandler {
     return { token, streamUrl };
   }
 
-  private issueStreamToken(meta: Omit<PendingStreamToken, "expiry"> = {}): string {
+  private issueStreamToken(meta: StreamSessionMetadata): string {
     const token = randomUUID();
     const now = Date.now();
     const expiry = resolveExpiresAtMsFromDurationMs(STREAM_TOKEN_TTL_MS, { nowMs: now });
@@ -650,7 +652,7 @@ export class RealtimeCallHandler {
     return token;
   }
 
-  private consumeStreamToken(token: string): Omit<PendingStreamToken, "expiry"> | null {
+  private consumeStreamToken(token: string): StreamSessionMetadata | null {
     const entry = this.pendingStreamTokens.get(token);
     if (!entry) {
       return null;
@@ -659,20 +661,15 @@ export class RealtimeCallHandler {
     if (!isFutureDateTimestampMs(entry.expiry)) {
       return null;
     }
-    return {
-      from: entry.from,
-      to: entry.to,
-      direction: entry.direction,
-      providerName: entry.providerName,
-      callId: entry.callId,
-    };
+    const { expiry: _expiry, ...metadata } = entry;
+    return metadata;
   }
 
   private handleCall(
     streamSid: string,
     callSid: string,
     ws: WebSocket,
-    callerMeta: Omit<PendingStreamToken, "expiry">,
+    callerMeta: StreamSessionMetadata,
     adapter: StreamFrameAdapter,
   ): RealtimeTelephonyBinding | null {
     const preparedCall = this.prepareCallInManager(callSid, callerMeta);
@@ -1701,10 +1698,7 @@ export class RealtimeCallHandler {
     }
   }
 
-  private prepareCallInManager(
-    callSid: string,
-    callerMeta: Omit<PendingStreamToken, "expiry"> = {},
-  ) {
+  private prepareCallInManager(callSid: string, callerMeta: StreamSessionMetadata) {
     const timestamp = Date.now();
     const baseFields = {
       providerCallId: callSid,
@@ -1728,7 +1722,7 @@ export class RealtimeCallHandler {
 
   private resolveRealtimeCall(
     callSid: string,
-    callerMeta: Omit<PendingStreamToken, "expiry">,
+    callerMeta: StreamSessionMetadata,
     baseFields: {
       providerCallId: string;
       timestamp: number;
@@ -1737,7 +1731,7 @@ export class RealtimeCallHandler {
       to?: string;
     },
   ): CallRecord | null {
-    if (callerMeta.callId) {
+    if (callerMeta.providerName === "telnyx" && callerMeta.callId) {
       const call = this.manager.getCall(callerMeta.callId);
       return call?.providerCallId === callSid ? call : null;
     }

--- a/extensions/voice-call/src/webhook/signed-call-boundary.test.ts
+++ b/extensions/voice-call/src/webhook/signed-call-boundary.test.ts
@@ -1,0 +1,369 @@
+// This boundary proof uses the real CallManager, TwilioProvider, VoiceCallWebhookServer,
+// RealtimeCallHandler, HTTP server, and WebSocket upgrade path. Its only behavioral test
+// doubles are the external RealtimeVoiceProviderPlugin and its RealtimeVoiceBridge; manager
+// spies are call-through observers, and persistence uses the production SQLite state store.
+import crypto from "node:crypto";
+import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-store-runtime";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type {
+  RealtimeVoiceBridge,
+  RealtimeVoiceProviderPlugin,
+} from "openclaw/plugin-sdk/realtime-voice";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import { VoiceCallConfigSchema } from "../config.js";
+import { CallManager } from "../manager.js";
+import { TwilioProvider } from "../providers/twilio.js";
+import { setVoiceCallStateRuntime, type VoiceCallStateRuntime } from "../runtime-state.js";
+import { VoiceCallWebhookServer } from "../webhook.js";
+import { connectWs, waitForClose } from "../websocket-test-support.js";
+import { RealtimeCallHandler } from "./realtime-handler.js";
+
+const MATCHING_CALL_SID = "CA-signed-boundary";
+const MISMATCHED_CALL_SID = "CA-other-boundary";
+const REDACTED_CALL_SID = "CA…redacted";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function installProductionStateStore(): void {
+  const state = {
+    resolveStateDir,
+    openSyncKeyedStore: <T>(
+      options: Parameters<VoiceCallStateRuntime["state"]["openSyncKeyedStore"]>[0],
+    ) => createPluginStateSyncKeyedStore<T>("voice-call", options),
+  } as VoiceCallStateRuntime["state"];
+  setVoiceCallStateRuntime({ state });
+}
+
+function requireBoundRequestUrl(server: VoiceCallWebhookServer, baseUrl: string): URL {
+  const address = (
+    server as unknown as { server?: { address?: () => unknown } }
+  ).server?.address?.();
+  if (
+    !address ||
+    typeof address !== "object" ||
+    !("port" in address) ||
+    typeof address.port !== "number" ||
+    !address.port
+  ) {
+    throw new Error("voice webhook server did not expose a bound port");
+  }
+  const requestUrl = new URL(baseUrl);
+  requestUrl.port = String(address.port);
+  return requestUrl;
+}
+
+async function postSignedTwilioWebhook(params: {
+  server: VoiceCallWebhookServer;
+  baseUrl: string;
+  authToken: string;
+  callSid?: string;
+  attempt: "missing" | "blank" | "matching" | "mismatched";
+}): Promise<{ response: Response; responseBody: string; streamUrl?: string }> {
+  const url = requireBoundRequestUrl(params.server, params.baseUrl);
+  const bodyParams = new URLSearchParams({
+    Direction: "inbound",
+    CallStatus: "ringing",
+    BoundaryAttempt: params.attempt,
+  });
+  if (params.callSid !== undefined) {
+    bodyParams.set("CallSid", params.callSid);
+  }
+  const body = bodyParams.toString();
+  let signedMaterial = url.toString();
+  for (const [key, value] of [...new URLSearchParams(body)].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    signedMaterial += key + value;
+  }
+  const signature = crypto
+    .createHmac("sha1", params.authToken)
+    .update(signedMaterial)
+    .digest("base64");
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-twilio-signature": signature,
+    },
+    body,
+  });
+  const responseBody = await response.text();
+  const streamUrl = responseBody.match(/url="([^"]+)"/)?.[1];
+  const outcome = streamUrl
+    ? "one-time stream URL returned=<one-time-token>"
+    : "rejected before stream issuance; pending sessions=0";
+  console.info(
+    `[boundary-proof] signed webhook POST CallSid=${params.callSid?.trim() ? REDACTED_CALL_SID : `<${params.attempt}>`} -> status=${response.status}; ${outcome}`,
+  );
+  return { response, responseBody, streamUrl };
+}
+
+function createExternalRealtimeProviderDouble() {
+  const bridgeEntries: Array<() => void> = [];
+  const bridge: RealtimeVoiceBridge = {
+    connect: async () => {},
+    sendAudio: () => {},
+    setMediaTimestamp: () => {},
+    submitToolResult: () => {},
+    acknowledgeMark: () => {},
+    close: () => {},
+    isConnected: () => true,
+    triggerGreeting: () => {},
+  };
+  const createBridge = vi.fn<RealtimeVoiceProviderPlugin["createBridge"]>(() => {
+    bridgeEntries.shift()?.();
+    return bridge;
+  });
+  const provider: RealtimeVoiceProviderPlugin = {
+    id: "openai",
+    label: "OpenAI",
+    isConfigured: () => true,
+    createBridge,
+  };
+  return {
+    createBridge,
+    provider,
+    waitForBridgeEntry: () =>
+      new Promise<void>((resolve) => {
+        bridgeEntries.push(resolve);
+      }),
+  };
+}
+
+async function connectSignedStream(streamUrl: string): Promise<WebSocket> {
+  const ws = await connectWs(streamUrl.replace(/^wss:/, "ws:"));
+  console.info(
+    "[boundary-proof] WebSocket upgrade accepted; one-time stream token=<one-time-token>",
+  );
+  return ws;
+}
+
+async function createSignedBoundaryHarness() {
+  installProductionStateStore();
+  const storePath = tempDirs.make("openclaw-signed-call-boundary-");
+  const authToken = "signed-realtime-boundary-token";
+  const twilioProvider = new TwilioProvider({ accountSid: "AC123", authToken });
+  const config = VoiceCallConfigSchema.parse({
+    provider: "twilio",
+    inboundPolicy: "open",
+    twilio: { accountSid: "AC123", authToken },
+    serve: { port: 1 },
+    realtime: {
+      enabled: true,
+      streamPath: "/voice/stream/realtime",
+      instructions: "Be helpful.",
+      toolPolicy: "safe-read-only",
+      tools: [],
+      providers: {},
+    },
+  });
+  config.serve.port = 0;
+  const manager = new CallManager(config, storePath);
+  const processEvent = vi.spyOn(manager, "processEvent");
+  const lookupCall = vi.spyOn(manager, "getCallByProviderCallId");
+  const {
+    createBridge,
+    provider: realtimeProvider,
+    waitForBridgeEntry,
+  } = createExternalRealtimeProviderDouble();
+  const server = new VoiceCallWebhookServer(
+    config,
+    manager,
+    twilioProvider,
+    undefined,
+    undefined,
+    undefined,
+    {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  );
+  const realtimeHandler = new RealtimeCallHandler(
+    config.realtime,
+    manager,
+    (call) => ({
+      agentId: call.agentId ?? "main",
+      instructions: "Be helpful.",
+      provider: realtimeProvider,
+      providerConfig: { apiKey: "test-key" },
+    }),
+    config.serve.path,
+    server.getStreamDisconnectLifecycle(),
+  );
+  server.setRealtimeHandler(realtimeHandler);
+  const sockets = new Set<WebSocket>();
+  const baseUrl = await server.start();
+  twilioProvider.setPublicUrl(requireBoundRequestUrl(server, baseUrl).toString());
+
+  return {
+    authToken,
+    baseUrl,
+    createBridge,
+    lookupCall,
+    processEvent,
+    realtimeHandler,
+    server,
+    sockets,
+    waitForBridgeEntry,
+    close: async () => {
+      for (const socket of sockets) {
+        socket.terminate();
+      }
+      await server.stop();
+      for (const call of manager.getActiveCalls()) {
+        manager.processEvent({
+          id: `boundary-cleanup-${call.callId}`,
+          type: "call.ended",
+          callId: call.callId,
+          providerCallId: call.providerCallId,
+          timestamp: Date.now(),
+          reason: "completed",
+        });
+      }
+      closeOpenClawStateDatabaseForTest();
+    },
+  };
+}
+
+function pendingStreamSessionCount(handler: RealtimeCallHandler): number {
+  return (handler as unknown as { pendingStreamTokens: ReadonlyMap<string, unknown> })
+    .pendingStreamTokens.size;
+}
+
+it.each([
+  ["missing", undefined],
+  ["blank", "   "],
+] as const)(
+  "rejects a signed Twilio webhook with a %s CallSid before stream issuance",
+  async (attempt, callSid) => {
+    const harness = await createSignedBoundaryHarness();
+
+    try {
+      const result = await postSignedTwilioWebhook({
+        server: harness.server,
+        baseUrl: harness.baseUrl,
+        authToken: harness.authToken,
+        callSid,
+        attempt,
+      });
+
+      expect(result.response.status).toBe(200);
+      expect(result.responseBody).toContain('<Reject reason="rejected" />');
+      expect(result.responseBody).not.toContain("<Stream");
+      expect(result.streamUrl).toBeUndefined();
+      expect(pendingStreamSessionCount(harness.realtimeHandler)).toBe(0);
+      expect(harness.lookupCall).not.toHaveBeenCalled();
+      expect(harness.processEvent).not.toHaveBeenCalled();
+      expect(harness.createBridge).not.toHaveBeenCalled();
+    } finally {
+      await harness.close();
+    }
+  },
+);
+
+it("binds signed Twilio calls before entering realtime lookup and bridge setup", async () => {
+  const harness = await createSignedBoundaryHarness();
+  const {
+    authToken,
+    baseUrl,
+    createBridge,
+    lookupCall,
+    processEvent,
+    server,
+    sockets,
+    waitForBridgeEntry,
+  } = harness;
+
+  try {
+    const matching = await postSignedTwilioWebhook({
+      server,
+      baseUrl,
+      authToken,
+      callSid: MATCHING_CALL_SID,
+      attempt: "matching",
+    });
+    expect(matching.response.status).toBe(200);
+    if (!matching.streamUrl) {
+      throw new Error("matching signed Twilio webhook did not return a realtime stream URL");
+    }
+    const matchingWs = await connectSignedStream(matching.streamUrl);
+    sockets.add(matchingWs);
+    const matchingClose = waitForClose(matchingWs);
+    const matchingBridgeEntry = waitForBridgeEntry();
+    matchingWs.send(
+      JSON.stringify({
+        event: "start",
+        start: { streamSid: "MZ-matching-boundary", callSid: MATCHING_CALL_SID },
+      }),
+    );
+    const prematureClose = await Promise.race([
+      matchingBridgeEntry.then(() => null),
+      matchingClose,
+    ]);
+    if (prematureClose) {
+      throw new Error(
+        `matching signed CallSid closed before bridge entry: code=${prematureClose.code} reason="${prematureClose.reason}"`,
+      );
+    }
+    expect(processEvent).toHaveBeenCalledTimes(2);
+    expect(lookupCall).toHaveBeenCalledOnce();
+    console.info(
+      `[boundary-proof] start frame sent CallSid=${REDACTED_CALL_SID} -> entry reached; lookup=${lookupCall.mock.calls.length} event=${processEvent.mock.calls.length} bridge=${createBridge.mock.calls.length}`,
+    );
+
+    matchingWs.close();
+    await matchingClose;
+    sockets.delete(matchingWs);
+    processEvent.mockClear();
+    lookupCall.mockClear();
+    createBridge.mockClear();
+
+    console.info("[boundary-proof] new session");
+    const mismatched = await postSignedTwilioWebhook({
+      server,
+      baseUrl,
+      authToken,
+      callSid: MATCHING_CALL_SID,
+      attempt: "mismatched",
+    });
+    expect(mismatched.response.status).toBe(200);
+    if (!mismatched.streamUrl) {
+      throw new Error("mismatched signed Twilio webhook did not return a realtime stream URL");
+    }
+    const mismatchedWs = await connectSignedStream(mismatched.streamUrl);
+    sockets.add(mismatchedWs);
+    const mismatchedClose = waitForClose(mismatchedWs);
+    const mismatchedBridgeEntry = waitForBridgeEntry();
+    mismatchedWs.send(
+      JSON.stringify({
+        event: "start",
+        start: { streamSid: "MZ-mismatched-boundary", callSid: MISMATCHED_CALL_SID },
+      }),
+    );
+    const mismatchOutcome = await Promise.race([
+      mismatchedClose.then((close) => ({ kind: "close", close }) as const),
+      mismatchedBridgeEntry.then(() => ({ kind: "bridge" }) as const),
+    ]);
+    if (mismatchOutcome.kind === "bridge") {
+      throw new Error("mismatched signed CallSid reached bridge entry instead of closing");
+    }
+    const { close } = mismatchOutcome;
+    sockets.delete(mismatchedWs);
+
+    expect(close).toEqual({
+      code: 1008,
+      reason: "Call identity does not match stream session",
+    });
+    expect(lookupCall).not.toHaveBeenCalled();
+    expect(processEvent).not.toHaveBeenCalled();
+    expect(createBridge).not.toHaveBeenCalled();
+    console.info(
+      `[boundary-proof] start frame sent CallSid=${REDACTED_CALL_SID} -> close code=${close.code} reason="${close.reason}"; lookup=${lookupCall.mock.calls.length} event=${processEvent.mock.calls.length} bridge=${createBridge.mock.calls.length}`,
+    );
+  } finally {
+    await harness.close();
+  }
+});

--- a/extensions/voice-call/src/webhook/signed-call-boundary.test.ts
+++ b/extensions/voice-call/src/webhook/signed-call-boundary.test.ts
@@ -21,8 +21,13 @@ import { VoiceCallWebhookServer } from "../webhook.js";
 import { connectWs, waitForClose } from "../websocket-test-support.js";
 import { RealtimeCallHandler } from "./realtime-handler.js";
 
-const MATCHING_CALL_SID = "CA-signed-boundary";
-const MISMATCHED_CALL_SID = "CA-other-boundary";
+const MATCHING_CALL_SID = "CA22222222222222222222222222222222";
+const MISMATCHED_CALL_SID = "CA33333333333333333333333333333333";
+const MISMATCH_SESSION_CALL_SID = "CA77777777777777777777777777777777";
+const ACCOUNT_SID = "AC11111111111111111111111111111111";
+const MATCHING_STREAM_SID = "MZ44444444444444444444444444444444";
+const MISMATCHED_STREAM_SID = "MZ55555555555555555555555555555555";
+const MULAW_SILENCE = Buffer.alloc(160, 0xff).toString("base64");
 const REDACTED_CALL_SID = "CA…redacted";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -62,10 +67,26 @@ async function postSignedTwilioWebhook(params: {
   attempt: "missing" | "blank" | "matching" | "mismatched";
 }): Promise<{ response: Response; responseBody: string; streamUrl?: string }> {
   const url = requireBoundRequestUrl(params.server, params.baseUrl);
+  // Fixtures follow Twilio's documented voice POST and Media Streams frames:
+  // https://www.twilio.com/docs/voice/twiml#twilios-request-to-your-application and https://www.twilio.com/docs/voice/media-streams/websocket-messages
   const bodyParams = new URLSearchParams({
-    Direction: "inbound",
+    AccountSid: ACCOUNT_SID,
+    From: "+14155550100",
+    To: "+14155550101",
     CallStatus: "ringing",
-    BoundaryAttempt: params.attempt,
+    ApiVersion: "2010-04-01",
+    Direction: "inbound",
+    ForwardedFrom: "+14155550102",
+    CallerName: "Carrier Boundary",
+    ParentCallSid: "CA66666666666666666666666666666666",
+    FromCity: "SAN FRANCISCO",
+    FromState: "CA",
+    FromZip: "94105",
+    FromCountry: "US",
+    ToCity: "OAKLAND",
+    ToState: "CA",
+    ToZip: "94612",
+    ToCountry: "US",
   });
   if (params.callSid !== undefined) {
     bodyParams.set("CallSid", params.callSid);
@@ -73,7 +94,7 @@ async function postSignedTwilioWebhook(params: {
   const body = bodyParams.toString();
   let signedMaterial = url.toString();
   for (const [key, value] of [...new URLSearchParams(body)].toSorted(([left], [right]) =>
-    left.localeCompare(right),
+    left < right ? -1 : left > right ? 1 : 0,
   )) {
     signedMaterial += key + value;
   }
@@ -102,9 +123,10 @@ async function postSignedTwilioWebhook(params: {
 
 function createExternalRealtimeProviderDouble() {
   const bridgeEntries: Array<() => void> = [];
+  const sendAudio = vi.fn();
   const bridge: RealtimeVoiceBridge = {
     connect: async () => {},
-    sendAudio: () => {},
+    sendAudio,
     setMediaTimestamp: () => {},
     submitToolResult: () => {},
     acknowledgeMark: () => {},
@@ -125,11 +147,57 @@ function createExternalRealtimeProviderDouble() {
   return {
     createBridge,
     provider,
+    sendAudio,
     waitForBridgeEntry: () =>
       new Promise<void>((resolve) => {
         bridgeEntries.push(resolve);
       }),
   };
+}
+
+function documentedTwilioStart(callSid: string, streamSid: string) {
+  return {
+    event: "start",
+    sequenceNumber: "1",
+    start: {
+      accountSid: ACCOUNT_SID,
+      streamSid,
+      callSid,
+      tracks: ["inbound"],
+      customParameters: { proof: "signed-call-boundary" },
+      mediaFormat: { encoding: "audio/x-mulaw", sampleRate: 8000, channels: 1 },
+    },
+    streamSid,
+  };
+}
+
+function sendDocumentedTwilioMedia(ws: WebSocket, streamSid: string): void {
+  for (let index = 0; index < 3; index += 1) {
+    ws.send(
+      JSON.stringify({
+        event: "media",
+        sequenceNumber: String(index + 2),
+        media: {
+          track: "inbound",
+          chunk: String(index + 1),
+          timestamp: String(index * 20),
+          payload: MULAW_SILENCE,
+        },
+        streamSid,
+      }),
+    );
+  }
+}
+
+function sendDocumentedTwilioStop(ws: WebSocket, callSid: string, streamSid: string): void {
+  ws.send(
+    JSON.stringify({
+      event: "stop",
+      sequenceNumber: "5",
+      stop: { accountSid: ACCOUNT_SID, callSid },
+      streamSid,
+    }),
+  );
 }
 
 async function connectSignedStream(streamUrl: string): Promise<WebSocket> {
@@ -144,11 +212,11 @@ async function createSignedBoundaryHarness() {
   installProductionStateStore();
   const storePath = tempDirs.make("openclaw-signed-call-boundary-");
   const authToken = "signed-realtime-boundary-token";
-  const twilioProvider = new TwilioProvider({ accountSid: "AC123", authToken });
+  const twilioProvider = new TwilioProvider({ accountSid: ACCOUNT_SID, authToken });
   const config = VoiceCallConfigSchema.parse({
     provider: "twilio",
     inboundPolicy: "open",
-    twilio: { accountSid: "AC123", authToken },
+    twilio: { accountSid: ACCOUNT_SID, authToken },
     serve: { port: 1 },
     realtime: {
       enabled: true,
@@ -166,6 +234,7 @@ async function createSignedBoundaryHarness() {
   const {
     createBridge,
     provider: realtimeProvider,
+    sendAudio,
     waitForBridgeEntry,
   } = createExternalRealtimeProviderDouble();
   const server = new VoiceCallWebhookServer(
@@ -204,6 +273,7 @@ async function createSignedBoundaryHarness() {
     createBridge,
     lookupCall,
     processEvent,
+    sendAudio,
     realtimeHandler,
     server,
     sockets,
@@ -272,6 +342,7 @@ it("binds signed Twilio calls before entering realtime lookup and bridge setup",
     createBridge,
     lookupCall,
     processEvent,
+    sendAudio,
     server,
     sockets,
     waitForBridgeEntry,
@@ -293,12 +364,8 @@ it("binds signed Twilio calls before entering realtime lookup and bridge setup",
     sockets.add(matchingWs);
     const matchingClose = waitForClose(matchingWs);
     const matchingBridgeEntry = waitForBridgeEntry();
-    matchingWs.send(
-      JSON.stringify({
-        event: "start",
-        start: { streamSid: "MZ-matching-boundary", callSid: MATCHING_CALL_SID },
-      }),
-    );
+    matchingWs.send(JSON.stringify({ event: "connected", protocol: "Call", version: "1.0.0" }));
+    matchingWs.send(JSON.stringify(documentedTwilioStart(MATCHING_CALL_SID, MATCHING_STREAM_SID)));
     const prematureClose = await Promise.race([
       matchingBridgeEntry.then(() => null),
       matchingClose,
@@ -310,6 +377,9 @@ it("binds signed Twilio calls before entering realtime lookup and bridge setup",
     }
     expect(processEvent).toHaveBeenCalledTimes(2);
     expect(lookupCall).toHaveBeenCalledOnce();
+    sendDocumentedTwilioMedia(matchingWs, MATCHING_STREAM_SID);
+    await vi.waitFor(() => expect(sendAudio).toHaveBeenCalledTimes(3));
+    sendDocumentedTwilioStop(matchingWs, MATCHING_CALL_SID, MATCHING_STREAM_SID);
     console.info(
       `[boundary-proof] start frame sent CallSid=${REDACTED_CALL_SID} -> entry reached; lookup=${lookupCall.mock.calls.length} event=${processEvent.mock.calls.length} bridge=${createBridge.mock.calls.length}`,
     );
@@ -326,7 +396,7 @@ it("binds signed Twilio calls before entering realtime lookup and bridge setup",
       server,
       baseUrl,
       authToken,
-      callSid: MATCHING_CALL_SID,
+      callSid: MISMATCH_SESSION_CALL_SID,
       attempt: "mismatched",
     });
     expect(mismatched.response.status).toBe(200);
@@ -337,11 +407,9 @@ it("binds signed Twilio calls before entering realtime lookup and bridge setup",
     sockets.add(mismatchedWs);
     const mismatchedClose = waitForClose(mismatchedWs);
     const mismatchedBridgeEntry = waitForBridgeEntry();
+    mismatchedWs.send(JSON.stringify({ event: "connected", protocol: "Call", version: "1.0.0" }));
     mismatchedWs.send(
-      JSON.stringify({
-        event: "start",
-        start: { streamSid: "MZ-mismatched-boundary", callSid: MISMATCHED_CALL_SID },
-      }),
+      JSON.stringify(documentedTwilioStart(MISMATCHED_CALL_SID, MISMATCHED_STREAM_SID)),
     );
     const mismatchOutcome = await Promise.race([
       mismatchedClose.then((close) => ({ kind: "close", close }) as const),


### PR DESCRIPTION
> Devin Robison · GPT-5 Codex · via @drobison00

## What Problem This Solves

Twilio realtime stream startup could associate a WebSocket with a call identity different from the signature-verified webhook request that generated its TwiML. A signed webhook with an absent or whitespace-only `CallSid` could also mint an unbound one-time stream URL.

## Why This Change Was Made

The TwiML path now trims and requires the signature-verified `CallSid` before any `<Stream>` response or one-time stream session is issued. A missing or blank signed `CallSid` receives the existing non-disclosing rejection response. Valid Twilio stream metadata always carries the bound call identity, so the WebSocket start-frame comparison is unconditional. Telnyx retains its existing internal-call binding flow.

## User Impact

Realtime Twilio audio can attach only to the call that received the corresponding signed TwiML response. Missing or blank call identities are rejected before stream issuance. A mismatched start frame is closed with policy code `1008` and reason `Call identity does not match stream session`, before call lookup, event processing, or external realtime bridge creation.

## Evidence

### Carrier simulator run against the built product

Production files are identical between `b05ba58e` (exercised below) and the current head `fcecc645`; the later commit is test-only.

The built product was run with the bundled Twilio voice-call path and bundled OpenAI realtime provider. A local fake OpenAI Realtime endpoint acknowledged `session.update`, counted input audio, and emitted one audio delta.

```text
22:42:06.661 signed full webhook -> HTTP 200 + <Connect><Stream>
22:42:06.668 connected + full start, signed CallSid=CA…redacted
22:42:06.726 product log: Realtime bridge starting (providerCallId=CA…redacted)
22:42:06.737 product talk event: session.ready
22:42:07.674 allowed path: realtime connections +1, input frames +50,
             server frames media ×6 + mark ×1
22:42:07.730 mismatch: close 1008 "Call identity does not match stream session",
             realtime connections +0
22:42:07.735 blank CallSid: HTTP 200 rejection TwiML, no Stream
22:42:07.738 invalid signature: HTTP 401 rejection
```

The invalid-signature status is the product's existing HTTP 401 contract; this change does not alter it.

Start frame that reached bridge setup:

```json
{"event":"start","sequenceNumber":"1","start":{"accountSid":"AC…redacted","streamSid":"MZ…redacted","callSid":"CA…redacted","tracks":["inbound"],"customParameters":{"proof":"carrier-sim-989"},"mediaFormat":{"encoding":"audio/x-mulaw","sampleRate":8000,"channels":1}},"streamSid":"MZ…redacted"}
```

Contract sources:

- https://www.twilio.com/docs/voice/twiml#twilios-request-to-your-application
- https://www.twilio.com/docs/usage/webhooks/webhooks-security
- https://www.twilio.com/docs/voice/media-streams/websocket-messages
- https://www.twilio.com/docs/voice/twiml/stream

This evidence does not include a session originated by Twilio's servers; the carrier side is a simulator that follows Twilio's documented webhook parameters, signature scheme, and Media Streams message formats, and signs requests with Twilio's official SDK.

### Committed boundary regression

The boundary test drives the documented Twilio message sequence (`connected` → full `start` → `media` → `stop`, with the full webhook parameter set) through the real `CallManager`, `TwilioProvider`, `VoiceCallWebhookServer`, `RealtimeCallHandler`, listening HTTP server, WebSocket upgrade, and production SQLite state store. The trace below is from the executed focused test; call identities, signing material, and one-time URLs are redacted.

```text
[missing]
[boundary-proof] signed webhook POST CallSid=<missing> -> status=200; rejected before stream issuance; pending sessions=0

[blank]
[boundary-proof] signed webhook POST CallSid=<blank> -> status=200; rejected before stream issuance; pending sessions=0

[matching]
[boundary-proof] signed webhook POST CallSid=<redacted-call-sid> -> status=200; one-time stream URL returned=<redacted-url>
[boundary-proof] WebSocket upgrade accepted; one-time stream token=<redacted-token>
[boundary-proof] start frame sent CallSid=<redacted-call-sid> -> entry reached; lookup=1 event=2 bridge=1

[mismatched]
[boundary-proof] signed webhook POST CallSid=<redacted-call-sid> -> status=200; one-time stream URL returned=<redacted-url>
[boundary-proof] WebSocket upgrade accepted; one-time stream token=<redacted-token>
[boundary-proof] start frame sent CallSid=<redacted-call-sid> -> close code=1008 reason="Call identity does not match stream session"; lookup=0 event=0 bridge=0

Test Files  1 passed (1)
Tests       3 passed (3)

[production hunks reverse-applied]
FAIL blank CallSid: signed request returned <Stream> instead of <Reject>
FAIL mismatch boundary: mismatched signed CallSid reached bridge entry instead of closing
[production hunks restored]
PASS missing + blank + matching + mismatch boundary coverage (3/3)
```

The remaining behavioral test doubles are the external `RealtimeVoiceProviderPlugin` and its `RealtimeVoiceBridge`; manager spies are call-through observers.

### Validation

```text
pnpm build                                                        PASS
carrier simulator against built product                           PASS
signed-call-boundary.test.ts                                      PASS (3 tests)
realtime-handler.test.ts + webhook.test.ts + lifecycle + routing  PASS
pnpm check:changed -- signed-call-boundary.test.ts                 PASS
pnpm format signed-call-boundary.test.ts                           PASS
git diff --check                                                   PASS
```

With the two production owner files temporarily restored to the pre-change base, the carrier-shaped test failed for the intended reasons: missing and blank CallSid values minted Stream URLs, and a mismatched start reached bridge entry. After restoration, all three tests passed.

Additional validation on the branch rebased onto current main:

- Existing webhook and realtime-handler suites: 2 files and 134 tests passed.
- Realtime lifecycle and routed-owner suites: 2 files and 21 tests passed.
- Core lint stripes 2/5 through 5/5 passed. Stripe 1/5 reported only the pre-existing `max-lines` count in `src/cli/gateway-backed-exit.process.test.ts`, which this change does not touch and which `main` already split under the cap in aef65cc5749.
- `pnpm check:changed -- <all six changed files>` passed formatting, production and test typechecks, changed-file lint, import cycles, plugin boundaries, dead-code scans, and repository guards.
- `git diff --check` passed.

<details>
<summary>Twilio carrier simulator used for the run</summary>

Install `ws` and `twilio` in a scratch npm project, configure the product webhook plus a fake realtime metrics endpoint, and run this script. Synthetic TLS uses a locally trusted test certificate; the lookup hook maps the synthetic proof hostname to loopback.

```js
import assert from "node:assert/strict";
import { randomBytes } from "node:crypto";
import https from "node:https";
import twilio from "twilio";
import WebSocket from "ws";

const webhookUrl = process.env.TWILIO_WEBHOOK_URL;
const authToken = process.env.TWILIO_AUTH_TOKEN;
const metricsUrl = process.env.FAKE_REALTIME_METRICS_URL;
assert(webhookUrl, "TWILIO_WEBHOOK_URL is required");
assert(authToken, "TWILIO_AUTH_TOKEN is required");
assert(metricsUrl, "FAKE_REALTIME_METRICS_URL is required");

const makeSid = (prefix) => prefix + randomBytes(16).toString("hex");
const accountSid = makeSid("AC");
const matchingCallSid = makeSid("CA");
const mismatchedCallSid = makeSid("CA");
const mismatchSignedCallSid = makeSid("CA");
const matchingStreamSid = makeSid("MZ");
const mismatchStreamSid = makeSid("MZ");
const mediaPayload = Buffer.alloc(160, 0xff).toString("base64");

const now = () => new Date().toISOString();
const redactSid = (value) => value.replace(/^(AC|CA|MZ).+$/, "$1…redacted");
const redactUrl = (value) => value.replace(/\/([0-9a-f-]{36})(?=$|[?#])/, "/<one-time-token>");
const log = (event, details = {}) =>
  console.log(JSON.stringify({ timestamp: now(), event, ...details }));
const loopbackLookup = (_hostname, options, callback) => {
  if (options?.all) {
    callback(null, [{ address: "127.0.0.1", family: 4 }]);
    return;
  }
  callback(null, "127.0.0.1", 4);
};

function documentedWebhookParams(callSid) {
  return {
    CallSid: callSid,
    AccountSid: accountSid,
    From: "+14155550100",
    To: "+14155550101",
    CallStatus: "ringing",
    ApiVersion: "2010-04-01",
    Direction: "inbound",
    ForwardedFrom: "+14155550102",
    CallerName: "Carrier Simulator",
    ParentCallSid: makeSid("CA"),
    FromCity: "SAN FRANCISCO",
    FromState: "CA",
    FromZip: "94105",
    FromCountry: "US",
    ToCity: "OAKLAND",
    ToState: "CA",
    ToZip: "94612",
    ToCountry: "US",
  };
}

async function postWebhook(params, signatureOverride) {
  const signature =
    signatureOverride ?? twilio.getExpectedTwilioSignature(authToken, webhookUrl, params);
  if (signatureOverride === undefined) {
    assert.equal(twilio.validateRequest(authToken, signature, webhookUrl, params), true);
  }
  const body = new URLSearchParams(params).toString();
  return new Promise((resolve, reject) => {
    const request = https.request(webhookUrl, {
      method: "POST",
      headers: {
        "content-type": "application/x-www-form-urlencoded",
        "content-length": Buffer.byteLength(body),
        "x-twilio-signature": signature,
      },
      lookup: loopbackLookup,
      rejectUnauthorized: false,
    }, (response) => {
      const chunks = [];
      response.on("data", (chunk) => chunks.push(chunk));
      response.on("end", () => resolve({
        status: response.statusCode,
        text: async () => Buffer.concat(chunks).toString("utf8"),
      }));
    });
    request.once("error", reject);
    request.end(body);
  });
}

function parseStreamUrl(twiml) {
  const encoded = twiml.match(/<Stream\s+url="([^"]+)"/)?.[1];
  return encoded?.replaceAll("&amp;", "&");
}

function openStream(streamUrl) {
  return new Promise((resolve, reject) => {
    const ws = new WebSocket(streamUrl, {
      lookup: loopbackLookup,
      rejectUnauthorized: false,
    });
    ws.once("open", () => resolve(ws));
    ws.once("error", reject);
  });
}

function waitForClose(ws, timeoutMs = 5000) {
  return new Promise((resolve, reject) => {
    const timer = setTimeout(() => reject(new Error("timed out waiting for stream close")), timeoutMs);
    ws.once("close", (code, reason) => {
      clearTimeout(timer);
      resolve({ code, reason: reason.toString() });
    });
  });
}

async function metrics() {
  const response = await fetch(metricsUrl);
  assert.equal(response.status, 200);
  return response.json();
}

function startFrame(callSid, streamSid) {
  return {
    event: "start",
    sequenceNumber: "1",
    start: {
      accountSid,
      streamSid,
      callSid,
      tracks: ["inbound"],
      customParameters: { proof: "carrier-sim-989" },
      mediaFormat: { encoding: "audio/x-mulaw", sampleRate: 8000, channels: 1 },
    },
    streamSid,
  };
}

async function runAllowedPath() {
  const before = await metrics();
  const response = await postWebhook(documentedWebhookParams(matchingCallSid));
  const twiml = await response.text();
  assert.equal(response.status, 200);
  assert.match(twiml, /<Connect>/);
  const streamUrl = parseStreamUrl(twiml);
  assert(streamUrl, "signed webhook did not return a Stream URL");
  log("webhook.accepted", { status: response.status, callSid: redactSid(matchingCallSid) });
  log("stream.url", { url: redactUrl(streamUrl) });

  const ws = await openStream(streamUrl);
  const serverFrames = [];
  ws.on("message", (data) => {
    const frame = JSON.parse(data.toString());
    serverFrames.push(frame);
    log("stream.server-frame", { type: frame.event ?? "unknown" });
  });
  ws.send(JSON.stringify({ event: "connected", protocol: "Call", version: "1.0.0" }));
  const start = startFrame(matchingCallSid, matchingStreamSid);
  ws.send(JSON.stringify(start));
  log("stream.start.sent", {
    frame: { ...start, start: { ...start.start, accountSid: "AC…redacted", streamSid: "MZ…redacted", callSid: "CA…redacted" }, streamSid: "MZ…redacted" },
  });
  for (let index = 0; index < 50; index += 1) {
    ws.send(
      JSON.stringify({
        event: "media",
        sequenceNumber: String(index + 2),
        media: {
          track: "inbound",
          chunk: String(index + 1),
          timestamp: String(index * 20),
          payload: mediaPayload,
        },
        streamSid: matchingStreamSid,
      }),
    );
  }
  await new Promise((resolve) => setTimeout(resolve, 500));
  ws.send(JSON.stringify({ event: "mark", sequenceNumber: "52", mark: { name: "carrier-proof" }, streamSid: matchingStreamSid }));
  ws.send(JSON.stringify({ event: "stop", sequenceNumber: "53", stop: { accountSid, callSid: matchingCallSid }, streamSid: matchingStreamSid }));
  await new Promise((resolve) => setTimeout(resolve, 500));
  if (ws.readyState === WebSocket.OPEN) ws.close(1000, "simulator complete");
  const close = await waitForClose(ws);
  const observed = await metrics();
  const realtimeSessionsAdded = observed.sessions - before.sessions;
  const realtimeAudioFramesAdded = observed.audioFrames - before.audioFrames;
  assert.equal(realtimeSessionsAdded, 1, "matching start did not create exactly one realtime session");
  assert(realtimeAudioFramesAdded >= 50, "media frames did not reach the realtime bridge target");
  assert(serverFrames.some((frame) => frame.event === "media"), "no outbound Twilio media frame received");
  log("allowed.complete", { mediaSent: 50, realtimeSessionsAdded, realtimeAudioFramesAdded, serverFrames: serverFrames.map((frame) => frame.event), close });
}

async function runMismatchPath() {
  const before = await metrics();
  const response = await postWebhook(documentedWebhookParams(mismatchSignedCallSid));
  const streamUrl = parseStreamUrl(await response.text());
  assert.equal(response.status, 200);
  assert(streamUrl);
  const ws = await openStream(streamUrl);
  ws.send(JSON.stringify({ event: "connected", protocol: "Call", version: "1.0.0" }));
  ws.send(JSON.stringify(startFrame(mismatchedCallSid, mismatchStreamSid)));
  const close = await waitForClose(ws);
  const after = await metrics();
  assert.deepEqual(close, { code: 1008, reason: "Call identity does not match stream session" });
  assert.equal(after.sessions, before.sessions, "mismatched start created a realtime session");
  log("mismatch.rejected", { callSid: redactSid(mismatchedCallSid), close, realtimeSessionsAdded: 0 });
}

async function runWebhookNegativePaths() {
  const blankParams = documentedWebhookParams("   ");
  const blankResponse = await postWebhook(blankParams);
  const blankBody = await blankResponse.text();
  assert.equal(blankResponse.status, 200);
  assert.match(blankBody, /<Reject reason="rejected" \/>/);
  assert.doesNotMatch(blankBody, /<Stream/);
  log("blank-call-sid.rejected", { status: blankResponse.status, streamIssued: false });

  const invalidResponse = await postWebhook(documentedWebhookParams(matchingCallSid), "invalid-signature");
  assert.equal(invalidResponse.status, 401);
  log("invalid-signature.rejected", { status: invalidResponse.status });
}

await runAllowedPath();
await runMismatchPath();
await runWebhookNegativePaths();
log("simulator.complete", { result: "PASS" });
```

</details>
