### PR TITLE
fix(ui): clear equivalent Usage filters from their menus

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -461,6 +461,7 @@ This label does not change which request the approval buttons resolve.
   </Accordion>
   <Accordion title="Usage">
     - Session-derived token and estimated-cost analysis stays separate from provider billing.
+    - Filter sessions with the provider, model, channel, or tool menus, or type case-insensitive `key:value` terms. Values within one category match as alternatives. Toggling a menu option preserves the other filters and their quoted text.
     - Select **Local** or **UTC** for hourly charts and peak error hours. Historical hour labels stay tied to the selected time zone, including when you view them across a daylight-saving transition.
     - Provider cards call `usage.status` and show live plan names, quota windows, balances, spend, and budgets reported by configured provider plugins.
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -530,7 +530,7 @@ suite.define(() => {
     );
   });
 
-  it("keeps selected provider alternatives visible and finds quoted session labels", async () => {
+  it("edits equivalent provider filters and finds quoted session labels", async () => {
     const date = dayOffset(0);
     const updatedAt = Date.now();
     const sessions = [
@@ -608,6 +608,21 @@ suite.define(() => {
         }
 
         const query = page.locator(".usage-query-input");
+        await page.keyboard.press("Escape");
+        for (const token of ["PROVIDER:OpenAI", 'provider:"openai"']) {
+          await query.fill(`${token} provider:anthropic`);
+          await query.press("Enter");
+          await expect
+            .poll(async () => (await sessionLabels.allTextContents()).toSorted())
+            .toEqual(["Research Review", "Team Planning"]);
+          await providerFilter.locator(".usage-filter-trigger").click();
+          const openai = providerFilter.locator('wa-dropdown-item[value="option:openai"]');
+          await expect.poll(() => openai.getAttribute("aria-checked")).toBe("true");
+          await openai.click();
+          await expect.poll(() => sessionLabels.allTextContents()).toEqual(["Research Review"]);
+          await expect.poll(() => query.inputValue()).toBe("provider:anthropic ");
+          await page.keyboard.press("Escape");
+        }
         await query.fill('label:"Team Planning"');
         await query.press("Enter");
         await expect.poll(() => sessionLabels.allTextContents()).toEqual(["Team Planning"]);

--- a/ui/src/pages/usage/query.test.ts
+++ b/ui/src/pages/usage/query.test.ts
@@ -1,7 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
 import {
-  addQueryToken,
   applySuggestionToQuery,
   buildQuerySuggestions,
   buildSessionsCsv,
@@ -14,12 +13,17 @@ describe("usage query token mutations", () => {
   const quotedLabel = 'label:"Team  Planning"';
 
   it("preserves quoted phrases when adding or replacing categorical tokens", () => {
-    expect(addQueryToken(`${quotedLabel} provider:openai`, "provider:anthropic")).toBe(
-      `${quotedLabel} provider:openai provider:anthropic `,
+    const query = `${quotedLabel} PROVIDER:"OpenAI"`;
+    expect(setQueryTokensForKey(query, "provider", ["openai", "anthropic"])).toBe(
+      `${query} provider:anthropic `,
     );
-    expect(setQueryTokensForKey(`${quotedLabel} provider:openai`, "provider", ["anthropic"])).toBe(
+    expect(setQueryTokensForKey(query, "provider", ["anthropic"])).toBe(
       `${quotedLabel} provider:anthropic `,
     );
+    expect(setQueryTokensForKey(`${quotedLabel} PROVIDER:`, "provider", ["openai"])).toBe(
+      `${quotedLabel} provider:openai `,
+    );
+    expect(setQueryTokensForKey(query, "provider", [])).toBe(`${quotedLabel} `);
   });
 
   it("removes an entire quoted term without leaving phrase fragments", () => {

--- a/ui/src/pages/usage/query.ts
+++ b/ui/src/pages/usage/query.ts
@@ -1,4 +1,3 @@
-// Control UI view renders usage query screen content.
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
@@ -235,25 +234,6 @@ const applySuggestionToQuery = (query: string, suggestion: string): string => {
 
 const normalizeQueryText = (value: string): string => normalizeLowercaseStringOrEmpty(value);
 
-const addQueryToken = (query: string, token: string): string => {
-  const trimmed = query.trim();
-  if (!trimmed) {
-    return `${token} `;
-  }
-  const tokens = extractQueryTerms(trimmed).map((term) => term.raw);
-  const last = tokens[tokens.length - 1] ?? "";
-  const tokenKey = token.includes(":") ? token.split(":")[0] : null;
-  const lastKey = last.includes(":") ? last.split(":")[0] : null;
-  if (last.endsWith(":") && tokenKey && lastKey === tokenKey) {
-    tokens[tokens.length - 1] = token;
-    return `${tokens.join(" ")} `;
-  }
-  if (tokens.includes(token)) {
-    return `${tokens.join(" ")} `;
-  }
-  return `${tokens.join(" ")} ${token} `;
-};
-
 const removeQueryToken = (query: string, token: string): string => {
   const tokens = extractQueryTerms(query).map((term) => term.raw);
   const next = tokens.filter((entry) => entry !== token);
@@ -262,15 +242,22 @@ const removeQueryToken = (query: string, token: string): string => {
 
 const setQueryTokensForKey = (query: string, key: string, values: string[]): string => {
   const normalizedKey = normalizeQueryText(key);
-  const tokens = extractQueryTerms(query)
-    .filter((term) => normalizeQueryText(term.key ?? "") !== normalizedKey)
-    .map((term) => term.raw);
-  const next = [...tokens, ...values.map((value) => `${key}:${value}`)];
+  const remaining = new Map(values.map((value) => [normalizeQueryText(value), value]));
+  const tokens: string[] = [];
+  // Retained values keep their authored spelling and quotes; serialize only new selections.
+  for (const term of extractQueryTerms(query)) {
+    if (
+      normalizeQueryText(term.key ?? "") !== normalizedKey ||
+      remaining.delete(normalizeQueryText(term.value))
+    ) {
+      tokens.push(term.raw);
+    }
+  }
+  const next = [...tokens, ...Array.from(remaining.values(), (value) => `${key}:${value}`)];
   return next.length ? `${next.join(" ")} ` : "";
 };
 
 export {
-  addQueryToken,
   applySuggestionToQuery,
   buildDailyCsv,
   buildQuerySuggestions,

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -441,9 +441,10 @@ describe("renderUsage", () => {
     props.callbacks.filters.onQueryDraftChange = onQueryDraftChange;
 
     render(renderUsage(props), container);
-    const option = [...container.querySelectorAll<HTMLElement>(".usage-filter-option")].find(
+    const option = [...container.querySelectorAll("wa-dropdown-item")].find(
       (item) => item.textContent?.trim() === "clear",
-    );
+    )!;
+    option.checked = true;
     option
       ?.closest("wa-dropdown")
       ?.dispatchEvent(new CustomEvent("wa-select", { detail: { item: option }, bubbles: true }));

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -23,7 +23,6 @@ import {
   sessionTouchesSelectedHours,
 } from "./metrics.ts";
 import {
-  addQueryToken,
   applySuggestionToQuery,
   buildDailyCsv,
   buildQuerySuggestions,
@@ -209,7 +208,7 @@ export function renderUsage(props: UsageProps) {
     agentScopedSessions,
     data.aggregates,
   );
-  const queryTerms = extractQueryTerms(filters.query);
+  const queryTerms = extractQueryTerms(filters.queryDraft);
   const selectedValuesFor = (key: string): string[] => {
     const normalized = normalizeQueryText(key);
     return queryTerms
@@ -396,7 +395,7 @@ export function renderUsage(props: UsageProps) {
       <wa-dropdown
         class="usage-filter-select"
         placement="bottom-start"
-        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+        @wa-select=${(event: CustomEvent<{ item: { value?: string; checked: boolean } }>) => {
           event.preventDefault();
           const value = event.detail.item.value;
           if (value === "command:select-all") {
@@ -411,12 +410,16 @@ export function renderUsage(props: UsageProps) {
           }
           if (value?.startsWith("option:")) {
             const optionValue = decodeURIComponent(value.slice("option:".length));
-            const token = `${key}:${optionValue}`;
-            const checked = selectedSet.has(normalizeQueryText(optionValue));
             filterActions.onQueryDraftChange(
-              checked
-                ? removeQueryToken(filters.queryDraft, token)
-                : addQueryToken(filters.queryDraft, token),
+              setQueryTokensForKey(
+                filters.queryDraft,
+                key,
+                event.detail.item.checked
+                  ? [...selected, optionValue]
+                  : selected.filter(
+                      (entry) => normalizeQueryText(entry) !== normalizeQueryText(optionValue),
+                    ),
+              ),
             );
           }
         }}


### PR DESCRIPTION
Fixes #136568.

## What Problem This Solves

Fixes an issue where Usage menu checkboxes could not clear equivalent typed filters such as `PROVIDER:OpenAI` or `provider:"openai"`. Rapid checkbox toggles could also leave the filter stuck on.

## Why This Change Was Made

All category changes now use one query mutation function that compares normalized identities while retaining authored terms. Menu state comes from the current draft, and checkbox intent comes from the component's already-updated checked state. The duplicate add-token path is removed.

Production **+23 / −33 = −10 LOC**; tests **+27 / −7 = +20**; docs **+1**. Query grammar, the existing debounce, accounting, configuration and protocol are unchanged.

## User Impact

Provider, model, channel and tool menus now update equivalent typed filters correctly. Select All, Clear, and individual toggles share the same behavior; other filters and quoted phrases remain intact.

## Evidence

Actual Chromium 151 input against separately built original/fixed production bundles verifies seven cases, including canonical controls and all four categories. The failing original extended E2E now passes; all 49 owner tests, all 10 Usage E2E cases and all 20 required changed checks pass. Independent Codex P2 review is clean.

A separate native input audit records two trusted clicks 3ms apart before the fix and 4ms apart after: the original query remains `provider:openai`, while the repaired query is empty and both sessions return. Served bundle hashes differ and are retained with the raw input events. An earlier audit with accidentally shared build output was excluded and replaced with isolated proof.

Root inspected the complete query/parser/view/page owners, changed tests, actual browser output and Web Awesome 3.12.0 source. Its checkbox is toggled before `wa-select`, so the event's checked state is the authoritative input.

Before, after unticking the equivalent typed filter: the menu is unchecked but one session remains selected.

![Before: equivalent filter remains active after untick](https://github.com/user-attachments/assets/b561fe99-0dfd-4e23-989e-023ead0c0044)

After the same action: the filter is cleared and both synthetic sessions return.

![After: query clears and both synthetic sessions return](https://github.com/user-attachments/assets/fae417fc-a656-4d34-b10d-ae9f12a14efd)

The captures contain synthetic fixture data only. No external provider or billing verification is claimed.

A separately reproduced follow-up remains: selected-day cost totals can ignore category filters. That accounting/data-contract repair is unchanged here and is not counted as fixed by this PR.

## Current-main CI refresh

A tree-identical CI refresh retains the complete reviewed source and proof. Earlier checks ran before the canonical main test split and CI runner/dependency acquisition fixes; the new PR event rebuilds the current merge ref through the normal required checks. There are no source, test, configuration or production-LOC changes in this refresh.

## Maintainer review disposition

The September 2 review's Web Awesome evidence decision and rank-up request are resolved by direct source inspection. In installed Web Awesome 3.12.0, dropdown `makeSelection` first sets `item.checked = !item.checked`, then constructs and dispatches `WaSelectEvent`; preventing that event controls closing, not the prior toggle. Root inspected the complete method in `chunk.KZJTFPDQ.js:467–485` and the recorded actual Chromium before/after flows. The repaired handler reads the component's post-toggle state.

Exact-head required CI, including `openclaw/ci-gate` in run 33681046059, is green. Root checked main `8caf8146c60e12edee91b944fc2c9fb90564a6da`: the only intervening edits in these owner files are the separately reviewed download-helper refactor from #136439, and they compose cleanly. The CI refresh leaves reviewed source, tests and behavioral proof unchanged.
