### PR TITLE
fix(slack): bound HTTP bodies before Bolt

### DIFF
--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -63,6 +63,7 @@ type SlackTestState = {
   appConstructorArgs?: Record<string, unknown>;
   appStartMock: Mock<(...args: unknown[]) => Promise<unknown>>;
   appStopMock: Mock<(...args: unknown[]) => Promise<unknown>>;
+  httpRequestListenerMock: Mock<(...args: unknown[]) => unknown>;
   interactionRegistrations: string[];
   sendMock: Mock<(...args: unknown[]) => Promise<unknown>>;
   replyMock: Mock<(...args: unknown[]) => unknown>;
@@ -91,6 +92,7 @@ const slackTestState: SlackTestState = vi.hoisted(() => {
     appConstructorArgs: undefined,
     appStartMock: vi.fn(),
     appStopMock: vi.fn(),
+    httpRequestListenerMock: vi.fn(),
     interactionRegistrations: [],
     sendMock: vi.fn(),
     replyMock: vi.fn(),
@@ -352,6 +354,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
   slackTestState.socketModeLogger = undefined;
   slackTestState.appStartMock.mockReset().mockResolvedValue(undefined);
   slackTestState.appStopMock.mockReset().mockResolvedValue(undefined);
+  slackTestState.httpRequestListenerMock.mockReset();
   slackTestState.interactionRegistrations.length = 0;
   slackTestState.sendMock.mockReset().mockResolvedValue(undefined);
   slackTestState.replyMock.mockReset();
@@ -507,7 +510,7 @@ vi.mock("@slack/bolt", () => {
     stop = (...args: unknown[]) => slackTestState.appStopMock(...args);
   }
   class HTTPReceiver {
-    requestListener = vi.fn();
+    requestListener = (...args: unknown[]) => slackTestState.httpRequestListenerMock(...args);
   }
   class SocketModeReceiver {
     client = {

--- a/extensions/slack/src/monitor/http-handler.test.ts
+++ b/extensions/slack/src/monitor/http-handler.test.ts
@@ -1,0 +1,189 @@
+import { createHmac } from "node:crypto";
+import { createServer, request, type RequestListener, type Server } from "node:http";
+import { HTTPReceiver } from "@slack/bolt";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSlackHttpRequestHandler } from "./http-handler.js";
+
+type TestServer = {
+  server: Server;
+  port: number;
+  requestCount: () => number;
+};
+
+type HttpResult = {
+  statusCode: number | undefined;
+  body: string;
+};
+
+type AsyncRequestListener = (...args: Parameters<RequestListener>) => Promise<void> | void;
+
+const servers: Server[] = [];
+
+async function startServer(handler: AsyncRequestListener): Promise<TestServer> {
+  let requestCount = 0;
+  const server = createServer((req, res) => {
+    requestCount += 1;
+    void handler(req, res);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test server did not expose a TCP port");
+  }
+  return { server, port: address.port, requestCount: () => requestCount };
+}
+
+function slackReceiver(): HTTPReceiver {
+  return new HTTPReceiver({
+    signingSecret: "test-secret",
+    endpoints: "/slack/events",
+  });
+}
+
+function openChunkedRequest(port: number): ReturnType<typeof request> {
+  const req = request({
+    host: "127.0.0.1",
+    port,
+    path: "/slack/events",
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "transfer-encoding": "chunked",
+      "x-slack-request-timestamp": String(Math.floor(Date.now() / 1000)),
+      "x-slack-signature": "v0=invalid",
+    },
+  });
+  req.on("error", () => {});
+  return req;
+}
+
+function readResponse(req: ReturnType<typeof request>): Promise<HttpResult> {
+  return new Promise((resolve, reject) => {
+    req.once("response", (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      res.once("end", () => resolve({ statusCode: res.statusCode, body }));
+    });
+    req.once("error", reject);
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.closeAllConnections();
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+describe("createSlackHttpRequestHandler", () => {
+  it("rejects an oversized chunked body before Bolt signature verification", async () => {
+    const { port } = await startServer(
+      createSlackHttpRequestHandler({
+        receiver: slackReceiver(),
+        accountId: "default",
+      }),
+    );
+    const req = openChunkedRequest(port);
+    const response = readResponse(req);
+
+    req.write(Buffer.alloc(768 * 1024, 0x61));
+    req.end(Buffer.alloc(768 * 1024, 0x62));
+
+    await expect(response).resolves.toEqual({
+      statusCode: 413,
+      body: "Payload too large",
+    });
+  });
+
+  it("rejects a stalled body before Bolt's void listener starts reading", async () => {
+    const { port } = await startServer(
+      createSlackHttpRequestHandler({
+        receiver: slackReceiver(),
+        accountId: "default",
+      }),
+    );
+    const req = openChunkedRequest(port);
+    const response = readResponse(req);
+
+    req.write("{");
+
+    await expect(response).resolves.toEqual({
+      statusCode: 408,
+      body: "Request body timeout",
+    });
+    req.destroy();
+  });
+
+  it("preserves Bolt signature verification for requests within the bounds", async () => {
+    const { port } = await startServer(
+      createSlackHttpRequestHandler({
+        receiver: slackReceiver(),
+        accountId: "default",
+      }),
+    );
+    const body = JSON.stringify({ type: "url_verification", challenge: "bounded" });
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = `v0=${createHmac("sha256", "test-secret")
+      .update(`v0:${timestamp}:${body}`)
+      .digest("hex")}`;
+    const req = request({
+      host: "127.0.0.1",
+      port,
+      path: "/slack/events",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "transfer-encoding": "chunked",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": signature,
+      },
+    });
+    const response = readResponse(req);
+
+    req.end(body);
+
+    await expect(response).resolves.toEqual({
+      statusCode: 200,
+      body: JSON.stringify({ challenge: "bounded" }),
+    });
+  });
+
+  it("bounds concurrent requests before another pre-auth body read starts", async () => {
+    const receiver = { requestListener: vi.fn() };
+    const { port, requestCount } = await startServer(
+      createSlackHttpRequestHandler({
+        receiver,
+        accountId: "default",
+      }),
+    );
+    const stalled = Array.from({ length: 8 }, () => openChunkedRequest(port));
+    for (const req of stalled) {
+      req.write("{");
+    }
+    await vi.waitFor(() => expect(requestCount()).toBe(8));
+
+    const competing = openChunkedRequest(port);
+    const response = readResponse(competing);
+    competing.end("{}");
+
+    await expect(response).resolves.toEqual({
+      statusCode: 429,
+      body: "Too Many Requests",
+    });
+    expect(receiver.requestListener).not.toHaveBeenCalled();
+    for (const req of stalled) {
+      req.destroy();
+    }
+  });
+});

--- a/extensions/slack/src/monitor/http-handler.ts
+++ b/extensions/slack/src/monitor/http-handler.ts
@@ -1,0 +1,51 @@
+// Slack HTTP ingress bounds the body before passing it to Bolt's void listener.
+import type { IncomingMessage, RequestListener, ServerResponse } from "node:http";
+import { finished } from "node:stream/promises";
+import {
+  beginWebhookRequestPipelineOrReject,
+  createWebhookInFlightLimiter,
+  readWebhookBodyOrReject,
+} from "openclaw/plugin-sdk/webhook-request-guards";
+
+const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
+const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+
+export function createSlackHttpRequestHandler(params: {
+  receiver: { requestListener: RequestListener };
+  accountId: string;
+}): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+  const inFlightLimiter = createWebhookInFlightLimiter();
+  const inFlightKey = `slack:${params.accountId}`;
+
+  return async (req, res) => {
+    const lifecycle = beginWebhookRequestPipelineOrReject({
+      req,
+      res,
+      allowMethods: ["POST"],
+      inFlightLimiter,
+      inFlightKey,
+    });
+    if (!lifecycle.ok) {
+      return;
+    }
+
+    try {
+      const body = await readWebhookBodyOrReject({
+        req,
+        res,
+        maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
+        timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
+        profile: "pre-auth",
+      });
+      if (!body.ok) {
+        return;
+      }
+
+      Object.assign(req, { rawBody: Buffer.from(body.value) });
+      params.receiver.requestListener(req, res);
+      await finished(res, { cleanup: true }).catch(() => undefined);
+    } finally {
+      lifecycle.release();
+    }
+  };
+}

--- a/extensions/slack/src/monitor/provider.ingress-start-cleanup.test.ts
+++ b/extensions/slack/src/monitor/provider.ingress-start-cleanup.test.ts
@@ -1,5 +1,13 @@
 // Slack tests cover provider ingress startup cleanup behavior.
+import {
+  createServer,
+  request,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleSlackHttpRequest } from "../http/registry.js";
 import { getSlackTestState, resetSlackTestState } from "../monitor.test-helpers.js";
 
 const ingressStartMock = vi.hoisted(() => vi.fn());
@@ -30,6 +38,109 @@ afterAll(() => {
 });
 
 describe("Slack ingress startup cleanup", () => {
+  it("rejects an oversized body before Bolt's void listener reads asynchronously", async () => {
+    const state = getSlackTestState();
+    state.httpRequestListenerMock.mockImplementation((reqValue, resValue) => {
+      const req = reqValue as IncomingMessage;
+      const res = resValue as ServerResponse;
+      void (async () => {
+        for await (const chunk of req) {
+          // Bolt buffers the full body before signature verification.
+          void chunk;
+        }
+        if (!res.headersSent) {
+          res.statusCode = 401;
+          res.end();
+        }
+      })();
+    });
+    state.config = {
+      ...state.config,
+      channels: {
+        slack: {
+          mode: "http",
+          signingSecret: "test-signing-secret",
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "open",
+        },
+      },
+    };
+    const controller = new AbortController();
+    const run = monitorSlackProvider({
+      botToken: "bot-token",
+      abortSignal: controller.signal,
+      config: state.config,
+    });
+    let server: Server | undefined;
+    let clientRequest: ReturnType<typeof request> | undefined;
+
+    try {
+      await vi.waitFor(() => expect(ingressStartMock).toHaveBeenCalledTimes(1));
+      let acceptRequest: (() => void) | undefined;
+      const accepted = new Promise<void>((resolve) => {
+        acceptRequest = resolve;
+      });
+      server = createServer((req, res) => {
+        acceptRequest?.();
+        void handleSlackHttpRequest(req, res);
+      });
+      await new Promise<void>((resolve) => {
+        server!.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("test server did not expose a TCP port");
+      }
+      clientRequest = request({
+        host: "127.0.0.1",
+        port: address.port,
+        path: "/slack/events",
+        method: "POST",
+        headers: { "transfer-encoding": "chunked" },
+      });
+      clientRequest.on("error", () => {});
+      const response = new Promise<{ statusCode: number | undefined; body: string }>(
+        (resolve, reject) => {
+          clientRequest!.once("response", (res) => {
+            let body = "";
+            res.setEncoding("utf8");
+            res.on("data", (chunk: string) => {
+              body += chunk;
+            });
+            res.once("end", () => resolve({ statusCode: res.statusCode, body }));
+          });
+          clientRequest!.once("error", reject);
+        },
+      );
+      clientRequest.flushHeaders();
+
+      await accepted;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      clientRequest.write(Buffer.alloc(768 * 1024, 0x61));
+      clientRequest.end(Buffer.alloc(768 * 1024, 0x62));
+
+      await expect(response).resolves.toEqual({
+        statusCode: 413,
+        body: "Payload too large",
+      });
+    } finally {
+      clientRequest?.destroy();
+      server?.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        if (server) {
+          server.close(() => resolve());
+        } else {
+          resolve();
+        }
+      });
+      controller.abort();
+      await run;
+    }
+  });
+
   it("stops ingress and the Bolt transport when ingress start throws", async () => {
     const startError = new Error("durable ingress unavailable");
     ingressStartMock.mockImplementation(() => {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -1,5 +1,5 @@
 // Slack provider module implements model/runtime integration.
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RequestListener } from "node:http";
 import { type FetchFunction, type WebClientOptions, WebClient } from "@slack/web-api";
 import {
   addAllowlistUserEntriesFromConfigEntry,
@@ -28,7 +28,6 @@ import {
   normalizeOptionalString,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { installRequestBodyLimitGuard } from "openclaw/plugin-sdk/webhook-request-guards";
 import {
   resolveSlackAccount,
   resolveSlackAccountAllowFrom,
@@ -70,6 +69,7 @@ import {
   type SlackInstallationIdentity,
 } from "./enterprise-install.js";
 import { registerSlackCommonEvents, registerSlackWorkspaceEvents } from "./events.js";
+import { createSlackHttpRequestHandler } from "./http-handler.js";
 import { createSlackDurableIngress } from "./ingress.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 import { openSlackPresenceCooldownStore } from "./presence-cooldown-store.js";
@@ -126,9 +126,6 @@ async function getSlackBoltInterop(): Promise<SlackBoltResolvedExports> {
 }
 
 const loadSlackRelaySource = createLazyRuntimeModule(() => import("./relay-source.js"));
-
-const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
-const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
 
 type SlackRuntimeIdentity = {
   botUserId: string;
@@ -462,28 +459,10 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 
   const slackHttpHandler =
     slackMode === "http" && receiver
-      ? async (req: IncomingMessage, res: ServerResponse) => {
-          const httpReceiver = receiver as {
-            requestListener: (req: IncomingMessage, res: ServerResponse) => unknown;
-          };
-          const guard = installRequestBodyLimitGuard(req, res, {
-            maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
-            timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
-            responseFormat: "text",
-          });
-          if (guard.isTripped()) {
-            return;
-          }
-          try {
-            await Promise.resolve(httpReceiver.requestListener(req, res));
-          } catch (err) {
-            if (!guard.isTripped()) {
-              throw err;
-            }
-          } finally {
-            guard.dispose();
-          }
-        }
+      ? createSlackHttpRequestHandler({
+          receiver: receiver as { requestListener: RequestListener },
+          accountId: account.accountId,
+        })
       : null;
   let unregisterHttpHandler: (() => void) | null = null;
   const unregisterSocketModeConnectionDiagnostics =


### PR DESCRIPTION
> Devin Robison · GPT-5 Codex · via @drobison00

## What Problem This Solves

Slack HTTP mode could stop enforcing OpenClaw's request size and timeout limits while Bolt
was still buffering a chunked body asynchronously.

## Why This Change Was Made

OpenClaw now reads the Slack webhook body under the existing 1 MiB and 30-second bounds
before invoking Bolt, then supplies the exact buffered body through Bolt's supported
`rawBody` request field. A per-account in-flight limit also bounds concurrent pre-auth body
reads and remains held until the response completes.

## User Impact

Oversized Slack webhook bodies receive `413`, stalled bodies receive `408`, and excess
concurrent requests receive `429` before Bolt begins signature verification. Valid signed
Slack requests continue through Bolt unchanged.

## Evidence

- Captured a frozen-base regression where a 1.5 MiB chunked body reached Bolt and returned the
  harness's simulated `401` instead of OpenClaw's expected `413`.
- Added real-Bolt coverage for oversized chunked input, a stalled body, and a valid signed
  URL-verification request.
- Added boundary coverage for the installed Slack provider handler and the default pre-auth
  concurrency capacity.
- Built a local-only merge of this exact head with `upstream/main`
  `564e544aac738d4677f3f6813af018e6a87cd759`; it merged cleanly and was never pushed.
- Focused merged-tree regression suite: 2 files, 6 tests passed.
- Full merged-tree Slack suite: 147 files, 2,692 tests passed.
- Path-scoped `pnpm check:changed` passed formatting, extension and extension-test typechecks,
  lint, dependency and boundary guards, dead-export scans, and import-cycle checks.
- `pnpm build` passed on the merged tree under Node `v24.15.0`.
- Bolt 5.0.0 `rawBody` contract, verified in the installed dependency source: `node_modules/@slack/bolt/dist/receivers/BufferedIncomingMessage.d.ts:5-7` declares `rawBody: Buffer`; `HTTPModuleFunctions.js:98-117` treats a request whose `rawBody` is a `Buffer` as already buffered and returns it without invoking `raw-body` again; `HTTPModuleFunctions.js:60-68` then verifies the exact bytes from `bufferedReq.rawBody`. `HTTPReceiver.js:294-307` starts its parse/verify closure without returning the promise, which is why the previous wrapper's guard was disposed early; the handler now reads within OpenClaw's bounds, supplies those bytes as `rawBody`, and holds the concurrency lease through response completion.
