### PR TITLE
fix: release retired session metadata after short listings

### DIFF
--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -15,7 +15,6 @@ import {
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { isTerminalSessionStatus, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { truncateUtf16Safe } from "../utils.js";
 import {
   estimateAggregateUsageCost,
@@ -242,8 +241,6 @@ export function resolveEstimatedSessionCostUsd(params: {
 
 const STALE_STORE_ONLY_CHILD_LINK_MS = 60 * 60 * 1_000;
 
-const SINGLE_ROW_CONTEXT_CACHE_MAX_ENTRIES = 64;
-
 export function isFinitePositiveTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
@@ -266,35 +263,11 @@ export function shouldKeepStoreOnlyChildLink(entry: SessionEntry, now: number): 
   );
 }
 
-type SingleRowChildSessionCandidateCacheEntry = {
-  entriesByKey: Map<string, SessionEntry>;
-  childSessionCandidatesByParentKey: Map<string, string[]>;
-};
-
-const singleRowChildSessionCandidateCache = new Map<
-  string,
-  SingleRowChildSessionCandidateCacheEntry
->();
-
-function rememberSingleRowChildSessionCandidateCacheEntry(
-  storePath: string,
-  entry: SingleRowChildSessionCandidateCacheEntry,
-) {
-  if (singleRowChildSessionCandidateCache.has(storePath)) {
-    singleRowChildSessionCandidateCache.delete(storePath);
-  }
-  singleRowChildSessionCandidateCache.set(storePath, entry);
-  pruneMapToMaxSize(singleRowChildSessionCandidateCache, SINGLE_ROW_CONTEXT_CACHE_MAX_ENTRIES);
-}
-
 function buildStoreChildSessionCandidateIndex(
-  store: Record<string, SessionEntry> | null | undefined,
-  selectedParents?: ReadonlySet<string>,
+  store: Record<string, SessionEntry>,
+  selectedParents: ReadonlySet<string>,
 ): Map<string, string[]> {
   const childSessionsByKey = new Map<string, string[]>();
-  if (!store) {
-    return childSessionsByKey;
-  }
   for (const [key, entry] of Object.entries(store)) {
     if (!entry) {
       continue;
@@ -304,44 +277,12 @@ function buildStoreChildSessionCandidateIndex(
       normalizeOptionalString(entry.parentSessionKey),
     ].filter((value): value is string => Boolean(value) && value !== key);
     for (const parentKey of parentKeys) {
-      if (!selectedParents || selectedParents.has(parentKey)) {
+      if (selectedParents.has(parentKey)) {
         addChildSessionKey(childSessionsByKey, parentKey, key);
       }
     }
   }
   return childSessionsByKey;
-}
-
-function singleRowChildSessionCacheMatches(
-  cached: SingleRowChildSessionCandidateCacheEntry,
-  store: Record<string, SessionEntry>,
-): boolean {
-  const entries = Object.entries(store);
-  return (
-    entries.length === cached.entriesByKey.size &&
-    entries.every(([key, entry]) => cached.entriesByKey.get(key) === entry)
-  );
-}
-
-export function getSingleRowChildSessionCandidates(params: {
-  storePath: string;
-  store: Record<string, SessionEntry> | null | undefined;
-}): Map<string, string[]> {
-  if (!params.store) {
-    return new Map();
-  }
-  const cached = singleRowChildSessionCandidateCache.get(params.storePath);
-  if (cached && singleRowChildSessionCacheMatches(cached, params.store)) {
-    return cached.childSessionCandidatesByParentKey;
-  }
-  const childSessionCandidatesByParentKey = buildStoreChildSessionCandidateIndex(params.store);
-  rememberSingleRowChildSessionCandidateCacheEntry(params.storePath, {
-    // Full-store snapshots can retain entry identities between short-list projections.
-    // Exact reads own fresh JSON and do not use this cache.
-    entriesByKey: new Map(Object.entries(params.store)),
-    childSessionCandidatesByParentKey,
-  });
-  return childSessionCandidatesByParentKey;
 }
 
 export function resolveRuntimeChildSessionKeys(
@@ -415,13 +356,13 @@ export function isCurrentSessionChildOwner(params: {
   );
 }
 
-/** Prepare only selected parents; a supplied candidate map belongs to the full-store caller. */
+// Combined-store reads create fresh entries. Keep only selected parents' links for
+// this projection; an identity cache would miss and retain the previous metadata.
 export function buildStoreChildSessionIndex(params: {
   store: Record<string, SessionEntry>;
   keys: readonly string[];
   now: number;
   subagentRuns?: SessionListRowContext["subagentRuns"];
-  candidates?: ReadonlyMap<string, readonly string[]>;
   excludedChildKeys?: ReadonlySet<string>;
   requireCurrentController?: boolean;
 }): Map<string, string[]> {
@@ -429,8 +370,7 @@ export function buildStoreChildSessionIndex(params: {
   if (params.keys.length === 0) {
     return children;
   }
-  const candidates =
-    params.candidates ?? buildStoreChildSessionCandidateIndex(params.store, new Set(params.keys));
+  const candidates = buildStoreChildSessionCandidateIndex(params.store, new Set(params.keys));
   for (const key of params.keys) {
     const childKeys = resolveStoreChildSessionKeysFromCandidates({ ...params, key, candidates });
     if (childKeys) {

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -50,7 +50,6 @@ import type {
 import {
   deriveSessionTitle,
   buildStoreChildSessionIndex,
-  getSingleRowChildSessionCandidates,
   isFinitePositiveTimestamp,
   isCurrentSessionChildOwner,
   shouldKeepStoreOnlyChildLink,
@@ -488,16 +487,11 @@ function prepareSessionList(params: ListSessionsFromStoreParams) {
   const sharedRowContext =
     usePreparedChildReads || selection.entries.length > 0 ? getRowContext() : undefined;
   const storePath = hasIncognito ? params.storePath : (params.durableStorePath ?? params.storePath);
-  const childCandidates =
-    !usePreparedChildReads && selection.entries.length > 0
-      ? getSingleRowChildSessionCandidates({ storePath, store })
-      : undefined;
   const storeChildSessionsByKey = buildStoreChildSessionIndex({
     store,
     keys: selection.entries.map(([key]) => key),
     now,
     subagentRuns: usePreparedChildReads ? sharedRowContext?.subagentRuns : undefined,
-    candidates: childCandidates,
     excludedChildKeys: filteredSessionKeys,
     requireCurrentController: !usePreparedChildReads,
   });

--- a/src/gateway/session-utils.child-cache-retention.test-support.ts
+++ b/src/gateway/session-utils.child-cache-retention.test-support.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { setRuntimeConfigSnapshot } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { listSessionsFromStoreAsync } from "./session-utils-list.js";
+
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const retired: WeakRef<SessionEntry>[] = [];
+const control = new WeakRef<SessionEntry>({ sessionId: "uncached", updatedAt: 1 });
+const cfg = {};
+setRuntimeConfigSnapshot(cfg);
+setActivePluginRegistry(createEmptyPluginRegistry());
+const parentKey = "agent:main:parent";
+const childKey = "agent:main:child";
+
+async function populate() {
+  const now = Date.now();
+  const parent: SessionEntry = { sessionId: "parent", updatedAt: now };
+  const child: SessionEntry = {
+    sessionId: "child",
+    updatedAt: now - 1,
+    parentSessionKey: parentKey,
+  };
+  retired.push(new WeakRef(parent), new WeakRef(child));
+  return listSessionsFromStoreAsync({
+    cfg,
+    storePath: "retired",
+    store: { [parentKey]: parent, [childKey]: child },
+    modelCatalog: [],
+    opts: { limit: 1 },
+  });
+}
+
+// A caller may keep the projected response after releasing its input snapshot.
+const result = await populate();
+assert.equal(result.sessions.length, 1);
+const row = result.sessions[0];
+assert.ok(row);
+assert.deepEqual(row.childSessions, [childKey]);
+for (let pass = 0; pass < 8; pass += 1) {
+  gc();
+  await setImmediate();
+}
+// Dereferencing during collection would itself keep the rows alive for that job.
+const retained = retired.flatMap((reference, index) => (reference.deref() ? [index] : []));
+assert.equal(control.deref(), undefined, "The uncached GC control must be collected");
+assert.deepEqual(row.childSessions, [childKey]);
+process.stdout.write(JSON.stringify({ retained }));

--- a/src/gateway/session-utils.child-cache-retention.test.ts
+++ b/src/gateway/session-utils.child-cache-retention.test.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { runNodeScript } from "../../test/helpers/run-node-script.js";
+
+it("keeps child links without retaining released session metadata", async ({ signal }) => {
+  const result = await runNodeScript(
+    [
+      "--expose-gc",
+      "--import",
+      "tsx",
+      fileURLToPath(
+        new URL("./session-utils.child-cache-retention.test-support.ts", import.meta.url),
+      ),
+    ],
+    { ...process.env, NODE_OPTIONS: "", TSX_DISABLE_CACHE: "1" },
+    15_000,
+    {
+      cwd: fileURLToPath(new URL("../../", import.meta.url)),
+      signal,
+      maxBuffer: 64 * 1024,
+      requireProcessTreeExit: process.platform !== "win32",
+    },
+  );
+  expect(result.error, result.stderr).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual({ retained: [] });
+}, 30_000);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -36,7 +36,7 @@ import { registerSessionAutomationSource } from "./session-automation-index.js";
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { projectSessionActor } from "./session-identity-projection.js";
 import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
-import { deriveSessionTitle, getSingleRowChildSessionCandidates } from "./session-utils-core.js";
+import { deriveSessionTitle } from "./session-utils-core.js";
 import { listSessionsFromStoreAsync } from "./session-utils-list.js";
 import {
   getSessionDefaults,
@@ -3372,34 +3372,6 @@ describe("gateway session utils", () => {
     } finally {
       resetConfigRuntimeState();
     }
-  });
-
-  test("short-list child candidates reuse stable full-store entry identities", () => {
-    const parentKey = "agent:main:main";
-    let spawnedByReads = 0;
-    const parent = { sessionId: "parent", updatedAt: 1 } as SessionEntry;
-    const child = {
-      sessionId: "child",
-      updatedAt: Date.now(),
-      get spawnedBy() {
-        spawnedByReads += 1;
-        return parentKey;
-      },
-    } as SessionEntry;
-    const storePath = "/tmp/openclaw-single-row-child-cache";
-
-    const first = getSingleRowChildSessionCandidates({
-      store: { [parentKey]: parent, "agent:main:child": child },
-      storePath,
-    });
-    const second = getSingleRowChildSessionCandidates({
-      store: { [parentKey]: parent, "agent:main:child": child },
-      storePath,
-    });
-
-    expect(first.get(parentKey)).toEqual(["agent:main:child"]);
-    expect(second.get(parentKey)).toEqual(["agent:main:child"]);
-    expect(spawnedByReads).toBe(1);
   });
 
   test("loadGatewaySessionEntryReadOnly rejects a persisted main alias", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary memory retention after short session listings. Large metadata from a completed listing could remain alive until another request replaced the cached store, or the bounded cache evicted it.

## Why This Change Was Made

The child-session candidate cache held every `SessionEntry` strongly to compare identities. Gateway RPC, embedded TUI, embedded tools, and startup prewarm all construct fresh combined entries, so those requests paid for a cache miss while retaining the preceding snapshot.

Remove that cache and its identity comparison, and use the existing request-local index for the selected parents. Live-controller, navigation-lineage, visibility, ordering, and freshness checks remain in their existing owner. A weak-reference cache would retain the redundant lookup path without useful cross-request hits.

Production: **+6/-72 (net -66)**. Tests/test support: **+79/-29 (net +50)**. The removed test asserted reuse of the retired cache; the replacement checks collection through the real list projection while preserving its returned child links. No schema, persistence, configuration, dependency-version, or public protocol change.

## User Impact

Retired listing snapshots are no longer pinned by this derived cache. This is bounded over-retention, not a demonstrated unbounded leak. It does not establish that the separate event-loop saturation issue is solved.

## Evidence

- Baseline: `aef65cc57490a5c67ca8dc934ac24225c6d1069c`.
- Heap snapshot: the strong retainer was the child candidate cache's entry map. A synthetic 384-entry fixture with 32 KiB summaries retained every entry and about 12.8 MB; the uncached control retained none.
- Real SQLite -> combined-store -> Gateway list projection -> database close: **48/48 entries retained before, 0/48 after**. Each fixture row carried a 32 KiB compaction summary; the returned parent still had all 47 child links. Uncached controls retained none.
- The new GC regression fails on the baseline with both input entries retained and passes after the refactor. **293 focused/sibling cases pass**, including child ownership, visibility, freshness and performance cases. Repeated after the frozen dependency refresh.
- Fresh `sourcePerformance` build succeeds. Independent managed Codex review is clean through P2.
- Real loopback Gateway on macOS/Node 26.8.1, isolated HOME/state: 32 turns, 48 seeds, 128 updates/4 clients, 3 history clients x 5 burst, 6 subscribers, visible observer, 100 ms cadence, 1000 ms mock stream delay. The unchanged concurrency harness was copied to an ignored artifact and only the list request changed to `{ limit: 1 }` (plus import relocation), to exercise this path.
- The live run passes unchanged **2000 ms control/handshake budgets**, with zero operation failures or plugin metadata scans: readiness max **138.5 ms**, sessions.list **310.5 ms**, Control UI HTTP **420.6 ms**, history p99 **380.4 ms**/max **381.9 ms**, fresh connection **118.2 ms**. Source/build inventories were unchanged and temporary state was removed.
- Limitations: this uses a synthetic provider and HTTP/RPC probes, not a rendered browser or real-provider test. **40/44 readiness samples remained degraded; event-loop utilization was 1.** No whole-Gateway memory percentage or universal latency improvement is claimed.
- Two Blacksmith Testbox attempts stopped at baseline Git authentication before checks/comparison and both leases were stopped. They are not passing Linux proof. The supported local changed-code gate passes all 29 checks after refreshing already-declared missing dependencies with the frozen lockfile; no source workaround or skipped check.

Hosted CI: [run 33676308549, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33676308549) passed on `321642251c725df0ce80d179f3ad3be71fae7b1a`. The first attempt had 155 successful jobs and one cancellation before any step executed; one normal retry targeted that job, without changing source. The required CI gate is now green.
