### PR TITLE
refactor(routing): remove unused unknown-DM route wrapper

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -8,7 +8,6 @@ import {
   listExactDirectMessageBindingPeerIds,
   resolveAgentRoute,
   resolveInboundLastRouteSessionKey,
-  resolveUnknownDirectMessageRoute,
 } from "./resolve-route.js";
 
 type ResolvedRouteExpectation = {
@@ -1267,10 +1266,11 @@ describe("unknown direct-message route decisions", () => {
       match: { channel: "telegram", accountId: "*" },
     });
 
-    const route = resolveUnknownDirectMessageRoute({
+    const route = resolveAgentRoute({
       cfg: { bindings },
       channel: "telegram",
       accountId: "default",
+      peer: { kind: "direct", id: "" },
     });
 
     expect(route.matchedBy).toBe(expectedMatchedBy);
@@ -1598,7 +1598,12 @@ describe("resolved route cache keys", () => {
       matchedBy: "binding.channel",
     });
     expectResolvedRoute(
-      resolveUnknownDirectMessageRoute({ cfg, channel: "telegram", accountId: "default" }),
+      resolveAgentRoute({
+        cfg,
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "direct", id: "" },
+      }),
       { agentId: "any-direct", matchedBy: "binding.peer.wildcard" },
     );
     expectResolvedRoute(
@@ -1632,7 +1637,12 @@ describe("resolved route cache keys", () => {
       matchedBy: "binding.channel",
     });
     expectResolvedRoute(
-      resolveUnknownDirectMessageRoute({ cfg, channel: "telegram", accountId: "default" }),
+      resolveAgentRoute({
+        cfg,
+        channel: "telegram",
+        accountId: "default",
+        peer: { kind: "direct", id: "" },
+      }),
       { agentId: "any-direct", matchedBy: "binding.peer.wildcard" },
     );
   });

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -900,11 +900,4 @@ export function listEffectiveGroupRouteBindings(cfg: OpenClawConfig) {
     );
   });
 }
-
-/** @internal Resolves fallback precedence for an unknown direct peer. */
-export function resolveUnknownDirectMessageRoute(
-  input: Pick<ResolveAgentRouteInput, "cfg" | "channel" | "accountId" | "dmScope" | "groupScope">,
-): ResolvedAgentRoute {
-  return resolveAgentRoute({ ...input, peer: { kind: "direct", id: "" } });
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #136463

## What Problem This Solves

Removes the unused internal unknown-DM routing wrapper left behind by the Doctor security-audit repair in #136463, prompted by cesura2k's September 2 Discord report. Only tests still called the wrapper after that repair landed.

## Why This Change Was Made

Use `resolveAgentRoute` directly with an empty direct peer and delete the forwarding function. Existing fallback-precedence and route-cache tests retain their assertions and call order. The removed helper was marked internal and was not exported by the public plugin SDK or package surface.

## User Impact

No user-visible behavior, configuration, stored state, routing algorithm, or public API changes. Production code shrinks by 7 lines; tests grow by 10 lines to make the existing direct-peer input explicit. No dependency, configuration, schema, protocol, or changelog changes.

## Evidence

Current head: `14c0e65137f9f3653c05756e1a8fdffd1824d56f`, rebased onto main after #136463 merged.

- `node scripts/run-vitest.mjs src/routing/resolve-route.test.ts`: all 71 cases passed on this head, including precedence and cache-call-order coverage.
- Fresh branch review: no accepted/actionable findings.
- `node --import ./scripts/tsx.mjs scripts/build-all.mts qaRuntime`: passed in 3m26.3s; the build stamp matches the current head.
- Call-site and SDK/package-export inspection: no production caller or public export of the removed wrapper.
- `node scripts/check-changed.mjs --base origin/main`: passed on this head, including core/test typechecks, all three unused-export scans (zero entries), lint, storage/security guards and zero runtime import cycles.
- Isolated compiled-CLI smoke on this head: Doctor `--fix --non-interactive` exited 0 in 122.692s; the existing two bindings stayed byte-equivalent, with no security-check throw or missing-owner error. Gateway `/startupz` returned 200 in 33.962s and shutdown exited 0. Fresh synthetic HOME/state/config on loopback port 63770; no operator state or real credentials used.

Synthetic live-proof transcript:
```text
doctor --fix --non-interactive: exit=0 timeout=false
bindingsUnchanged=true securityThrew=false missingOwner=false
gateway run: /startupz=200 readyMs=33962 shutdownExit=0
```
The synthetic Discord token is deliberately invalid; this proves local Doctor/startup behavior, not an authenticated channel roundtrip.

A stale task-local artifact lock initially stopped build/typechecking before compilation. Recovery followed the documented procedure after verifying no associated process or open handle remained; the successful build above is the retry. No source change, dependency reinstall, timeout increase, or safety-check bypass was used to recover it.

Latest ClawSweeper review on this exact head found no correctness/security findings and no pre-merge changes to make. Exact-head CI run [33679091801](https://github.com/openclaw/openclaw/actions/runs/33679091801) passed. Native preparation and merge completed; merged as `189a760143733e657ecbbf153fdc109566299098`, independently verified as an ancestor of main. The primary repair's migration/delivery proof is not substituted for this revision's smoke test.

The first native merge attempt hit an API rate limit after recording intent. The exact retained lock was recovered only after checking process absence, the open PR/timeline, current-main history and authenticated quota; one pinned `merge-recover` attempt then completed. No credential switch, code/head change or merge-gate bypass was used. Native completion: https://github.com/openclaw/openclaw/pull/136580#issuecomment-5516230486
