### PR TITLE
fix(update): prevent stale config chunk failure after source rebuild

### DIFF
--- a/src/cli/update-cli/update-execution.runtime.test.ts
+++ b/src/cli/update-cli/update-execution.runtime.test.ts
@@ -1,0 +1,20 @@
+import { expect, it, vi } from "vitest";
+
+const configWriterLoaded = vi.hoisted(() => vi.fn());
+
+vi.mock("../../config/io.write.js", () => {
+  configWriterLoaded();
+  return {};
+});
+
+vi.mock("./update-command-execution.js", () => ({ executeMutableUpdate: vi.fn() }));
+vi.mock("./update-command-post-update.js", () => ({ finishUpdate: vi.fn() }));
+vi.mock("./update-command-resume.js", () => ({ resumePostCoreUpdate: vi.fn() }));
+
+it("loads the config writer before update execution can replace hashed chunks", async () => {
+  expect(configWriterLoaded).not.toHaveBeenCalled();
+
+  await import("./update-execution.runtime.js");
+
+  expect(configWriterLoaded).toHaveBeenCalledOnce();
+});

--- a/src/cli/update-cli/update-execution.runtime.ts
+++ b/src/cli/update-cli/update-execution.runtime.ts
@@ -1,4 +1,8 @@
 // Planning stays light; load this whole surface before replacing the installed package.
+// Config writes are lazy for ordinary CLI startup, but update finalization can first write
+// after a rebuild removes the old hashed chunk. Preload that closure before mutation.
+import "../../config/io.write.js";
+
 export { executeMutableUpdate } from "./update-command-execution.js";
 export { finishUpdate } from "./update-command-post-update.js";
 export { resumePostCoreUpdate } from "./update-command-resume.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a source-checkout update could complete the checkout and build, then fail during post-update plugin/config processing with `ENOENT` for a deleted hashed `dist/io.write-*.js` chunk.

## Why This Change Was Made

The update runtime already loads its mutation/finalization closure before replacing build output. Config writing became lazy in #131503, leaving its hashed chunk outside that protected closure; a clean rebuild could delete the old file before the running updater's first config write. This change includes the config writer in the existing update-only preload boundary while preserving lazy loading for ordinary CLI startup.

Regression provenance: `4ee2216cd76b` / #131503, merged 2026-08-29. The reporter's rebuilt checkout contained `dist/io.write-CmAYV6f4.js`, while the still-running updater requested the pre-build `dist/io.write-HO5dwJY-.js`.

## User Impact

Source-checkout updates can finish plugin/config convergence after a clean rebuild without failing on a stale hashed config-writer path.

## Evidence

- Regression test fails before the production change with writer preload count `0`, then passes after the fix:
  - `node scripts/run-vitest.mjs src/cli/update-cli/update-execution.runtime.test.ts`
- `pnpm build` passes.
- Built `dist/update-execution.runtime-*.js` now eagerly imports its generated `io.write-*.js` chunk before update mutation.
- `node scripts/check-changed.mjs -- src/cli/update-cli/update-execution.runtime.ts src/cli/update-cli/update-execution.runtime.test.ts` passes.
- Independent autoreview: scoped clean at P0-P2.
- Production LOC: +4/-0 (preload + invariant comment). Tests: +20/-0.

Best-fix verdict: this is the existing lifecycle owner's preload boundary. Making config writes globally eager would regress ordinary CLI startup, retaining stale build files would weaken clean-build correctness, and adding stable aliases for arbitrary hashed chunks would create a parallel compatibility path.
