### PR TITLE
fix(gateway): name folder recents from Windows-style paths

### DIFF
--- a/src/gateway/server-methods/projects.test.ts
+++ b/src/gateway/server-methods/projects.test.ts
@@ -538,3 +538,35 @@ test("projects.remove refuses to delete a cloned checkout used by a live direct 
     await state.cleanup();
   }
 });
+
+test("projects.list names folder recents from Windows-style paths", async () => {
+  const state = await createOpenClawTestState({ layout: "state-only", prefix: "projects-rpc-" });
+  try {
+    const profile = ensureProfileForEmail("windows-recents@example.test");
+    replaceSessionEntrySync(
+      { agentId: "main", sessionKey: "agent:main:windows" },
+      {
+        sessionId: "session-windows",
+        updatedAt: 900,
+        createdActor: { type: "human", source: "profile", id: profile.id },
+        spawnedCwd: "C:\\Users\\dev\\projects\\windows-project",
+      },
+    );
+    const result = await invokeProjectMethod(
+      "projects.list",
+      {},
+      { agents: { list: [{ id: "main", default: true, workspace: "/workspace" }] } },
+      ["operator.write"],
+      profile.id,
+    );
+    expect((result?.payload as { recents?: unknown[] } | undefined)?.recents).toEqual([
+      {
+        kind: "folder",
+        folder: "C:\\Users\\dev\\projects\\windows-project",
+        displayName: "windows-project",
+      },
+    ]);
+  } finally {
+    await state.cleanup();
+  }
+});

--- a/src/gateway/server-methods/projects.test.ts
+++ b/src/gateway/server-methods/projects.test.ts
@@ -539,7 +539,17 @@ test("projects.remove refuses to delete a cloned checkout used by a live direct 
   }
 });
 
