### PR TITLE
fix(slack): replies to existing threads fail to send

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -750,6 +750,12 @@ surfaces:
 - `openclaw/plugin-sdk/thread-bindings-runtime` for thread-binding lifecycle
   and adapter registration
 
+The `threading.resolveReplyTransport` hook receives the payload's optional
+`replyToCurrent` intent separately from `replyToIsExplicit`. Channels whose
+native API requires a thread root can resolve a current-message reply against
+the admitted thread without redirecting arbitrary explicit `replyToId` targets.
+Omitted intent keeps the existing explicit-target behavior.
+
 Auth-only channels can usually stop at the default path: core handles
 approvals and the plugin just exposes outbound/auth capabilities. Native
 approval channels such as Matrix, Slack, Telegram, and custom chat transports

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1458,6 +1458,12 @@ describe("slackPlugin outbound", () => {
 
   it.each([
     {
+      name: "current",
+      replyToIsExplicit: true,
+      replyToCurrent: true,
+      expectedReplyToId: "1712345678.123456",
+    },
+    {
       name: "inherited",
       replyToIsExplicit: false,
       expectedReplyToId: "1712345678.123456",
@@ -1466,7 +1472,7 @@ describe("slackPlugin outbound", () => {
     { name: "unknown", replyToIsExplicit: undefined, expectedReplyToId: "1712345688.654321" },
   ])(
     "routes $name child replies to $expectedReplyToId",
-    ({ replyToIsExplicit, expectedReplyToId }) => {
+    ({ replyToIsExplicit, replyToCurrent, expectedReplyToId }) => {
       const resolveReplyTransport = slackPlugin.threading?.resolveReplyTransport;
       if (!resolveReplyTransport) {
         throw new Error("slack threading.resolveReplyTransport unavailable");
@@ -1478,6 +1484,7 @@ describe("slackPlugin outbound", () => {
           replyToId: "1712345688.654321",
           threadId: "1712345678.123456",
           replyToIsExplicit,
+          replyToCurrent,
         }),
       ).toEqual({ replyToId: expectedReplyToId, threadId: null });
     },

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -80,7 +80,11 @@ import {
   parseSlackTarget,
 } from "./target-parsing.js";
 import { slackContextTargetsMatch } from "./targets.js";
-import { normalizeSlackThreadTsCandidate, resolveSlackThreadTsValue } from "./thread-ts.js";
+import {
+  normalizeSlackThreadTsCandidate,
+  resolveSlackReplyThreadTs,
+  resolveSlackThreadTsValue,
+} from "./thread-ts.js";
 import { buildSlackThreadingToolContext } from "./threading-tool-context.js";
 
 // Lazy SDK loaders. The dynamic import is hidden behind a string-literal
@@ -876,14 +880,19 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
               toolContext,
             }),
           ),
-    resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit, replyDelivery }) => {
-      const allowedReplyToId = replyDelivery?.replyToMode === "off" ? undefined : replyToId;
-      // Slack's thread_ts identifies the root. Only known inherited replies may let
-      // that root replace a child timestamp; explicit and unknown callers stay reply-first.
-      const preferThreadId = replyToIsExplicit === false;
-      const resolvedReplyToId = resolveSlackThreadTsValue({
-        replyToId: preferThreadId ? threadId : allowedReplyToId,
-        threadId: preferThreadId ? allowedReplyToId : threadId,
+    resolveReplyTransport: ({
+      threadId,
+      replyToId,
+      replyToIsExplicit,
+      replyToCurrent,
+      replyDelivery,
+    }) => {
+      const resolvedReplyToId = resolveSlackReplyThreadTs({
+        replyToId: normalizeSlackThreadTsCandidate(replyToId),
+        threadId: normalizeSlackThreadTsCandidate(threadId),
+        replyToMode: replyDelivery?.replyToMode,
+        replyToIsExplicit,
+        replyToCurrent,
       });
       return {
         replyToId:

--- a/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-streaming.ts
@@ -13,12 +13,9 @@ import {
   stopSlackStream,
   type SlackStreamSession,
 } from "../../streaming.js";
+import { resolveSlackReplyThreadTs } from "../../thread-ts.js";
 import { countSlackTextUtf8Bytes } from "../../truncate.js";
-import {
-  deliverReplies,
-  readSlackReplyBlocks,
-  resolveDeliveredSlackReplyThreadTs,
-} from "../replies.js";
+import { deliverReplies, readSlackReplyBlocks } from "../replies.js";
 import {
   createSlackEventDeliveryTracker,
   resolveSlackStreamRecipientTeamId,
@@ -314,10 +311,11 @@ export function createSlackStreamingDeliveryRuntime(setup: SlackDispatchSetup) {
     if (params.kind === "final") {
       state.observedFinalReplyDelivery = true;
     }
-    const deliveredThreadTs = resolveDeliveredSlackReplyThreadTs({
+    const deliveredThreadTs = resolveSlackReplyThreadTs({
       replyToMode: replyDeliveryMode,
-      payloadReplyToId: params.payload.replyToId,
-      replyThreadTs: deliveryReplyThreadTs,
+      replyToId: params.payload.replyToId,
+      threadId: deliveryReplyThreadTs,
+      replyToCurrent: params.payload.replyToCurrent,
     });
     // Record the thread ts only after confirmed delivery success.
     rememberDeliveredThreadTs(params.kind, deliveredThreadTs);

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -998,12 +998,6 @@ vi.mock("../replies.js", async (importOriginal) => ({
   }),
   deliverReplies: deliverRepliesMock,
   readSlackReplyBlocks: () => mockedSlackReplyBlocks,
-  resolveDeliveredSlackReplyThreadTs: (params: {
-    replyToMode: "off" | "first" | "all" | "batched";
-    payloadReplyToId?: string;
-    replyThreadTs?: string;
-  }) =>
-    (params.replyToMode === "off" ? undefined : params.payloadReplyToId) ?? params.replyThreadTs,
   resolveSlackThreadTs: () => mockedReplyThreadTs,
 }));
 

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1774,6 +1774,8 @@ export async function prepareSlackMessage(params: {
             ]
           : undefined,
       TransportThreadId: directThreadRoutedToDmSession ? threadContext.messageThreadId : undefined,
+      // Keep the child message identity, but never inject it as Slack's thread root.
+      ReplyThreading: isThreadReply ? { implicitCurrentMessage: "deny" } : undefined,
       SlackAssistantThread: assistantThreadContext ? true : undefined,
       SlackAgentThread: agentViewThreadTs ? true : undefined,
       SlackAssistantThreadContextChannelId: assistantThreadContext?.channelId,

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -33,7 +33,6 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
 
 let deliverReplies: typeof import("./replies.js").deliverReplies;
 let createSlackReplyDeliveryPlan: typeof import("./replies.js").createSlackReplyDeliveryPlan;
-let resolveDeliveredSlackReplyThreadTs: typeof import("./replies.js").resolveDeliveredSlackReplyThreadTs;
 let resolveSlackThreadTs: typeof import("./replies.js").resolveSlackThreadTs;
 import { deliverSlackSlashReplies, sanitizeSlackMonitorReplyPayload } from "./replies.js";
 
@@ -140,12 +139,8 @@ function readPlainSectionTexts(message: SlashTestMessage): string[] {
 
 describe("deliverReplies identity passthrough", () => {
   beforeAll(async () => {
-    ({
-      createSlackReplyDeliveryPlan,
-      deliverReplies,
-      resolveDeliveredSlackReplyThreadTs,
-      resolveSlackThreadTs,
-    } = await import("./replies.js"));
+    ({ createSlackReplyDeliveryPlan, deliverReplies, resolveSlackThreadTs } =
+      await import("./replies.js"));
   });
 
   beforeEach(() => {
@@ -164,6 +159,35 @@ describe("deliverReplies identity passthrough", () => {
     const options = requireSendCall()[2];
     expect(options.identity).toBe(identity);
   });
+
+  it.each([
+    { name: "current reply", replyToCurrent: true, isCompactionNotice: false },
+    { name: "compaction notice", replyToCurrent: true, isCompactionNotice: true },
+    { name: "explicit target", replyToCurrent: false, isCompactionNotice: false },
+  ])(
+    "routes $name without mistaking a child for its thread root",
+    async ({ replyToCurrent, isCompactionNotice }) => {
+      sendMock.mockResolvedValue({ messageId: "1800000000.000003", channelId: "C123" });
+      await deliverReplies(
+        baseParams({
+          replies: [
+            {
+              text: "Thread reply",
+              replyToId: "1800000000.000002",
+              replyToCurrent,
+              isCompactionNotice,
+            },
+          ],
+          replyThreadTs: "1800000000.000001",
+          replyToMode: "all",
+        }),
+      );
+
+      expect(requireSendCall()[2].threadTs).toBe(
+        replyToCurrent ? "1800000000.000001" : "1800000000.000002",
+      );
+    },
+  );
 
   it("passes identity to sendMessageSlack for media replies", async () => {
     sendMock.mockResolvedValue(undefined);
@@ -449,41 +473,6 @@ describe("deliverReplies identity passthrough", () => {
       expect.objectContaining({ type: "section" }),
       expect.objectContaining({ type: "actions" }),
     ]);
-  });
-});
-
-describe("resolveDeliveredSlackReplyThreadTs", () => {
-  beforeAll(async () => {
-    ({ resolveDeliveredSlackReplyThreadTs } = await import("./replies.js"));
-  });
-
-  it("prefers explicit reply targets when reply tags are enabled", () => {
-    expect(
-      resolveDeliveredSlackReplyThreadTs({
-        replyToMode: "first",
-        payloadReplyToId: "explicit-thread",
-        replyThreadTs: "planned-thread",
-      }),
-    ).toBe("explicit-thread");
-  });
-
-  it("ignores explicit reply tags when replyToMode is off", () => {
-    expect(
-      resolveDeliveredSlackReplyThreadTs({
-        replyToMode: "off",
-        payloadReplyToId: "explicit-thread",
-        replyThreadTs: "planned-thread",
-      }),
-    ).toBe("planned-thread");
-  });
-
-  it("falls back to the planned reply thread when no explicit reply tag exists", () => {
-    expect(
-      resolveDeliveredSlackReplyThreadTs({
-        replyToMode: "batched",
-        replyThreadTs: "planned-thread",
-      }),
-    ).toBe("planned-thread");
   });
 });
 

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -41,6 +41,7 @@ import {
   resolveSlackReplyBlockResolution,
   resolveSlackReplyBlocks,
 } from "../reply-blocks.js";
+import { resolveSlackReplyThreadTs } from "../thread-ts.js";
 import type { SlackEventScope } from "./event-scope.js";
 import {
   createSlackResponseUrlBudget,
@@ -118,17 +119,6 @@ function resolveSlackMediaHookSpokenText(payload: ReplyPayload): string | undefi
   return spokenText?.trim() || undefined;
 }
 
-export function resolveDeliveredSlackReplyThreadTs(params: {
-  replyToMode: "off" | "first" | "all" | "batched";
-  payloadReplyToId?: string;
-  replyThreadTs?: string;
-}): string | undefined {
-  // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
-  // must not force threading.
-  const inlineReplyToId = params.replyToMode === "off" ? undefined : params.payloadReplyToId;
-  return inlineReplyToId ?? params.replyThreadTs;
-}
-
 export async function deliverReplies(params: {
   cfg: OpenClawConfig;
   replies: ReplyPayload[];
@@ -167,10 +157,11 @@ export async function deliverReplies(params: {
     if (payload.isReasoning === true) {
       continue;
     }
-    const threadTs = resolveDeliveredSlackReplyThreadTs({
+    const threadTs = resolveSlackReplyThreadTs({
       replyToMode: params.replyToMode,
-      payloadReplyToId: payload.replyToId,
-      replyThreadTs: params.replyThreadTs,
+      replyToId: payload.replyToId,
+      threadId: params.replyThreadTs,
+      replyToCurrent: payload.replyToCurrent,
     });
     const reply = resolveSendableOutboundReplyParts(payload);
     const textRaw =

--- a/extensions/slack/src/thread-ts.test.ts
+++ b/extensions/slack/src/thread-ts.test.ts
@@ -1,6 +1,44 @@
 // Slack tests cover thread ts plugin behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeSlackThreadTsCandidate, resolveSlackThreadTsValue } from "./thread-ts.js";
+import {
+  normalizeSlackThreadTsCandidate,
+  resolveSlackReplyThreadTs,
+  resolveSlackThreadTsValue,
+} from "./thread-ts.js";
+
+describe("Slack reply target selection", () => {
+  it("prefers explicit reply targets when reply tags are enabled", () => {
+    expect(
+      resolveSlackReplyThreadTs({
+        replyToMode: "first",
+        replyToId: "explicit-thread",
+        threadId: "planned-thread",
+      }),
+    ).toBe("explicit-thread");
+  });
+
+  it("ignores explicit reply tags when replyToMode is off", () => {
+    expect(
+      resolveSlackReplyThreadTs({
+        replyToMode: "off",
+        replyToId: "explicit-thread",
+        threadId: "planned-thread",
+      }),
+    ).toBe("planned-thread");
+  });
+
+  it("uses the planned thread when no explicit reply tag exists", () => {
+    expect(resolveSlackReplyThreadTs({ replyToMode: "batched", threadId: "planned-thread" })).toBe(
+      "planned-thread",
+    );
+  });
+
+  it("keeps a current reply target when there is no existing thread", () => {
+    expect(resolveSlackReplyThreadTs({ replyToCurrent: true, replyToId: "current-message" })).toBe(
+      "current-message",
+    );
+  });
+});
 
 describe("Slack thread_ts resolution", () => {
   it("accepts trimmed Slack timestamp strings", () => {

--- a/extensions/slack/src/thread-ts.ts
+++ b/extensions/slack/src/thread-ts.ts
@@ -1,7 +1,23 @@
 // Slack plugin module implements thread ts behavior.
+import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const SLACK_THREAD_TS_PATTERN = /^\d+\.\d+$/;
+
+export function resolveSlackReplyThreadTs(params: {
+  replyToId?: string;
+  threadId?: string;
+  replyToMode?: ReplyToMode;
+  replyToIsExplicit?: boolean;
+  replyToCurrent?: boolean;
+}): string | undefined {
+  const replyToId = params.replyToMode === "off" ? undefined : params.replyToId;
+  // Slack requires the root timestamp, not the current child. Only current or
+  // known inherited replies may replace an explicit target with that root.
+  return params.replyToCurrent || params.replyToIsExplicit === false
+    ? (params.threadId ?? replyToId)
+    : (replyToId ?? params.threadId);
+}
 
 export function normalizeSlackThreadTsCandidate(
   value?: string | number | null,

--- a/src/auto-reply/reply/followup-delivery.channel.test.ts
+++ b/src/auto-reply/reply/followup-delivery.channel.test.ts
@@ -37,6 +37,23 @@ function createChannelPlugin(id: ChannelPlugin["id"]): ChannelPlugin {
   });
 }
 
+function registerCurrentReplyThreading() {
+  const slack = createChannelPlugin("slack");
+  slack.threading = {
+    resolveReplyTransport: (params: {
+      threadId?: string | number | null;
+      replyToId?: string | null;
+      replyToCurrent?: boolean;
+    }) => ({
+      threadId: null,
+      replyToId: params.replyToCurrent ? String(params.threadId) : params.replyToId,
+    }),
+  };
+  setActivePluginRegistry(
+    createTestRegistry([{ pluginId: "slack", plugin: slack, source: "test" }]),
+  );
+}
+
 function createTurn(params: {
   messageProvider: string;
   originatingChannel: string;
@@ -139,6 +156,70 @@ afterEach(() => {
 });
 
 describe("follow-up delivery channel boundary", () => {
+  it.each([true, false])(
+    "carries current-reply intent (%s) through queued status delivery",
+    async (replyToCurrent) => {
+      registerCurrentReplyThreading();
+      const turn = createTurn({ messageProvider: "discord", originatingChannel: "slack" });
+      turn.queued.originatingThreadId = "111.000";
+      channelState.outcomes = ["delivered"];
+      await deliverFollowupDecision({
+        decision: {
+          kind: "deliver",
+          payloads: [
+            {
+              text: "Compacting context",
+              replyToId: "222.000",
+              replyToCurrent,
+              isCompactionNotice: true,
+            },
+          ],
+        },
+        turn,
+        defaults: createDefaults(vi.fn(async () => {})),
+        runId: "run-1",
+        runFollowup: vi.fn(async () => {}),
+        kind: "block",
+      });
+
+      expect(channelState.deliver).toHaveBeenCalledWith(
+        expect.objectContaining({ replyToId: replyToCurrent ? "111.000" : "222.000" }),
+      );
+    },
+  );
+
+  it("dedupes a current-reply status against its actual thread root", () => {
+    registerCurrentReplyThreading();
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: {},
+        payloads: [
+          {
+            text: "Compacting context",
+            replyToId: "222.000",
+            replyToCurrent: true,
+            isCompactionNotice: true,
+          },
+        ],
+        messageProvider: "slack",
+        originatingChannel: "slack",
+        originatingReplyToMode: "all",
+        originatingTo: "channel:C1",
+        originatingThreadId: "111.000",
+        sentTexts: ["Compacting context"],
+        sentTargets: [
+          {
+            tool: "slack",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "111.000",
+            text: "Compacting context",
+          },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
   it("renders post-compaction model failures after queued payload selection", () => {
     const decision = resolveFollowupDeliveryDecision({
       turn: createTurn({ messageProvider: "discord", originatingChannel: "discord" }),

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -32,6 +32,7 @@ type MessagingToolDedupeRouteParams = {
   originatingThreadId?: string | number;
   replyToId?: string;
   replyToIsExplicit?: boolean;
+  replyToCurrent?: boolean;
   replyDelivery?: ReplyDeliveryContext;
   accountId?: string;
 };
@@ -197,6 +198,7 @@ function resolveOriginThreadIdForPayload(params: {
   originatingThreadId?: string | number;
   replyToId?: string;
   replyToIsExplicit?: boolean;
+  replyToCurrent?: boolean;
   replyDelivery?: ReplyDeliveryContext;
 }): string | undefined {
   const originThreadId = normalizeThreadIdForComparison(params.originatingThreadId);
@@ -212,6 +214,7 @@ function resolveOriginThreadIdForPayload(params: {
     threadId: originThreadId,
     replyToId,
     replyToIsExplicit: params.replyToIsExplicit,
+    replyToCurrent: params.replyToCurrent,
     replyDelivery: params.replyDelivery,
   });
   if (transport?.threadId != null) {
@@ -253,6 +256,7 @@ function getMatchingMessagingToolReplyTargets(
     originatingThreadId: params.originatingThreadId,
     replyToId: params.replyToId,
     replyToIsExplicit: params.replyToIsExplicit,
+    replyToCurrent: params.replyToCurrent,
     replyDelivery: params.replyDelivery,
   });
   return sentTargets.filter((target) => {
@@ -363,7 +367,7 @@ export function resolveMessagingToolPayloadDedupe(
 
 type FilterMessagingToolReplyPayloadParams = Omit<
   MessagingToolDedupeRouteParams,
-  "replyToId" | "replyToIsExplicit" | "replyDelivery"
+  "replyToId" | "replyToIsExplicit" | "replyToCurrent" | "replyDelivery"
 > & {
   payload: ReplyPayload;
   sentMediaUrls?: string[];
@@ -391,6 +395,7 @@ export function filterMessagingToolReplyPayload(
     replyToIsExplicit: Boolean(
       metadata?.replyToIdExplicit || params.payload.replyToTag || params.payload.replyToCurrent,
     ),
+    replyToCurrent: params.payload.replyToCurrent,
     replyDelivery: metadata?.replyDelivery,
   });
   if (!decision.shouldDedupePayloads) {
@@ -432,7 +437,7 @@ export function filterMessagingToolReplyPayload(
 export function hasSourceRoutedMessagingToolDelivery(
   params: Omit<
     MessagingToolDedupeRouteParams,
-    "replyToId" | "replyToIsExplicit" | "replyDelivery"
+    "replyToId" | "replyToIsExplicit" | "replyToCurrent" | "replyDelivery"
   > & {
     messagingToolSentTexts?: string[];
     messagingToolSentMediaUrls?: string[];

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -310,6 +310,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       replyToIsExplicit: Boolean(
         payloadMetadata?.replyToIdExplicit || normalized.replyToTag || normalized.replyToCurrent,
       ),
+      replyToCurrent: normalized.replyToCurrent,
       replyDelivery,
     }) ?? null;
   const resolvedReplyToId =

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -442,6 +442,8 @@ export type ChannelThreadingAdapter = {
     replyToId?: string | null;
     /** True when replyToId came from an explicit payload target or reply tag. */
     replyToIsExplicit?: boolean;
+    /** Existing payload intent to reply to the current conversation, not an arbitrary target. */
+    replyToCurrent?: boolean;
     replyDelivery?: ReplyDeliveryContext;
   }) => ChannelReplyTransport | null;
   resolveFocusedBinding?: (params: {

--- a/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
@@ -390,13 +390,15 @@ describe("channel progress presentation through an isolated Gateway", () => {
   });
 
   it.each([
-    { channel: "discord" as const, native: false, rejectStop: false },
-    { channel: "slack" as const, native: true, rejectStop: false },
-    { channel: "slack" as const, native: false, rejectStop: false },
-    { channel: "slack" as const, native: true, rejectStop: true },
+    { channel: "discord" as const, native: false, thread: "root", rejectStop: false },
+    { channel: "slack" as const, native: true, thread: "root", rejectStop: false },
+    { channel: "slack" as const, native: false, thread: "root", rejectStop: false },
+    { channel: "slack" as const, native: true, thread: "root", rejectStop: true },
+    { channel: "slack" as const, native: false, thread: "reply", rejectStop: false },
+    { channel: "slack" as const, native: false, thread: "current", rejectStop: false },
   ])(
-    "keeps $channel progress quiet (native=$native, rejectStop=$rejectStop)",
-    async ({ channel, native, rejectStop }) => {
+    "keeps $channel progress quiet (native=$native, thread=$thread, rejectStop=$rejectStop)",
+    async ({ channel, native, thread, rejectStop }) => {
       const directory = await fs.mkdtemp(
         path.join(await fs.realpath(os.tmpdir()), "channel-progress-"),
       );
@@ -489,26 +491,48 @@ describe("channel progress presentation through an isolated Gateway", () => {
         expect(loadSessionEntryReadOnly(target)?.delivery).toEqual({ kind: "none" });
       };
       let expectedThreadTs: unknown;
-      const inbound = adapter.createInbound({
-        input: {
-          conversation: {
-            id: channel === "slack" ? "C12345678" : "123456789012345678",
-            kind: "group",
+      const injectProviderMessage = async (text: string, threadId?: string) => {
+        const inbound = adapter.createInbound({
+          input: {
+            conversation: {
+              id: channel === "slack" ? "C12345678" : "123456789012345678",
+              kind: "group",
+            },
+            senderId: channel === "slack" ? "U12345678" : "123456789012345679",
+            text,
+            ...(threadId ? { threadId } : {}),
           },
-          senderId: channel === "slack" ? "U12345678" : "123456789012345679",
-          text: `Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`sleep 3\`. After that command completes, reply exactly \`${FINAL_MARKER}\`.`,
-        },
-      });
-      const injected = await fetch(inbound.providerUrl, {
-        method: "POST",
-        headers: inbound.providerHeaders,
-        body: JSON.stringify(inbound.providerBody),
-      });
-      expect(injected.ok).toBe(true);
+        });
+        const injected = await fetch(inbound.providerUrl, {
+          method: "POST",
+          headers: inbound.providerHeaders,
+          body: JSON.stringify(inbound.providerBody),
+        });
+        expect(injected.ok).toBe(true);
+        return injected;
+      };
+      let threadId: string | undefined;
+      let inboundMessageId: unknown;
+      if (thread !== "root") {
+        // Seed only the provider's root; the Gateway receives the child below.
+        const root = asRecord(await (await injectProviderMessage("Original Slack thread")).json());
+        threadId = readStringValue(asRecord(root.message).ts);
+        expect(threadId).toEqual(expect.any(String));
+      }
+      const finalText = `${thread === "current" ? "[[reply_to_current]] " : ""}${FINAL_MARKER}`;
+      const injected = await injectProviderMessage(
+        `Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`sleep 3\`. After that command completes, reply exactly \`${finalText}\`.`,
+        threadId,
+      );
       if (adapter.manifest.provider === "slack") {
         const payload = asRecord(await injected.json());
         const event = asRecord(asRecord(payload.event).event);
         expectedThreadTs = event.thread_ts ?? event.ts;
+        inboundMessageId = event.ts;
+        if (threadId) {
+          expect(event.thread_ts).toBe(threadId);
+          expect(inboundMessageId).not.toBe(threadId);
+        }
         const body = JSON.stringify(payload.event);
         const timestamp = String(Math.floor(Date.now() / 1000));
         const signature = createHmac("sha256", adapter.manifest.signingSecret)
@@ -533,6 +557,10 @@ describe("channel progress presentation through an isolated Gateway", () => {
         [...api.messages.values()].filter((message) =>
           (readStringValue(message.text ?? message.content) ?? "").includes(FINAL_MARKER),
         );
+      if (threadId) {
+        await waitForFact(() => finalWrites().length > 0, "thread reply attempt");
+        expect(finalWrites()[0]?.body.thread_ts).toBe(threadId);
+      }
       if (!rejectStop) {
         await waitForFact(() => finalMessages().length > 0, "accepted final answer");
       }
@@ -585,7 +613,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
       );
       expect([...reactionNames]).toEqual([channel === "discord" ? "👀" : "eyes"]);
       const evidenceDir = path.join(process.cwd(), ".artifacts", "channel-progress-presentation");
-      const evidenceName = `${channel}-${native ? "native" : "draft"}${rejectStop ? "-stop-failure" : ""}`;
+      const evidenceName = `${channel}-${native ? "native" : "draft"}-${thread}${rejectStop ? "-stop-failure" : ""}`;
       await fs.mkdir(evidenceDir, { recursive: true });
       await fs.writeFile(
         path.join(evidenceDir, `${evidenceName}-diagnostic.json`),
@@ -633,6 +661,9 @@ describe("channel progress presentation through an isolated Gateway", () => {
         });
         expect(finalWrites()[0]?.accepted).toBeDefined();
       }
+      if (threadId) {
+        expect(finalMessages()[0]?.thread_ts).toBe(threadId);
+      }
       const tasks = writes
         .flatMap((write) => readChunks(write.body.chunks))
         .filter((chunk) => chunk.type === "task_update");
@@ -650,6 +681,9 @@ describe("channel progress presentation through an isolated Gateway", () => {
             native,
             rejectStop,
             originCleared,
+            thread,
+            threadId,
+            inboundMessageId,
             status: "pass",
             progressWrites: progressWrites.length,
             finalWrites: finalWrites().length,


### PR DESCRIPTION
Related: #96692, #135305. Follow-up to #136460; these issues remain open until the remaining delivery-outcome work is verified.

## What Problem This Solves

Fixes an issue where users replying inside an existing Slack thread could receive no answer or deferred-work status because the reply was sent using the incoming child message's timestamp as the thread root. The same mismatch affected queued current-reply and compaction notices.

Thanks to @shannon0430 for #96692 and Elton Lau for the field report that motivated the delivery-path investigation.

## Why This Change Was Made

Slack's `chat.postMessage` contract requires the parent timestamp for `thread_ts`, not a reply timestamp. Admission already knows both identities: this change preserves the incoming message identity and declines implicit current-message reply-ID injection only for genuine threaded Slack messages. Explicit `reply_to_current` intent survives the existing core routing and deduplication callbacks so the Slack owner can select the recorded root without mistaking an arbitrary explicit target for the current conversation.

One private Slack selector now owns the priority rule for monitor sends, delivery accounting, and generic queued delivery. The duplicated monitor helper and its copied mock are removed. Explicit arbitrary targets, explicit-false intent, omitted intent, top-level messages, and reply-off behavior keep their previous contracts. The SDK callback receives one optional transient field carrying an existing payload fact; no configuration, environment variable, stored representation, schema, protocol, dependency, or SDK subpath changes.

Production LOC: +57/-33, net +24; tests/test support: +215/-72, net +143; docs: +6. The production growth carries the existing intent across the routing/deduplication boundary and centralizes the Slack priority policy; both consumers must see the same fact to avoid either misdelivery or false deduplication.

## User Impact

Ordinary replies, explicit-current replies, and current-context notices stay in the admitted Slack thread, including queued routing. Looking at another thread or retaining the incoming child's message identity does not itself change the reply destination. This PR does not claim to repair every delivery failure. Universal quarantine for replies with every route fact absent is not implemented here and lies outside the proved scope; the existing route-less guard alone is not a reproduction showing valid admitted Slack routing facts can disappear in production.

## Evidence

Dependency contract: [Slack chat.postMessage](https://docs.slack.dev/reference/methods/chat.postMessage/) documents the parent timestamp requirement. The mock Slack API independently rejects a child timestamp with `thread_not_found`.

Before the production change, the queued current-reply and deduplication regressions failed with normal exit 1: the transport selected child `222.000` instead of root `111.000`, and a same-root delivered message was not deduplicated. The direct current-reply and compaction send assertions also failed; that local runner was interrupted during worker cleanup after assertions, so it is not the normal-exit proof.

The real mock-Gateway red run used unchanged production at `feff169c052cbb1ae330c5f35a788108a13fbfa6` with regression tests only. Both threaded cases failed with normal exit 1: the actual outbound request used child `1700000000.000101` instead of recorded root `1700000000.000100`.

Integrated candidate: `8a0aff8fd0957a3bd844b75f05e834040e0a4656`, based on `8b0cc701a0284f6b8e4697e1150f47e914aafedc`, after #136460 landed. The shared fixture preserves the origin-cleared plus rejected-stop case, all three root controls, and both child-thread cases. The production changes combined independently; only the shared fixture needed conflict resolution.

Focused owner/sibling suites on the integrated source: **589 passed, one platform-specific skip across 15 files**, normal exit 0. Coverage includes Slack native/draft fallback, channel routing, normal delivery, queued current/explicit-false and compaction-shaped sends, same-route deduplication, and existing Mattermost/Buzz callback behavior. All commands use `node scripts/run-vitest.mjs`.

Real mock-Gateway proof on the exact integrated head: **six scenarios passed**, normal test-runner exit 0 (134.57 seconds test duration). The ordinary and explicit-current threaded cases assert both the actual outbound request target and the accepted final message's root timestamp, plus exactly one final send. The inherited native failure case removes mutable session routing facts during the turn and rejects stream stop, while the final is still accepted in the admitted thread.

```text
$ node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts -t "thread='(reply|current)'"
# pre-fix production: 2 failed; normal exit 1
# actual thread_ts: child 1700000000.000101; expected root 1700000000.000100

$ node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
# exact integrated head 8a0aff8fd0957a3bd844b75f05e834040e0a4656
# 6 passed; normal test runner exit 0

$ node scripts/check-changed.mjs --base 8b0cc701a0284f6b8e4697e1150f47e914aafedc -- <all 15 changed files>
# full format/type/guard/lint pass; normal exit 0
# combined live/check command: 30m26.447s
```

```json
[{"kind":"mock-gateway","channel":"discord","native":false,"rejectStop":false,"originCleared":false,"thread":"root","status":"pass","progressWrites":1,"finalWrites":1,"distinctWorkingReactions":1,"taskIds":0,"syntheticDecoration":false},{"kind":"mock-gateway","channel":"slack","native":true,"rejectStop":false,"originCleared":false,"thread":"root","inboundMessageId":"1700000000.000100","status":"pass","progressWrites":2,"finalWrites":1,"distinctWorkingReactions":1,"taskIds":1,"syntheticDecoration":false},{"kind":"mock-gateway","channel":"slack","native":false,"rejectStop":false,"originCleared":false,"thread":"root","inboundMessageId":"1700000000.000100","status":"pass","progressWrites":2,"finalWrites":1,"distinctWorkingReactions":1,"taskIds":0,"syntheticDecoration":false},{"kind":"mock-gateway","channel":"slack","native":true,"rejectStop":true,"originCleared":true,"thread":"root","inboundMessageId":"1700000000.000100","status":"pass","progressWrites":2,"finalWrites":1,"distinctWorkingReactions":1,"taskIds":1,"syntheticDecoration":false},{"kind":"mock-gateway","channel":"slack","native":false,"rejectStop":false,"originCleared":false,"thread":"reply","threadId":"1700000000.000100","inboundMessageId":"1700000000.000101","status":"pass","progressWrites":2,"finalWrites":1,"distinctWorkingReactions":1,"taskIds":0,"syntheticDecoration":false},{"kind":"mock-gateway","channel":"slack","native":false,"rejectStop":false,"originCleared":false,"thread":"current","threadId":"1700000000.000100","inboundMessageId":"1700000000.000101","status":"pass","progressWrites":2,"finalWrites":1,"distinctWorkingReactions":1,"taskIds":0,"syntheticDecoration":false}]
```

The isolated proof uses mock Slack/Discord APIs, a mock provider, the built CLI, an ephemeral Gateway/state directory, synthetic events, and a free non-operator port. No real accounts or messages. Strict checks bind the run to the exact head, clean checkout, expected 15-path diff against its base, and SHA-256 of every changed file, not checkout metadata alone. Final fixture SHA-256: `511e39de6d61e2013e86f1a30f107bd7cff0921b1233c96a5d0f35a0628367ec`. All strict checks passed both before and after the run. The combined live/check command exited 0 after 30m26.447s, and the owned Testbox lease was stopped normally.

Fresh independent committed branch review completed with no actionable P0–P2 findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33679625097) is green; `node scripts/watch-pr-ci.mjs 136566 8a0aff8fd0957a3bd844b75f05e834040e0a4656` exited 0.

Tooling note: the repository Crabbox wrapper's changed-gate bootstrap twice failed before executing the earlier candidate because its anonymous base fetch required Git authentication. The documented wrapper-isolation path used the installed CLI with the same Blacksmith Testbox provider; no credentials, Git configuration, or wrapper source were changed. The anonymous-fetch owner is a named tooling follow-up, outside this Slack repair.

### Maintainer decision and rank-up move

Accepted: `replyToCurrent?: boolean` is the intended documented optional input to `ChannelThreadingAdapter.resolveReplyTransport`. Existing plugins retain their behavior when the field is ignored or omitted, and arbitrary explicit targets remain explicit. This carries an existing payload fact across the generic channel boundary; it adds no configuration, environment variable, stored representation, schema, or wire protocol. The +24 production lines are accepted for one shared Slack selector and aligned routing/deduplication fact propagation, with the duplicate monitor helper removed. This resolves the September 2 ClawSweeper contract-acceptance concern. The latest exact-head review at 20:39 UTC reported no code findings; its six-scenario proof rank-up is addressed by the transcript and verdicts above.
