### PR TITLE
fix(gateway): stop stale mutating restart recovery

### DIFF
--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -192,11 +192,20 @@ Three complementary mechanisms mark sessions whose turn did not finish:
 
 ## Automatic resume
 
-A few seconds after startup, the gateway re-dispatches each marked session
-with a synthetic system message telling the agent its previous turn was
-interrupted by a restart and to continue from the existing transcript. If a
-final reply had already been produced but not delivered, its text is included
-so the agent can deliver it instead of redoing the work.
+A few seconds after startup, the gateway classifies each marked session before
+deciding whether to continue it. Turns that contain only model work, audited
+read-only tools, or a replay-safe Code Mode checkpoint may be re-dispatched
+with a synthetic system message telling the agent to continue from the existing
+transcript. If a final reply had already been produced but not delivered, its
+text is included so the agent can deliver it instead of redoing the work.
+
+An interrupted turn that called a mutating or otherwise non-replay-safe tool is
+not resumed automatically. OpenClaw marks the session failed, preserves its
+transcript, and records a notice directing the operator to resume in a new
+session or use `/new` or `/reset`. This also prevents old intent from overwriting
+configuration or other remediation applied while the Gateway was offline. If a
+long turn exceeds the bounded recovery transcript and its read-only status
+cannot be proved, recovery fails closed in the same way.
 
 Startup reconciliation retries transient failures up to three times with
 exponential backoff. Separately, each interrupted main-session cycle has a
