### PR TITLE
fix(mcp): hide policy-denied plugin tools from ACP sessions [AI]

### DIFF
--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -167,7 +167,7 @@ describe("plugin tools MCP server", () => {
     expect(connectToolsMcpServerToStdioMock).toHaveBeenCalledOnce();
   });
 
-  it("threads global plugin tool policy into plugin resolution", async () => {
+  it("threads agentless global plugin tool policy into plugin resolution", async () => {
     getRuntimeConfigMock.mockReturnValueOnce({
       plugins: { enabled: true },
       tools: {
@@ -185,6 +185,76 @@ describe("plugin tools MCP server", () => {
     const resolvePolicy = requireToolPolicyParams(resolvePluginToolsMock);
     expect(resolvePolicy.toolAllowlist).toContain("memory_search");
     expect(resolvePolicy.toolDenylist).toEqual(["memory_forget"]);
+  });
+
+  it("enforces global and managed-agent plugin tool policy", async () => {
+    const deniedExecute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "denied executor ran" }],
+    });
+    const allowedExecute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "allowed executor ran" }],
+    });
+    resolvePluginToolsMock.mockReturnValue([
+      {
+        name: "plugin_allowed",
+        label: "Allowed control tool",
+        description: "Allowed control tool",
+        parameters: { type: "object", properties: {} },
+        execute: allowedExecute,
+      },
+      {
+        name: "plugin_denied",
+        label: "Denied tool",
+        description: "Denied tool",
+        parameters: { type: "object", properties: {} },
+        execute: deniedExecute,
+      },
+    ] as unknown as AnyAgentTool[]);
+    const { resolvePluginToolsForMcp } = await import("./plugin-tools-serve.js");
+
+    const tools = resolvePluginToolsForMcp({
+      config: {
+        plugins: { enabled: true },
+        tools: {
+          allow: ["plugin_allowed", "plugin_denied"],
+          deny: ["plugin_globally_denied"],
+        },
+        agents: {
+          list: [
+            {
+              id: "research",
+              tools: { allow: ["plugin_allowed"], deny: ["plugin_denied"] },
+            },
+          ],
+        },
+      } as never,
+      agentSessionKey: "agent:research:acp:session-1",
+    });
+    const handlers = createPluginToolsMcpHandlers(tools);
+
+    await expect(handlers.listTools()).resolves.toMatchObject({
+      tools: [{ name: "plugin_allowed" }],
+    });
+    await expect(handlers.callTool({ name: "plugin_denied" })).resolves.toMatchObject({
+      isError: true,
+      content: [{ text: "Unknown tool: plugin_denied" }],
+    });
+    expect(deniedExecute).not.toHaveBeenCalled();
+
+    await expect(handlers.callTool({ name: "plugin_allowed" })).resolves.toMatchObject({
+      content: [{ text: "allowed executor ran" }],
+    });
+    expect(allowedExecute).toHaveBeenCalledOnce();
+
+    for (const policyMock of [
+      ensureStandalonePluginToolRegistryLoadedMock,
+      resolvePluginToolsMock,
+    ]) {
+      expect(requireToolPolicyParams(policyMock)).toMatchObject({
+        toolAllowlist: ["plugin_allowed", "plugin_denied"],
+        toolDenylist: ["plugin_globally_denied", "plugin_denied"],
+      });
+    }
   });
 
   it("lists registered plugin tools and serializes non-array tool content", async () => {

--- a/src/mcp/plugin-tools-serve.ts
+++ b/src/mcp/plugin-tools-serve.ts
@@ -59,11 +59,12 @@ function resolvePluginToolPolicy(
         globalPolicy,
         agentPolicy: effective.agentPolicy,
         agentId: effective.agentId,
-      }).map((step) => ({
-        ...step,
-        // This bridge exposes only plugin tools, so core-tool entries are absent by design.
-        suppressUnavailableCoreToolWarning: true,
-      }))
+      }).map((step) =>
+        Object.assign({}, step, {
+          // This bridge exposes only plugin tools, so core-tool entries are absent by design.
+          suppressUnavailableCoreToolWarning: true,
+        }),
+      )
     : undefined;
   const policies = steps?.map((step) => step.policy) ?? [profilePolicy, globalPolicy];
   const toolAllowlist = collectExplicitAllowlist(policies);

--- a/src/mcp/plugin-tools-serve.ts
+++ b/src/mcp/plugin-tools-serve.ts
@@ -8,7 +8,13 @@
  */
 import { pathToFileURL } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { resolveEffectiveToolPolicy } from "../agents/agent-tools.policy.js";
 import { pickSandboxToolPolicy } from "../agents/sandbox-tool-policy.js";
