### PR TITLE
fix(macos): restrict Canvas NSWorkspace URL schemes

### DIFF
--- a/apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift
+++ b/apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift
@@ -42,16 +42,17 @@ extension CanvasWindowController {
             return
         }
 
-        // Only open external URLs when there is a registered handler, otherwise macOS will show a confusing
-        // "There is no application set to open the URL ..." alert (e.g. for about:blank).
-        if let appURL = NSWorkspace.shared.urlForApplication(toOpen: url) {
+        // Same NSWorkspace allowlist as Control UI. Do not launch file://, smb://, or app handlers.
+        if WebContentWorkspaceURL.isAllowed(url),
+           let appURL = NSWorkspace.shared.urlForApplication(toOpen: url)
+        {
             NSWorkspace.shared.open(
                 [url],
                 withApplicationAt: appURL,
                 configuration: NSWorkspace.OpenConfiguration(),
                 completionHandler: nil)
         } else {
-            canvasWindowLogger.debug("no application to open scheme=\(scheme ?? "-", privacy: .public)")
+            canvasWindowLogger.debug("blocked external scheme=\(scheme ?? "-", privacy: .public)")
         }
         decisionHandler(.cancel)
     }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+NavigationPolicy.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+NavigationPolicy.swift
@@ -27,11 +27,7 @@ extension DashboardWindowController {
     }
 
     static func isExternalURL(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased() else { return false }
-        if scheme == "http" || scheme == "https" {
-            return self.isHTTPURL(url)
-        }
-        return scheme == "mailto" || scheme == "tel"
+        WebContentWorkspaceURL.isAllowed(url)
     }
 
     static func isEditorURL(_ url: URL) -> Bool {

--- a/apps/macos/Sources/OpenClaw/WebContentWorkspaceURL.swift
+++ b/apps/macos/Sources/OpenClaw/WebContentWorkspaceURL.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum WebContentWorkspaceURL {
+    /// Schemes web content may hand to NSWorkspace.open: http, https, mailto, tel.
+    /// file://, smb://, and app URL handlers stay closed.
+    static func isAllowed(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        if scheme == "http" || scheme == "https" {
+            return url.host?.isEmpty == false
+        }
+        return scheme == "mailto" || scheme == "tel"
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/WebContentWorkspaceURLTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebContentWorkspaceURLTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct WebContentWorkspaceURLTests {
+    @Test(arguments: [
+        "https://docs.openclaw.ai/",
+        "http://127.0.0.1:18789/",
+        "mailto:hello@example.com",
+        "MAILTO:hello@example.com",
+        "tel:+15555550100",
+        "TEL:+15555550100",
+    ])
+    func `workspace open allowlist accepts Control UI schemes`(_ address: String) throws {
+        let url = try #require(URL(string: address))
+        #expect(WebContentWorkspaceURL.isAllowed(url))
+    }
+
+    @Test(arguments: [
+        "file:///etc/passwd",
+        "smb://files.example/share",
+        "slack://open",
+        "vscode://file/tmp/secret",
+        "javascript:alert(1)",
+        "data:text/html,hi",
+        "about:blank",
+        "ftp://files.example/pub",
+    ])
+    func `workspace open allowlist rejects arbitrary schemes`(_ address: String) throws {
+        let url = try #require(URL(string: address))
+        #expect(!WebContentWorkspaceURL.isAllowed(url))
+    }
+
+    @Test func `http and https require a host`() throws {
+        let noHost = try #require(URL(string: "https:"))
+        #expect(!WebContentWorkspaceURL.isAllowed(noHost))
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing a remote page in the macOS Canvas panel would have macOS launch Finder, an SMB share, or any registered app handler when that page navigated to `file://`, `smb://`, `slack://`, or a similar scheme. Control UI already refuses those launches and only hands `http`, `https`, `mailto`, and `tel` to NSWorkspace. Canvas did not.

## Why This Change Was Made

Canvas now uses the same NSWorkspace scheme allowlist as Control UI. `http` and `https` stay in the panel. `mailto` and `tel` can still open Mail or Phone. `file://`, `smb://`, and other app handlers are cancelled. The allowlist lives in one helper so Control UI and Canvas cannot drift.

## User Impact

A Canvas page can still open a normal web link, an email address, or a phone number. It can no longer pop Finder, mount a share, or launch Slack, Zoom, or an editor just because those schemes are registered on the Mac.

## Evidence

Live WKWebView run on this machine (macOS 26.6.2 25G83, Apple Swift 6.4, Node v26.8.2) against production `CanvasWindowController+Navigation.swift` and `WebContentWorkspaceURL.swift` at `e3c3ed8ba446b4feda61cda1dbdcabb401061de1`.

The driver compiled those two production files, created a real `WKWebView`, and forwarded every `WKNavigationAction` into `CanvasWindowController.webView(decidePolicyFor:)`. `NSWorkspace.open` was intercepted so Mail.app was not actually launched; the call was still recorded.

```console
$ swiftc -parse-as-library -o /tmp/proof-136518 /tmp/proof-136518-driver.swift apps/macos/Sources/OpenClaw/WebContentWorkspaceURL.swift apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift -framework AppKit -framework WebKit && /tmp/proof-136518
SWIZZLE_OK NSWorkspace.open intercepted
CONTROLLER CanvasWindowController delegate=Optional(<main.DelegateProbe: 0x8e8d4f140>)
FORWARD CanvasWindowController.webView(decidePolicyFor:) url=https://docs.openclaw.ai/canvas-proof.html type=-1
DECISION url=https://docs.openclaw.ai/canvas-proof.html policy=allow workspaceOpensBefore=0 workspaceOpensAfter=0
DID_FINISH https://docs.openclaw.ai/canvas-proof.html
LOADED https://docs.openclaw.ai/canvas-proof.html
NAV file:///etc/passwd from https://docs.openclaw.ai/canvas-proof.html
FORWARD CanvasWindowController.webView(decidePolicyFor:) url=file:///etc/passwd type=-1
DECISION url=file:///etc/passwd policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
RESULT href=file:///etc/passwd seen=true policy=cancel expect=cancel workspace=false expectWorkspace=false page=https://docs.openclaw.ai/canvas-proof.html newOpens=[] ok=true
NAV smb://files.example/share from https://docs.openclaw.ai/canvas-proof.html
FORWARD CanvasWindowController.webView(decidePolicyFor:) url=smb://files.example/share type=-1
DECISION url=smb://files.example/share policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
RESULT href=smb://files.example/share seen=true policy=cancel expect=cancel workspace=false expectWorkspace=false page=https://docs.openclaw.ai/canvas-proof.html newOpens=[] ok=true
NAV slack://open from https://docs.openclaw.ai/canvas-proof.html
FORWARD CanvasWindowController.webView(decidePolicyFor:) url=slack://open type=-1
DECISION url=slack://open policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
RESULT href=slack://open seen=true policy=cancel expect=cancel workspace=false expectWorkspace=false page=https://docs.openclaw.ai/canvas-proof.html newOpens=[] ok=true
NAV vscode://file/tmp/secret from https://docs.openclaw.ai/canvas-proof.html
FORWARD CanvasWindowController.webView(decidePolicyFor:) url=vscode://file/tmp/secret type=-1
DECISION url=vscode://file/tmp/secret policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
RESULT href=vscode://file/tmp/secret seen=true policy=cancel expect=cancel workspace=false expectWorkspace=false page=https://docs.openclaw.ai/canvas-proof.html newOpens=[] ok=true
NAV mailto:hello@example.com from https://docs.openclaw.ai/canvas-proof.html
FORWARD CanvasWindowController.webView(decidePolicyFor:) url=mailto:hello@example.com type=-1
WORKSPACE_OPEN mailto:hello@example.com app=Mail.app
DECISION url=mailto:hello@example.com policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=1
RESULT href=mailto:hello@example.com seen=true policy=cancel expect=cancel workspace=true expectWorkspace=true page=https://docs.openclaw.ai/canvas-proof.html newOpens=["mailto:hello@example.com app=Mail.app"] ok=true
NAV https://example.com/ from https://docs.openclaw.ai/canvas-proof.html
FORWARD CanvasWindowController.webView(decidePolicyFor:) url=https://example.com/ type=-1
DECISION url=https://example.com/ policy=allow workspaceOpensBefore=1 workspaceOpensAfter=1
RESULT href=https://example.com/ seen=true policy=allow expect=allow workspace=false expectWorkspace=false page=https://example.com/ newOpens=[] ok=true
DID_FINISH https://example.com/
WORKSPACE_OPENS_TOTAL ["mailto:hello@example.com app=Mail.app"]
DECISIONS ["https://docs.openclaw.ai/canvas-proof.html->allow", "file:///etc/passwd->cancel", "smb://files.example/share->cancel", "slack://open->cancel", "vscode://file/tmp/secret->cancel", "mailto:hello@example.com->cancel", "https://example.com/->allow"]
ALL PASSED
```

`file://`, `smb://`, `slack://`, and `vscode://` were cancelled before any `NSWorkspace.open`. `mailto:` still asked Mail.app, then cancelled the in-panel navigation. `https://example.com/` stayed in the web view (`DID_FINISH https://example.com/`) with no extra workspace open.

Related: Control UI allowlist from https://github.com/openclaw/openclaw/pull/102899. Canvas NSWorkspace-any-scheme behavior dates to `3bc1644f344` (2025-12-24).

## Real behavior proof

- **Behavior or issue addressed:** A remote Canvas page could launch `file://`, `smb://`, or any registered app URL through NSWorkspace. Those launches now match Control UI and stay closed.
- **Real environment tested:** macOS 26.6.2 (25G83), Apple Swift 6.4, Node v26.8.2, OpenClaw source at `/tmp/oc-136518` on `fix/macos-canvas-url-scheme-allowlist` tip `e3c3ed8ba446b4feda61cda1dbdcabb401061de1`.
- **Exact steps or command run after this patch:**

  ```bash
  cd /tmp/oc-136518
  swiftc -parse-as-library -o /tmp/proof-136518 /tmp/proof-136518-driver.swift apps/macos/Sources/OpenClaw/WebContentWorkspaceURL.swift apps/macos/Sources/OpenClaw/CanvasWindowController+Navigation.swift -framework AppKit -framework WebKit
  /tmp/proof-136518
  ```

- **Evidence after fix:** terminal output copied below.

  ```console
  $ /tmp/proof-136518
  FORWARD CanvasWindowController.webView(decidePolicyFor:) url=file:///etc/passwd type=-1
  DECISION url=file:///etc/passwd policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
  FORWARD CanvasWindowController.webView(decidePolicyFor:) url=smb://files.example/share type=-1
  DECISION url=smb://files.example/share policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
  FORWARD CanvasWindowController.webView(decidePolicyFor:) url=slack://open type=-1
  DECISION url=slack://open policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
  FORWARD CanvasWindowController.webView(decidePolicyFor:) url=vscode://file/tmp/secret type=-1
  DECISION url=vscode://file/tmp/secret policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=0
  FORWARD CanvasWindowController.webView(decidePolicyFor:) url=mailto:hello@example.com type=-1
  WORKSPACE_OPEN mailto:hello@example.com app=Mail.app
  DECISION url=mailto:hello@example.com policy=cancel workspaceOpensBefore=0 workspaceOpensAfter=1
  FORWARD CanvasWindowController.webView(decidePolicyFor:) url=https://example.com/ type=-1
  DECISION url=https://example.com/ policy=allow workspaceOpensBefore=1 workspaceOpensAfter=1
  DID_FINISH https://example.com/
  ALL PASSED
  ```

- **Observed result after fix:** Live `WKNavigationAction`s reached `CanvasWindowController.webView(decidePolicyFor:)`. Blocked schemes cancelled with zero `NSWorkspace.open` calls. `mailto:` still selected Mail.app, then cancelled the web view navigation. `https://example.com/` was allowed in-panel and finished loading there.
- **What was not tested:** A click inside a packaged signed OpenClaw.app Canvas window. The full macos-swift suite on this desktop (that job owns native tests on a disposable runner).

## Summary

Canvas `decidePolicyFor` used to treat any registered scheme as an external open. That is older than the Control UI sidebar allowlist in #102899 and left a remote Canvas document able to launch local handlers. This PR closes that gap without changing in-panel http(s) rendering or Control UI editor-URL launches from the trusted file sidebar.
