### PR TITLE
feat: show model sign-in method and account email

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -59,6 +59,8 @@ Reference for **LLM/model providers** (not chat channels like WhatsApp/Telegram)
 
 Open **Settings → Models** in the Control UI to add, replace, or remove provider API keys stored in `models.providers.<id>.apiKey`. The page identifies whether each API key comes from OpenClaw config or an environment variable without displaying the credential. Environment-provided keys remain managed by the gateway process environment.
 
+Open **Model Setup** from the page header to inspect detected AI access. When available, it shows the authentication method (API key or account sign-in) and the actual email address reported by the provider or local runtime. API keys and tokens stay hidden.
+
 Use **Test connection** to run a live provider probe and see latency or a categorized authentication, rate-limit, billing, timeout, or response error. A probe makes a real provider request and may consume a small number of tokens. OAuth and token profiles can also be logged out from the provider card.
 
 The **Defaults** card manages the primary model, utility model, first fallback, thinking level, and Fast mode from the configured model catalog. Changes save automatically to the existing `agents.defaults` settings. For the utility model, **Auto** leaves the setting unset and **Disabled** stores an empty string to turn utility routing off.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -55,6 +55,13 @@ Provider and channel execution paths must use the active runtime config snapshot
 
 ## Reusable runtime utilities
 
+Native command probes can use `signalProcessTree` from
+`openclaw/plugin-sdk/process-runtime`. Its `onComplete` callback runs after Unix
+signaling or the bounded Windows `taskkill` attempt, not proof that every process
+exited. Keep the probe pending through cleanup, use `detached: true` only for a
+process group you created, and start Windows tree termination while its root is
+still alive.
+
 Channel plugins that deliver agent replies directly can call
 `renderPresentationForDelivery(handler, payload)` from
 `openclaw/plugin-sdk/interactive-runtime` at delivery, after modifying hooks. Supply

--- a/extensions/anthropic/cli-auth-api.ts
+++ b/extensions/anthropic/cli-auth-api.ts
@@ -1,0 +1,2 @@
+/** Native Claude login discovery without importing the provider runtime. */
+export { probeClaudeCliAuthStatus } from "./cli-auth-seam.js";

--- a/extensions/anthropic/cli-auth-seam.test.ts
+++ b/extensions/anthropic/cli-auth-seam.test.ts
@@ -6,19 +6,29 @@ const { spawnSync } = vi.hoisted(() => ({
 
 vi.mock("node:child_process", () => ({ spawnSync }));
 
-const { probeClaudeCliAuthStatus } = await import("./cli-auth-seam.js");
+const { probeClaudeCliAuthStatus } = await import("./cli-auth-api.js");
 
 beforeEach(() => {
   spawnSync.mockReset();
 });
 
-it("asks Claude CLI to verify its own login", () => {
+it("asks Claude CLI for its active account and returns only safe display fields", () => {
   spawnSync.mockReturnValue({
     status: 0,
-    stdout: JSON.stringify({ loggedIn: true, authMethod: "claude.ai" }),
+    stdout: JSON.stringify({
+      loggedIn: true,
+      authMethod: "claude.ai",
+      email: " account@example.test ",
+      orgId: "private-organization",
+      accessToken: "synthetic-access-token",
+    }),
   });
 
-  expect(probeClaudeCliAuthStatus()).toEqual({ status: "available" });
+  expect(probeClaudeCliAuthStatus()).toEqual({
+    status: "available",
+    authMethod: "claude.ai",
+    email: "account@example.test",
+  });
 
   expect(spawnSync).toHaveBeenCalledWith(
     "claude",
@@ -26,6 +36,36 @@ it("asks Claude CLI to verify its own login", () => {
     expect.objectContaining({ timeout: 3_000 }),
   );
 });
+
+it.each(["api_key", "api_key_helper", "oauth_token", "third_party", "none", "unknown-method"])(
+  "does not attribute an account email to %s authentication",
+  (authMethod) => {
+    spawnSync.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ loggedIn: true, authMethod, email: "inactive@example.test" }),
+    });
+
+    expect(probeClaudeCliAuthStatus()).toEqual({
+      status: "available",
+      ...(authMethod === "unknown-method" ? {} : { authMethod }),
+    });
+  },
+);
+
+it.each([null, " ", "account@example.test\nother", "a".repeat(321)])(
+  "keeps account availability when its email cannot be displayed: %j",
+  (email) => {
+    spawnSync.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify({ loggedIn: true, authMethod: "claude.ai", email }),
+    });
+
+    expect(probeClaudeCliAuthStatus()).toEqual({
+      status: "available",
+      authMethod: "claude.ai",
+    });
+  },
+);
 
 it("does not inspect Claude token storage when the CLI reports logout", () => {
   spawnSync.mockReturnValue({ status: 1, stdout: "" });

--- a/extensions/anthropic/cli-auth-seam.test.ts
+++ b/extensions/anthropic/cli-auth-seam.test.ts
@@ -1,10 +1,17 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createWindowsCmdShimFixture, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { withMockedWindowsPlatform } from "openclaw/plugin-sdk/test-node-mocks";
 import { beforeEach, expect, it, vi } from "vitest";
 
 const { spawnSync } = vi.hoisted(() => ({
   spawnSync: vi.fn(),
 }));
 
-vi.mock("node:child_process", () => ({ spawnSync }));
+vi.mock("node:child_process", async () => {
+  const { mockNodeChildProcessSpawnSync } = await import("openclaw/plugin-sdk/test-node-mocks");
+  return mockNodeChildProcessSpawnSync(spawnSync);
+});
 
 const { probeClaudeCliAuthStatus } = await import("./cli-auth-api.js");
 
@@ -24,17 +31,90 @@ it("asks Claude CLI for its active account and returns only safe display fields"
     }),
   });
 