+import {
+  applyToolPolicyPipeline,
+  buildDefaultToolPolicyPipelineSteps,
+  type ToolPolicyPipelineStep,
+} from "../agents/tool-policy-pipeline.js";
 import {
   collectExplicitAllowlist,
   collectExplicitDenylist,
@@ -19,25 +25,53 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { logWarn } from "../logger.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { ensureStandalonePluginToolRegistryLoaded, resolvePluginTools } from "../plugins/tools.js";
 import { resolveToolsMcpAgentId, resolveToolsMcpSessionContext } from "./agent-session-env.js";
 import { connectToolsMcpServerToStdio, createToolsMcpServer } from "./tools-stdio-server.js";
 
-function resolvePluginToolPolicy(config: OpenClawConfig): {
+function resolvePluginToolPolicy(
+  config: OpenClawConfig,
+  context: ReturnType<typeof resolveToolsMcpSessionContext>,
+): {
   toolAllowlist?: string[];
   toolDenylist?: string[];
+  steps?: ToolPolicyPipelineStep[];
 } {
+  const effective = context.agentId
+    ? resolveEffectiveToolPolicy({
+        config,
+        agentId: context.agentId,
+        sessionKey: context.sessionKey,
+      })
+    : undefined;
   const profilePolicy = mergeAlsoAllowPolicy(
-    resolveToolProfilePolicy(config.tools?.profile),
-    config.tools?.alsoAllow,
+    resolveToolProfilePolicy(effective?.profile ?? config.tools?.profile),
+    effective?.profileAlsoAllow ?? config.tools?.alsoAllow,
   );
-  const globalPolicy = pickSandboxToolPolicy(config.tools);
-  const toolAllowlist = collectExplicitAllowlist([profilePolicy, globalPolicy]);
-  const toolDenylist = collectExplicitDenylist([profilePolicy, globalPolicy]);
+  const globalPolicy = effective?.globalPolicy ?? pickSandboxToolPolicy(config.tools);
+  const steps = effective
+    ? buildDefaultToolPolicyPipelineSteps({
+        profilePolicy,
+        profile: effective.profile,
+        globalPolicy,
+        agentPolicy: effective.agentPolicy,
+        agentId: effective.agentId,
+      }).map((step) => ({
+        ...step,
+        // This bridge exposes only plugin tools, so core-tool entries are absent by design.
+        suppressUnavailableCoreToolWarning: true,
+      }))
+    : undefined;
+  const policies = steps?.map((step) => step.policy) ?? [profilePolicy, globalPolicy];
+  const toolAllowlist = collectExplicitAllowlist(policies);
+  const toolDenylist = collectExplicitDenylist(policies);
   return {
     ...(toolAllowlist.length > 0 ? { toolAllowlist } : {}),
     ...(toolDenylist.length > 0 ? { toolDenylist } : {}),
+    steps,
   };
 }
 
@@ -46,18 +80,27 @@ export function resolvePluginToolsForMcp(params: {
   agentSessionKey?: string;
   agentId?: string;
 }): AnyAgentTool[] {
-  const context = { config: params.config, ...resolveToolsMcpSessionContext(params) };
-  const pluginToolPolicy = resolvePluginToolPolicy(params.config);
+  const sessionContext = resolveToolsMcpSessionContext(params);
+  const context = { config: params.config, ...sessionContext };
+  const { steps, ...pluginToolPolicy } = resolvePluginToolPolicy(params.config, sessionContext);
   const runtimeRegistry = ensureStandalonePluginToolRegistryLoaded({
     context,
     ...pluginToolPolicy,
   });
-  return resolvePluginTools({
+  const tools = resolvePluginTools({
     context,
     ...pluginToolPolicy,
     suppressNameConflicts: true,
     runtimeRegistry,
   });
+  return steps
+    ? applyToolPolicyPipeline({
+        tools,
+        toolMeta: getPluginToolMeta,
+        warn: logWarn,
+        steps,
+      })
+    : tools;
 }
 
 export function createPluginToolsMcpServer(


### PR DESCRIPTION
## What Problem This Solves

Addresses an issue where a managed ACP session could list and call plugin tools excluded by its configured agent tool policy when the optional plugin-tools MCP bridge was enabled.

## Why This Change Was Made

The bridge now resolves effective policy from the canonical managed-agent session context, reuses the standard profile/global/agent policy pipeline, bounds plugin discovery with the combined allow/deny rules, and applies the same ordered policy to the final MCP tool registry. The existing standalone agentless path is unchanged.

## User Impact

Policy-denied plugin tools no longer appear in managed ACP tool discovery and direct calls to them are rejected, while permitted plugin tools remain available.

## Evidence

- The focused regression failed before the change and passes at `73aee804eb910a8fc2e2a3b5757539db8703ad5a`.
- `node scripts/run-vitest.mjs src/mcp/plugin-tools-serve.test.ts` passed 21 tests.
- Targeted formatting and `git diff --check` passed.
- The Codex MCP contract was checked directly at `codex-rs/codex-mcp/src/rmcp_client.rs:610` and `codex-rs/codex-mcp/src/connection_manager.rs:856`: discovery uses `tools/list`, and dispatch uses `tools/call`.

AI-assisted implementation; source, dependency behavior, and tests were inspected directly.
