### PR TITLE
fix(macos): notify when background sessions finish

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -2231,6 +2231,7 @@
     {"id":"native.apple.806bacb5f14df90c","source":"Cost","surface":"apple","sites":[{"kind":"ui-named-argument","path":"apps/ios/Sources/Design/AgentProTab+Usage.swift"}]},
     {"id":"native.apple.104c29e39856706e","source":"Cost: %@","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift"}]},
     {"id":"native.apple.23f447855b25395a","source":"Could Not Change Primary Gateway","surface":"apple","sites":[{"kind":"ui-call","path":"apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"}]},
+    {"id":"native.apple.4adc28ed0e25f735","source":"Could Not Open Background Session","surface":"apple","sites":[{"kind":"ui-named-argument","path":"apps/macos/Sources/OpenClaw/DashboardManager.swift"}]},
     {"id":"native.apple.2e44cb00b99f5c81","source":"Could Not Open Gateway Window","surface":"apple","sites":[{"kind":"ui-named-argument","path":"apps/macos/Sources/OpenClaw/DashboardManager.swift"},{"kind":"ui-named-argument","path":"apps/macos/Sources/OpenClaw/WebChatManager.swift"}]},
     {"id":"native.apple.493c8a7bdfc34dcb","source":"Could Not Set Primary Gateway","surface":"apple","sites":[{"kind":"ui-named-argument","path":"apps/macos/Sources/OpenClaw/DashboardManager.swift"}]},
     {"id":"native.apple.b26583d7bf77eff2","source":"Could Not Switch Gateway","surface":"apple","sites":[{"kind":"ui-named-argument","path":"apps/macos/Sources/OpenClaw/DashboardManager.swift"}]},

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -30,6 +30,11 @@ final class DashboardManager {
 
     private struct SupersededDashboardPresentation: Error {}
 
+    private struct NavigationIntent {
+        let id = UUID()
+        let windowID: ObjectIdentifier?
+    }
+
     @ObservationIgnored private var controller: DashboardWindowController?
     @ObservationIgnored private var mainTarget = DashboardGatewayTarget.primary
     @ObservationIgnored private var auxiliaryWindows: [UUID: AuxiliaryWindowInstance] = [:]
@@ -38,7 +43,7 @@ final class DashboardManager {
     @ObservationIgnored private var presentationTask: Task<Void, Error>?
     @ObservationIgnored private var pendingOpenCommands: [DashboardNativeCommand] = []
     @ObservationIgnored private var openForCommandTask: Task<Void, Never>?
-    @ObservationIgnored private var navigationGeneration: UInt64 = 0
+    @ObservationIgnored private var navigationIntents: [DashboardGatewayTarget: NavigationIntent] = [:]
     @ObservationIgnored private var updater: UpdaterProviding?
     @ObservationIgnored private var displayedRouteRevision: UInt64?
     @ObservationIgnored private var displayedRouteAuthority: UInt64?
@@ -217,12 +222,12 @@ final class DashboardManager {
                 self.replaceWithRouteFailure(controller)
                 return
             }
-            self.replaceController(
+            self.replaceWindowController(
                 controller,
-                url: dashboardURL,
-                auth: auth,
-                mode: mode,
-                tlsParams: tlsParams)
+                configuration: WindowConfiguration(
+                    url: dashboardURL, auth: auth, tlsParams: tlsParams, mode: mode, displayName: "OpenClaw"),
+                target: .primary,
+                present: false)
             return
         }
         if dashboardURL == controller.currentURL {
@@ -235,30 +240,6 @@ final class DashboardManager {
             "dashboard endpoint changed; reloading url=\(dashboardLogString(for: dashboardURL), privacy: .public)")
         controller.update(url: dashboardURL, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
         self.displayedRouteRevision = routeRevision
-    }
-
-    private func replaceController(
-        _ current: DashboardWindowController,
-        url: URL,
-        auth: DashboardWindowAuth,
-        mode: AppState.ConnectionMode,
-        tlsParams: GatewayTLSParams?,
-        present: Bool = false)
-    {
-        guard self.controller === current else { return }
-        self.switchGenerations[ObjectIdentifier(current)] = nil
-        let window = current.detachWindowForReplacement()
-        let replacement = self.makePrimaryController(
-            url: url,
-            auth: auth,
-            mode: mode,
-            tlsParams: tlsParams,
-            reusingWindow: window)
-        self.controller = replacement
-        replacement.loadInBackground(url: url, auth: auth)
-        if present {
-            replacement.show()
-        }
     }
 
     private func replaceWithRouteFailure(_ current: DashboardWindowController) {
@@ -279,6 +260,7 @@ final class DashboardManager {
     }
 
     func presentDashboard() {
+        self.retireNavigation(for: self.mainTarget)
         if self.showConfiguredWindowIfPossible() {
             return
         }
@@ -314,28 +296,18 @@ final class DashboardManager {
         guard auth.hasCredential else {
             return false
         }
-        self.endpointGeneration &+= 1
-        if let controller, self.requiresIsolatedDashboardDocument(controller, auth: auth, endpoint: endpoint) {
-            self.replaceController(
-                controller,
-                url: url,
-                auth: auth,
-                mode: mode,
-                tlsParams: endpoint.tls?.params,
-                present: true)
-        } else if let controller {
-            controller.show(url: url, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
-        } else {
-            let controller = self.makePrimaryController(
-                url: url,
-                auth: auth,
-                mode: mode,
-                tlsParams: endpoint.tls?.params)
-            self.controller = controller
-            controller.show(url: url, auth: auth)
+        let previousController = self.controller
+        self.presentDashboard(
+            configuration: WindowConfiguration(
+                url: url, auth: auth, tlsParams: endpoint.tls?.params, mode: mode, displayName: "OpenClaw"),
+            endpoint: endpoint,
+            target: .primary,
+            source: previousController)
+        // A newly configured document supersedes older authentication lookups;
+        // merely reopening the unchanged document does not change its endpoint.
+        if self.controller !== previousController {
+            self.endpointGeneration &+= 1
         }
-        self.rememberPresentedEndpoint(endpoint)
-        self.observeEndpointChanges()
         Task { await self.refreshGatewaySnapshots() }
         Task { await self.routeProbe(.presentation) }
         return true
@@ -361,7 +333,6 @@ final class DashboardManager {
 
     private func showResolvedPrimaryDashboard() async throws {
         let mode = AppStateStore.shared.connectionMode
-        self.endpointGeneration &+= 1
         let generation = self.endpointGeneration
         let originalController = self.controller
         dashboardManagerLogger.info("dashboard show requested mode=\(String(describing: mode), privacy: .public)")
@@ -389,49 +360,55 @@ final class DashboardManager {
             token: token,
             password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
 
-        if let controller, self.requiresIsolatedDashboardDocument(controller, auth: auth, endpoint: endpoint) {
-            self.replaceController(
-                controller,
-                url: url,
-                auth: auth,
-                mode: mode,
-                tlsParams: endpoint.tls?.params,
-                present: true)
-            self.rememberPresentedEndpoint(endpoint)
-            self.observeEndpointChanges()
-            await self.refreshGatewaySnapshots()
-            return
-        } else if let controller {
-            dashboardManagerLogger.info("dashboard reuse window url=\(dashboardLogString(for: url), privacy: .public)")
-            controller.show(url: url, auth: auth, updateBridgeEnabled: Self.updateBridgeEnabled(mode: mode))
-            self.rememberPresentedEndpoint(endpoint)
-            self.observeEndpointChanges()
-            await self.refreshGatewaySnapshots()
-            return
-        }
-
-        dashboardManagerLogger.info("dashboard create window url=\(dashboardLogString(for: url), privacy: .public)")
-        let controller = self.makePrimaryController(
-            url: url,
-            auth: auth,
-            mode: mode,
-            tlsParams: endpoint.tls?.params)
-        self.controller = controller
-        controller.show(url: url, auth: auth)
-        self.rememberPresentedEndpoint(endpoint)
-        self.observeEndpointChanges()
+        let creatingWindow = self.controller == nil
+        self.presentDashboard(
+            configuration: WindowConfiguration(
+                url: url, auth: auth, tlsParams: endpoint.tls?.params, mode: mode, displayName: "OpenClaw"),
+            endpoint: endpoint,
+            target: .primary,
+            source: self.controller)
         await self.refreshGatewaySnapshots()
+        if creatingWindow {
+            Task { await self.routeProbe(.presentation) }
+        }
+    }
 
-        // Refresh the cached hello payload without blocking window creation.
-        Task { await self.routeProbe(.presentation) }
+    private func beginNavigation(
+        for target: DashboardGatewayTarget,
+        source: DashboardWindowController?) -> UUID
+    {
+        // Pending lookup intent is target-owned even before a native window exists.
+        let intent = NavigationIntent(windowID: source?.window.map(ObjectIdentifier.init))
+        self.navigationIntents[target] = intent
+        if target == self.mainTarget {
+            self.pendingOpenCommands.removeAll(where: \.supersedesPendingNavigation)
+        }
+        return intent.id
+    }
+
+    private func finishNavigation(_ intent: UUID, for target: DashboardGatewayTarget) {
+        if self.navigationIntents[target]?.id == intent {
+            self.navigationIntents[target] = nil
+        }
+    }
+
+    private func retireNavigation(
+        for target: DashboardGatewayTarget,
+        from source: DashboardWindowController? = nil)
+    {
+        if let source, let sourceTarget = self.target(for: source) {
+            self.navigationIntents[sourceTarget] = nil
+        }
+        self.navigationIntents[target] = nil
     }
 
     func show(atPath path: String, search: String? = nil) async {
-        self.navigationGeneration &+= 1
-        let generation = self.navigationGeneration
+        let target = self.mainTarget
+        let intent = self.beginNavigation(for: target, source: self.controller)
+        defer { self.finishNavigation(intent, for: target) }
         do {
             try await self.show()
-            guard generation == self.navigationGeneration else { return }
+            guard self.navigationIntents[target]?.id == intent else { return }
             guard let controller,
                   let fallbackURL = DashboardRouteMap.dashboardURL(
                       byAppendingSameAppPath: path,
@@ -443,7 +420,7 @@ final class DashboardManager {
                 search: search,
                 fallbackURL: fallbackURL))
         } catch {
-            guard generation == self.navigationGeneration else { return }
+            guard self.navigationIntents[target]?.id == intent else { return }
             self.showFailure(error)
         }
     }
@@ -470,7 +447,7 @@ final class DashboardManager {
         self.presentationGeneration &+= 1
         self.presentationTask?.cancel()
         self.presentationTask = nil
-        self.navigationGeneration &+= 1
+        self.navigationIntents.removeAll()
         self.openForCommandTask?.cancel()
         self.openForCommandTask = nil
         self.pendingOpenCommands.removeAll()
@@ -488,7 +465,7 @@ final class DashboardManager {
     func dispatchNativeCommand(_ command: DashboardNativeCommand) {
         if command.supersedesPendingNavigation {
             // This also invalidates a handoff still suspended in show(atPath:).
-            self.navigationGeneration &+= 1
+            self.retireNavigation(for: self.mainTarget)
         }
         NSApp.activate(ignoringOtherApps: true)
         if let controller, controller.isWindowOpen, controller.canDeliverNativeCommands {
@@ -502,6 +479,7 @@ final class DashboardManager {
         guard self.openForCommandTask == nil else { return }
         self.openForCommandTask = Task { @MainActor in
             defer { self.openForCommandTask = nil }
+            guard !self.pendingOpenCommands.isEmpty else { return }
             if !self.showConfiguredWindowIfPossible() {
                 do {
                     try await self.show()
@@ -594,48 +572,11 @@ final class DashboardManager {
             return
         }
         do {
-            let configuration = try await self.windowConfiguration(for: target)
+            let (configuration, _) = try await self.windowConfiguration(for: target)
             guard self.switchIsCurrent(generation, for: source), self.target(for: source) == currentTarget else {
                 return
             }
-            // Background reconciliation must not resurrect a window the user closed;
-            // explicit show/open callers opt back into presentation.
-            let shouldPresent = present ?? source.isWindowOpen
-            if self.controller === source {
-                if self.mainTarget == .primary, target != .primary {
-                    self.displayedRouteRevision = nil
-                    self.displayedRouteAuthority = nil
-                }
-                let windowAutosaveName = self.availableAutosaveName(for: target, replacing: source)
-                let window = source.detachWindowForReplacement()
-                self.mainTarget = target
-                let replacement = self.makeController(
-                    configuration: configuration,
-                    target: target,
-                    windowAutosaveName: windowAutosaveName,
-                    auxiliary: false,
-                    reusingWindow: window)
-                self.controller = replacement
-                replacement.loadInBackground(url: configuration.url, auth: configuration.auth)
-                if shouldPresent, present == true || !replacement.isWindowOpen {
-                    replacement.show()
-                }
-            } else if let windowID = self.auxiliaryWindows.first(where: { $0.value.controller === source })?.key {
-                let autosaveName = self.availableAutosaveName(for: target, replacing: source)
-                let window = source.detachWindowForReplacement()
-                let replacement = self.makeController(
-                    configuration: configuration,
-                    target: target,
-                    windowAutosaveName: autosaveName,
-                    auxiliary: true,
-                    reusingWindow: window)
-                self.installAuxiliaryWindowCloseHandler(replacement, windowID: windowID)
-                self.auxiliaryWindows[windowID] = AuxiliaryWindowInstance(target: target, controller: replacement)
-                replacement.loadInBackground(url: configuration.url, auth: configuration.auth)
-                if shouldPresent, present == true || !replacement.isWindowOpen {
-                    replacement.show()
-                }
-            }
+            self.replaceWindowController(source, configuration: configuration, target: target, present: present)
             self.finishSwitch(generation, for: source)
             await self.refreshGatewaySnapshots()
             self.updateFrontmostDashboardTarget()
@@ -646,27 +587,49 @@ final class DashboardManager {
         }
     }
 
+    @discardableResult
+    private func replaceWindowController(
+        _ source: DashboardWindowController,
+        configuration: WindowConfiguration,
+        target: DashboardGatewayTarget,
+        present: Bool? = nil) -> DashboardWindowController?
+    {
+        let isMainWindow = self.controller === source
+        let windowID = self.auxiliaryWindows.first { $0.value.controller === source }?.key
+        guard isMainWindow || windowID != nil else { return nil }
+        self.switchGenerations[ObjectIdentifier(source)] = nil
+        // Background reconciliation must not resurrect a window the user closed;
+        // explicit show/open callers opt back into presentation.
+        let shouldPresent = present ?? source.isWindowOpen
+        let autosaveName = self.availableAutosaveName(for: target, replacing: source)
+        let window = source.detachWindowForReplacement()
+        let replacement = self.makeController(
+            configuration: configuration,
+            target: target,
+            windowAutosaveName: autosaveName,
+            auxiliary: !isMainWindow,
+            reusingWindow: window)
+        if isMainWindow {
+            if self.mainTarget == .primary, target != .primary {
+                self.displayedRouteRevision = nil
+                self.displayedRouteAuthority = nil
+            }
+            self.mainTarget = target
+            self.controller = replacement
+        } else if let windowID {
+            self.auxiliaryWindows[windowID] = AuxiliaryWindowInstance(target: target, controller: replacement)
+        }
+        replacement.loadInBackground(url: configuration.url, auth: configuration.auth)
+        if shouldPresent, present == true || !replacement.isWindowOpen {
+            replacement.show()
+        }
+        return replacement
+    }
+
     private func openWindow(for target: DashboardGatewayTarget) async {
         do {
-            let configuration = try await self.windowConfiguration(for: target)
-            let windowID = UUID()
-            let previous = self.auxiliaryWindowOrder.reversed().lazy
-                .compactMap { self.auxiliaryWindows[$0] }
-                .first { $0.target == target }?
-                .controller
-            let controller = self.makeController(
-                configuration: configuration,
-                target: target,
-                windowAutosaveName: self.availableAutosaveName(for: target),
-                auxiliary: true)
-            self.installAuxiliaryWindowCloseHandler(controller, windowID: windowID)
-            self.auxiliaryWindows[windowID] = AuxiliaryWindowInstance(target: target, controller: controller)
-            self.auxiliaryWindowOrder.append(windowID)
-            if let previous {
-                let origin = previous.window?.frame.origin ?? .zero
-                controller.window?.setFrameOrigin(NSPoint(x: origin.x + 24, y: origin.y - 24))
-            }
-            controller.show(url: configuration.url, auth: configuration.auth)
+            let (configuration, _) = try await self.windowConfiguration(for: target)
+            self.openWindow(for: target, configuration: configuration)
             await self.refreshGatewaySnapshots()
             self.updateFrontmostDashboardTarget()
         } catch {
@@ -674,7 +637,34 @@ final class DashboardManager {
         }
     }
 
-    private func windowConfiguration(for target: DashboardGatewayTarget) async throws -> WindowConfiguration {
+    @discardableResult
+    private func openWindow(
+        for target: DashboardGatewayTarget,
+        configuration: WindowConfiguration) -> DashboardWindowController
+    {
+        let windowID = UUID()
+        let previous = self.auxiliaryWindowOrder.reversed().lazy
+            .compactMap { self.auxiliaryWindows[$0] }
+            .first { $0.target == target }?
+            .controller
+        let controller = self.makeController(
+            configuration: configuration,
+            target: target,
+            windowAutosaveName: self.availableAutosaveName(for: target),
+            auxiliary: true)
+        self.auxiliaryWindows[windowID] = AuxiliaryWindowInstance(target: target, controller: controller)
+        self.auxiliaryWindowOrder.append(windowID)
+        if let previous {
+            let origin = previous.window?.frame.origin ?? .zero
+            controller.window?.setFrameOrigin(NSPoint(x: origin.x + 24, y: origin.y - 24))
+        }
+        controller.show(url: configuration.url, auth: configuration.auth)
+        return controller
+    }
+
+    private func windowConfiguration(for target: DashboardGatewayTarget) async throws
+        -> (configuration: WindowConfiguration, endpoint: GatewayConnection.EndpointSnapshot)
+    {
         switch target {
         case .primary:
             let mode = AppStateStore.shared.connectionMode
@@ -686,12 +676,12 @@ final class DashboardManager {
                 gatewayUrl: Self.websocketURLString(for: url),
                 token: token,
                 password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
-            return WindowConfiguration(
+            return (WindowConfiguration(
                 url: url,
                 auth: auth,
                 tlsParams: endpoint.tls?.params,
                 mode: mode,
-                displayName: "OpenClaw")
+                displayName: "OpenClaw"), endpoint)
         case let .profile(profileID):
             let endpoint = try await self.profileEndpoint(profileID: profileID)
             let url = try GatewayEndpointStore.dashboardURL(
@@ -703,12 +693,12 @@ final class DashboardManager {
                 token: endpoint.config.token,
                 password: endpoint.config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
             let name = self.gatewayEntries.first { $0.id == target.bridgeID }?.name ?? url.host ?? "Gateway"
-            return WindowConfiguration(
+            return (WindowConfiguration(
                 url: url,
                 auth: auth,
                 tlsParams: endpoint.tls?.params,
                 mode: .remote,
-                displayName: name)
+                displayName: name), endpoint)
         }
     }
 
@@ -757,7 +747,55 @@ final class DashboardManager {
                     completion, target: target, sourceURL: sourceURL)
             }
         }
+        controller.onClosed = { [weak self, weak controller] in
+            guard let self, let controller else { return }
+            self.handleWindowClosed(controller)
+        }
         return controller
+    }
+
+    @discardableResult
+    private func presentDashboard(
+        configuration: WindowConfiguration,
+        endpoint: GatewayConnection.EndpointSnapshot,
+        target: DashboardGatewayTarget,
+        source: DashboardWindowController?) -> DashboardWindowController?
+    {
+        let presented: DashboardWindowController?
+        if let source {
+            if self.requiresIsolatedDashboardDocument(
+                source, auth: configuration.auth, endpoint: endpoint,
+                comparePrimaryRoute: source === self.controller && target == .primary)
+            {
+                presented = self.replaceWindowController(
+                    source, configuration: configuration, target: target, present: true)
+            } else {
+                // The URL can be unchanged while the document is a failure page.
+                source.show(
+                    url: configuration.url,
+                    auth: configuration.auth,
+                    updateBridgeEnabled: source === self.controller && target == .primary &&
+                        Self.updateBridgeEnabled(mode: configuration.mode))
+                presented = source
+            }
+        } else if self.mainTarget == target, self.controller == nil {
+            let controller = self.makeController(
+                configuration: configuration,
+                target: target,
+                windowAutosaveName: self.mainWindowAutosaveName,
+                auxiliary: false)
+            self.controller = controller
+            controller.show(url: configuration.url, auth: configuration.auth)
+            presented = controller
+        } else {
+            presented = self.openWindow(for: target, configuration: configuration)
+        }
+        if target == .primary, presented === self.controller {
+            self.rememberPresentedEndpoint(endpoint)
+            self.observeEndpointChanges()
+        }
+        self.updateFrontmostDashboardTarget()
+        return presented
     }
 
     func openBackgroundSession(
@@ -765,21 +803,46 @@ final class DashboardManager {
         target: DashboardGatewayTarget,
         sourceURL: URL) async
     {
+        let endpointGeneration = self.endpointGeneration
+        let source = self.dashboardController(for: target) ?? (self.mainTarget == target ? self.controller : nil)
+        let window = source?.window
+        let currentController = {
+            guard let window else {
+                return self.dashboardController(for: target) ?? (self.mainTarget == target ? self.controller : nil)
+            }
+            // AppKit updates this owner when the privileged document is replaced;
+            // changing focus must not retarget an already admitted click.
+            guard let controller = window.windowController as? DashboardWindowController,
+                  self.target(for: controller) == target else { return nil }
+            return controller
+        }
+        let intent = self.beginNavigation(for: target, source: source)
+        defer { self.finishNavigation(intent, for: target) }
+        let sourceGeneration = source?.windowIntentGeneration
+        let isCurrent = {
+            guard !Task.isCancelled, self.navigationIntents[target]?.id == intent,
+                  target != .primary || self.endpointGeneration == endpointGeneration else { return false }
+            guard let window else { return source == nil }
+            guard let current = currentController(), let sourceGeneration else { return false }
+            return current.window === window && current.windowIntentGeneration == sourceGeneration
+        }
         do {
-            let configuration = try await self.windowConfiguration(for: target)
+            let (configuration, endpoint) = try await self.windowConfiguration(for: target)
+            guard isCurrent() else { return }
             guard sourceURL == Self.notificationRoute(configuration.url) else {
                 throw NSError(domain: "Dashboard", code: 1, userInfo: [
                     NSLocalizedDescriptionKey:
                         "This Gateway connection changed. Open the session from its Gateway's session list.",
                 ])
             }
-            await self.performOpenOrFocusDashboard(for: target)
-            guard let controller = self.dashboardController(for: target),
-                  sourceURL == Self.notificationRoute(controller.dashboardBaseURL),
-                  let fallbackURL = DashboardRouteMap.dashboardURL(
-                      byAppendingSameAppPath: completion.path,
-                      search: completion.search,
-                      to: controller.dashboardBaseURL)
+            // Configuration lookup is the only suspension: a newer navigation or
+            // window close cannot interleave restoration and dispatch.
+            guard let controller = self.presentDashboard(
+                configuration: configuration, endpoint: endpoint, target: target, source: currentController()),
+                let fallbackURL = DashboardRouteMap.dashboardURL(
+                    byAppendingSameAppPath: completion.path,
+                    search: completion.search,
+                    to: configuration.url)
             else {
                 throw NSError(domain: "Dashboard", code: 1, userInfo: [
                     NSLocalizedDescriptionKey:
@@ -788,7 +851,9 @@ final class DashboardManager {
             }
             controller.dispatchNativeNavigation(DashboardNativeNavigation(
                 path: completion.path, search: completion.search, fallbackURL: fallbackURL))
+            Task { await self.refreshGatewaySnapshots() }
         } catch {
+            guard isCurrent() else { return }
             Self.showGatewayError(error, message: "Could Not Open Background Session")
         }
     }
@@ -805,18 +870,19 @@ final class DashboardManager {
         return route.url
     }
 
-    private func installAuxiliaryWindowCloseHandler(_ controller: DashboardWindowController, windowID: UUID) {
-        controller.onClosed = { [weak self, weak controller] in
-            guard let self, let controller,
-                  self.auxiliaryWindows[windowID]?.controller === controller
-            else {
-                return
-            }
-            self.switchGenerations[ObjectIdentifier(controller)] = nil
+    private func handleWindowClosed(_ controller: DashboardWindowController) {
+        guard let target = self.target(for: controller) else { return }
+        if let intent = self.navigationIntents[target],
+           intent.windowID == nil || intent.windowID == controller.window.map(ObjectIdentifier.init)
+        {
+            self.navigationIntents[target] = nil
+        }
+        self.switchGenerations[ObjectIdentifier(controller)] = nil
+        if let windowID = self.auxiliaryWindows.first(where: { $0.value.controller === controller })?.key {
             self.auxiliaryWindows.removeValue(forKey: windowID)
             self.auxiliaryWindowOrder.removeAll { $0 == windowID }
-            self.updateFrontmostDashboardTarget()
         }
+        self.updateFrontmostDashboardTarget()
     }
 
     private func autosaveName(for target: DashboardGatewayTarget) -> String {
@@ -1042,14 +1108,15 @@ extension DashboardManager {
     private func requiresIsolatedDashboardDocument(
         _ controller: DashboardWindowController,
         auth: DashboardWindowAuth,
-        endpoint: GatewayConnection.EndpointSnapshot) -> Bool
+        endpoint: GatewayConnection.EndpointSnapshot,
+        comparePrimaryRoute: Bool = true) -> Bool
     {
         !controller.hasTLSParams(endpoint.tls?.params) ||
             controller.auth.gatewayUrl != auth.gatewayUrl ||
             controller.auth.token != auth.token ||
             controller.auth.password != auth.password ||
-            endpoint.routeAuthority != self.displayedRouteAuthority ||
-            endpoint.revision.map { $0 != self.displayedRouteRevision } == true
+            (comparePrimaryRoute && (endpoint.routeAuthority != self.displayedRouteAuthority ||
+                    endpoint.revision.map { $0 != self.displayedRouteRevision } == true))
     }
 
     private func rememberPresentedEndpoint(_ endpoint: GatewayConnection.EndpointSnapshot) {
@@ -1076,8 +1143,10 @@ extension DashboardManager {
     func handleGatewayRequest(_ request: DashboardGatewaysRequest, from source: DashboardWindowController) {
         switch request {
         case let .select(target):
+            self.retireNavigation(for: target, from: source)
             Task { await self.switchTarget(target, in: source) }
         case let .openWindow(target):
+            self.retireNavigation(for: target)
             Task { await self.openWindow(for: target) }
         case let .setPrimary(target):
             guard self.target(for: source) == target else { return }
@@ -1109,10 +1178,12 @@ extension DashboardManager {
     }
 
     func openOrFocusDashboard(for target: DashboardGatewayTarget) {
+        self.retireNavigation(for: target)
         Task { await self.performOpenOrFocusDashboard(for: target) }
     }
 
     func switchFrontmostDashboard(to target: DashboardGatewayTarget) {
+        self.retireNavigation(for: target, from: self.frontmostDashboard()?.controller)
         Task { await self.performSwitchFrontmostDashboard(to: target) }
     }
 
@@ -1315,7 +1386,7 @@ extension DashboardManager {
     }
 
     func _testWindowTLSParams(for target: DashboardGatewayTarget) async throws -> GatewayTLSParams? {
-        try await self.windowConfiguration(for: target).tlsParams
+        try await self.windowConfiguration(for: target).configuration.tlsParams
     }
 
     func _testAuxiliaryWindows() -> [(target: DashboardGatewayTarget, controller: DashboardWindowController)] {

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -764,7 +764,9 @@ final class DashboardManager {
         let presented: DashboardWindowController?
         if let source {
             if self.requiresIsolatedDashboardDocument(
-                source, auth: configuration.auth, endpoint: endpoint,
+                source,
+                auth: configuration.auth,
+                endpoint: endpoint,
                 comparePrimaryRoute: source === self.controller && target == .primary)
             {
                 presented = self.replaceWindowController(
@@ -796,93 +798,6 @@ final class DashboardManager {
         }
         self.updateFrontmostDashboardTarget()
         return presented
-    }
-
-    func openBackgroundSession(
-        _ completion: DashboardBackgroundSessionCompletion,
-        target: DashboardGatewayTarget,
-        sourceURL: URL) async
-    {
-        let endpointGeneration = self.endpointGeneration
-        let source = self.dashboardController(for: target) ?? (self.mainTarget == target ? self.controller : nil)
-        let window = source?.window
-        let currentController = {
-            guard let window else {
-                return self.dashboardController(for: target) ?? (self.mainTarget == target ? self.controller : nil)
-            }
-            // AppKit updates this owner when the privileged document is replaced;
-            // changing focus must not retarget an already admitted click.
-            guard let controller = window.windowController as? DashboardWindowController,
-                  self.target(for: controller) == target else { return nil }
-            return controller
-        }
-        let intent = self.beginNavigation(for: target, source: source)
-        defer { self.finishNavigation(intent, for: target) }
-        let sourceGeneration = source?.windowIntentGeneration
-        let isCurrent = {
-            guard !Task.isCancelled, self.navigationIntents[target]?.id == intent,
-                  target != .primary || self.endpointGeneration == endpointGeneration else { return false }
-            guard let window else { return source == nil }
-            guard let current = currentController(), let sourceGeneration else { return false }
-            return current.window === window && current.windowIntentGeneration == sourceGeneration
-        }
-        do {
-            let (configuration, endpoint) = try await self.windowConfiguration(for: target)
-            guard isCurrent() else { return }
-            guard sourceURL == Self.notificationRoute(configuration.url) else {
-                throw NSError(domain: "Dashboard", code: 1, userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "This Gateway connection changed. Open the session from its Gateway's session list.",
-                ])
-            }
-            // Configuration lookup is the only suspension: a newer navigation or
-            // window close cannot interleave restoration and dispatch.
-            guard let controller = self.presentDashboard(
-                configuration: configuration, endpoint: endpoint, target: target, source: currentController()),
-                let fallbackURL = DashboardRouteMap.dashboardURL(
-                    byAppendingSameAppPath: completion.path,
-                    search: completion.search,
-                    to: configuration.url)
-            else {
-                throw NSError(domain: "Dashboard", code: 1, userInfo: [
-                    NSLocalizedDescriptionKey:
-                        "The originating Gateway window is no longer available. Open the session from its Gateway's session list.",
-                ])
-            }
-            controller.dispatchNativeNavigation(DashboardNativeNavigation(
-                path: completion.path, search: completion.search, fallbackURL: fallbackURL))
-            Task { await self.refreshGatewaySnapshots() }
-        } catch {
-            guard isCurrent() else { return }
-            Self.showGatewayError(error, message: "Could Not Open Background Session")
-        }
-    }
-
-    static func notificationRoute(_ url: URL) -> URL? {
-        // Retain only Gateway origin and mount. Authentication is supplied by
-        // the current owner when a notification opens its session.
-        guard let source = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
-        var route = URLComponents()
-        route.scheme = source.scheme
-        route.host = source.host
-        route.port = source.port
-        route.path = source.path
-        return route.url
-    }
-
-    private func handleWindowClosed(_ controller: DashboardWindowController) {
-        guard let target = self.target(for: controller) else { return }
-        if let intent = self.navigationIntents[target],
-           intent.windowID == nil || intent.windowID == controller.window.map(ObjectIdentifier.init)
-        {
-            self.navigationIntents[target] = nil
-        }
-        self.switchGenerations[ObjectIdentifier(controller)] = nil
-        if let windowID = self.auxiliaryWindows.first(where: { $0.value.controller === controller })?.key {
-            self.auxiliaryWindows.removeValue(forKey: windowID)
-            self.auxiliaryWindowOrder.removeAll { $0 == windowID }
-        }
-        self.updateFrontmostDashboardTarget()
     }
 
     private func autosaveName(for target: DashboardGatewayTarget) -> String {
@@ -1008,6 +923,94 @@ extension DashboardManager {
 }
 
 extension DashboardManager {
+    func openBackgroundSession(
+        _ completion: DashboardBackgroundSessionCompletion,
+        target: DashboardGatewayTarget,
+        sourceURL: URL) async
+    {
+        let endpointGeneration = self.endpointGeneration
+        let source = self.dashboardController(for: target) ?? (self.mainTarget == target ? self.controller : nil)
+        let window = source?.window
+        let currentController = {
+            guard let window else {
+                return self.dashboardController(for: target) ?? (self.mainTarget == target ? self.controller : nil)
+            }
+            // AppKit updates this owner when the privileged document is replaced;
+            // changing focus must not retarget an already admitted click.
+            guard let controller = window.windowController as? DashboardWindowController,
+                  self.target(for: controller) == target else { return nil }
+            return controller
+        }
+        let intent = self.beginNavigation(for: target, source: source)
+        defer { self.finishNavigation(intent, for: target) }
+        let sourceGeneration = source?.windowIntentGeneration
+        let isCurrent = {
+            guard !Task.isCancelled, self.navigationIntents[target]?.id == intent,
+                  target != .primary || self.endpointGeneration == endpointGeneration else { return false }
+            guard let window else { return source == nil }
+            guard let current = currentController(), let sourceGeneration else { return false }
+            return current.window === window && current.windowIntentGeneration == sourceGeneration
+        }
+        do {
+            let (configuration, endpoint) = try await self.windowConfiguration(for: target)
+            guard isCurrent() else { return }
+            guard sourceURL == Self.notificationRoute(configuration.url) else {
+                throw NSError(domain: "Dashboard", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "This Gateway connection changed. Open the session from its Gateway's session list.",
+                ])
+            }
+            // Configuration lookup is the only suspension: a newer navigation or
+            // window close cannot interleave restoration and dispatch.
+            guard let controller = self.presentDashboard(
+                configuration: configuration, endpoint: endpoint, target: target, source: currentController()),
+                let fallbackURL = DashboardRouteMap.dashboardURL(
+                    byAppendingSameAppPath: completion.path,
+                    search: completion.search,
+                    to: configuration.url)
+            else {
+                throw NSError(domain: "Dashboard", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "The originating Gateway window is no longer available. " +
+                        "Open the session from its Gateway's session list.",
+                ])
+            }
+            controller.dispatchNativeNavigation(DashboardNativeNavigation(
+                path: completion.path, search: completion.search, fallbackURL: fallbackURL))
+            Task { await self.refreshGatewaySnapshots() }
+        } catch {
+            guard isCurrent() else { return }
+            Self.showGatewayError(error, message: "Could Not Open Background Session")
+        }
+    }
+
+    static func notificationRoute(_ url: URL) -> URL? {
+        // Retain only Gateway origin and mount. Authentication is supplied by
+        // the current owner when a notification opens its session.
+        guard let source = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+        var route = URLComponents()
+        route.scheme = source.scheme
+        route.host = source.host
+        route.port = source.port
+        route.path = source.path
+        return route.url
+    }
+
+    private func handleWindowClosed(_ controller: DashboardWindowController) {
+        guard let target = self.target(for: controller) else { return }
+        if let intent = self.navigationIntents[target],
+           intent.windowID == nil || intent.windowID == controller.window.map(ObjectIdentifier.init)
+        {
+            self.navigationIntents[target] = nil
+        }
+        self.switchGenerations[ObjectIdentifier(controller)] = nil
+        if let windowID = self.auxiliaryWindows.first(where: { $0.value.controller === controller })?.key {
+            self.auxiliaryWindows.removeValue(forKey: windowID)
+            self.auxiliaryWindowOrder.removeAll { $0 == windowID }
+        }
+        self.updateFrontmostDashboardTarget()
+    }
+
     func show() async throws {
         try await self.currentPresentationTask().value
     }

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -736,7 +736,7 @@ final class DashboardManager {
         reusingWindow: NSWindow? = nil) -> DashboardWindowController
     {
         let primaryLocal = !auxiliary && target == .primary && configuration.mode == .local
-        return DashboardWindowController(
+        let controller = DashboardWindowController(
             url: configuration.url,
             auth: configuration.auth,
             websiteDataStore: self.websiteDataStore,
@@ -751,6 +751,58 @@ final class DashboardManager {
                 guard primaryLocal else { return false }
                 return await BrowserProfileImportModel.shared.requestAutomaticOfferIfEligible(while: shouldApply)
             })
+        controller.onBackgroundSessionOpen = { [weak self] completion, sourceURL in
+            Task { @MainActor in
+                await self?.openBackgroundSession(
+                    completion, target: target, sourceURL: sourceURL)
+            }
+        }
+        return controller
+    }
+
+    func openBackgroundSession(
+        _ completion: DashboardBackgroundSessionCompletion,
+        target: DashboardGatewayTarget,
+        sourceURL: URL) async
+    {
+        do {
+            let configuration = try await self.windowConfiguration(for: target)
+            guard sourceURL == Self.notificationRoute(configuration.url) else {
+                throw NSError(domain: "Dashboard", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "This Gateway connection changed. Open the session from its Gateway's session list.",
+                ])
+            }
+            await self.performOpenOrFocusDashboard(for: target)
+            guard let controller = self.dashboardController(for: target),
+                  sourceURL == Self.notificationRoute(controller.dashboardBaseURL),
+                  let fallbackURL = DashboardRouteMap.dashboardURL(
+                      byAppendingSameAppPath: completion.path,
+                      search: completion.search,
+                      to: controller.dashboardBaseURL)
+            else {
+                throw NSError(domain: "Dashboard", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "The originating Gateway window is no longer available. Open the session from its Gateway's session list.",
+                ])
+            }
+            controller.dispatchNativeNavigation(DashboardNativeNavigation(
+                path: completion.path, search: completion.search, fallbackURL: fallbackURL))
+        } catch {
+            Self.showGatewayError(error, message: "Could Not Open Background Session")
+        }
+    }
+
+    static func notificationRoute(_ url: URL) -> URL? {
+        // Retain only Gateway origin and mount. Authentication is supplied by
+        // the current owner when a notification opens its session.
+        guard let source = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+        var route = URLComponents()
+        route.scheme = source.scheme
+        route.host = source.host
+        route.port = source.port
+        route.path = source.path
+        return route.url
     }
 
     private func installAuxiliaryWindowCloseHandler(_ controller: DashboardWindowController, windowID: UUID) {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Notifications.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import UserNotifications
 import WebKit
 
@@ -6,6 +7,30 @@ enum DashboardNotificationsRequest: String {
     case status
     case requestPermission = "request-permission"
     case sendTest = "send-test"
+    case backgroundSessionCompleted = "background-session-completed"
+}
+
+struct DashboardBackgroundSessionCompletion {
+    let runId: String
+    let path: String
+    let search: String?
+
+    init?(body: Any) {
+        guard let payload = body as? [String: Any],
+              let runId = payload["runId"] as? String, !runId.isEmpty, runId.count <= 128,
+              let path = payload["path"] as? String, path.count <= 4096,
+              path.hasPrefix("/chat/"), DashboardRouteMap.isValidSameAppPath(path)
+        else { return nil }
+        let search = payload["search"] as? String
+        if let search {
+            guard search.count <= 2048, DashboardRouteMap.isValidSameAppSearch(search) else { return nil }
+        } else if payload["search"] != nil {
+            return nil
+        }
+        self.runId = runId
+        self.path = path
+        self.search = search
+    }
 }
 
 struct DashboardNotificationsSnapshot: Encodable, Equatable {
@@ -75,6 +100,24 @@ extension DashboardWindowController {
                 await self.publishNotificationsStatus()
                 self.notificationTestOutcome = await TestNotificationAction.send()
                 await self.publishNotificationsStatus()
+            }
+        case .backgroundSessionCompleted:
+            guard let completion = DashboardBackgroundSessionCompletion(body: message.body),
+                  let open = self.onBackgroundSessionOpen,
+                  let sourceRoute = DashboardManager.notificationRoute(self.currentURL)
+            else { return }
+            let sourceURL = self.currentURL
+            let sourceAuth = self.auth
+            let sourceID = self.notificationSourceID
+            Task { [weak self] in
+                await BackgroundSessionNotifications.shared.send(
+                    identifier: "\(sourceID)-\(completion.runId)",
+                    isCurrent: { [weak self] in
+                        guard let self else { return false }
+                        return self.window != nil && self.notificationSourceID == sourceID &&
+                            self.currentURL == sourceURL && self.auth == sourceAuth
+                    },
+                    open: { open(completion, sourceRoute) })
             }
         }
     }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -16,6 +16,9 @@ private final class DashboardWindowContentView: NSView {
 /// pinned at `--openclaw-native-titlebar-height`, resurrecting the traffic-light
 /// misalignment. Refusing the toggle keeps the two heights in lockstep.
 private final class DashboardWindow: NSWindow {
+    /// User intent belongs to the native window, not the privileged document it hosts.
+    var userIntentGeneration: UInt64 = 0
+
     override func toggleToolbarShown(_: Any?) {}
 
     override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
@@ -1070,6 +1073,10 @@ extension DashboardWindowController {
     }
 
     func windowWillClose(_: Notification) {
+        self.advanceWindowIntent()
+        self.advanceNavigationGeneration()
+        self.pendingNativeCommands = []
+        self.pendingNativeNavigation = nil
         self.webView.stopLoading()
         self.closeLinkBrowser(focusDashboard: false)
         self.onClosed?()
@@ -1154,6 +1161,7 @@ extension DashboardWindowController {
 
     func dispatchNativeCommand(_ command: DashboardNativeCommand) {
         if command.supersedesPendingNavigation {
+            self.advanceWindowIntent()
             self.advanceNavigationGeneration()
         }
         guard self.hasLiveContent else {
@@ -1169,9 +1177,6 @@ extension DashboardWindowController {
     }
 
     private func evaluateNativeCommand(_ command: DashboardNativeCommand) {
-        if command.supersedesPendingNavigation {
-            self.advanceNavigationGeneration()
-        }
         guard let fallback = command.legacyFallbackEventName else {
             self.webView.evaluateJavaScript(
                 "window.dispatchEvent(new CustomEvent(\(Self.jsStringLiteral(command.rawValue))))")
@@ -1202,6 +1207,7 @@ extension DashboardWindowController {
     }
 
     func dispatchNativeNavigation(_ navigation: DashboardNativeNavigation) {
+        self.advanceWindowIntent()
         self.advanceNavigationGeneration()
         guard self.hasLiveContent else {
             // Navigation is state selection, so only the newest destination matters while loading.
@@ -1233,6 +1239,14 @@ extension DashboardWindowController {
             else { return }
             self.load(navigation.fallbackURL)
         }
+    }
+
+    var windowIntentGeneration: UInt64? {
+        (self.window as? DashboardWindow)?.userIntentGeneration
+    }
+
+    private func advanceWindowIntent() {
+        (self.window as? DashboardWindow)?.userIntentGeneration &+= 1
     }
 
     private func advanceNavigationGeneration() {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -90,6 +90,8 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     var gatewaySnapshot: DashboardGatewaySnapshot?
     var notificationPermission = "notDetermined"
     var notificationTestOutcome: TestNotificationOutcome?
+    private(set) var notificationSourceID = UUID().uuidString
+    var onBackgroundSessionOpen: ((DashboardBackgroundSessionCompletion, URL) -> Void)?
     let tlsParams: GatewayTLSParams?
     private let dashboardFrameAutosaveName: String
     private let updater: UpdaterProviding?
@@ -1356,6 +1358,7 @@ extension DashboardWindowController {
     /// never pass through `load(_:)`, so commands queue for the new document.
     func webView(_ webView: WKWebView, didCommit _: WKNavigation!) {
         guard webView === self.webView else { return }
+        self.notificationSourceID = UUID().uuidString
         self.hasLiveContent = false
         // Swipe-back/⌘[ can leave the failure page through WKWebView history
         // without a `load(_:)`; a committed http(s) document is a real

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -353,6 +353,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         TerminationSignalWatcher.shared.start()
         MacNodeModeCoordinator.shared.start()
         if launchPlan.allowsInteractiveServices {
+            BackgroundSessionNotifications.shared.start()
             NodePairingApprovalPrompter.shared.start()
             DevicePairingApprovalPrompter.shared.start()
             ExecApprovalsPromptServer.shared.start()
@@ -399,6 +400,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_: Notification) {
+        BackgroundSessionNotifications.shared.stop()
         self.statusMenuController?.stop()
         QuickChatController.shared.stop()
         PresenceReporter.shared.stop()

--- a/apps/macos/Sources/OpenClaw/NotificationManager.swift
+++ b/apps/macos/Sources/OpenClaw/NotificationManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import OpenClawIPC
 import OpenClawKit
@@ -15,7 +16,15 @@ struct NotificationManager {
         return (val as? Bool) == true
     }()
 
-    func send(title: String, body: String, sound: String?, priority: NotificationPriority? = nil) async -> Bool {
+    func send(
+        title: String,
+        body: String,
+        sound: String?,
+        priority: NotificationPriority? = nil,
+        identifier: String = UUID().uuidString,
+        requestPermission: Bool = true,
+        isCurrent: () -> Bool = { true }) async -> Bool
+    {
         guard PermissionManager.notificationCenterAvailable else {
             self.logger.warning("notification skipped: process has no bundle identity")
             return false
@@ -24,6 +33,7 @@ struct NotificationManager {
         let status = await center.notificationSettings()
         guard !Task.isCancelled else { return false }
         if status.authorizationStatus == .notDetermined {
+            guard requestPermission else { return false }
             let granted = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
             guard !Task.isCancelled else { return false }
             if granted != true {
@@ -60,7 +70,8 @@ struct NotificationManager {
             }
         }
 
-        let req = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        guard isCurrent() else { return false }
+        let req = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         do {
             try await LiveNotificationCenter(center: center).add(req)
             self.logger.debug("notification queued")
@@ -68,6 +79,129 @@ struct NotificationManager {
         } catch {
             self.logger.error("notification send failed: \(error.localizedDescription)")
             return false
+        }
+    }
+}
+
+@MainActor
+struct BackgroundSessionNotificationActions {
+    private struct Action {
+        let sourceIdentifier: String
+        let open: () -> Void
+    }
+
+    private var actions: [String: Action] = [:]
+    private var actionOrder: [String] = []
+    private let maximumActions = 64
+
+    mutating func begin(sourceIdentifier: String, open: @escaping () -> Void)
+        -> (identifier: String, retired: [String])?
+    {
+        guard !self.actions.values.contains(where: { $0.sourceIdentifier == sourceIdentifier }) else { return nil }
+        // Actions retain routes, not windows. Retire the matching OS notice when
+        // bounding this process-lifetime queue so eviction leaves no dead button.
+        let retired = self.actionOrder.count >= self.maximumActions ? self.retire([self.actionOrder[0]]) : []
+        let requestIdentifier = "background-session-\(UUID().uuidString)"
+        self.actions[requestIdentifier] = Action(sourceIdentifier: sourceIdentifier, open: open)
+        self.actionOrder.append(requestIdentifier)
+        return (requestIdentifier, retired)
+    }
+
+    func contains(_ identifier: String) -> Bool {
+        self.actions[identifier] != nil
+    }
+
+    func openAction(for identifier: String) -> (() -> Void)? {
+        self.actions[identifier]?.open
+    }
+
+    mutating func finish(identifier: String, sent: Bool, sourceIsCurrent: Bool) -> [String] {
+        // add's completion can follow retirement. Each attempt owns a distinct
+        // OS identifier, so late cleanup cannot remove a replacement notice.
+        sent && self.contains(identifier) && sourceIsCurrent ? [] : self.retire([identifier])
+    }
+
+    mutating func retire(_ identifiers: [String]) -> [String] {
+        let removed = Set(identifiers)
+        self.actionOrder.removeAll { removed.contains($0) }
+        for identifier in identifiers {
+            self.actions.removeValue(forKey: identifier)
+        }
+        return identifiers
+    }
+
+    mutating func stop() -> [String] {
+        self.retire(self.actionOrder)
+    }
+}
+
+@MainActor
+final class BackgroundSessionNotifications: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = BackgroundSessionNotifications()
+
+    private var actions = BackgroundSessionNotificationActions()
+    private var isRunning = false
+
+    func start() {
+        guard PermissionManager.notificationCenterAvailable else { return }
+        UNUserNotificationCenter.current().delegate = self
+        self.isRunning = true
+    }
+
+    func stop() {
+        self.isRunning = false
+        self.remove(self.actions.stop())
+    }
+
+    func send(identifier: String, isCurrent: @escaping () -> Bool, open: @escaping () -> Void) async {
+        guard self.isRunning else { return }
+        guard let admission = self.actions.begin(sourceIdentifier: identifier, open: open) else { return }
+        self.remove(admission.retired)
+        let sent = await NotificationManager().send(
+            title: "OpenClaw",
+            body: "A background session finished. Open it to see the result.",
+            sound: nil,
+            identifier: admission.identifier,
+            requestPermission: false,
+            isCurrent: { self.actions.contains(admission.identifier) && isCurrent() })
+        self.remove(self.actions.finish(identifier: admission.identifier, sent: sent, sourceIsCurrent: isCurrent()))
+    }
+
+    private func remove(_ identifiers: [String]) {
+        guard !identifiers.isEmpty else { return }
+        guard PermissionManager.notificationCenterAvailable else { return }
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: identifiers)
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: identifiers)
+    }
+
+    nonisolated func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        willPresent _: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void)
+    {
+        // This delegate is app-wide: an empty result would also silence existing
+        // system.notify and test notifications that previously used OS presentation.
+        completionHandler([.banner, .list, .sound, .badge])
+    }
+
+    nonisolated func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse) async
+    {
+        let identifier = response.notification.request.identifier
+        let shouldOpen = response.actionIdentifier == UNNotificationDefaultActionIdentifier
+        await MainActor.run {
+            if shouldOpen, identifier.hasPrefix("background-session-") {
+                if let open = self.actions.openAction(for: identifier) {
+                    open()
+                } else {
+                    let alert = NSAlert()
+                    alert.messageText = "Background Session Notification Expired"
+                    alert.informativeText = "Open the session from its Gateway's session list."
+                    alert.runModal()
+                }
+            }
+            self.remove(self.actions.retire([identifier]))
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationWindowTests.swift
@@ -1,0 +1,495 @@
+import AppKit
+import Foundation
+import OpenClawKit
+import Testing
+import WebKit
+@testable import OpenClaw
+
+@MainActor
+extension DashboardWindowOwnershipTests {
+    @Test func `background completion restores a failed dashboard before navigating`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let manager = self.notificationManager(server: server)
+        defer { manager.close() }
+        try await manager.show()
+        let controller = try #require(manager._testController())
+        try await self.waitForDashboard(controller, path: "/")
+        let window = try #require(controller.window)
+
+        controller.webView(controller.webView, didFail: nil, withError: URLError(.networkConnectionLost))
+        #expect(!controller.canDeliverNativeCommands)
+        try await manager.openBackgroundSession(
+            self.completion(), target: .primary, sourceURL: server.url())
+
+        let restored = try #require(manager._testController())
+        #expect(restored.window === window)
+        #expect(restored.canDeliverNativeCommands)
+        try await self.waitForDashboard(restored, path: "/chat/main/dashboard/completed")
+        #expect(restored._testPendingNativeNavigation == nil)
+    }
+
+    @Test(arguments: ["new-session", "window-close", "manager-close"])
+    func `pending notification click cannot supersede newer window intent`(_ action: String) async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate(released: true)
+        let manager = self.notificationManager(server: server, gate: gate)
+        defer { manager.close() }
+        try await manager.show()
+        let controller = try #require(manager._testController())
+        try await self.waitForDashboard(controller, path: "/")
+        await gate.hold()
+
+        let click = Task { @MainActor in
+            try await manager.openBackgroundSession(
+                self.completion(), target: .primary, sourceURL: server.url())
+        }
+        await gate.waitUntilRequested()
+        switch action {
+        case "new-session": manager.dispatchNativeCommand(.newSession)
+        case "window-close": controller.window?.performClose(nil)
+        default: manager.close()
+        }
+        let generation = controller._testNavigationGeneration
+        await gate.release()
+        try await click.value
+
+        #expect(controller._testPendingNativeNavigation == nil)
+        #expect(controller._testNavigationGeneration == generation)
+        #expect(controller.currentURL.path == "/")
+        #expect(manager._testController() === controller)
+        #expect(controller.isWindowOpen == (action == "new-session"))
+    }
+
+    @Test func `notification clicked after window close reopens its exact session`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let manager = self.notificationManager(server: server)
+        defer { manager.close() }
+        try await manager.show()
+        let controller = try #require(manager._testController())
+        try await self.waitForDashboard(controller, path: "/")
+        let window = try #require(controller.window)
+        window.performClose(nil)
+        #expect(!controller.isWindowOpen)
+
+        try await manager.openBackgroundSession(
+            self.completion(), target: .primary, sourceURL: server.url())
+
+        let reopened = try #require(manager._testController())
+        #expect(reopened.window === window)
+        #expect(reopened.isWindowOpen)
+        try await self.waitForDashboard(reopened, path: "/chat/main/dashboard/completed")
+    }
+
+    @Test func `profile notification survives unrelated primary endpoint updates`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate(released: true)
+        let manager = self.notificationManager(server: server, gate: gate)
+        defer { manager.close() }
+        let target = DashboardGatewayTarget.profile("background")
+        await manager._testOpenWindow(for: target)
+        let controller = try #require(manager._testAuxiliaryWindows().first?.controller)
+        try await self.waitForDashboard(controller, path: "/")
+        await gate.hold()
+
+        let click = Task { @MainActor in
+            try await manager.openBackgroundSession(
+                self.completion(), target: target, sourceURL: server.url())
+        }
+        await gate.waitUntilRequested()
+        await manager.handleEndpointState(.connecting(mode: .remote, detail: "Connecting"))
+        await gate.release()
+        try await click.value
+
+        try await self.waitForDashboard(controller, path: "/chat/main/dashboard/completed")
+        #expect(manager._testAuxiliaryWindows().first?.controller === controller)
+    }
+
+    @Test func `older queued command replay does not cancel a newer notification click`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate(released: true)
+        let manager = self.notificationManager(server: server, gate: gate)
+        defer { manager.close() }
+        try await manager.show()
+        let controller = try #require(manager._testController())
+        try await self.waitForDashboard(controller, path: "/")
+        controller.webView(controller.webView, didCommit: nil)
+        controller.dispatchNativeCommand(.newSession)
+        #expect(controller._testPendingNativeCommands == [.newSession])
+        await gate.hold()
+
+        let click = Task { @MainActor in
+            try await manager.openBackgroundSession(
+                self.completion(), target: .primary, sourceURL: server.url())
+        }
+        await gate.waitUntilRequested()
+        controller.webView(controller.webView, didFinish: nil)
+        #expect(controller._testPendingNativeCommands.isEmpty)
+        await gate.release()
+        try await click.value
+
+        try await self.waitForDashboard(controller, path: "/chat/main/dashboard/completed")
+    }
+
+    @Test(arguments: ["same", "refreshed", "refreshed-close", "new-window-close"])
+    func `older manager command replay does not cancel a newer notification click`(_ scenario: String) async throws {
+        let server = try await DashboardHTTPFixture.start(
+            html: """
+            <html><body><script>
+            window.commandEvents = [];
+            window.addEventListener('openclaw:native-new-session', () => window.commandEvents.push('new-session'));
+            window.addEventListener('openclaw:native-toggle-search', event => {
+              event.preventDefault(); window.commandEvents.push('toggle');
+            });
+            window.addEventListener('openclaw:native-navigate', event => {
+              event.preventDefault(); history.pushState({}, '', event.detail.path);
+            });
+            </script></body></html>
+            """,
+            contentSecurityPolicy: "default-src 'none'; script-src 'unsafe-inline'")
+        defer { server.stop() }
+        let state = AppStateStore.shared
+        let previousMode = state.connectionMode
+        state.connectionMode = .remote
+        defer { state.connectionMode = previousMode }
+        let primaryGate = DashboardWindowOwnershipPresentationGate(released: true)
+        let notificationGate = DashboardWindowOwnershipPresentationGate()
+        let endpointURL = server.websocketURL()
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in
+                let request = await primaryGate.waitForRelease()
+                if request == (scenario == "new-window-close" ? 2 : 3) {
+                    await notificationGate.waitForRelease()
+                }
+                return GatewayConnection.EndpointSnapshot(
+                    config: (
+                        url: endpointURL,
+                        token: request == 1 || scenario == "same" ? "before" : "after",
+                        password: nil),
+                    routeAuthority: nil)
+            },
+            gatewayEntriesProvider: { [Self.primaryGateway] })
+        defer { manager.close() }
+        if scenario != "new-window-close" {
+            try await manager.show()
+            let controller = try #require(manager._testController())
+            try await self.waitForDashboard(controller, path: "/")
+            controller.window?.performClose(nil)
+        }
+        let originalWindow = manager._testController()?.window
+        await primaryGate.hold()
+        manager.dispatchNativeCommand(.newSession)
+        manager.dispatchNativeCommand(.commandPalette)
+        manager.dispatchNativeCommand(.commandPalette)
+        await primaryGate.waitUntilRequested()
+
+        let click = Task { @MainActor in
+            try await manager.openBackgroundSession(
+                self.completion(), target: .primary, sourceURL: server.url())
+        }
+        while await primaryGate.numberOfRequests() < (scenario == "new-window-close" ? 2 : 3) {
+            await Task.yield()
+        }
+        await primaryGate.release()
+        await notificationGate.waitUntilRequested()
+        let reopened = try await self.waitForQueuedToggles(manager)
+        let window = try #require(reopened.window)
+        if let originalWindow { #expect(window === originalWindow) }
+        let commands = try await reopened.webView.evaluateJavaScript("window.commandEvents") as? [String]
+        #expect(commands == ["toggle", "toggle"])
+        if scenario.hasSuffix("-close") {
+            window.performClose(nil)
+        }
+        await notificationGate.release()
+        try await click.value
+
+        let current = try #require(manager._testController())
+        #expect(current.window === window)
+        if scenario.hasSuffix("-close") {
+            #expect(!current.isWindowOpen)
+            #expect(current.webView.url?.path == "/")
+        } else {
+            try await self.waitForDashboard(current, path: "/chat/main/dashboard/completed")
+        }
+    }
+
+    @Test(arguments: ["same-close", "other-open"])
+    func `manual window admission retires only its target notification`(_ action: String) async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let state = AppStateStore.shared
+        let previousMode = state.connectionMode
+        state.connectionMode = .remote
+        defer { state.connectionMode = previousMode }
+        let gate = DashboardWindowOwnershipPresentationGate()
+        let endpointURL = server.websocketURL()
+        let endpoint = GatewayConnection.EndpointSnapshot(
+            config: (url: endpointURL, token: "synthetic", password: nil), routeAuthority: nil)
+        let manager = DashboardManager._testMake(
+            primaryEndpointProvider: { _ in endpoint },
+            profileEndpointProvider: { _ in
+                if await gate.numberOfRequests() == 0 { await gate.waitForRelease() }
+                return endpoint
+            },
+            gatewayEntriesProvider: {
+                [Self.primaryGateway, DashboardGatewayEntry(
+                    id: "profile:background", name: "Background", kind: "remote",
+                    isPrimary: false, canPromote: false, health: .ok)]
+            })
+        defer { manager.close() }
+        let target = DashboardGatewayTarget.profile("background")
+        let click = Task { @MainActor in
+            try await manager.openBackgroundSession(self.completion(), target: target, sourceURL: server.url())
+        }
+        await gate.waitUntilRequested()
+        manager.openOrFocusDashboard(for: action == "other-open" ? .primary : target)
+        let deadline = ContinuousClock.now + .seconds(5)
+        while manager._testController() == nil, manager._testAuxiliaryWindows().isEmpty,
+              ContinuousClock.now < deadline
+        {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let opened = try #require(manager._testController() ?? manager._testAuxiliaryWindows().first?.controller)
+        try await self.waitForDashboard(opened, path: "/")
+        if action == "same-close" { opened.window?.performClose(nil) }
+        await gate.release()
+        try await click.value
+
+        if action == "same-close" {
+            #expect(manager._testAuxiliaryWindows().isEmpty)
+        } else {
+            let completed = try #require(manager._testAuxiliaryWindows().first?.controller)
+            try await self.waitForDashboard(completed, path: "/chat/main/dashboard/completed")
+            #expect(opened.webView.url?.path == "/")
+        }
+    }
+
+    @Test func `command palette configured open preserves pending notification navigation`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        let config = """
+        {"gateway":{"remote":{"transport":"direct","url":"\(server.websocketURL())","token":"synthetic"}}}
+        """
+        try Data(config.utf8).write(to: URL(fileURLWithPath: configPath))
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": configPath,
+            "OPENCLAW_GATEWAY_TOKEN": nil,
+            "OPENCLAW_GATEWAY_PASSWORD": nil,
+        ]) {
+            let state = AppStateStore.shared
+            let previousMode = state.connectionMode
+            state.connectionMode = .remote
+            defer { state.connectionMode = previousMode }
+            let gate = DashboardWindowOwnershipPresentationGate(released: true)
+            let manager = self.notificationManager(server: server, gate: gate)
+            defer { manager.close() }
+            try await manager.show()
+            let controller = try #require(manager._testController())
+            try await self.waitForDashboard(controller, path: "/")
+            controller.window?.performClose(nil)
+            await gate.hold()
+            let click = Task { @MainActor in
+                try await manager.openBackgroundSession(self.completion(), target: .primary, sourceURL: server.url())
+            }
+            await gate.waitUntilRequested()
+            do {
+                manager.dispatchNativeCommand(.commandPalette)
+                let deadline = ContinuousClock.now + .seconds(5)
+                while !controller.isWindowOpen, ContinuousClock.now < deadline {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+                #expect(controller.isWindowOpen)
+            } catch {
+                click.cancel()
+                await gate.release()
+                _ = try? await click.value
+                throw error
+            }
+            await gate.release()
+            try await click.value
+            try await self.waitForDashboard(controller, path: "/chat/main/dashboard/completed")
+        }
+    }
+
+    @Test func `notification retains its native window when unrelated window moves forward`() async throws {
+        let server = try await DashboardHTTPFixture.start()
+        defer { server.stop() }
+        let gate = DashboardWindowOwnershipPresentationGate(released: true)
+        let manager = self.notificationManager(server: server, gate: gate)
+        defer { manager.close() }
+        try await manager.show()
+        let main = try #require(manager._testController())
+        await manager._testOpenWindow(for: .primary)
+        let clicked = try #require(manager._testAuxiliaryWindows().first?.controller)
+        await manager._testOpenWindow(for: .profile("background"))
+        let other = try #require(manager._testAuxiliaryWindows().first { $0.target != .primary }?.controller)
+        try await self.waitForDashboard(main, path: "/")
+        try await self.waitForDashboard(clicked, path: "/")
+        try await self.waitForDashboard(other, path: "/")
+        let windows = [main, clicked, other].compactMap(\.window)
+        clicked.show()
+        try #require(NSApp.orderedWindows.first(where: { windows.contains($0) }) === clicked.window)
+        try #require(windows.first(where: \.isKeyWindow).map { $0 === clicked.window } ?? true)
+        await gate.hold()
+        let click = Task { @MainActor in
+            try await manager.openBackgroundSession(self.completion(), target: .primary, sourceURL: server.url())
+        }
+        await gate.waitUntilRequested()
+        do {
+            other.show()
+            try #require(NSApp.orderedWindows.first(where: { windows.contains($0) }) === other.window)
+            try #require(windows.first(where: \.isKeyWindow).map { $0 === other.window } ?? true)
+        } catch {
+            click.cancel()
+            await gate.release()
+            _ = try? await click.value
+            throw error
+        }
+        await gate.release()
+        try await click.value
+
+        try await self.waitForDashboard(clicked, path: "/chat/main/dashboard/completed")
+        #expect(main.webView.url?.path == "/")
+        #expect(other.webView.url?.path == "/")
+    }
+
+    @Test(arguments: ["endpoint", "credentials"])
+    func `configured replacement fences a click suspended in authentication`(_ change: String) async throws {
+        let server = try await DashboardHTTPFixture.start()
+        let replacementServer = try await DashboardHTTPFixture.start()
+        defer { server.stop()
+            replacementServer.stop()
+        }
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        func writeConfig(url: URL, token: String) throws {
+            let config = """
+            {"gateway":{"remote":{"transport":"direct","url":"\(url)","token":"\(token)"}}}
+            """
+            try Data(config.utf8).write(to: URL(fileURLWithPath: configPath))
+        }
+        try writeConfig(url: server.websocketURL(), token: "before")
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": configPath,
+            "OPENCLAW_GATEWAY_TOKEN": nil,
+            "OPENCLAW_GATEWAY_PASSWORD": nil,
+        ]) {
+            let state = AppStateStore.shared
+            let previousMode = state.connectionMode
+            state.connectionMode = .remote
+            defer { state.connectionMode = previousMode }
+            let gate = DashboardWindowOwnershipPresentationGate(released: true)
+            let manager = DashboardManager._testMake(
+                authTokenProvider: { config in
+                    await gate.waitForRelease()
+                    return config.token
+                },
+                gatewayEntriesProvider: { [Self.primaryGateway] })
+            defer { manager.close() }
+            try await manager.show()
+            let original = try #require(manager._testController())
+            try await self.waitForDashboard(original, path: "/")
+            let window = try #require(original.window)
+            window.performClose(nil)
+            await gate.hold()
+            let click = Task { @MainActor in
+                try await manager.openBackgroundSession(self.completion(), target: .primary, sourceURL: server.url())
+            }
+            await gate.waitUntilRequested()
+            let replacement: DashboardWindowController
+            let nextURL = change == "endpoint" ? replacementServer.websocketURL() : server.websocketURL()
+            let nextToken = change == "credentials" ? "after" : "before"
+            do {
+                try writeConfig(url: nextURL, token: nextToken)
+                manager.dispatchNativeCommand(.commandPalette)
+                let deadline = ContinuousClock.now + .seconds(5)
+                while manager._testController() === original, ContinuousClock.now < deadline {
+                    try await Task.sleep(for: .milliseconds(10))
+                }
+                replacement = try #require(manager._testController())
+                try #require(replacement !== original)
+                try #require(replacement.window === window)
+                try await self.waitForDashboard(replacement, path: "/")
+            } catch {
+                click.cancel()
+                await gate.release()
+                _ = try? await click.value
+                throw error
+            }
+            await gate.release()
+            try await click.value
+
+            let current = try #require(manager._testController())
+            #expect(current === replacement)
+            #expect(current.auth.gatewayUrl == nextURL.absoluteString)
+            #expect(current.auth.token == nextToken)
+            #expect(current.webView.url?.path == "/")
+        }
+    }
+
+    private func notificationManager(
+        server: DashboardHTTPFixture,
+        gate: DashboardWindowOwnershipPresentationGate? = nil) -> DashboardManager
+    {
+        let endpointURL = server.websocketURL()
+        return DashboardManager._testMake(
+            primaryEndpointProvider: { _ in
+                await gate?.waitForRelease()
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: endpointURL, token: "synthetic", password: nil),
+                    routeAuthority: nil)
+            },
+            profileEndpointProvider: { _ in
+                await gate?.waitForRelease()
+                return GatewayConnection.EndpointSnapshot(
+                    config: (url: endpointURL, token: "synthetic", password: nil),
+                    routeAuthority: nil)
+            },
+            gatewayEntriesProvider: {
+                [Self.primaryGateway, DashboardGatewayEntry(
+                    id: "profile:background", name: "Background", kind: "remote",
+                    isPrimary: false, canPromote: false, health: .ok)]
+            })
+    }
+
+    private func waitForQueuedToggles(_ manager: DashboardManager) async throws -> DashboardWindowController {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while ContinuousClock.now < deadline {
+            if let controller = manager._testController(), controller.isWindowOpen,
+               let commands = try? await controller.webView.evaluateJavaScript("window.commandEvents") as? [String],
+               commands.filter({ $0 == "toggle" }).count == 2
+            {
+                return controller
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        throw URLError(.timedOut)
+    }
+
+    private func completion() throws -> DashboardBackgroundSessionCompletion {
+        try #require(DashboardBackgroundSessionCompletion(body: [
+            "runId": "synthetic-run", "path": "/chat/main/dashboard/completed",
+        ]))
+    }
+
+    private func waitForDashboard(_ controller: DashboardWindowController, path: String) async throws {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while ContinuousClock.now < deadline {
+            if controller.canDeliverNativeCommands, !controller.webView.isLoading,
+               controller.webView.url?.path == path
+            {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(controller.canDeliverNativeCommands)
+        #expect(controller.webView.url?.path == path)
+        throw URLError(.timedOut)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationsBridgeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardNotificationsBridgeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import UserNotifications
+import WebKit
 @testable import OpenClaw
 
 @MainActor
@@ -11,6 +12,110 @@ struct DashboardNotificationsBridgeTests {
             from: ["type": "request-permission"]) == .requestPermission)
         #expect(DashboardWindowController.notificationsRequest(
             from: ["type": "send-test"]) == .sendTest)
+        #expect(DashboardWindowController.notificationsRequest(
+            from: ["type": "background-session-completed"]) == .backgroundSessionCompleted)
+    }
+
+    @Test func `completion request preserves its exact session route without notification text`() throws {
+        let completion = try #require(DashboardBackgroundSessionCompletion(body: [
+            "runId": "run-1", "path": "/chat/research", "search": "?session=global",
+        ]))
+        #expect(completion.runId == "run-1")
+        #expect(completion.path == "/chat/research")
+        #expect(completion.search == "?session=global")
+    }
+
+    @Test func `completion request rejects malformed or external destinations`() {
+        let invalid: [[String: Any]] = [
+            ["runId": "", "path": "/chat/main"],
+            ["runId": String(repeating: "r", count: 129), "path": "/chat/main"],
+            ["runId": "run-1", "path": "https://other.example/chat/main"],
+            ["runId": "run-1", "path": "/chat/main#token=value"],
+            ["runId": "run-1", "path": "/settings"],
+            ["runId": "run-1", "path": "/chat/main", "search": true],
+            ["runId": "run-1", "path": "/chat/main", "search": "?session=%"],
+            ["runId": "run-1", "path": "/chat/main", "search": "?session=main#token=value"],
+        ]
+        for body in invalid {
+            #expect(DashboardBackgroundSessionCompletion(body: body) == nil)
+        }
+    }
+
+    @Test func `notification navigation keeps the originating Gateway and mount after auth refresh`() throws {
+        var components = try #require(URLComponents(string: "https://gateway.example/openclaw/"))
+        components.user = "test-user"
+        components.password = "test-password"
+        components.query = "token=before"
+        components.fragment = "token=before"
+        let original = try #require(components.url)
+        let refreshed = try #require(URL(string: "https://gateway.example/openclaw/#token=after"))
+        let otherGateway = try #require(URL(string: "https://other.example/openclaw/"))
+        let otherMount = try #require(URL(string: "https://gateway.example/other/"))
+        let route = try #require(DashboardManager.notificationRoute(original))
+        #expect(route.absoluteString == "https://gateway.example/openclaw/")
+        #expect(route == DashboardManager.notificationRoute(refreshed))
+        #expect(route != DashboardManager.notificationRoute(otherGateway))
+        #expect(route != DashboardManager.notificationRoute(otherMount))
+    }
+
+    @Test func `late enqueue cleanup cannot retire a replacement for the same background run`() throws {
+        var actions = BackgroundSessionNotificationActions()
+        let originalAdmission = actions.begin(sourceIdentifier: "source/run", open: {})
+        let original = try #require(originalAdmission)
+        #expect(actions.begin(sourceIdentifier: "source/run", open: {}) == nil)
+        #expect(actions.stop() == [original.identifier])
+        let replacementAdmission = actions.begin(sourceIdentifier: "source/run", open: {})
+        let replacement = try #require(replacementAdmission)
+
+        #expect(replacement.identifier != original.identifier)
+        #expect(actions.finish(
+            identifier: original.identifier, sent: true, sourceIsCurrent: true) == [original.identifier])
+        #expect(actions.contains(replacement.identifier))
+        #expect(actions.finish(identifier: replacement.identifier, sent: true, sourceIsCurrent: true).isEmpty)
+    }
+
+    @Test func `a document retired during enqueue removes its delivered notice and action`() throws {
+        var actions = BackgroundSessionNotificationActions()
+        let pendingAdmission = actions.begin(sourceIdentifier: "source/run", open: {})
+        let admission = try #require(pendingAdmission)
+
+        #expect(actions.finish(
+            identifier: admission.identifier, sent: true, sourceIsCurrent: false) == [admission.identifier])
+        #expect(!actions.contains(admission.identifier))
+        #expect(actions.openAction(for: admission.identifier) == nil)
+    }
+
+    @Test func `bounded notification actions evict only the oldest OS request`() throws {
+        var actions = BackgroundSessionNotificationActions()
+        let firstAdmission = actions.begin(sourceIdentifier: "first", open: {})
+        let first = try #require(firstAdmission)
+        for index in 1..<64 {
+            let pendingAdmission = actions.begin(sourceIdentifier: "run-\(index)", open: {})
+            let admission = try #require(pendingAdmission)
+            #expect(admission.retired.isEmpty)
+        }
+        let nextAdmission = actions.begin(sourceIdentifier: "next", open: {})
+        let next = try #require(nextAdmission)
+        #expect(next.retired == [first.identifier])
+        #expect(!actions.contains(first.identifier))
+        #expect(actions.contains(next.identifier))
+    }
+
+    @Test func `same URL document commit retires the notification source without changing the route`() throws {
+        let url = try #require(URL(string: "about:blank"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil),
+            websiteDataStore: .nonPersistent(),
+            windowAutosaveName: "DashboardNotificationDocument-\(UUID().uuidString)",
+            requestBrowserProfileImportOffer: { _ in false })
+        defer { controller.close() }
+        let sourceID = controller.notificationSourceID
+
+        controller.webView(controller.webView, didCommit: nil)
+
+        #expect(controller.currentURL == url)
+        #expect(controller.notificationSourceID != sourceID)
     }
 
     @Test func `rejects invalid notification requests`() {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowOwnershipTests.swift
@@ -49,19 +49,32 @@ private actor DashboardWindowOwnershipEndpointGate {
     }
 }
 
-private actor DashboardWindowOwnershipPresentationGate {
+actor DashboardWindowOwnershipPresentationGate {
     private var requested = false
     private var released = false
     private var requestCount = 0
     private var continuations: [CheckedContinuation<Void, Never>] = []
 
-    func waitForRelease() async {
+    init(released: Bool = false) {
+        self.released = released
+    }
+
+    func hold() {
+        self.requested = false
+        self.released = false
+    }
+
+    @discardableResult
+    func waitForRelease() async -> Int {
         self.requested = true
         self.requestCount += 1
-        guard !self.released else { return }
-        await withCheckedContinuation { continuation in
-            self.continuations.append(continuation)
+        let request = self.requestCount
+        if !self.released {
+            await withCheckedContinuation { continuation in
+                self.continuations.append(continuation)
+            }
         }
+        return request
     }
 
     func waitUntilRequested() async {
@@ -103,7 +116,7 @@ private final class DashboardWindowOwnershipTrackingWindow: NSWindow {
 @Suite(.serialized)
 @MainActor
 struct DashboardWindowOwnershipTests {
-    private static let primaryGateway = DashboardGatewayEntry(
+    static let primaryGateway = DashboardGatewayEntry(
         id: "primary",
         name: "Local Gateway",
         kind: "local",

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DashboardRouteMap.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DashboardRouteMap.swift
@@ -27,9 +27,8 @@ public enum DashboardRouteMap {
     /// no fragment, which the dashboard URL reserves for the auth token.
     public static func isValidSameAppSearch(_ search: String) -> Bool {
         guard search.hasPrefix("?"), !search.contains("#") else { return false }
-        var components = URLComponents()
-        components.percentEncodedQuery = String(search.dropFirst())
-        return components.percentEncodedQuery != nil
+        // Parse bridge input: assigning an invalid percentEncodedQuery traps.
+        return URLComponents(string: search, encodingInvalidCharacters: false)?.percentEncodedQuery != nil
     }
 
     public static func dashboardURL(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DashboardRouteMapTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DashboardRouteMapTests.swift
@@ -48,7 +48,10 @@ struct DashboardRouteMapTests {
         #expect(url.absoluteString == "http://127.0.0.1:18789/control/custodian?onboarding=1#token=test-token")
     }
 
-    @Test(arguments: ["", "onboarding=1", "?onboarding=1#x", "?a=b#frag"])
+    @Test(arguments: [
+        "", "onboarding=1", "?onboarding=1#x", "?a=b#frag",
+        "?session=%", "?session=%2", "?session=%GG", "?session=has space",
+    ])
     func `same-app search validation rejects non-query input`(_ search: String) throws {
         #expect(!DashboardRouteMap.isValidSameAppSearch(search))
         #expect(try DashboardRouteMap.dashboardURL(
@@ -57,7 +60,8 @@ struct DashboardRouteMapTests {
             to: #require(URL(string: "http://127.0.0.1:18789/control/"))) == nil)
     }
 
-    @Test func `same-app search validation accepts a plain query`() {
-        #expect(DashboardRouteMap.isValidSameAppSearch("?onboarding=1"))
+    @Test(arguments: ["?onboarding=1", "?session=%E2%9C%93%2Ffoo%25"])
+    func `same-app search validation accepts a plain query`(_ search: String) {
+        #expect(DashboardRouteMap.isValidSameAppSearch(search))
     }
 }

--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -81,6 +81,14 @@ The macOS app also asks automatically on your first chat send, but only while pe
 
 If the permission shows **Denied**, macOS will not re-prompt: select **Open System Settings**, allow notifications for OpenClaw there, and switch back — the page rechecks permission when the app regains focus. This permission belongs to macOS, not to Gateway config.
 
+### Background session completion
+
+When you start a session in the background from **New Session**, the macOS app posts a native notification after that run finishes, provided notification permission is already granted. Keep the originating dashboard loaded while it runs; you can minimize its window or work in another app. An in-app completion message also appears. Selecting the session before it finishes suppresses its completion notice.
+
+The native notification uses generic text, without the session title, prompt, or response. Select it to open the session on its originating Gateway, including when that window has since closed. If that Gateway connection changed or the notification expired after an app restart, open the session from the correct Gateway's session list instead.
+
+This is the **New Session** background-start flow, not a native notification for every chat response. Browser **Agent finished** preferences remain separate. Completing a background run never opens a new permission prompt; enable notifications in Settings first.
+
 ## Troubleshooting
 
 ### Enable is unavailable

--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -347,7 +347,9 @@ describe("OpenClaw native shell", () => {
       { path: "/dashboard/main/tasks/review", routeId: "dashboard" },
       { path: "/settings/agents/main/overview", routeId: "agents" },
       { path: "/settings/memory/dreams", routeId: "memory" },
-    ].flatMap((target) => ["", "/gateway"].map((basePath) => ({ ...target, basePath }))),
+    ].flatMap(({ path, routeId, search }) =>
+      ["", "/gateway"].map((basePath) => ({ path, routeId, search, basePath })),
+    ),
   )(
     "preserves native destination $basePath$path and acknowledges it",
     ({ path, routeId, search, basePath }) => {

--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -335,43 +335,41 @@ describe("OpenClaw native shell", () => {
     }
   });
 
-  it("navigates valid native Dashboard paths and acknowledges them", () => {
-    const navigate = vi.fn();
-    const shell = document.createElement("openclaw-app-shell") as unknown as ShellNavigationState;
-    shell.runtime = {
-      context: {
-        navigate,
-      } as unknown as ApplicationContext,
-    };
-    const event = new CustomEvent("openclaw:native-navigate", {
-      cancelable: true,
-      detail: { path: "/settings/channels" },
-    });
+  it.each(
+    [
+      { path: "/settings/channels", routeId: "channels" },
+      { path: "/custodian", routeId: "custodian", search: "?onboarding=1" },
+      {
+        path: "/chat/main/dashboard/12345678-90ab-cdef-1234-567890abcdef",
+        routeId: "chat",
+        search: "?nav=collapsed",
+      },
+      { path: "/dashboard/main/tasks/review", routeId: "dashboard" },
+      { path: "/settings/agents/main/overview", routeId: "agents" },
+      { path: "/settings/memory/dreams", routeId: "memory" },
+    ].flatMap((target) => ["", "/gateway"].map((basePath) => ({ ...target, basePath }))),
+  )(
+    "preserves native destination $basePath$path and acknowledges it",
+    ({ path, routeId, search, basePath }) => {
+      const navigate = vi.fn();
+      const shell = document.createElement("openclaw-app-shell") as unknown as ShellNavigationState;
+      shell.runtime = {
+        context: { navigate, basePath } as unknown as ApplicationContext,
+      };
+      const event = new CustomEvent("openclaw:native-navigate", {
+        cancelable: true,
+        detail: { path, search },
+      });
 
-    shell.handleNativeNavigate(event);
+      shell.handleNativeNavigate(event);
 
-    expect(event.defaultPrevented).toBe(true);
-    expect(navigate).toHaveBeenCalledExactlyOnceWith("channels", undefined);
-  });
-
-  it("carries a native same-app search into navigation", () => {
-    const navigate = vi.fn();
-    const shell = document.createElement("openclaw-app-shell") as unknown as ShellNavigationState;
-    shell.runtime = {
-      context: {
-        navigate,
-      } as unknown as ApplicationContext,
-    };
-    const event = new CustomEvent("openclaw:native-navigate", {
-      cancelable: true,
-      detail: { path: "/custodian", search: "?onboarding=1" },
-    });
-
-    shell.handleNativeNavigate(event);
-
-    expect(event.defaultPrevented).toBe(true);
-    expect(navigate).toHaveBeenCalledExactlyOnceWith("custodian", { search: "?onboarding=1" });
-  });
+      expect(event.defaultPrevented).toBe(true);
+      expect(navigate).toHaveBeenCalledExactlyOnceWith(routeId, {
+        pathname: `${basePath}${path}`,
+        ...(search ? { search } : {}),
+      });
+    },
+  );
 
   it.each(["#frag-only", "onboarding=1", "?onboarding=1#x"])(
     "ignores malformed native search %s and keeps the plain route",
@@ -381,6 +379,7 @@ describe("OpenClaw native shell", () => {
       shell.runtime = {
         context: {
           navigate,
+          basePath: "",
         } as unknown as ApplicationContext,
       };
       const event = new CustomEvent("openclaw:native-navigate", {
@@ -391,7 +390,7 @@ describe("OpenClaw native shell", () => {
       shell.handleNativeNavigate(event);
 
       expect(event.defaultPrevented).toBe(true);
-      expect(navigate).toHaveBeenCalledExactlyOnceWith("custodian", undefined);
+      expect(navigate).toHaveBeenCalledExactlyOnceWith("custodian", { pathname: "/custodian" });
     },
   );
 

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -287,19 +287,20 @@ export class ShellChromeOwner {
       return;
     }
     const routeId = routeIdFromPath(path);
-    if (!routeId || !this.host.context) {
+    const context = this.host.context;
+    if (!routeId || !context) {
       // Unhandled native routes remain eligible for the host's URL fallback.
       return;
     }
     event.preventDefault();
-    // Native callers may request route chrome via a query (e.g. the macOS
-    // onboarding handoff lands on /custodian?onboarding=1).
+    // Native paths are relative to the Gateway mount. A route ID alone loses
+    // the destination and can reopen the current session instead.
+    const options: ApplicationNavigationOptions = { pathname: `${context.basePath}${path}` };
     const search = detail?.search;
     if (typeof search === "string" && search.startsWith("?") && !search.includes("#")) {
-      this.host.navigate(routeId, { search });
-      return;
+      options.search = search;
     }
-    this.host.navigate(routeId);
+    this.host.navigate(routeId, options);
   };
 
   readonly handleNativeHistoryState = (event: Event): void => {

--- a/ui/src/app/native-notifications.test.ts
+++ b/ui/src/app/native-notifications.test.ts
@@ -126,6 +126,30 @@ describe("native notifications", () => {
     expect(postMessage.mock.calls).toEqual([[{ type: "send-test" }]]);
   });
 
+  it.each(["unknown", "notDetermined", "denied", "granted"] as const)(
+    "sends private background completion only with granted permission: %s",
+    (permission) => {
+      const postMessage = installBridge();
+      capability = createNativeNotificationsCapability();
+      if (permission !== "unknown") {
+        window.dispatchEvent(
+          new CustomEvent(NATIVE_NOTIFICATIONS_STATUS_EVENT, {
+            detail: { permission, test: null },
+          }),
+        );
+      }
+      postMessage.mockClear();
+
+      capability?.backgroundSessionCompleted({ runId: "run-1", path: "/chat/research" });
+
+      expect(postMessage.mock.calls).toEqual(
+        permission === "granted"
+          ? [[{ type: "background-session-completed", runId: "run-1", path: "/chat/research" }]]
+          : [],
+      );
+    },
+  );
+
   it("keeps permission and failed send as independent facts across focus refresh", () => {
     const postMessage = installBridge();
     capability = createNativeNotificationsCapability();

--- a/ui/src/app/native-notifications.ts
+++ b/ui/src/app/native-notifications.ts
@@ -13,7 +13,14 @@ type NativeNotificationsSnapshot = {
 type NativeNotificationsMessage =
   | { type: "status" }
   | { type: "request-permission" }
-  | { type: "send-test" };
+  | { type: "send-test" }
+  | ({ type: "background-session-completed" } & NativeBackgroundSessionCompletion);
+
+type NativeBackgroundSessionCompletion = {
+  runId: string;
+  path: string;
+  search?: string;
+};
 
 type WebKitNotificationsMessageHandler = {
   postMessage(message: NativeNotificationsMessage): void;
@@ -36,6 +43,7 @@ export type NativeNotificationsCapability = {
   subscribe(listener: (snapshot: NativeNotificationsSnapshot) => void): () => void;
   requestPermission(): void;
   sendTest(): void;
+  backgroundSessionCompleted(completion: NativeBackgroundSessionCompletion): void;
   dispose(): void;
 };
 
@@ -129,6 +137,11 @@ export function createNativeNotificationsCapability(): NativeNotificationsCapabi
       }
       publish({ ...snapshot, test: { state: "pending" } });
       postMessage({ type: "send-test" });
+    },
+    backgroundSessionCompleted(completion) {
+      if (snapshot.permission === "granted") {
+        postMessage({ type: "background-session-completed", ...completion });
+      }
     },
     dispose() {
       window.removeEventListener(NATIVE_NOTIFICATIONS_STATUS_EVENT, handleStatus);

--- a/ui/src/pages/new-session/background-session-notice.ts
+++ b/ui/src/pages/new-session/background-session-notice.ts
@@ -53,9 +53,10 @@ async function notifyWhenBackgroundSessionEnds(params: {
       if (observed.status === "pending" || observed.pendingError === true) {
         await delayRetry();
       } else if (observationalTimeout) {
-        const placement = params.context.placementStartup.get(params.key);
-        if (placement?.phase === "failed") {
-          result = { status: "error", error: placement.error };
+        // Startup display errors can mean unconfirmed delivery, not a failed run.
+        const initialTurn = params.context.placementStartup.get(params.key)?.initialTurn;
+        if (initialTurn?.sendState === "failed" && initialTurn.sendRunId === params.runId) {
+          result = { status: "error", error: initialTurn.sendError };
         } else {
           // A wait deadline is not a run outcome, even after startup custody retires.
           await delayRetry();

--- a/ui/src/pages/new-session/background-session-notice.ts
+++ b/ui/src/pages/new-session/background-session-notice.ts
@@ -14,6 +14,7 @@ type AgentWaitResult = {
   status?: "error" | "ok" | "pending" | "timeout";
   endedAt?: number;
   error?: string;
+  pendingError?: boolean;
   providerStarted?: boolean;
   stopReason?: string;
 };
@@ -49,16 +50,15 @@ async function notifyWhenBackgroundSessionEnds(params: {
         !observed.error &&
         !observed.stopReason &&
         observed.providerStarted !== true;
-      if (observed.status === "pending") {
+      if (observed.status === "pending" || observed.pendingError === true) {
         await delayRetry();
       } else if (observationalTimeout) {
         const placement = params.context.placementStartup.get(params.key);
         if (placement?.phase === "failed") {
           result = { status: "error", error: placement.error };
-        } else if (params.context.placementStartup.hasPendingTurn(params.key)) {
-          await delayRetry();
         } else {
-          result = observed;
+          // A wait deadline is not a run outcome, even after startup custody retires.
+          await delayRetry();
         }
       } else {
         result = observed;
@@ -97,6 +97,17 @@ async function notifyWhenBackgroundSessionEnds(params: {
         : result.stopReason === "rpc"
           ? t("sessionsView.statusKilled")
           : t("sessionsView.statusFailed");
+  const nativeTarget = sessionNavigationTarget({
+    face: "chat",
+    sessionKey: params.key,
+    fallbackAgentId: params.agentId,
+    exactKey: true,
+  });
+  params.context.nativeNotifications?.backgroundSessionCompleted({
+    runId: params.runId,
+    path: nativeTarget.options.pathname,
+    ...(nativeTarget.options.search ? { search: nativeTarget.options.search } : {}),
+  });
   showToast({
     fifo: true,
     message: `${resolveSessionDisplayName(params.key, row)}: ${status}`,

--- a/ui/src/pages/new-session/draft-submission-background.test.ts
+++ b/ui/src/pages/new-session/draft-submission-background.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createNativeNotificationsCapability } from "../../app/native-notifications.ts";
+import type { ApplicationPlacementStartupStatus } from "../../app/session-placement-startup.ts";
+import * as toast from "../../lib/toast.ts";
+import { createDraftFixture } from "./draft-submission-flow.test-support.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+function nativeBackgroundFixture(options: Parameters<typeof createDraftFixture>[0] = {}) {
+  const postMessage = vi.fn();
+  vi.stubGlobal("webkit", {
+    messageHandlers: { openclawNotifications: { postMessage } },
+  });
+  const nativeNotifications = createNativeNotificationsCapability();
+  const fixture = createDraftFixture(options);
+  Object.assign(fixture.context, { nativeNotifications, basePath: "" });
+  window.dispatchEvent(
+    new CustomEvent("openclaw:native-notifications-status", {
+      detail: { permission: "granted", test: null },
+    }),
+  );
+  vi.mocked(fixture.context.sessions.createResult).mockResolvedValue({
+    key: "agent:main:dashboard:background",
+    initialRun: { status: "started", runId: "run-background" },
+  });
+  fixture.flow.setMessage("finish in the background");
+  return { ...fixture, postMessage, dispose: () => nativeNotifications?.dispose() };
+}
+
+function failedPlacement(
+  sendState: "failed" | "unconfirmed",
+  sendRunId = "run-background",
+  error?: string,
+): ApplicationPlacementStartupStatus {
+  return {
+    sessionKey: "agent:main:dashboard:background",
+    targetKind: "device",
+    phase: "failed",
+    startedAt: 1,
+    error,
+    initialTurn: {
+      id: sendRunId,
+      text: "background turn",
+      createdAt: 1,
+      sendRunId,
+      sendState,
+      sendError: error,
+    },
+  };
+}
+
+describe("DraftSubmissionFlow background completion", () => {
+  it("delivers an accepted background completion to the native dashboard bridge", async () => {
+    const { context, flow, postMessage, dispose } = nativeBackgroundFixture({
+      request: async (method) => (method === "agent.wait" ? { status: "ok", endedAt: 1 } : {}),
+    });
+    try {
+      await flow.submit(undefined, true);
+      await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(2));
+      expect(postMessage).toHaveBeenLastCalledWith({
+        type: "background-session-completed",
+        runId: "run-background",
+        path: "/chat/main/dashboard/background",
+      });
+      expect(context.navigateAndWait).not.toHaveBeenCalled();
+    } finally {
+      dispose();
+    }
+  });
+
+  it.each(["selected session", "replaced Gateway"])(
+    "suppresses a background completion for the %s",
+    async (scenario) => {
+      const { context, flow, request, postMessage, dispose } = nativeBackgroundFixture();
+      request.mockImplementation(async (method) => {
+        if (method === "agent.wait") {
+          if (scenario === "selected session") {
+            context.gateway.snapshot.sessionKey = "agent:main:dashboard:background";
+          } else {
+            context.gateway.snapshot.client = null;
+          }
+          return { status: "ok", endedAt: 1 };
+        }
+        return {};
+      });
+      try {
+        await flow.submit(undefined, true);
+        await Promise.resolve();
+        expect(postMessage.mock.calls).toEqual([[{ type: "status" }]]);
+      } finally {
+        dispose();
+      }
+    },
+  );
+
+  it.each([
+    { scenario: "an observation deadline", observed: { status: "timeout" }, placement: null },
+    {
+      scenario: "a retryable provider error",
+      observed: { status: "timeout", error: "Retryable provider failure", pendingError: true },
+      placement: null,
+    },
+    { scenario: "a queued turn", observed: { status: "pending" }, placement: null },
+    {
+      scenario: "checking placement delivery",
+      observed: { status: "timeout" },
+      placement: failedPlacement("unconfirmed"),
+    },
+    {
+      scenario: "paused unconfirmed placement delivery",
+      observed: { status: "timeout" },
+      placement: failedPlacement("unconfirmed", "run-background", "Delivery remains unconfirmed"),
+    },
+    {
+      scenario: "a newer placement retry failure",
+      observed: { status: "timeout" },
+      placement: failedPlacement("failed", "newer-run", "Newer retry rejected"),
+    },
+    {
+      scenario: "a placement display error without a recorded send outcome",
+      observed: { status: "timeout" },
+      placement: { ...failedPlacement("failed"), initialTurn: undefined },
+    },
+  ])(
+    "waits for terminal background completion after $scenario",
+    async ({ observed, placement }) => {
+      vi.useFakeTimers();
+      const showToast = vi.spyOn(toast, "showToast").mockReturnValue(true);
+      let finishRun!: (result: { status: "ok"; endedAt: number }) => void;
+      const terminal = new Promise<{ status: "ok"; endedAt: number }>((resolve) => {
+        finishRun = resolve;
+      });
+      const observations = [Promise.resolve(observed), terminal];
+      const { context, flow, request, postMessage, dispose } = nativeBackgroundFixture({
+        request: async (method) => (method === "agent.wait" ? observations.shift() : {}),
+      });
+
+      Object.assign(context.placementStartup, { get: () => placement });
+
+      try {
+        await flow.submit(undefined, true);
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(postMessage.mock.calls).toEqual([[{ type: "status" }]]);
+        expect(showToast).not.toHaveBeenCalled();
+        expect(request.mock.calls.filter(([method]) => method === "agent.wait")).toHaveLength(2);
+
+        finishRun({ status: "ok", endedAt: 1 });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(postMessage.mock.calls).toEqual([
+          [{ type: "status" }],
+          [
+            {
+              type: "background-session-completed",
+              runId: "run-background",
+              path: "/chat/main/dashboard/background",
+            },
+          ],
+        ]);
+        expect(showToast).toHaveBeenCalledOnce();
+      } finally {
+        context.gateway.snapshot.client = null;
+        finishRun({ status: "ok", endedAt: 1 });
+        await vi.advanceTimersByTimeAsync(0);
+        dispose();
+      }
+    },
+  );
+
+  it("notifies a confirmed placement failure for the exact background run", async () => {
+    const showToast = vi.spyOn(toast, "showToast").mockReturnValue(true);
+    const { context, flow, request, postMessage, dispose } = nativeBackgroundFixture({
+      request: async (method) => (method === "agent.wait" ? { status: "timeout" } : {}),
+    });
+    Object.assign(context.placementStartup, {
+      get: () => failedPlacement("failed", "run-background", "Placement rejected"),
+    });
+    try {
+      await flow.submit(undefined, true);
+      await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(2));
+      expect(postMessage).toHaveBeenLastCalledWith({
+        type: "background-session-completed",
+        runId: "run-background",
+        path: "/chat/main/dashboard/background",
+      });
+      expect(showToast).toHaveBeenCalledOnce();
+      expect(request.mock.calls.filter(([method]) => method === "agent.wait")).toHaveLength(1);
+    } finally {
+      dispose();
+    }
+  });
+});

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -1,11 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SESSION_CREATE_RETRY_WINDOW_MS } from "../../../../packages/gateway-protocol/src/index.js";
 import type { ApplicationContext } from "../../app/context.ts";
-import { createNativeNotificationsCapability } from "../../app/native-notifications.ts";
 import { CHAT_ROUTE_READY_EVENT } from "../../app/route-transition.ts";
 import { consumeSessionNavigationHandoff } from "../../lib/sessions/navigation-handoff.ts";
 import { writeSessionPlacementRecovery } from "../../lib/sessions/session-placement-recovery.ts";
-import * as toast from "../../lib/toast.ts";
 import { buildChatApiAttachments } from "../chat/attachment-api.ts";
 import {
   getChatAttachmentDataUrl,
@@ -43,71 +41,7 @@ function stubObjectUrls(...urls: string[]) {
   return revokeObjectURL;
 }
 
-function nativeBackgroundFixture(options: Parameters<typeof createDraftFixture>[0] = {}) {
-  const postMessage = vi.fn();
-  vi.stubGlobal("webkit", {
-    messageHandlers: { openclawNotifications: { postMessage } },
-  });
-  const nativeNotifications = createNativeNotificationsCapability();
-  const fixture = createDraftFixture(options);
-  Object.assign(fixture.context, { nativeNotifications, basePath: "" });
-  window.dispatchEvent(
-    new CustomEvent("openclaw:native-notifications-status", {
-      detail: { permission: "granted", test: null },
-    }),
-  );
-  vi.mocked(fixture.context.sessions.createResult).mockResolvedValue({
-    key: "agent:main:dashboard:background",
-    initialRun: { status: "started", runId: "run-background" },
-  });
-  fixture.flow.setMessage("finish in the background");
-  return { ...fixture, postMessage, dispose: () => nativeNotifications?.dispose() };
-}
-
 describe("DraftSubmissionFlow", () => {
-  it("delivers an accepted background completion to the native dashboard bridge", async () => {
-    const { context, flow, postMessage, dispose } = nativeBackgroundFixture({
-      request: async (method) => (method === "agent.wait" ? { status: "ok", endedAt: 1 } : {}),
-    });
-    try {
-      await flow.submit(undefined, true);
-      await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(2));
-      expect(postMessage).toHaveBeenLastCalledWith({
-        type: "background-session-completed",
-        runId: "run-background",
-        path: "/chat/main/dashboard/background",
-      });
-      expect(context.navigateAndWait).not.toHaveBeenCalled();
-    } finally {
-      dispose();
-    }
-  });
-
-  it.each(["selected session", "replaced Gateway"])(
-    "suppresses a background completion for the %s",
-    async (scenario) => {
-      const { context, flow, request, postMessage, dispose } = nativeBackgroundFixture();
-      request.mockImplementation(async (method) => {
-        if (method === "agent.wait") {
-          if (scenario === "selected session") {
-            context.gateway.snapshot.sessionKey = "agent:main:dashboard:background";
-          } else {
-            context.gateway.snapshot.client = null;
-          }
-          return { status: "ok", endedAt: 1 };
-        }
-        return {};
-      });
-      try {
-        await flow.submit(undefined, true);
-        await Promise.resolve();
-        expect(postMessage.mock.calls).toEqual([[{ type: "status" }]]);
-      } finally {
-        dispose();
-      }
-    },
-  );
-
   it("keeps a direct background completion watch through a Gateway reconnect", async () => {
     vi.useFakeTimers();
     const { context, flow, request } = createDraftFixture();
@@ -169,53 +103,6 @@ describe("DraftSubmissionFlow", () => {
     });
     expect(flow.message).toBe("");
     expect(flow.submitting).toBe(false);
-  });
-
-  it.each([
-    { scenario: "an observation deadline", observed: { status: "timeout" } },
-    {
-      scenario: "a retryable provider error",
-      observed: { status: "timeout", error: "Retryable provider failure", pendingError: true },
-    },
-    { scenario: "a queued turn", observed: { status: "pending" } },
-  ])("waits for terminal background completion after $scenario", async ({ observed }) => {
-    vi.useFakeTimers();
-    const showToast = vi.spyOn(toast, "showToast").mockReturnValue(true);
-    let finishRun!: (result: { status: "ok"; endedAt: number }) => void;
-    const terminal = new Promise<{ status: "ok"; endedAt: number }>((resolve) => {
-      finishRun = resolve;
-    });
-    const observations = [Promise.resolve(observed), terminal];
-    const { context, flow, request, postMessage, dispose } = nativeBackgroundFixture({
-      request: async (method) => (method === "agent.wait" ? observations.shift() : {}),
-    });
-
-    try {
-      await flow.submit(undefined, true);
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(postMessage.mock.calls).toEqual([[{ type: "status" }]]);
-      expect(showToast).not.toHaveBeenCalled();
-      expect(request.mock.calls.filter(([method]) => method === "agent.wait")).toHaveLength(2);
-
-      finishRun({ status: "ok", endedAt: 1 });
-      await vi.advanceTimersByTimeAsync(0);
-      expect(postMessage.mock.calls).toEqual([
-        [{ type: "status" }],
-        [
-          {
-            type: "background-session-completed",
-            runId: "run-background",
-            path: "/chat/main/dashboard/background",
-          },
-        ],
-      ]);
-      expect(showToast).toHaveBeenCalledOnce();
-    } finally {
-      context.gateway.snapshot.client = null;
-      finishRun({ status: "ok", endedAt: 1 });
-      await vi.advanceTimersByTimeAsync(0);
-      dispose();
-    }
   });
 
   it("replays a frozen direct create without inheriting refreshed placement or mutable submit gates", async () => {

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SESSION_CREATE_RETRY_WINDOW_MS } from "../../../../packages/gateway-protocol/src/index.js";
 import type { ApplicationContext } from "../../app/context.ts";
+import { createNativeNotificationsCapability } from "../../app/native-notifications.ts";
 import { CHAT_ROUTE_READY_EVENT } from "../../app/route-transition.ts";
 import { consumeSessionNavigationHandoff } from "../../lib/sessions/navigation-handoff.ts";
 import { writeSessionPlacementRecovery } from "../../lib/sessions/session-placement-recovery.ts";
+import * as toast from "../../lib/toast.ts";
 import { buildChatApiAttachments } from "../chat/attachment-api.ts";
 import {
   getChatAttachmentDataUrl,
@@ -41,7 +43,71 @@ function stubObjectUrls(...urls: string[]) {
   return revokeObjectURL;
 }
 
+function nativeBackgroundFixture(options: Parameters<typeof createDraftFixture>[0] = {}) {
+  const postMessage = vi.fn();
+  vi.stubGlobal("webkit", {
+    messageHandlers: { openclawNotifications: { postMessage } },
+  });
+  const nativeNotifications = createNativeNotificationsCapability();
+  const fixture = createDraftFixture(options);
+  Object.assign(fixture.context, { nativeNotifications, basePath: "" });
+  window.dispatchEvent(
+    new CustomEvent("openclaw:native-notifications-status", {
+      detail: { permission: "granted", test: null },
+    }),
+  );
+  vi.mocked(fixture.context.sessions.createResult).mockResolvedValue({
+    key: "agent:main:dashboard:background",
+    initialRun: { status: "started", runId: "run-background" },
+  });
+  fixture.flow.setMessage("finish in the background");
+  return { ...fixture, postMessage, dispose: () => nativeNotifications?.dispose() };
+}
+
 describe("DraftSubmissionFlow", () => {
+  it("delivers an accepted background completion to the native dashboard bridge", async () => {
+    const { context, flow, postMessage, dispose } = nativeBackgroundFixture({
+      request: async (method) => (method === "agent.wait" ? { status: "ok", endedAt: 1 } : {}),
+    });
+    try {
+      await flow.submit(undefined, true);
+      await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(2));
+      expect(postMessage).toHaveBeenLastCalledWith({
+        type: "background-session-completed",
+        runId: "run-background",
+        path: "/chat/main/dashboard/background",
+      });
+      expect(context.navigateAndWait).not.toHaveBeenCalled();
+    } finally {
+      dispose();
+    }
+  });
+
+  it.each(["selected session", "replaced Gateway"])(
+    "suppresses a background completion for the %s",
+    async (scenario) => {
+      const { context, flow, request, postMessage, dispose } = nativeBackgroundFixture();
+      request.mockImplementation(async (method) => {
+        if (method === "agent.wait") {
+          if (scenario === "selected session") {
+            context.gateway.snapshot.sessionKey = "agent:main:dashboard:background";
+          } else {
+            context.gateway.snapshot.client = null;
+          }
+          return { status: "ok", endedAt: 1 };
+        }
+        return {};
+      });
+      try {
+        await flow.submit(undefined, true);
+        await Promise.resolve();
+        expect(postMessage.mock.calls).toEqual([[{ type: "status" }]]);
+      } finally {
+        dispose();
+      }
+    },
+  );
+
   it("keeps a direct background completion watch through a Gateway reconnect", async () => {
     vi.useFakeTimers();
     const { context, flow, request } = createDraftFixture();
@@ -105,22 +171,51 @@ describe("DraftSubmissionFlow", () => {
     expect(flow.submitting).toBe(false);
   });
 
-  it("stops a direct background watch when the exact run is unobservable", async () => {
+  it.each([
+    { scenario: "an observation deadline", observed: { status: "timeout" } },
+    {
+      scenario: "a retryable provider error",
+      observed: { status: "timeout", error: "Retryable provider failure", pendingError: true },
+    },
+    { scenario: "a queued turn", observed: { status: "pending" } },
+  ])("waits for terminal background completion after $scenario", async ({ observed }) => {
     vi.useFakeTimers();
-    const { context, flow, request } = createDraftFixture({
-      request: async (method) => (method === "agent.wait" ? { status: "timeout" } : {}),
+    const showToast = vi.spyOn(toast, "showToast").mockReturnValue(true);
+    let finishRun!: (result: { status: "ok"; endedAt: number }) => void;
+    const terminal = new Promise<{ status: "ok"; endedAt: number }>((resolve) => {
+      finishRun = resolve;
     });
-    vi.mocked(context.sessions.createResult).mockResolvedValue({
-      key: "agent:main:dashboard:unobservable",
-      initialRun: { status: "started", runId: "run-unobservable" },
+    const observations = [Promise.resolve(observed), terminal];
+    const { context, flow, request, postMessage, dispose } = nativeBackgroundFixture({
+      request: async (method) => (method === "agent.wait" ? observations.shift() : {}),
     });
-    flow.setMessage("start this in the background");
 
-    await flow.submit(undefined, true);
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(5_000);
+    try {
+      await flow.submit(undefined, true);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(postMessage.mock.calls).toEqual([[{ type: "status" }]]);
+      expect(showToast).not.toHaveBeenCalled();
+      expect(request.mock.calls.filter(([method]) => method === "agent.wait")).toHaveLength(2);
 
-    expect(request.mock.calls.filter(([method]) => method === "agent.wait")).toHaveLength(1);
+      finishRun({ status: "ok", endedAt: 1 });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(postMessage.mock.calls).toEqual([
+        [{ type: "status" }],
+        [
+          {
+            type: "background-session-completed",
+            runId: "run-background",
+            path: "/chat/main/dashboard/background",
+          },
+        ],
+      ]);
+      expect(showToast).toHaveBeenCalledOnce();
+    } finally {
+      context.gateway.snapshot.client = null;
+      finishRun({ status: "ok", endedAt: 1 });
+      await vi.advanceTimersByTimeAsync(0);
+      dispose();
+    }
   });
 
   it("replays a frozen direct create without inheriting refreshed placement or mutable submit gates", async () => {
@@ -709,6 +804,7 @@ describe("DraftSubmissionFlow", () => {
       context.gateway.snapshot.sessionKey = sessionKey;
     });
     const selectAgent = vi.fn();
+    let startupPending = background;
     let backgroundWaitAttempts = 0;
     const client = {
       recoveryScope: "principal-a",
@@ -724,6 +820,8 @@ describe("DraftSubmissionFlow", () => {
             throw new Error("gateway closed");
           }
           if (background && backgroundWaitAttempts === 2) {
+            // Placement custody retires when sending is accepted, before the run finishes.
+            startupPending = false;
             return { status: "timeout" };
           }
           if (background && backgroundWaitAttempts === 3) {
@@ -769,7 +867,7 @@ describe("DraftSubmissionFlow", () => {
       placementStartup: {
         start,
         get: vi.fn(() => undefined),
-        hasPendingTurn: vi.fn(() => background),
+        hasPendingTurn: vi.fn(() => startupPending),
       },
       config: { current: {} },
       navigateAndWait,


### PR DESCRIPTION
## What Problem This Solves

Starting a session in the background showed an in-app completion message but never posted the native macOS notification promised by the 2.0 announcement, even when notification permission was already enabled.

Thanks to [김훈기](https://discord.com/channels/1456350064065904867/1456350065223270435/1544577265294250025) for the September 2 report, and the [background-session announcement](https://discord.com/channels/1456350064065904867/1456350065223270435/1544572475378237461) for the explicit product contract.

## Why This Change Was Made

The background-session owner only delivered an in-app toast; it never handed completion to the existing native notification bridge. This change carries the accepted run's terminal outcome through that trusted bridge to macOS Notification Center, preserving suppression when the session is already being viewed.

A real long-running task also exposed a shipped wait-contract bug: the watcher treated a 30-second observation timeout as completion whenever placement startup custody had ended (including every direct run). `agent.wait` explicitly requires waiting again on the same run ID; startup custody does not describe execution liveness. The watcher now continues across observation deadlines and pending retry errors, while retaining true terminal outcomes and Gateway-client fencing. A placement display error also does not prove completion: checking/unconfirmed delivery remains observed, and a recorded failed send only ends the watcher when its run ID matches exactly. This prevents a newer retry failure from being attributed to the original background run.

The live click-through test also found that the existing native navigation receiver acknowledged a dynamic session path but discarded its pathname, reopening Home. The receiver now preserves the exact app-relative path under the current Gateway mount, including valid query parameters. The same repair covers native agent and memory deep links.

Real AppKit regression tests exposed lifecycle gaps after notification delivery: failed pages were only focused, pending lookups could reopen closed windows or override newer navigation, and queued commands could cancel a later completion click. The manager now resolves configuration once and restores/navigates without another suspension. Pending intent belongs to its Gateway target, while the native window retains user intent across authenticated document replacement. One registered close handler covers primary and auxiliary windows, including a lookup that began before a window existed. A non-navigation Cmd-K open retains unchanged configuration; an actual configured creation/replacement invalidates older authentication snapshots so a resumed click cannot restore an old endpoint or credential; an admitted click follows AppKit's controller for its captured window rather than selecting again by focus. Actual URL/auth/TLS/route-authority changes still replace the privileged document and invalidate obsolete work. Older navigation commands are retired, ordered command-palette toggles remain intact, and unrelated Gateway windows stay independent.

The native notification owner retains a bounded, process-lifetime action for the exact originating Gateway and session. It fences retired documents and late enqueue completions, removes evicted notifications, and revalidates the current Gateway route before reopening. Actions retain the destination without retaining the window; changed routes or expired actions produce recovery guidance. Existing notification permission is required; completion never opens a permission prompt. No new configuration, environment variables, persistent store, or Gateway protocol version change.

Review also found that the shared query validator could trap on malformed percent escapes. Its canonical parser now fails safely, using [Foundation's strict failable URL parsing](https://github.com/swiftlang/swift-foundation/blob/main/Sources/FoundationEssentials/URL/URLComponents.swift#L688) instead of assigning untrusted input to a trapping property. The existing shared tests reproduce the crash before the fix and pass afterward.

The 2026.8.2 macOS app publication lag itself is a release-process item outside this PR.

## User Impact

A background session started from New Session posts a native completion notification when it finishes and is not currently being viewed. Clicking it opens that session on its original Gateway. The notification contains only generic text, never the prompt, response, session title, credentials, or route. The originating dashboard must stay loaded while the run finishes; minimizing it or working in another app is supported.

This does not add a native notification for every foreground chat response or change browser Agent finished preferences.

## Evidence

The real locally Developer-ID-signed app ran against an isolated Gateway on port 61356 and a loopback synthetic provider on port 61355. No operator Gateway, production state, or external model API was used. The complete screenshots were inspected before upload; only synthetic task data appears.

The app posted a real native completion banner, and clicking it opened `/chat/main/dashboard/89e662a2-a606-4e51-9a1e-2e8387ecdeac` on the originating Gateway. The existing foreground test notification also displayed successfully.

- The background completion regression fails against the original toast-only owner and passes after the bridge is connected.
- 115 focused UI tests passed across five files, including draft submission/background completion, native notifications, the existing permission auto-prompt boundary, and native-shell navigation. The original four wait-contract cases passed; before the fix, direct timeout/pending-error cases notified prematurely and placement stopped after startup custody retired. Four further placement cases also fail before the exact recorded-outcome guard and pass afterward; genuine matching failure remains covered. The final background suite rerun passes all 11 tests.
- All 37 native-shell UI tests passed, including 12 root/mounted destination cases that fail before the pathname repair. The completion tests were moved without dropping assertions into a focused background-submission file to keep the original file below its size limit.
- Production Control UI builds passed after both the wait repair and navigation repair, including finalized-sidecar integrity and startup asset budgets. The served index changed from `index-C1F_JMT2.js` to `index-DNOO2HOa.js` before the final click proof.
- Final native build with tests passed in 72.75 seconds. The exact compiled bundle passed all 52 tests across seven complete window ownership, Gateway, and Settings-handoff suites in a disposable macOS 26.6 VM. All 17 notification-window cases passed separately; the configured-open/window-order regressions and endpoint/credential replacement cases also passed separately. No Window/WebView tests ran on the operator desktop.
- Regression proof precedes each owner repair: the original failed-page/close cases, direct and manager-queued command replay, credential replacement, newly created window close, manual open/close during lookup, configured Cmd-K, and unrelated-window ordering failed on their corresponding pre-fix candidates. The configured Cmd-K and window-order cases failed only their completed-session destination checks after every real window-order/reopen precondition passed. Key-focus preconditions from an earlier harness attempt did not hold and are not counted as product proof; no OS permission or activation-policy override was used.
- The final composite build also passed 49 non-AppKit tests under an OS sandbox, including the 12 native notification bridge/action tests. Notification-window methods remain in an extension of the original serialized suite after the coherent file split.
- Native i18n source, Android catalogs, and Apple catalogs verify successfully after the one-line generated inventory update.
- Shared route tests reproduce the original invalid-query crash and pass all 7 tests with the strict parser.
- Independent review found and repaired the invalid-query crash and an app-wide delegate presentation regression that would have suppressed existing foreground test/system notifications. Committed-branch P2 review of `0743953708675196af3e6df9a62f70e6d9f99884` and the subsequent lint-only change both passed with no actionable findings. The required final committed-branch P2 review of `da7a62340951ade8f3e0eeefce2bfdecff2f1485` also passed with no actionable findings across both complete evidence partitions.

Production: +537/-190, net +347 lines. Tests: +888/-64, net +824. Docs: +8/-0. Generated native i18n inventory: +1/-0. Growth adds the missing native transport and bounded action lifecycle, exact originating-Gateway reopening, and target/window-owned pending navigation. The shared query repair is net -1. The native follow-up is net +88 production lines (including three formatting-only lines): it replaces duplicate primary/auxiliary presentation and close paths with canonical ownership, including intent before a window exists and across document replacement. The release lint follow-up moves three unchanged methods into the existing presentation extension and wraps arguments/an equivalent string; all 354 macOS and 22 Swabble files pass the exact release lint wrapper, and the full format/catalog checks pass. Test moves do not change net LOC; the 321-line moved notification block preserved its bodies/assertions, with only a trailing blank removed. No test seam, assertion weakening, or size-limit suppression was added. Typecheck/build for the unchanged UI source, final native proof, and the prior whole-branch/incremental reviews pass; the final committed-head review also passes. The managed changed-file check stopped at a missing borrowed `mermaid` dependency after its preceding guardrails, formatting, core graph and UI i18n checks passed; no dependency repair or bypass was applied. Fresh-dependency exact-head CI now passes, including both typechecks, dependency checks and all UI/native jobs; this closes the coverage gap without relabeling the local command as a pass. The earlier full check was superseded, not counted as a pass.

### Signed live proof

```text
2026-09-02, America/Los_Angeles
App: locally built OpenClaw 2026.8.1, Developer ID Application: OpenClaw Foundation
State/config/home: disposable task directories; Gateway ws://127.0.0.1:61356
Provider: synthetic loopback OpenAI-compatible Responses server, port 61355
10:50:12.832 background session accepted
10:50:44.201 agent.wait observation deadline returned after 30002 ms
10:50:52     run still active; no completion notification enqueued
10:51:04.009 held synthetic provider released
10:51:04.030 provider returned HTTP 200
10:51:04.764 second agent.wait returned the terminal result
10:51:04.769 macOS accepted the native notification request, hasError: 0
11:02:12.569 final click-through session accepted
11:02:13.282 terminal agent.wait returned; real native banner captured
Notification clicked -> exact session 89e662a2-a606-4e51-9a1e-2e8387ecdeac opened
Foreground Settings > Notifications > Send test -> real Test notification banner
```

The earlier supplemental OS-banner close-window-then-click attempt was inconclusive: Computer Use lost its target window and the short-lived banner expired before a verified click. It is not counted as OS-notification proof. The final exact native test bundle verifies close-before-click reopening, close-during-lookup cancellation, and the other lifecycle cases through real AppKit windows and WebViews. The OS-banner captures above precede these lifecycle-only refinements; the notification producer, native enqueue bridge, and UI pathname receiver are unchanged. A fresh final-composite OS-banner capture is blocked by OS permission prompts that were not approved for interaction. No permission choice was made; the earlier real banner/click evidence and final native lifecycle proof remain distinct.

The held provider also held the optional title request, which hit its existing 15-second utility timeout; the real agent run continued and completed without retry. The first long-run capture attempt missed the short-lived OS banner, so a fresh completed run supplied the final screenshot and click-through proof. No screenshot is a mock-up.

Native completion banner:

![Real macOS background completion notification](https://github.com/user-attachments/assets/e8f8b772-6f02-4805-a493-8baaed1b87a9)

Click-through regression found during live proof, before preserving the native pathname (this intermediate candidate posted the notice but opened Home):

![Before native destination repair: Home opened instead of the completed session](https://github.com/user-attachments/assets/2404c677-72b1-48c0-ad74-2a3394bfd504)

After the shared receiver repair:

![After: native notification opened the exact completed session](https://github.com/user-attachments/assets/65b967df-0cd5-4435-b16c-2f97a352b8f2)

[Existing foreground test notification proof](https://github.com/user-attachments/assets/19cb737e-2bc9-41ec-a258-602a5e88d5f1).

### Native lifecycle proof

The preceding development composite with both reviewed macOS repairs was Developer-ID-signed, transferred to a fresh disposable VM directory, and passed deep strict signature verification. Its notification sources match `0743953708675196af3e6df9a62f70e6d9f99884`; archive SHA-256 is `b13b91a0faa5f3ba3d4493de97e6e800736c6bbfd43cdedf51b78d1038dc3cd7`. This verifies that signed artifact, before the later behavior-preserving lint move, not a fresh OS-banner run: the app was not launched and no permission setting changed during that verification.


```text
Disposable macOS VM: macOS 26.6 (25G72), arm64
Task HOME/state; saved HOME/Keychain and securityd access denied by OS sandbox
Configured replacement before: 1 test / 2 cases fail with 4 issues in 3.141 s
Same replacement cases after: pass in 3.605 s; all hard preconditions pass
Configured Cmd-K and native-window ordering: both fail before and pass after
All native notification-window regressions: 10 tests / 17 cases pass in 11.034 s
Complete native siblings: 52 tests / 7 suites pass in 15.578 s
Final native build with tests: pass in 72.75 s
Exact final test executable SHA-256:
49627db70590d417a231fe819bcbe5801c083d67181b141a42bb9179ae51ae59
```

The authentication-held replacement cases reproduced an old click restoring the previous endpoint or credential after the new configured document was installed; the final producer guard preserves the new owner. The preceding regressions also reproduced the older queued New Session overriding a completion click, failure across credential replacement, and reopening after a newly created or manually opened window closed. Those cases pass in the final 17-case run. Window-order proof uses actual AppKit ordering when the headless test application has no key window; it is not represented as OS keyboard-focus proof.

### Review follow-through

The [latest ClawSweeper rank-up move](https://github.com/openclaw/openclaw/pull/136519#issuecomment-5514529063) is fulfilled: native tests and release checks pass, and the [complete exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33684176076) succeeded for `da7a62340951ade8f3e0eeefce2bfdecff2f1485`. The required exact-head watcher finished GREEN; all 147 completed checks succeeded, with 22 intentional skips and none pending or failed. The final Apple Watch screenshot job also passed. [Recent main CI](https://github.com/openclaw/openclaw/actions/runs/33685688391) is green.

The preceding head’s CI found four manager lint violations, repaired by the behavior-preserving presentation-extension move and formatting above. It also failed in unchanged shared audio-playback, Gateway restart-drain, and transcript-scroll tests matching green main. Those failures did not recur on the fresh final-head jobs. The app-wide delegate is covered by the existing foreground test notification and final native bridge/action tests. No additional re-review was requested for the mechanical lint move after the recent clean behavioral review.

### Follow-up audit

NO-FOLLOW-UP: the canonical presentation and native-window intent consolidation is required within this fix; no independent rent-paying refactor remains in the touched owners.

One separate, source-inspected but not runtime-reproduced behavior follow-up remains: an explicit manual Dashboard show on an already-visible SSH-backed primary window can outlive a red-X close while its endpoint lookup is pending. `DashboardManager.showResolvedPrimaryDashboard` / `presentationIsCurrent` owns that older manual-show path; it predates this notification repair and is not claimed fixed here.
