### PR TITLE
test(infra): assert machine-name process boundary

### DIFF
--- a/src/infra/machine-name.test.ts
+++ b/src/infra/machine-name.test.ts
@@ -3,21 +3,9 @@ import os from "node:os";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const execFileMock = vi.hoisted(() => vi.fn());
+const runExecMock = vi.hoisted(() => vi.fn());
 
-vi.mock("node:child_process", async () => {
-  const { mockNodeChildProcessExecFile } = await import("openclaw/plugin-sdk/test-node-mocks");
-  return mockNodeChildProcessExecFile(
-    Object.assign(execFileMock, {
-      [Symbol.for("nodejs.util.promisify.custom")]: vi.fn(),
-      __promisify__: vi.fn(),
-    }) as typeof import("node:child_process").execFile,
-    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
-  );
-});
-
-const originalVitest = process.env.VITEST;
-const originalNodeEnv = process.env.NODE_ENV;
+vi.mock("../process/exec.js", () => ({ runExec: runExecMock }));
 
 async function importMachineName(scope: string) {
   return await importFreshModule<typeof import("./machine-name.js")>(
@@ -27,18 +15,8 @@ async function importMachineName(scope: string) {
 }
 
 afterEach(() => {
-  execFileMock.mockReset();
+  runExecMock.mockReset();
   vi.restoreAllMocks();
-  if (originalVitest === undefined) {
-    delete process.env.VITEST;
-  } else {
-    process.env.VITEST = originalVitest;
-  }
-  if (originalNodeEnv === undefined) {
-    delete process.env.NODE_ENV;
-  } else {
-    process.env.NODE_ENV = originalNodeEnv;
-  }
 });
 
 describe("getMachineDisplayName", () => {
@@ -68,6 +46,6 @@ describe("getMachineDisplayName", () => {
       await expect(machineName.getMachineDisplayName()).resolves.toBe(expected);
     }
     expect(hostnameSpy).toHaveBeenCalledTimes(expectedCalls);
-    expect(execFileMock).not.toHaveBeenCalled();
+    expect(runExecMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The machine-name tests could pass even if test-mode name lookup launched an unintended subprocess, so the suite no longer enforced its isolation guarantee.

## Why This Change Was Made

The resolver moved from `child_process.execFile` to `runExec`/Execa, but its test still watched the old function. Mock the current execution boundary and remove the unused `VITEST`/`NODE_ENV` restoration.

## User Impact

There is no product behavior change. Developers retain a meaningful guard against platform subprocesses during tests, with less obsolete harness code.

## Evidence

Both cases retain hostname trimming, case-insensitive `.local` removal, the blank-name fallback, repeated-lookup caching, and the no-subprocess assertion. Production code and its test-mode guard are unchanged. Test delta: +4/-26; production delta: 0.

- Original tests passed even with a temporary unintended `runExec(process.execPath, ["-e", ""])` call before the test-mode fallback. The same fault failed both repaired tests at the no-subprocess assertion, after the hostname/cache assertions passed. The temporary fault was restored before final validation.
- Machine-name, OS-summary, and runtime-prompt suites: 21 passed.
- Complete one-file `check-changed` gate: exit 0, including the affected infra typecheck, all dead-export scans, and typed lint. Trusted local execution unset only inherited `OPENCLAW_TESTBOX`.
- Formatting, diff checks, deslop, and fresh Codex review passed; no actionable findings through P2.

The local proof above was completed on the original patch committed as `360ceda37f085e4244b37b075fdce2b652eeb7a6`. Signed refresh `bf4c2de666605298ddb51c50d4b2d17c7e95a5b9` rebases that patch onto `0ad459206e689833afb6118862d7f63fd58c4f7a`. The entire one-file patch and its file contents are byte-identical; the machine-name owner, execution boundary, callers, helpers, infra test routing, dependency manifests/lockfile, and scoped guidance are unchanged. The inspected test-planning changes only register the separate CLI health-test split. No new local test or full gate run is claimed for the refresh; new exact-head CI is required.

[Original CI run 33670722527](https://github.com/openclaw/openclaw/actions/runs/33670722527) failed only `check-lint` and its aggregate gate. The [lint job](https://github.com/openclaw/openclaw/actions/runs/33670722527/job/100384298316) tested merge `3dd207d3653b86d47ed11152eddcbc7acf6a0f6a` and reported one error in an unchanged CLI test:

```text
src/cli/gateway-backed-exit.process.test.ts
1119:4  error  File has too many lines (1040).  eslint(max-lines)
1 problem (1 error, 0 warnings)
[oxlint:core] failed (exit 1)
```

That file is identical at the original Machine base, head, and CI main parent. The refreshed base contains the canonical CLI split in `aef65cc57490a5c67ca8dc934ac24225c6d1069c`; this PR adds no separate lint repair. The original CI run was not rerun.

Observed fault evidence:

```text
Original test + unintended runExec call:
 Test Files  1 passed (1)
      Tests  2 passed (2)

Repaired test + identical fault:
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Test Files  1 failed (1)
      Tests  2 failed (2)
```
