### PR TITLE
fix: scheduled Codex jobs lose native tools after an upgrade

### DIFF
--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -186,6 +186,24 @@ that authority; the next run reports that app access requires reauthorization.
 An update from a fresh authenticated owner turn can instead capture and store a
 new app ceiling for the updated job.
 
+When the same creator has Codex native execution, a default agent-turn job also
+captures that runtime capability. Its saved `toolsAllow` contains `codex_native`
+beside the ordinary OpenClaw tools. This is an authorization marker, not a tool
+to call: the marker alone grants nothing. Replay requires the captured runtime
+identity, current policy, and a compatible sandbox. Inherited MCP servers are
+limited to those callable on the creator thread; newly connected servers are
+not silently added to an existing job.
+
+To repair an older job that previously used native execution, update it from a
+fresh authenticated owner turn, retaining its existing tool names and adding
+`codex_native`. The update captures current runtime authority before saving.
+Keep its schedule, prompt, delivery target, and enabled state unchanged. Do not
+replace a deliberately narrow cap with `*`, and do not manually insert an
+authority envelope into storage. For a job that only needs connected apps, add
+`codex_apps` instead; it triggers the same authenticated capture without
+selecting native execution. Neither name can manufacture authority through a
+raw CLI or Gateway API write.
+
 ## Manage plugins from chat
 
 `/codex plugins` inspects or changes configured native Codex plugins from the

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -362,6 +362,43 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
+  it("retains captured native execution for scheduled jobs without widening their core tool cap", () => {
+    const params = createParams("/tmp/session.jsonl", "/tmp/workspace");
+    Object.assign(params, {
+      disableTools: false,
+      trigger: "cron",
+      toolsAllow: ["message", "codex_native"],
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+      pluginHarnessToolPolicyRestricted: true,
+      pluginHarnessConfiguredToolPolicyRestricted: false,
+      scheduledRuntimeAuthority: {
+        version: 1,
+        runtimeId: "codex",
+        namespace: "codex.apps",
+        payload: {
+          version: 1,
+          auth: { profileId: "codex:work", accountId: "account-1" },
+          apps: [],
+          nativeTools: { mcpServers: [] },
+        },
+      },
+    });
+
+    // A saved list of OpenClaw tools does not describe the native shell on the
+    // Codex host. Losing that distinction silently moves work to the gateway.
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(params.toolsAllow).toEqual(["message", "codex_native"]);
+
+    Object.assign(params, { pluginHarnessConfiguredToolPolicyRestricted: true });
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    Object.assign(params, { pluginHarnessConfiguredToolPolicyRestricted: false });
+    params.toolsAllow = ["message"];
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    params.toolsAllow = ["message", "codex_native"];
+    params.scheduledRuntimeAuthority = undefined;
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
   it("keeps policy-filterable OpenClaw coding replacements when native tools are disabled", () => {
     const tools = [
       "read",

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -45,6 +45,7 @@ import {
 import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
 import { mapCodexAppServerRemoteWorkspacePath } from "./remote-workspace-path.js";
 import type { CodexSandboxExecEnvironment } from "./sandbox-exec-server.js";
+import { hasScheduledCodexNativeToolAuthority } from "./scheduled-app-authority.js";
 import type { CodexEffectiveSessionPermissionPolicy } from "./session-permission-policy.js";
 import {
   CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
@@ -670,7 +671,8 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     sandboxExecServerEnabled?: boolean;
   } = {},
 ): boolean {
-  if (params.pluginHarnessToolPolicyRestricted === true) {
+  const capturedNativeTools = hasScheduledCodexNativeToolAuthority(params);
+  if (params.pluginHarnessToolPolicyRestricted === true && !capturedNativeTools) {
     return false;
   }
   if (isCodexMemoryFlushRun(params)) {
@@ -696,7 +698,7 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   // capability, so narrow OpenClaw allowlists must fail closed rather than
   // widening `message` or `web_search` into shell access.
   return (
-    hasWildcardCodexToolsAllow(toolsAllow) &&
+    (hasWildcardCodexToolsAllow(toolsAllow) || capturedNativeTools) &&
     canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
   );
 }

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -234,7 +234,7 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
     decision: { action: "resume"; binding: CodexAppServerThreadBinding } | { action: "start" },
   ) => {
     state.nativeHookRelay?.unregister();
-    if (params.pluginHarnessToolPolicyRestricted === true) {
+    if (runtime.runtimeParams.pluginHarnessToolPolicyRestricted === true) {
       state.nativeHookRelay = undefined;
       return {
         configPatch: buildCodexNativeHookRelayDisabledConfig(),

--- a/extensions/codex/src/app-server/run-attempt-runtime.ts
+++ b/extensions/codex/src/app-server/run-attempt-runtime.ts
@@ -115,7 +115,7 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
     maxTokens: undefined,
   } as unknown as EmbeddedRunAttemptParams["model"];
   const legacyScheduledAppRecoveryPrompt = buildLegacyScheduledCodexAppRecoveryPrompt(params);
-  const runtimeParams: EmbeddedRunAttemptParams = usesSupervisionConnection
+  let runtimeParams: EmbeddedRunAttemptParams = usesSupervisionConnection
     ? {
         ...paramsWithoutOuterNativeOwnership,
         provider: "codex",
@@ -224,6 +224,13 @@ export async function prepareCodexAttemptRuntime(connection: CodexAttemptConnect
     sandbox,
     { agentId: policyAgentId, runtimeSessionKey: sandboxSessionKey, sandboxExecServerEnabled },
   );
+  if (nativeToolSurfaceEnabled && runtimeParams.pluginHarnessToolPolicyRestricted === true) {
+    // Native eligibility above requires captured authority, an unrestricted
+    // current configured policy, and a compatible execution sandbox. Only the
+    // plugin's effective native-policy fact changes; the saved OpenClaw tool cap
+    // stays intact. All subsequent thread setup and native hooks use this view.
+    runtimeParams = { ...runtimeParams, pluginHarnessToolPolicyRestricted: false };
+  }
   preDynamicStartupStages.mark("native-tool-surface");
   const nativeProviderWebSearchSupport =
     resolveCodexWebSearchPlan({

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -123,7 +123,7 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
       buildFinalConfigPatch: buildNativeHookRelayFinalConfigPatch,
       nativeHookRelayRequired:
         connection.options.nativeHookRelay?.enabled !== false &&
-        params.pluginHarnessToolPolicyRestricted !== true &&
+        runtimeParams.pluginHarnessToolPolicyRestricted !== true &&
         connection.nativeHookRelayEvents.includes("pre_tool_use") &&
         (hasBeforeToolCallPolicy() ||
           (appServer.loopDetectionPreToolUseRelay &&

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -34,6 +34,7 @@ import {
   buildScheduledCodexAppServerConnectionIdentity,
   captureScheduledCodexAppAuthority,
   resolveScheduledCodexAppCreatorCaptureDecision,
+  readScheduledCodexCapabilityNames,
 } from "./scheduled-app-authority.js";
 import { releaseLeasedSharedCodexAppServerClient } from "./shared-client.js";
 
@@ -174,12 +175,18 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         }
       : undefined;
   const scheduledCodexAppAuth = preparedChatgptAuth ?? configuredAppServerAuth;
+  const captureNativeTools =
+    nativeToolSurfaceEnabled &&
+    scheduledCodexAppAuth !== undefined &&
+    !connection.usesSupervisionConnection &&
+    connection.appServer.start.homeScope !== "user";
   const appPolicy = resolveCodexPluginsPolicy(pluginConfig);
   const codexAppsMayBeVisible =
     appPolicy.enabled &&
     (appPolicy.allowAllPlugins || appPolicy.pluginPolicies.some((entry) => entry.enabled));
   const appCreatorCapture = resolveScheduledCodexAppCreatorCaptureDecision({
     appsMayBeVisible: codexAppsMayBeVisible,
+    nativeToolsMayBeVisible: captureNativeTools,
     authenticatedScheduledMode,
     usesSupervisionConnection: connection.usesSupervisionConnection,
     homeScope: connection.appServer.start.homeScope,
@@ -517,6 +524,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
               ? await captureScheduledCodexAppAuthority({
                   ...appSource,
                   auth: scheduledCodexAppAuth,
+                  captureNativeTools,
                   signal: options?.signal,
                 })
               : (() => {
@@ -525,7 +533,14 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
                   );
                 })()
             : undefined;
+        // Add this only after exact-run authority resolution, not to the initial
+        // dynamic tool list. An explicit update requesting the capability must
+        // invoke the authenticated resolver rather than save an unbacked marker.
+        const appendCapturedRuntimeCapabilities = () => {
+          authorityTools.push(...readScheduledCodexCapabilityNames(runtimeAuthority));
+        };
         if (!canResolveScheduledConfiguredMcpCreatorAuthority) {
+          appendCapturedRuntimeCapabilities();
           options?.signal?.throwIfAborted();
           return Object.freeze({
             tools: Object.freeze(authorityTools.map((entry) => Object.freeze(entry))),
@@ -578,6 +593,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
             ...toolBridge.availableTools,
             ...projectedConfiguredMcp.availableTools,
           ]);
+          appendCapturedRuntimeCapabilities();
           if (!captureRef.value) {
             throw new Error("configured MCP authority snapshot did not produce provenance");
           }

--- a/extensions/codex/src/app-server/run-attempt-turn-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-start.ts
@@ -18,6 +18,7 @@ import {
 } from "./attempt-results.js";
 import { isCodexContextRestartSelectionChangedError } from "./attempt-startup.js";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { buildPluginAppPolicyContext } from "./plugin-thread-config.js";
 import type { CodexTurnStartResponse } from "./protocol.js";
 import { emitCodexAppServerEvent, runCodexAgentEndHook } from "./run-attempt-lifecycle.js";
 import type { CodexAttemptNotificationController } from "./run-attempt-notification-controller.js";
@@ -313,11 +314,12 @@ export async function startCodexAttemptTurn(
     throw new Error("codex app-server turn/start failed without an error");
   }
   const authoritySourceRef = context.attemptTools.scheduledAppAuthoritySourceRef;
-  if (resourceState.thread.pluginAppPolicyContext) {
+  if (resourceState.thread.pluginAppPolicyContext || runtime.nativeToolSurfaceEnabled) {
     authoritySourceRef.current = {
       client: resourceState.client,
       threadId: resourceState.thread.threadId,
-      policyContext: resourceState.thread.pluginAppPolicyContext,
+      policyContext:
+        resourceState.thread.pluginAppPolicyContext ?? buildPluginAppPolicyContext({}, {}),
       configCwd: connection.effectiveCwd,
     };
   }

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -9,6 +9,7 @@ const mcpMocks = vi.hoisted(() => ({
     (options?: { signal?: AbortSignal }) => Promise<{
       tools: readonly (string | { name: string; pluginId?: string })[];
       provenance: { version: 1; source: "final-executable-surface" };
+      runtimeAuthority?: NonNullable<ReturnType<typeof createParams>["scheduledRuntimeAuthority"]>;
     }>
   >,
   captureCalls: [] as Array<{
@@ -231,6 +232,73 @@ function admitLocalOperatorCronAuthority(params: ReturnType<typeof createParams>
 }
 
 describe("runCodexAppServerAttempt configured MCP ownership", () => {
+  it("captures native authority on the creator and keeps native tools on scheduled replay", async () => {
+    const pluginConfig = {
+      appServer: {
+        transport: "websocket" as const,
+        url: "wss://codex.example.test/app-server",
+        homeScope: "agent" as const,
+        authToken: "fixture-token",
+      },
+      codexPlugins: { enabled: false },
+    };
+    const inventory = async (method: string) => {
+      if (method === "app/installed") {
+        return { apps: [] };
+      }
+      if (method === "mcpServerStatus/list") {
+        return { data: [{ name: "docs", tools: { search: {} } }], nextCursor: null };
+      }
+      return undefined;
+    };
+    const creator = createParams(
+      path.join(tempDir, "creator.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    setCodexTestModelSupportsTools(creator, true);
+    creator.runtimePlan = createCodexRuntimePlanFixture();
+    creator.trigger = "user";
+    admitLocalOperatorCronAuthority(creator);
+    const creatorHarness = createStartedThreadHarness(inventory);
+    const creatorRun = runCodexAppServerAttempt(creator, { pluginConfig });
+    await creatorHarness.waitForMethod("turn/start");
+    await vi.waitFor(() => expect(mcpMocks.authorityResolvers.length).toBeGreaterThan(0));
+    const captured = await mcpMocks.authorityResolvers[0]!();
+    expect(captured.tools).toContain("codex_native");
+    expect(captured.runtimeAuthority?.payload).toMatchObject({
+      apps: [],
+      nativeTools: { mcpServers: ["docs"] },
+    });
+    // The provisional dynamic catalog cannot independently authorize this name.
+    expect(mcpMocks.captureCalls[0]?.storedNames).not.toContain("codex_native");
+    await creatorHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await creatorRun;
+
+    const scheduled = createParams(
+      path.join(tempDir, "scheduled.jsonl"),
+      path.join(tempDir, "workspace"),
+      { sessionId: "scheduled", sessionKey: "agent:main:cron:fixture", runId: "scheduled-run" },
+    );
+    setCodexTestModelSupportsTools(scheduled, true);
+    scheduled.runtimePlan = createCodexRuntimePlanFixture();
+    scheduled.trigger = "cron";
+    scheduled.toolsAllow = ["message", "codex_native"];
+    scheduled.scheduledToolPolicy = { version: 1, mode: "trusted" };
+    scheduled.scheduledRuntimeAuthority = captured.runtimeAuthority;
+    scheduled.pluginHarnessToolPolicyRestricted = true;
+    scheduled.pluginHarnessConfiguredToolPolicyRestricted = false;
+    const replayHarness = createStartedThreadHarness(inventory);
+    const replay = runCodexAppServerAttempt(scheduled, { pluginConfig });
+    await replayHarness.waitForMethod("turn/start");
+    const request = replayHarness.requests.find((request) => request.method === "thread/start")
+      ?.params as { config?: Record<string, unknown> };
+    expect(request.config?.["features.shell_tool"]).not.toBe(false);
+    expect(request.config?.["features.unified_exec"]).not.toBe(false);
+    expect(scheduled.toolsAllow).toEqual(["message", "codex_native"]);
+    await replayHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await expect(replay).resolves.toBeDefined();
+  });
+
   it("does not replace bundle discovery with partial prepared plugin metadata", async () => {
     const sessionFile = path.join(tempDir, "session-partial-manifest-registry.jsonl");
     const params = createParams(sessionFile, path.join(tempDir, "workspace-partial-registry"));

--- a/extensions/codex/src/app-server/scheduled-app-authority.test.ts
+++ b/extensions/codex/src/app-server/scheduled-app-authority.test.ts
@@ -13,6 +13,7 @@ import {
   captureScheduledCodexAppAuthority,
   intersectCodexPluginThreadConfigWithScheduledAuthority,
   readCurrentCodexScheduledAppPolicy,
+  readScheduledCodexCapabilityNames,
   resolveScheduledCodexAppCreatorCaptureDecision,
 } from "./scheduled-app-authority.js";
 import { readCodexManagedRequirementsFingerprint } from "./thread-requests.js";
@@ -97,6 +98,73 @@ function threadConfig(): CodexPluginThreadConfig {
 }
 
 describe("scheduled Codex app authority", () => {
+  it("captures app and native capabilities independently without upgrading an older envelope", () => {
+    expect(readScheduledCodexCapabilityNames(undefined)).toEqual([]);
+    expect(readScheduledCodexCapabilityNames(authority())).toEqual(["codex_apps"]);
+    expect(
+      readScheduledCodexCapabilityNames(authority({ nativeTools: { mcpServers: [] } })),
+    ).toEqual(["codex_apps", "codex_native"]);
+    expect(() =>
+      readScheduledCodexCapabilityNames(authority({ nativeTools: { mcpServers: [false] } })),
+    ).toThrow("native tool authority is invalid");
+  });
+  it("captures the active native runtime even when it has no connected apps", async () => {
+    const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method === "app/installed") {
+        return { apps: [] };
+      }
+      if (method === "config/read") {
+        return { config: {} };
+      }
+      if (method === "mcpServerStatus/list") {
+        expect(params.threadId).toBe("native-creator");
+        return {
+          data: [
+            { name: "docs", tools: { search: {} } },
+            { name: "unavailable", tools: {} },
+          ],
+          nextCursor: null,
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+    await expect(
+      captureScheduledCodexAppAuthority({
+        client: { request } as never,
+        threadId: "native-creator",
+        policyContext: buildPluginAppPolicyContext({}, {}),
+        auth: { kind: "prepared-profile", profileId: "codex:work", accountId: "account-1" },
+        captureNativeTools: true,
+      }),
+    ).resolves.toEqual(
+      authority({
+        auth: { profileId: "codex:work", accountId: "account-1" },
+        apps: [],
+        nativeTools: { mcpServers: ["docs"] },
+      }),
+    );
+  });
+
+  it("does not admit inherited MCP servers added after native authority was captured", () => {
+    const intersected = intersectCodexPluginThreadConfigWithScheduledAuthority(
+      threadConfig(),
+      authority({ apps: [], nativeTools: { mcpServers: ["docs"] } }),
+      {
+        config: { mcp_servers: { docs: {}, newly_connected: {}, unavailable: {} } },
+        toolsByApp: new Map(),
+        mcpServerNames: ["docs", "newly_connected"],
+      },
+    );
+    expect(intersected.configPatch).toMatchObject({
+      mcp_servers: {
+        newly_connected: { enabled: false },
+        unavailable: { enabled: false },
+      },
+    });
+    expect(intersected.configPatch.mcp_servers).not.toHaveProperty("docs");
+    expect(intersected.provisionalAppIds).toEqual([]);
+  });
+
   it.each([
     {
       name: "scheduled continuation",

--- a/extensions/codex/src/app-server/scheduled-app-authority.ts
+++ b/extensions/codex/src/app-server/scheduled-app-authority.ts
@@ -24,6 +24,20 @@ import { withAbortableTimeout } from "./timeout.js";
 
 const CODEX_SCHEDULED_APP_AUTHORITY_NAMESPACE = "codex.apps";
 const CODEX_APPS_MCP_SERVER = "codex_apps";
+// A persisted capability, never an executable tool. A name alone grants nothing:
+// replay also requires the host-owned authority captured on the exact creator run.
+export const CODEX_SCHEDULED_NATIVE_TOOLS_CAPABILITY = "codex_native";
+export const CODEX_SCHEDULED_APPS_CAPABILITY = "codex_apps";
+
+export function readScheduledCodexCapabilityNames(
+  authority: EmbeddedRunAttemptParams["scheduledRuntimeAuthority"],
+): string[] {
+  const captured = parseScheduledCodexAppAuthority(authority);
+  return [
+    ...(captured?.apps.length ? [CODEX_SCHEDULED_APPS_CAPABILITY] : []),
+    ...(captured?.nativeTools ? [CODEX_SCHEDULED_NATIVE_TOOLS_CAPABILITY] : []),
+  ];
+}
 const MCP_STATUS_PAGE_SIZE = 100;
 const MCP_STATUS_MAX_PAGES = 100;
 const CODEX_APP_AUTHORITY_CAPTURE_TIMEOUT_MS = 60_000;
@@ -39,6 +53,7 @@ type CodexScheduledAppTool = {
 export type CurrentCodexScheduledAppPolicy = {
   config: Record<string, unknown>;
   toolsByApp: ReadonlyMap<string, ReadonlyMap<string, CodexScheduledAppTool>>;
+  mcpServerNames?: readonly string[];
 };
 
 export type ScheduledCodexAppCreatorAuth =
@@ -74,13 +89,14 @@ export function buildScheduledCodexAppServerConnectionIdentity(
 
 export function resolveScheduledCodexAppCreatorCaptureDecision(params: {
   appsMayBeVisible: boolean;
+  nativeToolsMayBeVisible?: boolean;
   authenticatedScheduledMode: boolean;
   usesSupervisionConnection: boolean;
   homeScope: string | undefined;
   hasPreparedAccountIdentity: boolean;
   hasConfiguredAppServerIdentity: boolean;
 }): { required: boolean; supported: boolean; unavailableReason?: string } {
-  if (!params.appsMayBeVisible) {
+  if (!params.appsMayBeVisible && !params.nativeToolsMayBeVisible) {
     return { required: false, supported: false };
   }
   const unavailableReason = params.authenticatedScheduledMode
@@ -116,6 +132,7 @@ type ScheduledCodexAppAuthorityAuth =
 type ScheduledCodexAppAuthorityPayload = {
   version: 1;
   auth: ScheduledCodexAppAuthorityAuth;
+  nativeTools?: { mcpServers: string[] };
   apps: Array<{
     id: string;
     allowDestructiveActions: boolean;
@@ -212,7 +229,43 @@ function parseScheduledCodexAppAuthority(
       tools,
     };
   });
-  return { version: 1, auth: parsedAuth, apps };
+  let nativeTools: ScheduledCodexAppAuthorityPayload["nativeTools"];
+  if (payload.nativeTools !== undefined) {
+    const native = asOptionalRecord(payload.nativeTools);
+    if (
+      !native ||
+      !Array.isArray(native.mcpServers) ||
+      native.mcpServers.some(
+        (name) => typeof name !== "string" || !name.trim() || name !== name.trim(),
+      )
+    ) {
+      throw new Error(
+        "Stored Codex native tool authority is invalid; reauthorize this automation.",
+      );
+    }
+    nativeTools = { mcpServers: [...new Set<string>(native.mcpServers)].toSorted() };
+  }
+  return { version: 1, auth: parsedAuth, apps, ...(nativeTools ? { nativeTools } : {}) };
+}
+
+/** Current config remains the ceiling; the cron cap only selects captured runtime authority. */
+export function hasScheduledCodexNativeToolAuthority(
+  params: Pick<
+    EmbeddedRunAttemptParams,
+    | "trigger"
+    | "scheduledToolPolicy"
+    | "pluginHarnessConfiguredToolPolicyRestricted"
+    | "toolsAllow"
+    | "scheduledRuntimeAuthority"
+  >,
+): boolean {
+  return (
+    params.trigger === "cron" &&
+    params.scheduledToolPolicy !== undefined &&
+    params.pluginHarnessConfiguredToolPolicyRestricted === false &&
+    params.toolsAllow?.includes(CODEX_SCHEDULED_NATIVE_TOOLS_CAPABILITY) === true &&
+    parseScheduledCodexAppAuthority(params.scheduledRuntimeAuthority)?.nativeTools !== undefined
+  );
 }
 
 type CodexScheduledAppPolicyRequest = (
@@ -223,8 +276,12 @@ type CodexScheduledAppPolicyRequest = (
 async function readCodexScheduledAppToolsByApp(params: {
   request: CodexScheduledAppPolicyRequest;
   threadId?: string;
-}): Promise<Map<string, Map<string, CodexScheduledAppTool>>> {
+}): Promise<{
+  toolsByApp: Map<string, Map<string, CodexScheduledAppTool>>;
+  mcpServerNames: string[];
+}> {
   const toolsByApp = new Map<string, Map<string, CodexScheduledAppTool>>();
+  const mcpServerNames = new Set<string>();
   const seenCursors = new Set<string>();
   let cursor: string | null | undefined;
   for (let page = 0; page < MCP_STATUS_MAX_PAGES; page += 1) {
@@ -242,6 +299,10 @@ async function readCodexScheduledAppToolsByApp(params: {
         throw new Error("Codex scheduled app inventory contained an invalid server status");
       }
       if (status.name !== CODEX_APPS_MCP_SERVER) {
+        const name = normalizeOptionalString(status.name);
+        if (name && Object.keys(status.tools).length > 0) {
+          mcpServerNames.add(name);
+        }
         continue;
       }
       for (const [toolName, tool] of Object.entries(status.tools)) {
@@ -268,7 +329,7 @@ async function readCodexScheduledAppToolsByApp(params: {
     }
     cursor = response.nextCursor;
     if (!cursor) {
-      return toolsByApp;
+      return { toolsByApp, mcpServerNames: [...mcpServerNames].toSorted() };
     }
     if (seenCursors.has(cursor)) {
       throw new Error("Codex app connector inventory repeated its pagination cursor");
@@ -284,7 +345,7 @@ export async function readCurrentCodexScheduledAppPolicy(params: {
   configCwd?: string;
   threadId?: string;
 }): Promise<CurrentCodexScheduledAppPolicy> {
-  const [configResponse, toolsByApp] = await Promise.all([
+  const [configResponse, inventory] = await Promise.all([
     params.request("config/read", {
       includeLayers: false,
       ...(params.configCwd ? { cwd: params.configCwd } : {}),
@@ -296,7 +357,7 @@ export async function readCurrentCodexScheduledAppPolicy(params: {
   }
   return {
     config: isJsonObject(configResponse.config) ? configResponse.config : {},
-    toolsByApp,
+    ...inventory,
   };
 }
 
@@ -355,6 +416,7 @@ export async function captureScheduledCodexAppAuthority(params: {
   threadId: string;
   policyContext: PluginAppPolicyContext;
   auth: ScheduledCodexAppCreatorAuth;
+  captureNativeTools?: boolean;
   configCwd?: string;
   signal?: AbortSignal;
   timeoutMs?: number;
@@ -453,7 +515,7 @@ export async function captureScheduledCodexAppAuthority(params: {
       ),
     }))
     .toSorted((left, right) => left.id.localeCompare(right.id));
-  if (apps.length === 0) {
+  if (apps.length === 0 && !params.captureNativeTools) {
     return undefined;
   }
   return {
@@ -464,6 +526,9 @@ export async function captureScheduledCodexAppAuthority(params: {
       version: 1,
       auth,
       apps,
+      ...(params.captureNativeTools
+        ? { nativeTools: { mcpServers: [...(currentPolicy.mcpServerNames ?? [])] } }
+        : {}),
     },
   };
 }
@@ -582,6 +647,24 @@ export function intersectCodexPluginThreadConfigWithScheduledAuthority(
   );
   const policyContext = buildPluginAppPolicyContext(apps, pluginAppIds);
   const configPatch = buildCodexPluginAppsConfigPatchFromPolicyContext(policyContext);
+  if (scheduled.nativeTools) {
+    const capturedServers = new Set(scheduled.nativeTools.mcpServers);
+    const currentServers = new Set([
+      ...Object.keys(asOptionalRecord(currentPolicy.config.mcp_servers) ?? {}),
+      ...(currentPolicy.mcpServerNames ?? []),
+    ]);
+    // Restoring native execution must not silently admit a plugin installed
+    // after this job was authorized. Never enable a currently disabled server;
+    // the current Codex configuration still owns transport and authentication.
+    const deniedServers = [...currentServers].filter(
+      (name) => name !== CODEX_APPS_MCP_SERVER && !capturedServers.has(name),
+    );
+    if (deniedServers.length > 0) {
+      configPatch.mcp_servers = Object.fromEntries(
+        deniedServers.toSorted().map((name) => [name, { enabled: false }]),
+      );
+    }
+  }
   const appsPatch = asOptionalRecord(configPatch.apps);
   for (const [appId, captured] of capturedById) {
     const appPatch = asOptionalRecord(appsPatch?.[appId]);

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -126,6 +126,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   operation?: EmbeddedRunAttemptOperation;
   /** Core-prepared fact that explicit requester/config policy restricts plugin-native tools. */
   pluginHarnessToolPolicyRestricted?: boolean;
+  /** Same fact before the per-run tool cap; captured runtime authority cannot override it. */
+  pluginHarnessConfiguredToolPolicyRestricted?: boolean;
   /** Audited exact denies that the plugin harness must enforce against native equivalents. */
   pluginHarnessToolPolicySafeDeniedTools?: readonly string[];
   preparedModelRuntime?: PreparedModelRuntimeSnapshot;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1482,12 +1482,15 @@ describe("runAgentHarnessAttempt", () => {
     const received: Array<{
       conversationToolPolicy: EmbeddedRunAttemptParams["conversationToolPolicy"];
       pluginHarnessToolPolicyRestricted: boolean | undefined;
+      pluginHarnessConfiguredToolPolicyRestricted: boolean | undefined;
       toolsAllow: string[] | undefined;
     }> = [];
     const runAttempt = vi.fn<AgentHarness["runAttempt"]>(async (attempt) => {
       received.push({
         conversationToolPolicy: attempt.conversationToolPolicy,
         pluginHarnessToolPolicyRestricted: attempt.pluginHarnessToolPolicyRestricted,
+        pluginHarnessConfiguredToolPolicyRestricted:
+          attempt.pluginHarnessConfiguredToolPolicyRestricted,
         toolsAllow: attempt.toolsAllow,
       });
       return createAttemptResult("codex");
@@ -1516,14 +1519,37 @@ describe("runAgentHarnessAttempt", () => {
       {
         conversationToolPolicy: { deny: ["exec"] },
         pluginHarnessToolPolicyRestricted: true,
+        pluginHarnessConfiguredToolPolicyRestricted: true,
         toolsAllow: undefined,
       },
       {
         conversationToolPolicy: { deny: ["exec"] },
         pluginHarnessToolPolicyRestricted: true,
+        pluginHarnessConfiguredToolPolicyRestricted: true,
         toolsAllow: ["Read", "Bash"],
       },
     ]);
+  });
+
+  it("distinguishes a saved tool cap from independently configured native restrictions", async () => {
+    const runAttempt = vi.fn<AgentHarness["runAttempt"]>(async () => createAttemptResult("codex"));
+    registerAgentHarness(
+      {
+        id: "codex",
+        label: "Codex",
+        conversationToolPolicySupport: "exact",
+        supports: (ctx) =>
+          ctx.provider === "codex" ? { supported: true, priority: 100 } : { supported: false },
+        runAttempt,
+      },
+      { ownerPluginId: "codex" },
+    );
+    await runAgentHarnessAttempt({ ...createAttemptParams(), toolsAllow: ["message"] });
+    expect(runAttempt.mock.calls[0]?.[0]).toMatchObject({
+      toolsAllow: ["message"],
+      pluginHarnessToolPolicyRestricted: true,
+      pluginHarnessConfiguredToolPolicyRestricted: false,
+    });
   });
 
   it("isolates native tools unless every exact deny is explicitly safe", async () => {

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -166,6 +166,7 @@ type ResolvedPluginHarnessToolPolicies = {
   runtimePolicies: Array<PluginHarnessToolPolicy | undefined>;
   safeDeniedToolNames: string[];
   toolPolicyRestricted: boolean;
+  configuredToolPolicyRestricted: boolean;
 };
 
 function listPluginAgentHarnesses(): AgentHarness[] {
@@ -686,6 +687,7 @@ function preparePluginHarnessParams(
       pluginHarnessToolPolicySafeDeniedTools:
         policies.safeDeniedToolNames.length > 0 ? policies.safeDeniedToolNames : undefined,
       pluginHarnessToolPolicyRestricted: policies.toolPolicyRestricted,
+      pluginHarnessConfiguredToolPolicyRestricted: policies.configuredToolPolicyRestricted,
     },
     policies,
   );
@@ -835,7 +837,7 @@ export function resolvePluginHarnessToolPolicies(
     : params.toolsAllow
       ? { allow: params.toolsAllow }
       : undefined;
-  const explicitPolicies = [
+  const configuredPolicies = [
     policy.globalPolicy,
     policy.globalProviderPolicy,
     policy.agentPolicy,
@@ -846,8 +848,8 @@ export function resolvePluginHarnessToolPolicies(
     policy.subagentPolicy,
     policy.inheritedToolPolicy,
     policy.runtimeToolPolicyForInheritance,
-    requestedToolPolicy,
   ];
+  const explicitPolicies = [...configuredPolicies, requestedToolPolicy];
   const safeDenyToolNameSet = safeDenyToolNames
     ? new Set(safeDenyToolNames.map(normalizeToolPolicyName))
     : undefined;
@@ -872,6 +874,14 @@ export function resolvePluginHarnessToolPolicies(
       requestedToolPolicy,
     ],
     safeDeniedToolNames: collectHarnessSafeDeniedToolNames(explicitPolicies, safeDenyToolNameSet),
+    // A saved job may also carry independently captured harness capabilities.
+    // Keep the configured/requester ceiling separate so a harness can honor that
+    // capture without treating the job's core-tool list as a new global policy.
+    configuredToolPolicyRestricted:
+      params.swarmCollector === true ||
+      configuredPolicies.some((explicitPolicy) =>
+        toolPolicyRestrictsHarnessNativeTools(explicitPolicy, safeDenyToolNameSet),
+      ),
     // Native tools bypass the collector's noninteractive OpenClaw wrappers.
     // Keep policy-allowed host replacements, without ambient input or approval surfaces.
     toolPolicyRestricted:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scheduled Codex jobs lose their native tools when a saved list of OpenClaw tools is treated as a restriction on the entire runtime. Restoring connected-app access alone does not fix this: shell and file work can still fall back to the gateway instead of the Codex host.

## Why This Change Was Made

Capture native execution alongside the existing runtime-bound app authority, and preserve the distinction between a job's tool cap and independently configured restrictions. New default jobs retain the capabilities available to their authenticated creator. Existing jobs can be reauthorized in place, without replacing their tool list with a wildcard.

The capability names alone grant nothing. Runtime identity, current policy, sandbox constraints, and the stored authority still apply. Inherited MCP servers are limited to the captured set; newly connected servers do not silently appear in old jobs. No database schema or Codex version change is needed.

## Evidence

Regression tests first reproduced lost native execution and missing runtime capture. The focused suite now passes 354 tests, including creator-to-scheduled-replay coverage, app-only authority, narrow permission caps, configured policy restrictions, and runtime identity checks. Formatting and the changed-file structural checks pass. The full local typecheck encounters unrelated installed-dependency mismatches; hosted CI will validate the pinned dependency set before merge.
