### PR TITLE
fix(ci): run the base-ref private-key scanner before package installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1733,7 +1733,7 @@ jobs:
         with:
           ref: ${{ github.workflow_sha }}
           path: .ci-harness
-          sparse-checkout: ".github/actions\n.github/zizmor.yml"
+          sparse-checkout: ".github/actions\n.github/zizmor.yml\nscripts/detect-private-keys.mts"
           persist-credentials: false
 
       - name: Resolve security diff base
@@ -1793,11 +1793,23 @@ jobs:
           else
             cp .ci-harness/.github/zizmor.yml "$trusted_policy"
           fi
+          # The key scanner is repo code, so pull requests run the exact-base
+          # copy: a candidate must not be able to neuter the guard that scans it.
+          trusted_scanner="$RUNNER_TEMP/detect-private-keys.mts"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            if ! git show "${BASE_SHA}:scripts/detect-private-keys.mts" > "$trusted_scanner" 2>/dev/null; then
+              rm -f "$trusted_scanner"
+              echo "::error title=trusted private-key scanner unavailable::Could not read scripts/detect-private-keys.mts from exact base ${BASE_SHA}; land the scanner on the base branch first."
+              exit 1
+            fi
+          else
+            cp .ci-harness/scripts/detect-private-keys.mts "$trusted_scanner"
+          fi
+          echo "PRIVATE_KEY_SCANNER_PATH=$trusted_scanner" >> "$GITHUB_ENV"
           cat > "$RUNNER_TEMP/security-fast-pre-commit.yaml" <<EOF
           repos:
             - repo: local
               hooks:
-                - { id: detect-private-key, name: detect private key, entry: detect-private-key, language: system, types: [text], exclude: '(^|/)(\.pre-commit-config\.yaml$|apps/ios/fastlane/Fastfile$|.*\.test\.ts$)' }
                 - id: zizmor
                   name: zizmor
                   entry: zizmor
@@ -1810,11 +1822,21 @@ jobs:
           EOF
           echo "PRE_COMMIT_CONFIG_PATH=$RUNNER_TEMP/security-fast-pre-commit.yaml" >> "$GITHUB_ENV"
 
-      - name: Install security scanners
-        run: python3 --version && python3 -m pip install --disable-pip-version-check pre-commit==4.6.2 pre-commit-hooks==6.0.0 zizmor==1.29.0
+      - name: Setup Node.js
+        env:
+          REQUESTED_NODE_VERSION: "24.x"
+        run: |
+          set -euo pipefail
+          source .ci-harness/.github/actions/setup-pnpm-store-cache/ensure-node.sh
+          openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
+      # First-party scan before any package install: no network, no third-party
+      # hook code, and a PyPI outage cannot stop it.
       - name: Detect committed private keys
-        run: GIT_ALLOW_PROTOCOL=file GIT_CONFIG_COUNT=0 pre-commit run --config "$PRE_COMMIT_CONFIG_PATH" --all-files detect-private-key
+        run: node "$PRIVATE_KEY_SCANNER_PATH"
+
+      - name: Install security scanners
+        run: python3 --version && python3 -m pip install --disable-pip-version-check pre-commit==4.6.2 zizmor==1.29.0
 
       - name: Audit changed GitHub workflows with zizmor
         env:
@@ -1843,14 +1865,6 @@ jobs:
           printf 'Auditing workflow files:\n%s\n' "${workflow_files[@]}"
           GIT_ALLOW_PROTOCOL=file GIT_CONFIG_COUNT=0 \
             pre-commit run --config "$PRE_COMMIT_CONFIG_PATH" zizmor --files "${workflow_files[@]}"
-
-      - name: Setup Node.js
-        env:
-          REQUESTED_NODE_VERSION: "24.x"
-        run: |
-          set -euo pipefail
-          source .ci-harness/.github/actions/setup-pnpm-store-cache/ensure-node.sh
-          openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
       - name: Audit production dependencies
         run: node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1830,8 +1830,10 @@ jobs:
           source .ci-harness/.github/actions/setup-pnpm-store-cache/ensure-node.sh
           openclaw_ensure_node "$REQUESTED_NODE_VERSION"
 
