### PR TITLE
fix(agents): declare sessions_spawn expectsCompletionMessage in the tool schema

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -245,6 +245,9 @@ In `prefer` mode, hidden sub-agents are for internal legwork that the user does 
 <ParamField path="cleanup" type='"delete" | "keep"' default="keep">
   `"delete"` archives the session immediately after announce (still keeps the transcript via rename).
 </ParamField>
+<ParamField path="expectsCompletionMessage" type="boolean" default="true">
+  Set `false` for fire-and-forget children. When the child finishes, OpenClaw skips the completion handoff to the requester (no announce or steer turn), records the delivery as not required, and still runs child cleanup. Inspect such children with `subagents` or `sessions_history`. `collect: true` always uses `false`.
+</ParamField>
 <ParamField path="sandbox" type='"inherit" | "require"' default="inherit">
   `require` rejects the spawn unless the target child runtime is sandboxed.
 </ParamField>
@@ -556,6 +559,7 @@ fallbacks. Fully isolated auth per agent is not supported yet.
 Sub-agents report back via an announce step:
 
 - The announce step runs inside the sub-agent session (not the requester session).
+- Runs spawned with `expectsCompletionMessage: false` skip the announce step entirely; the run registry records their delivery as not required.
 - An exact `ANNOUNCE_SKIP` response suppresses announce output.
 - For completion-required runs, an exact child `NO_REPLY` response or no output is a missing deliverable handed to the requester/parent for visible representation or retry; it is not credited as silent delivery.
 - Optional, duplicate, already-visible, or otherwise non-required paths may use exact `NO_REPLY` for intentional silence.

--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -15,7 +15,6 @@ import * as mod from "./subagent-registry.test-helpers.js";
 
 const noop = () => {};
 const MAIN_REQUESTER_SESSION_KEY = "agent:main:main";
