### PR TITLE
test(e2e): assert native Gateway client deadline budgets

### DIFF
--- a/test/scripts/gateway-network-client.test.ts
+++ b/test/scripts/gateway-network-client.test.ts
@@ -19,7 +19,19 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("gateway network client", () => {
+  function expectDeadlineBudgets(calls: Array<[number]>) {
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [timeoutMs] of calls) {
+      expect(timeoutMs).toBeGreaterThan(0);
+      expect(timeoutMs).toBeLessThanOrEqual(25);
+    }
+  }
+
   function rejectWhenAborted(signal: AbortSignal | null | undefined): Promise<never> {
     expect(signal).toBeInstanceOf(AbortSignal);
     const requestSignal = signal as AbortSignal;
@@ -159,13 +171,13 @@ describe("gateway network client", () => {
   });
 
   it("bounds a stalled suspension admin request by the client deadline", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     let requestSignal: AbortSignal | null | undefined;
     const fetchImpl = vi.fn<typeof fetch>((_input, init) => {
       requestSignal = init?.signal;
       return rejectWhenAborted(requestSignal);
     });
 
-    const startedAt = Date.now();
     await expect(
       runGatewaySuspensionPreRestartClient(
         {
@@ -178,12 +190,13 @@ describe("gateway network client", () => {
       ),
     ).rejects.toMatchObject({ name: "TimeoutError" });
 
-    expect(Date.now() - startedAt).toBeLessThan(500);
+    expectDeadlineBudgets(timeoutSpy.mock.calls);
     expect(requestSignal?.aborted).toBe(true);
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("keeps a stalled suspension response body inside the client deadline", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     let callCount = 0;
     let bodySignal: AbortSignal | null | undefined;
     const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
@@ -206,7 +219,6 @@ describe("gateway network client", () => {
       return response;
     });
 
-    const startedAt = Date.now();
     await expect(
       runGatewaySuspensionPreRestartClient(
         {
@@ -219,7 +231,7 @@ describe("gateway network client", () => {
       ),
     ).rejects.toMatchObject({ name: "TimeoutError" });
 
-    expect(Date.now() - startedAt).toBeLessThan(500);
+    expectDeadlineBudgets(timeoutSpy.mock.calls);
     expect(bodySignal?.aborted).toBe(true);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     const request = fetchImpl.mock.calls[1]?.[0];
@@ -233,6 +245,7 @@ describe("gateway network client", () => {
   });
 
   it("bounds a stalled post-restart admin request by the client deadline", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     const workDir = tempDirs.make("openclaw-gateway-network-post-restart-");
     const statePath = join(workDir, "suspension.json");
     writeFileSync(
@@ -249,7 +262,6 @@ describe("gateway network client", () => {
       return rejectWhenAborted(requestSignal);
     });
 
-    const startedAt = Date.now();
     await expect(
       runGatewaySuspensionPostRestartClient(
         {
@@ -262,7 +274,7 @@ describe("gateway network client", () => {
       ),
     ).rejects.toMatchObject({ name: "TimeoutError" });
 
-    expect(Date.now() - startedAt).toBeLessThan(500);
+    expectDeadlineBudgets(timeoutSpy.mock.calls);
     expect(requestSignal?.aborted).toBe(true);
     expect(fetchImpl).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## What Problem This Solves

The Gateway network client deadline tests can fail when a loaded host delays timer callbacks. In [the failing CI job](https://github.com/openclaw/openclaw/actions/runs/33667249944/job/100378896515), the stalled request correctly rejected with `TimeoutError`, but the extra elapsed-time assertion observed 680 ms against a 500 ms threshold.

## Why This Change Was Made

Observe the budget passed to the real `AbortSignal.timeout` factory and assert that every requested delay is positive and at most the configured 25 ms. Keep the real native timer, `TimeoutError`, aborted signal, request counts, and response-body checks across all three stalled request/body/post-restart cases. Restore the observation spies after each test.

This maintainer-requested test-audit repair checks deadline propagation and cancellation without treating host scheduling as a guarantee. [Node documents that timer callbacks have no exact timing guarantee](https://nodejs.org/api/timers.html#settimeoutcallback-delay-args).

## User Impact

No production behavior changes. The tests retain deadline coverage and reject oversized budgets while avoiding a host-load-dependent failure. Production +0/-0; tests +18/-6.

## Evidence

Signed head: `5e7a5c97a25e3f3c2b84e663778b9a88ccc4f0a1`; the committed test file matches the verified afterimage.

- `node scripts/run-vitest.mjs test/scripts/gateway-network-client.test.ts`: **23 passed before and after**, exit 0.
- The canonical three stalled-request tests also passed when a test-process preload registered each real native timeout and then blocked the event loop for 650 ms: **3 passed**, exit 0. No native timer was replaced.
- Standalone isolated-owner controls produced:

```text
Native 25 ms deadline + 650 ms event-loop block: PASS, TimeoutError, aborted=true
Wrong 1000 ms requested deadline: EXPECTED FAIL, invalid deadline budget 1000
Missing abort deadline: EXPECTED FAIL, no TimeoutError, aborted=false
```

- Normal `node scripts/check-changed.mjs --base origin/main -- test/scripts/gateway-network-client.test.ts`: **exit 0**, including root-test types, scripts lint, changed-file lint and selected guards. Formatting and `git diff --check` passed.
- Fresh independent Codex review: scoped-clean through P2, no actionable findings.

The controls use synthetic stalled transports. They demonstrate the scheduling-sensitive assertion and retained regression detection; they do not identify the exact scheduling cause inside the hosted runner or claim an authenticated Gateway/provider test.
