### PR TITLE
refactor(cli): consolidate logs timestamp coverage at the command boundary

### DIFF
--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayTransportError } from "../gateway/call.js";
 import type { RuntimeExitOptions } from "../runtime.js";
 import { runRegisteredCli } from "../test-utils/command-runner.js";
-import { formatLogTimestamp, registerLogsCli } from "./logs-cli.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { registerLogsCli } from "./logs-cli.js";
 
 const { MockGatewayTransportError } = vi.hoisted(() => ({
   MockGatewayTransportError: class extends Error {
@@ -162,20 +163,6 @@ function captureStderrWrites() {
   return writes;
 }
 
-async function withTimeZone<T>(timeZone: string, run: () => Promise<T> | T): Promise<T> {
-  const previous = process.env.TZ;
-  process.env.TZ = timeZone;
-  try {
-    return await run();
-  } finally {
-    if (previous === undefined) {
-      delete process.env.TZ;
-    } else {
-      process.env.TZ = previous;
-    }
-  }
-}
-
 describe("logs cli", () => {
   beforeEach(() => {
     readSystemdServiceRuntime.mockResolvedValue({ status: "stopped" });
@@ -290,74 +277,63 @@ describe("logs cli", () => {
     );
   });
 
-  it("emits local timestamps by default", async () => {
-    await withTimeZone("America/New_York", async () => {
-      callGatewayFromCli.mockResolvedValueOnce({
-        file: "/tmp/openclaw.log",
-        lines: [
-          JSON.stringify({
-            time: "2025-01-01T12:00:00.000Z",
-            _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
-            0: "line one",
-          }),
-        ],
+  it.each([
+    { mode: "plain local", tty: true, args: ["--plain"], time: "2025-01-01T07:00:00.000-05:00" },
+    {
+      mode: "plain --local-time",
+      tty: true,
+      args: ["--local-time", "--plain"],
+      time: "2025-01-01T07:00:00.000-05:00",
+    },
+    { mode: "plain UTC", tty: true, args: ["--utc", "--plain"], time: "2025-01-01T12:00:00.000Z" },
+    { mode: "pretty local", tty: true, args: [], time: "07:00:00-05:00" },
+    { mode: "pretty UTC", tty: true, args: ["--utc"], time: "12:00:00+00:00" },
+    { mode: "non-TTY local", tty: false, args: [], time: "2025-01-01T07:00:00.000-05:00" },
+  ])(
+    "renders $mode timestamps and preserves missing or malformed values",
+    async ({ tty, args, time }) => {
+      await withEnvAsync({ TZ: "America/New_York" }, async () => {
+        const stdoutTty = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+        Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: tty });
+        try {
+          callGatewayFromCli.mockResolvedValueOnce({
+            file: "/tmp/openclaw.log",
+            lines: [
+              { time: "2025-01-01T12:00:00.000Z", message: "valid timestamp" },
+              { message: "missing timestamp" },
+              { time: "", message: "empty timestamp" },
+              { time: "invalid-date", message: "invalid timestamp" },
+              { time: "not-a-date", message: "other invalid timestamp" },
+            ].map((entry) =>
+              JSON.stringify({
+                time: entry.time,
+                _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
+                0: entry.message,
+              }),
+            ),
+          });
+          const stdoutWrites = captureStdoutWrites();
+
+          await runLogsCli(["logs", "--no-color", ...args]);
+
+          expect(stdoutWrites.join("").trim().split("\n")).toEqual([
+            "Log file: /tmp/openclaw.log",
+            `${time} info gateway valid timestamp`,
+            "info gateway missing timestamp",
+            "info gateway empty timestamp",
+            "invalid-date info gateway invalid timestamp",
+            "not-a-date info gateway other invalid timestamp",
+          ]);
+        } finally {
+          if (stdoutTty) {
+            Object.defineProperty(process.stdout, "isTTY", stdoutTty);
+          } else {
+            Reflect.deleteProperty(process.stdout, "isTTY");
+          }
+        }
       });
-
-      const stdoutWrites = captureStdoutWrites();
-
-      await runLogsCli(["logs", "--plain"]);
-
-      const output = stdoutWrites.join("");
-      expect(output).toContain("line one");
-      expect(output).toContain("2025-01-01T07:00:00.000-05:00");
-    });
-  });
-
-  it("keeps --local-time accepted as the compatibility spelling", async () => {
-    await withTimeZone("America/New_York", async () => {
-      callGatewayFromCli.mockResolvedValueOnce({
-        file: "/tmp/openclaw.log",
-        lines: [
-          JSON.stringify({
-            time: "2025-01-01T12:00:00.000Z",
-            _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
-            0: "line one",
-          }),
-        ],
-      });
-
-      const stdoutWrites = captureStdoutWrites();
-
-      await runLogsCli(["logs", "--local-time", "--plain"]);
-
-      const output = stdoutWrites.join("");
-      expect(output).toContain("line one");
-      expect(output).toContain("2025-01-01T07:00:00.000-05:00");
-    });
-  });
-
-  it("wires --utc through CLI parsing and emits UTC timestamps", async () => {
-    await withTimeZone("America/New_York", async () => {
-      callGatewayFromCli.mockResolvedValueOnce({
-        file: "/tmp/openclaw.log",
-        lines: [
-          JSON.stringify({
-            time: "2025-01-01T12:00:00.000Z",
-            _meta: { logLevelName: "INFO", name: JSON.stringify({ subsystem: "gateway" }) },
-            0: "line one",
-          }),
-        ],
-      });
-
-      const stdoutWrites = captureStdoutWrites();
-
-      await runLogsCli(["logs", "--utc", "--plain"]);
-
-      const output = stdoutWrites.join("");
-      expect(output).toContain("line one");
-      expect(output).toContain("2025-01-01T12:00:00.000Z");
-    });
-  });
+    },
+  );
 
   it("warns when the output pipe closes", async () => {
     callGatewayFromCli.mockResolvedValueOnce({
@@ -586,7 +562,7 @@ describe("logs cli", () => {
 
       // Pin UTC: the recovered-line assertion below checks a rendered
       // timestamp, which otherwise follows the host time zone.
-      await withTimeZone("UTC", () =>
+      await withEnvAsync({ TZ: "UTC" }, () =>
         runLogsCli(["logs", "--follow", "--plain", "--interval", "1", "--timeout", "250"]),
       );
 
@@ -1165,55 +1141,6 @@ describe("logs cli", () => {
       "gateway closed (1000 normal closure): no close reason",
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-  describe("formatLogTimestamp", () => {
-    it("formats local timestamp in plain mode by default", async () => {
-      await withTimeZone("America/New_York", () => {
-        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z");
-        expect(result).toBe("2025-01-01T07:00:00.000-05:00");
-      });
-    });
-
-    it("formats local timestamp in pretty mode by default", async () => {
-      await withTimeZone("America/New_York", () => {
-        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty");
-        expect(result).toBe("07:00:00-05:00");
-      });
-    });
-
-    it("formats UTC timestamp in plain mode when localTime is false", () => {
-      const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "plain", false);
-      expect(result).toBe("2025-01-01T12:00:00.000Z");
-    });
-
-    it("formats UTC timestamp in pretty mode when localTime is false", () => {
-      const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty", false);
-      expect(result).toBe("12:00:00+00:00");
-    });
-
-    it("formats local time in plain mode when localTime is true", async () => {
-      await withTimeZone("America/New_York", () => {
-        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "plain", true);
-        expect(result).toBe("2025-01-01T07:00:00.000-05:00");
-      });
-    });
-
-    it("formats local time in pretty mode when localTime is true", async () => {
-      await withTimeZone("America/New_York", () => {
-        const result = formatLogTimestamp("2025-01-01T12:00:00.000Z", "pretty", true);
-        expect(result).toBe("07:00:00-05:00");
-      });
-    });
-
-    it.each([
-      { input: undefined, expected: "" },
-      { input: "", expected: "" },
-      { input: "invalid-date", expected: "invalid-date" },
-      { input: "not-a-date", expected: "not-a-date" },
-    ])("preserves timestamp fallback for $input", ({ input, expected }) => {
-      expect(formatLogTimestamp(input)).toBe(expected);
-    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -392,11 +392,7 @@ function isTransientFollowError(error: unknown): boolean {
   return isPlainGatewayRequestCloseError(message) || isPlainGatewayRequestTimeoutError(message);
 }
 
-export function formatLogTimestamp(
-  value?: string,
-  mode: "pretty" | "plain" = "plain",
-  localTime = true,
-) {
+function formatLogTimestamp(value?: string, mode: "pretty" | "plain" = "plain", localTime = true) {
   if (!value) {
     return "";
   }


### PR DESCRIPTION
## What Problem This Solves

The maintainer-requested test audit found duplicated timestamp setup in the logs CLI suite and a formatting helper exported solely for its direct tests. Those tests checked formatting in isolation, while the operator-facing contract also depends on Commander flags and terminal output mode.

## Why This Change Was Made

Consolidate the timestamp assertions into six real Commander/stdout cases covering plain local time, `--local-time`, plain UTC, pretty local/UTC, and non-TTY output. Each case asserts complete literal output lines for valid, missing, empty, and malformed timestamps. Reuse `withEnvAsync` for the meaningful timezone scope, including the existing follow-recovery test, and make `formatLogTimestamp` private.

Production scope is one test-only export removed; the helper body and defaults are unchanged. Measured production +1/-5 includes declaration formatting, not removed runtime logic. Test code is +59/-132 (net -73 lines).

## User Impact

No user-visible behavior changes. Existing follow recovery, cursor handling, URL redaction, authentication failures, JSON output, and local-port selection coverage remains intact.

## Evidence

The original signed head `91f896dfea17d36c79d2c54e5cbc4596f880852f` was tested against base `1623683f478b1e4a2e3d5632585f006ea142e08c`. The same four suites passed before (66 tests) and after consolidation (59 tests):

```sh
env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs src/cli/logs-cli.test.ts src/cli/logs-cli.port.test.ts src/logging/timestamps.test.ts src/logging/parse-log-line.test.ts
```

Inspected candidate terminal excerpts, from the logging and CLI shards respectively:

```text
Test Files  2 passed (2)
     Tests  12 passed (12)
Test Files  2 passed (2)
     Tests  47 passed (47)
[test] passed 2 Vitest shards in 35.47s
```

Five temporary adapter faults produced the intended assertion failures: forcing plain output failed both pretty cases; ignoring `--utc` failed both UTC cases; dropping malformed timestamps or inventing missing timestamps each failed all six cases; ignoring terminal detection failed the non-TTY case. After restoring the candidate, all 35 CLI tests passed again. Every fault run exited 1; normal baseline/candidate/restored runs exited 0.

Codex autoreview of that exact patch through P2: `scoped-clean`, no actionable findings, `patch is correct`.

The full normal local changed gate on the original head passed (exit 0, 1,481.97 seconds), including core/core-test typechecks, all three export scans, lint, and architecture/auth guards:

```sh
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs --base 1623683f478b1e4a2e3d5632585f006ea142e08c -- src/cli/logs-cli.ts src/cli/logs-cli.test.ts
```

Inspected gate output:

```text
[deadcode] Knip script unused-export scan passed with 0 entries.
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
Database-first legacy-store guard passed.
Import cycle check: 0 runtime value cycle(s).
```

Verification confirmed unchanged candidate source hashes across the original tests, review, full gate, and signed commit. Both the original and refreshed commits are authored and committed by Peter Steinberger, with verified signatures.


The mechanical refresh is signed head `d6a83eb8679bd65dcbe7386348dfc52b52dbe793` on `0df437f0071c53e95cbe1fd3d7a6e28079b67984`. Range-diff reports the same sole commit; the exact two-file patch and recorded file contents are identical. Nineteen related owner, caller, callee, test-support and docs files, relevant dependency versions, and the entire lockfile are unchanged between the two bases. The original head remains preserved. These checks establish an unchanged PR delta; they do not claim successful CI on the refreshed head.

Original PR CI was superseded by a delayed event in its cancelling PR concurrency group and then skipped all jobs. One normal native dispatch produced [run 33666741480](https://github.com/openclaw/openclaw/actions/runs/33666741480) on `91f896…`. Completed jobs exposed three failures:

| Job | Observed failure | Current disposition |
| --- | --- | --- |
| [Core lint](https://github.com/openclaw/openclaw/actions/runs/33666741480/job/100377771157) | `src/cli/gateway-backed-exit.process.test.ts` exceeded max-lines at 1,040 lines | The canonical `aef65cc` correction is included in the refreshed base. |
| [Built artifacts](https://github.com/openclaw/openclaw/actions/runs/33666741480/job/100377770223) | Built-CLI SQLite lifecycle proof could not list bundled plugin artifacts | The canonical fixture correction from [#136391](https://github.com/openclaw/openclaw/pull/136391), merge `1212f991db46ad4ffe8c11198c175a5736392a15`, is included. |
| [Agentic Gateway methods](https://github.com/openclaw/openclaw/actions/runs/33666741480/job/100377780123) | `chat.abort-incarnation.test.ts`, `reset=false completed=false`, failed with `ENOTEMPTY` while removing temporary state | Cleanup-failure attribution remains unresolved. This rebase is not claimed to fix it. |

The built-CLI fixture previously parsed the all-plugin inventory through a helper retaining only the last 256 KiB of output. The canonical correction inspects its explicit OpenAI plugin instead and preserves the bundled identity, built-path assertion, and complete lifecycle coverage. The failed Logs job omitted the inventory's raw stdout and exit code, so that individual parse failure cannot be proven directly from its diagnostic. The matching canonical failure was reproduced and corrected in #136391.

That correction has independent hosted proof: [CI 33654319698](https://github.com/openclaw/openclaw/actions/runs/33654319698) succeeded on `4f421e2036e7721330cc37461f1654a08622ee78`; its [built-artifacts job](https://github.com/openclaw/openclaw/actions/runs/33654319698/job/100331811984) includes the passing complete SQLite lifecycle test (73,744 ms). The corrected helper's Git blob exactly matches the refreshed base. This is prior proof for the canonical correction, not CI for this refreshed PR head.

**New exact-head CI is required before preparation or merge.** The cleanup failure remains an explicit validation concern; no failed assertion, test, buffer limit, or required check has been removed, relaxed, or waived.
