### PR TITLE
fix(skills): correct read-only diagnosis and channel setup

### DIFF
--- a/custodian-skills/add-model-provider/SKILL.md
+++ b/custodian-skills/add-model-provider/SKILL.md
@@ -44,10 +44,10 @@ To change a default model, use the in-session `set_default_model` action (with `
 ## Repair
 
 ```
-openclaw doctor --non-interactive
+openclaw doctor --lint
 ```
 
-If it reports a config repair, get approval, run `openclaw doctor --fix --non-interactive`, then re-run the Gather reads.
+`doctor --lint` can exit `1` for findings: read the report and continue the remaining checks. Ordinary `doctor` and `doctor --non-interactive` can write config/state; do not use them for diagnosis before approval. If a repair is needed, get explicit approval, run `openclaw doctor --fix --non-interactive`, then re-run the Gather reads.
 
 ## Prove
 

--- a/custodian-skills/cloud-image-bake/SKILL.md
+++ b/custodian-skills/cloud-image-bake/SKILL.md
@@ -46,11 +46,11 @@ The bundled crabbox profile currently has no `image` settings key — AWS select
 ## Repair
 
 ```
-openclaw doctor --non-interactive
+openclaw doctor --lint
 crabbox doctor --provider <backend> --json
 ```
 
-Apply `openclaw doctor --fix --non-interactive` only after approval, then re-read the profile and provider inventory.
+`doctor --lint` can exit `1` for findings: read the report and continue the remaining checks. Ordinary `doctor` and `doctor --non-interactive` can write config/state; do not use them for diagnosis before approval. Apply `openclaw doctor --fix --non-interactive` only after explicit approval, then re-read the profile and provider inventory.
 
 ## Prove
 

--- a/custodian-skills/configure-channel/SKILL.md
+++ b/custodian-skills/configure-channel/SKILL.md
@@ -23,11 +23,20 @@ openclaw config schema --json | jq '.properties.channels.properties.telegram'
 
 ## Mutate
 
+Confirm the intended account and access changes with the operator before writing. Preserve existing approved allowlist entries, `dmPolicy`, and `groupPolicy` unless their replacement or change is explicitly approved; never broaden access to make a probe pass.
+
 Preferred shell path — token staged as an env var on the gateway process or in a `0600` file, wired as a SecretRef (Telegram example):
 
 ```
 openclaw config set channels.telegram.botToken --ref-provider default --ref-source env --ref-id TELEGRAM_BOT_TOKEN
-openclaw config set channels.telegram.allowFrom '["+15555550123"]' --strict-json
+```
+
+With the bot connected and DM policy `pairing`, ask the operator to DM it. Read `Your Telegram user id` in the pairing reply, or run `openclaw logs --follow` and read `senderUserId` in that sender's `telegram pairing request` entry. Stop following once captured; keep unrelated logs private. If the current policy prevents this flow, use an already verified ID or report the discovery blocker; do not broaden access.
+
+Use the numeric **Telegram user ID**, not a phone number, username, chat/group ID, or bot ID. In this single-user example, `123456789` is a placeholder: replace it with the verified, approved user ID and retain any other approved entries.
+
+```
+openclaw config set channels.telegram.allowFrom '["123456789"]' --strict-json
 ```
 
 Multi-field changes in one validated write:
@@ -43,11 +52,11 @@ In-session alternative: call the `connect_channel` tool action with the channel 
 ## Repair
 
 ```
-openclaw doctor --non-interactive
-openclaw channels status --deep
+openclaw doctor --lint
+openclaw channels status --probe
 ```
 
-Apply `openclaw doctor --fix --non-interactive` only after approval, then re-check status.
+`doctor --lint` can exit `1` for findings: read the report and continue the remaining checks. Ordinary `doctor` and `doctor --non-interactive` can write config/state; do not use them for diagnosis before approval. Apply `openclaw doctor --fix --non-interactive` only after explicit approval, then re-check status.
 
 ## Prove
 

--- a/custodian-skills/diagnose-gateway/SKILL.md
+++ b/custodian-skills/diagnose-gateway/SKILL.md
@@ -10,13 +10,15 @@ This playbook is read-only: no config writes, no service restarts, no `doctor --
 ## Gather
 
 ```
-openclaw doctor --non-interactive
+openclaw doctor --lint
 openclaw gateway status --deep
 openclaw config validate
 openclaw channels status
 openclaw models status
 openclaw channels logs --channel <id>
 ```
+
+`doctor --lint` is read-only and can exit `1` for findings: read the report and continue the remaining checks. Do not substitute ordinary `doctor` or `doctor --non-interactive`; they can copy legacy config and migrate state without `--fix`.
 
 On managed installs, bounded recent logs: `./scripts/clawlog.sh` (repo checkout) or the log path printed at gateway startup (`/tmp/openclaw/openclaw-<date>.log` by default).
 
@@ -32,7 +34,7 @@ Correlate timestamps and identify the first owner-boundary failure.
 
 ## Mutate
 
-Nothing. This skill changes no state.
+Nothing. Do not change config, migrate state, or alter services. Diagnostic commands may still produce incidental logs or cache bookkeeping.
 
 ## Repair
 
@@ -44,13 +46,13 @@ Repeat the smallest read-only probe that exposes the condition and record its ou
 
 ```
 openclaw gateway status --deep
-openclaw channels status --deep
+openclaw channels status --probe
 ```
 
 If access, logs, or the gateway are unavailable, report that exact blocker rather than declaring a cause.
 
 ## Report
 
-Findings in causal order with evidence for each; current gateway/config/SecretRef/channel/port state; one recommended next skill or operator action. State explicitly that nothing was changed.
+Findings in causal order with evidence for each; current gateway/config/SecretRef/channel/port state; one recommended next skill or operator action. State explicitly that no config/service repairs or state migrations were performed.
 
 Further reference: https://docs.openclaw.ai/gateway/troubleshooting

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -192,7 +192,9 @@ In groups and forum topics, an explicit mention of the configured bot handle (fo
 
     ### Finding your Telegram user ID
 
-    Safer (no third-party bot): DM your bot, run `openclaw logs --follow`, read `from.id`.
+    Safer (no third-party bot): with DM policy `pairing`, DM your bot and read `Your Telegram user id` in its pairing reply. You can also run `openclaw logs --follow` and read `senderUserId` in the `telegram pairing request` entry. Both come from the incoming message's `from.id`.
+
+    Use your numeric user ID for `allowFrom`, not a phone number, username, chat/group ID, or the bot's ID. Stop following once you have the ID and keep unrelated log content private. If your current policy prevents this flow, use an already verified ID; do not broaden access just to discover it.
 
     Official Bot API method:
 

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -22,6 +22,7 @@ Related docs:
 openclaw channels list
 openclaw channels list --all
 openclaw channels status
+openclaw channels status --probe
 openclaw channels capabilities
 openclaw channels capabilities --channel discord --target channel:123
 openclaw channels resolve --channel slack "#general" "@jane"
@@ -63,6 +64,8 @@ such as `discord-archive` do not match `discord`.
 state plus probe results such as `works`, `probe failed`, `audit ok`, or `audit failed`.
 If the gateway is unreachable, `channels status` falls back to config-only summaries
 instead of live probe output.
+
+`channels status` does not support `--deep`; use `openclaw channels status --probe` for channel checks. The separate top-level `openclaw status --deep` command provides a broader status probe.
 
 ## Inbound dead letters
 

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -26,17 +26,20 @@ Related:
 
 ## Postures
 
-Doctor has five postures:
+Doctor supports these postures:
 
-| Posture                   | Command                                      | Behavior                                                                        |
-| ------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------- |
-| Inspect                   | `openclaw doctor` / `openclaw doctor --json` | Advisory checks in human or machine-readable form.                              |
-| Repair                    | `openclaw doctor --fix`                      | Applies supported repairs, using prompts unless non-interactive repair is safe. |
-| Lint                      | `openclaw doctor --lint [--json]`            | Read-only findings with threshold-based exit codes for CI gates.                |
-| Shared SQLite maintenance | `openclaw doctor --state-sqlite compact`     | Explicitly checkpoints, compacts, and verifies the canonical shared state DB.   |
-| Session SQLite tools      | `openclaw doctor --session-sqlite <mode>`    | Inspects or maintains SQLite sessions and explicitly imports legacy history.    |
+| Posture                   | Command                                   | Behavior                                                                         |
+| ------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------- |
+| Guided checks             | `openclaw doctor`                         | Legacy health flow; can copy legacy config and apply automatic state migrations. |
+| Advisory JSON             | `openclaw doctor --json`                  | Read-only findings; exits successfully after producing a report.                 |
+| Repair                    | `openclaw doctor --fix`                   | Applies supported repairs, using prompts unless non-interactive repair is safe.  |
+| Lint                      | `openclaw doctor --lint [--json]`         | Read-only findings with threshold-based exit codes for CI gates.                 |
+| Shared SQLite maintenance | `openclaw doctor --state-sqlite compact`  | Explicitly checkpoints, compacts, and verifies the canonical shared state DB.    |
+| Session SQLite tools      | `openclaw doctor --session-sqlite <mode>` | Inspects or maintains SQLite sessions and explicitly imports legacy history.     |
 
 Use `openclaw doctor --json` when an operator or script wants the advisory Doctor report as JSON. It exits successfully after producing a report; inspect `ok` and `findings` for health state. Use explicit `openclaw doctor --lint --json` when CI should exit nonzero for findings at the selected severity threshold. Prefer `--fix` when a human operator wants Doctor to edit config or state.
+
+For read-only diagnosis, use `--lint` or bare `--json`. Ordinary `doctor`, including `doctor --non-interactive`, can copy legacy config and migrate state even without `--fix`. `--non-interactive` suppresses prompts, not writes.
 
 After an exec-approval format upgrade, Doctor reports older generated approvals
 that are no longer active because they were not tied to a working directory.
@@ -248,7 +251,7 @@ openclaw doctor --lint --only core/doctor/gateway-config --json
 openclaw doctor --lint --skip core/doctor/skills-readiness
 ```
 
-`--only` and `--skip` accept full check ids and may be repeated. If an `--only` id is not registered, no check runs for that id; use `checksRun`/`checksSkipped` in the output to confirm a focused gate selects the checks you expect.
+`--only` and `--skip` accept full check ids and may be repeated. An unregistered `--only` id emits a `core/doctor/lint-selection` error finding; valid selected checks still run. Use `checksRun`/`checksSkipped` in the output to confirm a focused gate selects the checks you expect.
 
 To check model credentials, run `openclaw doctor --lint --only core/doctor/auth-profiles --json`.
 This opt-in check inspects shared credentials and each configured agent's local

--- a/docs/tools/custodian-skills.md
+++ b/docs/tools/custodian-skills.md
@@ -20,11 +20,13 @@ Every shipped Custodian skill uses the same five sections in this order:
 
 1. **Gather** reads redacted current config and probes live state.
 2. **Mutate** uses validated non-interactive writes — `openclaw config set` / `openclaw config patch` from a trusted shell, or the in-session Custodian tool actions where policy allows — never a direct file edit.
-3. **Repair** runs `openclaw doctor` and separates diagnosis from any approved repair.
+3. **Repair** diagnoses with `openclaw doctor --lint`; only an explicitly approved repair uses `openclaw doctor --fix --non-interactive`. The read-only `diagnose-gateway` skill recommends that separate step but never runs it.
 4. **Prove** exercises one live end-to-end outcome.
 5. **Report** records what changed, what was observed, and what remains.
 
 All five-section playbooks keep secret values out of prompts, logs, and files. Credentials use SecretRefs or credential stores. A workflow never claims success without its Prove outcome; it reports the exact blocker when live proof is unavailable.
+
+Lint exit code `1` means findings, not a failed diagnostic command: read the report and continue the remaining checks. Ordinary `doctor`, including `--non-interactive`, can copy legacy config and migrate state without `--fix`; it is not a read-only substitute. Read-only diagnostics exclude config/service repairs and state migrations, not incidental logs or cache bookkeeping. See [Doctor](/cli/doctor#lint-mode).
 
 ## First wave
 

--- a/skills/healthcheck/SKILL.md
+++ b/skills/healthcheck/SKILL.md
@@ -40,8 +40,10 @@ Common:
 ```bash
 openclaw security audit --deep
 openclaw gateway status --deep
-openclaw doctor
+openclaw doctor --lint
 ```
+
+`doctor --lint` can exit `1` for findings: read the report and continue the remaining checks. Ordinary `doctor` and `doctor --non-interactive` can copy legacy config and migrate state without `--fix`; reserve repairs for explicit approval. Read-only checks exclude config/service repairs and state migrations, but may produce incidental logs or cache bookkeeping.
 
 macOS:
 


### PR DESCRIPTION
Closes #136591 — shipped Custodian/healthcheck diagnosis and channel-example contract defects.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch; maintainers can edit it.

</details>

## What Problem This Solves

Fixes an issue where operators following official read-only diagnosis instructions could unexpectedly copy legacy configuration or migrate state. The same shipped playbooks also prescribed an unsupported channel-status flag and a phone-formatted Telegram allowlist identity, causing an argument error or leaving the intended sender unauthorized.

The defects were verified in stable `v2026.8.2` (`0965053fe6b9341776df147a6934b7485c60b5ca`) and current main at the investigation baseline. They are in the official skill files, not inventions of the [public discussion that prompted the audit](https://x.com/TriadDarren/status/2095205848062595143).

## Why This Change Was Made

Use the existing `doctor --lint` and `channels status --probe` contracts instead of changing runtime behavior to accommodate incorrect instructions. All four Custodian playbooks and healthcheck now separate diagnosis from explicitly approved repair, explain lint's findings-related exit code, and preserve the read-only diagnosis skill's prohibition on repair.

Telegram setup now uses a clearly labeled numeric user-ID placeholder, discovers the identity from the actual pairing reply or `senderUserId` pairing-log field, and preserves existing approved entries and policies. Blocked discovery is not permission to broaden access. Matching reference docs distinguish ordinary Doctor from read-only postures and top-level `status --deep` from channel probes; the nearby lint-selection docs also now mention the existing unknown-ID error finding.

## User Impact

Operators and agents can follow the bundled instructions without accidentally authorizing repair, invoking a nonexistent channel flag, or substituting a phone number for a Telegram user ID. Existing authentication, ownership, access-control, service, and migration safeguards remain unchanged. No new configuration, runtime fallback, dependency, or schema is introduced.

Read-only here excludes config/service repairs and state migrations; it does not promise that diagnostic logging or incidental cache bookkeeping never occurs.

## Evidence

**Source-audited ownership:** `src/cli/program/register.maintenance.ts` selects lint for `--lint` or bare `--json`; ordinary `--non-interactive` enters the legacy Doctor flow. `src/commands/doctor-config-preflight-legacy-config.ts` copies legacy config without a repair flag, and `src/flows/doctor-health-contributions.ts` automatically selects supported legacy-state migrations in non-interactive mode. `src/cli/channels-cli.ts` declares `--probe`, not `--deep`. `extensions/telegram/src/bot-access.ts` rejects nondigit sender IDs, while `dm-access.ts` owns the pairing reply and `senderUserId` log field.

**Existing behavior tests: 226 passed across eight files.** This includes the legacy-copy reproduction without repair mode, read-only Doctor routing and mutation rejection, lint state isolation, channel parsing, and Telegram normalization/access behavior:

```bash
node scripts/run-vitest.mjs src/cli/program/register.maintenance.test.ts src/commands/doctor-lint.test.ts src/commands/doctor-lint.state-isolation.test.ts src/flows/doctor-lint-flow.test.ts src/commands/doctor-config-preflight.legacy-copy.test.ts src/cli/channels-cli.test.ts extensions/telegram/src/bot-access.warn-dedupe.test.ts extensions/telegram/src/dm-access.test.ts
```

**Actual parser/normalizer/selected-lint probes: 3 passed before and after the instruction repair, then 3 passed in the final independent run.** The probes used an empty inherited environment with task-owned synthetic HOME/state/config. They exercised real registration and command actions, mocking only the channel probe's external Gateway RPC:

- `channels status --deep` raised `commander.unknownOption` with exit 1 before any Gateway call.
- `channels status --probe --json` dispatched `channels.status` with `probe: true` and returned the synthetic RPC result.
- The phone-formatted Telegram sample normalized to no allowed IDs and denied the sender; the numeric sample retained the ID and authorized its matching sender.
- `doctor --lint --json --only core/doctor/gateway-config --only core/doctor/sandbox/registry-files` ran both real checks and returned two warning findings with exit 1. Synthetic legacy config and registry bytes remained unchanged, no canonical config was created, the state directory tree stayed unchanged, and no Gateway call occurred.

The independent rerun exposed temporary proof-harness cold-import and fixture-ordering problems. The final harness establishes synthetic state and resets prior module captures before collecting the real owners; the final run passed without relaxed assertions or increased timeouts. No permanent skill-string snapshots or test-only production seams were added: the defect was instruction selection, not broken runtime behavior.

**Static checks passed:** docs listing; `node scripts/check-changed.mjs` on the nine changed paths (`docs-only` lane); final nine-file oxfmt check; four-page MDX check; `git diff --check`.

**Scope and proof limits:** nine Markdown files, +47/-24; executable production code +0/-0; checked-in tests +0/-0. No live operator state/config access, repair execution, full default lint scan, live Telegram/Gateway flow, or UI change. Isolated command/normalizer proof is intentional for this instruction-only repair; no live-channel or screenshot evidence is claimed.
