### PR TITLE
fix(oc-path): emit patches that preserve exact edit bytes

### DIFF
--- a/docs/cli/path.md
+++ b/docs/cli/path.md
@@ -232,6 +232,8 @@ document API), so untouched bytes usually survive; markdown rebuilds the file
 from its parsed structure on any edit, which can normalize incidental
 formatting outside the changed leaf. Add `--diff` when you want the preview
 as a focused before/after patch instead of the full rendered file.
+The patch records line-ending changes and missing final newlines, so applying
+it produces the same bytes as the write.
 
 ## Examples
 

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -5,6 +5,7 @@
   "description": "OpenClaw oc:// workspace path plugin",
   "type": "module",
   "dependencies": {
+    "diff": "9.0.0",
     "jsonc-parser": "3.3.1",
     "markdown-it": "15.0.0",
     "yaml": "2.9.0"

--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -441,25 +441,49 @@ describe("openclaw path CLI", () => {
       expect(readFileSync(filePath, "utf-8")).toBe(before);
     });
 
-    it("CLI-S05 --dry-run --diff prints a unified diff", async () => {
+    it.runIf(process.platform !== "win32").each([
+      { label: "LF", before: '{ "version": "1.0" }\n', json: false },
+      { label: "CRLF", before: '{ "version": "1.0" }\r\n', json: true },
+      { label: "no final newline", before: '{ "version": "1.0" }', json: true },
+      {
+        label: "middle-of-file",
+        before: `{\n${"  // leading context\n".repeat(5)}  "version": "1.0"\n${"  // trailing context\n".repeat(5)}}\n`,
+        json: true,
+      },
+    ])("emits an applicable $label dry-run patch", async ({ before, json }) => {
       const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");
-      const before = '{\n  "version": "1.0",\n  "enabled": true\n}\n';
+      const patchPath = join(workspaceDir, "preview.patch");
+      const after = before.replace('"1.0"', '"2.0"');
       writeFileSync(filePath, before, "utf-8");
       const rt = createTestRuntime();
       await pathSetCommand(
         "oc://gateway.jsonc/version",
         "2.0",
-        { cwd: workspaceDir, human: true, dryRun: true, diff: true },
+        { cwd: workspaceDir, human: !json, json, dryRun: true, diff: true },
         rt,
       );
+
       expect(rt.exitCode).toBe(0);
-      const out = stdoutText(rt);
-      expect(out).toContain("--- ");
-      expect(out).toContain("+++ ");
-      expect(out).toContain('-  "version": "1.0",');
-      expect(out).toContain('+  "version": "2.0",');
+      const output = stdoutText(rt);
+      const payload = json ? JSON.parse(output) : undefined;
+      const patch = json ? payload.diff : output;
+      if (json) {
+        expect(payload.bytes).toBe(after);
+      }
+      writeFileSync(patchPath, patch, "utf-8");
       expect(readFileSync(filePath, "utf-8")).toBe(before);
+      execFileSync(
+        "git",
+        ["apply", "--check", `-p${filePath.split("/").filter(Boolean).length}`, patchPath],
+        {
+          cwd: workspaceDir,
+        },
+      );
+      execFileSync("patch", ["--dry-run", "--fuzz=0", filePath, patchPath]);
+      expect(readFileSync(filePath, "utf-8")).toBe(before);
+      execFileSync("patch", ["--fuzz=0", filePath, patchPath]);
+      expect(readFileSync(filePath, "utf-8")).toBe(after);
     });
 
     it("CLI-S05c --dry-run --diff shows line-ending-only byte changes", async () => {

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -9,6 +9,7 @@
 import { constants as fsConstants, promises as fs } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import type { Command } from "commander";
+import { FILE_HEADERS_ONLY, formatPatch, structuredPatch } from "diff";
 import {
   MAX_JSONC_INPUT_BYTES,
   OcEmitSentinelError,
@@ -268,61 +269,45 @@ function formatMatchHuman(match: OcMatch): string {
   return `root @ L${match.line}`;
 }
 
-function splitDiffLines(s: string): readonly string[] {
-  return s === "" ? [] : s.split("\n");
-}
-
 function formatUnifiedDiff(oldBytes: string, newBytes: string, fsPath: string): string {
   if (oldBytes === newBytes) {
     return "";
   }
-  const oldLines = splitDiffLines(oldBytes);
-  const newLines = splitDiffLines(newBytes);
-  let prefix = 0;
-  while (
-    prefix < oldLines.length &&
-    prefix < newLines.length &&
-    oldLines[prefix] === newLines[prefix]
-  ) {
-    prefix++;
+  const oldLines = oldBytes.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+  const newLines = newBytes.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+  let start = 0;
+  while (start < oldLines.length && oldLines[start] === newLines[start]) {
+    start++;
   }
+  let oldEnd = oldLines.length;
+  let newEnd = newLines.length;
+  while (oldEnd > start && newEnd > start && oldLines[oldEnd - 1] === newLines[newEnd - 1]) {
+    oldEnd--;
+    newEnd--;
+  }
+  const contextStart = Math.max(0, start - 3);
+  const trailing = Math.min(3, oldLines.length - oldEnd);
 
-  let oldSuffix = oldLines.length - 1;
-  let newSuffix = newLines.length - 1;
-  while (
-    oldSuffix >= prefix &&
-    newSuffix >= prefix &&
-    oldLines[oldSuffix] === newLines[newSuffix]
-  ) {
-    oldSuffix--;
-    newSuffix--;
-  }
-
-  const context = 3;
-  const hunkStart = Math.max(0, prefix - context);
-  const hunkOldEnd = Math.min(oldLines.length - 1, oldSuffix + context);
-  const hunkNewEnd = Math.min(newLines.length - 1, newSuffix + context);
-  const oldCount = Math.max(0, hunkOldEnd - hunkStart + 1);
-  const newCount = Math.max(0, hunkNewEnd - hunkStart + 1);
-  const lines = [
-    `--- ${fsPath}`,
-    `+++ ${fsPath}`,
-    `@@ -${hunkStart + 1},${oldCount} +${hunkStart + 1},${newCount} @@`,
-  ];
-
-  for (let i = hunkStart; i < prefix; i++) {
-    lines.push(` ${oldLines[i] ?? ""}`);
-  }
-  for (let i = prefix; i <= oldSuffix; i++) {
-    lines.push(`-${oldLines[i] ?? ""}`);
-  }
-  for (let i = prefix; i <= newSuffix; i++) {
-    lines.push(`+${newLines[i] ?? ""}`);
-  }
-  for (let i = Math.max(oldSuffix + 1, prefix); i <= hunkOldEnd; i++) {
-    lines.push(` ${oldLines[i] ?? ""}`);
-  }
-  return `${lines.join("\n")}\n`;
+  // Empty-side patches preserve newline markers without a quadratic search
+  // when a Markdown edit normalizes every CRLF line in a large file.
+  const formatLines = (prefix: string, lines: string[]) =>
+    (structuredPatch("", "", "", lines.join("")).hunks[0]?.lines ?? []).map((line) =>
+      line.startsWith("+") ? `${prefix}${line.slice(1)}` : line,
+    );
+  const patch = structuredPatch(fsPath, fsPath, "", "");
+  patch.hunks.push({
+    oldStart: contextStart + 1,
+    oldLines: oldEnd - contextStart + trailing,
+    newStart: contextStart + 1,
+    newLines: newEnd - contextStart + trailing,
+    lines: [
+      ...formatLines(" ", oldLines.slice(contextStart, start)),
+      ...formatLines("-", oldLines.slice(start, oldEnd)),
+      ...formatLines("+", newLines.slice(start, newEnd)),
+      ...formatLines(" ", oldLines.slice(oldEnd, oldEnd + trailing)),
+    ],
+  });
+  return formatPatch(patch, FILE_HEADERS_ONLY);
 }
 
 // ---------- Commands -----------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1662,6 +1662,9 @@ importers:
 
   extensions/oc-path:
     dependencies:
+      diff:
+        specifier: 9.0.0
+        version: 9.0.0
       jsonc-parser:
         specifier: 3.3.1
         version: 3.3.1

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,6 +111,15 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
+async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
+  const root = tempDirs.make(`openclaw-${label}-`);
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify({ gateway }));
+  return { root, stateDir, configPath };
+}
+
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -185,20 +194,11 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
-    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: gateway.token },
-        },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
+      mode: "remote",
+      remote: { url: gateway.url, token: gateway.token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,16 +279,12 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
-      const root = tempDirs.make("openclaw-nodes-timeout-");
-      const stateDir = path.join(root, "state");
-      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
-      );
+      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
+        mode: "remote",
+        remote: { url: gateway.url, token },
+      });
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -315,18 +311,12 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-cli-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: { mode: "remote", remote: { url: gateway.url, token } },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
+      mode: "remote",
+      remote: { url: gateway.url, token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -344,22 +334,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -394,15 +380,11 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-explicit-auth",
+      { mode: "remote", remote: { url: gateway.url, token } },
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -421,22 +403,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -736,19 +714,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remtoe",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-invalid-config",
+      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({
@@ -1006,19 +975,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
-    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-rate-limit-json",
+      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,15 +111,6 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
-async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
-  const root = tempDirs.make(`openclaw-${label}-`);
-  const stateDir = path.join(root, "state");
-  const configPath = path.join(stateDir, "openclaw.json");
-  await fs.mkdir(stateDir, { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify({ gateway }));
-  return { root, stateDir, configPath };
-}
-
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -194,11 +185,20 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
+    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
-      mode: "remote",
-      remote: { url: gateway.url, token: gateway.token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: gateway.token },
+        },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,12 +279,16 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
+      const root = tempDirs.make("openclaw-nodes-timeout-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
-        mode: "remote",
-        remote: { url: gateway.url, token },
-      });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+      );
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -311,12 +315,18 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-cli-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
-      mode: "remote",
-      remote: { url: gateway.url, token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "remote", remote: { url: gateway.url, token } },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -334,18 +344,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -380,11 +394,15 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-explicit-auth",
-      { mode: "remote", remote: { url: gateway.url, token } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -403,18 +421,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -714,10 +736,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-invalid-config",
-      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remtoe",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({
@@ -975,10 +1006,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
+    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-rate-limit-json",
-      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/gateway/server.startup-recovery-webchat.test.ts
+++ b/src/gateway/server.startup-recovery-webchat.test.ts
@@ -16,6 +16,7 @@ import {
   getSessionWorkAdmissionOwnerRelease,
 } from "../sessions/session-lifecycle-admission.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { countPendingQueueItems } from "../utils/queue-helpers.js";
 import { getGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
 import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
@@ -183,11 +184,12 @@ it(
 
       const canceledRunId = "webchat-canceled-during-recovery";
       const survivorRunId = "webchat-survives-recovery";
+      const expectedQueuedMessages = new Map([
+        [canceledRunId, canceledMessage],
+        [survivorRunId, survivorMessage],
+      ]);
       await Promise.all(
-        [
-          [canceledRunId, canceledMessage],
-          [survivorRunId, survivorMessage],
-        ].map(async ([runId, message]) => {
+        Array.from(expectedQueuedMessages, async ([runId, message]) => {
           await expect(
             client.request("chat.send", {
               sessionKey,
@@ -202,8 +204,14 @@ it(
       );
       await vi.waitFor(() => {
         const queue = getExistingFollowupQueue(sessionKey);
+        // Active sources remain in items; started ACKs can precede queue admission.
+        expect(queue?.items).toHaveLength(expectedQueuedMessages.size);
+        expect(new Map(queue?.items.map(({ messageId, prompt }) => [messageId, prompt]))).toEqual(
+          expectedQueuedMessages,
+        );
         expect(queue?.inFlight).toHaveLength(1);
-        expect(queue?.items).toHaveLength(1);
+        expect(countPendingQueueItems(queue?.items ?? [], queue?.inFlight)).toBe(1);
+        expect(targetRequests).toHaveLength(1);
       });
       replacementOwner = await beginSessionWorkAdmission({
         scope: storePath,


### PR DESCRIPTION
## Summary

Fixes #136530.

A successful path set --dry-run --diff could emit an unusable patch: a trailing newline was counted as an extra physical line, and missing final newlines had no EOF markers. The formatter now keeps its linear prefix/suffix window and three real context lines, while diff9 owns line/EOF encoding and metadata serialization. This removes the handwritten headers and line emitter without introducing a quadratic whole-file diff.

Production **+37 / −51 = -14 LOC**; tests/support **+45 / −13 = +32**; docs **+2**.

## Validation

Actual compiled CLI, native patch and Git evidence:

| Fixture | Before | After |
| --- | --- | --- |
| LF JSONC | CLI0; patch1, nonexistent line2 | CLI0; patch dry-run/apply0; exact bytes |
| CRLF JSONC | CLI0; patch1 | CRLF preserved; exact bytes |
| Missing final LF | CLI0; patch1 | Correct EOF markers; exact bytes |
| Markdown newline normalization | CLI0; patch1 | Patch applies every normalized byte |
| No change | Empty diff; unchanged file | Same |
| Middle-of-file edit | Formatter contract regression covered | Git apply --check0 with default context rules |

The final compiled CLI previewed a16,777,155-byte Markdown fixture and native patch applied it to exactly16,522,953 expected bytes, SHA2560a656f6ffa66c7249267cc7bceb97e33d4cd6aaaf839078e6bdc055373bebd05. That observed run took3.56s including startup; no general benchmark claim is made. The3.3MB case also applied exactly. Empty-side structured segments avoid Myers work across wholesale line-ending changes while retaining genuine unchanged context required by Git.

- 70 owner/sibling tests pass, including byte fidelity and existing cross-kind edit sentinels.
- Actual built CLI exercises human and JSON output, verifies dry-run leaves source untouched, and applies emitted patches with native patch and Git.
- qaRuntime build and53 native compiled checks pass; the final full changed-file gate passes.
- Independent final Codex P2 review is clean. Root directly inspected the installed diff9 tokenizer, structured-patch/EOF serializer and edit-graph implementation.

Two candidate-review findings were fixed before publication: whole-file quadratic work and missing real context. Neither is counted as an additional issue. Native patch cases run on macOS and are skipped on Windows; portable sibling coverage remains. No configuration, state/schema, input limit or output-selection surface changes.

## Shared CI fixture follow-up

The temporary Gateway CLI fixture cleanup has been removed because [main already owns the canonical test split](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c). The cumulative PR no longer changes that file. The exact three-way file merge matches main byte for byte, retaining the health/transport cases, Linux socat case and cleanup hooks; typed lint and an independent Codex P2 review pass. No product issue or production deletion is credited to this reconciliation.

Startup-recovery coverage now uses the canonical fixture already landed in [#136473](https://github.com/openclaw/openclaw/pull/136473): await both exact queued message identities, assert one pending item alongside the active source, then retain cancellation, survivor and cleanup checks. This replaces the earlier pending-only assertion where present. The exact real-Gateway scenario passes after adoption; no production recovery behavior changes.

Fresh scoped typed lint/format checks and independent Codex P2 review pass. Shared review reuse is limited to identical before/after files and owner context. These CI repairs add no counted product issue.

## Current-main CI refresh

A tree-identical CI refresh retains the complete reviewed source and proof. Earlier checks ran before the canonical main test split and CI runner/dependency acquisition fixes; the new PR event rebuilds the current merge ref through the normal required checks. There are no source, test, configuration or production-LOC changes in this refresh.

## Final review disposition

The dependency review is complete. I directly inspected the pinned diff9 serializer and its tokenizer/edit graph, including EOF-marker handling, CRLF preservation and zero-line hunk headers. The package metadata identifies kpdecker/jsdiff; the live registry integrity matches the existing9.0.0 lock resolution. This only adds the consuming plugin importer. The listed secops owner’s standing QA/landing direction was verified through active team membership. The real compiled CLI plus native patch/Git byte checks cover the new call site.

Required [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33680807434/job/100423668615) passed for `aa7361b9164a5d08c2b4d050cae61de2bc055427`. Production owners are unchanged on main `31ed57e3953152fa826a444e742b3c0ec5149961` since the reproduced baseline, and the complete PR composes cleanly. The latest ClawSweeper review and its rank-up requests have been addressed; no actionable code finding remains.
