### PR TITLE
feat(meta): add Muse Spark 1.3 models

### DIFF
--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -77,6 +77,8 @@ openclaw onboard --non-interactive --accept-risk --skip-health \
 Prices and data-use terms come from Meta's
 [pricing and rate limits](https://dev.meta.ai/docs/pricing-rate-limits/)
 documentation.
+Meta's [model catalog](https://dev.meta.ai/docs/models) identifies Muse Spark 1.3
+as the latest version and recommends it for new work.
 
 | Model ref                         | Name                       | OpenClaw input | Reasoning | Context window | Input / cached input / output per 1M tokens |
 | --------------------------------- | -------------------------- | -------------- | --------- | -------------- | ------------------------------------------- |

--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -19,7 +19,7 @@ plugin.
 | Direct CLI flag            | `--meta-api-key <key>`             |
 | API                        | Responses API (`openai-responses`) |
 | Base URL                   | `https://api.meta.ai/v1`           |
-| Default model              | `meta/muse-spark-1.1`              |
+| Default model              | `meta/muse-spark-1.3`              |
 | OpenClaw reasoning default | `high` (`reasoning.effort`)        |
 
 ## Getting started
@@ -80,9 +80,11 @@ documentation.
 
 | Model ref                         | Name                       | OpenClaw input | Reasoning | Context window | Input / cached input / output per 1M tokens |
 | --------------------------------- | -------------------------- | -------------- | --------- | -------------- | ------------------------------------------- |
-| `meta/muse-spark-1.1`             | Muse Spark 1.1             | text, image    | yes       | 1,048,576      | $1.25 / $0.15 / $4.25                       |
+| `meta/muse-spark-1.3`             | Muse Spark 1.3             | text, image    | yes       | 1,048,576      | $1.25 / $0.15 / $4.25                       |
+| `meta/muse-spark-1.3-contributor` | Muse Spark 1.3 Contributor | text, image    | yes       | 1,048,576      | $0.10 / $0.002 / $0.20                      |
 | `meta/muse-spark-1.2`             | Muse Spark 1.2             | text, image    | yes       | 1,048,576      | $1.25 / $0.15 / $4.25                       |
 | `meta/muse-spark-1.2-contributor` | Muse Spark 1.2 Contributor | text, image    | yes       | 1,048,576      | $0.10 / $0.002 / $0.20                      |
+| `meta/muse-spark-1.1`             | Muse Spark 1.1             | text, image    | yes       | 1,048,576      | $1.25 / $0.15 / $4.25                       |
 
 <Warning>
 Meta's [pricing documentation](https://dev.meta.ai/docs/pricing-rate-limits/) and
@@ -132,9 +134,9 @@ Muse Spark does not accept `reasoning.effort: "none"`. OpenClaw maps
   env: { vars: { MODEL_API_KEY: "<key>" } },
   agents: {
     defaults: {
-      model: { primary: "meta/muse-spark-1.1" },
+      model: { primary: "meta/muse-spark-1.3" },
       models: {
-        "meta/muse-spark-1.1": { alias: "Muse Spark 1.1" },
+        "meta/muse-spark-1.3": { alias: "Muse Spark 1.3" },
       },
     },
   },

--- a/extensions/meta/README.md
+++ b/extensions/meta/README.md
@@ -5,7 +5,7 @@ Official OpenClaw provider plugin for the **Meta API** — an OpenAI-compatible
 
 - **Base URL:** `https://api.meta.ai/v1`
 - **Auth:** `Authorization: Bearer $MODEL_API_KEY`
-- **Models:** `muse-spark-1.1`, `muse-spark-1.2`, `muse-spark-1.2-contributor` (reasoning models)
+- **Models:** `muse-spark-1.3`, `muse-spark-1.3-contributor`, `muse-spark-1.2`, `muse-spark-1.2-contributor`, `muse-spark-1.1` (reasoning models)
   - Context window: 1,048,576 tokens (input + output share the budget)
   - Reasoning effort: `minimal | low | medium | high | xhigh` (OpenClaw default: `high`)
   - Vision: image input in `user` messages
@@ -55,7 +55,7 @@ export MODEL_API_KEY=<key>
 {
   agents: {
     defaults: {
-      model: { primary: "meta/muse-spark-1.1" },
+      model: { primary: "meta/muse-spark-1.3" },
     },
   },
 }

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -14,12 +14,14 @@ import { prepareModelForSimpleCompletion } from "@openclaw/ai/transports";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { streamSimple, type Context, type Model } from "openclaw/plugin-sdk/llm";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildMetaProvider } from "./api.js";
 import plugin from "./index.js";
