### PR TITLE
fix(cli): run message plugin cleanup before exiting

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -50,6 +50,10 @@ Every action accepts: `--channel <name>`, `--account <id>`, `--json`,
 `--dry-run`, `--verbose`. Actions that take a destination also accept
 `-t, --target <dest>`.
 
+Local message actions run the loaded plugins' shutdown hooks before exiting, including
+after an action fails. Cleanup has a 2.5-second overall budget and does not change
+the action's exit status. `message read` skips these shutdown hooks.
+
 ## SecretRef resolution
 
 `openclaw message` resolves channel SecretRefs before running the action,

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -400,7 +400,7 @@ registerHooks({
   },
 });
 const { createMessageCliHelpers } = await import(${JSON.stringify(pathToFileURL(path.resolve("src/cli/program/message/helpers.ts")).href)});
-const { runMessageAction } = createMessageCliHelpers({}, "fixture");
+const { runMessageAction } = createMessageCliHelpers("fixture");
 await runMessageAction("broadcast", {
   channel: "fixture",
   targets: ["ok-target", "failed-target"],

--- a/src/cli/message-plugin-cleanup.process.test.ts
+++ b/src/cli/message-plugin-cleanup.process.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { runCliProcessChild } from "./cli-process-child.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("message CLI plugin cleanup", () => {
+  it.each([
+    { name: "successful JSON", fail: false, json: true, pending: false },
+    { name: "successful text", fail: false, json: false, pending: false },
+    { name: "failed JSON", fail: true, json: true, pending: false },
+    { name: "failed text", fail: true, json: false, pending: false },
+    { name: "stalled cleanup", fail: false, json: true, pending: true },
+  ])("runs owned shutdown hooks after $name output", async ({ fail, json, pending }) => {
+    const root = tempDirs.make("openclaw-message-cleanup-");
+    const pluginDir = path.join(root, "plugin");
+    const configPath = path.join(root, "openclaw.json");
+    const marker = path.join(root, "stopped.txt");
+    const id = "message-cleanup-fixture";
+    const meta = {
+      id,
+      label: "Message cleanup fixture",
+      selectionLabel: "Message cleanup fixture",
+      docsPath: "/channels/test",
+      blurb: "Synthetic local channel",
+    };
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: id,
+        version: "1.0.0",
+        type: "module",
+        openclaw: { extensions: ["./index.js"], setupEntry: "./index.js", channel: meta },
+      }),
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id,
+        channels: [id],
+        configSchema: { type: "object" },
+        channelConfigs: { [id]: { schema: { type: "object" } } },
+      }),
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "index.js"),
+      `import fs from "node:fs";
+export const plugin = {
+  id: ${JSON.stringify(id)}, meta: ${JSON.stringify(meta)},
+  capabilities: { chatTypes: ["direct"] },
+  config: {
+    listAccountIds: () => ["default"],
+    resolveAccount: () => ({ accountId: "default", enabled: true }),
+    isConfigured: () => true, isEnabled: () => true,
+  },
+  messaging: {
+    normalizeTarget(raw) { ${fail ? 'throw new Error("synthetic target failure");' : "return raw;"} },
+    targetResolver: { looksLikeId: () => true },
+  },
+  outbound: { deliveryMode: "direct", sendText() { throw new Error("dry-run must not send"); } },
+};
+export default { id: plugin.id, register(api) {
+  api.registerChannel({ plugin });
+  api.on("gateway_stop", () => {
+    fs.appendFileSync(${JSON.stringify(marker)}, "stopped\\n");
+    ${pending ? "return new Promise(() => {});" : "return Promise.resolve();"}
+  });
+} };`,
+    );
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: { defaults: { workspace: path.join(root, "workspace") } },
+        plugins: { load: { paths: [pluginDir] }, entries: { [id]: { enabled: true } } },
+        channels: { [id]: { enabled: true } },
+        logging: { level: "silent", consoleLevel: "silent" },
+      }),
+    );
+
+    const result = await runCliProcessChild({
+      nodeArgs: [
+        "--import",
+        "tsx",
+        "src/entry.ts",
+        "message",
+        "send",
+        "--dry-run",
+        "--channel",
+        id,
+        "--target",
+        "user:synthetic",
+        "--message",
+        "Synthetic payload",
+        ...(json ? ["--json"] : []),
+      ],
+      env: {
+        PATH: process.env.PATH,
+        ESBUILD_WORKER_THREADS: process.env.ESBUILD_WORKER_THREADS,
+        HOME: root,
+        USERPROFILE: root,
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        OPENCLAW_NO_RESPAWN: "1",
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        NO_COLOR: "1",
+      },
+    });
+
+    expect(result.signal, result.stderr).toBeNull();
+    expect(result.code, result.stderr).toBe(fail ? 1 : 0);
+    await expect(fs.readFile(marker, "utf8")).resolves.toBe("stopped\n");
+    if (json) {
+      expect(JSON.parse(result.stdout)).toMatchObject(
+        fail ? { ok: false, error: { message: "synthetic target failure" } } : { dryRun: true },
+      );
+    }
+    if (pending) {
+      expect(result.stderr).toContain("gateway_stop hook exceeded 2500ms; continuing");
+    }
+  });
+});

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -1,7 +1,8 @@
 // Message program helper tests cover message command helper behavior and mocks.
 import { Command } from "commander";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { addTestHook, createMockPluginRegistry } from "../../../plugins/hooks.test-helpers.js";
 import { registerMessagePollCommand } from "./register.poll.js";
 import { registerMessageReactionsCommands } from "./register.reactions.js";
 import { registerMessageReadEditDeleteCommands } from "./register.read-edit-delete.js";
