### PR TITLE
test(config): move schema hint test data out of production

### DIFF
--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -5,14 +5,21 @@ import { isSensitiveUrlConfigPath } from "@openclaw/net-policy/redact-sensitive-
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { buildSecretInputSchema } from "../plugin-sdk/secret-input-schema.js";
-import { buildBaseHints, testApi } from "./schema.hints.js";
+import {
+  buildBaseHints,
+  collectMatchingSchemaPaths,
+  mapSensitivePaths,
+  testApi,
+} from "./schema.hints.js";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import { OpenClawSchema } from "./zod-schema.js";
 import { OpenClawSchemaShape } from "./zod-schema.root-shape.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
-const { collectMatchingSchemaPaths, mapSensitivePaths, SECTION_DOCS_URLS, SECTIONS_WITHOUT_DOCS } =
-  testApi;
+const { SECTION_DOCS_URLS } = testApi;
+// Root sections without beginner-worthy pages stay explicit. Adding a root config key
+// requires choosing a docsUrl or listing it here.
+const SECTIONS_WITHOUT_DOCS = ["$schema", "meta", "attachments"] as const;
 const BUNDLED_CHANNEL_HINT_PREFIXES = [
   "channels.discord",
   "channels.imessage",

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -96,10 +96,6 @@ const SECTION_DOCS_URLS = {
   surfaces: "https://docs.openclaw.ai/concepts/messages",
 } as const satisfies Record<string, string>;
 
-// Root sections without beginner-worthy pages stay explicit. Adding a root config key
-// requires choosing a docsUrl or listing it here.
-const SECTIONS_WITHOUT_DOCS = ["$schema", "meta", "attachments"] as const;
-
 const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.publicOrigin": "https://gateway.example.com",
   "gateway.remote.url": "ws://host:18789",
@@ -343,8 +339,5 @@ function mapSensitivePathsMut(schema: z.ZodType, path: string, hints: ConfigUiHi
 
 /** @internal */
 export const testApi = {
-  collectMatchingSchemaPaths,
-  mapSensitivePaths,
   SECTION_DOCS_URLS,
-  SECTIONS_WITHOUT_DOCS,
 };


### PR DESCRIPTION
## What Problem This Solves

A maintainer-requested test audit found that the schema-hint runtime module carried a test-only list of sections without documentation, plus duplicate test access paths to functions already used directly by production callers.

## Why This Change Was Made

Move the documentation exception list and its existing comment into the test and import the two existing runtime functions directly. Keep the private documentation map exposed through the existing test API: its exact path-to-URL projection check detects wrong links even when both destination pages exist.

## User Impact

No user-facing behavior change. Every existing documentation and sensitivity test body is unchanged, including the non-root audio, presence, and voicewake projections. The production file loses seven test-support lines; the test gains seven net lines. No production algorithm, config option, schema, dependency, or public API changes.

## Evidence

Before and after, this canonical command passed all 42 tests across three files (13 schema hints, 24 help/tier quality, 5 schema redaction):

```sh
env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs src/config/schema.hints.test.ts src/config/schema.help.quality.test.ts src/config/redact-snapshot.schema.test.ts
```

Captured terminal results:

```text
Before: [test] passed 2 Vitest shards in 8.22s
After:  [test] passed 2 Vitest shards in 7.10s
```

Both runs reported 24 tooling tests and 18 runtime-config tests passing.

Standalone production `buildBaseHints()` and `computeBaseConfigSchemaResponse({ generatedAt: "schema-hints-audit" })` output was byte-identical before/after: 1,104 base hints, 2,560 response hints, 2,118,334 bytes; SHA-256 `17f579ffad54b8d8c951831efa6b0b0492d115a2132a1d3d2e1586d5db3965d8`. This exercises the real schema/hint owners without Vitest or mocks; it does not claim live Gateway or provider proof.

Targeted formatting and `git diff --check` passed. Fresh managed Codex review found no actionable P0–P2 findings. The normal core/coreTests changed gate passed: core and core-test typechecks, all three dead-export scans, changed-file lint and the selected architecture guards.

<details>
<summary>Reproduce the standalone owner-output hash</summary>

This is the same production probe used before and after the cleanup, with its stdout sent to the hash utility instead of a capture file:

```sh
env -u OPENCLAW_TESTBOX TZ=UTC node --import ./scripts/tsx.mjs --input-type=module <<'NODE' | shasum -a 256
import { buildBaseHints } from './src/config/schema.hints.ts';
import { computeBaseConfigSchemaResponse } from './src/config/schema-base.ts';

process.stdout.write(JSON.stringify({
  baseHints: buildBaseHints(),
  schemaResponse: computeBaseConfigSchemaResponse({ generatedAt: 'schema-hints-audit' }),
}, null, 2) + '\n');
NODE
```

Both saved before/after files produced `17f579ffad54b8d8c951831efa6b0b0492d115a2132a1d3d2e1586d5db3965d8`; `cmp` exited 0. No test mocks, Gateway, provider, or real user configuration is used.

</details>

### Mechanical refresh onto current main

Rebased onto `c2579f14f0dc6ff49acd096be865a407a011a67a`, which contains the canonical CLI line-cap and Gateway client deadline-test repairs. The two-file patch and both afterimages are unchanged from the original reviewed head.

The three focused suites passed again before and after the refresh: 24 tooling tests and 18 runtime-config tests each time (42 total). The same standalone production probe also returned byte-identical output on current main and the refreshed head, matching the original 2,118,334-byte capture and SHA-256 above. This directly covers current main’s intervening schema-tag ordering refactor. Dependencies, the documentation-map projection assertions, and every sensitivity test are unchanged. The original changed-gate and Codex review evidence remains applicable to this mechanical patch.

The remaining private documentation-map access is intentional; the [maintainer response](https://github.com/openclaw/openclaw/pull/136520#issuecomment-5514772099) includes the discriminating wrong-link control for the proposed output-derived replacement.
