### PR TITLE
perf(macos): reduce idle menu-bar CPU use

### DIFF
--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -221,23 +221,15 @@ final class ControlChannel {
     }
 
     func health(timeout: TimeInterval? = nil) async throws -> Data {
-        do {
-            let start = Date()
-            var params: [String: AnyHashable]?
-            if let timeout {
-                params = ["timeout": AnyHashable(Int(timeout * 1000))]
-            }
-            let timeoutMs = (timeout ?? 15) * 1000
-            let payload = try await self.request(method: "health", params: params, timeoutMs: timeoutMs)
-            let ms = Date().timeIntervalSince(start) * 1000
-            self.lastPingMs = ms
-            self.setStateThrottled(.connected)
-            return payload
-        } catch {
-            let message = Self.friendlyGatewayMessage(error, configRoot: OpenClawConfigFile.loadDict())
-            self.setStateThrottled(.degraded(message))
-            throw ControlChannelError.badResponse(message)
+        let start = Date()
+        var params: [String: AnyHashable]?
+        if let timeout {
+            params = ["timeout": AnyHashable(Int(timeout * 1000))]
         }
+        let timeoutMs = (timeout ?? 15) * 1000
+        let payload = try await self.request(method: "health", params: params, timeoutMs: timeoutMs)
+        self.lastPingMs = Date().timeIntervalSince(start) * 1000
+        return payload
     }
 
     func lastHeartbeat() async throws -> ControlHeartbeatEvent? {
@@ -251,21 +243,15 @@ final class ControlChannel {
         timeoutMs: Double? = nil,
         retryTransportFailures: Bool = true) async throws -> Data
     {
-        do {
+        try await self.performRequest {
             let rawParams = params?.reduce(into: [String: OpenClawKit.AnyCodable]()) {
                 $0[$1.key] = OpenClawKit.AnyCodable($1.value.base)
             }
-            let data = try await GatewayConnection.shared.request(
+            return try await GatewayConnection.shared.request(
                 method: method,
                 params: rawParams,
                 timeoutMs: timeoutMs,
                 retryTransportFailures: retryTransportFailures)
-            self.setStateThrottled(.connected)
-            return data
-        } catch {
-            let message = Self.friendlyGatewayMessage(error, configRoot: OpenClawConfigFile.loadDict())
-            self.setStateThrottled(.degraded(message))
-            throw ControlChannelError.badResponse(message)
         }
     }
 
@@ -273,13 +259,22 @@ final class ControlChannel {
         _ request: OpenClawChatGatewayRequest,
         retryTransportFailures: Bool = true) async throws -> Data
     {
+        try await self.performRequest {
+            try await GatewayConnection.shared.request(request, retryTransportFailures: retryTransportFailures)
+        }
+    }
+
+    private func performRequest(_ operation: () async throws -> Data) async throws -> Data {
+        try Task.checkCancellation()
         do {
-            let data = try await GatewayConnection.shared.request(
-                request,
-                retryTransportFailures: retryTransportFailures)
+            let data = try await operation()
+            try Task.checkCancellation()
             self.setStateThrottled(.connected)
             return data
         } catch {
+            // Closing a view cancels its requests, not the shared connection.
+            // Only failures belonging to a live caller may trigger recovery.
+            try Task.checkCancellation()
             let message = Self.friendlyGatewayMessage(error, configRoot: OpenClawConfigFile.loadDict())
             self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)

--- a/apps/macos/Sources/OpenClaw/CronJobsStore.swift
+++ b/apps/macos/Sources/OpenClaw/CronJobsStore.swift
@@ -7,6 +7,11 @@ import OSLog
 @MainActor
 @Observable
 final class CronJobsStore {
+    enum Consumer: Hashable {
+        case statusMenu
+        case settings
+    }
+
     static let shared = CronJobsStore()
 
     var jobs: [CronJob] = []
@@ -22,6 +27,7 @@ final class CronJobsStore {
     var lastError: String?
     var statusMessage: String?
 
+    @ObservationIgnored private var consumers: Set<Consumer> = []
     private let logger = Logger(subsystem: "ai.openclaw", category: "cron.ui")
     private var refreshTask: Task<Void, Never>?
     private var runsTask: Task<Void, Never>?
@@ -39,8 +45,12 @@ final class CronJobsStore {
         self.isPreview = isPreview
     }
 
-    func start() {
-        guard !self.isPreview, self.eventTask == nil else { return }
+    func start(_ consumer: Consumer) {
+        guard !self.isPreview, self.consumers.insert(consumer).inserted else { return }
+        guard self.eventTask == nil else {
+            self.scheduleRefresh(delayMs: 0)
+            return
+        }
         self.eventTask = Task { [weak self, gateway] in
             for await push in await gateway.subscribe() {
                 guard !Task.isCancelled, let self else { return }
@@ -52,19 +62,24 @@ final class CronJobsStore {
         }
     }
 
-    func stop() {
+    func stop(_ consumer: Consumer) {
+        self.consumers.remove(consumer)
+        // Settings owns history; either visible surface can keep job updates alive.
+        if consumer == .settings || self.consumers.isEmpty {
+            self.invalidateRuns()
+        }
+        guard self.consumers.isEmpty else { return }
         self.jobsGeneration &+= 1
         self.isLoadingJobs = false
         SimpleTaskSupport.stop(task: &self.refreshTask)
-        self.invalidateRuns()
         SimpleTaskSupport.stop(task: &self.eventTask)
         SimpleTaskSupport.stop(task: &self.pollTask)
     }
 
     func refreshJobs() async {
         guard !self.isLoadingJobs, !Task.isCancelled else { return }
-        // Manual and scheduled refreshes share the pane's lifetime; stop also
-        // invalidates callers whose task is not owned by this store.
+        // Manual and scheduled refreshes share the active consumers' lifetime; the final
+        // stop also invalidates callers whose task is not owned by this store.
         self.jobsGeneration &+= 1
         let generation = self.jobsGeneration
         self.isLoadingJobs = true
@@ -193,13 +208,20 @@ final class CronJobsStore {
     private func handle(cronEvent evt: CronEvent) {
         // Keep UI in sync with the gateway scheduler.
         self.scheduleRefresh(delayMs: 250)
-        if evt.action == "finished", let selected = self.selectedJobId, selected == evt.jobId {
+        if self.consumers.contains(.settings), evt.action == "finished",
+           let selected = self.selectedJobId, selected == evt.jobId
+        {
             self.refreshRuns(jobId: selected, delay: 0.2)
         }
     }
 
     private func scheduleRefresh(delayMs: Int = 250) {
-        SimpleTaskSupport.schedule(task: &self.refreshTask, delay: TimeInterval(delayMs) / 1000) { [weak self] in
+        let previousTask = self.refreshTask
+        previousTask?.cancel()
+        self.refreshTask = Task { [weak self] in
+            // Even a canceled debounce must drain its predecessor before a replacement can refresh.
+            await previousTask?.value
+            guard await SimpleTaskSupport.waitForNextOperation(interval: TimeInterval(delayMs) / 1000) else { return }
             await self?.refreshJobs()
         }
     }

--- a/apps/macos/Sources/OpenClaw/CronSettings+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/CronSettings+Layout.swift
@@ -17,7 +17,7 @@ extension CronSettings {
             self.updateActiveWork(active: active)
         }
         .onDisappear {
-            self.store.stop()
+            self.store.stop(.settings)
             self.channelsStore.stop()
         }
         .sheet(isPresented: self.$showEditor) {
@@ -57,10 +57,10 @@ extension CronSettings {
 
     private func updateActiveWork(active: Bool) {
         if active {
-            self.store.start()
+            self.store.start(.settings)
             self.channelsStore.start()
         } else {
-            self.store.stop()
+            self.store.stop(.settings)
             self.channelsStore.stop()
         }
     }

--- a/apps/macos/Sources/OpenClaw/HealthStore.swift
+++ b/apps/macos/Sources/OpenClaw/HealthStore.swift
@@ -124,13 +124,14 @@ final class HealthStore {
     }
 
     func refresh(onDemand: Bool = false) async {
-        guard !self.isRefreshing else { return }
+        guard !self.isRefreshing, !Task.isCancelled else { return }
         self.isRefreshing = true
         defer { self.isRefreshing = false }
         let previousError = self.lastError
 
         do {
             let data = try await ControlChannel.shared.health(timeout: 15)
+            guard !Task.isCancelled else { return }
             if let decoded = decodeHealthSnapshot(from: data) {
                 self.snapshot = decoded
                 self.lastSuccess = Date()
@@ -146,6 +147,7 @@ final class HealthStore {
                 }
             }
         } catch {
+            guard !Task.isCancelled else { return }
             let desc = error.localizedDescription
             self.lastError = desc
             if onDemand { self.snapshot = nil }

--- a/apps/macos/Sources/OpenClaw/NodesStore.swift
+++ b/apps/macos/Sources/OpenClaw/NodesStore.swift
@@ -80,11 +80,23 @@ final class NodesStore {
     }
 
     func start() {
-        guard self.task == nil else { return }
+        guard self.task == nil || self.task?.isCancelled == true else { return }
+        let previousTask = self.task
+        let interval = self.interval
         self.scheduleLocalNodeIdentityPreparation()
-        SimpleTaskSupport.startDetachedLoop(task: &self.task, interval: self.interval) { [weak self] in
-            await self?.refresh()
+        self.task = Task { [weak self] in
+            await previousTask?.value
+            guard !Task.isCancelled else { return }
+            repeat {
+                guard let self else { return }
+                await self.refresh()
+            } while await SimpleTaskSupport.waitForNextOperation(interval: interval)
         }
+    }
+
+    func stop() {
+        // Reopening joins this task before refreshing so it cannot inherit stale isLoading.
+        self.task?.cancel()
     }
 
     private func scheduleLocalNodeIdentityPreparation() {
@@ -130,18 +142,20 @@ final class NodesStore {
     }
 
     func refresh() async {
+        guard !self.isLoading, !Task.isCancelled else { return }
         self.scheduleLocalNodeIdentityPreparation()
-        if self.isLoading { return }
         self.statusMessage = nil
         self.isLoading = true
         defer { self.isLoading = false }
         do {
             let data = try await GatewayConnection.shared.requestRaw(method: "node.list", params: nil, timeoutMs: 8000)
+            guard !Task.isCancelled else { return }
             let decoded = try JSONDecoder().decode(NodeListResponse.self, from: data)
             self.nodes = decoded.nodes
             self.lastError = nil
             self.statusMessage = nil
         } catch {
+            guard !Task.isCancelled else { return }
             if Self.isCancelled(error) {
                 self.logger.debug("node.list cancelled; keeping last nodes")
                 if self.nodes.isEmpty {

--- a/apps/macos/Sources/OpenClaw/StatusMenuController.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuController.swift
@@ -91,9 +91,12 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         // Cache projection must precede network work: AppKit begins tracking immediately.
         self.renderCachedMenu()
         self.isMenuOpen = true
+        let previousTask = self.refreshTask
         self.refreshTask?.cancel()
         self.refreshTask = Task { [weak self] in
-            guard let self else { return }
+            // Reopening must wait for canceled store refreshes to release their loading state.
+            await previousTask?.value
+            guard let self, !Task.isCancelled else { return }
             async let sessionRefresh: Void = self.sessions.refresh(force: true)
             async let approvalRefresh: Void = self.approvals.refresh()
             async let healthRefresh: Void = HealthStore.shared.refresh(onDemand: true)
@@ -109,6 +112,7 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
         guard menu === self.menu else { return }
         StatusMenuHighlightDelegate.shared.menu(menu, willHighlight: nil)
         self.isMenuOpen = false
+        self.refreshTask?.cancel()
         self.sessions.cancelPreviewTasks()
         self.summaries.menuDidClose()
         // Leaving the menu attached makes subsequent left clicks open AppKit's menu.
@@ -130,6 +134,8 @@ final class StatusMenuController: NSObject, NSMenuDelegate {
     private func installButton(in item: NSStatusItem) {
         guard let button = item.button else { return }
         let host = NSHostingView(rootView: self.makeIconView())
+        // The constraints below own sizing; animation must not remeasure the status item.
+        host.sizingOptions = []
         host.translatesAutoresizingMaskIntoConstraints = false
         button.addSubview(host)
         NSLayoutConstraint.activate([

--- a/apps/macos/Sources/OpenClaw/StatusMenuSessions.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuSessions.swift
@@ -18,6 +18,7 @@ final class StatusMenuSessions: NSObject {
     @ObservationIgnored private let refreshInterval: TimeInterval = 12
 
     func refresh(force: Bool = false) async {
+        guard !Task.isCancelled else { return }
         if !force,
            let updatedAt,
            Date().timeIntervalSince(updatedAt) < self.refreshInterval
@@ -35,12 +36,14 @@ final class StatusMenuSessions: NSObject {
 
         do {
             let snapshot = try await SessionLoader.loadSnapshot(limit: 32)
+            guard !Task.isCancelled else { return }
             self.cachedSnapshot = snapshot
             self.rows = snapshot.rows
             self.errorText = nil
             self.updatedAt = Date()
             self.prewarmPreviews(for: snapshot.rows)
         } catch {
+            guard !Task.isCancelled else { return }
             self.cachedSnapshot = nil
             self.rows = []
             self.errorText = self.compactError(error)

--- a/apps/macos/Sources/OpenClaw/StatusMenuSummaries.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuSummaries.swift
@@ -48,22 +48,25 @@ final class StatusMenuSummaries: NSObject {
     func refresh(onUpdate: @escaping @MainActor () -> Void) {
         self.updateHandler = onUpdate
         self.nodes.start()
-        self.cron.start()
+        self.cron.start(.statusMenu)
         guard self.refreshTask == nil else { return }
 
         self.refreshTask = Task { [weak self] in
-            guard let self else { return }
-            async let jobs: Void = self.refreshAutomations()
-            async let devices: Void = self.refreshDevices()
+            guard let self, !Task.isCancelled else { return }
             async let usage: Void = self.refreshUsage()
             async let cost: Void = self.refreshCost()
-            _ = await (jobs, devices, usage, cost)
+            _ = await (usage, cost)
+            guard !Task.isCancelled else { return }
             self.refreshTask = nil
         }
     }
 
     func menuDidClose() {
         self.updateHandler = nil
+        self.nodes.stop()
+        self.cron.stop(.statusMenu)
+        self.refreshTask?.cancel()
+        self.refreshTask = nil
         self.usageRetry?.cancel()
         self.usageRetry = nil
         self.usageRetryAttempts = 0
@@ -259,20 +262,8 @@ final class StatusMenuSummaries: NSObject {
         return false
     }
 
-    private func refreshAutomations() async {
-        guard self.isConnected else { return }
-        await self.cron.refreshJobs()
-        self.updateHandler?()
-    }
-
-    private func refreshDevices() async {
-        guard self.isConnected else { return }
-        await self.nodes.refresh()
-        self.updateHandler?()
-    }
-
     private func refreshUsage() async {
-        guard self.isConnected,
+        guard !Task.isCancelled, self.isConnected,
               self.usageUpdatedAt.map({ Date().timeIntervalSince($0) >= 30 }) ?? true
         else { return }
 
@@ -325,14 +316,17 @@ final class StatusMenuSummaries: NSObject {
     }
 
     private func refreshCost() async {
-        guard self.isConnected,
+        guard !Task.isCancelled, self.isConnected,
               self.costUpdatedAt.map({ Date().timeIntervalSince($0) >= 45 }) ?? true
         else { return }
 
         do {
-            self.cachedCost = try await CostUsageLoader.loadSummary()
+            let summary = try await CostUsageLoader.loadSummary()
+            guard !Task.isCancelled else { return }
+            self.cachedCost = summary
             self.costError = nil
         } catch {
+            guard !Task.isCancelled else { return }
             self.cachedCost = nil
             let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
             self.costError = message.isEmpty

--- a/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CronJobsStoreTests.swift
@@ -65,7 +65,8 @@ private final class CronGatewayFixture: @unchecked Sendable {
         recoveryEligible: Bool = false,
         initialRunsFailure: (any Error & Sendable)? = nil,
         holdJobList: Bool = false,
-        onRequestRecorded: (@Sendable () -> Void)? = nil)
+        onRequestRecorded: (@Sendable () -> Void)? = nil,
+        onEndpointLookup: (@Sendable (Int) async -> Void)? = nil)
     {
         let requests = CronGatewayRequestLog()
         self.requests = requests
@@ -107,6 +108,7 @@ private final class CronGatewayFixture: @unchecked Sendable {
             self.gateway = GatewayConnection(
                 endpointProvider: {
                     await requests.lookupEndpoint()
+                    await onEndpointLookup?(requests.endpointLookupCount())
                     return GatewayConnection.EndpointSnapshot(
                         config: (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil),
                         routeAuthority: nil)
@@ -118,6 +120,7 @@ private final class CronGatewayFixture: @unchecked Sendable {
             self.gateway = GatewayConnection(
                 configProvider: {
                     await requests.lookupEndpoint()
+                    await onEndpointLookup?(requests.endpointLookupCount())
                     return (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil)
                 },
                 sessionBox: WebSocketSessionBox(session: self.session))
@@ -214,7 +217,7 @@ struct CronJobsStoreTests {
             await store.refreshJobs()
         }
         func cleanup() async {
-            store.stop()
+            store.stop(.settings)
             refresh.cancel()
             signal.finish()
             await refresh.value
@@ -229,7 +232,7 @@ struct CronJobsStoreTests {
             let pending = try #require(recorded, "refresh ended before cron.list arrived")
             // A buffered request can outlive its refresh; stop must still precede completion.
             try #require(store.isLoadingJobs)
-            store.stop()
+            store.stop(.settings)
             store.lastError = "current pane error"
             if succeeds {
                 try await fixture.respondWithJobs(to: pending)
@@ -252,7 +255,7 @@ struct CronJobsStoreTests {
     @Test func `selecting another job sends its history request while the previous request is pending`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
+        defer { store.stop(.settings) }
         store.selectJob("job-a")
         let firstRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
         store.runEntries = [self.entry(jobId: "job-a", summary: "old A")]
@@ -285,7 +288,7 @@ struct CronJobsStoreTests {
     @Test func `late failure from a superseded job preserves the selected jobs own failure`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
+        defer { store.stop(.settings) }
         store.selectJob("job-a")
         let firstRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
         store.runEntries = [self.entry(jobId: "job-a", summary: "old A")]
@@ -312,7 +315,7 @@ struct CronJobsStoreTests {
     func `manual refresh replaces the selected jobs pending request without accepting stale success`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
+        defer { store.stop(.settings) }
         store.selectJob("job-a")
         let originalRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
 
@@ -337,7 +340,7 @@ struct CronJobsStoreTests {
     @Test func `manual refresh after failure clears the old error and publishes the successful retry`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
+        defer { store.stop(.settings) }
         store.selectJob("job-a")
         let failedRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
         try await fixture.fail(failedRequest, message: "temporary history failure")
@@ -359,8 +362,8 @@ struct CronJobsStoreTests {
     @Test func `finished events refresh only the job still selected after their debounce`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
-        store.start()
+        defer { store.stop(.settings) }
+        store.start(.settings)
         try #require(await self.waitUntil { store.jobs.count == 2 })
         store.selectJob("job-a")
         let firstRequest = try #require(await fixture.waitForRequest(jobId: "job-a"))
@@ -397,9 +400,9 @@ struct CronJobsStoreTests {
     {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
+        defer { store.stop(.settings) }
         if source == "event" {
-            store.start()
+            store.start(.settings)
             try #require(await self.waitUntil { store.jobs.count == 2 })
         }
         store.selectJob("job-a")
@@ -417,7 +420,7 @@ struct CronJobsStoreTests {
         let previousHistory = store.runEntries.map(\.summary)
         let previousError = store.lastError
 
-        store.stop()
+        store.stop(.settings)
 
         #expect(!store.isLoadingRuns)
         if outcome == "success" {
@@ -437,7 +440,7 @@ struct CronJobsStoreTests {
     @Test func `removing the selected job cancels its pending history before refreshing jobs`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
+        defer { store.stop(.settings) }
         store.selectJob("job-a")
         let pending = try #require(await fixture.waitForRequest(jobId: "job-a"))
         store.runEntries = [self.entry(jobId: "job-a", summary: "removed history")]
@@ -460,7 +463,7 @@ struct CronJobsStoreTests {
     func `job list refresh invalidates pending history when another client removed its selected job`() async throws {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
-        defer { store.stop() }
+        defer { store.stop(.settings) }
         store.selectJob("job-a")
         let pending = try #require(await fixture.waitForRequest(jobId: "job-a"))
         store.runEntries = [self.entry(jobId: "job-a", summary: "old history")]
@@ -482,7 +485,7 @@ struct CronJobsStoreTests {
     @Test func `superseded history never activates the local Gateway or its launch agent`() async throws {
         try await self.withLocalGatewayRecovery { fixture in
             let store = CronJobsStore(gateway: fixture.gateway)
-            defer { store.stop() }
+            defer { store.stop(.settings) }
             store.selectJob("job-a")
             _ = try #require(await fixture.waitForRequest(jobId: "job-a"))
 
@@ -505,7 +508,7 @@ struct CronJobsStoreTests {
     @Test func `uncancelled history transport failures activate the Gateway and retry`() async throws {
         try await self.withLocalGatewayRecovery(initialRunsFailure: URLError(.networkConnectionLost)) { fixture in
             let store = CronJobsStore(gateway: fixture.gateway)
-            defer { store.stop() }
+            defer { store.stop(.settings) }
 
             store.selectJob("job-a")
 
@@ -526,7 +529,7 @@ struct CronJobsStoreTests {
         let fixture = CronGatewayFixture()
         let store = CronJobsStore(gateway: fixture.gateway)
 
-        store.start()
+        store.start(.settings)
         try #require(await self.waitUntil { store.jobs.count == 2 })
 
         #expect(store.schedulerEnabled == true)
@@ -536,10 +539,124 @@ struct CronJobsStoreTests {
         #expect(await fixture.requests.requestCount(method: "cron.status") == 1)
         #expect(await fixture.requests.requestCount(method: "cron.list") == 1)
 
-        store.stop()
+        store.stop(.settings)
 
         #expect(!store.isLoadingRuns)
         #expect(fixture.session.snapshotCancelCount() == 0)
+    }
+
+    @Test(arguments: ["menu", "settings"])
+    func `shared refresh survives either consumer closing and stops after both close`(
+        firstClosed: String) async throws
+    {
+        let fixture = CronGatewayFixture()
+        let store = CronJobsStore(gateway: fixture.gateway)
+        func cleanup() async {
+            store.stop(.settings)
+            store.stop(.statusMenu)
+            await fixture.gateway.shutdown()
+        }
+        do {
+            store.start(.settings)
+            store.start(.statusMenu)
+            try #require(await self.waitUntil { store.jobs.count == 2 })
+            store.selectJob("job-a")
+            let initial = try #require(await fixture.waitForRequest(jobId: "job-a"))
+            try await fixture.respond(to: initial, jobId: "job-a", summary: "existing history")
+            try #require(await self.waitUntil { !store.isLoadingRuns && !store.isLoadingJobs })
+
+            store.stop(firstClosed == "menu" ? .statusMenu : .settings)
+            let statusCount = await fixture.requests.requestCount(method: "cron.status")
+            try await fixture.sendFinishedEvent(jobId: "job-a")
+            _ = try #require(
+                await fixture.waitForRequest(method: "cron.status", occurrence: statusCount),
+                "Closing one consumer must retain refresh for the other visible consumer")
+
+            if firstClosed == "menu" {
+                let refreshed = try #require(await fixture.waitForRequest(jobId: "job-a", occurrence: 1))
+                try await fixture.respond(to: refreshed, jobId: "job-a", summary: "visible settings")
+                try #require(await self.waitUntil { !store.isLoadingRuns })
+                #expect(store.runEntries.first?.summary == "visible settings")
+            } else {
+                #expect(await fixture.waitForRequest(
+                    jobId: "job-a", occurrence: 1, timeout: .milliseconds(300)) == nil)
+                #expect(store.selectedJobId == "job-a")
+                #expect(store.runEntries.first?.summary == "existing history")
+            }
+
+            store.stop(firstClosed == "menu" ? .settings : .statusMenu)
+            let finalStatusCount = await fixture.requests.requestCount(method: "cron.status")
+            try await fixture.sendFinishedEvent(jobId: "job-a")
+            #expect(await fixture.waitForRequest(
+                method: "cron.status", occurrence: finalStatusCount, timeout: .milliseconds(350)) == nil)
+            #expect(!store.isLoadingRuns)
+        } catch {
+            await cleanup()
+            throw error
+        }
+        await cleanup()
+    }
+
+    @Test(arguments: ["consumer", "event", "reopened consumer"])
+    func `replacement refresh waits for the cancelled event refresh to drain`(replacement: String) async throws {
+        let (lookups, entered) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        let (releases, release) = AsyncStream<Void>.makeStream()
+        // An unstructured wait keeps endpoint completion pending after its caller is cancelled.
+        let heldLookup = Task { for await _ in releases {} }
+        let fixture = CronGatewayFixture(onEndpointLookup: { count in
+            guard count == 3 else { return }
+            entered.yield(())
+            await heldLookup.value
+        })
+        let store = CronJobsStore(gateway: fixture.gateway)
+        func cleanup() async {
+            release.finish()
+            entered.finish()
+            store.stop(.settings)
+            store.stop(.statusMenu)
+            await heldLookup.value
+            await fixture.gateway.shutdown()
+        }
+        do {
+            store.start(.settings)
+            try #require(await self.waitUntil { store.jobs.count == 2 && !store.isLoadingJobs })
+            await fixture.requests.removeJob("job-a")
+            try await fixture.sendFinishedEvent(jobId: "job-b")
+            let reachedGate = try await AsyncTimeout.withTimeout(
+                seconds: 2,
+                onTimeout: { URLError(.timedOut) })
+            {
+                for await _ in lookups {
+                    return true
+                }
+                return false
+            }
+            try #require(reachedGate)
+
+            if replacement == "event" {
+                try await fixture.sendFinishedEvent(jobId: "job-b")
+            } else {
+                store.start(.statusMenu)
+                if replacement == "reopened consumer" {
+                    // Cancel the intermediate join before its task can run on this actor.
+                    store.stop(.statusMenu)
+                    store.start(.statusMenu)
+                }
+            }
+            #expect(await fixture.waitForRequest(
+                method: "cron.list", occurrence: 1, timeout: .milliseconds(350)) == nil)
+            release.finish()
+            _ = try #require(
+                await fixture.waitForRequest(method: "cron.list", occurrence: 1),
+                "The replacement must refresh after the cancelled request drains")
+            try #require(await self.waitUntil { !store.isLoadingJobs })
+            #expect(store.jobs.map(\.id) == ["job-b"])
+            #expect(store.lastError == nil)
+        } catch {
+            await cleanup()
+            throw error
+        }
+        await cleanup()
     }
 
     private func entry(jobId: String, summary: String) -> CronRunLogEntry {

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -10,12 +10,14 @@ title: "Menu bar"
 - The current agent work state renders in the menu bar icon and in the first status row of the menu.
 - Health status is hidden while work is active; it returns once all sessions are idle.
 - A root "Context" item opens a submenu with recent sessions instead of expanding them in the root menu.
-- A "Nodes" block in the root menu lists paired **devices** only (from `node.list`), not client/presence entries.
+- A "Devices" block in the root menu lists paired **devices** only (from `node.list`), not client/presence entries.
 - A root "Usage" section appears below Context when provider usage snapshots are available, followed by cost details when available.
 - When two or more Gateways are available, the first status row includes the primary Gateway name and a root "Gateways" section lists every Gateway with its health and primary marker. Select a row to open or focus that Gateway's dashboard; hold Option to reveal "Set as Primary…" for eligible saved Gateways.
 - **Quick Chat** opens the floating main-session composer; its current global shortcut appears beside the item.
 
 Single-Gateway setups keep the existing menu unchanged. With two or more Gateways, the app's main **Gateways** menu also assigns Command-1 through Command-9 in catalog order. Its checkmark follows the frontmost dashboard window, and selecting an item switches that window in place or opens the selected Gateway when no dashboard window exists.
+
+The Devices and Automations summaries refresh while the menu is open. Closing it stops their menu-owned polling; the native Cron Jobs settings pane, when enabled, keeps its own refresh running while active. Cached summaries remain available when the menu reopens.
 
 ## State model
 

--- a/docs/platforms/mac/menu-bar.md
+++ b/docs/platforms/mac/menu-bar.md
@@ -17,7 +17,7 @@ title: "Menu bar"
 
 Single-Gateway setups keep the existing menu unchanged. With two or more Gateways, the app's main **Gateways** menu also assigns Command-1 through Command-9 in catalog order. Its checkmark follows the frontmost dashboard window, and selecting an item switches that window in place or opens the selected Gateway when no dashboard window exists.
 
-The Devices and Automations summaries refresh while the menu is open. Closing it stops their menu-owned polling; the native Cron Jobs settings pane, when enabled, keeps its own refresh running while active. Cached summaries remain available when the menu reopens.
+The Devices and Automations summaries refresh while the menu is open. Closing it stops their menu-owned polling. An active native Cron Jobs settings pane keeps its own refresh running. Cached summaries remain available when the menu reopens.
 
 ## State model
 


### PR DESCRIPTION
Closes #136562

## What Problem This Solves

Fixes an issue where the macOS app keeps polling Devices and Automations after users close the status menu. The animated, explicitly sized menu-bar icon also repeatedly asks SwiftUI for intrinsic-size measurements while idle.

## Why This Change Was Made

The menu now owns the lifetime of its refresh work. Cron tracks the menu and native settings as separate consumers, so closing either surface does not stop the other; the final consumer releases polling and subscriptions. Replacement tasks drain canceled predecessors before starting, including rapid menu open–close–reopen. Canceled view requests preserve cached data and do not mark the shared control connection unhealthy.

The 18-by-18-point icon's existing constraints now own its size. Animations, their cadence, and dynamic menu-row sizing are unchanged. Duplicate summary refresh producers and duplicate control-channel error handling are removed.

## User Impact

Less native background work with the menu closed, without a new setting or a less animated icon. Cached summaries still render immediately on reopening. A separately active native Cron Jobs settings pane keeps refreshing; the default Cron Jobs tab remains the dashboard handoff.

## Evidence

One matched pair of four-minute healthy-idle runs, using signed arm64 Debug apps with default icon animations enabled and no dashboard window:

| Measurement | Before | After |
| --- | ---: | ---: |
| Native CPU time over 240 seconds | 5.60 s | 4.88 s |
| Mean native CPU, percentage of one core | 2.33% | 2.03% |
| Closed-menu `node.list` requests | 8 | 0 |
| Closed-menu `cron.status` / `cron.list` requests | 8 / 8 | 0 / 0 |
| Health requests | 4 | 4 |

This pair measured about 13% lower native CPU. Separate one-minute Instruments CPU/wakeup readings varied; no whole-system, battery-life, or energy claim is made. Time Profiler recorded sampled inclusive CPU weight for `NSHostingView.updateConstraints` decreasing from 150 ms to 35 ms; `_sizeThatFits` went from 14 ms of sampled weight to no samples. These are sampling observations, not exact timings or proof of zero calls. The comparison used macOS 27 beta/Xcode 27 beta, matching build settings, and the local MLX helper omitted equally from both builds.

The final source passes 33 focused native test cases (29 declarations) in an independently canary-checked OS sandbox that blocks operator files, Keychain/preferences IPC, network access, and child launches. Coverage includes both shared-consumer closing orders, late completions, debounce cancellation, and unchanged animation cadence. The new rapid-reopen case actually failed before the final drain correction and passed with identical test bytes afterward; the final formatted tree was rebuilt and checked separately. This is focused proof, not a claim that the full native suite ran locally.

A fresh independent P0–P2 autoreview is clean after correcting that drain-chain finding. Changed Swift production files pass pinned SwiftLint; changed Swift files and the docs pass formatting checks. No dependency, configuration, storage-schema, or protocol changes.

The original performance pair predates the final intermediate-debounce correction; that correction changes replacement ordering, not closed-menu polling or icon animation. The final arm64 Debug app was rebuilt with the canonical Swift wrapper, signed with the matching OpenClaw Foundation Developer ID, and passed deep/strict signature and bundled-worker readiness checks. Its dSYM matches the executable UUID; all 949 tracked native source hashes remained frozen through publication. Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/33679805460) passed on `0ddb5fad76cdca68a0077a347d534f830dc5d4a6`, including the full Swift tests, release build, all three macOS Node lanes, docs, native localization, security and the aggregate gate. [macOS Periphery](https://github.com/openclaw/openclaw/actions/runs/33679805421) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33679805369) passed as well. The native tests waited for runner capacity but passed on their original attempt; no fallback dispatch or CI setting change was needed.

**UI attachment limitation:** Both real before/after 48-by-48 icon crops were visually inspected and are byte-identical. GitHub's user-attachments endpoint returned HTTP 403; this CLI has no `--attach` support and no verified fallback publisher is installed. The inspected before/after icon crops are identical, but public image attachments are unavailable. No private traces or desktop captures are posted.

Production LOC: +100/-64 (net +36); tests/test support: +135/-18; docs: +3/-1. The production growth represents separate consumer ownership and cancellation-safe task lifetime; duplicate refresh and error-handling paths were removed. Generic task scheduling stays unchanged because superseded run-history requests must not block a new selection.

Follow-up, not a claim from these measurements: scope the retained General settings pane's five-second Tailscale polling to its active lifetime; its CPU impact is unmeasured. Regression provenance for all historical polling behavior remains unknown.
