### PR TITLE
fix(ui): clarify session PR hover state

### DIFF
--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -236,9 +236,9 @@ describe("renderSessionHovercard", () => {
     expect(links[0]?.target).toBe("_blank");
     expect(links[0]?.rel).toContain("noopener");
     expect(links[0]?.querySelector(".session-hovercard__pr-title")?.textContent).toBe("First");
-    expect(links[0]?.querySelector(".session-hovercard__pr-title")?.getAttribute("title")).toBe(
-      "First",
-    );
+    expect(
+      links[0]?.querySelector(".session-hovercard__pr-title")?.getAttribute("title"),
+    ).toBeNull();
     expect(links[0]?.querySelector(".session-hovercard__pr-number")).toBeNull();
     expect(links[0]?.querySelector(".session-hovercard__pr-author")).toBeNull();
     expect(

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -489,7 +489,7 @@ function renderPullRequestRow(pullRequest: ControlUiSessionPullRequest) {
       title=${checks ? `${state} · ${checks}` : state}
       >${pullRequestStateIcon(pullRequest.state)}</span
     >
-    <span class="session-hovercard__pr-title" title=${pullRequest.title}>${pullRequest.title}</span>
+    <span class="session-hovercard__pr-title">${pullRequest.title}</span>
     ${renderDiffStats(pullRequest)}
   </a>`;
 }

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -312,7 +312,7 @@ suite.define(() => {
         const fullPrTitle =
           "Restore the session hovercard with compact interactive attribution details";
         await expect.poll(() => prTitle.textContent()).toBe(fullPrTitle);
-        expect(await prTitle.getAttribute("title")).toBe(fullPrTitle);
+        expect(await prTitle.getAttribute("title")).toBeNull();
         expect(await prRow.getAttribute("aria-label")).toContain(fullPrTitle);
         expect(await card.locator(".session-hovercard__more").textContent()).toBe("+2 more");
         expect(
@@ -325,7 +325,14 @@ suite.define(() => {
         await expect
           .poll(() => prRow.evaluate((node) => getComputedStyle(node).textDecorationLine))
           .toBe("none");
-        await captureProof(page, "sidebar-row-hovercard-maximum.png");
+        const restingBackground = await prRow.evaluate(
+          (node) => getComputedStyle(node).backgroundColor,
+        );
+        await prRow.hover();
+        await expect
+          .poll(() => prRow.evaluate((node) => getComputedStyle(node).backgroundColor))
+          .not.toBe(restingBackground);
+        await captureProof(page, "sidebar-row-hovercard-pr-hover.png");
         await expect
           .poll(async () =>
             (await card.locator(".session-hovercard__attribution-copy").textContent())

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -287,11 +287,20 @@
   align-items: center;
   column-gap: var(--space-2);
   min-width: 0;
+  margin-inline: calc(-1 * var(--space-2));
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   /* The row is an anchor: without these it falls back to default link styling. */
   color: var(--muted);
   text-decoration: none;
   font-size: var(--control-ui-text-sm);
   line-height: 1.4;
+  transition: background-color 120ms ease;
+}
+
+.session-hovercard__pr-row:hover,
+.session-hovercard__pr-row:focus-visible {
+  background: var(--bg-hover);
 }
 
 .session-hovercard__pr-state-icon,


### PR DESCRIPTION
## What Problem This Solves

The session hovercard PR title used a native `title` tooltip, which obscured nearby content, while the linked row had no visible hover feedback.

## Why This Change Was Made

The PR title no longer carries a native tooltip. The complete title remains available in the link's accessible label, and the entire PR row now uses the existing hover background token on pointer hover and keyboard focus.

The PR row is the architectural owner for both behaviors; no protocol, persistence, configuration, or data-shape changes are involved.

## User Impact

PR links in session hovercards feel clickable without covering the card with a tooltip. Keyboard users receive the same visible state.

## Evidence

| Before | After |
| --- | --- |
| ![Before: native PR tooltip obscures the session hovercard](https://github.com/user-attachments/assets/350ed255-e651-49e5-a020-7f673b742382) | ![After: PR row uses a visible hover background](https://github.com/user-attachments/assets/616e2b18-bd49-4c1b-83c8-9597490dd6fa) |

- Confirmed pre-fix regression: the focused component test failed because the PR title still exposed a `title` attribute.
- Focused component suite: 32/32 passed.
- Mocked-Gateway hovercard E2E: 1/1 passed; verifies no title tooltip attribute, preserved full-title accessibility, and a changed row background on hover.
- `check:changed`: passed for the four touched UI files.
- Structured autoreview: clean at P1.
- Judged LOC: production +10/-1 (net +9) for the new row interaction treatment; tests +12/-5 (net +7).