-      # First-party scan before any package install: no network, no third-party
-      # hook code, and a PyPI outage cannot stop it.
+      # First-party scan before any package install: the scan itself uses no
+      # network and no third-party hook code, so a PyPI outage cannot stop it.
+      # Node 24 comes from the runner tool cache; the shared helper downloads
+      # only on images that lack it.
       - name: Detect committed private keys
         run: node "$PRIVATE_KEY_SCANNER_PATH"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,6 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=500]
       - id: check-merge-conflict
-      - id: detect-private-key
-        exclude: '(^|/)(\.pre-commit-config\.yaml$|apps/ios/fastlane/Fastfile$|.*\.test\.ts$)'
   # Shell script linting
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0
@@ -71,6 +69,13 @@ repos:
   # Project checks (same commands as CI)
   - repo: local
     hooks:
+      # node scripts/detect-private-keys.mts (scanner owns its exclude list)
+      - id: detect-private-key
+        name: detect private key
+        entry: node scripts/detect-private-keys.mts
+        language: system
+        types: [text]
+
       # node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high
       - id: pnpm-audit-prod
         name: pnpm-audit-prod

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -355,7 +355,7 @@ OpenClaw uses several security and release-validation layers. No single scanner 
 
 ### Secret Detection
 
-OpenClaw runs the in-repo `scripts/detect-private-keys.mts` scanner in CI (the same private-key marker set as the pre-commit-hooks `detect-private-key` hook, with no network or third-party hook execution) over every tracked regular file except colocated `*.test.ts` fixtures and the iOS Fastfile; pull requests run the base branch's copy of the scanner and fail if the base branch lacks it. The local `detect-private-key` pre-commit hook runs the same scanner over the text files pre-commit hands it. Secret-resolution behavior stays covered by the dedicated secrets test surface.
+OpenClaw runs the in-repo `scripts/detect-private-keys.mts` scanner in CI (the same private-key marker set as the pre-commit-hooks `detect-private-key` hook, with no hook-repo fetches, package installs, or third-party hook execution in the scan's path) over every tracked regular file except colocated `*.test.ts` fixtures and the iOS Fastfile; pull requests run the base branch's copy of the scanner and fail if the base branch lacks it. The local `detect-private-key` pre-commit hook runs the same scanner over the text files pre-commit hands it. Secret-resolution behavior stays covered by the dedicated secrets test surface.
 
 Run the key scan locally:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -355,12 +355,12 @@ OpenClaw uses several security and release-validation layers. No single scanner 
 
 ### Secret Detection
 
-OpenClaw runs the pre-commit `detect-private-key` hook in CI and keeps secret-resolution behavior covered by the dedicated secrets test surface.
+OpenClaw runs the in-repo `scripts/detect-private-keys.mts` scanner in CI (the same private-key marker set as the pre-commit-hooks `detect-private-key` hook, with no network or third-party hook execution) over every tracked regular file except colocated `*.test.ts` fixtures and the iOS Fastfile; pull requests run the base branch's copy of the scanner and fail if the base branch lacks it. The local `detect-private-key` pre-commit hook runs the same scanner over the text files pre-commit hands it. Secret-resolution behavior stays covered by the dedicated secrets test surface.
 
 Run the key scan locally:
 
 ```bash
-pre-commit run --all-files detect-private-key
+node scripts/detect-private-keys.mts
 ```
 
 ### Static Analysis

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -892,10 +892,10 @@ For phone-number-based channels, consider running the assistant on a separate nu
 
 ## Secret scanning
 
-CI runs the pre-commit `detect-private-key` hook over the repository. If it fails, remove or rotate the committed key material, then reproduce locally:
+CI runs the in-repo `scripts/detect-private-keys.mts` scanner over every tracked regular file except colocated `*.test.ts` fixtures and the iOS Fastfile; pull requests run the base branch's copy of the scanner and fail if the base branch lacks it. The local `detect-private-key` pre-commit hook runs the same scanner over the text files pre-commit hands it. If CI fails, remove or rotate the committed key material, then reproduce locally:
 
 ```bash
-pre-commit run --all-files detect-private-key
+node scripts/detect-private-keys.mts
 ```
 
 ## Reporting security issues

--- a/test/scripts/ci-security-fast-workflow.test.ts
+++ b/test/scripts/ci-security-fast-workflow.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -14,6 +14,7 @@ type WorkflowStep = {
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const workflowPath = ".github/workflows/ci.yml";
+const scannerPath = "scripts/detect-private-keys.mts";
 const localGitEnvironment = {
   GIT_ALLOW_PROTOCOL: "file",
   GIT_CONFIG_COUNT: "0",
@@ -22,6 +23,7 @@ const localGitEnvironment = {
   GIT_TERMINAL_PROMPT: "0",
 };
 const localGitCommand = "GIT_ALLOW_PROTOCOL=file GIT_CONFIG_COUNT=0";
+const neuteredScanner = "process.exit(0);\n";
 
 function securityJob() {
   const workflow = parse(readFileSync(workflowPath, "utf8")) as {
@@ -40,6 +42,14 @@ function securityStep(name: string): WorkflowStep {
     throw new Error(`security-fast step is missing: ${name}`);
   }
   return step;
+}
+
+function securityStepIndex(name: string): number {
+  const index = securityJob().steps.findIndex((candidate) => candidate.name === name);
+  if (index < 0) {
+    throw new Error(`security-fast step is missing: ${name}`);
+  }
+  return index;
 }
 
 function writeExecutable(filePath: string, source: string): void {
@@ -98,6 +108,7 @@ function createFixture() {
   const runnerTemp = join(root, "runner");
   const githubEnv = join(root, "github-env");
   mkdirSync(join(repo, ".github"), { recursive: true });
+  mkdirSync(join(repo, "scripts"));
   mkdirSync(bin);
   mkdirSync(runnerTemp);
 
@@ -107,23 +118,31 @@ function createFixture() {
   runGit(repo, "commit", "--allow-empty", "-m", "initial");
   const missingPolicySha = runGit(repo, "rev-parse", "HEAD");
   writeFileSync(join(repo, ".github", "zizmor.yml"), "rules:\n  trusted-base: {}\n");
+  const realScanner = readFileSync(resolve(scannerPath));
+  writeFileSync(join(repo, scannerPath), realScanner);
   runGit(repo, "add", ".");
   runGit(repo, "commit", "-m", "base policy");
   const baseSha = runGit(repo, "rev-parse", "HEAD");
 
+  // The candidate poisons every input it could: policy, hook config, and the
+  // scanner itself, while adding a key the neutered scanner would let through.
   writeFileSync(join(repo, ".github", "zizmor.yml"), "rules:\n  candidate-poison: {}\n");
   writeFileSync(
     join(repo, ".pre-commit-config.yaml"),
     "repos:\n  - repo: https://example.invalid/poison.git\n",
   );
+  writeFileSync(join(repo, scannerPath), neuteredScanner);
+  writeFileSync(join(repo, "leaked.pem"), "-----BEGIN RSA PRIVATE KEY-----\nfixture only\n");
   runGit(repo, "add", ".");
   runGit(repo, "commit", "-m", "candidate policy");
 
   mkdirSync(join(repo, ".ci-harness", ".github"), { recursive: true });
+  mkdirSync(join(repo, ".ci-harness", "scripts"), { recursive: true });
   writeFileSync(
     join(repo, ".ci-harness", ".github", "zizmor.yml"),
     "rules:\n  trusted-harness: {}\n",
   );
+  writeFileSync(join(repo, ".ci-harness", scannerPath), realScanner);
 
   const realGit = execFileSync("sh", ["-c", "command -v git"], {
     encoding: "utf8",
@@ -170,6 +189,7 @@ exec "$OPENCLAW_TEST_REAL_GIT" "$@"
     },
     githubEnv,
     missingPolicySha,
+    realScanner,
     repo,
     runnerTemp,
   };
@@ -203,11 +223,17 @@ describe("security-fast workflow", () => {
     expect(checkoutHarness.with?.ref).toBe("${{ github.workflow_sha }}");
     expect(checkoutHarness.with?.["persist-credentials"]).toBe(false);
     expect(checkoutHarness.with?.["sparse-checkout"]).toContain(".github/zizmor.yml");
+    expect(checkoutHarness.with?.["sparse-checkout"]).toContain(scannerPath);
     expect(job.steps.some((step) => step.name === "Resolve Python runtime")).toBe(false);
     expect(install.run).toContain("python3 --version");
-    expect(install.run).toContain("pre-commit==4.6.2 pre-commit-hooks==6.0.0 zizmor==1.29.0");
+    expect(install.run).toContain("pre-commit==4.6.2 zizmor==1.29.0");
+    expect(install.run).not.toContain("pre-commit-hooks");
     expect(prepare.run).not.toMatch(/origin\/|BASE_REF|PRE_COMMIT_CONFIG_PATH:-/u);
-    expect(detect.run).toContain(localGitCommand);
+    // The first-party key scan runs before any package install can fail or
+    // execute third-party code, and never through pre-commit.
+    expect(detect.run).toBe('node "$PRIVATE_KEY_SCANNER_PATH"');
+    expect(securityStepIndex("Setup Node.js")).toBeLessThan(securityStepIndex(detect.name!));
+    expect(securityStepIndex(detect.name!)).toBeLessThan(securityStepIndex(install.name!));
     expect(zizmor.run).toContain(localGitCommand);
 
     const fixture = createFixture();
@@ -224,14 +250,6 @@ describe("security-fast workflow", () => {
       {
         repo: "local",
         hooks: [
-          {
-            id: "detect-private-key",
-            name: "detect private key",
-            entry: "detect-private-key",
-            language: "system",
-            types: ["text"],
-            exclude: String.raw`(^|/)(\.pre-commit-config\.yaml$|apps/ios/fastlane/Fastfile$|.*\.test\.ts$)`,
-          },
           {
             id: "zizmor",
             name: "zizmor",
@@ -256,6 +274,18 @@ describe("security-fast workflow", () => {
       "rules:\n  trusted-base: {}\n",
     );
     expect(readFileSync(configPath, "utf8")).not.toContain("example.invalid");
+
+    const trustedScanner = prepared.githubEnvironment.PRIVATE_KEY_SCANNER_PATH;
+    expect(trustedScanner).toBe(join(fixture.runnerTemp, "detect-private-keys.mts"));
+    expect(readFileSync(trustedScanner!)).toEqual(fixture.realScanner);
+
+    const scanned = runStep(detect, fixture.repo, {
+      ...fixture.environment,
+      ...prepared.githubEnvironment,
+    });
+    expect(scanned.status).toBe(1);
+    expect(scanned.stderr).toContain("Private key found: leaked.pem (BEGIN RSA PRIVATE KEY)");
+    expect(scanned.stderr).toContain("[detect-private-keys] FAILED (exit 1)");
   });
 
   it("fails closed for a missing exact-base policy and trusts the harness otherwise", () => {
@@ -274,6 +304,30 @@ describe("security-fast workflow", () => {
       expect(readFileSync(join(fixture.runnerTemp, "zizmor.yml"), "utf8")).toBe(
         "rules:\n  trusted-harness: {}\n",
       );
+      expect(readFileSync(join(fixture.runnerTemp, "detect-private-keys.mts"))).toEqual(
+        fixture.realScanner,
+      );
     }
+  });
+
+  it("fails closed when the exact base has no scanner instead of running the candidate copy", () => {
+    const fixture = createFixture();
+    // A base with the policy but not the scanner: the bootstrap gap a
+    // candidate could otherwise exploit with a neutered scanner.
+    writeFileSync(join(fixture.repo, ".github", "zizmor.yml"), "rules:\n  trusted-base: {}\n");
+    runGit(fixture.repo, "rm", "-q", "--cached", scannerPath);
+    runGit(fixture.repo, "add", ".github/zizmor.yml");
+    runGit(fixture.repo, "commit", "-m", "base without scanner");
+    const rejected = prepareConfig(
+      fixture,
+      "pull_request",
+      runGit(fixture.repo, "rev-parse", "HEAD"),
+    );
+    expect(rejected.result.status).not.toBe(0);
+    expect(`${rejected.result.stdout}${rejected.result.stderr}`).toContain(
+      "trusted private-key scanner unavailable",
+    );
+    expect(rejected.githubEnvironment).toEqual({});
+    expect(existsSync(join(fixture.runnerTemp, "detect-private-keys.mts"))).toBe(false);
   });
 });


### PR DESCRIPTION
Related: #133724, #136419, #136388

Stage two of the rollout started in #136419 (which landed the scanner as dormant tooling), rebased onto #136388.

## What Problem This Solves

After #136388, `security-fast` no longer fetches hook repositories over anonymous git, but its private-key scan still depends on a PyPI install of `pre-commit-hooks` and executes that third-party package's `detect-private-key` entry point, and the in-repo scanner from #136419 is not wired anywhere. This PR makes the key scan first-party: it runs before any package install, with no network access and no third-party code in the scan's own path, and pull requests execute the exact-base copy of the scanner so a candidate cannot neuter the guard that scans it.

## Why This Change Was Made

In `security-fast`:

- **Trusted scanner selection.** "Prepare trusted scanner config" now also selects `scripts/detect-private-keys.mts`, using the same trust rules #136388 established for the zizmor policy: pull requests read it from the exact base SHA and fail closed with an actionable `::error` if the base lacks it (partial file removed, nothing exported); push and manual runs copy it from the `.ci-harness` checkout at `github.workflow_sha`, which the sparse checkout now includes. The path is exported as `PRIVATE_KEY_SCANNER_PATH`.
- **Ordering.** Node 24 setup moves ahead of the scanners, and "Detect committed private keys" becomes `node "$PRIVATE_KEY_SCANNER_PATH"`, placed before "Install security scanners". A PyPI outage or pip failure can no longer prevent the key scan.
- **Dependency removal.** `pre-commit-hooks==6.0.0` is dropped from the pip install and the generated pre-commit config keeps only the zizmor hook. `pre-commit` and `zizmor` remain for the changed-workflow audit.

Elsewhere, `.pre-commit-config.yaml` replaces the upstream `detect-private-key` hook with a `local` hook running the same script, so local runs and CI share one marker set and exclude list (the scanner no longer contains literal markers, so no self carve-out is needed). `SECURITY.md` and `docs/gateway/security/index.md` describe the CI scope (every tracked regular file except `*.test.ts` fixtures and the iOS Fastfile, base-branch copy for PRs, fail closed) and the local hook's text-file scope.

Not changed: the zizmor path, the trufflehog scan, `persist-credentials: false`, the production dependency audit.

### Node runtime prerequisite (ClawSweeper decision)

ClawSweeper's review of the first head asked whether a Node download before the scan is an accepted prerequisite. Decision: yes, narrowly. The scan needs Node 24 for native type stripping, and `openclaw_ensure_node` resolves it from the runner tool cache: the green stage-one job on the Blacksmith image logged `Using Node 24.19.0 from /opt/hostedtoolcache/node/24.19.0/x64/bin/node`, and hosted `ubuntu-24.04` images carry the same cache. The helper's nodejs.org download runs only on images that lack a cached Node 24, capped at two minutes with retries, and its failure fails the job rather than skipping the scan. The workflow comment and `SECURITY.md` state the guarantee precisely: no hook-repo fetches, package installs, or third-party hook execution in the scan's path. Making the scanner plain JavaScript to run on the image default Node would remove even the tool-cache prerequisite, but renaming the file would re-open the base-ref bootstrap gap for one more landing; not worth it for a path that is cache-served on every current image.

## User Impact

Maintainers and contributors get a `security-fast` key scan that cannot fail on hook or package fetches, cannot be weakened by the PR it scans, and runs the same code locally via `node scripts/detect-private-keys.mts` or the `detect-private-key` pre-commit hook. The marker set is unchanged (verified against pre-commit-hooks `v6.0.0`, commit `3e8a8703`, in #136419).

## Evidence

- `test/scripts/ci-security-fast-workflow.test.ts` (updated owner test from #136388, 3 tests): executes the real "Prepare trusted scanner config" body against a fixture whose candidate commit poisons the zizmor policy, the hook config, and the scanner itself while adding a key; asserts the exported scanner is byte-identical to the base copy and that running the real "Detect committed private keys" body flags `leaked.pem` with the `[detect-private-keys] FAILED (exit 1)` trailer. Also asserts step ordering (Node setup, then scan, then pip install), the pip line without `pre-commit-hooks`, the harness copy for `push`/`workflow_dispatch`, and fail-closed behavior when the exact base has the policy but no scanner (error emitted, nothing exported, no partial file).
- `test/scripts/detect-private-keys.test.ts` (16 tests, unchanged) still passes.
- `actionlint`, `pnpm check:workflows` (actionlint, zizmor over `ci.yml`, git-owner and interpolation guards), oxfmt/oxlint, test-root typecheck lane: green.
- Codex autoreview: scoped-clean at P0.
- This PR's own `security-fast` run exercises the base-ref selection for real, since `main` now carries the scanner.

Production LOC (vs base): `ci.yml` +29/-13, `.pre-commit-config.yaml` +7/-2, docs +4/-4 | Tests: +65/-11
