### PR TITLE
improve(ui): expand session participant links

### DIFF
--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -652,7 +652,10 @@ describe("renderSessionHovercard", () => {
       "openclaw-viewer-facepile",
     );
     await facepile?.updateComplete;
-    expect(facepile?.querySelector(".viewer-avatar--overflow")?.textContent).toBe("+3");
+    expect(facepile?.querySelectorAll(".viewer-avatar:not(.viewer-avatar--overflow)")).toHaveLength(
+      4,
+    );
+    expect(facepile?.querySelector(".viewer-avatar--overflow")?.textContent).toBe("+1");
   });
 
   it("renders nothing when no session facts are known", () => {

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -20,8 +20,6 @@ import { sessionOwnerInitials, type SessionCreatedActor } from "./session-owner-
 import { progressCardHeadsUp, renderProgressCardMarkdown } from "./session-progress-card.ts";
 import "./viewer-facepile.ts";
 
-const MAX_VISIBLE_ATTRIBUTION_FACES = 3;
-
 function participantLabel(participant: SessionParticipant): string {
   return participant.label?.trim() || participant.identity.id;
 }
@@ -307,7 +305,7 @@ function renderSessionAttribution({
         ? html`<openclaw-viewer-facepile
             .staticParticipants=${remainingParticipants}
             .totalCount=${otherCount}
-            .maxVisible=${MAX_VISIBLE_ATTRIBUTION_FACES - 1}
+            .maxVisible=${remainingParticipants.length}
             .personActivity=${personActivity}
           ></openclaw-viewer-facepile>`
         : nothing}

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -333,6 +333,25 @@ suite.define(() => {
               .trim(),
           )
           .toBe("Ada King & 4 others");
+        const attribution = card.locator(".session-hovercard__attribution");
+        const attributionName = attribution.locator("a.session-hovercard__attribution-name");
+        expect(await attributionName.getAttribute("href")).toBe("/activity?person=profile-ada");
+        const linkedAvatars = attribution.locator(".person-activity-avatar-link .viewer-avatar");
+        await expect.poll(() => linkedAvatars.count()).toBe(3);
+        const collapsedSpread = await linkedAvatars.evaluateAll((avatars) => {
+          const left = avatars.map((avatar) => avatar.getBoundingClientRect().left);
+          return left.at(-1)! - left[0]!;
+        });
+        await attributionName.hover();
+        await expect
+          .poll(async () => {
+            const left = await linkedAvatars.evaluateAll((avatars) =>
+              avatars.map((avatar) => avatar.getBoundingClientRect().left),
+            );
+            return left.at(-1)! - left[0]!;
+          })
+          .toBeGreaterThan(collapsedSpread + 5);
+        await captureProof(page, "sidebar-row-hovercard-attribution-expanded.png");
         expect(await card.locator(".session-hovercard__attribution").textContent()).not.toContain(
           "You",
         );

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -77,6 +77,8 @@
 }
 
 .session-hovercard__attribution-avatars {
+  --session-hovercard-face-gap: -5px;
+
   display: inline-flex;
   align-items: center;
   flex: none;
@@ -84,7 +86,20 @@
 }
 
 .session-hovercard__attribution-avatars .viewer-facepile {
-  margin-left: -5px;
+  margin-left: var(--session-hovercard-face-gap);
+  transition: margin-left 120ms ease;
+}
+
+.session-hovercard__attribution-avatars
+  .viewer-facepile
+  > openclaw-tooltip:not(:first-child)
+  .viewer-avatar {
+  margin-left: var(--session-hovercard-face-gap);
+  transition: margin-left 120ms ease;
+}
+
+.session-hovercard__attribution:is(:hover, :focus-within) .session-hovercard__attribution-avatars {
+  --session-hovercard-face-gap: 2px;
 }
 
 .session-hovercard__attribution-copy {


### PR DESCRIPTION
## What Problem This Solves

Session attribution can contain several known people, but the compact facepile hides some projected participants behind an overflow badge and overlaps the visible avatar links enough that their individual click targets are hard to distinguish.

## Why This Change Was Made

The hovercard now renders every participant already present in the bounded session projection. The facepile stays compact at rest, then expands on attribution hover or keyboard focus so each known profile avatar has a distinct Activity link target.

The primary profile name remains the labelled Activity link. Unqualified labels without a durable profile identity remain plain text instead of creating a dead person route.

No protocol, persistence, configuration, or SQLite changes are involved; the existing session projection is bounded to four participant records.

## User Impact

Single-person attribution has a clickable name. With multiple people, hovering or focusing the attribution reveals each known linked avatar while preserving the compact resting layout.

## Evidence

| Before: compact facepile | After: linked name + expanded faces |
| --- | --- |
| ![Before: participant avatars overlap in the compact session attribution](https://github.com/user-attachments/assets/44c4d9ce-2054-4f73-9d01-d5f3f1e6dd48) | ![After: hovering the linked name expands each known participant avatar](https://github.com/user-attachments/assets/0b80b138-855a-4605-980e-3f49b1b8bc41) |

- Confirmed pre-fix regression: the component test exposed only 2 of 4 projected participant avatars and reported the other known people as overflow.
- Focused component suite: 32/32 passed.
- Mocked-Gateway hovercard E2E: 1/1 passed; verifies the primary name Activity URL, three linked profile avatars, and increased avatar spacing on hover.
- `check:changed`: passed for the four touched UI files.
- Structured autoreview: clean at P1.
- Judged LOC: production +17/-4 (net +13) for bounded participant rendering and the scoped expansion state; tests +23/-1 (net +22).