-  expect(probeClaudeCliAuthStatus()).toEqual({
+  expect(probeClaudeCliAuthStatus({ command: "/test/claude" })).toEqual({
     status: "available",
     authMethod: "claude.ai",
     email: "account@example.test",
   });
 
   expect(spawnSync).toHaveBeenCalledWith(
-    "claude",
+    "/test/claude",
     ["auth", "status", "--json"],
     expect.objectContaining({ timeout: 3_000 }),
   );
+});
+
+it.each(["PATH", "explicit"])("runs a Windows Claude npm shim selected by %s", async (source) => {
+  await withTempDir("anthropic-cli-auth-", async (dir) => {
+    const home = await fs.realpath(dir);
+    const shimPath = path.join(home, "claude.cmd");
+    const scriptPath = path.join(home, "node_modules", "@anthropic-ai", "claude-code", "cli.cjs");
+    const configDir = path.join(home, "selected account");
+    await createWindowsCmdShimFixture({
+      shimPath,
+      scriptPath,
+      shimLine: [
+        "GOTO start",
+        ":find_dp0",
+        "SET dp0=%~dp0",
+        "EXIT /b",
+        ":start",
+        "CALL :find_dp0",
+        `"${process.execPath}" "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\cli.cjs" %*`,
+      ].join("\r\n"),
+    });
+    await fs.writeFile(
+      scriptPath,
+      `
+        const assert = require("node:assert/strict");
+        assert.deepEqual(process.argv.slice(2), ["auth", "status", "--json"]);
+        assert.equal(process.env.ANTHROPIC_API_KEY, undefined);
+        assert.equal(process.env.CLAUDE_CODE_OAUTH_TOKEN, undefined);
+        assert.equal(process.env.CLAUDE_CONFIG_DIR, ${JSON.stringify(configDir)});
+        process.stdout.write(JSON.stringify({
+          loggedIn: true, authMethod: "claude.ai", email: "windows@example.test"
+        }));
+      `,
+    );
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    spawnSync.mockImplementation(actual.spawnSync);
+
+    withMockedWindowsPlatform(() => {
+      expect(
+        probeClaudeCliAuthStatus({
+          ...(source === "explicit" ? { command: shimPath } : {}),
+          env: {
+            PATH: `${home};${path.dirname(process.execPath)}`,
+            PATHEXT: ".CMD;.EXE;.BAT",
+            HOME: home,
+            USERPROFILE: home,
+            ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+            ANTHROPIC_API_KEY: "synthetic-ignored-api-key",
+            CLAUDE_CODE_OAUTH_TOKEN: "synthetic-ignored-token",
+            CLAUDE_CONFIG_DIR: configDir,
+          },
+        }),
+      ).toEqual({ status: "available", authMethod: "claude.ai", email: "windows@example.test" });
+      expect(spawnSync).toHaveBeenCalledWith(
+        process.execPath,
+        [scriptPath, "auth", "status", "--json"],
+        expect.any(Object),
+      );
+    });
+  });
+});
+
+it("reports unresolved Windows wrappers as unreadable without spawning", async () => {
+  await withTempDir("anthropic-cli-auth-", async (dir) => {
+    const command = path.join(dir, "claude.cmd");
+    await fs.writeFile(command, "@echo off\r\necho unsupported wrapper\r\n");
+    spawnSync.mockReturnValue({ status: null, error: new Error("not executable") });
+
+    withMockedWindowsPlatform(() => {
+      expect(probeClaudeCliAuthStatus({ command, env: {} })).toEqual({ status: "unreadable" });
+      expect(spawnSync).not.toHaveBeenCalled();
+    });
+  });
 });
 
 it.each(["api_key", "api_key_helper", "oauth_token", "third_party", "none", "unknown-method"])(

--- a/extensions/anthropic/cli-auth-seam.ts
+++ b/extensions/anthropic/cli-auth-seam.ts
@@ -1,5 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgram,
+} from "openclaw/plugin-sdk/windows-spawn";
 import { CLAUDE_CLI_CLEAR_ENV } from "./cli-constants.js";
 
 const CLAUDE_CLI_AUTH_METHODS = [
@@ -28,20 +32,27 @@ export function probeClaudeCliAuthStatus(params?: {
   for (const name of CLAUDE_CLI_CLEAR_ENV) {
     delete env[name];
   }
-  const result = spawnSync(params?.command ?? "claude", ["auth", "status", "--json"], {
-    encoding: "utf8",
-    env,
-    maxBuffer: 64 * 1024,
-    timeout: 3_000,
-    windowsHide: true,
-  });
-  if (result.error || result.status === null) {
-    return { status: "unreadable" };
-  }
-  if (result.status !== 0) {
-    return { status: "missing" };
-  }
   try {
+    const program = resolveWindowsSpawnProgram({
+      command: params?.command ?? "claude",
+      env,
+      packageName: "@anthropic-ai/claude-code",
+    });
+    const invocation = materializeWindowsSpawnProgram(program, ["auth", "status", "--json"]);
+    const result = spawnSync(invocation.command, invocation.argv, {
+      encoding: "utf8",
+      env,
+      maxBuffer: 64 * 1024,
+      timeout: 3_000,
+      shell: invocation.shell,
+      windowsHide: invocation.windowsHide ?? true,
+    });
+    if (result.error || result.status === null) {
+      return { status: "unreadable" };
+    }
+    if (result.status !== 0) {
+      return { status: "missing" };
+    }
     const parsed: unknown = JSON.parse(result.stdout);
     if (!isRecord(parsed) || parsed.loggedIn !== true) {
       return { status: "missing" };

--- a/extensions/anthropic/cli-auth-seam.ts
+++ b/extensions/anthropic/cli-auth-seam.ts
@@ -1,8 +1,23 @@
 import { spawnSync } from "node:child_process";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { CLAUDE_CLI_CLEAR_ENV } from "./cli-constants.js";
 
-type ClaudeCliAuthStatus = { status: "available" } | { status: "missing" | "unreadable" };
+const CLAUDE_CLI_AUTH_METHODS = [
+  "claude.ai",
+  "api_key",
+  "api_key_helper",
+  "oauth_token",
+  "third_party",
+  "none",
+] as const;
+
+type ClaudeCliAuthStatus =
+  | {
+      status: "available";
+      authMethod?: (typeof CLAUDE_CLI_AUTH_METHODS)[number];
+      email?: string;
+    }
+  | { status: "missing" | "unreadable" };
 
 /** Ask Claude CLI whether its own login is usable without reading token material. */
 export function probeClaudeCliAuthStatus(params?: {
@@ -31,7 +46,13 @@ export function probeClaudeCliAuthStatus(params?: {
     if (!isRecord(parsed) || parsed.loggedIn !== true) {
       return { status: "missing" };
     }
-    return { status: "available" };
+    const authMethod = CLAUDE_CLI_AUTH_METHODS.find((method) => method === parsed.authMethod);
+    const email = authMethod === "claude.ai" ? normalizeOptionalString(parsed.email) : undefined;
+    return {
+      status: "available",
+      ...(authMethod ? { authMethod } : {}),
+      ...(email && email.length <= 320 && !/[\r\n]/u.test(email) ? { email } : {}),
+    };
   } catch {
     return { status: "unreadable" };
   }

--- a/extensions/openai/cli-auth-api.test.ts
+++ b/extensions/openai/cli-auth-api.test.ts
@@ -1,0 +1,228 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { isPidAlive, killProcessTree } from "openclaw/plugin-sdk/process-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readCodexCliAccount } from "./cli-auth-api.js";
+
+type ProbeTrace = {
+  pid: number;
+  descendantPid?: number;
+  codexHome: string;
+  args: string[];
+  messages: Array<{ method: string; params?: unknown }>;
+};
+
+const fixtures = new Set<string>();
+
+async function readTrace(home: string): Promise<ProbeTrace> {
+  return JSON.parse(await fs.readFile(path.join(home, "trace.json"), "utf8")) as ProbeTrace;
+}
+
+async function createProbeFixture(response: unknown, mode = "account") {
+  const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openai-cli-account-")));
+  fixtures.add(home);
+  const command = path.join(home, "native codex.mjs");
+  const script = `#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+const mode = ${JSON.stringify(mode)};
+const response = ${JSON.stringify(response)};
+const tracePath = path.join(process.env.CODEX_HOME ?? ${JSON.stringify(home)}, 'trace.json');
+const trace = { pid: process.pid, codexHome: process.env.CODEX_HOME, args: process.argv.slice(2), messages: [] };
+if (mode === 'stubborn') {
+  process.on('SIGTERM', () => {});
+  const descendant = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+  trace.descendantPid = descendant.pid;
+}
+const save = () => fs.writeFileSync(tracePath, JSON.stringify(trace));
+save();
+let initialized = false;
+let notified = false;
+const reply = (message, afterWrite) => {
+  const line = JSON.stringify(message) + '\\n';
+  process.stdout.write(line.slice(0, 5));
+  setImmediate(() => { process.stdout.write(line.slice(5)); afterWrite?.(); });
+};
+const input = readline.createInterface({ input: process.stdin });
+input.on('line', (line) => {
+  const message = JSON.parse(line);
+  trace.messages.push(message);
+  save();
+  if (message.method === 'initialize') {
+    reply({ id: message.id, result: {} }, () => { initialized = true; });
+  } else if (message.method === 'initialized') {
+    if (!initialized) process.exit(2);
+    notified = true;
+  } else if (message.method === 'account/read') {
+    if (!initialized || !notified) process.exit(3);
+    if (mode === 'silent') return;
+    if (mode === 'overflow') { process.stdout.write('x'.repeat(65 * 1024)); return; }
+    if (mode === 'malformed') { process.stdout.write('not-json\\n'); return; }
+    if (mode === 'error') { reply({ id: message.id, error: { code: -32000, message: 'synthetic-secret-error' } }); return; }
+    process.stdout.write(JSON.stringify({ method: 'configWarning', params: { message: 'synthetic warning' } }) + '\\n');
+    reply({ id: message.id, result: response });
+  } else process.exit(4);
+});
+// EOF before the deferred response intentionally loses it, as native Codex does.
+input.on('close', () => process.exit(0));
+`;
+  await fs.writeFile(command, script, { mode: 0o755 });
+  const env: NodeJS.ProcessEnv = {
+    HOME: home,
+    USERPROFILE: home,
+    CODEX_HOME: home,
+    PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH ?? ""}`,
+    ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+  };
+  return { command, env, home };
+}
+
+async function expectProbeStopped(home: string) {
+  const trace = await readTrace(home);
+  await vi.waitFor(() => {
+    expect(isPidAlive(trace.pid)).toBe(false);
+    if (trace.descendantPid) {
+      expect(isPidAlive(trace.descendantPid)).toBe(false);
+    }
+  });
+  return trace;
+}
+
+afterEach(async () => {
+  for (const home of fixtures) {
+    const trace = await readTrace(home).catch(() => undefined);
+    for (const pid of [trace?.pid, trace?.descendantPid]) {
+      if (pid && isPidAlive(pid)) {
+        killProcessTree(pid, {
+          detached: pid === trace?.pid && process.platform !== "win32",
+          force: true,
+        });
+      }
+    }
+    await fs.rm(home, { recursive: true, force: true });
+  }
+  fixtures.clear();
+});
+
+describe("native Codex account discovery", () => {
+  it("waits for initialization and keeps stdin open until the account response", async () => {
+    const fixture = await createProbeFixture({
+      account: { type: "chatgpt", email: " active@example.test ", accessToken: "synthetic-token" },
+      requiresOpenaiAuth: true,
+    });
+
+    await expect(readCodexCliAccount(fixture)).resolves.toEqual({
+      type: "chatgpt",
+      email: "active@example.test",
+    });
+    const trace = await expectProbeStopped(fixture.home);
+    expect(trace.codexHome).toBe(fixture.home);
+    expect(trace.args).toEqual(["app-server", "--listen", "stdio://"]);
+    expect(trace.messages.map((message) => message.method)).toEqual([
+      "initialize",
+      "initialized",
+      "account/read",
+    ]);
+    expect(trace.messages[2]?.params).toEqual({ refreshToken: false });
+  });
+
+  it.each([
+    {
+      name: "API key",
+      account: { type: "apiKey", email: "unrelated@example.test", apiKey: "synthetic-key" },
+      expected: { type: "apiKey" },
+    },
+    {
+      name: "missing email",
+      account: { type: "chatgpt", email: null },
+      expected: { type: "chatgpt" },
+    },
+    {
+      name: "multiline email",
+      account: { type: "chatgpt", email: "a@example.test\nb" },
+      expected: { type: "chatgpt" },
+    },
+    {
+      name: "oversized email",
+      account: { type: "chatgpt", email: "a".repeat(321) },
+      expected: { type: "chatgpt" },
+    },
+    {
+      name: "unsupported account",
+      account: { type: "amazonBedrock", email: "unrelated@example.test" },
+      expected: { type: "unknown" },
+    },
+    { name: "malformed account", account: {}, expected: null },
+  ])("projects $name without borrowing another identity", async ({ account, expected }) => {
+    const fixture = await createProbeFixture({ account, requiresOpenaiAuth: true });
+    await expect(readCodexCliAccount(fixture)).resolves.toEqual(expected);
+    await expectProbeStopped(fixture.home);
+  });
+
+  it.each([true, false])(
+    "preserves an absent native account with requiresOpenaiAuth=%s",
+    async (requiresOpenaiAuth) => {
+      const fixture = await createProbeFixture({ account: null, requiresOpenaiAuth });
+      await expect(readCodexCliAccount(fixture)).resolves.toEqual({
+        type: "none",
+        requiresOpenaiAuth,
+      });
+      await expectProbeStopped(fixture.home);
+    },
+  );
+
+  it.each(["malformed", "overflow", "error"])(
+    "stops a %s response without exposing diagnostics",
+    async (mode) => {
+      const fixture = await createProbeFixture({}, mode);
+      await expect(readCodexCliAccount(fixture)).resolves.toBeNull();
+      await expectProbeStopped(fixture.home);
+    },
+  );
+
+  it("terminates a stubborn process tree after receiving its account", async () => {
+    const fixture = await createProbeFixture({ account: { type: "apiKey" } }, "stubborn");
+    await expect(readCodexCliAccount(fixture)).resolves.toEqual({ type: "apiKey" });
+    const trace = await expectProbeStopped(fixture.home);
+    expect(trace.descendantPid).toBeTypeOf("number");
+  });
+
+  it("ends an unresponsive native probe at its deadline", async () => {
+    const fixture = await createProbeFixture({}, "silent");
+    await expect(readCodexCliAccount(fixture)).resolves.toBeNull();
+    await expectProbeStopped(fixture.home);
+  });
+
+  it.each([
+    { homeKey: "none", allowed: false },
+    { homeKey: "HOME", allowed: process.platform !== "win32" },
+    { homeKey: "USERPROFILE", allowed: false },
+  ])("launches only with a supported injected home: $homeKey", async ({ homeKey, allowed }) => {
+    const fixture = await createProbeFixture({ account: { type: "apiKey" } });
+    const env: NodeJS.ProcessEnv = {
+      PATH: fixture.env.PATH,
+      ...(fixture.env.SystemRoot ? { SystemRoot: fixture.env.SystemRoot } : {}),
+      ...(homeKey === "none" ? {} : { [homeKey]: fixture.home }),
+    };
+    const result = await readCodexCliAccount({ command: fixture.command, env });
+    if (allowed) {
+      expect(result).toEqual({ type: "apiKey" });
+      await expectProbeStopped(fixture.home);
+    } else {
+      expect(result).toBeNull();
+      await expect(fs.stat(path.join(fixture.home, "trace.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
+  });
+
+  it("returns unavailable for an executable that cannot start", async () => {
+    const fixture = await createProbeFixture({});
+    await expect(
+      readCodexCliAccount({ command: path.join(fixture.home, "missing"), env: fixture.env }),
+    ).resolves.toBeNull();
+  });
+});

--- a/extensions/openai/cli-auth-api.test.ts
+++ b/extensions/openai/cli-auth-api.test.ts
@@ -1,6 +1,8 @@
+import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Worker } from "node:worker_threads";
 import { isPidAlive, killProcessTree } from "openclaw/plugin-sdk/process-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readCodexCliAccount } from "./cli-auth-api.js";
@@ -25,6 +27,7 @@ async function createProbeFixture(response: unknown, mode = "account") {
   const command = path.join(home, "native codex.mjs");
   const script = `#!/usr/bin/env node
 import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
@@ -32,13 +35,15 @@ const mode = ${JSON.stringify(mode)};
 const response = ${JSON.stringify(response)};
 const tracePath = path.join(process.env.CODEX_HOME ?? ${JSON.stringify(home)}, 'trace.json');
 const trace = { pid: process.pid, codexHome: process.env.CODEX_HOME, args: process.argv.slice(2), messages: [] };
-if (mode === 'stubborn') {
-  process.on('SIGTERM', () => {});
-  const descendant = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000)'], { stdio: 'ignore' });
-  trace.descendantPid = descendant.pid;
-}
 const save = () => fs.writeFileSync(tracePath, JSON.stringify(trace));
 save();
+if (mode === 'stubborn' || mode === 'stubborn-descendant') {
+  if (mode === 'stubborn') process.on('SIGTERM', () => {});
+  const descendant = spawn(process.execPath, ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1000); process.send("ready", () => process.disconnect());'], { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });
+  trace.descendantPid = descendant.pid;
+  save();
+  await once(descendant, 'message');
+}
 let initialized = false;
 let notified = false;
 const reply = (message, afterWrite) => {
@@ -91,7 +96,7 @@ async function expectProbeStopped(home: string) {
   return trace;
 }
 
-afterEach(async () => {
+async function cleanupFixtures() {
   for (const home of fixtures) {
     const trace = await readTrace(home).catch(() => undefined);
     for (const pid of [trace?.pid, trace?.descendantPid]) {
@@ -102,10 +107,15 @@ afterEach(async () => {
         });
       }
     }
+    if (trace) {
+      await expectProbeStopped(home);
+    }
     await fs.rm(home, { recursive: true, force: true });
   }
   fixtures.clear();
-});
+}
+
+afterEach(cleanupFixtures);
 
 describe("native Codex account discovery", () => {
   it("waits for initialization and keeps stdin open until the account response", async () => {
@@ -189,6 +199,51 @@ describe("native Codex account discovery", () => {
     const trace = await expectProbeStopped(fixture.home);
     expect(trace.descendantPid).toBeTypeOf("number");
   });
+
+  // POSIX group cleanup must finish before the caller can discard its Worker timers.
+  it.skipIf(process.platform === "win32")(
+    "cleans up a stubborn descendant before its caller terminates the worker",
+    async () => {
+      const fixture = await createProbeFixture(
+        { account: { type: "apiKey" } },
+        "stubborn-descendant",
+      );
+      const workerPath = path.join(fixture.home, "reader-worker.mjs");
+      await fs.writeFile(
+        workerPath,
+        `
+          import { parentPort, workerData } from "node:worker_threads";
+          const { readCodexCliAccount } = await import(workerData.moduleUrl);
+          parentPort.postMessage(await readCodexCliAccount(workerData.fixture));
+        `,
+      );
+      const worker = new Worker(workerPath, {
+        execArgv: ["--import", new URL("../../scripts/tsx.mjs", import.meta.url).href],
+        env: fixture.env,
+        workerData: {
+          moduleUrl: new URL("./cli-auth-api.ts", import.meta.url).href,
+          fixture,
+        },
+      });
+
+      try {
+        const [account] = await once(worker, "message", {
+          signal: AbortSignal.timeout(10_000),
+        });
+        await worker.terminate();
+        expect(account).toEqual({ type: "apiKey" });
+        const trace = await expectProbeStopped(fixture.home);
+        expect(trace.descendantPid).toBeTypeOf("number");
+      } finally {
+        try {
+          await worker.terminate();
+        } finally {
+          await cleanupFixtures();
+        }
+      }
+    },
+    15_000,
+  );
 
   it("ends an unresponsive native probe at its deadline", async () => {
     const fixture = await createProbeFixture({}, "silent");

--- a/extensions/openai/cli-auth-api.ts
+++ b/extensions/openai/cli-auth-api.ts
@@ -1,0 +1,174 @@
+import { spawn } from "node:child_process";
+import { killProcessTree } from "openclaw/plugin-sdk/process-runtime";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgram,
+} from "openclaw/plugin-sdk/windows-spawn";
+import packageJson from "./package.json" with { type: "json" };
+
+type CodexCliAccount =
+  | { type: "apiKey" }
+  | { type: "chatgpt"; email?: string }
+  | { type: "none"; requiresOpenaiAuth: boolean }
+  | { type: "unknown" };
+
+function projectCodexCliAccount(response: Record<string, unknown>): CodexCliAccount | null {
+  const account = response.account;
+  if (account === null && typeof response.requiresOpenaiAuth === "boolean") {
+    return { type: "none", requiresOpenaiAuth: response.requiresOpenaiAuth };
+  }
+  if (!isRecord(account) || typeof account.type !== "string") {
+    return null;
+  }
+  if (account.type === "apiKey") {
+    return { type: "apiKey" };
+  }
+  if (account.type !== "chatgpt") {
+    return { type: "unknown" };
+  }
+  const email = normalizeOptionalString(account.email);
+  return {
+    type: "chatgpt",
+    ...(email && email.length <= 320 && !/[\r\n]/u.test(email) ? { email } : {}),
+  };
+}
+
+/** Reads the native account before setup has installed a harness or configured an agent. */
+export async function readCodexCliAccount(params: {
+  command: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<CodexCliAccount | null> {
+  const env = params.env ?? process.env;
+  // Windows native home lookup ignores HOME/USERPROFILE; injected environments need CODEX_HOME.
+  if (
+    env !== process.env &&
+    !env.CODEX_HOME?.trim() &&
+    (process.platform === "win32" || !env.HOME?.trim())
+  ) {
+    return null;
+  }
+  try {
+    const program = resolveWindowsSpawnProgram({
+      command: params.command,
+      env,
+      packageName: "@openai/codex",
+    });
+    const invocation = materializeWindowsSpawnProgram(program, [
+      "app-server",
+      "--listen",
+      "stdio://",
+    ]);
+    const detached = process.platform !== "win32";
+    const child = spawn(invocation.command, invocation.argv, {
+      env,
+      detached,
+      stdio: ["pipe", "pipe", "ignore"],
+      shell: invocation.shell,
+      windowsHide: invocation.windowsHide ?? true,
+    });
+    return await new Promise<CodexCliAccount | null>((resolve) => {
+      let phase: "initialize" | "account" | "closing" | "closed" = "initialize";
+      let result: CodexCliAccount | null = null;
+      let output = "";
+      let outputBytes = 0;
+      const terminate = (force: boolean) => {
+        if (child.pid) {
+          killProcessTree(child.pid, { detached, force, graceMs: 200 });
+        }
+      };
+      const finish = (force: boolean) => {
+        if (phase === "closed") {
+          return;
+        }
+        phase = "closed";
+        clearTimeout(timer);
+        if (force) {
+          terminate(true);
+        }
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.unref();
+        resolve(result);
+      };
+      const stop = (account: CodexCliAccount | null) => {
+        if (phase === "closing" || phase === "closed") {
+          return;
+        }
+        phase = "closing";
+        result = account;
+        output = "";
+        // Stop descendants while the parent is alive so Windows can enumerate the tree.
+        terminate(false);
+      };
+      const timer = setTimeout(() => finish(true), 3_000);
+      const send = (messages: object[]) => {
+        try {
+          child.stdin.write(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`);
+        } catch {
+          stop(null);
+        }
+      };
+      child.once("error", () => stop(null));
+      child.once("close", () => finish(phase !== "closing"));
+      child.stdin.on("error", () => stop(null));
+      child.stdout.on("error", () => stop(null));
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        if (phase === "closing" || phase === "closed") {
+          return;
+        }
+        outputBytes += Buffer.byteLength(chunk);
+        if (outputBytes > 64 * 1024) {
+          stop(null);
+          return;
+        }
+        output += chunk;
+        let newline: number;
+        while ((newline = output.indexOf("\n")) !== -1) {
+          const line = output.slice(0, newline);
+          output = output.slice(newline + 1);
+          try {
+            const message: unknown = JSON.parse(line);
+            if (
+              !isRecord(message) ||
+              "method" in message ||
+              message.id !== (phase === "initialize" ? 1 : 2)
+            ) {
+              continue;
+            }
+            if (message.error || !isRecord(message.result)) {
+              stop(null);
+              return;
+            }
+            if (phase === "initialize") {
+              phase = "account";
+              send([
+                { method: "initialized" },
+                { id: 2, method: "account/read", params: { refreshToken: false } },
+              ]);
+            } else {
+              stop(projectCodexCliAccount(message.result));
+              return;
+            }
+          } catch {
+            stop(null);
+            return;
+          }
+        }
+      });
+      // Codex closes its connection on stdin EOF, so keep it open until account/read answers.
+      send([
+        {
+          id: 1,
+          method: "initialize",
+          params: {
+            clientInfo: { name: "openclaw", title: "OpenClaw", version: packageJson.version },
+          },
+        },
+      ]);
+    });
+  } catch {
+    return null;
+  }
+}

--- a/extensions/openai/cli-auth-api.ts
+++ b/extensions/openai/cli-auth-api.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { killProcessTree } from "openclaw/plugin-sdk/process-runtime";
+import { signalProcessTree } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   materializeWindowsSpawnProgram,
@@ -72,24 +72,31 @@ export async function readCodexCliAccount(params: {
       let result: CodexCliAccount | null = null;
       let output = "";
       let outputBytes = 0;
-      const terminate = (force: boolean) => {
-        if (child.pid) {
-          killProcessTree(child.pid, { detached, force, graceMs: 200 });
-        }
-      };
-      const finish = (force: boolean) => {
+      let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
+      const finish = () => {
         if (phase === "closed") {
           return;
         }
         phase = "closed";
         clearTimeout(timer);
-        if (force) {
-          terminate(true);
+        clearTimeout(cleanupTimer);
+        const complete = () => {
+          // A bounded taskkill attempt can fail; still stop our live direct child.
+          if (!detached && child.exitCode === null && child.signalCode === null) {
+            child.kill("SIGKILL");
+          }
+          child.stdin.destroy();
+          child.stdout.destroy();
+          child.unref();
+          resolve(result);
+        };
+        // A Unix group can outlive its leader. Finish signaling before the caller
+        // terminates its worker; Windows must not target an already-exited root PID.
+        if (child.pid && (detached || (child.exitCode === null && child.signalCode === null))) {
+          signalProcessTree(child.pid, "SIGKILL", { detached, onComplete: complete });
+        } else {
+          complete();
         }
-        child.stdin.destroy();
-        child.stdout.destroy();
-        child.unref();
-        resolve(result);
       };
       const stop = (account: CodexCliAccount | null) => {
         if (phase === "closing" || phase === "closed") {
@@ -98,10 +105,15 @@ export async function readCodexCliAccount(params: {
         phase = "closing";
         result = account;
         output = "";
-        // Stop descendants while the parent is alive so Windows can enumerate the tree.
-        terminate(false);
+        // Windows must enumerate the live tree before terminating its root.
+        if (!detached || !child.pid) {
+          finish();
+          return;
+        }
+        signalProcessTree(child.pid, "SIGTERM", { detached });
+        cleanupTimer = setTimeout(finish, 200);
       };
-      const timer = setTimeout(() => finish(true), 3_000);
+      const timer = setTimeout(finish, 3_000);
       const send = (messages: object[]) => {
         try {
           child.stdin.write(`${messages.map((message) => JSON.stringify(message)).join("\n")}\n`);
@@ -110,7 +122,7 @@ export async function readCodexCliAccount(params: {
         }
       };
       child.once("error", () => stop(null));
-      child.once("close", () => finish(phase !== "closing"));
+      child.once("close", finish);
       child.stdin.on("error", () => stop(null));
       child.stdout.on("error", () => stop(null));
       child.stdout.setEncoding("utf8");

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -1,5 +1,6 @@
 // Inference backend detection tests cover the documented ladder and login-awareness.
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as facadeRuntime from "../plugin-sdk/facade-runtime.js";
 import type { LocalCommandProbe } from "../system-agent/probes.js";
 import {
   ANTHROPIC_API_DEFAULT_MODEL_REF,
@@ -58,6 +59,16 @@ afterAll(() => {
   vi.resetModules();
 });
 
+beforeEach(() => {
+  vi.spyOn(facadeRuntime, "tryLoadActivatedBundledPluginPublicSurfaceModule").mockResolvedValue(
+    null,
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 function probeDeps(found: Record<string, boolean>) {
   return async (command: string): Promise<LocalCommandProbe> => ({
     command,
@@ -66,6 +77,92 @@ function probeDeps(found: Record<string, boolean>) {
 }
 
 describe("detectInferenceBackends", () => {
+  it.each([
+    {
+      account: { type: "chatgpt", email: "alex@example.com" },
+      detail: "logged in · ChatGPT account · alex@example.com",
+      credentials: true,
+    },
+    {
+      account: { type: "chatgpt" },
+      detail: "logged in · ChatGPT account · email unavailable",
+      credentials: true,
+    },
+    {
+      account: { type: "apiKey", email: "stale@example.com" },
+      detail: "logged in · API key (usage-billed)",
+      credentials: true,
+    },
+    {
+      account: { type: "none", requiresOpenaiAuth: true },
+      detail: "installed, not logged in — run `codex login`, then check again",
+      credentials: false,
+    },
+    {
+      account: { type: "none", requiresOpenaiAuth: false },
+      detail: "installed",
+      credentials: undefined,
+    },
+    { account: { type: "unknown" }, detail: "installed", credentials: undefined },
+  ])(
+    "shows native Codex authentication before installing its runtime: $detail",
+    async ({ account, detail, credentials }) => {
+      vi.mocked(facadeRuntime.tryLoadActivatedBundledPluginPublicSurfaceModule).mockImplementation(
+        async ({ dirName }) =>
+          dirName === "openai" ? { readCodexCliAccount: async () => account } : null,
+      );
+      const candidates = await detectInferenceBackends({
+        env: {},
+        platform: "linux",
+        deps: {
+          probeLocalCommand: probeDeps({ codex: true }),
+          readCodexCliCredentials: () => ({ type: "oauth", email: "saved@example.com" }),
+        },
+      });
+
+      expect(candidates).toMatchObject([{ kind: "codex-cli", detail }]);
+      expect(candidates[0]?.credentials).toBe(credentials);
+      expect(JSON.stringify(candidates)).not.toContain("saved@example.com");
+    },
+  );
+
+  it("does not promote native API-key access using an unrelated saved OAuth token", async () => {
+    vi.mocked(facadeRuntime.tryLoadActivatedBundledPluginPublicSurfaceModule).mockResolvedValue({
+      readCodexCliAccount: async () => ({ type: "apiKey" }),
+    });
+    const candidates = await detectInferenceBackends({
+      env: { OPENAI_API_KEY: "synthetic-environment-key" },
+      platform: "linux",
+      deps: {
+        probeLocalCommand: probeDeps({ codex: true }),
+        readCodexCliCredentials: () => ({ type: "oauth" }),
+      },
+    });
+
+    expect(candidates.map((candidate) => candidate.kind)).toEqual(["openai-api-key", "codex-cli"]);
+  });
+
+  it.each([
+    ["claude.ai", "logged in · Claude account · alex@example.com"],
+    ["api_key", "logged in · API key (usage-billed)"],
+    ["unknown", "logged in · authentication method unavailable"],
+  ])("shows the native Claude authentication method: %s", async (authMethod, detail) => {
+    vi.mocked(facadeRuntime.tryLoadActivatedBundledPluginPublicSurfaceModule).mockResolvedValue({
+      probeClaudeCliAuthStatus: () => ({
+        status: "available",
+        authMethod,
+        email: "alex@example.com",
+      }),
+    });
+    const candidates = await detectInferenceBackends({
+      env: {},
+      platform: "linux",
+      deps: { probeLocalCommand: probeDeps({ claude: true }) },
+    });
+
+    expect(candidates).toMatchObject([{ kind: "claude-cli", credentials: true, detail }]);
+  });
+
   it("returns nothing when no backend exists", async () => {
     const candidates = await detectInferenceBackends({
       env: {},
@@ -164,7 +261,10 @@ describe("detectInferenceBackends", () => {
     });
 
     expect(candidates.map((candidate) => candidate.kind)).toEqual(["openai-api-key", "codex-cli"]);
-    expect(candidates[1]).toMatchObject({ credentials: true, detail: "logged in" });
+    expect(candidates[1]).toMatchObject({
+      credentials: true,
+      detail: "logged in · authentication method unavailable",
+    });
   });
 
   it("keeps API-key-helper-backed Claude after environment keys", async () => {
@@ -219,7 +319,7 @@ describe("detectInferenceBackends", () => {
       {
         kind: "claude-cli",
         credentials: true,
-        detail: "logged in · Claude subscription",
+        detail: "logged in · Claude account · email unavailable",
       },
     ]);
   });
@@ -381,13 +481,17 @@ describe("detectInferenceBackends", () => {
   });
 
   it.each([
-    ["ChatGPT", "Logged in using ChatGPT", "logged in · ChatGPT subscription"],
+    ["ChatGPT", "Logged in using ChatGPT", "logged in · ChatGPT account · email unavailable"],
     [
       "API key",
       "Logged in using an API key - sk-proj-1***23456",
       "logged in · API key (usage-billed)",
     ],
-    ["unrecognized auth", "Logged in using access token", "logged in"],
+    [
+      "unrecognized auth",
+      "Logged in using access token",
+      "logged in · authentication method unavailable",
+    ],
   ])("classifies Codex %s login status", async (_auth, loginOutput, expectedDetail) => {
     const probe = async (command: string, args: string[] = ["--version"]) => ({
       command,
@@ -538,7 +642,7 @@ describe("detectInferenceBackends", () => {
       {
         kind: "codex-cli",
         credentials: true,
-        detail: "logged in · ChatGPT subscription",
+        detail: "logged in · ChatGPT account · email unavailable",
       },
     ]);
   });

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -12,6 +12,7 @@ import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { tryLoadActivatedBundledPluginPublicSurfaceModule } from "../plugin-sdk/facade-runtime.js";
 import { probeLocalCommand, type LocalCommandProbe } from "../system-agent/probes.js";
 import {
   CLAUDE_CLI_DEFAULT_MODEL_REF,
@@ -78,21 +79,29 @@ function detectCliCredentialState(params: {
   return params.platform === "darwin" ? undefined : false;
 }
 
-type CliAuthKind = "api-key" | "chatgpt-subscription" | "claude-subscription";
-type CliLoginState = { credentials: boolean | undefined; authKind?: CliAuthKind };
+type CliAuthKind = "api-key" | "chatgpt-subscription" | "claude-subscription" | "token";
+type CliLoginState = {
+  credentials: boolean | undefined;
+  authKind?: CliAuthKind;
+  email?: string;
+};
 
 const CLI_AUTH_KIND_LABEL: Record<CliAuthKind, string> = {
   "api-key": "API key (usage-billed)",
-  "chatgpt-subscription": "ChatGPT subscription",
-  "claude-subscription": "Claude subscription",
+  "chatgpt-subscription": "ChatGPT account",
+  "claude-subscription": "Claude account",
+  token: "OAuth token",
 };
 
 function describeCliDetail(state: CliLoginState, loginHint: string): string {
   if (state.authKind) {
-    return `logged in · ${CLI_AUTH_KIND_LABEL[state.authKind]}`;
+    const account =
+      state.authKind === "chatgpt-subscription" || state.authKind === "claude-subscription";
+    const identity = account ? ` · ${state.email || "email unavailable"}` : "";
+    return `logged in · ${CLI_AUTH_KIND_LABEL[state.authKind]}${identity}`;
   }
   if (state.credentials === true) {
-    return "logged in";
+    return "logged in · authentication method unavailable";
   }
   if (state.credentials === false) {
     return `installed, not logged in — ${loginHint}, then check again`;
@@ -126,27 +135,84 @@ async function classifyCodexLoginStatus(
 }
 
 async function detectClaudeLoginState(
-  probe: typeof probeLocalCommand,
+  _probe: typeof probeLocalCommand,
   command: string,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<CliLoginState> {
-  const status = await probe(command, ["auth", "status", "--text"], { timeoutMs: 3_000 });
-  if (status.timedOut) {
+  type ClaudeAuthFacade = {
+    probeClaudeCliAuthStatus: (params: {
+      command: string;
+      env: NodeJS.ProcessEnv;
+    }) =>
+      | { status: "available"; authMethod?: string; email?: string }
+      | { status: "missing" | "unreadable" };
+  };
+  try {
+    const facade = await tryLoadActivatedBundledPluginPublicSurfaceModule<ClaudeAuthFacade>({
+      dirName: "anthropic",
+      artifactBasename: "cli-auth-api.js",
+      env,
+    });
+    const status = facade?.probeClaudeCliAuthStatus({ command, env });
+    if (status?.status !== "available") {
+      return { credentials: status?.status === "missing" ? false : undefined };
+    }
+    switch (status.authMethod) {
+      case "claude.ai":
+        return { credentials: true, authKind: "claude-subscription", email: status.email };
+      case "api_key":
+      case "api_key_helper":
+        return { credentials: true, authKind: "api-key" };
+      case "oauth_token":
+        return { credentials: true, authKind: "token" };
+      default:
+        return { credentials: true };
+    }
+  } catch {
     return { credentials: undefined };
   }
-  if (status.error) {
-    return { credentials: false };
-  }
-  const method = status.version?.replace(/^Login method:\s*/iu, "").trim();
-  return {
-    credentials: true,
-    ...(method
-      ? {
-          authKind: /api\s*key/iu.test(method)
-            ? ("api-key" as const)
-            : ("claude-subscription" as const),
-        }
-      : {}),
+}
+
+async function readCodexNativeLoginState(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<CliLoginState | undefined> {
+  type CodexAuthFacade = {
+    readCodexCliAccount: (params: {
+      command: string;
+      env: NodeJS.ProcessEnv;
+    }) => Promise<
+      | { type: "apiKey" }
+      | { type: "chatgpt"; email?: string }
+      | { type: "none"; requiresOpenaiAuth: boolean }
+      | { type: "unknown" }
+      | null
+    >;
   };
+  try {
+    const facade = await tryLoadActivatedBundledPluginPublicSurfaceModule<CodexAuthFacade>({
+      dirName: "openai",
+      artifactBasename: "cli-auth-api.js",
+      env,
+    });
+    const account = await facade?.readCodexCliAccount({ command, env });
+    switch (account?.type) {
+      case "apiKey":
+        return { credentials: true, authKind: "api-key" };
+      case "chatgpt":
+        return { credentials: true, authKind: "chatgpt-subscription", email: account.email };
+      case "none":
+        return { credentials: account.requiresOpenaiAuth ? false : undefined };
+      case "unknown":
+        return { credentials: undefined };
+      case undefined:
+        return undefined;
+    }
+  } catch {
+    // Older CLIs can still report their login method when account/read is unavailable.
+    // A separate saved token never proves which account the native runtime selected.
+  }
+  return undefined;
 }
 
 // Deliberately boolean-shaped: this signature is reachable from the exported
@@ -283,7 +349,7 @@ export async function detectInferenceBackends(
   if (claudeProbe.found && !claudeProbe.timedOut) {
     const loginState = options.deps?.detectClaudeLoginState
       ? await options.deps.detectClaudeLoginState(probe, claudeProbe.command)
-      : await detectClaudeLoginState(probe, claudeProbe.command);
+      : await detectClaudeLoginState(probe, claudeProbe.command, env);
     const credentials = loginState.credentials;
     if (credentials === true && loginState.authKind === "claude-subscription") {
       subscriptionPromotionEligibleCliKinds.add("claude-cli");
@@ -301,22 +367,27 @@ export async function detectInferenceBackends(
     const codexCredential = readCodex();
     const loginState: CliLoginState = options.deps?.detectCodexLoginState
       ? { credentials: await options.deps.detectCodexLoginState(probe, codexProbe.command) }
-      : options.deps?.readCodexCliCredentials
-        ? {
-            credentials: detectCliCredentialState({
-              probe: codexProbe,
-              hasStoredCredentials: codexCredential !== null,
-              platform,
-            }),
-            ...(codexCredential?.type === "oauth"
-              ? { authKind: "chatgpt-subscription" as const }
-              : {}),
-          }
-        : await classifyCodexLoginStatus(probe, codexProbe.command);
+      : ((await readCodexNativeLoginState(codexProbe.command, env)) ??
+        (options.deps?.readCodexCliCredentials
+          ? {
+              credentials: detectCliCredentialState({
+                probe: codexProbe,
+                hasStoredCredentials: codexCredential !== null,
+                platform,
+              }),
+              ...(codexCredential?.type === "oauth"
+                ? { authKind: "chatgpt-subscription" as const }
+                : {}),
+            }
+          : await classifyCodexLoginStatus(probe, codexProbe.command)));
     const credentials = loginState.credentials;
     // Promote only prompt-free ChatGPT OAuth tokens. Status-only logins may be metered;
     // keychain-only ChatGPT users conservatively stay usable in the fallback tier.
-    if (credentials === true && codexCredential?.type === "oauth") {
+    if (
+      credentials === true &&
+      loginState.authKind === "chatgpt-subscription" &&
+      codexCredential?.type === "oauth"
+    ) {
       subscriptionPromotionEligibleCliKinds.add("codex-cli");
     }
     cliCandidates.push({

--- a/src/plugin-sdk/process-runtime.ts
+++ b/src/plugin-sdk/process-runtime.ts
@@ -13,7 +13,7 @@ export {
 export { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 export type { OomScoreAdjustedSpawn, OomWrapOptions } from "../process/linux-oom-score.js";
 export { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
-export { killProcessTree } from "../process/kill-tree.js";
+export { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
 export {
   getFileLockProcessStartTime,
   isPidAlive,

--- a/ui/src/e2e/browser-route-handoff.e2e.test.ts
+++ b/ui/src/e2e/browser-route-handoff.e2e.test.ts
@@ -404,7 +404,16 @@ suite.define(() => {
               query: { profile: "managed" },
               body: { targetId: "t1", type: "png" },
             });
-          const hostRequests = (await gateway.getRequests("browser.request")).slice(beforeHostOpen);
+          const afterHostOpen = (await gateway.getRequests("browser.request")).slice(
+            beforeHostOpen,
+          );
+          // The old view can resize while Playwright delivers the click. Selection
+          // starts with /tabs; validate its route and every request after it.
+          const selectionStart = afterHostOpen.findIndex(
+            (request) => asNullableRecord(request.params)?.path === "/tabs",
+          );
+          expect(selectionStart).toBeGreaterThanOrEqual(0);
+          const hostRequests = afterHostOpen.slice(selectionStart);
           expect(hostRequests.map((request) => asNullableRecord(request.params)?.path)).toEqual(
             expect.arrayContaining(["/tabs", "/tabs/focus", "/screenshot", "/act"]),
           );

--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -264,9 +264,9 @@ suite.define(() => {
                   scroller: boolean;
                   pending: ReturnType<typeof pendingAboveReader>;
                 };
-                let resolveReady!: () => void;
+                let resolveReady!: (position: Pick<InputArrival, "top" | "max">) => void;
                 let rejectReady!: (error: Error) => void;
-                const ready = new Promise<void>((resolve, reject) => {
+                const ready = new Promise<Pick<InputArrival, "top" | "max">>((resolve, reject) => {
                   resolveReady = resolve;
                   rejectReady = reject;
                 });
@@ -286,7 +286,10 @@ suite.define(() => {
                   }
                   scroller.removeEventListener("scroll", onScroll);
                   document.addEventListener(eventType, onInput, { capture: true, passive: true });
-                  resolveReady();
+                  resolveReady({
+                    top: scroller.scrollTop,
+                    max: scroller.scrollHeight - scroller.clientHeight,
+                  });
                 };
                 const onInput = (event: Event) => {
                   // Sample the real input before the scroller's takeover handler cancels motion.
@@ -319,7 +322,7 @@ suite.define(() => {
               // Arm before START; its post-click bookkeeping must not delay native input.
               const interrupt = input
                 .evaluate((observation) => observation.ready)
-                .then(async () => {
+                .then(async (position) => {
                   if (wheel) {
                     await page.mouse.move(
                       track!.x + track!.width / 2,
@@ -329,8 +332,9 @@ suite.define(() => {
                   } else {
                     await page.mouse.click(track!.x + track!.width - 3, track!.y + 20);
                   }
+                  return position;
                 });
-              const [arrival] = await Promise.all([
+              const [arrival, started] = await Promise.all([
                 input.evaluate((observation) => observation.arrived),
                 interrupt,
                 page.locator(".chat-scroll-to-bottom").click(),
@@ -338,16 +342,16 @@ suite.define(() => {
               expect(arrival).toMatchObject({ trusted: true, scroller: true });
               await fs.writeFile(
                 path.join(artifactDir, "native-input.json"),
-                JSON.stringify(arrival, null, 2),
+                JSON.stringify({ started, arrival }, null, 2),
               );
-              if (!wheel || reducedMotion === "no-preference") {
-                expect(arrival.top).toBeGreaterThan(0);
-              }
+              // A passive wheel listener can run after the compositor scrolls.
+              // Prove motion started from its pre-input native scroll sample.
+              during = wheel ? started : arrival;
+              expect(during.top).toBeGreaterThan(0);
               if (!wheel) {
                 expect(arrival.pending).not.toBeNull();
                 expect(arrival.pending!.bottom).toBeLessThanOrEqual(arrival.pending!.viewportTop);
               }
-              during = arrival;
             } finally {
               await input.evaluate((observation) => observation.dispose());
               await input.dispose();

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -45,6 +45,68 @@ const localPrepareOptions = [
 ];
 
 suite.define(() => {
+  it("refreshes detected authentication without retaining an account email for API-key access", async () => {
+    await suite.withPage(
+      {
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
+          : {}),
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        const candidate = {
+          kind: "codex-cli",
+          brandId: "openai",
+          label: "Codex",
+          modelRef: "openai/gpt-5.6-luna",
+          recommended: false,
+          credentials: true,
+        };
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "openclaw.setup.detect"],
+          methodResponses: {
+            "openclaw.setup.detect": {
+              sequence: [
+                "logged in · ChatGPT account · alex@example.com",
+                "logged in · API key (usage-billed)",
+              ].map((detail) => ({
+                candidates: [{ ...candidate, detail }],
+                manualProviders: [],
+                workspace: "/tmp/openclaw-e2e",
+                setupComplete: false,
+              })),
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+        const row = page.locator('[data-candidate-kind="codex-cli"]');
+        await expect.poll(() => row.textContent()).toContain("ChatGPT account · alex@example.com");
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, "auth-account-desktop.png"),
+            fullPage: true,
+          });
+        }
+        const detectionCount = (await gateway.getRequests("openclaw.setup.detect")).length;
+        await page.getByRole("button", { name: "Check again" }).click();
+        await expect
+          .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
+          .toBe(detectionCount + 1);
+        await expect.poll(() => row.textContent()).toContain("API key (usage-billed)");
+        expect(await row.textContent()).not.toContain("alex@example.com");
+        if (artifactDir) {
+          await page.screenshot({
+            path: path.join(artifactDir, "auth-api-key-desktop.png"),
+            fullPage: true,
+          });
+        }
+      },
+    );
+  });
+
   it("hands first-run model setup to the custodian in onboarding chrome", async () => {
     await suite.withPage(
       {

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -85,6 +85,28 @@ describe("renderModelSetup", () => {
     expect(container.querySelectorAll("img")).toHaveLength(0);
   });
 
+  it.each(["logged in · ChatGPT account · alex@example.com", "logged in · API key (usage-billed)"])(
+    "shows detected authentication without credential values: %s",
+    (detail) => {
+      const secret = "synthetic-private-token";
+      const container = mount(
+        props({
+          page: {
+            phase: "ready",
+            result: {
+              ...detected,
+              candidates: [{ ...detected.candidates[0]!, detail: `${detail} · token=${secret}` }],
+            },
+          },
+        }),
+      );
+      const row = container.querySelector('[data-candidate-kind="codex-cli"]')!;
+
+      expect(text(row)).toContain(detail);
+      expect(text(row)).not.toContain(secret);
+    },
+  );
+
   it("identifies provider families separately from their credential methods", () => {
     const container = mount(
       props({


### PR DESCRIPTION
Related: #122140

## What Problem This Solves

Model Setup identifies detected Codex and Claude access as “logged in,” but does not show which account is selected. The older subscription label can also overstate what the authentication method proves. Operators need to distinguish API-key access from account sign-in and see the account email before testing and selecting a model.

## Why This Change Was Made

Read the selected account from each native CLI’s authentication owner, then carry its method and email through the existing candidate detail field. Codex uses a bounded, short-lived `account/read` handshake in the bundled OpenAI plugin, so discovery works before the optional Codex harness or a default agent exists. Claude reuses its existing environment-cleared JSON auth-status probe and removes the duplicate first-line text classifier.

Do not infer the active email from saved profile labels or separate credential files. Configured-model cards remain unchanged because a native CLI account does not establish the identity of an OpenClaw-managed profile. There are no configuration, wire-format, database, or credential-store changes.

## User Impact

Detected cards show **ChatGPT account · email**, **Claude account · email**, **API key (usage-billed)**, or the reported token method. Missing emails and unknown methods stay explicit. API keys, tokens, and unrelated saved-profile emails are never included. Refreshing detection replaces the old account details, including removing an email when access changes to an API key. Existing **Test & use** model verification remains required.

## Evidence

- **Independent Codex autoreview: scoped-clean through P2**, with complete changed-source, owner/caller, and native-protocol context.
- **191 focused tests passed** (one Windows-only case skipped on this macOS host), covering native Codex process/handshake behavior, method and email projection, setup detection, Claude status and migration consumers, and UI rendering. New core regression cases were observed failing before the implementation.
- **All 6 Model Setup browser tests, 4 route-handoff browser tests, and 8 transcript-disclosure browser tests passed**, including **Check again** transitioning from account/email to API-key access without retaining the email. The route-handoff and disclosure suites cover the separately diagnosed CI test-boundary repairs below.
- **Real Codex executable, isolated synthetic credentials:** source and built-plugin readers returned the correct account email/API-key method; complete detection also passed with no default agent and the optional Codex plugin disabled. Fixture auth-file bytes were unchanged. No real credentials or model request were used. This proves native account reading, not a paid inference call or zero native-startup side effects.
- **Full post-repair build passed**, including SDK export checks, 53 built control-plane module loads, declarations, and the UI. Local static validation passed cumulatively: core/plugin typechecks and SDK surface/boundary checks, followed by the final updated-plugin lint/type/guard run and remaining core guards. Earlier exhaustive-switch and test-only promise-callback lint findings were corrected and rechecked.
- Directly inspected upstream Codex contracts: [account variants](https://github.com/openai/codex/blob/1bc8fb16ae53512c0c7723a436e4b11be81ad4a8/codex-rs/app-server-protocol/src/protocol/v2/account.rs#L22), [account-read ownership](https://github.com/openai/codex/blob/1bc8fb16ae53512c0c7723a436e4b11be81ad4a8/codex-rs/app-server/src/request_processors/account_processor.rs#L1108), and [initialization ordering](https://github.com/openai/codex/blob/1bc8fb16ae53512c0c7723a436e4b11be81ad4a8/codex-rs/app-server/src/message_processor.rs#L852).

### Pre-merge repairs and CI context

Independent review caught two defects before landing. The Codex reader now completes its process-tree signaling before setup can terminate the detection worker; a real Worker regression failed on a surviving descendant before the fix and passes afterward. The existing process-runtime SDK exposes its canonical completion helper, including bounded Windows taskkill completion. Claude auth discovery now resolves Windows command shims through the existing safe launcher, matching [Node’s Windows command-script contract](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows). PATH and explicit-shim cases execute real Node fixtures and verify arguments, cleared credentials, and the selected config directory; unresolved wrappers remain unreadable without shell execution. All three cases failed before the fix and pass afterward. These are Windows-resolver tests on macOS, not a native Windows-host run.

The initial CI run found an unchanged CLI-test max-lines failure, repaired on main by `aef65cc57490`; the PR was rebased to consume that fix, with a byte-identical feature patch. A separate UI shard timed out before its browser tests started, with all 4,498 executed tests passing. That shard did not contain the changed Model Setup tests. No harness changes or larger timeouts were introduced. A subsequent run passed all selected build/UI/E2E/type/lint/test jobs but failed to fetch the security scanner’s public pre-commit dependency; the scanner itself never ran. The next run passed security but exposed an existing browser-route test race: it counted a legitimate old-route resize sent before Playwright delivered the new-route click. A test-only correction starts at the first selection `/tabs` request, regardless of destination, and retains every subsequent routing assertion. All four cases pass; replaying the exact failed trace also verifies wrong-route requests still fail. A separate shard never acquired a runner and executed no tests. The following run completed with 174 successful jobs and only a current-main disclosure test race (plus the dependent aggregate gate) failing: its passive wheel listener sampled the viewport after Chromium had already applied the wheel scroll. GitHub tested a newer main version of that test, so this branch was rebased onto `afadc3843604ddc93fd95791302a2b89e9cc8d49` with the existing feature and route-test patch verified byte-identical. The test now carries the already-observed positive scroll-start sample into the wheel assertion, separately verifies trusted input/target, and preserves pointer, recovery, durable anchoring, and remount checks. This follows [Chrome's passive-wheel contract](https://developer.chrome.com/blog/scrolling-intervention-2). All eight existing cases pass; no production behavior or timeout changed. **Final exact-head hosted CI is green:** [run 33683400809](https://github.com/openclaw/openclaw/actions/runs/33683400809) passed on `033f97c5488e46bfde1e0dd3208c6601a54afae0`, including all 14 browser E2E shards, the real-Gateway lane, and the required `openclaw/ci-gate` (176 successful jobs, 16 intentional skips).

### Native production-path trace

Added in response to ClawSweeper's proof request. The source and fully built production paths were rerun against the repaired source tree now committed as `2852b4cc95f79acf7333b3fa0b56124032f8c83a`. Both commands below completed successfully and emitted the same trace; the built run used plain Node without a TypeScript loader.

The temporary harness launches the **actual installed Codex executable**, then calls the production `readCodexCliAccount` and `detectInferenceBackends` exports without mocked native responses. It replaces the entire subprocess environment with an isolated fixture home, selects native file-backed credentials, disables the optional Codex plugin, and configures no agents. Only the auth-file contents are synthetic. Assertions check the returned account and full candidate detail, then compare auth-file bytes before and after. No real account credentials or inference request are used.

```sh
node --import ./scripts/tsx.mjs /tmp/openclaw-model-auth-public-trace.mjs
env -u NODE_OPTIONS node /tmp/openclaw-model-auth-built-public-trace.mjs
```

```json
{"stage":"native-account-read","scenario":"account email","account":{"type":"chatgpt","email":"alex@example.com"},"authFileUnchanged":true}
{"stage":"production-detectInferenceBackends","scenario":"account email","candidate":{"kind":"codex-cli","modelRef":"openai/gpt-5.6-sol","label":"Codex","detail":"logged in · ChatGPT account · alex@example.com","credentials":true},"optionalCodexPluginEnabled":false,"configuredAgents":0,"authFileUnchanged":true}
{"stage":"native-account-read","scenario":"API key without email","account":{"type":"apiKey"},"authFileUnchanged":true}
{"stage":"production-detectInferenceBackends","scenario":"API key without email","candidate":{"kind":"codex-cli","modelRef":"openai/gpt-5.6-sol","label":"Codex","detail":"logged in · API key (usage-billed)","credentials":true},"optionalCodexPluginEnabled":false,"configuredAgents":0,"authFileUnchanged":true}
```

The source command deliberately uses the [repository's documented TypeScript preload](https://github.com/openclaw/openclaw/blob/e31d0dffaa49e2c89f322508e173a335fbdb9920/docs/reference/test.md#L198). A preliminary raw-TSX invocation incorrectly rewrote compiled ESM dependency imports into CommonJS; the supported preload and the independent plain-Node built run both pass with unchanged production code. The trace proves native discovery into the setup candidate; the browser tests and frames below prove the existing candidate-detail rendering and refresh behavior.

### Integrated native Gateway-to-UI proof

A further run exercised the **actual installed Codex executable → production detection worker → real loopback Gateway WebSocket → Model Setup UI**, without mocked RPC responses. The whole harness ran in a fresh OS process with an explicit environment allowlist and isolated, file-only synthetic credentials. It observed the account/email candidate over the real setup RPC, switched only the fixture auth file to API-key access, clicked **Check again**, and observed the new candidate and removal of the old email. Each auth read left the fixture bytes unchanged; no inference request or real-account credential was used in this successful run.

The run is tied to reviewed source tree `532837004f45e56c701119feb7fa2b2736de1f3d` at `2852b4cc95f79acf7333b3fa0b56124032f8c83a`, with recorded source/built-module hashes. Compilation occurred before the commit, so the build footer still names `b9ead713`; subsequent commit `060c723836452f7fb881523a1c789a0878927e6c` changes only the unrelated browser-route test, not these runtime/UI sources. Background sidecars were deferred and unrelated services disabled; the setup worker, Gateway RPC, and UI were real.

After the final mechanical rebase, this integrated flow was rerun successfully against freshly built source head `e2f23e2e06430fdef15321c1e82681e9eda5ea28` (tree `841a99466fcc26eeaf3dd284f67081c2589abb3b`); the build metadata matches that head. The only pending change was the disclosure E2E repair, now committed as `033f97c5488e46bfde1e0dd3208c6601a54afae0`. Recorded production/UI source and built-module hashes were rechecked unchanged after that commit. Account/email and API-key refresh again passed through the real Gateway, and both new local captures were inspected. The earlier uploaded frames below retain their original attribution. Focused tests (191), all 18 relevant browser cases, the fresh full build, staged type/lint/guard checks, and the independent test-fix review also passed after the rebase.

```json
{"stage":"observed-real-setup-rpc","phase":"account","ok":true,"candidate":{"kind":"codex-cli","modelRef":"openai/gpt-5.6-sol","detail":"logged in · ChatGPT account · alex@example.com","credentials":true}}
{"stage":"account-ui-rendered","authFileUnchanged":true}
{"stage":"observed-real-setup-rpc","phase":"api-key","ok":true,"candidate":{"kind":"codex-cli","modelRef":"openai/gpt-5.6-sol","detail":"logged in · API key (usage-billed)","credentials":true}}
{"stage":"api-key-ui-rendered-after-check-again","previousEmailAbsent":true,"authFileUnchanged":true}
```

### Before / after

The before frame is a mock-Gateway fixture representing the old label, not a historical live-account capture. Both after frames come from the integrated real-Gateway run above, using only synthetic account data. All complete captures were inspected before upload; their build footers differ as described above.

| Before: method only | After: selected account email |
| --- | --- |
| ![Before: logged in with subscription label](https://github.com/user-attachments/assets/b62013b9-4d6e-446f-b18c-cb653c90492e) | ![After: ChatGPT account and synthetic email](https://github.com/user-attachments/assets/3b18bb14-3223-4a80-b4c2-ea84bb3ae7b3) |

After refreshing with API-key access:

![After: API-key method without stale account email](https://github.com/user-attachments/assets/63a2465a-2595-42fe-8fcd-cd38c8e90ae0)

### Scope and follow-up

Production delta: **+291 net lines**; tests: **+604**; docs: **+9**. Production growth provides the bounded bootstrap-native account handshake, environment isolation, and process-tree cleanup without loading the optional runtime. The existing rendering/wire path is reused.

Named pre-existing follow-up: make the generic `probeLocalCommand` method-only fallback honor an independently injected environment. It currently inherits `process.env`; this patch does not claim otherwise and never takes an email from that fallback. The native proof isolates the whole subprocess environment.

Additional named pre-existing follow-up: source Model Setup workers still select raw `--import tsx` in `src/system-agent/setup-inference-detection.ts`, bypassing the curated ESM preload. That branch predates this PR and is absent for built workers; align the source-worker bootstrap with `scripts/tsx.mjs` and extend the existing real-worker import-only-dependency fixture. The integrated proof above uses the built production path, not a source-loader workaround.

The operator-admin identity display and narrow additive SDK helper are [confirmed maintainer scope for this landing](https://github.com/openclaw/openclaw/pull/136521#issuecomment-5515867364).