@@ -343,6 +352,8 @@ channels.start --params '{"channel":"<id>"}'`
   See also [Gateway](/gateway) (safe mode paragraph) for the same control-plane
   vs channel-autostart split.
 
+- **Main-session mutation boundary:** mutating or unprovable interrupted turns
+  are tombstoned with a visible recovery notice instead of being re-dispatched.
 - **Main-session attempt budget:** three charged automatic dispatch attempts
   per interrupted cycle; exhaustion tombstones that session until it is
   inspected and replaced.

--- a/extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts
+++ b/extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts
@@ -1,11 +1,12 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { afterEach, describe, expect, it } from "vitest";
 import { startQaBusServer } from "./bus-server.js";
 import { createQaBusState } from "./bus-state.js";
 import { createQaGatewayChild } from "./gateway-child.js";
 import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
-import { QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER } from "./providers/mock-openai/mock-openai-contracts.js";
 import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
 import { createQaChannelTransport } from "./qa-channel-transport.js";
 import { waitForQaTransportCondition } from "./qa-transport.js";
@@ -32,7 +33,7 @@ describe.skipIf(process.platform === "win32")("gateway hard-kill recovery", () =
     }
   });
 
-  it("reconciles an orphaned run and replies to a new inbound send after SIGKILL", async () => {
+  it("tombstones orphaned mutating work without overwriting newer config", async () => {
     const state = createQaBusState();
     const transport = createQaChannelTransport(state);
     const bus = await startQaBusServer({ state });
@@ -65,8 +66,7 @@ describe.skipIf(process.platform === "win32")("gateway hard-kill recovery", () =
         tools: {
           ...cfg.tools,
           alsoAllow: ["qa_restart_wait", "qa_restart_unsafe_probe"],
-          // Suspend the 30-second tool so the model's wait is pending at SIGKILL.
-          codeMode: { enabled: true, timeoutMs: 10_000 },
+          codeMode: { enabled: false },
         },
       }),
     });
@@ -85,7 +85,7 @@ describe.skipIf(process.platform === "win32")("gateway hard-kill recovery", () =
         accountId: transport.accountId,
         conversation,
         senderId: conversation.id,
-        text: "Code Mode restart wait QA check. Original prompt marker: KILL-RESTART-PROMPT.",
+        text: "Mutating restart wait QA check. Original prompt marker: KILL-RESTART-MUTATING-PROMPT.",
       });
       const pending = await transport.waitForCondition(
         async () => {
@@ -94,8 +94,8 @@ describe.skipIf(process.platform === "win32")("gateway hard-kill recovery", () =
             return undefined;
           }
           const transcript = await readSessionTranscriptSummary({ gateway }, sessionKey);
-          return (transcript.assistantToolCallCounts.wait ?? 0) >
-            (transcript.completedToolCallCounts.wait ?? 0)
+          return (transcript.assistantToolCallCounts.qa_restart_wait ?? 0) >
+            (transcript.completedToolCallCounts.qa_restart_wait ?? 0)
             ? { entry, transcript }
             : undefined;
         },
@@ -111,53 +111,60 @@ describe.skipIf(process.platform === "win32")("gateway hard-kill recovery", () =
         30_000,
         25,
       );
-      await gateway.restartAfterStateMutation(async () => {
+      await gateway.restartAfterStateMutation(async ({ configPath }) => {
         const orphan = (await readRawQaSessionStore({ gateway }))[sessionKey];
         expect(orphan).toMatchObject({ sessionId: pending.entry.sessionId, status: "running" });
         expect(orphan?.abortedLastRun).not.toBe(true);
+        const cfg = asOptionalRecord(JSON.parse(await fs.readFile(configPath, "utf8"))) ?? {};
+        const agents = asOptionalRecord(cfg.agents) ?? {};
+        const next = {
+          ...cfg,
+          agents: {
+            ...agents,
+            defaults: {
+              ...asOptionalRecord(agents.defaults),
+              timeoutSeconds: 654,
+            },
+          },
+        };
+        await fs.writeFile(configPath, `${JSON.stringify(next, null, 2)}\n`, "utf8");
       });
       expect(gateway.pid).not.toBe(pid);
       await transport.waitReady({ gateway });
       await transport.waitForCondition(
         async () => {
-          if (!gateway.logs().includes("dispatching restart-safe recovery")) {
+          if (!gateway.logs().includes("tombstoned main-session restart recovery")) {
             return undefined;
           }
-          const transcript = await readSessionTranscriptSummary({ gateway }, sessionKey);
-          return transcript.eventCursor > pending.transcript.eventCursor ? true : undefined;
+          const entry = (await readRawQaSessionStore({ gateway }))[sessionKey];
+          return entry?.status === "failed" ? true : undefined;
         },
         120_000,
         25,
       );
       expect(gateway.logs()).toContain("marked 1 startup-orphaned main session(s)");
-
-      const sinceIndex = state
-        .getSnapshot()
-        .messages.filter((message) => message.direction === "outbound").length;
-      const second = await transport.sendInbound({
-        accountId: transport.accountId,
-        conversation,
-        senderId: conversation.id,
-        // This current-turn fixture takes precedence over the restart prompt in history.
-        text: "repeated request queued reply gateway qa check",
-      });
-      const reply = await transport.waitForOutbound({
-        conversation,
-        sinceIndex,
-        textIncludes: QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER,
-        timeoutMs: 180_000,
-      });
-      expect(reply.replyToId).toBe(second.id);
-      expect(reply.accountId).toBe(transport.accountId);
+      expect(gateway.logs()).not.toContain("dispatching restart-safe recovery");
+      const repairedConfig = asOptionalRecord(
+        JSON.parse(await fs.readFile(gateway.configPath, "utf8")),
+      );
+      expect(
+        asOptionalRecord(asOptionalRecord(repairedConfig?.agents)?.defaults)?.timeoutSeconds,
+      ).toBe(654);
       const settled = await transport.waitForCondition(
         async () => {
           const entry = (await readRawQaSessionStore({ gateway }))[sessionKey];
-          return entry?.status === "done" ? entry : undefined;
+          return entry?.status === "failed" ? entry : undefined;
         },
         30_000,
         25,
       );
       expect(settled.sessionId).toBe(pending.entry.sessionId);
+      await transport.waitForOutbound({
+        conversation,
+        sinceIndex: 0,
+        textIncludes: "couldn't continue this session after a gateway restart",
+        timeoutMs: 30_000,
+      });
     } catch (error) {
       const diagnostics = await Promise.allSettled([
         readRawQaSessionStore({ gateway }),

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -409,6 +409,7 @@ export const QA_MCP_CODE_MODE_PROMPT_RE = /mcp code mode qa check/i;
 export const QA_RESTART_CODE_MODE_WAIT_PROMPT_RE = /code mode restart wait qa check/i;
 export const QA_RESTART_RECOVERY_PROMPT_RE = /previous turn was interrupted by a gateway restart/i;
 export const QA_KILL_RESTART_PROMPT_RE = /\bKILL-RESTART-PROMPT\b/u;
+export const QA_KILL_RESTART_MUTATING_PROMPT_RE = /\bKILL-RESTART-MUTATING-PROMPT\b/u;
 export const QA_KILL_RESTART_RECOVERED_MARKER = "KILL-RESTART-RECOVERED-OK";
 const QA_AUDIO_TRANSCRIPTION_TEXT =
   "Reply with only this exact marker: WHATSAPP_QA_AUDIO_TRANSCRIPT_OK";

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -108,6 +108,7 @@ import {
   QA_RESTART_CODE_MODE_WAIT_PROMPT_RE,
   QA_RESTART_RECOVERY_PROMPT_RE,
   QA_KILL_RESTART_PROMPT_RE,
+  QA_KILL_RESTART_MUTATING_PROMPT_RE,
   QA_KILL_RESTART_RECOVERED_MARKER,
   QA_MCP_CODE_MODE_API_FILE_PROMPT_RE,
   type MockScenarioState,
@@ -937,6 +938,19 @@ async function buildResponsesPayload(
     QA_RESTART_RECOVERY_PROMPT_RE.test(allInputText)
   ) {
     return buildAssistantEvents(QA_KILL_RESTART_RECOVERED_MARKER);
+  }
+  if (QA_KILL_RESTART_MUTATING_PROMPT_RE.test(allInputText)) {
+    const mutationCompleted = input.some(
+      (item) =>
+        (item.type === "function_call_output" || item.type === "custom_tool_call_output") &&
+        stringifyScenarioToolOutput(item.output).includes("unsafe-probe-executed"),
+    );
+    if (mutationCompleted) {
+      return buildToolCallEventsWithArgs("qa_restart_wait", {});
+    }
+    if (hasToolDefinition(body, "qa_restart_unsafe_probe")) {
+      return buildToolCallEventsWithArgs("qa_restart_unsafe_probe", {});
+    }
   }
   if (QA_RESTART_CODE_MODE_WAIT_PROMPT_RE.test(allInputText)) {
     const progress = readRestartCheckpointProgress(input);

--- a/src/agents/main-session-recovery/main-session-restart-recovery-failure.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-failure.ts
@@ -37,9 +37,9 @@ async function sendRestartRecoveryTombstoneNotice(params: {
   gatewayRuntime: GatewayRecoveryRuntime;
   reason: string;
   sessionKey: string;
-}): Promise<void> {
+}): Promise<"failed" | "sent" | "suppressed"> {
   try {
-    await params.gatewayRuntime.sendRecoveryNotice({
+    const result = await params.gatewayRuntime.sendRecoveryNotice({
       channel: params.deliveryContext.channel,
       to: params.deliveryContext.to,
       accountId: params.deliveryContext.accountId,
@@ -47,13 +47,18 @@ async function sendRestartRecoveryTombstoneNotice(params: {
       text: TOMBSTONED_SESSION_NOTICE,
       idempotencyKey: buildRestartRecoveryTombstoneNoticeKey(params.entry),
     });
+    if (result.suppressed) {
+      return "suppressed";
+    }
     mainSessionRecoveryLog.info(
       `sent restart recovery tombstone notice: ${params.sessionKey} (${params.reason})`,
     );
+    return "sent";
   } catch (error) {
     mainSessionRecoveryLog.warn(
       `failed to send restart recovery tombstone notice ${params.sessionKey}: ${String(error)}`,
     );
+    return "failed";
   }
 }
 
@@ -63,7 +68,7 @@ async function writeRestartRecoveryTombstoneNotice(params: {
   sessionKey: string;
   storePath: string;
   expectedSessionState: SessionTranscriptTurnExpectedState;
-  sessionLifecyclePatch: SessionTranscriptTurnLifecyclePatch;
+  sessionLifecyclePatch?: SessionTranscriptTurnLifecyclePatch;
 }): Promise<"failed" | "stale" | "written"> {
   const result = await appendAssistantMessageToSessionTranscript({
     agentId: params.agentId,
@@ -199,12 +204,23 @@ export async function tombstoneMainRestartRecoveryWithNotice(params: {
   if (!tombstonedEntry) {
     return "skipped";
   }
-  await sendRestartRecoveryTombstoneNotice({
+  const notice = await sendRestartRecoveryTombstoneNotice({
     deliveryContext,
     entry: tombstonedEntry,
     gatewayRuntime: params.gatewayRuntime,
     reason: params.reason,
     sessionKey: params.sessionKey,
   });
+  if (notice !== "sent") {
+    return (await writeRestartRecoveryTombstoneNotice({
+      agentId: params.agentId,
+      entry: tombstonedEntry,
+      expectedSessionState: buildRestartRecoveryExpectedState(tombstonedEntry),
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+    })) === "written"
+      ? "tombstoned"
+      : "notice_failed";
+  }
   return "tombstoned";
 }

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createNestedToolActivity } from "../../sessions/nested-tool-activity.js";
 import { resolveMainSessionResumePolicy } from "./main-session-restart-recovery-resume-policy.js";
 
 vi.mock("../code-mode-control-tools.js", () => ({
@@ -68,6 +69,7 @@ function codeModeCheckpoint(params: {
   return {
     role: "toolResult",
     toolName: "exec",
+    toolCallId: "exec-call",
     content: [
       {
         type: "text",
@@ -89,6 +91,32 @@ function codeModeWait(runId = "code-run") {
   };
 }
 
+function nestedToolActivity(toolName: string, parentToolCallId = "exec-call") {
+  return createNestedToolActivity({
+    runId: "code-run",
+    scopeId: "code-scope",
+    afterEntryId: null,
+    startOrder: 0,
+    parentToolCallId,
+    toolCallId: `${toolName}-call`,
+    toolName,
+    input: {},
+    result: { content: [{ type: "text", text: "done" }] },
+    isError: false,
+    startedAt: 1,
+    timestamp: 2,
+  });
+}
+
+function missingToolResult(toolName: string) {
+  return {
+    role: "toolResult",
+    toolName,
+    details: { reason: "missing_tool_result" },
+    content: [{ type: "text", text: "outcome unknown" }],
+  };
+}
+
 describe("resolveMainSessionResumePolicy former terminal states", () => {
   it.each([
     {
@@ -99,7 +127,10 @@ describe("resolveMainSessionResumePolicy former terminal states", () => {
     {
       label: "delivered receipt without tool-call correlation",
       params: { deliveryReceiptState: "delivered-terminal" as const },
-      expected: { action: "resume", forceRestartSafeTools: true },
+      expected: {
+        action: "resume",
+        forceRestartSafeTools: true,
+      },
     },
     ...(["pending", "handled-reply", "handled-unrecoverable"] as const).map((state) => ({
       label: `before_agent_reply ${state}`,
@@ -134,7 +165,10 @@ describe("resolveMainSessionResumePolicy former terminal states", () => {
           },
         ],
       },
-      expected: { action: "resume", forceRestartSafeTools: true },
+      expected: {
+        action: "resume",
+        forceRestartSafeTools: true,
+      },
     },
     {
       label: "non-replay-safe Code Mode checkpoint",
@@ -144,7 +178,10 @@ describe("resolveMainSessionResumePolicy former terminal states", () => {
           codeModeCheckpoint({ replaySafe: false, runId: "code-run" }),
         ],
       },
-      expected: { action: "resume", forceRestartSafeTools: true },
+      expected: {
+        action: "tombstone",
+        reason: "interrupted turn included mutating tool work",
+      },
     },
     {
       label: "Code Mode wait with an unmatched checkpoint",
@@ -155,7 +192,10 @@ describe("resolveMainSessionResumePolicy former terminal states", () => {
           codeModeWait(),
         ],
       },
-      expected: { action: "resume", forceRestartSafeTools: true },
+      expected: {
+        action: "tombstone",
+        reason: "interrupted turn included mutating tool work",
+      },
     },
     {
       label: "mixed Code Mode wait and side-effecting call",
@@ -173,7 +213,10 @@ describe("resolveMainSessionResumePolicy former terminal states", () => {
           },
         ],
       },
-      expected: { action: "resume", forceRestartSafeTools: true },
+      expected: {
+        action: "tombstone",
+        reason: "interrupted turn included mutating tool work",
+      },
     },
   ])("maps $label to $expected", ({ params, expected }) => {
     expect(resolvePolicy(params)).toEqual(expected);
@@ -192,6 +235,184 @@ describe("resolveMainSessionResumePolicy former terminal states", () => {
       action: "resume",
       forceRestartSafeTools: true,
       forceCodeModeTools: true,
+    });
+  });
+
+  it("trusts nested Code Mode work only behind a replay-safe checkpoint", () => {
+    const nested = nestedToolActivity("plugin_lookup");
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "continue the code run" },
+          codeModeCheckpoint({ replaySafe: true, runId: "code-run" }),
+          nested,
+          codeModeWait(),
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "continue the code run" },
+          codeModeCheckpoint({ replaySafe: false, runId: "code-run" }),
+          nested,
+          codeModeWait(),
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+  });
+
+  it("does not let an earlier Code Mode checkpoint cover later nested work", () => {
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "continue the code run" },
+          codeModeCheckpoint({ replaySafe: true, runId: "code-run" }),
+          nestedToolActivity("write", "later-exec-call"),
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+  });
+
+  it("does not let a checkpoint cover later nested work from the same call", () => {
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "continue the code run" },
+          codeModeCheckpoint({ replaySafe: true, runId: "code-run" }),
+          nestedToolActivity("write"),
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+  });
+
+  it("requires a checkpoint even when nested Code Mode work is read-only", () => {
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "continue the code run" },
+          nestedToolActivity("read", "uncheckpointed-exec"),
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+  });
+
+  it("distinguishes approval-pending from an unknown mutating outcome", () => {
+    const execCall = {
+      role: "assistant",
+      stopReason: "toolUse",
+      content: [
+        { type: "toolCall", id: "exec-call", name: "exec", arguments: { command: "touch x" } },
+      ],
+    };
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "run it" },
+          execCall,
+          {
+            ...missingToolResult("exec"),
+            toolCallId: "exec-call",
+            details: { status: "approval-pending" },
+          },
+        ],
+      }),
+    ).toEqual({ action: "resume", forceRestartSafeTools: true });
+    expect(
+      resolvePolicy({
+        messages: [{ role: "user", content: "run it" }, execCall, missingToolResult("exec")],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+  });
+
+  it("does not let a later approval hide an earlier mutation", () => {
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "update both settings" },
+          {
+            role: "assistant",
+            stopReason: "toolUse",
+            content: [
+              { type: "toolCall", id: "write-call", name: "write", arguments: { path: "x" } },
+            ],
+          },
+          { role: "toolResult", toolName: "write", toolCallId: "write-call", content: "done" },
+          {
+            role: "assistant",
+            stopReason: "toolUse",
+            content: [
+              {
+                type: "toolCall",
+                id: "exec-call",
+                name: "exec",
+                arguments: { command: "touch y" },
+              },
+            ],
+          },
+          {
+            ...missingToolResult("exec"),
+            toolCallId: "exec-call",
+            details: { status: "approval-pending" },
+          },
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+  });
+
+  it("does not apply a replay-safe checkpoint to another Code Mode call", () => {
+    expect(
+      resolvePolicy({
+        messages: [
+          { role: "user", content: "continue both code runs" },
+          nestedToolActivity("write"),
+          codeModeCheckpoint({ replaySafe: false, runId: "code-run-b" }),
+          {
+            ...codeModeCheckpoint({ replaySafe: true, runId: "code-run-a" }),
+            toolCallId: "other-exec-call",
+          },
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
+  });
+
+  it("rejects a non-tail unproven Code Mode call before hook resume", () => {
+    expect(
+      resolvePolicy({
+        beforeAgentReplyState: "handled-reply",
+        messages: [
+          { role: "user", content: "continue the code run" },
+          codeModeCheckpoint({ replaySafe: false, runId: "code-run" }),
+          { role: "assistant", content: [{ type: "text", text: "partial" }] },
+        ],
+      }),
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
     });
   });
 });
@@ -263,7 +484,7 @@ describe("resolveMainSessionResumePolicy progress tails", () => {
     ).toEqual({ action: "resume", forceRestartSafeTools: false });
   });
 
-  it("retains replay restrictions when final-phase async delivery follows a side-effecting call", () => {
+  it("terminalizes a side-effecting call even when async delivery follows it", () => {
     expect(
       resolveMainSessionResumePolicy([
         { role: "user", content: "finish the interrupted work" },
@@ -276,7 +497,10 @@ describe("resolveMainSessionResumePolicy progress tails", () => {
         },
         asyncDeliveryMessage("The background check finished.", "async-after-exec"),
       ]),
-    ).toEqual({ action: "resume", forceRestartSafeTools: true });
+    ).toEqual({
+      action: "tombstone",
+      reason: "interrupted turn included mutating tool work",
+    });
   });
 
   it("never treats unkeyed stream fallbacks as authoritative progress", () => {

--- a/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.ts
@@ -1,5 +1,7 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
+import { readNestedToolActivity } from "../../sessions/nested-tool-activity.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "../code-mode-control-tools.js";
 import {
   getTranscriptMessageRole as getMessageRole,
@@ -11,6 +13,7 @@ import {
   AGENT_RUN_RESTART_ABORT_ERROR,
   AGENT_RUN_RESTART_ABORT_ERROR_CODE,
 } from "../run-termination.js";
+import { buildToolMutationState } from "../tool-mutation.js";
 import { isAgentToolReplaySafe } from "../tool-replay-safety.js";
 
 function readDeliveredTerminalSourceReplyToolCallId(
@@ -125,6 +128,17 @@ type DanglingToolCallClassification =
   | { kind: "code-mode" }
   | { kind: "resumable"; forceRestartSafeTools: boolean };
 
+function isCodeModeControlCall(block: Record<string, unknown>, name: string): boolean {
+  if (name === CODE_MODE_WAIT_TOOL_NAME) {
+    return true;
+  }
+  if (name !== CODE_MODE_EXEC_TOOL_NAME) {
+    return false;
+  }
+  const args = block.arguments ?? block.input;
+  return Boolean(args && typeof args === "object" && Object.hasOwn(args, "code"));
+}
+
 // A dangling call may have committed before its result persisted, so anything
 // outside the audited replay-safe allowlist keeps the restart-safe tool
 // restriction: the continuation can inspect and report, but never silently
@@ -135,6 +149,7 @@ function classifyDanglingToolCalls(content: unknown): DanglingToolCallClassifica
     return undefined;
   }
   let allReplaySafe = true;
+  let hasCodeModeControl = false;
   let hasToolCall = false;
   for (const block of content) {
     if (!block || typeof block !== "object") {
@@ -145,17 +160,21 @@ function classifyDanglingToolCalls(content: unknown): DanglingToolCallClassifica
       continue;
     }
     const name = normalizeOptionalString((block as { name?: unknown }).name);
-    if (name === CODE_MODE_EXEC_TOOL_NAME || name === CODE_MODE_WAIT_TOOL_NAME) {
-      return { kind: "code-mode" };
-    }
-    if (!isAgentToolReplaySafe({ name })) {
+    if (name && isCodeModeControlCall(asOptionalRecord(block) ?? {}, name)) {
+      hasCodeModeControl = true;
+    } else if (!isAgentToolReplaySafe({ name })) {
       allReplaySafe = false;
     }
     hasToolCall = true;
   }
-  return hasToolCall
-    ? { kind: "resumable", forceRestartSafeTools: !allReplaySafe }
-    : { kind: "none" };
+  if (!hasToolCall) {
+    return { kind: "none" };
+  }
+  return !allReplaySafe
+    ? { kind: "resumable", forceRestartSafeTools: true }
+    : hasCodeModeControl
+      ? { kind: "code-mode" }
+      : { kind: "resumable", forceRestartSafeTools: false };
 }
 
 // Unlike isPendingAssistantToolCall, visible text beside the call is fine —
@@ -178,7 +197,7 @@ function readResumablePendingToolCallTail(
 
 function readCodeModeCheckpoint(
   message: unknown,
-): { replaySafe: boolean; runId?: string } | undefined {
+): { replaySafe: boolean; runId?: string; toolCallId?: string } | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
   }
@@ -207,12 +226,13 @@ function readCodeModeCheckpoint(
       replaySafe?: unknown;
       runId?: unknown;
     };
+    const toolCallId = normalizeOptionalString(asOptionalRecord(message)?.toolCallId);
     if (result.status === "completed" || result.status === "failed") {
-      return { replaySafe: result.replaySafe === true };
+      return { replaySafe: result.replaySafe === true, ...(toolCallId ? { toolCallId } : {}) };
     }
     const runId = normalizeOptionalString(result.runId);
     return result.status === "waiting" && runId
-      ? { replaySafe: result.replaySafe === true, runId }
+      ? { replaySafe: result.replaySafe === true, runId, ...(toolCallId ? { toolCallId } : {}) }
       : undefined;
   } catch {
     return undefined;
@@ -351,6 +371,116 @@ function requiresRestartSafeToolResult(message: unknown): boolean {
   return status.reason === "missing_tool_result" || status.status === "approval-pending";
 }
 
+function isApprovalPendingToolResult(message: unknown): boolean {
+  if (!message || typeof message !== "object" || getMessageRole(message) !== "toolResult") {
+    return false;
+  }
+  return asOptionalRecord(asOptionalRecord(message)?.details)?.status === "approval-pending";
+}
+
+function resolveApprovalPendingToolCallId(
+  messages: readonly unknown[],
+  message: unknown,
+): string | undefined {
+  const explicitId = normalizeOptionalString(asOptionalRecord(message)?.toolCallId);
+  if (explicitId) {
+    return explicitId;
+  }
+  const toolName = normalizeOptionalString(asOptionalRecord(message)?.toolName);
+  if (!toolName) {
+    return undefined;
+  }
+  const latestUserIndex = messages.findLastIndex(
+    (candidate) => getMessageRole(candidate) === "user",
+  );
+  const matchingIds = messages.slice(Math.max(0, latestUserIndex)).flatMap((candidate) => {
+    if (getMessageRole(candidate) !== "assistant") {
+      return [];
+    }
+    const content = asOptionalRecord(candidate)?.content;
+    return Array.isArray(content)
+      ? content.flatMap((block) => {
+          const record = asOptionalRecord(block);
+          return normalizeOptionalString(record?.name) === toolName
+            ? [normalizeOptionalString(record?.id)].filter((id): id is string => Boolean(id))
+            : [];
+        })
+      : [];
+  });
+  return matchingIds.length === 1 ? matchingIds[0] : undefined;
+}
+
+function hasUnprovenToolWorkInCurrentTurn(
+  messages: readonly unknown[],
+  ignoredToolCallId?: string,
+): boolean {
+  const latestUserIndex = messages.findLastIndex((message) => getMessageRole(message) === "user");
+  const currentTurnStart = Math.max(0, latestUserIndex);
+  const checkpoints = messages.flatMap((message, index) => {
+    if (index < currentTurnStart) {
+      return [];
+    }
+    if (isRestartAbortedWaitFailure(message)) {
+      return [];
+    }
+    const checkpoint = readCodeModeCheckpoint(message);
+    return checkpoint ? [{ ...checkpoint, index }] : [];
+  });
+  if (checkpoints.some((checkpoint) => !checkpoint.replaySafe)) {
+    return true;
+  }
+  for (let index = currentTurnStart; index < messages.length; index += 1) {
+    const message = messages[index];
+    const nested = readNestedToolActivity(message);
+    const nestedCheckpoint = nested?.details.parentToolCallId
+      ? checkpoints.find(
+          (checkpoint) =>
+            checkpoint.toolCallId === nested.details.parentToolCallId && checkpoint.index >= index,
+        )
+      : undefined;
+    if (nested && !nestedCheckpoint) {
+      return true;
+    }
+    if (getMessageRole(message) !== "assistant") {
+      continue;
+    }
+    const content = asOptionalRecord(message)?.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const block of content) {
+      const record = asOptionalRecord(block);
+      const type = normalizeOptionalString(record?.type);
+      const name = normalizeOptionalString(record?.name);
+      if (!name || (type !== "toolCall" && type !== "toolUse" && type !== "tool_use")) {
+        continue;
+      }
+      if (normalizeOptionalString(record?.id) === ignoredToolCallId) {
+        continue;
+      }
+      const args = record?.arguments ?? record?.input;
+      if (isCodeModeControlCall(record ?? {}, name)) {
+        const toolCallId = normalizeOptionalString(record?.id);
+        const runId = normalizeOptionalString(asOptionalRecord(args)?.runId);
+        const checkpoint = checkpoints.find((candidate) =>
+          name === CODE_MODE_EXEC_TOOL_NAME
+            ? candidate.toolCallId === toolCallId && candidate.index >= index
+            : candidate.runId === runId && candidate.index <= index,
+        );
+        if (!checkpoint) {
+          return true;
+        }
+        continue;
+      }
+      const mutation = buildToolMutationState(name, args);
+      if (mutation.mutatingAction || !mutation.replaySafe) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 type MainSessionResumePolicy =
   | {
       action: "complete";
@@ -358,6 +488,7 @@ type MainSessionResumePolicy =
       toolCallId: string;
     }
   | { action: "complete"; reason: "handled-silent" }
+  | { action: "tombstone"; reason: "interrupted turn included mutating tool work" }
   | {
       action: "resume";
       forceRestartSafeTools: boolean;
@@ -380,28 +511,16 @@ export function resolveMainSessionResumePolicy(
     return { action: "complete", reason: "delivered-terminal", toolCallId: mirroredToolCallId };
   }
   if (deliveryReceiptState === "delivered-terminal") {
-    return deliveryToolCallId
-      ? {
-          action: "complete",
-          reason: "delivered-terminal-receipt",
-          toolCallId: deliveryToolCallId,
-        }
-      : { action: "resume", forceRestartSafeTools: true };
-  }
-  if (deliveryReceiptState === "terminal-pending") {
-    return { action: "resume", forceRestartSafeTools: true };
+    if (deliveryToolCallId) {
+      return {
+        action: "complete",
+        reason: "delivered-terminal-receipt",
+        toolCallId: deliveryToolCallId,
+      };
+    }
   }
   if (beforeAgentReplyState === "handled-silent") {
     return { action: "complete", reason: "handled-silent" };
-  }
-  if (beforeAgentReplyState === "pending") {
-    return { action: "resume", forceRestartSafeTools: true };
-  }
-  if (beforeAgentReplyState === "handled-reply") {
-    return { action: "resume", forceRestartSafeTools: true };
-  }
-  if (beforeAgentReplyState === "handled-unrecoverable") {
-    return { action: "resume", forceRestartSafeTools: true };
   }
   // Progress can commit after the recovery mark while the old run is winding
   // down. It is not a terminal turn boundary; preserve it in the transcript
@@ -433,24 +552,44 @@ export function resolveMainSessionResumePolicy(
     meaningfulMessages.shift();
   }
   const lastMeaningful = meaningfulMessages[0];
+  if (isApprovalPendingToolResult(lastMeaningful)) {
+    const approvalCallId = resolveApprovalPendingToolCallId(messages, lastMeaningful);
+    if (approvalCallId && !hasUnprovenToolWorkInCurrentTurn(messages, approvalCallId)) {
+      return { action: "resume", forceRestartSafeTools: true };
+    }
+  }
+  if (hasUnprovenToolWorkInCurrentTurn(messages)) {
+    return { action: "tombstone", reason: "interrupted turn included mutating tool work" };
+  }
+  if (requiresRestartSafeToolResult(lastMeaningful)) {
+    return { action: "resume", forceRestartSafeTools: true };
+  }
+  if (
+    deliveryReceiptState !== undefined ||
+    beforeAgentReplyState === "pending" ||
+    beforeAgentReplyState === "handled-reply" ||
+    beforeAgentReplyState === "handled-unrecoverable"
+  ) {
+    return { action: "resume", forceRestartSafeTools: true };
+  }
   if (forceRestartSafeTools && isPendingAssistantToolCall(lastMeaningful)) {
     return { action: "resume", forceRestartSafeTools: true };
   }
   if (isRestartAbortedWaitFailure(lastMeaningful)) {
-    return { action: "resume", forceRestartSafeTools: true };
+    return { action: "tombstone", reason: "interrupted turn included mutating tool work" };
   }
   const waitCall = readCodeModeWaitCall(lastMeaningful);
   if (waitCall) {
     const checkpoint = readCodeModeCheckpoint(meaningfulMessages[1]);
     return checkpoint?.replaySafe === true && checkpoint.runId === waitCall.runId
       ? { action: "resume", forceRestartSafeTools: true, forceCodeModeTools: true }
-      : { action: "resume", forceRestartSafeTools: true };
+      : { action: "tombstone", reason: "interrupted turn included mutating tool work" };
   }
   const tailCheckpoint = readCodeModeCheckpoint(lastMeaningful);
   if (tailCheckpoint) {
     return tailCheckpoint.replaySafe
       ? { action: "resume", forceRestartSafeTools: true, forceCodeModeTools: true }
-      : { action: "resume", forceRestartSafeTools: true };
+      : { action: "tombstone", reason: "interrupted turn included mutating tool work" };
   }
   // A tool call interrupted mid-execution resumes like the manual re-send the
   // failure notice used to demand: the dangling call is dropped from the next
@@ -465,15 +604,10 @@ export function resolveMainSessionResumePolicy(
       ? classifyDanglingToolCalls((lastMeaningful as { content?: unknown }).content)
       : undefined;
   if (danglingControlCalls?.kind === "code-mode") {
-    // Without an exact replay-safe checkpoint, Code Mode controls stay unavailable.
-    // The model can inspect the transcript under the ordinary restart-safe restriction.
-    return { action: "resume", forceRestartSafeTools: true };
+    return { action: "tombstone", reason: "interrupted turn included mutating tool work" };
   }
   if (!lastMeaningful || !isResumableTailMessage(lastMeaningful)) {
     return { action: "resume", forceRestartSafeTools: false };
-  }
-  if (requiresRestartSafeToolResult(lastMeaningful)) {
-    return { action: "resume", forceRestartSafeTools: true };
   }
   // A later tool result can hide the checkpoint at the transcript tail; keep
   // the interrupted turn restricted without borrowing an earlier turn's state.

--- a/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   type InternalSessionEntry as SessionEntry,
@@ -13,7 +14,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { GatewayRecoveryRuntime } from "../../gateway/server-instance-runtime.types.js";
-import { readSessionMessagesAsync } from "../../gateway/session-transcript-readers.js";
+import { readRecentSessionMessagesWithStatsAsync } from "../../gateway/session-transcript-readers.js";
 import { resolveGatewaySessionStoreTarget } from "../../gateway/session-utils.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { findDeliveryIntentOwner } from "../../infra/outbound/delivery-queue-storage.js";
@@ -509,30 +510,9 @@ export async function recoverStore(params: {
       result[completed ? "settled" : "skipped"]++;
       continue;
     }
-    if (pendingAction === "fail") {
-      await resumeCurrent({
-        ...(entry.pendingFinalDelivery?.kind === "replayable"
-          ? { pendingFinalDeliveryText: entry.pendingFinalDelivery.text }
-          : {}),
-        forceRestartSafeTools: true,
-      });
-      continue;
-    }
-
-    if (
-      entry.pendingFinalDelivery?.kind === "replayable" &&
-      entry.restartRecoveryForceSafeTools === true
-    ) {
-      await resumeCurrent({
-        pendingFinalDeliveryText: entry.pendingFinalDelivery.text,
-        forceRestartSafeTools: true,
-      });
-      continue;
-    }
-
-    let messages: unknown[];
+    let transcript;
     try {
-      messages = await readSessionMessagesAsync(
+      transcript = await readRecentSessionMessagesWithStatsAsync(
         {
           agentId,
           sessionEntry: entry,
@@ -541,7 +521,6 @@ export async function recoverStore(params: {
           storePath: params.storePath,
         },
         {
-          mode: "recent",
           maxMessages: 20,
           maxBytes: 256 * 1024,
         },
@@ -550,31 +529,42 @@ export async function recoverStore(params: {
       if (stopped()) {
         return result;
       }
-      if (entry.pendingFinalDelivery?.kind === "replayable") {
-        mainSessionRecoveryLog.warn(
-          `transcript unavailable for ${sessionKey}; resuming its durable pending final delivery`,
-        );
-        await resumeCurrent({
-          pendingFinalDeliveryText: entry.pendingFinalDelivery.text,
-        });
-        continue;
-      }
-      mainSessionRecoveryLog.warn(`failed to read transcript for ${sessionKey}: ${String(err)}`);
-      result.failed++;
+      mainSessionRecoveryLog.warn(`transcript unavailable for ${sessionKey}: ${String(err)}`);
+      const tombstone = await tombstoneMainRestartRecoveryWithNotice({
+        agentId,
+        cfg: params.cfg,
+        entry,
+        gatewayRuntime: params.gatewayRuntime,
+        observation: recoveryView.observation,
+        reason: "interrupted turn transcript is unavailable",
+        sessionKey,
+        storePath: params.storePath,
+      });
+      result[tombstone === "notice_failed" ? "failed" : "skipped"]++;
       continue;
     }
+    const messages = transcript.messages;
+    const currentTurnBoundaryVisible =
+      transcript.totalMessages === messages.length ||
+      messages.some((message) => asOptionalRecord(message)?.role === "user");
 
     if (stopped()) {
       return result;
     }
-    if (entry.pendingFinalDelivery?.kind === "replayable") {
-      await resumeCurrent({
-        pendingFinalDeliveryText: entry.pendingFinalDelivery.text,
-        forceRestartSafeTools: hasReplaySafeCodeModeCheckpointInCurrentTurn(messages),
+    if (!currentTurnBoundaryVisible) {
+      const tombstone = await tombstoneMainRestartRecoveryWithNotice({
+        agentId,
+        cfg: params.cfg,
+        entry,
+        gatewayRuntime: params.gatewayRuntime,
+        observation: recoveryView.observation,
+        reason: "interrupted turn exceeded the bounded recovery transcript",
+        sessionKey,
+        storePath: params.storePath,
       });
+      result[tombstone === "notice_failed" ? "failed" : "skipped"]++;
       continue;
     }
-
     // Completion reports are delivery turns, not human work. Same-process
     // rotation retains their announce run ids; a full restart can recover the
     // same fact from the already-persisted user-message provenance.
@@ -644,10 +634,30 @@ export async function recoverStore(params: {
       }
       continue;
     }
+    if (resumePolicy.action === "tombstone") {
+      const tombstone = await tombstoneMainRestartRecoveryWithNotice({
+        agentId,
+        cfg: params.cfg,
+        entry,
+        gatewayRuntime: params.gatewayRuntime,
+        observation: recoveryView.observation,
+        reason: resumePolicy.reason,
+        sessionKey,
+        storePath: params.storePath,
+      });
+      result[tombstone === "notice_failed" ? "failed" : "skipped"]++;
+      continue;
+    }
 
     await resumeCurrent({
+      ...(entry.pendingFinalDelivery?.kind === "replayable"
+        ? { pendingFinalDeliveryText: entry.pendingFinalDelivery.text }
+        : {}),
       forceRestartSafeTools:
-        entry.restartRecoveryForceSafeTools === true || resumePolicy.forceRestartSafeTools,
+        entry.restartRecoveryForceSafeTools === true ||
+        pendingAction === "fail" ||
+        hasReplaySafeCodeModeCheckpointInCurrentTurn(messages) ||
+        resumePolicy.forceRestartSafeTools,
       forceCodeModeTools: resumePolicy.forceCodeModeTools === true,
     });
   }

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -453,8 +453,8 @@ async function writeMainSessionTranscript(
 async function writeCompletedToolTranscript(sessionsDir: string): Promise<void> {
   await writeTranscript(sessionsDir, "main-session", [
     makeUserMessage("run the tool"),
-    { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
-    makeToolResultMessage(),
+    { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "read" }] },
+    makeToolResultMessage("done", { toolName: "read", toolCallId: "call-1" }),
   ]);
 }
 
@@ -1280,11 +1280,14 @@ describe("main-session-restart-recovery", () => {
     });
     await writeTranscript(sessionsDir, fixture.sessionId, [
       fixture.userMessage,
-      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
-      { role: "toolResult", content: "done" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "read" }] },
+      { role: "toolResult", toolName: "read", toolCallId: "call-1", content: "done" },
     ]);
 
-    await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 1 });
+    await expectRecovery(
+      { started: 0, settled: 0, failed: 0, skipped: 1 },
+      { gateway: { tailscale: { mode: "off" } } },
+    );
     expect(callGateway).not.toHaveBeenCalled();
     expect(loadSessionEntry({ sessionKey: fixture.sessionKey, storePath })).toMatchObject({
       status: "killed",
@@ -1314,8 +1317,8 @@ describe("main-session-restart-recovery", () => {
           sourceTool: "subagent_announce",
         },
       },
-      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
-      { role: "toolResult", content: "done" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "read" }] },
+      { role: "toolResult", toolName: "read", toolCallId: "call-1", content: "done" },
     ]);
 
     await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
@@ -1341,8 +1344,8 @@ describe("main-session-restart-recovery", () => {
     });
     await writeTranscript(sessionsDir, "topic-41819-session", [
       { role: "user", content: "earlier human request" },
-      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
-      { role: "toolResult", content: "done" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "read" }] },
+      { role: "toolResult", toolName: "read", toolCallId: "call-1", content: "done" },
     ]);
     const updateSessionEntry = sessionAccessor.updateSessionEntry;
     let injectedHumanRun = false;
@@ -1845,8 +1848,10 @@ describe("main-session-restart-recovery", () => {
       makeUserMessage("first restart continuation", {
         idempotencyKey: `${previousRecoveryRunId}:user`,
       }),
-      makeMessageToolCall("later-tool-call"),
-      makeMessageToolResult("later-tool-call"),
+      createAssistantToolCallMessage([
+        { type: "toolCall", id: "later-read", name: "read", arguments: { path: "README.md" } },
+      ]),
+      makeToolResultMessage("done", { toolCallId: "later-read", toolName: "read" }),
     ]);
     let dispatchedRunId: string | undefined;
     let dispatchError: unknown;
@@ -2357,9 +2362,16 @@ describe("main-session-restart-recovery", () => {
   it("resumes stale approval-pending exec tool results with restart-safe tools", async () => {
     const sessionsDir = await writeMainSessionTranscript([
       { role: "user", content: "run a command that needs approval" },
-      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call-1", name: "exec", arguments: { command: "echo stale" } },
+        ],
+      },
       {
         role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "exec",
         content: "Approval required (id stale, full stale-approval-id).",
         details: {
           status: "approval-pending",
@@ -2412,8 +2424,8 @@ describe("main-session-restart-recovery", () => {
       });
       await writeTranscript(sessionsDir, "main-session", [
         { role: "user", content: "calculate the answer" },
-        { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "calc" }] },
-        { role: "toolResult", content: "42" },
+        { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "read" }] },
+        { role: "toolResult", toolName: "read", toolCallId: "call-1", content: "42" },
       ]);
 
       await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 }, {});
@@ -2826,8 +2838,8 @@ describe("main-session-restart-recovery", () => {
     });
     await writeTranscript(sessionsDir, "main-session", [
       { role: "user", content: "calculate the answer" },
-      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "calc" }] },
-      { role: "toolResult", content: "42" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "read" }] },
+      { role: "toolResult", toolName: "read", toolCallId: "call-1", content: "42" },
     ]);
 
     await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
@@ -4005,6 +4017,36 @@ describe("main-session-restart-recovery", () => {
     });
   });
 
+  it.each(["suppressed", "failed"] as const)(
+    "writes the recovery notice to the transcript when channel delivery is %s",
+    async (outcome) => {
+      const { storePath, sessionKey } = await makeMainSessionFixture({
+        sessionKey: "agent:main:discord:direct:123",
+        mainRestartRecovery: {
+          cycleId: "cycle-exhausted",
+          revision: 1,
+          chargedAttempts: 3,
+        },
+        restartRecoveryDeliveryContext: discordDeliveryContext,
+      });
+      if (outcome === "suppressed") {
+        sendRecoveryNotice.mockResolvedValueOnce({ suppressed: true });
+      } else {
+        sendRecoveryNotice.mockRejectedValueOnce(new Error("channel unavailable"));
+      }
+
+      await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 1 });
+
+      const transcript = await loadTestTranscript(sessionKey, storePath);
+      expect(transcript.at(-1)?.message?.content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: expect.stringContaining("couldn't continue") }),
+        ]),
+      );
+      expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("failed");
+    },
+  );
+
   it("rejects foreground takeover while tombstoning exhausted recovery", async () => {
     const { sessionsDir, storePath, sessionKey } = await makeMainSessionFixture({
       mainRestartRecovery: {
@@ -5140,16 +5182,6 @@ describe("main-session-restart-recovery", () => {
       }),
       false,
     ],
-    [
-      "a dangling side-effecting call",
-      {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call-1", name: "write", arguments: {} }],
-        stopReason: "aborted",
-        errorMessage: "Worker inference aborted.",
-      },
-      true,
-    ],
   ])(
     "resumes an aborted tail persisted with %s",
     async (_label, assistantMessage, forceRestartSafeTools) => {
@@ -5267,8 +5299,8 @@ describe("main-session-restart-recovery", () => {
     },
     {
       replaySafe: false,
-      expected: { started: 1, settled: 0, failed: 0, skipped: 0 },
-      gatewayCalls: 1,
+      expected: { started: 0, settled: 0, failed: 0, skipped: 1 },
+      gatewayCalls: 0,
     },
   ])(
     "classifies a direct waiting checkpoint with replaySafe=$replaySafe",
@@ -5293,9 +5325,8 @@ describe("main-session-restart-recovery", () => {
 
       await expectRecovery(expected);
       expect(callGateway).toHaveBeenCalledTimes(gatewayCalls);
-      expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-      if (!replaySafe) {
-        expect(gatewayParams()).not.toHaveProperty("forceCodeModeTools");
+      if (replaySafe) {
+        expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
       }
     },
   );
@@ -5416,7 +5447,7 @@ describe("main-session-restart-recovery", () => {
     expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
   });
 
-  it("keeps restart safety after the recovery prompt leaves the recent transcript window", async () => {
+  it("tombstones when the recovery prompt leaves the recent transcript window", async () => {
     await writeMainSessionTranscript(
       [
         { role: "user", content: "do the thing" },
@@ -5429,8 +5460,29 @@ describe("main-session-restart-recovery", () => {
       { restartRecoveryForceSafeTools: true },
     );
 
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+    await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("does not assume a truncated interrupted turn was read-only", async () => {
+    const sessionsDir = await writeMainSessionTranscript([
+      { role: "user", content: "update the system and report back" },
+      createAssistantToolCallMessage([
+        { type: "toolCall", id: "call-write", name: "write", arguments: { path: "state" } },
+      ]),
+      ...Array.from({ length: 24 }, (_, index) => ({
+        role: "toolResult",
+        toolName: "read",
+        content: [{ type: "text", text: `later read ${index}` }],
+      })),
+    ]);
+
+    await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(readStore(path.join(sessionsDir, "sessions.json"))["agent:main:main"]).toMatchObject({
+      status: "failed",
+      mainRestartRecovery: { tombstone: expect.any(Object) },
+    });
   });
 
   it("resumes an in-flight safe tool call across a repeated restart", async () => {
@@ -5480,7 +5532,7 @@ describe("main-session-restart-recovery", () => {
     expect(gatewayParams()).not.toHaveProperty("forceRestartSafeTools");
   });
 
-  it("resumes safely without replaying visible assistant text beside a Code Mode wait", async () => {
+  it("tombstones a Code Mode wait mixed with visible assistant text", async () => {
     await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage("exec"),
@@ -5495,10 +5547,8 @@ describe("main-session-restart-recovery", () => {
       ]),
     ]);
 
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-    expect(gatewayParams()).not.toHaveProperty("forceCodeModeTools");
+    await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -5565,79 +5615,46 @@ describe("main-session-restart-recovery", () => {
     expect(callGateway).toHaveBeenCalledTimes(1);
   });
 
-  it("resumes a side-effecting tool call restricted to restart-safe tools", async () => {
-    await writeMainSessionTranscript([
-      { role: "user", content: "do the thing" },
+  it("does not resume a mutating turn after newer operator remediation", async () => {
+    const sessionsDir = await writeMainSessionTranscript([
+      { role: "user", content: "enable the gateway integration" },
       createAssistantToolCallMessage([
-        { type: "text", text: "Running the check now." },
-        { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "true" } },
+        {
+          type: "toolCall",
+          id: "call-bash-1",
+          name: "exec",
+          arguments: { command: "openclaw config set gateway.tailscale.mode serve" },
+        },
       ]),
-    ]);
-
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-  });
-
-  it("reports an interrupted native tool outcome as unknown", async () => {
-    await writeMainSessionTranscript([
-      { role: "user", content: "run the command" },
-      createAssistantToolCallMessage([
-        { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "true" } },
-      ]),
-      {
-        role: "toolResult",
-        toolName: "bash",
+      makeToolResultMessage("Config updated", {
         toolCallId: "call-bash-1",
-        content: "native tool call had no matching result",
-        details: { reason: "missing_tool_result" },
-        isError: true,
-      },
+        toolName: "exec",
+      }),
     ]);
 
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(gatewayParams().message).toContain("unknown outcome");
-    expect(gatewayParams().message).toContain("never claim completion or success");
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-  });
-
-  it("keeps a confirmed native tool failure distinct from an unknown outcome", async () => {
-    await writeMainSessionTranscript([
-      { role: "user", content: "run the command" },
-      createAssistantToolCallMessage([
-        { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "false" } },
+    await expectRecovery(
+      { started: 0, settled: 0, failed: 0, skipped: 1 },
+      { gateway: { tailscale: { mode: "off" } } },
+    );
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(readStore(path.join(sessionsDir, "sessions.json"))["agent:main:main"]).toMatchObject({
+      status: "failed",
+      abortedLastRun: false,
+      mainRestartRecovery: {
+        tombstone: {
+          reason: "interrupted turn included mutating tool work",
+        },
+      },
+    });
+    const transcript = await loadTestTranscript(
+      "agent:main:main",
+      path.join(sessionsDir, "sessions.json"),
+    );
+    expect(transcript.at(-1)?.message?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: expect.stringContaining("couldn't continue") }),
       ]),
-      {
-        role: "toolResult",
-        toolName: "bash",
-        toolCallId: "call-bash-1",
-        content: "command failed with exit code 1",
-        details: { reason: "nonzero_exit" },
-        isError: true,
-      },
-    ]);
-
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(gatewayParams()).not.toHaveProperty("forceRestartSafeTools");
-  });
-
-  it("keeps a dangling side-effecting call in an aborted tail restricted", async () => {
-    await writeMainSessionTranscript([
-      { role: "user", content: "do the thing" },
-      {
-        role: "assistant",
-        content: [
-          { type: "text", text: "Kicking that off." },
-          { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "true" } },
-        ],
-        stopReason: "aborted",
-        errorMessage: "This operation was aborted",
-      },
-    ]);
-
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+    );
   });
 
   it("resumes an interrupted replay-safe tool call without restricting tools", async () => {
@@ -5771,12 +5788,13 @@ describe("main-session-restart-recovery", () => {
         })),
       ]);
 
-      await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-      expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
       if (restoresCodeModeTools) {
+        await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
+        expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
         expect(gatewayParams()).toMatchObject({ forceCodeModeTools: true });
       } else {
-        expect(gatewayParams()).not.toHaveProperty("forceCodeModeTools");
+        await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 1 });
+        expect(callGateway).not.toHaveBeenCalled();
       }
     },
   );
@@ -5800,43 +5818,15 @@ describe("main-session-restart-recovery", () => {
         replaySafe: true,
       },
     },
-  ])("resumes a Code Mode wait safely after a $label", async ({ checkpoint }) => {
+  ])("tombstones a Code Mode wait after a $label", async ({ checkpoint }) => {
     await writeMainSessionTranscript([
       { role: "user", content: "do the thing" },
       codeModeCheckpointMessage("wait", checkpoint),
       codeModeWaitCallMessage(),
     ]);
 
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-    expect(gatewayParams()).not.toHaveProperty("forceCodeModeTools");
-  });
-
-  it("resumes a mixed Code Mode wait and side-effecting tool tail safely", async () => {
-    await writeMainSessionTranscript([
-      { role: "user", content: "do the thing" },
-      codeModeCheckpointMessage("exec"),
-      createAssistantToolCallMessage([
-        {
-          type: "toolCall",
-          id: "call-wait-1",
-          name: "wait",
-          arguments: { runId: "cm_interrupted" },
-        },
-        {
-          type: "toolCall",
-          id: "call-write-1",
-          name: "write",
-          arguments: { path: "result.txt", content: "done" },
-        },
-      ]),
-    ]);
-
-    await expectRecovery({ started: 1, settled: 0, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    expect(gatewayParams()).toMatchObject({ forceRestartSafeTools: true });
-    expect(gatewayParams()).not.toHaveProperty("forceCodeModeTools");
+    await expectRecovery({ started: 0, settled: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Closes #136290

## What Problem This Solves

Fixes an issue where a main-session channel turn that had already mutated state could be resumed automatically after a Gateway restart, even when the Gateway had been offline and an operator had applied newer remediation. The synthetic continuation could overwrite the repaired configuration and trigger another restart without fresh user input.

## Why This Change Was Made

Main-session restart recovery now completes already-recorded terminal facts, but sends every possible synthetic model continuation through one fail-closed policy. The policy uses the canonical argument-aware tool mutation contract, exact approval and Code Mode call identities, checkpoint ordering, nested Code Mode activity, and a bounded current-turn transcript; mutating or unproven work is tombstoned with a visible notice instead of resumed.

Policy decision: automatically resume only turns proven safe by current-turn evidence. Tombstone mutating or unproven turns (recommended and implemented); alternatives were a wall-clock age cutoff, which still permits immediate stale mutation, or restart-safe tool filtering, which only limits future tools after old intent has already been revived.

No configuration, database schema, protocol, timeout, or compatibility surface changes.

## User Impact

Operators can restart a repaired Gateway without an interrupted mutating turn silently undoing the repair. Affected users receive a clear recovery notice and can continue from a replacement session. Plain model work, audited read-only tools, and exactly checkpointed replay-safe Code Mode work retain automatic recovery.

## Evidence

Before the fix, the isolated hard-kill channel flow left a real tool call pending, restarted the Gateway without a new inbound message, logged `dispatching restart-safe recovery`, and advanced the old transcript. Testbox: https://github.com/openclaw/openclaw/actions/runs/33647179896.

The regression test failed on pre-fix code with `{ started: 1 }` where no dispatch was expected. Testbox: https://github.com/openclaw/openclaw/actions/runs/33648297810.

After the fix, the same isolated Gateway flow completes a non-replay-safe plugin mutation, blocks in a second tool, receives `SIGKILL`, applies an out-of-band config repair while stopped, and starts again with no new message. It tombstones the session, sends the channel notice, retains the repaired config, and performs no synthetic recovery dispatch. Final Testbox: https://github.com/openclaw/openclaw/actions/runs/33678191455 (`tbx_01m1hw68mveg9cesj571ya372j`).

Validation:

- `node scripts/run-vitest.mjs src/agents/main-session-recovery/main-session-restart-recovery-resume-policy.test.ts src/agents/main-session-recovery/main-session-restart-recovery.test.ts src/agents/restart-abort-code-propagation.test.ts --reporter=dot` (209 tests passed after rebase)
- `node scripts/check-changed.mjs` (passed after rebase)
- `pnpm test extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts -- --reporter=verbose` (1 passed on isolated Testbox)
- Final autoreview: scoped-clean at P1

Production LOC: core +244/-84 (net +160); docs +16/-5. Tests and QA support: +414/-178. The core growth establishes the missing lifecycle capability: canonical mutation classification, exact approval/Code Mode identity and ordering, bounded fail-closed transcript handling, a single pre-dispatch gate, and guaranteed visible tombstone fallback.
