### PR TITLE
fix(cli): complete Bash option values without duplicate prefixes

### DIFF
--- a/docs/cli/completion.md
+++ b/docs/cli/completion.md
@@ -48,6 +48,7 @@ Installed source lines preserve literal cache paths, including spaces, quotes, d
 
 - Without `--install` or `--write-state`, the command prints the script to stdout.
 - Completion generation eagerly loads the full command tree, including plugin CLI commands, so nested subcommands are included.
+- Bash completion supports both `--flag value` and `--flag=value`, including named profiles before nested commands.
 - `openclaw update` refreshes the completion cache automatically after a successful update; `openclaw doctor` can repair missing or stale completion setups.
 
 ## Related

--- a/src/cli/completion-cli.bash.test.ts
+++ b/src/cli/completion-cli.bash.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDocumentedCompletionProgram,
+  runGeneratedBashCompletion,
+} from "./completion-cli.test-support.js";
+
+describe("completion-cli native Bash words", () => {
+  it.skipIf(process.platform !== "darwin")("uses macOS Bash byte offsets in a UTF-8 locale", () => {
+    const prefix = "openclaw gateway --token=é status --j";
+
+    expect(
+      runGeneratedBashCompletion(
+        createDocumentedCompletionProgram(),
+        ["openclaw", "gateway", "--token=é", "status", "--json"],
+        {
+          line: `${prefix}son`,
+          word: "--j",
+          point: Buffer.byteLength(prefix),
+          bashPath: "/bin/bash",
+          env: { ...process.env, LC_ALL: "en_US.UTF-8" },
+        },
+      ),
+    ).toEqual(["--json"]);
+  });
+
+  it.skipIf(process.platform === "win32").each([
+    {
+      line: "openclaw completion --shell=",
+      words: ["openclaw", "completion", "--shell", "="],
+      word: "",
+      expected: ["zsh", "bash", "powershell", "fish"],
+    },
+    {
+      line: "openclaw --profile=gateway completion --shell f",
+      words: ["openclaw", "--profile", "=", "gateway", "completion", "--shell", "f"],
+      word: "f",
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw completion --shell=f",
+      words: ["openclaw", "completion", "--shell=f"],
+      word: "f",
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw completion --shell=fish",
+      words: ["openclaw", "completion", "--shell", "=", "fish"],
+      word: "f",
+      point: 29,
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw completion --shell=fish",
+      words: ["openclaw", "completion", "--shell=fish"],
+      word: "f",
+      point: 29,
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw completion --shell=fish",
+      words: ["openclaw", "completion", "--shell", "=", "fish"],
+      word: "",
+      point: 28,
+      expected: ["zsh", "bash", "powershell", "fish"],
+    },
+    {
+      line: "openclaw completion --shell=bogus",
+      words: ["openclaw", "completion", "--shell", "=", "bogus"],
+      word: "b",
+      point: 29,
+      expected: ["bash"],
+    },
+    {
+      line: "openclaw completion --sh=fish",
+      words: ["openclaw", "completion", "--sh=fish"],
+      word: "--sh",
+      point: 24,
+      expected: ["--shell"],
+    },
+    {
+      line: "openclaw completion -ysfish",
+      words: ["openclaw", "completion", "-ysfish"],
+      word: "-ysf",
+      point: 24,
+      expected: ["-ysfish"],
+    },
+    {
+      line: "openclaw --profile=gateway completion --shell=fish --yes",
+      words: [
+        "openclaw",
+        "--profile",
+        "=",
+        "gateway",
+        "completion",
+        "--shell",
+        "=",
+        "fish",
+        "--yes",
+      ],
+      word: "f",
+      point: 47,
+      cword: 7,
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw completion --shell=fish",
+      words: ["openclaw", "completion", "--shell=fish"],
+      word: "comple",
+      point: 15,
+      cword: 1,
+      expected: ["completion"],
+    },
+    {
+      line: "openclaw gateway --token = status --j",
+      words: ["openclaw", "gateway", "--token", "=", "status", "--j"],
+      word: "--j",
+      expected: ["--json"],
+    },
+    {
+      line: "openclaw completion>/dev/null --shell f",
+      words: ["openclaw", "completion", ">", "/dev/null", "--shell", "f"],
+      word: "f",
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw gateway --token=prefix:status --f",
+      words: ["openclaw", "gateway", "--token", "=", "prefix", ":", "status", "--f"],
+      word: "--f",
+      expected: ["--force"],
+    },
+    {
+      line: "openclaw gateway --token=foo==status --f",
+      words: ["openclaw", "gateway", "--token", "=", "foo", "==", "status", "--f"],
+      word: "--f",
+      expected: ["--force"],
+    },
+  ])("respects native Bash word boundaries in $line at $point", ({ words, expected, ...input }) => {
+    const program = createDocumentedCompletionProgram().option("--profile <name>", "Profile");
+
+    expect(runGeneratedBashCompletion(program, words, input)).toEqual(expected);
+  });
+});

