### PR TITLE
fix: doctor cannot load Teams state checker after a source build

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1471,7 +1471,9 @@ Use it when setup, doctor, status, or read-only presence flows need a cheap yes/
 }
 ```
 
-Use `env.allOf` when every listed variable is required and `env.anyOf` when any one non-empty variable is enough. If a tiny non-runtime check needs more than environment metadata, use `specifier` plus `exportName` as shown for `persistedAuthState`; when `env` is present, OpenClaw uses it without loading that module. If the check needs full config resolution or the real channel runtime, keep that logic in the plugin `config.hasConfiguredState` hook instead.
+Use `env.allOf` when every listed variable is required and `env.anyOf` when any one non-empty variable is enough. If a tiny non-runtime check needs more than environment metadata, use `specifier` plus `exportName` as shown for `persistedAuthState`. A complete `specifier` and `exportName` pair takes precedence over `env`; env-only metadata avoids loading a module. If the check needs full config resolution or the real channel runtime, keep that logic in the plugin `config.hasConfiguredState` hook instead.
+
+For both state probes, OpenClaw builds rewrite source specifiers to the exact emitted JavaScript artifact, including its `.js` or `.cjs` extension. Built checkout metadata uses paths relative to the plugin root; standalone packages use the plugin-local `dist/` directory.
 
 ## Discovery precedence (duplicate plugin ids)
 

--- a/scripts/copy-bundled-plugin-metadata.mts
+++ b/scripts/copy-bundled-plugin-metadata.mts
@@ -7,6 +7,7 @@ import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
 import {
   mergeGeneratedChannelConfigs,
   readGeneratedBundledChannelConfigs,
+  resolvePluginRuntimeChannelMetadata,
 } from "./lib/plugin-npm-package-manifest.mts";
 import { isRecord } from "./lib/record-shared.mjs";
 import {
@@ -33,12 +34,8 @@ function rewritePackageExtensions(entries: unknown, extension: string): string[]
   }
 
   return entries
-    .filter((entry) => typeof entry === "string" && entry.trim().length > 0)
-    .map((entry) => {
-      const normalized = entry.replace(/^\.\//, "");
-      const rewritten = normalized.replace(/\.[^.]+$/u, extension);
-      return `./${rewritten}`;
-    });
+    .map((entry) => rewritePackageEntry(entry, extension))
+    .filter((entry) => entry !== undefined);
 }
 
 function rewritePackageEntry(entry: unknown, extension: string): string | undefined {
@@ -301,10 +298,16 @@ export function copyBundledPluginMetadata(params: CopyMetadataParams = {}): void
       removeFileIfExists(distPackageJsonPath);
       continue;
     }
-    if (packageJson && isRecord(packageJson.openclaw) && "extensions" in packageJson.openclaw) {
+    if (packageJson && isRecord(packageJson.openclaw)) {
       const extension = buildEntry.runtimeExtension;
+      const channel = resolvePluginRuntimeChannelMetadata(packageJson.openclaw.channel, {
+        pluginDir: dirent.name,
+        runtimeBuildOutputs: rewritePackageExtensions(buildEntry.sourceEntries, extension) ?? [],
+        runtimeRoot: ".",
+      });
       packageJson.openclaw = {
         ...packageJson.openclaw,
+        ...(channel ? { channel } : {}),
         extensions: rewritePackageExtensions(packageJson.openclaw.extensions, extension),
         ...(typeof packageJson.openclaw.setupEntry === "string"
           ? { setupEntry: rewritePackageEntry(packageJson.openclaw.setupEntry, extension) }

--- a/scripts/lib/plugin-npm-package-manifest.mts
+++ b/scripts/lib/plugin-npm-package-manifest.mts
@@ -158,58 +158,44 @@ function assertPluginNpmRuntimeBuildExists(plan: PluginNpmRuntimeBuildPlan) {
   assertPackageFilesDoNotExcludeRequiredRuntimeArtifacts(plan);
 }
 
-function resolvePackagedChannelStateMetadata(
-  metadata: unknown,
-  metadataKey: string,
-  plan: PluginNpmRuntimeBuildPlan,
+/** Map channel probes to the selected build outputs relative to the emitted package.json. */
+export function resolvePluginRuntimeChannelMetadata(
+  channel: unknown,
+  params: { pluginDir: string; runtimeBuildOutputs: string[]; runtimeRoot: "." | "dist" },
 ) {
-  if (
-    !metadata ||
-    !isRecord(metadata) ||
-    typeof metadata.specifier !== "string" ||
-    !metadata.specifier.trim()
-  ) {
-    return metadata;
-  }
-
-  const normalizedSpecifier = normalizePackPath(metadata.specifier);
-  const sourceEntry = normalizedSpecifier.replace(/\.(?:[cm]?[jt]s)$/u, "");
-  const runtimeSpecifier = plan.runtimeBuildOutputs.find((runtimePath) => {
-    const normalizedRuntimePath = normalizePackPath(runtimePath);
-    return (
-      normalizedRuntimePath === normalizedSpecifier ||
-      normalizedRuntimePath.replace(/^dist\//u, "").replace(/\.(?:[cm]?js)$/u, "") === sourceEntry
-    );
-  });
-  if (!runtimeSpecifier) {
-    throw new Error(
-      `channel ${metadataKey} specifier '${metadata.specifier}' has no package-local runtime output for ${plan.pluginDir}`,
-    );
-  }
-
-  // Published plugins omit source files; installed channel probes must load
-  // the exact ESM or CommonJS sidecar emitted by the package runtime build.
-  return {
-    ...metadata,
-    specifier: runtimeSpecifier,
-  };
-}
-
-function resolvePackagedChannelMetadata(plan: PluginNpmRuntimeBuildPlan) {
-  const channel = plan.packageJson.openclaw?.channel;
   if (!isRecord(channel)) {
     return channel;
   }
 
   const packagedChannel: JsonRecord = { ...channel };
   for (const metadataKey of ["configuredState", "persistedAuthState"]) {
-    if (Object.hasOwn(channel, metadataKey)) {
-      packagedChannel[metadataKey] = resolvePackagedChannelStateMetadata(
-        channel[metadataKey],
-        metadataKey,
-        plan,
+    const metadata = channel[metadataKey];
+    if (
+      !Object.hasOwn(channel, metadataKey) ||
+      !isRecord(metadata) ||
+      typeof metadata.specifier !== "string" ||
+      !metadata.specifier.trim()
+    ) {
+      continue;
+    }
+    const normalizedSpecifier = normalizePackPath(metadata.specifier);
+    const sourceEntry = normalizedSpecifier.replace(/\.(?:[cm]?[jt]s)$/u, "");
+    const runtimeSpecifier = params.runtimeBuildOutputs.find((runtimePath) => {
+      const normalizedRuntimePath = normalizePackPath(runtimePath);
+      const relativeRuntimePath = path.posix.relative(params.runtimeRoot, normalizedRuntimePath);
+      return (
+        normalizedRuntimePath === normalizedSpecifier ||
+        relativeRuntimePath.replace(/\.(?:[cm]?js)$/u, "") === sourceEntry
+      );
+    });
+    if (!runtimeSpecifier) {
+      throw new Error(
+        `channel ${metadataKey} specifier '${metadata.specifier}' has no runtime output for ${params.pluginDir}`,
       );
     }
+    // Native Node resolution does not infer .cjs from a stem. Both checkout and
+    // standalone metadata must name the exact sidecar selected by their build.
+    packagedChannel[metadataKey] = { ...metadata, specifier: runtimeSpecifier };
   }
   return packagedChannel;
 }
@@ -885,7 +871,11 @@ export function resolveAugmentedPluginNpmPackageJson(params: PluginPackageParams
   }
   assertPluginNpmRuntimeBuildExists(plan);
 
-  const packagedChannel = resolvePackagedChannelMetadata(plan);
+  const packagedChannel = resolvePluginRuntimeChannelMetadata(plan.packageJson.openclaw?.channel, {
+    pluginDir: plan.pluginDir,
+    runtimeBuildOutputs: plan.runtimeBuildOutputs,
+    runtimeRoot: "dist",
+  });
   const packageJson: PluginPackageJson = {
     ...plan.packageJson,
     files: plan.packageFiles,

--- a/test/scripts/build-external-plugin-local-dist.test.ts
+++ b/test/scripts/build-external-plugin-local-dist.test.ts
@@ -23,12 +23,33 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(resetPluginCache);
 
+const channelStateFixtures = {
+  configuredState: {
+    specifier: "./configured-state",
+    exportName: "hasConfiguredChannelState",
+    env: { allOf: ["DEMO_TOKEN"] },
+  },
+  persistedAuthState: {
+    specifier: "./auth-presence.ts",
+    exportName: "hasPersistedChannelAuth",
+  },
+};
+
+function writeChannelStateFixtures(pluginRoot: string) {
+  for (const { specifier, exportName } of Object.values(channelStateFixtures)) {
+    fs.writeFileSync(
+      path.join(pluginRoot, `${specifier.replace(/\.ts$/u, "")}.ts`),
+      `export function ${exportName}({ cfg }) { return cfg.ready === true; }\n`,
+    );
+  }
+}
+
 describe("external plugin local dist build", () => {
   it("keeps excluded plugin graphs isolated and their runtime metadata loadable", async () => {
     const repoRoot = fs.realpathSync(tempDirs.make("openclaw-isolated-plugin-graphs-"));
     const plugins = [
-      { id: "external-esm", runtimeFormat: "esm", publishToNpm: true, bundledDist: true },
       { id: "external-cjs", runtimeFormat: "cjs", publishToNpm: true, bundledDist: true },
+      { id: "external-esm", runtimeFormat: "esm", publishToNpm: true, bundledDist: true },
       { id: "external-only", runtimeFormat: "cjs", publishToNpm: true, bundledDist: false },
       { id: "private-plugin", runtimeFormat: "esm", publishToNpm: false, bundledDist: true },
     ];
@@ -53,12 +74,14 @@ describe("external plugin local dist build", () => {
           openclaw: {
             extensions: ["./index.ts"],
             setupEntry: "./setup-entry.ts",
+            channel: { id, label: id, ...channelStateFixtures },
             build: { runtimeFormat, bundledDist },
             release: { publishToNpm },
           },
         }),
       );
       fs.writeFileSync(path.join(pluginRoot, "openclaw.plugin.json"), JSON.stringify({ id }));
+      writeChannelStateFixtures(pluginRoot);
       fs.writeFileSync(
         path.join(pluginRoot, "runtime-api.ts"),
         `export const identity = ${JSON.stringify(id)};`,
@@ -107,17 +130,56 @@ describe("external plugin local dist build", () => {
           `
         import assert from "node:assert/strict";
         import { readFileSync } from "node:fs";
