### PR TITLE
fix: stabilize macOS approval expiry and rejection tests

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalQueueStoreTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawProtocol
 import Testing
 @testable import OpenClaw
 @testable import OpenClawKit
@@ -44,13 +45,13 @@ private struct ApprovalGatewayRequest: Sendable {
 }
 
 private actor ApprovalGatewayRequestLog {
-    private var listedRequests: [ApprovalFixtureRequest]
+    private var makeListedRequests: @Sendable () -> [ApprovalFixtureRequest]
     private var requests: [ApprovalGatewayRequest] = []
     private var nextSequence = 0
     private var resolveRejection: String?
 
-    init(initialRequests: [ApprovalFixtureRequest]) {
-        self.listedRequests = initialRequests
+    init(initialRequests: @escaping @Sendable () -> [ApprovalFixtureRequest]) {
+        self.makeListedRequests = initialRequests
     }
 
     func append(_ request: ApprovalGatewayRequest) {
@@ -62,14 +63,15 @@ private actor ApprovalGatewayRequestLog {
     }
 
     func listResponse() -> String {
-        String(decoding: try! JSONEncoder().encode(self.listedRequests), as: UTF8.self)
+        // Start fixture lifetimes at the Gateway response, after cold connection work.
+        String(decoding: try! JSONEncoder().encode(self.makeListedRequests()), as: UTF8.self)
     }
 
     /// Simulates another client (the modal prompter) winning the resolution
     /// race server-side: resolves reject and the authoritative list is empty.
     func markResolvedElsewhere(reason: String = "APPROVAL_ALREADY_RESOLVED") {
         self.resolveRejection = reason
-        self.listedRequests = []
+        self.makeListedRequests = { [] }
     }
 
     func resolveRejectionReason() -> String? {
@@ -87,7 +89,10 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
     let session: GatewayTestWebSocketSession
     let gateway: GatewayConnection
 
-    init(initialRequests: [ApprovalFixtureRequest] = []) {
+    init(
+        initialRequests: @escaping @Sendable () -> [ApprovalFixtureRequest] = { [] },
+        listResponseDelay: Duration = .zero)
+    {
         let requestLog = ApprovalGatewayRequestLog(initialRequests: initialRequests)
         self.requestLog = requestLog
         self.session = GatewayTestWebSocketSession(taskFactory: {
@@ -97,10 +102,17 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
                 if request.method.hasSuffix("approval.resolve"),
                    let reason = await requestLog.resolveRejectionReason()
                 {
-                    let response =
-                        #"{"type":"res","id":"\#(request.id)","ok":false,"error":{"message":"\#(reason)"}}"#
-                    socket.emitReceiveSuccess(.data(Data(response.utf8)))
+                    let response = ResponseFrame(
+                        type: "res", id: request.id, ok: false,
+                        error: ErrorShape(
+                            code: "INVALID_REQUEST",
+                            message: "approval already resolved",
+                            details: .init(["reason": reason])))
+                    try socket.emitReceiveSuccess(.data(JSONEncoder().encode(response)))
                     return
+                }
+                if request.method == "exec.approval.list", listResponseDelay > .zero {
+                    try await Task.sleep(for: listResponseDelay)
                 }
                 let payload = if request.method == "exec.approval.list" {
                     await requestLog.listResponse()
@@ -159,11 +171,13 @@ private final class ApprovalGatewayFixture: @unchecked Sendable {
 @MainActor
 struct ExecApprovalQueueStoreTests {
     @Test func `refresh seeds direct gateway list and excludes expired approvals`() async {
-        let fixture = ApprovalGatewayFixture(initialRequests: [
-            ApprovalFixtureRequest(id: "later", sessionKey: "work", createdOffsetMs: 200),
-            ApprovalFixtureRequest(id: "expired", expiresOffsetMs: -100),
-            ApprovalFixtureRequest(id: "earlier", createdOffsetMs: -200),
-        ])
+        let fixture = ApprovalGatewayFixture(initialRequests: {
+            [
+                ApprovalFixtureRequest(id: "later", sessionKey: "work", createdOffsetMs: 200),
+                ApprovalFixtureRequest(id: "expired", expiresOffsetMs: -100),
+                ApprovalFixtureRequest(id: "earlier", createdOffsetMs: -200),
+            ]
+        })
         let store = ExecApprovalQueueStore(gateway: fixture.gateway)
         defer { store.stop() }
 
@@ -176,9 +190,9 @@ struct ExecApprovalQueueStoreTests {
     }
 
     @Test func `losing a resolution race re-syncs from the authoritative queue`() async throws {
-        let fixture = ApprovalGatewayFixture(initialRequests: [
-            ApprovalFixtureRequest(id: "contested"),
-        ])
+        let fixture = ApprovalGatewayFixture(initialRequests: {
+            [ApprovalFixtureRequest(id: "contested")]
+        })
         let store = ExecApprovalQueueStore(gateway: fixture.gateway)
         defer { store.stop() }
 
@@ -188,6 +202,16 @@ struct ExecApprovalQueueStoreTests {
         // The modal prompter (a second presentation surface on the same event
         // stream) resolves first; the gateway rejects this store's attempt.
         await fixture.requestLog.markResolvedElsewhere()
+        // A malformed response can also trigger timeout recovery; require a decoded rejection.
+        let rejection = try await #require(throws: GatewayResponseError.self) {
+            try await fixture.gateway.requestVoid(
+                method: .execApprovalResolve,
+                params: ["id": .init(contested.id), "decision": .init("deny")],
+                timeoutMs: 10000)
+        }
+        #expect(rejection.code == "INVALID_REQUEST")
+        #expect(rejection.detailsReason == "APPROVAL_ALREADY_RESOLVED")
+
         await store.resolve(request: contested, decision: .deny)
 
         #expect(store.requests.isEmpty)
@@ -210,10 +234,11 @@ struct ExecApprovalQueueStoreTests {
         try #require(await self.waitUntil { store.requests.isEmpty })
     }
 
-    @Test func `expired requests disappear without a gateway resolution event`() async throws {
-        let fixture = ApprovalGatewayFixture(initialRequests: [
-            ApprovalFixtureRequest(id: "short-lived", expiresOffsetMs: 500),
-        ])
+    @Test(arguments: [0, 600])
+    func `expired requests disappear without a gateway resolution event`(listResponseDelayMs: Int) async throws {
+        let fixture = ApprovalGatewayFixture(initialRequests: {
+            [ApprovalFixtureRequest(id: "short-lived", expiresOffsetMs: 500)]
+        }, listResponseDelay: .milliseconds(listResponseDelayMs))
         let store = ExecApprovalQueueStore(gateway: fixture.gateway)
         defer { store.stop() }
 
@@ -223,11 +248,13 @@ struct ExecApprovalQueueStoreTests {
     }
 
     @Test func `explicit decision policy excludes allow always and blocks unavailable decisions`() async {
-        let fixture = ApprovalGatewayFixture(initialRequests: [
-            ApprovalFixtureRequest(
-                id: "deny-only",
-                allowedDecisions: ["allow-always", "deny"]),
-        ])
+        let fixture = ApprovalGatewayFixture(initialRequests: {
+            [
+                ApprovalFixtureRequest(
+                    id: "deny-only",
+                    allowedDecisions: ["allow-always", "deny"]),
+            ]
+        })
         let store = ExecApprovalQueueStore(gateway: fixture.gateway)
         defer { store.stop() }
         await store.refresh()


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the macOS approval queue tests could fail during slow connection setup, or appear to validate a rejected approval only after a request timed out. These failures obscured whether approval expiry and competing-client recovery actually worked.

## Why This Change Was Made

Create time-sensitive fixtures when the mocked Gateway prepares its response, not before the connection starts. Encode rejection responses with the shared protocol types and require the expected Gateway error before checking that the store re-fetches the authoritative queue. The original 500 ms expiry and queue assertions remain intact; no production behavior or timeout changes.

## User Impact

No end-user behavior changes. Maintainers get reliable expiry coverage and a test that distinguishes a real approval rejection from timeout recovery. Scope: one test file, +53/-26 lines; production delta: zero. Related: #135808.

## Evidence

- Reproduced the expiry failure with a 600 ms response-preparation delay against the original 500 ms fixture lifetime. The repaired existing test covers both 0 and 600 ms delays without increasing the lifetime.
- A freshly built native RED run failed with `NSError` (Gateway request timeout) where the regression assertion required `GatewayResponseError`. The corrected response includes the canonical `INVALID_REQUEST` code and `APPROVAL_ALREADY_RESOLVED` reason.
- The freshly built native GREEN suite passed all six methods/seven case executions, zero issues, in 1.673 seconds. The rejection case completed in 0.004 seconds and still verified authoritative queue re-listing. This exercised the production native Gateway client with a mock WebSocket, not a live Gateway or rendered UI.
- Native RED/GREEN used base `0ebdbe6155adc2413896989f61ca6fadc5fb4b12`. The sole subsequent source change was the formatter moving `try` outward over the same JSON encoding expression; the native results are not presented as an exact formatted-head run.
- Independent managed Codex review of the final formatted diff and owner/caller/protocol evidence: no actionable P0–P2 findings. All 12 changed-file checks passed, including strict Swift lint and the native schema guard. Complete submitted-head CI passed: eight selected jobs succeeded and 25 were correctly skipped, including successful native test and release jobs. The required aggregate gate passed; no checks were waived.

## Review follow-up

The requested expiry and structured-rejection trace is included below from the full native CI run. It covers the changed test fixture using the production native Gateway client; replacing the fixture with a live Gateway would not exercise the code changed by this PR. This is native fixture behavior proof, not a live Gateway or rendered-UI claim. A separate focused rerun was not performed.

### Exact-head native CI evidence

The `macos-swift (tests)` job [100380864505](https://github.com/openclaw/openclaw/actions/runs/33667835000/job/100380864505) completed successfully for PR head `ef7966b5808755991b1087cb82bca2e02c8e48ff`. GitHub checked out merge commit `f182d901a149c08fbd7e2c1b0c5ea87f572b0ed2`, merging that head into `f92a12c5813fb880ed6a05c4a728fd5f4ccc5473`. The fixture and unchanged production owner in the merge were independently read back and are byte-identical to the PR head (fixture SHA-256 `3a6807e62ba4cd7d017f94c01e73c26f1f99ebc851a1a77ca24be3848929be0a`).

This is an excerpt from the **full CI suite**, not a separate focused rerun. `ExecApprovalQueueStoreTests` passed all six methods/seven cases, including the original 500 ms expiry scenario with both 0 and 600 ms response-preparation delays. The structured-rejection method passed in 9.304 seconds. Its source requires `GatewayResponseError`, `INVALID_REQUEST`, and `APPROVAL_ALREADY_RESOLVED`; successful assertion values are not individually printed in the log, so this is a source-bound method pass rather than a separate wire trace.

| Fixture method | CI result and reported elapsed time |
| --- | --- |
| refresh seeds direct gateway list and excludes expired approvals | Passed, 3.237 s |
| losing a resolution race re-syncs from the authoritative queue | Passed, 9.304 s |
| requested and resolved events update the shared queue | Passed, 1.755 s |
| expired requests disappear without a gateway resolution event | Passed, 8.071 s (both 0/600 ms cases) |
| explicit decision policy excludes allow always and blocks unavailable decisions | Passed, 3.339 s |
| system agent approvals resolve through the unified kind-aware gateway method | Passed, 5.334 s |

The complete Mac Swift Testing run reported **1,926 tests in 200 suites passed**; XCTest reported **4 tests, 0 failures**. The separate named-profile `AppStateIsolationTests` invocation passed **2 tests in 1 suite**. The same job's preceding shared `OpenClawKit` step passed **1,577 tests in 121 suites**. Its later isolated render step passed **1 test in 1 suite**. These are separate runner-reported totals, not one inflated combined count.

```text
2026-09-02T18:54:01.1109600Z HEAD is now at f182d901 Merge ef7966b5808755991b1087cb82bca2e02c8e48ff into f92a12c5813fb880ed6a05c4a728fd5f4ccc5473
2026-09-02T19:12:09.1483380Z ◇ Suite ExecApprovalQueueStoreTests started.
2026-09-02T19:12:09.1752110Z ◇ Test "refresh seeds direct gateway list and excludes expired approvals" started.
2026-09-02T19:12:13.6103550Z ✔ Test "refresh seeds direct gateway list and excludes expired approvals" passed after 3.237 seconds.
2026-09-02T19:12:13.6104290Z ◇ Test "losing a resolution race re-syncs from the authoritative queue" started.
2026-09-02T19:12:28.8784060Z ✔ Test "losing a resolution race re-syncs from the authoritative queue" passed after 9.304 seconds.
2026-09-02T19:12:28.8784650Z ◇ Test "requested and resolved events update the shared queue" started.
2026-09-02T19:12:28.8921050Z ✔ Test "requested and resolved events update the shared queue" passed after 1.755 seconds.
2026-09-02T19:12:28.8922030Z ◇ Test "expired requests disappear without a gateway resolution event" started.
2026-09-02T19:12:28.8990960Z ◇ Test case passing 1 argument listResponseDelayMs → 0 to "expired requests disappear without a gateway resolution event" started.
2026-09-02T19:12:52.3474240Z ◇ Test case passing 1 argument listResponseDelayMs → 600 to "expired requests disappear without a gateway resolution event" started.
2026-09-02T19:12:52.6937320Z ✔ Test "expired requests disappear without a gateway resolution event" with 2 test cases passed after 8.071 seconds.
2026-09-02T19:12:52.7043310Z ◇ Test "explicit decision policy excludes allow always and blocks unavailable decisions" started.
2026-09-02T19:12:53.2644860Z ✔ Test "explicit decision policy excludes allow always and blocks unavailable decisions" passed after 3.339 seconds.
2026-09-02T19:12:53.2653170Z ◇ Test "system agent approvals resolve through the unified kind-aware gateway method" started.
2026-09-02T19:12:53.3585960Z ✔ Test "system agent approvals resolve through the unified kind-aware gateway method" passed after 5.334 seconds.
2026-09-02T19:12:53.3586630Z ✔ Suite ExecApprovalQueueStoreTests passed after 31.070 seconds.
2026-09-02T19:13:21.8534300Z ✔ Test run with 1926 tests in 200 suites passed after 68.863 seconds.
```

The full-suite fixture elapsed time is not compared with the isolated local run as a performance claim. Separately, [the complete submitted-head CI run](https://github.com/openclaw/openclaw/actions/runs/33667835000) finished successfully at 19:41:08 UTC: eight selected jobs passed and 25 were correctly skipped. The required aggregate gate passed. The latest 19:34 UTC ClawSweeper review has no blocking findings or remaining before-merge items.
