### PR TITLE
test(gateway): restore abort fixture env when cleanup fails

### DIFF
--- a/src/gateway/server-methods/chat.abort-registry.test-support.ts
+++ b/src/gateway/server-methods/chat.abort-registry.test-support.ts
@@ -48,18 +48,21 @@ export function useChatAbortRegistryFixture() {
     });
   });
   afterEach(async () => {
-    await settleSubagentRegistryPersistenceWork();
-    resetSubagentRegistryForTests({ persist: false });
-    resetTaskRegistryForTests({ persist: false });
-    resetTaskFlowRegistryForTests({ persist: false });
-    schedulerTesting.reset();
-    resetTaskRegistryControlRuntimeForTests();
-    await cleanupSessionStateForTest({ stateDir });
-    testing.setDepsForTest();
-    clearConfigCache();
-    clearRuntimeConfigSnapshot();
-    await rm(stateDir, { recursive: true, force: true });
-    env.restore();
+    try {
+      await settleSubagentRegistryPersistenceWork();
+      resetSubagentRegistryForTests({ persist: false });
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      schedulerTesting.reset();
+      resetTaskRegistryControlRuntimeForTests();
+      await cleanupSessionStateForTest({ stateDir });
+      testing.setDepsForTest();
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      await rm(stateDir, { recursive: true, force: true });
+    } finally {
+      env.restore();
+    }
   });
 
   return {


### PR DESCRIPTION
## What Problem This Solves

The shared cancellation fixture left `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` pointing at its temporary state when teardown failed. Later tests could then inherit the failed fixture's environment.

## Why This Change Was Made

Restore the captured environment in `finally` at the owning fixture. Preserve every cleanup operation, its order, and the original cleanup exception. This follows the same release obligation as the existing environment helpers; it adds no retry, delay, or production seam.

## User Impact

No production behavior changes. Cancellation regression tests retain their assertions and restore their environment even when cleanup reports an error. Production +0/-0; one test-support file +15/-12, net +3.

## Evidence

Signed head: `9874c8368a456a47c4b937c6a92a66447a3f9ceb`.

- A temporary fault probe registered the real fixture hooks, ran real setup and drains, and injected only a removal rejection. Before the fix, the exact rejection-object assertion passed, then the environment assertion failed: the selected state remained the temporary fixture instead of `/tmp/chat-abort-prior-state`.
- The unchanged probe passed after the fix: the original error object propagated, the previous state override was restored, and an originally absent config override was removed.
- The probe, all four fixture consumers, and canonical environment/session-cleanup tests passed: **59 tests across seven files**. The 58 existing cases and their assertions are unchanged. The temporary probe was removed from the candidate after proof.
- The normal changed-file gate passed, including core-test typechecking, static guards, formatting, all dead-export scans, and changed-file lint. Fresh independent Codex review found no actionable P0–P2 findings; the signed commit retains the reviewed bytes.

The original Linux `ENOTEMPTY` producer remains unidentified. This change repairs the separately reproduced environment leak; it does not claim to fix the original removal failure. The earlier Linux replay passed all 4,339 shared and 315 isolated cases without reproducing that failure, so no assertion, timeout, or removal retry was changed.