-test("projects.list names folder recents from Windows-style paths", async () => {
+test.each([
+  ["POSIX", "/Users/dev/projects/posix-project", "posix-project"],
+  ["POSIX with a trailing separator", "/Users/dev/projects/posix-project/", "posix-project"],
+  ["Windows", "C:\\Users\\dev\\projects\\windows-project", "windows-project"],
+  [
+    "Windows with a trailing separator",
+    "C:\\Users\\dev\\projects\\windows-project\\",
+    "windows-project",
+  ],
+  ["mixed separators", "C:\\Users/dev\\projects/mixed-project/", "mixed-project"],
+] as const)("projects.list names folder recents from %s paths", async (_, folder, displayName) => {
   const state = await createOpenClawTestState({ layout: "state-only", prefix: "projects-rpc-" });
   try {
     const profile = ensureProfileForEmail("windows-recents@example.test");
@@ -549,7 +559,7 @@ test("projects.list names folder recents from Windows-style paths", async () => 
         sessionId: "session-windows",
         updatedAt: 900,
         createdActor: { type: "human", source: "profile", id: profile.id },
-        spawnedCwd: "C:\\Users\\dev\\projects\\windows-project",
+        spawnedCwd: folder,
       },
     );
     const result = await invokeProjectMethod(
@@ -562,8 +572,8 @@ test("projects.list names folder recents from Windows-style paths", async () => 
     expect((result?.payload as { recents?: unknown[] } | undefined)?.recents).toEqual([
       {
         kind: "folder",
-        folder: "C:\\Users\\dev\\projects\\windows-project",
-        displayName: "windows-project",
+        folder,
+        displayName,
       },
     ]);
   } finally {

--- a/src/gateway/server-methods/projects.ts
+++ b/src/gateway/server-methods/projects.ts
@@ -88,7 +88,10 @@ const PROJECTS_LIST_MAX_RAW_CANDIDATES = Math.max(
 
 function folderDisplayName(folder: string): string {
   const trimmed = folder.replace(/[\\/]+$/u, "");
-  return path.posix.basename(trimmed) || path.win32.basename(trimmed) || folder;
+  // Recents carry whatever separator the session host used, so split on both.
+  // path.posix.basename hands back a backslash path unchanged, which left the
+  // win32 basename it was chained to behind an `||` that never fires.
+  return trimmed.split(/[\\/]/u).at(-1) || folder;
 }
 
 function checkoutName(checkoutPath: string): string {

--- a/src/gateway/server-methods/projects.ts
+++ b/src/gateway/server-methods/projects.ts
@@ -88,9 +88,6 @@ const PROJECTS_LIST_MAX_RAW_CANDIDATES = Math.max(
 
 function folderDisplayName(folder: string): string {
   const trimmed = folder.replace(/[\\/]+$/u, "");
-  // Recents carry whatever separator the session host used, so split on both.
-  // path.posix.basename hands back a backslash path unchanged, which left the
-  // win32 basename it was chained to behind an `||` that never fires.
   return trimmed.split(/[\\/]/u).at(-1) || folder;
 }
 


### PR DESCRIPTION
## What Problem This Solves

`folderDisplayName` chained `path.posix.basename(trimmed) || path.win32.basename(trimmed)`. POSIX basename returns a backslash path unchanged, so the first call is always truthy and the win32 fallback never runs. A Windows recent such as `C:\Users\dev\projects\windows-project` reached the New Session picker labeled with its whole path instead of `windows-project`.

## Fix

Split once on both separators after trimming trailing ones, in the helper that already owned the label. The stored `folder` value is untouched, only its display name changes.

## Evidence

Both traces below are from a real Gateway process against a throwaway state dir, seeded with one session whose `spawnedCwd` is a Windows path, then called over the WebSocket transport. Same input path in both, `C:\Users\dev\projects\windows-project\`.

Current main, `f5e6bd872c9230af6507dd8c4682de5898939ca4`:

```text
--- projects.list request ---
{"type":"req","id":"r1","method":"projects.list","params":{}}
--- projects.list response ---
{
  "type": "res",
  "id": "r1",
  "ok": true,
  "payload": {
    "projects": [
      {
        "id": "workspace:main",
        "displayName": "workspace",
        "repoRoot": "/tmp/oc-gw-trace-hAeO3G/workspace",
        "source": "workspace",
        "agentId": "main"
      }
    ],
    "recents": [
      {
        "kind": "folder",
        "folder": "C:\\Users\\dev\\projects\\windows-project\\",
        "displayName": "C:\\Users\\dev\\projects\\windows-project"
      }
    ]
  }
}
```

This head, `5c6e40f53c005fcae6c0c45b5d207db4f4759b8d`:

```text
--- projects.list request ---
{"type":"req","id":"r1","method":"projects.list","params":{}}
--- projects.list response ---
{
  "type": "res",
  "id": "r1",
  "ok": true,
  "payload": {
    "projects": [
      {
        "id": "workspace:main",
        "displayName": "workspace",
        "repoRoot": "/tmp/oc-gw-trace-JL6rHs/workspace",
        "source": "workspace",
        "agentId": "main"
      }
    ],
    "recents": [
      {
        "kind": "folder",
        "folder": "C:\\Users\\dev\\projects\\windows-project\\",
        "displayName": "windows-project"
      }
    ]
  }
}
```

Gateway-method tests on this head:

```text
 ✓ src/gateway/server-methods/projects.test.ts > projects.list names folder recents from POSIX paths 175ms
 ✓ src/gateway/server-methods/projects.test.ts > projects.list names folder recents from POSIX with a trailing separator paths 190ms
 ✓ src/gateway/server-methods/projects.test.ts > projects.list names folder recents from Windows paths 186ms
 ✓ src/gateway/server-methods/projects.test.ts > projects.list names folder recents from Windows with a trailing separator paths 202ms
 ✓ src/gateway/server-methods/projects.test.ts > projects.list names folder recents from mixed separators paths 209ms
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Path handling here is pure string work, so it reproduces on Linux without a Windows host.

AI-assisted. Fully tested.