+import { applyMetaConfig } from "./onboard.js";
 import { wrapMetaProviderStream } from "./stream.js";
 
-const CATALOG_CAP_MODEL_ID = "muse-spark-1.2";
+const CATALOG_CAP_MODEL_ID = "muse-spark-1.3";
 const initialAiTransportHost = getAiTransportHost();
 
 function resolveCatalogModel(modelId: string): Model<"openai-responses"> {
@@ -100,7 +102,18 @@ describe("meta provider", () => {
       id: "api-key",
       kind: "api_key",
       label: "Meta API key",
-      starterModel: "meta/muse-spark-1.1",
+      starterModel: "meta/muse-spark-1.3",
+    });
+  });
+
+  it("applies Muse Spark 1.3 as the onboarding default and alias", () => {
+    const config = applyMetaConfig({});
+
+    expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
+      "meta/muse-spark-1.3",
+    );
+    expect(config.agents?.defaults?.models?.["meta/muse-spark-1.3"]).toEqual({
+      alias: "Muse Spark 1.3",
     });
   });
 
@@ -112,7 +125,7 @@ describe("meta provider", () => {
     }
     const model = {
       ...resolveCatalogModel(CATALOG_CAP_MODEL_ID),
-      api: "openclaw-provider-stream:meta:muse-spark-1.2",
+      api: "openclaw-provider-stream:meta:muse-spark-1.3",
     } as Model;
 
     for (const hook of [provider.wrapStreamFn, provider.wrapSimpleCompletionStreamFn]) {
@@ -148,7 +161,7 @@ describe("meta provider", () => {
     }
     const model = {
       ...resolveCatalogModel(CATALOG_CAP_MODEL_ID),
-      api: "openclaw-provider-stream:meta:muse-spark-1.2",
+      api: "openclaw-provider-stream:meta:muse-spark-1.3",
     } as Model;
     let capturedPayload: Record<string, unknown> | undefined;
     const baseStreamFn: StreamFn = (streamModel, _context, options) => {
@@ -204,6 +217,26 @@ describe("meta provider", () => {
     const model = providerConfig.models.find((m) => m.id === "muse-spark-1.2");
     if (!model) {
       throw new Error("Expected muse-spark-1.2 model");
+    }
+    expect(model.contextWindow).toBe(1048576);
+    expect(model.maxTokens).toBe(131072);
+    expect(model.reasoning).toBe(true);
+    expect(model.input).toEqual(["text", "image"]);
+    expect(model.cost).toEqual({
+      input: 1.25,
+      output: 4.25,
+      cacheRead: 0.15,
+      cacheWrite: 0,
+    });
+  });
+
+  it("builds the muse-spark-1.3 catalog entry over openai-responses", () => {
+    const providerConfig = buildMetaProvider();
+    expect(providerConfig.baseUrl).toBe("https://api.meta.ai/v1");
+    expect(providerConfig.api).toBe("openai-responses");
+    const model = providerConfig.models.find((m) => m.id === "muse-spark-1.3");
+    if (!model) {
+      throw new Error("Expected muse-spark-1.3 model");
     }
     expect(model.contextWindow).toBe(1048576);
     expect(model.maxTokens).toBe(131072);
@@ -432,12 +465,32 @@ describe("meta provider", () => {
     });
   });
 
+  it("builds the discounted muse-spark-1.3-contributor catalog entry", () => {
+    const providerConfig = buildMetaProvider();
+    const model = providerConfig.models.find((m) => m.id === "muse-spark-1.3-contributor");
+    if (!model) {
+      throw new Error("Expected muse-spark-1.3-contributor model");
+    }
+    expect(model.contextWindow).toBe(1048576);
+    expect(model.maxTokens).toBe(131072);
+    expect(model.reasoning).toBe(true);
+    expect(model.input).toEqual(["text", "image"]);
+    expect(model.cost).toEqual({
+      input: 0.1,
+      output: 0.2,
+      cacheRead: 0.002,
+      cacheWrite: 0,
+    });
+  });
+
   it("publishes a non-empty display name for every catalog model", () => {
     const models = buildMetaProvider().models;
     expect(models.map(({ id, name }) => ({ id, name }))).toEqual([
-      { id: "muse-spark-1.1", name: "Muse Spark 1.1" },
+      { id: "muse-spark-1.3", name: "Muse Spark 1.3" },
+      { id: "muse-spark-1.3-contributor", name: "Muse Spark 1.3 Contributor" },
       { id: "muse-spark-1.2", name: "Muse Spark 1.2" },
       { id: "muse-spark-1.2-contributor", name: "Muse Spark 1.2 Contributor" },
+      { id: "muse-spark-1.1", name: "Muse Spark 1.1" },
     ]);
     expect(models.every((model) => model.name.trim().length > 0)).toBe(true);
   });
@@ -451,9 +504,11 @@ describe("meta provider", () => {
     const resolveThinkingProfile = requireThinkingProfileResolver(provider);
     const reasoningModels = buildMetaProvider().models.filter((model) => model.reasoning);
     expect(reasoningModels.map((model) => model.id)).toEqual([
-      "muse-spark-1.1",
+      "muse-spark-1.3",
+      "muse-spark-1.3-contributor",
       "muse-spark-1.2",
       "muse-spark-1.2-contributor",
+      "muse-spark-1.1",
     ]);
     for (const model of reasoningModels) {
       const profile = resolveThinkingProfile({

--- a/extensions/meta/meta.live.test.ts
+++ b/extensions/meta/meta.live.test.ts
@@ -7,8 +7,12 @@ import { buildMetaProvider } from "./provider-catalog.js";
 import { wrapMetaProviderStream } from "./stream.js";
 
 const MODEL_API_KEY = process.env.MODEL_API_KEY?.trim() ?? "";
-const STANDARD_LIVE_MODEL_IDS = ["muse-spark-1.1", "muse-spark-1.2"] as const;
-const CONTRIBUTOR_LIVE_MODEL_ID = "muse-spark-1.2-contributor";
+const STANDARD_LIVE_MODEL_IDS = ["muse-spark-1.3", "muse-spark-1.2", "muse-spark-1.1"] as const;
+const STANDARD_CAP_LIVE_MODEL_IDS = ["muse-spark-1.3", "muse-spark-1.2"] as const;
+const CONTRIBUTOR_LIVE_MODEL_IDS = [
+  "muse-spark-1.3-contributor",
+  "muse-spark-1.2-contributor",
+] as const;
 // Validated 96x96 PNG: white background with a 20x72 green vertical center bar.
 const GREEN_VERTICAL_CENTER_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAMAAADVRocKAAAABlBMVEUAsUD///8TauZEAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAQklEQVRo3u3ZMQEAAAjDsOHfNAY44SI1EAFNHRcAAABYAzIEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHwHymoEAACXNba4HmGuMYsrAAAAAElFTkSuQmCC";
@@ -246,9 +250,13 @@ describeLive("meta plugin live", () => {
     120_000,
   );
 
-  it("uses the 131072 catalog output cap for muse-spark-1.2 when maxTokens is zero", async () => {
-    await expectLiveCatalogCapCompletion("muse-spark-1.2");
-  }, 120_000);
+  it.each(STANDARD_CAP_LIVE_MODEL_IDS)(
+    "uses the 131072 catalog output cap for %s when maxTokens is zero",
+    async (modelId) => {
+      await expectLiveCatalogCapCompletion(modelId);
+    },
+    120_000,
+  );
 
   it.each(STANDARD_LIVE_MODEL_IDS)(
     "accepts image input for %s",
@@ -260,20 +268,34 @@ describeLive("meta plugin live", () => {
 });
 
 describeContributorLive("meta contributor plugin live", () => {
-  it("lists the contributor model via the /models endpoint", async () => {
+  it("lists the contributor models via the /models endpoint", async () => {
     const ids = await fetchLiveModelIds();
-    expect(ids).toContain(CONTRIBUTOR_LIVE_MODEL_ID);
+    for (const modelId of CONTRIBUTOR_LIVE_MODEL_IDS) {
+      expect(ids).toContain(modelId);
+    }
   }, 30_000);
 
-  it("completes a contributor Responses API turn with high reasoning effort", async () => {
-    await expectLiveTextCompletion(CONTRIBUTOR_LIVE_MODEL_ID);
-  }, 120_000);
+  it.each(CONTRIBUTOR_LIVE_MODEL_IDS)(
+    "completes a %s Responses API turn with high reasoning effort",
+    async (modelId) => {
+      await expectLiveTextCompletion(modelId);
+    },
+    120_000,
+  );
 
-  it("uses the 131072 catalog output cap for contributor when maxTokens is zero", async () => {
-    await expectLiveCatalogCapCompletion(CONTRIBUTOR_LIVE_MODEL_ID);
-  }, 120_000);
+  it.each(CONTRIBUTOR_LIVE_MODEL_IDS)(
+    "uses the 131072 catalog output cap for %s when maxTokens is zero",
+    async (modelId) => {
+      await expectLiveCatalogCapCompletion(modelId);
+    },
+    120_000,
+  );
 
-  it("accepts image input for the contributor model", async () => {
-    await expectLiveImageCompletion(CONTRIBUTOR_LIVE_MODEL_ID);
-  }, 120_000);
+  it.each(CONTRIBUTOR_LIVE_MODEL_IDS)(
+    "accepts image input for %s",
+    async (modelId) => {
+      await expectLiveImageCompletion(modelId);
+    },
+    120_000,
+  );
 });

--- a/extensions/meta/onboard.ts
+++ b/extensions/meta/onboard.ts
@@ -17,6 +17,6 @@ export const { applyConfig: applyMetaConfig } = createModelCatalogPresetAppliers
     api: "openai-responses",
     baseUrl: META_BASE_URL,
     catalogModels: buildMetaCatalogModels(),
-    aliases: [{ modelRef: META_DEFAULT_MODEL_REF, alias: "Muse Spark 1.1" }],
+    aliases: [{ modelRef: META_DEFAULT_MODEL_REF, alias: "Muse Spark 1.3" }],
   }),
 });

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -27,11 +27,11 @@
       "meta": {
         "baseUrl": "https://api.meta.ai/v1",
         "api": "openai-responses",
-        "defaultModel": "muse-spark-1.1",
+        "defaultModel": "muse-spark-1.3",
         "models": [
           {
-            "id": "muse-spark-1.1",
-            "name": "Muse Spark 1.1",
+            "id": "muse-spark-1.3",
+            "name": "Muse Spark 1.3",
             "reasoning": true,
             "input": [
               "text",
@@ -62,6 +62,42 @@
               "input": 1.25,
               "output": 4.25,
               "cacheRead": 0.15,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "muse-spark-1.3-contributor",
+            "name": "Muse Spark 1.3 Contributor",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "off": "minimal",
+              "minimal": "minimal",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh"
+            },
+            "compat": {
+              "supportsTools": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            },
+            "cost": {
+              "input": 0.1,
+              "output": 0.2,
+              "cacheRead": 0.002,
               "cacheWrite": 0
             }
           },
@@ -134,6 +170,42 @@
               "input": 0.1,
               "output": 0.2,
               "cacheRead": 0.002,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "muse-spark-1.1",
+            "name": "Muse Spark 1.1",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "off": "minimal",
+              "minimal": "minimal",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh"
+            },
+            "compat": {
+              "supportsTools": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            },
+            "cost": {
+              "input": 1.25,
+              "output": 4.25,
+              "cacheRead": 0.15,
               "cacheWrite": 0
             }
           }


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's Meta provider catalog stops at Muse Spark 1.2, so users with Muse Spark 1.3 access cannot select the new Standard or Contributor model and onboarding still chooses the older default.

## Why This Change Was Made

Add Muse Spark 1.3 and Muse Spark 1.3 Contributor to the Meta plugin-owned catalog, make 1.3 the onboarding default, and keep the existing 1.1 and 1.2 models available. The documentation and focused tests are updated with the corresponding capabilities, limits, pricing, ordering, and live-test coverage.

## User Impact

Meta users can select `meta/muse-spark-1.3` or `meta/muse-spark-1.3-contributor`, and new Meta setups default to Muse Spark 1.3. Existing Muse Spark 1.1 and 1.2 configurations remain supported.

## Evidence

### Published Meta contract

Verified against Meta's public documentation on September 2, 2026:

- [Models](https://dev.meta.ai/docs/models) lists `muse-spark-1.3` as the latest version and recommended default, plus `muse-spark-1.3-contributor`. Both advertise a 1,048,576-token context window and text/image input support used by OpenClaw.
- [Pricing and rate limits](https://dev.meta.ai/docs/pricing-rate-limits/) lists Standard 1.3 pricing as $1.25 input / $0.15 cached input / $4.25 output per 1M tokens, and Contributor 1.3 pricing as $0.10 / $0.002 / $0.20.

### Local and isolated verification

- `pnpm test:extension meta` — 24 tests passed on the final rebased candidate.
- Focused provider runtime and catalog suite — 117 tests passed.
- `pnpm check:changed` — passed formatting, metadata, typecheck, lint, dead-code, and import-cycle gates.
- `pnpm build` — passed locally and in the isolated AWS checkout.
- `openclaw models list --provider meta --all --plain` — listed both 1.3 model refs alongside the existing catalog.

### Fresh redacted exact-head live proof

Run on commit `82ec8e229c452afe692748c4715ea7bc6d3956dd` through OpenClaw's Meta provider stream wrapper and Responses transport. Credentials and request identifiers are omitted.

```text
[provider-transport-fetch] start provider=meta api=openai-responses model=muse-spark-1.3 method=POST url=https://api.meta.ai/v1/responses
[provider-transport-fetch] response provider=meta api=openai-responses model=muse-spark-1.3 status=200 contentType=text/event-stream
[meta:live-proof] {"sourceCommit":"82ec8e229c452afe692748c4715ea7bc6d3956dd","entrypoint":"OpenClaw Meta live test -> provider stream wrapper -> streamSimple","requestedModel":"meta/muse-spark-1.3","effectiveModel":"meta/muse-spark-1.3","payloadModel":"muse-spark-1.3","providerResponseModel":"muse-spark-1.3","httpStatus":200,"observedResponse":"PATCH_OK","stopReason":"stop","fallbackUsed":false,"credential":"redacted"}

[provider-transport-fetch] start provider=meta api=openai-responses model=muse-spark-1.3-contributor method=POST url=https://api.meta.ai/v1/responses
[provider-transport-fetch] response provider=meta api=openai-responses model=muse-spark-1.3-contributor status=200 contentType=text/event-stream
[meta:live-proof] {"sourceCommit":"82ec8e229c452afe692748c4715ea7bc6d3956dd","entrypoint":"OpenClaw Meta live test -> provider stream wrapper -> streamSimple","requestedModel":"meta/muse-spark-1.3-contributor","effectiveModel":"meta/muse-spark-1.3-contributor","payloadModel":"muse-spark-1.3-contributor","providerResponseModel":"muse-spark-1.3-contributor","httpStatus":200,"observedResponse":"PATCH_OK","stopReason":"stop","fallbackUsed":false,"credential":"redacted"}
```

Focused exact-head live suite result: **1 file passed; 2 tests passed; 14 unrelated live cases skipped**.
