### PR TITLE
fix(health): report active probes when the preferred account is unconfigured

### DIFF
--- a/docs/cli/health.md
+++ b/docs/cli/health.md
@@ -32,6 +32,7 @@ openclaw health --debug
 
 - Without `--verbose`, the Gateway can return a cached snapshot (fresh for up to 60 seconds and unchanged from live channel runtime state) and refresh it in the background for the next caller.
 - `--verbose` forces a live probe (per-channel account probes), prints Gateway connection details, and expands human-readable output across all configured accounts and agents instead of just the default agent.
+- An unconfigured preferred account does not hide probe results from other active accounts. Ordinary output still follows the default agent's account bindings; `--verbose` includes all accounts.
 - `--json` always returns the full snapshot: channels, per-account probes, plugin load state, context-engine quarantine state, model-pricing cache state, event-loop health, delivery-queue warnings, and per-agent session stores.
 - Session ages in text and JSON use the Gateway's clock.
 - Top-level `ok: true` means the health RPC succeeded and the Gateway produced a snapshot. Queue warnings do not change it to `false`.

--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -50,6 +50,7 @@ const createHealthSummary = (
 
 function createMultiAccountHealthSummary(
   secondary: Partial<ChannelAccountHealthSummary>,
+  primaryOverrides: Partial<ChannelAccountHealthSummary> = {},
 ): HealthSummary {
   const primary = {
     accountId: "main",
@@ -58,20 +59,22 @@ function createMultiAccountHealthSummary(
     linked: true,
     healthState: "healthy",
     probe: { ok: true, elapsedMs: 12 },
+    ...primaryOverrides,
+  };
+  const secondaryAccount = {
+    accountId: "alerts",
+    enabled: true,
+    configured: true,
+    linked: true,
+    ...secondary,
   };
   return createHealthSummary({
     channels: {
       matrix: {
         ...primary,
         accounts: {
-          main: primary,
-          alerts: {
-            accountId: "alerts",
-            enabled: true,
-            configured: true,
-            linked: true,
-            ...secondary,
-          },
+          [primary.accountId]: primary,
+          [secondaryAccount.accountId]: secondaryAccount,
         },
       },
     },
@@ -233,6 +236,75 @@ describe("formatHealthChannelLines", () => {
     expect(
       formatHealthChannelLines(summary, { accountMode: "all", accountIdsByChannel }),
     ).toStrictEqual(["Matrix: blocked"]);
+  });
+
+  it.each([
+    {
+      name: "successful",
+      probe: { ok: true, elapsedMs: 12 },
+      expected: "ok (12ms)",
+      expectedAll: "ok (alerts:alerts:12ms)",
+    },
+    {
+      name: "failed",
+      probe: { ok: false, error: "sync rejected" },
+      expected: "failed (unknown) - sync rejected",
+      expectedAll: "failed (unknown) - sync rejected",
+    },
+  ])(
+    "reports the $name active probe when the preferred account is unconfigured",
+    ({ probe, expected, expectedAll }) => {
+      const summary = createMultiAccountHealthSummary(
+        { healthState: "healthy", probe },
+        { configured: false, linked: undefined, healthState: undefined, probe: undefined },
+      );
+      const accountIdsByChannel = { matrix: ["main"] };
+
+      expect(formatHealthChannelLines(summary)).toStrictEqual([`Matrix: ${expected}`]);
+      expect(
+        formatHealthChannelLines(summary, { accountMode: "all", accountIdsByChannel }),
+      ).toStrictEqual([`Matrix: ${expectedAll}`]);
+      expect(
+        formatHealthChannelLines(summary, { accountMode: "default", accountIdsByChannel }),
+      ).toStrictEqual(["Matrix: not configured"]);
+      expect(
+        formatHealthChannelLines(summary, {
+          accountIdsByChannel: { matrix: ["alerts"] },
+        }),
+      ).toStrictEqual([`Matrix: ${expected}`]);
+    },
+  );
+
+  it("keeps the healthy preferred account ahead of numeric account-key order", () => {
+    const summary = createMultiAccountHealthSummary(
+      { accountId: "1", probe: { ok: true, elapsedMs: 1 } },
+      { accountId: "9", probe: { ok: true, elapsedMs: 9 } },
+    );
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual(["Matrix: ok (9ms)"]);
+    expect(
+      formatHealthChannelLines(summary, { accountIdsByChannel: { matrix: ["1", "9"] } }),
+    ).toStrictEqual(["Matrix: ok (1ms)"]);
+  });
+
+  it.each([undefined, {}])("preserves the channel snapshot when accounts are %j", (accounts) => {
+    const summary = createHealthSummary({
+      channels: {
+        matrix: {
+          accountId: "main",
+          configured: true,
+          probe: { ok: true, elapsedMs: 12 },
+          accounts,
+        },
+      },
+      channelOrder: ["matrix"],
+      channelLabels: { matrix: "Matrix" },
+    });
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual(["Matrix: ok (12ms)"]);
+    expect(formatHealthChannelLines(summary, { accountMode: "all" })).toStrictEqual([
+      "Matrix: ok (12ms)",
+    ]);
   });
 
   it.each([

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -131,15 +131,6 @@ const formatAccountProbeTiming = (summary: ChannelAccountHealthSummary): string 
   return `${handle}:${accountId}:${timing}`;
 };
 
-const isProbeFailure = (summary: ChannelAccountHealthSummary): boolean => {
-  const probe = asNullableRecord(summary.probe);
-  if (!probe) {
-    return false;
-  }
-  const ok = typeof probe.ok === "boolean" ? probe.ok : null;
-  return ok === false;
-};
-
 /** Formats terse channel and activated-plugin health lines for shared CLI surfaces. */
 export const formatHealthChannelLines = (
   summary: HealthSummary,
@@ -161,17 +152,13 @@ export const formatHealthChannelLines = (
     }
     const label = summary.channelLabels?.[channelId] ?? channelId;
     const accountSummaries = channelSummary.accounts ?? {};
-    const accountIds = opts.accountIdsByChannel?.[channelId];
-    const filteredSummaries =
-      accountIds && accountIds.length > 0
-        ? accountIds
-            .map((accountId) => accountSummaries[accountId])
-            .filter((entry): entry is ChannelAccountHealthSummary => Boolean(entry))
-        : undefined;
-    const listSummaries =
-      accountMode === "all"
-        ? Object.values(accountSummaries)
-        : (filteredSummaries ?? (channelSummary.accounts ? Object.values(accountSummaries) : []));
+    const accountIds = accountMode === "all" ? undefined : opts.accountIdsByChannel?.[channelId];
+    const listSummaries = accountIds?.length
+      ? accountIds.flatMap((accountId) => accountSummaries[accountId] ?? [])
+      : Object.values(accountSummaries);
+    const preferredSummary = accountIds?.length
+      ? (listSummaries[0] ?? channelSummary)
+      : channelSummary;
     const activeSummaries = listSummaries.filter(
       (account) =>
         account.enabled !== false &&
@@ -180,6 +167,7 @@ export const formatHealthChannelLines = (
         account.statusState !== "disabled" &&
         account.statusState !== "unconfigured",
     );
+    // Preserve active preferred order without letting inactive defaults mask other probes.
     const selectedSummary =
       activeSummaries.find(
         (account) =>
@@ -188,8 +176,9 @@ export const formatHealthChannelLines = (
             account.statusState !== "linked" &&
             account.statusState !== "configured"),
       ) ??
-      filteredSummaries?.[0] ??
-      channelSummary;
+      activeSummaries.find((account) => account.accountId === preferredSummary.accountId) ??
+      activeSummaries[0] ??
+      preferredSummary;
     const botUsernames = activeSummaries
       .map((account) => {
         const probeRecord = asNullableRecord(account.probe);
@@ -234,7 +223,9 @@ export const formatHealthChannelLines = (
             .map((account) => formatAccountProbeTiming(account))
             .filter((value): value is string => Boolean(value))
         : [];
-    const failedSummary = activeSummaries.find((summaryLocal) => isProbeFailure(summaryLocal));
+    const failedSummary = activeSummaries.find(
+      (account) => asNullableRecord(account.probe)?.ok === false,
+    );
     if (failedSummary) {
       const failureLine = formatProbeLine(failedSummary.probe, { botUsernames });
       if (failureLine) {


### PR DESCRIPTION
Closes #136598

## What Problem This Solves

An unconfigured preferred account caused `health --verbose` and `gateway health` to print “not configured” even when another account was running and its probe had succeeded or failed. The shared detailed-status health row consequently showed OFF and hid the useful result.

## Why This Change Was Made

The collector already records the correct per-account facts. Build the requested account list once and choose an active representative before falling back to an inactive preferred record. Preserve preferred healthy identity, explicit bindings and degraded/failed precedence. This removes duplicate account selection and the single-use probe-failure wrapper.

## User Impact

All-account and unscoped health output shows active probes. Ordinary health still respects the default agent's explicit account bindings, including an inactive-only scope. Collection, JSON payloads, channel configuration, runtime behavior and authorization remain unchanged.

## Evidence

Before production edits, the two authentic owner regressions fail with38 existing cases passing. Afterward107 tests across five owner/caller/collector files pass. All29 required changed-surface checks and one cumulative independent Codex P2 review pass;40 source/dataset/settings hashes match afterward.

The same12 real collector → loopback WebSocket → `src/entry.ts` CLI scenarios ran before and after. Every CLI exits0, both streams reach EOF, and each JSON result exactly matches the snapshot served to it. Actual unconfigured-default output:

| Flow | Before | After |
| --- | --- | --- |
| `health --verbose`, healthy alerts | `QA Health: not configured` | `QA Health: ok (alerts:alerts:12ms)` |
| `gateway health`, healthy alerts | `QA Health: not configured` | `QA Health: ok (12ms)` |
| Either flow, failed alerts | `QA Health: not configured` | `QA Health: failed (unknown) - synthetic provider unavailable` |

The shared status-row owner changes OFF to OK/WARN for those snapshots. Disabled-default failure, explicit inactive-only scope, numeric preferred IDs, degraded states, inactive sibling exclusion and absent/empty account maps are covered. An unscoped disabled-default success now also reports its active probe instead of only “configured”; it is the same representative-selection repair.

This proof uses synthetic channel/provider input with the real collector and CLI. It does not claim an external provider, a full production Gateway process, a packaged-binary run or a complete `status --deep` invocation. The status assertion exercises its shared row owner. Stablev2026.8.2 was inspected as source only.

Production: **14 added /23 removed (net−9)**. Tests:+80/−8; docs:+1. One original root. The previous secondary-failure behavior from#129088 remains covered. Closed#107742 was a reporter-confirmed binding/config issue; explicit inactive bindings remain intact here. Open#129844 repairs the separate restart-health owner.

## Final review disposition

Both review-environment gaps are resolved: the full current-main source is available locally and the health formatter remains byte-identical to the reproduced baseline; pnpm docs:list passes and lists the reviewed health page. The shared formatter repair is covered through the real collector, loopback WebSocket and source CLI, including active healthy/failing accounts and explicitly inactive scope.

Required [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33681548561/job/100425648546) passed for `7053f841f5f47bcd3c11ab4dc1c74b53f4822e9e`. Production owners are unchanged on main `31ed57e3953152fa826a444e742b3c0ec5149961` since the reproduced baseline, and the complete PR composes cleanly. The latest ClawSweeper review and its rank-up requests have been addressed; no actionable code finding remains.
