### PR TITLE
fix(agents): prefer configured identity in CLI summaries

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -37,6 +37,10 @@ openclaw agents delete work
 
 Options: `--json`, `--bindings` (include full routing rules, not only per-agent counts/summaries).
 
+Identity fields saved in config take precedence. Fields that are not configured
+fall back to `IDENTITY.md` in the agent's workspace. Unsupported avatar values
+and unreadable local images also fall back to the workspace avatar.
+
 ### `agents add [name]`
 
 Options: `--workspace <dir>`, `--model <id>`, `--agent-dir <dir>`, `--bind <channel[:accountId]>` (repeatable), `--non-interactive`, `--json`.

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -145,7 +145,7 @@ function parseIdentityMarkdown(content: string): AgentIdentityFile {
 }
 
 /** Return true when the parsed identity has any meaningful user-supplied value. */
-export function identityHasValues(identity: AgentIdentityFile): boolean {
+function identityHasValues(identity: AgentIdentityFile): boolean {
   return Boolean(
     identity.name ||
     identity.emoji ||

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,6 +111,15 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
+async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
+  const root = tempDirs.make(`openclaw-${label}-`);
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify({ gateway }));
+  return { root, stateDir, configPath };
+}
+
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -185,20 +194,11 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
-    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: gateway.token },
-        },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
+      mode: "remote",
+      remote: { url: gateway.url, token: gateway.token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,16 +279,12 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
-      const root = tempDirs.make("openclaw-nodes-timeout-");
-      const stateDir = path.join(root, "state");
-      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
-      );
+      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
+        mode: "remote",
+        remote: { url: gateway.url, token },
+      });
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -315,18 +311,12 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-cli-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: { mode: "remote", remote: { url: gateway.url, token } },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
+      mode: "remote",
+      remote: { url: gateway.url, token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -344,22 +334,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -394,15 +380,11 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-explicit-auth",
+      { mode: "remote", remote: { url: gateway.url, token } },
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -421,22 +403,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -736,19 +714,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remtoe",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-invalid-config",
+      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({
@@ -1006,19 +975,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
-    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-rate-limit-json",
+      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,15 +111,6 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
-async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
-  const root = tempDirs.make(`openclaw-${label}-`);
-  const stateDir = path.join(root, "state");
-  const configPath = path.join(stateDir, "openclaw.json");
-  await fs.mkdir(stateDir, { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify({ gateway }));
-  return { root, stateDir, configPath };
-}
-
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -194,11 +185,20 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
+    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
-      mode: "remote",
-      remote: { url: gateway.url, token: gateway.token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: gateway.token },
+        },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,12 +279,16 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
+      const root = tempDirs.make("openclaw-nodes-timeout-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
-        mode: "remote",
-        remote: { url: gateway.url, token },
-      });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+      );
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -311,12 +315,18 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-cli-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
-      mode: "remote",
-      remote: { url: gateway.url, token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "remote", remote: { url: gateway.url, token } },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -334,18 +344,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -380,11 +394,15 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-explicit-auth",
-      { mode: "remote", remote: { url: gateway.url, token } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -403,18 +421,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -714,10 +736,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-invalid-config",
-      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remtoe",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({
@@ -975,10 +1006,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
+    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-rate-limit-json",
-      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -8,7 +8,11 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { loadAgentIdentityFromFile } from "../agents/identity-file.js";
+import {
+  type AgentIdentityFile,
+  loadAgentIdentityFromFile,
+  loadAgentIdentityFromWorkspace,
+} from "../agents/identity-file.js";
 import { DEFAULT_IDENTITY_FILENAME } from "../agents/workspace.js";
 import { ExpectedCliError } from "../cli/failure-output.js";
 import { replaceConfigFile } from "../config/config.js";
@@ -20,12 +24,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
-import {
-  type AgentIdentity,
-  findAgentEntryIndex,
-  listAgentEntries,
-  loadAgentIdentity,
-} from "./agents.config.js";
+import { findAgentEntryIndex, listAgentEntries } from "./agents.config.js";
 import { requireValidConfigFileSnapshot } from "./config-validation.js";
 
 type AgentsSetIdentityOptions = {
@@ -130,7 +129,7 @@ export async function agentsSetIdentityCommand(
   const list = listAgentEntries(cfg);
   const index = findAgentEntryIndex(list, resolvedAgentId);
 
-  let identityFromFile: AgentIdentity | null = null;
+  let identityFromFile: AgentIdentityFile | null = null;
   if (wantsIdentityFile) {
     if (identityFilePath) {
       try {
@@ -139,7 +138,7 @@ export async function agentsSetIdentityCommand(
         failAgentIdentity(formatErrorMessage(error));
       }
     } else if (workspaceDir) {
-      identityFromFile = loadAgentIdentity(workspaceDir);
+      identityFromFile = loadAgentIdentityFromWorkspace(workspaceDir);
     }
     if (!identityFromFile) {
       const targetPath =

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -201,6 +201,68 @@ describe("agentsListCommand", () => {
     ]);
   });
 
+  it.each([
+    {
+      label: "configured",
+      identity: {
+        name: " Chosen Identity ",
+        emoji: "🦉",
+        avatar: "https://example.invalid/new.png",
+      },
+      expected: {
+        identityName: "Chosen Identity",
+        identityEmoji: "🦉",
+        identityAvatarUrl: "https://example.invalid/new.png",
+        identitySource: "config",
+      },
+    },
+    {
+      label: "partially configured",
+      identity: { name: "Chosen Identity" },
+      expected: {
+        identityName: "Chosen Identity",
+        identityEmoji: "🦞",
+        identityAvatarUrl: "https://example.invalid/workspace.png",
+        identitySource: "config",
+      },
+    },
+    ...[
+      { label: "workspace-only", identity: undefined },
+      { label: "blank configured", identity: { name: " ", emoji: "\t", avatar: " " } },
+      { label: "unsupported configured avatar", identity: { avatar: "slack://avatar.png" } },
+    ].map(({ label, identity }) => ({
+      label,
+      identity,
+      expected: {
+        identityName: "Workspace Identity",
+        identityEmoji: "🦞",
+        identityAvatarUrl: "https://example.invalid/workspace.png",
+        identitySource: "identity",
+      },
+    })),
+  ])("lists $label identity values with workspace fallback", async ({ identity, expected }) => {
+    await withTestDir({ prefix: "openclaw-agent-identity-list-" }, async (workspace) => {
+      const identityPath = path.join(workspace, "IDENTITY.md");
+      const identityFile =
+        "# Identity\n\n- Name: Workspace Identity\n- Emoji: 🦞\n- Avatar: https://example.invalid/workspace.png\n";
+      fs.writeFileSync(identityPath, identityFile);
+      requireValidConfigMock.mockResolvedValue({
+        agents: { entries: { proof: { workspace, identity } } },
+      } satisfies OpenClawConfig);
+      const jsonRuntime = createRuntime();
+      await agentsListCommand({ json: true }, jsonRuntime);
+      expect(jsonRuntime.json[0]).toEqual([expect.objectContaining(expected)]);
+
+      const textRuntime = createRuntime();
+      await agentsListCommand({}, textRuntime);
+      const source = expected.identitySource === "config" ? "config" : "IDENTITY.md";
+      expect(vi.mocked(textRuntime.log).mock.calls.flat().join("\n")).toContain(
+        `Identity: ${expected.identityEmoji} ${expected.identityName} (${source})`,
+      );
+      expect(fs.readFileSync(identityPath, "utf8")).toBe(identityFile);
+    });
+  });
+
   it("sanitizes configured agent text without changing JSON summaries", async () => {
     const control = "\u001B]0;agents-list-injection\u0007";
     const identityName = `${control}Operator 🦞\r\nforged-row`;

--- a/src/commands/agents.config.ts
+++ b/src/commands/agents.config.ts
@@ -6,14 +6,14 @@ import {
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   listAgentEntries,
+  resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   tryResolveLegacyCompatibilityAgentId,
   toAgentEntriesRecord,
 } from "../agents/agent-scope.js";
 import { resolveAgentAvatarUrlFromSource } from "../agents/identity-avatar-file.js";
-import type { AgentIdentityFile } from "../agents/identity-file.js";
-import { identityHasValues, loadAgentIdentityFromWorkspace } from "../agents/identity-file.js";
+import { loadAgentIdentityFromWorkspace } from "../agents/identity-file.js";
 import { pinLegacyInheritedAuthOwnerForRosterTransition } from "../agents/legacy-inherited-auth-dir.js";
 import { pinSurvivorWorkspaceForRosterCollapse } from "../config/agent-workspace-roster-transition.js";
 import { listRouteBindings } from "../config/bindings.js";
@@ -43,33 +43,12 @@ export type AgentSummary = {
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
 
-export type AgentIdentity = AgentIdentityFile;
 export { listAgentEntries };
 
 /** Find a configured agent entry by normalized id. */
 export function findAgentEntryIndex(list: AgentEntry[], agentId: string): number {
   const id = normalizeAgentId(agentId);
   return list.findIndex((entry) => normalizeAgentId(entry.id) === id);
-}
-
-function resolveAgentModel(cfg: OpenClawConfig, agentId: string) {
-  const entry = listAgentEntries(cfg).find(
-    (agent) => normalizeAgentId(agent.id) === normalizeAgentId(agentId),
-  );
-  const entryPrimary = resolvePrimaryStringValue(entry?.model);
-  if (entryPrimary) {
-    return entryPrimary;
-  }
-  return resolvePrimaryStringValue(cfg.agents?.defaults?.model);
-}
-
-/** Load non-empty identity metadata from a workspace identity file. */
-export function loadAgentIdentity(workspace: string): AgentIdentity | null {
-  const parsed = loadAgentIdentityFromWorkspace(workspace);
-  if (!parsed) {
-    return null;
-  }
-  return identityHasValues(parsed) ? parsed : null;
 }
 
 /** Build config-derived summaries for text/JSON agent listing. */
@@ -92,33 +71,27 @@ export function buildAgentSummaries(cfg: OpenClawConfig): AgentSummary[] {
 
   return ordered.map((id) => {
     const workspace = resolveAgentWorkspaceDir(cfg, id);
-    const identity = loadAgentIdentity(workspace);
-    const configIdentity = configuredAgents.find(
-      (agent) => normalizeAgentId(agent.id) === id,
-    )?.identity;
-    const identityName = identity?.name ?? configIdentity?.name?.trim();
-    const identityEmoji = identity?.emoji ?? configIdentity?.emoji?.trim();
-    const identityAvatarUrl = resolveAgentAvatarUrlFromSource(
-      cfg,
-      id,
-      identity?.avatar ?? configIdentity?.avatar,
-    );
-    const identitySource = identity
-      ? "identity"
-      : configIdentity && (identityName || identityEmoji || identityAvatarUrl)
-        ? "config"
-        : undefined;
+    const identity = loadAgentIdentityFromWorkspace(workspace);
+    const agentConfig = resolveAgentConfig(cfg, id);
+    const configName = normalizeOptionalString(agentConfig?.identity?.name);
+    const configEmoji = normalizeOptionalString(agentConfig?.identity?.emoji);
+    const configAvatarUrl = resolveAgentAvatarUrlFromSource(cfg, id, agentConfig?.identity?.avatar);
+    // Validate each avatar before choosing so a stale path cannot hide the workspace image.
+    const identityAvatarUrl =
+      configAvatarUrl ?? resolveAgentAvatarUrlFromSource(cfg, id, identity?.avatar);
+    const identitySource =
+      configName || configEmoji || configAvatarUrl ? "config" : identity ? "identity" : undefined;
     const summary: AgentSummary = {
       id,
-      name: normalizeOptionalString(
-        configuredAgents.find((agent) => normalizeAgentId(agent.id) === id)?.name,
-      ),
-      identityName,
-      identityEmoji,
+      name: normalizeOptionalString(agentConfig?.name),
+      identityName: configName ?? identity?.name,
+      identityEmoji: configEmoji ?? identity?.emoji,
       identitySource,
       workspace,
       agentDir: resolveAgentDir(cfg, id),
-      model: resolveAgentModel(cfg, id),
+      model:
+        resolvePrimaryStringValue(agentConfig?.model) ??
+        resolvePrimaryStringValue(cfg.agents?.defaults?.model),
       bindings: bindingCounts.get(id) ?? 0,
       isDefault: defaultAgentId !== undefined && id === normalizeAgentId(defaultAgentId),
     };

--- a/src/gateway/assistant-identity.ts
+++ b/src/gateway/assistant-identity.ts
@@ -4,8 +4,8 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { loadAgentIdentityFromWorkspace } from "../agents/identity-file.js";
 import { resolveAgentIdentity } from "../agents/identity.js";
-import { loadAgentIdentity } from "../commands/agents.config.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -117,7 +117,7 @@ export function resolveAssistantIdentity(params: {
   const agentId = resolveAssistantAgentId(params.cfg, params.agentId);
   const workspaceDir = params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, agentId);
   const agentIdentity = resolveAgentIdentity(params.cfg, agentId);
-  const fileIdentity = workspaceDir ? loadAgentIdentity(workspaceDir) : null;
+  const fileIdentity = workspaceDir ? loadAgentIdentityFromWorkspace(workspaceDir) : null;
 
   const agentName = normalizeIdentityValue("name", agentIdentity?.name);
   const fileName = normalizeIdentityValue("name", fileIdentity?.name);


### PR DESCRIPTION
## Summary

Fixes #136536.

After agents set-identity succeeded, agents list could still show the old IDENTITY.md name, emoji and avatar. The summary builder now reads one canonical resolved agent config and prefers each usable configured field. Unset fields retain workspace fallback, and an unsupported avatar URI or unreadable local image cannot hide a valid workspace avatar.

The refactor deletes repeated roster scans, a duplicate identity-loader wrapper/type alias, and the Gateway's dependency on the command layer. The file loader already validates meaningful identity values, so its now-unused internal predicate export becomes private. Configuration writers, Gateway normalization/truncation, schema and persistence are unchanged.

Production **+29 / −57 = -28 LOC**; tests/support **+62 / −0 = +62**; docs **+4**.

## Validation

The actual compiled CLI ran set-identity → list JSON → config get → list human against the same synthetic workspace.

| Readback | Before | After |
| --- | --- | --- |
| set-identity and config get | Chosen Identity / 🦉 / chosen.png | Same |
| agents list --json | Workspace Identity / 🦞 / workspace.png | Chosen Identity / 🦉 / chosen.png |
| Human listing | Identity: 🦞 Workspace Identity (IDENTITY.md) | Identity: 🦉 Chosen Identity (config) |
| IDENTITY.md bytes | Unchanged | Unchanged |

Two regression cases fail before the repair. Afterward83 tests across six owner/sibling files pass, with one existing Windows-only skip. Coverage includes partial/blank identities, invalid-avatar fallback, normalized roster lookup, model defaults, file loaders and Gateway identity. Both qaRuntime builds complete their postbuild phases and53 native checks.

The final unused-export cleanup preserves the function body and both local callers;13 loader tests were rerun afterward. The final full changed-file gate and fresh independent Codex P2 review pass on the six frozen files. Root inspected the complete owners/callers, actual CLI output, stable source and current-main owner equality. First introduction is unknown; the historical command split already carried this behavior.

This changes readback of existing configuration only; no new setting, identity authority, persistence rule or migration is added.

## Shared CI fixture follow-up

The temporary Gateway CLI fixture cleanup has been removed because [main already owns the canonical test split](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c). The cumulative PR no longer changes that file. The exact three-way file merge matches main byte for byte, retaining the health/transport cases, Linux socat case and cleanup hooks; typed lint and an independent Codex P2 review pass. No product issue or production deletion is credited to this reconciliation.

Fresh scoped typed lint/format checks and independent Codex P2 review pass. Shared review reuse is limited to identical before/after files and owner context. These CI repairs add no counted product issue.

## Current-main CI refresh

A tree-identical CI refresh retains the complete reviewed source and proof. Earlier checks ran before the canonical main test split and CI runner/dependency acquisition fixes; the new PR event rebuilds the current merge ref through the normal required checks. There are no source, test, configuration or production-LOC changes in this refresh.

## Final review disposition

The final maintainer review accepts configured identity precedence in the shared summary owner, with validated per-field workspace fallback and unchanged stored configuration/workspace bytes. Current-main owner comparison confirms the original defect remains; the compiled set-identity/list sequence and sibling Gateway coverage establish the behavior.

Required [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33680880520/job/100427309176) passed for `261f00f481bafc500df2321bb9affd7467acce6a`. Production owners are unchanged on main `31ed57e3953152fa826a444e742b3c0ec5149961` since the reproduced baseline, and the complete PR composes cleanly. The latest ClawSweeper review and its rank-up requests have been addressed; no actionable code finding remains.
