### PR TITLE
fix(channels): keep capability timeout reports alive

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -238,6 +238,7 @@ Notes:
 
 - `--channel` is optional; omit it to list every channel (including plugin-provided channels).
 - `--account` is only valid with `--channel`.
+- Each account probe and diagnostics step has its own timeout. A stalled step is reported in both text and JSON output, and the command continues with the remaining accounts.
 - `--target` accepts `channel:<id>` or a raw numeric channel id and only applies to Discord. For Discord voice channels, the permission check flags missing `ViewChannel`, `Connect`, `Speak`, `SendMessages`, and `ReadMessageHistory`.
 - Probes are provider-specific: Discord bot identity + intents plus optional channel permissions; Slack bot + user scopes; Telegram bot flags + webhook; Signal daemon version; Microsoft Teams app token + Graph roles/scopes (annotated where known). Channels without probes report `Probe: unavailable`.
 

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,6 +111,15 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
+async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
+  const root = tempDirs.make(`openclaw-${label}-`);
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify({ gateway }));
+  return { root, stateDir, configPath };
+}
+
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -185,20 +194,11 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
-    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: gateway.token },
-        },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
+      mode: "remote",
+      remote: { url: gateway.url, token: gateway.token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,16 +279,12 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
-      const root = tempDirs.make("openclaw-nodes-timeout-");
-      const stateDir = path.join(root, "state");
-      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
-      );
+      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
+        mode: "remote",
+        remote: { url: gateway.url, token },
+      });
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -315,18 +311,12 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-cli-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: { mode: "remote", remote: { url: gateway.url, token } },
-      }),
-    );
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
+      mode: "remote",
+      remote: { url: gateway.url, token },
+    });
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -344,22 +334,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -394,15 +380,11 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-explicit-auth",
+      { mode: "remote", remote: { url: gateway.url, token } },
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -421,22 +403,18 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
-    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-call-stored-auth",
+      { mode: "remote", remote: { url: gateway.url } },
+    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
-    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -736,19 +714,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
-    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remtoe",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "node-pairing-invalid-config",
+      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({
@@ -1006,19 +975,10 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
-    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({
-        gateway: {
-          mode: "remote",
-          remote: { url: gateway.url, token: "test-token" },
-        },
-      }),
+    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
+      "gateway-rate-limit-json",
+      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -111,15 +111,6 @@ async function prepareUnreachableGatewayCliFixture(params: {
   return { root, stateDir, configPath };
 }
 
-async function prepareGatewayCliFixture(label: string, gateway: Record<string, unknown>) {
-  const root = tempDirs.make(`openclaw-${label}-`);
-  const stateDir = path.join(root, "state");
-  const configPath = path.join(stateDir, "openclaw.json");
-  await fs.mkdir(stateDir, { recursive: true });
-  await fs.writeFile(configPath, JSON.stringify({ gateway }));
-  return { root, stateDir, configPath };
-}
-
 function expectUnreachableGatewayTransportFailure(
   result: Awaited<ReturnType<typeof runIsolatedGatewayCli>>,
   output: "json" | "text",
@@ -194,11 +185,20 @@ describe("gateway-backed CLI process exit", () => {
     { status: "ok" as const, text: "pong", exitCode: 0 },
     { status: "error" as const, text: "provider failed", exitCode: 1 },
   ])("exits $exitCode after an agent turn reports $status", async ({ status, text, exitCode }) => {
+    const root = tempDirs.make(`openclaw-agent-turn-${status}-`);
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startAgentTurnGateway({ status, text });
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(`agent-turn-${status}`, {
-      mode: "remote",
-      remote: { url: gateway.url, token: gateway.token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: gateway.token },
+        },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["agent", "--agent", "main", "--message", "ping", "--json"],
@@ -279,12 +279,16 @@ describe("gateway-backed CLI process exit", () => {
   ])(
     "validates a $label nodes timeout before opening a Gateway connection",
     async ({ timeout, valid }) => {
+      const root = tempDirs.make("openclaw-nodes-timeout-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
       const token = "test-token";
       const gateway = await startNodePairingGateway(token);
-      const { root, stateDir, configPath } = await prepareGatewayCliFixture("nodes-timeout", {
-        mode: "remote",
-        remote: { url: gateway.url, token },
-      });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+      );
 
       const result = await runIsolatedGatewayCli({
         args: ["nodes", "list", "--timeout", timeout, "--json"],
@@ -311,12 +315,18 @@ describe("gateway-backed CLI process exit", () => {
   );
 
   it("dispatches node pairing mutations without opening the writable state database", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-cli-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "test-token";
     const gateway = await startNodePairingGateway(token);
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture("node-pairing-cli", {
-      mode: "remote",
-      remote: { url: gateway.url, token },
-    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: { mode: "remote", remote: { url: gateway.url, token } },
+      }),
+    );
 
     const result = await runIsolatedGatewayCli({
       args: ["nodes", "approve", "request-1", "--json"],
@@ -334,18 +344,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("uses existing device auth without persisting a hello-issued token or coordinator state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startNodePairingGateway(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -380,11 +394,15 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with explicit auth without creating shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-explicit-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const token = "configured-token";
     const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-explicit-auth",
-      { mode: "remote", remote: { url: gateway.url, token } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
     );
     expect(await snapshotSharedStateArtifacts(stateDir)).toEqual({});
 
@@ -403,18 +421,22 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("calls a reachable Gateway with stored auth without changing shared state", async () => {
+    const root = tempDirs.make("openclaw-gateway-call-stored-auth-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const storedToken = "stored-device-token";
     const gateway = await startGatewayStabilityRpcServer(storedToken, "issued-device-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-call-stored-auth",
-      { mode: "remote", remote: { url: gateway.url } },
-    );
     const stateEnv = {
       ...process.env,
       HOME: root,
       OPENCLAW_HOME: root,
       OPENCLAW_STATE_DIR: stateDir,
     };
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url } } }),
+    );
     const identity = loadOrCreateDeviceIdentity({ env: stateEnv });
     storeOriginDeviceToken({
       gatewayScope: gatewayOriginScope(gateway.url),
@@ -714,10 +736,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("rejects invalid remote config before a node pairing mutation without opening state", async () => {
+    const root = tempDirs.make("openclaw-node-pairing-invalid-config-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startNodePairingGateway("test-token");
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "node-pairing-invalid-config",
-      { mode: "remtoe", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remtoe",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({
@@ -975,10 +1006,19 @@ describe("gateway-backed CLI process exit", () => {
   });
 
   it("preserves pre-hello rate-limit details through the real health entry point", async () => {
+    const root = tempDirs.make("openclaw-gateway-rate-limit-json-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
     const gateway = await startRateLimitedGateway();
-    const { root, stateDir, configPath } = await prepareGatewayCliFixture(
-      "gateway-rate-limit-json",
-      { mode: "remote", remote: { url: gateway.url, token: "test-token" } },
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "remote",
+          remote: { url: gateway.url, token: "test-token" },
+        },
+      }),
     );
 
     const result = await runIsolatedGatewayCli({

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -26,6 +26,7 @@ import { getRuntimeConfig, type OpenClawConfig } from "../../config/config.js";
 import { danger } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { ABSOLUTE_DEADLINE_EXPIRED, awaitWithinDeadline } from "../../utils/absolute-deadline.js";
 import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
 import { requireValidConfigFileSnapshot } from "../config-validation.js";
 import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
@@ -55,55 +56,22 @@ type ChannelCapabilitiesReport = {
 
 const CHANNEL_CAPABILITIES_TIMEOUT_MAX_MS = 30_000;
 
-type ChannelCapabilitiesStepResult<T> =
-  | { kind: "value"; value: T }
-  | { kind: "error"; error: unknown }
-  | { kind: "timeout" };
-
-function resolveChannelCapabilitiesTimeoutMs(timeoutMs: number) {
-  return Math.min(timeoutMs, CHANNEL_CAPABILITIES_TIMEOUT_MAX_MS);
-}
-
-async function raceChannelCapabilitiesStep<T>(params: {
-  timeoutMs: number;
-  run: () => Promise<T> | T;
-}): Promise<ChannelCapabilitiesStepResult<T>> {
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<ChannelCapabilitiesStepResult<T>>((resolve) => {
-    timeout = setTimeout(() => resolve({ kind: "timeout" }), params.timeoutMs);
-    timeout.unref?.();
-  });
-  const resultPromise: Promise<ChannelCapabilitiesStepResult<T>> = Promise.resolve()
-    .then(params.run)
-    .then(
-      (value): ChannelCapabilitiesStepResult<T> => ({ kind: "value", value }),
-      (error: unknown): ChannelCapabilitiesStepResult<T> => ({ kind: "error", error }),
-    );
-  const result = await Promise.race([resultPromise, timeoutPromise]);
-  if (timeout) {
-    clearTimeout(timeout);
-  }
-  return result;
-}
-
+// These CLI waits need a referenced deadline so stalled plugins still produce a report.
 async function runChannelCapabilitiesProbe(params: {
   timeoutMs: number;
   run: () => unknown;
 }): Promise<unknown> {
-  const result = await raceChannelCapabilitiesStep(params);
-  switch (result.kind) {
-    case "value":
-      return result.value;
-    case "timeout":
-      return {
-        ok: false,
-        timedOut: true,
-        error: `probe timed out after ${params.timeoutMs}ms`,
-      };
-    case "error":
-      return { ok: false, error: formatErrorMessage(result.error) };
+  try {
+    const result = await awaitWithinDeadline(
+      async () => params.run(),
+      Date.now() + params.timeoutMs,
+    );
+    return result === ABSOLUTE_DEADLINE_EXPIRED
+      ? { ok: false, timedOut: true, error: `probe timed out after ${params.timeoutMs}ms` }
+      : result;
+  } catch (error) {
+    return { ok: false, error: formatErrorMessage(error) };
   }
-  return undefined;
 }
 
 async function runChannelCapabilitiesDiagnostics(params: {
@@ -113,31 +81,22 @@ async function runChannelCapabilitiesDiagnostics(params: {
     | ChannelCapabilitiesDiagnostics
     | undefined;
 }): Promise<ChannelCapabilitiesDiagnostics | undefined> {
-  const result = await raceChannelCapabilitiesStep(params);
-  switch (result.kind) {
-    case "value":
-      return result.value;
-    case "timeout":
-      return {
-        lines: [
-          {
-            text: `Diagnostics: timed out after ${params.timeoutMs}ms`,
-            tone: "error",
-          },
-        ],
-        details: { timedOut: true },
-      };
-    case "error":
-      return {
-        lines: [
-          {
-            text: `Diagnostics: failed (${formatErrorMessage(result.error)})`,
-            tone: "error",
-          },
-        ],
-      };
+  try {
+    const result = await awaitWithinDeadline(
+      async () => params.run(),
+      Date.now() + params.timeoutMs,
+    );
+    return result === ABSOLUTE_DEADLINE_EXPIRED
+      ? {
+          lines: [{ text: `Diagnostics: timed out after ${params.timeoutMs}ms`, tone: "error" }],
+          details: { timedOut: true },
+        }
+      : result;
+  } catch (error) {
+    return {
+      lines: [{ text: `Diagnostics: failed (${formatErrorMessage(error)})`, tone: "error" }],
+    };
   }
-  return undefined;
 }
 
 function formatSupport(capabilities?: ChannelCapabilities) {
@@ -322,8 +281,9 @@ export async function channelsCapabilitiesCommand(
     return;
   }
   let cfg = await resolveCapabilitiesRuntimeConfig(configSnapshot.config, runtime);
-  const timeoutMs = resolveChannelCapabilitiesTimeoutMs(
+  const timeoutMs = Math.min(
     parseTimeoutMsWithFallback(opts.timeout, 10_000, { invalidType: "error" }),
+    CHANNEL_CAPABILITIES_TIMEOUT_MAX_MS,
   );
   const rawChannel = normalizeLowercaseStringOrEmpty(opts.channel);
   const rawTarget = normalizeOptionalString(opts.target) ?? "";

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -231,6 +231,112 @@ describe("cli json stdout contract", () => {
     },
   );
 
+  it.each(["probe", "diagnostics"])(
+    "keeps the CLI alive until stalled channel capability %s reports its timeout",
+    async (stage) => {
+      await withTempHome(
+        async (tempHome) => {
+          const pluginDir = path.join(tempHome, "capability-plugin");
+          const workspace = path.join(tempHome, "workspace");
+          await fs.mkdir(pluginDir);
+          await fs.mkdir(workspace);
+          const id = "capability-fixture";
+          const meta = {
+            id,
+            label: "Capability fixture",
+            selectionLabel: "Capability fixture",
+            docsPath: "/channels/test",
+            blurb: "Synthetic channel",
+          };
+          const schema = {
+            type: "object",
+            additionalProperties: false,
+            properties: { enabled: { type: "boolean" } },
+          };
+          await fs.writeFile(
+            path.join(pluginDir, "package.json"),
+            JSON.stringify({
+              name: id,
+              version: "1.0.0",
+              type: "module",
+              openclaw: {
+                extensions: ["./index.js"],
+                setupEntry: "./index.js",
+                channel: meta,
+              },
+            }),
+          );
+          await fs.writeFile(
+            path.join(pluginDir, "openclaw.plugin.json"),
+            JSON.stringify({
+              id,
+              channels: [id],
+              configSchema: { type: "object", additionalProperties: false, properties: {} },
+              channelConfigs: { [id]: { schema } },
+            }),
+          );
+          await fs.writeFile(
+            path.join(pluginDir, "index.js"),
+            `export const plugin = {
+              id: ${JSON.stringify(id)}, meta: ${JSON.stringify(meta)},
+              capabilities: { chatTypes: ["direct"] },
+              configSchema: { schema: ${JSON.stringify(schema)} },
+              config: {
+                listAccountIds: () => ["default"],
+                resolveAccount: () => ({ accountId: "default", enabled: true }),
+                isConfigured: () => true, isEnabled: () => true,
+              },
+              status: {
+                async probeAccount() { return ${stage === "probe" ? "new Promise(() => {})" : "{ ok: true }"}; },
+                async buildCapabilitiesDiagnostics() { return ${stage === "diagnostics" ? "new Promise(() => {})" : "{ lines: [] }"}; },
+              },
+            };
+            export default { id: plugin.id, register(api) { api.registerChannel({ plugin }); } };`,
+          );
+          const configPath = path.join(tempHome, "openclaw.json");
+          await fs.writeFile(
+            configPath,
+            JSON.stringify({
+              agents: { defaults: { workspace } },
+              plugins: { load: { paths: [pluginDir] }, entries: { [id]: { enabled: true } } },
+              channels: { [id]: { enabled: true } },
+              logging: { level: "silent", consoleLevel: "silent" },
+            }),
+          );
+
+          const result = runBuiltCli(
+            tempHome,
+            ["channels", "capabilities", "--json", "--timeout", "20"],
+            {
+              OPENCLAW_CONFIG_PATH: configPath,
+              OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+              OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            },
+            { inheritEnvironment: false },
+          );
+
+          expect(result.status, result.stderr).toBe(0);
+          const [report] = JSON.parse(result.stdout).channels;
+          expect(report.channel).toBe(id);
+          if (stage === "probe") {
+            expect(report.probe).toEqual({
+              ok: false,
+              timedOut: true,
+              error: "probe timed out after 20ms",
+            });
+          } else {
+            expect(report.probe).toEqual({ ok: true });
+            expect(report.diagnostics).toEqual({
+              lines: [{ text: "Diagnostics: timed out after 20ms", tone: "error" }],
+              details: { timedOut: true },
+            });
+          }
+        },
+        { prefix: "openclaw-capabilities-timeout-e2e-" },
+      );
+    },
+  );
+
   it("returns one canonical document for a command that previously failed on stderr only", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## Summary

Fixes #136538.

A stalled channel probe or diagnostics callback could make channels capabilities exit13 with no JSON or text, before its own timeout reported anything. Its private race had unreferenced the only timer keeping this one-shot command alive.

Both result adapters now use the existing absolute-deadline helper. The private race, duplicate result union and one-use timeout wrapper are deleted. Existing error/result shapes, synchronous throws, per-step10s default/30s ceiling and continuation through later accounts are preserved. The timeout reports an outcome; it does not claim to cancel plugin work.

Production **+29 / −69 = -40 LOC**; tests/support **+106 / −0 = +106**; docs **+1**.

## Validation

Actual compiled CLI with an unchanged synthetic two-account plugin:

| Case | Before | After |
| --- | --- | --- |
| Pending probe, JSON/text | Exit13; empty stdout; healthy account not reached | Timeout report; healthy account processed; exit0 |
| Pending diagnostics, JSON/text | Exit13; empty stdout; healthy account not reached | Diagnostics timeout; healthy account processed; exit0 |
| Success, synchronous throws, rejection | Structured result/error reports | Preserved |

Actual after output includes:

```json
[
  {"accountId":"blocked","probe":{"ok":false,"timedOut":true,"error":"probe timed out after 200ms"}},
  {"accountId":"healthy","probe":{"ok":true}}
]
```

The diagnostics sibling reports lines:[{text:"Diagnostics: timed out after 200ms",tone:"error"}] and details:{timedOut:true}, then processes the healthy account. These are excerpts of real child-process output, not simulated command results.

- Both new child-process regressions fail before editing with the intended exit13/no-output symptom.
- 95 focused tests, all37 existing CLI JSON E2Es and eight compiled before/after scenarios pass.
- Canonical E2E build admission rebuilt the candidate. The complete changed-file gate passes on frozen sources.
- One combined independent Codex P2 review is clean; its pending-gate note is resolved by the final successful gate.
- Root inspected the complete command, unchanged shared deadline helper, parser/registration, actual output and stable/current-main owner contracts.

Proof uses isolated synthetic plugin/config state and real Node processes. No external channel call or message delivery is claimed.

## Shared CI fixture follow-up

The temporary Gateway CLI fixture cleanup has been removed because [main already owns the canonical test split](https://github.com/openclaw/openclaw/commit/aef65cc57490a5c67ca8dc934ac24225c6d1069c). The cumulative PR no longer changes that file. The exact three-way file merge matches main byte for byte, retaining the health/transport cases, Linux socat case and cleanup hooks; typed lint and an independent Codex P2 review pass. No product issue or production deletion is credited to this reconciliation.

The unrelated Code Mode TypeScript CI case was rerun locally with the entire file in original declaration order: 7/7 pass on unchanged source. No cancellation assertion or production lifecycle code was changed; fresh hosted CI remains the relevant confirmation.

Fresh scoped typed lint/format checks and independent Codex P2 review pass. Shared review reuse is limited to identical before/after files and owner context. These CI repairs add no counted product issue.