@@ -22,7 +23,8 @@ vi.mock("../../../globals.js", () => ({
   setVerbose: vi.fn(),
 }));
 
-const loadPluginRegistryHandleMock = vi.fn(() => ({ gatewayHandlers: {} }));
+const pluginRegistry = createMockPluginRegistry([]);
+const loadPluginRegistryHandleMock = vi.fn(() => pluginRegistry);
 vi.mock("../../../config/config.js", () => ({ getRuntimeConfig: () => ({}) }));
 vi.mock("../../../plugins/channel-plugin-ids.js", () => ({
   resolveConfiguredChannelPluginIds: () => ["configured-channel"],
@@ -33,29 +35,26 @@ vi.mock("../../../plugins/loader.js", () => ({
   loadPluginRegistryHandle: loadPluginRegistryHandleMock,
 }));
 
-const hasHooksMock = vi.fn((_hookName: string) => false);
 const runGatewayStopMock = vi.fn(
   async (_eventValue: { reason?: string }, _ctx: Record<string, unknown>) => {},
 );
-const runGlobalGatewayStopSafelyMock = vi.fn(
-  async (params: {
-    event: { reason?: string };
-    ctx: Record<string, unknown>;
-    onError?: (err: unknown) => void;
-  }) => {
-    if (!hasHooksMock("gateway_stop")) {
-      return;
-    }
-    try {
-      await runGatewayStopMock(params.event, params.ctx);
-    } catch (err) {
-      params.onError?.(err);
-    }
-  },
-);
-vi.mock("../../../plugins/hook-runner-global.js", () => ({
-  runGlobalGatewayStopSafely: runGlobalGatewayStopSafelyMock,
+const hookErrorMock = vi.fn();
+vi.mock("../../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    debug: vi.fn(),
+    warn: hookErrorMock,
+    error: hookErrorMock,
+  }),
 }));
+
+function registerStopHook() {
+  addTestHook({
+    registry: pluginRegistry,
+    pluginId: "test-plugin",
+    hookName: "gateway_stop",
+    handler: runGatewayStopMock,
+  });
+}
 
 const exitMock = vi.fn((_code: number): never => {
   throw new Error("exit");
@@ -72,6 +71,9 @@ vi.mock("../../deps.js", () => ({
 }));
 
 const { createMessageCliHelpers } = await import("./helpers.js");
+const { initializeGlobalHookRunner, resetGlobalHookRunner } =
+  await import("../../../plugins/hook-runner-global.js");
+afterEach(resetGlobalHookRunner);
 
 const NON_NEGATIVE_INTEGER_FLAGS = new Set(["--delete-days", "--duration-min"]);
 
@@ -82,8 +84,7 @@ const baseSendOptions = {
 };
 
 function createRunMessageAction() {
-  const fakeCommand = { help: vi.fn() } as never;
-  return createMessageCliHelpers(fakeCommand, "discord").runMessageAction;
+  return createMessageCliHelpers("discord").runMessageAction;
 }
 
 async function runSendAction(opts: Record<string, unknown> = {}) {
@@ -140,9 +141,9 @@ describe("runMessageAction", () => {
     getChannelPluginMock.mockReset();
     mockChannelExecutionModes({ telegram: "gateway" });
     messageCommandMock.mockClear().mockResolvedValue(undefined);
-    hasHooksMock.mockClear().mockReturnValue(false);
+    pluginRegistry.typedHooks.length = 0;
+    resetGlobalHookRunner();
     runGatewayStopMock.mockClear().mockResolvedValue(undefined);
-    runGlobalGatewayStopSafelyMock.mockClear();
     exitMock.mockClear().mockImplementation((_code: number): never => {
       throw new Error("exit");
     });
@@ -193,7 +194,7 @@ describe("runMessageAction", () => {
       });
       const program = new Command();
       const message = program.command("message");
-      registerMessageSendCommand(message, createMessageCliHelpers(message, "discord"));
+      registerMessageSendCommand(message, createMessageCliHelpers("discord"));
 
       await expect(
         program.parseAsync(
@@ -242,7 +243,7 @@ describe("runMessageAction", () => {
       });
       const program = new Command();
       const message = program.command("message");
-      const helpers = createMessageCliHelpers(message, "telegram");
+      const helpers = createMessageCliHelpers("telegram");
       registerMessageSendCommand(message, helpers);
       registerMessagePollCommand(message, helpers);
       registerMessageReactionsCommands(message, helpers);
@@ -573,8 +574,38 @@ describe("runMessageAction", () => {
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
+  it("finalizes only the command's registry when a process root also has hooks", async () => {
+    const rootStop = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "gateway_stop", handler: rootStop, pluginId: "process-root" },
+      ]),
+    );
+    registerStopHook();
+
+    await runSendAction();
+
+    expect(runGatewayStopMock).toHaveBeenCalledOnce();
+    expect(rootStop).not.toHaveBeenCalled();
+  });
+
+  it("leaves Gateway-owned resources running when the CLI loads no registry", async () => {
+    const rootStop = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "gateway_stop", handler: rootStop, pluginId: "process-root" },
+      ]),
+    );
+    mockChannelExecutionModes({ discord: "gateway" });
+
+    await runSendAction();
+
+    expect(loadPluginRegistryHandleMock).not.toHaveBeenCalled();
+    expect(rootStop).not.toHaveBeenCalled();
+  });
+
   it("runs gateway_stop hooks before exit when registered", async () => {
-    hasHooksMock.mockReturnValueOnce(true);
+    registerStopHook();
     await runSendAction();
 
     expect(runGatewayStopMock).toHaveBeenCalledWith({ reason: "cli message action complete" }, {});
@@ -582,7 +613,7 @@ describe("runMessageAction", () => {
   });
 
   it("skips gateway_stop hooks for read-only message reads", async () => {
-    hasHooksMock.mockReturnValueOnce(true);
+    registerStopHook();
     const runMessageAction = createRunMessageAction();
 
     await expect(
@@ -593,7 +624,6 @@ describe("runMessageAction", () => {
       }),
     ).rejects.toThrow("exit");
 
-    expect(runGlobalGatewayStopSafelyMock).not.toHaveBeenCalled();
     expect(runGatewayStopMock).not.toHaveBeenCalled();
     expect(exitMock).toHaveBeenCalledWith(0);
   });
@@ -601,7 +631,7 @@ describe("runMessageAction", () => {
   it("bounds gateway_stop hooks so message actions still exit", async () => {
     vi.useFakeTimers();
     try {
-      hasHooksMock.mockReturnValueOnce(true);
+      registerStopHook();
       runGatewayStopMock.mockImplementationOnce(() => new Promise(() => {}));
       const runMessageAction = createRunMessageAction();
 
@@ -626,7 +656,7 @@ describe("runMessageAction", () => {
   });
 
   it("runs gateway_stop hooks on failure before exit(1)", async () => {
-    hasHooksMock.mockReturnValueOnce(true);
+    registerStopHook();
     messageCommandMock.mockRejectedValueOnce(new Error("send failed"));
     await runSendAction();
 
@@ -636,7 +666,7 @@ describe("runMessageAction", () => {
 
   it("runs gateway_stop hooks before exit(1) for a failed broadcast result", async () => {
     const order: string[] = [];
-    hasHooksMock.mockReturnValueOnce(true);
+    registerStopHook();
     messageCommandMock.mockResolvedValueOnce({
       kind: "broadcast",
       channel: "telegram",
@@ -672,28 +702,27 @@ describe("runMessageAction", () => {
   });
 
   it("logs gateway_stop failure and still exits with success code", async () => {
-    hasHooksMock.mockReturnValueOnce(true);
+    registerStopHook();
     runGatewayStopMock.mockRejectedValueOnce(new Error("hook failed"));
     await runSendAction();
 
-    expect(errorMock).toHaveBeenCalledWith("gateway_stop hook failed: hook failed");
+    expect(hookErrorMock).toHaveBeenCalledWith(expect.stringContaining("hook failed"));
     expect(exitMock).toHaveBeenCalledWith(0);
   });
 
   it("logs gateway_stop failure and preserves failure exit code when send fails", async () => {
-    hasHooksMock.mockReturnValueOnce(true);
+    registerStopHook();
     messageCommandMock.mockRejectedValueOnce(new Error("send failed"));
     runGatewayStopMock.mockRejectedValueOnce(new Error("hook failed"));
     await runSendAction();
 
-    expect(errorMock).toHaveBeenNthCalledWith(1, "send failed");
-    expect(errorMock).toHaveBeenNthCalledWith(2, "gateway_stop hook failed: hook failed");
+    expect(errorMock).toHaveBeenCalledWith("send failed");
+    expect(hookErrorMock).toHaveBeenCalledWith(expect.stringContaining("hook failed"));
     expect(exitMock).toHaveBeenCalledWith(1);
   });
 
   it("passes action and maps account to accountId", async () => {
-    const fakeCommand = { help: vi.fn() } as never;
-    const { runMessageAction } = createMessageCliHelpers(fakeCommand, "discord");
+    const { runMessageAction } = createMessageCliHelpers("discord");
 
     await expect(
       runMessageAction("poll", {

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -2,7 +2,6 @@ import {
   parseStrictNonNegativeInteger,
   parseStrictPositiveInteger,
 } from "@openclaw/normalization-core/number-coercion";
-// Shared helpers for message CLI actions: common flags, plugin preload, numeric validation, and stop hooks.
 import type { Command } from "commander";
 import { getChannelPlugin } from "../../../channels/plugins/index.js";
 import {
@@ -16,16 +15,21 @@ import { danger, setVerbose } from "../../../globals.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { CHANNEL_TARGET_DESCRIPTION } from "../../../infra/outbound/channel-target.js";
 import { resolveMessageActionOutcome } from "../../../infra/outbound/message-action-contracts.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { withActivatedPluginIds } from "../../../plugins/activation-context.js";
 import {
   resolveConfiguredChannelPluginIds,
   resolveDiscoverableScopedChannelPluginIds,
 } from "../../../plugins/channel-plugin-ids.js";
-import { runGlobalGatewayStopSafely } from "../../../plugins/hook-runner-global.js";
+import { createHookRunner } from "../../../plugins/hooks.js";
 import { loadPluginRegistryHandle } from "../../../plugins/loader.js";
 import type { PluginRegistry } from "../../../plugins/registry-types.js";
 import { withPluginRuntimeRegistryScope } from "../../../plugins/runtime/gateway-request-scope.js";
 import { defaultRuntime } from "../../../runtime.js";
+import {
+  ABSOLUTE_DEADLINE_EXPIRED,
+  awaitWithinDeadline,
+} from "../../../utils/absolute-deadline.js";
 import { runCommandWithRuntime } from "../../cli-utils.js";
 import { createDefaultDeps } from "../../deps.js";
 
@@ -38,7 +42,6 @@ export type MessageCliHelpers = {
 };
 
 const GATEWAY_STOP_TIMEOUT_MS = 2500;
-const ACTIONS_WITHOUT_STOP_HOOKS = new Set(["read"]);
 const ACTIONS_REQUIRING_CONFIGURED_CHANNEL_PRELOAD = new Set(["broadcast"]);
 const CHANNEL_MESSAGE_ACTION_NAME_SET = new Set<string>(CHANNEL_MESSAGE_ACTION_NAMES);
 const STRICT_POSITIVE_INTEGER_OPTIONS = new Map([
@@ -81,23 +84,16 @@ function validateMessageNumericOptions(opts: Record<string, unknown>): void {
   }
 }
 
-async function runPluginStopHooks(): Promise<void> {
-  let timeout: NodeJS.Timeout | null = null;
-  const hookRun = runGlobalGatewayStopSafely({
-    event: { reason: "cli message action complete" },
-    ctx: {},
-    onError: (err) =>
-      defaultRuntime.error(danger(`gateway_stop hook failed: ${formatErrorMessage(err)}`)),
-  });
-  const bounded = new Promise<"timeout">((resolve) => {
-    timeout = setTimeout(() => resolve("timeout"), GATEWAY_STOP_TIMEOUT_MS);
-    timeout.unref?.();
-  });
-  const result = await Promise.race([hookRun.then(() => "done" as const), bounded]);
-  if (timeout) {
-    clearTimeout(timeout);
-  }
-  if (result === "timeout") {
+async function runPluginStopHooks(registry: PluginRegistry): Promise<void> {
+  const runner = createHookRunner(registry, { logger: createSubsystemLogger("plugins") });
+  const result = await awaitWithinDeadline(
+    () =>
+      withPluginRuntimeRegistryScope(registry, () =>
+        runner.runGatewayStop({ reason: "cli message action complete" }, {}),
+      ),
+    Date.now() + GATEWAY_STOP_TIMEOUT_MS,
+  );
+  if (result === ABSOLUTE_DEADLINE_EXPIRED) {
     defaultRuntime.error(
       danger(`gateway_stop hook exceeded ${GATEWAY_STOP_TIMEOUT_MS}ms; continuing`),
     );
@@ -148,91 +144,82 @@ function resolveMessagePluginPreloadPlan(
 }
 
 /** Create shared option decorators and the common message action runner. */
-export function createMessageCliHelpers(
-  message: Command,
-  messageChannelOptions: string,
-): MessageCliHelpers {
-  const withMessageBase = (command: Command) =>
-    command
-      .option("--channel <channel>", `Channel: ${messageChannelOptions}`)
-      .option("--account <id>", "Channel account id (accountId)")
-      .option("--json", "Output result as JSON", false)
-      .option("--dry-run", "Print payload and skip sending", false)
-      .option("--verbose", "Verbose logging", false);
-
-  const withMessageTarget = (command: Command) =>
-    command.option("-t, --target <dest>", CHANNEL_TARGET_DESCRIPTION);
-  const withRequiredMessageTarget = (command: Command) =>
-    command.requiredOption("-t, --target <dest>", CHANNEL_TARGET_DESCRIPTION);
-
-  const runMessageAction = async (action: string, opts: Record<string, unknown>) => {
-    setVerbose(Boolean(opts.verbose));
-    let failed = false;
-    let result: Awaited<ReturnType<typeof messageCommand>> | undefined;
-    let pluginRegistry: PluginRegistry | undefined;
-    await runCommandWithRuntime(
-      defaultRuntime,
-      async () => {
-        validateMessageNumericOptions(opts);
-        if (action === "poll" && opts.pollAnonymous === true && opts.pollPublic === true) {
-          throw new Error("--poll-anonymous and --poll-public are mutually exclusive.");
-        }
-        const preloadPlan = resolveMessagePluginPreloadPlan(action, opts);
-        if (preloadPlan.preload) {
-          const config = getRuntimeConfig();
-          const pluginIds = preloadPlan.channelId
-            ? resolveDiscoverableScopedChannelPluginIds({
-                config,
-                activationSourceConfig: config,
-                channelIds: [preloadPlan.channelId],
-                env: process.env,
-              })
-            : resolveConfiguredChannelPluginIds({
-                config,
-                activationSourceConfig: config,
-                env: process.env,
-              });
-          const activatedConfig = withActivatedPluginIds({ config, pluginIds }) ?? config;
-          pluginRegistry = loadPluginRegistryHandle({
-            config: activatedConfig,
-            activationSourceConfig: activatedConfig,
-            onlyPluginIds: pluginIds,
-            throwOnLoadError: true,
-          });
-        }
-        const deps = createDefaultDeps();
-        const run = () =>
-          messageCommand(
-            {
-              ...normalizeMessageOptions(opts),
-              action,
-            },
-            deps,
-            defaultRuntime,
-          );
-        result = await withPluginRuntimeRegistryScope(pluginRegistry, run);
-      },
-      (err) => {
-        failed = true;
-        defaultRuntime.error(danger(formatErrorMessage(err)));
-      },
-    );
-    // Outbound actions may start plugin-side resources; run bounded stop hooks even after failure.
-    if (!ACTIONS_WITHOUT_STOP_HOOKS.has(action)) {
-      await withPluginRuntimeRegistryScope(pluginRegistry, runPluginStopHooks);
-    }
-    failed ||= result !== undefined && !resolveMessageActionOutcome(result).ok;
-    defaultRuntime.exit(failed ? 1 : 0);
-  };
-
-  // `message` is only used for `message.help({ error: true })`, keep the
-  // command-specific helpers grouped here.
-  void message;
-
+export function createMessageCliHelpers(messageChannelOptions: string): MessageCliHelpers {
   return {
-    withMessageBase,
-    withMessageTarget,
-    withRequiredMessageTarget,
-    runMessageAction,
+    withMessageBase: (command) =>
+      command
+        .option("--channel <channel>", `Channel: ${messageChannelOptions}`)
+        .option("--account <id>", "Channel account id (accountId)")
+        .option("--json", "Output result as JSON", false)
+        .option("--dry-run", "Print payload and skip sending", false)
+        .option("--verbose", "Verbose logging", false),
+
+    withMessageTarget: (command) =>
+      command.option("-t, --target <dest>", CHANNEL_TARGET_DESCRIPTION),
+    withRequiredMessageTarget: (command) =>
+      command.requiredOption("-t, --target <dest>", CHANNEL_TARGET_DESCRIPTION),
+
+    runMessageAction: async (action, opts) => {
+      setVerbose(Boolean(opts.verbose));
+      let failed = false;
+      let result: Awaited<ReturnType<typeof messageCommand>> | undefined;
+      let pluginRegistry: PluginRegistry | undefined;
+      try {
+        await runCommandWithRuntime(
+          defaultRuntime,
+          async () => {
+            validateMessageNumericOptions(opts);
+            if (action === "poll" && opts.pollAnonymous === true && opts.pollPublic === true) {
+              throw new Error("--poll-anonymous and --poll-public are mutually exclusive.");
+            }
+            const preloadPlan = resolveMessagePluginPreloadPlan(action, opts);
+            if (preloadPlan.preload) {
+              const config = getRuntimeConfig();
+              const pluginIds = preloadPlan.channelId
+                ? resolveDiscoverableScopedChannelPluginIds({
+                    config,
+                    activationSourceConfig: config,
+                    channelIds: [preloadPlan.channelId],
+                    env: process.env,
+                  })
+                : resolveConfiguredChannelPluginIds({
+                    config,
+                    activationSourceConfig: config,
+                    env: process.env,
+                  });
+              const activatedConfig = withActivatedPluginIds({ config, pluginIds }) ?? config;
+              pluginRegistry = loadPluginRegistryHandle({
+                config: activatedConfig,
+                activationSourceConfig: activatedConfig,
+                onlyPluginIds: pluginIds,
+                throwOnLoadError: true,
+              });
+            }
+            const deps = createDefaultDeps();
+            const run = () =>
+              messageCommand(
+                {
+                  ...normalizeMessageOptions(opts),
+                  action,
+                },
+                deps,
+                defaultRuntime,
+              );
+            result = await withPluginRuntimeRegistryScope(pluginRegistry, run);
+          },
+          (err) => {
+            failed = true;
+            defaultRuntime.error(danger(formatErrorMessage(err)));
+          },
+        );
+      } finally {
+        // Finalize only this command's registry, including JSON/expected errors that rethrow.
+        if (pluginRegistry && action !== "read") {
+          await runPluginStopHooks(pluginRegistry);
+        }
+      }
+      failed ||= result !== undefined && !resolveMessageActionOutcome(result).ok;
+      defaultRuntime.exit(failed ? 1 : 0);
+    },
   };
 }

--- a/src/cli/program/register.message.test.ts
+++ b/src/cli/program/register.message.test.ts
@@ -106,7 +106,7 @@ describe("registerMessageCommands", () => {
     registerMessageCommands(program, ctx);
 
     const message = requireProgramCommand(program, "message");
-    expect(createMessageCliHelpersMock).toHaveBeenCalledWith(message, "telegram|discord");
+    expect(createMessageCliHelpersMock).toHaveBeenCalledWith("telegram|discord");
 
     const expectedRegistrars = [
       registerMessageSendCommandMock,

--- a/src/cli/program/register.message.ts
+++ b/src/cli/program/register.message.ts
@@ -52,7 +52,7 @@ ${formatHelpExamples([
 ${theme.muted("Docs:")} ${formatDocsLink("/cli/message", "docs.openclaw.ai/cli/message")}`,
     );
 
-  const helpers = createMessageCliHelpers(message, ctx.messageChannelOptions);
+  const helpers = createMessageCliHelpers(ctx.messageChannelOptions);
   registerMessageSendCommand(message, helpers);
   registerMessageBroadcastCommand(message, helpers);
   registerMessagePollCommand(message, helpers);

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -7,6 +7,7 @@ export const cliProcessTestFiles = [
   "src/cli/gateway-backed-exit.process.test.ts",
   "src/cli/gateway-cli/shutdown-hard-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",
+  "src/cli/message-plugin-cleanup.process.test.ts",
   "src/cli/hooks-cli.process.test.ts",
   "src/cli/plugins-authoring.process.test.ts",
   "src/cli/mcp-cli.import-boundary.test.ts",


### PR DESCRIPTION
Fixes #136563.

## What Problem This Solves

Fixes an issue where local message commands exit without running their plugins' registered cleanup hooks, including after an action fails. The command loaded a private registry while cleanup still looked for a global runner.

## Why This Change Was Made

Cleanup now creates the canonical hook runner from the exact registry owned by the command, inside that registry's runtime scope. A structural `finally` covers success and error/JSON unwinding. The existing absolute-deadline helper replaces the private timer race; unused factory arguments and duplicate wrapper structure are deleted.

This restores the lifecycle contract introduced by [#16580](https://github.com/openclaw/openclaw/pull/16580) after the scoped-handle transition in [#117587](https://github.com/openclaw/openclaw/pull/117587). Gateway and unrelated process-root hooks retain their own owner.

Production **+90 / −103 = −13 LOC**; tests/support **+197 / −42 = +155**; docs **+4**.

## User Impact

Local message plugins receive their shutdown callback before command exit. The existing 2.5-second overall cleanup budget, read exemption, hook-error logging, action exit status and JSON result shape are preserved. A timed-out hook is reported; underlying plugin work is not claimed to be cancelled.

## Evidence

Real compiled CLI runs used the same complete synthetic adapter before and after the fix. No external message was sent.

| Actual CLI cases | Before | After |
| --- | --- | --- |
| Successful send dry-run, JSON/text | 0 shutdown callbacks; exit 0 | 1 callback; exit 0 |
| Failed action, JSON/text | 0 callbacks; exit 1 | 1 callback; exit 1 |
| Pending cleanup, JSON/text | 0 callbacks; exit 0 | Callback attempted; existing 2500ms warning; exit 0 |
| Throwing cleanup, JSON/text | 0 callbacks; exit 0 | Callback attempted; failure logged; exit 0 |
| Read dry-run control | 0 callbacks | 0 callbacks |

The nine before/after cases preserve command stdout and exit status. Fixture hashes match, and the final adapter produces no discovery warning. Five authentic source-CLI regressions fail before production edits and pass after; 147 owner/sibling tests and the existing structured-broadcast process case also pass. Tests explicitly retain unrelated process-root hooks and Gateway-owned resources.

The complete eight-file changed gate and full build pass. A single connected Codex P2 review is clean; its pending-gate note is resolved by the completed immutable gate. Root directly inspected the full command, registry loader/scope, hook runner, deadline helper, tests, actual output, stable history and current-main owner contracts. The earlier partitioned review was not used as a complete verdict.


<details>
<summary>Recorded compiled CLI output and callback traces</summary>

Captured on September 2 using Node 24.19.0. The commands below are shown relative to each compiled checkout; the per-case local adapter records its own hook invocation. The adapter throws if a real send is attempted. Both sides use identical adapter files; the normal adapter SHA256 is `03a96fdbdc37acd7e718da20bca4833c0b69484e121706dbdd7be0ab3898b3b2`.

```sh
node dist/entry.js message send --dry-run --channel qa-message-cleanup --target user:synthetic --message 'Synthetic dry-run payload' --json
node dist/entry.js message read --dry-run --channel qa-message-cleanup --target user:synthetic --json
```

The text cases omit `--json`. Each error/pending case swaps only the synthetic adapter behavior. Original baseline `65e5b2e19c9d` entry SHA256: `ce8ce0116c248f23e8a29fb3e8cff07d9c162a40f0030c870a5640eb43960835`; fixed entry SHA256: `94a3945cfb1257cd295413aa0ab651fcd4598a2b17bfb2ccd3c5eb55204e3c5a`. The fixed build was made from the exact production source committed in this PR.

The following retained result extract includes exact after-run stdout/stderr and the adapter's exact shutdown events. Before/after stdout is byte-identical in all nine cases. The before count was computed from each complete trace; unrelated registration/normalization events are omitted here.

```json
[
  {
    "case": "success-json",
    "before": {
      "exit": 0,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 0,
      "stdout": "{\n  \"action\": \"send\",\n  \"channel\": \"qa-message-cleanup\",\n  \"dryRun\": true,\n  \"handledBy\": \"core\",\n  \"payload\": {\n    \"channel\": \"qa-message-cleanup\",\n    \"to\": \"user:synthetic\",\n    \"via\": \"direct\",\n    \"mediaUrl\": null,\n    \"dryRun\": true\n  }\n}\n",
      "stderr": "",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376897441
        }
      ]
    }
  },
  {
    "case": "success-text",
    "before": {
      "exit": 0,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 0,
      "stdout": "[dry-run] would run send via qa-message-cleanup\n",
      "stderr": "",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376899179
        }
      ]
    }
  },
  {
    "case": "action-failure-json",
    "before": {
      "exit": 1,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 1,
      "stdout": "{\n  \"ok\": false,\n  \"error\": {\n    \"type\": \"cli_error\",\n    \"message\": \"synthetic target validation failure\"\n  }\n}\n",
      "stderr": "[openclaw] Could not start the CLI.\n[openclaw] Reason: synthetic target validation failure\n[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.\n[openclaw] Try: openclaw doctor\n[openclaw] Help: openclaw --help\n",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376902129
        }
      ]
    }
  },
  {
    "case": "action-failure-text",
    "before": {
      "exit": 1,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 1,
      "stdout": "",
      "stderr": "synthetic target validation failure\n",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376903871
        }
      ]
    }
  },
  {
    "case": "pending-json",
    "before": {
      "exit": 0,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 0,
      "stdout": "{\n  \"action\": \"send\",\n  \"channel\": \"qa-message-cleanup\",\n  \"dryRun\": true,\n  \"handledBy\": \"core\",\n  \"payload\": {\n    \"channel\": \"qa-message-cleanup\",\n    \"to\": \"user:synthetic\",\n    \"via\": \"direct\",\n    \"mediaUrl\": null,\n    \"dryRun\": true\n  }\n}\n",
      "stderr": "gateway_stop hook exceeded 2500ms; continuing\n",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376905813
        }
      ]
    }
  },
  {
    "case": "pending-text",
    "before": {
      "exit": 0,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 0,
      "stdout": "[dry-run] would run send via qa-message-cleanup\n",
      "stderr": "gateway_stop hook exceeded 2500ms; continuing\n",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376910883
        }
      ]
    }
  },
  {
    "case": "throw-json",
    "before": {
      "exit": 0,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 0,
      "stdout": "{\n  \"action\": \"send\",\n  \"channel\": \"qa-message-cleanup\",\n  \"dryRun\": true,\n  \"handledBy\": \"core\",\n  \"payload\": {\n    \"channel\": \"qa-message-cleanup\",\n    \"to\": \"user:synthetic\",\n    \"via\": \"direct\",\n    \"mediaUrl\": null,\n    \"dryRun\": true\n  }\n}\n",
      "stderr": "[plugins] [hooks] gateway_stop handler from qa-message-cleanup failed: synthetic cleanup failure\n",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376915641
        }
      ]
    }
  },
  {
    "case": "throw-text",
    "before": {
      "exit": 0,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 0,
      "stdout": "[dry-run] would run send via qa-message-cleanup\n",
      "stderr": "[plugins] [hooks] gateway_stop handler from qa-message-cleanup failed: synthetic cleanup failure\n",
      "shutdownEvents": [
        {
          "event": "gateway_stop",
          "at": 1788376918201
        }
      ]
    }
  },
  {
    "case": "read-exemption",
    "before": {
      "exit": 0,
      "shutdownEvents": 0
    },
    "after": {
      "exit": 0,
      "stdout": "{\n  \"action\": \"read\",\n  \"channel\": \"qa-message-cleanup\",\n  \"dryRun\": true,\n  \"handledBy\": \"dry-run\",\n  \"payload\": {\n    \"ok\": true,\n    \"dryRun\": true,\n    \"channel\": \"qa-message-cleanup\",\n    \"action\": \"read\"\n  }\n}\n",
      "stderr": "",
      "shutdownEvents": []
    }
  }
]
```

</details>

## Current-main CI refresh

A tree-identical CI refresh retains the complete reviewed source and proof. Earlier checks ran before the canonical main test split and CI runner/dependency acquisition fixes; the new PR event rebuilds the current merge ref through the normal required checks. There are no source, test, configuration or production-LOC changes in this refresh.

## Final review disposition

The final review accepts cleanup on the exact command-owned registry. The nine published compiled CLI traces preserve output and exit status while proving one bounded shutdown callback, with zero callbacks for the read exemption. Gateway-owned registries remain outside this lifecycle. The review’s remaining CI prerequisite is satisfied.

Required [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33680965717/job/100423822010) passed for `eba5c8bb5d92d71120a6b79b276f331d4369065a`. Production owners are unchanged on main `31ed57e3953152fa826a444e742b3c0ec5149961` since the reproduced baseline, and the complete PR composes cleanly. The latest ClawSweeper review and its rank-up requests have been addressed; no actionable code finding remains.