+        import { createRequire } from "node:module";
         import { pathToFileURL } from "node:url";
         const root = pathToFileURL(process.cwd() + "/");
+        const require = createRequire(new URL("package.json", root));
         const pkg = JSON.parse(readFileSync(new URL("package.json", root)));
         for (const entry of [...pkg.openclaw.extensions, pkg.openclaw.setupEntry]) {
           assert.equal((await import(new URL(entry, root))).identity, ${JSON.stringify(id)});
+        }
+        for (const key of ["configuredState", "persistedAuthState"]) {
+          const state = pkg.openclaw.channel[key];
+          const checker = require(require.resolve(state.specifier))[state.exportName];
+          assert.equal(checker({ cfg: {} }), false);
+          assert.equal(checker({ cfg: { ready: true } }), true);
         }
       `,
         ],
         { cwd: pluginRoot, encoding: "utf8" },
       );
       expect(probe.status, probe.stdout + probe.stderr).toBe(0);
+      expect(metadata.openclaw.channel).toEqual({
+        id,
+        label: id,
+        configuredState: {
+          ...channelStateFixtures.configuredState,
+          specifier: `./configured-state${extension}`,
+        },
+        persistedAuthState: {
+          ...channelStateFixtures.persistedAuthState,
+          specifier: `./auth-presence${extension}`,
+        },
+      });
+      const sourcePackagePath = path.join(repoRoot, "extensions", id, "package.json");
+      const sourceText = fs.readFileSync(sourcePackagePath, "utf8");
+      const sourcePackage = JSON.parse(sourceText);
+      expect(sourcePackage.openclaw.channel).toEqual({ id, label: id, ...channelStateFixtures });
+      // Env-only declarations have no module to rewrite; invalid module declarations fail the build.
+      sourcePackage.openclaw.channel.configuredState = { env: { anyOf: ["DEMO_TOKEN"] } };
+      fs.writeFileSync(sourcePackagePath, JSON.stringify(sourcePackage));
+      copyBundledPluginMetadata({ repoRoot, env: {} });
+      expect(
+        JSON.parse(fs.readFileSync(path.join(pluginRoot, "package.json"), "utf8")).openclaw.channel
+          .configuredState,
+      ).toEqual(sourcePackage.openclaw.channel.configuredState);
+      sourcePackage.openclaw.channel.persistedAuthState.specifier = "./missing-state";
+      fs.writeFileSync(sourcePackagePath, JSON.stringify(sourcePackage));
+      expect(() => copyBundledPluginMetadata({ repoRoot, env: {} })).toThrow(
+        `channel persistedAuthState specifier './missing-state' has no runtime output for ${id}`,
+      );
+      fs.writeFileSync(sourcePackagePath, sourceText);
+      copyBundledPluginMetadata({ repoRoot, env: {} });
     }
 
     const distRoot = path.join(repoRoot, "dist");
@@ -428,6 +490,7 @@ describe("external plugin local dist build", () => {
             extensions: ["./index.ts"],
             setupEntry: "./setup-entry.ts",
             build: { bundledDist: id !== "demo", runtimeFormat: "cjs" },
+            channel: { id, ...channelStateFixtures },
             release: { publishToNpm: true },
           },
         }),
@@ -435,6 +498,7 @@ describe("external plugin local dist build", () => {
       for (const entry of ["index.ts", "setup-entry.ts"]) {
         fs.writeFileSync(path.join(pluginRoot, entry), "export {};\n");
       }
+      writeChannelStateFixtures(pluginRoot);
     }
     // Evaluate the real compiler config against synthetic plugins. These links
     // expose existing read-only config inputs; no core graph is compiled.
@@ -471,8 +535,12 @@ describe("external plugin local dist build", () => {
     expect(compiler.status, compiler.stderr).toBe(0);
     const compilerEntries: string[] = JSON.parse(compiler.stdout);
     expect(compilerEntries).toEqual([
+      "extensions/demo/auth-presence",
+      "extensions/demo/configured-state",
       "extensions/demo/index",
       "extensions/demo/setup-entry",
+      "extensions/packaged/auth-presence",
+      "extensions/packaged/configured-state",
       "extensions/packaged/index",
       "extensions/packaged/setup-entry",
     ]);
@@ -488,6 +556,17 @@ describe("external plugin local dist build", () => {
     );
     expect(builtPackage.openclaw.extensions).toEqual(["./index.js"]);
     expect(builtPackage.openclaw.setupEntry).toBe("./setup-entry.js");
+    expect(builtPackage.openclaw.channel).toEqual({
+      id: "demo",
+      configuredState: {
+        ...channelStateFixtures.configuredState,
+        specifier: "./configured-state.js",
+      },
+      persistedAuthState: {
+        ...channelStateFixtures.persistedAuthState,
+        specifier: "./auth-presence.js",
+      },
+    });
     expect(fs.existsSync(path.join(distRoot, "extensions/unselected"))).toBe(false);
     expect(listExternalPluginLocalDistPackageDirs({ repoRoot, env })).toEqual([]);
     const distEntry = path.join(distRoot, "entry.js");


### PR DESCRIPTION
Closes #136499
Related: #135478, #124600

## What Problem This Solves

Fixes an issue where operators running doctor after a successful source-checkout build would see `core/doctor/channel-package-state-capabilities` report that the Microsoft Teams `configuredState` checker could not load, even when Teams was not configured.

## Why This Change Was Made

The checker was emitted as `configured-state.cjs`, but source-checkout package metadata still advertised the extensionless `./configured-state`. Node's native resolver does not infer `.cjs`. Main/setup entry metadata already followed the selected build format; the channel-state metadata did not.

The metadata producer now shares the standalone package transformation for both `configuredState` and `persistedAuthState`, naming the exact output selected by the canonical build plan. Checkout output uses the plugin root and standalone packages use plugin-local `dist/`. This keeps Docker-selected unified ESM, isolated CommonJS, env-only declarations, export names, and authored source manifests coherent. Unmapped module declarations fail at the build owner rather than advertising missing runtime files.

No runtime loader fallback, Teams authentication change, new dependency, configuration option, or schema change is introduced. The two standalone-only transformation layers become one shared implementation. The nearby manifest docs now accurately describe module-over-env precedence and emitted state-probe paths.

## User Impact

Doctor can load the Teams configured-state checker from a clean source build without a false missing-artifact warning. Other module-backed configured/auth-state capabilities retain their selected format, and standalone plugin packages retain their existing host-peer contract. Operators do not need a configuration workaround or manual dependency installation.

## Evidence

### Merged replacement

Merged by one explicitly approved native replacement recovery as [`16c07ee67e0e14d4acaaa9d06b88e796e95e1b8a`](https://github.com/openclaw/openclaw/commit/16c07ee67e0e14d4acaaa9d06b88e796e95e1b8a). **Exact source/prepared replacement:** [`48a8d882d133e42ee03abb305996ce37bd715206`](https://github.com/openclaw/openclaw/commit/48a8d882d133e42ee03abb305996ce37bd715206), based on `4a9356416adecc3ff7dba41a372f13af959eb57a`. At preparation, source and remote heads matched; tree `24243f6b7d8994af0619bea0efe6b21b4b4f591f` remains the tested/reviewed tree. Exact-head `pull_request` [CI run 33684625927, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33684625927) completed **SUCCESS**, including the required [openclaw/ci-gate, job 100433118938](https://github.com/openclaw/openclaw/actions/runs/33684625927/job/100433118938).

`OPENCLAW_TESTBOX=1 scripts/pr prepare-run 136509` completed successfully using native exact-head hosted-CI proof. The remote was already at the prepared head, so the wrapper skipped pushing. No rebase, source edit, new commit, full local suite, or new lease was needed. The operator subsequently approved this exact replacement SHA. One recovery request was accepted and merged; native read-only reconciliation verified the landed tree against the exact prepared source. The original issue is closed. See the unresolved late-review finding below.

The mechanical rebase resolves the shared test-prelude conflict while retaining [#136399](https://github.com/openclaw/openclaw/pull/136399)'s cache reset, runtime-artifact imports, stale opposite-format fixture, and selected-entry assertions alongside this repair's `channelStateFixtures` and native configured/persisted-auth invocation tests. Manual resolution combined the preludes and added separating whitespace. The three nonconflicting source/docs files are byte-identical to `376125a426c74c9b2abc745bcb70e75454442529`; the repair remains four files against its new base, with no additional production change.

Fresh proof on the exact final tree: **37 focused cases passed** — 19 builder/packaging contracts across three files (47 intentionally filtered) using the command retained below, plus all 18 loader-artifact cases. Root-test types, scoped formatting/lint, and relevant guards passed. Fresh mandatory Codex autoreview of the full resolved delta at P3 threshold completed before rebase continuation: **scoped-clean, no findings**. The final commit tree was then verified equal to the reviewed/tested tree. This is focused proof, not a fresh full build or full suite.

```bash
node scripts/run-vitest.mjs src/plugins/plugin-runtime-artifact-resolution.test.ts
node scripts/check-changed.mjs -- test/scripts/build-external-plugin-local-dist.test.ts
git diff --check HEAD^ HEAD
```

Current delta: production/tooling **+44/-51 (net -7)**; tests **+80/-1 (net +79)**; docs **+3/-1**.

The earlier [20:45 UTC ClawSweeper review](https://github.com/openclaw/openclaw/pull/136509#issuecomment-5514401452) has no code/security findings. Its current-main source-read limitation is addressed by direct inspection recorded during replacement review: #136399 changes runtime artifact selection, but neither metadata producer gained the state-probe rewrite. Its maintainer landing-decision item is covered by the existing explicit land request; that request does **not** approve replacement-head recovery. This mechanical conflict resolution retains main behavior; no unnecessary re-review was requested.

**Recovery receipt:** the approved single attempt `d07e6a0a-aaca-4f71-b416-40e09ee6ce9d` was consumed once. Native reconciliation retains receipt OID `b0ca54588bb948da582e30399ebcd1211ac95012`, phase `merged`, `accepted=true`, landed `16c07ee67e0e14d4acaaa9d06b88e796e95e1b8a`, with explicit replacement-head authorization and prior outcome `f620812148559e77e984d0430ccc73c92dad6b01` retained in ancestry. The prior dispatch capture is preserved in that history and in the local evidence archive. Interruption prevented the wrapper's normal completion comment/cleanup path; this existing proof comment is updated instead of posting a duplicate. No second recovery request was made. Task-owned worktree/branch cleanup was completed separately after verifying ownership and archiving all native evidence; the valid receipt remains at phase `merged`, without manufacturing a `complete` stamp.

### Late review finding — unresolved follow-up

The [21:51 UTC ClawSweeper review](https://github.com/openclaw/openclaw/pull/136509#issuecomment-5514401452), published during the recovery operation, reports a P2 compatibility gap: the mapper treats a nonempty `specifier` as module-backed without also requiring a nonempty `exportName`, so an env-backed incomplete module pair can become a build failure. The new finding was noticed while recovery was in progress; interruption occurred after GitHub had accepted the merge at 21:54:08 UTC. This finding was **not resolved by this landing**. No source change or further merge request was made. It needs a focused follow-up covering complete-pair mapping and env-plus-incomplete-pair preservation.

### Historical repair and built-artifact evidence

The following runs predate the replacement head. They remain unchanged-production evidence, not replacement-head CI or a fresh full-build claim.

- Before editing, a clean Linux full package build reproduced the exact warning. The CommonJS file existed and its named checker returned `false` for empty/partial synthetic setup and `true` for complete synthetic setup, while resolving the metadata stem failed with `MODULE_NOT_FOUND`.
- Two added regressions failed before the repair and passed afterward: native resolution/invocation from actual ESM/CommonJS build metadata, and Docker-selected ESM metadata. The existing fixture also protects env-only metadata, source-manifest preservation, missing-output rejection, dependency ownership, and relocation.
- Original focused proof: **19 passed, 47 intentionally filtered out, across 3 files**. This is not a full-suite claim.

```bash
node scripts/run-vitest.mjs test/scripts/build-external-plugin-local-dist.test.ts test/plugin-npm-package-manifest.test.ts test/plugin-npm-runtime-build.test.ts --testNamePattern 'external plugin local dist build|overlays package-local runtime metadata|packs and loads both mapped|refuses to pack publishable|refuses package file rules|rejects a symlinked package dist root|plans package-local runtime entries|includes top-level public runtime surfaces|builds doctor contract surfaces|plans msteams startup'
```

- Changed guards, script/root-test typechecking, formatting, and scoped lint passed:

```bash
node scripts/check-changed.mjs -- docs/plugins/manifest.md scripts/copy-bundled-plugin-metadata.mts scripts/lib/plugin-npm-package-manifest.mts test/scripts/build-external-plugin-local-dist.test.ts
```

- Clean Linux full build:

```bash
pnpm install --frozen-lockfile
```

```bash
pnpm build:package
```

- Built CLI proof used an isolated HOME/state/config and no provider/channel credentials:

```bash
node openclaw.mjs doctor --lint --severity-min warning --json
```

  Package-state capability findings changed **1 → 0**. Other warnings from the deliberately minimal fixture (gateway auth, heartbeat setup, loopback hosting) remain; this is not a claim that the fixture's entire doctor report was warning-free.
- All seven module-backed capabilities in the built artifact resolved: Feishu, Matrix, Microsoft Teams, Nextcloud Talk, Slack, SMS, and WhatsApp.
- Packed the actual Teams npm artifact through the canonical manifest wrapper, extracted it, supplied its already-declared OpenClaw host peer, and invoked the advertised `./dist/configured-state.cjs` export successfully. The 35-file tarball contained the built checker, no source checker, and no npm lockfiles.
- Baseline Testbox command evidence: https://github.com/openclaw/openclaw/actions/runs/33658685092 (`tbx_01m1hh67cz9cjtm3asd25rsm10`). Fixed build/package evidence: https://github.com/openclaw/openclaw/actions/runs/33661886954 (`tbx_01m1hjyw1yvh56g2txtk2e7bd8`). The synchronized affected producer hashes match the reviewed patch; these are command results on leased Testboxes, not claims about the parent workflow conclusion or Git HEAD matching the synchronized tree. Both leases were stopped.
- Validation detours: the local full build refused an ancestor dependency change during compilation; two reused-Testbox sync attempts timed out before executing the candidate. An artifact-free proof checkout resolved sync, and its clean full build passed. The first extracted-package probe omitted the declared host peer; correcting the consumer setup passed without a production change.
- Codex autoreview: scoped-clean at the default P0 threshold. No production host was accessed or changed. This is a CLI/package diagnostic fix, so the real built-CLI JSON comparison is the relevant behavior proof; no chat/UI rendering changed.

Production/tooling LOC: **+44/-51 (net -7)**. Tests at the superseded head: **+79/-1 (net +78)**. Docs: **+3/-1**.

Provenance: raw-parent comparison of `87ecc61b1dde2a511347469bfde2055be22af9fd` with `b6966bed624492c7d030278b78ebcbb69cd97194` verified the source-checkout isolation change selected Teams' existing CommonJS format while leaving state-probe metadata unchanged. Current main's affected owners were also checked; the missing rewrite was still present.

### Historical CI refresh for superseded head 376125a426c7

Head: [`376125a426c74c9b2abc745bcb70e75454442529`](https://github.com/openclaw/openclaw/commit/376125a426c74c9b2abc745bcb70e75454442529). The four-file Teams repair is byte-identical to the previously reviewed patch; no additional repair code was retained. Fresh exact-commit Codex autoreview is scoped-clean at the default P0 threshold (lower-priority findings are outside that scope).

The rebase imports two canonical main fixes for unrelated failures in [the original CI run](https://github.com/openclaw/openclaw/actions/runs/33665615725): [aef65cc57490](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c) splits the oversized gateway-backed CLI test suite and registers its health suite; [#136473](https://github.com/openclaw/openclaw/pull/136473), landed as [564e544aac73](https://github.com/openclaw/openclaw/commit/564e544aac738d4677f3f6813af018e6a87cd759), corrects the startup-recovery test barrier's overlapping active/pending queue counting without changing queue runtime behavior. The failed startup job tested the old barrier in synthetic merge `768aa9cad38e55bf5b7f0730b508a53c8c54ad46`; rerunning that old run would not test these main fixes.

Superseded-head proof: the focused metadata/tooling run passed **19 tests** (47 intentionally filtered); canonical CLI lint and config-CLI test types passed; the CI planner passed **47 tests**. The earlier **46-pass / 1 expected Linux-only skip** CLI runtime result predates this final rebase and is not an exact-final-head rerun. The prior clean Linux build, built doctor **1 → 0** package-state findings, seven sibling capability resolutions, and actual Teams tarball proof above remain unchanged-patch evidence, not a new full-build claim.

Local Gateway replays: the first rebased startup-recovery replay hit the unchanged **90,000 ms** test timeout (219 s total transform time). A subsequent single-file focused-owner retry also hit **90,000 ms** (146 s total transform time). Neither reported the old queue-count assertion; neither is green, and those timings alone do not establish a runtime cause.

The same focused-owner test then **passed on Linux/Node 24.19.0**, with its original timeout, isolation, assertions, and production code: **1 test passed**, 21.8 s test time / 38.2 s Vitest duration. Testbox [run 33676955525](https://github.com/openclaw/openclaw/actions/runs/33676955525), lease `tbx_01m1hvfht069nt24yct9p7x1wn`, used the standard synchronized candidate source. The test, queue/admission/dispatch owners, package manifest, and lockfile hashes matched the candidate before and after execution; this is not an underlying checkout-Git-HEAD attestation. The command exited 0 and the lease was stopped.

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.startup-recovery-webchat.test.ts
```

Exact-head `pull_request` CI **completed successfully** on `376125a426c74c9b2abc745bcb70e75454442529`: [run 33676171381, attempt 3](https://github.com/openclaw/openclaw/actions/runs/33676171381), including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33676171381/job/100413206625). Attempt 1's preflight and attempt 2's `check-additional-boundaries-bcd` were cancelled before runner acquisition, with no executed steps. Once the other jobs finished, only the unacquired boundary job was rerun; attempt 3 passed it and the dependent gate while reusing successful checks. No source or runner-policy change was used to resolve those infrastructure cancellations.

The earlier 20:26 UTC ClawSweeper revision had no code findings and required completed CI on the old head; run 33676171381 attempt 3 satisfied those historical CI items only. The comment was updated at 20:45 UTC with the source-read limitation and maintainer-decision items addressed in the current replacement section above. The two Mac timeouts remain failures, not green proof, and the Linux source-sync evidence is not a checkout-Git-HEAD attestation.
