### PR TITLE
fix(slack): prevent Socket Mode startup timeouts

### DIFF
--- a/extensions/slack/src/client-options.ts
+++ b/extensions/slack/src/client-options.ts
@@ -43,6 +43,16 @@ const SLACK_LOOKUP_RETRY_OPTIONS: RetryOptions = {
   retries: 0,
 };
 
+function normalizeSlackFetchInit(init?: RequestInit): RequestInit | undefined {
+  if (init?.body !== "") {
+    return init;
+  }
+  // Parameterless Slack Web API calls use an explicit empty body. Older Undici HTTP/2
+  // clients can leave that request stream open instead of setting END_STREAM on HEADERS.
+  const { body: _body, ...rest } = init;
+  return rest;
+}
+
 /** Build the dispatcher shared by Slack Web API fetches and Socket Mode. */
 export function resolveSlackProxyDispatcher(): SlackProxyDispatcher | undefined {
   const options = resolveEnvHttpProxyAgentOptions();
@@ -64,14 +74,21 @@ function buildSlackFetch(
   if (!dispatcher || isDebugProxyGlobalFetchPatchInstalled()) {
     // Debug capture patches global fetch after installing its proxy-aware dispatcher.
     // A package-owned fetch would bypass capture whenever ambient proxy env is present.
-    return resolveFetch() as NonNullable<WebClientOptions["fetch"]> | undefined;
+    const slackFetch = resolveFetch();
+    if (!slackFetch) {
+      return undefined;
+    }
+    return ((input: RequestInfo | URL, init?: RequestInit) =>
+      slackFetch(input, normalizeSlackFetchInit(init))) as NonNullable<WebClientOptions["fetch"]>;
   }
   const { fetch: slackFetch } = loadSlackUndiciRuntime();
   return ((input: RequestInfo | URL, init?: RequestInit) => {
     // Slack Web API invokes this hook with URL/string inputs. The cast only bridges
     // duplicate Undici Request types while the package-owned fetch and dispatcher stay paired.
     const slackInput = input as Parameters<typeof slackFetch>[0];
-    const slackInit = { ...init, dispatcher } as Parameters<typeof slackFetch>[1];
+    const slackInit = { ...normalizeSlackFetchInit(init), dispatcher } as Parameters<
+      typeof slackFetch
+    >[1];
     return slackFetch(slackInput, slackInit);
   }) as NonNullable<WebClientOptions["fetch"]>;
 }

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -476,6 +476,50 @@ describe("slack proxy dispatcher", () => {
     expect(requireFetch(resolveSlackWebClientOptions())).toBeTypeOf("function");
   });
 
+  it("omits explicit empty bodies from Slack SDK requests", async () => {
+    const globalFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const fetch = requireFetch(resolveSlackWebClientOptions());
+      await fetch("https://slack.com/api/auth.test", {
+        body: "",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      });
+
+      expect(globalFetch).toHaveBeenCalledWith("https://slack.com/api/auth.test", {
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      });
+    } finally {
+      globalFetch.mockRestore();
+    }
+  });
+
+  it("preserves nonempty Slack SDK request bodies", async () => {
+    const globalFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const fetch = requireFetch(resolveSlackWebClientOptions());
+      await fetch("https://slack.com/api/chat.postMessage", {
+        body: "channel=C123&text=hello",
+        method: "POST",
+      });
+
+      expect(globalFetch).toHaveBeenCalledWith(
+        "https://slack.com/api/chat.postMessage",
+        expect.objectContaining({
+          body: "channel=C123&text=hello",
+          method: "POST",
+        }),
+      );
+    } finally {
+      globalFetch.mockRestore();
+    }
+  });
+
   it("preserves an explicitly provided fetch", async () => {
     process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
     const customFetch = vi.fn() as never;

--- a/extensions/slack/src/client.web-api.test.ts
+++ b/extensions/slack/src/client.web-api.test.ts
@@ -161,6 +161,31 @@ afterEach(() => {
 });
 
 describe("Slack Web API routing", () => {
+  it("omits the empty body emitted by auth.test", async () => {
+    for (const key of TEST_ENV_KEYS) {
+      delete process.env[key];
+    }
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, team_id: "TMOCK", user_id: "UMOCK" }), {
+        status: 200,
+      }),
+    );
+    try {
+      const client = createSlackWebClient("xoxb-empty-body-proof", {
+        retryConfig: { retries: 0 },
+        timeout: 1000,
+      });
+
+      await expect(client.auth.test()).resolves.toMatchObject({ ok: true });
+      expect(globalFetch).toHaveBeenCalledOnce();
+      const init = globalFetch.mock.calls[0]?.[1];
+      expect(init).toMatchObject({ method: "POST" });
+      expect(init).not.toHaveProperty("body");
+    } finally {
+      globalFetch.mockRestore();
+    }
+  });
+
   it("retries two transient startup auth failures", async () => {
     const fetchMock = vi
       .fn()

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -151,6 +151,36 @@ describe("auth.test boot call", () => {
     }
   });
 
+  it("omits the empty body on the shipped Socket Mode startup path", async () => {
+    for (const key of PROXY_ENV_KEYS) {
+      vi.stubEnv(key, "");
+    }
+    const actualClient = await vi.importActual<typeof import("../client.js")>("../client.js");
+    useSlackStartupAuthClientOnce(actualClient.createSlackStartupAuthClient);
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          bot_id: "BBOT",
+          is_enterprise_install: false,
+          ok: true,
+          team_id: "T1",
+          user_id: "UBOT",
+        }),
+        { headers: { "content-type": "application/json" }, status: 200 },
+      ),
+    );
+    const monitor = startSlackMonitor(monitorSlackProvider);
+    try {
+      await stopSlackMonitor(monitor);
+
+      expect(globalFetch).toHaveBeenCalledOnce();
+      expect(globalFetch.mock.calls[0]?.[1]).toMatchObject({ method: "POST" });
+      expect(globalFetch.mock.calls[0]?.[1]).not.toHaveProperty("body");
+    } finally {
+      globalFetch.mockRestore();
+    }
+  });
+
   it("warns when auth.test returns a user id without bot_id", async () => {
     const runtimeLog = vi.fn();
     const client = getSlackClient();


### PR DESCRIPTION
Related: #119861

## What Problem This Solves

Fixes an issue where Slack Socket Mode users can remain disconnected after startup when parameterless Slack Web API calls stall and return HTTP 408 stream timeouts.

## Why This Change Was Made

The Slack SDK serializes parameterless calls such as `auth.test` and `apps.connections.open` with an explicit empty-string body. Affected Undici HTTP/2 clients do not close zero-length request streams in the initial HEADERS frame, causing Slack to wait until its stream timeout.

This behavior was fixed upstream in nodejs/undici#5169. OpenClaw's Slack fetch wrapper now omits only explicit empty-string bodies. Nonempty request payloads and caller-provided fetch implementations remain unchanged.

## User Impact

Slack Socket Mode can establish reliably on runtimes carrying affected Undici behavior, without token rotation or an OpenClaw/runtime rollback.

## Evidence

### Live HTTP/2 transport proof

Credential-free proof against Slack's real `api.test` endpoint from the patched source checkout. The harness used the Slack plugin's own Undici dispatcher with `allowH2: true`; ALPN was captured from `undici:client:connected` diagnostics. No authorization header or Slack token was supplied.

```text
$ node --import tsx ./slack-http2-proof.mts
node=v26.0.0 slack-owned-undici=7.29.0
raw explicit empty body: Error: proof timeout; elapsed=3011ms; alpn=h2
patched parameterless api.test: ok=true; elapsed=245ms; alpn=h2
patched nonempty api.test: ok=true; elapsed=222ms; alpn=h2
```

This proves the changed production wrapper completes the affected parameterless Slack SDK request over HTTP/2 while preserving a nonempty request. The raw control reproduces the pre-fix stalled stream using the same runtime, endpoint, dispatcher version, and negotiated protocol.

### Automated verification

- Added unit coverage for empty-body omission and nonempty-body preservation.
- Added coverage through a real `@slack/web-api` `auth.test` call.
- Focused Slack tests: 48/48 passed.
- Full Slack extension suite: 146 files / 2,690 tests passed.
- `pnpm tsgo:extensions` passed.
- `pnpm tsgo:extensions:test` passed.
- Formatting and oxlint checks passed on all touched files.
- Added a regression through the shipped Socket Mode monitor startup path; it uses the real startup auth client and fails on the pre-fix baseline because global fetch receives `body: ""`.

### Independent maintainer verification

- Direct inspection of Slack Web API 8.0.0 confirms that `auth.test` serializes an empty argument map to `body: ""` before calling the configured fetch function.
- Direct inspection of the Slack plugin's pinned Undici 7.29.0 confirms that H2 ends a request stream only for a null body or GET/HEAD, while Undici 8.10.0 adds the zero-content-length case.
- Credential-free live verification against Slack's real `api.test` endpoint negotiated H2 with the plugin-pinned Undici 7.29.0 dispatcher.
- On current `main` at `9b093430a25f62bc33d3736128036e6eb7de88b7`, explicit-empty raw transport and SDK `auth.test` stalled; omitted and nonempty requests returned HTTP 200.
- On the committed repair head at `23b1fbc06dfeba57941295ba2d05401d14edcb71`, the raw explicit-empty control still stalled, while the production-wrapped SDK `auth.test` reached Slack and returned the expected credential-free `not_authed` response; the downstream H2 request body was null.
- No authorization header or Slack credential was supplied in either live run.