-const MAIN_REQUESTER_DISPLAY_KEY = "main";
 
 type LifecycleData = {
   phase?: string;
@@ -314,7 +313,7 @@ describe("subagent registry lifecycle error grace", () => {
       childSessionKey: `agent:main:subagent:${childSuffix}`,
       requesterSessionKey: MAIN_REQUESTER_SESSION_KEY,
       requesterAgentId: "main",
-      requesterDisplayKey: MAIN_REQUESTER_DISPLAY_KEY,
+      requesterDisplayKey: "main",
       task,
       cleanup: "keep",
       expectsCompletionMessage,
@@ -434,6 +433,7 @@ describe("subagent registry lifecycle error grace", () => {
       label: "Visible child",
       runtime: "subagent",
       sandbox: "inherit",
+      expectsCompletionMessage: true,
       options: {
         agentSessionKey: MAIN_REQUESTER_SESSION_KEY,
         requesterTurnRunId,

--- a/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.requester-wake.e2e.test.ts
@@ -231,6 +231,7 @@ describe("requester settle wake product flow", () => {
       label: params.runId,
       runtime: "subagent",
       sandbox: "inherit",
+      expectsCompletionMessage: true,
       options: {
         agentSessionKey: MAIN_REQUESTER_SESSION_KEY,
         requesterTurnRunId: params.requesterTurnRunId,

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1268,6 +1268,7 @@ describe("spawnSubagentDirect seam flow", () => {
       label: "",
       runtime: "subagent",
       sandbox: "inherit",
+      expectsCompletionMessage: true,
       options: {
         agentSessionKey: controllerSessionKey,
         completionOwnerKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -422,6 +422,53 @@ describe("sessions_spawn tool", () => {
     });
   });
 
+  it("declares expectsCompletionMessage and forwards false to hidden, ACP, and visible spawns", async () => {
+    registerAcpBackendForTest();
+    await withTestDir({ prefix: "openclaw-spawn-completion-" }, async (dir) => {
+      const callGateway = vi.fn(async () => ({
+        key: "agent:main:dashboard:child",
+        runStarted: true,
+        runId: "run-visible",
+      }));
+      const registerRun = vi.fn();
+      const tool = createSessionsSpawnTool({
+        agentSessionKey: "agent:main:main",
+        config: { session: { store: path.join(dir, "sessions.json") } },
+        callGateway: callGateway as never,
+        registerRun,
+        countActiveRuns: () => 0,
+      });
+      const schema = tool.parameters as {
+        properties?: Record<string, { type?: string } | undefined>;
+      };
+      expect(schema.properties?.expectsCompletionMessage).toMatchObject({ type: "boolean" });
+
+      await tool.execute("hidden", { task: "hidden child", expectsCompletionMessage: false });
+      expect(
+        mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect")
+          .expectsCompletionMessage,
+      ).toBe(false);
+
+      await tool.execute("acp", {
+        task: "ACP child",
+        runtime: "acp",
+        expectsCompletionMessage: false,
+      });
+      expect(
+        mockCallArg(hoisted.spawnAcpDirectMock, 0, 0, "spawnAcpDirect").expectsCompletionMessage,
+      ).toBe(false);
+
+      await tool.execute("visible", {
+        task: "visible child",
+        visible: true,
+        expectsCompletionMessage: false,
+      });
+      expect(registerRun).toHaveBeenCalledWith(
+        expect.objectContaining({ expectsCompletionMessage: false }),
+      );
+    });
+  });
+
   it("forwards collector parameters and requesting run identity when enabled", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -212,6 +212,12 @@ function createSessionsSpawnToolSchema(params: {
     cleanup: optionalStringEnum(["delete", "keep"] as const, {
       description: "Hidden session cleanup; visible=true always keeps the session.",
     }),
+    expectsCompletionMessage: Type.Optional(
+      Type.Boolean({
+        description:
+          "false: fire-and-forget; requester gets no completion handoff when the child finishes. collect=true forces false.",
+      }),
+    ),
     sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES, {
       description: '"inherit" parent sandbox policy; "require" fails unless child is sandboxed.',
     }),
@@ -465,6 +471,7 @@ export function createSessionsSpawnTool(
           requestedAgentId,
           runTimeoutSeconds,
           sandbox,
+          expectsCompletionMessage,
           options: opts,
         });
       const visibleResult = opts?.expectedParentSessionId

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -107,6 +107,7 @@ export async function maybeSpawnVisibleSession(params: {
   requestedAgentId?: string;
   runTimeoutSeconds?: number;
   sandbox: "inherit" | "require";
+  expectsCompletionMessage: boolean;
   options?: VisibleSessionsSpawnOptions;
 }): Promise<Record<string, unknown> | undefined> {
   const promptedAt = Date.now();
@@ -420,7 +421,7 @@ export async function maybeSpawnVisibleSession(params: {
         cleanup: "keep",
         label: params.label || undefined,
         runTimeoutSeconds,
-        expectsCompletionMessage: params.raw.expectsCompletionMessage !== false,
+        expectsCompletionMessage: params.expectsCompletionMessage,
         spawnMode: "run",
       });
     } catch (error) {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -55,6 +55,10 @@
             "description": "Child working directory. Visible paths outside configured agent workspaces require operator.admin. Omitted with worktree=true: inherit the same-agent parent managed repository; otherwise use the target agent workspace.",
             "type": "string"
           },
+          "expectsCompletionMessage": {
+            "description": "false: fire-and-forget; requester gets no completion handoff when the child finishes. collect=true forces false.",
+            "type": "boolean"
+          },
           "group": {
             "description": "Custom sidebar group for a visible session; a new name creates the group. Omit or pass an empty string to leave it ungrouped.",
             "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -204,6 +204,10 @@
           "description": "Child working directory. Visible paths outside configured agent workspaces require operator.admin. Omitted with worktree=true: inherit the same-agent parent managed repository; otherwise use the target agent workspace.",
           "type": "string"
         },
+        "expectsCompletionMessage": {
+          "description": "false: fire-and-forget; requester gets no completion handoff when the child finishes. collect=true forces false.",
+          "type": "boolean"
+        },
         "group": {
           "description": "Custom sidebar group for a visible session; a new name creates the group. Omit or pass an empty string to leave it ungrouped.",
           "type": "string"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=d34d752dc536112b64be490513a501650982c65b48000ce5146780e49e9a05ad
-+++ discord-group-codex-message-tool.md	sha256=b5fdd042400d28e793090195c5f14c11446eb8f723bfbb14ebac9ee25835f9e7
+--- telegram-direct-codex-message-tool.md	sha256=6834059ed477093ce7b6a97e2f5202636381f7b5ec2970ea7dd0c292177ed8da
++++ discord-group-codex-message-tool.md	sha256=413470f5f0d53825beb7db6d59c31449534e74bec6d02b1d1f94ed38a9b14362
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -29,10 +29,10 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
 @@ -242,2 +242,2 @@
--    "chars": 56379,
--    "roughTokens": 14095
-+    "chars": 56959,
-+    "roughTokens": 14240
+-    "chars": 56597,
+-    "roughTokens": 14150
++    "chars": 57177,
++    "roughTokens": 14295
 @@ -246,2 +246,2 @@
 -    "chars": 3224,
 -    "roughTokens": 806
@@ -44,10 +44,10 @@
 +    "chars": 28650,
 +    "roughTokens": 7163
 @@ -254,2 +254,2 @@
--    "chars": 83551,
--    "roughTokens": 20888
-+    "chars": 85611,
-+    "roughTokens": 21403
+-    "chars": 83769,
+-    "roughTokens": 20943
++    "chars": 85829,
++    "roughTokens": 21458
 @@ -258,2 +258,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 56379,
-    "roughTokens": 14095
+    "chars": 56597,
+    "roughTokens": 14150
   },
   "openClawDeveloperInstructions": {
     "chars": 3224,
@@ -251,8 +251,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6793
   },
   "totalWithDynamicToolsJson": {
-    "chars": 83551,
-    "roughTokens": 20888
+    "chars": 83769,
+    "roughTokens": 20943
   },
   "userInputText": {
     "chars": 863,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=d34d752dc536112b64be490513a501650982c65b48000ce5146780e49e9a05ad
-+++ telegram-heartbeat-codex-tool.md	sha256=34e5effb10b918859678a8f46e06602c59f14854a05c80732731f8f3d1093c60
+--- telegram-direct-codex-message-tool.md	sha256=6834059ed477093ce7b6a97e2f5202636381f7b5ec2970ea7dd0c292177ed8da
++++ telegram-heartbeat-codex-tool.md	sha256=9fc042dfa7bf05c08427e45fc9a336cfbd0ea4a3290c4efe752702b89e58a91b
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -30,20 +30,20 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
 @@ -242,2 +239,2 @@
--    "chars": 56379,
--    "roughTokens": 14095
-+    "chars": 57872,
-+    "roughTokens": 14468
+-    "chars": 56597,
+-    "roughTokens": 14150
++    "chars": 58090,
++    "roughTokens": 14523
 @@ -250,2 +247,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 27512,
 +    "roughTokens": 6878
 @@ -254,2 +251,2 @@
--    "chars": 83551,
--    "roughTokens": 20888
-+    "chars": 85386,
-+    "roughTokens": 21347
+-    "chars": 83769,
+-    "roughTokens": 20943
++    "chars": 85604,
++    "roughTokens": 21401
 @@ -258,2 +255,2 @@
 -    "chars": 863,
 -    "roughTokens": 216


### PR DESCRIPTION
## What Problem This Solves

`sessions_spawn` honored `expectsCompletionMessage: false` from raw model arguments on the hidden, ACP, and visible spawn paths, but the key was never declared in the tool schema built by `createSessionsSpawnToolSchema`, never listed in `docs/tools/subagents.md`, and read twice from raw args (`sessions-spawn-tool.ts` and `sessions-spawn-visible.ts`). A model that emitted the key silently turned off the completion handoff for that child; a model that never saw it in the schema had no way to use a capability we ship.

## Why This Change Was Made

The flag is a shipped contract, not an accident: the 2026.5.2 release notes announced "honor `sessions_spawn` with `expectsCompletionMessage: false`" as the fix for #75848 (fire-and-forget children that must not displace the parent's interactive thread), and the cloud worker executor (`src/gateway/worker-environments/worker-session-tool-executor.ts`) relies on it to spawn visible worktree children without a completion handoff. Swarm `collect` already forces it to `false`. Removing the raw read would break that contract and the backend caller for no product gain, so the fix declares the parameter instead:

- `expectsCompletionMessage` is now an optional boolean in the schema with a short model-facing description.
- The tool computes the value once and threads it into `maybeSpawnVisibleSession`, which no longer re-reads raw args; the parameter is required there, so the three direct test callers pass it explicitly.
- `docs/tools/subagents.md` documents the parameter and notes that such runs skip the announce step with delivery recorded as not required.
- The Codex-runtime happy-path prompt snapshots that embed this schema are regenerated (+4 lines per catalog, roughly 55 rough tokens per prompt).
- The retry-grace e2e test file sat exactly at the 1000-line lint cap; a single-use display-key constant is inlined rather than adding a suppression.

Production LOC: +9/-1 (net +8, all schema declaration plus one threaded boolean) | Tests/fixtures: +83/-26 | Docs: +4/-0.

## User Impact

Models now see and can deliberately use `expectsCompletionMessage: false` for fire-and-forget children; the default (`true`) and every existing caller behave exactly as before. Operators reading the sub-agent docs see the parameter and its semantics. No config, protocol, or storage change.

## Evidence

- Regression test `declares expectsCompletionMessage and forwards false to hidden, ACP, and visible spawns` in `src/agents/tools/sessions-spawn-tool.test.ts` fails pre-fix on the missing schema property (`expected undefined to match object { type: 'boolean' }`) and passes post-fix.
- `pnpm test src/agents/tools/sessions-spawn-tool.test.ts src/gateway/worker-environments/worker-session-tool-executor.test.ts`: 135 + 25 passed.
- `pnpm test` on the three edited e2e/spawn test files: 84 + 16 + 14 passed.
- `OPENCLAW_STATE_DIR=<scratch> pnpm check:changed`: all lanes green (typecheck core + core tests, lint core, prompt snapshot drift, boundaries, dead-export scan). The isolated state dir is required because the generator opens the operator's live state DB; a follow-up makes that path hermetic.
- `pnpm prompt:snapshots:check`: snapshots current; `test/scripts/prompt-snapshots.test.ts` passes.
- Codex autoreview of the final diff: scoped-clean, no findings.

Refs #75848.
