### PR TITLE
refactor(ui): keep images stable with less media rendering work

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4009,7 +4009,7 @@ ui/src/pages/chat/components/chat-message-attachment-availability.ts	1
 ui/src/pages/chat/components/chat-message-bubble.ts	2
 ui/src/pages/chat/components/chat-message-confirmation.ts	2
 ui/src/pages/chat/components/chat-message-markdown.ts	1
-ui/src/pages/chat/components/chat-message-media.ts	13
+ui/src/pages/chat/components/chat-message-media.ts	3
 ui/src/pages/chat/components/chat-message-timestamp.ts	4
 ui/src/pages/chat/components/chat-model-picker-options.ts	2
 ui/src/pages/chat/components/chat-model-picker.ts	7

--- a/ui/src/lib/chat/message-normalizer-attachments.ts
+++ b/ui/src/lib/chat/message-normalizer-attachments.ts
@@ -1,3 +1,4 @@
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { MessageContentItem } from "./chat-types.ts";
 
@@ -38,32 +39,23 @@ export function normalizeAttachmentContentBlock(value: unknown): MessageContentI
   if (typeof attachment.url !== "string") {
     return [];
   }
-  return [
-    {
-      type: "attachment",
-      attachment: {
-        url: attachment.url,
-        kind: attachment.kind,
-        label: attachment.label,
-        ...(mimeType !== undefined ? { mimeType } : {}),
-        ...(attachment.isVoiceNote === true ? { isVoiceNote: true } : {}),
-        ...(typeof attachment.artifactId === "string" ? { artifactId: attachment.artifactId } : {}),
-        ...(attachment.playback === "native" || attachment.playback === "transcode"
-          ? { playback: attachment.playback }
-          : {}),
-        ...(typeof attachment.sizeBytes === "number" && attachment.sizeBytes >= 0
-          ? { sizeBytes: attachment.sizeBytes }
-          : {}),
-        ...(typeof attachment.durationMs === "number" && attachment.durationMs >= 0
-          ? { durationMs: attachment.durationMs }
-          : {}),
-        ...(typeof attachment.width === "number" && attachment.width > 0
-          ? { width: attachment.width }
-          : {}),
-        ...(typeof attachment.height === "number" && attachment.height > 0
-          ? { height: attachment.height }
-          : {}),
-      },
-    },
-  ];
+  const normalized: Extract<MessageContentItem, { type: "attachment" }>["attachment"] = {
+    url: attachment.url,
+    kind: attachment.kind,
+    label: attachment.label,
+    ...(mimeType !== undefined ? { mimeType } : {}),
+    ...(attachment.isVoiceNote === true ? { isVoiceNote: true } : {}),
+    ...(typeof attachment.artifactId === "string" ? { artifactId: attachment.artifactId } : {}),
+    ...(attachment.playback === "native" || attachment.playback === "transcode"
+      ? { playback: attachment.playback }
+      : {}),
+  };
+  for (const key of ["sizeBytes", "durationMs", "width", "height"] as const) {
+    const numeric = asFiniteNumber(attachment[key]);
+    const dimension = key === "width" || key === "height";
+    if (numeric !== undefined && (dimension ? numeric > 0 : numeric >= 0)) {
+      normalized[key] = numeric;
+    }
+  }
+  return [{ type: "attachment", attachment: normalized }];
 }

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -568,6 +568,18 @@ describe("message-normalizer", () => {
               width: value,
               height: value,
             },
+            {
+              type: "attachment",
+              attachment: {
+                kind: "document",
+                url: "/media/document",
+                label: "Document",
+                sizeBytes: value,
+                durationMs: value,
+                width: value,
+                height: value,
+              },
+            },
           ],
         });
         expect(result.content).toEqual([
@@ -582,6 +594,10 @@ describe("message-normalizer", () => {
             rawText: null,
           },
           { type: "attachment", attachment: { kind: "video", url: "/media/clip", label: "Video" } },
+          {
+            type: "attachment",
+            attachment: { kind: "document", url: "/media/document", label: "Document" },
+          },
         ]);
       },
     );

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -6,7 +6,6 @@ import { mediaKindFromMime } from "@openclaw/media-core/constants";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { z } from "zod";
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import {
   extractCanvasShortcodes,
@@ -31,23 +30,6 @@ import { formatSenderLabel, normalizeSenderIdentity } from "./sender-label.ts";
 const OPAQUE_ID_LABEL_SUFFIX_RE =
   /\s+\(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)$/iu;
 
-const optionalMessageStringSchema = z.string().optional().catch(undefined);
-const optionalMessageNumberSchema = z.number().optional().catch(undefined);
-const rawAttachmentSchema = z
-  .looseObject({
-    code: optionalMessageStringSchema,
-    kind: optionalMessageStringSchema,
-    url: optionalMessageStringSchema,
-    label: optionalMessageStringSchema,
-    mimeType: optionalMessageStringSchema,
-    artifactId: optionalMessageStringSchema,
-    sizeBytes: optionalMessageNumberSchema,
-    durationMs: optionalMessageNumberSchema,
-    width: optionalMessageNumberSchema,
-    height: optionalMessageNumberSchema,
-  })
-  .optional()
-  .catch(undefined);
 type CanvasPreview = Extract<MessageContentItem, { type: "canvas" }>["preview"];
 type MessageDelivery = { audioAsVoice?: true; replyToCurrent?: true; replyToId?: string };
 
@@ -245,42 +227,22 @@ function coerceAudioContentBlock(
   const rawMediaType = readStringField(source, "media_type")?.trim();
   const mediaType = rawMediaType?.toLowerCase().startsWith("audio/") ? rawMediaType : "audio/mpeg";
   const type = source.type;
-  const rawData = readStringField(source, "data");
-  if (type === "base64" && rawData !== undefined) {
-    const data = rawData.trim();
-    if (!data) {
-      return null;
-    }
-    const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
-    return {
-      type: "attachment",
-      attachment: {
-        url,
-        kind: "audio",
-        label: readStringField(item, "label")?.trim() || "Audio",
-        mimeType: mediaType,
-        ...(item.isVoiceNote === true ? { isVoiceNote: true } : {}),
-      },
-    };
+  const data = readStringField(source, type === "base64" ? "data" : "url")?.trim();
+  if (!data || (type !== "base64" && type !== "url")) {
+    return null;
   }
-  const rawUrl = readStringField(source, "url");
-  if (type === "url" && rawUrl !== undefined) {
-    const url = rawUrl.trim();
-    if (!url) {
-      return null;
-    }
-    return {
-      type: "attachment",
-      attachment: {
-        url,
-        kind: "audio",
-        label: readStringField(item, "label")?.trim() || "Audio",
-        mimeType: mediaType,
-        ...(item.isVoiceNote === true ? { isVoiceNote: true } : {}),
-      },
-    };
-  }
-  return null;
+  const url =
+    type === "base64" && !data.startsWith("data:") ? `data:${mediaType};base64,${data}` : data;
+  return {
+    type: "attachment",
+    attachment: {
+      url,
+      kind: "audio",
+      label: readStringField(item, "label")?.trim() || "Audio",
+      mimeType: mediaType,
+      ...(item.isVoiceNote === true ? { isVoiceNote: true } : {}),
+    },
+  };
 }
 
 function coerceManagedMediaContentBlock(
@@ -479,12 +441,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
         return [];
       }
       if (type === "attachment" || type === "attachment_error") {
-        return (
-          normalizeAttachmentContentBlock({
-            type,
-            attachment: rawAttachmentSchema.parse(item.attachment),
-          }) ?? []
-        );
+        return normalizeAttachmentContentBlock(item) ?? [];
       }
       const rawPreview = type === "canvas" ? asOptionalRecord(item.preview) : undefined;
       if (rawPreview) {

--- a/ui/src/pages/chat/chat-history.media.test.ts
+++ b/ui/src/pages/chat/chat-history.media.test.ts
@@ -4,7 +4,7 @@ import {
   readTranscriptMediaEntries,
 } from "../../lib/chat/message-extract.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
-import { extractMessageAttachments } from "./components/chat-message-media.ts";
+import { projectMessageMedia } from "./components/chat-message-media.ts";
 
 const MANAGED_UUID = "43007e90-2ade-43f2-a781-42b843e9eca3";
 
@@ -75,7 +75,7 @@ describe("chat history attachment card labels", () => {
   });
 
   it("labels a managed inbound attachment with the persisted original fileName", () => {
-    const attachments = extractMessageAttachments(
+    const { attachments } = projectMessageMedia(
       userMessageWithMedia([
         {
           path: `media://inbound/report---${MANAGED_UUID}.pdf`,
@@ -89,7 +89,7 @@ describe("chat history attachment card labels", () => {
   });
 
   it("restores the original name from a legacy managed inbound UUID suffix when fileName is absent", () => {
-    const attachments = extractMessageAttachments(
+    const { attachments } = projectMessageMedia(
       userMessageWithMedia([
         {
           path: `media://inbound/openclaw-attachment-test---${MANAGED_UUID}.docx`,
@@ -104,7 +104,7 @@ describe("chat history attachment card labels", () => {
   it("leaves non-managed https attachment paths unchanged", () => {
     // `---old` is not a canonical managed UUID suffix, so it must not be stripped
     // from https URLs (which never carry the collision-safe managed suffix).
-    const attachments = extractMessageAttachments(
+    const { attachments } = projectMessageMedia(
       userMessageWithMedia([
         {
           path: "https://example.com/files/openclaw-attachment-test---old.docx",
@@ -117,7 +117,7 @@ describe("chat history attachment card labels", () => {
   });
 
   it("does not strip a managed inbound basename that lacks a UUID suffix", () => {
-    const attachments = extractMessageAttachments(
+    const { attachments } = projectMessageMedia(
       userMessageWithMedia([
         {
           path: "media://inbound/plain-name.docx",
@@ -132,7 +132,7 @@ describe("chat history attachment card labels", () => {
   it("strips only the terminal managed UUID suffix, preserving a UUID-shaped segment in the original name", () => {
     // Legacy record (no persisted fileName) whose original filename itself
     // contains a "---<uuid>"-shaped segment before the terminal managed suffix.
-    const attachments = extractMessageAttachments(
+    const { attachments } = projectMessageMedia(
       userMessageWithMedia([
         {
           path: `media://inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890-final---${MANAGED_UUID}.docx`,
@@ -148,7 +148,7 @@ describe("chat history attachment card labels", () => {
 
   it("preserves a dotted UUID-shaped segment in a legacy attachment name", () => {
     const path = `media://inbound/report---a1b2c3d4-e5f6-7890-abcd-ef1234567890.backup---${MANAGED_UUID}.pdf`;
-    const attachments = extractMessageAttachments(
+    const { attachments } = projectMessageMedia(
       userMessageWithMedia([{ path, contentType: "application/pdf" }]),
       [],
     );

--- a/ui/src/pages/chat/components/chat-message-attachment-availability.ts
+++ b/ui/src/pages/chat/components/chat-message-attachment-availability.ts
@@ -36,17 +36,6 @@ type AssistantAttachmentAvailability =
       unconfirmed?: true;
     };
 
-export type ManagedAttachmentAvailability =
-  | { status: "checking"; refreshAfter?: number; refreshAttempts?: number }
-  | {
-      status: "available";
-      url: string;
-      expiresAt?: number;
-      refreshAfter?: number;
-      refreshAttempts?: number;
-    }
-  | { status: "unavailable"; reason: string; checkedAt: number };
-
 export const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 const ASSISTANT_ATTACHMENT_METADATA_FETCH_TIMEOUT_MS = 30_000;
 export const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
@@ -331,19 +320,6 @@ function scheduleAssistantAttachmentRefresh(
     // replacement is minted; a checking card would reset native playback.
     notifyChatMediaResourceSubscribers(resource);
   });
-}
-
-export function managedAttachmentRefreshDelayMs(refreshAttempts: number): number {
-  return ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS * 2 ** Math.max(0, refreshAttempts - 1);
-}
-
-export function selectLaterExpiringManagedAttachment(
-  current: Extract<ManagedAttachmentAvailability, { status: "available" }> | null,
-  incoming: Extract<ManagedAttachmentAvailability, { status: "available" }>,
-): Extract<ManagedAttachmentAvailability, { status: "available" }> {
-  return current?.expiresAt !== undefined && current.expiresAt >= (incoming.expiresAt ?? 0)
-    ? current
-    : incoming;
 }
 
 export function isManagedOutgoingMediaSource(source: string): boolean {

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -12,12 +12,9 @@ import {
   ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS,
   ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS,
   isManagedOutgoingMediaSource,
-  managedAttachmentRefreshDelayMs,
   resolveAssistantAttachmentAvailability,
   resolveManagedOutgoingMediaSessionKey,
   retryAssistantAttachmentAvailability,
-  selectLaterExpiringManagedAttachment,
-  type ManagedAttachmentAvailability,
 } from "./chat-message-attachment-availability.ts";
 import {
   attachmentFailureReason,
@@ -42,21 +39,43 @@ import {
 } from "./chat-message-media.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
 
-function retainManagedAttachmentUntilExpiry(
-  resource: ChatMediaResource<ManagedAttachmentAvailability>,
-  availability: Extract<ManagedAttachmentAvailability, { status: "available" }> | null,
-  refreshAttempts: number,
-): Extract<ManagedAttachmentAvailability, { status: "available" }> | null {
-  if (!availability?.expiresAt || availability.expiresAt <= Date.now()) {
-    return null;
-  }
-  const retained = {
-    ...availability,
-    refreshAfter: availability.expiresAt,
-    refreshAttempts,
+type ManagedAttachmentAvailability =
+  | { status: "checking"; refreshAfter?: number; refreshAttempts?: number }
+  | {
+      status: "available";
+      url: string;
+      expiresAt?: number;
+      refreshAfter?: number;
+      refreshAttempts?: number;
+    }
+  | { status: "unavailable"; reason: string; checkedAt: number };
+
+function unavailableManagedAttachment(): ManagedAttachmentAvailability {
+  return {
+    status: "unavailable",
+    reason: t("chat.attachments.unavailable"),
+    checkedAt: Date.now(),
   };
-  setManagedAttachmentAvailability(resource, retained);
-  return retained;
+}
+
+function retryManagedAttachment(
+  candidate: Extract<ManagedAttachmentAvailability, { status: "available" }> | null,
+  refreshAttempts: number,
+  now = Date.now(),
+): ManagedAttachmentAvailability {
+  const available =
+    candidate?.expiresAt !== undefined && candidate.expiresAt <= now ? null : candidate;
+  if (refreshAttempts >= ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES) {
+    // Exhaustion stops renewal, not playback: retain a valid ticket only until its expiry.
+    return available?.expiresAt
+      ? { ...available, refreshAfter: available.expiresAt, refreshAttempts }
+      : unavailableManagedAttachment();
+  }
+  return {
+    ...(available ?? { status: "checking" }),
+    refreshAfter: now + ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS * 2 ** refreshAttempts,
+    refreshAttempts: refreshAttempts + 1,
+  };
 }
 
 function applyResourceBasePath(source: string, resourceBasePath: string | undefined): string {
@@ -80,9 +99,9 @@ function setManagedAttachmentAvailability(
   resource: ChatMediaResource<ManagedAttachmentAvailability>,
   availability: ManagedAttachmentAvailability,
   scheduleExpiryOnly = false,
-): void {
+): ManagedAttachmentAvailability {
   if (!isChatMediaResourceCurrent(resource)) {
-    return;
+    return availability;
   }
   resource.value = availability;
   const refreshAt =
@@ -106,6 +125,7 @@ function setManagedAttachmentAvailability(
     }
     notifyChatMediaResourceSubscribers(resource);
   });
+  return availability;
 }
 
 function resolveManagedAttachmentAvailability(
@@ -121,19 +141,11 @@ function resolveManagedAttachmentAvailability(
     if (new URL(attachment.url, window.location.origin).searchParams.get("mediaTicket")?.trim()) {
       return { status: "available", url: attachment.url };
     }
-    return {
-      status: "unavailable",
-      reason: t("chat.attachments.unavailable"),
-      checkedAt: Date.now(),
-    };
+    return unavailableManagedAttachment();
   }
   const sessionKey = resolveManagedOutgoingMediaSessionKey(attachment.url);
   if (!sessionKey) {
-    return {
-      status: "unavailable",
-      reason: t("chat.attachments.unavailable"),
-      checkedAt: Date.now(),
-    };
+    return unavailableManagedAttachment();
   }
   const cacheKey = `${connectionEpoch ?? 0}::${attachment.url}::${attachment.artifactId}`;
   const resource = observeChatMediaResource<ManagedAttachmentAvailability>(
@@ -144,47 +156,32 @@ function resolveManagedAttachmentAvailability(
   );
   const cached = resource.value;
   const now = Date.now();
-  if (cached?.status === "unavailable") {
-    setManagedAttachmentAvailability(resource, cached);
-    return cached;
-  }
   if (
-    cached?.status === "checking" &&
-    cached.refreshAfter !== undefined &&
-    cached.refreshAfter > now
+    cached?.status === "unavailable" ||
+    (cached?.status === "checking" &&
+      cached.refreshAfter !== undefined &&
+      cached.refreshAfter > now)
   ) {
-    setManagedAttachmentAvailability(resource, cached);
-    return cached;
+    return setManagedAttachmentAvailability(resource, cached);
   }
   if (cached?.status === "available") {
+    const expired = cached.expiresAt !== undefined && cached.expiresAt <= now;
     if (
-      cached.expiresAt !== undefined &&
-      cached.expiresAt <= now &&
+      expired &&
       (cached.refreshAttempts ?? 0) >= ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES
     ) {
       resource.retryAttempted = true;
-      const unavailable: ManagedAttachmentAvailability = {
-        status: "unavailable",
-        reason: t("chat.attachments.unavailable"),
-        checkedAt: now,
-      };
-      setManagedAttachmentAvailability(resource, unavailable);
-      return unavailable;
+      return setManagedAttachmentAvailability(resource, unavailableManagedAttachment());
     }
     if (
-      cached.expiresAt !== undefined &&
-      cached.expiresAt <= now &&
+      expired &&
       (resource.pending || (cached.refreshAfter !== undefined && cached.refreshAfter > now))
     ) {
-      const checking: ManagedAttachmentAvailability = {
+      return setManagedAttachmentAvailability(resource, {
         status: "checking",
-        ...(!resource.pending && cached.refreshAfter !== undefined
-          ? { refreshAfter: cached.refreshAfter }
-          : {}),
+        refreshAfter: resource.pending ? undefined : cached.refreshAfter,
         refreshAttempts: cached.refreshAttempts,
-      };
-      setManagedAttachmentAvailability(resource, checking);
-      return checking;
+      });
     }
     const refreshAt =
       cached.refreshAfter ??
@@ -192,8 +189,7 @@ function resolveManagedAttachmentAvailability(
         ? undefined
         : cached.expiresAt - ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS);
     if (refreshAt === undefined || refreshAt > now) {
-      setManagedAttachmentAvailability(resource, cached);
-      return cached;
+      return setManagedAttachmentAvailability(resource, cached);
     }
   }
   if (resource.pending) {
@@ -203,113 +199,65 @@ function resolveManagedAttachmentAvailability(
     cached?.status === "available" && (cached.expiresAt === undefined || cached.expiresAt > now)
       ? cached
       : null;
-  const keepCurrentForRetry = () => {
-    if (!current && cached?.status !== "checking") {
-      return null;
-    }
-    const refreshAttempts = current?.refreshAttempts ?? cached?.refreshAttempts ?? 0;
-    if (refreshAttempts >= ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES) {
-      return retainManagedAttachmentUntilExpiry(resource, current, refreshAttempts);
-    }
-    const nextRefreshAttempts = refreshAttempts + 1;
-    const refreshAfter = Date.now() + managedAttachmentRefreshDelayMs(nextRefreshAttempts);
-    const retryAvailability: ManagedAttachmentAvailability =
-      !current || (current.expiresAt !== undefined && current.expiresAt <= Date.now())
-        ? { status: "checking", refreshAfter, refreshAttempts: nextRefreshAttempts }
-        : { ...current, refreshAfter, refreshAttempts: nextRefreshAttempts };
-    setManagedAttachmentAvailability(resource, retryAvailability);
-    return retryAvailability;
-  };
-  const handleResolutionFailure = () => {
-    const retryAvailability = keepCurrentForRetry();
-    if (retryAvailability) {
-      return retryAvailability;
-    }
-    if ((cached?.refreshAttempts ?? 0) >= ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES) {
-      resource.retryAttempted = true;
-    }
-    const unavailable: ManagedAttachmentAvailability = {
-      status: "unavailable",
-      reason: t("chat.attachments.unavailable"),
-      checkedAt: Date.now(),
-    };
-    setManagedAttachmentAvailability(resource, unavailable);
-    return unavailable;
-  };
+  const refreshAttempts = cached?.refreshAttempts ?? 0;
+  const handleResolutionFailure = () =>
+    current || cached?.status === "checking"
+      ? retryManagedAttachment(current, refreshAttempts)
+      : unavailableManagedAttachment();
   if (!current) {
     setManagedAttachmentAvailability(resource, { status: "checking" });
   }
   const pending = Promise.resolve()
-    .then(() => resolveArtifactDownload({ sessionKey, artifactId: attachment.artifactId! }))
-    .then((result) => {
+    .then(async () => {
+      let availability: ManagedAttachmentAvailability;
+      try {
+        const result = await resolveArtifactDownload({
+          sessionKey,
+          artifactId: attachment.artifactId!,
+        });
+        const url = result?.url.trim();
+        if (!url) {
+          availability = handleResolutionFailure();
+        } else {
+          const parsedExpiresAt = Date.parse(result?.expiresAt ?? "");
+          const resolvedAt = Date.now();
+          const expiresAt = Number.isFinite(parsedExpiresAt)
+            ? parsedExpiresAt
+            : resolvedAt + 5 * 60_000;
+          const incoming: Extract<ManagedAttachmentAvailability, { status: "available" }> = {
+            status: "available",
+            url,
+            expiresAt,
+          };
+          availability =
+            expiresAt - resolvedAt > ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS
+              ? incoming
+              : retryManagedAttachment(
+                  refreshAttempts >= ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES &&
+                    current?.expiresAt !== undefined &&
+                    current.expiresAt >= expiresAt
+                    ? current
+                    : incoming,
+                  refreshAttempts,
+                  resolvedAt,
+                );
+        }
+      } catch {
+        availability = handleResolutionFailure();
+      }
       if (!isChatMediaResourceCurrent(resource)) {
         return null;
       }
-      const url = result?.url.trim();
-      if (!url) {
-        return handleResolutionFailure();
-      }
-      const parsedExpiresAt = Date.parse(result?.expiresAt ?? "");
-      const expiresAt = Number.isFinite(parsedExpiresAt)
-        ? parsedExpiresAt
-        : Date.now() + 5 * 60_000;
-      const refreshAttempts = cached?.refreshAttempts ?? 0;
-      if (
-        expiresAt - Date.now() <= ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS &&
+      if (availability.status === "available" && availability.refreshAttempts === undefined) {
+        resource.retryAttempted = false;
+      } else if (
+        availability.status === "unavailable" &&
         refreshAttempts >= ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES
       ) {
-        const incoming: Extract<ManagedAttachmentAvailability, { status: "available" }> = {
-          status: "available",
-          url,
-          expiresAt,
-        };
-        const retained = retainManagedAttachmentUntilExpiry(
-          resource,
-          selectLaterExpiringManagedAttachment(current, incoming),
-          refreshAttempts,
-        );
-        if (retained) {
-          return retained;
-        }
         resource.retryAttempted = true;
-        const unavailable: ManagedAttachmentAvailability = {
-          status: "unavailable",
-          reason: t("chat.attachments.unavailable"),
-          checkedAt: Date.now(),
-        };
-        setManagedAttachmentAvailability(resource, unavailable);
-        return unavailable;
       }
-      const nextRefreshAttempts = refreshAttempts + 1;
-      const needsEarlyRefresh =
-        expiresAt - Date.now() <= ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS;
-      if (expiresAt <= Date.now()) {
-        const retryAvailability: ManagedAttachmentAvailability = {
-          status: "checking",
-          refreshAfter: Date.now() + managedAttachmentRefreshDelayMs(nextRefreshAttempts),
-          refreshAttempts: nextRefreshAttempts,
-        };
-        setManagedAttachmentAvailability(resource, retryAvailability);
-        return retryAvailability;
-      }
-      const availability: ManagedAttachmentAvailability = {
-        status: "available",
-        url,
-        expiresAt,
-        ...(needsEarlyRefresh
-          ? {
-              refreshAfter: Date.now() + managedAttachmentRefreshDelayMs(nextRefreshAttempts),
-              refreshAttempts: nextRefreshAttempts,
-            }
-          : {}),
-      };
-      if (!needsEarlyRefresh) {
-        resource.retryAttempted = false;
-      }
-      setManagedAttachmentAvailability(resource, availability);
-      return availability;
+      return setManagedAttachmentAvailability(resource, availability);
     })
-    .catch(handleResolutionFailure)
     .finally(() => {
       if (resource.pending === pending) {
         resource.pending = undefined;

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -39,12 +39,9 @@ import { renderAssistantAttachments } from "./chat-message-attachments.ts";
 import { renderMessageImages } from "./chat-message-images.ts";
 import type { MessageActionDetails } from "./chat-message-markdown.ts";
 import {
-  extractImages,
-  extractMessageAttachments,
-  extractPairingQrExpiryNotices,
+  projectMessageMedia,
   schedulePairingQrExpiryRefresh,
   type ArtifactDownloadResolver,
-  type PairingQrExpiryNotice,
 } from "./chat-message-media.ts";
 import {
   detectJson,
@@ -175,25 +172,30 @@ function renderReplyPreview(
   `;
 }
 
-function renderPairingQrExpiryNotices(notices: PairingQrExpiryNotice[]) {
-  if (notices.length === 0) {
+function renderPairingQrExpiryNotices(count: number) {
+  if (count === 0) {
     return nothing;
   }
   return html`
     <div class="chat-pairing-qr-notices">
-      ${notices.map(
-        (notice) => html`
+      ${Array.from(
+        { length: count },
+        () => html`
           <div
             class="chat-assistant-attachment-card chat-assistant-attachment-card--blocked chat-pairing-qr-expired"
           >
             <div class="chat-assistant-attachment-card__header">
               <span class="chat-assistant-attachment-card__icon">${icons.alertTriangle}</span>
-              <span class="chat-assistant-attachment-card__title">${notice.title}</span>
+              <span class="chat-assistant-attachment-card__title"
+                >${t("chat.pairingQrExpired.title")}</span
+              >
               <span class="chat-assistant-attachment-badge chat-assistant-attachment-badge--muted"
                 >${t("chat.pairingQrExpired.badge")}</span
               >
             </div>
-            <div class="chat-assistant-attachment-card__reason">${notice.reason}</div>
+            <div class="chat-assistant-attachment-card__reason">
+              ${t("chat.pairingQrExpired.reason")}
+            </div>
           </div>
         `,
       )}
@@ -260,8 +262,13 @@ export function renderGroupedMessage(
 
   const toolCards = (opts.showToolCalls ?? true) ? extractToolCardsCached(message) : [];
   const hasToolCards = toolCards.length > 0;
-  schedulePairingQrExpiryRefresh(messageKey, message, opts.onRequestUpdate);
-  const images = extractImages(message);
+  const {
+    images,
+    attachments: visibleAttachments,
+    expiredPairingQrCount,
+    nextPairingQrExpiresAt,
+  } = projectMessageMedia(message, normalizedMessage.content);
+  schedulePairingQrExpiryRefresh(messageKey, nextPairingQrExpiresAt, opts.onRequestUpdate);
   const hasImages = images.length > 0;
   const imageRenderOptions = {
     ...(hasImages ? imageMessageIdentity(message, opts.sessionKey) : {}),
@@ -274,12 +281,8 @@ export function renderGroupedMessage(
     onOpenImage: opts.onOpenImage,
     resolveArtifactDownload: opts.resolveArtifactDownload,
   };
-  const pairingQrExpiryNotices = extractPairingQrExpiryNotices(message);
-  const hasPairingQrExpiryNotices = pairingQrExpiryNotices.length > 0;
-
   const displayMarkdown = resolveMessageDisplayMarkdown(message, normalizedMessage);
   const actionText = opts.messageActions?.markdown ?? displayMarkdown;
-  const visibleAttachments = extractMessageAttachments(message, normalizedMessage.content);
   const assistantViewBlocks = normalizedMessage.content.filter(
     (item): item is Extract<MessageContentItem, { type: "canvas" }> => item.type === "canvas",
   );
@@ -319,7 +322,7 @@ export function renderGroupedMessage(
     !reasoningMarkdown &&
     !hasToolCards &&
     !hasImages &&
-    !hasPairingQrExpiryNotices &&
+    expiredPairingQrCount === 0 &&
     visibleAttachments.length === 0 &&
     assistantViewBlocks.length === 0 &&
     !normalizedMessage.replyTarget
@@ -411,7 +414,7 @@ export function renderGroupedMessage(
     hasToolCards &&
     !markdown &&
     !hasImages &&
-    !hasPairingQrExpiryNotices &&
+    expiredPairingQrCount === 0 &&
     visibleAttachments.length === 0 &&
     assistantViewBlocks.length === 0 &&
     !reasoningMarkdown;
@@ -419,7 +422,7 @@ export function renderGroupedMessage(
   const toolRenderOptions = { ...opts, messageKey, onOpenSidebar };
   // Collapsed tool results must not load attachments or render hidden markdown.
   const renderBody = () => html`
-    ${renderPairingQrExpiryNotices(pairingQrExpiryNotices)}
+    ${renderPairingQrExpiryNotices(expiredPairingQrCount)}
     ${renderMessageImages(images, imageRenderOptions)}
     ${renderAssistantAttachments(
       visibleAttachments,

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -3,12 +3,10 @@ import { AsyncDirective, directive } from "lit/async-directive.js";
 import { Directive } from "lit/directive.js";
 import { keyed } from "lit/directives/keyed.js";
 import { repeat } from "lit/directives/repeat.js";
-import { until } from "lit/directives/until.js";
 import { normalizeBasePath } from "../../../app-route-paths.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import {
-  openExternalUrlSafe,
   reserveExternalWindowForDeferredNavigation,
   resolveSafeExternalUrl,
 } from "../../../lib/open-external-url.ts";
@@ -39,7 +37,6 @@ import {
   type ChatMediaResource,
   type ImageBlock,
   type ImageRenderOptions,
-  type RenderableImageBlock,
 } from "./chat-message-media.ts";
 
 const MANAGED_OUTGOING_IMAGE_FETCH_TIMEOUT_MS = 30_000;
@@ -62,10 +59,12 @@ class MessageImageResourceDirective extends AsyncDirective {
   private image: ImageBlock | undefined;
   private options: ImageRenderOptions | undefined;
   private element: HTMLImageElement | undefined;
+  private managed = false;
+  private pendingPreview: Promise<string | null> | undefined;
   private presentationKey = Symbol("image-presentation");
   private retained: RetainedInlineImage | { status: "unavailable" } | undefined;
-  private onRequestUpdate: (() => void) | undefined;
-  private readonly requestUpdate = () => this.onRequestUpdate?.();
+  // Resource updates stay in this part; row ResizeObserver owns layout changes.
+  private readonly requestUpdate = () => this.refreshImage();
   private readonly onSettled = (event: Event, source: string) => {
     // A removed IMG may finish after denial; it no longer owns displayed pixels.
     const element = event.currentTarget;
@@ -93,6 +92,8 @@ class MessageImageResourceDirective extends AsyncDirective {
   override render(image: ImageBlock, options: ImageRenderOptions | undefined) {
     const previous = this.image;
     if (previous?.url !== image.url || previous?.artifactId !== image.artifactId) {
+      this.managed = isManagedOutgoingMediaSource(image.url);
+      this.pendingPreview = undefined;
       this.releaseRetainedImage();
       // The gallery binds the exact submission/slot. Retain only pixels this
       // mounted IMG has loaded, never another pane's cached preview.
@@ -124,16 +125,17 @@ class MessageImageResourceDirective extends AsyncDirective {
       releaseChatMediaResourceSubscriber(this.requestUpdate);
       return noChange;
     }
-    this.onRequestUpdate = options?.onRequestUpdate;
+    const onRequestUpdate = options?.onRequestUpdate;
 
     // Lit owns each image part. Reparent its stable subscription when the pane
     // callback changes without discarding its loaded resource.
-    if (this.onRequestUpdate) {
-      observeChatMediaResourceSubscriber(this.onRequestUpdate, this.requestUpdate);
+    if (onRequestUpdate) {
+      this.pendingPreview = undefined;
+      observeChatMediaResourceSubscriber(onRequestUpdate, this.requestUpdate);
     } else {
       releaseChatMediaResourceSubscriber(this.requestUpdate);
     }
-    const subscriptionOptions = this.onRequestUpdate
+    const subscriptionOptions = onRequestUpdate
       ? { ...options, onRequestUpdate: this.requestUpdate }
       : options;
     const availability = resolveAssistantAttachmentAvailability(
@@ -186,8 +188,7 @@ class MessageImageResourceDirective extends AsyncDirective {
             : undefined,
       });
     }
-    const renderable = { ...image, displayUrl };
-    if (!isManagedOutgoingMediaSource(displayUrl)) {
+    if (!this.managed) {
       const retained = this.retained;
       if (
         availability.status === "available" &&
@@ -201,26 +202,39 @@ class MessageImageResourceDirective extends AsyncDirective {
           CANONICAL_IMAGE_HANDOFF_TIMEOUT_MS,
         );
       }
-      return this.present(this.renderImageElement(renderable, displayUrl, options));
+      return this.present(this.renderImageElement(image, displayUrl, options));
     }
-    // Keep this render's callbacks when the image resolves, not later directive options.
-    const preview = resolveManagedOutgoingImageBlobUrl(
+    const resource = resolveManagedOutgoingImageResource(
       displayUrl,
       subscriptionOptions,
       image.artifactId,
-    ).then((previewUrl) =>
-      previewUrl ? this.renderImageElement(renderable, previewUrl, options) : nothing,
     );
-    return this.present(until(preview, nothing));
+    const pending = resource.pending;
+    // Standalone renders settle without opting into pane-owned automatic retries.
+    if (!onRequestUpdate && pending && this.pendingPreview !== pending) {
+      this.pendingPreview = pending;
+      void pending.then((previewUrl) => {
+        if (this.pendingPreview === pending && this.isConnected && this.image) {
+          this.pendingPreview = undefined;
+          this.setValue(
+            this.present(
+              previewUrl ? this.renderImageElement(this.image, previewUrl, this.options) : nothing,
+            ),
+          );
+        }
+      });
+    }
+    return this.present(
+      resource.value ? this.renderImageElement(image, resource.value, options) : nothing,
+    );
   }
 
   private renderImageElement(
-    img: RenderableImageBlock,
+    img: ImageBlock,
     previewUrl: string,
     opts: ImageRenderOptions | undefined,
   ) {
     const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
-    const managed = isManagedOutgoingMediaSource(img.displayUrl);
     // Upscale genuinely tiny sources enough to read and operate without
     // stretching every transcript image into a fixed-size tile.
     const imageClass =
@@ -228,7 +242,7 @@ class MessageImageResourceDirective extends AsyncDirective {
         ? "chat-message-image chat-message-image--small"
         : "chat-message-image";
     return html`
-      <span class="chat-image-frame ${managed ? "chat-image-frame--managed" : ""}">
+      <span class="chat-image-frame ${this.managed ? "chat-image-frame--managed" : ""}">
         <button
           type="button"
           class="chat-message-image-button"
@@ -248,7 +262,7 @@ class MessageImageResourceDirective extends AsyncDirective {
             height=${img.height ?? nothing}
           />
         </button>
-        ${managed ? renderManagedImageActions(img, opts) : nothing}
+        ${this.managed ? renderManagedImageActions(img, opts) : nothing}
       </span>
     `;
   }
@@ -280,6 +294,7 @@ class MessageImageResourceDirective extends AsyncDirective {
   protected override disconnected() {
     this.releaseRetainedImage();
     this.element = undefined;
+    this.pendingPreview = undefined;
     this.presentationKey = Symbol("image-presentation");
     releaseChatMediaResourceSubscriber(this.requestUpdate);
   }
@@ -293,62 +308,47 @@ class MessageImageResourceDirective extends AsyncDirective {
 const renderMessageImageResource = directive(MessageImageResourceDirective);
 
 function openMessageImage(
-  img: RenderableImageBlock,
+  img: ImageBlock,
   previewUrl: string,
   opts: ImageRenderOptions | undefined,
 ) {
   const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
   const requestVersion = opts?.onRequestOpenImage?.();
-  if (!isManagedOutgoingMediaSource(img.displayUrl)) {
+  if (!isManagedOutgoingMediaSource(img.url)) {
     openResolvedImage(opts?.onOpenImage, previewUrl, title, undefined, requestVersion);
     return;
   }
 
-  const cacheKey = resolveManagedOutgoingImageBlobUrlCacheKey(
-    img.displayUrl,
-    opts,
-    img.artifactId,
-    "full",
-  );
-  const cached = readManagedImageBlobUrl(cacheKey);
-  if (cached) {
-    const release = opts?.onOpenImage ? retainManagedImageBlobUrl(cacheKey) : undefined;
-    openResolvedImage(opts?.onOpenImage, cached, title, release, requestVersion);
+  const resource = resolveManagedOutgoingImageResource(img.url, opts, img.artifactId, "full");
+  const open = (url: string) => {
+    const release = opts?.onOpenImage ? retainManagedImageBlobUrl(resource.cacheKey) : undefined;
+    openResolvedImage(opts?.onOpenImage, url, title, release, requestVersion);
+  };
+  if (resource.value) {
+    open(resource.value);
     return;
   }
 
-  if (!opts?.onOpenImage) {
-    const pendingWindow = reserveExternalWindowForDeferredNavigation();
-    void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
-      .then((freshUrl) => {
-        const safeUrl = freshUrl
-          ? resolveSafeExternalUrl(freshUrl, window.location.href, { allowDataImage: true })
-          : null;
-        if (!safeUrl) {
-          pendingWindow?.close();
-          showToast({ message: t("chat.imageLightbox.loadFailed") });
-        } else if (pendingWindow) {
-          pendingWindow.location.replace(safeUrl);
-        } else {
-          openExternalUrlSafe(safeUrl, { allowDataImage: true });
-        }
-      })
-      .catch(() => {
-        pendingWindow?.close();
-        showToast({ message: t("chat.imageLightbox.loadFailed") });
-      });
-    return;
-  }
-  void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
+  const pendingWindow = opts?.onOpenImage ? null : reserveExternalWindowForDeferredNavigation();
+  const failed = () => {
+    pendingWindow?.close();
+    showToast({ message: t("chat.imageLightbox.loadFailed") });
+  };
+  const pending = resource.pending ?? Promise.resolve(null);
+  void pending
     .then((freshUrl) => {
-      if (!freshUrl) {
-        showToast({ message: t("chat.imageLightbox.loadFailed") });
-        return;
+      const safeUrl = freshUrl
+        ? resolveSafeExternalUrl(freshUrl, window.location.href, { allowDataImage: true })
+        : null;
+      if (!safeUrl) {
+        failed();
+      } else if (pendingWindow) {
+        pendingWindow.location.replace(safeUrl);
+      } else {
+        open(safeUrl);
       }
-      const release = cacheKey ? retainManagedImageBlobUrl(cacheKey) : undefined;
-      openResolvedImage(opts.onOpenImage, freshUrl, title, release, requestVersion);
     })
-    .catch(() => showToast({ message: t("chat.imageLightbox.loadFailed") }));
+    .catch(failed);
 }
 
 class MessageImagesDirective extends Directive {
@@ -423,35 +423,28 @@ class MessageImagesDirective extends Directive {
 
 export const renderMessageImages = directive(MessageImagesDirective);
 
-function resolveManagedOutgoingImageBlobUrlCacheKey(
+function resolveManagedOutgoingImageResource(
   source: string,
   opts?: ImageRenderOptions,
   artifactId?: string,
   variant: ManagedImageVariant = "thumbnail",
-): string {
+): ChatMediaResource<string | null> {
+  const variantUrl = buildManagedOutgoingImageVariantUrl(source, variant, opts?.resourceBasePath);
   const authToken = opts?.authToken?.trim() ?? "";
-  return `${buildManagedOutgoingImageVariantUrl(source, variant, opts?.resourceBasePath)}::${authToken}::${artifactId?.trim() ?? ""}`;
-}
-
-async function resolveManagedOutgoingImageBlobUrl(
-  source: string,
-  opts?: ImageRenderOptions,
-  artifactId?: string,
-  variant: ManagedImageVariant = "thumbnail",
-): Promise<string | null> {
-  const cacheKey = resolveManagedOutgoingImageBlobUrlCacheKey(source, opts, artifactId, variant);
+  const artifactKey = artifactId?.trim() ?? "";
+  const cacheKey = `${variantUrl}::${authToken}::${artifactKey}`;
   const resource = observeChatMediaResource<string | null>(
     "managed-image",
     cacheKey,
     opts?.onRequestUpdate,
-    `${buildManagedOutgoingImageVariantUrl(source, variant, opts?.resourceBasePath)}::${artifactId?.trim() ?? ""}`,
+    `${variantUrl}::${artifactKey}`,
   );
   const cached = readManagedImageBlobUrl(cacheKey);
   if (cached) {
     resource.value = cached;
     resource.retryAttempted = false;
     resource.unavailableAt = undefined;
-    return cached;
+    return resource;
   }
   if (resource.value === null) {
     if (
@@ -459,11 +452,11 @@ async function resolveManagedOutgoingImageBlobUrl(
       resource.unavailableAt === undefined ||
       Date.now() - resource.unavailableAt < MANAGED_OUTGOING_IMAGE_RETRY_MS
     ) {
-      return null;
+      return resource;
     }
     resource.retryAttempted = true;
-    resource.value = undefined;
   }
+  resource.value = undefined;
   if (!resource.pending) {
     const controller = new AbortController();
     resource.abortController = controller;
@@ -494,12 +487,14 @@ async function resolveManagedOutgoingImageBlobUrl(
       if (resource.pending === pending) {
         resource.pending = undefined;
       }
-      trimManagedImageMissResources();
+      if (resource.value === null && resource.subscribers.size === 0 && !resource.pending) {
+        trimManagedImageMissResources();
+      }
       notifyChatMediaResourceSubscribers(resource);
     });
     resource.pending = pending;
   }
-  return resource.pending;
+  return resource;
 }
 
 function buildManagedOutgoingImageVariantUrl(
@@ -582,7 +577,8 @@ async function readManagedOutgoingImageBlob(
   opts?: ImageRenderOptions,
   artifactId?: string,
 ): Promise<Blob> {
-  const blobUrl = await resolveManagedOutgoingImageBlobUrl(source, opts, artifactId, "full");
+  const resource = resolveManagedOutgoingImageResource(source, opts, artifactId, "full");
+  const blobUrl = resource.value ?? (await resource.pending);
   if (!blobUrl) {
     throw new Error("managed image is unavailable");
   }
@@ -641,14 +637,11 @@ async function convertImageBlobToPng(blob: Blob): Promise<Blob> {
   }
 }
 
-function renderManagedImageActions(
-  image: RenderableImageBlock,
-  opts: ImageRenderOptions | undefined,
-) {
+function renderManagedImageActions(image: ImageBlock, opts: ImageRenderOptions | undefined) {
   const title = image.alt?.trim() || t("chat.imageLightbox.untitled");
   const download = async () => {
     try {
-      const blob = await readManagedOutgoingImageBlob(image.displayUrl, opts, image.artifactId);
+      const blob = await readManagedOutgoingImageBlob(image.url, opts, image.artifactId);
       downloadImageBlob(blob, imageDownloadFileName(title, blob.type));
     } catch {
       showToast({ message: t("chat.imageLightbox.downloadFailed") });
@@ -659,7 +652,7 @@ function renderManagedImageActions(
       if (!navigator.clipboard?.write || typeof ClipboardItem === "undefined") {
         throw new Error("image clipboard is unavailable");
       }
-      const png = readManagedOutgoingImageBlob(image.displayUrl, opts, image.artifactId).then(
+      const png = readManagedOutgoingImageBlob(image.url, opts, image.artifactId).then(
         convertImageBlobToPng,
       );
       void png.catch(() => {});

--- a/ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts
+++ b/ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts
@@ -2,7 +2,7 @@
 
 import { html, render } from "lit";
 import { guard } from "lit/directives/guard.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { resolveAssistantAttachmentAvailability } from "./chat-message-attachment-availability.ts";
 import { renderMessageImages } from "./chat-message-images.ts";
 import {
@@ -11,8 +11,8 @@ import {
   readManagedImageBlobUrl,
   releaseChatMediaResourceSubscriber,
   schedulePairingQrExpiryRefresh,
+  type ImageBlock,
   type ImageRenderOptions,
-  type RenderableImageBlock,
 } from "./chat-message-media.ts";
 
 const subscribers = new Set<() => void>();
@@ -67,9 +67,8 @@ function renderManagedImage(
   options: ImageRenderOptions = {},
   artifactId?: string,
 ) {
-  const image: RenderableImageBlock = {
+  const image: ImageBlock = {
     url: source,
-    displayUrl: source,
     alt: "Managed image",
     ...(artifactId ? { artifactId } : {}),
   };
@@ -85,9 +84,8 @@ describe("chat media resource lifecycle", () => {
   it("marks one-to-five image turns for the transcript and sent-message layouts", () => {
     const container = document.createElement("div");
     for (const count of [1, 2, 3, 4, 5]) {
-      const images: RenderableImageBlock[] = Array.from({ length: count }, (_, index) => ({
+      const images: ImageBlock[] = Array.from({ length: count }, (_, index) => ({
         url: `data:image/png;base64,image-${count}-${index}`,
-        displayUrl: `data:image/png;base64,image-${count}-${index}`,
         alt: `Image ${index + 1}`,
         width: count === 1 ? 16 : 640,
         height: count === 1 ? 16 : 640,
@@ -107,20 +105,12 @@ describe("chat media resource lifecycle", () => {
   });
 
   it("refreshes every split pane when a shared pairing QR expires", async () => {
-    const message = {
-      content: [
-        {
-          type: "openclaw_pairing_qr",
-          image_url: "data:image/png;base64,cXJwbmc=",
-          expiresAtMs: Date.now() + 1_000,
-        },
-      ],
-    };
+    const expiresAt = Date.now() + 1_000;
     const refreshFirst = observeSubscriber(vi.fn());
     const refreshSecond = observeSubscriber(vi.fn());
 
-    schedulePairingQrExpiryRefresh("shared-pairing-qr", message, refreshFirst);
-    schedulePairingQrExpiryRefresh("shared-pairing-qr", message, refreshSecond);
+    schedulePairingQrExpiryRefresh("shared-pairing-qr", expiresAt, refreshFirst);
+    schedulePairingQrExpiryRefresh("shared-pairing-qr", expiresAt, refreshSecond);
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(refreshFirst).toHaveBeenCalledOnce();
@@ -129,19 +119,7 @@ describe("chat media resource lifecycle", () => {
 
   it("releases a pairing QR expiry timer when its chat pane disconnects", async () => {
     const refresh = observeSubscriber(vi.fn());
-    schedulePairingQrExpiryRefresh(
-      "disconnected-pairing-qr",
-      {
-        content: [
-          {
-            type: "openclaw_pairing_qr",
-            image_url: "data:image/png;base64,cXJwbmc=",
-            expiresAtMs: Date.now() + 1_000,
-          },
-        ],
-      },
-      refresh,
-    );
+    schedulePairingQrExpiryRefresh("disconnected-pairing-qr", Date.now() + 1_000, refresh);
 
     releaseChatMediaResourceSubscriber(refresh);
     await vi.advanceTimersByTimeAsync(1_000);
@@ -175,6 +153,45 @@ describe("chat media resource lifecycle", () => {
     expect(
       container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
     ).toBe(blobUrl);
+  });
+
+  it("keeps a cached managed image mounted during rerenders and uses current callbacks", async () => {
+    const source = managedImageSource();
+    installManagedImageUrls();
+    const fetchMock = vi.fn(async () => imageResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const container = document.body.appendChild(document.createElement("div"));
+    const previousOpen = vi.fn<NonNullable<ImageRenderOptions["onOpenImage"]>>();
+    const currentOpen = vi.fn<NonNullable<ImageRenderOptions["onOpenImage"]>>();
+    onTestFinished(() => {
+      for (const [item] of [...previousOpen.mock.calls, ...currentOpen.mock.calls]) {
+        item.release?.();
+      }
+      render(null, container);
+      container.remove();
+    });
+    renderManagedImage(container, source, {
+      onRequestUpdate: observeSubscriber(vi.fn()),
+      onOpenImage: previousOpen,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const displayed = container.querySelector(".chat-message-image");
+    expect(displayed).not.toBeNull();
+
+    renderManagedImage(container, source, {
+      onRequestUpdate: observeSubscriber(vi.fn()),
+      onOpenImage: currentOpen,
+    });
+    // A settled cache hit must not blank the native image for a promise turn.
+    expect(container.querySelector(".chat-message-image")).toBe(displayed);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(container.querySelector(".chat-message-image")).toBe(displayed);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    container.querySelector<HTMLButtonElement>(".chat-message-image-button")?.click();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(previousOpen).not.toHaveBeenCalled();
+    expect(currentOpen).toHaveBeenCalledOnce();
   });
 
   it("stops after one automatic retry for a permanently unavailable managed image", async () => {

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -13,11 +13,6 @@ import {
   labelForMediaPath,
 } from "../../../lib/media-file-extension.ts";
 
-export type PairingQrExpiryNotice = {
-  title: string;
-  reason: string;
-};
-
 export type ImageBlock = {
   url: string;
   factIndex?: number;
@@ -46,10 +41,6 @@ export type ImageRenderOptions = {
   onRequestOpenImage?: () => number;
   onOpenImage?: (item: ImageLightboxItem, requestVersion?: number) => void;
   resolveArtifactDownload?: ArtifactDownloadResolver;
-};
-
-export type RenderableImageBlock = ImageBlock & {
-  displayUrl: string;
 };
 
 export type AttachmentItem = Extract<MessageContentItem, { type: "attachment" }>;
@@ -345,95 +336,74 @@ function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
   }
 }
 
-function buildBase64ImageUrl(params: { data: string; mediaType?: string }): string {
-  return params.data.startsWith("data:")
-    ? params.data
-    : `data:${params.mediaType ?? "image/png"};base64,${params.data}`;
+function buildBase64ImageUrl(data: string, mediaType: unknown): string {
+  return data.startsWith("data:")
+    ? data
+    : `data:${typeof mediaType === "string" ? mediaType : "image/png"};base64,${data}`;
 }
 
-function crossOriginStructuredSvgAttachment(
-  source: unknown,
-  mediaType: unknown,
-  metadata: Record<string, unknown> = {},
-): AttachmentItem | null {
-  if (typeof source !== "string" || !isSvgImageMediaPath(source, mediaType)) {
-    return null;
-  }
-  try {
-    const url = new URL(source, window.location.href);
-    if (
-      (url.protocol !== "http:" && url.protocol !== "https:") ||
-      url.origin === window.location.origin
-    ) {
-      return null;
-    }
-  } catch {
-    return null;
-  }
-  const sizeBytes = asFiniteNumber(metadata.sizeBytes);
-  return {
-    type: "attachment",
-    attachment: {
-      url: source,
-      kind: "image",
-      label:
-        (typeof metadata.fileName === "string" && metadata.fileName.trim()) ||
-        (typeof metadata.alt === "string" && metadata.alt.trim()) ||
-        labelForMediaPath(source),
-      mimeType: typeof mediaType === "string" ? mediaType : "image/svg+xml",
-      ...(typeof metadata.artifactId === "string" ? { artifactId: metadata.artifactId } : {}),
-      ...(sizeBytes !== undefined ? { sizeBytes } : {}),
-    },
-  };
-}
-
-function extractStructuredSvgAttachments(message: unknown): AttachmentItem[] {
-  const content = asNonArrayRecord(message).content;
-  if (!Array.isArray(content)) {
-    return [];
-  }
-  const attachments: AttachmentItem[] = [];
-  const append = (attachment: AttachmentItem | null) => {
-    if (
-      attachment &&
-      !attachments.some((item) => item.attachment.url === attachment.attachment.url)
-    ) {
-      attachments.push(attachment);
-    }
-  };
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const entry = asNonArrayRecord(block);
-    if (entry.type === "image") {
-      const source = asOptionalRecord(entry.source);
-      append(
-        crossOriginStructuredSvgAttachment(entry.url, entry.mimeType ?? source?.media_type, entry),
-      );
-    } else if (entry.type === "image_url") {
-      const imageUrl = asOptionalRecord(entry.image_url);
-      append(crossOriginStructuredSvgAttachment(imageUrl?.url, undefined));
-    } else if (entry.type === "input_image") {
-      const imageUrl = entry.image_url;
-      const source = asOptionalRecord(entry.source);
-      append(
-        crossOriginStructuredSvgAttachment(
-          typeof imageUrl === "string" ? imageUrl : asOptionalRecord(imageUrl)?.url,
-          undefined,
-        ),
-      );
-      append(crossOriginStructuredSvgAttachment(source?.url, source?.media_type));
-    }
-  }
-  return attachments;
-}
-
-export function extractImages(message: unknown): ImageBlock[] {
-  const m = message as Record<string, unknown>;
-  const content = m.content;
+export function projectMessageMedia(
+  message: unknown,
+  content: readonly MessageContentItem[],
+  nowMs = Date.now(),
+) {
+  const record = asNonArrayRecord(message);
+  const blocks = Array.isArray(record.content) ? record.content : [];
   const images: ImageBlock[] = [];
-  const layout = asNonArrayRecord(asNonArrayRecord(m["__openclaw"]).mediaImageLayout);
+  const attachments: AssistantAttachmentItem[] = [];
+  const attachmentUrls = new Set<string>();
+  let expiredPairingQrCount = 0;
+  let nextPairingQrExpiresAt: number | undefined;
+  const appendAttachment = (item: AssistantAttachmentItem) => {
+    if (item.type === "attachment_error" || !attachmentUrls.has(item.attachment.url)) {
+      attachments.push(item);
+      if (item.type === "attachment") {
+        attachmentUrls.add(item.attachment.url);
+      }
+    }
+  };
+  for (const item of content) {
+    if (item.type === "attachment" || item.type === "attachment_error") {
+      appendAttachment(item);
+    }
+  }
+  const appendSvgAttachment = (
+    source: unknown,
+    mediaType?: unknown,
+    metadata?: Record<string, unknown>,
+  ): boolean => {
+    if (typeof source !== "string" || !isSvgImageMediaPath(source, mediaType)) {
+      return false;
+    }
+    try {
+      const url = new URL(source, window.location.href);
+      if (
+        (url.protocol !== "http:" && url.protocol !== "https:") ||
+        url.origin === window.location.origin
+      ) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+    const sizeBytes = asFiniteNumber(metadata?.sizeBytes);
+    appendAttachment({
+      type: "attachment",
+      attachment: {
+        url: source,
+        kind: "image",
+        label:
+          (typeof metadata?.fileName === "string" && metadata.fileName.trim()) ||
+          (typeof metadata?.alt === "string" && metadata.alt.trim()) ||
+          labelForMediaPath(source),
+        mimeType: typeof mediaType === "string" ? mediaType : "image/svg+xml",
+        ...(typeof metadata?.artifactId === "string" ? { artifactId: metadata.artifactId } : {}),
+        ...(sizeBytes !== undefined ? { sizeBytes } : {}),
+      },
+    });
+    return true;
+  };
+  const layout = asNonArrayRecord(asNonArrayRecord(record["__openclaw"]).mediaImageLayout);
   const slots = Array.isArray(layout.slots) ? layout.slots.map(asNonArrayRecord) : [];
   const factIndexes = slots.length > 0 ? new Set(slots.map((slot) => slot.factIndex)) : undefined;
   // Reject ambiguous layouts before deduplication: fact positions, including
@@ -450,204 +420,139 @@ export function extractImages(message: unknown): ImageBlock[] {
     ) &&
     factIndexes.size === slots.length;
   const inlineSlots = validLayout ? slots.filter((slot) => slot.kind === "inline") : [];
-  const alignedInline =
-    inlineSlots.length > 0 &&
-    Array.isArray(content) &&
-    content.filter((block) => asNonArrayRecord(block).type === "image").length ===
-      inlineSlots.length;
   let inlineIndex = 0;
 
-  if (Array.isArray(content)) {
-    for (const block of content) {
-      if (typeof block !== "object" || block === null) {
-        continue;
-      }
-      const b = block as Record<string, unknown>;
-      const blockImages: ImageBlock[] = [];
-
-      if (b.type === "image") {
-        // Handle source object format from optimistic user sends.
-        const source = b.source as Record<string, unknown> | undefined;
-        const factIndex = alignedInline ? inlineSlots[inlineIndex]?.factIndex : undefined;
-        const imageMeta = {
+  for (const value of blocks) {
+    const block = asOptionalRecord(value);
+    if (!block) {
+      continue;
+    }
+    const source = asOptionalRecord(block.source);
+    if (block.type === "image") {
+      const factIndex = inlineSlots[inlineIndex++]?.factIndex;
+      // The structured SVG reference is independent of inline data in the same block.
+      const svg = appendSvgAttachment(block.url, block.mimeType ?? source?.media_type, block);
+      const base64Source =
+        source?.type === "base64" && typeof source.data === "string" ? source : undefined;
+      const data = base64Source ? base64Source.data : block.data;
+      const url =
+        typeof data === "string"
+          ? buildBase64ImageUrl(data, base64Source ? base64Source.media_type : block.mimeType)
+          : !svg && typeof block.url === "string"
+            ? block.url
+            : undefined;
+      if (url !== undefined) {
+        images.push({
+          url,
           ...(typeof factIndex === "number" ? { factIndex } : {}),
-          artifactId: typeof b.artifactId === "string" ? b.artifactId : undefined,
-          alt: typeof b.alt === "string" ? b.alt : undefined,
-          fileName: typeof b.fileName === "string" ? b.fileName : undefined,
-          openUrl: typeof b.openUrl === "string" ? b.openUrl : undefined,
-          sizeBytes: asFiniteNumber(b.sizeBytes),
-          width: typeof b.width === "number" ? b.width : undefined,
-          height: typeof b.height === "number" ? b.height : undefined,
-        };
-        inlineIndex += 1;
-        if (source?.type === "base64" && typeof source.data === "string") {
-          appendImageBlock(blockImages, {
-            url: buildBase64ImageUrl({
-              data: source.data,
-              mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
-            }),
-            ...imageMeta,
-          });
-        } else if (typeof b.data === "string") {
-          // Direct tool-result image block from imageResult() / read tool.
-          appendImageBlock(blockImages, {
-            url: buildBase64ImageUrl({
-              data: b.data,
-              mediaType: typeof b.mimeType === "string" ? b.mimeType : undefined,
-            }),
-            ...imageMeta,
-          });
-        } else if (
-          typeof b.url === "string" &&
-          !crossOriginStructuredSvgAttachment(b.url, b.mimeType ?? source?.media_type, b)
-        ) {
-          appendImageBlock(blockImages, { url: b.url, ...imageMeta });
-        }
-      } else if (b.type === "image_url") {
-        // OpenAI format
-        const imageUrl = b.image_url as Record<string, unknown> | undefined;
-        if (
-          typeof imageUrl?.url === "string" &&
-          !crossOriginStructuredSvgAttachment(imageUrl.url, undefined)
-        ) {
-          appendImageBlock(blockImages, { url: imageUrl.url });
-        }
-      } else if (b.type === "input_image") {
-        const imageUrl = b.image_url;
-        if (
-          typeof imageUrl === "string" &&
-          !crossOriginStructuredSvgAttachment(imageUrl, undefined)
-        ) {
-          appendImageBlock(blockImages, { url: imageUrl });
-        } else if (imageUrl && typeof imageUrl === "object") {
-          const url = (imageUrl as Record<string, unknown>).url;
-          if (typeof url === "string" && !crossOriginStructuredSvgAttachment(url, undefined)) {
-            appendImageBlock(blockImages, { url });
-          }
-        }
-        const source = b.source as Record<string, unknown> | undefined;
-        if (
-          typeof source?.url === "string" &&
-          !crossOriginStructuredSvgAttachment(source.url, source.media_type)
-        ) {
-          appendImageBlock(blockImages, { url: source.url });
-        } else if (typeof source?.data === "string") {
-          appendImageBlock(blockImages, {
-            url: buildBase64ImageUrl({
-              data: source.data,
-              mediaType: typeof source.media_type === "string" ? source.media_type : undefined,
-            }),
-          });
-        }
-      } else if (b.type === "openclaw_pairing_qr") {
-        if (isExpiredPairingQrBlock(b)) {
-          continue;
-        }
-        const imageUrl = b.image_url;
-        if (typeof imageUrl === "string") {
-          appendImageBlock(blockImages, {
-            url: imageUrl,
-            alt: typeof b.alt === "string" ? b.alt : undefined,
-          });
-        }
+          artifactId: typeof block.artifactId === "string" ? block.artifactId : undefined,
+          alt: typeof block.alt === "string" ? block.alt : undefined,
+          fileName: typeof block.fileName === "string" ? block.fileName : undefined,
+          openUrl: typeof block.openUrl === "string" ? block.openUrl : undefined,
+          sizeBytes: asFiniteNumber(block.sizeBytes),
+          width: typeof block.width === "number" ? block.width : undefined,
+          height: typeof block.height === "number" ? block.height : undefined,
+        });
+      }
+    } else if (block.type === "image_url") {
+      const url = asOptionalRecord(block.image_url)?.url;
+      if (typeof url === "string" && !appendSvgAttachment(url)) {
+        images.push({ url });
+      }
+    } else if (block.type === "input_image") {
+      const blockImages: ImageBlock[] = [];
+      const url =
+        typeof block.image_url === "string"
+          ? block.image_url
+          : asOptionalRecord(block.image_url)?.url;
+      if (typeof url === "string" && !appendSvgAttachment(url)) {
+        blockImages.push({ url });
+      }
+      const svg = appendSvgAttachment(source?.url, source?.media_type);
+      if (typeof source?.url === "string" && !svg) {
+        appendImageBlock(blockImages, { url: source.url });
+      } else if (typeof source?.data === "string") {
+        appendImageBlock(blockImages, {
+          url: buildBase64ImageUrl(source.data, source.media_type),
+        });
       }
       // Separate blocks are separate attachments, including identical uploads.
       images.push(...blockImages);
+    } else if (block.type === "openclaw_pairing_qr") {
+      const expiresAt = asFiniteNumber(block.expiresAtMs);
+      if (expiresAt !== undefined) {
+        if (expiresAt <= nowMs) {
+          expiredPairingQrCount += 1;
+          continue;
+        }
+        nextPairingQrExpiresAt = Math.min(nextPairingQrExpiresAt ?? expiresAt, expiresAt);
+      }
+      if (typeof block.image_url === "string") {
+        images.push({
+          url: block.image_url,
+          alt: typeof block.alt === "string" ? block.alt : undefined,
+        });
+      }
     }
   }
-
+  // Only a complete inline layout may lend its fact positions to mounted previews.
+  if (inlineIndex !== inlineSlots.length) {
+    for (const image of images) {
+      delete image.factIndex;
+    }
+  }
   for (const {
     path: mediaPath,
     mediaType,
     fileName,
     sizeBytes,
+    durationMs,
+    width,
+    height,
     factIndex,
   } of readTranscriptMediaEntries(message)) {
-    if (!isImageMediaPath(mediaPath, mediaType) || isSvgImageMediaPath(mediaPath, mediaType)) {
-      continue;
-    }
-    appendImageBlock(images, {
-      url: mediaPath,
-      fileName,
-      sizeBytes,
-      ...(validLayout && factIndexes.has(factIndex) ? { factIndex } : {}),
-    });
-  }
-
-  return images;
-}
-
-function readPairingQrExpiresAtMs(block: Record<string, unknown>): number | undefined {
-  return asFiniteNumber(block.expiresAtMs);
-}
-
-function isExpiredPairingQrBlock(block: Record<string, unknown>, nowMs = Date.now()): boolean {
-  const expiresAtMs = readPairingQrExpiresAtMs(block);
-  return expiresAtMs !== undefined && expiresAtMs <= nowMs;
-}
-
-export function extractPairingQrExpiryNotices(
-  message: unknown,
-  nowMs = Date.now(),
-): PairingQrExpiryNotice[] {
-  const m = message as Record<string, unknown>;
-  const content = m.content;
-  if (!Array.isArray(content)) {
-    return [];
-  }
-  const notices: PairingQrExpiryNotice[] = [];
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const b = block as Record<string, unknown>;
-    if (b.type === "openclaw_pairing_qr" && isExpiredPairingQrBlock(b, nowMs)) {
-      notices.push({
-        title: t("chat.pairingQrExpired.title"),
-        reason: t("chat.pairingQrExpired.reason"),
+    const image = isImageMediaPath(mediaPath, mediaType);
+    const svg = image && isSvgImageMediaPath(mediaPath, mediaType);
+    if (image && !svg) {
+      appendImageBlock(images, {
+        url: mediaPath,
+        fileName,
+        sizeBytes,
+        ...(validLayout && factIndexes.has(factIndex) ? { factIndex } : {}),
+      });
+    } else {
+      appendAttachment({
+        type: "attachment",
+        attachment: {
+          url: mediaPath,
+          kind: svg
+            ? "image"
+            : isAudioTranscriptMediaPath(mediaPath, mediaType)
+              ? "audio"
+              : isVideoTranscriptMediaPath(mediaPath, mediaType)
+                ? "video"
+                : "document",
+          label: fileName?.trim() || labelForMediaPath(mediaPath),
+          ...(typeof mediaType === "string" ? { mimeType: mediaType } : {}),
+          ...(sizeBytes !== undefined ? { sizeBytes } : {}),
+          ...(durationMs !== undefined ? { durationMs } : {}),
+          ...(width !== undefined ? { width } : {}),
+          ...(height !== undefined ? { height } : {}),
+        },
       });
     }
   }
-  return notices;
-}
-
-function resolveNearestFuturePairingQrExpiresAtMs(
-  message: unknown,
-  nowMs = Date.now(),
-): number | undefined {
-  const m = message as Record<string, unknown>;
-  const content = m.content;
-  if (!Array.isArray(content)) {
-    return undefined;
-  }
-  let nearestExpiresAtMs: number | undefined;
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const b = block as Record<string, unknown>;
-    if (b.type !== "openclaw_pairing_qr") {
-      continue;
-    }
-    const expiresAtMs = readPairingQrExpiresAtMs(b);
-    if (expiresAtMs === undefined || expiresAtMs <= nowMs) {
-      continue;
-    }
-    nearestExpiresAtMs =
-      nearestExpiresAtMs === undefined ? expiresAtMs : Math.min(nearestExpiresAtMs, expiresAtMs);
-  }
-  return nearestExpiresAtMs;
+  return { images, attachments, expiredPairingQrCount, nextPairingQrExpiresAt };
 }
 
 export function schedulePairingQrExpiryRefresh(
   messageKey: string,
-  message: unknown,
+  refreshAt: number | undefined,
   onRequestUpdate: (() => void) | undefined,
 ) {
   if (!onRequestUpdate) {
     return;
   }
-  const refreshAt = resolveNearestFuturePairingQrExpiresAtMs(message);
   if (refreshAt === undefined) {
     const subscriber = chatMediaSubscribers.get(onRequestUpdate);
     const resourceKey = chatMediaResourceKey("pairing-qr", messageKey);
@@ -670,74 +575,13 @@ export function extractMessageMediaText(
   message: unknown,
   content = normalizeMessage(message).content,
 ): string {
+  const { images, attachments } = projectMessageMedia(message, content);
   return [
-    ...extractImages(message).map(
+    ...images.map(
       (image) => image.fileName?.trim() || image.alt?.trim() || t("chat.imageLightbox.untitled"),
     ),
-    ...extractMessageAttachments(message, content).map(
+    ...attachments.map(
       (item) => item.attachment.label.trim() || t("chat.attachments.attachedFile"),
     ),
   ].join("\n");
-}
-
-export function extractMessageAttachments(
-  message: unknown,
-  content: readonly MessageContentItem[],
-): AssistantAttachmentItem[] {
-  const attachmentUrls = new Set<string>();
-  return [
-    ...content.filter(
-      (item): item is AssistantAttachmentItem =>
-        item.type === "attachment" || item.type === "attachment_error",
-    ),
-    ...extractStructuredSvgAttachments(message),
-    ...extractTranscriptAttachments(message),
-  ].filter((item) => {
-    if (item.type === "attachment_error") {
-      return true;
-    }
-    const unique = !attachmentUrls.has(item.attachment.url);
-    attachmentUrls.add(item.attachment.url);
-    return unique;
-  });
-}
-
-function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
-  const attachments: AttachmentItem[] = [];
-  for (const {
-    path: mediaPath,
-    mediaType,
-    fileName,
-    sizeBytes,
-    durationMs,
-    width,
-    height,
-  } of readTranscriptMediaEntries(message)) {
-    const image = isImageMediaPath(mediaPath, mediaType);
-    const svg = image && isSvgImageMediaPath(mediaPath, mediaType);
-    if (image && !svg) {
-      continue;
-    }
-    const kind = svg
-      ? "image"
-      : isAudioTranscriptMediaPath(mediaPath, mediaType)
-        ? "audio"
-        : isVideoTranscriptMediaPath(mediaPath, mediaType)
-          ? "video"
-          : "document";
-    attachments.push({
-      type: "attachment",
-      attachment: {
-        url: mediaPath,
-        kind,
-        label: fileName?.trim() || labelForMediaPath(mediaPath),
-        ...(typeof mediaType === "string" ? { mimeType: mediaType } : {}),
-        ...(sizeBytes !== undefined ? { sizeBytes } : {}),
-        ...(durationMs !== undefined ? { durationMs } : {}),
-        ...(width !== undefined ? { width } : {}),
-        ...(height !== undefined ? { height } : {}),
-      },
-    });
-  }
-  return attachments;
 }

--- a/ui/src/pages/chat/components/chat-message-pairing-qr-lifecycle.test.ts
+++ b/ui/src/pages/chat/components/chat-message-pairing-qr-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   isChatMediaResourceCurrent,
   observeChatMediaResource,
+  projectMessageMedia,
   releaseChatMediaResourceSubscriber,
   schedulePairingQrExpiryRefresh,
 } from "./chat-message-media.ts";
@@ -54,23 +55,27 @@ describe("pairing QR expiry resource lifecycle", () => {
     const refresh = observeSubscriber(vi.fn());
     const resolvedMessage = typeof message === "function" ? message() : message;
 
-    schedulePairingQrExpiryRefresh(messageKey, resolvedMessage, refresh);
+    schedulePairingQrExpiryRefresh(
+      messageKey,
+      projectMessageMedia(resolvedMessage, []).nextPairingQrExpiresAt,
+      refresh,
+    );
 
     expect(vi.getTimerCount()).toBe(0);
     expect(observeChatMediaResource<void>("pairing-qr", messageKey).subscribers.size).toBe(0);
 
     // Reattach the probe so normal subscriber cleanup also removes its resource.
-    schedulePairingQrExpiryRefresh(messageKey, pairingQrMessage(Date.now() + 1_000), refresh);
+    schedulePairingQrExpiryRefresh(messageKey, Date.now() + 1_000, refresh);
   });
 
   it("removes the last subscription when a previously active QR loses its expiry", async () => {
     const messageKey = crypto.randomUUID();
     const refresh = observeSubscriber(vi.fn());
 
-    schedulePairingQrExpiryRefresh(messageKey, pairingQrMessage(Date.now() + 1_000), refresh);
+    schedulePairingQrExpiryRefresh(messageKey, Date.now() + 1_000, refresh);
     const resource = observeChatMediaResource<void>("pairing-qr", messageKey);
 
-    schedulePairingQrExpiryRefresh(messageKey, { content: [] }, refresh);
+    schedulePairingQrExpiryRefresh(messageKey, undefined, refresh);
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(isChatMediaResourceCurrent(resource)).toBe(false);
@@ -83,16 +88,16 @@ describe("pairing QR expiry resource lifecycle", () => {
     const messageKey = crypto.randomUUID();
     const first = observeSubscriber(vi.fn());
     const second = observeSubscriber(vi.fn());
-    const message = pairingQrMessage(Date.now() + 1_000);
+    const expiresAt = Date.now() + 1_000;
     const independentResource = observeChatMediaResource<void>(
       "assistant-attachment",
       crypto.randomUUID(),
       first,
     );
 
-    schedulePairingQrExpiryRefresh(messageKey, message, first);
-    schedulePairingQrExpiryRefresh(messageKey, message, second);
-    schedulePairingQrExpiryRefresh(messageKey, { content: [] }, first);
+    schedulePairingQrExpiryRefresh(messageKey, expiresAt, first);
+    schedulePairingQrExpiryRefresh(messageKey, expiresAt, second);
+    schedulePairingQrExpiryRefresh(messageKey, undefined, first);
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(first).not.toHaveBeenCalled();

--- a/ui/src/pages/new-session/draft-composer.ts
+++ b/ui/src/pages/new-session/draft-composer.ts
@@ -15,7 +15,7 @@ import { refreshSlashCommands } from "../chat/chat-commands.ts";
 import type { CapabilityMenuProps } from "../chat/components/chat-composer-types.ts";
 import { renderAssistantAttachments } from "../chat/components/chat-message-attachments.ts";
 import { renderMessageImages } from "../chat/components/chat-message-images.ts";
-import { extractImages, extractMessageAttachments } from "../chat/components/chat-message-media.ts";
+import { projectMessageMedia } from "../chat/components/chat-message-media.ts";
 import {
   detectJson,
   renderMessageJson,
@@ -68,8 +68,7 @@ function renderNewSessionSubmission(
   const key = "new-session-submission";
   const normalized = normalizeMessage(message);
   const senderHue = normalized.sender ? resolveIdentityHue(normalized.sender) : null;
-  const images = extractImages(message);
-  const attachments = extractMessageAttachments(message, normalized.content);
+  const { images, attachments } = projectMessageMedia(message, normalized.content);
   const markdown = resolveMessageDisplayMarkdown(message, normalized);
   const json = detectJson(markdown);
   const imageOptions = { onOpenImage };


### PR DESCRIPTION
Related: #136072, #136446

<details>
<summary>Additional instructions</summary>

This PR uses a same-repository branch; maintainers can edit it directly.

</details>

## What Problem This Solves

Fixes an issue where already-loaded chat images were removed and inserted again during ordinary rerenders. The surrounding media pipeline also repeated content scans, attachment validation, URL preparation, and ticket-state construction. This is the requested larger refactor following the image-continuity fixes above.

## Why This Change Was Made

One media projection now supplies images, attachment cards, QR-expiry notices, and the next expiry deadline. Raw attachments go through the canonical normalizer once. Cached managed images render synchronously, and resource completion updates the owning image directive instead of asking the whole pane to rerender. Managed full-download ticket renewal has one guarded publication boundary and one retry-state constructor.

The old duplicate scans, schema, wrappers, and managed-only shared exports are removed. Thumbnail blobs and full-download tickets remain separate transports. Auth/connection fences, cleanup, blob-cache bounds, lightbox retention, QR expiry, sparse attachment facts, and repeated uploads keep their existing contracts. No dependency, public configuration, database schema, protocol, or changelog changes.

Production LOC: **+408 / -696, net -288** across eight files. Tests: **+83 / -45, net +38**. The assertion-safety baseline changes one line, reducing the media module's cast debt from thirteen to three.

## User Impact

Loaded images stay mounted during routine media rerenders, with less repeated work. Sending one image or several identical images, opening/downloading attachments, expired pairing QR notices, and scroll anchoring retain their existing behavior and layout.

This does not remove every shared transcript invalidation: removing `chatMediaRenderVersion` safely remains a separate follow-up because QR and non-image attachment updates still depend on that ownership boundary.

## Evidence

The cached-image regression fails on baseline `2c2e5014f71ab4e2a9f550719b7298bf6eb65d21` and passes on this change. The same 100-render measurement produced:

| Work measured | Before | After |
| --- | ---: | ---: |
| Native image removals/replacements | 100 | 0 |
| URL constructions | 400 | 100 |
| Thumbnail fetches | 1 | 1 |

These are DOM/work counts from the same jsdom scenario, not browser-paint timings or a claimed wall-clock speedup.

- **502/502** focused tests across fourteen files, plus **five consecutive stress runs / 2,510 passing executions**, with no failures or skipped tests in the final runs.
- **10/10 Chromium E2E checks** for image handoff/custody, generated-image actions, intrinsic resizing, and transcript disclosure/scroll anchoring.
- **Real authenticated, isolated Gateway and real model:** sent one image and then three identical uploads through the actual UI. Both turns received valid model replies; all four transcript images decoded and remained visible. Persisted attachment counts were one and three with distinct positions.
- **Full changed-file gates passed:** formatting, types, i18n, coercion/dead-export checks, core lint, UI style lint, and script guards. Earlier verification iterations exposed an extra ticket-publication Promise delay and a retained lightbox handle in the new test; both were corrected without weakening existing assertions or retry budgets.
- **Independent Codex review:** scoped-clean through P2, no actionable findings. All thirteen committed paths are byte-identical to the final focused-test source record. The final built JS/CSS, index, and asset manifest are byte-identical to the live-tested build after the final lint-only rename.

The live Gateway, browser, and temporary credentials were cleaned up; the normal operator Gateway was not touched.

Hosted validation: the [normal exact-head PR CI](https://github.com/openclaw/openclaw/actions/runs/33681690461) passed on its first attempt, and the [additional full exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33681658771) passed on attempt two. The required `openclaw/ci-gate` is green. This completes the sole rank-up move in the fresh ClawSweeper review.

The extra full run initially hit an unchanged dropdown test's animation-observation timeout and an Android third-party job's existing 20-minute limit. The complete dropdown file passed 28/28 on both baseline and candidate; both CI lanes then passed one targeted rerun without source, assertion, or timeout changes. Named follow-ups if these recur: investigate dropdown animation-event observation; collect Android test progress/XML and JVM diagnostics before another retry. No specific Android hang or infrastructure outage was established.

### Before / after

Independent captures of the same synthetic conversation, fixed clock, and 1280×900 viewport on the exact pre-refactor baseline and the verified candidate. The settled screenshots are pixel-identical: these pictures show layout preservation, while the failing/passing regression and operation counts above establish the removed remounts. Each capture loaded one decoded image through one thumbnail fetch, with zero page errors and served JS/CSS checked against its own build manifest.

| Before refactor (`2c2e5014f71a`) | After refactor (`543cadfc05eb`) |
| --- | --- |
| ![Before refactor: settled synthetic image conversation](https://github.com/user-attachments/assets/daa56dc3-f053-4bc4-8b75-53426482c153) | ![After refactor: same settled synthetic image conversation](https://github.com/user-attachments/assets/cb92554b-b217-4fc5-8741-342e45ea1792) |

<details>
<summary>Real-Gateway UI proof: one image, then three repeated uploads</summary>

Actual file uploads, normal authentication, a real model, and visible replies. All four transcript images loaded; repeated images were preserved as separate attachments. The capture contains only task-created synthetic content and was inspected before upload.

![Real-Gateway image conversation with three repeated uploads and a valid image-count reply](https://github.com/user-attachments/assets/00e702eb-0cda-4676-91b6-d287b4eca7c4)

</details>
