### PR TITLE
docs: add v2026.9.1 release notes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2160,6 +2160,7 @@
                 "group": "Release notes",
                 "pages": [
                   "releases/index",
+                  "releases/2026.9.1",
                   "releases/2026.8.2",
                   "releases/2026.8.1",
                   "releases/2026.7.1",

--- a/docs/releases/2026.9.1.md
+++ b/docs/releases/2026.9.1.md
@@ -1,0 +1,2759 @@
+---
+title: "v2026.9.1"
+summary: "Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations."
+description: "Detailed OpenClaw v2026.9.1 release notes covering setup, the Control UI, updates, messaging, memory, skills, native apps, models, automations, browser and computer use, plugins, security, performance, fixes, and maintainer changes."
+keywords:
+  - OpenClaw
+  - v2026.9.1
+  - release notes
+  - Mermaid
+  - Control UI
+  - Android
+---
+
+# v2026.9.1
+
+Mermaid diagrams now render directly inside conversations in the Control UI, Android, iPhone, iPad, and Mac, and Android gains a fuller chat and session experience. Updates preserve more of a working setup and stop before a known problem becomes a broken restart. When an update does fail, OpenClaw gives you a clearer path back to a working installation. Testing also found lower memory use and less repeated work while OpenClaw handled long conversations and large installations.
+
+**Release scale:** 922 pull requests, 6 direct commits, and 241 contributors.
+
+## Installation and Onboarding
+
+Getting OpenClaw running now takes a shorter path when the machine already has usable AI access, while longer setup paths leave existing choices and files alone when a check fails or a different route is selected. This release also tightens Windows installation, macOS AI setup, shell configuration, Connect handoffs, and managed local-model downloads.
+
+<AccordionGroup>
+
+<Accordion title="Quick Start to the Web Dashboard">
+
+On a fresh local install, the recommended Quick Start path can reuse verified Claude Code or Codex access, or an existing provider key, and open the web dashboard after one choice. The [installation](/install) and [guided setup](/start/wizard) flow keeps the Gateway in the current terminal until you stop it with Ctrl+C, preserves the configuration afterward, and leaves background service installation as an explicit later step.
+
+On a headless machine, the same path provides a one-time authenticated dashboard link and an SSH tunnel template instead of exposing reusable Gateway credentials. Custom setup, remote Gateway onboarding, and non-interactive setup keep their existing paths when Quick Start is not the right fit.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reach the web dashboard from the recommended Quick Start path ([#134221](https://github.com/openclaw/openclaw/pull/134221)). Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Provider Choices and Setup State">
+
+Guided onboarding can once again configure custom and local providers, including endpoints that do not need an API key, and verifies a real response before making the new model active. Failed or cancelled checks leave the previous configuration alone, while setup reruns preserve an existing agent roster and workspace instead of attaching temporary verification work to them.
+
+OpenClaw also compares the CLI's selected state and configuration paths with the local Gateway before guarded setup actions. When a mismatch is proven, it shows both locations and a command that targets the Gateway's store before credentials are written; offline setup remains available when there is no installed service to compare against.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Verify imported model settings without attaching temporary setup state to an existing agent ([#132477](https://github.com/openclaw/openclaw/pull/132477)).
+- Restore verified custom and local providers in guided onboarding ([#134907](https://github.com/openclaw/openclaw/pull/134907)).
+
+**Security and trust**
+
+- Stop proven CLI and Gateway state-directory mismatches before guarded writes ([#134403](https://github.com/openclaw/openclaw/pull/134403)). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Windows Installation and CLI Backends">
+
+Windows PowerShell 5.1 installation no longer treats harmless npm or Corepack warnings as command failures, and the portable Git bootstrap can complete without an interactive document-parsing step when Git is not already installed. The warnings remain visible, real nonzero exits still fail, and PowerShell 7 keeps its existing download behavior.
+
+Eligible npm-installed CLI backends can also be selected by their ordinary command name during Windows onboarding. OpenClaw now follows the platform's PATHEXT lookup while retaining the neighboring POSIX launcher used by Git Bash, so there is no need to hard-code a `.cmd` path or delete one of npm's shims.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Let harmless npm and Corepack warnings pass on Windows PowerShell 5.1 ([#134385](https://github.com/openclaw/openclaw/pull/134385)). Thanks @ly85206559.
+- Download portable Git without interactive parsing on Windows PowerShell 5.1 ([#134412](https://github.com/openclaw/openclaw/pull/134412)). Thanks @ly85206559.
+- Resolve npm-installed Windows CLI backends through PATHEXT ([#135138](https://github.com/openclaw/openclaw/pull/135138)). Thanks @gaoanze888, @Vasanthdev2004.
+
+</details>
+
+</Accordion>
+
+<Accordion title="AI Setup on macOS">
+
+The macOS AI setup sheet now shows the selected provider and the actual installation or verification activity instead of presenting an elapsed-time percentage as progress. Input controls appear when the setup needs an answer, capability consent remains explicit, and late responses from an older attempt no longer replace the current setup state.
+
+When someone declines capability review or cancels activation, the app now says that setup was cancelled and offers a clear retry instead of calling it a Gateway failure. Failed or unconfirmed cancellation stays visible, so another connection can be chosen without mistaking the outcome for a completed setup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show confirmed macOS setup cancellation as a retryable outcome ([#134654](https://github.com/openclaw/openclaw/pull/134654)).
+- Show real macOS AI setup activity and keep replies attached to the current attempt ([#135041](https://github.com/openclaw/openclaw/pull/135041)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Shell Setup and Connect Handoffs">
+
+When an npm install fails, the shell installer still shows the useful terminal details and npm's durable debug log, but no longer points to a temporary installer log that has already been removed. Shell completion installation and reinstall also preserve literal cache paths containing quotes, dollar signs, or backslashes across Bash, zsh, Fish, and the emitted PowerShell command, without replacing unrelated profile commands.
+
+The existing `openclaw connect` command is easier to find in the CLI reference, and its target-file handoff now accepts bounded regular-file inputs without deleting a rejected, unreadable, or oversized file. Successful regular-file and symlink handoffs retain their single-use behavior, while failed inputs stay available for inspection or recovery.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Remove the missing installer-log breadcrumb while preserving useful diagnostics ([#134655](https://github.com/openclaw/openclaw/pull/134655)). Thanks @mohamedelrefaiy.
+- Preserve rejected Connect target files and bound reads to regular files ([#134957](https://github.com/openclaw/openclaw/pull/134957)). Thanks @xialonglee, @obviyus.
+- Preserve literal completion cache paths across supported shells ([#136241](https://github.com/openclaw/openclaw/pull/136241)). Thanks @steipete.
+
+**Documentation**
+
+- Add the existing Connect command to the CLI index ([#134917](https://github.com/openclaw/openclaw/pull/134917)). Thanks @qingminglong.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Managed llama.cpp Installation">
+
+Managed llama.cpp server installation remains automatic, but downloaded ZIP and TAR archives now pass through the bounded extractor used elsewhere in OpenClaw. Malformed or hostile archives fail without writing outside the installation tree, archive-provided links are skipped, and the required loader aliases are recreated as contained regular files.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep managed llama.cpp archives and loader aliases inside the installation tree ([#129035](https://github.com/openclaw/openclaw/pull/129035)). Thanks @pgondhi987.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## The New Web UI
+
+The [Control UI](/web/control-ui) now gives visual answers, active work, and long-running conversations more room to behave like one workspace. Diagrams render where they are discussed, starting or returning to a session takes less waiting and repeated work, and the interface does a better job of holding what you sent, your reading position, and the agent or session you were actually looking at.
+
+<AccordionGroup>
+
+<Accordion title="Mermaid Diagrams Inside the Conversation">
+
+Completed Mermaid fences now render as diagrams directly in chat, with the exact source, copy, expansion, and zoom controls kept beside the result. The diagram follows the active theme and stays in place while the rest of an answer arrives, so a flowchart or sequence diagram can be read without moving it into another tool.
+
+The renderer is lazy-loaded and isolated from the rest of the page, and model-authored output is reduced to passive SVG before display. Incomplete fences remain code, while invalid, oversized, or externally dependent diagrams fall back to readable source with an error instead of being treated as a successful render.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Render completed Mermaid diagrams with source, copy, expansion, and zoom controls ([#134913](https://github.com/openclaw/openclaw/pull/134913)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Starting, Switching, and Repairing Sessions">
+
+New Session now puts the first prompt and its images on screen as soon as you send them, keeps the draft available if creation fails, and moves into the confirmed conversation without an extra lookup. Chat and New Session also load fewer closed workspace features up front, while larger session lists do less repeated sidebar work when you switch between conversations. Those performance results come from controlled local and synthetic large-roster tests, not a promise that every browser or Gateway will see the same speedup, and the measured warm Chat path included a small composer-readiness regression.
+
+Returning to existing work is steadier too. Dashboards and background tasks stay with the selected agent, interrupted or timed-out sessions show a more truthful state, failed cloud or device sessions can be restarted from Chat when a compatible target is available, and Ask OpenClaw keeps the conversation and draft visible while its runtime is repaired. Sidebar groups, hovercards, assignment menus, status icons, and keyboard navigation make large or multi-agent workspaces easier to scan without changing the underlying session, permission, or placement boundaries.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Bring collapse, search, and new-session controls into the agent header ([#134365](https://github.com/openclaw/openclaw/pull/134365)). Thanks @vyctorbrzezowski.
+- Make session ownership, current work, and progress easier to scan in hovercards ([#134636](https://github.com/openclaw/openclaw/pull/134636)). Thanks @Patrick-Erichsen.
+- Give session titles and their status icons clearer separation ([#134764](https://github.com/openclaw/openclaw/pull/134764)). Thanks @Patrick-Erichsen.
+- Reduce repeated work when switching sessions and loading conversation branches ([#135021](https://github.com/openclaw/openclaw/pull/135021)).
+- Trim additional sidebar work when switching through large session lists ([#135332](https://github.com/openclaw/openclaw/pull/135332)).
+- Consolidate session assignment and appearance controls into clearer menus ([#135526](https://github.com/openclaw/openclaw/pull/135526)). Thanks @vyctorbrzezowski.
+- Speed up retained-chat switching in measured large-session workflows ([#135574](https://github.com/openclaw/openclaw/pull/135574)).
+
+**Bug fixes**
+
+- Keep compressed archived sessions under their real identities in Usage history ([#131017](https://github.com/openclaw/openclaw/pull/131017)). Thanks @Alix-007, @emes.
+- Match session-group action contrast to the Sessions toolbar ([#134631](https://github.com/openclaw/openclaw/pull/134631)). Thanks @Patrick-Erichsen.
+- Keep dashboards and background tasks attached to the selected agent ([#134714](https://github.com/openclaw/openclaw/pull/134714)). Thanks @ctbritt, @MertBasar0.
+- Show pinned sessions with a filled neutral pin ([#134775](https://github.com/openclaw/openclaw/pull/134775)). Thanks @Patrick-Erichsen.
+- Restore Ask OpenClaw launcher compatibility and preserve the conversation during recovery ([#134776](https://github.com/openclaw/openclaw/pull/134776)).
+- Keep quickly reopened menus dismissible and restore focus correctly ([#135006](https://github.com/openclaw/openclaw/pull/135006)). Thanks @vyctorbrzezowski.
+- Remove the duplicate Ask OpenClaw shortcut from Inbox while retaining its other entry points ([#135008](https://github.com/openclaw/openclaw/pull/135008)).
+- Restart an established failed cloud or device session from Chat on a compatible target ([#135024](https://github.com/openclaw/openclaw/pull/135024)). Thanks @jalehman.
+- Preserve the real terminal timeout reason in the sidebar and clear stale failures after success ([#135466](https://github.com/openclaw/openclaw/pull/135466)). Thanks @steipete.
+- Hide the unusable Rewind action while an agent is working ([#135521](https://github.com/openclaw/openclaw/pull/135521)). Thanks @Patrick-Erichsen.
+- Keep long sidebar group titles on one readable marquee line ([#135523](https://github.com/openclaw/openclaw/pull/135523)). Thanks @Patrick-Erichsen.
+- Tighten Recent Chats alignment, spacing, and hover feedback ([#135524](https://github.com/openclaw/openclaw/pull/135524)). Thanks @Patrick-Erichsen.
+- Return keyboard focus to the visible menu after switching submenus ([#135629](https://github.com/openclaw/openclaw/pull/135629)).
+- Use device-specific wording while paired-device sessions start ([#135681](https://github.com/openclaw/openclaw/pull/135681)).
+- Reduce unnecessary startup work on New Session and Chat while keeping saved panels restorable ([#136021](https://github.com/openclaw/openclaw/pull/136021)). Thanks @steipete.
+- Keep large catalog groups compact with independent Show more controls ([#136040](https://github.com/openclaw/openclaw/pull/136040)). Thanks @fuller-stack-dev.
+- Show the first new-session message immediately and restore its contents if creation fails ([#136069](https://github.com/openclaw/openclaw/pull/136069)).
+
+**Security and trust**
+
+- Show inherited Full Access as active as soon as a session opens ([#134732](https://github.com/openclaw/openclaw/pull/134732)). Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Conversation Order and Reading Position">
+
+The chat transcript now holds together more consistently as live events become saved history. Reconnects and refreshes keep one copy of a completed answer, queued prompts stay above the replies they produced, commentary remains distinct from the final answer, and manually taking over the scroll position is less likely to be undone by delayed layout work. Compaction now appears as one calm inline marker that settles into a durable completed state instead of splitting itself across temporary and saved notices.
+
+The composer is less fragile around the edges of an active turn. You can begin the next prompt immediately after sending, remove queued input without a false storage warning, keep late dictation after pressing Stop, and reply to attachment-only messages with a useful reference. Sent images remain visible while history takes ownership of them, Office attachment failures no longer wedge later turns through known display blocks, and silent command failures or plugin-delayed final replies still leave timely, visible progress or warning text.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Replace compaction's button-like spinner with a calm, accessible folding status ([#135988](https://github.com/openclaw/openclaw/pull/135988)). Thanks @steipete.
+
+**Bug fixes**
+
+- Make staged attachments easier to remove by touch in Chat and New Session ([#123893](https://github.com/openclaw/openclaw/pull/123893)).
+- Clear stale working controls after an interrupted run is confirmed in history ([#134457](https://github.com/openclaw/openclaw/pull/134457)). Thanks @RomneyDa.
+- Keep long collapsed prompts readable without overlapping text ([#134833](https://github.com/openclaw/openclaw/pull/134833)). Thanks @steipete.
+- Reconcile live and saved commentary by run and item identity ([#134888](https://github.com/openclaw/openclaw/pull/134888)).
+- Insert late dictation once into the current draft after Stop ([#135109](https://github.com/openclaw/openclaw/pull/135109)). Thanks @obviyus, @jadabreu.
+- Retain one clear warning when an exec or Bash failure is the only visible reply ([#135119](https://github.com/openclaw/openclaw/pull/135119)).
+- Keep attachment display cards out of model history and restore Office document sends ([#135185](https://github.com/openclaw/openclaw/pull/135185)). Thanks @gaoanze888, @obviyus, @snls1994, @gordonzhy.
+- Let the next prompt accept input immediately after the current one is sent ([#135345](https://github.com/openclaw/openclaw/pull/135345)). Thanks @Takhoffman.
+- Restore replies and source navigation for attachment-only assistant messages ([#135393](https://github.com/openclaw/openclaw/pull/135393)).
+- Keep recovered queued prompts above the replies they produced ([#135568](https://github.com/openclaw/openclaw/pull/135568)).
+- Prevent a saved assistant reply from appearing twice during reconnect or history refresh ([#135715](https://github.com/openclaw/openclaw/pull/135715)). Thanks @starship863, @dustin-nowak.
+- Respect manual transcript scrolling during delayed row measurement ([#135738](https://github.com/openclaw/openclaw/pull/135738)).
+- Remove queued input without restoring an old draft or showing a false storage error ([#135790](https://github.com/openclaw/openclaw/pull/135790)).
+- Remove the redundant waiting receipt after a chat message is accepted ([#135901](https://github.com/openclaw/openclaw/pull/135901)).
+- Restore compact token-count labels without changing the underlying totals ([#135951](https://github.com/openclaw/openclaw/pull/135951)).
+- Show commentary progress before a plugin finishes validating the final reply ([#135954](https://github.com/openclaw/openclaw/pull/135954)). Thanks @JosephNatsu.
+- Keep sent images visible while saved history takes ownership of the message ([#136072](https://github.com/openclaw/openclaw/pull/136072)). Thanks @steipete.
+- Carry compaction from its live status into one persistent transcript marker ([#136169](https://github.com/openclaw/openclaw/pull/136169)).
+
+**Security and trust**
+
+- Explain denied WebChat resets without weakening the required administrator permission ([#134696](https://github.com/openclaw/openclaw/pull/134696)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Everyday Workspace Polish">
+
+The surfaces around the conversation have had the same attention. Dashboards fill narrow screens, long task progress and Review content use the space available to them, settings show useful loading shapes, and the model picker, agent picker, Side chat, Appearance, Usage, publication controls, and pull request previews are easier to scan. Keyboard menus recover cleanly, scrollbars remain visible beside fades, stale assets are less likely to survive a cache check, and smaller initial Settings data leaves more startup headroom without claiming a measured end-user latency gain.
+
+Accessibility and authority state are clearer in several places, including a stable localized name for the composer, reduced-motion loading indicators, properly displayed wildcard tool policies, named approval requesters, optionless credential prompts, and specific recovery guidance for trusted-proxy sign-in failures. One regression remains in the sidebar. Shorter pin and unpin tooltips also became the icon buttons' accessible names, so assistive-technology users can lose the session-specific context that used to be repeated there.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Give Side chat one direct clear action and consistent naming ([#134478](https://github.com/openclaw/openclaw/pull/134478)). Thanks @Patrick-Erichsen.
+- Replace ambiguous settings loading text with accessible page-shaped placeholders ([#134684](https://github.com/openclaw/openclaw/pull/134684)). Thanks @Patrick-Erichsen.
+- Defer Settings-only English text to leave more room in the initial download ([#135131](https://github.com/openclaw/openclaw/pull/135131)). Thanks @steipete.
+- Place Theme and Accent color together in Appearance settings ([#135547](https://github.com/openclaw/openclaw/pull/135547)). Thanks @vyctorbrzezowski.
+- Clarify model-selection scope and the session reset action on wide and narrow screens ([#136160](https://github.com/openclaw/openclaw/pull/136160)).
+
+**Bug fixes**
+
+- Show recoverable file-editor load failures instead of a blank retry loop ([#123220](https://github.com/openclaw/openclaw/pull/123220)). Thanks @wanyongstar.
+- Make dashboard cards fill narrow screens and preserve their desktop arrangement ([#133814](https://github.com/openclaw/openclaw/pull/133814)). Thanks @MoerAI, @vyctorbrzezowski.
+- Give the chat composer one stable accessible name across changing states ([#133829](https://github.com/openclaw/openclaw/pull/133829)). Thanks @aniruddhaadak80.
+- Make long task-progress cards scroll without moving the page or hiding the composer ([#134517](https://github.com/openclaw/openclaw/pull/134517)). Thanks @VACInc, @cpgeek, @nybbs2003.
+- Delay incidental microphone-picker motion while keeping keyboard interaction immediate ([#134653](https://github.com/openclaw/openclaw/pull/134653)). Thanks @Patrick-Erichsen.
+- Align settings headings and make automation failures easier to find ([#134659](https://github.com/openclaw/openclaw/pull/134659)). Thanks @Patrick-Erichsen.
+- Remove the repeated Agent picker label and keep the opening menu opaque ([#134680](https://github.com/openclaw/openclaw/pull/134680)). Thanks @Patrick-Erichsen.
+- Simplify pull request hovercard statistics while preserving the full PR link ([#134791](https://github.com/openclaw/openclaw/pull/134791)). Thanks @Patrick-Erichsen.
+- Keep Usage peak-error hour labels correct through daylight-saving changes ([#135153](https://github.com/openclaw/openclaw/pull/135153)).
+- Keep sidebar and transcript fades from covering visible scrollbars ([#135564](https://github.com/openclaw/openclaw/pull/135564)). Thanks @vyctorbrzezowski.
+- Return current Control UI assets when a cached entity tag is stale ([#135619](https://github.com/openclaw/openclaw/pull/135619)).
+- Let long task reviews fill docked and expanded side panels ([#135926](https://github.com/openclaw/openclaw/pull/135926)). Thanks @obviyus, @asgeirtj.
+- Make publishing-account controls compact while keeping the selected identity reachable ([#136002](https://github.com/openclaw/openclaw/pull/136002)).
+- Add localized composer accessibility labels across supported non-English locales ([#136006](https://github.com/openclaw/openclaw/pull/136006)).
+- Remove the bright static shimmer band when reduced motion is enabled ([#136153](https://github.com/openclaw/openclaw/pull/136153)).
+
+**Security and trust**
+
+- Present optionless credential and free-text questions without misleading choice controls ([#134598](https://github.com/openclaw/openclaw/pull/134598)). Thanks @Patrick-Erichsen, @goslingmanagment.
+- Give trusted-proxy login failures specific, redacted recovery guidance ([#135584](https://github.com/openclaw/openclaw/pull/135584)).
+- Display wildcard tool policies accurately without changing policy enforcement ([#135786](https://github.com/openclaw/openclaw/pull/135786)). Thanks @steipete.
+- Name the requesting session on projected approval cards without changing approval authority ([#136091](https://github.com/openclaw/openclaw/pull/136091)).
+
+**Limits and compatibility**
+
+- Shorten pin and unpin tooltips while retaining the unresolved loss of session context in accessible names ([#134651](https://github.com/openclaw/openclaw/pull/134651)). Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Updates and Maintenance
+
+[Updates](/install/updating) now make a clearer distinction between work OpenClaw can finish safely and work that needs your attention first. The updater protects more of the setup already on the machine, hands service-owned restarts to a process that can survive them, and leaves recoverable failures with enough context for Doctor or a configured coding agent to take over the investigation.
+
+<AccordionGroup>
+
+<Accordion title="Update Readiness and Restart Handoffs">
+
+Before OpenClaw restarts, it now checks the parts of your installation that actually need to be ready for the new version. Missing local-memory setup, unresolved plugin consent, or incomplete approval migration stops the update with a specific repair path, while a migration warning that does not make required state unsafe can leave the Gateway reachable in a clearly degraded state so you can run Doctor instead of watching a supervisor restart it forever.
+
+Updates started by an agent on a managed Linux or macOS Gateway can hand the work to a detached helper before the service stops, and Windows agent-initiated restarts use the Gateway-owned restart path rather than dying with the old process tree. That handoff confirms the update was accepted, not that it finished, and npm 12 local archives still need a comma-free path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Leaner installations without unused Sharp and ONNX dependency chains, with Chromium or Chrome now required for meme PNG output ([#134923](https://github.com/openclaw/openclaw/pull/134923)).
+
+**Bug fixes**
+
+- Windows agent-initiated Gateway restarts survive the old process tree ([#134549](https://github.com/openclaw/openclaw/pull/134549)). Thanks @nerclid, @w1130150306.
+- Updates stop before restarting when a selected plugin readiness check fails ([#134699](https://github.com/openclaw/openclaw/pull/134699)). Thanks @Patrick-Erichsen, @vyctorbrzezowski.
+- Blank backup intervals fail instead of silently creating a 24-hour schedule ([#134799](https://github.com/openclaw/openclaw/pull/134799)). Thanks @marmar9615-cloud.
+- Update readiness loads only the Doctor integrations needed for the selected checks ([#135161](https://github.com/openclaw/openclaw/pull/135161)).
+- Blank Gateway suspension waits fail before a lease is acquired ([#135270](https://github.com/openclaw/openclaw/pull/135270)). Thanks @qingminglong.
+- Agent-launched updates move to the managed helper before stopping the Gateway ([#135701](https://github.com/openclaw/openclaw/pull/135701)). Thanks @steipete.
+- Nonfatal migration warnings allow a visible degraded startup with Doctor guidance ([#135713](https://github.com/openclaw/openclaw/pull/135713)). Thanks @Zak-Finance.
+- npm 12 accepts comma-free local release archives through installer and updater paths ([`bdf508b8ad`](https://github.com/openclaw/openclaw/commit/bdf508b8ad7e02b06f4e944c29ef835ced2bef22)). Thanks @steipete.
+
+**Security and trust**
+
+- Incomplete exec-approval repairs keep the Gateway stopped and return failure ([#135454](https://github.com/openclaw/openclaw/pull/135454)). Thanks @steipete.
+- Unresolved plugin consent blocks update finalization before bindings change or the Gateway restarts ([#135460](https://github.com/openclaw/openclaw/pull/135460)). Thanks @steipete, @hannesrudolph, @xiaomijituan, @weirdo-world.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Settings and State Through Updates">
+
+An update or Doctor repair now does more to preserve the setup you already authored, including configuration includes and environment expressions, agent rosters and workspaces, plugin payloads and policy, credentials, scheduled work, device pairings, and session history. When old and new state disagree, repairs either prove the change is safe or stop before writing, and concurrent Gateway work no longer gets silently replaced by an older Doctor snapshot.
+
+The same rule reaches the edges of maintenance. Interactive uninstall keeps local state and workspaces unless you explicitly select them, Windows snapshots work in mixed PowerShell installations, workspace exclusions are applied before backup traversal, and plugin recovery publishes a trusted install record only after it has verified what it is installing.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Windows snapshots work when PowerShell 7 is installed alongside Windows PowerShell ([#121618](https://github.com/openclaw/openclaw/pull/121618)). Thanks @fr-meyer.
+- Doctor preserves newer cron definitions, runtime state, and authorization during concurrent repairs ([#127999](https://github.com/openclaw/openclaw/pull/127999)). Thanks @yetval.
+- Valid device pairings survive contaminated legacy records during migration ([#134483](https://github.com/openclaw/openclaw/pull/134483)). Thanks @qdivan, @obviyus, @samson1357924.
+- Identical legacy session events no longer block transcript migration ([#134568](https://github.com/openclaw/openclaw/pull/134568)). Thanks @shakkernerd.
+- Doctor retains recognized official plugin settings written before installation ([#134717](https://github.com/openclaw/openclaw/pull/134717)). Thanks @obviyus, @abacha.
+- Explicit multi-agent roster repairs preserve supported per-agent settings ([#134758](https://github.com/openclaw/openclaw/pull/134758)). Thanks @Lendersmark, @vdruts.
+- Valid per-agent authentication overrides no longer look like unfinished shared-auth migration ([#134808](https://github.com/openclaw/openclaw/pull/134808)). Thanks @fuller-stack-dev.
+- Legacy agent-list upgrades keep the first agent on its established workspace ([#134892](https://github.com/openclaw/openclaw/pull/134892)). Thanks @Lendersmark.
+- Interrupted shared-credential migrations can restore verified archived credentials ([#134952](https://github.com/openclaw/openclaw/pull/134952)). Thanks @steipete, @erameson.
+- Redundant legacy credential subsets can converge without deleting the richer shared store ([#135096](https://github.com/openclaw/openclaw/pull/135096)). Thanks @jodok, @felixboenkost-droid.
+- Historical completed migrations can recover credentials when the archive and missing migrated credentials are verified ([#135346](https://github.com/openclaw/openclaw/pull/135346)). Thanks @steipete, @erameson.
+- Doctor preserves authored includes, environment expressions, and identifiable legacy agents ([#135671](https://github.com/openclaw/openclaw/pull/135671)). Thanks @fuller-stack-dev.
+- Update and installation rollback preserves current credentials, cron behavior, and owned plugin or hook state ([#135736](https://github.com/openclaw/openclaw/pull/135736)).
+- External companion plugin payloads survive Doctor and bundled-to-external update repair ([#135791](https://github.com/openclaw/openclaw/pull/135791)). Thanks @hannesrudolph, @weirdo-world, @xiaomijituan.
+- Backup workspace exclusions are applied before traversal while included absolute links remain protected ([#135830](https://github.com/openclaw/openclaw/pull/135830)). Thanks @obviyus, @jarvismazz, @yubingjiaocn, @ericcaiwx-star, @ruel225.
+- Plugin repair diagnostics follow the recorded install root instead of a broken same-ID source copy ([#135834](https://github.com/openclaw/openclaw/pull/135834)).
+
+**Security and trust**
+
+- Interactive uninstall defaults preserve local state, configuration, and workspaces ([#134299](https://github.com/openclaw/openclaw/pull/134299)). Thanks @PollyBot13, @kodi.
+- Missing-record npm plugin recovery verifies registry provenance before publishing trust ([#135451](https://github.com/openclaw/openclaw/pull/135451)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Doctor Repairs for Older State">
+
+Doctor can now resolve more of the old state that used to leave an installation stuck between versions, including empty legacy roots and approval stubs, stale workspace setup files, malformed scheduled jobs, incomplete Skill Workshop proposals, and narrowly safe database, roster, and workspace migrations. Repair stays deliberately conservative. Conflicting or populated state remains available for recovery, invalid cron jobs go to quarantine with their identity and reason, and successful repairs are designed to stay clean on the next pass.
+
+When Doctor cannot finish automatically, its diagnostics now point more directly at the thing that needs attention, including retained workspace files, plugin version drift, shared credential health, managed Tailscale ownership, and externally configured paths that a copied-state rehearsal can still reach. Long database maintenance keeps its lease while it works, and managed Tailscale upgrades can reclaim only the ordinary exclusive route that still points to the configured local Gateway.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Empty legacy state roots converge on the active OpenClaw state without replacing populated state ([#114678](https://github.com/openclaw/openclaw/pull/114678)). Thanks @harjothkhara, @obviyus, @xiaodongEdtech.
+- Gateway startup under load exposes health earlier and improves scoped recovery behavior ([#132186](https://github.com/openclaw/openclaw/pull/132186)). Thanks @galiniliev.
+- Incomplete Skill Workshop proposal migrations preserve recoverable files and converge on later Doctor runs ([#132917](https://github.com/openclaw/openclaw/pull/132917)). Thanks @xydt-juyaohui, @obviyus, @lakemike.
+- Schema-17 session repair now rolls back the whole attempt when migration is rejected ([#134272](https://github.com/openclaw/openclaw/pull/134272)). Thanks @RileyJJY, @obviyus, @abacha.
+- Doctor safely clears empty reserved workspace attestations that block agent turns ([#134641](https://github.com/openclaw/openclaw/pull/134641)). Thanks @leilei3167, @obviyus, @rosssaunders, @courtneyr-dev, @guarismo.
+- MCP lint finishes against private state when live SQLite state is busy ([#134698](https://github.com/openclaw/openclaw/pull/134698)). Thanks @obviyus, @pfrederiksen.
+- Malformed legacy cron jobs are quarantined so valid jobs and Gateway startup can continue ([#134704](https://github.com/openclaw/openclaw/pull/134704)). Thanks @obviyus, @Nielsh82.
+- Doctor repairs markerless keyed and legacy multi-agent rosters without changing routing choices ([#134706](https://github.com/openclaw/openclaw/pull/134706)). Thanks @Lendersmark.
+- Post-upgrade Doctor reports official plugin version drift with an actionable update command ([#134719](https://github.com/openclaw/openclaw/pull/134719)). Thanks @Lendersmark, @oshunter.
+- Blocked workspace cleanup warnings name the retained legacy file ([#134751](https://github.com/openclaw/openclaw/pull/134751)). Thanks @rosssaunders.
+- Healthy legacy heartbeat artifacts no longer produce false transcript corruption warnings ([#134765](https://github.com/openclaw/openclaw/pull/134765)). Thanks @obviyus, @LiuwqGit, @sblindt, @ayaangazali.
+- BOOT.md startup checks use their own temporary session without overwriting retained history ([#134831](https://github.com/openclaw/openclaw/pull/134831)). Thanks @miguelarios.
+- Long database scans and migrations renew their maintenance lease while Doctor works ([#134880](https://github.com/openclaw/openclaw/pull/134880)).
+- Shared credential health remains visible in explicit fleets without a default agent ([#134902](https://github.com/openclaw/openclaw/pull/134902)). Thanks @Lendersmark.
+- Managed Tailscale upgrades reclaim only an exclusive predecessor route for the configured Gateway ([#135394](https://github.com/openclaw/openclaw/pull/135394)). Thanks @jjjhenriksen, @Lendersmark.
+- Stale workspace setup migrations preserve canonical facts, archive the source, and converge ([#135755](https://github.com/openclaw/openclaw/pull/135755)). Thanks @jjjhenriksen, @Deregtx, @guarismo.
+- Managed Tailscale sudo failures on Linux now include the supported operator-grant command ([#135825](https://github.com/openclaw/openclaw/pull/135825)). Thanks @pengzh1, @obviyus, @ezimerman.
+
+**Security and trust**
+
+- Policy-free legacy exec-approval stubs can be archived and retired without replacing SQLite policy ([#135981](https://github.com/openclaw/openclaw/pull/135981)). Thanks @Ma77h3hac83r.
+
+**Documentation**
+
+- The CLI index now links the existing database preflight and ownership commands ([#135279](https://github.com/openclaw/openclaw/pull/135279)). Thanks @qingminglong.
+- Doctor guidance explains how copied-state repairs can still reach explicitly configured external paths ([#135312](https://github.com/openclaw/openclaw/pull/135312)). Thanks @vdruts.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Investigating a Failed Update">
+
+When an interactive update gets far enough to fail operationally, OpenClaw can now carry a bounded, sanitized record of that attempt into its existing triage flow instead of making you reconstruct the failure from scratch. The CLI can offer a configured Claude Code, Codex, OpenCode, or Pi session after updater cleanup, and the Control UI can open Ask OpenClaw with the recorded cause for an investigation-first conversation.
+
+That investigation does not get authority to retry the update, repair state, or restart the Gateway on its own, and a successful investigation does not turn the original update into a success. JSON, `--yes`, background, and managed-service runs remain diagnostic-only, preserving the original exit result while printing the next commands for an operator to use.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Built-in triage carries sanitized failure context into the CLI or Control UI after eligible update failures ([#134865](https://github.com/openclaw/openclaw/pull/134865)).
+
+**Bug fixes**
+
+- Failed updates preserve configuration and can hand investigation to an installed coding agent ([#134490](https://github.com/openclaw/openclaw/pull/134490)). Thanks @fuller-stack-dev.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Messaging
+
+Messaging in [channels](/channels) is less about whether a reply was technically sent and more about whether it arrived in the right conversation with its context, controls, and final outcome intact. This release carries that work across approvals, thread routing, rich replies, queues, restarts, voice, and the failure paths that used to leave either the person or the operator guessing.
+
+<AccordionGroup>
+
+<Accordion title="Approving Delegated Changes from Chat">
+
+When a delegated system agent asks to change OpenClaw configuration or plugins, operators can now approve or deny the request from a configured channel and see whether it was applied, denied, cancelled, expired, or could not be applied. The request remains tied to the run that created it, so closing that run also closes its authority to make the change, while Telegram keeps the approval and completion messages in the forum or direct-message topic where the request began.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Approve delegated configuration and plugin changes from supported channels ([#134670](https://github.com/openclaw/openclaw/pull/134670)). Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reply Context and Agent Identity">
+
+Replies now hold onto more of the context that made them meaningful. Microsoft Teams channel threads include their parent and sibling messages even when Teams omits reply metadata, cross-session deliveries are written into the receiving conversation, and LINE tells the answering turn whether a group message actually addressed the bot. Wildcard peer routes no longer change with lookup order, and Slack RPC replies keep the selected agent’s configured name and emoji.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep the configured Slack agent identity on RPC-delivered replies ([#122078](https://github.com/openclaw/openclaw/pull/122078)). Thanks @Iskam31.
+- Restore parent and sibling context in Microsoft Teams channel threads ([#129345](https://github.com/openclaw/openclaw/pull/129345)). Thanks @amalysh.
+- Record cross-session deliveries in the receiving conversation history ([#134083](https://github.com/openclaw/openclaw/pull/134083)). Thanks @edenfunf, @VACInc, @abacha.
+- Carry LINE group-mention context into the turn that answers ([#135195](https://github.com/openclaw/openclaw/pull/135195)). Thanks @edenfunf.
+- Route unknown direct messages through the configured wildcard peer consistently ([#135351](https://github.com/openclaw/openclaw/pull/135351)). Thanks @teddytennant, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Complete Controls, Cards, and Formatted Replies">
+
+Rich replies are less likely to lose the part somebody actually needed. Matrix and Feishu or Lark deliver offered controls, while LINE preserves card text, buttons, questions, and overflow choices when media is unavailable or a generated card is too large for the platform. Long task lists keep their structure across message chunks, and ordinary Markdown examples, citations, image URLs, and labeled links survive parsing without disappearing or triggering the wrong fetch.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve Matrix code containing double pipes without hiding the reply ([#128453](https://github.com/openclaw/openclaw/pull/128453)). Thanks @ruel225, @petergaultney.
+- Keep LINE card text and controls when optional media is unavailable ([#132571](https://github.com/openclaw/openclaw/pull/132571)). Thanks @edenfunf.
+- Deliver buttons and selections in Matrix agent replies ([#133268](https://github.com/openclaw/openclaw/pull/133268)). Thanks @edenfunf, @ml12580.
+- Let LINE agents offer the controls the channel already supports ([#134915](https://github.com/openclaw/openclaw/pull/134915)). Thanks @edenfunf.
+- Preserve LINE quick-reply questions and every offered choice ([#134976](https://github.com/openclaw/openclaw/pull/134976)). Thanks @edenfunf.
+- Preserve task lists and structured Markdown across message chunks ([#135200](https://github.com/openclaw/openclaw/pull/135200)).
+- Fall back to complete text when a generated LINE card is too large ([#135229](https://github.com/openclaw/openclaw/pull/135229)). Thanks @edenfunf.
+- Deliver Feishu and Lark controls, links, attachments, and accurate partial results ([#135255](https://github.com/openclaw/openclaw/pull/135255)). Thanks @edenfunf.
+- Keep Markdown citations from being mistaken for pasted URLs to fetch ([#135341](https://github.com/openclaw/openclaw/pull/135341)). Thanks @teddytennant, @obviyus.
+- Preserve Google Chat link labels that contain spaces ([#136151](https://github.com/openclaw/openclaw/pull/136151)). Thanks @ericcaiwx-star, @obviyus, @KimOckHyun.
+- Preserve literal Markdown images and balanced image URL punctuation ([#136228](https://github.com/openclaw/openclaw/pull/136228)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Channel Queues Through Restarts">
+
+Several channel failures now recover without making a healthy conversation look dead. Telegram can move past a stale session start and acknowledges stored button presses before a busy chat finishes earlier work, while channel routes release cleanly during replacement, Matrix can repair an upgraded sync database with Doctor, and Slack Socket Mode or relay accounts no longer depend on an inactive HTTP-only secret. Failed configured channels remain visible as blocked with a safe recovery hint instead of disappearing from status and health.
+
+Older supported Feishu, Telegram, WhatsApp, and Matrix plugins keep dispatching inbound replies after the host updates, installed external channels work with generic message actions and broadcast planning, and narrower Slack lookup problems and Tlon parser stalls are repaired. These are channel-specific repairs rather than a claim that every transport now behaves identically.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reuse Slack Enterprise thread lookups across matching events ([#121598](https://github.com/openclaw/openclaw/pull/121598)). Thanks @mikasa0818.
+- Show why Slack rejected an inbound attempt before dispatch ([#132723](https://github.com/openclaw/openclaw/pull/132723)). Thanks @zhangguiping-xydt, @Phillis, @ayaangazali.
+- Release abandoned channel routes so account recovery can continue ([#133297](https://github.com/openclaw/openclaw/pull/133297)). Thanks @zhangguiping-xydt, @goffern.
+- Acknowledge durably stored Telegram button presses promptly ([#133379](https://github.com/openclaw/openclaw/pull/133379)). Thanks @Paeddy87, @zhangguiping-xydt.
+- Repair stale Matrix sync databases while preserving existing state ([#134742](https://github.com/openclaw/openclaw/pull/134742)). Thanks @w9n, @obviyus.
+- Start Slack Socket Mode and relay without resolving an unused HTTP secret ([#134827](https://github.com/openclaw/openclaw/pull/134827)).
+- Keep failed configured channels visible in status and health ([#135082](https://github.com/openclaw/openclaw/pull/135082)). Thanks @vguyon-dev, @0xCyda, @liemnhoang.
+- Let Telegram queues recover from a stale session start ([#135154](https://github.com/openclaw/openclaw/pull/135154)). Thanks @brettdaman, @obviyus.
+- Keep older supported channel plugins dispatching replies after host updates ([#135179](https://github.com/openclaw/openclaw/pull/135179)). Thanks @nissl24, @fridaylans2000-art, @obviyus, @jooey, @fufales, @itanyplus, @dtump, @XXlaoxxc, @desksk, @chengoak.
+- Send ordinary Tlon hashtag lines without stalling the parser ([#135181](https://github.com/openclaw/openclaw/pull/135181)).
+- Use installed external channels in generic message actions and broadcasts ([#135831](https://github.com/openclaw/openclaw/pull/135831)). Thanks @ruel225, @obviyus, @TailsProwerWorks.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Clear Outcomes for Delivery Failures">
+
+When delivery cannot finish, the result is now less ambiguous. Rejected webhook uploads across bundled channels receive their complete response before the connection closes, malformed Signal response text fails visibly, and an affected iMessage send explains that its bridge stopped responding and gives the operator the two recovery commands. Context-only prompts no longer hang at completion, while Discord thread replies split after mention expansion and avoid replaying an uncertain or partially accepted webhook delivery as a duplicate bot message.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject corrupted text in Signal JSON responses with a visible failure ([#121569](https://github.com/openclaw/openclaw/pull/121569)). Thanks @sunlit-deng.
+- Finish webhook rejection responses before closing the connection ([#126818](https://github.com/openclaw/openclaw/pull/126818)). Thanks @edenfunf, @obviyus.
+- Explain an unresponsive iMessage bridge and show the recovery commands ([#134572](https://github.com/openclaw/openclaw/pull/134572)). Thanks @omarshahine.
+- Complete auto-replies whose prompt ends with context or metadata ([#135070](https://github.com/openclaw/openclaw/pull/135070)).
+- Deliver long Discord webhook replies without duplicate fallback messages ([#135963](https://github.com/openclaw/openclaw/pull/135963)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Stopping Replies and Progress">
+
+Stopping or replacing a turn now does a better job of stopping the work and narration attached to it. Active link fetches and processors are cancelled with the reply, obsolete narration cannot update a newer draft, Control UI commentary reconciles as one update, and Slack waits for a complete first preamble while keeping quiet-preview settings quiet. Successful reaction-only and background work also avoid misleading missing-reply fallbacks.
+
+Discord follows the same final-outcome discipline in several focused paths. Cancelled voice consults remain quiet, model-picker choices report their real result, and ambient or message-tool-only work does not leak a session-busy warning that its reply policy said to suppress.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop active link fetches and processors when their reply is cancelled ([#132883](https://github.com/openclaw/openclaw/pull/132883)). Thanks @SunnyShu0925, @steipete.
+- Keep quiet Slack previews on the latest authored preamble ([#134716](https://github.com/openclaw/openclaw/pull/134716)). Thanks @pash-openai.
+- Cancel obsolete progress narration when its turn ends ([#134839](https://github.com/openclaw/openclaw/pull/134839)).
+- Reconcile generated commentary as one update during runs and reconnects ([#135081](https://github.com/openclaw/openclaw/pull/135081)). Thanks @akagifreeez, @obviyus, @tomroberts78.
+- Keep cancelled Discord voice consults quiet and reusable ([#135380](https://github.com/openclaw/openclaw/pull/135380)).
+- Apply Discord model-picker choices without false failure replies ([#135382](https://github.com/openclaw/openclaw/pull/135382)). Thanks @Call44, @BoatAngle.
+- Respect quiet reply policy for Discord session-busy notices ([#135444](https://github.com/openclaw/openclaw/pull/135444)).
+- Keep connected apps available and wait for a complete Slack preamble ([#136092](https://github.com/openclaw/openclaw/pull/136092)). Thanks @pash-openai.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Voice Replies and Discord Voice Sessions">
+
+Discord voice capture now has one owner per speaker and stops oversized batch utterances with an actionable warning instead of accumulating memory or sending a partial transcript. For inbound WhatsApp voice notes, Codex dynamic replies can once again return voice when automatic inbound TTS is enabled, while later text-only turns remain text and the audio decision stays attached to the reply that received it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Bound Discord voice capture and clean up each speaker’s session ([#135870](https://github.com/openclaw/openclaw/pull/135870)). Thanks @LZY3538.
+- Preserve inbound audio for automatic Codex voice replies ([#135884](https://github.com/openclaw/openclaw/pull/135884)). Thanks @hyper-sdn.
+
+</details>
+
+</Accordion>
+
+<Accordion title="WhatsApp Acknowledgement Migration">
+
+Doctor now says when a legacy WhatsApp acknowledgement setting could not survive migration exactly as written. It identifies a shadowed emoji, shows which shared emoji remains active, and warns when the old acknowledgement scope changes or cannot be represented so operators can review `messages.ackReactionScope` instead of accepting a misleading clean migration.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report a shadowed WhatsApp acknowledgement emoji during migration ([#119501](https://github.com/openclaw/openclaw/pull/119501)). Thanks @harjothkhara, @obviyus, @abacha.
+- Warn when WhatsApp acknowledgement scope cannot be preserved ([#129825](https://github.com/openclaw/openclaw/pull/129825)). Thanks @zhangguiping-xydt, @obviyus.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Memory
+
+[Memory](/concepts/memory) now keeps rebuildable index work separate from the conversations people need to protect. There is a safe reset path that leaves sessions and transcripts in place, search avoids needless full rebuilds for healthy or ordinarily dirty indexes, legacy retrieval settings survive Doctor upgrades, and long conversations retain capture progress through compaction while closed transcript views release message text they no longer need.
+
+<AccordionGroup>
+
+<Accordion title="Resetting and Rebuilding Memory Indexes">
+
+Built-in Memory now has an explicit `openclaw memory reset` path that discards only rebuildable index data for one agent or every configured agent while preserving sessions, transcripts, memory source files, and other durable agent state. It asks before acting, requires `--yes` in non-interactive use, treats an absent or empty index as a successful no-op, and refuses to race indexing already in progress.
+
+Full reindexes are safer around that path. Replacement caches are bounded before publication, failed full rebuilds leave the previously published cache intact, a memory change during automatic maintenance gets one retry against current content, and abandoned workspace locks can recover after process-ID reuse. Recovery messages identify whether an incompatible index belongs to OpenClaw or configuration, warn when an explicit rebuild may contact a paid embedding provider, and retain the unreadable source path; ordinary replies remain available while a legacy index is repaired in the background, and combined memory and wiki searches continue to show the affected agent's repair instructions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reset derived memory indexes without deleting sessions or transcripts ([#135653](https://github.com/openclaw/openclaw/pull/135653)). Thanks @AlexisBallo2.
+
+**Bug fixes**
+
+- Retry automatic index maintenance once after a concurrent memory change ([#134333](https://github.com/openclaw/openclaw/pull/134333)). Thanks @TheAngryPit, @obviyus.
+- Recover abandoned Memory Core locks after process-ID reuse ([#135051](https://github.com/openclaw/openclaw/pull/135051)). Thanks @pengzh1, @obviyus, @gru-10k.
+- Keep replies available while a legacy index is repaired in the background ([#135062](https://github.com/openclaw/openclaw/pull/135062)). Thanks @LifeViwer.
+- Bound forced-reindex cache publication and preserve the live cache after failure ([#135373](https://github.com/openclaw/openclaw/pull/135373)). Thanks @AlexisBallo2.
+- Keep agent-scoped repair instructions beside successful wiki results ([#135415](https://github.com/openclaw/openclaw/pull/135415)).
+- Identify index-mismatch ownership and retain unreadable-source details ([#135864](https://github.com/openclaw/openclaw/pull/135864)). Thanks @yetval, @obviyus, @CjTruHeart.
+
+**Documentation**
+
+- Explain how to rebuild memory without deleting the shared conversation database ([#135431](https://github.com/openclaw/openclaw/pull/135431)). Thanks @AlexisBallo2.
+
+**Limits and compatibility**
+
+- Reset does not shrink existing SQLite allocation, restore already deleted history, or act as a privacy purge, and the planned separate derived-index database remains future work.
+- Automatic project and trigger recall remains unavailable while legacy source classification is pending, and an explicit rebuild may use a paid embedding provider.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Search Without Needless Rebuilding">
+
+One-shot `openclaw memory search` commands can reuse a healthy persisted index and exit instead of starting indexing work after they already found the answer. The command still checks its sources, so a real change starts maintenance and becomes searchable rather than leaving the clean state frozen forever.
+
+When an index is dirty, ordinary memory-file and session changes can be applied incrementally while searches remain available instead of repeatedly selecting a full rebuild. Workspace discovery also skips symlinked and other non-regular memory entries rather than allowing one linked `USER.md` to abort indexing for every regular file.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Skip linked and other non-regular workspace memory files without aborting the sync ([#135042](https://github.com/openclaw/openclaw/pull/135042)). Thanks @ruel225, @obviyus, @kiranvk-2011.
+- Let clean one-shot memory searches return without reindexing ([#135520](https://github.com/openclaw/openclaw/pull/135520)). Thanks @gaoanze888, @obviyus, @LifeViwer.
+- Apply pending memory changes without repeatedly rebuilding the full index ([#136064](https://github.com/openclaw/openclaw/pull/136064)). Thanks @ThatGuySizemore.
+
+**Limits and compatibility**
+
+- Symlink targets remain intentionally unread, and a separate multimodal file-replacement race is not fixed here.
+- The improvement from incremental maintenance varies by index and workload, while full publication and retry policy remain unchanged.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Retrieval Settings and Embedding Providers">
+
+Running `openclaw doctor --fix` on an older configuration no longer silently drops an agent's knowledge paths or session-memory choices and falls back to global defaults. Custom OpenAI-compatible embedding providers can also resolve a saved API-key or bearer-token profile before indexing or search, while invalid or unavailable bindings stop before a network request rather than selecting a different credential.
+
+The packaged local path is less fragile too. The official Linux x64 Docker image now includes the runtime needed for managed llama.cpp embeddings to pass their executable preflight, and malformed Amazon Bedrock embedding responses produce a clear error instead of being accepted through replacement decoding.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject malformed Amazon Bedrock embedding-response encoding ([#133716](https://github.com/openclaw/openclaw/pull/133716)). Thanks @RileyJJY.
+- Include the managed llama.cpp runtime prerequisite in the Linux x64 Docker image ([#134532](https://github.com/openclaw/openclaw/pull/134532)). Thanks @chelsealong, @henrique-simoes.
+- Resolve saved API-key and bearer-token profiles for compatible embedding providers ([#134744](https://github.com/openclaw/openclaw/pull/134744)). Thanks @0x-Parzival.
+- Preserve each agent's memory-search settings during legacy Doctor upgrades ([#134760](https://github.com/openclaw/openclaw/pull/134760)). Thanks @obviyus, @vdruts.
+
+**Limits and compatibility**
+
+- Managed llama.cpp support here is limited to Linux x64, and this repair does not add managed ARM64 support.
+- Saved profiles apply to compatible embedding APIs, while literal and blank keys retain their existing behavior.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Visible Recall Outcomes">
+
+On eligible private-chat turns, Active Memory now tells the main model when deep recall was intentionally skipped or unavailable, so an absent lookup is not mistaken for a successful search that found nothing relevant. The note stays bounded and leaves provider errors and sensitive search details out of model context.
+
+Memory Core Dreaming also carries an explicitly selected agent through deep consolidation in multi-agent setups, letting recalled facts consolidate under the right owner instead of silently falling back to append-only storage. When no owner is available, that safer append-only fallback remains.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep deep memory consolidation attached to its selected agent ([#135166](https://github.com/openclaw/openclaw/pull/135166)). Thanks @zhangguiping-xydt, @obviyus, @giangthb.
+- Tell the model when Active Memory recall was skipped or unavailable ([#135193](https://github.com/openclaw/openclaw/pull/135193)). Thanks @Alix-007, @obviyus, @wave-workflow.
+
+**Limits and compatibility**
+
+- Active Memory outcome notes apply to eligible private-chat turns, and timeout-budget alignment remains unimplemented.
+- Deep consolidation under an explicit owner is limited to Memory Core Dreaming in multi-agent setups.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Memory Capture in Long Conversations">
+
+LanceDB auto-capture now keeps its place when a long conversation is compacted, avoids embedding facts it has already handled, serializes overlapping capture for the same conversation, and lets in-flight automatic capture finish before the plugin closes. New facts are less likely to disappear behind retained messages after compaction.
+
+Large transcript scans can begin processing without first retaining every message payload, while each active chat view owns the recovered full text it needs and releases that text when the view closes. Split panes keep their own valid content, so closing one does not strip the conversation from another that is still open.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve LanceDB auto-capture progress through compaction and shutdown ([#131329](https://github.com/openclaw/openclaw/pull/131329)). Thanks @hartmark.
+- Release recovered transcript text when its chat view closes ([#135326](https://github.com/openclaw/openclaw/pull/135326)).
+
+**Limits and compatibility**
+
+- The shutdown guarantee covers automatic capture, not explicit memory tools or automatic recall, and completed-text history remains bounded.
+- Transcript handling does not establish lower ordinary idle memory, lower peak process memory, or faster scan latency.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Skills
+
+Skills are becoming something a team can own without turning the host into a ticket queue. People sharing a Gateway can keep their own libraries, share work deliberately, and carry the exact selected revision into the session that needs it, while overwrites, policy failures, and optional runtime dependencies leave clearer recovery paths.
+
+<AccordionGroup>
+
+<Accordion title="Personal Skill Libraries for Shared Teams">
+
+Signed-in teammates on a shared Gateway can create, import, update, and reuse skills without host access. A library starts private, sharing does not hand over edit rights, and ownership can move to a team when the skill itself becomes shared work, so routine authoring no longer has to pass through an administrator.
+
+ZIP imports now reserve room across profiles as well. One person with many unfinished uploads cannot occupy every pending slot, while existing uploads can still finish and linked or merged identities continue to share one allowance. Each session also keeps the immutable skill revision that was selected, including its supporting files and executable permissions, as work moves through local, sandbox, cloud, or node workers.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Give signed-in teammates private, shareable skill libraries ([#134068](https://github.com/openclaw/openclaw/pull/134068)). Thanks @RomneyDa, @steipete.
+
+**Bug fixes**
+
+- Reserve personal-skill ZIP-import capacity across profiles ([#135593](https://github.com/openclaw/openclaw/pull/135593)).
+
+**Limits and compatibility**
+
+- Revision delivery preserves the existing solo workspace-skills workflow and stays within one trusted Gateway domain.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Skill Editing, Migration, and Runtime Checks">
+
+Claude migration can overwrite a generated skill without making local edits disposable. `migrate apply claude --overwrite` now backs up the whole target skill directory, records the recovery path even if a later write fails, and checks that the command source still exists before changing the target.
+
+The surrounding runtime reports and installs are more truthful too. Source-run Gateways can load compiled OpenAI and Memory Core plugins again, context-free harness checks distinguish allowlist, denylist, and disabled-plugin policy from a missing installation, and copied hook packs attempt the optional runtime packages their handlers need.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Back up an overwritten generated skill before Claude migration ([#134302](https://github.com/openclaw/openclaw/pull/134302)). Thanks @PollyBot13, @steipete.
+- Restore compiled plugin loading in source Gateways ([#135077](https://github.com/openclaw/openclaw/pull/135077)).
+- Explain allowlist, denylist, and disabled-plugin harness failures accurately ([#135206](https://github.com/openclaw/openclaw/pull/135206)). Thanks @fuller-stack-dev, @goslingmanagment.
+- Install optional hook-pack runtime dependencies when npm can provide them ([#136050](https://github.com/openclaw/openclaw/pull/136050)).
+
+**Limits and compatibility**
+
+- Compiled plugin loading is scoped to source Gateway runs, and optional hook packages are attempted rather than guaranteed to install.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Native Apps
+
+The native apps take two visible steps forward in this release. [Android](/platforms/android) gets a much fuller everyday workspace for chat, sessions, navigation, and appearance, while Android, [iPhone and iPad](/platforms/ios), and [macOS](/platforms/macos) can turn Mermaid source into readable diagrams inside the conversation. Around those larger changes, reconnects hold on to accepted work, voice stays with the turn that started it, and several platform-specific setup and helper paths handle failure more cleanly.
+
+<AccordionGroup>
+
+<Accordion title="Android’s Fuller Everyday Workspace">
+
+The Android app now brings the pieces people reach for during a normal conversation into one more complete native experience. The composer has a full-width writing area with compact actions, model names remain readable, and searchable controls expose models, effort, Fast Mode, and permissions without crowding the transcript. Sessions can be browsed or created from the native catalog, the sidebar can be arranged around the places you use, and theme families and accents stay with the correct profile through offline changes, reconnects, and app recreation.
+
+That work also keeps the app usable on narrow screens and with larger text, and it gives an actionable Providers and Models route before sending with an explicitly selected model whose authentication is unavailable. That check still follows the availability reported by the connected Gateway and is scoped to explicitly selected models.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Bring Android chat, sessions, the sidebar, and appearance closer to the browser workspace ([#134939](https://github.com/openclaw/openclaw/pull/134939)). Thanks @IWhatsskill, @obviyus.
+
+**Bug fixes**
+
+- Explain authentication problems before sending with an explicitly selected unavailable model ([#134884](https://github.com/openclaw/openclaw/pull/134884)). Thanks @fuller-stack-dev.
+- Keep drafts and chat controls readable on narrow or large-text layouts ([#135432](https://github.com/openclaw/openclaw/pull/135432)). Thanks @KangBumS.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Mermaid Diagrams Across Android, iOS, and macOS">
+
+Mermaid diagrams no longer have to be read as raw code in supported native chats. Android and iOS render completed diagrams inline with source, copy, retry, and expanded-preview controls, while macOS brings diagrams to both full chat and Quick Chat and keeps that window open while a larger preview is in use. Each app keeps readable source for streaming, invalid, oversized, or temporarily failed diagrams instead of replacing it with an empty box.
+
+Rendering stays local rather than depending on a network diagram service. Android offers a sharp full-screen view with zoom and pan, iOS adds an offline-capable vector preview with zoom, pan, and rotation, and macOS uses compact desktop controls with native Close and Escape behavior. The exact controls follow each platform rather than pretending the three implementations are identical.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Render Mermaid diagrams in Android chat with source, retry, and full-screen controls ([#135342](https://github.com/openclaw/openclaw/pull/135342)). Thanks @steipete.
+- Render Mermaid diagrams in iOS chat with an offline-capable vector preview ([#135470](https://github.com/openclaw/openclaw/pull/135470)). Thanks @steipete.
+- Localize Android Mermaid controls and recovery guidance across supported locales ([#135600](https://github.com/openclaw/openclaw/pull/135600)).
+- Render Mermaid diagrams in macOS full chat and Quick Chat while preserving equations and preview ownership ([#135746](https://github.com/openclaw/openclaw/pull/135746)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Reconnects, Retries, and Queued Messages">
+
+Android now keeps the replacement Gateway connection in charge while an older connection finishes shutting down, so retired cleanup is less likely to publish a false offline state or discard an accepted request outcome. Messages acknowledged after reconnect move past Sending, a new conversation remains selected for the next message, later queued sends keep moving, and a queued message you delete stays gone even if an older refresh finishes afterward.
+
+The same ownership cleanup reaches other native conversation paths. Apple chat can retry immediately after a session-settings failure, iPhone history refreshes reconcile a streamed reply with its canonical transcript row instead of leaving an older duplicate, and native session progress cards retain the selected agent and workspace context.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Make Retry Send available immediately after Apple session-settings failures ([#134752](https://github.com/openclaw/openclaw/pull/134752)).
+- Keep the selected agent and workspace on native session progress cards ([#135426](https://github.com/openclaw/openclaw/pull/135426)). Thanks @obviyus, @rwinkelman, @Synthetic2802.
+- Remove stale duplicate iPhone replies after history refresh or cache restore ([#135789](https://github.com/openclaw/openclaw/pull/135789)).
+- Keep replacement Android Gateway connections authoritative during reconnect cleanup ([#135878](https://github.com/openclaw/openclaw/pull/135878)).
+- Advance acknowledged Android messages beyond Sending after reconnect ([#135961](https://github.com/openclaw/openclaw/pull/135961)).
+- Keep new Android conversations selected and later queued sends moving ([#136078](https://github.com/openclaw/openclaw/pull/136078)).
+- Stop deleted Android queued messages from returning after a delayed refresh ([#136161](https://github.com/openclaw/openclaw/pull/136161)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Voice Ownership Across Native Apps">
+
+Talk and realtime voice now carry the acknowledged agent, run, and reply through the clients involved in the conversation, which keeps a consult on the intended agent, prevents an unrelated newer chat reply from being read back, and makes Stop target the work that actually started. Host cancellation is also reported as cancellation instead of a tool failure while the voice call remains open.
+
+On Apple Watch, dictated messages, spoken replies, playback, and retries remain attached to their original chat, and a spoken reply that outlasts the Watch’s wait points the user back to Chat on iPhone. Android offers an explicit voice-note recording path when on-device dictation is unavailable without discarding the draft, while macOS reuses a compatible speech recognizer, keeps the Talk overlay visible through a quick toggle, and packages the resources required by local MLX speech. The recognizer change removes one source of avoidable churn, but it does not establish that the broader open Apple speech-service memory report is fully fixed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep Voice Call sessions open when host work is cancelled and settle tool failures once ([#134924](https://github.com/openclaw/openclaw/pull/134924)).
+- Preserve the acknowledged agent and run across Talk consults, history, and Stop ([#135031](https://github.com/openclaw/openclaw/pull/135031)). Thanks @astra-openclaw.
+- Reuse compatible macOS speech recognizers across repeated voice captures ([#135401](https://github.com/openclaw/openclaw/pull/135401)). Thanks @Colton-Harris.
+- Package the resources required by local MLX speech on macOS ([#135592](https://github.com/openclaw/openclaw/pull/135592)).
+- Keep Apple Watch replies, playback, and retries with their original voice turn ([#135697](https://github.com/openclaw/openclaw/pull/135697)).
+- Preserve the macOS Talk overlay through quick toggles ([#135731](https://github.com/openclaw/openclaw/pull/135731)). Thanks @HuzaifaChaudary.
+- Explain when Apple Watch stops waiting to speak a reply ([#135765](https://github.com/openclaw/openclaw/pull/135765)).
+- Offer voice-note recording when Android dictation is unavailable without losing the draft ([#135794](https://github.com/openclaw/openclaw/pull/135794)). Thanks @RaviTharuma.
+- Keep iOS realtime voice consults attached to their own replies ([#135795](https://github.com/openclaw/openclaw/pull/135795)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Apple App Setup, Chat Controls, and Watch Authorization">
+
+macOS onboarding now brings failed AI setup, rejected-key details, and the retry action back into view instead of leaving someone stranded between setup and chat. Once inside chat, a cleaner two-row composer keeps context, model, effort, voice, send, attachment, branch, and verbosity controls reachable in narrow windows without duplicating model and usage details in the toolbar.
+
+iOS now explains whether a model choice changes the current session, the agent default, or the global default, and it blocks unavailable choices or permanent authentication failures before a live send while still allowing offline queueing and temporary cooldowns. Localization coverage catches more dynamic macOS text and newer Apple controls, while a revoked or replaced Watch connection can no longer receive another command or submit a late result through the retired connection.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Refresh localized native labels and correct the Hindi token-usage counter ([#134627](https://github.com/openclaw/openclaw/pull/134627)). Thanks @steipete.
+- Add supported-locales coverage for newer Apple model setup and status messages ([#135543](https://github.com/openclaw/openclaw/pull/135543)).
+- Keep essential macOS chat controls accessible in a cleaner narrow-window composer ([#135608](https://github.com/openclaw/openclaw/pull/135608)).
+
+**Bug fixes**
+
+- Reveal macOS onboarding failures and restore immediate setup retries ([#134756](https://github.com/openclaw/openclaw/pull/134756)).
+- Explain iOS model-selection scope and block unavailable authenticated sends ([#135044](https://github.com/openclaw/openclaw/pull/135044)). Thanks @fuller-stack-dev, @goslingmanagment.
+- Keep dynamic macOS text inside generated localization coverage ([#135511](https://github.com/openclaw/openclaw/pull/135511)).
+
+**Security and trust**
+
+- Stop revoked or replaced Watch connections from receiving work or returning late results ([#135904](https://github.com/openclaw/openclaw/pull/135904)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Desktop Setup and Remote Work">
+
+Fresh Linux desktop installs can again choose a Gateway on another computer before installing a local CLI, while local setup keeps its existing installer path. The desktop companion also receives a compatible local-discovery refresh, with its Windows updater deliberately held on the earlier version until an upstream cleanup conflict is resolved.
+
+Remote and supervised work recovers in a few narrower places as well. Paired-node Claude runs can fall back to the node’s native Claude login when forwarded credentials are blank, SSH worker desktops avoid Unix-socket failures caused by long temporary paths, and completed Windows worker turns close their owned state before removing the runtime directory so the slot can be reclaimed normally.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Refresh compatible desktop-companion dependencies and local discovery behavior ([#135557](https://github.com/openclaw/openclaw/pull/135557)). Thanks @steipete.
+
+**Bug fixes**
+
+- Close Windows worker state before removing its runtime directory ([#134911](https://github.com/openclaw/openclaw/pull/134911)).
+- Preserve native Claude login when paired-node credentials are blank ([#134932](https://github.com/openclaw/openclaw/pull/134932)). Thanks @rockytanf.
+- Keep SSH worker desktops working when the host temporary path is too long ([#135456](https://github.com/openclaw/openclaw/pull/135456)). Thanks @ly85206559.
+- Restore Linux first-run local and remote Gateway choices without requiring the CLI ([#135650](https://github.com/openclaw/openclaw/pull/135650)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Native Packaging and Background Helpers">
+
+Several less visible repairs keep the apps from failing around dependencies and helper processes. iOS development can resolve the available WebRTC 152 package again, Android refreshes camera, image, diagram, local-storage, and math-rendering foundations while preserving its existing database schemas and stored state, and the Licenses screen now includes the missing packaged notices.
+
+Background ownership is tighter too. Native Gateway invocations no longer report a timeout after the operation has already settled, private node workers exit after their owned cleanup even when stdin or a plugin child keeps the event loop active, and macOS helper pipes accept short readiness messages while retaining split or final diagnostics from MLX speech, SSH, node workers, computer control, and cookie sync.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report native Gateway timeouts only when the timeout actually wins ([#135287](https://github.com/openclaw/openclaw/pull/135287)). Thanks @steipete.
+- Refresh Android libraries and include missing packaged license notices ([#135563](https://github.com/openclaw/openclaw/pull/135563)).
+- Let private node workers exit after successful owned cleanup ([#135665](https://github.com/openclaw/openclaw/pull/135665)). Thanks @Colton-Harris, @obviyus.
+- Preserve Android stored state while updating Room and correct the highest valid Unicode input in KaTeX ([#135670](https://github.com/openclaw/openclaw/pull/135670)).
+- Keep macOS native helper reads bounded while preserving readiness and final diagnostics ([#136214](https://github.com/openclaw/openclaw/pull/136214)).
+
+**Limits and compatibility**
+
+- Move iOS builds to an available validated WebRTC 152 release ([#134942](https://github.com/openclaw/openclaw/pull/134942)).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Models and Providers
+
+Choosing a model should not be an exercise in wondering what else the click changed. [Model selection](/concepts/models) now tells you whether a choice is for this session, one agent, or the global default before it is saved, while provider logins and catalog changes flow into the model list without the ritual Gateway restart. This release also tightens the less visible part of that promise, so a temporary provider failure, a quiet Codex turn, or a disconnected node is much less likely to send work down the wrong route.
+
+<AccordionGroup>
+
+<Accordion title="Model Selection, Defaults, and Reasoning">
+
+The Control UI now gathers the main model, utility model, first fallback, thinking level, and Fast Mode in one autosaving Defaults card, with the scope of a model change shown before you make it. It preserves the rest of an ordered fallback chain when the first choice changes, and refuses to replace a working model when the required harness cannot be activated. The full fallback order still lives in the CLI, and the scope disclosure is currently a Control UI feature rather than a native-app picker feature.
+
+Reasoning choices now stay attached to the runtime that actually owns them. Eligible Sol and Terra turns keep Ultra through supported child-session boundaries, configured native Codex models show the effort levels their account advertises, and Luna remains capped at Max. Anthropic Fable 5.1 joins the shared API and Claude CLI catalogs, supported local Ollama routes remain selectable, and status views keep an authored context cap when a model runs through a provider alias.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Bring model defaults into one autosaving card ([#134813](https://github.com/openclaw/openclaw/pull/134813)). Thanks @Patrick-Erichsen.
+- Add Anthropic Fable 5.1 to shared model metadata ([#135638](https://github.com/openclaw/openclaw/pull/135638)).
+
+**Bug fixes**
+
+- Apply configured thinking mappings when a request omits `--thinking` ([#132697](https://github.com/openclaw/openclaw/pull/132697)). Thanks @wangjx-xydt, @nina-grech.
+- Show model-selection scope before saving ([#134473](https://github.com/openclaw/openclaw/pull/134473)). Thanks @fuller-stack-dev, @goslingmanagment, @Marvinthebored.
+- Keep the working selection when a model harness cannot activate ([#134837](https://github.com/openclaw/openclaw/pull/134837)). Thanks @steipete, @goslingmanagment.
+- Keep supported local Ollama routes selectable ([#135095](https://github.com/openclaw/openclaw/pull/135095)). Thanks @obviyus, @BoatAngle.
+- Preserve Ultra across runtimes and child sessions ([#135397](https://github.com/openclaw/openclaw/pull/135397)). Thanks @steipete.
+- Report configured context caps through provider aliases ([#135580](https://github.com/openclaw/openclaw/pull/135580)). Thanks @VACInc.
+- Restore advertised reasoning choices for configured native Codex models ([#136061](https://github.com/openclaw/openclaw/pull/136061)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Provider Accounts and Model Catalogs">
+
+Provider state is now much closer to what you actually configured. Model Provider settings stop counting unrelated web-search and extraction credentials as model accounts, externally authenticated OpenAI models remain visible without a second login, and compatible catalog updates survive both credential changes and hot reloads. A new provider login, a settings edit, or a compatible model change can refresh the inventory when it is next requested instead of leaving the old list in place until a restart.
+
+The recovery path is less mysterious too. OpenAI relogin can repair stale profile order, Doctor preserves custom-provider environment references instead of turning them into broken stored keys, forced login clears the credential owner it is meant to replace, and a changed provider priority reaches a running Gateway. Google and Vertex configuration can also restore their bundled provider plugin through restrictive allowlists, while read-only catalog work and GitHub Copilot authentication avoid loading discovery or agent-runtime work they cannot use.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Load GitHub Copilot provider authentication without the full agent runtime ([#134626](https://github.com/openclaw/openclaw/pull/134626)).
+
+**Bug fixes**
+
+- Keep tool-only credentials out of the model-provider inventory ([#134218](https://github.com/openclaw/openclaw/pull/134218)). Thanks @wantosure, @beastyrabbit.
+- Refresh the model catalog after provider login ([#134361](https://github.com/openclaw/openclaw/pull/134361)). Thanks @obviyus.
+- Retain refreshed credentials for matching custom agent directories ([#134862](https://github.com/openclaw/openclaw/pull/134862)). Thanks @Lendersmark.
+- Keep externally authenticated providers in model menus ([#135046](https://github.com/openclaw/openclaw/pull/135046)). Thanks @goslingmanagment.
+- Refresh model catalogs after credentials and settings change ([#135063](https://github.com/openclaw/openclaw/pull/135063)). Thanks @elikampf.
+- Show concise, redacted OAuth recovery errors in the Control UI ([#135112](https://github.com/openclaw/openclaw/pull/135112)). Thanks @shakkernerd.
+- Auto-enable configured Google and Vertex provider plugins ([#135239](https://github.com/openclaw/openclaw/pull/135239)). Thanks @Solvely-Colin.
+- Retain discovered models through compatible hot reloads ([#135353](https://github.com/openclaw/openclaw/pull/135353)). Thanks @goslingmanagment.
+- Repair stale OpenAI profile order after relogin ([#135355](https://github.com/openclaw/openclaw/pull/135355)). Thanks @obviyus, @mattcbianco.
+- Preserve custom-provider SecretRefs through Doctor repair ([#135357](https://github.com/openclaw/openclaw/pull/135357)). Thanks @obviyus, @dannevang.
+- Diagnose shared-auth relocation conflicts and clear forced-login owners ([#135739](https://github.com/openclaw/openclaw/pull/135739)). Thanks @Deregtx, @cksagente-dot.
+- Publish refreshed provider priority to a running Gateway ([#135847](https://github.com/openclaw/openclaw/pull/135847)). Thanks @josephbergvinson, @obviyus, @yetval.
+- Skip unused runtime discovery for read-only catalog queries ([#136020](https://github.com/openclaw/openclaw/pull/136020)). Thanks @609NFT, @LiuwqGit.
+- Recover setup and agent admission when a catalog owner is replaced (#127284) ([`bf599a7217`](https://github.com/openclaw/openclaw/commit/bf599a721784849e350c18ff703c9e75de939e0d)). Thanks @RomneyDa, @karkarl, @AndrewEAUS.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Provider Usage and Price Estimates">
+
+Provider status now has one genuinely useful addition for xAI users, with OAuth-authenticated SuperGrok accounts able to show usage, reset time, plan, and prepaid balance in the usual status surfaces when xAI supplies them. API-key billing remains a separate bucket. DeepInfra and Anthropic Vertex estimates also follow their current advertised and regional rates more closely, but these are OpenClaw estimates rather than a change to what either provider bills.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show SuperGrok usage for OAuth-authenticated xAI accounts ([#135766](https://github.com/openclaw/openclaw/pull/135766)). Thanks @steipete.
+
+**Bug fixes**
+
+- Refresh DeepInfra estimates from native pricing ([#134893](https://github.com/openclaw/openclaw/pull/134893)).
+- Keep Anthropic Vertex Sonnet 5 estimates on current regional rates ([#135761](https://github.com/openclaw/openclaw/pull/135761)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Model Retries and Fallbacks">
+
+Temporary provider failures now have one bounded retry owner, so a brief outage can recover quietly while a persistent one reaches the normal profile or model fallback path, or gives you an actionable error, within the retry window. A busy session stops after the first model candidate instead of making every fallback look broken, while hard Anthropic and Bedrock refusals stop immediately with revise-and-retry guidance rather than resending the request. Doctor can also remove a stale automatic OpenAI route without disturbing an intentional model choice.
+
+The recovery details matter just as much as the retry count. Affected llama.cpp context-limit failures can compact and retry, OpenAI Responses conversations keep compact continuation when tool lists or safely admitted large-integer arguments change, and pre-output transport failures can resume after completed tools without running them again. Provider and context diagnostics now survive more of these paths, while the official failover guide matches the controller that actually owns them.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Repair stale Doctor route pins without removing intentional choices ([#102180](https://github.com/openclaw/openclaw/pull/102180)). Thanks @849261680, @cpwilhelmi.
+- Keep context usage when Anthropic-compatible providers omit a cache counter ([#126473](https://github.com/openclaw/openclaw/pull/126473)). Thanks @ayaangazali, @Oliverbot26.
+- Preserve OpenAI Responses continuation when tool lists change ([#132951](https://github.com/openclaw/openclaw/pull/132951)). Thanks @hartmark.
+- Compact and retry current llama.cpp context-limit failures ([#133888](https://github.com/openclaw/openclaw/pull/133888)). Thanks @gokay-ai, @Areson.
+- Stop busy-session conflicts before cycling through fallbacks ([#134219](https://github.com/openclaw/openclaw/pull/134219)). Thanks @obviyus, @svdwalt007, @tzlwn1.
+- Give transient model failures one bounded retry controller ([#134281](https://github.com/openclaw/openclaw/pull/134281)). Thanks @obviyus.
+- Preserve OpenAI Responses continuation across admitted tool arguments ([#134423](https://github.com/openclaw/openclaw/pull/134423)). Thanks @hartmark.
+- Stop retries and fallbacks after hard Anthropic and Bedrock refusals ([#134980](https://github.com/openclaw/openclaw/pull/134980)). Thanks @Marvinthebored, @Peetiegonzalez, @obviyus.
+- Preserve safe provider details on failed chat events ([#135102](https://github.com/openclaw/openclaw/pull/135102)). Thanks @steipete.
+- Recover eligible pre-output transport failures without replaying completed tools ([#135105](https://github.com/openclaw/openclaw/pull/135105)).
+- Preserve the latest valid context reading from Anthropic-compatible proxies ([#135467](https://github.com/openclaw/openclaw/pull/135467)). Thanks @Yigtwxx.
+
+**Documentation**
+
+- Align failover guidance with the current retry controller ([#135374](https://github.com/openclaw/openclaw/pull/135374)). Thanks @Marvinthebored, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Codex and Claude CLI Work">
+
+Long-running Codex work no longer ends just because its progress is quiet, and finite time limits follow elapsed time without throwing away useful partial output. Idle Codex chats can resume while other chats and catalog reads share the same app server, and prompt-hook changes either take effect safely on the next persistent turn or stop before inference with a recovery path instead of silently keeping stale instructions.
+
+Claude CLI setup now works through supported mise and asdf shims, local Claude failures keep bounded credential-redacted diagnostics, and Claude CLI-backed utility models can produce digests, progress, and tool titles through the runtime that owns their authentication. Codex and CLI agents only offer remote shell execution when a connected node can actually run commands, existing broken harnesses explain which plugin needs attention, and the official plugin now aligns managed installs and checks on Codex 0.152.1. Claude Code session catalogs also avoid rescanning an unchanged projects tree on every poll, with the improvement depending on the size of the catalog, disk load, and watcher availability.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Align managed Codex installs and release checks on 0.152.1 ([#136184](https://github.com/openclaw/openclaw/pull/136184)). Thanks @steipete.
+- Reuse watched Claude Code catalog snapshots between polls ([#136222](https://github.com/openclaw/openclaw/pull/136222)). Thanks @giangthb.
+
+**Bug fixes**
+
+- Preserve admitted channel identity through Codex hooks and compaction ([#129402](https://github.com/openclaw/openclaw/pull/129402)). Thanks @ashawwal.
+- Keep late CLI output from crashing the Gateway after timeout ([#132582](https://github.com/openclaw/openclaw/pull/132582)). Thanks @TARSDrakon.
+- Stop interrupting active Codex turns during quiet native work ([#134755](https://github.com/openclaw/openclaw/pull/134755)). Thanks @obviyus, @ernestrolfson-design.
+- Avoid a redundant legacy model key after Claude CLI activation ([#134779](https://github.com/openclaw/openclaw/pull/134779)). Thanks @leilei3167, @obviyus, @aaajiao.
+- Retain credential-redacted diagnostics from failed Claude subprocesses ([#134794](https://github.com/openclaw/openclaw/pull/134794)).
+- Explain unavailable model harnesses and their recovery paths ([#135118](https://github.com/openclaw/openclaw/pull/135118)). Thanks @fuller-stack-dev, @goslingmanagment.
+- Let Claude CLI connect through supported PATH shims ([#135124](https://github.com/openclaw/openclaw/pull/135124)). Thanks @zhangguiping-xydt, @obviyus, @masatokawano.
+- Stop using stale instructions after Codex prompt-hook changes ([#135577](https://github.com/openclaw/openclaw/pull/135577)).
+- Route utility completions through the selected runtime ([#135711](https://github.com/openclaw/openclaw/pull/135711)). Thanks @goslingmanagment.
+- Hide Codex node execution when no capable node is connected ([#136000](https://github.com/openclaw/openclaw/pull/136000)).
+- Hide CLI remote execution when no executable node is connected ([#136067](https://github.com/openclaw/openclaw/pull/136067)).
+- Let idle Codex chats resume while unrelated chats keep running ([#136196](https://github.com/openclaw/openclaw/pull/136196)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Local and Self-Hosted Models">
+
+Self-hosted model routes now behave more like services OpenClaw can actually live with. Existing llama.cpp-compatible web apps can fall back to `/v1/models` when their root models endpoint serves HTML or unusable data, managed diagnostics stop reading oversized response bodies without a bound, and OpenClaw waits for managed local model processes to stop before finishing shutdown. The shutdown proof is scoped to Linux and systemd, and the discovery fallback was exercised at the provider boundary rather than as a complete Unsloth inference run.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Bound managed llama.cpp diagnostic responses ([#132490](https://github.com/openclaw/openclaw/pull/132490)). Thanks @RileyJJY, @steipete.
+- Stop managed local providers before Gateway shutdown completes ([#134890](https://github.com/openclaw/openclaw/pull/134890)). Thanks @MoerAI, @obviyus, @Deregtx.
+- Discover models behind llama.cpp-compatible web app endpoints ([#135445](https://github.com/openclaw/openclaw/pull/135445)). Thanks @gaoanze888, @Bloodis94.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Provider-Backed Tools">
+
+Provider choice now carries more cleanly into the tools around a conversation. Native Model Studio and Qwen routes honor prompt-cache retention, a selected web-fetch provider no longer trips over credentials for providers it never intended to use, and Local CLI speech generation follows the request timeout. Corrupted Volcengine speech responses fail clearly, while eligible OpenAI OAuth accounts can again transcribe inbound voice notes and configured batch audio without a separate API key. OAuth entitlement and quota are still account-specific, and custom Model Studio proxies remain opt-in for cache markers.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject corrupted text bytes in Volcengine TTS responses ([#134010](https://github.com/openclaw/openclaw/pull/134010)). Thanks @ZengWen-DT.
+- Honor Model Studio cache defaults and retention ([#135093](https://github.com/openclaw/openclaw/pull/135093)).
+- Apply request timeouts to Local CLI speech generation ([#135222](https://github.com/openclaw/openclaw/pull/135222)).
+- Resolve the selected web-fetch provider before unrelated credential checks ([#135504](https://github.com/openclaw/openclaw/pull/135504)).
+- Restore OpenAI OAuth audio transcription ([#135855](https://github.com/openclaw/openclaw/pull/135855)). Thanks @yungchentang, @kAIborg24.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Automations and Scheduling
+
+[Scheduled work](/automation/cron-jobs) now keeps more of its identity from creation through delivery. An automation can begin with the access somebody already configured, make it through a restart without quietly becoming a different job, and leave a result that is easier to find and understand afterward. Recurring work also gets a deliberate choice about missed jobs, while one-time jobs keep their separate recovery behavior.
+
+<AccordionGroup>
+
+<Accordion title="Creating Automations with Existing Access">
+
+Configured Codex app-server users can create app-backed automations through the authenticated connection they already use, without preparing a second OpenClaw profile or supplying a separate tool allowlist. Reauthenticating the same endpoint keeps the automation usable, while a removed endpoint, changed connection identity, unavailable plugin, or newly disallowed app or tool stops before app work and leaves an actionable recorded failure.
+
+Creation now also returns the resolved announcement route or the reason it failed closed before the job is saved, so an operator can fix delivery before trusting it. Integrations that call CronService directly can switch a job between command, script, and agent-turn payloads without inventing omitted optional fields, while malformed environments remain rejected.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Create app-backed automations with configured Codex app-server authentication ([#134525](https://github.com/openclaw/openclaw/pull/134525)). Thanks @sjf-oa.
+- Preserve optional fields when direct CronService callers change a job's payload kind ([#134639](https://github.com/openclaw/openclaw/pull/134639)). Thanks @solomonneas.
+- Show the resolved announcement route or fail-closed reason when an isolated job is created ([#135003](https://github.com/openclaw/openclaw/pull/135003)). Thanks @ericcaiwx-star, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="One-Time Schedules Through Restarts and Unusual Dates">
+
+One-time jobs keep their newer retry time when the Gateway restarts, and an immediate main-session job can still wake its selected agent when periodic heartbeats are disabled. Successful one-shot jobs configured for deletion are removed as expected rather than being left behind in a disabled state.
+
+Older schedules are handled more carefully too. Upgrades that have not yet completed the affected legacy migration preserve whether a job was enabled, malformed legacy rows are quarantined without preventing valid jobs from loading, and expanded-year one-time dates honor their selected time zone and display the correct year. The migration repair does not reconstruct enabled state for databases that already passed through the earlier faulty v13 path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve legacy automation enabled state while upgrading older databases ([#132868](https://github.com/openclaw/openclaw/pull/132868)). Thanks @CanReader, @obviyus.
+- Run immediate one-shot main-session jobs when periodic heartbeats are disabled ([#134648](https://github.com/openclaw/openclaw/pull/134648)). Thanks @sunlit-deng, @obviyus, @LowCode191.
+- Keep a one-time job's durable retry time through Gateway startup recovery ([#135083](https://github.com/openclaw/openclaw/pull/135083)). Thanks @rwinkelman, @obviyus, @meircohen.
+- Quarantine invalid legacy schedule rows without blocking valid jobs ([#135829](https://github.com/openclaw/openclaw/pull/135829)). Thanks @teddytennant, @obviyus.
+- Apply selected time zones and correct year display to expanded-year one-time dates ([#135973](https://github.com/openclaw/openclaw/pull/135973)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choosing What Happens to Missed Recurring Jobs">
+
+Operators who do not want stale reminders, digests, or model calls after downtime can enable `cron.skipMissedJobs: true`. On startup, OpenClaw advances overdue recurring schedules to their next future occurrence and saves that decision before normal scheduling resumes. The setting is opt-in, so leaving it unset or false preserves the existing catch-up behavior, and one-time jobs are not skipped.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add an opt-in setting to skip missed recurring jobs after downtime ([#135071](https://github.com/openclaw/openclaw/pull/135071)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Heartbeat Routes, Quiet Replies, and Deadlines">
+
+Scheduled agent work now keeps model aliases attached to the selected agent, and system-owned heartbeats can reach their configured provider after a clean Gateway restart by using the currently published runtime. Long or unlimited heartbeat runs honor the configured deadline instead of inheriting a fixed ten-minute cutoff, while destination-only wakes retain the rest of the configured heartbeat behavior.
+
+The delivery edges are quieter and more accurate as well. An explicit `NO_REPLY` after successful tool work stays silent, the first-alert explanation appears only on the first alert for an isolated default route, and bounded `agents_wait` calls keep their requested duration when the system clock moves forward or backward.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep scheduled model aliases scoped to the selected agent ([#135069](https://github.com/openclaw/openclaw/pull/135069)). Thanks @elikampf.
+- Measure `agents_wait` deadlines consistently through system clock changes ([#135292](https://github.com/openclaw/openclaw/pull/135292)). Thanks @qingminglong, @steipete.
+- Show the first-alert explanation once for isolated default routes ([#135849](https://github.com/openclaw/openclaw/pull/135849)). Thanks @obviyus, @rwinkelman, @virtexvirtuoso.
+- Preserve deliberate silent completion after scheduled tool work ([#135919](https://github.com/openclaw/openclaw/pull/135919)). Thanks @leilei3167, @obviyus, @Frank683456.
+- Honor configured finite and unlimited heartbeat deadlines ([#135925](https://github.com/openclaw/openclaw/pull/135925)). Thanks @xialonglee, @obviyus, @jaxonparrott.
+- Bind scheduled system heartbeats to the published runtime after restart ([#136256](https://github.com/openclaw/openclaw/pull/136256)). Thanks @obviyus, @Famyoff.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Automation Links, History, and Alerts">
+
+An Automations link now opens the intended job and highlighted run even when that job sits beyond the loaded page or outside the current agent filter, with a visible lookup error when it is no longer available. Session-restricted operators receive complete pages and accurate totals for the run history they are allowed to see, while large name-sorted job lists avoid repeating the same locale setup for every comparison.
+
+Schedule and history durations also keep all meaningful units across locales, and a settled failure alert appears as delivered, not delivered, or genuinely unknown in the live job view. Confirmed non-delivery retains a bounded redacted error and the existing in-app fallback, while immutable run-history entries remain unchanged.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse locale-aware comparison work within large name-sorted job lists ([#135597](https://github.com/openclaw/openclaw/pull/135597)).
+
+**Bug fixes**
+
+- Show complete duration quantities across localized schedules and run history ([#133224](https://github.com/openclaw/openclaw/pull/133224)).
+- Persist settled failure-alert outcomes in live automation status ([#135516](https://github.com/openclaw/openclaw/pull/135516)). Thanks @RayWangyangMa, @obviyus, @bassmediagroup.
+- Open linked jobs and highlighted runs beyond the loaded list or active filter ([#136012](https://github.com/openclaw/openclaw/pull/136012)). Thanks @steipete.
+- Page run history after applying existing session-visibility rules ([#136043](https://github.com/openclaw/openclaw/pull/136043)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Completed Automation Session Cleanup">
+
+Successful isolated jobs now release their run ownership before removing an unused continuation session, avoiding the stale row and misleading competing-work warning that could remain after completion. Generated-media jobs use the same ordering before the final Gateway response, with cleanup kept to the lifecycle that owns the run.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Remove unused isolated-job continuation sessions after successful completion ([#135155](https://github.com/openclaw/openclaw/pull/135155)). Thanks @brettdaman, @obviyus.
+- Clean up generated-media run sessions before the final Gateway response ([#135517](https://github.com/openclaw/openclaw/pull/135517)). Thanks @jmewing, @obviyus, @goslingmanagment, @giangthb.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Disabling Managed Scheduled Backups">
+
+`openclaw backup disable` can find the managed backup after its schedule has been renamed or moved beyond the first 200 jobs in a larger automation inventory. It follows the schedule's stable declaration identity, so an unrelated automation with the same name is left alone.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Find managed backup schedules by stable identity across renames and complete inventories ([#136133](https://github.com/openclaw/openclaw/pull/136133)).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Browser and Computer Use
+
+Browser control is more predictable from the first local screenshot to an attached Chrome tab or a remote desktop. Standalone agents can reach the local browser without borrowing Gateway credentials, selected tabs keep valid commands through ordinary group changes, paired-machine actions report where they ran, and Chrome MCP endpoint checks happen before a connection begins.
+
+<AccordionGroup>
+
+<Accordion title="Local Browser Runs and Screenshots">
+
+Standalone agents with the `browser` tool enabled now default to the local browser when no Gateway or node route was selected. Viewport, full-page, and element screenshots capture through the page session that owns the current device settings, preserving mobile scale and touch behavior, while an interrupted Chromium capture returns a recovery error instead of leaving later screenshots or resizes stuck.
+
+That host-first default is an intentional change for unpinned standalone runs. Anyone who relied on implicit browser-node discovery should select `auto` or an explicit node, and full-page capture after pinch zoom remains a Chromium edge case. Malformed form-fill requests also stop before changing the page and identify the unsupported field instead of silently accepting only part of the request.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reject unsupported browser form fields before changing the page ([#131400](https://github.com/openclaw/openclaw/pull/131400)). Thanks @LiuwqGit, @obviyus, @srb11e.
+- Route standalone agents to the local browser and return complete, recoverable screenshots ([#135315](https://github.com/openclaw/openclaw/pull/135315)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Selected Chrome Tabs and Existing Sessions">
+
+Selected-tab automation now keeps newly admitted commands valid while older group lookups finish and while a new tab goes through normal group setup. Genuine access changes still revoke stale work, restored access can recover, and a tab created during a relay disconnect is cleaned up instead of being left behind.
+
+Existing-session attachments now use the reviewed Chrome DevTools MCP 1.8.0 release rather than following a moving `latest` tag. Custom launch commands remain operator-managed, while offline hosts need that exact package cached or an operator-provided executable.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve selected-tab commands when an older group lookup finishes late ([#135186](https://github.com/openclaw/openclaw/pull/135186)).
+- Keep new Chrome tabs authorized through ordinary group setup and clean up interrupted creations ([#135210](https://github.com/openclaw/openclaw/pull/135210)).
+- Pin default existing-session attachments to the reviewed Chrome MCP release ([#136121](https://github.com/openclaw/openclaw/pull/136121)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Paired Computers and Remote Desktops">
+
+Commands sent to paired nodes now consider only connected machines that can actually execute them. OpenClaw selects a node automatically only when one eligible target remains, asks for an explicit choice when several qualify, and includes the effective node in successful, failed, and timed-out results instead of silently redirecting work to the wrong computer.
+
+Computer input is more faithful to what the agent and user can see. Successful typing and key actions on paired macOS Peekaboo nodes report success after the action occurs, screenshot-grounded clicks share one bounded frame across unusual capture shapes, smaller-Mac Settings can resize and scroll, and multiline WebVNC text keeps its line breaks. Windows remote-desktop handoff retains the authenticated TightVNC viewer until its replacement is ready, while large macOS CUA Computer responses use less temporary memory without changing the existing response limit or setup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce temporary memory pressure for large macOS CUA Computer responses ([#135094](https://github.com/openclaw/openclaw/pull/135094)).
+
+**Bug fixes**
+
+- Report completed macOS typing and key actions as successful ([#134689](https://github.com/openclaw/openclaw/pull/134689)). Thanks @gaoanze888, @wbstrbt.
+- Keep the authenticated Windows desktop viewer during control handoff ([#134903](https://github.com/openclaw/openclaw/pull/134903)).
+- Align desktop actions with their screenshots and improve small-screen Settings and WebVNC text entry ([#135582](https://github.com/openclaw/openclaw/pull/135582)).
+
+**Security and trust**
+
+- Select only capable execution nodes, require a choice when several qualify, and report the target ([#131767](https://github.com/openclaw/openclaw/pull/131767)). Thanks @vyctorbrzezowski.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Browser Policy and Private Talk Context">
+
+Custom Chrome MCP endpoint arguments now pass through the same hostname policy as the endpoint OpenClaw will actually use, before a subprocess or network connection begins. Unsafe, malformed, empty, duplicate, or conflicting arguments fail clearly without echoing credential-bearing URLs, while trusted overrides and host-local attachment continue to work.
+
+New Browser Talk conversations also keep the internal consultation question, context, and speaking instructions out of later model turns while preserving genuine speech, assistant results, and lossless exports. Existing unflagged records are not rewritten, and the separate decision about how a consultation answer should be presented remains open.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep new Browser Talk consultation prompts out of later model context ([#135423](https://github.com/openclaw/openclaw/pull/135423)). Thanks @Conan-Scott.
+- Apply hostname policy to the effective Chrome MCP endpoint before connecting ([#135857](https://github.com/openclaw/openclaw/pull/135857)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Search Dates and Presented Browser Output">
+
+Brave and Tavily search results now preserve valid absolute publication dates in the existing `published` field, helping freshness-sensitive work distinguish when a source was published without treating relative ages, fetch times, arbitrary text, or search filters as publication dates.
+
+Agents also receive clearer guidance for presenting a widget, dashboard, portal, or separate browser preview. The guidance keeps token-bearing launch links private, uses the presentation surface that is actually available, and says when an interaction was not verified. This changes how existing tools are described and selected, not what they can render or which tools are available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve valid Brave and Tavily publication dates for freshness-sensitive searches ([#136017](https://github.com/openclaw/openclaw/pull/136017)). Thanks @rogerallen1.
+- Distinguish widgets, dashboards, portals, and browser previews while keeping launch links private ([#136195](https://github.com/openclaw/openclaw/pull/136195)).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Plugins and Integrations
+
+Plugins now behave more like installed software that stays under the operator's control. Updates preserve reviewed state, managed provider removals remain removed after restart, channel setup follows the agent that was actually selected, and the integrations around them do a better job of keeping credentials, errors, and cleanup inside the right boundary.
+
+<AccordionGroup>
+
+<Accordion title="Plugin State Through Installs and Updates">
+
+Verified first-party plugins can move through installation, updates, re-enablement, and Doctor repair without stopping for a capability prompt that OpenClaw can already resolve from matching catalog, package, and source identity. That exception remains deliberately narrow, so local artifacts, third-party packages, custom registries, and conflicting or incomplete provenance still require explicit review.
+
+Older installs also behave more predictably. Capability acceptance is saved against the replacement artifact during a legacy update, reinstalling a deliberately disabled plugin leaves it disabled until the operator enables it, and registry or inventory reads no longer mistake build-only metadata for a changed plugin. Catalog work does less repeated processing, bundle capabilities remain visible in JSON and verbose inventory, and complete POSIX source builds keep their external plugin dependencies after the checkout moves.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse prepared plugin catalog details across management actions ([#135260](https://github.com/openclaw/openclaw/pull/135260)).
+
+**Bug fixes**
+
+- Save accepted capabilities when updating an enabled legacy plugin ([#134172](https://github.com/openclaw/openclaw/pull/134172)). Thanks @RileyJJY, @beastyrabbit.
+- Ignore build-only stamps when deciding whether the plugin registry is fresh ([#134780](https://github.com/openclaw/openclaw/pull/134780)). Thanks @RayWangyangMa, @obviyus, @axiom-ncis.
+- Preserve bundle capabilities in JSON and verbose plugin inventory ([#135245](https://github.com/openclaw/openclaw/pull/135245)). Thanks @ssaade01, @tayoun.
+- Keep external plugin dependencies valid after relocating a complete POSIX source build ([#135903](https://github.com/openclaw/openclaw/pull/135903)).
+
+**Security and trust**
+
+- Bypass capability consent only for catalog-verified first-party plugins ([#134933](https://github.com/openclaw/openclaw/pull/134933)).
+
+**Documentation**
+
+- Clarify that reinstalling a disabled plugin does not enable it ([#134875](https://github.com/openclaw/openclaw/pull/134875)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Uninstalling and Repairing Plugins">
+
+Uninstalling a managed provider plugin now means it stays uninstalled after the Gateway restarts, even when an old model, provider, or channel choice still refers to it. Reinstalling later does not silently reactivate it, so the final enable step remains an explicit operator choice.
+
+The recovery paths around removal are safer too. Exact orphaned path-source records can be cleaned up through the normal CLI instead of by editing OpenClaw state, another plugin's channel configuration is preserved during that cleanup, and versionless scoped ClawHub packages produce the expected warning when existing Claws still depend on them. Malformed archive names no longer derail staging, while updated 1Password guidance explains how to recover after Homebrew moves the `op` executable without pinning another disposable path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover exact orphan plugin records through normal update and uninstall commands ([#134590](https://github.com/openclaw/openclaw/pull/134590)). Thanks @MoerAI, @obviyus, @abacha.
+- Preserve another plugin's channel settings during orphan cleanup ([#134759](https://github.com/openclaw/openclaw/pull/134759)). Thanks @steipete, @MoerAI, @abacha.
+- Keep explicitly uninstalled managed provider plugins removed after restart ([#135729](https://github.com/openclaw/openclaw/pull/135729)). Thanks @devzeroLL, @obviyus.
+- Warn before removing scoped ClawHub plugins that still support existing Claws ([#135749](https://github.com/openclaw/openclaw/pull/135749)). Thanks @teddytennant, @obviyus.
+- Give malformed ClawHub archive names a safe temporary target ([#135803](https://github.com/openclaw/openclaw/pull/135803)). Thanks @teddytennant.
+
+**Documentation**
+
+- Explain recovery after Homebrew changes a 1Password CLI path ([#134832](https://github.com/openclaw/openclaw/pull/134832)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Channel Setup for the Selected Agent">
+
+Multi-agent operators can select the intended agent for channel add, channel-specific capabilities, login, logout, remove, and resolve, with that workspace retained while OpenClaw discovers, installs, or reloads the channel plugin. The existing System Agent, sole-agent, and legacy-owner rules still apply when no selector is supplied, while ambiguous or invalid ownership stops before authentication or setup begins.
+
+Channel status also stops advertising accounts that were explicitly disabled, and Twitch's outbound setup error now names the real `accessToken` setting. The separate Twitch connection-time diagnostic still needs the same wording correction.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Hide explicitly disabled manifest accounts from channel capabilities and status ([#135417](https://github.com/openclaw/openclaw/pull/135417)). Thanks @ly85206559.
+- Name Twitch's `accessToken` setting in outbound setup errors ([#135421](https://github.com/openclaw/openclaw/pull/135421)). Thanks @ly85206559.
+- Preserve the selected agent across channel setup and plugin discovery ([#135505](https://github.com/openclaw/openclaw/pull/135505)). Thanks @abacha, @Hansen1018.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Personal GitHub Accounts and Authenticated Dashboards">
+
+People sharing a Gateway can connect their own GitHub account from Profile and explicitly choose it for Publish PR without replacing the System account or an agent account. Publication remains bound to the signed-in owner, selected connection, authorized session, and accepted worktree state, and an uncertain publication can be confirmed by that same owner after a restart. This does not replace ordinary shell credentials or turn a personal publication connection into a general GitHub identity for agent commands.
+
+Gateway-hosted commands that use a managed GitHub profile stay with the credential selected at process launch. If that profile disappears or loses its token, later commands stop with reconnect guidance instead of falling back to a native account, while already running commands retain their launch credential. Dashboards can read GitHub Actions through a repository-scoped grant and the owning agent's authenticated access without exposing a token or creating a general authenticated proxy; existing anonymous widgets need to be updated or regenerated, and Publish PR credential checks may remain cached for up to 60 seconds.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Connect personal GitHub accounts alongside System and agent accounts ([#133799](https://github.com/openclaw/openclaw/pull/133799)). Thanks @steipete.
+- Reuse recent successful credential checks in the Publish PR account chooser ([#136223](https://github.com/openclaw/openclaw/pull/136223)).
+
+**Bug fixes**
+
+- Show GitHub connection failures once in Profile settings ([#135428](https://github.com/openclaw/openclaw/pull/135428)). Thanks @steipete.
+- Replace dashboard widget records instead of returning stale props ([#135748](https://github.com/openclaw/openclaw/pull/135748)). Thanks @teddytennant, @obviyus.
+
+**Security and trust**
+
+- Stop managed GitHub exec from falling back to a native account ([#134351](https://github.com/openclaw/openclaw/pull/134351)).
+- Read GitHub Actions through the owning agent's bounded repository grant ([#135740](https://github.com/openclaw/openclaw/pull/135740)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="WhatsApp, QQ Bot, and Weixin Plugin Updates">
+
+Source-built Docker images now include the WhatsApp runtime when it is explicitly selected, rather than accepting the choice and producing an image without the channel. Existing QQ Bot installs recorded under the former `@openclaw/qqbot` package can move to `@tencent-connect/openclaw-qqbot` 2.0.3 while preserving channel configuration and credentials, with failed updates leaving the working legacy record in place.
+
+Catalog-driven Weixin installs now select the SDK-compatible 2.4.8 package, and affected 2.4.6 operators have explicit update and restart guidance. The evidence verifies package selection, integrity, and compatibility rather than an authenticated Weixin message roundtrip.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Package the explicitly selected WhatsApp runtime in Docker source builds ([#120660](https://github.com/openclaw/openclaw/pull/120660)). Thanks @fr-meyer.
+- Migrate trusted legacy QQ Bot installs to the renamed official package ([#130894](https://github.com/openclaw/openclaw/pull/130894)). Thanks @cxyhhhhh.
+- Select the Weixin package compatible with the current Plugin SDK ([#134854](https://github.com/openclaw/openclaw/pull/134854)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Voice Call Setup and Feishu Document Results">
+
+Voice Call setup now catches a missing response owner before telephony resources start on a multi-agent installation and points directly to `plugins.entries.voice-call.config.agentId`. Single-agent and explicitly owned setups keep their existing behavior, while affected multi-agent operators need to rerun setup and restart the Gateway after choosing the owner.
+
+Voice Call diagnostic commands now stream large custom logs with backpressure, follow rotation and truncation more carefully, and honor whether SQLite history should start with retained records or only new ones. Feishu document actions also stop counting rejected access grants or image replacements as successes, while retaining a document that was created successfully and continuing with later images after one replacement fails.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report missing Voice Call ownership during multi-agent setup ([#134739](https://github.com/openclaw/openclaw/pull/134739)). Thanks @felixboenkost-droid.
+- Stream Voice Call diagnostics with backpressure and correct history handling ([#134838](https://github.com/openclaw/openclaw/pull/134838)). Thanks @sunlit-deng.
+- Validate Feishu access grants and image replacements before reporting success ([#135106](https://github.com/openclaw/openclaw/pull/135106)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Plugin Startup and Shutdown">
+
+Optional command implementations for memory-wiki, policy, QA Lab, and Voice Call now load only when their command is selected, while bundled web-search providers keep executable runtime code unloaded until OpenClaw chooses one. Activation planning reuses prepared alias work as well, but those component improvements do not establish a universal or end-to-end Gateway startup speedup.
+
+When a plugin does fail, retries preserve the original actionable load error instead of making a rejected module graph appear to recover through a fallback. SQLite-backed plugin state keeps its bounded WAL retry through wall-clock changes, loads that finish after shutdown begins are retired, and interrupted service startup shares one cleanup result so a stop handler is not called twice for the same attempt.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse plugin alias resolution during activation planning ([#134812](https://github.com/openclaw/openclaw/pull/134812)).
+- Defer bundled web-search provider runtimes until a provider is selected ([#135073](https://github.com/openclaw/openclaw/pull/135073)).
+
+**Bug fixes**
+
+- Delay optional plugin CLI implementations until their commands are invoked ([#133105](https://github.com/openclaw/openclaw/pull/133105)). Thanks @ly85206559.
+- Preserve the original plugin load error across retries ([#134874](https://github.com/openclaw/openclaw/pull/134874)). Thanks @0xCyda, @Lendersmark.
+- Keep Plugin SDK SQLite WAL retries bounded across wall-clock changes ([#135019](https://github.com/openclaw/openclaw/pull/135019)). Thanks @xialonglee, @obviyus.
+- Retire plugin loads that complete after Gateway shutdown begins ([#135122](https://github.com/openclaw/openclaw/pull/135122)). Thanks @elikampf.
+- Run an interrupted plugin service's stop handler once per startup attempt ([#135993](https://github.com/openclaw/openclaw/pull/135993)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Plugin SDK Compatibility and Session APIs">
+
+External plugins built against the 2026.8.1 SDK keep their conversation-binding inspection import, and accepted legacy `docks` commands remain reachable under Tools after upgrade. Plugin authors also gain a supported facade for the same node CLI helpers OpenClaw uses, while source plugins can load `.mtsx` and `.ctsx` configured-state or persisted-auth checkers without falsely reporting that state as absent.
+
+Strict single-message and atomic-batch transcript appends can once again omit the documented optional `storePath` and resolve the selected agent's configured or default store. Explicit-environment integrations can create and reopen non-main incognito sessions without replacing the process environment, with incognito data remaining memory-only. Corrected migration guidance separates public SDK exports, retained compatibility imports, injected alternatives, and compatibility deadlines without claiming new runtime exports.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Publish supported node CLI helpers for plugin authors and Canvas ([#135303](https://github.com/openclaw/openclaw/pull/135303)).
+
+**Bug fixes**
+
+- Preserve external plugin inspection imports and legacy command definitions through upgrade ([#135322](https://github.com/openclaw/openclaw/pull/135322)). Thanks @steipete.
+- Load `.mtsx` and `.ctsx` source-plugin state checkers ([#135820](https://github.com/openclaw/openclaw/pull/135820)). Thanks @steipete.
+- Resolve the optional store path for strict transcript appends ([#136201](https://github.com/openclaw/openclaw/pull/136201)).
+- Keep explicit environments attached to incognito session creation ([#136227](https://github.com/openclaw/openclaw/pull/136227)).
+
+**Documentation**
+
+- Correct Plugin SDK migration paths and compatibility deadline guidance ([#136024](https://github.com/openclaw/openclaw/pull/136024)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="OAuth MCP Servers with Strict Request Sizing">
+
+OpenClaw can connect to OAuth-enabled Streamable HTTP and SSE MCP servers that reject POST requests without a known size, including through `openclaw mcp probe`. The initial authenticated request and one token-refresh retry now reuse the same sized payload while changing only the bearer authorization. This does not fix the separate in-Gateway path that can send an unexpanded bearer-token placeholder.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Send OAuth MCP requests with a known request size across token refresh ([#136234](https://github.com/openclaw/openclaw/pull/136234)). Thanks @LiuwqGit, @obviyus, @Volevanius.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Plugins Hub Accessibility and Polish">
+
+ClawHub search now tells screen-reader users when a search finishes and how many results it found, while preserving the visible layout and stale-result protection. Read-only operators see one permissions warning instead of a duplicate page alert, and blocked actions can explain themselves through focus, hover, or tap without attempting a mutation.
+
+First-party catalog entries use artwork already bundled with OpenClaw when it is available, avoiding fallback letter tiles and unnecessary remote icon requests when the CDN is blocked, while third-party artwork retains the authenticated proxy path. The Workshop tab also lines up with the shared Plugins content column on wide screens without changing its narrow layout.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Announce ClawHub search completion and result counts to assistive technology ([#133091](https://github.com/openclaw/openclaw/pull/133091)). Thanks @SunnyShu0925.
+- Replace the duplicate plugin admin warning with explanations on blocked actions ([#134860](https://github.com/openclaw/openclaw/pull/134860)). Thanks @Patrick-Erichsen.
+- Use bundled artwork for trusted scoped first-party plugin icons ([#135957](https://github.com/openclaw/openclaw/pull/135957)). Thanks @obviyus, @Grynn.
+- Align Plugins Workshop with the shared content column for #134871 ([`61404b6c2a`](https://github.com/openclaw/openclaw/commit/61404b6c2a91871b2a4f5819ca98b06a90077796)). Thanks @Patrick-Erichsen.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Security and Privacy
+
+OpenClaw can now remember an eligible approval without turning it into blanket permission. Durable MCP grants remain tied to one agent, configured server, and tool, remote Codex placement grants remain tied to the process and placement that earned them, and stricter session or server policy still wins. The same boundary now follows delegated agent creation more carefully, while private diagnostics, saved reasoning, network requests, guest workspaces, and administrative automation each get narrower protections of their own.
+
+<AccordionGroup>
+
+<Accordion title="Scoped Durable Approvals">
+
+Codex now follows the effective session posture when deciding whether an MCP tool needs approval, so a default full-permission session can use an unannotated tool without stopping for a permission card on every call. Stricter postures and explicit server overrides still apply, and Allow Always follows the tool across argument and working-directory changes for the current session. For an eligible MCP tool on an OpenClaw-configured server, that choice can also become a durable grant for the exact agent, server, and tool across later sessions and Gateway restarts; Codex apps, native plugin servers, computer-use servers, explicit `prompt` mode, and ambiguous matches remain outside it.
+
+Remote Codex placement approvals use a narrower lifetime. Allow Always can be reused while the same placement, pairing, environment, workspace, parent approval, and Gateway process remain valid, but a restart, move, re-pairing, authority change, or expiry requires a fresh decision. Approval lifetimes entered through the CLI must now be whole positive days within the existing range, so malformed input leaves the approval pending instead of silently choosing a different duration.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse Allow Always for the same active remote Codex placement ([#132370](https://github.com/openclaw/openclaw/pull/132370)). Thanks @jalehman.
+- Persist eligible MCP tool grants across Codex sessions and Gateway restarts ([#136019](https://github.com/openclaw/openclaw/pull/136019)).
+
+**Bug fixes**
+
+- Reject malformed approval grant lifetimes without resolving the approval ([#133806](https://github.com/openclaw/openclaw/pull/133806)). Thanks @qingminglong.
+- Follow the Codex session posture and honor Allow Always across tool inputs ([#135812](https://github.com/openclaw/openclaw/pull/135812)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Delegated Agent Authority">
+
+Delegated agent creation now keeps checking the authority of the run that requested it through workspace, identity, session, and configuration writes. If that run ends while creation is still being prepared, OpenClaw stops before starting the next persistent effect instead of finishing later and reporting success for a request that is no longer authorized. Users can check `openclaw agents list` and retry from an active run.
+
+The boundary is forward-looking rather than destructive. A filesystem write that already started may finish, a fully published agent remains available, and its required bookkeeping can complete rather than leaving partial state behind.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Stop delegated agent creation after the requesting run loses authority ([#136090](https://github.com/openclaw/openclaw/pull/136090)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Guest Coding Inside Private Workspaces">
+
+Sandbox-required guests can once again write files, patch code, run project-local commands, and delegate work inside a private workspace with `workspaceAccess` set to `none`. The shared agent workspace and host credentials remain outside that boundary, managed skill overlays remain read-only, an explicit `ro` workspace remains read-only, and networking stays off unless an operator enables it.
+
+Existing containers are recreated once to adopt the new mount format. Public cloning and dependency downloads still need operator-enabled networking, and arbitrary shell enforcement on a remote host still depends on that remote operator's filesystem policy.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Restore writable guest coding and delegated work inside private isolated workspaces ([#135702](https://github.com/openclaw/openclaw/pull/135702)). Thanks @whyuds.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Private Data in Diagnostics">
+
+Doctor now compares the selected state directory only with the effective account's default, avoiding sibling home-directory paths and unrelated backup warnings on shared systems. If a targeted session import or restore cannot archive a transcript, its durable migration record keeps useful failure details and the original recovery source while masking secret-shaped values; iOS agent deep links omit the complete incoming URL from diagnostics, and configuration responses redact credentials, SecretRef identifiers, and internal plugin metadata from pre-migration snapshots.
+
+These protections are scoped to the named Doctor, iOS, and configuration-response paths. Snapshot redaction does not change stored configuration or migration inputs, and it does not repair the separate startup or runtime corruption symptoms that were not reproduced by the configuration fix.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep sibling account paths out of Doctor state-directory checks ([#122586](https://github.com/openclaw/openclaw/pull/122586)). Thanks @vincentkoc, @lidge-jun, @richard-scott.
+- Redact secret-shaped values from durable Doctor archive failures ([#122628](https://github.com/openclaw/openclaw/pull/122628)). Thanks @sunlit-deng, @obviyus.
+- Omit iOS agent deep-link URLs from diagnostic logs ([#134738](https://github.com/openclaw/openclaw/pull/134738)). Thanks @eleqtrizit.
+- Redact pre-migration configuration snapshots returned by diagnostics ([#134940](https://github.com/openclaw/openclaw/pull/134940)). Thanks @joemc1470.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Saved Codex Reasoning">
+
+Newly recorded Codex dashboard turns now keep reasoning as typed thinking instead of mirroring it into ordinary answer text. Saved reasoning appears under **Worked** only when the session explicitly uses `/reasoning on` and the local **View → Reasoning** control is enabled, while `off` and `stream` keep it hidden after reload without hiding the final answer.
+
+Previously malformed transcript rows are not rewritten. This change is also limited to saved Codex reasoning in the Control UI and does not resolve separate provider or channel-streaming leakage reports.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep newly saved Codex reasoning hidden until it is explicitly enabled ([#136008](https://github.com/openclaw/openclaw/pull/136008)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Network Destinations and Azure BYOK Requests">
+
+Operators can now deny selected destinations across browser access, guarded web fetches, and automation webhooks without maintaining a complete allowlist. Exact hostnames and wildcard subdomains are rejected before DNS resolution and before allow or private-network exceptions, while an absent or empty blocklist leaves existing behavior unchanged. This is a destination policy rather than a complete browser egress firewall, a wildcard does not cover its apex host, and supported Chrome MCP endpoints supplied only through `mcpArgs` remain outside the shipped hostname check.
+
+Azure OpenAI BYOK traffic through the Copilot extension also gains a separate request boundary. Each local proxy receives a fresh credential, verifies it before accepting request-body data, and removes it before forwarding upstream, while configured provider headers and the existing non-Azure nonce path remain intact. The Azure path relies on header forwarding verified for the shipped Copilot SDK version.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add hostname blocklists to browser, web-fetch, and automation-webhook policies ([#135097](https://github.com/openclaw/openclaw/pull/135097)).
+
+**Security and trust**
+
+- Authenticate Azure OpenAI BYOK proxy requests from active Copilot sessions ([#134781](https://github.com/openclaw/openclaw/pull/134781)). Thanks @eleqtrizit.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Scoped Sign-In and Device Tokens">
+
+GitHub-backed Cloudflare Access and Tailscale sign-in can use the Gateway's existing GitHub credential for public profile verification, reducing failures caused by the anonymous API quota. Named operator roles are still admitted only after identity is verified, and an unavailable verification service now produces an accurate retryable error instead of opening a session with no usable scope.
+
+Authorized operators can also rotate or revoke approved scoped node tokens through `openclaw devices`. The operation cannot add a role or widen the approved scope baseline, under-scoped callers remain blocked, and operator-token operations with broader stored scopes may still require a broader authenticated connection.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep GitHub-backed named-role sign-in scoped through profile verification ([#134724](https://github.com/openclaw/openclaw/pull/134724)).
+- Restore authorized rotation and revocation of approved scoped node tokens ([#135617](https://github.com/openclaw/openclaw/pull/135617)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Configuration and Secrets Automation">
+
+Automation can now guard one direct `config set` operation with an expectation that the current value is absent or exactly matches supplied JSON. A mismatch writes nothing, reveals neither value, and leaves the existing final snapshot guard in place for later races. The expectation does not apply to batch or dry-run mode, redirected SecretRef writes, or roster updates.
+
+Secrets commands using `--json` now return one parseable document on success or failure across reload, audit, configure, apply, and store list or get operations. Human-readable output and documented exit codes remain unchanged, and this is an output-contract repair rather than a change to secret contents, storage, or security policy.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add compare-and-set expectations to direct configuration updates ([#136137](https://github.com/openclaw/openclaw/pull/136137)). Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Keep Secrets CLI JSON failures machine-readable ([#136142](https://github.com/openclaw/openclaw/pull/136142)). Thanks @qingminglong, @obviyus.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Quality-of-Life Improvements
+
+OpenClaw spends less time repeating work you never asked it to do. Long conversations and concurrent replies use less CPU and memory in the measured workloads, large installations give health checks and session views more room to respond, and routine starts, commands, files, worktrees, logs, and remote checks shed a long tail of avoidable overhead.
+
+<AccordionGroup>
+
+<Accordion title="Long Conversations and Concurrent Replies">
+
+Large conversations no longer drag as much unrelated history through every nearby task. Resets read only the navigation data they need, session inspection walks backward without copying the history, and ordinary turns avoid several unnecessary session reads, which leaves more room for the conversation itself.
+
+The streaming path also does less work as replies grow. Concurrent long replies reuse their prepared text instead of repeatedly rebuilding it, producing substantially lower CPU and memory use in the tested workloads while preserving tool ordering, corrections, reply targeting, and final media. These measurements cover the built-in runtime on defined local workloads rather than model-provider latency.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Prepare agent turns with lighter session reads ([#134814](https://github.com/openclaw/openclaw/pull/134814)). Thanks @steipete.
+- Scan long session histories without copying them ([#134930](https://github.com/openclaw/openclaw/pull/134930)). Thanks @steipete.
+- Reduce overhead for concurrent streaming replies ([#135751](https://github.com/openclaw/openclaw/pull/135751)).
+- Reduce CPU work for concurrent final-answer streams ([#136041](https://github.com/openclaw/openclaw/pull/136041)).
+- Reduce CPU and memory use while several long replies stream ([#136180](https://github.com/openclaw/openclaw/pull/136180)).
+
+**Bug fixes**
+
+- Reduce memory spikes in model catalogs, conversation resets, and code-heavy chats ([#134722](https://github.com/openclaw/openclaw/pull/134722)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Code Mode with Less Repeated Work">
+
+Repeated Code Mode work can reuse bounded warm workers and look up only the requested session, cutting preparation and CPU work once those workers are warm. Snapshot buffers also move between tool calls without another storage-format copy. The warm pools can retain materially more process memory, so this improves the measured Code Mode workloads without establishing a general Gateway capacity or throughput gain.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reuse warm Code Mode workers and perform exact session lookups ([#134935](https://github.com/openclaw/openclaw/pull/134935)).
+- Transfer Code Mode snapshots without storage-format copies ([#135040](https://github.com/openclaw/openclaw/pull/135040)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Large Installation Health and Session Views">
+
+Gateways with large agent rosters now reuse prepared roster, model, and workspace facts during one startup batch, which lets real HTTP health checks answer again instead of leaving a listening socket that never becomes useful. Other fleet startup costs can still produce noticeable post-listen delays, but the repeated discovery work covered here is gone.
+
+Installations with large saved-session histories also keep less conversation data in memory and do far less work to count or list sessions, while read-only diagnostics stay out of SQLite's writer lifecycle. Retained Control UI assets use less memory on constrained ARM64 hosts as well, improving headroom in the tested 768 MiB and 1 GiB setups, though 512 MiB without swap can still fail when status work overlaps startup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Retain less Gateway and Activity memory with large session histories ([#134891](https://github.com/openclaw/openclaw/pull/134891)). Thanks @petercheng.
+- Keep HTTP health checks responsive while large agent rosters start ([#135773](https://github.com/openclaw/openclaw/pull/135773)). Thanks @LiuwqGit, @609NFT, @obviyus.
+- Keep large session listings lightweight and fresh after equal-timestamp edits ([#135976](https://github.com/openclaw/openclaw/pull/135976)).
+- Keep read-only diagnostics out of SQLite writer state ([#136010](https://github.com/openclaw/openclaw/pull/136010)). Thanks @obviyus, @Grynn.
+- Bound retained Control UI asset memory on constrained hosts ([#136108](https://github.com/openclaw/openclaw/pull/136108)). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Startup and Command Overhead">
+
+Common startup paths now load less optional code and reuse more work they have already verified. Gateway readiness avoids repeated Doctor and plugin-metadata preparation, ordinary shell commands defer model review and follow-up delivery until those paths are actually needed, and concurrent first turns share one workspace Git setup. Approval, elevation, cancellation, and delivery rules stay where they were.
+
+Everyday command feedback is less surprising too. A temporary login-shell failure can recover on a later lookup without restarting the Gateway, `/agents` takes one coherent view of the subagent registry, automatic TTS leaves routine command output as text, zsh completion keeps examples literal, and strict-JSON errors point to the safer file-backed patch workflow.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce repeated Gateway startup and configuration work ([#134807](https://github.com/openclaw/openclaw/pull/134807)).
+- Remove redundant payload from npm installations ([#135478](https://github.com/openclaw/openclaw/pull/135478)). Thanks @steipete.
+- Load optional exec review and follow-up paths only when needed ([#136124](https://github.com/openclaw/openclaw/pull/136124)). Thanks @steipete.
+- Reuse verified plugin metadata during foreground Gateway startup ([#136141](https://github.com/openclaw/openclaw/pull/136141)). Thanks @steipete.
+- Load optional Control UI styles with the surfaces that use them ([#136186](https://github.com/openclaw/openclaw/pull/136186)). Thanks @steipete.
+
+**Bug fixes**
+
+- Retry environment and command discovery after a transient login-shell failure ([#125378](https://github.com/openclaw/openclaw/pull/125378)). Thanks @qdivan.
+- Bound oversized telemetry update responses without replacing valid cached state ([#132492](https://github.com/openclaw/openclaw/pull/132492)). Thanks @RileyJJY.
+- Share workspace Git setup across concurrent first turns ([#134537](https://github.com/openclaw/openclaw/pull/134537)).
+- Keep `/agents` status on one coherent registry snapshot ([#134677](https://github.com/openclaw/openclaw/pull/134677)). Thanks @vincentkoc.
+- Keep routine terminal command replies out of automatic TTS ([#134802](https://github.com/openclaw/openclaw/pull/134802)). Thanks @najef1979-code.
+- Preserve literal examples in zsh completion descriptions ([#135114](https://github.com/openclaw/openclaw/pull/135114)). Thanks @walker1211.
+- Point strict-JSON parse failures to the file-backed patch workflow ([#135203](https://github.com/openclaw/openclaw/pull/135203)). Thanks @SunnyShu0925.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Managed Worktrees on Other Storage">
+
+Managed worktrees can now live on another chosen disk or folder without moving the rest of OpenClaw's state, and existing worktrees keep using the locations already recorded for them. This release first raised the shared checkout target to 100, then removed the hard admission ceiling entirely, so sufficient disk space governs new worktrees and restores while 100 remains the automatic cleanup target. Manual and protected worktrees keep their existing safeguards.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add a global storage root for new managed worktrees ([#134872](https://github.com/openclaw/openclaw/pull/134872)).
+- Raise the shared managed-worktree target to 100 ([#135885](https://github.com/openclaw/openclaw/pull/135885)).
+
+**Bug fixes**
+
+- Use available disk space instead of checkout count for new worktree admission ([#135989](https://github.com/openclaw/openclaw/pull/135989)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Project Directories for Local Agents">
+
+Local agents can work directly in an existing project directory while their instructions and memory remain in OpenClaw's managed workspace. Existing setups keep their old behavior unless a separate directory is configured, session-created and paired-agent directories still take precedence, and the split-directory option is limited to unsandboxed runs.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Let local agents work in a configured project directory ([#135080](https://github.com/openclaw/openclaw/pull/135080)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Conversation Branches and Session Continuity">
+
+Supervised Codex Chats can use **Fork from here** on newer canonical messages, retain the native conversation history through a Gateway restart, and open the chosen input as an unsent draft without changing the source conversation. Descendant forks and paginated `/btw` side questions retain that native lineage as well.
+
+Underneath that workflow, nested session writes remain ordered, malformed cyclic ancestry returns bounded context instead of hanging, and a stale local CLI recovery attempt can no longer replace a newer session. Older canonical messages without recorded native provenance remain outside the new fork path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep native history when supervised Codex Chats fork canonical messages ([#134660](https://github.com/openclaw/openclaw/pull/134660)). Thanks @kevin2966n.
+
+**Bug fixes**
+
+- Keep nested session writes in their expected order ([#131456](https://github.com/openclaw/openclaw/pull/131456)). Thanks @gaoanze888, @Grynn.
+- Return bounded context for cyclic session ancestry ([#131567](https://github.com/openclaw/openclaw/pull/131567)). Thanks @igs-rogenlo.
+- Stop stale local CLI recovery from replacing a newer session ([#135168](https://github.com/openclaw/openclaw/pull/135168)). Thanks @mushuiyu886, @obviyus.
+
+**Limits and compatibility**
+
+- Canonical-message forks require recorded native provenance and were accepted locally on macOS, not across every managed Desktop, Windows, crash, or multiwriter path.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Large Files, Terminal Output, and Logs">
+
+Large downloads, generated media, multipart uploads, and command results now avoid several full-size temporary copies while preserving the same bytes, limits, timeouts, and error details. Terminal replay evicts old buffered output in one pass, and very long styled or Unicode lines reach their existing width limit with much less temporary work.
+
+Logging follows the same theme. Text loggers reuse stable formatting, JSON console output skips work it does not need, completed payloads are released as slow writes finish, and `console.trace()` keeps one readable redacted stack instead of producing a duplicate error record.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Avoid duplicate allocations while reading large HTTP response bodies ([#134954](https://github.com/openclaw/openclaw/pull/134954)).
+- Reuse owned response buffers for speech and generated media ([#135014](https://github.com/openclaw/openclaw/pull/135014)).
+- Avoid full-size intermediate copies for supported multipart uploads ([#135162](https://github.com/openclaw/openclaw/pull/135162)).
+- Decode large command output without another byte copy ([#135189](https://github.com/openclaw/openclaw/pull/135189)). Thanks @steipete.
+- Truncate long terminal text with less temporary memory and latency ([#135918](https://github.com/openclaw/openclaw/pull/135918)).
+- Skip unused formatting work for large console logs ([#136028](https://github.com/openclaw/openclaw/pull/136028)).
+
+**Bug fixes**
+
+- Keep terminal replay responsive during bulk buffered-output eviction ([#135183](https://github.com/openclaw/openclaw/pull/135183)).
+- Reuse console styles without crashing on inherited subsystem names ([#135932](https://github.com/openclaw/openclaw/pull/135932)). Thanks @steipete.
+- Release completed log payloads while slow writes continue ([#136030](https://github.com/openclaw/openclaw/pull/136030)). Thanks @steipete.
+- Preserve redacted trace stacks without duplicate file-log errors ([#136066](https://github.com/openclaw/openclaw/pull/136066)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Remote Gateway Timing and Cleanup">
+
+Remote Gateway and paired-node operations now hold their timing and cleanup boundaries through clock changes, suspend, cancellation, and concurrent shutdown. Node wake retries use elapsed time, stale presence expires in the intended order, and an SSH-backed probe does not call itself stopped until its child process and forwarded port are gone. Remote health output also uses the Gateway's own ages, avoiding misleading status when the two machines' clocks disagree.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep node wake retries and reconnect waits correct through clock changes ([#133354](https://github.com/openclaw/openclaw/pull/133354)). Thanks @qingminglong.
+- Wait for SSH tunnel processes to exit before stop returns ([#133847](https://github.com/openclaw/openclaw/pull/133847)). Thanks @aniruddhaadak80.
+- Expire stale Gateway presence correctly after clock rollback or suspend ([#134737](https://github.com/openclaw/openclaw/pull/134737)). Thanks @lzhan011, @obviyus.
+- Cancel interrupted SSH-backed probes and release their forwarded ports ([#135182](https://github.com/openclaw/openclaw/pull/135182)). Thanks @aniruddhaadak80, @obviyus.
+- Show Gateway-relative ages and cleaner heartbeat details in remote status ([#136093](https://github.com/openclaw/openclaw/pull/136093)). Thanks @jeffrey4341.
+
+**Documentation**
+
+- Explain that node approvals live on the paired-device record ([#122726](https://github.com/openclaw/openclaw/pull/122726)). Thanks @191612731-cloud, @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Background Work and Conversation Concurrency">
+
+Removed or replaced sessions no longer leave an obsolete observer scheduling utility-model work that cannot be saved. A subagent settlement wake that reaches its deadline also cancels the exact accepted run and releases the requester's single-concurrency lane, letting later messages continue instead of piling up behind stale retries. That cancellation is scoped to settlement wakes and the shared direct-announcement deadline path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop obsolete session observers from scheduling work they cannot persist ([#133220](https://github.com/openclaw/openclaw/pull/133220)). Thanks @SunnyShu0925, @ruel225.
+- Release requester sessions after a subagent settlement wake times out ([#135854](https://github.com/openclaw/openclaw/pull/135854)). Thanks @obviyus, @nikolascostello, @pengzh1.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Documentation for Existing Paths">
+
+Several places where the product already had a working route but the documentation did not make it obvious are now clearer. Supported `/login` aliases, SecretRef defaults, TaskFlow audit warnings, uv-managed Python execution, and dead-letter recovery commands are documented where people look for them, retired pages lead to current migration guidance, and the Lite Mode Showcase link reaches the actual skill. Translation handling is less likely to strand localized pages on protected placeholders, while the expanded v2026.8.2 page is easier to navigate by topic and remains historical documentation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Show the supported `/login` aliases in the command reference ([#118045](https://github.com/openclaw/openclaw/pull/118045)). Thanks @AAliKKhan.
+- Point the Showcase Lite Mode card to the published skill ([#120645](https://github.com/openclaw/openclaw/pull/120645)). Thanks @firepinn.
+- Explain the built-in default aliases for environment and store SecretRefs ([#122730](https://github.com/openclaw/openclaw/pull/122730)). Thanks @191612731-cloud, @fujixm5.
+- Explain the TaskFlow timestamp warning and which audit codes apply ([#124672](https://github.com/openclaw/openclaw/pull/124672)). Thanks @qingminglong.
+- Document uv-managed Python environments for exec ([#129930](https://github.com/openclaw/openclaw/pull/129930)). Thanks @ralphptorres.
+- List channel dead-letter inspection and resubmission commands in the CLI index ([#134711](https://github.com/openclaw/openclaw/pull/134711)). Thanks @qingminglong.
+- Redirect retired pages to maintained migration guidance ([#134712](https://github.com/openclaw/openclaw/pull/134712)).
+- Keep protected placeholders from stalling documentation translation ([#134934](https://github.com/openclaw/openclaw/pull/134934)). Thanks @steipete.
+- Expand the historical v2026.8.2 release page with topic and source detail ([#135805](https://github.com/openclaw/openclaw/pull/135805)). Thanks @hannesrudolph.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Other Bug Fixes
+
+The smaller fixes in this release are easier to understand when they stay attached to the place you actually notice them. Sessions now keep interrupted requests and finished child work attached to the right run, attachments hold on to their real text and type, command-line tools stop on ambiguous targets, and status, logs, remote connections, and channel-specific edges report what actually happened instead of quietly substituting a plausible answer.
+
+<AccordionGroup>
+
+<Accordion title="Interrupted Sessions and Child Work">
+
+Interrupted work now keeps its shape through restart and cleanup. A user message interrupted by a Gateway restart remains in later model context, cloud-session cleanup failures stay visible and retryable without discarding accepted workspace changes, and retried agent or CLI commands remain attached to the process tree that actually owns their cancellation, output, and diagnostics.
+
+Child work also settles more cleanly. Completion-required CLI-backed results resume after the parent yields without replaying an already delivered result, a successful child with no final message can finish quietly, and a rejected requester wake no longer retries forever. Catalog-backed sessions retain the runtime they were created with, ordinary wait deadlines are no longer mislabeled as Gateway shutdown, and simultaneous session starts avoid repeating the same Git preparation work.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Avoid duplicate Git preparation during concurrent session starts ([#134912](https://github.com/openclaw/openclaw/pull/134912)).
+- Resume completion-required CLI child results after a parent yields ([#134974](https://github.com/openclaw/openclaw/pull/134974)). Thanks @VACInc, @aoclaw-glitch.
+- Keep the selected catalog runtime through session creation ([#135048](https://github.com/openclaw/openclaw/pull/135048)).
+- Keep cloud sessions stopped and make cleanup failures retryable ([#135583](https://github.com/openclaw/openclaw/pull/135583)).
+- Distinguish ordinary wait deadlines from Gateway shutdown ([#135797](https://github.com/openclaw/openclaw/pull/135797)).
+- Let successful subagents with no final message finish quietly ([#135846](https://github.com/openclaw/openclaw/pull/135846)). Thanks @jakestenger, @louisfy, @obviyus.
+- Preserve an interrupted user message through Gateway restart recovery ([#136023](https://github.com/openclaw/openclaw/pull/136023)). Thanks @leilei3167, @obviyus, @yetval.
+- Stop rejected subagent requester wakes from retrying forever ([#136033](https://github.com/openclaw/openclaw/pull/136033)). Thanks @obviyus, @Grynn.
+- Keep command retries bound to the correct lifecycle and output activity ([#136053](https://github.com/openclaw/openclaw/pull/136053)). Thanks @steipete.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Agent Runs and Tool Results">
+
+Long-running work gives the agent more useful signals before it goes off course. A background command tells Code Mode how to poll for its eventual output, early tool-loop warnings reach the model before the blocking threshold, completed fallback reports stop delegated work from launching again on the covered CLI path, and cleanup can finish even when plugin setup fails.
+
+The result is easier to trust as well. Chat `/bash` replies show the real exit code or signal, successful PDF and image analysis remains available to Code Mode and Tool Search, nested calls retire stale terminal summaries after the accepted result settles, and explicit multi-agent fleets use the selected agent for status and diagnostics instead of requiring an unrelated System Agent owner.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Stop CLI fallback completion reports from launching delegated work again ([#115405](https://github.com/openclaw/openclaw/pull/115405)). Thanks @MertBasar0.
+- Tell background commands how to retrieve their eventual output ([#132756](https://github.com/openclaw/openclaw/pull/132756)). Thanks @sashankh, @shad0wca7.
+- Show real failure codes and signals for chat `/bash` commands ([#133414](https://github.com/openclaw/openclaw/pull/133414)). Thanks @MoerAI.
+- Retain successful PDF and image analysis in Code Mode and Tool Search ([#135037](https://github.com/openclaw/openclaw/pull/135037)).
+- Finish subagent cleanup when plugin setup fails ([#135098](https://github.com/openclaw/openclaw/pull/135098)).
+- Show tool-loop warnings to the agent before blocking ([#135103](https://github.com/openclaw/openclaw/pull/135103)). Thanks @steipete.
+- Finalize nested Tool Search summaries and release stale presentation state ([#135398](https://github.com/openclaw/openclaw/pull/135398)).
+- Use explicitly selected agents for fleet status and diagnostics ([#135447](https://github.com/openclaw/openclaw/pull/135447)). Thanks @Hansen1018, @abacha.
+
+**Security and trust**
+
+- Compact Code Mode and Tool Search paths still have an unresolved review concern around wrapping newly visible media-analysis text as untrusted content.
+
+**Limits and compatibility**
+
+- Background-command guidance is only the producer-side part of the reported wait problem, and the fallback delegation gate does not cover the explicitly excluded primary CLI, subscription-auth orchestrator, or peer-conversation paths.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Attachments and Conversation Media">
+
+Attachments now arrive with their identity intact across several awkward boundaries. Paths ending in dot segments fall back to a usable name, long UTF-8 text remains recognizable when a character crosses the inspection boundary, streamed files keep a type and extension that match the saved bytes, and inferred legacy text keeps accents, currency symbols, and other non-ASCII characters. Rejected URL downloads also release their transport promptly, while repeatedly changing one conversation avatar no longer pushes other current avatars out of the cache.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Release superseded avatar data without evicting other current avatars ([#134978](https://github.com/openclaw/openclaw/pull/134978)).
+- Keep usable attachment names when path metadata ends in dot segments ([#135135](https://github.com/openclaw/openclaw/pull/135135)). Thanks @arpe1618.
+- Recognize UTF-8 text when a character crosses the attachment inspection boundary ([#135227](https://github.com/openclaw/openclaw/pull/135227)).
+- Preserve the correct type and extension for streamed attachments ([#135232](https://github.com/openclaw/openclaw/pull/135232)).
+- Preserve inferred text encoding and release rejected downloads promptly ([#135928](https://github.com/openclaw/openclaw/pull/135928)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="CLI Automation and Target Selection">
+
+Command-line automation now fails without guessing. MCP read commands return the normal JSON failure document on early errors, `agent exec` preserves the original run failure and exit code when cleanup also fails, and Windows command lookup ignores empty `PATHEXT` entries instead of treating an extensionless file as runnable.
+
+Explicitly blank session, store, and dead-letter account selectors now stop before OpenClaw can fall back to a default target. Omitting those selectors still keeps the existing default behavior, so scripts can choose between a deliberate default and an explicit target without an empty variable quietly changing what the command touches.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Return the standard JSON failure document from MCP read commands ([#132379](https://github.com/openclaw/openclaw/pull/132379)). Thanks @wangmiao0668000666.
+- Reject blank agent session selectors before dispatch ([#134797](https://github.com/openclaw/openclaw/pull/134797)). Thanks @marmar9615-cloud.
+- Preserve the original `agent exec` failure when cleanup also fails ([#135273](https://github.com/openclaw/openclaw/pull/135273)). Thanks @SebTardif.
+- Reject a blank session-store selector instead of choosing the default store ([#135742](https://github.com/openclaw/openclaw/pull/135742)). Thanks @marmar9615-cloud, @obviyus.
+- Ignore empty `PATHEXT` entries during Windows command lookup ([#135807](https://github.com/openclaw/openclaw/pull/135807)). Thanks @teddytennant.
+- Reject blank dead-letter account selectors instead of choosing the default account ([#135848](https://github.com/openclaw/openclaw/pull/135848)). Thanks @masatohoshino, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Status, Logs, and Diagnostics">
+
+Status and logs now make a problem visible without overstating what is healthy. Detailed status reports show inbound queue pressure and dead letters even when channel connectivity looks fine, usage requests reject unsupported fixed offsets instead of returning totals for the wrong day, and Telegram and TUI status retain known context usage after tool-only turns.
+
+The same principle carries through troubleshooting. Rolling log tails read the file OpenClaw is currently writing, session-observer warnings show a redacted cause instead of an empty object, failover counters agree across console and structured logs, and failed search or Git snapshot diagnostics explain what was lost while keeping sensitive values out of persisted output. Plugin validation reports every genuinely missing field in one pass, tool-policy warnings stop recommending grants that an active deny would block, and native PR quota failures once again include safe manual retry guidance for both observed GraphQL variants while failed SSH tunnel startup cleans up its readiness work.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report every missing plugin configuration field with accurate dependency guidance ([#93842](https://github.com/openclaw/openclaw/pull/93842)). Thanks @bladin.
+- Reject invalid fixed UTC offsets in usage date requests ([#124568](https://github.com/openclaw/openclaw/pull/124568)). Thanks @zyw02.
+- Explain when failed search diagnostics discarded earlier error output ([#132627](https://github.com/openclaw/openclaw/pull/132627)). Thanks @Alix-007, @gustav-bliss.
+- Keep context usage visible after tool-only turns ([#134634](https://github.com/openclaw/openclaw/pull/134634)). Thanks @goslingmanagment, @dmsrg399.
+- Show delivery-queue pressure and dead letters in detailed status reports ([#134889](https://github.com/openclaw/openclaw/pull/134889)). Thanks @Lendersmark.
+- Show the redacted cause of session-observer failures ([#135337](https://github.com/openclaw/openclaw/pull/135337)). Thanks @LiuwqGit, @Cobblestone-Digital1.
+- Tail the active file when logging uses a configured rolling path ([#135769](https://github.com/openclaw/openclaw/pull/135769)).
+- Keep failover counters current in console diagnostics ([#135844](https://github.com/openclaw/openclaw/pull/135844)).
+- Restore GitHub quota retry guidance and clean up failed SSH tunnel startup ([#135873](https://github.com/openclaw/openclaw/pull/135873)).
+
+**Security and trust**
+
+- Stop tool-profile warnings from recommending grants blocked by active policy ([#132623](https://github.com/openclaw/openclaw/pull/132623)). Thanks @sunlit-deng, @shbernal, @SuperMarioYL.
+- Preserve useful Git snapshot failure details while redacting sensitive values ([#135455](https://github.com/openclaw/openclaw/pull/135455)). Thanks @ly85206559, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Connected Device and Remote Gateway State">
+
+Remote and connected setups now hold on to the state they actually observed. SSH tunnel startup keeps its configured listener timeout even if the system clock changes, node age filters use the Gateway's latest recorded connection time, and the Devices roster keeps the genuine Gateway visible while remaining bounded under peer pressure and hostname collisions. At the HTTP edge, clients that explicitly reject HTML receive the existing startup or not-found response instead of an unwanted app shell, while ordinary browser navigation keeps working as before.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Respect explicit HTML rejection in Gateway content negotiation ([#118197](https://github.com/openclaw/openclaw/pull/118197)). Thanks @peterolkhov.
+- Keep the genuine Gateway visible in a bounded Devices roster ([#134740](https://github.com/openclaw/openclaw/pull/134740)). Thanks @lzhan011.
+- Keep SSH tunnel listener timeouts stable across system clock changes ([#135281](https://github.com/openclaw/openclaw/pull/135281)). Thanks @xialonglee.
+- Keep recently connected nodes inside CLI age filters ([#135936](https://github.com/openclaw/openclaw/pull/135936)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Channel Commands and Relay Ordering">
+
+Two narrower channel fixes remove behavior that depended on the wrong condition. Native `/compact` now gives an explicit authorization refusal without starting compaction work when the sender is not allowed to use it, while Buzz applies stable event ordering when profile or room updates share a timestamp instead of letting arrival order decide which state wins.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Return an explicit refusal for unauthorized native `/compact` commands ([#131408](https://github.com/openclaw/openclaw/pull/131408)). Thanks @igs-rogenlo.
+
+**Bug fixes**
+
+- Resolve equal-timestamp Buzz profile and room updates deterministically ([#134861](https://github.com/openclaw/openclaw/pull/134861)). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Maintainer and Internal Changes
+
+This release includes 415 maintainer-only units covering the machinery behind how OpenClaw is tested, reviewed, built, translated, packaged, and released. They tighten the evidence we rely on, remove duplicated internal work, and keep tooling failures from looking like successful validation, but they do not add a separate user workflow and should not be read as public product claims.
+
+<AccordionGroup>
+
+<Accordion title="CI and test reliability">
+
+CI and focused test work now exposes skipped, crashed, mistimed, or incompletely cleaned validation more clearly, while reusing safe fixtures and build inputs to shorten maintainer feedback without changing product behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Use Windows-safe workspace skill fixtures ([#132199](https://github.com/openclaw/openclaw/pull/132199)). Thanks @africoding, @aniruddhaadak80, @Patrick-Erichsen.
+- Wait for checkout fixtures to finish cleanup ([#133897](https://github.com/openclaw/openclaw/pull/133897)). Thanks @RomneyDa.
+- Share setup and declaration work ([#134593](https://github.com/openclaw/openclaw/pull/134593)).
+- Reduce packaging checks for native Swift test edits ([#134793](https://github.com/openclaw/openclaw/pull/134793)).
+- Adopt a lightweight producer metadata fixture ([#134809](https://github.com/openclaw/openclaw/pull/134809)).
+- Start long Mac CI work earlier across partitioned jobs ([#134847](https://github.com/openclaw/openclaw/pull/134847)). Thanks @vincentkoc.
+- Trim command-test jobs and omit unused runtime builds ([#135039](https://github.com/openclaw/openclaw/pull/135039)).
+- Serve avatar fixtures without screenshot capture ([#135101](https://github.com/openclaw/openclaw/pull/135101)).
+- Execute Swift release builds and tests in parallel ([#135108](https://github.com/openclaw/openclaw/pull/135108)).
+- Reduce hard-link archive fixture races ([#135165](https://github.com/openclaw/openclaw/pull/135165)).
+- Give source-launching command tests their own CI lane ([#135170](https://github.com/openclaw/openclaw/pull/135170)). Thanks @steipete.
+- Separate artifact writers while verification runs in parallel ([#135226](https://github.com/openclaw/openclaw/pull/135226)). Thanks @steipete.
+- Retain compiler caches across helper checkouts ([#135269](https://github.com/openclaw/openclaw/pull/135269)).
+- Tie shard timings to test membership ([#135288](https://github.com/openclaw/openclaw/pull/135288)).
+- Split lint work while sharing native SDK declarations ([#135302](https://github.com/openclaw/openclaw/pull/135302)).
+- Trim preflight and rebalance isolated CI tooling ([#135440](https://github.com/openclaw/openclaw/pull/135440)).
+- Limit declaration caches to generator inputs ([#135559](https://github.com/openclaw/openclaw/pull/135559)).
+- Rebalance shard weights without raising runner limits ([#135585](https://github.com/openclaw/openclaw/pull/135585)).
+- Retain exact unit selection for CI ([#135772](https://github.com/openclaw/openclaw/pull/135772)).
+- Preserve split test families in separate jobs ([#135816](https://github.com/openclaw/openclaw/pull/135816)).
+- Populate transform caches during test collection ([#135875](https://github.com/openclaw/openclaw/pull/135875)).
+- Reduce waiting for delegated approval expiry ([#135891](https://github.com/openclaw/openclaw/pull/135891)).
+- Normalize installer fixtures for changed-file release lint ([`d3deb20a78`](https://github.com/openclaw/openclaw/commit/d3deb20a78e3c4c10997d9df022500e6799f52fa)).
+- Add regression coverage for stale one-shot delivery retention ([#131691](https://github.com/openclaw/openclaw/pull/131691)). Thanks @LiuwqGit, @steipete.
+- Verify model selection through image-tool execution ([#134536](https://github.com/openclaw/openclaw/pull/134536)).
+- Drop redundant registration coverage ([#134548](https://github.com/openclaw/openclaw/pull/134548)).
+- Drop duplicate task detail reset case ([#134637](https://github.com/openclaw/openclaw/pull/134637)).
+- Centralize title-retention disk fixtures across isolated readers ([#134642](https://github.com/openclaw/openclaw/pull/134642)).
+- Run sender-role coverage through the real Tlon monitor ([#134646](https://github.com/openclaw/openclaw/pull/134646)). Thanks @steipete.
+- Coordinate Reef inbox entry and wait for cleanup ([#134652](https://github.com/openclaw/openclaw/pull/134652)). Thanks @steipete.
+- Wait directly for Raft bridge startup ([#134656](https://github.com/openclaw/openclaw/pull/134656)).
+- Centralize bounded response fixtures and remove duplicate coverage ([#134661](https://github.com/openclaw/openclaw/pull/134661)).
+- Set pointer state before testing submenu highlight clearing ([#134669](https://github.com/openclaw/openclaw/pull/134669)). Thanks @steipete.
+- Wait for WebSocket receive callbacks directly ([#134671](https://github.com/openclaw/openclaw/pull/134671)).
+- Drop duplicate thinking normalization case ([#134674](https://github.com/openclaw/openclaw/pull/134674)). Thanks @steipete.
+- Initialize pairing diagnostics once for the Doctor suite ([#134675](https://github.com/openclaw/openclaw/pull/134675)).
+- Bypass file setup for supplied playback probes ([#134676](https://github.com/openclaw/openclaw/pull/134676)).
+- Coordinate macOS worker backpressure without timing races ([#134702](https://github.com/openclaw/openclaw/pull/134702)). Thanks @steipete.
+- Share the dev-branch filesystem fixture ([#134707](https://github.com/openclaw/openclaw/pull/134707)).
+- Share startup owners across each suite ([#134720](https://github.com/openclaw/openclaw/pull/134720)).
+- Share immutable native-host fixtures ([#134728](https://github.com/openclaw/openclaw/pull/134728)).
+- Centralize Rastermill metadata setup ([#134733](https://github.com/openclaw/openclaw/pull/134733)).
+- Limit Windows encoding module resets ([#134747](https://github.com/openclaw/openclaw/pull/134747)).
+- Coordinate provider property probes without sleep delays ([#134754](https://github.com/openclaw/openclaw/pull/134754)).
+- Share QA facade graphs within suites ([#134763](https://github.com/openclaw/openclaw/pull/134763)). Thanks @steipete.
+- Share the native extension loader owner ([#134792](https://github.com/openclaw/openclaw/pull/134792)). Thanks @steipete.
+- Share immutable registry fixture archives ([#134804](https://github.com/openclaw/openclaw/pull/134804)).
+- Give one owner to Vitest include selection ([#134805](https://github.com/openclaw/openclaw/pull/134805)). Thanks @vincentkoc.
+- Unify startup parser CLI coverage ([#134811](https://github.com/openclaw/openclaw/pull/134811)). Thanks @steipete.
+- Share the Gmail diagnostics module graph ([#134825](https://github.com/openclaw/openclaw/pull/134825)).
+- Bypass discarded native fixture copies ([#134840](https://github.com/openclaw/openclaw/pull/134840)).
+- Streamline retry and timeout fixtures ([#134852](https://github.com/openclaw/openclaw/pull/134852)).
+- Make pending-disable coverage wait for macOS shutdown ([#134856](https://github.com/openclaw/openclaw/pull/134856)). Thanks @vincentkoc.
+- Give WhatsApp auth fixtures owned cleanup and remove duplicates ([#134863](https://github.com/openclaw/openclaw/pull/134863)).
+- Drop redundant provider catalog setup ([#134881](https://github.com/openclaw/openclaw/pull/134881)).
+- Use scoped clocks for channel ingress polling tests ([#134885](https://github.com/openclaw/openclaw/pull/134885)).
+- Unify duplicate transport coverage ([#134894](https://github.com/openclaw/openclaw/pull/134894)).
+- Coordinate concurrent Foundry token refreshes without sleeps ([#134909](https://github.com/openclaw/openclaw/pull/134909)).
+- Share SSH upload fixtures and await child startup ([#134928](https://github.com/openclaw/openclaw/pull/134928)).
+- Wait for ask_user RPC startup without polling ([#134936](https://github.com/openclaw/openclaw/pull/134936)).
+- Source suite types from their canonical declarations ([#134948](https://github.com/openclaw/openclaw/pull/134948)).
+- Share canonical terminal fixture promise helpers ([#134949](https://github.com/openclaw/openclaw/pull/134949)).
+- Give oc-path CLI fixtures owned setup and cleanup ([#134961](https://github.com/openclaw/openclaw/pull/134961)).
+- Drop copied store and own state fixture cleanup ([#134973](https://github.com/openclaw/openclaw/pull/134973)).
+- Share setup across Google Meet CLI output cases ([#134981](https://github.com/openclaw/openclaw/pull/134981)).
+- Share sealed payload across corruption cases ([#134986](https://github.com/openclaw/openclaw/pull/134986)).
+- Adopt shell command fixtures for baseline selection ([#134991](https://github.com/openclaw/openclaw/pull/134991)).
+- Adopt native CRC32 for the large paste fixture ([#135001](https://github.com/openclaw/openclaw/pull/135001)).
+- Unify abortable sleep timing coverage ([#135004](https://github.com/openclaw/openclaw/pull/135004)).
+- Limit Git identity to maintenance fixture lifetime ([#135011](https://github.com/openclaw/openclaw/pull/135011)). Thanks @steipete.
+- Check CI retry delays without a real wait ([#135020](https://github.com/openclaw/openclaw/pull/135020)). Thanks @steipete.
+- Separate static provider catalogs from network-capable discovery ([#135074](https://github.com/openclaw/openclaw/pull/135074)).
+- Give QA suite verdict accounting one implementation ([#135078](https://github.com/openclaw/openclaw/pull/135078)). Thanks @steipete.
+- Centralize mock assistant streaming event construction ([#135090](https://github.com/openclaw/openclaw/pull/135090)). Thanks @steipete.
+- Keep bounded live provider failure diagnostics ([#135120](https://github.com/openclaw/openclaw/pull/135120)). Thanks @steipete.
+- Retain update fixture plugin and temporary-file ownership ([#135141](https://github.com/openclaw/openclaw/pull/135141)).
+- End the Doctor memory probe after flushing its result ([#135146](https://github.com/openclaw/openclaw/pull/135146)). Thanks @vincentkoc.
+- Centralize evidence builder execution context ([#135158](https://github.com/openclaw/openclaw/pull/135158)). Thanks @steipete.
+- Centralize Mantis report rendering and summary fields ([#135160](https://github.com/openclaw/openclaw/pull/135160)).
+- Centralize standard live transport CLI composition ([#135325](https://github.com/openclaw/openclaw/pull/135325)). Thanks @steipete.
+- Coordinate CUA transport and recording fixtures directly ([#135363](https://github.com/openclaw/openclaw/pull/135363)).
+- Share commit-resolution setup ([#135560](https://github.com/openclaw/openclaw/pull/135560)).
+- Share packed artifact identity fixture ([#135572](https://github.com/openclaw/openclaw/pull/135572)).
+- Share immutable worker bundle archive ([#135579](https://github.com/openclaw/openclaw/pull/135579)).
+- Centralize immutable pnpm launcher fixtures ([#135586](https://github.com/openclaw/openclaw/pull/135586)).
+- Wait for version diagnostic completion ([#135594](https://github.com/openclaw/openclaw/pull/135594)).
+- Unify root help fast-path coverage ([#135605](https://github.com/openclaw/openclaw/pull/135605)).
+- Give one owner to PR wrapper fixture identities ([#135611](https://github.com/openclaw/openclaw/pull/135611)).
+- Streamline library wire proof assertions ([#135616](https://github.com/openclaw/openclaw/pull/135616)). Thanks @steipete.
+- Share directory archive runtime ([#135624](https://github.com/openclaw/openclaw/pull/135624)). Thanks @steipete.
+- Centralize immutable GitHub CLI fixture commands ([#135640](https://github.com/openclaw/openclaw/pull/135640)).
+- Share immutable oversized stream chunks ([#135643](https://github.com/openclaw/openclaw/pull/135643)).
+- Reduce leaked concurrent node configuration workers ([#135644](https://github.com/openclaw/openclaw/pull/135644)).
+- Share maintenance warning runtime ([#135651](https://github.com/openclaw/openclaw/pull/135651)).
+- Limit QR temporary files to their test ([#135662](https://github.com/openclaw/openclaw/pull/135662)).
+- Bring plugin artifact fixtures in line with build policy ([#135667](https://github.com/openclaw/openclaw/pull/135667)). Thanks @vincentkoc.
+- Unify proxy file rejection coverage ([#135672](https://github.com/openclaw/openclaw/pull/135672)).
+- Wait for signal-fixture process groups before cleanup ([#135685](https://github.com/openclaw/openclaw/pull/135685)).
+- Unify missing-credential selection coverage ([#135698](https://github.com/openclaw/openclaw/pull/135698)).
+- Give one owner to auth fixture environment cleanup ([#135703](https://github.com/openclaw/openclaw/pull/135703)).
+- Share immutable import URL fixtures ([#135712](https://github.com/openclaw/openclaw/pull/135712)).
+- Add regression coverage for startup consent convergence ([#135718](https://github.com/openclaw/openclaw/pull/135718)). Thanks @ge0el, @boramyleng.
+- Share deferred gates in terminal lifecycle tests ([#135719](https://github.com/openclaw/openclaw/pull/135719)).
+- Close Gateway fixture peers after assertion failures ([#135721](https://github.com/openclaw/openclaw/pull/135721)). Thanks @steipete.
+- Share notice runtime and stabilize capability navigation ([#135733](https://github.com/openclaw/openclaw/pull/135733)).
+- Share unchanged declaration groups ([#135735](https://github.com/openclaw/openclaw/pull/135735)).
+- Give Vault resolver wire fixtures one lifecycle owner ([#135741](https://github.com/openclaw/openclaw/pull/135741)).
+- Stop synthetic voice-call tunnels after failed assertions ([#135752](https://github.com/openclaw/openclaw/pull/135752)).
+- Unify live model Docker wrapper guards ([#135758](https://github.com/openclaw/openclaw/pull/135758)). Thanks @RomneyDa.
+- Unify Codex live harness guards ([#135759](https://github.com/openclaw/openclaw/pull/135759)). Thanks @RomneyDa.
+- Remove brittle Telegram live Docker source mirrors ([#135760](https://github.com/openclaw/openclaw/pull/135760)). Thanks @RomneyDa.
+- Give one owner to PR wrapper fixture cleanup ([#135763](https://github.com/openclaw/openclaw/pull/135763)).
+- Wait for LanceDB fixture work before removing state ([#135781](https://github.com/openclaw/openclaw/pull/135781)).
+- Share immutable IPA validator tools ([#135784](https://github.com/openclaw/openclaw/pull/135784)).
+- Centralize setup for short plugin fallback jobs ([#135787](https://github.com/openclaw/openclaw/pull/135787)).
+- Wait for Web Push sends before fixture cleanup ([#135792](https://github.com/openclaw/openclaw/pull/135792)).
+- Give plugin E2E child shutdown one owner ([#135804](https://github.com/openclaw/openclaw/pull/135804)).
+- Share one Diffs plugin registration fixture ([#135810](https://github.com/openclaw/openclaw/pull/135810)).
+- Wait for IRC socket and ingress completion events ([#135817](https://github.com/openclaw/openclaw/pull/135817)).
+- Provide the title runtime backend inside Gateway fixtures ([#135823](https://github.com/openclaw/openclaw/pull/135823)).
+- Share performance fixture snapshot metadata ([#135940](https://github.com/openclaw/openclaw/pull/135940)).
+- Drive disclosure-scroll reconciliation with the browser clock ([#135952](https://github.com/openclaw/openclaw/pull/135952)).
+- Surface chat-pane metadata listener fixture failures ([#135965](https://github.com/openclaw/openclaw/pull/135965)).
+- Share compiled cron ownership workers ([#135967](https://github.com/openclaw/openclaw/pull/135967)).
+- Share prepared CLI in lifecycle E2E suites ([#135971](https://github.com/openclaw/openclaw/pull/135971)).
+- End finite Google Meet fake process streams promptly ([#136003](https://github.com/openclaw/openclaw/pull/136003)).
+- Limit shared fixtures and join failed downloads ([#136027](https://github.com/openclaw/openclaw/pull/136027)). Thanks @steipete.
+- Pack npm fixtures once per install scenario ([#136044](https://github.com/openclaw/openclaw/pull/136044)).
+- Build Microsoft Teams retention rows in batches ([#136055](https://github.com/openclaw/openclaw/pull/136055)).
+- Centralize browser lifetime across isolated contexts ([#136101](https://github.com/openclaw/openclaw/pull/136101)).
+- Give Control UI fixtures one cleanup owner ([#136150](https://github.com/openclaw/openclaw/pull/136150)).
+- Close every Control UI Board fixture resource ([#136182](https://github.com/openclaw/openclaw/pull/136182)).
+- Limit direct-reference planning searches to test sources ([#136193](https://github.com/openclaw/openclaw/pull/136193)).
+- Share session branch fixture history ([#136209](https://github.com/openclaw/openclaw/pull/136209)). Thanks @steipete.
+- Adopt prepared entry in Gateway QA fixtures ([#136245](https://github.com/openclaw/openclaw/pull/136245)).
+- Prove auth-profile rotation with tighter agent fixtures ([#136254](https://github.com/openclaw/openclaw/pull/136254)).
+
+**Bug fixes**
+
+- Reject invalid shard concurrency before CI work starts ([#120161](https://github.com/openclaw/openclaw/pull/120161)). Thanks @qingminglong.
+- Use full CI coverage when changed-scope arguments are malformed ([#120913](https://github.com/openclaw/openclaw/pull/120913)). Thanks @qingminglong.
+- Limit recent timing samples to successful main pushes ([#133778](https://github.com/openclaw/openclaw/pull/133778)). Thanks @qingminglong.
+- Keep active Testbox sessions alive through long commands ([#134725](https://github.com/openclaw/openclaw/pull/134725)).
+- Verify usable SSH access on native Windows Testboxes ([#134828](https://github.com/openclaw/openclaw/pull/134828)).
+- Report one final failure for each test invocation ([#134850](https://github.com/openclaw/openclaw/pull/134850)).
+- Treat active Windows SSH sessions as non-idle ([#134927](https://github.com/openclaw/openclaw/pull/134927)).
+- Send Swift metadata changes to their owner tests ([#134983](https://github.com/openclaw/openclaw/pull/134983)). Thanks @steipete.
+- Finish draft setup before measuring composer renders ([#135075](https://github.com/openclaw/openclaw/pull/135075)). Thanks @steipete.
+- Surface matching full-release decisions sooner ([#135076](https://github.com/openclaw/openclaw/pull/135076)).
+- Run type-aware lint for changed root tests ([#135123](https://github.com/openclaw/openclaw/pull/135123)).
+- Run browser checks for browser-harness-only changes ([#136125](https://github.com/openclaw/openclaw/pull/136125)).
+- Fail the final CI gate when selected jobs are skipped ([#136187](https://github.com/openclaw/openclaw/pull/136187)). Thanks @MohammedAlkindi.
+- Report final lint failures after child cleanup ([#134668](https://github.com/openclaw/openclaw/pull/134668)).
+- Retain crash exit codes and failure evidence for test shards ([#134688](https://github.com/openclaw/openclaw/pull/134688)).
+- Make forked-context QA fail without child history ([#134708](https://github.com/openclaw/openclaw/pull/134708)). Thanks @RomneyDa.
+- Retain nested suite ownership and share progress transitions ([#135027](https://github.com/openclaw/openclaw/pull/135027)).
+- Keep repository test wrappers interruptible during cleanup ([#135439](https://github.com/openclaw/openclaw/pull/135439)). Thanks @steipete.
+- Stop concurrent macOS fixtures from starving child cleanup ([#135501](https://github.com/openclaw/openclaw/pull/135501)).
+- Retain retained inputs across nested Vitest cleanup ([#135647](https://github.com/openclaw/openclaw/pull/135647)).
+- Stop canceled fixtures from outliving test cleanup ([#135883](https://github.com/openclaw/openclaw/pull/135883)).
+- Keep Codex sandbox tests inside isolated state homes ([#135943](https://github.com/openclaw/openclaw/pull/135943)).
+- Finish QA tool progress from completed result status ([#135995](https://github.com/openclaw/openclaw/pull/135995)). Thanks @steipete.
+- Finish cleanup when subprocess errors contain cycles ([#136057](https://github.com/openclaw/openclaw/pull/136057)).
+- Keep mixed Control UI test runs scoped to requested paths ([#136136](https://github.com/openclaw/openclaw/pull/136136)).
+- Keep Crabline crypto inside bundled QA builds ([#136166](https://github.com/openclaw/openclaw/pull/136166)).
+- Emit complete QA Responses stream lifecycles ([#136167](https://github.com/openclaw/openclaw/pull/136167)).
+- Fail empty named-file test runs unless explicitly allowed ([#135609](https://github.com/openclaw/openclaw/pull/135609)).
+- Retain partial Anthropic output when QA completions fail ([#136001](https://github.com/openclaw/openclaw/pull/136001)).
+- Return nonstreaming QA Responses in the expected SDK shape ([#136062](https://github.com/openclaw/openclaw/pull/136062)). Thanks @steipete.
+- Accept string content in QA Responses messages ([#136109](https://github.com/openclaw/openclaw/pull/136109)). Thanks @steipete.
+- Retain bounded bootstrap diagnostics after timeouts ([#136111](https://github.com/openclaw/openclaw/pull/136111)). Thanks @steipete.
+- Format IPv6 QA listener URLs at their owners ([#136132](https://github.com/openclaw/openclaw/pull/136132)).
+
+**Security and trust**
+
+- Fetch security-scan history before removing checkout credentials ([#136232](https://github.com/openclaw/openclaw/pull/136232)). Thanks @steipete.
+- Require transport tests to prove SSRF denial ([#134879](https://github.com/openclaw/openclaw/pull/134879)).
+- Centralize trust audit fixture lifetime ([#136243](https://github.com/openclaw/openclaw/pull/136243)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Release and package tooling">
+
+Release preparation retains stronger artifact identity, retry, review, and publication boundaries, while removing repeated builds from the protected path where the frozen evidence supports reuse.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add macOS 2026.8.2 to the stable Sparkle feed ([#135680](https://github.com/openclaw/openclaw/pull/135680)).
+- Isolate Plugin SDK cleanup from runner metadata ([#134443](https://github.com/openclaw/openclaw/pull/134443)). Thanks @RomneyDa.
+- Share compiler-consumed declaration inputs ([#134734](https://github.com/openclaw/openclaw/pull/134734)).
+- Parallelize independent full-release verification paths ([#134746](https://github.com/openclaw/openclaw/pull/134746)). Thanks @vincentkoc.
+- Balance release verification tails and reuse checked downloads ([#134824](https://github.com/openclaw/openclaw/pull/134824)).
+- Check production Control UI budgets before full validation ([#134877](https://github.com/openclaw/openclaw/pull/134877)).
+- Qualify npm betas without unrelated release jobs ([#134966](https://github.com/openclaw/openclaw/pull/134966)).
+- Bypass full history for release artifact consumers ([#135128](https://github.com/openclaw/openclaw/pull/135128)).
+- Centralize version script argument parsing ([#135264](https://github.com/openclaw/openclaw/pull/135264)).
+- Reuse prepared packages and overlap publication work ([#135367](https://github.com/openclaw/openclaw/pull/135367)). Thanks @steipete.
+- Recover with an explicitly approved replacement PR head ([#135622](https://github.com/openclaw/openclaw/pull/135622)).
+- Assemble publication artifacts during validation ([#135639](https://github.com/openclaw/openclaw/pull/135639)).
+- Create macOS release architectures concurrently ([#135753](https://github.com/openclaw/openclaw/pull/135753)). Thanks @steipete.
+- Trim Docker cache export overhead ([#135832](https://github.com/openclaw/openclaw/pull/135832)).
+- Reduce copying and cache transfer during image preparation ([#135877](https://github.com/openclaw/openclaw/pull/135877)). Thanks @steipete.
+- Reuse Docker work and narrow plugin verification inputs ([#135960](https://github.com/openclaw/openclaw/pull/135960)).
+- Synchronize packages, native metadata, and generated 2026.9.1 artifacts ([`431d778f54`](https://github.com/openclaw/openclaw/commit/431d778f545386a812912b80bc6f75aa7a449dd4)).
+- Centralize JSON key sorter ([#135157](https://github.com/openclaw/openclaw/pull/135157)). Thanks @vincentkoc.
+- Share canonical Docker CLI flag parser ([#135207](https://github.com/openclaw/openclaw/pull/135207)). Thanks @steipete.
+
+**Bug fixes**
+
+- Generate stable appcasts correctly with macOS Bash ([#135687](https://github.com/openclaw/openclaw/pull/135687)).
+- Keep mixed skill and core changes in normal maintainer review ([#131619](https://github.com/openclaw/openclaw/pull/131619)). Thanks @MertBasar0, @shojikumaru.
+- Use a supported baseline for frozen installer validation ([#134519](https://github.com/openclaw/openclaw/pull/134519)). Thanks @RomneyDa.
+- Reject ineligible release evidence before deep verification ([#134694](https://github.com/openclaw/openclaw/pull/134694)).
+- Recover retained merges from another checkout ([#134778](https://github.com/openclaw/openclaw/pull/134778)).
+- Preserve blocker identity across retried child jobs ([#134782](https://github.com/openclaw/openclaw/pull/134782)).
+- Retain original attempts in reused validation ([#134820](https://github.com/openclaw/openclaw/pull/134820)).
+- Restore validated evidence reuse and corrected advisory ranges ([#134870](https://github.com/openclaw/openclaw/pull/134870)).
+- Require durable completed ClawSweeper review evidence ([#134926](https://github.com/openclaw/openclaw/pull/134926)). Thanks @vincentkoc.
+- Keep Doctor health discovery available in packaged QA fixtures ([#134944](https://github.com/openclaw/openclaw/pull/134944)).
+- Continue unaffected advisory checks after access denials ([#135015](https://github.com/openclaw/openclaw/pull/135015)).
+- Publish the frozen Codex plugin with its approved pin ([#135246](https://github.com/openclaw/openclaw/pull/135246)). Thanks @steipete.
+- Publish verified plugin tarballs without rebuilding them ([#135289](https://github.com/openclaw/openclaw/pull/135289)).
+- Load npm configuration for trusted plugin publication ([#135323](https://github.com/openclaw/openclaw/pull/135323)).
+- Restore serializable protocol declaration builds ([#135360](https://github.com/openclaw/openclaw/pull/135360)).
+- Resume notarization from retained signed artifacts ([#135601](https://github.com/openclaw/openclaw/pull/135601)).
+- Distinguish quota exhaustion from authentication failures ([#135657](https://github.com/openclaw/openclaw/pull/135657)).
+- Allow reviewed squash messages in native merge tooling ([#135888](https://github.com/openclaw/openclaw/pull/135888)).
+- Include the sparse release-context helper in validation ([#135902](https://github.com/openclaw/openclaw/pull/135902)). Thanks @RomneyDa.
+- Keep trusted release tooling in validation checkouts ([#135983](https://github.com/openclaw/openclaw/pull/135983)). Thanks @vincentkoc.
+- Report missing full-release child dispatches directly ([#136004](https://github.com/openclaw/openclaw/pull/136004)). Thanks @vincentkoc.
+- Accept historical npm targets with an existing UI bundle ([#136054](https://github.com/openclaw/openclaw/pull/136054)). Thanks @vincentkoc.
+- Reuse matching prepared artifacts after failed release jobs ([#136112](https://github.com/openclaw/openclaw/pull/136112)).
+- Validate frozen releases against their available capabilities ([#136127](https://github.com/openclaw/openclaw/pull/136127)). Thanks @vincentkoc.
+- Accept numbered draft changelogs during validation ([#136134](https://github.com/openclaw/openclaw/pull/136134)). Thanks @steipete.
+- Keep macOS tooling out of Linux upgrade proofs ([#136152](https://github.com/openclaw/openclaw/pull/136152)).
+- Finish merge receipts safely after main advances ([#135396](https://github.com/openclaw/openclaw/pull/135396)).
+- Preserve ignored files during PR worktree preparation ([#135500](https://github.com/openclaw/openclaw/pull/135500)).
+- Protect package markers during concurrent builds ([#134835](https://github.com/openclaw/openclaw/pull/134835)). Thanks @steipete.
+- Keep macOS worker packaging on the destination volume ([#134857](https://github.com/openclaw/openclaw/pull/134857)). Thanks @steipete.
+
+**Security and trust**
+
+- Scan publishable plugin inputs without executing candidate code ([#126887](https://github.com/openclaw/openclaw/pull/126887)). Thanks @vincentkoc, @RomneyDa.
+- Stop Docker promotion on unrelated lookup failures ([#135113](https://github.com/openclaw/openclaw/pull/135113)). Thanks @vincentkoc.
+- Bind ClawHub source attribution to the authorized commit ([#135368](https://github.com/openclaw/openclaw/pull/135368)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Documentation and localization">
+
+Documentation and generated localization work keeps maintainer guidance, release history, translation inputs, and native locale generation aligned with the code they describe.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Skip documentation translation dispatches when the sync token is absent ([#70002](https://github.com/openclaw/openclaw/pull/70002)). Thanks @xudaiyanzi.
+- Install Go before documentation localization checks ([#134745](https://github.com/openclaw/openclaw/pull/134745)). Thanks @vincentkoc.
+- Retry malformed native translations during locale refresh ([#136086](https://github.com/openclaw/openclaw/pull/136086)). Thanks @vincentkoc.
+- Place the session-color note under the iOS 2026.8.11 release ([`753853a7d9`](https://github.com/openclaw/openclaw/commit/753853a7d93ef392c363624714edf186c7ad5dcd)). Thanks @joshavant.
+- Ignore example links inside fenced documentation code ([#132727](https://github.com/openclaw/openclaw/pull/132727)). Thanks @qingminglong.
+- Refresh update-screen translation records ([#134645](https://github.com/openclaw/openclaw/pull/134645)).
+- Replace session-companion translations with side-chat wording ([#134672](https://github.com/openclaw/openclaw/pull/134672)).
+- Refresh login, model, and chat-question translations ([#134822](https://github.com/openclaw/openclaw/pull/134822)).
+- Refresh session-hovercard translation records ([#134882](https://github.com/openclaw/openclaw/pull/134882)).
+- Refresh model-default and plugin-permission translations ([#134950](https://github.com/openclaw/openclaw/pull/134950)).
+- Refresh Mermaid control translations ([#135050](https://github.com/openclaw/openclaw/pull/135050)).
+- Refresh protected locale-generation metadata ([#135201](https://github.com/openclaw/openclaw/pull/135201)).
+- Refresh GitHub, publication, and update-diagnostic translations ([#135474](https://github.com/openclaw/openclaw/pull/135474)).
+- Refresh session-recovery and skill-library translations ([#135529](https://github.com/openclaw/openclaw/pull/135529)).
+- Refresh plugin-search and session-worker translations ([#135723](https://github.com/openclaw/openclaw/pull/135723)).
+- Refresh trusted-proxy and session-assignment translations ([#135756](https://github.com/openclaw/openclaw/pull/135756)).
+- Remove retired queued-message localization records ([#135939](https://github.com/openclaw/openclaw/pull/135939)).
+- Make Android composer expectations locale-aware ([#136007](https://github.com/openclaw/openclaw/pull/136007)). Thanks @vincentkoc.
+- Refresh model-selection translations across supported locales ([#136191](https://github.com/openclaw/openclaw/pull/136191)).
+- Avoid duplicate Android resources for equivalent Unicode text ([#136164](https://github.com/openclaw/openclaw/pull/136164)). Thanks @vincentkoc.
+- Point OAuth guidance to the active login implementations ([#125791](https://github.com/openclaw/openclaw/pull/125791)). Thanks @santhiprakash.
+- Bring the v2026.8.1 release page to the final tag ([#134929](https://github.com/openclaw/openclaw/pull/134929)). Thanks @hannesrudolph.
+- Reserve changelog edits for release preparation ([#135136](https://github.com/openclaw/openclaw/pull/135136)).
+- Move the historical beta clarification into a footnote ([#135595](https://github.com/openclaw/openclaw/pull/135595)). Thanks @hannesrudolph.
+- Add release scale and contribution totals to prior pages ([#135822](https://github.com/openclaw/openclaw/pull/135822)). Thanks @hannesrudolph.
+- Refresh Gateway update and disconnect recovery translations ([#135669](https://github.com/openclaw/openclaw/pull/135669)).
+
+</details>
+
+</Accordion>
+
+<Accordion title="Internal refactors and performance">
+
+Behavior-preserving refactors consolidate duplicated ownership and trim repeated parsing, copying, allocation, and setup across the runtime and repository.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Streamline configured-channel presence ([#134362](https://github.com/openclaw/openclaw/pull/134362)).
+- Unify report formatting ownership ([#134466](https://github.com/openclaw/openclaw/pull/134466)). Thanks @steipete.
+- Move prepared plugin metadata maps without copying ([#134581](https://github.com/openclaw/openclaw/pull/134581)). Thanks @steipete.
+- Unify storage mutation parsing ([#134585](https://github.com/openclaw/openclaw/pull/134585)). Thanks @steipete.
+- Preserve Doctor plugin contracts lightweight ([#134601](https://github.com/openclaw/openclaw/pull/134601)).
+- Unify command diagnostic tails ([#134607](https://github.com/openclaw/openclaw/pull/134607)). Thanks @steipete, @vincentkoc.
+- Remove brittle Android screenshot source mirrors ([#134613](https://github.com/openclaw/openclaw/pull/134613)). Thanks @RomneyDa.
+- Remove brittle live CLI backend source mirrors ([#134614](https://github.com/openclaw/openclaw/pull/134614)). Thanks @RomneyDa.
+- Drop redundant system-agent source mirror ([#134615](https://github.com/openclaw/openclaw/pull/134615)). Thanks @RomneyDa.
+- Centralize path existence policy ([#134630](https://github.com/openclaw/openclaw/pull/134630)). Thanks @vincentkoc.
+- Share PNG encoder for context maps ([#134632](https://github.com/openclaw/openclaw/pull/134632)).
+- Centralize approval card text escaping ([#134643](https://github.com/openclaw/openclaw/pull/134643)). Thanks @vincentkoc.
+- Centralize canonical realpath fallback ([#134650](https://github.com/openclaw/openclaw/pull/134650)). Thanks @vincentkoc.
+- Give one owner to release cohort convergence ([#134664](https://github.com/openclaw/openclaw/pull/134664)). Thanks @jalehman, @r0ckvn, @Finn763.
+- Trim repeated turn preparation work ([#134673](https://github.com/openclaw/openclaw/pull/134673)).
+- Centralize evidence finding builder ([#134691](https://github.com/openclaw/openclaw/pull/134691)). Thanks @vincentkoc.
+- Share selected auth snapshot paths ([#134693](https://github.com/openclaw/openclaw/pull/134693)).
+- Centralize raw target-field guard ([#134695](https://github.com/openclaw/openclaw/pull/134695)). Thanks @vincentkoc.
+- Centralize SQLite reliability stderr formatting ([#134762](https://github.com/openclaw/openclaw/pull/134762)). Thanks @vincentkoc.
+- Centralize spawn output coercion ([#134821](https://github.com/openclaw/openclaw/pull/134821)). Thanks @vincentkoc.
+- Give mock previews shared state and request handling ([#134836](https://github.com/openclaw/openclaw/pull/134836)).
+- Drop duplicated Claude model checks ([#134842](https://github.com/openclaw/openclaw/pull/134842)). Thanks @steipete.
+- Centralize person-page classification ([#134844](https://github.com/openclaw/openclaw/pull/134844)). Thanks @vincentkoc.
+- Streamline agent migration traversal ([#134845](https://github.com/openclaw/openclaw/pull/134845)).
+- Update Control UI boot manifest ([#134876](https://github.com/openclaw/openclaw/pull/134876)). Thanks @vincentkoc.
+- Centralize env reference normalization ([#134904](https://github.com/openclaw/openclaw/pull/134904)). Thanks @vincentkoc.
+- Unify hook requirement reports ([#134905](https://github.com/openclaw/openclaw/pull/134905)). Thanks @steipete.
+- Unify table style metadata ([#134908](https://github.com/openclaw/openclaw/pull/134908)). Thanks @steipete.
+- Centralize span clipping logic ([#134910](https://github.com/openclaw/openclaw/pull/134910)). Thanks @steipete.
+- Trim repeated work during turn preparation ([#134921](https://github.com/openclaw/openclaw/pull/134921)). Thanks @steipete.
+- Centralize lazy runtime forwarding ([#134945](https://github.com/openclaw/openclaw/pull/134945)).
+- Centralize terminal report context ([#134946](https://github.com/openclaw/openclaw/pull/134946)).
+- Drop duplicate metric inventory ([#134947](https://github.com/openclaw/openclaw/pull/134947)).
+- Centralize tab id validation ([#134958](https://github.com/openclaw/openclaw/pull/134958)). Thanks @vincentkoc.
+- Centralize markdown link boundary checks ([#134962](https://github.com/openclaw/openclaw/pull/134962)). Thanks @vincentkoc.
+- Centralize media and control card construction ([#134964](https://github.com/openclaw/openclaw/pull/134964)).
+- Centralize token style and block transitions ([#134965](https://github.com/openclaw/openclaw/pull/134965)).
+- Centralize wildcard callback host check ([#134977](https://github.com/openclaw/openclaw/pull/134977)). Thanks @vincentkoc.
+- Reduce intermediate timestamp objects ([#134979](https://github.com/openclaw/openclaw/pull/134979)).
+- Share canonical tool result envelopes ([#134984](https://github.com/openclaw/openclaw/pull/134984)). Thanks @steipete.
+- Share validators for rebuilt tool schemas ([#134988](https://github.com/openclaw/openclaw/pull/134988)).
+- Call Memory Wiki source synchronization through its canonical path ([#134992](https://github.com/openclaw/openclaw/pull/134992)). Thanks @vincentkoc.
+- Discard superseded message-tool catalogs after registry replacement ([#134998](https://github.com/openclaw/openclaw/pull/134998)).
+- Centralize API success assertion ([#135005](https://github.com/openclaw/openclaw/pull/135005)). Thanks @vincentkoc.
+- Share the current process start identity ([#135007](https://github.com/openclaw/openclaw/pull/135007)).
+- Drop runtime getter aliases ([#135012](https://github.com/openclaw/openclaw/pull/135012)). Thanks @vincentkoc.
+- Give one owner to skipped stage outcomes ([#135029](https://github.com/openclaw/openclaw/pull/135029)). Thanks @steipete.
+- Give one owner to document table patch actions ([#135030](https://github.com/openclaw/openclaw/pull/135030)).
+- Use one alias parser for Android Talk directives ([#135033](https://github.com/openclaw/openclaw/pull/135033)).
+- Share normalized stream tool-call facts ([#135034](https://github.com/openclaw/openclaw/pull/135034)).
+- Share canonical text result envelopes ([#135043](https://github.com/openclaw/openclaw/pull/135043)).
+- Centralize structured action argument formatting ([#135047](https://github.com/openclaw/openclaw/pull/135047)).
+- Centralize channel list page request ([#135059](https://github.com/openclaw/openclaw/pull/135059)). Thanks @vincentkoc.
+- Centralize concrete select menu construction ([#135064](https://github.com/openclaw/openclaw/pull/135064)).
+- Share Feishu Drive comment preparation and pagination ([#135065](https://github.com/openclaw/openclaw/pull/135065)).
+- Centralize tool registration and result adapters ([#135066](https://github.com/openclaw/openclaw/pull/135066)).
+- Centralize rich-text fallback rendering ([#135072](https://github.com/openclaw/openclaw/pull/135072)). Thanks @steipete.
+- Reduce redundant catalog sanitization ([#135091](https://github.com/openclaw/openclaw/pull/135091)).
+- Unify executable search providers ([#135099](https://github.com/openclaw/openclaw/pull/135099)).
+- Centralize text and media dispatch preparation ([#135100](https://github.com/openclaw/openclaw/pull/135100)).
+- Reduce unused document encodings and buffer copies ([#135107](https://github.com/openclaw/openclaw/pull/135107)).
+- Look up bounded browser request history by identifier ([#135116](https://github.com/openclaw/openclaw/pull/135116)).
+- Drop redundant aliases from canonical session snapshots ([#135121](https://github.com/openclaw/openclaw/pull/135121)).
+- Centralize Apple voice configuration helpers ([#135125](https://github.com/openclaw/openclaw/pull/135125)).
+- Centralize channel deny rule guard ([#135126](https://github.com/openclaw/openclaw/pull/135126)). Thanks @vincentkoc.
+- Unify JSON Schema child traversal ([#135145](https://github.com/openclaw/openclaw/pull/135145)).
+- Drop dead private tool-warning state ([#135148](https://github.com/openclaw/openclaw/pull/135148)).
+- Use one Perplexity runtime configuration resolver ([#135159](https://github.com/openclaw/openclaw/pull/135159)).
+- Create only the requested provider index ([#135169](https://github.com/openclaw/openclaw/pull/135169)).
+- Trim repeated schema reads during database opens ([#135172](https://github.com/openclaw/openclaw/pull/135172)).
+- Source output types from protocol schema ([#135174](https://github.com/openclaw/openclaw/pull/135174)).
+- Bypass empty tool-result planning branches ([#135204](https://github.com/openclaw/openclaw/pull/135204)). Thanks @steipete.
+- Trim work when preparing explicit replies ([#135208](https://github.com/openclaw/openclaw/pull/135208)).
+- Share accepted tool-result transcript snapshots ([#135220](https://github.com/openclaw/openclaw/pull/135220)).
+- Route Apple Watch inbound events through one owner ([#135235](https://github.com/openclaw/openclaw/pull/135235)). Thanks @steipete.
+- Unify inbound and outbound sending ([#135254](https://github.com/openclaw/openclaw/pull/135254)).
+- Source shared meeting types from the canonical owner ([#135257](https://github.com/openclaw/openclaw/pull/135257)).
+- Centralize bounded Graph pagination ([#135258](https://github.com/openclaw/openclaw/pull/135258)).
+- Reduce redundant image auth lookup ([#135259](https://github.com/openclaw/openclaw/pull/135259)). Thanks @steipete.
+- Share protocol-owned model and checkpoint types ([#135265](https://github.com/openclaw/openclaw/pull/135265)).
+- Centralize grouped report argument parsing ([#135271](https://github.com/openclaw/openclaw/pull/135271)). Thanks @steipete.
+- Drop unused web runtime facades ([#135274](https://github.com/openclaw/openclaw/pull/135274)).
+- Source session projections from protocol types ([#135275](https://github.com/openclaw/openclaw/pull/135275)).
+- Give one owner to failure output at the CLI owner ([#135284](https://github.com/openclaw/openclaw/pull/135284)).
+- Share command display sanitization ([#135285](https://github.com/openclaw/openclaw/pull/135285)). Thanks @steipete.
+- Build release profiles from shared ordered phases ([#135294](https://github.com/openclaw/openclaw/pull/135294)).
+- Assemble Control UI encoding preferences once ([#135304](https://github.com/openclaw/openclaw/pull/135304)).
+- Centralize effective catalog model projection ([#135306](https://github.com/openclaw/openclaw/pull/135306)). Thanks @steipete.
+- Reduce PNG checksum buffer copies ([#135313](https://github.com/openclaw/openclaw/pull/135313)).
+- Drop unused CLI runtime plumbing ([#135317](https://github.com/openclaw/openclaw/pull/135317)).
+- Centralize message payload projections ([#135319](https://github.com/openclaw/openclaw/pull/135319)). Thanks @steipete.
+- Release Tool Search catalogs when agent runs end ([#135321](https://github.com/openclaw/openclaw/pull/135321)).
+- Drop duplicate native send flow ([#135336](https://github.com/openclaw/openclaw/pull/135336)).
+- Share MCP metadata during inventory reads ([#135369](https://github.com/openclaw/openclaw/pull/135369)).
+- Trim work for ordinary log records ([#135375](https://github.com/openclaw/openclaw/pull/135375)).
+- Give one owner to generic image hook ownership ([#135386](https://github.com/openclaw/openclaw/pull/135386)). Thanks @steipete.
+- Share prepared provider auth environment candidates ([#135390](https://github.com/openclaw/openclaw/pull/135390)).
+- Preserve refusal display independent of runtime policy ([#135391](https://github.com/openclaw/openclaw/pull/135391)). Thanks @Marvinthebored, @obviyus.
+- Streamline transcript reads and recovery state ([#135392](https://github.com/openclaw/openclaw/pull/135392)).
+- Reduce discarded body buffers ([#135405](https://github.com/openclaw/openclaw/pull/135405)).
+- Reduce full-string encoding for bounded prefixes ([#135412](https://github.com/openclaw/openclaw/pull/135412)).
+- Reduce cloning credentials for presence checks ([#135464](https://github.com/openclaw/openclaw/pull/135464)). Thanks @steipete.
+- Share measured widths while wrapping terminal tables ([#135473](https://github.com/openclaw/openclaw/pull/135473)).
+- Reduce copying outbound node duplex fragments ([#135475](https://github.com/openclaw/openclaw/pull/135475)).
+- Share sorted ranges while rendering context maps ([#135476](https://github.com/openclaw/openclaw/pull/135476)).
+- Drop unused Gateway metadata scope hashing ([#135477](https://github.com/openclaw/openclaw/pull/135477)). Thanks @steipete.
+- Unify selection handling ([#135497](https://github.com/openclaw/openclaw/pull/135497)).
+- Streamline discovery, setup, and update reporting ([#135598](https://github.com/openclaw/openclaw/pull/135598)). Thanks @abacha, @Bloodis94, @Hansen1018.
+- Reduce materializing unused process output ([#135602](https://github.com/openclaw/openclaw/pull/135602)).
+- Drop redundant finalize-hook message copy ([#135607](https://github.com/openclaw/openclaw/pull/135607)).
+- Reduce transient executable-header buffers ([#135625](https://github.com/openclaw/openclaw/pull/135625)).
+- Store tool-set snapshots directly in context memory ([#135626](https://github.com/openclaw/openclaw/pull/135626)).
+- Share full catalog rendering ([#135674](https://github.com/openclaw/openclaw/pull/135674)). Thanks @steipete.
+- Trim temporary reply-formatting allocations ([#135725](https://github.com/openclaw/openclaw/pull/135725)).
+- Streamline upgrade and triage tests ([#135799](https://github.com/openclaw/openclaw/pull/135799)).
+- Reuse Control UI asset parent directories during retention ([#135806](https://github.com/openclaw/openclaw/pull/135806)).
+- Drop unused node subscription methods ([#135818](https://github.com/openclaw/openclaw/pull/135818)).
+- Streamline failed-turn settlement and Codex fixtures ([#135833](https://github.com/openclaw/openclaw/pull/135833)).
+- Streamline managed command completion ([#135850](https://github.com/openclaw/openclaw/pull/135850)).
+- Streamline Control UI history and config processing ([#135851](https://github.com/openclaw/openclaw/pull/135851)).
+- Give one owner to browser route preparation ([#135869](https://github.com/openclaw/openclaw/pull/135869)).
+- Trim memory used to capture large command output ([#135894](https://github.com/openclaw/openclaw/pull/135894)).
+- Reduce repeated JSON copies of Code Mode text results ([#135898](https://github.com/openclaw/openclaw/pull/135898)).
+- Share macOS version probes across startup consumers ([#135911](https://github.com/openclaw/openclaw/pull/135911)).
+- Use the prepared CLI for Claws lifecycle checks ([#135915](https://github.com/openclaw/openclaw/pull/135915)).
+- Streamline startup worker presentation ([#135916](https://github.com/openclaw/openclaw/pull/135916)).
+- Trim repeated Gateway method inventory allocations ([#135931](https://github.com/openclaw/openclaw/pull/135931)).
+- Load update recovery support only when an update starts ([#135942](https://github.com/openclaw/openclaw/pull/135942)).
+- Trim allocations when rendering attributed Markdown ([#135950](https://github.com/openclaw/openclaw/pull/135950)).
+- Give one owner to model accounting at stream ingress ([#135956](https://github.com/openclaw/openclaw/pull/135956)).
+- Reduce unused bundle builds in standalone E2E runs ([#135962](https://github.com/openclaw/openclaw/pull/135962)). Thanks @steipete.
+- Validate Control UI manifests without redundant sorting ([#135972](https://github.com/openclaw/openclaw/pull/135972)).
+- Assemble file log fields once per record ([#135974](https://github.com/openclaw/openclaw/pull/135974)).
+- Reduce a redundant copy when building the base config schema ([#135986](https://github.com/openclaw/openclaw/pull/135986)).
+- Drop memory test dependency indirection ([#135994](https://github.com/openclaw/openclaw/pull/135994)).
+- Reduce redundant provider catalog model copies ([#135998](https://github.com/openclaw/openclaw/pull/135998)).
+- Reduce line arrays when stripping reasoning preambles ([#136014](https://github.com/openclaw/openclaw/pull/136014)).
+- Drop disposable plugin metadata test fixtures ([#136031](https://github.com/openclaw/openclaw/pull/136031)).
+- Retain required agent selection fields ([#136056](https://github.com/openclaw/openclaw/pull/136056)). Thanks @RomneyDa.
+- Share prepared plugin metadata normalizers ([#136063](https://github.com/openclaw/openclaw/pull/136063)).
+- Centralize session visibility types ([#136065](https://github.com/openclaw/openclaw/pull/136065)). Thanks @RomneyDa.
+- Source run history type from wire schema ([#136075](https://github.com/openclaw/openclaw/pull/136075)). Thanks @RomneyDa.
+- Check sessions yield stream contract ([#136077](https://github.com/openclaw/openclaw/pull/136077)). Thanks @RomneyDa.
+- Compute model catalog runtime capabilities once ([#136080](https://github.com/openclaw/openclaw/pull/136080)). Thanks @steipete.
+- Reduce materializing text and media for presence checks ([#136099](https://github.com/openclaw/openclaw/pull/136099)). Thanks @steipete.
+- Trim Linux CI fixture process scans ([#136114](https://github.com/openclaw/openclaw/pull/136114)).
+- Unify shared session menu rendering ([#136119](https://github.com/openclaw/openclaw/pull/136119)).
+- Share captured model-catalog visibility state ([#136162](https://github.com/openclaw/openclaw/pull/136162)).
+- Drop retired voice UI and unify command ownership ([#136192](https://github.com/openclaw/openclaw/pull/136192)).
+- Streamline shared message rendering ([#136216](https://github.com/openclaw/openclaw/pull/136216)).
+- Reduce full plugin scans for known contribution owners ([#135953](https://github.com/openclaw/openclaw/pull/135953)). Thanks @steipete.
+
+**Security and trust**
+
+- Reduce unnecessary Unicode marker folding ([#135514](https://github.com/openclaw/openclaw/pull/135514)).
+- Apply one strict policy to dependency specifications ([#135110](https://github.com/openclaw/openclaw/pull/135110)). Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="QA and maintainer workflow fixes">
+
+The remaining maintainer fixes repair local previews, QA simulators, merge helpers, packaging checks, and other contributor workflows without turning those changes into public product claims.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep Vitest timing history stable across discovery order changes ([#120105](https://github.com/openclaw/openclaw/pull/120105)). Thanks @qingminglong, @vincentkoc.
+- Emit progress during Control UI E2E builds ([#135025](https://github.com/openclaw/openclaw/pull/135025)).
+- Restore the CLI test type gate for optional TTY overrides ([#135407](https://github.com/openclaw/openclaw/pull/135407)). Thanks @itsuzef.
+- Stabilize state-directory safety proof under CI load ([#135495](https://github.com/openclaw/openclaw/pull/135495)). Thanks @lzhan011.
+- Tie exec approval fixtures to the canonical cwd owner ([#134937](https://github.com/openclaw/openclaw/pull/134937)).
+- Allow macOS shell-timeout fixtures a startup margin ([#134969](https://github.com/openclaw/openclaw/pull/134969)). Thanks @steipete.
+- Make native plugin-loading regressions visible to tests ([#135425](https://github.com/openclaw/openclaw/pull/135425)).
+- Reach the package update in Docker survivor validation ([#135561](https://github.com/openclaw/openclaw/pull/135561)). Thanks @fuller-stack-dev.
+- Use isolated linking for eligible macOS source installs ([#135728](https://github.com/openclaw/openclaw/pull/135728)).
+- Keep preview avatar requests away from the operator Gateway ([#134686](https://github.com/openclaw/openclaw/pull/134686)).
+- Isolate concurrent standalone previews from external connections ([#135724](https://github.com/openclaw/openclaw/pull/135724)). Thanks @steipete.
+- Reject oversized QA uploads without crashing shutdown ([#135938](https://github.com/openclaw/openclaw/pull/135938)).
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -12,6 +12,7 @@ without making you scan the raw changelog first.
 
 ## Releases
 
+- [v2026.9.1](/releases/2026.9.1) - Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and less repeated work in long conversations and large installations.
 - [v2026.8.2](/releases/2026.8.2) - Home beside your work, a Linux desktop companion, background sessions, safer upgrades, dependable replies and voice, and four new themes.
 - [v2026.8.1](/releases/2026.8.1) - A rebuilt web experience, simpler
   onboarding, stronger memory and session continuity, and a very large


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where readers looking for the v2026.9.1 product story would have to reconstruct it from the raw release history instead of having one curated, source-linked docs page.

## Why This Change Was Made

This adds an evidence-backed v2026.9.1 release page and links it from the release index. The page follows the existing v2026.8.1 and v2026.8.2 structure, uses the fixed release taxonomy, keeps maintainer work separate from the reader-facing story, and accounts for the complete frozen range from v2026.8.2 through `d3deb20a78e3c4c10997d9df022500e6799f52fa`.

## User Impact

Readers can understand the main v2026.9.1 changes in plain language, follow the relevant documentation, and expand source lists for complete PR, direct-commit, and contributor provenance.

## Evidence

- Completed and validated 928/928 release units with zero pending, active, or failed analysis work.
- Verified 922 pull-request links and 6 direct commits in the page, with no missing or extra release units.
- Verified release scale of 922 pull requests, 6 direct commits, and 241 contributors under the established credit exclusions.
- Independent full-page semantic review: `APPROVED_FOR_HUMAN_REVIEW`.
- `git diff --check`
- Main-repo single-page MDX check: `node scripts/check-docs-mdx.mjs docs/releases/2026.9.1.md`
- Publish-mirror preview build completed successfully before moving the reviewed source change here.

The operator's existing OpenClaw checkout was not modified; this isolated branch changes only the canonical English docs source. This PR does not publish or merge anything by itself.
