### PR TITLE
fix(plugins): preserve inspection diagnostics and configured policy

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -529,6 +529,8 @@ See [Plugin shapes](/plugins/architecture#plugin-shapes) for more on the capabil
 
 <Note>
 The `--json` flag outputs a machine-readable report suitable for scripting and auditing. `inspect --all` renders a fleet-wide table with shape, capability kinds, compatibility notices, bundle capabilities, and hook summary columns. `info` is an alias for `inspect`.
+
+Global discovery diagnostics go to stderr, including with `--json`. This explains partial inventory when workspace discovery has no selected system owner, even when no plugins are found. Plugin-specific diagnostics stay in each report. Policy fields use the same case-insensitive plugin ID matching as runtime configuration; the reported plugin ID retains its declared spelling.
 </Note>
 
 ## Doctor

--- a/src/cli/plugins-cli.inspect.test.ts
+++ b/src/cli/plugins-cli.inspect.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { recordInstalledPluginIndexInstallOwner } from "../plugins/installed-plugin-index-install-owner.js";
+import type { PluginInspectReport } from "../plugins/status.js";
 import {
   createInstalledPluginIndexSnapshot,
   createPluginRecord,
@@ -47,6 +48,34 @@ function setInspectInstallRecords(
   return metadata;
 }
 
+function createInspectReport(
+  overrides: Partial<PluginInspectReport> & Pick<PluginInspectReport, "plugin">,
+): PluginInspectReport {
+  return {
+    workspaceDir: "/workspace",
+    shape: "non-capability",
+    capabilityMode: "none",
+    capabilityCount: 0,
+    capabilities: [],
+    typedHooks: [],
+    customHooks: [],
+    tools: [],
+    commands: [],
+    cliCommands: [],
+    services: [],
+    gatewayDiscoveryServices: [],
+    gatewayMethods: [],
+    mcpServers: [],
+    lspServers: [],
+    httpRouteCount: 0,
+    bundleCapabilities: [],
+    diagnostics: [],
+    policy: { allowedModels: [], hasAllowedModelsConfig: false },
+    compatibility: [],
+    ...overrides,
+  };
+}
+
 describe("plugins cli inspect", () => {
   beforeEach(() => {
     resetPluginsCliTestState();
@@ -54,6 +83,65 @@ describe("plugins cli inspect", () => {
     workshopMocks.loadMetadata.mockReset();
     workshopMocks.loadMetadata.mockReturnValue({ index: createInstalledPluginIndexSnapshot([]) });
   });
+
+  it.each(
+    [false, true].flatMap((runtime) =>
+      [false, true].flatMap((json) =>
+        ["empty", "all", "single", "missing"].map((selection) => ({ runtime, json, selection })),
+      ),
+    ),
+  )(
+    "preserves global diagnostics on stderr with $selection, runtime=$runtime, json=$json",
+    async ({ runtime, json, selection }) => {
+      const plugin = createPluginRecord({ id: "shared-plugin" });
+      const diagnostic = { level: "warn" as const, pluginId: plugin.id, message: "Plugin warning" };
+      const inspect = createInspectReport({ plugin, diagnostics: [diagnostic] });
+      const reports = selection === "empty" || selection === "missing" ? [] : [inspect];
+      const report = {
+        plugins: reports.map((entry) => entry.plugin),
+        diagnostics: [
+          {
+            level: "warn" as const,
+            code: "workspace-scope-omitted",
+            message: "Workspace discovery was skipped; select the system owner.",
+          },
+          diagnostic,
+        ],
+      };
+      buildPluginSnapshotReportMock.mockReturnValue(report);
+      buildPluginDiagnosticsReportMock.mockReturnValue(report);
+      buildPluginInspectReportMock.mockReturnValue(inspect);
+      buildAllPluginInspectReportsMock.mockReturnValue(reports);
+      const args = [
+        "plugins",
+        "inspect",
+        selection === "single" ? plugin.id : selection === "missing" ? "missing-plugin" : "--all",
+        ...(runtime ? ["--runtime"] : []),
+        ...(json ? ["--json"] : []),
+      ];
+      const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+      try {
+        const command = runPluginsCommand(args);
+        if (selection === "missing") {
+          await expect(command).rejects.toThrow("__exit__:1");
+          expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+        } else {
+          await command;
+          if (json) {
+            expect(pluginsCliRuntimeLogs).toHaveLength(1);
+            expect(JSON.parse(pluginsCliRuntimeLogs[0] ?? "null")).toEqual(
+              selection === "single" ? inspect : reports,
+            );
+          }
+        }
+        const warnings = stderr.mock.calls.map(([chunk]) => String(chunk)).join("");
+        expect(warnings.match(/Workspace discovery was skipped/g)).toHaveLength(1);
+        expect(warnings).not.toContain("Plugin warning");
+      } finally {
+        stderr.mockRestore();
+      }
+    },
+  );
 
   it.each([false, true])(
     "reports package-owned install provenance with runtime=%s",
@@ -168,18 +256,12 @@ describe("plugins cli inspect", () => {
         plugins: [createPluginRecord({ id: pluginId, name: "Mem0" })],
         diagnostics: [],
       });
-      const inspectReport = {
-        workspaceDir: "/workspace",
+      const inspectReport = createInspectReport({
         plugin: createPluginRecord({ id: pluginId, name: "Mem0" }),
         shape: "hook-only",
         capabilityMode: "plain",
         capabilityCount: 1,
-        capabilities: [],
         typedHooks: [{ name: "agent_end" }],
-        customHooks: [],
-        tools: [],
-        commands: [],
-        cliCommands: [],
         services: ["mem0-background"],
         gatewayDiscoveryServices: ["mem0-discovery", "mem0-discovery-secondary"],
         mcpServers: [
@@ -187,18 +269,12 @@ describe("plugins cli inspect", () => {
           { name: "remote", hasStdioTransport: false },
           { name: "broken", hasStdioTransport: false, unsupported: true },
         ],
-        lspServers: [],
-        httpRouteCount: 0,
-        bundleCapabilities: [],
-        diagnostics: [],
         policy: {
           allowConversationAccess: true,
           allowedModels: [],
           hasAllowedModelsConfig: false,
         },
-        usesLegacyBeforeAgentStart: false,
-        compatibility: [],
-      };
+      });
       buildPluginInspectReportMock.mockReturnValue(inspectReport);
 
       await runPluginsCommand(["plugins", "inspect", pluginId]);
@@ -276,32 +352,15 @@ describe("plugins cli inspect", () => {
       ],
       diagnostics: [],
     });
-    buildPluginInspectReportMock.mockReturnValue({
-      workspaceDir: "/workspace",
-      plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
-      shape: "hook-only",
-      capabilityMode: "plain",
-      capabilityCount: 1,
-      capabilities: [],
-      typedHooks: [],
-      customHooks: [],
-      tools: [],
-      commands: [],
-      cliCommands: [],
-      services: [],
-      gatewayDiscoveryServices: ["mem0-runtime-discovery"],
-      mcpServers: [],
-      lspServers: [],
-      httpRouteCount: 0,
-      bundleCapabilities: [],
-      diagnostics: [],
-      policy: {
-        allowedModels: [],
-        hasAllowedModelsConfig: false,
-      },
-      usesLegacyBeforeAgentStart: false,
-      compatibility: [],
-    });
+    buildPluginInspectReportMock.mockReturnValue(
+      createInspectReport({
+        plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
+        shape: "hook-only",
+        capabilityMode: "plain",
+        capabilityCount: 1,
+        gatewayDiscoveryServices: ["mem0-runtime-discovery"],
+      }),
+    );
 
     for (const selector of ["openclaw-mem0", "Mem0"]) {
       await runPluginsCommand(["plugins", "inspect", selector, "--runtime"]);

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -4,8 +4,10 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { listAgentIds } from "../agents/agent-scope-config.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { formatConsoleDiagnosticLine } from "../logging/json-console-line.js";
 import { resolvePluginControlPlaneWorkspace } from "../plugins/control-plane-workspace.js";
 import { resolveInstalledPluginPackageOwnership } from "../plugins/installed-plugin-package-ownership.js";
+import type { PluginDiagnostic } from "../plugins/manifest-types.js";
 import { tracePluginLifecyclePhase } from "../plugins/plugin-lifecycle-trace.js";
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
@@ -28,6 +30,19 @@ function failPluginInspect(message: string, json: boolean | undefined): void {
     defaultRuntime.error(message);
   }
   defaultRuntime.exit(1);
+}
+
+function writeGlobalPluginDiagnostics(diagnostics: readonly PluginDiagnostic[]): void {
+  for (const { pluginId, level, message } of diagnostics) {
+    if (!pluginId) {
+      const line = formatConsoleDiagnosticLine({
+        level,
+        message: shortenHomeInString(`${level.toUpperCase()}: ${message}`),
+      });
+      // Global discovery diagnostics also matter when the JSON result is an empty array.
+      process.stderr.write(`${line}\n`);
+    }
+  }
 }
 
 function formatInspectSection(title: string, lines: string[]): string[] {
@@ -166,6 +181,7 @@ export async function runPluginsInspectCommand(
           () => buildPluginSnapshotReport(reportParams),
           { command: "inspect", all: true },
         );
+    writeGlobalPluginDiagnostics(report.diagnostics);
     const inspectAll = buildAllPluginInspectReports({
       config: cfg,
       ...loggerParams,
@@ -238,6 +254,7 @@ export async function runPluginsInspectCommand(
     snapshotReport.plugins.find((entry) => entry.id === id) ??
     snapshotReport.plugins.find((entry) => entry.name === id);
   if (!targetPlugin) {
+    writeGlobalPluginDiagnostics(snapshotReport.diagnostics);
     if (id === "skill-workshop") {
       const { detectSkillWorkshopToolPolicyDiagnostic } =
         await import("../skills/workshop/tool-policy-diagnostic.js");
@@ -275,6 +292,7 @@ export async function runPluginsInspectCommand(
         { command: "inspect", pluginId: targetPlugin.id },
       )
     : snapshotReport;
+  writeGlobalPluginDiagnostics(report.diagnostics);
   const inspect = buildPluginInspectReport({
     id: targetPlugin.id,
     config: cfg,

--- a/src/plugins/status.test-fixtures.ts
+++ b/src/plugins/status.test-fixtures.ts
@@ -7,6 +7,35 @@ import type { PluginHookName } from "./types.js";
 
 export { createPluginRecord };
 
+export function createCompatChainFixture() {
+  const config = { plugins: { allow: ["telegram"] } };
+  const pluginIds = ["anthropic", "openai"];
+  const enabledConfig = {
+    plugins: {
+      allow: ["telegram"],
+      entries: {
+        anthropic: { enabled: true },
+        openai: { enabled: true },
+      },
+    },
+  };
+  return { config, pluginIds, enabledConfig };
+}
+
+export function createAutoEnabledStatusConfig(
+  entries: Record<string, unknown>,
+  rawConfigOverrides?: Record<string, unknown>,
+) {
+  const rawConfig = { plugins: {}, ...rawConfigOverrides };
+  const autoEnabledConfig = {
+    ...rawConfig,
+    plugins: {
+      entries,
+    },
+  };
+  return { rawConfig, autoEnabledConfig };
+}
+
 export function createInstalledPluginIndexSnapshot(
   plugins: Array<Record<string, unknown>>,
 ): Record<string, unknown> {

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -4,6 +4,8 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
+  createAutoEnabledStatusConfig,
+  createCompatChainFixture,
   createCompatibilityNotice,
   createCustomHook,
   createInstalledPluginIndexSnapshot,
@@ -230,21 +232,6 @@ function expectAutoEnabledStatusLoad(params: { rawConfig: unknown }) {
   });
 }
 
-function createCompatChainFixture() {
-  const config = { plugins: { allow: ["telegram"] } };
-  const pluginIds = ["anthropic", "openai"];
-  const enabledConfig = {
-    plugins: {
-      allow: ["telegram"],
-      entries: {
-        anthropic: { enabled: true },
-        openai: { enabled: true },
-      },
-    },
-  };
-  return { config, pluginIds, enabledConfig };
-}
-
 function expectBundledCompatChainApplied(params: {
   config: unknown;
   pluginIds: string[];
@@ -261,20 +248,6 @@ function expectBundledCompatChainApplied(params: {
     return;
   }
   expectMetadataSnapshotLoaderCall({ config: params.enabledConfig, loadModules: false });
-}
-
-function createAutoEnabledStatusConfig(
-  entries: Record<string, unknown>,
-  rawConfigOverrides?: Record<string, unknown>,
-) {
-  const rawConfig = { plugins: {}, ...rawConfigOverrides };
-  const autoEnabledConfig = {
-    ...rawConfig,
-    plugins: {
-      entries,
-    },
-  };
-  return { rawConfig, autoEnabledConfig };
 }
 
 function expectAutoEnabledDemoCompatibilityNoticesPreserveRawConfig() {
@@ -668,57 +641,72 @@ describe("plugin status reports", () => {
     expect(plugin?.imported).toBe(true);
   });
 
-  it("builds an inspect report with capability shape and policy", () => {
-    loadConfigMock.mockReturnValue({
-      plugins: {
-        entries: {
-          google: {
-            hooks: { allowPromptInjection: false, allowConversationAccess: true },
-            subagent: {
-              allowModelOverride: true,
-              allowedModels: ["openai/gpt-5.5"],
+  it.each(["google", "GoOgLe"])(
+    "builds an inspect report with capability shape and policy for %s",
+    (pluginId) => {
+      loadConfigMock.mockReturnValue({
+        plugins: {
+          entries: {
+            google: {
+              hooks: {
+                allowPromptInjection: false,
+                allowConversationAccess: true,
+                timeoutMs: 1700,
+                timeouts: { gateway_stop: 1300 },
+              },
+              subagent: {
+                allowModelOverride: true,
+                allowedModels: ["openai/gpt-5.5"],
+              },
             },
           },
         },
-      },
-    });
-    setPluginLoadResult({
-      plugins: [
-        createPluginRecord({
-          id: "google",
-          name: "Google",
-          description: "Google provider plugin",
-          origin: "bundled",
-          providerIds: ["google"],
-          mediaUnderstandingProviderIds: ["google"],
-          imageGenerationProviderIds: ["google"],
-          webSearchProviderIds: ["google"],
-        }),
-      ],
-      diagnostics: [{ level: "warn", pluginId: "google", message: "watch this surface" }],
-    });
+      });
+      setPluginLoadResult({
+        plugins: [
+          createPluginRecord({
+            id: pluginId,
+            name: "Google",
+            description: "Google provider plugin",
+            origin: "bundled",
+            providerIds: ["google"],
+            mediaUnderstandingProviderIds: ["google"],
+            imageGenerationProviderIds: ["google"],
+            webSearchProviderIds: ["google"],
+          }),
+        ],
+        diagnostics: [{ level: "warn", pluginId, message: "watch this surface" }],
+      });
 
-    const inspect = expectInspectReport("google");
+      const inspect = expectInspectReport(pluginId);
 
-    expectInspectShape(inspect, {
-      shape: "hybrid-capability",
-      capabilityMode: "hybrid",
-      capabilityKinds: ["text-inference", "media-understanding", "image-generation", "web-search"],
-    });
-    expect(inspect.compatibility).toStrictEqual([]);
-    expectInspectPolicy(inspect, {
-      allowPromptInjection: false,
-      allowConversationAccess: true,
-      hookTimeoutMs: undefined,
-      hookTimeouts: undefined,
-      allowModelOverride: true,
-      allowedModels: ["openai/gpt-5.5"],
-      hasAllowedModelsConfig: true,
-    });
-    expect(inspect.diagnostics).toEqual([
-      { level: "warn", pluginId: "google", message: "watch this surface" },
-    ]);
-  });
+      expectInspectShape(inspect, {
+        shape: "hybrid-capability",
+        capabilityMode: "hybrid",
+        capabilityKinds: [
+          "text-inference",
+          "media-understanding",
+          "image-generation",
+          "web-search",
+        ],
+      });
+      expect(inspect.compatibility).toStrictEqual([]);
+      expectInspectPolicy(inspect, {
+        allowPromptInjection: false,
+        allowConversationAccess: true,
+        hookTimeoutMs: 1700,
+        hookTimeouts: { gateway_stop: 1300 },
+        allowModelOverride: true,
+        allowedModels: ["openai/gpt-5.5"],
+        hasAllowedModelsConfig: true,
+      });
+      expect(inspect.diagnostics).toEqual([
+        { level: "warn", pluginId, message: "watch this surface" },
+      ]);
+      expect(inspect.plugin.id).toBe(pluginId);
+      expect(buildAllPluginInspectReports()).toEqual([inspect]);
+    },
+  );
 
   it("prefers exact plugin ids over display names in individual and all inspect reports", () => {
     setPluginLoadResult({

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -29,6 +29,7 @@ import {
   loadPluginMetadataSnapshot,
   type PluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
+import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import { resolveBundledProviderCompatPluginIds } from "./providers.js";
 import type { PluginRegistry } from "./registry.js";
 import { listImportedRuntimePluginIds } from "./runtime.js";
@@ -356,39 +357,38 @@ export function buildPluginDiagnosticsReport(params?: PluginReportParams): Plugi
   return buildPluginReport(params, true);
 }
 
-export function buildPluginInspectReport(params: {
-  id: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  logger?: PluginLogger;
+type PluginInspectParams = Pick<
+  PluginReportParams,
+  "config" | "workspaceDir" | "env" | "logger"
+> & {
   report?: PluginStatusReportLike;
-  resolvedConfig?: OpenClawConfig;
-}): PluginInspectReport | null {
-  const rawConfig = params.config ?? getRuntimeConfig();
-  const config =
-    params.resolvedConfig ??
-    resolvePluginRuntimeLoadContext({
-      config: rawConfig,
-      env: params.env,
-      logger: params.logger,
-      workspaceDir: params.workspaceDir,
-    }).config;
-  const report =
-    params.report ??
-    buildPluginDiagnosticsReport({
-      config: rawConfig,
-      logger: params.logger,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    });
-  const plugin =
-    report.plugins.find((entry) => entry.id === params.id) ??
-    report.plugins.find((entry) => entry.name === params.id);
-  if (!plugin) {
-    return null;
-  }
+};
 
+function resolvePluginInspectContext({ report, ...params }: PluginInspectParams) {
+  const { rawConfig, config } = resolvePluginRuntimeLoadContext(params);
+  return {
+    report: report ?? buildPluginDiagnosticsReport({ ...params, config: rawConfig }),
+    entries: normalizePluginsConfig(config.plugins).entries,
+  };
+}
+
+export function buildPluginInspectReport({
+  id,
+  ...params
+}: PluginInspectParams & {
+  id: string;
+}): PluginInspectReport | null {
+  const context = resolvePluginInspectContext(params);
+  const plugin =
+    context.report.plugins.find((entry) => entry.id === id) ??
+    context.report.plugins.find((entry) => entry.name === id);
+  return plugin ? buildPluginInspectRecord(plugin, context) : null;
+}
+
+function buildPluginInspectRecord(
+  plugin: PluginRegistry["plugins"][number],
+  { report, entries }: ReturnType<typeof resolvePluginInspectContext>,
+): PluginInspectReport {
   const typedHooks = report.typedHooks
     .filter((entry) => entry.pluginId === plugin.id)
     .map((entry) => ({
@@ -410,7 +410,7 @@ export function buildPluginInspectReport(params: {
       optional: entry.optional,
     }));
   const diagnostics = report.diagnostics.filter((entry) => entry.pluginId === plugin.id);
-  const policyEntry = normalizePluginsConfig(config.plugins).entries[plugin.id];
+  const policyEntry = entries[normalizePluginPolicyId(plugin.id)];
   const shapeSummary = buildPluginShapeSummary({ plugin, report });
   const shape = shapeSummary.shape;
   const gatewayMethods = (report.gatewayMethodDescriptors ?? [])
@@ -509,61 +509,20 @@ export function buildPluginInspectReport(params: {
   };
 }
 
-export function buildAllPluginInspectReports(params?: {
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  logger?: PluginLogger;
-  report?: PluginStatusReportLike;
-}): PluginInspectReport[] {
-  const rawConfig = params?.config ?? getRuntimeConfig();
-  const config = resolvePluginRuntimeLoadContext({
-    config: rawConfig,
-    env: params?.env,
-    logger: params?.logger,
-    workspaceDir: params?.workspaceDir,
-  }).config;
-  const report =
-    params?.report ??
-    buildPluginDiagnosticsReport({
-      config: rawConfig,
-      logger: params?.logger,
-      workspaceDir: params?.workspaceDir,
-      env: params?.env,
-    });
-
-  return report.plugins
-    .map((plugin) =>
-      buildPluginInspectReport({
-        id: plugin.id,
-        config: rawConfig,
-        logger: params?.logger,
-        workspaceDir: params?.workspaceDir,
-        env: params?.env,
-        resolvedConfig: config,
-        report,
-      }),
-    )
-    .filter((entry): entry is PluginInspectReport => entry !== null);
+export function buildAllPluginInspectReports(
+  params: PluginInspectParams = {},
+): PluginInspectReport[] {
+  const context = resolvePluginInspectContext(params);
+  return context.report.plugins.map((plugin) => buildPluginInspectRecord(plugin, context));
 }
 
-export function buildPluginCompatibilityWarnings(params?: {
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  logger?: PluginLogger;
-  report?: PluginStatusReportLike;
-}): string[] {
+export function buildPluginCompatibilityWarnings(params?: PluginInspectParams): string[] {
   return buildPluginCompatibilityNotices(params).map(formatPluginCompatibilityNotice);
 }
 
-export function buildPluginCompatibilityNotices(params?: {
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  logger?: PluginLogger;
-  report?: PluginStatusReportLike;
-}): PluginCompatibilityNotice[] {
+export function buildPluginCompatibilityNotices(
+  params?: PluginInspectParams,
+): PluginCompatibilityNotice[] {
   return buildAllPluginInspectReports(params).flatMap((inspect) => inspect.compatibility);
 }
 


### PR DESCRIPTION
Closes #136594
Closes #136595

## What Problem This Solves

Plugin inspection silently dropped global discovery warnings and lost configured policy fields for mixed-case plugin IDs. A partial workspace inventory could look complete, while a valid configured plugin appeared to have no hook policy.

## Why This Change Was Made

Keep global diagnostics at the CLI output boundary, including empty and missing-target results. A shared inspection context resolves config and policy once, then projects each known plugin directly. Policy lookup uses the existing canonical key while preserving declared plugin identity. This deletes duplicate context construction, repeated per-plugin lookup and impossible-null filtering.

## User Impact

Single/all and metadata/runtime inspection explain partial inventory on stderr and display configured policy consistently. The existing JSON array/object shapes, per-plugin diagnostics, import scope, install metadata and exit codes remain intact. No new configuration, dependency, store or enforcement behavior is introduced.

## Evidence

A real compiled CLI comparison ran25 cases against the same synthetic fixtures on baseline65e5b2e19c9db6460494682bacc4bee10db755fd and the fix. Twelve inspection forms regain one global warning; four mixed-case policy projections regain their configured fields. Remaining stdout/JSON data, imports and exits match. Metadata-only inspection imports no plugin; single runtime inspection imports only its selected plugin. Missing targets still exit1 without runtime imports.

For `node dist/entry.js plugins inspect --all --json` with no selected workspace owner, both builds print `[]` and exit0. Before: stderr is empty. After: stderr contains exactly:

```text
WARN: Workspace plugin discovery was skipped because multiple explicit agents are configured without agents.defaults.systemAgent.agentId. This partial result includes bundled, managed, and global plugins only; set agents.defaults.systemAgent.agentId to include that owner's workspace plugins.
```

For `node dist/entry.js plugins inspect QaMixedInspect --json`, the policy projection changes from `{"allowedModels":[],"hasAllowedModelsConfig":false}` to:

```json
{"allowPromptInjection":false,"allowConversationAccess":true,"hookTimeoutMs":1700,"hookTimeouts":{"gateway_stop":1300},"allowModelOverride":false,"allowedModels":[],"hasAllowedModelsConfig":true}
```

The lowercase control already returned that policy and is unchanged. Compiled entry SHA256: baseline `ce8ce0116c248f23e8a29fb3e8cff07d9c162a40f0030c870a5640eb43960835`; fixed `873b62e37ba2e38f6ba84ef56d4d1b8b421e7498a482edb967097270a1b90da7`.

The original16 CLI and one policy regressions fail before production edits. All113 focused owner/CLI/registry/dependency-policy tests pass; the final61-test owner subset passes after moving29 existing fixture lines to their test-support owner. `pnpm build`, the complete six-file `scripts/check-changed.mjs` gate, and one cumulative independent Codex P2 review pass. The review recorded the gate as pending; it subsequently passed with unchanged sources.

Production: **57 added /80 removed (net−23)**. Tests/support:192 added /116 removed, including the pure fixture move. Docs:+2. This repairs two original reporting roots. The separate blocked-hook registration work in#136474 changes the producer of hook diagnostics and remains independent.

## Final review disposition

The final maintainer review confirms stderr receives only report-global diagnostics and declared IDs remain unchanged while policy lookup uses the normalized key. The25 actual compiled CLI before/after cases preserve JSON shapes, output controls and import scope. No runtime policy enforcement or configuration surface changes.

Required [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33681450722/job/100425505843) passed for `740ead7142532bd7eae622f7e084ae551686e98d`. Production owners are unchanged on main `31ed57e3953152fa826a444e742b3c0ec5149961` since the reproduced baseline, and the complete PR composes cleanly. The latest ClawSweeper review and its rank-up requests have been addressed; no actionable code finding remains.
