### PR TITLE
test(cli): exercise the real config snapshot cache

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -716,25 +716,15 @@ describe("ensureConfigReady", () => {
   });
 
   it("retries the cached config snapshot after a read rejection", async () => {
-    const originalVitest = process.env.VITEST;
-    process.env.VITEST = "false";
     const transientError = new Error("temporary config read failure");
     const recoveredSnapshot = makeSnapshot();
     readConfigFileSnapshotMock
       .mockRejectedValueOnce(transientError)
       .mockResolvedValueOnce(recoveredSnapshot);
 
-    try {
-      await expect(runEnsureConfigReady(["health"])).rejects.toThrow(transientError);
-      await expect(runEnsureConfigReady(["health"])).resolves.toBeDefined();
-      await expect(runEnsureConfigReady(["health"])).resolves.toBeDefined();
-    } finally {
-      if (originalVitest === undefined) {
-        delete process.env.VITEST;
-      } else {
-        process.env.VITEST = originalVitest;
-      }
-    }
+    await expect(runEnsureConfigReady(["health"])).rejects.toThrow(transientError);
+    await expect(runEnsureConfigReady(["health"])).resolves.toBeDefined();
+    await expect(runEnsureConfigReady(["health"])).resolves.toBeDefined();
 
     expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(2);
     expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(undefined, {});

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -204,10 +204,6 @@ async function getConfigSnapshot(
       ...(measure ? { measure } : {}),
     });
   }
