### PR TITLE
test(prompt-snapshots): generate Codex happy-path snapshots under a hermetic state dir

### DIFF
--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -29,6 +29,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../../../src/plugins/runtime.js";
+import { withStateDirEnv } from "../../../src/test-helpers/state-dir-env.js";
 import { resolveRelativeBundledPluginPublicModuleId } from "../../../src/test-utils/bundled-plugin-public-surface.js";
 import { createTestRegistry } from "../../../src/test-utils/channel-plugins.js";
 import {
@@ -1025,24 +1026,28 @@ function renderReadme(scenarios: PromptScenario[]): string {
 
 /** Build all Codex happy-path prompt snapshot files without writing them. */
 export async function createHappyPathPromptSnapshotFiles(): Promise<PromptSnapshotFile[]> {
-  const codexApi = await loadCodexPromptSnapshotApi();
-  const scenarios = await createScenarios(codexApi);
-  const files = [
-    {
-      path: path.join(CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR, "README.md"),
-      content: renderReadme(scenarios),
-    },
-    ...scenarios.map((scenario) => ({
-      path: path.join(CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR, `${scenario.id}.md`),
-      content: renderScenarioSnapshot(codexApi, scenario),
-    })),
-    ...scenarios.map((scenario) => ({
-      path: path.join(CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR, scenario.toolSnapshotFile),
-      content: stableJson(scenario.dynamicTools),
-    })),
-  ];
-  return files.map((file) => ({
-    path: file.path,
-    content: file.content.endsWith("\n") ? file.content : `${file.content}\n`,
-  }));
+  // Plugin-policy hashing reads machine state from the process state dir.
+  // Pin a fresh one so snapshot generation never reads the host's live database.
+  return withStateDirEnv("openclaw-prompt-snapshot-", async () => {
+    const codexApi = await loadCodexPromptSnapshotApi();
+    const scenarios = await createScenarios(codexApi);
+    const files = [
+      {
+        path: path.join(CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR, "README.md"),
+        content: renderReadme(scenarios),
+      },
+      ...scenarios.map((scenario) => ({
+        path: path.join(CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR, `${scenario.id}.md`),
+        content: renderScenarioSnapshot(codexApi, scenario),
+      })),
+      ...scenarios.map((scenario) => ({
+        path: path.join(CODEX_RUNTIME_HAPPY_PATH_PROMPT_SNAPSHOT_DIR, scenario.toolSnapshotFile),
+        content: stableJson(scenario.dynamicTools),
+      })),
+    ];
+    return files.map((file) => ({
+      path: file.path,
+      content: file.content.endsWith("\n") ? file.content : `${file.content}\n`,
+    }));
+  });
 }

--- a/test/scripts/prompt-snapshots.test.ts
+++ b/test/scripts/prompt-snapshots.test.ts
@@ -2,7 +2,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   materializeCodexDynamicToolSnapshot,
   materializeCodexPromptSnapshot,
@@ -17,6 +18,13 @@ import {
   runCodexModelPromptFixtureSync,
 } from "../../scripts/sync-codex-model-prompt-fixture.js";
 import { getPluginModuleLoaderStats } from "../../src/plugins/plugin-module-loader-cache.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../src/state/openclaw-state-db-contract.js";
+import { resolveOpenClawStateSqlitePath } from "../../src/state/openclaw-state-db.paths.js";
+import {
+  restoreStateDirEnv,
+  setStateDirEnv,
+  snapshotStateDirEnv,
+} from "../../src/test-helpers/state-dir-env.js";
 import { createHappyPathPromptSnapshotFiles } from "../helpers/agents/happy-path-prompt-snapshots.js";
 import {
   CODEX_MODEL_PROMPT_FIXTURE_DIR,
@@ -38,9 +46,41 @@ function renderedPromptSection(content: string, heading: string, nextHeading: st
   return content.slice(start, end);
 }
 
+let generated: Awaited<ReturnType<typeof createHappyPathPromptSnapshotFiles>>;
+let pluginLoaderCallsBefore: number;
+let pluginLoaderCallsAfter: number;
+let poisonedStateRoot: string | undefined;
+const stateDirEnv = snapshotStateDirEnv();
+
 describe("happy path prompt snapshots", () => {
+  beforeAll(async () => {
+    poisonedStateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-prompt-snapshot-poison-"));
+    const databasePath = resolveOpenClawStateSqlitePath({
+      ...process.env,
+      OPENCLAW_STATE_DIR: poisonedStateRoot,
+    });
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`PRAGMA user_version = ${OPENCLAW_STATE_SCHEMA_VERSION + 1}`);
+    } finally {
+      database.close();
+    }
+    setStateDirEnv(poisonedStateRoot);
+
+    pluginLoaderCallsBefore = getPluginModuleLoaderStats().calls;
+    generated = await createHappyPathPromptSnapshotFiles();
+    pluginLoaderCallsAfter = getPluginModuleLoaderStats().calls;
+  }, 300_000);
+
+  afterAll(() => {
+    restoreStateDirEnv(stateDirEnv);
+    if (poisonedStateRoot) {
+      fs.rmSync(poisonedStateRoot, { recursive: true, force: true });
+    }
+  });
+
   it("reconstructs complete Codex tool catalogs from readable full-tool overrides", async () => {
-    const generated = await createHappyPathPromptSnapshotFiles();
     const scenarios = [
       { name: "telegram-direct", replacements: [] },
       { name: "discord-group", replacements: ["sessions_spawn"] },
@@ -129,12 +169,10 @@ describe("happy path prompt snapshots", () => {
     // plugin-loader call here means a scenario channel (or another plugin
     // surface) fell back to source re-transpilation, which re-evaluates the
     // core graph and stalls the lane by minutes.
-    const callsBefore = getPluginModuleLoaderStats().calls;
-    const files = await createHappyPathPromptSnapshotFiles();
-    expect(files.length).toBeGreaterThan(0);
+    expect(generated.length).toBeGreaterThan(0);
     const stats = getPluginModuleLoaderStats();
     expect(
-      stats.calls - callsBefore,
+      pluginLoaderCallsAfter - pluginLoaderCallsBefore,
       `prompt snapshot generation hit the jiti plugin loader; targets: ${stats.topSourceTransformTargets
         .map((entry) => entry.target)
         .join(", ")}`,


### PR DESCRIPTION
## What Problem This Solves

The Codex happy-path prompt snapshot builder (`test/helpers/agents/happy-path-prompt-snapshots.ts`) pins its workspace, agent, and session fixtures under `/tmp/openclaw-happy-path/` but never pins the state directory. Plugin-policy hashing (`resolveInstalledPluginIndexPolicyHash` → `readBundledDiscoveryModeMemoized` → `readConfigMachineState`) therefore opens the operator's live `~/.openclaw/state/openclaw.sqlite`. On a host whose running gateway has migrated that database past the checkout's supported schema, `pnpm prompt:snapshots:gen`, `pnpm prompt:snapshots:check`, the `check:changed` "prompt snapshot drift" lane, and `test/scripts/prompt-snapshots.test.ts` all die with `SqliteSchemaVersionError` before doing any work (observed on 2026-09-02: live schema 16, checkout 15, while landing #136570).

Separately, the owner test performed the cold in-process generation (about 50 s on a quiet 32-core machine, dominated by first-time module and plugin loading) inside its first `it` under Vitest's default 120 s per-test timeout, so it timed out under CI or parallel-worktree load, and the file regenerated more than once.

## Why This Change Was Made

The runtime's fail-closed schema check is correct and is not touched. The fixture builder is the owner of its own environment, so it is made hermetic there:

- `createHappyPathPromptSnapshotFiles` now runs under `withStateDirEnv`: a fresh temporary `OPENCLAW_STATE_DIR` per generation, restored afterwards. A fixed `/tmp` path was rejected because parallel worktrees on one machine would share a SQLite file and a stale copy could itself be newer than the checkout.
- The owner test does the single cold generation once in a budgeted `beforeAll` (300 s) under a deliberately poisoned state dir: a real SQLite file at the resolved path stamped `user_version = OPENCLAW_STATE_SCHEMA_VERSION + 1`. Hermeticity is thereby asserted on every run, the jiti perf contract measures the captured loader-call delta instead of regenerating, and the first case no longer races the per-test timeout.

Production LOC: 0 | Tests/test support: +69/-26.

## User Impact

None at runtime. Maintainers and CI get a prompt-snapshot generator, drift check, and owner test that never depend on the host's `~/.openclaw` state, plus a faster, load-tolerant owner test (first case ~50 s → ~1 s).

## Evidence

- Pre-fix (test scaffolding only): `pnpm test:serial test/scripts/prompt-snapshots.test.ts` fails in `beforeAll` with `SqliteSchemaVersionError ... uses newer schema version 16; this build supports 15` against the poisoned path; plain `pnpm prompt:snapshots:check` on this host fails the same way against `~/.openclaw/state/openclaw.sqlite`.
- Post-fix, with no `OPENCLAW_STATE_DIR` override: `pnpm prompt:snapshots:check` → "Prompt snapshots are current (7 files)"; `pnpm test:serial test/scripts/prompt-snapshots.test.ts` → 16 passed (first case 1.09 s); `pnpm check:changed` green end to end including the drift lane and the owner test lane.
- Committed fixtures under `test/fixtures/agents/prompt-snapshots/` are byte-identical, proving the state dir does not leak into snapshot bytes.
- Codex autoreview of the diff: scoped-clean, no findings.
