### PR TITLE
test(ui): run native scroll proof on real browser time

### DIFF
--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -146,7 +146,6 @@ suite.define(() => {
           recordVideo: { dir: artifactDir },
         },
         async ({ page }) => {
-          await page.clock.install();
           const gateway = await installMockGateway(page, {
             heldMethods: ["chat.message.get"],
             historyMessages: Array.from({ length: 60 }, (_, index) => ({
@@ -414,8 +413,10 @@ suite.define(() => {
           await waitForChatScrollIdle(page);
           // Outlast virtual-core's five-second scroll reconciliation deadline:
           // the assertion protects durable geometry, not a transient resize frame.
-          await page.clock.runFor(5_500);
-          const final = await bubble.evaluate((element, nextId) => {
+          const final = await bubble.evaluate(async (element, nextId) => {
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, 5_500);
+            });
             const row = element.closest<HTMLElement>(".chat-virtual-row")!;
             const scroller = row.closest<HTMLElement>(".chat-thread")!;
             const next = scroller


### PR DESCRIPTION
## Summary

- keep the native smooth-scroll proof on real Chromium time
- wait out virtual-core's five-second reconciliation window with a browser-side timer
- preserve the existing offset, anchor, geometry, trusted-input, and timeout assertions

## Problem

The parameterized native-scroll proof installed Playwright's fake clock before exercising Chromium smooth scrolling. Native scroll animation frames do not advance with `page.clock.runFor()`, so the exact CI row could retain an interrupted `scrollTop` of `84` instead of returning to `0`.

Exact pre-fix CI evidence:

- PR #136388 head `4a35cefa22e650f62ed9a08846b99b794e2aca23`
- run `33665281700`, job `100365806709`
- `('no-preference', 'wheel', 'within-viewport')` failed at line 350: expected `0`, received `84`
- retained CI artifact: `control-ui-e2e-timeout-5-1`

## Change

Remove the early `page.clock.install()` from this native smooth-scroll family and replace `page.clock.runFor(5_500)` with a real browser-side `setTimeout(5_500)`.

No production code or assertions changed.

## Test Audit

- observable invariant: interrupted native scrolling settles before durable virtual-row geometry is measured
- regression mechanism: the fake Playwright clock freezes browser-owned smooth-scroll frames
- sibling coverage: default/reduced motion, wheel, synthetic pointer, and trusted native pointer
- production seam: none

## Validation

- affected Chromium row: `1 passed`, `7 skipped`
- four-case parameterized family: `4 passed`, `4 skipped`
- retained per-row proof: four PNG frames, `interrupted-scroll.json`, and Chromium WebM
- all four JSON records preserve `gap: 0`; native-pointer evidence preserves `trusted: true`
- `git diff --check`
- mandatory autoreview: scoped clean, no actionable findings, correctness `0.99`

## Diff

- changed files: `ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts`
- test LOC: `+4/-3`
- production LOC: `0`

## Dependency Check

No Codex protocol or runtime dependency. Direct inspection covered `codex-rs/core/src/session/inject.rs:13-24` and `codex-rs/protocol/src/items.rs:136-157`.

Follow-up to #136388.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted codex session transcript</summary>

```text
source: [LOCAL_SESSION]
redaction: local paths, credentials, raw tool output, unrelated parent-session traffic

[user]
Execute the focused Control UI fake-clock baseline repair. Scope only the native
smooth-scroll family in chat-transcript-disclosure-anchor.e2e.test.ts, preserve
all assertions, prove the affected Chromium case and four-case family, run
autoreview, then open a draft PR without landing it.

[user]
Rebase once onto exact main 564e544aac738d4677f3f6813af018e6a87cd759
before push and PR creation. Do not widen scope or rebase again.

[assistant]
Created an isolated full-clone GWT, rebased once onto the required SHA, captured
the deterministic pre-fix CI failure, and changed only the requested test file.

[assistant]
Affected Chromium proof passed 1/1; the parameterized family passed 4/4 with
screenshots, JSON, and video retained. Diff check and mandatory autoreview passed.
```

</details>
<!-- agent-transcript:end -->