--- a/src/cli/completion-cli.test-support.ts
+++ b/src/cli/completion-cli.test-support.ts
@@ -5,8 +5,41 @@ import path from "node:path";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { Command } from "commander";
 import { expect, it, type TestAPI } from "vitest";
-import { getCompletionScript } from "./completion-cli.js";
+import { getCompletionScript, registerCompletionCli } from "./completion-cli.js";
 import { quoteCliArg } from "./quote-cli-arg.js";
+
+export function createCompletionProgram(): Command {
+  const program = new Command();
+  program.name("openclaw");
+  program.description("CLI root");
+  program.option("-v, --verbose", "Verbose output");
+  program.option(
+    "--status-json",
+    "Output JSON (alias for `models status --json`) in $OPENCLAW_STATE_DIR",
+  );
+
+  const gateway = program.command("gateway").description("Gateway commands");
+  gateway.option("--force", "Force the action");
+  gateway.option("-t, --token <token>", "Gateway token");
+
+  gateway.command("status").description("Show gateway status").option("--json", "JSON output");
+  gateway.command("restart").description("Restart gateway");
+  program
+    .command("agent")
+    .description("Agent commands")
+    .option("--verbose <on|off>", "Set verbosity");
+  const sessions = program.command("sessions").description("Session commands");
+  sessions.option("--verbose", "Verbose output");
+  sessions.command("cleanup").description("Clean sessions").option("--dry-run", "Preview cleanup");
+
+  return program;
+}
+
+export function createDocumentedCompletionProgram(): Command {
+  const program = createCompletionProgram();
+  registerCompletionCli(program);
+  return program;
+}
 
 export function createAliasedCompletionProgram(): Command {
   const program = new Command();
@@ -26,24 +59,32 @@ export function createAliasedCompletionProgram(): Command {
 export function runGeneratedBashCompletion(
   program: Command,
   words: readonly string[],
-  input: { line?: string; word?: string } = {},
+  input: {
+    line?: string;
+    word?: string;
+    point?: number;
+    cword?: number;
+    bashPath?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {},
 ): string[] {
   const script = getCompletionScript("bash", program);
   const result = spawnSync(
-    "bash",
+    input.bashPath ?? "bash",
     [
       "--noprofile",
       "--norc",
       "-c",
       `${script}
 COMP_WORDS=(${words.map(quoteCliArg).join(" ")})
-COMP_CWORD=${words.length - 1}
+COMP_CWORD=${input.cword ?? words.length - 1}
 COMP_LINE=${quoteCliArg(input.line ?? words.join(" "))}
+COMP_POINT=${input.point ?? "${#COMP_LINE}"}
 _openclaw_completion openclaw ${quoteCliArg(input.word ?? words.at(-1) ?? "")}
 printf '%s\\n' "\${COMPREPLY[@]}"
 `,
     ],
-    { encoding: "utf8" },
+    { encoding: "utf8", env: input.env },
   );
 
   if (result.error) {

--- a/src/cli/completion-cli.test-support.ts
+++ b/src/cli/completion-cli.test-support.ts
@@ -23,7 +23,11 @@ export function createAliasedCompletionProgram(): Command {
   return program;
 }
 
-export function runGeneratedBashCompletion(program: Command, words: readonly string[]): string[] {
+export function runGeneratedBashCompletion(
+  program: Command,
+  words: readonly string[],
+  input: { line?: string; word?: string } = {},
+): string[] {
   const script = getCompletionScript("bash", program);
   const result = spawnSync(
     "bash",
@@ -34,7 +38,8 @@ export function runGeneratedBashCompletion(program: Command, words: readonly str
       `${script}
 COMP_WORDS=(${words.map(quoteCliArg).join(" ")})
 COMP_CWORD=${words.length - 1}
-_openclaw_completion
+COMP_LINE=${quoteCliArg(input.line ?? words.join(" "))}
+_openclaw_completion openclaw ${quoteCliArg(input.word ?? words.at(-1) ?? "")}
 printf '%s\\n' "\${COMPREPLY[@]}"
 `,
     ],

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -5,9 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { Command, Option } from "commander";
 import { afterAll, describe, expect, it } from "vitest";
-import { getCompletionScript, registerCompletionCli } from "./completion-cli.js";
+import { getCompletionScript } from "./completion-cli.js";
 import {
   createAliasedCompletionProgram,
+  createCompletionProgram,
+  createDocumentedCompletionProgram,
   itWithFish,
   itWithPowerShell,
   PowerShellCompletionRunner,
@@ -21,39 +23,6 @@ const powerShellCompletion = new PowerShellCompletionRunner();
 afterAll(async () => {
   await powerShellCompletion.close();
 });
-
-function createCompletionProgram(): Command {
-  const program = new Command();
-  program.name("openclaw");
-  program.description("CLI root");
-  program.option("-v, --verbose", "Verbose output");
-  program.option(
-    "--status-json",
-    "Output JSON (alias for `models status --json`) in $OPENCLAW_STATE_DIR",
-  );
-
-  const gateway = program.command("gateway").description("Gateway commands");
-  gateway.option("--force", "Force the action");
-  gateway.option("-t, --token <token>", "Gateway token");
-
-  gateway.command("status").description("Show gateway status").option("--json", "JSON output");
-  gateway.command("restart").description("Restart gateway");
-  program
-    .command("agent")
-    .description("Agent commands")
-    .option("--verbose <on|off>", "Set verbosity");
-  const sessions = program.command("sessions").description("Session commands");
-  sessions.option("--verbose", "Verbose output");
-  sessions.command("cleanup").description("Clean sessions").option("--dry-run", "Preview cleanup");
-
-  return program;
-}
-
-function createDocumentedCompletionProgram(): Command {
-  const program = createCompletionProgram();
-  registerCompletionCli(program);
-  return program;
-}
 
 function createOptionalChoiceCompletionProgram(): Command {
   const program = new Command().name("openclaw");
@@ -749,55 +718,6 @@ _openclaw_root_completion
     expect(runGeneratedBashCompletion(createDocumentedCompletionProgram(), words)).toEqual(
       expected,
     );
-  });
-
-  it.skipIf(process.platform === "win32").each([
-    {
-      line: "openclaw completion --shell=",
-      words: ["openclaw", "completion", "--shell", "="],
-      word: "",
-      expected: ["zsh", "bash", "powershell", "fish"],
-    },
-    {
-      line: "openclaw --profile=gateway completion --shell f",
-      words: ["openclaw", "--profile", "=", "gateway", "completion", "--shell", "f"],
-      word: "f",
-      expected: ["fish"],
-    },
-    {
-      line: "openclaw completion --shell=f",
-      words: ["openclaw", "completion", "--shell=f"],
-      word: "f",
-      expected: ["fish"],
-    },
-    {
-      line: "openclaw gateway --token = status --j",
-      words: ["openclaw", "gateway", "--token", "=", "status", "--j"],
-      word: "--j",
-      expected: ["--json"],
-    },
-    {
-      line: "openclaw completion>/dev/null --shell f",
-      words: ["openclaw", "completion", ">", "/dev/null", "--shell", "f"],
-      word: "f",
-      expected: ["fish"],
-    },
-    {
-      line: "openclaw gateway --token=prefix:status --f",
-      words: ["openclaw", "gateway", "--token", "=", "prefix", ":", "status", "--f"],
-      word: "--f",
-      expected: ["--force"],
-    },
-    {
-      line: "openclaw gateway --token=foo==status --f",
-      words: ["openclaw", "gateway", "--token", "=", "foo", "==", "status", "--f"],
-      word: "--f",
-      expected: ["--force"],
-    },
-  ])("respects native Bash word boundaries in $line", ({ line, words, word, expected }) => {
-    const program = createDocumentedCompletionProgram().option("--profile <name>", "Profile");
-
-    expect(runGeneratedBashCompletion(program, words, { line, word })).toEqual(expected);
   });
 
   it.skipIf(process.platform === "win32").each([

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -741,14 +741,63 @@ _openclaw_root_completion
       expected: ["--shell=fish"],
     },
     {
-      name: "an inline short shell flag",
+      name: "an unsupported equals prefix in a short option value",
       words: ["openclaw", "completion", "-s=f"],
-      expected: ["-s=fish"],
+      expected: [],
     },
   ])("completes validated values in real Bash after $name", ({ words, expected }) => {
     expect(runGeneratedBashCompletion(createDocumentedCompletionProgram(), words)).toEqual(
       expected,
     );
+  });
+
+  it.skipIf(process.platform === "win32").each([
+    {
+      line: "openclaw completion --shell=",
+      words: ["openclaw", "completion", "--shell", "="],
+      word: "",
+      expected: ["zsh", "bash", "powershell", "fish"],
+    },
+    {
+      line: "openclaw --profile=gateway completion --shell f",
+      words: ["openclaw", "--profile", "=", "gateway", "completion", "--shell", "f"],
+      word: "f",
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw completion --shell=f",
+      words: ["openclaw", "completion", "--shell=f"],
+      word: "f",
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw gateway --token = status --j",
+      words: ["openclaw", "gateway", "--token", "=", "status", "--j"],
+      word: "--j",
+      expected: ["--json"],
+    },
+    {
+      line: "openclaw completion>/dev/null --shell f",
+      words: ["openclaw", "completion", ">", "/dev/null", "--shell", "f"],
+      word: "f",
+      expected: ["fish"],
+    },
+    {
+      line: "openclaw gateway --token=prefix:status --f",
+      words: ["openclaw", "gateway", "--token", "=", "prefix", ":", "status", "--f"],
+      word: "--f",
+      expected: ["--force"],
+    },
+    {
+      line: "openclaw gateway --token=foo==status --f",
+      words: ["openclaw", "gateway", "--token", "=", "foo", "==", "status", "--f"],
+      word: "--f",
+      expected: ["--force"],
+    },
+  ])("respects native Bash word boundaries in $line", ({ line, words, word, expected }) => {
+    const program = createDocumentedCompletionProgram().option("--profile <name>", "Profile");
+
+    expect(runGeneratedBashCompletion(program, words, { line, word })).toEqual(expected);
   });
 
   it.skipIf(process.platform === "win32").each([
@@ -892,7 +941,9 @@ _openclaw_root_completion
         "--shell=fish",
       ]);
       expect(
-        runGeneratedBashCompletion(program, ["openclaw", "completion", "--shell", "=", "f"]),
+        runGeneratedBashCompletion(program, ["openclaw", "completion", "--shell", "=", "f"], {
+          line: "openclaw completion --shell=f",
+        }),
       ).toEqual(["fish"]);
       expect(runGeneratedBashCompletion(program, ["openclaw", "completion", "-sf"])).toEqual([
         "-sfish",
@@ -909,6 +960,21 @@ _openclaw_root_completion
         "-yspowershell",
         "-ysfish",
       ]);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "preserves pending short-cluster choices that start with a hyphen in real Bash",
+    () => {
+      const program = new Command()
+        .name("openclaw")
+        .option("-v, --verbose", "Verbose output")
+        .addOption(new Option("-m, --mode <mode>").choices(["-legacy"]))
+        .exitOverride();
+
+      program.parse(["-vm", "-legacy"], { from: "user" });
+      expect(program.opts()).toEqual({ verbose: true, mode: "-legacy" });
+      expect(runGeneratedBashCompletion(program, ["openclaw", "-vm", "-le"])).toEqual(["-legacy"]);
     },
   );
 

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -399,6 +399,10 @@ _${rootCmd}_completion() {
     local cur opts command_path candidate_path value_options word flag i cword remaining_line word_prefix
     local choice_flag choice_prefix choice_completion_prefix short_group short_flag short_index
     local -a words=()
+    # Before Bash 4.3, COMP_POINT is a byte offset; string spans must use the same units.
+    if ((BASH_VERSINFO[0] < 4 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 3))); then
+        local LC_ALL=C
+    fi
     COMPREPLY=()
     remaining_line="\${COMP_LINE}"
     # Rejoin '=' and ':' wordbreaks, preserving redirections and whitespace boundaries.
@@ -415,6 +419,8 @@ _${rootCmd}_completion() {
     done
     cword=$((\${#words[@]} - 1))
     cur="\${words[cword]}"
+    # COMP_WORDS includes text after the cursor; only the prefix participates in completion.
+    cur="\${cur:0:\${#cur} + COMP_POINT - \${#COMP_LINE} + \${#remaining_line}}"
     word_prefix="\${cur%"$2"}"
     opts="${root.completions.join(" ")}"
     value_options="${root.valueOptions.join(" ")}"

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -392,22 +392,36 @@ ${funcName}() {
 function generateBashCompletion(program: Command): string {
   const rootCmd = program.name();
   const { root, descendants: contexts } = collectShellCompletionCommandTree(program);
-  const rootCompletions = root.completions;
-  const rootValueOptions = root.valueOptions;
   const commandPathUpdate = generateBashCommandPathUpdate(contexts);
   const choiceCompletion = generateBashOptionChoiceCompletion([root, ...contexts]);
   return `
 _${rootCmd}_completion() {
-    local cur opts command_path candidate_path value_options word flag i
+    local cur opts command_path candidate_path value_options word flag i cword remaining_line word_prefix
     local choice_flag choice_prefix choice_completion_prefix short_group short_flag short_index
+    local -a words=()
     COMPREPLY=()
-    cur="\${COMP_WORDS[COMP_CWORD]}"
-    opts="${rootCompletions.join(" ")}"
-    value_options="${rootValueOptions.join(" ")}"
+    remaining_line="\${COMP_LINE}"
+    # Rejoin '=' and ':' wordbreaks, preserving redirections and whitespace boundaries.
+    # Bash versions split '=' differently; $2 remains the fragment Readline will replace.
+    for ((i = 0; i <= COMP_CWORD; i++)); do
+        word="\${COMP_WORDS[i]}"
+        if ((i > 0)) && [[ -n "\${word}" && "\${remaining_line}" == "\${word}"* &&
+            ( "\${word}" =~ ^[=:]+$ || "\${COMP_WORDS[i-1]}" =~ ^[=:]+$ ) ]]; then
+            words[\${#words[@]}-1]+="\${word}"
+        else
+            words+=("\${word}")
+        fi
+        remaining_line="\${remaining_line#*"\${word}"}"
+    done
+    cword=$((\${#words[@]} - 1))
+    cur="\${words[cword]}"
+    word_prefix="\${cur%"$2"}"
+    opts="${root.completions.join(" ")}"
+    value_options="${root.valueOptions.join(" ")}"
     command_path=""
 
-    for ((i = 1; i < COMP_CWORD; i++)); do
-        word="\${COMP_WORDS[i]}"
+    for ((i = 1; i < cword; i++)); do
+        word="\${words[i]}"
         if [[ \${word} == -* ]]; then
             flag="\${word%%=*}"
             if [[ \${word} != *=* && " \${value_options} " == *" \${flag} "* ]]; then
@@ -416,52 +430,39 @@ _${rootCmd}_completion() {
             continue
         fi
 
-        if [[ -n "\${command_path}" ]]; then
-            candidate_path="\${command_path} \${word}"
-        else
-            candidate_path="\${word}"
-        fi
-
+        candidate_path="\${command_path:+\${command_path} }\${word}"
 ${commandPathUpdate}
     done
 
-    choice_flag="\${COMP_WORDS[COMP_CWORD-1]}"
+    choice_flag="\${words[cword-1]}"
     choice_prefix="\${cur}"
     choice_completion_prefix=""
-    if [[ "\${cur}" == -*=* ]]; then
+    if [[ "\${cur}" == --*=* ]]; then
         choice_flag="\${cur%%=*}"
         choice_prefix="\${cur#*=}"
         choice_completion_prefix="\${choice_flag}="
-    elif [[ "\${choice_flag}" == "=" ]]; then
-        choice_flag="\${COMP_WORDS[COMP_CWORD-2]}"
     fi
-    if [[ "\${choice_flag}" == -??* && "\${choice_flag}" != --* ]]; then
-        short_group="\${choice_flag#-}"
+    for short_group in "\${choice_flag}" "\${cur}"; do
+        [[ "\${short_group}" == -??* && "\${short_group}" != --* ]] || continue
+        short_group="\${short_group#-}"
         for ((short_index = 0; short_index < \${#short_group}; short_index++)); do
             short_flag="-\${short_group:short_index:1}"
             if [[ " \${value_options} " == *" \${short_flag} "* ]]; then
-                if ((short_index == \${#short_group} - 1)); then
+                if [[ "\${cur}" == "-\${short_group}" ]]; then
+                    choice_flag="\${short_flag}"
+                    choice_prefix="\${short_group:short_index+1}"
+                    choice_completion_prefix="-\${short_group:0:short_index+1}"
+                elif ((short_index == \${#short_group} - 1)); then
                     choice_flag="\${short_flag}"
                 fi
                 break
             fi
         done
-    fi
-    if [[ "\${cur}" == -??* && "\${cur}" != --* && "\${cur}" != *=* ]]; then
-        short_group="\${cur#-}"
-        for ((short_index = 0; short_index < \${#short_group}; short_index++)); do
-            short_flag="-\${short_group:short_index:1}"
-            if [[ " \${value_options} " == *" \${short_flag} "* ]]; then
-                choice_flag="\${short_flag}"
-                choice_prefix="\${short_group:short_index+1}"
-                choice_completion_prefix="-\${short_group:0:short_index+1}"
-                break
-            fi
-        done
-    fi
+    done
 
 ${choiceCompletion}
     COMPREPLY=( $(compgen -W "\${opts}" -- "\${cur}") )
+    COMPREPLY=("\${COMPREPLY[@]#"\${word_prefix}"}")
 }
 
 complete -F _${rootCmd}_completion ${rootCmd}
@@ -482,10 +483,11 @@ function generateBashOptionChoiceCompletion(contexts: ShellCompletionContext[]):
             : `[[ \${#COMPREPLY[@]} -gt 0 || -n "\${choice_completion_prefix}" || "\${choice_prefix}" != -* ]]`;
           return `            ${optionFlags})
                 local -a choice_values=(${escapedChoices})
-                local choice
+                local choice completion
                 for choice in "\${choice_values[@]}"; do
                     if [[ "\${choice}" == "\${choice_prefix}"* ]]; then
-                        COMPREPLY+=("\${choice_completion_prefix}\${choice}")
+                        completion="\${choice_completion_prefix}\${choice}"
+                        COMPREPLY+=("\${completion#"\${word_prefix}"}")
                     fi
                 done
                 if ${shouldReturn}; then
@@ -504,35 +506,20 @@ ${optionCases}
   return cases ? `    case "\${command_path}" in\n${cases}\n    esac\n` : "";
 }
 
-function generateBashCompletionContextCases(contexts: ShellCompletionContext[]): string {
-  const segments = contexts.map((context) => {
+function generateBashCommandPathUpdate(contexts: ShellCompletionContext[]): string {
+  const cases = contexts.map((context) => {
     const patterns = context.pathVariants
       .map((commandPath) => `"${commandPath.join(" ")}"`)
       .join("|");
-    return `              ${patterns})
-                opts="${context.completions.join(" ")}"
-                value_options="${context.valueOptions.join(" ")}"
-                ;;`;
-  });
-  return segments.join("\n");
-}
-
-function generateBashCommandPathUpdate(contexts: ShellCompletionContext[]): string {
-  if (contexts.length === 0) {
-    return "";
-  }
-  const commandPathPatterns = contexts
-    .flatMap((context) => context.pathVariants)
-    .map((commandPath) => `"${commandPath.join(" ")}"`)
-    .join("|");
-  return `        case "\${candidate_path}" in
-          ${commandPathPatterns})
+    return `          ${patterns})
             command_path="\${candidate_path}"
-            case "\${command_path}" in
-${generateBashCompletionContextCases(contexts)}
-            esac
-            ;;
-        esac`;
+            opts="${context.completions.join(" ")}"
+            value_options="${context.valueOptions.join(" ")}"
+            ;;`;
+  });
+  return cases.length
+    ? `        case "\${candidate_path}" in\n${cases.join("\n")}\n        esac`
+    : "";
 }
 
 function generatePowerShellCompletion(program: Command): string {


### PR DESCRIPTION
Fixes #136556.

## What Problem This Solves

Fixes an issue where users completing Bash options after `=` would receive no choices or a duplicated option prefix. A named profile such as `--profile=gateway` could also send completion into the wrong command context.

## Why This Change Was Made

The generator now reconstructs adjacent equals/colon fragments once and uses those same logical words for command selection and option choices. Returned text respects the fragment Readline actually replaces. Whitespace and shell redirections remain separate. Shared short-option scanning and command-context dispatch replace duplicated paths.

Production **+54 / −61 = −7 LOC**; tests/support **+217 / −43 = +174**; docs **+1**. Generated Bash output is 149,561 bytes versus 144,723 before; this is a correctness repair and source simplification, with no generated-size or speed claim.

## User Impact

Both `--flag value` and `--flag=value` complete correctly across the tested native Bash versions, including named profiles before nested commands. Attached short values continue to work. The unusable `-s=fish` suggestion is removed: the real Commander parser treats its value as `=fish` and already rejects it.

Other shell generators emit byte-identical output. No installation, configuration, storage, dependency or global `COMP_WORDBREAKS` change is introduced.

## Evidence

The original and rebuilt compiled CLI generated scripts inside isolated synthetic state. Real interactive Tab presses exercised those scripts:

| Native case | Before | After |
| --- | --- | --- |
| Bash 5.3: `completion --shell=` | No choices | All four supported shells |
| Bash 5.3: `--profile=gateway completion --shell f` | No choices | `fish` |
| Bash 3.2: `completion --shell=f` | Whole option returned for the `f` replacement span | `fish`, without a duplicate prefix |

- Three original regression failures are retained. All 173 focused owner/sibling tests pass.
- Sixty-two interactive cases pass across Bash 3.2.57 and 5.3.15, covering redirections, quotes, colon/repeated-equals fragments and short clusters. Bash 5.3 insertion buffers are checked exactly, including cursor-in-middle cases; Bash 3.2 callbacks and transcripts verify candidates and prefix behavior. Proof never executes the typed command.
- Fish and PowerShell executables are unavailable locally: 107 native cases skip. Their unchanged output hashes and static sibling checks are verified.
- The complete required changed-file gate and canonical runtime build, including 53 built-module checks, pass. Independent Codex review is clean through P2. Two regressions caught in earlier candidates were fixed and reproduced before the final review; neither is counted as another original issue.
- Root directly inspected the complete generator/command-tree owners, actual native results, installed Commander 15 parser and GNU Bash manual. The affected Bash owner is present in stable `v2026.8.2` and unchanged on current main; no unverified introduction attribution is made.

## Review finding and native cursor proof

The September 2 ClawSweeper P2 finding and its rank-up request are addressed. Reconstructed words retain the complete command-line token; matching now trims that token to the actual cursor before deriving Readline replacement text. Real Tab presses with the cursor after `f` in `--shell=fish` formerly returned an empty candidate on the first candidate; both Bash 3.2 and 5.3 now return `fish`. This keeps the existing right-of-cursor suffix under native Readline's `skip-completed-text=off` setting. No shell editing setting is changed.

The final 62 native cases preserve the preceding 40 cases and add 22 cursor/UTF-8 controls; all 62 restore the caller's locale. GNU release source confirms the offset unit changes at Bash 4.3: `pcomplete.c` in Bash 4.2 binds the byte index directly, while Bash 4.3 converts the prefix through `MB_STRLEN`. The generated function uses local byte semantics only for those older versions. A real Bash 3.2 UTF-8 regression failed before that correction and passes afterward. Bash 4.2/4.3 themselves were source-inspected, not executed.

The dependency-inspection gap is also closed: root personally inspected Commander 15.0.0 `lib/command.js:1760–1907` (`parseOptions`) and `lib/option.js` choice validation. Actual parser proof rejects `-s=fish` because the attached short value is literally `=fish`; `-sfish` and `-ysfish` remain covered.

The final canonical runtime build, all 29 required changed-file checks, and one cumulative independent Codex review through P2 pass with frozen inputs. Bash 3.2 lacks `READLINE_LINE`, so its evidence is the real callback plus PTY transcript. Quoted enum completion such as `--shell="fish"` with the cursor inside the quotes remains a named pre-existing follow-up; no repair of that separate behavior is claimed.

## Final review disposition

The latest ClawSweeper review reports no actionable defect. Its remaining Commander source-inspection gap is resolved by the direct installed-source and actual parser checks above. Its maintainer decision is covered by the explicit request to land this repair. Required exact-head CI is green.