-  // Tests often mutate config fixtures; caching can make those flaky.
-  if (process.env.VITEST === "true") {
-    return readConfigFileSnapshot(measure ? { measure } : undefined);
-  }
   if (!configSnapshotPromise) {
     const pendingSnapshot = readConfigFileSnapshot(measure ? { measure } : undefined);
     configSnapshotPromise = pendingSnapshot;


### PR DESCRIPTION
## What Problem This Solves

The CLI config guard disabled its normal snapshot cache whenever Vitest was running. Tests already reset the guard state between fixtures, and the cache regression had to change `VITEST` temporarily just to exercise the production path.

## Why This Change Was Made

Remove the test-mode branch and the regression test's environment workaround. Keep the same rejected-read eviction, successful snapshot reuse, non-observing diagnostic reads, doctor recovery invalidation, and per-test state reset. Every existing assertion remains.

This removes four production lines and ten test lines. Ordinary CLI behavior, migration ownership, public exports, config options, and storage formats are unchanged.

## Evidence

The existing cache test still protects the original failed-read regression from #83944. Removing only its environment workaround against the old implementation failed exactly as expected:

```text
retries the cached config snapshot after a read rejection
expected "vi.fn()" to be called 2 times, but got 3 times
Tests  1 failed | 84 passed (85)
```

After removing the production test-mode exception, all 191 cases across the same eight CLI files passed before and after. This includes the real node-worker bootstrap tests, command bootstrap, preaction output/agent ownership, route selection, and cold-import checks.

```sh
env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs \
  src/cli/program/config-guard.test.ts src/cli/node-worker-bootstrap.test.ts \
  src/cli/command-bootstrap.test.ts src/cli/program/preaction.test.ts \
  src/cli/program/preaction-agent-owner.test.ts src/cli/program/preaction-output-mode.test.ts \
  src/cli/route.test.ts src/cli/channels-status-cold-imports.test.ts
```

```text
Before: Test Files 8 passed (8); Tests 191 passed (191)
After:  Test Files 8 passed (8); Tests 191 passed (191)
```

Targeted formatting and diff checks passed. The full normal `check-changed` command completed successfully, including production/test typechecks, dead-export checks, lint, and the remaining structural guards. The source hashes were unchanged throughout the gate. Fresh independent Codex review found no actionable findings through P2.

```sh
env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- \
  src/cli/program/config-guard.ts src/cli/program/config-guard.test.ts
```

```text
Full changed gate: exit 0; source unchanged
Independent review: scoped-clean through P2
```

### Mechanical refresh

Signed commit `f1e7c4c3d84c8f2a4cf7a2e9be0948cd04527948` rebases the same two-file change onto `7b0fc05505aaa4856ab1e19469c6eb0a5929c3f0`. Its complete patch and both afterimages are byte-identical to the reviewed `8601a930`; the config cache/read owners, CLI bootstrap callers, test files, and dependency manifests/lockfile are unchanged. No second full changed gate is claimed for this mechanical refresh.

The [previous exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33669544114) completed with one primary failure: the unrelated Gateway CLI test exceeded the 1,000-line limit. The new base includes the canonical [CLI test split](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c); refreshed exact-head CI is required. No old workflow was rerun.

### Real configuration-backed bootstrap proof

At refreshed head `f1e7c4c3`, a standalone Node process invoked the production `ensureCliCommandBootstrap` with real config files and the ordinary config reader. No Vitest runner, I/O mocks, module replacements, or injected reader were used. Both a normal environment and a separate `VITEST=true` process passed the same sequence on macOS arm64 / Node v26.5.0.

The fixture removes its own working directory while selecting a relative state path. The resulting real `ENOENT/uv_cwd` exception is recorded through `readConfigFileSnapshot → getConfigSnapshot → ensureConfigReady → ensureCliCommandBootstrap`. Restoring the working directory and absolute fixture state path lets the **same process** recover. This is a config-path-resolution failure, not an invented disk-read errno or a claim that normal CLI behavior was broken.

After recovery, rewriting the real config from port 18789 to 18790 leaves the observing bootstrap at 18789 (cached), a `logs` diagnostic sees 18790 (fresh), and the next observing bootstrap returns 18789 (the diagnostic did not replace its cache). This closes the requested real configuration-I/O proof; the existing failed-read regression and 191-case suite retain the focused fault and sibling coverage. No Gateway server, credential, or user-owned profile was involved. Both processes exited 0 and their owned database handles closed.

<details>
<summary>Standalone proof source and observed terminal output</summary>

Save the following as `proof.mjs`, then run from the repository root with a fresh temporary profile (repeat with `VITEST=true` for environment parity):

```sh
fixture="$(mktemp -d "${TMPDIR:-/tmp}/d409-config-bootstrap-XXXXXXXX")"
env -i PATH="$PATH" HOME="$fixture" OPENCLAW_HOME="$fixture" \
  OPENCLAW_STATE_DIR="$fixture/state-owner" \
  OPENCLAW_CONFIG_PATH="$fixture/state-owner/openclaw.json" NO_COLOR=1 \
  node --import ./scripts/tsx.mjs /path/to/proof.mjs "$PWD"
```

```js
import assert from 'node:assert/strict';
import fs from 'node:fs';
import path from 'node:path';
import { pathToFileURL } from 'node:url';
Error.stackTraceLimit = 30;

const root = process.argv[2];
const fixture = process.env.HOME;
assert(fixture.includes('d409-config-bootstrap-'));
const load = (p) => import(pathToFileURL(path.join(root, p)).href);
const { closeOpenClawStateDatabaseByPath } = await load('src/state/openclaw-state-db.ts');
const { resolveOpenClawStateSqlitePath } = await load('src/state/openclaw-state-db.paths.ts');
const { ensureCliCommandBootstrap } = await load('src/cli/command-bootstrap.ts');
const { getRuntimeConfigSourceSnapshot } = await load('src/config/config.ts');
const { createNonExitingRuntime } = await load('src/runtime.ts');
await load('src/cli/program/config-guard.ts');
const stateDb = resolveOpenClawStateSqlitePath();
const configPath = process.env.OPENCLAW_CONFIG_PATH;
const runtime = createNonExitingRuntime();
const writeConfig = (port) => fs.writeFileSync(configPath, JSON.stringify({
  gateway: { mode: 'local', port },
  plugins: { enabled: false },
})+'\n');
const bootstrap = (commandPath) => ensureCliCommandBootstrap({ runtime, commandPath, loadPlugins: false });
const records = [];
fs.mkdirSync(path.dirname(configPath), {recursive:true});
writeConfig(18789);
try {
  const removedCwd = path.join(fixture,'removed-cwd');
  fs.mkdirSync(removedCwd);
  process.chdir(removedCwd);
  fs.rmdirSync(removedCwd);
  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
  process.env.OPENCLAW_STATE_DIR='state-owner';
  let rejected;
  try { await bootstrap(['health']); } catch(error) { rejected=error; }
  assert.equal(rejected?.code, 'ENOENT');
  assert.match(rejected.message, /uv_cwd/);
  fs.writeFileSync(path.join(fixture,'initial-error-stack.txt'),rejected.stack+'\n');
  assert.match(rejected.stack, /readConfigFileSnapshot/);
  assert.match(rejected.stack, /getConfigSnapshot/);
  records.push({stage:'config snapshot rejects on removed working directory',errorCode:rejected.code,syscall:rejected.syscall});
  process.chdir(fixture);
  process.env.OPENCLAW_STATE_DIR=originalStateDir;
  await bootstrap(['health']);
  assert.equal(getRuntimeConfigSourceSnapshot()?.gateway?.port,18789);
  records.push({stage:'same-process bootstrap recovery with real config file',port:18789});
  writeConfig(18790);
  await bootstrap(['health']);
  assert.equal(getRuntimeConfigSourceSnapshot()?.gateway?.port,18789);
  records.push({stage:'observing bootstrap reuses original snapshot',diskPort:18790,runtimePort:18789});
  await bootstrap(['logs']);
  assert.equal(getRuntimeConfigSourceSnapshot()?.gateway?.port,18790);
  records.push({stage:'non-observing diagnostic reads updated file',runtimePort:18790});
  await bootstrap(['health']);
  assert.equal(getRuntimeConfigSourceSnapshot()?.gateway?.port,18789);
  records.push({stage:'diagnostic read did not replace observing cache',runtimePort:18789});
  console.log(JSON.stringify({node:process.version,vitestEnvironment:process.env.VITEST??null,records},null,2));
} finally {
  process.chdir(root);
  closeOpenClawStateDatabaseByPath(stateDb);
}
```

Observed output with `VITEST` absent (exit 0):

```json
{
  "node": "v26.5.0",
  "vitestEnvironment": null,
  "records": [
    {
      "stage": "config snapshot rejects on removed working directory",
      "errorCode": "ENOENT",
      "syscall": "uv_cwd"
    },
    {
      "stage": "same-process bootstrap recovery with real config file",
      "port": 18789
    },
    {
      "stage": "observing bootstrap reuses original snapshot",
      "diskPort": 18790,
      "runtimePort": 18789
    },
    {
      "stage": "non-observing diagnostic reads updated file",
      "runtimePort": 18790
    },
    {
      "stage": "diagnostic read did not replace observing cache",
      "runtimePort": 18789
    }
  ]
}
```

The separate `VITEST=true` run returned the same five records and exit 0. The captured stack included the exact cache owner and caller; fixture source hashes remained unchanged.

</details>
