### PR TITLE
fix(cli): emit snapshots for approval allowlist JSON no-ops

### DIFF
--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -198,6 +198,9 @@ openclaw approvals allowlist add --agent "*" "/usr/bin/uname"
 openclaw approvals allowlist remove "~/Projects/**/bin/rg"
 ```
 
+Adding an existing pattern or removing a missing one succeeds without writing.
+With `--json`, these commands return the unchanged, redacted approvals snapshot.
+
 ## Common options
 
 `get`, `set`, and `allowlist add|remove` all support:

--- a/src/cli/exec-approvals-cli.allowlist-json.test.ts
+++ b/src/cli/exec-approvals-cli.allowlist-json.test.ts
@@ -1,0 +1,87 @@
+import "./exec-approvals-cli.test-support.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as execApprovals from "../infra/exec-approvals.js";
+
+const {
+  callGatewayFromCli,
+  defaultRuntime,
+  localSnapshot,
+  loggedOutput,
+  resetExecApprovalsCliMocks,
+  runApprovalsCommand,
+  runtimeErrors,
+} = await import("./exec-approvals-cli.test-support.js");
+
+describe("exec approvals allowlist JSON no-ops", () => {
+  beforeEach(resetExecApprovalsCliMocks);
+
+  it.each([
+    ["local", [], null],
+    ["gateway", ["--gateway"], "exec.approvals.get"],
+    ["node", ["--node", "macbook"], "exec.approvals.node.get"],
+  ] as const)(
+    "reports JSON no-ops without saving on the %s target",
+    async (target, args, method) => {
+      for (const operation of ["add", "remove"] as const) {
+        const socketPath = "/tmp/noop-exec-approvals.sock";
+        localSnapshot.file = {
+          version: 1,
+          socket: { path: socketPath, token: "fixture-noop-token" },
+          ...(operation === "add"
+            ? { agents: { "*": { allowlist: [{ pattern: "/usr/bin/uptime", lastUsedAt: 123 }] } } }
+            : {}),
+        };
+        const snapshot = {
+          path: localSnapshot.path,
+          exists: localSnapshot.exists,
+          hash: localSnapshot.hash,
+          file: localSnapshot.file,
+          ...(target === "node"
+            ? {
+                resolvedDefaults: {
+                  security: "allowlist",
+                  ask: "on-miss",
+                  askFallback: "deny",
+                  autoAllowSkills: false,
+                },
+              }
+            : {}),
+        };
+        const before = structuredClone(snapshot);
+        const updateExecApprovals = vi.mocked(execApprovals.updateExecApprovals);
+        updateExecApprovals.mockClear();
+        callGatewayFromCli.mockClear();
+        defaultRuntime.log.mockClear();
+        defaultRuntime.writeJson.mockClear();
+        if (method) {
+          callGatewayFromCli.mockResolvedValueOnce(snapshot);
+        }
+
+        await runApprovalsCommand([
+          "approvals",
+          "allowlist",
+          operation,
+          "/usr/bin/uptime",
+          ...args,
+          "--json",
+        ]);
+
+        expect(defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith(
+          { ...before, file: { ...before.file, socket: { path: socketPath } } },
+          0,
+        );
+        const output = defaultRuntime.writeJson.mock.calls[0]?.[0];
+        expect(output).not.toHaveProperty("raw");
+        expect(JSON.stringify(output)).not.toContain("fixture-noop-token");
+        expect(snapshot).toEqual(before);
+        expect(updateExecApprovals).not.toHaveBeenCalled();
+        expect(callGatewayFromCli.mock.calls.map(([called]) => called)).toEqual(
+          method ? [method] : [],
+        );
+        expect(loggedOutput()).not.toContain("Writing local approvals.");
+        expect(defaultRuntime.exit).not.toHaveBeenCalled();
+        expect(runtimeErrors).toHaveLength(0);
+      }
+    },
+  );
+});

--- a/src/cli/exec-approvals-cli.test-support.ts
+++ b/src/cli/exec-approvals-cli.test-support.ts
@@ -1,0 +1,166 @@
+// Suites load this fixture before the CLI so runtime dependencies see the mocks.
+import { Command } from "commander";
+import { vi } from "vitest";
+import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "../infra/exec-approvals.js";
+import { registerExecApprovalsCli } from "./exec-approvals-cli.js";
+
+const mocks = vi.hoisted(() => {
+  const runtimeErrors: string[] = [];
+  const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
+  const readBestEffortConfig = vi.fn(async () => ({}));
+  const defaultRuntime = {
+    log: vi.fn(),
+    error: vi.fn((...args: unknown[]) => {
+      runtimeErrors.push(stringifyArgs(args));
+    }),
+    writeStdout: vi.fn((value: string) => {
+      defaultRuntime.log(value.endsWith("\n") ? value.slice(0, -1) : value);
+    }),
+    writeJson: vi.fn((value: unknown, space = 2) => {
+      defaultRuntime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+    }),
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }),
+  };
+  return {
+    callGatewayFromCli: vi.fn(
+      async (
+        method: string,
+        _opts: unknown,
+        params?: unknown,
+        _extra?: unknown,
+      ): Promise<unknown> => {
+        if (method.endsWith(".get")) {
+          if (method === "config.get") {
+            return {
+              config: {
+                tools: {
+                  exec: {
+                    security: "full",
+                    ask: "off",
+                  },
+                },
+              },
+            };
+          }
+          const snapshot = {
+            path: "/tmp/exec-approvals.json",
+            exists: true,
+            hash: "hash-1",
+            file: { version: 1, agents: {} },
+          };
+          return method === "exec.approvals.node.get"
+            ? {
+                ...snapshot,
+                resolvedDefaults: {
+                  security: "allowlist" as const,
+                  ask: "on-miss" as const,
+                  askFallback: "deny" as const,
+                  autoAllowSkills: false,
+                },
+              }
+            : snapshot;
+        }
+        return { method, params };
+      },
+    ),
+    defaultRuntime,
+    readBestEffortConfig,
+    runtimeErrors,
+  };
+});
+
+export const { callGatewayFromCli, defaultRuntime, readBestEffortConfig, runtimeErrors } = mocks;
+export const localSnapshot: ExecApprovalsSnapshot = {
+  path: "/tmp/local-exec-approvals.json",
+  exists: true,
+  raw: "{}",
+  hash: "hash-local",
+  file: { version: 1, agents: {} },
+};
+
+function resetLocalSnapshot() {
+  localSnapshot.exists = true;
+  localSnapshot.raw = "{}";
+  localSnapshot.hash = "hash-local";
+  localSnapshot.file = { version: 1, agents: {} };
+}
+
+vi.mock("./gateway-rpc.js", () => ({
+  callGatewayFromCli: (method: string, opts: unknown, params?: unknown, extra?: unknown) =>
+    mocks.callGatewayFromCli(method, opts, params, extra),
+}));
+
+vi.mock("./nodes-cli/rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("./nodes-cli/rpc.js")>("./nodes-cli/rpc.js");
+  return {
+    ...actual,
+    resolveCliNodeId: vi.fn(async () => "node-1"),
+  };
+});
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: mocks.defaultRuntime,
+}));
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    readBestEffortConfig: mocks.readBestEffortConfig,
+  };
+});
+
+vi.mock("../infra/exec-approvals.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/exec-approvals.js")>(
+    "../infra/exec-approvals.js",
+  );
+  return {
+    ...actual,
+    readExecApprovalsSnapshot: () => localSnapshot,
+    updateExecApprovals: vi.fn(
+      async ({
+        baseHash,
+        update,
+      }: {
+        baseHash?: string;
+        update: (file: ExecApprovalsFile) => ExecApprovalsFile | null;
+      }) => {
+        if (baseHash !== undefined && baseHash !== localSnapshot.hash) {
+          return null;
+        }
+        const next = update(structuredClone(localSnapshot.file));
+        if (next !== null) {
+          localSnapshot.file = next;
+          localSnapshot.raw = JSON.stringify(next);
+          localSnapshot.hash = "hash-local-written";
+        }
+        return structuredClone(localSnapshot);
+      },
+    ),
+  };
+});
+
+export function loggedOutput(): string {
+  return defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
+}
+
+export function resetExecApprovalsCliMocks(): void {
+  resetLocalSnapshot();
+  runtimeErrors.length = 0;
+  callGatewayFromCli.mockClear();
+  readBestEffortConfig.mockClear();
+  defaultRuntime.log.mockClear();
+  defaultRuntime.error.mockClear();
+  defaultRuntime.writeStdout.mockClear();
+  defaultRuntime.writeJson.mockClear();
+  defaultRuntime.exit.mockClear();
+}
+
+export async function runApprovalsCommand(args: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  registerExecApprovalsCli(program);
+  await program.parseAsync(args, { from: "user" });
+}

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,15 +1,25 @@
+import "./exec-approvals-cli.test-support.js";
 import fs from "node:fs";
 import path from "node:path";
 import { Readable } from "node:stream";
-import { Command } from "commander";
 // Exec approvals CLI tests cover approval command registration and output handling.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { SESSION_EXEC_OVERRIDES_NOTE } from "../infra/exec-approvals-effective.js";
 import * as execApprovals from "../infra/exec-approvals.js";
-import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
-import { registerExecApprovalsCli, testing } from "./exec-approvals-cli.js";
+import { testing } from "./exec-approvals-cli.js";
+
+const {
+  callGatewayFromCli,
+  defaultRuntime,
+  localSnapshot,
+  loggedOutput,
+  readBestEffortConfig,
+  resetExecApprovalsCliMocks,
+  runApprovalsCommand,
+  runtimeErrors,
+} = await import("./exec-approvals-cli.test-support.js");
 
 describe("exec approvals CLI error formatting", () => {
   it("keeps the bounded first line UTF-16 well-formed", () => {
@@ -19,83 +29,7 @@ describe("exec approvals CLI error formatting", () => {
   });
 });
 
-const mocks = vi.hoisted(() => {
-  const runtimeErrors: string[] = [];
-  const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
-  const readBestEffortConfig = vi.fn(async () => ({}));
-  const defaultRuntime = {
-    log: vi.fn(),
-    error: vi.fn((...args: unknown[]) => {
-      runtimeErrors.push(stringifyArgs(args));
-    }),
-    writeStdout: vi.fn((value: string) => {
-      defaultRuntime.log(value.endsWith("\n") ? value.slice(0, -1) : value);
-    }),
-    writeJson: vi.fn((value: unknown, space = 2) => {
-      defaultRuntime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
-    }),
-    exit: vi.fn((code: number) => {
-      throw new Error(`__exit__:${code}`);
-    }),
-  };
-  return {
-    callGatewayFromCli: vi.fn(
-      async (
-        method: string,
-        _opts: unknown,
-        params?: unknown,
-        _extra?: unknown,
-      ): Promise<unknown> => {
-        if (method.endsWith(".get")) {
-          if (method === "config.get") {
-            return {
-              config: {
-                tools: {
-                  exec: {
-                    security: "full",
-                    ask: "off",
-                  },
-                },
-              },
-            };
-          }
-          const snapshot = {
-            path: "/tmp/exec-approvals.json",
-            exists: true,
-            hash: "hash-1",
-            file: { version: 1, agents: {} },
-          };
-          return method === "exec.approvals.node.get"
-            ? {
-                ...snapshot,
-                resolvedDefaults: {
-                  security: "allowlist" as const,
-                  ask: "on-miss" as const,
-                  askFallback: "deny" as const,
-                  autoAllowSkills: false,
-                },
-              }
-            : snapshot;
-        }
-        return { method, params };
-      },
-    ),
-    defaultRuntime,
-    readBestEffortConfig,
-    runtimeErrors,
-  };
-});
-
-const { callGatewayFromCli, defaultRuntime, readBestEffortConfig, runtimeErrors } = mocks;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
-const localSnapshot = {
-  path: "/tmp/local-exec-approvals.json",
-  exists: true,
-  raw: "{}",
-  hash: "hash-local",
-  file: { version: 1, agents: {} } as ExecApprovalsFile,
-};
 
 function createMcpToolGrant(tool = "publish_page") {
   return { server: "project-docs", tool, source: "allow-always" as const, addedAt: Date.now() };
@@ -145,10 +79,6 @@ function expectGatewayCall(index: number, method: string, params: unknown) {
   expect(call[2]).toEqual(params);
 }
 
-function loggedOutput(): string {
-  return defaultRuntime.log.mock.calls.map(([line]) => String(line ?? "")).join("\n");
-}
-
 function writtenJson(): Record<string, unknown> {
   const value = firstMockArg(vi.mocked(defaultRuntime.writeJson));
   return requireRecord(value, "written json");
@@ -172,81 +102,7 @@ function scopeByLabel(label: string, output: Record<string, unknown> = writtenJs
   return requireRecord(scope, `policy scope ${label}`);
 }
 
-function resetLocalSnapshot() {
-  localSnapshot.exists = true;
-  localSnapshot.raw = "{}";
-  localSnapshot.hash = "hash-local";
-  localSnapshot.file = { version: 1, agents: {} };
-}
-
-vi.mock("./gateway-rpc.js", () => ({
-  callGatewayFromCli: (method: string, opts: unknown, params?: unknown, extra?: unknown) =>
-    mocks.callGatewayFromCli(method, opts, params, extra),
-}));
-
-vi.mock("./nodes-cli/rpc.js", async () => {
-  const actual = await vi.importActual<typeof import("./nodes-cli/rpc.js")>("./nodes-cli/rpc.js");
-  return {
-    ...actual,
-    resolveCliNodeId: vi.fn(async () => "node-1"),
-  };
-});
-
-vi.mock("../runtime.js", () => ({
-  defaultRuntime: mocks.defaultRuntime,
-}));
-
-vi.mock("../config/config.js", async () => {
-  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-  return {
-    ...actual,
-    readBestEffortConfig: mocks.readBestEffortConfig,
-  };
-});
-
-vi.mock("../infra/exec-approvals.js", async () => {
-  const actual = await vi.importActual<typeof import("../infra/exec-approvals.js")>(
-    "../infra/exec-approvals.js",
-  );
-  return {
-    ...actual,
-    readExecApprovalsSnapshot: () => localSnapshot,
-    updateExecApprovals: vi.fn(
-      async ({
-        baseHash,
-        update,
-      }: {
-        baseHash?: string;
-        update: (file: ExecApprovalsFile) => ExecApprovalsFile | null;
-      }) => {
-        if (baseHash !== undefined && baseHash !== localSnapshot.hash) {
-          return null;
-        }
-        const next = update(structuredClone(localSnapshot.file));
-        if (next !== null) {
-          localSnapshot.file = next;
-          localSnapshot.raw = JSON.stringify(next);
-          localSnapshot.hash = "hash-local-written";
-        }
-        return structuredClone(localSnapshot);
-      },
-    ),
-  };
-});
-
 describe("exec approvals CLI", () => {
-  const createProgram = () => {
-    const program = new Command();
-    program.exitOverride();
-    registerExecApprovalsCli(program);
-    return program;
-  };
-
-  const runApprovalsCommand = async (args: string[]) => {
-    const program = createProgram();
-    await program.parseAsync(args, { from: "user" });
-  };
-
   const runNativeApprovalsFileCommand = async (filePath: string) => {
     callGatewayFromCli.mockResolvedValue({
       enabled: true,
@@ -265,17 +121,7 @@ describe("exec approvals CLI", () => {
     ]);
   };
 
-  beforeEach(() => {
-    resetLocalSnapshot();
-    runtimeErrors.length = 0;
-    callGatewayFromCli.mockClear();
-    readBestEffortConfig.mockClear();
-    defaultRuntime.log.mockClear();
-    defaultRuntime.error.mockClear();
-    defaultRuntime.writeStdout.mockClear();
-    defaultRuntime.writeJson.mockClear();
-    defaultRuntime.exit.mockClear();
-  });
+  beforeEach(resetExecApprovalsCliMocks);
 
   it.each([
     ["local", [], null],

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1115,13 +1115,6 @@ function normalizeAllowlistEntry(entry: { pattern?: string } | null): string | n
   return pattern ? pattern : null;
 }
 
-function ensureAgent(file: ExecApprovalsFile, agentKey: string): ExecApprovalsAgent {
-  const agents = file.agents ?? {};
-  const entry = agents[agentKey] ?? {};
-  file.agents = agents;
-  return entry;
-}
-
 function isEmptyAgent(agent: ExecApprovalsAgent): boolean {
   const allowlist = Array.isArray(agent.allowlist) ? agent.allowlist : [];
   return (
@@ -1134,16 +1127,7 @@ function isEmptyAgent(agent: ExecApprovalsAgent): boolean {
   );
 }
 
-async function loadWritableAllowlistAgent(opts: ExecApprovalsCliOpts): Promise<{
-  nodeId: string | null;
-  source: "gateway" | "node" | "local";
-  targetLabel: string;
-  baseHash: string;
-  file: ExecApprovalsFile;
-  agentKey: string;
-  agent: ExecApprovalsAgent;
-  allowlistEntries: NonNullable<ExecApprovalsAgent["allowlist"]>;
-}> {
+async function loadWritableAllowlistAgent(opts: ExecApprovalsCliOpts) {
   const agentKey = resolveAgentKey(opts.agent);
   if (agentKey !== "*") {
     const source = !opts.gateway && !opts.node ? "local" : opts.gateway ? "gateway" : "node";
@@ -1153,8 +1137,8 @@ async function loadWritableAllowlistAgent(opts: ExecApprovalsCliOpts): Promise<{
     }
     resolveConfiguredAgentId(config, agentKey);
   }
-  const { snapshot, nodeId, source, targetLabel, baseHash, kind } =
-    await loadWritableSnapshotTarget(opts);
+  const target = await loadWritableSnapshotTarget(opts);
+  const { snapshot, kind } = target;
   if (kind === "native" || !isFileApprovalsSnapshot(snapshot)) {
     exitWithError(
       "Host-native node approvals do not support allowlist mutations; use approvals set --node with host-native JSON.",
@@ -1163,10 +1147,10 @@ async function loadWritableAllowlistAgent(opts: ExecApprovalsCliOpts): Promise<{
   const file = snapshot.file;
   file.version = 1;
 
-  const agent = ensureAgent(file, agentKey);
+  const agent: ExecApprovalsAgent = file.agents?.[agentKey] ?? {};
   const allowlistEntries = Array.isArray(agent.allowlist) ? agent.allowlist : [];
 
-  return { nodeId, source, targetLabel, baseHash, file, agentKey, agent, allowlistEntries };
+  return { ...target, snapshot, file, agentKey, agent, allowlistEntries };
 }
 
 type WritableAllowlistAgentContext = Awaited<ReturnType<typeof loadWritableAllowlistAgent>> & {
@@ -1184,16 +1168,12 @@ async function runAllowlistMutation(
     const context = await loadWritableAllowlistAgent(opts);
     const shouldSave = await mutate({ ...context, trimmedPattern });
     if (!shouldSave) {
+      if (opts.json) {
+        defaultRuntime.writeJson(redactExecApprovals(context.snapshot), 0);
+      }
       return;
     }
-    await saveSnapshotTargeted({
-      opts,
-      source: context.source,
-      nodeId: context.nodeId,
-      file: context.file,
-      baseHash: context.baseHash,
-      targetLabel: context.targetLabel,
-    });
+    await saveSnapshotTargeted({ ...context, opts });
   } catch (err) {
     failApprovalsCommand(err, opts);
   }


### PR DESCRIPTION
Fixes #136573.

## What Problem This Solves

Repeating an approval allowlist add, or removing a missing pattern, succeeds with empty stdout under `--json`. This breaks scripts consuming the otherwise consistent snapshot result.

## Why This Change Was Made

The shared mutation runner now returns the existing redacted snapshot on a no-op. Its context carries the canonical target and snapshot through normal writes too, deleting duplicated target types and unpacking. Removing `ensureAgent` keeps operation preparation from creating an agent map when no write will occur; the existing mutation callbacks already publish actual map changes.

Production **+9 / −29 = −20 LOC**; tests/support **+267 / −168 = +99** (including an existing fixture moved into shared test support); docs **+3**.

## User Impact

Both local and remote no-op commands keep returning success without rewriting approvals, now with one parseable JSON snapshot. Socket credentials and raw input remain redacted. Native policy rejection, unknown-agent validation, ordinary writes, target metadata and human output retain their existing behavior. This changes output only; authorization, policies, configuration, store ownership and schema stay unchanged.

The missing output dates to the original CLI in `3686bde783fd` and is present in stable v2026.8.2. The distinct no-write announcement repair in [#125960](https://github.com/openclaw/openclaw/pull/125960) is preserved.

## Evidence

Three target regression cases fail on original production, then pass for local, Gateway and node targets. They cover both operations, zero write calls, absent agent maps, socket/raw redaction and retained node defaults. All 73 owner/sibling tests pass, including existing ordinary mutations, native policies, pending/resolve and MCP grant behavior.

The same ten actual compiled CLI commands run in their original order before and after, each in isolated synthetic state. All commands exit 0; JSON results improve from 5/7 to 7/7. Both no-op snapshots match the saved file and hash exactly, with unchanged human no-op text. Full before/after builds and the complete five-file changed gate pass. The initial test-size failure was resolved by moving its existing fixture and splitting the new suite; no suppression or assertions were removed. Final connected Codex P2 review is clean. Its pending-gate note is resolved by the completed immutable gate.

<details>
<summary>Recorded compiled CLI no-op output</summary>

These are retained stdout/stderr from the second add and second remove; only the temporary state root is normalized to `<synthetic-state>`. The synthetic path cannot authorize a real executable. The same stored snapshots are checked immediately before and after each no-op.

```json
[
  {
    "command": "node dist/entry.js approvals allowlist add /nonexistent/qa-synthetic-json-proof --json",
    "before": {
      "exit": 0,
      "stdout": "",
      "stderr": "Already allowlisted.\n"
    },
    "after": {
      "exit": 0,
      "stdout": "{\"path\":\"<synthetic-state>/state/state/openclaw.sqlite#exec_approvals_config\",\"exists\":true,\"hash\":\"8e13773bdfa6916f23eb68f4a2a409225802bf19d6d133897dbe1d5b3e2863af\",\"file\":{\"version\":1,\"socket\":{\"path\":\"<synthetic-state>/state/exec-approvals.sock\"},\"defaults\":{},\"agents\":{\"*\":{\"allowlist\":[{\"pattern\":\"/nonexistent/qa-synthetic-json-proof\",\"id\":\"5b18eadb-ccab-4d1a-8f08-41920e3f0425\",\"lastUsedAt\":1788377509615}]}}}}\n",
      "stderr": "Already allowlisted.\n"
    }
  },
  {
    "command": "node dist/entry.js approvals allowlist remove /nonexistent/qa-synthetic-json-proof --json",
    "before": {
      "exit": 0,
      "stdout": "",
      "stderr": "Pattern not found.\n"
    },
    "after": {
      "exit": 0,
      "stdout": "{\"path\":\"<synthetic-state>/state/state/openclaw.sqlite#exec_approvals_config\",\"exists\":true,\"hash\":\"270332392ad4510404738992b6e295e082462c75a50677ebfb0928a2c920a587\",\"file\":{\"version\":1,\"socket\":{\"path\":\"<synthetic-state>/state/exec-approvals.sock\"},\"defaults\":{},\"agents\":{}}}\n",
      "stderr": "Pattern not found.\n"
    }
  }
]
```

</details>
